### PR TITLE
fix(tasks): wake queued completion events

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1747,7 +1747,9 @@ describe("runHeartbeatOnce", () => {
       agents: {
         defaults: {
           workspace: workspaceDir,
-          ...(params.unscheduled ? {} : { heartbeat: { every: "5m", target: "whatsapp" } }),
+          heartbeat: params.unscheduled
+            ? { every: "0m", target: "whatsapp" }
+            : { every: "5m", target: "whatsapp" },
         },
       },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -2017,6 +2019,7 @@ tasks:
         fileState: "empty",
         source: "background-task",
         reason: "background-task",
+        unscheduled: true,
         queueSystemEvent: true,
         expectedStatus: "ran",
         expectedSendCalls: 1,
@@ -2029,6 +2032,7 @@ tasks:
         fileState: "empty",
         source: "background-task-blocked",
         reason: "background-task-blocked",
+        unscheduled: true,
         queueSystemEvent: true,
         expectedStatus: "ran",
         expectedSendCalls: 1,

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1708,8 +1708,8 @@ describe("runHeartbeatOnce", () => {
 
   async function runHeartbeatScratchScenario(params: {
     fileState: HeartbeatScratchState;
-    source?: "notifications-event";
-    reason?: "interval" | "wake";
+    source?: "notifications-event" | "background-task" | "background-task-blocked";
+    reason?: "interval" | "wake" | "background-task" | "background-task-blocked";
     unscheduled?: boolean;
     queueCronEvent?: boolean;
     queueSystemEvent?: boolean;
@@ -1962,8 +1962,8 @@ tasks:
     const cases: Array<{
       name: string;
       fileState: HeartbeatScratchState;
-      reason?: "interval" | "wake";
-      source?: "notifications-event";
+      reason?: "interval" | "wake" | "background-task" | "background-task-blocked";
+      source?: "notifications-event" | "background-task" | "background-task-blocked";
       unscheduled?: boolean;
       queueCronEvent?: boolean;
       queueSystemEvent?: boolean;
@@ -1972,6 +1972,7 @@ tasks:
       expectedSendCalls: number;
       expectedReplyCalls: number;
       expectCronContext?: boolean;
+      expectedVisibleReplyMarker?: string;
       replyText?: string;
     }> = [
       {
@@ -2010,6 +2011,30 @@ tasks:
         expectedSendCalls: 1,
         expectedReplyCalls: 1,
         replyText: "post-update event processed",
+      },
+      {
+        name: "empty file + background task wake runs",
+        fileState: "empty",
+        source: "background-task",
+        reason: "background-task",
+        queueSystemEvent: true,
+        expectedStatus: "ran",
+        expectedSendCalls: 1,
+        expectedReplyCalls: 1,
+        expectedVisibleReplyMarker: "background task result processed",
+        replyText: "background task result processed",
+      },
+      {
+        name: "empty file + blocked background task wake runs",
+        fileState: "empty",
+        source: "background-task-blocked",
+        reason: "background-task-blocked",
+        queueSystemEvent: true,
+        expectedStatus: "ran",
+        expectedSendCalls: 1,
+        expectedReplyCalls: 1,
+        expectedVisibleReplyMarker: "blocked background task follow-up processed",
+        replyText: "blocked background task follow-up processed",
       },
       {
         name: "empty file + queued cron interval runs",
@@ -2072,16 +2097,28 @@ tasks:
       expectedReplyCalls,
       expectedSendCalls,
       expectCronContext,
+      expectedVisibleReplyMarker,
       ...scenario
     } of cases) {
       const { res, replySpy, sendWhatsApp } = await runHeartbeatScratchScenario(scenario);
       try {
-        expect(res.status, name).toBe(expectedStatus);
-        if (res.status === "skipped") {
-          expect(res.reason, name).toBe(expectedSkipReason);
+        expect(
+          {
+            status: res.status,
+            skipReason: res.status === "skipped" ? res.reason : undefined,
+            replyCalls: replySpy.mock.calls.length,
+            sendCalls: sendWhatsApp.mock.calls.length,
+          },
+          name,
+        ).toEqual({
+          status: expectedStatus,
+          skipReason: expectedSkipReason,
+          replyCalls: expectedReplyCalls,
+          sendCalls: expectedSendCalls,
+        });
+        if (expectedVisibleReplyMarker) {
+          expect(sendWhatsApp.mock.calls[0]?.[1], name).toContain(expectedVisibleReplyMarker);
         }
-        expect(replySpy, name).toHaveBeenCalledTimes(expectedReplyCalls);
-        expect(sendWhatsApp, name).toHaveBeenCalledTimes(expectedSendCalls);
         if (expectCronContext) {
           const calledCtx = replyBody(replySpy);
           expect(calledCtx.Provider, name).toBe("cron-event");

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -986,12 +986,16 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  const unscheduledAgentConfig = {
+    agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
+  } as OpenClawConfig;
+
   it.each([
     {
       name: "an agent without a heartbeat schedule",
-      cfg: {
-        agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
-      } as OpenClawConfig,
+      source: "notifications-event" as const,
+      reason: "wake",
+      cfg: unscheduledAgentConfig,
       agentId: "ops",
       sessionKey: "agent:ops:main",
       heartbeat: { target: "last" },
@@ -1002,30 +1006,52 @@ describe("startHeartbeatRunner", () => {
         agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
         session: { scope: "global" },
       } as OpenClawConfig,
+      source: "notifications-event" as const,
+      reason: "wake",
       agentId: "main",
       sessionKey: "global",
       heartbeat: { every: "0m", target: "last" },
     },
-  ])("runs one targeted notification wake for $name", async (testCase) => {
+    {
+      name: "an unscheduled agent after task completion",
+      source: "background-task" as const,
+      reason: "background-task",
+      cfg: unscheduledAgentConfig,
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
+      heartbeat: undefined,
+    },
+    {
+      name: "an unscheduled agent after a blocked task follow-up",
+      source: "background-task-blocked" as const,
+      reason: "background-task-blocked",
+      cfg: unscheduledAgentConfig,
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
+      heartbeat: undefined,
+    },
+  ])("runs one targeted $source wake for $name", async (testCase) => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     const runner = await expectWakeDispatch({
       cfg: testCase.cfg,
       runSpy,
       wake: {
-        source: "notifications-event",
+        source: testCase.source,
         intent: "immediate",
-        reason: "wake",
+        reason: testCase.reason,
         ...(testCase.sessionKey === "global" ? { agentId: testCase.agentId } : {}),
         sessionKey: testCase.sessionKey,
-        heartbeat: { target: "last" },
+        ...(testCase.heartbeat
+          ? { heartbeat: { ...testCase.heartbeat, target: "last" as const } }
+          : {}),
         coalesceMs: 0,
       },
       expectedCall: {
         agentId: testCase.agentId,
-        source: "notifications-event",
+        source: testCase.source,
         intent: "immediate",
-        reason: "wake",
+        reason: testCase.reason,
         sessionKey: testCase.sessionKey,
         heartbeat: testCase.heartbeat,
       },

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -986,16 +986,12 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
-  const unscheduledAgentConfig = {
-    agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
-  } as OpenClawConfig;
-
   it.each([
     {
       name: "an agent without a heartbeat schedule",
-      source: "notifications-event" as const,
-      reason: "wake",
-      cfg: unscheduledAgentConfig,
+      cfg: {
+        agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
+      } as OpenClawConfig,
       agentId: "ops",
       sessionKey: "agent:ops:main",
       heartbeat: { target: "last" },
@@ -1006,52 +1002,30 @@ describe("startHeartbeatRunner", () => {
         agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
         session: { scope: "global" },
       } as OpenClawConfig,
-      source: "notifications-event" as const,
-      reason: "wake",
       agentId: "main",
       sessionKey: "global",
       heartbeat: { every: "0m", target: "last" },
     },
-    {
-      name: "an unscheduled agent after task completion",
-      source: "background-task" as const,
-      reason: "background-task",
-      cfg: unscheduledAgentConfig,
-      agentId: "ops",
-      sessionKey: "agent:ops:main",
-      heartbeat: undefined,
-    },
-    {
-      name: "an unscheduled agent after a blocked task follow-up",
-      source: "background-task-blocked" as const,
-      reason: "background-task-blocked",
-      cfg: unscheduledAgentConfig,
-      agentId: "ops",
-      sessionKey: "agent:ops:main",
-      heartbeat: undefined,
-    },
-  ])("runs one targeted $source wake for $name", async (testCase) => {
+  ])("runs one targeted notification wake for $name", async (testCase) => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     const runner = await expectWakeDispatch({
       cfg: testCase.cfg,
       runSpy,
       wake: {
-        source: testCase.source,
+        source: "notifications-event",
         intent: "immediate",
-        reason: testCase.reason,
+        reason: "wake",
         ...(testCase.sessionKey === "global" ? { agentId: testCase.agentId } : {}),
         sessionKey: testCase.sessionKey,
-        ...(testCase.heartbeat
-          ? { heartbeat: { ...testCase.heartbeat, target: "last" as const } }
-          : {}),
+        heartbeat: { target: "last" },
         coalesceMs: 0,
       },
       expectedCall: {
         agentId: testCase.agentId,
-        source: testCase.source,
+        source: "notifications-event",
         intent: "immediate",
-        reason: testCase.reason,
+        reason: "wake",
         sessionKey: testCase.sessionKey,
         heartbeat: testCase.heartbeat,
       },

--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -1,14 +1,13 @@
-// Tests hook-source heartbeat wake dispatch for agents without a recurring
-// heartbeat schedule. Split out of heartbeat-runner.scheduler.test.ts so that
-// file stays inside the oxlint max-lines budget; these tests cover the
-// `isTargetedImmediateHookWake` path that lets a scoped hook wake run once for
-// a known but unscheduled agent (and rejects unconfigured targets).
+// Tests targeted unscheduled heartbeat wake dispatch for configured agents
+// without a recurring heartbeat schedule. Split out of
+// heartbeat-runner.scheduler.test.ts so that file stays inside the oxlint
+// max-lines budget.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState, type OpenClawConfig } from "../config/config.js";
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
 import { requestHeartbeat } from "./heartbeat-wake.js";
 
-describe("startHeartbeatRunner hook wake targeting", () => {
+describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
   type RunOnce = Parameters<typeof startHeartbeatRunner>[0]["runOnce"];
   type MockRunOnce = RunOnce & { mock: { calls: unknown[][] } };
   const TEST_SCHEDULER_SEED = "heartbeat-runner-test-seed";
@@ -98,6 +97,38 @@ describe("startHeartbeatRunner hook wake targeting", () => {
     });
     runner.stop();
   });
+
+  it.each([
+    { source: "background-task", reason: "background-task" },
+    { source: "background-task-blocked", reason: "background-task-blocked" },
+  ] as const)(
+    "runs one targeted unscheduled $source wake for a configured agent",
+    async ({ source, reason }) => {
+      useFakeHeartbeatTime();
+      const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+      const runner = await expectWakeDispatch({
+        cfg: {
+          agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
+        } as OpenClawConfig,
+        runSpy,
+        wake: {
+          source,
+          intent: "immediate",
+          reason,
+          sessionKey: "agent:ops:main",
+          coalesceMs: 0,
+        },
+        expectedCall: {
+          agentId: "ops",
+          source,
+          intent: "immediate",
+          reason,
+          sessionKey: "agent:ops:main",
+        },
+      });
+      runner.stop();
+    },
+  );
 
   it("rejects targeted hook wakes for unconfigured agents", async () => {
     useFakeHeartbeatTime();

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -59,33 +59,29 @@ type TargetedImmediateWakeParams = {
   sessionKey?: string;
 };
 
-function isTargetedImmediateSystemEventWake(params: TargetedImmediateWakeParams): boolean {
-  return (
-    params.source === "notifications-event" &&
-    params.intent === "immediate" &&
-    params.reason?.trim() === "wake" &&
-    normalizeOptionalString(params.sessionKey) !== undefined
-  );
-}
-
-/**
- * Hook result/failure wakes carry an explicit agent or session target and must be able
- * to wake a known agent that has no recurring heartbeat schedule; otherwise the
- * queued hook event sits unread. This is the hook counterpart of
- * `isTargetedImmediateSystemEventWake` — narrowly gated to targeted hook sources.
- */
-function isTargetedImmediateHookWake(params: TargetedImmediateWakeParams): boolean {
-  return (
-    params.source === "hook" &&
-    params.intent === "immediate" &&
-    (params.reason?.trim().startsWith("hook:") ?? false) &&
-    (normalizeOptionalString(params.agentId) !== undefined ||
-      normalizeOptionalString(params.sessionKey) !== undefined)
-  );
-}
-
 export function isTargetedImmediateUnscheduledWake(params: TargetedImmediateWakeParams): boolean {
-  return isTargetedImmediateSystemEventWake(params) || isTargetedImmediateHookWake(params);
+  if (params.intent !== "immediate") {
+    return false;
+  }
+  const hasSessionTarget = normalizeOptionalString(params.sessionKey) !== undefined;
+  const hasTarget = hasSessionTarget || normalizeOptionalString(params.agentId) !== undefined;
+  if (!hasTarget) {
+    return false;
+  }
+
+  // These sources queue targeted events that would otherwise sit unread for a
+  // configured agent without a recurring heartbeat schedule.
+  switch (params.source) {
+    case "notifications-event":
+      return hasSessionTarget && params.reason?.trim() === "wake";
+    case "hook":
+      return params.reason?.trim().startsWith("hook:") ?? false;
+    case "background-task":
+    case "background-task-blocked":
+      return true;
+    default:
+      return false;
+  }
 }
 
 export function isConfiguredHeartbeatAgent(cfg: OpenClawConfig, agentId: string): boolean {

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -45,6 +45,8 @@ export function resolveHeartbeatWakePayloadFlags(params: {
       source === "hook" ||
       source === "acp-spawn" ||
       source === "session-state" ||
+      source === "background-task" ||
+      source === "background-task-blocked" ||
       reason === "wake",
   };
 }


### PR DESCRIPTION
Closes #123067

## What Problem This Solves

Background-task completion and blocked-follow-up events could remain queued without their requested proactive turn in two cases: heartbeat scratch existed but was empty, or the requester belonged to a configured agent without a recurring heartbeat schedule.

## Why This Change Was Made

Task delivery already records the terminal event in the requester session and requests an immediate, explicitly targeted wake. The heartbeat owner did not classify the two task sources as payload-bearing, and its one-shot unscheduled admission named only notification and hook events.

The canonical wake policy now treats both task sources as queued payload and admits their immediate targeted turn for configured agents. The configured-agent and global heartbeat-enable gates remain authoritative, and the one-shot wake does not enroll an agent in recurring scheduling. The existing source-family predicates were consolidated into one closed decision, leaving production code net smaller.

## User Impact

Background task results and blocked follow-ups are delivered proactively instead of remaining silently `session_queued` until an unrelated later interaction—or being lost on restart. Agents do not need a recurring heartbeat schedule solely to receive their own task completion.

## Evidence

- Tests-first reproduction: empty-scratch task wakes skipped before payload classification; configured unscheduled task wakes returned `disabled` before one-shot admission.
- Exact-head focused proof: 59/59 passed across the targeted-unscheduled scheduler boundary and direct heartbeat execution.
- Scheduler coverage uses the existing split-out targeted-wake owner, preserving hook cases while proving both task sources for configured agents without a cadence.
- Exact-head hosted changed gate passed on Testbox `tbx_01kzx8x1hp0m4eff9jt7kw5e0g`; Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31688967670.
- Isolated restart stress proof passed 1/1 (`gateway-restart-inflight-run`) with zero failures/skips on Testbox `tbx_01kzx40pw8805368tzhfkcbt5w`; Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31682511059.
- Final integrated Codex autoreview: clean, no findings, confidence 0.98; TruffleHog clean.
- Exact-head CI completed green: https://github.com/openclaw/openclaw/actions/runs/31688904168.

Production delta: +24/-26, net -2. Tests: +88/-16, net +72.
