### PR TITLE
fix(approvals): reject stale controls after lifecycle replacement

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/GatewayExecApprovals.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/GatewayExecApprovals.kt
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 data class GatewayExecApprovalSummary(
   val id: String,
+  val instanceId: String? = null,
   val commandText: NativeText,
   val commandPreview: String?,
   val warningText: String?,
@@ -211,9 +212,11 @@ internal fun buildGatewayExecApprovalGetParams(id: String): JsonObject = buildJs
 internal fun buildGatewayExecApprovalResolveParams(
   id: String,
   decision: String,
+  instanceId: String? = null,
 ): JsonObject =
   buildJsonObject {
     put("id", id)
+    instanceId?.let { put("instanceId", it) }
     put("kind", "exec")
     put("decision", decision)
   }
@@ -387,15 +390,23 @@ internal fun legacyGatewayExecApprovalTerminal(
 private fun parseGatewayExecApprovalSnapshot(obj: JsonObject): GatewayExecApprovalSnapshot? {
   val status = obj.strictString("status") ?: return null
   val expectedKeys = APPROVAL_SNAPSHOT_KEYS_BY_STATUS[status] ?: return null
-  if (!obj.hasExactKeys(expectedKeys)) return null
+  if (
+    status == "pending" &&
+    !obj.hasExactKeys(expectedKeys) &&
+    !obj.hasExactKeys(expectedKeys + "instanceId")
+  ) {
+    return null
+  }
+  if (status != "pending" && !obj.hasExactKeys(expectedKeys)) return null
   val id = obj.strictApprovalId("id") ?: return null
+  val instanceId = obj.optionalString("instanceId", requireNonEmpty = true) ?: return null
   obj.strictNonEmptyString("urlPath") ?: return null
   val createdAtMs = obj.strictNonNegativeLong("createdAtMs") ?: return null
   val expiresAtMs = obj.strictNonNegativeLong("expiresAtMs") ?: return null
   val presentation = obj["presentation"].asObjectOrNull() ?: return null
   val summary = parseGatewayExecApprovalPresentation(id, createdAtMs, expiresAtMs, presentation) ?: return null
   return when (status) {
-    "pending" -> GatewayExecApprovalSnapshot.Pending(summary)
+    "pending" -> GatewayExecApprovalSnapshot.Pending(summary.copy(instanceId = instanceId.value))
     "allowed" ->
       parseTerminalApproval(
         obj = obj,
@@ -528,8 +539,8 @@ private fun JsonObject.strictNonNegativeLong(key: String): Long? =
     ?.longOrNull
     ?.takeIf { it >= 0 }
 
-// Closed-schema contract: the gateway protocol declares approval results with
-// additionalProperties:false, so additive protocol changes hard-fail old clients by design.
+// Closed-schema contract: accept only the fields declared by the negotiated
+// approval projection, including its optional pending instance token.
 private fun JsonObject.hasExactKeys(expected: Set<String>): Boolean = keys == expected
 
 private fun JsonObject.hasOnlyKeys(allowed: Set<String>): Boolean = keys.all(allowed::contains)

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -1544,8 +1544,9 @@ class MainViewModel private constructor(
   fun resolveExecApproval(
     id: String,
     decision: String,
+    instanceId: String?,
   ) {
-    ensureRuntime().resolveExecApproval(id = id, decision = decision)
+    ensureRuntime().resolveExecApproval(id = id, decision = decision, instanceId = instanceId)
   }
 
   fun dismissExecApprovalsNotice(expected: GatewayExecApprovalNotice) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -1554,8 +1554,9 @@ class MainViewModel private constructor(
   fun resolveExecApproval(
     id: String,
     decision: String,
+    instanceId: String?,
   ) {
-    ensureRuntime().resolveExecApproval(id = id, decision = decision)
+    ensureRuntime().resolveExecApproval(id = id, decision = decision, instanceId = instanceId)
   }
 
   fun dismissExecApprovalsNotice(expected: GatewayExecApprovalNotice) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -794,6 +794,7 @@ class NodeRuntime private constructor(
     val stableId: String,
     val id: String,
     val decision: String,
+    val instanceId: String?,
     // Captured at registration: canonical readback needs it after a refresh has
     // already replaced the visible rows, or the legacy get parse drops the row.
     val createdAtMs: Long?,
@@ -2749,12 +2750,17 @@ class NodeRuntime private constructor(
   fun resolveExecApproval(
     id: String,
     decision: String,
+    instanceId: String? = null,
   ) {
     val exactId = id.takeIf(::isWellFormedGatewayApprovalId)
     val normalizedDecision = normalizeGatewayExecApprovalDecision(decision)
     if (exactId == null || normalizedDecision == null) return
     scope.launch {
-      resolveExecApprovalOnGateway(id = exactId, decision = normalizedDecision)
+      resolveExecApprovalOnGateway(
+        id = exactId,
+        decision = normalizedDecision,
+        instanceId = instanceId,
+      )
     }
   }
 
@@ -7214,6 +7220,7 @@ class NodeRuntime private constructor(
   private suspend fun resolveExecApprovalOnGateway(
     id: String,
     decision: String,
+    instanceId: String?,
   ) {
     val gatewayScope = captureGatewayDataScope() ?: return
     val methodsSnapshot = captureGatewayMethods()
@@ -7223,14 +7230,18 @@ class NodeRuntime private constructor(
         synchronized(execApprovalsStateLock) {
           if (!operatorConnected || id in resolvedExecApprovalIds) return@synchronized
           val currentRows = _execApprovals.value
-          if (currentRows.none { it.id == id && it.resolvingDecision == null }) return@synchronized
+          val selectedRow =
+            currentRows.firstOrNull {
+              it.id == id && it.instanceId == instanceId && it.resolvingDecision == null
+            } ?: return@synchronized
           if (pendingExecApprovalWrites.containsKey(id)) return@synchronized
           val pendingWrite =
             PendingExecApprovalWrite(
               gatewayScope.stableId,
               id,
               decision,
-              currentRows.firstOrNull { it.id == id }?.createdAtMs,
+              selectedRow.instanceId,
+              selectedRow.createdAtMs,
             )
           pendingExecApprovalWrites[id] = pendingWrite
           registeredWrite = pendingWrite
@@ -7247,7 +7258,14 @@ class NodeRuntime private constructor(
     val pendingWrite = registeredWrite
     if (!scopeCurrent || pendingWrite == null) return
     try {
-      val resolution = submitExecApprovalResolution(gatewayScope, methodsSnapshot, id, decision)
+      val resolution =
+        submitExecApprovalResolution(
+          gatewayScope,
+          methodsSnapshot,
+          id,
+          decision,
+          pendingWrite.instanceId,
+        )
       markExecApprovalWriteRequestFinished(pendingWrite)
       publishGatewayApprovalData(gatewayScope, methodsSnapshot) {
         synchronized(execApprovalsStateLock) {
@@ -7314,10 +7332,11 @@ class NodeRuntime private constructor(
     methodsSnapshot: GatewayMethodsSnapshot,
     id: String,
     decision: String,
+    instanceId: String?,
   ): GatewayExecApprovalResolution =
     when (methodsSnapshot.approvalRpcFamily) {
       GatewayApprovalRpcFamily.Canonical -> {
-        val params = buildGatewayExecApprovalResolveParams(id, decision).toString()
+        val params = buildGatewayExecApprovalResolveParams(id, decision, instanceId).toString()
         val response =
           requestGatewayApprovalData(
             gatewayScope = gatewayScope,
@@ -7337,6 +7356,7 @@ class NodeRuntime private constructor(
         val legacyParams =
           buildJsonObject {
             put("id", JsonPrimitive(id))
+            instanceId?.let { put("instanceId", JsonPrimitive(it)) }
             put("decision", JsonPrimitive(decision))
           }.toString()
         val legacyResponse =

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -788,6 +788,7 @@ class NodeRuntime private constructor(
     val stableId: String,
     val id: String,
     val decision: String,
+    val instanceId: String?,
     // Captured at registration: canonical readback needs it after a refresh has
     // already replaced the visible rows, or the legacy get parse drops the row.
     val createdAtMs: Long?,
@@ -2731,12 +2732,17 @@ class NodeRuntime private constructor(
   fun resolveExecApproval(
     id: String,
     decision: String,
+    instanceId: String? = null,
   ) {
     val exactId = id.takeIf(::isWellFormedGatewayApprovalId)
     val normalizedDecision = normalizeGatewayExecApprovalDecision(decision)
     if (exactId == null || normalizedDecision == null) return
     scope.launch {
-      resolveExecApprovalOnGateway(id = exactId, decision = normalizedDecision)
+      resolveExecApprovalOnGateway(
+        id = exactId,
+        decision = normalizedDecision,
+        instanceId = instanceId,
+      )
     }
   }
 
@@ -7102,6 +7108,7 @@ class NodeRuntime private constructor(
   private suspend fun resolveExecApprovalOnGateway(
     id: String,
     decision: String,
+    instanceId: String?,
   ) {
     val gatewayScope = captureGatewayDataScope() ?: return
     val methodsSnapshot = captureGatewayMethods()
@@ -7111,14 +7118,18 @@ class NodeRuntime private constructor(
         synchronized(execApprovalsStateLock) {
           if (!operatorConnected || id in resolvedExecApprovalIds) return@synchronized
           val currentRows = _execApprovals.value
-          if (currentRows.none { it.id == id && it.resolvingDecision == null }) return@synchronized
+          val selectedRow =
+            currentRows.firstOrNull {
+              it.id == id && it.instanceId == instanceId && it.resolvingDecision == null
+            } ?: return@synchronized
           if (pendingExecApprovalWrites.containsKey(id)) return@synchronized
           val pendingWrite =
             PendingExecApprovalWrite(
               gatewayScope.stableId,
               id,
               decision,
-              currentRows.firstOrNull { it.id == id }?.createdAtMs,
+              selectedRow.instanceId,
+              selectedRow.createdAtMs,
             )
           pendingExecApprovalWrites[id] = pendingWrite
           registeredWrite = pendingWrite
@@ -7135,7 +7146,14 @@ class NodeRuntime private constructor(
     val pendingWrite = registeredWrite
     if (!scopeCurrent || pendingWrite == null) return
     try {
-      val resolution = submitExecApprovalResolution(gatewayScope, methodsSnapshot, id, decision)
+      val resolution =
+        submitExecApprovalResolution(
+          gatewayScope,
+          methodsSnapshot,
+          id,
+          decision,
+          pendingWrite.instanceId,
+        )
       markExecApprovalWriteRequestFinished(pendingWrite)
       publishGatewayApprovalData(gatewayScope, methodsSnapshot) {
         synchronized(execApprovalsStateLock) {
@@ -7202,10 +7220,11 @@ class NodeRuntime private constructor(
     methodsSnapshot: GatewayMethodsSnapshot,
     id: String,
     decision: String,
+    instanceId: String?,
   ): GatewayExecApprovalResolution =
     when (methodsSnapshot.approvalRpcFamily) {
       GatewayApprovalRpcFamily.Canonical -> {
-        val params = buildGatewayExecApprovalResolveParams(id, decision).toString()
+        val params = buildGatewayExecApprovalResolveParams(id, decision, instanceId).toString()
         val response =
           requestGatewayApprovalData(
             gatewayScope = gatewayScope,
@@ -7225,6 +7244,7 @@ class NodeRuntime private constructor(
         val legacyParams =
           buildJsonObject {
             put("id", JsonPrimitive(id))
+            instanceId?.let { put("instanceId", JsonPrimitive(it)) }
             put("decision", JsonPrimitive(decision))
           }.toString()
         val legacyResponse =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -2395,7 +2395,7 @@ internal data class SettingsMetric(
 @Composable
 private fun ExecApprovalsPanel(
   approvals: List<GatewayExecApprovalSummary>,
-  onResolve: (String, String) -> Unit,
+  onResolve: (String, String, String?) -> Unit,
 ) {
   Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
     approvals.forEach { approval ->
@@ -2410,7 +2410,7 @@ private fun ExecApprovalsPanel(
 @Composable
 private fun ExecApprovalCard(
   approval: GatewayExecApprovalSummary,
-  onResolve: (String, String) -> Unit,
+  onResolve: (String, String, String?) -> Unit,
 ) {
   val resolving = approval.resolvingDecision != null
   ClawPanel {
@@ -2437,14 +2437,14 @@ private fun ExecApprovalCard(
           if (action.decision == "allow-once") {
             ClawPrimaryButton(
               text = action.label,
-              onClick = { onResolve(approval.id, action.decision) },
+              onClick = { onResolve(approval.id, action.decision, approval.instanceId) },
               enabled = !resolving,
               modifier = Modifier.fillMaxWidth(),
             )
           } else {
             ClawSecondaryButton(
               text = action.label,
-              onClick = { onResolve(approval.id, action.decision) },
+              onClick = { onResolve(approval.id, action.decision, approval.instanceId) },
               enabled = !resolving,
               modifier = Modifier.fillMaxWidth(),
             )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -2392,7 +2392,7 @@ internal data class SettingsMetric(
 @Composable
 private fun ExecApprovalsPanel(
   approvals: List<GatewayExecApprovalSummary>,
-  onResolve: (String, String) -> Unit,
+  onResolve: (String, String, String?) -> Unit,
 ) {
   Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
     approvals.forEach { approval ->
@@ -2407,7 +2407,7 @@ private fun ExecApprovalsPanel(
 @Composable
 private fun ExecApprovalCard(
   approval: GatewayExecApprovalSummary,
-  onResolve: (String, String) -> Unit,
+  onResolve: (String, String, String?) -> Unit,
 ) {
   val resolving = approval.resolvingDecision != null
   ClawPanel {
@@ -2434,14 +2434,14 @@ private fun ExecApprovalCard(
           if (action.decision == "allow-once") {
             ClawPrimaryButton(
               text = action.label,
-              onClick = { onResolve(approval.id, action.decision) },
+              onClick = { onResolve(approval.id, action.decision, approval.instanceId) },
               enabled = !resolving,
               modifier = Modifier.fillMaxWidth(),
             )
           } else {
             ClawSecondaryButton(
               text = action.label,
-              onClick = { onResolve(approval.id, action.decision) },
+              onClick = { onResolve(approval.id, action.decision, approval.instanceId) },
               enabled = !resolving,
               modifier = Modifier.fillMaxWidth(),
             )

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalParsingTest.kt
@@ -297,6 +297,27 @@ class GatewayExecApprovalParsingTest {
       """{"id":"approval-1","kind":"exec","decision":"deny"}""",
       buildGatewayExecApprovalResolveParams(id = "approval-1", decision = "deny").toString(),
     )
+    assertEquals(
+      """{"id":"approval-1","instanceId":"instance:approval-1","kind":"exec","decision":"deny"}""",
+      buildGatewayExecApprovalResolveParams(
+        id = "approval-1",
+        decision = "deny",
+        instanceId = "instance:approval-1",
+      ).toString(),
+    )
+  }
+
+  @Test
+  fun parsesOptionalPendingInstanceId() {
+    val payload =
+      pendingGetPayload().replace(
+        "\"status\": \"pending\"",
+        "\"status\": \"pending\", \"instanceId\": \"instance:approval-1\"",
+      )
+    val pending =
+      parseGatewayExecApprovalGetPayload(payload, json, expectedId = "approval-1")
+        as? GatewayExecApprovalSnapshot.Pending
+    assertEquals("instance:approval-1", pending?.summary?.instanceId)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
@@ -44,6 +44,69 @@ class GatewayExecApprovalRuntimeTest {
   }
 
   @Test
+  fun canonicalResolveEchoesPendingInstanceId() =
+    runBlocking {
+      val runtime =
+        approvalRuntime(approvals = listOf(approvalSummary(instanceId = "instance:approval-1")))
+      var sentParams: String? = null
+      runtime.gatewayDataRequestOverrideForTests = { _, method, params ->
+        check(method == "approval.resolve")
+        sentParams = params
+        unifiedResolve(applied = true, status = "denied", decision = "deny")
+      }
+
+      runtime.resolveExecApproval("approval-1", "deny", "instance:approval-1")
+      waitUntil { runtime.execApprovals.value.isEmpty() }
+
+      assertEquals(
+        """{"id":"approval-1","instanceId":"instance:approval-1","kind":"exec","decision":"deny"}""",
+        sentParams,
+      )
+    }
+
+  @Test
+  fun staleInstanceCannotResolveSameIdReplacement() =
+    runBlocking {
+      val runtime =
+        approvalRuntime(approvals = listOf(approvalSummary(instanceId = "instance:replacement")))
+      var requestCount = 0
+      runtime.gatewayDataRequestOverrideForTests = { _, _, _ ->
+        requestCount += 1
+        unifiedResolve(applied = true, status = "denied", decision = "deny")
+      }
+
+      runtime.resolveExecApproval("approval-1", "deny", "instance:stale")
+      delay(50)
+
+      assertEquals(0, requestCount)
+      assertEquals("instance:replacement", runtime.execApprovals.value.single().instanceId)
+    }
+
+  @Test
+  fun legacyResolveEchoesPendingInstanceId() =
+    runBlocking {
+      val runtime =
+        approvalRuntime(
+          methods = legacyMethods,
+          approvals = listOf(approvalSummary(instanceId = "instance:approval-1")),
+        )
+      var sentParams: String? = null
+      runtime.gatewayDataRequestOverrideForTests = { _, method, params ->
+        check(method == "exec.approval.resolve")
+        sentParams = params
+        """{"ok":true}"""
+      }
+
+      runtime.resolveExecApproval("approval-1", "deny", "instance:approval-1")
+      waitUntil { runtime.execApprovals.value.isEmpty() }
+
+      assertEquals(
+        """{"id":"approval-1","instanceId":"instance:approval-1","decision":"deny"}""",
+        sentParams,
+      )
+    }
+
+  @Test
   fun anotherSurfaceWinnerClosesLocalCardFromCanonicalResolveResult() =
     runBlocking {
       val runtime = approvalRuntime()
@@ -1091,9 +1154,11 @@ class GatewayExecApprovalRuntimeTest {
   private fun approvalSummary(
     id: String = "approval-1",
     commandText: String = "echo ok",
+    instanceId: String? = null,
   ): GatewayExecApprovalSummary =
     GatewayExecApprovalSummary(
       id = id,
+      instanceId = instanceId,
       commandText = verbatimText(commandText),
       commandPreview = "echo",
       warningText = null,

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
@@ -79,7 +79,12 @@ class GatewayExecApprovalRuntimeTest {
       delay(50)
 
       assertEquals(0, requestCount)
-      assertEquals("instance:replacement", runtime.execApprovals.value.single().instanceId)
+      assertEquals(
+        "instance:replacement",
+        runtime.execApprovals.value
+          .single()
+          .instanceId,
+      )
     }
 
   @Test

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -63,6 +63,7 @@ final class NodeAppModel {
 
     struct ExecApprovalPrompt: Identifiable, Equatable, Codable {
         let id: String
+        let instanceId: String?
         let kind: String?
         let gatewayStableID: String
         let commandText: String
@@ -80,6 +81,7 @@ final class NodeAppModel {
 
         init(
             id: String,
+            instanceId: String? = nil,
             kind: String?,
             gatewayStableID: String,
             commandText: String,
@@ -96,6 +98,7 @@ final class NodeAppModel {
             pluginSeverity: String? = nil)
         {
             self.id = id
+            self.instanceId = instanceId
             self.kind = kind
             self.gatewayStableID = gatewayStableID
             self.commandText = commandText
@@ -8347,6 +8350,7 @@ extension NodeAppModel {
             guard self.isValidExecApprovalPresentation(presentation) else { return nil }
             prompt = ExecApprovalPrompt(
                 id: snapshot.id,
+                instanceId: snapshot.instanceid,
                 kind: presentation.kind,
                 gatewayStableID: gatewayStableID,
                 commandText: presentation.commandtext,
@@ -8361,6 +8365,7 @@ extension NodeAppModel {
             guard self.isValidPluginApprovalPresentation(presentation) else { return nil }
             prompt = ExecApprovalPrompt(
                 id: snapshot.id,
+                instanceId: snapshot.instanceid,
                 kind: presentation.kind,
                 gatewayStableID: gatewayStableID,
                 commandText: presentation.title,
@@ -9033,6 +9038,7 @@ extension NodeAppModel {
         self.pendingExecApprovalPromptErrorText = nil
         let outcome = await resolveExecApprovalNotificationDecision(
             approvalId: prompt.id,
+            approvalInstanceId: prompt.instanceId,
             approvalKind: prompt.kind,
             decision: decision,
             expectedGatewayStableID: prompt.gatewayStableID,
@@ -9073,6 +9079,7 @@ extension NodeAppModel {
 
     private func resolveExecApprovalNotificationDecision(
         approvalId: String,
+        approvalInstanceId: String? = nil,
         approvalKind: String?,
         decision: String,
         expectedGatewayStableID: String,
@@ -9144,6 +9151,7 @@ extension NodeAppModel {
             let payloadJSON = try Self.encodePayload(
                 ApprovalResolveParams(
                     id: approvalID,
+                    instanceid: approvalInstanceId,
                     kind: approvalKind,
                     decision: approvalDecision))
             let response = try await self.operatorGateway.request(

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -5974,6 +5974,7 @@ extension NodeAppModel {
         let preview = Self.trimmedOrNil(prompt.commandPreview) ?? Self.trimmedOrNil(prompt.commandText)
         return OpenClawWatchExecApprovalItem(
             id: prompt.id,
+            instanceId: prompt.instanceId,
             gatewayStableID: prompt.gatewayStableID,
             commandText: prompt.commandText,
             commandPreview: preview,
@@ -7260,6 +7261,7 @@ extension NodeAppModel {
         }
         let outcome = await resolveExecApprovalNotificationDecision(
             approvalId: approvalID,
+            approvalInstanceId: routedEvent.approvalInstanceId,
             approvalKind: prompt.kind,
             decision: routedEvent.decision.rawValue,
             expectedGatewayStableID: prompt.gatewayStableID,
@@ -8427,6 +8429,7 @@ extension NodeAppModel {
         }
         return ExecApprovalPrompt(
             id: approvalId,
+            instanceId: input.instanceId,
             kind: approvalKind,
             gatewayStableID: exactGatewayStableID,
             commandText: normalizedCommandText,

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -5918,6 +5918,7 @@ extension NodeAppModel {
         let preview = Self.trimmedOrNil(prompt.commandPreview) ?? Self.trimmedOrNil(prompt.commandText)
         return OpenClawWatchExecApprovalItem(
             id: prompt.id,
+            instanceId: prompt.instanceId,
             gatewayStableID: prompt.gatewayStableID,
             commandText: prompt.commandText,
             commandPreview: preview,
@@ -7204,6 +7205,7 @@ extension NodeAppModel {
         }
         let outcome = await resolveExecApprovalNotificationDecision(
             approvalId: approvalID,
+            approvalInstanceId: routedEvent.approvalInstanceId,
             approvalKind: prompt.kind,
             decision: routedEvent.decision.rawValue,
             expectedGatewayStableID: prompt.gatewayStableID,
@@ -8360,6 +8362,7 @@ extension NodeAppModel {
         }
         return ExecApprovalPrompt(
             id: approvalId,
+            instanceId: input.instanceId,
             kind: approvalKind,
             gatewayStableID: exactGatewayStableID,
             commandText: normalizedCommandText,

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -63,6 +63,7 @@ final class NodeAppModel {
 
     struct ExecApprovalPrompt: Identifiable, Equatable, Codable {
         let id: String
+        let instanceId: String?
         let kind: String?
         let gatewayStableID: String
         let commandText: String
@@ -80,6 +81,7 @@ final class NodeAppModel {
 
         init(
             id: String,
+            instanceId: String? = nil,
             kind: String?,
             gatewayStableID: String,
             commandText: String,
@@ -96,6 +98,7 @@ final class NodeAppModel {
             pluginSeverity: String? = nil)
         {
             self.id = id
+            self.instanceId = instanceId
             self.kind = kind
             self.gatewayStableID = gatewayStableID
             self.commandText = commandText
@@ -8280,6 +8283,7 @@ extension NodeAppModel {
             guard self.isValidExecApprovalPresentation(presentation) else { return nil }
             prompt = ExecApprovalPrompt(
                 id: snapshot.id,
+                instanceId: snapshot.instanceid,
                 kind: presentation.kind,
                 gatewayStableID: gatewayStableID,
                 commandText: presentation.commandtext,
@@ -8294,6 +8298,7 @@ extension NodeAppModel {
             guard self.isValidPluginApprovalPresentation(presentation) else { return nil }
             prompt = ExecApprovalPrompt(
                 id: snapshot.id,
+                instanceId: snapshot.instanceid,
                 kind: presentation.kind,
                 gatewayStableID: gatewayStableID,
                 commandText: presentation.title,
@@ -8966,6 +8971,7 @@ extension NodeAppModel {
         self.pendingExecApprovalPromptErrorText = nil
         let outcome = await resolveExecApprovalNotificationDecision(
             approvalId: prompt.id,
+            approvalInstanceId: prompt.instanceId,
             approvalKind: prompt.kind,
             decision: decision,
             expectedGatewayStableID: prompt.gatewayStableID,
@@ -9006,6 +9012,7 @@ extension NodeAppModel {
 
     private func resolveExecApprovalNotificationDecision(
         approvalId: String,
+        approvalInstanceId: String? = nil,
         approvalKind: String?,
         decision: String,
         expectedGatewayStableID: String,
@@ -9077,6 +9084,7 @@ extension NodeAppModel {
             let payloadJSON = try Self.encodePayload(
                 ApprovalResolveParams(
                     id: approvalID,
+                    instanceid: approvalInstanceId,
                     kind: approvalKind,
                     decision: approvalDecision))
             let response = try await self.operatorGateway.request(

--- a/apps/ios/Sources/Services/NodeServiceProtocols.swift
+++ b/apps/ios/Sources/Services/NodeServiceProtocols.swift
@@ -109,6 +109,7 @@ enum WatchMessageKind: String, Codable, Equatable {
 struct WatchExecApprovalResolveEvent: Codable, Equatable {
     var replyId: String
     var approvalId: String
+    var approvalInstanceId: String? = nil
     var gatewayStableID: String?
     var decision: OpenClawWatchExecApprovalDecision
     var sentAtMs: Int64?

--- a/apps/ios/Sources/Services/NodeServiceProtocols.swift
+++ b/apps/ios/Sources/Services/NodeServiceProtocols.swift
@@ -109,7 +109,7 @@ enum WatchMessageKind: String, Codable, Equatable {
 struct WatchExecApprovalResolveEvent: Codable, Equatable {
     var replyId: String
     var approvalId: String
-    var approvalInstanceId: String? = nil
+    var approvalInstanceId: String?
     var gatewayStableID: String?
     var decision: OpenClawWatchExecApprovalDecision
     var sentAtMs: Int64?

--- a/apps/ios/Sources/Services/WatchMessagingPayloadCodec.swift
+++ b/apps/ios/Sources/Services/WatchMessagingPayloadCodec.swift
@@ -89,6 +89,9 @@ enum WatchMessagingPayloadCodec {
         if let gatewayStableID = GatewayStableIdentifier.exact(item.gatewayStableID) {
             payload["gatewayStableID"] = gatewayStableID
         }
+        if let instanceId = self.exactNonEmpty(item.instanceId) {
+            payload["instanceId"] = instanceId
+        }
         if let commandPreview = nonEmpty(item.commandPreview) {
             payload["commandPreview"] = commandPreview
         }
@@ -353,10 +356,12 @@ enum WatchMessagingPayloadCodec {
         }
         let replyId = self.exactNonEmpty(payload["replyId"] as? String) ?? UUID().uuidString
         let gatewayStableID = GatewayStableIdentifier.exact(payload["gatewayStableID"] as? String)
+        let approvalInstanceId = self.exactNonEmpty(payload["approvalInstanceId"] as? String)
         let sentAtMs = (payload["sentAtMs"] as? NSNumber)?.int64Value
         return WatchExecApprovalResolveEvent(
             replyId: replyId,
             approvalId: approvalId,
+            approvalInstanceId: approvalInstanceId,
             gatewayStableID: gatewayStableID,
             decision: decision,
             sentAtMs: sentAtMs,

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -443,13 +443,13 @@ private func makePendingExecApprovalJSON(
 {
     makePendingApprovalJSON(
         id: approvalID,
-        instanceID: instanceID,
         presentation: execApprovalPresentation(
             commandText: commandText,
             commandPreview: commandPreview,
             warningText: warningText,
             agentID: agentID,
-            allowedDecisions: allowedDecisions))
+            allowedDecisions: allowedDecisions),
+        instanceID: instanceID)
 }
 
 private func makeDeniedExecApprovalJSON(

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -418,6 +418,7 @@ private func pluginApprovalPresentation(
 private func makePendingApprovalJSON(
     id: String,
     presentation: ApprovalPresentation,
+    instanceID: String? = nil,
     createdAtMs: Int = 100,
     expiresAtMs: Int = 4_000_000_000_000) -> String
 {
@@ -427,11 +428,13 @@ private func makePendingApprovalJSON(
         createdatms: createdAtMs,
         expiresatms: expiresAtMs,
         presentation: presentation,
+        instanceid: instanceID,
         status: "pending"))))
 }
 
 private func makePendingExecApprovalJSON(
     _ approvalID: String,
+    instanceID: String? = nil,
     commandText: String = "echo held",
     commandPreview: String? = nil,
     warningText: String? = nil,
@@ -440,6 +443,7 @@ private func makePendingExecApprovalJSON(
 {
     makePendingApprovalJSON(
         id: approvalID,
+        instanceID: instanceID,
         presentation: execApprovalPresentation(
             commandText: commandText,
             commandPreview: commandPreview,
@@ -1565,11 +1569,13 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
     @Test @MainActor func `unified approval resolve reports and applies canonical late winner`() async throws {
         let paramsData = try JSONEncoder().encode(ApprovalResolveParams(
             id: "approval-race",
+            instanceid: "instance-race",
             kind: .exec,
             decision: .deny))
         let params = try #require(JSONSerialization.jsonObject(with: paramsData) as? [String: String])
         #expect(params == [
             "id": "approval-race",
+            "instanceId": "instance-race",
             "kind": "exec",
             "decision": "deny",
         ])

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -6944,6 +6944,7 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
     @Test @MainActor func `watch exec approval codec preserves gateway owner`() throws {
         let approval = OpenClawWatchExecApprovalItem(
             id: "approval-a",
+            instanceId: " instance-a ",
             gatewayStableID: "gateway-a",
             commandText: "echo safe",
             warningText: "Review shell expansion",
@@ -6952,16 +6953,19 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
             OpenClawWatchExecApprovalPromptMessage(approval: approval))
         let encodedApproval = try #require(prompt["approval"] as? [String: Any])
         #expect(encodedApproval["gatewayStableID"] as? String == "gateway-a")
+        #expect(encodedApproval["instanceId"] as? String == " instance-a ")
         #expect(encodedApproval["warningText"] as? String == "Review shell expansion")
 
         let reply = try #require(WatchMessagingPayloadCodec.parseExecApprovalResolvePayload([
             "type": OpenClawWatchPayloadType.execApprovalResolve.rawValue,
             "replyId": "reply-a",
             "approvalId": "approval-a",
+            "approvalInstanceId": " instance-a ",
             "gatewayStableID": "gateway-a",
             "decision": OpenClawWatchExecApprovalDecision.allowOnce.rawValue,
         ], transport: "sendMessage"))
         #expect(reply.gatewayStableID == "gateway-a")
+        #expect(reply.approvalInstanceId == " instance-a ")
 
         let resolved = WatchMessagingPayloadCodec.encodeExecApprovalResolvedPayload(
             OpenClawWatchExecApprovalResolvedMessage(

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -6760,6 +6760,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `watch exec approval codec preserves gateway owner`() throws {
         let approval = OpenClawWatchExecApprovalItem(
             id: "approval-a",
+            instanceId: " instance-a ",
             gatewayStableID: "gateway-a",
             commandText: "echo safe",
             warningText: "Review shell expansion",
@@ -6768,16 +6769,19 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             OpenClawWatchExecApprovalPromptMessage(approval: approval))
         let encodedApproval = try #require(prompt["approval"] as? [String: Any])
         #expect(encodedApproval["gatewayStableID"] as? String == "gateway-a")
+        #expect(encodedApproval["instanceId"] as? String == " instance-a ")
         #expect(encodedApproval["warningText"] as? String == "Review shell expansion")
 
         let reply = try #require(WatchMessagingPayloadCodec.parseExecApprovalResolvePayload([
             "type": OpenClawWatchPayloadType.execApprovalResolve.rawValue,
             "replyId": "reply-a",
             "approvalId": "approval-a",
+            "approvalInstanceId": " instance-a ",
             "gatewayStableID": "gateway-a",
             "decision": OpenClawWatchExecApprovalDecision.allowOnce.rawValue,
         ], transport: "sendMessage"))
         #expect(reply.gatewayStableID == "gateway-a")
+        #expect(reply.approvalInstanceId == " instance-a ")
 
         let resolved = WatchMessagingPayloadCodec.encodeExecApprovalResolvedPayload(
             OpenClawWatchExecApprovalResolvedMessage(

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -418,6 +418,7 @@ private func pluginApprovalPresentation(
 private func makePendingApprovalJSON(
     id: String,
     presentation: ApprovalPresentation,
+    instanceID: String? = nil,
     createdAtMs: Int = 100,
     expiresAtMs: Int = 4_000_000_000_000) -> String
 {
@@ -427,11 +428,13 @@ private func makePendingApprovalJSON(
         createdatms: createdAtMs,
         expiresatms: expiresAtMs,
         presentation: presentation,
+        instanceid: instanceID,
         status: "pending"))))
 }
 
 private func makePendingExecApprovalJSON(
     _ approvalID: String,
+    instanceID: String? = nil,
     commandText: String = "echo held",
     commandPreview: String? = nil,
     warningText: String? = nil,
@@ -440,6 +443,7 @@ private func makePendingExecApprovalJSON(
 {
     makePendingApprovalJSON(
         id: approvalID,
+        instanceID: instanceID,
         presentation: execApprovalPresentation(
             commandText: commandText,
             commandPreview: commandPreview,
@@ -1405,11 +1409,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `unified approval resolve reports and applies canonical late winner`() async throws {
         let paramsData = try JSONEncoder().encode(ApprovalResolveParams(
             id: "approval-race",
+            instanceid: "instance-race",
             kind: .exec,
             decision: .deny))
         let params = try #require(JSONSerialization.jsonObject(with: paramsData) as? [String: String])
         #expect(params == [
             "id": "approval-race",
+            "instanceId": "instance-race",
             "kind": "exec",
             "decision": "deny",
         ])

--- a/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
+++ b/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
@@ -49,7 +49,7 @@ struct OpenClawWatchApp: App {
                         self.inboxStore.markReplyResult(result, actionLabel: action.label)
                     }
                 },
-                onExecApprovalDecision: { approvalId, gatewayStableID, decision in
+                onExecApprovalDecision: { approvalId, approvalInstanceId, gatewayStableID, decision in
                     guard let receiver = self.receiver else { return }
                     guard let attemptID = self.inboxStore.beginExecApprovalDecision(
                         approvalId: approvalId,
@@ -59,6 +59,7 @@ struct OpenClawWatchApp: App {
                     Task { @MainActor in
                         let result = await receiver.sendExecApprovalResolve(
                             approvalId: approvalId,
+                            approvalInstanceId: approvalInstanceId,
                             gatewayStableID: gatewayStableID,
                             attemptID: attemptID,
                             decision: decision)

--- a/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
+++ b/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
@@ -49,7 +49,7 @@ struct OpenClawWatchApp: App {
                         self.inboxStore.markReplyResult(result, actionLabel: action.label, attemptID: attemptID)
                     }
                 },
-                onExecApprovalDecision: { approvalId, gatewayStableID, decision in
+                onExecApprovalDecision: { approvalId, approvalInstanceId, gatewayStableID, decision in
                     guard let receiver = self.receiver else { return }
                     guard let attemptID = self.inboxStore.beginExecApprovalDecision(
                         approvalId: approvalId,
@@ -59,6 +59,7 @@ struct OpenClawWatchApp: App {
                     Task { @MainActor in
                         let result = await receiver.sendExecApprovalResolve(
                             approvalId: approvalId,
+                            approvalInstanceId: approvalInstanceId,
                             gatewayStableID: gatewayStableID,
                             attemptID: attemptID,
                             decision: decision)

--- a/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
@@ -226,6 +226,7 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
 
     func sendExecApprovalResolve(
         approvalId: String,
+        approvalInstanceId: String? = nil,
         gatewayStableID: String?,
         attemptID: String,
         decision: WatchExecApprovalDecision) async -> WatchReplySendResult
@@ -240,6 +241,7 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         let payload = Self.encodeExecApprovalResolvePayload(
             WatchExecApprovalResolveMessage(
                 approvalId: approvalId,
+                approvalInstanceId: approvalInstanceId,
                 gatewayStableID: gatewayStableID,
                 decision: decision,
                 replyId: attemptID,
@@ -621,6 +623,9 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         }
         if let gatewayStableID = WatchGatewayID.exact(message.gatewayStableID) {
             payload["gatewayStableID"] = gatewayStableID
+        }
+        if let approvalInstanceId = message.approvalInstanceId, !approvalInstanceId.isEmpty {
+            payload["approvalInstanceId"] = approvalInstanceId
         }
         if let text = message.text?.trimmingCharacters(in: .whitespacesAndNewlines),
            !text.isEmpty

--- a/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
@@ -624,9 +624,6 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         if let gatewayStableID = WatchGatewayID.exact(message.gatewayStableID) {
             payload["gatewayStableID"] = gatewayStableID
         }
-        if let approvalInstanceId = message.approvalInstanceId, !approvalInstanceId.isEmpty {
-            payload["approvalInstanceId"] = approvalInstanceId
-        }
         if let text = message.text?.trimmingCharacters(in: .whitespacesAndNewlines),
            !text.isEmpty
         {
@@ -674,6 +671,9 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         ]
         if let gatewayStableID = WatchGatewayID.exact(message.gatewayStableID) {
             payload["gatewayStableID"] = gatewayStableID
+        }
+        if let approvalInstanceId = message.approvalInstanceId, !approvalInstanceId.isEmpty {
+            payload["approvalInstanceId"] = approvalInstanceId
         }
         if let sentAtMs = message.sentAtMs {
             payload["sentAtMs"] = sentAtMs

--- a/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
@@ -225,6 +225,7 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
 
     func sendExecApprovalResolve(
         approvalId: String,
+        approvalInstanceId: String? = nil,
         gatewayStableID: String?,
         attemptID: String,
         decision: WatchExecApprovalDecision) async -> WatchReplySendResult
@@ -239,6 +240,7 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         let payload = Self.encodeExecApprovalResolvePayload(
             WatchExecApprovalResolveMessage(
                 approvalId: approvalId,
+                approvalInstanceId: approvalInstanceId,
                 gatewayStableID: gatewayStableID,
                 decision: decision,
                 replyId: attemptID,
@@ -604,6 +606,9 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         }
         if let gatewayStableID = WatchGatewayID.exact(message.gatewayStableID) {
             payload["gatewayStableID"] = gatewayStableID
+        }
+        if let approvalInstanceId = message.approvalInstanceId, !approvalInstanceId.isEmpty {
+            payload["approvalInstanceId"] = approvalInstanceId
         }
         if let text = message.text?.trimmingCharacters(in: .whitespacesAndNewlines),
            !text.isEmpty

--- a/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
@@ -607,9 +607,6 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         if let gatewayStableID = WatchGatewayID.exact(message.gatewayStableID) {
             payload["gatewayStableID"] = gatewayStableID
         }
-        if let approvalInstanceId = message.approvalInstanceId, !approvalInstanceId.isEmpty {
-            payload["approvalInstanceId"] = approvalInstanceId
-        }
         if let text = message.text?.trimmingCharacters(in: .whitespacesAndNewlines),
            !text.isEmpty
         {
@@ -657,6 +654,9 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         ]
         if let gatewayStableID = WatchGatewayID.exact(message.gatewayStableID) {
             payload["gatewayStableID"] = gatewayStableID
+        }
+        if let approvalInstanceId = message.approvalInstanceId, !approvalInstanceId.isEmpty {
+            payload["approvalInstanceId"] = approvalInstanceId
         }
         if let sentAtMs = message.sentAtMs {
             payload["sentAtMs"] = sentAtMs

--- a/apps/ios/WatchApp/Sources/WatchInboxView.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxView.swift
@@ -1467,7 +1467,7 @@ private enum WatchNativeTextInput {
 
 private struct WatchExecApprovalListView: View {
     var store: WatchInboxStore
-    var onDecision: ((String, String?, WatchExecApprovalDecision) -> Void)?
+    var onDecision: ((String, String?, String?, WatchExecApprovalDecision) -> Void)?
 
     var body: some View {
         WatchDetailScroll(title: "Approvals") {
@@ -1535,7 +1535,7 @@ private struct WatchExecApprovalListView: View {
 private struct WatchExecApprovalDetailView: View {
     var store: WatchInboxStore
     let record: WatchExecApprovalRecord
-    var onDecision: ((String, String?, WatchExecApprovalDecision) -> Void)?
+    var onDecision: ((String, String?, String?, WatchExecApprovalDecision) -> Void)?
 
     var body: some View {
         WatchDetailScroll(title: "Review Command") {
@@ -1569,6 +1569,7 @@ private struct WatchExecApprovalDetailView: View {
                             WatchDecisionButton(title: "Allow Once", color: .green) {
                                 self.onDecision?(
                                     currentRecord.approvalID,
+                                    currentRecord.approval.instanceId,
                                     currentRecord.approval.gatewayStableID,
                                     .allowOnce)
                             }
@@ -1578,6 +1579,7 @@ private struct WatchExecApprovalDetailView: View {
                             WatchDecisionButton(title: "Deny", color: WatchClawStyle.accent) {
                                 self.onDecision?(
                                     currentRecord.approvalID,
+                                    currentRecord.approval.instanceId,
                                     currentRecord.approval.gatewayStableID,
                                     .deny)
                             }

--- a/apps/ios/WatchApp/Sources/WatchInboxView.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxView.swift
@@ -20,7 +20,7 @@ struct WatchInboxView: View {
     var store: WatchInboxStore
     var directNode: WatchDirectNode
     var onAction: ((WatchPromptAction) -> Void)?
-    var onExecApprovalDecision: ((String, String?, WatchExecApprovalDecision) -> Void)?
+    var onExecApprovalDecision: ((String, String?, String?, WatchExecApprovalDecision) -> Void)?
     var onRefreshExecApprovalReview: (() -> Void)?
     var onRefreshAppSnapshot: (() -> Void)?
     var onAppCommand: ((WatchAppCommand) -> Void)?
@@ -46,7 +46,7 @@ private struct WatchControlSurfaceView: View {
     var store: WatchInboxStore
     var directNode: WatchDirectNode
     var onAction: ((WatchPromptAction) -> Void)?
-    var onExecApprovalDecision: ((String, String?, WatchExecApprovalDecision) -> Void)?
+    var onExecApprovalDecision: ((String, String?, String?, WatchExecApprovalDecision) -> Void)?
     var onRefreshExecApprovalReview: (() -> Void)?
     var onRefreshAppSnapshot: (() -> Void)?
     var onAppCommand: ((WatchAppCommand) -> Void)?

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -13,6 +13,7 @@ final class ExecApprovalsGatewayPrompter {
 
     struct GatewayApprovalRequest: Codable {
         var id: String
+        var instanceId: String?
         var request: ExecApprovalPromptRequest
         var createdAtMs: Int
         var expiresAtMs: Int
@@ -59,21 +60,29 @@ final class ExecApprovalsGatewayPrompter {
                 return
             }
             if evt.event == "openclaw.approval.requested" {
+                var params: [String: AnyCodable] = [
+                    "id": AnyCodable(request.id),
+                    "kind": AnyCodable("system-agent"),
+                    "decision": AnyCodable(decision.rawValue),
+                ]
+                if let instanceId = request.instanceId {
+                    params["instanceId"] = AnyCodable(instanceId)
+                }
                 try await GatewayConnection.shared.requestVoid(
                     method: .approvalResolve,
-                    params: [
-                        "id": AnyCodable(request.id),
-                        "kind": AnyCodable("system-agent"),
-                        "decision": AnyCodable(decision.rawValue),
-                    ],
+                    params: params,
                     timeoutMs: 10000)
             } else {
+                var params: [String: AnyCodable] = [
+                    "id": AnyCodable(request.id),
+                    "decision": AnyCodable(decision.rawValue),
+                ]
+                if let instanceId = request.instanceId {
+                    params["instanceId"] = AnyCodable(instanceId)
+                }
                 try await GatewayConnection.shared.requestVoid(
                     method: .execApprovalResolve,
-                    params: [
-                        "id": AnyCodable(request.id),
-                        "decision": AnyCodable(decision.rawValue),
-                    ],
+                    params: params,
                     timeoutMs: 10000)
             }
         } catch {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
@@ -54,6 +54,7 @@ public struct OpenClawWatchAction: Codable, Sendable, Equatable, Identifiable {
 
 public struct OpenClawWatchExecApprovalItem: Codable, Sendable, Equatable, Identifiable {
     public var id: String
+    public var instanceId: String?
     public var gatewayStableID: String?
     public var commandText: String
     public var commandPreview: String?
@@ -67,6 +68,7 @@ public struct OpenClawWatchExecApprovalItem: Codable, Sendable, Equatable, Ident
 
     public init(
         id: String,
+        instanceId: String? = nil,
         gatewayStableID: String? = nil,
         commandText: String,
         commandPreview: String? = nil,
@@ -79,6 +81,7 @@ public struct OpenClawWatchExecApprovalItem: Codable, Sendable, Equatable, Ident
         risk: OpenClawWatchRisk? = nil)
     {
         self.id = id
+        self.instanceId = instanceId
         self.gatewayStableID = gatewayStableID
         self.commandText = commandText
         self.commandPreview = commandPreview
@@ -113,6 +116,7 @@ public struct OpenClawWatchExecApprovalPromptMessage: Codable, Sendable, Equatab
 public struct OpenClawWatchExecApprovalResolveMessage: Codable, Sendable, Equatable {
     public var type: OpenClawWatchPayloadType
     public var approvalId: String
+    public var approvalInstanceId: String?
     public var gatewayStableID: String?
     public var decision: OpenClawWatchExecApprovalDecision
     public var replyId: String
@@ -120,6 +124,7 @@ public struct OpenClawWatchExecApprovalResolveMessage: Codable, Sendable, Equata
 
     public init(
         approvalId: String,
+        approvalInstanceId: String? = nil,
         gatewayStableID: String? = nil,
         decision: OpenClawWatchExecApprovalDecision,
         replyId: String,
@@ -127,6 +132,7 @@ public struct OpenClawWatchExecApprovalResolveMessage: Codable, Sendable, Equata
     {
         self.type = .execApprovalResolve
         self.approvalId = approvalId
+        self.approvalInstanceId = approvalInstanceId
         self.gatewayStableID = gatewayStableID
         self.decision = decision
         self.replyId = replyId

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18047,6 +18047,7 @@ public struct StandingGrantApprovalScope: Codable, Sendable {
 
 public struct ExecApprovalPresentation: Codable, Sendable {
     public let kind: String
+    public let instanceid: String?
     public let commandtext: String
     public let commandpreview: AnyCodable?
     public let warningtext: AnyCodable?
@@ -18058,6 +18059,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
 
     public init(
         kind: String,
+        instanceid: String? = nil,
         commandtext: String,
         commandpreview: AnyCodable? = nil,
         warningtext: AnyCodable? = nil,
@@ -18068,6 +18070,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
         alloweddecisions: [ApprovalDecision])
     {
         self.kind = kind
+        self.instanceid = instanceid
         self.commandtext = commandtext
         self.commandpreview = commandpreview
         self.warningtext = warningtext
@@ -18080,6 +18083,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case kind
+        case instanceid = "instanceId"
         case commandtext = "commandText"
         case commandpreview = "commandPreview"
         case warningtext = "warningText"
@@ -18093,6 +18097,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
 
 public struct PluginApprovalPresentation: Codable, Sendable {
     public let kind: String
+    public let instanceid: String?
     public let title: String
     public let description: String
     public let detail: String?
@@ -18105,6 +18110,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
 
     public init(
         kind: String,
+        instanceid: String? = nil,
         title: String,
         description: String,
         detail: String? = nil,
@@ -18116,6 +18122,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
         alloweddecisions: [ApprovalDecision])
     {
         self.kind = kind
+        self.instanceid = instanceid
         self.title = title
         self.description = description
         self.detail = detail
@@ -18129,6 +18136,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case kind
+        case instanceid = "instanceId"
         case title
         case description
         case detail
@@ -18143,6 +18151,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
 
 public struct SystemAgentApprovalPresentation: Codable, Sendable {
     public let kind: String
+    public let instanceid: String?
     public let title: String
     public let description: String
     public let proposalhash: String
@@ -18151,6 +18160,7 @@ public struct SystemAgentApprovalPresentation: Codable, Sendable {
 
     public init(
         kind: String,
+        instanceid: String? = nil,
         title: String,
         description: String,
         proposalhash: String,
@@ -18158,6 +18168,7 @@ public struct SystemAgentApprovalPresentation: Codable, Sendable {
         alloweddecisions: [AnyCodable])
     {
         self.kind = kind
+        self.instanceid = instanceid
         self.title = title
         self.description = description
         self.proposalhash = proposalhash
@@ -18167,6 +18178,7 @@ public struct SystemAgentApprovalPresentation: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case kind
+        case instanceid = "instanceId"
         case title
         case description
         case proposalhash = "proposalHash"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18181,6 +18181,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
     public let createdatms: Int
     public let expiresatms: Int
     public let presentation: ApprovalPresentation
+    public let instanceid: String?
     public let status: String
     public let sourcesessionkey: String?
 
@@ -18190,6 +18191,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         createdatms: Int,
         expiresatms: Int,
         presentation: ApprovalPresentation,
+        instanceid: String? = nil,
         status: String,
         sourcesessionkey: String? = nil)
     {
@@ -18198,6 +18200,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         self.createdatms = createdatms
         self.expiresatms = expiresatms
         self.presentation = presentation
+        self.instanceid = instanceid
         self.status = status
         self.sourcesessionkey = sourcesessionkey
     }
@@ -18208,6 +18211,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         case createdatms = "createdAtMs"
         case expiresatms = "expiresAtMs"
         case presentation
+        case instanceid = "instanceId"
         case status
         case sourcesessionkey = "sourceSessionKey"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18517,18 +18517,11 @@ public struct ApprovalResolveParams: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case id
-        case kind
-        case decision
-        case reviewer
-        case grantexpiresindays = "grantExpiresInDays"
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
         case instanceid = "instanceId"
         case kind
         case decision
         case reviewer
+        case grantexpiresindays = "grantExpiresInDays"
     }
 }
 
@@ -18938,6 +18931,7 @@ public struct ExecApprovalResolveParams: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case id
+        case instanceid = "instanceId"
         case decision
         case reviewer
         case grantexpiresindays = "grantExpiresInDays"
@@ -19047,13 +19041,6 @@ public struct ExecApprovalGrantsRevokeResult: Codable, Sendable {
         outcome: AnyCodable)
     {
         self.outcome = outcome
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case instanceid = "instanceId"
-        case decision
-        case reviewer
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18477,6 +18477,7 @@ public struct ApprovalHistoryResult: Codable, Sendable {
 
 public struct ApprovalResolveParams: Codable, Sendable {
     public let id: String
+    public let instanceid: String?
     public let kind: ApprovalKind
     public let decision: ApprovalDecision
     public let reviewer: [String: AnyCodable]?
@@ -18484,12 +18485,14 @@ public struct ApprovalResolveParams: Codable, Sendable {
 
     public init(
         id: String,
+        instanceid: String? = nil,
         kind: ApprovalKind,
         decision: ApprovalDecision,
         reviewer: [String: AnyCodable]? = nil,
         grantexpiresindays: Int? = nil)
     {
         self.id = id
+        self.instanceid = instanceid
         self.kind = kind
         self.decision = decision
         self.reviewer = reviewer
@@ -18502,6 +18505,13 @@ public struct ApprovalResolveParams: Codable, Sendable {
         case decision
         case reviewer
         case grantexpiresindays = "grantExpiresInDays"
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case instanceid = "instanceId"
+        case kind
+        case decision
+        case reviewer
     }
 }
 
@@ -18890,17 +18900,20 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
 
 public struct ExecApprovalResolveParams: Codable, Sendable {
     public let id: String
+    public let instanceid: String?
     public let decision: String
     public let reviewer: [String: AnyCodable]?
     public let grantexpiresindays: Int?
 
     public init(
         id: String,
+        instanceid: String? = nil,
         decision: String,
         reviewer: [String: AnyCodable]? = nil,
         grantexpiresindays: Int? = nil)
     {
         self.id = id
+        self.instanceid = instanceid
         self.decision = decision
         self.reviewer = reviewer
         self.grantexpiresindays = grantexpiresindays
@@ -19017,6 +19030,12 @@ public struct ExecApprovalGrantsRevokeResult: Codable, Sendable {
         outcome: AnyCodable)
     {
         self.outcome = outcome
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case instanceid = "instanceId"
+        case decision
+        case reviewer
     }
 }
 
@@ -19455,17 +19474,26 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
 
 public struct PluginApprovalResolveParams: Codable, Sendable {
     public let id: String
+    public let instanceid: String?
     public let decision: String
     public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
+        instanceid: String? = nil,
         decision: String,
         reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
+        self.instanceid = instanceid
         self.decision = decision
         self.reviewer = reviewer
+    }
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case instanceid = "instanceId"
+        case decision
+        case reviewer
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18522,6 +18522,7 @@ public struct ApprovalResolveParams: Codable, Sendable {
         case reviewer
         case grantexpiresindays = "grantExpiresInDays"
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case instanceid = "instanceId"
@@ -19047,6 +19048,7 @@ public struct ExecApprovalGrantsRevokeResult: Codable, Sendable {
     {
         self.outcome = outcome
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case instanceid = "instanceId"
@@ -19505,6 +19507,7 @@ public struct PluginApprovalResolveParams: Codable, Sendable {
         self.decision = decision
         self.reviewer = reviewer
     }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case instanceid = "instanceId"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -17905,6 +17905,7 @@ public struct TerminalExitEvent: Codable, Sendable {
 
 public struct ExecApprovalPresentation: Codable, Sendable {
     public let kind: String
+    public let instanceid: String?
     public let commandtext: String
     public let commandpreview: AnyCodable?
     public let warningtext: AnyCodable?
@@ -17915,6 +17916,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
 
     public init(
         kind: String,
+        instanceid: String? = nil,
         commandtext: String,
         commandpreview: AnyCodable? = nil,
         warningtext: AnyCodable? = nil,
@@ -17924,6 +17926,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
         alloweddecisions: [ApprovalDecision])
     {
         self.kind = kind
+        self.instanceid = instanceid
         self.commandtext = commandtext
         self.commandpreview = commandpreview
         self.warningtext = warningtext
@@ -17935,6 +17938,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case kind
+        case instanceid = "instanceId"
         case commandtext = "commandText"
         case commandpreview = "commandPreview"
         case warningtext = "warningText"
@@ -17947,6 +17951,7 @@ public struct ExecApprovalPresentation: Codable, Sendable {
 
 public struct PluginApprovalPresentation: Codable, Sendable {
     public let kind: String
+    public let instanceid: String?
     public let title: String
     public let description: String
     public let detail: String?
@@ -17958,6 +17963,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
 
     public init(
         kind: String,
+        instanceid: String? = nil,
         title: String,
         description: String,
         detail: String? = nil,
@@ -17968,6 +17974,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
         alloweddecisions: [ApprovalDecision])
     {
         self.kind = kind
+        self.instanceid = instanceid
         self.title = title
         self.description = description
         self.detail = detail
@@ -17980,6 +17987,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case kind
+        case instanceid = "instanceId"
         case title
         case description
         case detail
@@ -17993,6 +18001,7 @@ public struct PluginApprovalPresentation: Codable, Sendable {
 
 public struct SystemAgentApprovalPresentation: Codable, Sendable {
     public let kind: String
+    public let instanceid: String?
     public let title: String
     public let description: String
     public let proposalhash: String
@@ -18001,6 +18010,7 @@ public struct SystemAgentApprovalPresentation: Codable, Sendable {
 
     public init(
         kind: String,
+        instanceid: String? = nil,
         title: String,
         description: String,
         proposalhash: String,
@@ -18008,6 +18018,7 @@ public struct SystemAgentApprovalPresentation: Codable, Sendable {
         alloweddecisions: [AnyCodable])
     {
         self.kind = kind
+        self.instanceid = instanceid
         self.title = title
         self.description = description
         self.proposalhash = proposalhash
@@ -18017,6 +18028,7 @@ public struct SystemAgentApprovalPresentation: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case kind
+        case instanceid = "instanceId"
         case title
         case description
         case proposalhash = "proposalHash"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18337,17 +18337,20 @@ public struct ApprovalHistoryResult: Codable, Sendable {
 
 public struct ApprovalResolveParams: Codable, Sendable {
     public let id: String
+    public let instanceid: String?
     public let kind: ApprovalKind
     public let decision: ApprovalDecision
     public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
+        instanceid: String? = nil,
         kind: ApprovalKind,
         decision: ApprovalDecision,
         reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
+        self.instanceid = instanceid
         self.kind = kind
         self.decision = decision
         self.reviewer = reviewer
@@ -18355,6 +18358,7 @@ public struct ApprovalResolveParams: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case id
+        case instanceid = "instanceId"
         case kind
         case decision
         case reviewer
@@ -18747,21 +18751,25 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
 
 public struct ExecApprovalResolveParams: Codable, Sendable {
     public let id: String
+    public let instanceid: String?
     public let decision: String
     public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
+        instanceid: String? = nil,
         decision: String,
         reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
+        self.instanceid = instanceid
         self.decision = decision
         self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
+        case instanceid = "instanceId"
         case decision
         case reviewer
     }
@@ -19133,21 +19141,25 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
 
 public struct PluginApprovalResolveParams: Codable, Sendable {
     public let id: String
+    public let instanceid: String?
     public let decision: String
     public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
+        instanceid: String? = nil,
         decision: String,
         reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
+        self.instanceid = instanceid
         self.decision = decision
         self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
+        case instanceid = "instanceId"
         case decision
         case reviewer
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18031,6 +18031,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
     public let createdatms: Int
     public let expiresatms: Int
     public let presentation: ApprovalPresentation
+    public let instanceid: String?
     public let status: String
 
     public init(
@@ -18039,6 +18040,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         createdatms: Int,
         expiresatms: Int,
         presentation: ApprovalPresentation,
+        instanceid: String? = nil,
         status: String)
     {
         self.id = id
@@ -18046,6 +18048,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         self.createdatms = createdatms
         self.expiresatms = expiresatms
         self.presentation = presentation
+        self.instanceid = instanceid
         self.status = status
     }
 
@@ -18055,6 +18058,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         case createdatms = "createdAtMs"
         case expiresatms = "expiresAtMs"
         case presentation
+        case instanceid = "instanceId"
         case status
     }
 }

--- a/extensions/discord/src/approval-custom-id.ts
+++ b/extensions/discord/src/approval-custom-id.ts
@@ -11,6 +11,7 @@ function encodeDiscordApprovalCustomId(action: DiscordApprovalAction): string {
   return [
     `execapproval:kind=${action.approvalKind}`,
     `id=${encodeURIComponent(action.approvalId)}`,
+    ...(action.instanceId ? [`instance=${encodeURIComponent(action.instanceId)}`] : []),
     `action=${action.decision}`,
   ].join(";");
 }
@@ -27,7 +28,9 @@ function encodeBoundedDiscordApprovalCustomId(action: DiscordApprovalAction): st
     approvalId: buildApprovalResolutionRef({
       approvalId: action.approvalId,
       approvalKind: action.approvalKind,
+      instanceId: action.instanceId,
     }),
+    instanceId: undefined,
   });
 }
 
@@ -48,10 +51,12 @@ export function buildExecApprovalCustomId(
   approvalId: string,
   approvalKind: DiscordApprovalAction["approvalKind"],
   decision: DiscordApprovalAction["decision"],
+  instanceId?: string,
 ): string {
   return encodeBoundedDiscordApprovalCustomId({
     type: "approval",
     approvalId,
+    ...(instanceId ? { instanceId } : {}),
     approvalKind,
     decision,
   });
@@ -67,6 +72,7 @@ function decodeCustomIdValue(value: string): string | null {
 
 export function parseExecApprovalData(data: ComponentData): {
   approvalId: string;
+  instanceId?: string;
   approvalKind: DiscordApprovalAction["approvalKind"];
   action: DiscordApprovalAction["decision"];
 } | null {
@@ -78,6 +84,7 @@ export function parseExecApprovalData(data: ComponentData): {
   const rawId = coerce(data.id);
   const rawKind = coerce(data.kind);
   const rawAction = coerce(data.action);
+  const rawInstanceId = coerce(data.instance);
   if (!rawId || (rawKind !== "exec" && rawKind !== "plugin") || !rawAction) {
     return null;
   }
@@ -85,11 +92,13 @@ export function parseExecApprovalData(data: ComponentData): {
     return null;
   }
   const approvalId = decodeCustomIdValue(rawId);
-  if (!approvalId) {
+  const instanceId = rawInstanceId ? decodeCustomIdValue(rawInstanceId) : undefined;
+  if (!approvalId || (rawInstanceId && !instanceId)) {
     return null;
   }
   return {
     approvalId,
+    ...(instanceId ? { instanceId } : {}),
     approvalKind: rawKind,
     action: rawAction,
   };

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -123,6 +123,7 @@ class ExecApprovalActionButton extends Button {
 
   constructor(params: {
     approvalId: string;
+    instanceId?: string;
     approvalKind: PendingApprovalView["approvalKind"];
     descriptor: ExecApprovalActionDescriptor;
   }) {
@@ -131,6 +132,7 @@ class ExecApprovalActionButton extends Button {
       params.approvalId,
       params.approvalKind,
       params.descriptor.decision,
+      params.instanceId,
     );
     this.label = params.descriptor.label;
     this.style =
@@ -147,6 +149,7 @@ class ExecApprovalActionButton extends Button {
 class ExecApprovalActionRow extends Row<Button> {
   constructor(params: {
     approvalId: string;
+    instanceId?: string;
     approvalKind: PendingApprovalView["approvalKind"];
     actions: readonly ExecApprovalActionDescriptor[];
   }) {
@@ -155,6 +158,7 @@ class ExecApprovalActionRow extends Row<Button> {
         (descriptor) =>
           new ExecApprovalActionButton({
             approvalId: params.approvalId,
+            instanceId: params.instanceId,
             approvalKind: params.approvalKind,
             descriptor,
           }),
@@ -166,6 +170,7 @@ class ExecApprovalActionRow extends Row<Button> {
 function createApprovalActionRow(view: PendingApprovalView): Row<Button> {
   return new ExecApprovalActionRow({
     approvalId: view.approvalId,
+    instanceId: view.instanceId,
     approvalKind: view.approvalKind,
     actions: view.actions,
   });

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -128,6 +128,7 @@ class ExecApprovalActionButton extends Button {
 
   constructor(params: {
     approvalId: string;
+    instanceId?: string;
     approvalKind: PendingApprovalView["approvalKind"];
     descriptor: ExecApprovalActionDescriptor;
   }) {
@@ -136,6 +137,7 @@ class ExecApprovalActionButton extends Button {
       params.approvalId,
       params.approvalKind,
       params.descriptor.decision,
+      params.instanceId,
     );
     this.label = params.descriptor.label;
     this.style =
@@ -152,6 +154,7 @@ class ExecApprovalActionButton extends Button {
 class ExecApprovalActionRow extends Row<Button> {
   constructor(params: {
     approvalId: string;
+    instanceId?: string;
     approvalKind: PendingApprovalView["approvalKind"];
     actions: readonly ExecApprovalActionDescriptor[];
   }) {
@@ -160,6 +163,7 @@ class ExecApprovalActionRow extends Row<Button> {
         (descriptor) =>
           new ExecApprovalActionButton({
             approvalId: params.approvalId,
+            instanceId: params.instanceId,
             approvalKind: params.approvalKind,
             descriptor,
           }),
@@ -171,6 +175,7 @@ class ExecApprovalActionRow extends Row<Button> {
 function createApprovalActionRow(view: PendingApprovalView): Row<Button> {
   return new ExecApprovalActionRow({
     approvalId: view.approvalId,
+    instanceId: view.instanceId,
     approvalKind: view.approvalKind,
     actions: view.actions,
   });

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -33,6 +33,7 @@ type ExecApprovalButtonContext = {
     approvalKind: PendingApprovalView["approvalKind"],
     decision: ExecApprovalDecision,
     senderId: string,
+    instanceId?: string,
   ) => Promise<ExecApprovalResolveResult>;
 };
 
@@ -138,12 +139,20 @@ class ExecApprovalButton extends Button {
       await interaction.acknowledge();
     } catch {}
 
-    const result = await this.ctx.resolveApproval(
-      parsed.approvalId,
-      parsed.approvalKind,
-      parsed.action,
-      userId,
-    );
+    const result = parsed.instanceId
+      ? await this.ctx.resolveApproval(
+          parsed.approvalId,
+          parsed.approvalKind,
+          parsed.action,
+          userId,
+          parsed.instanceId,
+        )
+      : await this.ctx.resolveApproval(
+          parsed.approvalId,
+          parsed.approvalKind,
+          parsed.action,
+          userId,
+        );
     if (!result.ok) {
       try {
         await interaction.followUp({
@@ -199,11 +208,12 @@ export function createDiscordExecApprovalButtonContext(params: {
         accountId: params.accountId,
         configOverride: params.config,
       }),
-    resolveApproval: async (approvalId, approvalKind, decision, senderId) => {
+    resolveApproval: async (approvalId, approvalKind, decision, senderId, instanceId) => {
       try {
         const resolution = await resolveApprovalOverGateway({
           cfg: params.cfg,
           approvalId,
+          instanceId,
           approvalKind,
           decision,
           channel: "discord",

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -319,6 +319,7 @@ describe("buildDiscordInteractiveComponents", () => {
               action: {
                 type: "approval",
                 approvalId: "opaque:approval;id=7",
+                instanceId: "instance-1",
                 approvalKind: "plugin",
                 decision: "deny",
               },
@@ -339,7 +340,7 @@ describe("buildDiscordInteractiveComponents", () => {
               label: "Deny",
               style: "danger",
               internalCustomId:
-                "execapproval:kind=plugin;id=opaque%3Aapproval%3Bid%3D7;action=deny",
+                "execapproval:kind=plugin;id=opaque%3Aapproval%3Bid%3D7;instance=instance-1;action=deny",
             },
           ],
         },
@@ -360,6 +361,7 @@ describe("buildDiscordInteractiveComponents", () => {
     expect(built.entries).toEqual([]);
     expect(parseExecApprovalData(parseCustomId(customId ?? "").data)).toEqual({
       approvalId: "opaque:approval;id=7",
+      instanceId: "instance-1",
       approvalKind: "plugin",
       action: "deny",
     });
@@ -478,6 +480,7 @@ describe("buildDiscordInteractiveComponents", () => {
               action: {
                 type: "approval",
                 approvalId: overlongId,
+                instanceId: "instance-1",
                 approvalKind: "exec",
                 decision: "allow-once",
               },
@@ -491,7 +494,11 @@ describe("buildDiscordInteractiveComponents", () => {
       firstBlock?.type === "actions" ? firstBlock.buttons?.[0]?.internalCustomId : undefined;
     expect(customId?.length).toBeLessThanOrEqual(100);
     expect(parseExecApprovalData(parseCustomId(customId ?? "").data)).toEqual({
-      approvalId: buildApprovalResolutionRef({ approvalId: overlongId, approvalKind: "exec" }),
+      approvalId: buildApprovalResolutionRef({
+        approvalId: overlongId,
+        approvalKind: "exec",
+        instanceId: "instance-1",
+      }),
       approvalKind: "exec",
       action: "allow-once",
     });

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -258,6 +258,7 @@ describe("buildDiscordInteractiveComponents", () => {
               action: {
                 type: "approval",
                 approvalId: "opaque:approval;id=7",
+                instanceId: "instance-1",
                 approvalKind: "plugin",
                 decision: "deny",
               },
@@ -278,7 +279,7 @@ describe("buildDiscordInteractiveComponents", () => {
               label: "Deny",
               style: "danger",
               internalCustomId:
-                "execapproval:kind=plugin;id=opaque%3Aapproval%3Bid%3D7;action=deny",
+                "execapproval:kind=plugin;id=opaque%3Aapproval%3Bid%3D7;instance=instance-1;action=deny",
             },
           ],
         },
@@ -299,6 +300,7 @@ describe("buildDiscordInteractiveComponents", () => {
     expect(built.entries).toEqual([]);
     expect(parseExecApprovalData(parseCustomId(customId ?? "").data)).toEqual({
       approvalId: "opaque:approval;id=7",
+      instanceId: "instance-1",
       approvalKind: "plugin",
       action: "deny",
     });
@@ -355,6 +357,7 @@ describe("buildDiscordInteractiveComponents", () => {
               action: {
                 type: "approval",
                 approvalId: overlongId,
+                instanceId: "instance-1",
                 approvalKind: "exec",
                 decision: "allow-once",
               },
@@ -368,7 +371,11 @@ describe("buildDiscordInteractiveComponents", () => {
       firstBlock?.type === "actions" ? firstBlock.buttons?.[0]?.internalCustomId : undefined;
     expect(customId?.length).toBeLessThanOrEqual(100);
     expect(parseExecApprovalData(parseCustomId(customId ?? "").data)).toEqual({
-      approvalId: buildApprovalResolutionRef({ approvalId: overlongId, approvalKind: "exec" }),
+      approvalId: buildApprovalResolutionRef({
+        approvalId: overlongId,
+        approvalKind: "exec",
+        instanceId: "instance-1",
+      }),
       approvalKind: "exec",
       action: "allow-once",
     });

--- a/extensions/googlechat/src/approval-card-actions.ts
+++ b/extensions/googlechat/src/approval-card-actions.ts
@@ -16,6 +16,7 @@ type GoogleChatApprovalCardBinding = {
   token: string;
   accountId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   decision: ExecApprovalDecision;
   allowedDecisions: readonly ExecApprovalDecision[];

--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -144,6 +144,7 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
       token: "token-1",
       accountId: "default",
       approvalId: "approval-1",
+      instanceId: "approval-1-instance",
       approvalKind: "exec",
       decision: "allow-once",
       allowedDecisions: ["allow-once", "deny"],
@@ -163,6 +164,7 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
     expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: expect.any(Object),
       approvalId: "approval-1",
+      instanceId: "approval-1-instance",
       approvalKind: "exec",
       decision: "allow-once",
       channel: "googlechat",

--- a/extensions/googlechat/src/approval-card-click.ts
+++ b/extensions/googlechat/src/approval-card-click.ts
@@ -84,6 +84,7 @@ export async function maybeHandleGoogleChatApprovalCardClick(params: {
     result = await resolveApprovalOverGateway({
       cfg: params.target.config,
       approvalId: consumed.approvalId,
+      ...(consumed.instanceId ? { instanceId: consumed.instanceId } : {}),
       approvalKind: consumed.approvalKind,
       decision: consumed.decision,
       channel: "googlechat",

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -388,6 +388,7 @@ export const googleChatApprovalNativeRuntime = createChannelApprovalNativeRuntim
           token: actionToken.token,
           accountId: entry.accountId,
           approvalId: request.id,
+          instanceId: request.instanceId,
           approvalKind,
           decision: actionToken.decision,
           allowedDecisions: pendingPayload.allowedDecisions,

--- a/extensions/imessage/src/approval-handler.runtime.ts
+++ b/extensions/imessage/src/approval-handler.runtime.ts
@@ -71,6 +71,7 @@ type PreparedIMessageApprovalTarget = {
 };
 type IMessageApprovalPromptBinding = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
 };
@@ -226,6 +227,7 @@ async function deliverIMessageApprovalPoll(params: {
   cfg: OpenClawConfig;
   target: PreparedIMessageApprovalTarget;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   expiresAtMs: number;
   question: string;
@@ -298,6 +300,7 @@ async function deliverIMessageApprovalPoll(params: {
       conversation: { chatGuid },
       ...(pollGuid ? { pollGuid } : {}),
       approvalId: params.approvalId,
+      instanceId: params.instanceId,
       approvalKind: params.approvalKind,
       optionDecisions,
       expiresAtMs: params.expiresAtMs,
@@ -428,6 +431,7 @@ const eagerlyBoundApprovalEntries = new WeakSet<PendingIMessageApprovalEntry>();
 function bindIMessageApprovalEntry(params: {
   entry: PendingIMessageApprovalEntry;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   expiresAtMs: number;
@@ -458,6 +462,7 @@ function bindIMessageApprovalEntry(params: {
               conversation: params.entry.conversation,
               messageId,
               approvalId: params.approvalId,
+              instanceId: params.instanceId,
               approvalKind: params.approvalKind,
               allowedDecisions: params.allowedDecisions,
               ttlMs,
@@ -471,6 +476,7 @@ function bindIMessageApprovalEntry(params: {
         conversation: params.entry.conversation,
         pollGuid: params.entry.poll.pollGuid,
         approvalId: params.approvalId,
+        instanceId: params.instanceId,
         approvalKind: params.approvalKind,
         optionDecisions: params.entry.poll.optionDecisions,
         expiresAtMs: params.expiresAtMs,
@@ -585,6 +591,7 @@ export const imessageApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
                 cfg,
                 target: preparedTarget,
                 approvalId: view.approvalId,
+                instanceId: view.instanceId,
                 approvalKind: view.approvalKind,
                 expiresAtMs: view.expiresAtMs,
                 question: pendingPayload.pollText,
@@ -620,6 +627,7 @@ export const imessageApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
         const bound = bindIMessageApprovalEntry({
           entry,
           approvalId: view.approvalId,
+          instanceId: view.instanceId,
           approvalKind: view.approvalKind,
           allowedDecisions: pendingPayload.allowedDecisions,
           expiresAtMs: view.expiresAtMs,
@@ -658,6 +666,7 @@ export const imessageApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
       return bindIMessageApprovalEntry({
         entry,
         approvalId: request.id,
+        instanceId: view.instanceId,
         approvalKind: view.approvalKind,
         allowedDecisions: pendingPayload.allowedDecisions,
         expiresAtMs: view.expiresAtMs,

--- a/extensions/imessage/src/approval-native.ts
+++ b/extensions/imessage/src/approval-native.ts
@@ -215,6 +215,7 @@ function buildIMessageExecPendingPayload(params: { request: ExecApprovalRequest;
   const command = resolveExecApprovalCommandDisplay(params.request.request).commandText;
   const payload = buildTypedExecApprovalPendingReplyPayload({
     approvalId: params.request.id,
+    instanceId: params.request.instanceId,
     approvalSlug: params.request.id.slice(0, 8),
     approvalCommandId: params.request.id,
     warningText: params.request.request.warningText ?? undefined,

--- a/extensions/imessage/src/approval-polls.test.ts
+++ b/extensions/imessage/src/approval-polls.test.ts
@@ -44,6 +44,7 @@ function bind(overrides?: {
     conversation: { handle: APPROVER },
     pollGuid: POLL_GUID,
     approvalId: "exec-1",
+    instanceId: "instance-1",
     approvalKind: "exec",
     optionDecisions:
       overrides?.optionDecisions ??
@@ -177,6 +178,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         approvalId: "exec-1",
+        instanceId: "instance-1",
         decision: "allow-once",
         senderId: APPROVER,
         gatewayRuntime,

--- a/extensions/imessage/src/approval-polls.ts
+++ b/extensions/imessage/src/approval-polls.ts
@@ -48,6 +48,7 @@ const APPROVAL_DECISIONS = new Set<ExecApprovalReplyDecision>([
 /** JSON-safe: option pairs stay an array so the persistent store round-trips. */
 type IMessageApprovalPollTarget = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   optionDecisions: ReadonlyArray<readonly [string, ExecApprovalReplyDecision]>;
 };
@@ -89,7 +90,12 @@ function readPersistedTarget(value: unknown): IMessageApprovalPollTarget | null 
       : [];
   });
   return optionDecisions.length > 0
-    ? { approvalId: target.approvalId, approvalKind: target.approvalKind, optionDecisions }
+    ? {
+        approvalId: target.approvalId,
+        ...(typeof target.instanceId === "string" ? { instanceId: target.instanceId } : {}),
+        approvalKind: target.approvalKind,
+        optionDecisions,
+      }
     : null;
 }
 
@@ -162,6 +168,7 @@ function registerIMessageApprovalPollTarget(params: {
   conversation: IMessageApprovalConversationKey;
   pollGuid?: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   optionDecisions: ReadonlyArray<readonly [string, ExecApprovalReplyDecision]>;
   expiresAtMs: number;
@@ -190,6 +197,7 @@ function registerIMessageApprovalPollTarget(params: {
   }
   const target: IMessageApprovalPollTarget = {
     approvalId,
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     approvalKind: params.approvalKind,
     optionDecisions: params.optionDecisions,
   };
@@ -462,6 +470,7 @@ export async function maybeResolveIMessageApprovalPollVote(params: {
   if (event.malformedVotes) {
     warn("approval poll vote ignored: malformed complete vote set", {
       approvalId: target.approvalId,
+      instanceId: target.instanceId,
       actorHandle: event.actorHandle,
     });
     return true;
@@ -541,6 +550,7 @@ export async function maybeResolveIMessageApprovalPollVote(params: {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
       approvalId: target.approvalId,
+      instanceId: target.instanceId,
       approvalKind: target.approvalKind,
       decision,
       channel: "imessage",

--- a/extensions/imessage/src/approval-reaction-poll-targets.ts
+++ b/extensions/imessage/src/approval-reaction-poll-targets.ts
@@ -28,6 +28,7 @@ export type PendingIMessageApprovalReactionPollTarget = {
   conversation: IMessageApprovalConversationKey;
   messageId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   expiresAtMs: number;
@@ -158,6 +159,7 @@ function readPersistedPollTarget(value: unknown): PendingIMessageApprovalReactio
     conversation,
     messageId,
     approvalId,
+    ...(typeof target.instanceId === "string" ? { instanceId: target.instanceId } : {}),
     approvalKind: target.approvalKind,
     allowedDecisions,
     expiresAtMs,
@@ -170,6 +172,7 @@ export function recordIMessageApprovalReactionPollTarget(params: {
   conversation: IMessageApprovalConversationKey;
   messageId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
@@ -183,6 +186,7 @@ export function recordIMessageApprovalReactionPollTarget(params: {
     conversation: params.conversation,
     messageId: params.messageId,
     approvalId: params.approvalId,
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     approvalKind: params.approvalKind,
     allowedDecisions: params.allowedDecisions,
     expiresAtMs: expiry.expiresAtMs,

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -178,6 +178,7 @@ function bindObservedConversation(params: {
       conversation,
       messageId,
       approvalId: params.target.approvalId,
+      instanceId: params.target.instanceId,
       approvalKind: params.target.approvalKind,
       allowedDecisions: params.target.allowedDecisions,
       ttlMs,

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -577,6 +577,7 @@ describe("iMessage approval reactions", () => {
       conversation: { chatId: 42, chatGuid: "iMessage;+;restart" },
       messageId: "restart-message",
       approvalId: "exec-restart",
+      instanceId: "instance-restart",
       allowedDecisions: ["allow-once", "deny"],
     });
     await vi.waitFor(async () => {
@@ -592,6 +593,7 @@ describe("iMessage approval reactions", () => {
     ).toEqual([
       expect.objectContaining({
         approvalId: "exec-restart",
+        instanceId: "instance-restart",
         messageId: "restart-message",
         conversation: expect.objectContaining({ chatId: 42, chatGuid: "iMessage;+;restart" }),
       }),
@@ -698,6 +700,7 @@ describe("iMessage approval reactions", () => {
       conversation: { handle: "+15551230000" },
       messageId: "approval-message",
       approvalId: "exec-success",
+      instanceId: "instance-success",
       allowedDecisions: ["allow-once", "deny"],
     });
 
@@ -716,6 +719,9 @@ describe("iMessage approval reactions", () => {
     ).resolves.toBe(true);
 
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: "instance-success" }),
+    );
 
     // Second tapback (toggle to 👎) must not hit the resolver — the in-memory
     // binding was cleared on the first success.

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -48,6 +48,7 @@ const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
 type IMessageApprovalReactionResolution = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
 };
@@ -213,6 +214,7 @@ export function addIMessageApprovalReactionHintToStructuredPayload(params: {
       ...params.payload.channelData,
       [IMESSAGE_APPROVAL_DELIVERY_BINDING_KEY]: buildApprovalReactionDeliveredBindingMarker({
         approvalId: metadata.approvalId,
+        instanceId: metadata.instanceId,
         approvalSlug: metadata.approvalSlug,
         approvalKind: metadata.approvalKind,
         allowedDecisions: metadata.allowedDecisions,
@@ -228,6 +230,7 @@ export function registerIMessageApprovalReactionTarget(params: {
   conversation: IMessageApprovalConversationKey;
   messageId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
@@ -247,7 +250,12 @@ export function registerIMessageApprovalReactionTarget(params: {
   ) {
     return null;
   }
-  const target = { approvalId, approvalKind: params.approvalKind, allowedDecisions };
+  const target = {
+    approvalId,
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
+    approvalKind: params.approvalKind,
+    allowedDecisions,
+  };
   // Register the binding under every key we can derive from the conversation
   // (chat_guid / chat_identifier / chat_id / handle). Inbound lookup precedence
   // can differ from outbound — e.g. send only sees `{handle: "+1..."}` for a
@@ -354,6 +362,7 @@ export function registerIMessageApprovalReactionTargetForDeliveredPayload(params
           conversation,
           messageId,
           approvalId: binding.approvalId,
+          instanceId: binding.instanceId,
           approvalKind: binding.approvalKind,
           allowedDecisions: binding.allowedDecisions,
           ttlMs: params.ttlMs,
@@ -540,6 +549,7 @@ export async function handleIMessageApprovalReaction(params: {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
       approvalId: target.approvalId,
+      instanceId: target.instanceId,
       approvalKind: target.approvalKind,
       decision: target.decision,
       channel: "imessage",

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -112,6 +112,7 @@ function readPersistedTarget(value: unknown): IMessageApprovalReactionTarget | n
   }
   return {
     approvalId: target.approvalId,
+    ...(typeof target.instanceId === "string" ? { instanceId: target.instanceId } : {}),
     approvalKind: target.approvalKind,
     allowedDecisions,
   };
@@ -276,6 +277,7 @@ export function registerIMessageApprovalReactionTarget(params: {
     conversation: params.conversation,
     messageId,
     approvalId,
+    instanceId: params.instanceId,
     approvalKind: params.approvalKind,
     allowedDecisions,
     ttlMs: params.ttlMs,
@@ -392,6 +394,7 @@ function resolveTarget(params: {
   return target
     ? {
         approvalId: target.approvalId,
+        ...(params.target?.instanceId ? { instanceId: params.target.instanceId } : {}),
         approvalKind: target.approvalKind,
         decision: target.decision,
       }

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -68,6 +68,7 @@ type MatrixApprovalMetadataBase = {
   version: 1;
   type: "approval.request";
   id: string;
+  instanceId?: string;
   state: "pending";
   kind: PendingApprovalView["approvalKind"];
   phase: "pending";
@@ -107,6 +108,7 @@ type MatrixApprovalExtraContent = {
 };
 type PendingApprovalContent = {
   approvalId: string;
+  instanceId?: string;
   text: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   extraContent: MatrixApprovalExtraContent;
@@ -248,6 +250,7 @@ function buildMatrixApprovalMetadata(params: {
     version: 1,
     type: "approval.request",
     id: params.view.approvalId,
+    ...(params.view.instanceId ? { instanceId: params.view.instanceId } : {}),
     state: "pending",
     kind: params.view.approvalKind,
     phase: params.view.phase,
@@ -301,6 +304,7 @@ function buildPendingApprovalContent(params: {
           request: {
             approvalKind: "plugin",
             id: params.view.approvalId,
+            instanceId: params.view.instanceId,
             request: {
               title: params.view.title,
               description: params.view.description ?? "",
@@ -318,6 +322,7 @@ function buildPendingApprovalContent(params: {
         })
       : buildExecApprovalPendingReplyPayload({
           approvalId: params.view.approvalId,
+          instanceId: params.view.instanceId,
           approvalSlug: params.view.approvalId.slice(0, 8),
           approvalCommandId: params.view.approvalId,
           ask: params.view.ask ?? undefined,
@@ -336,6 +341,7 @@ function buildPendingApprovalContent(params: {
   const text = payload.text ?? "";
   return {
     approvalId: params.view.approvalId,
+    ...(params.view.instanceId ? { instanceId: params.view.instanceId } : {}),
     text: hint ? (text ? `${hint}\n\n${text}` : hint) : text,
     allowedDecisions,
     extraContent: {
@@ -494,6 +500,7 @@ export const matrixApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
         roomId: result.roomId,
         eventId: reactionEventId,
         approvalId: pendingPayload.approvalId,
+        instanceId: pendingPayload.instanceId,
         approvalKind: view.approvalKind,
         allowedDecisions: pendingPayload.allowedDecisions,
         ttlMs: view.expiresAtMs - Date.now(),
@@ -580,6 +587,7 @@ export const matrixApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
         roomId: target.roomId,
         eventId: target.eventId,
         approvalId: params.pendingPayload.approvalId,
+        instanceId: params.pendingPayload.instanceId,
         approvalKind: params.view.approvalKind,
         allowedDecisions: params.pendingPayload.allowedDecisions,
         ttlMs: params.view.expiresAtMs - Date.now(),

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -41,6 +41,7 @@ type MatrixApprovalReactionBinding = {
 
 type MatrixApprovalReactionResolution = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
 };
@@ -48,6 +49,7 @@ type MatrixApprovalReactionResolution = {
 type MatrixApprovalReactionTarget = {
   accountId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   roomId: string;
   eventId: string;
@@ -98,6 +100,9 @@ function readPersistedTarget(target: unknown): MatrixApprovalReactionTarget | nu
   return {
     accountId,
     approvalId,
+    ...(typeof value.instanceId === "string" && value.instanceId
+      ? { instanceId: value.instanceId }
+      : {}),
     approvalKind: value.approvalKind,
     roomId,
     eventId,
@@ -199,6 +204,7 @@ export function registerMatrixApprovalReactionTarget(params: {
   roomId: string;
   eventId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
@@ -226,6 +232,7 @@ export function registerMatrixApprovalReactionTarget(params: {
   const target = {
     accountId,
     approvalId,
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     approvalKind: params.approvalKind,
     roomId: params.roomId.trim(),
     eventId: params.eventId.trim(),
@@ -257,6 +264,7 @@ export function unregisterMatrixApprovalReactionTarget(params: {
 export async function unregisterMatrixApprovalReactionTargetsForApproval(params: {
   accountId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
 }): Promise<MatrixApprovalReactionTargetRef[]> {
   const accountId = normalizeAccountId(params.accountId);
@@ -270,6 +278,7 @@ export async function unregisterMatrixApprovalReactionTargetsForApproval(params:
     if (
       entry.target.approvalId === approvalId &&
       entry.target.accountId === accountId &&
+      (params.instanceId === undefined || entry.target.instanceId === params.instanceId) &&
       entry.target.approvalKind === params.approvalKind
     ) {
       matches.set(key, entry.target);
@@ -287,6 +296,7 @@ export async function unregisterMatrixApprovalReactionTargetsForApproval(params:
       if (
         target?.approvalId === approvalId &&
         target.accountId === accountId &&
+        (params.instanceId === undefined || target.instanceId === params.instanceId) &&
         target.approvalKind === params.approvalKind &&
         buildReactionTargetKey(target.accountId, target.roomId, target.eventId) === entry.key
       ) {
@@ -330,6 +340,7 @@ function resolveTarget(params: {
   }
   return {
     approvalId: target.approvalId,
+    ...(target.instanceId ? { instanceId: target.instanceId } : {}),
     approvalKind: target.approvalKind,
     decision,
   };

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -176,6 +176,7 @@ describe("matrix approval reactions", () => {
       roomId: "!ops:example.org",
       eventId: "$approval-msg",
       approvalId: "req-123",
+      instanceId: "req-123-instance",
       approvalKind: "exec",
       allowedDecisions: ["allow-once", "allow-always", "deny"],
     });
@@ -196,6 +197,7 @@ describe("matrix approval reactions", () => {
     expect(resolveMatrixApproval).toHaveBeenCalledWith({
       cfg,
       approvalId: "req-123",
+      instanceId: "req-123-instance",
       approvalKind: "exec",
       decision: "allow-once",
       channel: "matrix",

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -52,6 +52,7 @@ async function retireMatrixApprovalReactionTargets(params: {
   roomId: string;
   targetEventId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   result: ApprovalResolveResult;
   logVerboseMessage: (message: string) => void;
@@ -60,6 +61,7 @@ async function retireMatrixApprovalReactionTargets(params: {
   const registeredTargets = await unregisterMatrixApprovalReactionTargetsForApproval({
     accountId,
     approvalId: params.approvalId,
+    instanceId: params.instanceId,
     approvalKind: params.approvalKind,
   });
   const targets = new Map<string, { accountId: string; roomId: string; eventId: string }>();
@@ -127,6 +129,7 @@ async function maybeResolveMatrixApprovalReaction(params: {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
       approvalId: params.target.approvalId,
+      ...(params.target.instanceId ? { instanceId: params.target.instanceId } : {}),
       approvalKind: params.target.approvalKind,
       decision: params.target.decision,
       channel: "matrix",
@@ -142,6 +145,7 @@ async function maybeResolveMatrixApprovalReaction(params: {
       roomId: params.roomId,
       targetEventId: params.targetEventId,
       approvalId: params.target.approvalId,
+      instanceId: params.target.instanceId,
       approvalKind: params.target.approvalKind,
       result,
       logVerboseMessage: params.logVerboseMessage,
@@ -156,6 +160,7 @@ async function maybeResolveMatrixApprovalReaction(params: {
       await unregisterMatrixApprovalReactionTargetsForApproval({
         accountId: params.accountId,
         approvalId: params.target.approvalId,
+        instanceId: params.target.instanceId,
         approvalKind: params.target.approvalKind,
       });
       params.logVerboseMessage(

--- a/extensions/msteams/src/approval-card-actions.ts
+++ b/extensions/msteams/src/approval-card-actions.ts
@@ -12,6 +12,7 @@ export type MSTeamsApprovalCardBinding = {
   token: string;
   accountId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   decision: ExecApprovalDecision;
   allowedDecisions: readonly ExecApprovalDecision[];

--- a/extensions/msteams/src/approval-card-submit.test.ts
+++ b/extensions/msteams/src/approval-card-submit.test.ts
@@ -106,6 +106,7 @@ function createContext(params: {
 function registerBinding(params: {
   token: string;
   accountId?: string;
+  instanceId?: string;
   approvalKind?: ChannelApprovalKind;
   decision?: ExecApprovalDecision;
   allowedDecisions?: readonly ExecApprovalDecision[];
@@ -116,6 +117,7 @@ function registerBinding(params: {
     token: params.token,
     accountId: params.accountId ?? "default",
     approvalId: `approval-${params.token}`,
+    instanceId: params.instanceId,
     approvalKind: params.approvalKind ?? "exec",
     decision: params.decision ?? "allow-once",
     allowedDecisions: params.allowedDecisions ?? ["allow-once", "deny"],
@@ -205,7 +207,12 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
 
   it("requires an allowlisted AAD identity and preserves tokens for the authorized approver", async () => {
     const token = "authorization";
-    registerBinding({ token, approvalKind: "plugin", decision: "deny" });
+    registerBinding({
+      token,
+      instanceId: "authorization-instance",
+      approvalKind: "plugin",
+      decision: "deny",
+    });
     const deps = createDeps();
 
     await expect(
@@ -224,6 +231,7 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
     expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: deps.cfg,
       approvalId: `approval-${token}`,
+      instanceId: "authorization-instance",
       approvalKind: "plugin",
       decision: "deny",
       channel: "msteams",

--- a/extensions/msteams/src/approval-card-submit.ts
+++ b/extensions/msteams/src/approval-card-submit.ts
@@ -99,6 +99,7 @@ export async function maybeHandleMSTeamsApprovalCardSubmit(params: {
     result = await resolveApprovalOverGateway({
       cfg: deps.cfg,
       approvalId: consumed.approvalId,
+      ...(consumed.instanceId ? { instanceId: consumed.instanceId } : {}),
       approvalKind: consumed.approvalKind,
       decision: consumed.decision,
       channel: "msteams",

--- a/extensions/msteams/src/approval-handler.runtime.ts
+++ b/extensions/msteams/src/approval-handler.runtime.ts
@@ -111,6 +111,7 @@ export const msTeamsApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
             token: actionToken.token,
             accountId: entry.accountId,
             approvalId: request.id,
+            instanceId: request.instanceId,
             approvalKind,
             decision: actionToken.decision,
             allowedDecisions: pendingPayload.allowedDecisions,

--- a/extensions/signal/src/approval-handler.runtime.ts
+++ b/extensions/signal/src/approval-handler.runtime.ts
@@ -221,6 +221,7 @@ export const signalApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
         conversationKey: entry.conversationKey,
         messageId: entry.messageId,
         approvalId: request.id,
+        instanceId: request.instanceId,
         approvalKind: view.approvalKind,
         allowedDecisions: pendingPayload.reactionPayload.allowedDecisions,
         targetAuthorKeys: entry.targetAuthorKeys,

--- a/extensions/signal/src/approval-reactions.test.ts
+++ b/extensions/signal/src/approval-reactions.test.ts
@@ -68,6 +68,7 @@ describe("Signal approval reactions", () => {
     };
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "exec-structured-approval",
+      instanceId: "exec-structured-instance",
       approvalSlug: "exec-str",
       allowedDecisions: ["allow-once", "deny"],
       command: "printf test",
@@ -113,6 +114,7 @@ describe("Signal approval reactions", () => {
       }),
     ).resolves.toEqual({
       approvalId: "exec-structured-approval",
+      instanceId: "exec-structured-instance",
       approvalKind: "exec",
       decision: "allow-once",
       route: {
@@ -765,6 +767,55 @@ describe("Signal approval reactions", () => {
       senderId: "+15551230000",
       gatewayUrl: undefined,
     });
+  });
+
+  it("keeps a same-id replacement actionable after a stale lifecycle reaction", async () => {
+    const cfg = {
+      channels: { signal: { allowFrom: ["+15551230000"] } },
+      approvals: { exec: { enabled: true, mode: "session" as const } },
+    };
+    for (const [messageId, instanceId] of [
+      ["old-message", "old-instance"],
+      ["current-message", "current-instance"],
+    ] as const) {
+      registerSignalApprovalReactionTarget({
+        accountId: "default",
+        conversationKey: "+15551230000",
+        messageId,
+        approvalId: "exec-reused",
+        instanceId,
+        approvalKind: "exec",
+        allowedDecisions: ["allow-once"],
+        targetAuthorKeys: ["+15550009999"],
+        route: approvalRoute,
+        routeAllowed: true,
+      });
+    }
+    resolverMocks.resolveSignalApproval
+      .mockRejectedValueOnce(new Error("stale lifecycle"))
+      .mockResolvedValueOnce({
+        applied: true,
+        approval: { status: "allowed", decision: "allow-once" },
+      });
+    resolverMocks.isApprovalNotFoundError.mockReturnValueOnce(true);
+
+    for (const messageId of ["old-message", "current-message"]) {
+      await expect(
+        maybeResolveSignalApprovalReaction({
+          cfg,
+          accountId: "default",
+          conversationKey: "+15551230000",
+          messageId,
+          reactionKey: "👍",
+          actorId: "+15551230000",
+          targetAuthor: "+15550009999",
+        }),
+      ).resolves.toBe(true);
+    }
+
+    expect(
+      resolverMocks.resolveSignalApproval.mock.calls.map(([request]) => request.instanceId),
+    ).toEqual(["old-instance", "current-instance"]);
   });
 
   it("authorizes reactions using Signal defaultTo approvers", async () => {

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -42,6 +42,7 @@ const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
 type SignalApprovalReactionResolution = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
   route: SignalApprovalReactionRoute;
@@ -203,6 +204,9 @@ function readPersistedTarget(target: unknown): SignalApprovalReactionTarget | nu
         };
   return {
     approvalId: value.approvalId,
+    ...(typeof value.instanceId === "string" && value.instanceId
+      ? { instanceId: value.instanceId }
+      : {}),
     approvalKind: value.approvalKind,
     allowedDecisions,
     targetAuthorKeys: value.targetAuthorKeys,
@@ -222,6 +226,7 @@ export function registerSignalApprovalReactionTarget(params: {
   conversationKey: string;
   messageId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   targetAuthorKeys: readonly string[];
@@ -279,6 +284,7 @@ export function registerSignalApprovalReactionTarget(params: {
         } satisfies SignalApprovalReactionRoute);
   const target: SignalApprovalReactionTarget = {
     approvalId,
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     approvalKind: params.approvalKind,
     allowedDecisions,
     targetAuthorKeys,
@@ -420,6 +426,7 @@ export function registerSignalApprovalReactionTargetForDeliveredPayload(params: 
           conversationKey,
           messageId,
           approvalId: metadata.approvalId,
+          instanceId: metadata.instanceId,
           approvalKind: metadata.approvalKind,
           allowedDecisions: metadata.allowedDecisions,
           targetAuthorKeys,
@@ -468,6 +475,7 @@ function resolveTarget(params: {
   }
   return {
     approvalId: resolved.approvalId,
+    ...(resolved.instanceId ? { instanceId: resolved.instanceId } : {}),
     approvalKind: resolved.approvalKind,
     decision: resolved.decision,
     route: resolved.route,
@@ -562,6 +570,7 @@ export async function maybeResolveSignalApprovalReaction(params: {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
       approvalId: target.approvalId,
+      ...(target.instanceId ? { instanceId: target.instanceId } : {}),
       approvalKind: target.approvalKind,
       decision: target.decision,
       channel: "signal",

--- a/extensions/slack/src/approval-actions.test.ts
+++ b/extensions/slack/src/approval-actions.test.ts
@@ -10,6 +10,7 @@ describe("Slack approval actions", () => {
       type: "approval" as const,
       approvalId: "plugin:req/50%/😀",
       approvalKind: "plugin" as const,
+      instanceId: "instance/50%/😀",
       decision: "allow-always" as const,
     };
 
@@ -17,6 +18,27 @@ describe("Slack approval actions", () => {
 
     expect(encoded).not.toContain("/approve ");
     expect(decodeSlackApprovalAction(encoded)).toEqual(action);
+  });
+
+  it("binds compact callbacks to the approval lifecycle", () => {
+    const approvalId = `approval/${"x".repeat(SLACK_BUTTON_VALUE_MAX)}`;
+    const action = {
+      type: "approval" as const,
+      approvalId,
+      approvalKind: "exec" as const,
+      instanceId: `instance/${"y".repeat(SLACK_BUTTON_VALUE_MAX)}`,
+      decision: "deny" as const,
+    };
+
+    expect(decodeSlackApprovalAction(encodeSlackApprovalAction(action))).toEqual({
+      ...action,
+      approvalId: buildApprovalResolutionRef({
+        approvalId,
+        approvalKind: "exec",
+        instanceId: action.instanceId,
+      }),
+      instanceId: undefined,
+    });
   });
 
   it("uses the durable transport reference when a Unicode id exceeds Slack's value limit", () => {

--- a/extensions/slack/src/approval-actions.ts
+++ b/extensions/slack/src/approval-actions.ts
@@ -14,9 +14,10 @@ function isApprovalDecision(value: unknown): value is SlackApprovalAction["decis
 
 /** Encode portable approval facts without exposing a slash command to Slack callbacks. */
 export function encodeSlackApprovalAction(action: SlackApprovalAction): string {
-  const encode = (approvalId: string) =>
+  const encode = (approvalId: string, includeInstance = true) =>
     `${SLACK_APPROVAL_VALUE_PREFIX}${JSON.stringify({
       approvalId,
+      ...(includeInstance && action.instanceId ? { instanceId: action.instanceId } : {}),
       approvalKind: action.approvalKind,
       decision: action.decision,
     })}`;
@@ -27,7 +28,9 @@ export function encodeSlackApprovalAction(action: SlackApprovalAction): string {
         buildApprovalResolutionRef({
           approvalId: action.approvalId,
           approvalKind: action.approvalKind,
+          instanceId: action.instanceId,
         }),
+        false,
       );
 }
 
@@ -42,10 +45,21 @@ export function decodeSlackApprovalAction(value: unknown): SlackApprovalAction |
       return null;
     }
     const record = decoded as Record<string, unknown>;
+    const keys = Object.keys(record);
     if (
-      Object.keys(record).length !== 3 ||
+      (keys.length !== 3 && keys.length !== 4) ||
+      keys.some(
+        (key) =>
+          key !== "approvalId" &&
+          key !== "instanceId" &&
+          key !== "approvalKind" &&
+          key !== "decision",
+      ) ||
       typeof record.approvalId !== "string" ||
       record.approvalId.length === 0 ||
+      (record.instanceId !== undefined &&
+        (typeof record.instanceId !== "string" || record.instanceId.length === 0)) ||
+      (keys.length === 4 && typeof record.instanceId !== "string") ||
       (record.approvalKind !== "exec" && record.approvalKind !== "plugin") ||
       !isApprovalDecision(record.decision)
     ) {
@@ -54,6 +68,7 @@ export function decodeSlackApprovalAction(value: unknown): SlackApprovalAction |
     return {
       type: "approval",
       approvalId: record.approvalId,
+      ...(typeof record.instanceId === "string" ? { instanceId: record.instanceId } : {}),
       approvalKind: record.approvalKind,
       decision: record.decision,
     };

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -655,6 +655,7 @@ async function handleSlackApprovalInteraction(params: {
     const result = await resolveApprovalOverGateway({
       cfg: params.ctx.cfg,
       approvalId: params.approval.approvalId,
+      instanceId: params.approval.instanceId,
       approvalKind: params.approval.approvalKind,
       decision: params.approval.decision,
       channel: "slack",

--- a/extensions/telegram/src/approval-callback-data.test.ts
+++ b/extensions/telegram/src/approval-callback-data.test.ts
@@ -91,6 +91,34 @@ describe("approval callback data", () => {
     expect(parseTelegramApprovalCallbackData(callbackData)).toEqual(action);
   });
 
+  it("round-trips the approval lifecycle and binds compact callbacks to it", () => {
+    const exact = {
+      type: "approval" as const,
+      approvalId: "approval-1",
+      approvalKind: "exec" as const,
+      instanceId: "instance-1",
+      decision: "deny" as const,
+    };
+    expect(parseTelegramApprovalCallbackData(buildTelegramApprovalCallbackData(exact))).toEqual(
+      exact,
+    );
+
+    const approvalId = "x".repeat(80);
+    expect(
+      parseTelegramApprovalCallbackData(
+        buildTelegramApprovalCallbackData({ ...exact, approvalId }),
+      ),
+    ).toEqual({
+      ...exact,
+      approvalId: buildApprovalResolutionRef({
+        approvalId,
+        approvalKind: "exec",
+        instanceId: "instance-1",
+      }),
+      instanceId: undefined,
+    });
+  });
+
   it("uses the canonical id at the Unicode byte boundary and compacts beyond it", () => {
     const exactId = "\u{1F4F1}".repeat(13);
     const compactedId = "\u{1F4F1}".repeat(14);

--- a/extensions/telegram/src/approval-callback-data.ts
+++ b/extensions/telegram/src/approval-callback-data.ts
@@ -4,6 +4,7 @@ import type { MessagePresentationAction } from "openclaw/plugin-sdk/interactive-
 
 export const TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64;
 const TELEGRAM_APPROVAL_CALLBACK_PREFIX = "tga1:";
+const TELEGRAM_BOUND_APPROVAL_CALLBACK_PREFIX = "tga2:";
 
 export type TelegramApprovalCallback = Extract<MessagePresentationAction, { type: "approval" }>;
 
@@ -18,7 +19,10 @@ export function fitsTelegramCallbackData(value: string): boolean {
 
 /** Reserve the Telegram approval namespace even when a callback is malformed. */
 export function hasTelegramApprovalCallbackPrefix(data?: string | null): boolean {
-  return data?.startsWith(TELEGRAM_APPROVAL_CALLBACK_PREFIX) === true;
+  return (
+    data?.startsWith(TELEGRAM_APPROVAL_CALLBACK_PREFIX) === true ||
+    data?.startsWith(TELEGRAM_BOUND_APPROVAL_CALLBACK_PREFIX) === true
+  );
 }
 
 /** Encode a typed approval action into Telegram-private, versioned callback data. */
@@ -41,15 +45,21 @@ export function buildTelegramApprovalCallbackData(
   if (!kind || !decision) {
     return undefined;
   }
-  const encode = (approvalId: string) =>
-    `${TELEGRAM_APPROVAL_CALLBACK_PREFIX}${kind}:${decision}:${approvalId}`;
-  const exact = encode(action.approvalId);
+  const encode = (approvalId: string, instanceId?: string) =>
+    `${instanceId ? TELEGRAM_BOUND_APPROVAL_CALLBACK_PREFIX : TELEGRAM_APPROVAL_CALLBACK_PREFIX}${kind}:${decision}:${instanceId ? encodeURIComponent(approvalId) : approvalId}${instanceId ? `:${encodeURIComponent(instanceId)}` : ""}`;
+  const exact = encode(action.approvalId, action.instanceId);
   if (fitsTelegramCallbackData(exact)) {
     return exact;
   }
   // Telegram caps callback_data at 64 UTF-8 bytes. The full digest is only a
   // durable locator; Gateway authorization still guards the canonical record.
-  return encode(buildApprovalResolutionRef({ approvalId: action.approvalId, approvalKind }));
+  return encode(
+    buildApprovalResolutionRef({
+      approvalId: action.approvalId,
+      approvalKind,
+      instanceId: action.instanceId,
+    }),
+  );
 }
 
 /** Decode only callbacks emitted by buildTelegramApprovalCallbackData. */
@@ -59,7 +69,10 @@ export function parseTelegramApprovalCallbackData(
   if (!hasTelegramApprovalCallbackPrefix(data) || !data || !fitsTelegramCallbackData(data)) {
     return null;
   }
-  const encoded = data.slice(TELEGRAM_APPROVAL_CALLBACK_PREFIX.length);
+  const bound = data.startsWith(TELEGRAM_BOUND_APPROVAL_CALLBACK_PREFIX);
+  const encoded = data.slice(
+    (bound ? TELEGRAM_BOUND_APPROVAL_CALLBACK_PREFIX : TELEGRAM_APPROVAL_CALLBACK_PREFIX).length,
+  );
   if (encoded.length < 5 || encoded[1] !== ":" || encoded[3] !== ":") {
     return null;
   }
@@ -72,11 +85,26 @@ export function parseTelegramApprovalCallbackData(
         : encoded[2] === "d"
           ? "deny"
           : null;
-  const approvalId = encoded.slice(4);
-  if (!approvalKind || !decision || !approvalId) {
+  const payload = encoded.slice(4);
+  const [rawApprovalId, rawInstanceId] = bound ? payload.split(":", 2) : [payload, undefined];
+  let approvalId: string;
+  let instanceId: string | undefined;
+  try {
+    approvalId = bound ? decodeURIComponent(rawApprovalId ?? "") : (rawApprovalId ?? "");
+    instanceId = bound ? decodeURIComponent(rawInstanceId ?? "") : undefined;
+  } catch {
     return null;
   }
-  return { type: "approval", approvalId, approvalKind, decision };
+  if (!approvalKind || !decision || !approvalId || (bound && !instanceId)) {
+    return null;
+  }
+  return {
+    type: "approval",
+    approvalId,
+    ...(instanceId ? { instanceId } : {}),
+    approvalKind,
+    decision,
+  };
 }
 
 export function rewriteTelegramApprovalDecisionAlias(value: string): string {

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -89,6 +89,7 @@ function buildPendingPayload(params: {
         })
       : buildExecApprovalPendingReplyPayload({
           approvalId: params.request.id,
+          instanceId: params.request.instanceId,
           approvalSlug: params.request.id.slice(0, 8),
           approvalCommandId: params.request.id,
           warningText:

--- a/extensions/telegram/src/bot-handlers.callback-router-controls.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router-controls.ts
@@ -160,6 +160,7 @@ export function createTelegramCallbackApprovalRuntime(params: {
     (await resolveApproval({
       cfg: runtimeCfg,
       approvalId: approvalCallback.approvalId,
+      instanceId: approvalCallback.instanceId,
       approvalKind: approvalCallback.approvalKind,
       decision: approvalCallback.decision,
       channel: "telegram",

--- a/extensions/telegram/src/exec-approval-forwarding.ts
+++ b/extensions/telegram/src/exec-approval-forwarding.ts
@@ -33,6 +33,7 @@ export function buildTelegramExecApprovalPendingPayload(params: {
 }) {
   return buildTypedExecApprovalPendingReplyPayload({
     approvalId: params.request.id,
+    instanceId: params.request.instanceId,
     approvalSlug: params.request.id.slice(0, 8),
     approvalCommandId: params.request.id,
     warningText: params.request.request.warningText ?? undefined,

--- a/extensions/whatsapp/src/approval-handler.runtime.test.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.test.ts
@@ -1,8 +1,14 @@
 // Whatsapp tests cover approval handler plugin behavior.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { whatsappApprovalNativeRuntime } from "./approval-handler.runtime.js";
+import {
+  clearWhatsAppApprovalReactionTargetsForTest,
+  resolveWhatsAppApprovalReactionTargetWithPersistence,
+} from "./approval-reactions.js";
 
 describe("whatsappApprovalNativeRuntime", () => {
+  beforeEach(() => clearWhatsAppApprovalReactionTargetsForTest());
+
   it("renders allowed thumbs-only reactions in pending exec approvals", async () => {
     const payload = await whatsappApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
@@ -182,5 +188,40 @@ describe("whatsappApprovalNativeRuntime", () => {
         accountId: "work",
       },
     });
+  });
+
+  it("binds same-id native prompts to their lifecycle instances", async () => {
+    for (const [messageId, instanceId] of [
+      ["old-message", "old-instance"],
+      ["current-message", "current-instance"],
+    ] as const) {
+      await expect(
+        whatsappApprovalNativeRuntime.interactions!.bindPending({
+          entry: {
+            accountId: "default",
+            to: "+15551230000",
+            remoteJid: "15551230000@s.whatsapp.net",
+            messageId,
+          },
+          request: { id: "exec-reused", instanceId },
+          view: {
+            approvalKind: "exec",
+            approvalId: "exec-reused",
+            expiresAtMs: Date.now() + 60_000,
+          },
+          pendingPayload: {
+            reactionPayload: { allowedDecisions: ["allow-once"] },
+          },
+        } as never),
+      ).resolves.toBe(true);
+      await expect(
+        resolveWhatsAppApprovalReactionTargetWithPersistence({
+          accountId: "default",
+          remoteJid: "15551230000@s.whatsapp.net",
+          messageId,
+          reactionKey: "👍",
+        }),
+      ).resolves.toMatchObject({ approvalId: "exec-reused", instanceId });
+    }
   });
 });

--- a/extensions/whatsapp/src/approval-handler.runtime.test.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.test.ts
@@ -196,7 +196,7 @@ describe("whatsappApprovalNativeRuntime", () => {
       ["current-message", "current-instance"],
     ] as const) {
       await expect(
-        whatsappApprovalNativeRuntime.interactions!.bindPending({
+        whatsappApprovalNativeRuntime.interactions!.bindPending!({
           entry: {
             accountId: "default",
             to: "+15551230000",

--- a/extensions/whatsapp/src/approval-handler.runtime.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.ts
@@ -145,6 +145,7 @@ export const whatsappApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
         remoteJid: entry.remoteJid,
         messageId: entry.messageId,
         approvalId: request.id,
+        instanceId: request.instanceId,
         approvalKind: view.approvalKind,
         allowedDecisions: pendingPayload.reactionPayload.allowedDecisions,
         ttlMs: Math.max(1, view.expiresAtMs - Date.now()),

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -41,12 +41,17 @@ function approvalConfig(allowFrom: string[]) {
   };
 }
 
-function registerExecApprovalTarget(params: { remoteJid: string; approvalId?: string }): void {
+function registerExecApprovalTarget(params: {
+  remoteJid: string;
+  approvalId?: string;
+  instanceId?: string;
+}): void {
   registerWhatsAppApprovalReactionTarget({
     accountId: "default",
     remoteJid: params.remoteJid,
     messageId: "approval-message",
     approvalId: params.approvalId ?? "exec-direct",
+    instanceId: params.instanceId,
     approvalKind: "exec",
     allowedDecisions: ["allow-once", "deny"],
   });
@@ -337,7 +342,10 @@ describe("WhatsApp approval reactions", () => {
       actorId: "+15551230001",
     },
   ])("resolves direct approval reactions across PN/LID target drift: $name", async (testCase) => {
-    registerExecApprovalTarget({ remoteJid: testCase.storedRemoteJid });
+    registerExecApprovalTarget({
+      remoteJid: testCase.storedRemoteJid,
+      instanceId: "exec-direct-instance",
+    });
     const lidLookup: LidLookup = {
       getLIDForPN: vi.fn().mockResolvedValue(testCase.lidForPn ?? null),
       getPNForLID: vi.fn().mockResolvedValue(testCase.pnForLid ?? null),
@@ -359,6 +367,7 @@ describe("WhatsApp approval reactions", () => {
     expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledWith({
       cfg: approvalConfig([testCase.actorId]),
       approvalId: "exec-direct",
+      instanceId: "exec-direct-instance",
       approvalKind: "exec",
       decision: "allow-once",
       channel: "whatsapp",

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -34,6 +34,7 @@ type WhatsAppApprovalDeliveryBinding = ApprovalReactionDeliveryBinding;
 
 type WhatsAppApprovalReactionResolution = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   decision: ExecApprovalReplyDecision;
 };
@@ -129,6 +130,9 @@ function readPersistedTarget(target: unknown): WhatsAppApprovalReactionTarget | 
   }
   return {
     approvalId: value.approvalId,
+    ...(typeof value.instanceId === "string" && value.instanceId
+      ? { instanceId: value.instanceId }
+      : {}),
     approvalKind: value.approvalKind,
     allowedDecisions,
   };
@@ -225,6 +229,7 @@ export function registerWhatsAppApprovalReactionTarget(params: {
   remoteJid: string;
   messageId: string;
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
   ttlMs?: number;
@@ -244,6 +249,7 @@ export function registerWhatsAppApprovalReactionTarget(params: {
   }
   const target: WhatsAppApprovalReactionTarget = {
     approvalId,
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     approvalKind: params.approvalKind,
     allowedDecisions,
   };
@@ -324,6 +330,7 @@ export function registerWhatsAppApprovalReactionTargetForDeliveredPayload(params
           remoteJid,
           messageId,
           approvalId: binding.approvalId,
+          instanceId: binding.instanceId,
           approvalKind: binding.approvalKind,
           allowedDecisions: binding.allowedDecisions,
           ttlMs: params.ttlMs,
@@ -356,6 +363,7 @@ function resolveTarget(params: {
   return resolved
     ? {
         approvalId: resolved.approvalId,
+        ...(resolved.instanceId ? { instanceId: resolved.instanceId } : {}),
         approvalKind: resolved.approvalKind,
         decision: resolved.decision,
       }
@@ -507,6 +515,7 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
       approvalId: target.approvalId,
+      ...(target.instanceId ? { instanceId: target.instanceId } : {}),
       approvalKind: target.approvalKind,
       decision: target.decision,
       channel: "whatsapp",

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -251,6 +251,7 @@ export const ApprovalChannelReviewerSchema = closedObject({
 
 export const ApprovalResolveParamsSchema = closedObject({
   id: ApprovalRecordCommonFields.id,
+  instanceId: Type.Optional(NonEmptyString),
   kind: ApprovalKindSchema,
   decision: ApprovalDecisionSchema,
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -90,6 +90,7 @@ const SystemAgentApprovalAllowedDecisionsSchema = Type.Tuple([
 export const ExecApprovalPresentationSchema = Type.Object(
   {
     kind: Type.Literal("exec"),
+    instanceId: Type.Optional(NonEmptyString),
     commandText: NonEmptyString,
     commandPreview: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
@@ -108,6 +109,7 @@ export const ExecApprovalPresentationSchema = Type.Object(
 /** Plugin-supplied reviewer text safe to persist and render across surfaces. */
 export const PluginApprovalPresentationSchema = closedObject({
   kind: Type.Literal("plugin"),
+  instanceId: Type.Optional(NonEmptyString),
   title: Type.String({ minLength: 1, maxLength: 80 }),
   description: Type.String({ minLength: 1, maxLength: 512 }),
   detail: Type.Optional(Type.String({ minLength: 1, maxLength: 16_384 })),
@@ -121,6 +123,7 @@ export const PluginApprovalPresentationSchema = closedObject({
 /** Reviewer-safe OpenClaw system change. Exact operation stays host-local. */
 export const SystemAgentApprovalPresentationSchema = closedObject({
   kind: Type.Literal("system-agent"),
+  instanceId: Type.Optional(NonEmptyString),
   title: Type.String({ minLength: 1, maxLength: 80 }),
   description: Type.String({ minLength: 1, maxLength: 512 }),
   proposalHash: Type.String({ pattern: "^[a-f0-9]{64}$" }),

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -169,6 +169,7 @@ const ApprovalResolutionFields = {
 /** Approval that has not yet accepted a reviewer decision. */
 export const PendingApprovalSnapshotSchema = closedObject({
   ...ApprovalRecordCommonFields,
+  instanceId: Type.Optional(NonEmptyString),
   status: Type.Literal("pending"),
 });
 

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -220,6 +220,7 @@ const ApprovalResolutionFields = {
 /** Approval that has not yet accepted a reviewer decision. */
 export const PendingApprovalSnapshotSchema = closedObject({
   ...ApprovalRecordCommonFields,
+  instanceId: Type.Optional(NonEmptyString),
   status: Type.Literal("pending"),
   /** Canonical raising session when projected into a session-scoped reviewer surface. */
   sourceSessionKey: Type.Optional(NonEmptyString),

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -304,6 +304,7 @@ export const ApprovalChannelReviewerSchema = closedObject({
 
 export const ApprovalResolveParamsSchema = closedObject({
   id: ApprovalRecordCommonFields.id,
+  instanceId: Type.Optional(NonEmptyString),
   kind: ApprovalKindSchema,
   decision: ApprovalDecisionSchema,
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -139,6 +139,7 @@ const SystemAgentApprovalAllowedDecisionsSchema = Type.Tuple([
 export const ExecApprovalPresentationSchema = Type.Object(
   {
     kind: Type.Literal("exec"),
+    instanceId: Type.Optional(NonEmptyString),
     commandText: NonEmptyString,
     commandPreview: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
@@ -158,6 +159,7 @@ export const ExecApprovalPresentationSchema = Type.Object(
 /** Plugin-supplied reviewer text safe to persist and render across surfaces. */
 export const PluginApprovalPresentationSchema = closedObject({
   kind: Type.Literal("plugin"),
+  instanceId: Type.Optional(NonEmptyString),
   title: Type.String({ minLength: 1, maxLength: 80 }),
   description: Type.String({ minLength: 1, maxLength: 512 }),
   detail: Type.Optional(Type.String({ minLength: 1, maxLength: 16_384 })),
@@ -172,6 +174,7 @@ export const PluginApprovalPresentationSchema = closedObject({
 /** Reviewer-safe OpenClaw system change. Exact operation stays host-local. */
 export const SystemAgentApprovalPresentationSchema = closedObject({
   kind: Type.Literal("system-agent"),
+  instanceId: Type.Optional(NonEmptyString),
   title: Type.String({ minLength: 1, maxLength: 80 }),
   description: Type.String({ minLength: 1, maxLength: 512 }),
   proposalHash: Type.String({ pattern: "^[a-f0-9]{64}$" }),

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -314,6 +314,7 @@ export const ExecApprovalRequestParamsSchema = closedObject({
 /** Reviewer decision payload for one pending exec approval. */
 export const ExecApprovalResolveParamsSchema = closedObject({
   id: NonEmptyString,
+  instanceId: Type.Optional(NonEmptyString),
   decision: NonEmptyString,
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),
   // Per-grant expiry override for allow-always on automation approvals:

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -312,6 +312,7 @@ export const ExecApprovalRequestParamsSchema = closedObject({
 /** Reviewer decision payload for one pending exec approval. */
 export const ExecApprovalResolveParamsSchema = closedObject({
   id: NonEmptyString,
+  instanceId: Type.Optional(NonEmptyString),
   decision: NonEmptyString,
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),
 });

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -56,6 +56,7 @@ export const PluginApprovalRequestParamsSchema = closedObject({
 /** Reviewer decision payload resolving one pending plugin approval request. */
 export const PluginApprovalResolveParamsSchema = closedObject({
   id: NonEmptyString,
+  instanceId: Type.Optional(NonEmptyString),
   decision: NonEmptyString,
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),
 });

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -82,6 +82,7 @@ export const PluginApprovalRequestParamsSchema = closedObject({
 /** Reviewer decision payload resolving one pending plugin approval request. */
 export const PluginApprovalResolveParamsSchema = closedObject({
   id: NonEmptyString,
+  instanceId: Type.Optional(NonEmptyString),
   decision: NonEmptyString,
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -937,6 +937,7 @@ export class ApprovalsNamespace {
     return await this.client.request("exec.approval.resolve", {
       id: approvalId,
       decision: params.decision,
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     });
   }
 }

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -303,7 +303,11 @@ async function createFakeGateway(port = 0): Promise<FakeGateway> {
       }
 
       if (frame.method === "exec.approval.resolve") {
-        expect(frame.params).toMatchObject({ id: "approval-1", decision: "allow-once" });
+        expect(frame.params).toMatchObject({
+          id: "approval-1",
+          instanceId: "approval-instance-1",
+          decision: "allow-once",
+        });
         reply({ ok: true, params: frame.params as JsonObject | undefined });
         return;
       }
@@ -488,7 +492,10 @@ describe("OpenClaw SDK websocket e2e", () => {
       const approvals = expectJsonObject(await oc.approvals.list());
       expect(approvals.approvals).toEqual([]);
       const approvalResult = expectJsonObject(
-        await oc.approvals.respond("approval-1", { decision: "allow-once" }),
+        await oc.approvals.respond("approval-1", {
+          instanceId: "approval-instance-1",
+          decision: "allow-once",
+        }),
       );
       expect(approvalResult.ok).toBe(true);
 

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -777,7 +777,11 @@ describe("OpenClaw SDK", () => {
     });
 
     await expect(oc.approvals.list()).resolves.toEqual({ approvals: [] });
-    const staleDecision = { id: "stale-approval", decision: "allow-once" as const };
+    const staleDecision = {
+      id: "stale-approval",
+      instanceId: "approval-instance-old",
+      decision: "allow-once" as const,
+    };
     await expect(oc.approvals.respond("approval-123", staleDecision)).resolves.toEqual({
       ok: true,
     });
@@ -791,7 +795,11 @@ describe("OpenClaw SDK", () => {
       {
         method: "exec.approval.resolve",
         options: undefined,
-        params: { id: "approval-123", decision: "allow-once" },
+        params: {
+          id: "approval-123",
+          instanceId: "approval-instance-old",
+          decision: "allow-once",
+        },
       },
     ]);
   });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -151,6 +151,7 @@ export type ApprovalMode = "ask" | "never" | "auto" | "trusted";
 
 export type ApprovalDecisionParams = {
   decision: "allow-once" | "allow-always" | "deny";
+  instanceId?: string;
 };
 
 /** Terminal and non-terminal status values returned by Run.wait. */

--- a/src/acp/permission-relay.test.ts
+++ b/src/acp/permission-relay.test.ts
@@ -12,6 +12,7 @@ function buildOptionsForAllowedDecisions(allowedDecisions: unknown) {
     sessionId: "session-1",
     event: {
       approvalId: "approval-1",
+      instanceId: "instance:approval-1",
       command: "echo ok",
     },
     details: { allowedDecisions },
@@ -34,6 +35,7 @@ describe("ACP permission relay helpers", () => {
       kind: "exec",
       status: "pending",
       approvalId: "approval-1",
+      instanceId: "instance:approval-1",
       title: "Command approval requested",
       toolCallId: "tool-1",
       command: "echo stale",
@@ -42,6 +44,7 @@ describe("ACP permission relay helpers", () => {
     if (!event) {
       throw new Error("approval event did not parse");
     }
+    expect(event.instanceId).toBe("instance:approval-1");
 
     expect(
       buildAcpPermissionRequest({
@@ -95,6 +98,7 @@ describe("ACP permission relay helpers", () => {
     expect(
       parseGatewayExecApprovalRequestEventPayload({
         id: "approval-raw",
+        instanceId: "instance:approval-raw",
         request: {
           command: "echo raw",
           host: "gateway",
@@ -104,6 +108,7 @@ describe("ACP permission relay helpers", () => {
       }),
     ).toEqual({
       approvalId: "approval-raw",
+      instanceId: "instance:approval-raw",
       command: "echo raw",
       host: "gateway",
       toolCallId: "tool-raw",

--- a/src/acp/permission-relay.ts
+++ b/src/acp/permission-relay.ts
@@ -10,6 +10,7 @@ export type GatewayExecApprovalDecision = "allow-once" | "allow-always" | "deny"
 
 export type GatewayExecApprovalEvent = {
   approvalId: string;
+  instanceId?: string;
   command?: string;
   host?: string;
   title?: string;
@@ -87,6 +88,7 @@ export function parseGatewayExecApprovalEventData(
   }
   return {
     approvalId,
+    instanceId: readNonEmptyString(data.instanceId),
     command: readNonEmptyString(data.command),
     host: readNonEmptyString(data.host),
     title: readNonEmptyString(data.title),
@@ -106,6 +108,7 @@ export function parseGatewayExecApprovalRequestEventPayload(
   const requestRecord = request as Record<string, unknown>;
   return {
     approvalId,
+    instanceId: readNonEmptyString(payload.instanceId),
     command:
       readNonEmptyString(requestRecord.command) ?? readNonEmptyString(requestRecord.commandPreview),
     host: readNonEmptyString(requestRecord.host),

--- a/src/acp/translator.agent-events.ts
+++ b/src/acp/translator.agent-events.ts
@@ -173,16 +173,16 @@ export class AcpTranslatorAgentEvents {
     runId?: string,
     opts: { denyActive?: boolean } = {},
   ): void {
-    for (const [approvalId, relay] of this.approvalRelays) {
+    for (const [relayKey, relay] of this.approvalRelays) {
       if (relay.sessionId !== sessionId) {
         continue;
       }
       if (runId && relay.runId !== runId) {
         continue;
       }
-      this.approvalRelays.delete(approvalId);
+      this.approvalRelays.delete(relayKey);
       if (opts.denyActive && relay.state === "active") {
-        void this.resolveGatewayApproval(approvalId, "deny");
+        void this.resolveGatewayApproval(relay, "deny");
       }
     }
   }
@@ -209,7 +209,8 @@ export class AcpTranslatorAgentEvents {
     approvalEvent: GatewayExecApprovalEvent;
   }): void {
     const approvalEvent = params.approvalEvent;
-    if (this.approvalRelays.has(approvalEvent.approvalId)) {
+    const relayKey = this.approvalRelayKey(approvalEvent);
+    if (this.approvalRelays.has(relayKey)) {
       return;
     }
 
@@ -227,12 +228,14 @@ export class AcpTranslatorAgentEvents {
 
     const relay: AcpPendingApprovalRelay = {
       approvalId: approvalEvent.approvalId,
+      instanceId: approvalEvent.instanceId,
+      relayKey,
       runId: pending.idempotencyKey,
       sessionId: pending.sessionId,
       sessionKey: pending.sessionKey,
       state: "active",
     };
-    this.approvalRelays.set(relay.approvalId, relay);
+    this.approvalRelays.set(relay.relayKey, relay);
     void this.runApprovalRelay(relay, correlatedApprovalEvent);
   }
 
@@ -273,7 +276,7 @@ export class AcpTranslatorAgentEvents {
     try {
       const details = await this.getGatewayApprovalDetails(relay.approvalId);
       if (!this.isApprovalRelayActive(relay)) {
-        resolved = await this.resolveGatewayApproval(relay.approvalId, "deny");
+        resolved = await this.resolveGatewayApproval(relay, "deny");
         return;
       }
 
@@ -291,15 +294,15 @@ export class AcpTranslatorAgentEvents {
       }
 
       const selectedDecision = this.isApprovalRelayActive(relay) && decision ? decision : "deny";
-      resolved = await this.resolveGatewayApproval(relay.approvalId, selectedDecision);
+      resolved = await this.resolveGatewayApproval(relay, selectedDecision);
     } finally {
-      const current = this.approvalRelays.get(relay.approvalId);
+      const current = this.approvalRelays.get(relay.relayKey);
       if (current === relay && current.state === "active") {
         if (resolved) {
           // Keep completed relays until prompt cleanup as replay/dedup sentinels.
           current.state = "completed";
         } else {
-          this.approvalRelays.delete(relay.approvalId);
+          this.approvalRelays.delete(relay.relayKey);
         }
       }
     }
@@ -319,27 +322,34 @@ export class AcpTranslatorAgentEvents {
   }
 
   private async resolveGatewayApproval(
-    approvalId: string,
+    relay: AcpPendingApprovalRelay,
     decision: GatewayExecApprovalDecision,
   ): Promise<boolean> {
     try {
       await this.gateway.request("exec.approval.resolve", {
-        id: approvalId,
+        id: relay.approvalId,
+        ...(relay.instanceId ? { instanceId: relay.instanceId } : {}),
         decision,
       });
       return true;
     } catch (err) {
-      this.log(`approval relay resolve failed for ${approvalId}: ${String(err)}`);
+      this.log(`approval relay resolve failed for ${relay.approvalId}: ${String(err)}`);
       return false;
     }
   }
 
   private isApprovalRelayActive(relay: AcpPendingApprovalRelay): boolean {
     return (
-      this.approvalRelays.get(relay.approvalId) === relay &&
+      this.approvalRelays.get(relay.relayKey) === relay &&
       relay.state === "active" &&
       this.getPendingPrompt(relay.sessionId, relay.runId) !== undefined
     );
+  }
+
+  private approvalRelayKey(event: GatewayExecApprovalEvent): string {
+    // Approval ids can be reused after settlement; the Gateway instance token
+    // keeps an older ACP prompt from deduping or resolving its replacement.
+    return `${event.approvalId}\u0000${event.instanceId ?? ""}`;
   }
 
   private findUniquePendingBySessionKey(sessionKey: string): AcpPendingPrompt | undefined {

--- a/src/acp/translator.agent-events.ts
+++ b/src/acp/translator.agent-events.ts
@@ -173,16 +173,16 @@ export class AcpTranslatorAgentEvents {
     runId?: string,
     opts: { denyActive?: boolean } = {},
   ): void {
-    for (const [approvalId, relay] of this.approvalRelays) {
+    for (const [relayKey, relay] of this.approvalRelays) {
       if (relay.sessionId !== sessionId) {
         continue;
       }
       if (runId && relay.runId !== runId) {
         continue;
       }
-      this.approvalRelays.delete(approvalId);
+      this.approvalRelays.delete(relayKey);
       if (opts.denyActive && relay.state === "active") {
-        void this.resolveGatewayApproval(approvalId, "deny");
+        void this.resolveGatewayApproval(relay, "deny");
       }
     }
   }
@@ -209,7 +209,8 @@ export class AcpTranslatorAgentEvents {
     approvalEvent: GatewayExecApprovalEvent;
   }): void {
     const approvalEvent = params.approvalEvent;
-    const existing = this.approvalRelays.get(approvalEvent.approvalId);
+    const relayKey = this.approvalRelayKey(approvalEvent);
+    const existing = this.approvalRelays.get(relayKey);
     if (existing) {
       void this.retryApprovalRelayDecision(existing);
       return;
@@ -229,12 +230,14 @@ export class AcpTranslatorAgentEvents {
 
     const relay: AcpPendingApprovalRelay = {
       approvalId: approvalEvent.approvalId,
+      instanceId: approvalEvent.instanceId,
+      relayKey,
       runId: pending.idempotencyKey,
       sessionId: pending.sessionId,
       sessionKey: pending.sessionKey,
       state: "active",
     };
-    this.approvalRelays.set(relay.approvalId, relay);
+    this.approvalRelays.set(relay.relayKey, relay);
     void this.runApprovalRelay(relay, correlatedApprovalEvent);
   }
 
@@ -276,7 +279,7 @@ export class AcpTranslatorAgentEvents {
     try {
       const details = await this.getGatewayApprovalDetails(relay.approvalId);
       if (!this.isApprovalRelayActive(relay)) {
-        resolved = await this.resolveGatewayApproval(relay.approvalId, "deny");
+        resolved = await this.resolveGatewayApproval(relay, "deny");
         return;
       }
 
@@ -293,9 +296,9 @@ export class AcpTranslatorAgentEvents {
       }
 
       const selectedDecision = this.isApprovalRelayActive(relay) && decision ? decision : "deny";
-      resolved = await this.resolveGatewayApproval(relay.approvalId, selectedDecision);
+      resolved = await this.resolveGatewayApproval(relay, selectedDecision);
     } finally {
-      const current = this.approvalRelays.get(relay.approvalId);
+      const current = this.approvalRelays.get(relay.relayKey);
       if (current === relay && current.state === "active") {
         if (resolved) {
           // Keep completed relays until prompt cleanup as replay/dedup sentinels.
@@ -305,7 +308,7 @@ export class AcpTranslatorAgentEvents {
           // decision until reconnect or a duplicate event can deliver it.
           current.pendingDecision = decision;
         } else {
-          this.approvalRelays.delete(relay.approvalId);
+          this.approvalRelays.delete(relay.relayKey);
         }
       }
     }
@@ -318,7 +321,7 @@ export class AcpTranslatorAgentEvents {
     if (!decision || !this.isApprovalRelayActive(relay)) {
       return;
     }
-    const resolved = await this.resolveGatewayApproval(relay.approvalId, decision);
+    const resolved = await this.resolveGatewayApproval(relay, decision);
     if (!resolved || !this.isApprovalRelayActive(relay)) {
       return;
     }
@@ -346,27 +349,34 @@ export class AcpTranslatorAgentEvents {
   }
 
   private async resolveGatewayApproval(
-    approvalId: string,
+    relay: AcpPendingApprovalRelay,
     decision: GatewayExecApprovalDecision,
   ): Promise<boolean> {
     try {
       await this.gateway.request("exec.approval.resolve", {
-        id: approvalId,
+        id: relay.approvalId,
+        ...(relay.instanceId ? { instanceId: relay.instanceId } : {}),
         decision,
       });
       return true;
     } catch (err) {
-      this.log(`approval relay resolve failed for ${approvalId}: ${String(err)}`);
+      this.log(`approval relay resolve failed for ${relay.approvalId}: ${String(err)}`);
       return false;
     }
   }
 
   private isApprovalRelayActive(relay: AcpPendingApprovalRelay): boolean {
     return (
-      this.approvalRelays.get(relay.approvalId) === relay &&
+      this.approvalRelays.get(relay.relayKey) === relay &&
       relay.state === "active" &&
       this.getPendingPrompt(relay.sessionId, relay.runId) !== undefined
     );
+  }
+
+  private approvalRelayKey(event: GatewayExecApprovalEvent): string {
+    // Approval ids can be reused after settlement; the Gateway instance token
+    // keeps an older ACP prompt from deduping or resolving its replacement.
+    return `${event.approvalId}\u0000${event.instanceId ?? ""}`;
   }
 
   private findUniquePendingBySessionKey(sessionKey: string): AcpPendingPrompt | undefined {

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -31,6 +31,7 @@ function createApprovalEvent(params: {
   runId: string;
   sessionKey?: string;
   toolCallId?: string;
+  instanceId?: string;
 }): EventFrame {
   return {
     type: "event",
@@ -45,6 +46,7 @@ function createApprovalEvent(params: {
         status: "pending",
         title: "Command approval requested",
         approvalId: params.approvalId ?? "approval-1",
+        instanceId: params.instanceId,
         toolCallId: params.toolCallId,
         command: "echo event",
         host: "gateway",
@@ -58,12 +60,14 @@ function createApprovalRequestEvent(params: {
   sessionKey?: string;
   command?: string;
   toolCallId?: string;
+  instanceId?: string;
 }): EventFrame {
   return {
     type: "event",
     event: "exec.approval.requested",
     payload: {
       id: params.approvalId ?? "approval-1",
+      instanceId: params.instanceId,
       createdAtMs: 1,
       expiresAtMs: 2,
       request: {
@@ -169,7 +173,9 @@ function hasApprovalRelay(agent: AcpGatewayAgent, approvalId: string): boolean {
       approvalRelays: Map<string, unknown>;
     }
   ).approvalRelays;
-  return relayMap.has(approvalId);
+  return [...relayMap.values()].some(
+    (relay) => (relay as { approvalId?: string }).approvalId === approvalId,
+  );
 }
 
 function requireRecord(value: unknown): Record<string, unknown> {
@@ -247,6 +253,31 @@ describe("ACP translator permission relay", () => {
       expect(approvalResolveCalls(harness.request)).toHaveLength(1);
     });
 
+    await cleanupHarness(harness);
+  });
+
+  it("keeps same-id replacement relays distinct and echoes each instance", async () => {
+    const harness = await createHarness();
+    const first = createApprovalEvent({
+      runId: harness.runId,
+      approvalId: "approval-reused",
+      instanceId: "instance:first",
+    });
+    const replacement = createApprovalEvent({
+      runId: harness.runId,
+      approvalId: "approval-reused",
+      instanceId: "instance:replacement",
+    });
+
+    await harness.agent.handleGatewayEvent(first);
+    await vi.waitFor(() => expect(approvalResolveCalls(harness.request)).toHaveLength(1));
+    await harness.agent.handleGatewayEvent(replacement);
+    await vi.waitFor(() => expect(approvalResolveCalls(harness.request)).toHaveLength(2));
+
+    expect(approvalResolveCalls(harness.request).map(([, params]) => params)).toEqual([
+      { id: "approval-reused", instanceId: "instance:first", decision: "allow-once" },
+      { id: "approval-reused", instanceId: "instance:replacement", decision: "allow-once" },
+    ]);
     await cleanupHarness(harness);
   });
 

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -32,6 +32,7 @@ function createApprovalEvent(params: {
   runId: string;
   sessionKey?: string;
   toolCallId?: string;
+  instanceId?: string;
 }): EventFrame {
   return {
     type: "event",
@@ -46,6 +47,7 @@ function createApprovalEvent(params: {
         status: "pending",
         title: "Command approval requested",
         approvalId: params.approvalId ?? "approval-1",
+        instanceId: params.instanceId,
         toolCallId: params.toolCallId,
         command: "echo event",
         host: "gateway",
@@ -59,12 +61,14 @@ function createApprovalRequestEvent(params: {
   sessionKey?: string;
   command?: string;
   toolCallId?: string;
+  instanceId?: string;
 }): EventFrame {
   return {
     type: "event",
     event: "exec.approval.requested",
     payload: {
       id: params.approvalId ?? "approval-1",
+      instanceId: params.instanceId,
       createdAtMs: 1,
       expiresAtMs: 2,
       request: {
@@ -167,10 +171,10 @@ function approvalResolveCalls(request: ReturnType<typeof vi.fn>) {
 function approvalRelayPendingDecision(agent: AcpGatewayAgent, approvalId: string): unknown {
   const relayMap = (
     agent as unknown as {
-      approvalRelays: Map<string, { pendingDecision?: unknown }>;
+      approvalRelays: Map<string, { approvalId: string; pendingDecision?: unknown }>;
     }
   ).approvalRelays;
-  return relayMap.get(approvalId)?.pendingDecision;
+  return [...relayMap.values()].find((relay) => relay.approvalId === approvalId)?.pendingDecision;
 }
 
 function captureApprovalDecisionRetry(
@@ -178,13 +182,13 @@ function captureApprovalDecisionRetry(
   approvalId: string,
 ): () => Promise<void> {
   const internal = agent as unknown as {
-    approvalRelays: Map<string, unknown>;
+    approvalRelays: Map<string, { approvalId: string }>;
     promptStream: {
       agentEvents: { retryApprovalRelayDecision: (relay: unknown) => Promise<void> };
     };
   };
   const relay = expectDefined(
-    internal.approvalRelays.get(approvalId),
+    [...internal.approvalRelays.values()].find((candidate) => candidate.approvalId === approvalId),
     "approval relay test invariant",
   );
   return () => internal.promptStream.agentEvents.retryApprovalRelayDecision(relay);
@@ -265,6 +269,31 @@ describe("ACP translator permission relay", () => {
       expect(approvalResolveCalls(harness.request)).toHaveLength(1);
     });
 
+    await cleanupHarness(harness);
+  });
+
+  it("keeps same-id replacement relays distinct and echoes each instance", async () => {
+    const harness = await createHarness();
+    const first = createApprovalEvent({
+      runId: harness.runId,
+      approvalId: "approval-reused",
+      instanceId: "instance:first",
+    });
+    const replacement = createApprovalEvent({
+      runId: harness.runId,
+      approvalId: "approval-reused",
+      instanceId: "instance:replacement",
+    });
+
+    await harness.agent.handleGatewayEvent(first);
+    await vi.waitFor(() => expect(approvalResolveCalls(harness.request)).toHaveLength(1));
+    await harness.agent.handleGatewayEvent(replacement);
+    await vi.waitFor(() => expect(approvalResolveCalls(harness.request)).toHaveLength(2));
+
+    expect(approvalResolveCalls(harness.request).map(([, params]) => params)).toEqual([
+      { id: "approval-reused", instanceId: "instance:first", decision: "allow-once" },
+      { id: "approval-reused", instanceId: "instance:replacement", decision: "allow-once" },
+    ]);
     await cleanupHarness(harness);
   });
 
@@ -445,7 +474,11 @@ describe("ACP translator permission relay", () => {
       resolveApproval,
       requestPermission: vi.fn(() => permission.promise),
     });
-    const event = createApprovalEvent({ runId: harness.runId, approvalId: "approval-replay" });
+    const event = createApprovalEvent({
+      runId: harness.runId,
+      approvalId: "approval-replay",
+      instanceId: "instance:replay",
+    });
 
     await harness.agent.handleGatewayEvent(event);
     await vi.waitFor(() => {
@@ -462,6 +495,7 @@ describe("ACP translator permission relay", () => {
     });
     expect(harness.request).toHaveBeenCalledWith("exec.approval.resolve", {
       id: "approval-replay",
+      instanceId: "instance:replay",
       decision: "allow-once",
     });
     expect(harness.requestPermission).toHaveBeenCalledTimes(1);

--- a/src/acp/translator.prompt-state.ts
+++ b/src/acp/translator.prompt-state.ts
@@ -23,6 +23,8 @@ export type AcpPendingPrompt = {
 
 export type AcpPendingApprovalRelay = {
   approvalId: string;
+  instanceId?: string;
+  relayKey: string;
   runId: string;
   sessionId: string;
   sessionKey: string;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -499,6 +499,7 @@ function queuePendingToolMedia(
 
 function readExecApprovalPendingDetails(result: unknown): {
   approvalId: string;
+  instanceId?: string;
   approvalSlug: string;
   expiresAtMs?: number;
   allowedDecisions?: readonly ExecApprovalDecision[];
@@ -528,6 +529,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   }
   return {
     approvalId,
+    instanceId: readStringValue(details.instanceId),
     approvalSlug,
     expiresAtMs: typeof details.expiresAtMs === "number" ? details.expiresAtMs : undefined,
     allowedDecisions: Array.isArray(details.allowedDecisions)
@@ -631,6 +633,7 @@ export async function emitToolResultOutput(params: {
       await ctx.params.onToolResult(
         buildTypedExecApprovalPendingReplyPayload({
           approvalId: approvalPending.approvalId,
+          instanceId: approvalPending.instanceId,
           approvalSlug: approvalPending.approvalSlug,
           allowedDecisions: approvalPending.allowedDecisions,
           command: approvalPending.command,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -484,6 +484,7 @@ function queuePendingToolMedia(
 
 function readExecApprovalPendingDetails(result: unknown): {
   approvalId: string;
+  instanceId?: string;
   approvalSlug: string;
   expiresAtMs?: number;
   allowedDecisions?: readonly ExecApprovalDecision[];
@@ -513,6 +514,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   }
   return {
     approvalId,
+    instanceId: readStringValue(details.instanceId),
     approvalSlug,
     expiresAtMs: typeof details.expiresAtMs === "number" ? details.expiresAtMs : undefined,
     allowedDecisions: Array.isArray(details.allowedDecisions)
@@ -616,6 +618,7 @@ export async function emitToolResultOutput(params: {
       await ctx.params.onToolResult(
         buildTypedExecApprovalPendingReplyPayload({
           approvalId: approvalPending.approvalId,
+          instanceId: approvalPending.instanceId,
           approvalSlug: approvalPending.approvalSlug,
           allowedDecisions: approvalPending.allowedDecisions,
           command: approvalPending.command,

--- a/src/cli/exec-approvals-cli.pending-resolve.test.ts
+++ b/src/cli/exec-approvals-cli.pending-resolve.test.ts
@@ -60,11 +60,13 @@ function pendingApprovalSnapshot(params: {
   kind?: "exec" | "plugin" | "system-agent";
   allowedDecisions?: string[];
   expiresAtMs?: number;
+  instanceId?: string;
 }) {
   const kind = params.kind ?? "exec";
   return {
     approval: {
       id: params.id,
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
       status: "pending",
       urlPath: `/approve/${params.id}`,
       createdAtMs: Date.now() - 1_000,
@@ -341,7 +343,7 @@ describe("exec approvals pending and resolve CLI", () => {
           if (requestedId === displayId) {
             throw new Error("approval not found");
           }
-          return pendingApprovalSnapshot({ id: approvalId });
+          return pendingApprovalSnapshot({ id: approvalId, instanceId: "instance-cli" });
         }
         if (method === "approval.resolve") {
           return {
@@ -362,6 +364,7 @@ describe("exec approvals pending and resolve CLI", () => {
     expect(callGatewayFromCli.mock.calls[2]?.[0]).toBe("approval.resolve");
     expect(callGatewayFromCli.mock.calls[2]?.[2]).toEqual({
       id: approvalId,
+      instanceId: "instance-cli",
       kind: "exec",
       decision: "allow-once",
     });

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -764,6 +764,9 @@ async function resolvePendingApproval(
     opts,
     {
       id,
+      ...(current.status === "pending" && current.instanceId
+        ? { instanceId: current.instanceId }
+        : {}),
       kind: current.presentation.kind,
       decision,
       ...(expiresInDaysRaw !== undefined ? { grantExpiresInDays: expiresInDaysRaw } : {}),

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -691,6 +691,9 @@ async function resolvePendingApproval(
     opts,
     {
       id,
+      ...(current.status === "pending" && current.instanceId
+        ? { instanceId: current.instanceId }
+        : {}),
       kind: current.presentation.kind,
       decision,
     },

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -343,6 +343,11 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       const inserted = insertOperatorApproval({
         approval: {
           id: record.id,
+          resolutionRef: buildApprovalResolutionRef({
+            approvalId: record.id,
+            approvalKind: this.approvalKind,
+            instanceId: record.instanceId,
+          }),
           kind: this.approvalKind,
           presentation: presentation!,
           requester: {
@@ -421,6 +426,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       resolutionRef: buildApprovalResolutionRef({
         approvalId: record.id,
         approvalKind: this.approvalKind,
+        instanceId: record.instanceId,
       }),
       kind: this.approvalKind,
       status,

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -86,6 +86,7 @@ type ExecApprovalResolutionSource = "operator" | "auto-review";
 
 export type ExecApprovalRecord<TPayload = ExecApprovalRequestPayload> = {
   id: string;
+  instanceId: string;
   request: TPayload;
   createdAtMs: number;
   expiresAtMs: number;
@@ -275,6 +276,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     const resolvedId = hasExplicitId ? id : randomUUID();
     const record: ExecApprovalRecord<TPayload> = {
       id: resolvedId,
+      instanceId: randomUUID(),
       request,
       createdAtMs: now,
       expiresAtMs,

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -309,6 +309,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       ? buildApprovalPresentation({
           kind: this.approvalKind,
           request: record.request,
+          instanceId: record.instanceId,
           allowedDecisions: allowedDecisions ?? [],
         })
       : null;
@@ -412,6 +413,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     const presentation = buildApprovalPresentation({
       kind: this.approvalKind,
       request: record.request,
+      instanceId: record.instanceId,
       allowedDecisions: normalizeAllowedDecisions(
         this.options.resolveAllowedDecisions?.(record.request),
       ),

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -81,6 +81,7 @@ type ExecApprovalResolutionSource = "operator" | "auto-review";
 
 export type ExecApprovalRecord<TPayload = ExecApprovalRequestPayload> = {
   id: string;
+  instanceId: string;
   request: TPayload;
   createdAtMs: number;
   expiresAtMs: number;
@@ -262,6 +263,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     const resolvedId = hasExplicitId ? id : randomUUID();
     const record: ExecApprovalRecord<TPayload> = {
       id: resolvedId,
+      instanceId: randomUUID(),
       request,
       createdAtMs: now,
       expiresAtMs,

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -296,6 +296,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       ? buildApprovalPresentation({
           kind: this.approvalKind,
           request: record.request,
+          instanceId: record.instanceId,
           allowedDecisions: allowedDecisions ?? [],
         })
       : null;
@@ -398,6 +399,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     const presentation = buildApprovalPresentation({
       kind: this.approvalKind,
       request: record.request,
+      instanceId: record.instanceId,
       allowedDecisions: normalizeAllowedDecisions(
         this.options.resolveAllowedDecisions?.(record.request),
       ),

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -330,6 +330,11 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       const inserted = insertOperatorApproval({
         approval: {
           id: record.id,
+          resolutionRef: buildApprovalResolutionRef({
+            approvalId: record.id,
+            approvalKind: this.approvalKind,
+            instanceId: record.instanceId,
+          }),
           kind: this.approvalKind,
           presentation: presentation!,
           requester: {
@@ -407,6 +412,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       resolutionRef: buildApprovalResolutionRef({
         approvalId: record.id,
         approvalKind: this.approvalKind,
+        instanceId: record.instanceId,
       }),
       kind: this.approvalKind,
       status,

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -125,6 +125,7 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     const effectiveBindingArgv = bindingArgv ?? commandArgv ?? [command];
     return {
       id: "approval-1",
+      instanceId: "approval-instance-1",
       request: {
         host: "node",
         nodeId: "node-1",

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -103,6 +103,7 @@ export type OperatorApprovalRecord = {
 
 type NewOperatorApproval = {
   id: string;
+  resolutionRef?: string;
   kind: OperatorApprovalKind;
   presentation: ApprovalPresentation;
   requester?: Partial<OperatorApprovalRequester>;
@@ -1328,10 +1329,8 @@ export function insertOperatorApproval(params: {
 }): InsertOperatorApprovalResult {
   const input = params.approval;
   const id = requireApprovalId(input.id);
-  const resolutionRef = buildApprovalResolutionRef({
-    approvalId: id,
-    approvalKind: input.kind,
-  });
+  const resolutionRef =
+    input.resolutionRef ?? buildApprovalResolutionRef({ approvalId: id, approvalKind: input.kind });
   const runtimeEpoch = requireString(input.runtimeEpoch, "operator approval runtime epoch");
   if (!isValidTimestamp(input.createdAtMs) || !isValidTimestamp(input.expiresAtMs)) {
     throw new Error("operator approval timestamps must be non-negative safe integers");

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -466,7 +466,11 @@ function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRe
   if (
     presentation.kind !== kind ||
     row.resolution_ref !==
-      buildApprovalResolutionRef({ approvalId: row.approval_id, approvalKind: kind }) ||
+      buildApprovalResolutionRef({
+        approvalId: row.approval_id,
+        approvalKind: kind,
+        instanceId: presentation.instanceId,
+      }) ||
     !hasValidLifecycleTuple({ row, status, decision, terminalReason, resolverKind }) ||
     (status === "allowed" &&
       (!decision || !Array.prototype.includes.call(presentation.allowedDecisions, decision)))

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -98,6 +98,7 @@ export type OperatorApprovalRecord = {
 
 type NewOperatorApproval = {
   id: string;
+  resolutionRef?: string;
   kind: OperatorApprovalKind;
   presentation: ApprovalPresentation;
   requester?: Partial<OperatorApprovalRequester>;
@@ -1267,10 +1268,8 @@ export function insertOperatorApproval(params: {
 }): InsertOperatorApprovalResult {
   const input = params.approval;
   const id = requireApprovalId(input.id);
-  const resolutionRef = buildApprovalResolutionRef({
-    approvalId: id,
-    approvalKind: input.kind,
-  });
+  const resolutionRef =
+    input.resolutionRef ?? buildApprovalResolutionRef({ approvalId: id, approvalKind: input.kind });
   const runtimeEpoch = requireString(input.runtimeEpoch, "operator approval runtime epoch");
   if (!isValidTimestamp(input.createdAtMs) || !isValidTimestamp(input.expiresAtMs)) {
     throw new Error("operator approval timestamps must be non-negative safe integers");

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -444,7 +444,11 @@ function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRe
   if (
     presentation.kind !== kind ||
     row.resolution_ref !==
-      buildApprovalResolutionRef({ approvalId: row.approval_id, approvalKind: kind }) ||
+      buildApprovalResolutionRef({
+        approvalId: row.approval_id,
+        approvalKind: kind,
+        instanceId: presentation.instanceId,
+      }) ||
     !hasValidLifecycleTuple({ row, status, decision, terminalReason, resolverKind }) ||
     (status === "allowed" &&
       (!decision || !Array.prototype.includes.call(presentation.allowedDecisions, decision)))

--- a/src/gateway/server-methods/approval-record-lookup.ts
+++ b/src/gateway/server-methods/approval-record-lookup.ts
@@ -127,6 +127,7 @@ export function listVisiblePendingApprovalRequests<TPayload>(params: {
 }): Array<{
   approvalKind?: ChannelApprovalKind;
   id: string;
+  instanceId: string;
   request: TPayload;
   createdAtMs: number;
   expiresAtMs: number;
@@ -140,8 +141,8 @@ export function listVisiblePendingApprovalRequests<TPayload>(params: {
         ...(params.cfg ? { cfg: params.cfg } : {}),
       }),
     )
-    .map(({ id, request, createdAtMs, expiresAtMs }) => {
-      const approval = { id, request, createdAtMs, expiresAtMs };
+    .map(({ id, instanceId, request, createdAtMs, expiresAtMs }) => {
+      const approval = { id, instanceId, request, createdAtMs, expiresAtMs };
       return params.approvalKind
         ? Object.assign(approval, { approvalKind: params.approvalKind })
         : approval;

--- a/src/gateway/server-methods/approval-record-lookup.ts
+++ b/src/gateway/server-methods/approval-record-lookup.ts
@@ -82,6 +82,7 @@ export function listVisiblePendingApprovalRequests<TPayload>(params: {
 }): Array<{
   approvalKind?: ChannelApprovalKind;
   id: string;
+  instanceId: string;
   request: TPayload;
   createdAtMs: number;
   expiresAtMs: number;
@@ -89,8 +90,8 @@ export function listVisiblePendingApprovalRequests<TPayload>(params: {
   return params.manager
     .listPendingRecords()
     .filter((record) => isApprovalRecordVisibleToClient({ record, client: params.client ?? null }))
-    .map(({ id, request, createdAtMs, expiresAtMs }) => {
-      const approval = { id, request, createdAtMs, expiresAtMs };
+    .map(({ id, instanceId, request, createdAtMs, expiresAtMs }) => {
+      const approval = { id, instanceId, request, createdAtMs, expiresAtMs };
       return params.approvalKind
         ? Object.assign(approval, { approvalKind: params.approvalKind })
         : approval;

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -1286,6 +1286,34 @@ describe("handlePendingApprovalRequest", () => {
     expect(manager.getSnapshot(record.id)?.decision).toBeUndefined();
   });
 
+  it("rejects a decision bound to an older approval instance", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo replacement" }, 60_000, "approval-reused");
+    void manager.register(record, 60_000);
+    const respond = vi.fn();
+
+    await handleApprovalResolve({
+      approvalKind: "exec",
+      manager,
+      inputId: record.id,
+      instanceId: "older-instance",
+      decision: "allow-once",
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        broadcastToConnIds: vi.fn(),
+      } as unknown as GatewayRequestContext,
+      client: null,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown or expired approval id" }),
+    );
+    expect(manager.getSnapshot(record.id)?.decision).toBeUndefined();
+  });
+
   it("does not wait on decisions for approvals hidden from the caller", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -1124,6 +1124,34 @@ describe("handlePendingApprovalRequest", () => {
     expect(manager.getSnapshot(record.id)?.decision).toBeUndefined();
   });
 
+  it("rejects a decision bound to an older approval instance", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo replacement" }, 60_000, "approval-reused");
+    void manager.register(record, 60_000);
+    const respond = vi.fn();
+
+    await handleApprovalResolve({
+      approvalKind: "exec",
+      manager,
+      inputId: record.id,
+      instanceId: "older-instance",
+      decision: "allow-once",
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        broadcastToConnIds: vi.fn(),
+      } as unknown as GatewayRequestContext,
+      client: null,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown or expired approval id" }),
+    );
+    expect(manager.getSnapshot(record.id)?.decision).toBeUndefined();
+  });
+
   it("does not wait on decisions for approvals hidden from the caller", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -58,6 +58,7 @@ type RequestedApprovalEvent<
 > = {
   approvalKind?: TKind;
   id: string;
+  instanceId?: string;
   request: TPayload;
   createdAtMs: number;
   expiresAtMs: number;
@@ -75,6 +76,7 @@ type ApprovalRequestDeliveryRoute = "approval-client" | "forwarder" | "turn-sour
 
 type ApprovalResolveParams = {
   id: string;
+  instanceId?: string;
   decision: string;
   reviewer?: ApprovalChannelReviewer;
 };
@@ -153,6 +155,7 @@ export function buildRequestedApprovalEvent<
   return {
     ...(approvalKind ? { approvalKind } : {}),
     id: record.id,
+    instanceId: record.instanceId,
     request: record.request,
     createdAtMs: record.createdAtMs,
     expiresAtMs: record.expiresAtMs,
@@ -167,6 +170,7 @@ export function resolveApprovalDecisionParams<TParams extends ApprovalResolvePar
   respond: RespondFn;
 }): {
   inputId: string;
+  instanceId?: string;
   decision: ExecApprovalDecision;
   reviewer?: ApprovalChannelReviewer;
 } | null {
@@ -180,6 +184,7 @@ export function resolveApprovalDecisionParams<TParams extends ApprovalResolvePar
   }
   return {
     inputId: rawParams.id,
+    ...(rawParams.instanceId ? { instanceId: rawParams.instanceId } : {}),
     decision: rawParams.decision,
     ...(rawParams.reviewer ? { reviewer: rawParams.reviewer } : {}),
   };
@@ -484,6 +489,7 @@ export async function handleApprovalResolve<
   approvalKind: ChannelApprovalKind;
   manager: ExecApprovalManager<TPayload>;
   inputId: string;
+  instanceId?: string;
   decision: ExecApprovalDecision;
   respond: RespondFn;
   context: GatewayRequestContext;
@@ -557,6 +563,11 @@ export async function handleApprovalResolve<
       return;
     }
     respondPendingApprovalLookupError({ respond: params.respond, response: resolved.response });
+    return;
+  }
+
+  if (params.instanceId && resolved.snapshot.instanceId !== params.instanceId) {
+    respondUnknownOrExpiredApproval(params.respond);
     return;
   }
 

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -57,6 +57,7 @@ type RequestedApprovalEvent<
 > = {
   approvalKind?: TKind;
   id: string;
+  instanceId?: string;
   request: TPayload;
   createdAtMs: number;
   expiresAtMs: number;
@@ -74,6 +75,7 @@ type ApprovalRequestDeliveryRoute = "approval-client" | "forwarder" | "turn-sour
 
 type ApprovalResolveParams = {
   id: string;
+  instanceId?: string;
   decision: string;
   reviewer?: ApprovalChannelReviewer;
 };
@@ -152,6 +154,7 @@ export function buildRequestedApprovalEvent<
   return {
     ...(approvalKind ? { approvalKind } : {}),
     id: record.id,
+    instanceId: record.instanceId,
     request: record.request,
     createdAtMs: record.createdAtMs,
     expiresAtMs: record.expiresAtMs,
@@ -166,6 +169,7 @@ export function resolveApprovalDecisionParams<TParams extends ApprovalResolvePar
   respond: RespondFn;
 }): {
   inputId: string;
+  instanceId?: string;
   decision: ExecApprovalDecision;
   reviewer?: ApprovalChannelReviewer;
 } | null {
@@ -179,6 +183,7 @@ export function resolveApprovalDecisionParams<TParams extends ApprovalResolvePar
   }
   return {
     inputId: rawParams.id,
+    ...(rawParams.instanceId ? { instanceId: rawParams.instanceId } : {}),
     decision: rawParams.decision,
     ...(rawParams.reviewer ? { reviewer: rawParams.reviewer } : {}),
   };
@@ -471,6 +476,7 @@ export async function handleApprovalResolve<
   approvalKind: ChannelApprovalKind;
   manager: ExecApprovalManager<TPayload>;
   inputId: string;
+  instanceId?: string;
   decision: ExecApprovalDecision;
   respond: RespondFn;
   context: GatewayRequestContext;
@@ -544,6 +550,11 @@ export async function handleApprovalResolve<
       return;
     }
     respondPendingApprovalLookupError({ respond: params.respond, response: resolved.response });
+    return;
+  }
+
+  if (params.instanceId && resolved.snapshot.instanceId !== params.instanceId) {
+    respondUnknownOrExpiredApproval(params.respond);
     return;
   }
 

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -571,7 +571,7 @@ describe("unified approval handlers", () => {
     const databaseOptions = createDatabaseOptions();
     const managers = createManagers(databaseOptions);
     const id = "exec:approval.with_safe-punctuation";
-    registerExec(managers.exec, {
+    const pending = registerExec(managers.exec, {
       id,
       reviewerDeviceIds: ["reviewer-a"],
       request: {
@@ -604,6 +604,7 @@ describe("unified approval handlers", () => {
     expect(validateApprovalGetResult(response.result)).toBe(true);
     expect(approvalFromResult(response.result)).toMatchObject({
       id,
+      instanceId: pending.record.instanceId,
       status: "pending",
       urlPath: "/operator/approve/exec%3Aapproval.with_safe-punctuation",
       presentation: {

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -423,7 +423,7 @@ describe("unified approval handlers", () => {
     const databaseOptions = createDatabaseOptions();
     const managers = createManagers(databaseOptions);
     const id = "exec:approval.with_safe-punctuation";
-    registerExec(managers.exec, {
+    const pending = registerExec(managers.exec, {
       id,
       reviewerDeviceIds: ["reviewer-a"],
       request: {
@@ -456,6 +456,7 @@ describe("unified approval handlers", () => {
     expect(validateApprovalGetResult(response.result)).toBe(true);
     expect(approvalFromResult(response.result)).toMatchObject({
       id,
+      instanceId: pending.record.instanceId,
       status: "pending",
       urlPath: "/operator/approve/exec%3Aapproval.with_safe-punctuation",
       presentation: {

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -400,7 +400,7 @@ export function createApprovalHandlers(
           ? params.execApprovalManager.getLiveSnapshot(record.id)
           : record.kind === "plugin"
             ? params.pluginApprovalManager.getLiveSnapshot(record.id)
-            : undefined;
+            : params.systemAgentApprovalManager?.getLiveSnapshot(record.id);
       if (resolveParams?.reviewer && (!custody || !liveRecord || !custody.authorizes(liveRecord))) {
         respondApprovalNotFound(respond);
         return;
@@ -417,6 +417,10 @@ export function createApprovalHandlers(
           return;
         }
         respond(true, { applied: false, approval }, undefined);
+        return;
+      }
+      if (resolveParams?.instanceId && liveRecord?.instanceId !== resolveParams.instanceId) {
+        respondApprovalNotFound(respond);
         return;
       }
       const resolver = custody

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -438,7 +438,7 @@ export function createApprovalHandlers(
           ? params.execApprovalManager.getLiveSnapshot(record.id)
           : record.kind === "plugin"
             ? params.pluginApprovalManager.getLiveSnapshot(record.id)
-            : undefined;
+            : params.systemAgentApprovalManager?.getLiveSnapshot(record.id);
       if (resolveParams?.reviewer && (!custody || !liveRecord || !custody.authorizes(liveRecord))) {
         respondApprovalNotFound(respond);
         return;
@@ -455,6 +455,10 @@ export function createApprovalHandlers(
           return;
         }
         respond(true, { applied: false, approval }, undefined);
+        return;
+      }
+      if (resolveParams?.instanceId && liveRecord?.instanceId !== resolveParams.instanceId) {
+        respondApprovalNotFound(respond);
         return;
       }
       const resolver = custody

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -60,6 +60,7 @@ type CreateApprovalHandlersParams = {
 function buildApprovalSnapshot(
   record: OperatorApprovalRecord,
   controlUiBasePath: string,
+  instanceId?: string,
 ): ApprovalSnapshot | null {
   const common = {
     id: record.id,
@@ -68,6 +69,7 @@ function buildApprovalSnapshot(
     urlPath: `${controlUiBasePath}/approve/${encodeURIComponent(record.id)}`,
     createdAtMs: record.createdAtMs,
     expiresAtMs: record.expiresAtMs,
+    ...(record.status === "pending" && instanceId ? { instanceId } : {}),
   };
   if (record.status === "pending") {
     return common as ApprovalSnapshot;
@@ -102,6 +104,17 @@ function buildApprovalSnapshot(
     return { ...terminal, decision: "deny" } as ApprovalSnapshot;
   }
   return terminal as ApprovalSnapshot;
+}
+
+function getLiveApprovalRecord(
+  params: CreateApprovalHandlersParams,
+  record: OperatorApprovalRecord,
+) {
+  return record.kind === "exec"
+    ? params.execApprovalManager.getLiveSnapshot(record.id)
+    : record.kind === "plugin"
+      ? params.pluginApprovalManager.getLiveSnapshot(record.id)
+      : params.systemAgentApprovalManager?.getLiveSnapshot(record.id);
 }
 
 function resolveApprovalResolver(client: GatewayClient | null): OperatorApprovalResolver {
@@ -386,7 +399,10 @@ export function createApprovalHandlers(
       const controlUiBasePath = normalizeControlUiBasePath(
         context.getRuntimeConfig()?.gateway?.controlUi?.basePath,
       );
-      const approval = record ? buildApprovalSnapshot(record, controlUiBasePath) : null;
+      const liveRecord = record ? getLiveApprovalRecord(params, record) : undefined;
+      const approval = record
+        ? buildApprovalSnapshot(record, controlUiBasePath, liveRecord?.instanceId)
+        : null;
       if (!approval) {
         respondApprovalNotFound(respond);
         return;
@@ -433,12 +449,7 @@ export function createApprovalHandlers(
             reviewer: resolveParams.reviewer,
           })
         : null;
-      const liveRecord =
-        record.kind === "exec"
-          ? params.execApprovalManager.getLiveSnapshot(record.id)
-          : record.kind === "plugin"
-            ? params.pluginApprovalManager.getLiveSnapshot(record.id)
-            : params.systemAgentApprovalManager?.getLiveSnapshot(record.id);
+      const liveRecord = getLiveApprovalRecord(params, record);
       if (resolveParams?.reviewer && (!custody || !liveRecord || !custody.authorizes(liveRecord))) {
         respondApprovalNotFound(respond);
         return;

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -58,6 +58,7 @@ type CreateApprovalHandlersParams = {
 function buildApprovalSnapshot(
   record: OperatorApprovalRecord,
   controlUiBasePath: string,
+  instanceId?: string,
 ): ApprovalSnapshot | null {
   const common = {
     id: record.id,
@@ -66,6 +67,7 @@ function buildApprovalSnapshot(
     urlPath: `${controlUiBasePath}/approve/${encodeURIComponent(record.id)}`,
     createdAtMs: record.createdAtMs,
     expiresAtMs: record.expiresAtMs,
+    ...(record.status === "pending" && instanceId ? { instanceId } : {}),
   };
   if (record.status === "pending") {
     return common as ApprovalSnapshot;
@@ -100,6 +102,17 @@ function buildApprovalSnapshot(
     return { ...terminal, decision: "deny" } as ApprovalSnapshot;
   }
   return terminal as ApprovalSnapshot;
+}
+
+function getLiveApprovalRecord(
+  params: CreateApprovalHandlersParams,
+  record: OperatorApprovalRecord,
+) {
+  return record.kind === "exec"
+    ? params.execApprovalManager.getLiveSnapshot(record.id)
+    : record.kind === "plugin"
+      ? params.pluginApprovalManager.getLiveSnapshot(record.id)
+      : params.systemAgentApprovalManager?.getLiveSnapshot(record.id);
 }
 
 function resolveApprovalResolver(client: GatewayClient | null): OperatorApprovalResolver {
@@ -349,7 +362,10 @@ export function createApprovalHandlers(
       const controlUiBasePath = normalizeControlUiBasePath(
         context.getRuntimeConfig()?.gateway?.controlUi?.basePath,
       );
-      const approval = record ? buildApprovalSnapshot(record, controlUiBasePath) : null;
+      const liveRecord = record ? getLiveApprovalRecord(params, record) : undefined;
+      const approval = record
+        ? buildApprovalSnapshot(record, controlUiBasePath, liveRecord?.instanceId)
+        : null;
       if (!approval) {
         respondApprovalNotFound(respond);
         return;
@@ -395,12 +411,7 @@ export function createApprovalHandlers(
             reviewer: resolveParams.reviewer,
           })
         : null;
-      const liveRecord =
-        record.kind === "exec"
-          ? params.execApprovalManager.getLiveSnapshot(record.id)
-          : record.kind === "plugin"
-            ? params.pluginApprovalManager.getLiveSnapshot(record.id)
-            : params.systemAgentApprovalManager?.getLiveSnapshot(record.id);
+      const liveRecord = getLiveApprovalRecord(params, record);
       if (resolveParams?.reviewer && (!custody || !liveRecord || !custody.authorizes(liveRecord))) {
         respondApprovalNotFound(respond);
         return;

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -427,7 +427,7 @@ export function createExecApprovalHandlers(
       if (!decisionPromise) {
         return;
       }
-      const requestEvent: ExecApprovalRequest = buildRequestedApprovalEvent(record, "exec");
+      const requestEvent = buildRequestedApprovalEvent(record, "exec");
       const forwardRequest = opts?.forwarder?.handleRequested.bind(opts.forwarder);
       const iosPushRequest = opts?.iosPushDelivery?.handleRequested?.bind(opts.iosPushDelivery);
       await handlePendingApprovalRequest({
@@ -487,12 +487,13 @@ export function createExecApprovalHandlers(
       if (!resolveParams) {
         return;
       }
-      const { inputId, decision, reviewer } = resolveParams;
+      const { inputId, instanceId, decision, reviewer } = resolveParams;
       let autoReviewResolution = false;
       await handleApprovalResolve({
         approvalKind: "exec",
         manager,
         inputId,
+        instanceId,
         decision,
         respond,
         context,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -486,7 +486,7 @@ export function createExecApprovalHandlers(
       if (!decisionPromise) {
         return;
       }
-      const requestEvent: ExecApprovalRequest = buildRequestedApprovalEvent(record, "exec");
+      const requestEvent = buildRequestedApprovalEvent(record, "exec");
       const forwardRequest = opts?.forwarder?.handleRequested.bind(opts.forwarder);
       const iosPushRequest = opts?.iosPushDelivery?.handleRequested?.bind(opts.iosPushDelivery);
       await handlePendingApprovalRequest({
@@ -606,7 +606,7 @@ export function createExecApprovalHandlers(
       if (!resolveParams) {
         return;
       }
-      const { inputId, decision, reviewer } = resolveParams;
+      const { inputId, instanceId, decision, reviewer } = resolveParams;
       // Grant terms freeze at resolve time. An explicit per-resolve override
       // (custom operator UIs) wins over the configured default; the manager
       // applies tools.exec.grantExpiryDays when this stays undefined.
@@ -621,6 +621,7 @@ export function createExecApprovalHandlers(
         approvalKind: "exec",
         manager,
         inputId,
+        instanceId,
         decision,
         respond,
         context,

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -313,11 +313,12 @@ export function createPluginApprovalHandlers(
       if (!resolveParams) {
         return;
       }
-      const { inputId, decision, reviewer } = resolveParams;
+      const { inputId, instanceId, decision, reviewer } = resolveParams;
       await handleApprovalResolve({
         approvalKind: "plugin",
         manager,
         inputId,
+        instanceId,
         decision,
         respond,
         context,

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -304,11 +304,12 @@ export function createPluginApprovalHandlers(
       if (!resolveParams) {
         return;
       }
-      const { inputId, decision, reviewer } = resolveParams;
+      const { inputId, instanceId, decision, reviewer } = resolveParams;
       await handleApprovalResolve({
         approvalKind: "plugin",
         manager,
         inputId,
+        instanceId,
         decision,
         respond,
         context,

--- a/src/infra/approval-gateway-resolver.test.ts
+++ b/src/infra/approval-gateway-resolver.test.ts
@@ -67,6 +67,7 @@ describe("resolveApprovalOverGateway", () => {
       cfg: { gateway: { auth: { token: "cfg-token" } } } as never,
       approvalId: "approval-1",
       approvalKind: "exec",
+      instanceId: "instance-1",
       decision: "allow-once",
       gatewayUrl: "ws://gateway.example.test",
       clientDisplayName: "QuietChat approval (default)",
@@ -85,6 +86,7 @@ describe("resolveApprovalOverGateway", () => {
     expect(hoisted.clientRequest).toHaveBeenCalledWith("approval.resolve", {
       id: "approval-1",
       kind: "exec",
+      instanceId: "instance-1",
       decision: "allow-once",
     });
     expect(result).toEqual({ applied: true, approval: recordedApproval });

--- a/src/infra/approval-gateway-resolver.ts
+++ b/src/infra/approval-gateway-resolver.ts
@@ -17,6 +17,7 @@ import type { ChannelApprovalKind } from "./approval-types.js";
 type ResolveApprovalOverGatewayBaseParams = {
   cfg: OpenClawConfig;
   approvalId: string;
+  instanceId?: string;
   decision: ApprovalDecision;
   channel?: string;
   accountId?: string | null;
@@ -133,6 +134,7 @@ export async function resolveApprovalOverGateway(
       "approval.resolve",
       {
         id: approvalId,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         kind: canonicalKind,
         decision: params.decision,
         ...(reviewer ? { reviewer } : {}),
@@ -150,6 +152,7 @@ export async function resolveApprovalOverGateway(
     if (hasCanonicalKind) {
       const resolveParams: ApprovalResolveParams = {
         id: approvalId,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         kind: canonicalKind,
         decision: params.decision,
         ...(reviewer ? { reviewer } : {}),
@@ -162,6 +165,7 @@ export async function resolveApprovalOverGateway(
     ): Promise<void> => {
       await gatewayClient.request(method, {
         id: approvalId,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         decision: params.decision,
         ...(reviewer ? { reviewer } : {}),
       });

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -45,6 +45,7 @@ function sanitizeOptionalSingleLine(value: unknown): string | null {
 
 function buildExecApprovalPresentation(params: {
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (!isRecord(params.request)) {
@@ -61,6 +62,7 @@ function buildExecApprovalPresentation(params: {
       : null;
   return {
     kind: "exec",
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     commandText,
     commandPreview,
     warningText,
@@ -73,6 +75,7 @@ function buildExecApprovalPresentation(params: {
 
 function buildPluginApprovalPresentation(params: {
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (!isRecord(params.request)) {
@@ -104,6 +107,7 @@ function buildPluginApprovalPresentation(params: {
     : null;
   return {
     kind: "plugin",
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     title,
     description,
     ...(detail ? { detail } : {}),
@@ -117,6 +121,7 @@ function buildPluginApprovalPresentation(params: {
 
 function buildSystemAgentApprovalPresentation(params: {
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (!isRecord(params.request)) {
@@ -130,6 +135,7 @@ function buildSystemAgentApprovalPresentation(params: {
   }
   return {
     kind: "system-agent",
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     title: truncateUtf16Safe(sanitizeExecApprovalDisplayText(title), 80),
     description: truncateUtf16Safe(sanitizeExecApprovalWarningText(description), 512),
     proposalHash: request.proposalHash,
@@ -142,6 +148,7 @@ function buildSystemAgentApprovalPresentation(params: {
 export function buildApprovalPresentation(params: {
   kind: ApprovalKind;
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (params.kind === "exec") {

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -46,6 +46,7 @@ function sanitizeOptionalSingleLine(value: unknown): string | null {
 
 function buildExecApprovalPresentation(params: {
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (!isRecord(params.request)) {
@@ -63,6 +64,7 @@ function buildExecApprovalPresentation(params: {
   const scope = request.scope ? sanitizeApprovalScope(request.scope) : null;
   return {
     kind: "exec",
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     commandText,
     commandPreview,
     warningText,
@@ -76,6 +78,7 @@ function buildExecApprovalPresentation(params: {
 
 function buildPluginApprovalPresentation(params: {
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (!isRecord(params.request)) {
@@ -108,6 +111,7 @@ function buildPluginApprovalPresentation(params: {
   const scope = request.scope ? sanitizeApprovalScope(request.scope) : null;
   return {
     kind: "plugin",
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     title,
     description,
     ...(detail ? { detail } : {}),
@@ -122,6 +126,7 @@ function buildPluginApprovalPresentation(params: {
 
 function buildSystemAgentApprovalPresentation(params: {
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (!isRecord(params.request)) {
@@ -135,6 +140,7 @@ function buildSystemAgentApprovalPresentation(params: {
   }
   return {
     kind: "system-agent",
+    ...(params.instanceId ? { instanceId: params.instanceId } : {}),
     title: truncateUtf16Safe(sanitizeExecApprovalDisplayText(title), 80),
     description: truncateUtf16Safe(sanitizeExecApprovalWarningText(description), 512),
     proposalHash: request.proposalHash,
@@ -147,6 +153,7 @@ function buildSystemAgentApprovalPresentation(params: {
 export function buildApprovalPresentation(params: {
   kind: ApprovalKind;
   request: unknown;
+  instanceId?: string;
   allowedDecisions: readonly ApprovalDecision[];
 }): ApprovalPresentation | null {
   if (params.kind === "exec") {

--- a/src/infra/approval-resolution-ref.test.ts
+++ b/src/infra/approval-resolution-ref.test.ts
@@ -21,6 +21,24 @@ describe("approval resolution references", () => {
     );
   });
 
+  it("binds lifecycle-aware locators without changing legacy locators", () => {
+    const legacy = buildApprovalResolutionRef({ approvalId: "same-id", approvalKind: "exec" });
+    const first = buildApprovalResolutionRef({
+      approvalId: "same-id",
+      approvalKind: "exec",
+      instanceId: "instance-1",
+    });
+
+    expect(first).not.toBe(legacy);
+    expect(
+      buildApprovalResolutionRef({
+        approvalId: "same-id",
+        approvalKind: "exec",
+        instanceId: "instance-2",
+      }),
+    ).not.toBe(first);
+  });
+
   it.each(["", "a".repeat(42), "a".repeat(44), "!".repeat(43)])(
     "rejects malformed transport references %#",
     (value) => {

--- a/src/infra/approval-resolution-ref.ts
+++ b/src/infra/approval-resolution-ref.ts
@@ -7,12 +7,16 @@ const APPROVAL_RESOLUTION_REF_LENGTH = 43;
 export function buildApprovalResolutionRef(params: {
   approvalId: string;
   approvalKind: "exec" | "plugin" | "system-agent";
+  instanceId?: string;
 }): string {
-  return createHash("sha256")
+  const hash = createHash("sha256")
     .update(params.approvalKind, "utf8")
     .update("\0", "utf8")
-    .update(params.approvalId, "utf8")
-    .digest("base64url");
+    .update(params.approvalId, "utf8");
+  if (params.instanceId) {
+    hash.update("\0", "utf8").update(params.instanceId, "utf8");
+  }
+  return hash.digest("base64url");
 }
 
 export function isApprovalResolutionRef(value: string): boolean {

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -64,6 +64,7 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
   const { commandText, commandPreview } = resolveExecApprovalCommandDisplay(request.request);
   return {
     approvalId: request.id,
+    ...(request.instanceId ? { instanceId: request.instanceId } : {}),
     approvalKind: "exec",
     phase,
     title: phase === "pending" ? "Exec Approval Required" : "Exec Approval",
@@ -89,6 +90,7 @@ function buildPluginViewBase<TPhase extends ApprovalPhase>(
 ): PluginApprovalViewBase & { phase: TPhase } {
   return {
     approvalId: request.id,
+    ...(request.instanceId ? { instanceId: request.instanceId } : {}),
     approvalKind: "plugin",
     phase,
     title: request.request.title,
@@ -109,6 +111,7 @@ export function buildPendingApprovalView(request: ApprovalRequest): PendingAppro
       ...buildPluginViewBase(normalizedRequest, "pending"),
       actions: buildTypedApprovalActionDescriptors({
         approvalCommandId: normalizedRequest.id,
+        instanceId: normalizedRequest.instanceId,
         approvalKind: normalizedRequest.approvalKind,
         allowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions(
           normalizedRequest.request,
@@ -121,6 +124,7 @@ export function buildPendingApprovalView(request: ApprovalRequest): PendingAppro
     ...buildExecViewBase(normalizedRequest, "pending"),
     actions: buildTypedApprovalActionDescriptors({
       approvalCommandId: normalizedRequest.id,
+      instanceId: normalizedRequest.instanceId,
       approvalKind: normalizedRequest.approvalKind,
       ask: normalizedRequest.request.ask,
       allowedDecisions: resolveExecApprovalRequestAllowedDecisions(normalizedRequest.request),

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -71,6 +71,7 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
   const { commandText, commandPreview } = resolveExecApprovalCommandDisplay(request.request);
   return {
     approvalId: request.id,
+    ...(request.instanceId ? { instanceId: request.instanceId } : {}),
     approvalKind: "exec",
     phase,
     title: phase === "pending" ? "Exec Approval Required" : "Exec Approval",
@@ -97,6 +98,7 @@ function buildPluginViewBase<TPhase extends ApprovalPhase>(
 ): PluginApprovalViewBase & { phase: TPhase } {
   return {
     approvalId: request.id,
+    ...(request.instanceId ? { instanceId: request.instanceId } : {}),
     approvalKind: "plugin",
     phase,
     title: request.request.title,
@@ -118,6 +120,7 @@ export function buildPendingApprovalView(request: ApprovalRequest): PendingAppro
       ...buildPluginViewBase(normalizedRequest, "pending"),
       actions: buildTypedApprovalActionDescriptors({
         approvalCommandId: normalizedRequest.id,
+        instanceId: normalizedRequest.instanceId,
         approvalKind: normalizedRequest.approvalKind,
         allowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions(
           normalizedRequest.request,
@@ -130,6 +133,7 @@ export function buildPendingApprovalView(request: ApprovalRequest): PendingAppro
     ...buildExecViewBase(normalizedRequest, "pending"),
     actions: buildTypedApprovalActionDescriptors({
       approvalCommandId: normalizedRequest.id,
+      instanceId: normalizedRequest.instanceId,
       approvalKind: normalizedRequest.approvalKind,
       ask: normalizedRequest.request.ask,
       allowedDecisions: resolveExecApprovalRequestAllowedDecisions(normalizedRequest.request),

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -29,6 +29,7 @@ export type ApprovalMetadataView = {
 
 type ApprovalViewBase = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   phase: ApprovalPhase;
   title: string;

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -30,6 +30,7 @@ export type ApprovalMetadataView = {
 
 type ApprovalViewBase = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   phase: ApprovalPhase;
   title: string;

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -34,6 +34,7 @@ export type ExecApprovalUnavailableReason =
 
 export type ExecApprovalReplyMetadata = {
   approvalId: string;
+  instanceId?: string;
   approvalSlug: string;
   approvalKind: ChannelApprovalKind;
   agentId?: string;
@@ -59,6 +60,7 @@ export type TypedApprovalActionDescriptor = ExecApprovalActionDescriptor & {
 export type ExecApprovalPendingReplyParams = {
   warningText?: string;
   approvalId: string;
+  instanceId?: string;
   approvalSlug: string;
   approvalCommandId?: string;
   ask?: string | null;
@@ -139,6 +141,7 @@ export function buildExecApprovalCommandText(params: {
 
 type BuildExecApprovalActionDescriptorsParams = {
   approvalCommandId: string;
+  instanceId?: string;
   ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 };
@@ -220,6 +223,7 @@ export function buildTypedApprovalActionDescriptors(
         action: {
           type: "approval",
           approvalId,
+          ...(params.instanceId ? { instanceId: params.instanceId } : {}),
           approvalKind: params.approvalKind,
           decision: descriptor.decision,
         },
@@ -254,6 +258,7 @@ export function buildApprovalPresentationFromActionDescriptors(
 
 type BuildApprovalPresentationParams = {
   approvalId: string;
+  instanceId?: string;
   ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 };
@@ -265,6 +270,7 @@ export function buildApprovalButtonPresentation(
   return buildApprovalPresentationFromActionDescriptors(
     buildExecApprovalActionDescriptors({
       approvalCommandId: params.approvalId,
+      instanceId: params.instanceId,
       ask: params.ask,
       allowedDecisions: params.allowedDecisions,
     }),
@@ -278,6 +284,7 @@ export function buildTypedApprovalPresentation(
   return buildApprovalPresentationFromActionDescriptors(
     buildTypedApprovalActionDescriptors({
       approvalCommandId: params.approvalId,
+      instanceId: params.instanceId,
       approvalKind: params.approvalKind,
       ask: params.ask,
       allowedDecisions: params.allowedDecisions,
@@ -301,11 +308,13 @@ export function buildExecApprovalPresentation(params: {
 /** Build an exec-approval presentation with canonical typed decision actions. */
 export function buildTypedExecApprovalPresentation(params: {
   approvalCommandId: string;
+  instanceId?: string;
   ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 }): MessagePresentation | undefined {
   return buildTypedApprovalPresentation({
     approvalId: params.approvalCommandId,
+    instanceId: params.instanceId,
     approvalKind: "exec",
     ask: params.ask,
     allowedDecisions: params.allowedDecisions,
@@ -448,6 +457,7 @@ export function buildExecApprovalPendingReplyPayload(
     channelData: {
       execApproval: {
         approvalId: params.approvalId,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         approvalSlug: params.approvalSlug,
         approvalKind: "exec",
         agentId: normalizeOptionalString(params.agentId),
@@ -467,6 +477,7 @@ export function buildTypedExecApprovalPendingReplyPayload(
     ...payload,
     presentation: buildTypedExecApprovalPresentation({
       approvalCommandId: params.approvalId,
+      instanceId: params.instanceId,
       allowedDecisions: resolveAllowedDecisions(params),
     }),
   };

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -35,6 +35,7 @@ export type ExecApprovalUnavailableReason =
 
 export type ExecApprovalReplyMetadata = {
   approvalId: string;
+  instanceId?: string;
   approvalSlug: string;
   approvalKind: ChannelApprovalKind;
   agentId?: string;
@@ -60,6 +61,7 @@ export type TypedApprovalActionDescriptor = ExecApprovalActionDescriptor & {
 export type ExecApprovalPendingReplyParams = {
   warningText?: string;
   approvalId: string;
+  instanceId?: string;
   approvalSlug: string;
   approvalCommandId?: string;
   ask?: string | null;
@@ -141,6 +143,7 @@ export function buildExecApprovalCommandText(params: {
 
 type BuildExecApprovalActionDescriptorsParams = {
   approvalCommandId: string;
+  instanceId?: string;
   ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 };
@@ -222,6 +225,7 @@ export function buildTypedApprovalActionDescriptors(
         action: {
           type: "approval",
           approvalId,
+          ...(params.instanceId ? { instanceId: params.instanceId } : {}),
           approvalKind: params.approvalKind,
           decision: descriptor.decision,
         },
@@ -256,6 +260,7 @@ export function buildApprovalPresentationFromActionDescriptors(
 
 type BuildApprovalPresentationParams = {
   approvalId: string;
+  instanceId?: string;
   ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 };
@@ -267,6 +272,7 @@ export function buildApprovalButtonPresentation(
   return buildApprovalPresentationFromActionDescriptors(
     buildExecApprovalActionDescriptors({
       approvalCommandId: params.approvalId,
+      instanceId: params.instanceId,
       ask: params.ask,
       allowedDecisions: params.allowedDecisions,
     }),
@@ -280,6 +286,7 @@ export function buildTypedApprovalPresentation(
   return buildApprovalPresentationFromActionDescriptors(
     buildTypedApprovalActionDescriptors({
       approvalCommandId: params.approvalId,
+      instanceId: params.instanceId,
       approvalKind: params.approvalKind,
       ask: params.ask,
       allowedDecisions: params.allowedDecisions,
@@ -303,11 +310,13 @@ export function buildExecApprovalPresentation(params: {
 /** Build an exec-approval presentation with canonical typed decision actions. */
 export function buildTypedExecApprovalPresentation(params: {
   approvalCommandId: string;
+  instanceId?: string;
   ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 }): MessagePresentation | undefined {
   return buildTypedApprovalPresentation({
     approvalId: params.approvalCommandId,
+    instanceId: params.instanceId,
     approvalKind: "exec",
     ask: params.ask,
     allowedDecisions: params.allowedDecisions,
@@ -453,6 +462,7 @@ export function buildExecApprovalPendingReplyPayload(
     channelData: {
       execApproval: {
         approvalId: params.approvalId,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         approvalSlug: params.approvalSlug,
         approvalKind: "exec",
         agentId: normalizeOptionalString(params.agentId),
@@ -472,6 +482,7 @@ export function buildTypedExecApprovalPendingReplyPayload(
     ...payload,
     presentation: buildTypedExecApprovalPresentation({
       approvalCommandId: params.approvalId,
+      instanceId: params.instanceId,
       allowedDecisions: resolveAllowedDecisions(params),
     }),
   };

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -385,6 +385,7 @@ export function getExecApprovalReplyMetadata(
     return null;
   }
   const approvalKind = record.approvalKind === "plugin" ? "plugin" : "exec";
+  const instanceId = normalizeOptionalString(record.instanceId);
   const allowedDecisions = Array.isArray(record.allowedDecisions)
     ? record.allowedDecisions.filter(
         (value): value is ExecApprovalReplyDecision =>
@@ -395,6 +396,7 @@ export function getExecApprovalReplyMetadata(
   const sessionKey = normalizeOptionalString(record.sessionKey);
   return {
     approvalId,
+    ...(instanceId ? { instanceId } : {}),
     approvalSlug,
     approvalKind,
     agentId,

--- a/src/infra/exec-approvals-core.ts
+++ b/src/infra/exec-approvals-core.ts
@@ -209,6 +209,7 @@ export type ExecApprovalRequest = {
   /** Descriptive wire metadata; readers derive it from the payload when absent. */
   approvalKind?: "exec";
   id: string;
+  instanceId?: string;
   request: ExecApprovalRequestPayload;
   createdAtMs: number;
   expiresAtMs: number;

--- a/src/infra/exec-approvals-core.ts
+++ b/src/infra/exec-approvals-core.ts
@@ -222,6 +222,7 @@ export type ExecApprovalRequest = {
   /** Descriptive wire metadata; readers derive it from the payload when absent. */
   approvalKind?: "exec";
   id: string;
+  instanceId?: string;
   request: ExecApprovalRequestPayload;
   createdAtMs: number;
   expiresAtMs: number;

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -39,6 +39,7 @@ export type PluginApprovalRequest = {
   /** Descriptive wire metadata; readers derive it from the payload when absent. */
   approvalKind?: "plugin";
   id: string;
+  instanceId?: string;
   request: PluginApprovalRequestPayload;
   createdAtMs: number;
   expiresAtMs: number;

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -42,6 +42,7 @@ export type PluginApprovalRequest = {
   /** Descriptive wire metadata; readers derive it from the payload when absent. */
   approvalKind?: "plugin";
   id: string;
+  instanceId?: string;
   request: PluginApprovalRequestPayload;
   createdAtMs: number;
   expiresAtMs: number;

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -85,6 +85,7 @@ export type MessagePresentationAction =
       /** Resolve one durable operator approval without exposing transport callback data. */
       type: "approval";
       approvalId: string;
+      instanceId?: string;
       approvalKind: ChannelApprovalKind;
       decision: "allow-once" | "allow-always" | "deny";
     }
@@ -528,17 +529,25 @@ function normalizePresentationAction(raw: unknown): MessagePresentationAction | 
       return undefined;
     }
     const approvalId = record.approvalId;
+    const instanceId = record.instanceId;
     const approvalKind = record.approvalKind;
     const decision = record.decision;
     if (
       typeof approvalId !== "string" ||
       !isWellFormedApprovalId(approvalId) ||
+      (instanceId !== undefined && (typeof instanceId !== "string" || !instanceId)) ||
       (approvalKind !== "exec" && approvalKind !== "plugin") ||
       (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny")
     ) {
       return undefined;
     }
-    return { type: "approval", approvalId, approvalKind, decision };
+    return {
+      type: "approval",
+      approvalId,
+      ...(typeof instanceId === "string" ? { instanceId } : {}),
+      approvalKind,
+      decision,
+    };
   }
   if (type === "question") {
     if (record.type !== "question") {

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -99,6 +99,7 @@ export type MessagePresentationAction =
       /** Resolve one durable operator approval without exposing transport callback data. */
       type: "approval";
       approvalId: string;
+      instanceId?: string;
       approvalKind: ChannelApprovalKind;
       decision: "allow-once" | "allow-always" | "deny";
     }
@@ -537,17 +538,25 @@ function normalizePresentationAction(raw: unknown): MessagePresentationAction | 
       return undefined;
     }
     const approvalId = record.approvalId;
+    const instanceId = record.instanceId;
     const approvalKind = record.approvalKind;
     const decision = record.decision;
     if (
       typeof approvalId !== "string" ||
       !isWellFormedApprovalId(approvalId) ||
+      (instanceId !== undefined && (typeof instanceId !== "string" || !instanceId)) ||
       (approvalKind !== "exec" && approvalKind !== "plugin") ||
       (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny")
     ) {
       return undefined;
     }
-    return { type: "approval", approvalId, approvalKind, decision };
+    return {
+      type: "approval",
+      approvalId,
+      ...(typeof instanceId === "string" ? { instanceId } : {}),
+      approvalKind,
+      decision,
+    };
   }
   if (type === "question") {
     if (record.type !== "question") {

--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -44,6 +44,13 @@ type BridgeInternals = {
     message: { role: string; content: unknown };
   }) => Promise<void>;
   listPendingApprovals: () => unknown[];
+  respondToApproval: (params: {
+    kind: "exec" | "plugin";
+    id: string;
+    instanceId?: string;
+    decision: "allow-once" | "allow-always" | "deny";
+  }) => Promise<Record<string, unknown>>;
+  requestGateway: ReturnType<typeof vi.fn>;
   close: () => Promise<void>;
   server: { server: { notification: (n: unknown) => Promise<void> } } | null;
   sendNotification: (notification: { method: string }) => Promise<void>;
@@ -208,6 +215,37 @@ describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals 
 
       vi.advanceTimersByTime(SWEEP_INTERVAL_MS + ONE_MINUTE_MS);
       expect(bridge.pendingApprovals.size).toBe(0);
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("approval responses retain the observed request instance across same-id replacement", async () => {
+    const bridge = makeBridge();
+    bridge.requestGateway = vi.fn(async () => ({ ok: true }));
+    try {
+      await bridge.handleGatewayEvent({
+        event: "exec.approval.requested",
+        payload: { id: "approval-1", instanceId: "instance-old" },
+      });
+      const [observed] = bridge.listPendingApprovals() as Array<{ instanceId?: string }>;
+      await bridge.handleGatewayEvent({
+        event: "exec.approval.requested",
+        payload: { id: "approval-1", instanceId: "instance-replacement" },
+      });
+
+      await bridge.respondToApproval({
+        kind: "exec",
+        id: "approval-1",
+        instanceId: observed?.instanceId,
+        decision: "deny",
+      });
+
+      expect(bridge.requestGateway).toHaveBeenCalledWith("exec.approval.resolve", {
+        id: "approval-1",
+        instanceId: "instance-old",
+        decision: "deny",
+      });
     } finally {
       await bridge.close();
     }

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -303,16 +303,19 @@ export class OpenClawChannelBridge {
   async respondToApproval(params: {
     kind: ChannelApprovalKind;
     id: string;
+    instanceId?: string;
     decision: ApprovalDecision;
   }): Promise<Record<string, unknown>> {
     if (params.kind === "exec") {
       return await this.requestGateway("exec.approval.resolve", {
         id: params.id,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         decision: params.decision,
       });
     }
     return await this.requestGateway("plugin.approval.resolve", {
       id: params.id,
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
       decision: params.decision,
     });
   }
@@ -500,6 +503,10 @@ export class OpenClawChannelBridge {
       approval: {
         kind,
         id,
+        instanceId:
+          typeof payload.instanceId === "string" && payload.instanceId.trim()
+            ? payload.instanceId.trim()
+            : undefined,
         request:
           payload.request && typeof payload.request === "object"
             ? (payload.request as Record<string, unknown>)

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -326,16 +326,19 @@ export class OpenClawChannelBridge {
   async respondToApproval(params: {
     kind: ChannelApprovalKind;
     id: string;
+    instanceId?: string;
     decision: ApprovalDecision;
   }): Promise<Record<string, unknown>> {
     if (params.kind === "exec") {
       return await this.requestGateway("exec.approval.resolve", {
         id: params.id,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         decision: params.decision,
       });
     }
     return await this.requestGateway("plugin.approval.resolve", {
       id: params.id,
+      ...(params.instanceId ? { instanceId: params.instanceId } : {}),
       decision: params.decision,
     });
   }
@@ -523,6 +526,10 @@ export class OpenClawChannelBridge {
       approval: {
         kind,
         id,
+        instanceId:
+          typeof payload.instanceId === "string" && payload.instanceId.trim()
+            ? payload.instanceId.trim()
+            : undefined,
         request:
           payload.request && typeof payload.request === "object"
             ? (payload.request as Record<string, unknown>)

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -91,6 +91,7 @@ export type ApprovalDecision = "allow-once" | "allow-always" | "deny";
 export type PendingApproval = {
   kind: ChannelApprovalKind;
   id: string;
+  instanceId?: string;
   request?: Record<string, unknown>;
   createdAtMs?: number;
   expiresAtMs?: number;

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -199,10 +199,16 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     {
       kind: z.enum(["exec", "plugin"]),
       id: z.string().min(1),
+      instance_id: z.string().min(1).optional(),
       decision: z.enum(["allow-once", "allow-always", "deny"]),
     },
-    async ({ kind, id, decision }) => {
-      const result = await bridge.respondToApproval({ kind, id, decision });
+    async ({ kind, id, instance_id, decision }) => {
+      const result = await bridge.respondToApproval({
+        kind,
+        id,
+        ...(instance_id ? { instanceId: instance_id } : {}),
+        decision,
+      });
       return {
         content: [{ type: "text", text: "approval resolved" }],
         structuredContent: { result },

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -197,10 +197,16 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     {
       kind: z.enum(["exec", "plugin"]),
       id: z.string().min(1),
+      instance_id: z.string().min(1).optional(),
       decision: z.enum(["allow-once", "allow-always", "deny"]),
     },
-    async ({ kind, id, decision }) => {
-      const result = await bridge.respondToApproval({ kind, id, decision });
+    async ({ kind, id, instance_id, decision }) => {
+      const result = await bridge.respondToApproval({
+        kind,
+        id,
+        ...(instance_id ? { instanceId: instance_id } : {}),
+        decision,
+      });
       return {
         content: [{ type: "text", text: "approval resolved" }],
         structuredContent: { result },

--- a/src/plugin-sdk/approval-reaction-binding.ts
+++ b/src/plugin-sdk/approval-reaction-binding.ts
@@ -6,6 +6,7 @@ import type { ReplyPayload } from "./reply-payload.js";
 /** Validated identity and decisions shared by typed approval delivery surfaces. */
 export type ApprovalReactionDeliveryBinding = {
   approvalId: string;
+  instanceId?: string;
   approvalKind: ChannelApprovalKind;
   allowedDecisions: ExecApprovalReplyDecision[];
   approvalSlug?: string;
@@ -72,6 +73,7 @@ export function readApprovalReactionDeliveryMetadata(
   }
   const approvalId = options.trimApprovalId ? record.approvalId.trim() : record.approvalId;
   const approvalSlug = typeof record.approvalSlug === "string" ? record.approvalSlug.trim() : "";
+  const instanceId = typeof record.instanceId === "string" ? record.instanceId : undefined;
   const allowedDecisions = readApprovalReactionDecisionList(record.allowedDecisions);
   if (
     !approvalId ||
@@ -84,6 +86,7 @@ export function readApprovalReactionDeliveryMetadata(
   }
   return {
     approvalId,
+    ...(instanceId ? { instanceId } : {}),
     approvalKind: record.approvalKind,
     allowedDecisions,
     ...(approvalSlug ? { approvalSlug } : {}),
@@ -112,7 +115,9 @@ export function readApprovalReactionPresentationBinding(params: {
     !actions?.length ||
     actions.some(
       (action) =>
-        action.approvalId !== metadata.approvalId || action.approvalKind !== metadata.approvalKind,
+        action.approvalId !== metadata.approvalId ||
+        action.approvalKind !== metadata.approvalKind ||
+        action.instanceId !== metadata.instanceId,
     )
   ) {
     return null;
@@ -141,9 +146,11 @@ export function readApprovalReactionDeliveredBinding(params: {
       ? record.approvalId.trim()
       : record.approvalId;
   const markerSlug = typeof record.approvalSlug === "string" ? record.approvalSlug.trim() : "";
+  const markerInstanceId = typeof record.instanceId === "string" ? record.instanceId : undefined;
   const decisions = readApprovalReactionDecisionList(record.allowedDecisions);
   return record.version === 1 &&
     markerId === metadata.approvalId &&
+    markerInstanceId === metadata.instanceId &&
     record.approvalKind === metadata.approvalKind &&
     (!params.requireApprovalSlug || markerSlug === metadata.approvalSlug) &&
     decisions &&

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -25,6 +25,7 @@ import {
 describe("plugin-sdk/approval-reaction-runtime", () => {
   const execRequest: ExecApprovalRequest = {
     id: "exec-approval-123",
+    instanceId: "exec-instance-123",
     request: {
       command: "touch /tmp/foo",
       cwd: "/Users/test/project",
@@ -39,6 +40,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
 
   const pluginRequest: PluginApprovalRequest = {
     id: "plugin:approval-123",
+    instanceId: "plugin-instance-123",
     request: {
       title: "Use 1Password",
       description: "Allow Codex to use 1Password?",
@@ -169,6 +171,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       resolveTypedApprovalReactionTarget({
         target: {
           approvalId: "exec-looking-id",
+          instanceId: "exec-instance-123",
           approvalKind: "plugin",
           allowedDecisions: ["allow-once", "deny"],
           route: { deliveryMode: "session" },
@@ -177,6 +180,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       }),
     ).toEqual({
       approvalId: "exec-looking-id",
+      instanceId: "exec-instance-123",
       approvalKind: "plugin",
       decision: "allow-once",
       normalizedEmoji: "👍",
@@ -245,6 +249,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
     expect(payload.presentation).toBeUndefined();
     expect(payload.channelData?.execApproval).toMatchObject({
       approvalId: "exec-approval-123",
+      instanceId: "exec-instance-123",
       approvalKind: "exec",
       allowedDecisions: ["allow-once", "allow-always", "deny"],
       sessionKey: "main:signal:+15555550123",
@@ -319,6 +324,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
     expect(payload.presentation).toBeUndefined();
     expect(payload.channelData?.execApproval).toMatchObject({
       approvalId: "plugin:approval-123",
+      instanceId: "plugin-instance-123",
       approvalKind: "plugin",
       allowedDecisions: ["allow-once", "deny"],
     });

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -68,6 +68,7 @@ export type ApprovalReactionDecisionResolution = {
 /** Stored target metadata needed to convert a reaction into an approval decision. */
 export type ApprovalReactionTargetRecord<TRoute = unknown> = {
   approvalId: string;
+  instanceId?: string;
   /** Explicit ownership; omission is supported only by the deprecated resolver. */
   approvalKind?: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -69,6 +69,7 @@ export type ApprovalReactionDecisionResolution = {
 /** Stored target metadata needed to convert a reaction into an approval decision. */
 export type ApprovalReactionTargetRecord<TRoute = unknown> = {
   approvalId: string;
+  instanceId?: string;
   /** Explicit ownership; omission is supported only by the deprecated resolver. */
   approvalKind?: ChannelApprovalKind;
   allowedDecisions: readonly ExecApprovalReplyDecision[];

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -81,6 +81,7 @@ export type ApprovalReactionTargetRecord<TRoute = unknown> = {
 export type ApprovalReactionTargetResolution<TRoute = unknown> =
   ApprovalReactionDecisionResolution & {
     approvalId: string;
+    instanceId?: string;
     approvalKind: ChannelApprovalKind;
     route?: TRoute;
   };
@@ -243,6 +244,7 @@ function resolveApprovalReactionTargetInternal<TRoute>(params: {
   }
   return {
     approvalId,
+    ...(target.instanceId ? { instanceId: target.instanceId } : {}),
     approvalKind: resolvedKind,
     decision: decision.decision,
     normalizedEmoji: decision.normalizedEmoji,
@@ -420,6 +422,7 @@ function buildMetadataPayload(params: {
     buildApprovalPendingReplyPayload({
       approvalKind: params.view.approvalKind,
       approvalId: params.view.approvalId,
+      instanceId: params.view.instanceId,
       approvalSlug: params.view.approvalId.slice(0, 8),
       text: params.text,
       agentId: params.view.agentId ?? null,

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -21,6 +21,7 @@ const DEFAULT_ALLOWED_DECISIONS = ["allow-once", "allow-always", "deny"] as cons
 type BuildApprovalPendingReplyPayloadParams = {
   /** Stable approval id used by `/approve` commands and metadata correlation. */
   approvalId: string;
+  instanceId?: string;
   /** Short channel-facing approval slug for compact metadata displays. */
   approvalSlug: string;
   /** Visible approval request text sent to the channel. */
@@ -51,6 +52,7 @@ export function buildApprovalPendingReplyPayload(
     channelData: {
       execApproval: {
         approvalId: params.approvalId,
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         approvalSlug: params.approvalSlug,
         approvalKind: params.approvalKind ?? "exec",
         agentId: normalizeOptionalString(params.agentId),
@@ -72,6 +74,7 @@ export function buildTypedApprovalPendingReplyPayload(
     ...payload,
     presentation: buildTypedApprovalPresentation({
       approvalId: params.approvalId,
+      instanceId: params.instanceId,
       approvalKind: params.approvalKind,
       allowedDecisions: params.allowedDecisions ?? DEFAULT_ALLOWED_DECISIONS,
     }),
@@ -124,6 +127,7 @@ export function buildPluginApprovalPendingReplyPayload(
   return buildApprovalPendingReplyPayload({
     approvalKind: "plugin",
     approvalId: params.request.id,
+    instanceId: params.request.instanceId,
     approvalSlug: params.approvalSlug ?? params.request.id.slice(0, 8),
     text: params.text ?? buildPluginApprovalRequestMessage(params.request, params.nowMs),
     allowedDecisions:
@@ -140,6 +144,7 @@ export function buildTypedPluginApprovalPendingReplyPayload(
   return buildTypedApprovalPendingReplyPayload({
     approvalKind: "plugin",
     approvalId: params.request.id,
+    instanceId: params.request.instanceId,
     approvalSlug: params.approvalSlug ?? params.request.id.slice(0, 8),
     text: params.text ?? buildPluginApprovalRequestMessage(params.request, params.nowMs),
     allowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions({

--- a/src/state/openclaw-state-db-legacy-backfills.ts
+++ b/src/state/openclaw-state-db-legacy-backfills.ts
@@ -17,11 +17,14 @@ export function ensureOperatorApprovalResolutionRefs(db: DatabaseSync): void {
   runSqliteImmediateTransactionSync(db, () => {
     ensureColumn(db, "operator_approvals", "resolution_ref TEXT");
     const rows = db
-      .prepare("SELECT approval_id, kind, resolution_ref FROM operator_approvals")
+      .prepare(
+        "SELECT approval_id, kind, resolution_ref, presentation_json FROM operator_approvals",
+      )
       .all() as Array<{
       approval_id?: unknown;
       kind?: unknown;
       resolution_ref?: unknown;
+      presentation_json?: unknown;
     }>;
     const update = db.prepare(
       "UPDATE operator_approvals SET resolution_ref = ? WHERE approval_id = ?",
@@ -33,9 +36,16 @@ export function ensureOperatorApprovalResolutionRefs(db: DatabaseSync): void {
       ) {
         throw new Error("operator approval row cannot be assigned a transport reference");
       }
+      const presentation =
+        typeof row.presentation_json === "string"
+          ? safeParseJsonRecord(row.presentation_json)
+          : undefined;
+      const instanceId =
+        typeof presentation?.instanceId === "string" ? presentation.instanceId : undefined;
       const resolutionRef = buildApprovalResolutionRef({
         approvalId: row.approval_id,
         approvalKind: row.kind,
+        instanceId,
       });
       if (row.resolution_ref !== resolutionRef) {
         update.run(resolutionRef, row.approval_id);

--- a/src/state/openclaw-state-db-legacy-backfills.ts
+++ b/src/state/openclaw-state-db-legacy-backfills.ts
@@ -36,12 +36,11 @@ export function ensureOperatorApprovalResolutionRefs(db: DatabaseSync): void {
       ) {
         throw new Error("operator approval row cannot be assigned a transport reference");
       }
-      const presentation =
+      const rawInstanceId =
         typeof row.presentation_json === "string"
-          ? safeParseJsonRecord(row.presentation_json)
+          ? safeParseJsonRecord(row.presentation_json)?.instanceId
           : undefined;
-      const instanceId =
-        typeof presentation?.instanceId === "string" ? presentation.instanceId : undefined;
+      const instanceId = typeof rawInstanceId === "string" ? rawInstanceId : undefined;
       const resolutionRef = buildApprovalResolutionRef({
         approvalId: row.approval_id,
         approvalKind: row.kind,

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -469,13 +469,14 @@ describe("GatewayChatClient", () => {
     (client as unknown as { client: { request: typeof request } }).client.request = request;
 
     await expect(client.listPluginApprovals()).resolves.toEqual(pending);
-    await expect(client.resolvePluginApproval("plugin:skill-1", "allow-once")).resolves.toEqual({
-      ok: true,
-    });
+    await expect(
+      client.resolvePluginApproval("plugin:skill-1", "allow-once", "instance:plugin-1"),
+    ).resolves.toEqual({ ok: true });
 
     expect(request).toHaveBeenNthCalledWith(1, "plugin.approval.list", {});
     expect(request).toHaveBeenNthCalledWith(2, "plugin.approval.resolve", {
       id: "plugin:skill-1",
+      instanceId: "instance:plugin-1",
       decision: "allow-once",
     });
   });

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -446,13 +446,14 @@ describe("GatewayChatClient", () => {
     (client as unknown as { client: { request: typeof request } }).client.request = request;
 
     await expect(client.listPluginApprovals()).resolves.toEqual(pending);
-    await expect(client.resolvePluginApproval("plugin:skill-1", "allow-once")).resolves.toEqual({
-      ok: true,
-    });
+    await expect(
+      client.resolvePluginApproval("plugin:skill-1", "allow-once", "instance:plugin-1"),
+    ).resolves.toEqual({ ok: true });
 
     expect(request).toHaveBeenNthCalledWith(1, "plugin.approval.list", {});
     expect(request).toHaveBeenNthCalledWith(2, "plugin.approval.resolve", {
       id: "plugin:skill-1",
+      instanceId: "instance:plugin-1",
       decision: "allow-once",
     });
   });

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -469,9 +469,10 @@ export class GatewayChatClient implements TuiBackend {
     return await this.client.request("plugin.approval.list", {});
   }
 
-  async resolvePluginApproval(id: string, decision: TuiApprovalDecision) {
+  async resolvePluginApproval(id: string, decision: TuiApprovalDecision, instanceId?: string) {
     return await this.client.request<{ ok?: boolean }>("plugin.approval.resolve", {
       id,
+      ...(instanceId ? { instanceId } : {}),
       decision,
     });
   }

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -42,6 +42,7 @@ export type TuiTaskSuggestionAcceptMode = NonNullable<TaskSuggestionsAcceptParam
 
 export type TuiPluginApproval = {
   id: string;
+  instanceId?: string;
   request: {
     title: string;
     description?: string | null;
@@ -213,7 +214,11 @@ export type TuiBackend = {
   listModels: (opts?: { agentId?: string }) => Promise<TuiModelChoice[]>;
   listCommands?: (opts?: CommandsListParams) => Promise<CommandEntry[]>;
   listPluginApprovals?: () => Promise<unknown>;
-  resolvePluginApproval?: (id: string, decision: TuiApprovalDecision) => Promise<{ ok?: boolean }>;
+  resolvePluginApproval?: (
+    id: string,
+    decision: TuiApprovalDecision,
+    instanceId?: string,
+  ) => Promise<{ ok?: boolean }>;
   getTaskSuggestionActionCapabilities?: () => TuiTaskSuggestionActionCapabilities;
   listTaskSuggestions?: () => Promise<TaskSuggestion[]>;
   listCloudWorkerProfiles?: () => Promise<string[]>;

--- a/src/tui/tui-plugin-approvals.test.ts
+++ b/src/tui/tui-plugin-approvals.test.ts
@@ -15,6 +15,7 @@ type TestSelector = Component & {
 function approvalPayload(overrides: Record<string, unknown> = {}) {
   return {
     id: "plugin:skill-1",
+    instanceId: "instance:plugin-1",
     request: {
       title: "Apply workspace skill proposal",
       description: "Apply a pending workspace skill proposal into live workspace skills.",
@@ -151,7 +152,11 @@ describe("TUI plugin approvals", () => {
     harness.selectors[0]?.onSelectionChange?.({ value: "allow-once", label: "Allow once" });
     harness.selectors[0]?.onSelect?.({ value: "allow-once", label: "Allow once" });
     await vi.waitFor(() => {
-      expect(harness.resolvePluginApproval).toHaveBeenCalledWith("plugin:skill-1", "allow-once");
+      expect(harness.resolvePluginApproval).toHaveBeenCalledWith(
+        "plugin:skill-1",
+        "allow-once",
+        "instance:plugin-1",
+      );
     });
     expect(harness.closeOverlay).toHaveBeenCalledTimes(1);
     expect(harness.addSystem).toHaveBeenLastCalledWith("workspace skill approval: allowed once");
@@ -427,7 +432,11 @@ describe("TUI plugin approvals", () => {
 
     harness.selectors[0]?.onSelect?.({ value: "allow-once", label: "Allow once" });
     await vi.waitFor(() => {
-      expect(harness.resolvePluginApproval).toHaveBeenCalledWith("plugin:skill-1", "allow-once");
+      expect(harness.resolvePluginApproval).toHaveBeenCalledWith(
+        "plugin:skill-1",
+        "allow-once",
+        "instance:plugin-1",
+      );
     });
   });
 

--- a/src/tui/tui-plugin-approvals.test.ts
+++ b/src/tui/tui-plugin-approvals.test.ts
@@ -15,6 +15,7 @@ type TestSelector = Component & {
 function approvalPayload(overrides: Record<string, unknown> = {}) {
   return {
     id: "plugin:skill-1",
+    instanceId: "instance:plugin-1",
     request: {
       title: "Apply workspace skill proposal",
       description: "Apply a pending workspace skill proposal into live workspace skills.",
@@ -151,7 +152,11 @@ describe("TUI plugin approvals", () => {
     harness.selectors[0]?.onSelectionChange?.({ value: "allow-once", label: "Allow once" });
     harness.selectors[0]?.onSelect?.({ value: "allow-once", label: "Allow once" });
     await vi.waitFor(() => {
-      expect(harness.resolvePluginApproval).toHaveBeenCalledWith("plugin:skill-1", "allow-once");
+      expect(harness.resolvePluginApproval).toHaveBeenCalledWith(
+        "plugin:skill-1",
+        "allow-once",
+        "instance:plugin-1",
+      );
     });
     expect(harness.closeOverlay).toHaveBeenCalledTimes(1);
     expect(harness.addSystem).toHaveBeenLastCalledWith("workspace skill approval: allowed once");
@@ -308,7 +313,11 @@ describe("TUI plugin approvals", () => {
 
     harness.selectors[0]?.onSelect?.({ value: "allow-once", label: "Allow once" });
     await vi.waitFor(() => {
-      expect(harness.resolvePluginApproval).toHaveBeenCalledWith("plugin:skill-1", "allow-once");
+      expect(harness.resolvePluginApproval).toHaveBeenCalledWith(
+        "plugin:skill-1",
+        "allow-once",
+        "instance:plugin-1",
+      );
     });
   });
 

--- a/src/tui/tui-plugin-approvals.ts
+++ b/src/tui/tui-plugin-approvals.ts
@@ -167,6 +167,8 @@ function parseTuiPluginApproval(payload: unknown): TuiPluginApproval | null {
   }
   return {
     id,
+    instanceId:
+      typeof record.instanceId === "string" ? record.instanceId.trim() || undefined : undefined,
     request: {
       title,
       description: typeof request.description === "string" ? request.description : null,
@@ -325,7 +327,11 @@ export function createTuiPluginApprovalController(deps: TuiPluginApprovalControl
         if (!deps.client.resolvePluginApproval) {
           throw new Error("plugin approval resolution is unavailable");
         }
-        const result = await deps.client.resolvePluginApproval(approval.id, decision);
+        const result = await deps.client.resolvePluginApproval(
+          approval.id,
+          decision,
+          approval.instanceId,
+        );
         if (result?.ok === false) {
           stale = true;
         } else {

--- a/src/tui/tui-plugin-approvals.ts
+++ b/src/tui/tui-plugin-approvals.ts
@@ -166,6 +166,8 @@ function parseTuiPluginApproval(payload: unknown): TuiPluginApproval | null {
   }
   return {
     id,
+    instanceId:
+      typeof record.instanceId === "string" ? record.instanceId.trim() || undefined : undefined,
     request: {
       title,
       description: typeof request.description === "string" ? request.description : null,
@@ -333,7 +335,11 @@ export function createTuiPluginApprovalController(deps: TuiPluginApprovalControl
         if (!deps.client.resolvePluginApproval) {
           throw new Error("plugin approval resolution is unavailable");
         }
-        const result = await deps.client.resolvePluginApproval(approval.id, decision);
+        const result = await deps.client.resolvePluginApproval(
+          approval.id,
+          decision,
+          approval.instanceId,
+        );
         if (result?.ok === false) {
           stale = true;
         } else {

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -23,6 +23,8 @@ export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
 
 export type ExecApprovalRequest = {
   id: string;
+  /** Gateway-owned lifecycle identity. Older event producers omit it. */
+  instanceId?: string;
   kind: "exec" | "plugin" | "system-agent";
   request: ExecApprovalRequestPayload;
   pluginTitle?: string;
@@ -126,6 +128,7 @@ function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | nul
   }
   return {
     id,
+    instanceId: normalizeOptionalString(payload.instanceId) ?? undefined,
     kind: "exec",
     request: {
       command,
@@ -194,6 +197,7 @@ function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequest | n
 
   return {
     id,
+    instanceId: normalizeOptionalString(payload.instanceId) ?? undefined,
     kind: "plugin",
     request: {
       command: title,
@@ -227,6 +231,7 @@ function parseSystemAgentApprovalRequested(payload: unknown): ExecApprovalReques
   }
   return {
     id,
+    instanceId: normalizeOptionalString(payload.instanceId) ?? undefined,
     kind: "system-agent",
     request: {
       command,
@@ -265,13 +270,18 @@ export async function resolveApprovalRequest(
   if (approval.kind === "system-agent") {
     await client.request("approval.resolve", {
       id: approval.id,
+      ...(approval.instanceId ? { instanceId: approval.instanceId } : {}),
       kind: "system-agent",
       decision,
     });
     return;
   }
   const method = approval.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
-  await client.request(method, { id: approval.id, decision });
+  await client.request(method, {
+    id: approval.id,
+    ...(approval.instanceId ? { instanceId: approval.instanceId } : {}),
+    decision,
+  });
 }
 
 function pruneExecApprovalQueue(queue: ExecApprovalRequest[]): ExecApprovalRequest[] {

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -25,6 +25,8 @@ export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
 
 export type ExecApprovalRequest = {
   id: string;
+  /** Gateway-owned lifecycle identity. Older event producers omit it. */
+  instanceId?: string;
   kind: "exec" | "plugin" | "system-agent";
   request: ExecApprovalRequestPayload;
   pluginTitle?: string;
@@ -175,6 +177,7 @@ function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | nul
   }
   return {
     id,
+    instanceId: normalizeOptionalString(payload.instanceId) ?? undefined,
     kind: "exec",
     request: {
       command,
@@ -244,6 +247,7 @@ function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequest | n
 
   return {
     id,
+    instanceId: normalizeOptionalString(payload.instanceId) ?? undefined,
     kind: "plugin",
     request: {
       command: title,
@@ -277,6 +281,7 @@ function parseSystemAgentApprovalRequested(payload: unknown): ExecApprovalReques
   }
   return {
     id,
+    instanceId: normalizeOptionalString(payload.instanceId) ?? undefined,
     kind: "system-agent",
     request: {
       command,
@@ -315,13 +320,18 @@ export async function resolveApprovalRequest(
   if (approval.kind === "system-agent") {
     await client.request("approval.resolve", {
       id: approval.id,
+      ...(approval.instanceId ? { instanceId: approval.instanceId } : {}),
       kind: "system-agent",
       decision,
     });
     return;
   }
   const method = approval.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
-  await client.request(method, { id: approval.id, decision });
+  await client.request(method, {
+    id: approval.id,
+    ...(approval.instanceId ? { instanceId: approval.instanceId } : {}),
+    decision,
+  });
 }
 
 function pruneExecApprovalQueue(queue: ExecApprovalRequest[]): ExecApprovalRequest[] {

--- a/ui/src/app/overlays-access.test-support.ts
+++ b/ui/src/app/overlays-access.test-support.ts
@@ -22,9 +22,10 @@ export function deferred<T = unknown>() {
   return { promise, reject, resolve };
 }
 
-export function approval(id: string, createdAtMs: number) {
+export function approval(id: string, createdAtMs: number, instanceId = `${id}:${createdAtMs}`) {
   return {
     id,
+    instanceId,
     createdAtMs,
     expiresAtMs: Date.now() + 60_000,
     request: { command: `echo ${id}` },
@@ -79,10 +80,10 @@ export function createGatewayHarness(
         listener(frame);
       }
     },
-    emitApproval(id: string, createdAtMs: number) {
+    emitApproval(id: string, createdAtMs: number, instanceId?: string) {
       const event: GatewayEventFrame = {
         event: "exec.approval.requested",
-        payload: approval(id, createdAtMs),
+        payload: approval(id, createdAtMs, instanceId),
         type: "event",
       };
       for (const listener of eventListeners) {
@@ -104,6 +105,7 @@ export function createGatewayHarness(
         event: "openclaw.approval.requested",
         payload: {
           id,
+          instanceId: `${id}:${createdAtMs}`,
           createdAtMs,
           expiresAtMs: Date.now() + 60_000,
           request: {

--- a/ui/src/app/overlays-access.test-support.ts
+++ b/ui/src/app/overlays-access.test-support.ts
@@ -22,9 +22,10 @@ export function deferred<T = unknown>() {
   return { promise, reject, resolve };
 }
 
-export function approval(id: string, createdAtMs: number) {
+export function approval(id: string, createdAtMs: number, instanceId = `${id}:${createdAtMs}`) {
   return {
     id,
+    instanceId,
     createdAtMs,
     expiresAtMs: Date.now() + 60_000,
     request: { command: `echo ${id}` },
@@ -78,10 +79,10 @@ export function createGatewayHarness(
         listener(frame);
       }
     },
-    emitApproval(id: string, createdAtMs: number) {
+    emitApproval(id: string, createdAtMs: number, instanceId?: string) {
       const event: GatewayEventFrame = {
         event: "exec.approval.requested",
-        payload: approval(id, createdAtMs),
+        payload: approval(id, createdAtMs, instanceId),
         type: "event",
       };
       for (const listener of eventListeners) {
@@ -103,6 +104,7 @@ export function createGatewayHarness(
         event: "openclaw.approval.requested",
         payload: {
           id,
+          instanceId: `${id}:${createdAtMs}`,
           createdAtMs,
           expiresAtMs: Date.now() + 60_000,
           request: {

--- a/ui/src/app/overlays.approval-replacement.test.ts
+++ b/ui/src/app/overlays.approval-replacement.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./overlays-access.test-support.ts";
 import { createApplicationOverlays } from "./overlays.ts";
 
-function approvalRace(id: string, replacementCreatedAtMs: number) {
+function approvalRace(id: string, replacementInstanceId: string) {
   const resolveAttempt = deferred();
   const request = vi.fn<RequestFn>((method) =>
     method.endsWith(".list") ? Promise.resolve([]) : resolveAttempt.promise,
@@ -18,7 +18,7 @@ function approvalRace(id: string, replacementCreatedAtMs: number) {
   harness.emitApproval(id, 1_000);
   const original = overlays.snapshot.approvalQueue[0];
   const decision = overlays.decideApproval("allow-once");
-  harness.emitApproval(id, replacementCreatedAtMs);
+  harness.emitApproval(id, 1_000, replacementInstanceId);
   return { decision, original, overlays, request, resolveAttempt };
 }
 
@@ -27,7 +27,7 @@ describe("application approval replacement races", () => {
     it(`keeps a refreshed approval owned by its pending decision after ${outcome}`, async () => {
       const { decision, original, overlays, resolveAttempt } = approvalRace(
         "approval-refreshed",
-        1_000,
+        "approval-refreshed:1000",
       );
 
       expect(overlays.snapshot.approvalQueue[0]).not.toBe(original);
@@ -69,7 +69,7 @@ describe("application approval replacement races", () => {
     async ({ error, stale }) => {
       const { decision, overlays, request, resolveAttempt } = approvalRace(
         "approval-reused",
-        2_000,
+        "replacement-instance",
       );
       const listRequestCount = request.mock.calls.filter(([method]) =>
         method.endsWith(".list"),
@@ -83,7 +83,7 @@ describe("application approval replacement races", () => {
       await decision;
 
       expect(overlays.snapshot.approvalQueue).toEqual([
-        expect.objectContaining({ createdAtMs: 2_000, id: "approval-reused" }),
+        expect.objectContaining({ instanceId: "replacement-instance", id: "approval-reused" }),
       ]);
       expect(overlays.snapshot.approvalErrors).toEqual(new Map());
       if (stale) {

--- a/ui/src/app/overlays.approval-replacement.test.ts
+++ b/ui/src/app/overlays.approval-replacement.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import {
+  client,
+  createGatewayHarness,
+  deferred,
+  type RequestFn,
+} from "./overlays-access.test-support.ts";
+import { createApplicationOverlays } from "./overlays.ts";
+
+function approvalRace(id: string, replacementCreatedAtMs: number) {
+  const resolveAttempt = deferred();
+  const request = vi.fn<RequestFn>((method) =>
+    method.endsWith(".list") ? Promise.resolve([]) : resolveAttempt.promise,
+  );
+  const harness = createGatewayHarness(client(request));
+  const overlays = createApplicationOverlays(harness.gateway);
+  harness.emitApproval(id, 1_000);
+  const original = overlays.snapshot.approvalQueue[0];
+  const decision = overlays.decideApproval("allow-once");
+  harness.emitApproval(id, replacementCreatedAtMs);
+  return { decision, original, overlays, request, resolveAttempt };
+}
+
+describe("application approval replacement races", () => {
+  for (const outcome of ["success", "failure"] as const) {
+    it(`keeps a refreshed approval owned by its pending decision after ${outcome}`, async () => {
+      const { decision, original, overlays, resolveAttempt } = approvalRace(
+        "approval-refreshed",
+        1_000,
+      );
+
+      expect(overlays.snapshot.approvalQueue[0]).not.toBe(original);
+      expect(overlays.snapshot.approvalQueue[0]).toMatchObject({
+        createdAtMs: 1_000,
+        id: "approval-refreshed",
+        kind: "exec",
+      });
+
+      if (outcome === "success") {
+        resolveAttempt.resolve({ ok: true });
+      } else {
+        resolveAttempt.reject(new Error("gateway unavailable"));
+      }
+      await decision;
+
+      if (outcome === "success") {
+        expect(overlays.snapshot.approvalQueue).toEqual([]);
+        expect(overlays.snapshot.approvalErrors).toEqual(new Map());
+      } else {
+        expect(overlays.snapshot.approvalQueue).toEqual([
+          expect.objectContaining({ createdAtMs: 1_000, id: "approval-refreshed" }),
+        ]);
+        expect(overlays.snapshot.approvalErrors.get("approval-refreshed")).toBe(
+          "Approval failed: gateway unavailable",
+        );
+      }
+      expect(overlays.snapshot.approvalBusy).toBe(false);
+      overlays.dispose();
+    });
+  }
+
+  it.each([
+    { error: undefined, name: "success", stale: false },
+    { error: "gateway unavailable", name: "failure", stale: false },
+    { error: "unknown or expired approval id", name: "stale failure", stale: true },
+  ])(
+    "keeps a same-id replacement after the original decision's $name",
+    async ({ error, stale }) => {
+      const { decision, overlays, request, resolveAttempt } = approvalRace(
+        "approval-reused",
+        2_000,
+      );
+      const listRequestCount = request.mock.calls.filter(([method]) =>
+        method.endsWith(".list"),
+      ).length;
+
+      if (error) {
+        resolveAttempt.reject(new Error(error));
+      } else {
+        resolveAttempt.resolve({ ok: true });
+      }
+      await decision;
+
+      expect(overlays.snapshot.approvalQueue).toEqual([
+        expect.objectContaining({ createdAtMs: 2_000, id: "approval-reused" }),
+      ]);
+      expect(overlays.snapshot.approvalErrors).toEqual(new Map());
+      if (stale) {
+        expect(request.mock.calls.filter(([method]) => method.endsWith(".list"))).toHaveLength(
+          listRequestCount,
+        );
+      }
+      expect(overlays.snapshot.approvalBusy).toBe(false);
+      overlays.dispose();
+    },
+  );
+});

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -226,6 +226,7 @@ describe("application approval overlays", () => {
 
     expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
       id: "approval-authorized",
+      instanceId: "approval-authorized:1000",
       decision: "allow-once",
     });
     overlays.dispose();
@@ -485,6 +486,7 @@ describe("application approval overlays", () => {
 
     expect(request).toHaveBeenCalledWith("approval.resolve", {
       id: "system-agent:1",
+      instanceId: "system-agent:1:1000",
       kind: "system-agent",
       decision: "allow-once",
     });
@@ -656,6 +658,7 @@ describe("application approval overlays", () => {
 
     expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
       id: "approval-newer",
+      instanceId: "approval-newer:2000",
       decision: "deny",
     });
     expect(overlays.snapshot.approvalQueue.map((entry) => entry.id)).toEqual(["approval-oldest"]);

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -226,6 +226,7 @@ describe("application approval overlays", () => {
 
     expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
       id: "approval-authorized",
+      instanceId: "approval-authorized:1000",
       decision: "allow-once",
     });
     overlays.dispose();
@@ -485,6 +486,7 @@ describe("application approval overlays", () => {
 
     expect(request).toHaveBeenCalledWith("approval.resolve", {
       id: "system-agent:1",
+      instanceId: "system-agent:1:1000",
       kind: "system-agent",
       decision: "allow-once",
     });
@@ -687,6 +689,7 @@ describe("application approval overlays", () => {
 
     expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
       id: "approval-newer",
+      instanceId: "approval-newer:2000",
       decision: "deny",
     });
     expect(overlays.snapshot.approvalQueue.map((entry) => entry.id)).toEqual(["approval-oldest"]);

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -633,16 +633,25 @@ export function createApplicationOverlays(
         operation.grantGeneration === approvalGrantGeneration &&
         readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals &&
         isCurrentClient(operation.client);
+      // A refresh can reconstruct the same approval, while a reused id
+      // with a different creation time denotes a new protected request.
+      const isCurrentApproval = () =>
+        promptState.execApprovalQueue.some(
+          (entry) =>
+            entry.id === active.id &&
+            entry.kind === active.kind &&
+            entry.createdAtMs === active.createdAtMs,
+        );
       publish();
       try {
         await resolveApprovalRequest(client, active, decision);
-        if (!isCurrentOperation()) {
+        if (!isCurrentOperation() || !isCurrentApproval()) {
           return;
         }
         clearResolvedExecApprovalPrompt(promptState, active.id);
       } catch (error) {
         if (isStaleApprovalResolutionError(error)) {
-          if (!isCurrentOperation()) {
+          if (!isCurrentOperation() || !isCurrentApproval()) {
             return;
           }
           clearResolvedExecApprovalPrompt(promptState, active.id);
@@ -653,10 +662,7 @@ export function createApplicationOverlays(
           }
           return;
         }
-        if (
-          isCurrentOperation() &&
-          promptState.execApprovalQueue.some((entry) => entry.id === active.id)
-        ) {
+        if (isCurrentOperation() && isCurrentApproval()) {
           promptState.execApprovalErrors.set(active.id, `Approval failed: ${formatUiError(error)}`);
         }
       } finally {

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -618,14 +618,19 @@ export function createApplicationOverlays(
         operation.grantGeneration === approvalGrantGeneration &&
         readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals &&
         isCurrentClient(operation.client);
-      // A refresh can reconstruct the same approval, while a reused id
-      // with a different creation time denotes a new protected request.
+      // The Gateway owns this lifecycle token. Approval ids are reusable, so
+      // an older decision must never settle or annotate a replacement record.
       const isCurrentApproval = () => {
         const queued = promptState.execApprovalQueue.find((entry) => entry.id === active.id);
         if (!queued) {
           return isProjectedApproval;
         }
-        return queued.kind === active.kind && queued.createdAtMs === active.createdAtMs;
+        return (
+          queued.kind === active.kind &&
+          (active.instanceId
+            ? queued.instanceId === active.instanceId
+            : !queued.instanceId && queued.createdAtMs === active.createdAtMs)
+        );
       };
       publish();
       try {

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -633,14 +633,16 @@ export function createApplicationOverlays(
         operation.grantGeneration === approvalGrantGeneration &&
         readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals &&
         isCurrentClient(operation.client);
-      // A refresh can reconstruct the same approval, while a reused id
-      // with a different creation time denotes a new protected request.
+      // The Gateway owns this lifecycle token. Approval ids are reusable, so
+      // an older decision must never settle or annotate a replacement record.
       const isCurrentApproval = () =>
         promptState.execApprovalQueue.some(
           (entry) =>
             entry.id === active.id &&
             entry.kind === active.kind &&
-            entry.createdAtMs === active.createdAtMs,
+            (active.instanceId
+              ? entry.instanceId === active.instanceId
+              : !entry.instanceId && entry.createdAtMs === active.createdAtMs),
         );
       publish();
       try {

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -618,16 +618,25 @@ export function createApplicationOverlays(
         operation.grantGeneration === approvalGrantGeneration &&
         readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals &&
         isCurrentClient(operation.client);
+      // A refresh can reconstruct the same approval, while a reused id
+      // with a different creation time denotes a new protected request.
+      const isCurrentApproval = () => {
+        const queued = promptState.execApprovalQueue.find((entry) => entry.id === active.id);
+        if (!queued) {
+          return isProjectedApproval;
+        }
+        return queued.kind === active.kind && queued.createdAtMs === active.createdAtMs;
+      };
       publish();
       try {
         await resolveApprovalRequest(client, active, decision);
-        if (!isCurrentOperation()) {
+        if (!isCurrentOperation() || !isCurrentApproval()) {
           return;
         }
         clearResolvedExecApprovalPrompt(promptState, active.id);
       } catch (error) {
         if (isStaleApprovalResolutionError(error)) {
-          if (!isCurrentOperation()) {
+          if (!isCurrentOperation() || !isCurrentApproval()) {
             return;
           }
           clearResolvedExecApprovalPrompt(promptState, active.id);
@@ -638,11 +647,7 @@ export function createApplicationOverlays(
           }
           return;
         }
-        if (
-          isCurrentOperation() &&
-          (isProjectedApproval ||
-            promptState.execApprovalQueue.some((entry) => entry.id === active.id))
-        ) {
+        if (isCurrentOperation() && isCurrentApproval()) {
           promptState.execApprovalErrors.set(active.id, `Approval failed: ${formatUiError(error)}`);
         }
       } finally {

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -353,6 +353,7 @@ describe("sidebar attention refresh ownership", () => {
       expect(decideApproval).toHaveBeenCalledExactlyOnceWith("allow-once", "selected");
       expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
         id: "selected",
+        instanceId: "selected:2",
         decision: "allow-once",
       });
       if (reopen) {

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -94,6 +94,52 @@ suite.define(() => {
     await expect.poll(() => newerRow.getByRole("button", { name: /Deny/ }).isEnabled()).toBe(true);
   });
 
+  it("keeps a reused-id replacement actionable after the older decision fails", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage, { sessionKey: activeSessionKey });
+
+    await currentPage.goto(controlUiSessionUrl(suite.server?.baseUrl ?? "", activeSessionKey));
+    await gateway.waitForRequest("sessions.list");
+    await gateway.deferNext("exec.approval.resolve");
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-reused", "echo original approval", 1_000),
+    );
+    await currentPage.getByText("echo original approval", { exact: true }).waitFor();
+    await currentPage.getByRole("button", { name: "Allow once" }).click();
+
+    // The Gateway broadcasts the old resolution before replying to the decision.
+    await gateway.emitGatewayEvent("exec.approval.resolved", {
+      decision: "allow-once",
+      id: "approval-reused",
+    });
+    await expect
+      .poll(() => currentPage.getByText("echo original approval", { exact: true }).count())
+      .toBe(0);
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-reused", "echo replacement approval", 2_000),
+    );
+    const replacement = currentPage.getByText("echo replacement approval", { exact: true });
+    await replacement.waitFor();
+
+    await gateway.rejectDeferred("exec.approval.resolve", {
+      code: "UNAVAILABLE",
+      message: "gateway unavailable",
+    });
+    await expect.poll(() => replacement.isVisible()).toBe(true);
+    await expect.poll(() => currentPage.locator(".exec-approval-error").count()).toBe(0);
+    const denyButton = currentPage.getByRole("button", { name: "Deny" });
+    await expect.poll(() => denyButton.isEnabled()).toBe(true);
+    await denyButton.click();
+    await expect
+      .poll(async () => (await gateway.getRequests("exec.approval.resolve")).length)
+      .toBe(2);
+    await expect.poll(() => replacement.count()).toBe(0);
+  });
+
   it("keeps approvals passive until the Inbox opens the full queue", async () => {
     if (captureUiProof) {
       await mkdir(proofDir, { recursive: true });

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -17,9 +17,16 @@ const activeSessionKey = "agent:main:main";
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "approval-flow");
 
-function approval(id: string, command: string, createdAtMs: number, sessionKey = activeSessionKey) {
+function approval(
+  id: string,
+  command: string,
+  createdAtMs: number,
+  sessionKey = activeSessionKey,
+  instanceId = `${id}:${createdAtMs}`,
+) {
   return {
     id,
+    instanceId,
     createdAtMs,
     expiresAtMs: Date.now() + 60_000,
     request: { command, agentId: "main", sessionKey },
@@ -120,7 +127,13 @@ suite.define(() => {
       .toBe(0);
     await gateway.emitGatewayEvent(
       "exec.approval.requested",
-      approval("approval-reused", "echo replacement approval", 2_000),
+      approval(
+        "approval-reused",
+        "echo replacement approval",
+        1_000,
+        activeSessionKey,
+        "replacement-instance",
+      ),
     );
     const replacement = currentPage.getByText("echo replacement approval", { exact: true });
     await replacement.waitFor();

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -21,9 +21,16 @@ const activeSessionKey = "agent:main:main";
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "approval-flow");
 
-function approval(id: string, command: string, createdAtMs: number, sessionKey = activeSessionKey) {
+function approval(
+  id: string,
+  command: string,
+  createdAtMs: number,
+  sessionKey = activeSessionKey,
+  instanceId = `${id}:${createdAtMs}`,
+) {
   return {
     id,
+    instanceId,
     createdAtMs,
     expiresAtMs: Date.now() + 60_000,
     request: { command, agentId: "main", sessionKey },
@@ -124,7 +131,13 @@ suite.define(() => {
       .toBe(0);
     await gateway.emitGatewayEvent(
       "exec.approval.requested",
-      approval("approval-reused", "echo replacement approval", 2_000),
+      approval(
+        "approval-reused",
+        "echo replacement approval",
+        1_000,
+        activeSessionKey,
+        "replacement-instance",
+      ),
     );
     const replacement = currentPage.getByText("echo replacement approval", { exact: true });
     await replacement.waitFor();

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -98,6 +98,52 @@ suite.define(() => {
       .toBe(true);
   });
 
+  it("keeps a reused-id replacement actionable after the older decision fails", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage, { sessionKey: activeSessionKey });
+
+    await currentPage.goto(controlUiSessionUrl(suite.server?.baseUrl ?? "", activeSessionKey));
+    await gateway.waitForRequest("sessions.list");
+    await gateway.deferNext("exec.approval.resolve");
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-reused", "echo original approval", 1_000),
+    );
+    await currentPage.getByText("echo original approval", { exact: true }).waitFor();
+    await currentPage.getByRole("button", { name: "Allow once" }).click();
+
+    // The Gateway broadcasts the old resolution before replying to the decision.
+    await gateway.emitGatewayEvent("exec.approval.resolved", {
+      decision: "allow-once",
+      id: "approval-reused",
+    });
+    await expect
+      .poll(() => currentPage.getByText("echo original approval", { exact: true }).count())
+      .toBe(0);
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-reused", "echo replacement approval", 2_000),
+    );
+    const replacement = currentPage.getByText("echo replacement approval", { exact: true });
+    await replacement.waitFor();
+
+    await gateway.rejectDeferred("exec.approval.resolve", {
+      code: "UNAVAILABLE",
+      message: "gateway unavailable",
+    });
+    await expect.poll(() => replacement.isVisible()).toBe(true);
+    await expect.poll(() => currentPage.locator(".exec-approval-error").count()).toBe(0);
+    const denyButton = currentPage.getByRole("button", { name: "Deny" });
+    await expect.poll(() => denyButton.isEnabled()).toBe(true);
+    await denyButton.click();
+    await expect
+      .poll(async () => (await gateway.getRequests("exec.approval.resolve")).length)
+      .toBe(2);
+    await expect.poll(() => replacement.count()).toBe(0);
+  });
+
   it("keeps approvals passive until the sidebar attention chip opens the full queue", async () => {
     if (captureUiProof) {
       await mkdir(proofDir, { recursive: true });

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -246,10 +246,11 @@ describe("ApprovalPage", () => {
     { name: "reviewer", scopes: ["operator.approvals"] },
     { name: "administrator", scopes: ["operator.admin"] },
   ])("allows an authenticated $name to resolve a durable approval", async ({ scopes }) => {
+    const instanceId = "instance-current";
     const request = vi.fn(
       async (method: string): Promise<unknown> =>
         method === "approval.get"
-          ? ({ approval: pendingApproval() } satisfies ApprovalGetResult)
+          ? ({ approval: pendingApproval({ instanceId }) } satisfies ApprovalGetResult)
           : ({ applied: true, approval: allowedApproval() } satisfies ApprovalResolveResult),
     );
     const { page } = createPage({
@@ -263,6 +264,7 @@ describe("ApprovalPage", () => {
 
     expect(request).toHaveBeenCalledWith("approval.resolve", {
       id: "exec:approval-1",
+      instanceId,
       kind: "exec",
       decision: "allow-once",
     });

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -240,10 +240,11 @@ describe("ApprovalPage", () => {
     { name: "reviewer", scopes: ["operator.approvals"] },
     { name: "administrator", scopes: ["operator.admin"] },
   ])("allows an authenticated $name to resolve a durable approval", async ({ scopes }) => {
+    const instanceId = "instance-current";
     const request = vi.fn(
       async (method: string): Promise<unknown> =>
         method === "approval.get"
-          ? ({ approval: pendingApproval() } satisfies ApprovalGetResult)
+          ? ({ approval: pendingApproval({ instanceId }) } satisfies ApprovalGetResult)
           : ({ applied: true, approval: allowedApproval() } satisfies ApprovalResolveResult),
     );
     const { page } = createPage({
@@ -257,6 +258,7 @@ describe("ApprovalPage", () => {
 
     expect(request).toHaveBeenCalledWith("approval.resolve", {
       id: "exec:approval-1",
+      instanceId,
       kind: "exec",
       decision: "allow-once",
     });

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -416,6 +416,7 @@ export class ApprovalPage extends OpenClawLightDomElement {
     try {
       const result = await client.request<ApprovalResolveResult>("approval.resolve", {
         id,
+        ...(approval.instanceId ? { instanceId: approval.instanceId } : {}),
         kind,
         decision,
       });

--- a/ui/src/pages/approval/approval-page.ts
+++ b/ui/src/pages/approval/approval-page.ts
@@ -403,7 +403,6 @@ export class ApprovalPage extends OpenClawLightDomElement {
     ) {
       return;
     }
-    const kind = approval.presentation.kind;
     const generation = ++this.operationGeneration;
     const isCurrentDecision = () =>
       this.isCurrentOperation({ client, generation, id }) && this.hasApprovalGrantAccess;
@@ -417,7 +416,7 @@ export class ApprovalPage extends OpenClawLightDomElement {
       const result = await client.request<ApprovalResolveResult>("approval.resolve", {
         id,
         ...(approval.instanceId ? { instanceId: approval.instanceId } : {}),
-        kind,
+        kind: approval.presentation.kind,
         decision,
       });
       if (!isCurrentDecision()) {
@@ -426,7 +425,7 @@ export class ApprovalPage extends OpenClawLightDomElement {
       if (
         !validateApprovalResolveResult(result) ||
         result.approval.id !== id ||
-        result.approval.presentation.kind !== kind ||
+        result.approval.presentation.kind !== approval.presentation.kind ||
         !appliedDecisionMatches(result, decision)
       ) {
         // The write outcome is unknown. Keep every decision disabled until a

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -253,6 +253,7 @@ describe("AppSidebar session attention", () => {
   it("shows approval attention ahead of a run error", async () => {
     const approval = {
       id: "approval-1",
+      instanceId: "approval-instance-1",
       kind: "exec",
       request: { command: "git status", sessionKey },
       createdAtMs: Date.now(),
@@ -277,6 +278,7 @@ describe("AppSidebar session attention", () => {
     const mainKey = "agent:main:main";
     const approval = {
       id: "approval-main",
+      instanceId: "approval-main-instance",
       kind: "exec",
       request: { command: "git status", sessionKey: mainKey },
       createdAtMs: Date.now(),
@@ -398,6 +400,7 @@ describe("AppSidebar session attention", () => {
       ]);
       const approval = {
         id: "approval-child",
+        instanceId: "approval-child-instance",
         kind: "exec",
         request: { command: "git status", sessionKey: childKey },
         createdAtMs: Date.now(),

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -265,6 +265,7 @@ describe("AppSidebar session attention", () => {
   it("shows approval attention ahead of a run error", async () => {
     const approval = {
       id: "approval-1",
+      instanceId: "approval-instance-1",
       kind: "exec",
       request: { command: "git status", sessionKey },
       createdAtMs: Date.now(),
@@ -289,6 +290,7 @@ describe("AppSidebar session attention", () => {
     const mainKey = "agent:main:main";
     const approval = {
       id: "approval-main",
+      instanceId: "approval-main-instance",
       kind: "exec",
       request: { command: "git status", sessionKey: mainKey },
       createdAtMs: Date.now(),
@@ -415,6 +417,7 @@ describe("AppSidebar session attention", () => {
       ]);
       const approval = {
         id: "approval-child",
+        instanceId: "approval-child-instance",
         kind: "exec",
         request: { command: "git status", sessionKey: childKey },
         createdAtMs: Date.now(),


### PR DESCRIPTION
Related: #114492 (intentional focused split; the source PR is otherwise untouched)

## What Problem This Solves

Fixes an issue where an older approval control could decide a newer approval after an ID was reused. The same race could also remove a replacement approval from the Control UI or attach the older decision's error to it.

## Why This Change Was Made

The Gateway now mints a unique lifecycle instance for every approval and validates it at the final resolution owner. That instance is carried through protocol events, durable presentation state, typed actions, first-party apps, the SDK, MCP/ACP/TUI/CLI clients, and Discord, Slack, Telegram, and iMessage controls. Portable reaction/card bindings now carry the same lifecycle instance through Signal, WhatsApp, Matrix, Google Chat, and Teams to the final Gateway resolver. The Control UI separately reconciles an awaited decision only with the exact approval generation it captured.

The protocol addition is backward compatible: controls that carry an instance fail closed when the ID now names another lifecycle, while shipped tokenless clients retain their existing ID-based route. Existing ID-only resolution-reference digests are unchanged.

## User Impact

Approval controls now authorize only the prompt that created them. Reused-ID replacements remain visible and actionable, stale channel buttons/reactions cannot decide a newer request, and matching current controls continue to resolve normally across first-party surfaces.

## Evidence

- Current-main relevance: the mechanical recovery rebase onto `ca90c248889901294858ebd11a30fd45da273517` preserved the owner-bound patch. The rebased main still resolved approvals by reusable ID alone in `src/gateway/exec-approval-manager.ts`, `src/gateway/server-methods/approval-shared.ts`, the unified protocol schemas, and `ui/src/app/overlays.ts`; `src/gateway/operator-approval-store.ts` intentionally expires terminal rows, so later ID reuse is a supported lifecycle state. Subsequent live-main churn through `ee0d376e0fe976691ea6985357577949bd4def85` changed 56 paths with zero overlap against this PR.
- Owner proof: a transient, uncommitted E2E started an authenticated Gateway, registered the real iMessage plugin/control path, verified a stale lifecycle control returned approval-not-found while `approval.get` remained `pending`, then verified the matching control resolved to `allowed` / `allow-once`. Testbox `tbx_01m155kj14xgkp7kyjrrd9dtvs`, 1/1 passed, wrapper exit 0: https://github.com/openclaw/openclaw/actions/runs/33214239355
- Focused UI unit proof: `node scripts/run-vitest.mjs ui/src/app/overlays.approval-replacement.test.ts`, 5/5 passed. Coverage includes success, ordinary failure, stale/expired failure, and distinct generations with the same timestamp.
- Retained Control UI browser proof after the final repair: the single reused-ID replacement flow passed 1/1 (four unrelated cases skipped). Testbox `tbx_01m1583yj5cn8av75gt9ytfj13`, wrapper exit 0: https://github.com/openclaw/openclaw/actions/runs/33217279661
- Full changed-surface gate: core/core-test/UI/extension/extension-test/app typechecks, formatting, lint, SDK/plugin boundaries, dead-code and import-cycle checks, architecture ratchets, and selected app-support tests passed. Testbox `tbx_01m155y8d4kxwj7xwctx5t2kq1`, wrapper exit 0: https://github.com/openclaw/openclaw/actions/runs/33214662789
- Final attributable CI repairs: Swift protocol generation/check passed on Testbox `tbx_01m157z5fz7pa3m88yphzrxrhb` (https://github.com/openclaw/openclaw/actions/runs/33217113233), and `ui/src/components/sidebar-attention.test.ts` passed 35/35 on Testbox `tbx_01m158a0r6eprarzs7r034e4xd` (https://github.com/openclaw/openclaw/actions/runs/33217494937).
- ClawSweeper P1 fail-before proof: existing portable-runtime assertions failed exactly 3/18 because exec metadata, plugin metadata, and resolved targets dropped `instanceId`; 15 siblings passed. Testbox `tbx_01m158x887b2cr837s2xr7x5kn`: https://github.com/openclaw/openclaw/actions/runs/33218135966
- P1 post-fix/final-effect proof: 89/89 focused tests passed across the portable owner plus Signal, WhatsApp, Matrix, Google Chat, and Teams; the representative Signal regression verifies a stale same-ID lifecycle is retired before the current lifecycle succeeds. Core/core-test/extension/extension-test typechecks, extension lint, import cycles, and plugin boundaries also passed. Testbox `tbx_01m159t7dhs4sfpfzd7knc9p4j`: https://github.com/openclaw/openclaw/actions/runs/33219079064
- Formatting: exact 20-file repair proof `tbx_01m159dgx8zn1nap8mqe7z9ksz` (https://github.com/openclaw/openclaw/actions/runs/33218667430); final compressed Signal test proof `tbx_01m15apng37ybnder4czxgwp3e` (https://github.com/openclaw/openclaw/actions/runs/33220011101).
- Native WhatsApp fail-before/fix proof: the same-ID native-binding regression failed because `old-instance` was absent on Testbox `tbx_01m15bmvb92pvr56vz4evm5xww` (https://github.com/openclaw/openclaw/actions/runs/33220935016). After forwarding `request.instanceId` at `bindPending`, 23/23 native/downstream WhatsApp tests and extension production typecheck passed on `tbx_01m15brqrhhgzesec2k66em3ay` (https://github.com/openclaw/openclaw/actions/runs/33221053040); CI then exposed the generic optional `bindPending` method type; the narrow test-only `bindPending!` correction passed a fresh non-incremental extension-test typecheck locally.
- Fresh Autoreview examined the exact final test-only CI correction and reported no findings (`patch is correct`, confidence 0.99; thread `01a04ac5-0321-72c2-afb2-722871673a1c`).
- Recovery focused proof: ACP lifecycle and reconnect replay, Control UI approval reconciliation, Swift protocol parity, and the retained reused-ID browser flow all passed: Testbox `tbx_01m1adh3crka3ks89gfwmrsvny`, 74/74 focused tests plus protocol check, wrapper exit 0: https://github.com/openclaw/openclaw/actions/runs/33339951810. Exact conflict-file formatting passed on Testbox `tbx_01m1admrcx6jfd0bxd5ckr0bn2`: https://github.com/openclaw/openclaw/actions/runs/33340042237. Fresh full-branch Autoreview reported no actionable findings.\n- Exact-head CI: attempt 2 passed every selected job, including `openclaw/ci-gate`, at head `8300e46d4a5db58c4f847d60d94bde644bad6fe9`: https://github.com/openclaw/openclaw/actions/runs/33340158264\n- Topology: range-diff preserves all 18 lifecycle commits from source head `db85299d89b88aa9dcc72f049ed85f2558ef1731`. The mechanical recovery rebase moved prior head `24e115e2e807cc5c7f6f13df72ce52e93842a826` onto `ca90c248889901294858ebd11a30fd45da273517`; the current exact head is `8300e46d4a5db58c4f847d60d94bde644bad6fe9`.
- LOC: total +1179/-124 across 115 files; classified production/support +569/-104 and tests +610/-20. The positive production delta is the additive lifecycle capability propagated across every decision producer/consumer plus generated first-party protocol models; keeping it at one client would leave sibling stale controls authoritative.

Visual proof shows the reused-ID replacement arriving, remaining actionable after the older decision fails, and resolving normally. Capture code and media are not committed.

Replacement arrives while the older same-ID decision is pending:

![Replacement approval arrives](https://github.com/user-attachments/assets/63dc003b-9faf-4253-86b7-81944b5cb1da)

Replacement remains actionable after the older decision fails:

![Replacement approval remains actionable](https://github.com/user-attachments/assets/ec473fc7-c626-4d49-89bf-750e4671026d)

Replacement resolves normally:

![Replacement approval resolved](https://github.com/user-attachments/assets/389a1cd4-ec0e-4c8d-bad8-434c6077be89)

