### PR TITLE
fix(release): keep validation evidence reuse dependency-free

### DIFF
--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -4,6 +4,8 @@ import { runTsxCliShim } from "./lib/tsx-cli-shim.mjs";
 const args = process.argv.slice(2);
 if (args.length === 1 && args[0] === "--macos-versions-only") {
   // Evidence reuse runs before dependencies exist; only this file-read-only probe bypasses tsx.
+  const { writeFailedTrailer } = await import("./lib/failed-trailer.mts");
+  process.once("exit", (exitCode) => writeFailedTrailer("release-preflight", exitCode));
   await import("./release-preflight.mts");
 } else {
   await runTsxCliShim(import.meta.url, {

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 import { runTsxCliShim } from "./lib/tsx-cli-shim.mjs";
 
-await runTsxCliShim(import.meta.url, {
-  implementation: "./release-preflight.mts",
-  failureTool: "release-preflight",
-});
+const args = process.argv.slice(2);
+if (args.length === 1 && args[0] === "--macos-versions-only") {
+  // Evidence reuse runs before dependencies exist; only this file-read-only probe bypasses tsx.
+  await import("./release-preflight.mts");
+} else {
+  await runTsxCliShim(import.meta.url, {
+    implementation: "./release-preflight.mts",
+    failureTool: "release-preflight",
+  });
+}

--- a/test/scripts/release-preflight.test.ts
+++ b/test/scripts/release-preflight.test.ts
@@ -1,7 +1,7 @@
 // Release preflight tests keep generated-artifact checks fail-closed for operators.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { delimiter, join, resolve } from "node:path";
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
@@ -123,11 +123,77 @@ function makeReleaseFixture(
   return root;
 }
 
+function makeIsolatedPreflightFixture(params: Parameters<typeof makeReleaseFixture>[0] = {}): {
+  root: string;
+  script: string;
+} {
+  const root = makeReleaseFixture(params);
+  const files = [
+    "scripts/release-preflight.mjs",
+    "scripts/release-preflight.mts",
+    "scripts/windows-cmd-helpers.mjs",
+    "scripts/lib/error-format.mts",
+    "scripts/lib/managed-child-process.mts",
+    "scripts/lib/release-version.mjs",
+    "scripts/lib/tsx-cli-shim.mjs",
+    "scripts/lib/windows-taskkill.mjs",
+  ];
+  for (const file of files) {
+    const destination = join(root, file);
+    mkdirSync(dirname(destination), { recursive: true });
+    copyFileSync(file, destination);
+  }
+  return { root, script: join(root, "scripts", "release-preflight.mjs") };
+}
+
+function runIsolatedPreflight(
+  args: string[],
+  params: Parameters<typeof makeReleaseFixture>[0] = {},
+) {
+  const fixture = makeIsolatedPreflightFixture(params);
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+  delete env.NODE_PATH;
+  delete env.PNPM_CONFIG_MODULES_DIR;
+  delete env.npm_config_modules_dir;
+  return spawnSync(process.execPath, [fixture.script, ...args], {
+    cwd: fixture.root,
+    encoding: "utf8",
+    env,
+  });
+}
+
 function readPnpmLog(logPath: string): string[] {
   return readFileSync(logPath, "utf8").trimEnd().split("\n").filter(Boolean);
 }
 
 describe("scripts/release-preflight.mjs", () => {
+  it("checks valid macOS metadata without node_modules", () => {
+    const result = runIsolatedPreflight(["--macos-versions-only"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("[release-preflight] macOS app version metadata OK");
+  });
+
+  it("reports stale macOS metadata without node_modules", () => {
+    const result = runIsolatedPreflight(["--macos-versions-only"], {
+      shortVersion: "2026.6.10",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'CFBundleShortVersionString is "2026.6.10"; expected "2026.7.1" from package.json base version',
+    );
+  });
+
+  it("keeps multi-argument invocations on the tsx shim", () => {
+    const result = runIsolatedPreflight(["--macos-versions-only", "--check"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Cannot find module 'tsx'");
+    expect(result.stderr).toContain("[release-preflight] FAILED (exit 1)");
+  });
+
   it("rejects unknown arguments before running release checks", () => {
     const result = runPreflight(["--fiix"]);
 

--- a/test/scripts/release-preflight.test.ts
+++ b/test/scripts/release-preflight.test.ts
@@ -133,6 +133,7 @@ function makeIsolatedPreflightFixture(params: Parameters<typeof makeReleaseFixtu
     "scripts/release-preflight.mts",
     "scripts/windows-cmd-helpers.mjs",
     "scripts/lib/error-format.mts",
+    "scripts/lib/failed-trailer.mts",
     "scripts/lib/managed-child-process.mts",
     "scripts/lib/release-version.mjs",
     "scripts/lib/tsx-cli-shim.mjs",
@@ -184,6 +185,7 @@ describe("scripts/release-preflight.mjs", () => {
     expect(result.stderr).toContain(
       'CFBundleShortVersionString is "2026.6.10"; expected "2026.7.1" from package.json base version',
     );
+    expect(result.stderr.trimEnd().split("\n").at(-1)).toBe("[release-preflight] FAILED (exit 1)");
   });
 
   it("keeps multi-argument invocations on the tsx shim", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation evidence reuse would falsely reject a valid release target when the reuse job ran before dependencies were installed. The `--macos-versions-only` probe failed to resolve `tsx`, reported inconsistent version metadata, and launched the full heavy validation graph.

Observed in https://github.com/openclaw/openclaw/actions/runs/31682802265/job/94391990566.

## Why This Change Was Made

The exact sole `--macos-versions-only` invocation now imports the TypeScript implementation through supported Node's native TypeScript loader. All other invocations retain the existing `tsx` shim and dependency contract.

## User Impact

Release operators can reuse qualified exact-SHA or changelog-only validation evidence without installing dependencies or accidentally starting duplicate heavy validation.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-preflight.test.ts`
  - 1 file passed, 16 tests passed
  - covers valid and stale metadata with no `node_modules`
  - proves stale metadata preserves the real validation error and ends with `[release-preflight] FAILED (exit 1)`
  - proves multi-argument invocations still fail through the normal `tsx` shim when `tsx` is absent
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean, no accepted/actionable findings; overall correct 0.99
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/release-preflight.mjs test/scripts/release-preflight.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/release-preflight.mjs test/scripts/release-preflight.test.ts`
- `git diff --check`

No changelog entry: release-infrastructure-only blocker fix.
