### PR TITLE
feat(android): unify chat composer with iOS and web design

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -12875,7 +12875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 424,
+      "line": 433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -12883,7 +12883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -12891,7 +12891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 703,
+      "line": 712,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -12899,7 +12899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1054,
+      "line": 1063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -12907,7 +12907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1134,
+      "line": 1143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Show Sidebar",
       "surface": "android",
@@ -12915,7 +12915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1150,
+      "line": 1159,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -12923,7 +12923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1151,
+      "line": 1160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -12931,7 +12931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1152,
+      "line": 1161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -12939,7 +12939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1165,
+      "line": 1174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -12947,7 +12947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1170,
+      "line": 1179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -12955,7 +12955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1189,
+      "line": 1198,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dashboard",
       "surface": "android",
@@ -12963,7 +12963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1197,
+      "line": 1206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -12971,7 +12971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1218,
+      "line": 1227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -12979,7 +12979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1416,
+      "line": 1425,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -12987,7 +12987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1418,
+      "line": 1427,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -12995,7 +12995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1470,
+      "line": 1479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading thread",
       "surface": "android",
@@ -13003,7 +13003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1503,
+      "line": 1512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -13011,7 +13011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1577,
+      "line": 1586,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -13019,7 +13019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1581,
+      "line": 1590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -13027,7 +13027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1583,
+      "line": 1592,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -13035,7 +13035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1585,
+      "line": 1594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -13043,7 +13043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1608,
+      "line": 1617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -13051,7 +13051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1609,
+      "line": 1618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -13059,7 +13059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1668,
+      "line": 1677,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -13067,7 +13067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1669,
+      "line": 1678,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent threads and next steps.",
       "surface": "android",
@@ -13075,7 +13075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1670,
+      "line": 1679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
       "surface": "android",
@@ -13083,7 +13083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1674,
+      "line": 1683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -13091,7 +13091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1675,
+      "line": 1684,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -13099,7 +13099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1676,
+      "line": 1685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -13107,7 +13107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1680,
+      "line": 1689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -13115,7 +13115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1681,
+      "line": 1690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -13123,7 +13123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1682,
+      "line": 1691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -13131,7 +13131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1766,
+      "line": 1775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -13139,7 +13139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1767,
+      "line": 1776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -13147,7 +13147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1768,
+      "line": 1777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -13155,7 +13155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1769,
+      "line": 1778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -13163,7 +13163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1808,
+      "line": 1817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Image",
       "surface": "android",
