### PR TITLE
fix(diffs): guard malformed tool arguments

### DIFF
--- a/extensions/diffs/src/tool.test.ts
+++ b/extensions/diffs/src/tool.test.ts
@@ -359,6 +359,21 @@ describe("diffs tool", () => {
     ).rejects.toThrow("Invalid baseUrl");
   });
 
+  it("returns a tool input error for malformed raw arguments", async () => {
+    const tool = createDiffsTool({
+      api: createApi(),
+      store,
+      defaults: DEFAULT_DIFFS_TOOL_DEFAULTS,
+    });
+
+    await expect(tool.execute?.("tool-malformed-null", null)).rejects.toThrow(
+      "Provide patch or both before and after text.",
+    );
+    await expect(tool.execute?.("tool-malformed-undefined", undefined)).rejects.toThrow(
+      "Provide patch or both before and after text.",
+    );
+  });
+
   it("rejects oversized patch payloads", async () => {
     const tool = createDiffsTool({
       api: createApi(),

--- a/extensions/diffs/src/tool.ts
+++ b/extensions/diffs/src/tool.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import { optionalFiniteNumberSchema, stringEnum } from "openclaw/plugin-sdk/channel-actions";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { readFiniteNumberParam } from "openclaw/plugin-sdk/param-readers";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  asNonArrayRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
 import type { Static } from "typebox";
 import type { AnyAgentTool, OpenClawPluginApi, OpenClawPluginToolContext } from "../api.js";
@@ -131,8 +134,8 @@ export function createDiffsTool(params: {
       "Create a read-only diff viewer from before/after text or a unified patch. Returns a gateway viewer URL for interactive viewing and can also render the same diff to a PNG or PDF.",
     parameters: DiffsToolSchema,
     execute: async (_toolCallId, rawParams) => {
-      const toolParams = rawParams as DiffsToolParams;
-      const rawRecord = rawParams as Record<string, unknown>;
+      const toolParams = asNonArrayRecord(rawParams) as DiffsToolParams;
+      const rawRecord = toolParams as Record<string, unknown>;
       const artifactContext = buildArtifactContext(params.context);
       const input = normalizeDiffInput(toolParams);
       if (input.kind === "before_after" && input.before === input.after) {


### PR DESCRIPTION
## Summary

- Guard the production `diffs` tool against null, undefined, array, and primitive raw arguments by reusing the existing non-array record coercion helper.
- Preserve existing diff rendering, artifact persistence, and identical-input behavior.

## What Problem This Solves

Malformed tool payloads can reach the `diffs` executor after schema validation is erased. Before this change, a null payload crashed while reading `patch` instead of returning the plugin's normal tool input error.

## Why This Change Was Made

The repository already uses `asNonArrayRecord` at an adjacent production tool boundary for the same malformed-argument class. Reusing it at the `diffs` executor is the smallest policy-neutral fix and leaves the existing `normalizeDiffInput` validation messages unchanged.

## User Impact

Malformed `diffs` calls now return a stable `ToolInputError`. Valid before/after and patch inputs still render and persist artifacts through the existing SQLite-backed store.

## Evidence

- Real call-chain proof exercised `createDiffsTool(...).execute` with the production diff renderer, `DiffArtifactStore`, SQLite-backed `diffs` blob store, and authorized artifact readback. No mocks or copied helper logic were used.
- The same command, entrypoint, input, and dependency boundary ran on base `792b2054df2c549c0c739727557823a5df189c99` and exact head `76ed5c39a5e8a0e511943d3b1d70b020183d301d`.
- Before-fix base: malformed `null` raised `TypeError: Cannot read properties of null (reading 'patch')`; valid before/after produced a persisted viewer with 112,564 decoded HTML bytes and SQLite blob count 1.
- After-fix head: malformed `null` returns `ToolInputError: Provide patch or both before and after text.`; the same valid path produces the same persisted viewer result and SQLite blob count 1.
- Unchanged control: identical before/after input remains `changed: false` and does not create another artifact.
- Canonical precedent: merged sibling `openclaw/openclaw#122549` reuses `asNonArrayRecord` at an adjacent production tool boundary.

```text
base 792b2054df2c549c0c739727557823a5df189c99: malformed=TypeError; valid=changed:true,persistedViewerBytes:112564,sqlite.blobCount:1; identical=changed:false
head 76ed5c39a5e8a0e511943d3b1d70b020183d301d: malformed=ToolInputError; valid=changed:true,persistedViewerBytes:112564,sqlite.blobCount:1; identical=changed:false
negative-control exact head: identical before/after remains changed:false
```

<details>
<summary>Full live proof source</summary>

```ts
import fs from "node:fs/promises";
import path from "node:path";
import { DatabaseSync } from "node:sqlite";
import { pathToFileURL } from "node:url";

function flag(name: string): string {
  const index = process.argv.indexOf(name);
  const value = index >= 0 ? process.argv[index + 1] : undefined;
  if (!value) throw new Error(`Missing ${name}`);
  return value;
}

async function load<T>(repoRoot: string, relativePath: string): Promise<T> {
  return (await import(pathToFileURL(path.join(repoRoot, relativePath)).href)) as T;
}

async function main(): Promise<void> {
  const repoRoot = path.resolve(flag("--repo"));
  const runRoot = path.resolve(flag("--run-root"));
  const stateRoot = path.join(runRoot, "state");
  const artifactRoot = path.join(runRoot, "artifacts");
  process.env.OPENCLAW_STATE_DIR = stateRoot;
  const { createPluginBlobStore } = await load<any>(repoRoot, "src/plugin-state/plugin-blob-store.ts");
  const { closePluginStateDatabase } = await load<any>(repoRoot, "src/plugin-state/plugin-state-store.ts");
  const { resolveDiffsPluginDefaults } = await load<any>(repoRoot, "extensions/diffs/src/config.ts");
  const { DiffArtifactStore } = await load<any>(repoRoot, "extensions/diffs/src/store.ts");
  const { createDiffsTool } = await load<any>(repoRoot, "extensions/diffs/src/tool.ts");
  const blobStore = createPluginBlobStore("diffs", {
    namespace: "diff-artifacts",
    maxEntries: 2048,
    maxBytesPerEntry: 32 * 1024 * 1024,
    maxBytesPerNamespace: 256 * 1024 * 1024,
    overflowPolicy: "reject-new",
  });
  const store = new DiffArtifactStore({ rootDir: artifactRoot, blobStore });
  const tool = createDiffsTool({
    api: { config: { gateway: { port: 18789, bind: "loopback" } } },
    store,
    defaults: resolveDiffsPluginDefaults(undefined),
    viewerBaseUrl: "http://127.0.0.1:18789",
  });
  await fs.mkdir(runRoot, { recursive: true });
  let malformed: { ok: boolean; error?: string };
  try {
    await tool.execute("live-proof-malformed", null);
    malformed = { ok: true };
  } catch (error) {
    malformed = { ok: false, error: String(error) };
  }
  const validResult = await tool.execute("live-proof-valid", {
    before: "one\n",
    after: "two\n",
    path: "README.md",
    mode: "view",
  });
  const validDetails = validResult.details as Record<string, unknown>;
  const viewer = await store.readAuthorizedViewer(
    String(validDetails.artifactId),
    String(String(validDetails.viewerPath).split("/").at(-1)),
  );
  const identicalResult = await tool.execute("live-proof-identical", {
    before: "same\n",
    after: "same\n",
    mode: "view",
  });
  const database = new DatabaseSync(path.join(stateRoot, "state", "openclaw.sqlite"));
  const blobCount = Number(database.prepare("SELECT COUNT(*) AS count FROM plugin_blob_entries WHERE plugin_id = ?").get("diffs").count);
  database.close();
  closePluginStateDatabase();
  console.log(JSON.stringify({
    malformed,
    valid: {
      changed: validDetails.changed,
      inputKind: validDetails.inputKind,
      fileCount: validDetails.fileCount,
      viewerUrl: validDetails.viewerUrl,
      persistedViewerBytes: viewer?.html.byteLength ?? 0,
    },
    identical: {
      changed: (identicalResult.details as Record<string, unknown>).changed,
      text: identicalResult.content.find((part) => part.type === "text")?.text,
    },
    sqlite: { blobCount },
  }, null, 2));
}

main().catch((error) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

## Tests

- `node scripts/run-vitest.mjs run extensions/diffs/src/tool.test.ts` (22 passed)

AI-assisted: built with Codex
