### PR TITLE
fix: picker option labels collapse to ellipsis at phone widths

### DIFF
--- a/ui/src/components/select-picker.ts
+++ b/ui/src/components/select-picker.ts
@@ -23,6 +23,8 @@ export type PickerParams<Option extends PickerOption> = {
 };
 
 export function renderPicker<Option extends PickerOption>(params: PickerParams<Option>) {
+  // Web Awesome syncs the listbox to its trigger; keep 8ch for the label after
+  // its fixed check and leading-icon columns instead of collapsing the options.
   const options =
     params.value === null ||
     params.value === "" ||
@@ -39,7 +41,7 @@ export function renderPicker<Option extends PickerOption>(params: PickerParams<O
     <wa-select
       id=${params.id ?? nothing}
       class=${`settings-select picker-select ${params.className ?? ""}`}
-      style="width:100%;min-width:0"
+      style="width:100%;min-width:138px"
       title=${params.title ?? nothing}
       placement=${params.placement ?? nothing}
       .value=${params.value}

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -27,7 +27,7 @@ const DESKTOP_CONTEXT: BrowserContextOptions = {
 };
 const MOBILE_CONTEXT: BrowserContextOptions = {
   ...BASE_CONTEXT,
-  viewport: { height: 568, width: 320 },
+  viewport: { height: 740, width: 364 },
 };
 const MODELS = [
   { id: "gpt-5.5", name: "GPT 5.5", provider: "openai" },
@@ -127,7 +127,20 @@ suite.define(() => {
   it("keeps the mobile footer controls separated and reveals session modes on hover or focus", async () => {
     await withNewSessionPage(MOBILE_CONTEXT, async (page) => {
       await installMockGateway(page, {
-        models: [{ id: "gpt-5.6-sol", name: "GPT 5.6 Sol", provider: "openai" }],
+        models: [
+          {
+            id: "gpt-5.6-luna",
+            name: "GPT 5.6 Luna",
+            provider: "openai",
+            contextWindow: 400_000,
+          },
+          {
+            id: "claude-sonnet-4-6",
+            name: "Claude Sonnet 4.6",
+            provider: "anthropic",
+            contextWindow: 200_000,
+          },
+        ],
         hasMultipleSessionSharingIdentities: true,
       });
       await page.goto(`${suite.server.baseUrl}new`);
@@ -178,9 +191,6 @@ suite.define(() => {
       expect(modelBox).not.toBeNull();
       expect((attachBox?.x ?? 0) + (attachBox?.width ?? 0)).toBeLessThanOrEqual(draftBox?.x ?? 0);
       expect((draftBox?.x ?? 0) + (draftBox?.width ?? 0)).toBeLessThanOrEqual(incognitoBox?.x ?? 0);
-      expect((incognitoBox?.x ?? 0) + (incognitoBox?.width ?? 0)).toBeLessThanOrEqual(
-        modelBox?.x ?? 0,
-      );
       for (const control of [attachBox, draftBox, incognitoBox, modelBox]) {
         expect(control?.x ?? 0).toBeGreaterThanOrEqual(footerBox?.x ?? 0);
         expect((control?.x ?? 0) + (control?.width ?? 0)).toBeLessThanOrEqual(
@@ -188,12 +198,41 @@ suite.define(() => {
         );
       }
       // The new-session footer keeps flex (not the shared chat mobile grid), so
-      // all four controls share one 320px row; wrap or overflow here means the
-      // new-session.css mobile override regressed.
+      // its transient mode switches can wrap before the model picker overflows.
       const controlsOverflow = await footer.evaluate(
         (element) => element.scrollWidth - element.clientWidth,
       );
       expect(controlsOverflow).toBe(0);
+
+      const picker = newSessionModelPicker(page);
+      await picker.click();
+      await expect.poll(() => picker.getAttribute("open")).toBe("");
+      const optionLabelWidths = await picker.locator("wa-option").evaluateAll((options) =>
+        options.flatMap((option) => {
+          if (option.getBoundingClientRect().width === 0) {
+            return [];
+          }
+          const label = option.querySelector<HTMLElement>(".picker-select__label")!;
+          const probe = document.createElement("span");
+          probe.style.cssText = `position:fixed;visibility:hidden;width:8ch;font:${getComputedStyle(label).font}`;
+          document.body.append(probe);
+          const minimum = probe.getBoundingClientRect().width;
+          probe.remove();
+          return [
+            {
+              label: label.textContent?.trim(),
+              minimum,
+              width: label.getBoundingClientRect().width,
+            },
+          ];
+        }),
+      );
+      expect(optionLabelWidths.length).toBeGreaterThanOrEqual(2);
+      for (const entry of optionLabelWidths) {
+        expect(entry.width, JSON.stringify(entry)).toBeGreaterThanOrEqual(entry.minimum);
+      }
+      await captureUiProof(page, "mobile-model-picker-labels.png");
+      await picker.click();
 
       await attach.click();
       await expect.poll(() => takePhoto.isVisible()).toBe(true);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -292,9 +292,15 @@ function composerControlsHtml(crowded = false) {
       <div class="chat-composer-model-control">
         <div class="chat-controls__session chat-controls__model chat-controls__model-settings">
           <div class="chat-controls__model-control">
-          <div class="chat-controls__inline-select-trigger chat-controls__model-trigger" data-chat-composer-model="true" aria-label="Chat model">
-            <span class="chat-controls__inline-select-label">GPT-5.6 Luna</span>
-          </div>
+            <div class="chat-controls__model-control-row">
+              <div class="model-picker">
+                <wa-select class="settings-select picker-select model-picker__select chat-controls__model-picker" style="display:block;width:100%;min-width:138px">
+                  <div class="chat-controls__inline-select-trigger chat-controls__model-trigger" data-chat-composer-model="true" aria-label="Chat model">
+                    <span class="chat-controls__inline-select-label">GPT-5.6 Luna</span>
+                  </div>
+                </wa-select>
+              </div>
+            </div>
           </div>
           <details class="chat-controls__inline-select chat-controls__effort-picker">
           <summary class="chat-controls__inline-select-trigger chat-controls__effort-trigger" data-chat-composer-effort="true" aria-label="Effort">
@@ -2515,6 +2521,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           footer: rectFor(".agent-chat__composer-footer"),
           meta: rectFor(".agent-chat__composer-meta"),
           model: rectFor(".chat-controls__model-trigger"),
+          modelPicker: rectFor(".chat-controls__model-picker"),
           modelLabel: rectFor(".chat-controls__model-trigger .chat-controls__inline-select-label"),
           overrides: rectFor(".agent-chat__session-overrides-pill"),
           status: rectFor(".agent-chat__composer-run-status"),
@@ -2522,7 +2529,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         };
       });
 
-      expect(layout.controls.scrollWidth).toBeLessThanOrEqual(layout.controls.clientWidth + 1);
+      expect(layout.controls.scrollWidth, JSON.stringify(layout)).toBeLessThanOrEqual(
+        layout.controls.clientWidth + 1,
+      );
       for (const control of [
         layout.status,
         layout.overrides,
@@ -2539,6 +2548,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(trigger.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
         expect(trigger.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
       }
+      expect(layout.modelPicker.width).toBeGreaterThanOrEqual(138);
       expect(layout.modelLabel.scrollWidth).toBeLessThanOrEqual(layout.modelLabel.clientWidth + 1);
       for (const [left, right] of [
         [layout.status, layout.overrides],

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3763,12 +3763,8 @@ button.chat-reply-preview--message:disabled {
     margin-left: 0;
   }
 
-  /* Reserve the readable model trigger, 44px effort target, and their gap;
-     keep the picker cluster right-aligned like desktop while transient status
-     text yields before either picker does. */
   .agent-chat__input .agent-chat__composer-controls .chat-composer-model-control {
     flex: 0 1 auto;
-    min-width: 138px;
   }
 
   .agent-chat__input .agent-chat__composer-controls .chat-controls__model-picker {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3758,7 +3758,7 @@ button.chat-reply-preview--message:disabled {
   .agent-chat__composer-controls .chat-controls__model,
   .chat-composer-model-control {
     width: fit-content;
-    min-width: 0;
+    min-width: min-content;
     max-width: min(70vw, 100%);
     margin-left: 0;
   }
@@ -4290,7 +4290,7 @@ button.chat-reply-preview--message:disabled {
 
 .chat-controls__model {
   grid-area: model;
-  min-width: 0;
+  min-width: min-content;
   max-width: none;
 }
 
@@ -4302,18 +4302,18 @@ button.chat-reply-preview--message:disabled {
 
 .chat-controls__model-control {
   display: grid;
-  min-width: 0;
+  min-width: min-content;
   flex: 1 1 auto;
 }
 
 .chat-controls__model-control-row {
   display: flex;
   align-items: center;
-  min-width: 0;
+  min-width: min-content;
 }
 
 .chat-controls__model-control-row .model-picker {
-  min-width: 0;
+  min-width: min-content;
   flex: 1 1 auto;
 }
 

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -749,6 +749,7 @@ wa-dropdown.new-session-page__start-menu {
      Keep those pills intrinsic and let the model picker use the remaining width. */
   .new-session-page__composer .agent-chat__composer-controls {
     display: flex;
+    flex-wrap: wrap;
     gap: 2px;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the unified model/channel picker dropdown rendered option labels as 1–2 characters ("G..", "D..", "a..") in narrow viewports — the fixed icon and check columns kept their width while the label collapsed to 0px, making options indistinguishable.

## Why This Change Was Made

Web Awesome sizes the listbox to its trigger, and the shared picker allowed `min-width: 0`, so narrow new-session controls squeezed the whole select to ~35px. The shared component now carries the readable floor (138px, previously a chat-only CSS rule that got deleted as duplicate), and the new-session composer controls wrap before squeezing the picker. Channel options inherit the same fix through the shared renderer.

After, at 364px:

![mobile picker with readable labels](https://github.com/user-attachments/assets/1804a6b9-1fe2-4554-be7d-513b7244f341)

## User Impact

Picker options stay readable at phone widths across every surface using the shared component.

## Evidence

- Extended mobile E2E at 364px requires ≥8ch of visible label width: failed pre-fix (label width 0px, required 75.64px), passes post-fix.
- Model/channel picker component tests: 4 passed; existing mobile chat test passes.
- Production LOC net −1 (tests +39).