@@ -13171,279 +13171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1824,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Additional images hidden: ${omittedImageCount}",
-      "surface": "android",
-      "id": "native.android.952a88e71b4aaee4"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1879,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Preparing audio…",
-      "surface": "android",
-      "id": "native.android.5aafbef3744d86f3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1879,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Speaking…",
-      "surface": "android",
-      "id": "native.android.d7919c440a82f426"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1910,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Close",
-      "surface": "android",
-      "id": "native.android.bd78ce1e86e900b3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1910,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "View all",
-      "surface": "android",
-      "id": "native.android.b686b1bc61494ee2"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1940,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Tools running",
-      "surface": "android",
-      "id": "native.android.781f84dfaf7da9d6"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1944,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "OpenClaw is working",
-      "surface": "android",
-      "id": "native.android.d851a32f367f8b31"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1949,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "+${toolCalls.size - 4} more",
-      "surface": "android",
-      "id": "native.android.0fd6b75cadc0ce75"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1969,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "+${moreWorkingCount} more working",
-      "surface": "android",
-      "id": "native.android.f2da5ffc1adaad58"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2040,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "+${diff.added}",
-      "surface": "android",
-      "id": "native.android.db391c2712f7340b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2043,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "−${diff.removed}",
-      "surface": "android",
-      "id": "native.android.babb72da2d6270a2"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2068,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Subagent working",
-      "surface": "android",
-      "id": "native.android.e58b3c8805c79bd0"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2070,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Subagent failed",
-      "surface": "android",
-      "id": "native.android.bdfea93e16940c82"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2071,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Subagent cancelled",
-      "surface": "android",
-      "id": "native.android.9fde542e43b4e73b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2072,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Subagent finished",
-      "surface": "android",
-      "id": "native.android.0bba48c12caa076a"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 2135,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "$completedCount/${steps.size}",
-      "surface": "android",
-      "id": "native.android.22d747642a3887cd"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2142,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Collapse plan checklist",
-      "surface": "android",
-      "id": "native.android.5d9378441e3bb86e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2142,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Expand plan checklist",
-      "surface": "android",
-      "id": "native.android.cc46adc71637695d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2275,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Dismiss shared-image warning",
-      "surface": "android",
-      "id": "native.android.f3806d79e43f568f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2379,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Stop",
-      "surface": "android",
-      "id": "native.android.76d574acfac94fee"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2466,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Switch branch",
-      "surface": "android",
-      "id": "native.android.be42506226307680"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2490,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Untitled branch",
-      "surface": "android",
-      "id": "native.android.39ea147abba2af8a"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2505,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Current branch",
-      "surface": "android",
-      "id": "native.android.4e2cbf557e2e3cd6"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2517,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Messages: $count",
-      "surface": "android",
-      "id": "native.android.d79a4188788ccf49"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2525,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "$count · $updated",
-      "surface": "android",
-      "id": "native.android.76e548dffafc9de9"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2554,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Default",
-      "surface": "android",
-      "id": "native.android.2cb3ec7379426dfe"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2620,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Pin model",
-      "surface": "android",
-      "id": "native.android.f8d0f6ba7608abc3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2620,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Unpin model",
-      "surface": "android",
-      "id": "native.android.09a13ed8f039a9c3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2637,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "No commands found",
-      "surface": "android",
-      "id": "native.android.5953c956ff208e6e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2679,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Command",
-      "surface": "android",
-      "id": "native.android.b1a0dca9f421aaaa"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2699,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Gateway offline",
-      "surface": "android",
-      "id": "native.android.8e3e367df24cae4b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2745,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Close thinking level selector",
-      "surface": "android",
-      "id": "native.android.36ed01582459bc10"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2745,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Open thinking level selector",
-      "surface": "android",
-      "id": "native.android.82d6389036a1e211"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2811,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Attach image",
-      "surface": "android",
-      "id": "native.android.623e434c83e3c020"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2816,
+      "line": 1828,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -13451,15 +13179,279 @@
     },
     {
       "kind": "ui-call",
-      "line": 2821,
+      "line": 1833,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Attach video",
+      "source": "Additional images hidden: ${omittedImageCount}",
       "surface": "android",
-      "id": "native.android.1bf18cef7a720c58"
+      "id": "native.android.952a88e71b4aaee4"
     },
     {
       "kind": "ui-call",
-      "line": 2852,
+      "line": 1888,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Preparing audio…",
+      "surface": "android",
+      "id": "native.android.5aafbef3744d86f3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1888,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Speaking…",
+      "surface": "android",
+      "id": "native.android.d7919c440a82f426"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1919,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Close",
+      "surface": "android",
+      "id": "native.android.bd78ce1e86e900b3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1919,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "View all",
+      "surface": "android",
+      "id": "native.android.b686b1bc61494ee2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1949,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Tools running",
+      "surface": "android",
+      "id": "native.android.781f84dfaf7da9d6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1953,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "OpenClaw is working",
+      "surface": "android",
+      "id": "native.android.d851a32f367f8b31"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1958,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "+${toolCalls.size - 4} more",
+      "surface": "android",
+      "id": "native.android.0fd6b75cadc0ce75"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1978,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "+${moreWorkingCount} more working",
+      "surface": "android",
+      "id": "native.android.f2da5ffc1adaad58"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2049,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "+${diff.added}",
+      "surface": "android",
+      "id": "native.android.db391c2712f7340b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2052,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "−${diff.removed}",
+      "surface": "android",
+      "id": "native.android.babb72da2d6270a2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2077,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Subagent working",
+      "surface": "android",
+      "id": "native.android.e58b3c8805c79bd0"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2079,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Subagent failed",
+      "surface": "android",
+      "id": "native.android.bdfea93e16940c82"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2080,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Subagent cancelled",
+      "surface": "android",
+      "id": "native.android.9fde542e43b4e73b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2081,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Subagent finished",
+      "surface": "android",
+      "id": "native.android.0bba48c12caa076a"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 2144,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "$completedCount/${steps.size}",
+      "surface": "android",
+      "id": "native.android.22d747642a3887cd"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2151,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Collapse plan checklist",
+      "surface": "android",
+      "id": "native.android.5d9378441e3bb86e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2151,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Expand plan checklist",
+      "surface": "android",
+      "id": "native.android.cc46adc71637695d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2284,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Dismiss shared-image warning",
+      "surface": "android",
+      "id": "native.android.f3806d79e43f568f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2411,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Switch branch",
+      "surface": "android",
+      "id": "native.android.be42506226307680"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2435,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Untitled branch",
+      "surface": "android",
+      "id": "native.android.39ea147abba2af8a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2450,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Current branch",
+      "surface": "android",
+      "id": "native.android.4e2cbf557e2e3cd6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2462,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Messages: $count",
+      "surface": "android",
+      "id": "native.android.d79a4188788ccf49"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2470,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "$count · $updated",
+      "surface": "android",
+      "id": "native.android.76e548dffafc9de9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2499,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Default",
+      "surface": "android",
+      "id": "native.android.2cb3ec7379426dfe"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2565,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Pin model",
+      "surface": "android",
+      "id": "native.android.f8d0f6ba7608abc3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2565,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Unpin model",
+      "surface": "android",
+      "id": "native.android.09a13ed8f039a9c3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2582,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "No commands found",
+      "surface": "android",
+      "id": "native.android.5953c956ff208e6e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2624,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Command",
+      "surface": "android",
+      "id": "native.android.b1a0dca9f421aaaa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2644,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Gateway offline",
+      "surface": "android",
+      "id": "native.android.8e3e367df24cae4b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2706,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Add attachment",
+      "surface": "android",
+      "id": "native.android.3fea3a91bbd7ee4e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2710,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Photos",
+      "surface": "android",
+      "id": "native.android.9db5d4b832ddaf20"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2714,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Videos",
+      "surface": "android",
+      "id": "native.android.827fd291f6fd3120"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2718,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Files",
+      "surface": "android",
+      "id": "native.android.8c3f70be12db2b69"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -13467,7 +13459,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 2881,
+      "line": 2823,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Context ${contextPercent}% used",
+      "surface": "android",
+      "id": "native.android.96cbc35556fd6f2e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2836,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "${contextPercent}%",
+      "surface": "android",
+      "id": "native.android.3332655e560cb682"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2873,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -13475,7 +13483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2881,
+      "line": 2873,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -13483,7 +13491,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 2981,
+      "line": 2908,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Stop",
+      "surface": "android",
+      "id": "native.android.76d574acfac94fee"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -13491,7 +13507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2990,
+      "line": 2997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -13499,7 +13515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3002,
+      "line": 3009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -13507,7 +13523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3011,
+      "line": 3018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -13515,7 +13531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3012,
+      "line": 3019,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -13523,7 +13539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3019,
+      "line": 3026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -13531,7 +13547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3078,
+      "line": 3085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -13539,7 +13555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3089,
+      "line": 3096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -13547,7 +13563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3090,
+      "line": 3097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -13555,7 +13571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3091,
+      "line": 3098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -13563,31 +13579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3110,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Context ${(it * 100).roundToInt()}%",
-      "surface": "android",
-      "id": "native.android.4d756c15804130ff"
-    },
-    {
-      "kind": "ui-call",
-      "line": 3111,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Context --",
-      "surface": "android",
-      "id": "native.android.5d9cafb38a925db9"
-    },
-    {
-      "kind": "ui-call",
-      "line": 3112,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
-      "surface": "android",
-      "id": "native.android.4e6c67df44d588d3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 3151,
+      "line": 3146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -13595,7 +13587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3152,
+      "line": 3147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -13603,7 +13595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3153,
+      "line": 3148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -13611,7 +13603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3154,
+      "line": 3149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -13619,7 +13611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3155,
+      "line": 3150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -13627,7 +13619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3156,
+      "line": 3151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -13635,7 +13627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3157,
+      "line": 3152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -13643,7 +13635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3158,
+      "line": 3153,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -121,9 +122,11 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Photo
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -153,11 +156,14 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -216,16 +222,19 @@ internal fun chatReaderListBottomInset(showJumpToLatest: Boolean): Dp =
 internal enum class ChatComposerTrailingAction {
   StartTalk,
   StopTalk,
+  Stop,
   Send,
 }
 
 /** Talk must remain stoppable even when the active session adds text to the draft. */
 internal fun resolveChatComposerTrailingAction(
   talkActive: Boolean,
+  runActive: Boolean,
   sendEnabled: Boolean,
 ): ChatComposerTrailingAction =
   when {
     talkActive -> ChatComposerTrailingAction.StopTalk
+    runActive -> ChatComposerTrailingAction.Stop
     sendEnabled -> ChatComposerTrailingAction.Send
     else -> ChatComposerTrailingAction.StartTalk
   }
@@ -2280,26 +2289,6 @@ private fun ChatComposer(
       AttachmentStrip(attachments = attachments, onRemoveAttachment = onRemoveAttachment)
     }
 
-    Row(
-      modifier = Modifier.fillMaxWidth(),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-      ChatModelChip(
-        label = selectedModelLabel,
-        enabled = modelPickerEnabled,
-        onClick = onOpenModelPicker,
-        modifier = Modifier.weight(1f),
-      )
-      ChatContextMeter(
-        thinkingLevel = thinkingLevel,
-        thinkingSupported = thinkingSupported,
-        expanded = thinkingSelectorExpanded,
-        contextUsage = contextUsage,
-        onClick = { thinkingSelectorExpanded = !thinkingSelectorExpanded },
-      )
-    }
-
     if (thinkingSelectorExpanded && thinkingSupported) {
       ChatThinkingLevelSelector(
         options = thinkingOptions,
@@ -2343,8 +2332,17 @@ private fun ChatComposer(
           onToggleDictation = onToggleDictation,
           talkActive = talkActive,
           onToggleTalk = onToggleTalk,
+          runActive = pendingRunCount > 0,
+          onAbort = onAbort,
           sendEnabled = sendEnabled,
           onSend = onSend,
+          selectedModelLabel = selectedModelLabel,
+          modelPickerEnabled = modelPickerEnabled,
+          onOpenModelPicker = onOpenModelPicker,
+          thinkingLevel = thinkingLevel,
+          thinkingSupported = thinkingSupported,
+          onToggleThinkingSelector = { thinkingSelectorExpanded = !thinkingSelectorExpanded },
+          contextUsage = contextUsage,
           modifier = Modifier.weight(1f),
         )
       }
@@ -2359,27 +2357,6 @@ private fun ChatComposer(
         onFixConnection = onFixConnection,
         onCopyDiagnostics = onCopyDiagnostics,
       )
-    }
-
-    if (pendingRunCount > 0) {
-      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-        Surface(
-          onClick = onAbort,
-          modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-          shape = RoundedCornerShape(ClawTheme.radii.pill),
-          color = ClawTheme.colors.canvas,
-          contentColor = ClawTheme.colors.text,
-        ) {
-          Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-          ) {
-            Box(modifier = Modifier.size(8.dp).background(ClawTheme.colors.danger, RoundedCornerShape(2.dp)))
-            Text(text = nativeString("Stop"), style = ClawTheme.type.label)
-          }
-        }
-      }
     }
   }
 }
