### PR TITLE
fix(release): include plugin tooling dependencies

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/plugin-npm-release.yml"
       - "extensions/**"
       - "package.json"
+      - "packages/normalization-core/**"
       - "scripts/generate-npm-package-lock.mjs"
       - "scripts/generate-npm-package-lock.mts"
       - "scripts/lib/npm-publish-plan.mjs"
@@ -340,7 +341,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .release-tooling
           fetch-depth: 1
-          sparse-checkout: scripts
+          sparse-checkout: |
+            packages/normalization-core
+            scripts
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -114,7 +114,7 @@ describe("plugin npm extended-stable workflow", () => {
     expect(preflightCheckout.with).toMatchObject({
       ref: "${{ github.workflow_sha }}",
       path: ".release-tooling",
-      "sparse-checkout": "scripts",
+      "sparse-checkout": "packages/normalization-core\nscripts\n",
     });
     const previewCommand = step(parsed.jobs?.preview_plugin_pack, "Preview publish command").run;
     expect(previewCommand).toContain(".release-tooling/scripts/plugin-npm-publish.sh");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin npm preflight failed for every selected plugin because the trusted packaging checkout omitted a source dependency required by the lockfile generator.

## Why This Change Was Made

The trusted `.release-tooling` sparse checkout now includes `packages/normalization-core` alongside `scripts`. The workflow push filter also tracks that dependency, and the existing workflow contract test locks both paths in place.

## User Impact

Maintainers can generate immutable plugin npm preflight artifacts from a frozen release SHA again. This does not publish packages or change runtime behavior.

## Evidence

- Failure before: https://github.com/openclaw/openclaw/actions/runs/31682835395
- `node scripts/run-vitest.mjs test/scripts/plugin-npm-extended-stable-workflow.test.ts` - 11 passed
- `actionlint .github/workflows/plugin-npm-release.yml` - passed
- workflow YAML and sparse-checkout closure parse check - passed
- targeted `pnpm format:check` - passed
- `git diff --check` - passed