@@ -2411,38 +2388,6 @@ private fun ChatThinkingLevelSelector(
           row.firstOrNull { option -> chatThinkingOptionLabel(option, languageTag) == selected }?.let { onSelect(it.id) }
         },
         modifier = Modifier.fillMaxWidth(),
-      )
-    }
-  }
-}
-
-@Composable
-private fun ChatModelChip(
-  label: String,
-  enabled: Boolean,
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  Surface(
-    onClick = onClick,
-    enabled = enabled,
-    modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-    shape = RoundedCornerShape(ClawTheme.radii.pill),
-    color = ClawTheme.colors.canvas,
-    contentColor = if (enabled) ClawTheme.colors.text else ClawTheme.colors.textMuted,
-  ) {
-    Row(
-      modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-      Icon(imageVector = Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(13.dp), tint = ClawTheme.colors.textSubtle)
-      Text(
-        text = label,
-        style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
-        color = if (enabled) ClawTheme.colors.textMuted else ClawTheme.colors.textSubtle,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
       )
     }
   }
@@ -2713,68 +2658,6 @@ private fun ChatOfflineNotice(
 }
 
 @Composable
-private fun ChatContextMeter(
-  thinkingLevel: String,
-  thinkingSupported: Boolean,
-  expanded: Boolean,
-  contextUsage: ChatContextUsage,
-  onClick: () -> Unit,
-) {
-  val contextFraction = contextMeterWidth(contextUsage) ?: 0f
-  Row(
-    modifier = Modifier.width(178.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(7.dp),
-  ) {
-    Surface(
-      onClick = onClick,
-      enabled = thinkingSupported,
-      modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-      shape = RoundedCornerShape(ClawTheme.radii.pill),
-      color = ClawTheme.colors.canvas,
-      contentColor = ClawTheme.colors.text,
-    ) {
-      Row(
-        modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-      ) {
-        if (thinkingSupported) {
-          Icon(
-            imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-            contentDescription = if (expanded) nativeString("Close thinking level selector") else nativeString("Open thinking level selector"),
-            modifier = Modifier.size(13.dp),
-            tint = ClawTheme.colors.textSubtle,
-          )
-        }
-        Text(
-          text = contextMeterLabel(contextUsage, thinkingLevel, thinkingSupported),
-          style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
-          color = ClawTheme.colors.textMuted,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
-        )
-      }
-    }
-    Box(
-      modifier =
-        Modifier
-          .weight(1f)
-          .height(3.dp)
-          .background(ClawTheme.colors.surfacePressed, RoundedCornerShape(999.dp)),
-    ) {
-      Box(
-        modifier =
-          Modifier
-            .fillMaxWidth(contextFraction)
-            .height(3.dp)
-            .background(ClawTheme.colors.primary, RoundedCornerShape(999.dp)),
-      )
-    }
-  }
-}
-
-@Composable
 private fun ChatInputPill(
   value: String,
   onValueChange: (String) -> Unit,
@@ -2788,11 +2671,21 @@ private fun ChatInputPill(
   onToggleDictation: () -> Unit,
   talkActive: Boolean,
   onToggleTalk: () -> Unit,
+  runActive: Boolean,
+  onAbort: () -> Unit,
   sendEnabled: Boolean,
   onSend: () -> Unit,
+  selectedModelLabel: String,
+  modelPickerEnabled: Boolean,
+  onOpenModelPicker: () -> Unit,
+  thinkingLevel: String,
+  thinkingSupported: Boolean,
+  onToggleThinkingSelector: () -> Unit,
+  contextUsage: ChatContextUsage,
   modifier: Modifier = Modifier,
 ) {
   val hardwareEnterHandler = remember { PhysicalChatSendKeyHandler() }
+  var attachmentMenuExpanded by rememberSaveable { mutableStateOf(false) }
 
   Surface(
     modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
@@ -2801,74 +2694,173 @@ private fun ChatInputPill(
     contentColor = ClawTheme.colors.text,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Row(
-      modifier = Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(7.dp),
-    ) {
-      Surface(onClick = onPickImages, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
-        Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Default.Add, contentDescription = nativeString("Attach image"), modifier = Modifier.size(20.dp))
+    Column {
+      Row(
+        modifier = Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+      ) {
+        Box {
+          Surface(onClick = { attachmentMenuExpanded = true }, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
+            Box(contentAlignment = Alignment.Center) {
+              Icon(imageVector = Icons.Default.Add, contentDescription = nativeString("Add attachment"), modifier = Modifier.size(20.dp))
+            }
+          }
+          DropdownMenu(expanded = attachmentMenuExpanded, onDismissRequest = { attachmentMenuExpanded = false }) {
+            DropdownMenuItem(text = { Text(nativeString("Photos")) }, leadingIcon = { Icon(Icons.Default.Photo, contentDescription = null) }, onClick = {
+              attachmentMenuExpanded = false
+              onPickImages()
+            })
+            DropdownMenuItem(text = { Text(nativeString("Videos")) }, leadingIcon = { Icon(Icons.Default.Videocam, contentDescription = null) }, onClick = {
+              attachmentMenuExpanded = false
+              onPickVideo()
+            })
+            DropdownMenuItem(text = { Text(nativeString("Files")) }, leadingIcon = { Icon(Icons.Default.AttachFile, contentDescription = null) }, onClick = {
+              attachmentMenuExpanded = false
+              onPickAudioOrDocument()
+            })
+          }
         }
-      }
-      Surface(onClick = onPickAudioOrDocument, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
-        Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Default.AttachFile, contentDescription = nativeString("Attachment"), modifier = Modifier.size(20.dp))
-        }
-      }
-      Surface(onClick = onPickVideo, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
-        Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Default.Videocam, contentDescription = nativeString("Attach video"), modifier = Modifier.size(20.dp))
-        }
-      }
-      Box(modifier = Modifier.weight(1f)) {
-        ChatTextFieldValueAdapter(
-          value = value,
-          onValueChange = onValueChange,
-          keyHandler = hardwareEnterHandler,
-        ) { textFieldValue, updateTextFieldValue ->
-          BasicTextField(
-            value = textFieldValue,
-            onValueChange = updateTextFieldValue,
-            textStyle = ClawTheme.type.body.copy(color = ClawTheme.colors.text),
-            cursorBrush = SolidColor(ClawTheme.colors.primary),
-            minLines = 1,
-            maxLines = 4,
-            modifier =
-              Modifier
-                .fillMaxWidth()
-                .onPreInterceptKeyBeforeSoftKeyboard { event ->
-                  hardwareEnterHandler.handle(
-                    event = event,
-                    sendEnabled = sendEnabled,
-                    textEmpty = textFieldValue.text.isEmpty(),
-                    compositionActive = textFieldValue.composition != null,
-                    onSend = onSend,
-                  )
-                },
-            decorationBox = { innerTextField ->
-              Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
-                if (value.isEmpty()) {
-                  Text(text = nativeString("Message OpenClaw"), style = ClawTheme.type.body, color = ClawTheme.colors.textSubtle)
+        Box(modifier = Modifier.weight(1f)) {
+          ChatTextFieldValueAdapter(
+            value = value,
+            onValueChange = onValueChange,
+            keyHandler = hardwareEnterHandler,
+          ) { textFieldValue, updateTextFieldValue ->
+            BasicTextField(
+              value = textFieldValue,
+              onValueChange = updateTextFieldValue,
+              textStyle = ClawTheme.type.body.copy(color = ClawTheme.colors.text),
+              cursorBrush = SolidColor(ClawTheme.colors.primary),
+              minLines = 1,
+              maxLines = 4,
+              modifier =
+                Modifier
+                  .fillMaxWidth()
+                  .onPreInterceptKeyBeforeSoftKeyboard { event ->
+                    hardwareEnterHandler.handle(
+                      event = event,
+                      sendEnabled = sendEnabled,
+                      textEmpty = textFieldValue.text.isEmpty(),
+                      compositionActive = textFieldValue.composition != null,
+                      onSend = onSend,
+                    )
+                  },
+              decorationBox = { innerTextField ->
+                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+                  if (value.isEmpty()) {
+                    Text(text = nativeString("Message OpenClaw"), style = ClawTheme.type.body, color = ClawTheme.colors.textSubtle)
+                  }
+                  innerTextField()
                 }
-                innerTextField()
-              }
-            },
-          )
+              },
+            )
+          }
+        }
+        ChatComposerMicButton(
+          dictationActive = dictationActive,
+          dictationEnabled = dictationEnabled,
+          voiceNoteEnabled = recordVoiceNoteEnabled,
+          onToggleDictation = onToggleDictation,
+          onStartVoiceNote = onStartVoiceNote,
+        )
+        when (resolveChatComposerTrailingAction(talkActive = talkActive, runActive = runActive, sendEnabled = sendEnabled)) {
+          ChatComposerTrailingAction.Send -> SendButton(enabled = true, onClick = onSend)
+          ChatComposerTrailingAction.StartTalk -> LiveTalkButton(active = false, onClick = onToggleTalk)
+          ChatComposerTrailingAction.StopTalk -> {
+            // Talk keeps the morph slot, but run abort must stay reachable while both overlap.
+            if (runActive) StopButton(onClick = onAbort)
+            LiveTalkButton(active = true, onClick = onToggleTalk)
+          }
+          ChatComposerTrailingAction.Stop -> StopButton(onClick = onAbort)
         }
       }
-      ChatComposerMicButton(
-        dictationActive = dictationActive,
-        dictationEnabled = dictationEnabled,
-        voiceNoteEnabled = recordVoiceNoteEnabled,
-        onToggleDictation = onToggleDictation,
-        onStartVoiceNote = onStartVoiceNote,
+      ChatComposerFooter(
+        selectedModelLabel = selectedModelLabel,
+        modelPickerEnabled = modelPickerEnabled,
+        onOpenModelPicker = onOpenModelPicker,
+        thinkingLevel = thinkingLevel,
+        thinkingSupported = thinkingSupported,
+        onToggleThinkingSelector = onToggleThinkingSelector,
+        contextUsage = contextUsage,
       )
-      when (resolveChatComposerTrailingAction(talkActive = talkActive, sendEnabled = sendEnabled)) {
-        ChatComposerTrailingAction.Send -> SendButton(enabled = true, onClick = onSend)
-        ChatComposerTrailingAction.StartTalk -> LiveTalkButton(active = false, onClick = onToggleTalk)
-        ChatComposerTrailingAction.StopTalk -> LiveTalkButton(active = true, onClick = onToggleTalk)
+    }
+  }
+}
+
+@Composable
+private fun ChatComposerFooter(
+  selectedModelLabel: String,
+  modelPickerEnabled: Boolean,
+  onOpenModelPicker: () -> Unit,
+  thinkingLevel: String,
+  thinkingSupported: Boolean,
+  onToggleThinkingSelector: () -> Unit,
+  contextUsage: ChatContextUsage,
+) {
+  val contextFraction = contextMeterWidth(contextUsage)
+  val contextPercent = contextFraction?.let { (it * 100).roundToInt() }
+  Row(
+    modifier = Modifier.fillMaxWidth().padding(start = 9.dp, end = 9.dp, bottom = 2.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(2.dp),
+  ) {
+    ChatComposerFooterChip(
+      label = selectedModelLabel,
+      enabled = modelPickerEnabled,
+      onClick = onOpenModelPicker,
+      modifier = Modifier.weight(1f, fill = false),
+    )
+    if (thinkingSupported) {
+      ChatComposerFooterChip(
+        label = contextMeterThinkingLabel(thinkingLevel),
+        enabled = true,
+        onClick = onToggleThinkingSelector,
+      )
+    }
+    Spacer(modifier = Modifier.weight(1f))
+    if (contextFraction != null && contextPercent != null) {
+      val description = nativeString("Context \${contextPercent}% used", contextPercent)
+      val trackColor = ClawTheme.colors.surfacePressed
+      val progressColor = ClawTheme.colors.primary
+      Row(
+        modifier = Modifier.clearAndSetSemantics { contentDescription = description },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+      ) {
+        Canvas(modifier = Modifier.size(14.dp)) {
+          val stroke = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round)
+          drawCircle(color = trackColor, style = stroke)
+          drawArc(color = progressColor, startAngle = -90f, sweepAngle = contextFraction * 360f, useCenter = false, style = stroke)
+        }
+        Text(text = nativeString("\${contextPercent}%", contextPercent), style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
       }
+    }
+  }
+}
+
+@Composable
+private fun ChatComposerFooterChip(
+  label: String,
+  enabled: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    onClick = onClick,
+    enabled = enabled,
+    modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
+    shape = RoundedCornerShape(ClawTheme.radii.pill),
+    color = Color.Transparent,
+    contentColor = if (enabled) ClawTheme.colors.textMuted else ClawTheme.colors.textSubtle,
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+      Text(text = label, modifier = Modifier.weight(1f, fill = false), style = ClawTheme.type.caption, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      Icon(imageVector = Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(13.dp), tint = ClawTheme.colors.textSubtle)
     }
   }
 }
@@ -2886,8 +2878,8 @@ private fun LiveTalkButton(
         .size(ClawTheme.spacing.touchTarget)
         .semantics { contentDescription = buttonDescription },
     shape = CircleShape,
-    color = ClawTheme.colors.danger,
-    contentColor = Color.White,
+    color = if (active) ClawTheme.colors.danger else ClawTheme.colors.surfaceRaised,
+    contentColor = if (active) Color.White else ClawTheme.colors.text,
   ) {
     Box(contentAlignment = Alignment.Center) {
       if (active) {
@@ -2899,6 +2891,21 @@ private fun LiveTalkButton(
           modifier = Modifier.size(20.dp),
         )
       }
+    }
+  }
+}
+
+@Composable
+private fun StopButton(onClick: () -> Unit) {
+  Surface(
+    onClick = onClick,
+    modifier = Modifier.size(ClawTheme.spacing.touchTarget),
+    shape = CircleShape,
+    color = ClawTheme.colors.danger,
+    contentColor = Color.White,
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      Icon(imageVector = Icons.Default.Stop, contentDescription = nativeString("Stop"), modifier = Modifier.size(20.dp))
     }
   }
 }
@@ -3098,18 +3105,6 @@ internal fun contextMeterWidth(usage: ChatContextUsage): Float? {
   val total = usage.totalTokens?.takeIf { it >= 0L } ?: return null
   val context = usage.contextTokens?.takeIf { it > 0L } ?: return null
   return (total.toDouble() / context.toDouble()).coerceIn(0.0, 1.0).toFloat()
-}
-
-internal fun contextMeterLabel(
-  usage: ChatContextUsage,
-  thinkingLevel: String,
-  thinkingSupported: Boolean = true,
-): String {
-  val contextLabel =
-    contextMeterWidth(usage)?.let {
-      nativeString("Context \${(it * 100).roundToInt()}%", (it * 100).roundToInt())
-    } ?: nativeString("Context --")
-  return if (thinkingSupported) nativeString("\$contextLabel · \${contextMeterThinkingLabel(thinkingLevel)}", contextLabel, contextMeterThinkingLabel(thinkingLevel)) else contextLabel
 }
 
 internal fun contextMeterThinkingLabel(value: String): String {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatContextMeterTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatContextMeterTest.kt
@@ -47,7 +47,6 @@ class ChatContextMeterTest {
 
     assertEquals(ChatContextUsage(totalTokens = 1_250L, totalTokensFresh = true, contextTokens = 5_000L), usage)
     assertEquals(0.25f, contextMeterWidth(usage))
-    assertEquals("Context 25% · High", contextMeterLabel(usage, "high"))
   }
 
   @Test
@@ -72,7 +71,6 @@ class ChatContextMeterTest {
       )
 
     assertEquals(ChatContextUsage(totalTokens = 41_000L, totalTokensFresh = true, contextTokens = 100_000L), usage)
-    assertEquals("Context 41% · Off", contextMeterLabel(usage, "off"))
   }
 
   @Test
@@ -80,7 +78,6 @@ class ChatContextMeterTest {
     val usage = ChatContextUsage(totalTokens = 8_200L, totalTokensFresh = true, contextTokens = null)
 
     assertNull(contextMeterWidth(usage))
-    assertEquals("Context -- · Medium", contextMeterLabel(usage, "medium"))
   }
 
   @Test
@@ -88,7 +85,6 @@ class ChatContextMeterTest {
     val usage = ChatContextUsage(totalTokens = 150_000L, totalTokensFresh = true, contextTokens = 100_000L)
 
     assertEquals(1.0f, contextMeterWidth(usage))
-    assertEquals("Context 100% · Low", contextMeterLabel(usage, "low"))
   }
 
   @Test
@@ -96,23 +92,17 @@ class ChatContextMeterTest {
     val usage = ChatContextUsage(totalTokens = 82_000L, totalTokensFresh = false, contextTokens = 100_000L)
 
     assertNull(contextMeterWidth(usage))
-    assertEquals("Context -- · High", contextMeterLabel(usage, "high"))
   }
 
   @Test
-  fun contextMeterHidesThinkingLabelWhenUnsupported() {
-    val usage = ChatContextUsage(totalTokens = 2_500L, totalTokensFresh = true, contextTokens = 10_000L)
-
-    assertEquals("Context 25%", contextMeterLabel(usage, "high", thinkingSupported = false))
-  }
-
-  @Test
-  fun contextMeterPreservesGatewayThinkingLevelIds() {
-    val usage = ChatContextUsage(totalTokens = null, totalTokensFresh = null, contextTokens = null)
-
-    assertEquals("Context -- · xhigh", contextMeterLabel(usage, "xhigh"))
-    assertEquals("Context -- · adaptive", contextMeterLabel(usage, "adaptive"))
-    assertEquals("Context -- · ultra", contextMeterLabel(usage, "ultra"))
+  fun thinkingLabelsMapKnownLevelsAndPreserveGatewayIds() {
+    assertEquals("Off", contextMeterThinkingLabel("off"))
+    assertEquals("Low", contextMeterThinkingLabel("low"))
+    assertEquals("Medium", contextMeterThinkingLabel("medium"))
+    assertEquals("High", contextMeterThinkingLabel("high"))
+    assertEquals("xhigh", contextMeterThinkingLabel("xhigh"))
+    assertEquals("adaptive", contextMeterThinkingLabel("adaptive"))
+    assertEquals("ultra", contextMeterThinkingLabel("ultra"))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
@@ -73,18 +73,22 @@ class ChatScreenTest {
   }
 
   @Test
-  fun activeTalkAlwaysKeepsTheStopControlVisible() {
+  fun composerTrailingActionPreservesTalkAndRunStopPrecedence() {
     assertEquals(
       ChatComposerTrailingAction.StopTalk,
-      resolveChatComposerTrailingAction(talkActive = true, sendEnabled = true),
+      resolveChatComposerTrailingAction(talkActive = true, runActive = true, sendEnabled = true),
+    )
+    assertEquals(
+      ChatComposerTrailingAction.Stop,
+      resolveChatComposerTrailingAction(talkActive = false, runActive = true, sendEnabled = true),
     )
     assertEquals(
       ChatComposerTrailingAction.Send,
-      resolveChatComposerTrailingAction(talkActive = false, sendEnabled = true),
+      resolveChatComposerTrailingAction(talkActive = false, runActive = false, sendEnabled = true),
     )
     assertEquals(
       ChatComposerTrailingAction.StartTalk,
-      resolveChatComposerTrailingAction(talkActive = false, sendEnabled = false),
+      resolveChatComposerTrailingAction(talkActive = false, runActive = false, sendEnabled = false),
     )
   }
 


### PR DESCRIPTION
## What Problem This Solves

The Android chat composer was visually overloaded: three separate attachment buttons (image, file, video), a full-width model chip row plus a combined "Context -- · Low" thinking/context meter above the input, an always-red Live Talk button that read as "recording in progress" while idle, and a separate centered Stop pill during runs. Seven tap targets across two rows competed with the text field, and the same screen's bottom nav already carries a dedicated Voice tab.

## Why This Change Was Made

Unifies the Android composer with the iOS and web Control UI composer architecture. iOS consolidates attachments into a single plus menu and keeps the composer to three controls; web puts model/effort as quiet footer chips inside the composer card with a small context ring, and morphs the trailing button between talk/send/stop. Android now follows the same shape while staying Android-native (bottom-sheet pickers, existing inline thinking selector, durable-outbox send unchanged). Non-goals: no capability toggles in the plus menu yet (web has skills/connectors there), no camera capture item, no picker/dictation/voice-note behavior changes.

## User Impact

- One `+` button opens a menu with Photos / Videos / Files instead of three permanent attachment buttons.
- Model and thinking level are compact footer chips inside the composer card; the separate picker row is gone. Same pickers open on tap.
- Context usage is a small ring + percentage that only appears when fresh usage is known (no more "Context --" placeholder).
- The trailing button morphs: Talk (neutral, no longer alarm-red) when idle, Send when there is content, red Stop while a run is active (replacing the separate Stop pill). Active Talk stays red with the waveform animation.
- Net production LOC is negative; no gateway, outbox, or draft-store changes.

## Evidence

Focused unit tests + lint + assemble (local, Android SDK present):

- `./gradlew :app:testPlayDebugUnitTest --tests "ai.openclaw.app.ui.chat.*"` — BUILD SUCCESSFUL
- `./gradlew :app:ktlintCheck` — BUILD SUCCESSFUL
- `node --import tsx scripts/run-android-gradle.mts :app:assemblePlayDebug` — BUILD SUCCESSFUL

Live-tested on emulator (sdk_gphone64_arm64, API 36) against a live gateway: full send round-trip, attachment menu, thinking selector, model sheet, talk/send/stop morphs, and context ring appearing at 9% after the first reply.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/a1c5d68a-1c0e-48cc-a2f9-c949adbb3180" width="320" /> | <img src="https://github.com/user-attachments/assets/4e4b6a1b-3fe9-4d44-a80d-9c5120dba96e" width="320" /> |

<details>
<summary>More states: plus menu, thinking selector, send morph, stop morph, context ring</summary>

| Plus menu | Thinking selector | Send morph |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/e2a253d4-a27b-466b-95a0-0cc80d7f1038" width="240" /> | <img src="https://github.com/user-attachments/assets/480a8af2-97f6-4743-a771-b2f0656cdc07" width="240" /> | <img src="https://github.com/user-attachments/assets/c89a9f59-6448-4fd7-8e9f-a88a6c65ad54" width="240" /> |

| Stop during run | Context ring after reply |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/53f00b3c-84ec-4ad9-9a92-6561f918cbe9" width="240" /> | <img src="https://github.com/user-attachments/assets/dc56070f-0c28-406b-b1ca-7a70278bb601" width="240" /> |

</details>

Overlap state: while live talk and a run are active at the same time, the composer shows both End Talk and the red run-abort Stop, so the run stays cancelable without ending talk (matches the pre-change reachability where the Stop pill coexisted with the talk button). Attachment capture moves from one tap to two, matching iOS/web.
