### PR TITLE
fix(ui): restore the composer model picker dialog

### DIFF
--- a/ui/src/components/web-awesome-migration.node.test.ts
+++ b/ui/src/components/web-awesome-migration.node.test.ts
@@ -40,7 +40,10 @@ describe("Web Awesome control ownership", () => {
     ).toEqual([]);
     expect(
       await matchingFiles(/<details\b[^>]*class=["'][^"']*(?:menu|select|popover|dropdown)/u),
-    ).toEqual(["pages/chat/components/chat-effort-picker.ts"]);
+    ).toEqual([
+      "pages/chat/components/chat-effort-picker.ts",
+      "pages/chat/components/chat-model-picker.ts",
+    ]);
   });
 
   it("limits custom comboboxes to dynamic suggestion surfaces", async () => {
@@ -50,6 +53,7 @@ describe("Web Awesome control ownership", () => {
       "components/command-palette.ts",
       "pages/chat/components/chat-composer-skill-menu.ts",
       "pages/chat/components/chat-composer-slash-menu.ts",
+      "pages/chat/components/chat-model-picker.ts",
     ]);
   });
 

--- a/ui/src/e2e/chat-composer-accessory-focus.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-accessory-focus.e2e.test.ts
@@ -114,10 +114,17 @@ suite.define(() => {
         await trigger.press("Enter");
       }
 
-      const modelTrigger = composer.locator("wa-select.chat-controls__model-picker");
+      const modelTrigger = composer.locator(".chat-controls__model-picker > summary");
       await outside.focus();
       await modelTrigger.click();
-      await expect.poll(() => modelTrigger.getAttribute("open")).toBe("");
+      expect(await modelTrigger.evaluate((element) => document.activeElement === element)).toBe(
+        true,
+      );
+      expect(
+        await page
+          .locator(".chat-controls__model-search")
+          .evaluate((element) => document.activeElement === element),
+      ).toBe(false);
       await page.keyboard.press("Escape");
 
       await outside.focus();

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -30,14 +30,12 @@ suite.define(() => {
 
       for (const picker of [
         {
-          menu: "wa-select.chat-controls__model-picker wa-option:last-of-type",
-          trigger: "wa-select.chat-controls__model-picker",
-          clearsComposer: false,
+          menu: ".chat-controls__model-menu",
+          trigger: '[data-chat-model-select="true"]',
         },
         {
           menu: ".chat-controls__effort-menu",
           trigger: '[data-chat-thinking-select="true"]',
-          clearsComposer: true,
         },
       ]) {
         await composer.locator(picker.trigger).click();
@@ -56,9 +54,7 @@ suite.define(() => {
           throw new Error(`expected mobile layout boxes for ${picker.menu}`);
         }
         expect(menuBox.y).toBeGreaterThanOrEqual(0);
-        expect(menuBox.y + menuBox.height).toBeLessThanOrEqual(
-          (picker.clearsComposer ? composerBox.y : triggerBox.y) + 1,
-        );
+        expect(menuBox.y + menuBox.height).toBeLessThanOrEqual(composerBox.y + 1);
         expect(triggerBox.y + triggerBox.height).toBeLessThanOrEqual(376);
         expect(footerBox.y + footerBox.height).toBeLessThanOrEqual(376);
         await composer.locator(picker.trigger).click();
@@ -147,7 +143,7 @@ suite.define(() => {
       const composerShell = page.locator(".agent-chat__composer-shell");
       const chatContent = page.locator("main.content--chat");
       const chatMain = page.locator(".chat-workbench__main");
-      const model = composer.locator("wa-select.chat-controls__model-picker");
+      const model = composer.locator('[data-chat-model-select="true"]');
       const effort = composer.locator('[data-chat-thinking-select="true"]');
       const usage = composer.locator('[data-chat-provider-usage="true"]');
       const contextUsage = composer.locator(".context-ring");
@@ -199,7 +195,7 @@ suite.define(() => {
       await expect.poll(() => composer.locator(".agent-chat__composer-header").count()).toBe(0);
       await expect
         .poll(async () =>
-          (await model.locator("wa-option[selected] .picker-select__label").textContent())?.trim(),
+          (await model.locator(".chat-controls__inline-select-label").textContent())?.trim(),
         )
         .toBe("GPT-5.5");
       await expect
@@ -276,14 +272,16 @@ suite.define(() => {
         .toBe(1);
       await page.keyboard.press("Escape");
       await model.click();
+      const providerHeadings = composer.locator("[data-chat-model-provider]");
       await expect
-        .poll(() => model.locator("wa-option").allTextContents())
-        .toEqual(
-          expect.arrayContaining([
-            expect.stringContaining("GPT-5.4 Pro"),
-            expect.stringContaining("Claude Sonnet 4.6"),
-          ]),
-        );
+        .poll(async () => (await providerHeadings.allTextContents()).map((label) => label.trim()))
+        .toEqual(["OpenAI", "Anthropic"]);
+      await expect
+        .poll(() => composer.locator('[data-chat-model-provider-group="openai"]').textContent())
+        .toContain("GPT-5.4 Pro");
+      const anthropicModels = composer.locator('[data-chat-model-provider-group="anthropic"]');
+      await expect.poll(() => anthropicModels.isVisible()).toBe(true);
+      await expect.poll(() => anthropicModels.textContent()).toContain("Claude Sonnet 4.6");
       await model.click();
 
       const [
@@ -477,6 +475,14 @@ suite.define(() => {
 
       await page.setViewportSize({ width: 393, height: 852 });
       await expect.poll(() => camera.count()).toBe(0);
+      // Resize re-layout is async; wait for the header controls to adopt the
+      // mobile width before sampling one-shot bounding boxes below.
+      await expect
+        .poll(async () => {
+          const settled = await settings.boundingBox();
+          return settled ? settled.x + settled.width : Number.POSITIVE_INFINITY;
+        })
+        .toBeLessThanOrEqual(393);
       const [mobileAttachBox, mobileModelBox, mobileSettingsBox, mobileContextBox, mobileVoiceBox] =
         await Promise.all([
           attach.boundingBox(),
@@ -540,7 +546,7 @@ suite.define(() => {
       await textarea.fill("");
       await expect.poll(() => camera.count()).toBe(0);
       await model.click();
-      const mobilePickerBox = await model.locator("wa-option:last-of-type").boundingBox();
+      const mobilePickerBox = await composer.locator(".chat-controls__model-menu").boundingBox();
       expect(mobilePickerBox).not.toBeNull();
       if (!mobilePickerBox) {
         throw new Error("expected mobile model picker to have a layout box");
@@ -645,14 +651,20 @@ suite.define(() => {
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
 
       const composer = page.locator(".agent-chat__input");
-      const modelPicker = composer.locator("wa-select.chat-controls__model-picker");
-      await expect.poll(() => modelPicker.locator("wa-option").count()).toBe(2);
+      const providers = composer.locator("[data-chat-model-provider]");
       await expect
-        .poll(async () => (await modelPicker.locator("wa-option").allTextContents()).join(" "))
+        .poll(async () => (await providers.allTextContents()).map((label) => label.trim()))
+        .toEqual(["OpenAI"]);
+      await expect
+        .poll(() => composer.locator('[data-chat-model-provider-group="openai"]').textContent())
         .toContain("GPT-5.5");
-      // The catalog default is unavailable, but the empty-string sentinel must
-      // remain so an existing session override can still be cleared.
-      await expect.poll(() => modelPicker.locator('wa-option[value=""]').count()).toBe(1);
+      await expect
+        .poll(() => composer.locator('[data-chat-model-provider-group="codex"]').count())
+        .toBe(0);
+      // The advertised default is unavailable, so no usable catalog row is
+      // marked as the default and no synthetic empty row is introduced.
+      await expect.poll(() => composer.locator('[data-chat-model-default="true"]').count()).toBe(0);
+      await expect.poll(() => composer.locator('[data-chat-model-option=""]').count()).toBe(0);
     });
   });
 
@@ -749,9 +761,7 @@ suite.define(() => {
         page.locator('openclaw-chat-pane[aria-hidden="false"] .agent-chat__input');
       await expect
         .poll(() =>
-          activeComposer()
-            .locator('wa-select.chat-controls__model-picker wa-option[value="openai/work-model"]')
-            .count(),
+          activeComposer().locator('[data-chat-model-option="openai/work-model"]').count(),
         )
         .toBe(1);
       expect(await gateway.getRequests("models.list")).toEqual([
@@ -770,18 +780,12 @@ suite.define(() => {
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
       await expect
         .poll(() =>
-          activeComposer()
-            .locator(
-              'wa-select.chat-controls__model-picker wa-option[value="anthropic/other-model"]',
-            )
-            .count(),
+          activeComposer().locator('[data-chat-model-option="anthropic/other-model"]').count(),
         )
         .toBe(1);
       await expect
         .poll(() =>
-          activeComposer()
-            .locator('wa-select.chat-controls__model-picker wa-option[value="openai/work-model"]')
-            .count(),
+          activeComposer().locator('[data-chat-model-option="openai/work-model"]').count(),
         )
         .toBe(0);
       expect(await gateway.getRequests("models.list")).toEqual([
@@ -855,11 +859,7 @@ suite.define(() => {
       const composer = page.locator(".agent-chat__input");
       await expect
         .poll(async () =>
-          (
-            await composer
-              .locator("wa-select.chat-controls__model-picker wa-option")
-              .allTextContents()
-          ).join(" "),
+          (await composer.locator("[data-chat-model-option]").allTextContents()).join(" "),
         )
         .not.toContain("GPT Default");
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);

--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -432,13 +432,7 @@ suite.define(() => {
       await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
       await page.getByText("First token visible.").waitFor({ timeout: 10_000 });
       await expect
-        .poll(() =>
-          page
-            .locator("wa-select.chat-controls__model-picker .picker-select__label", {
-              hasText: "Startup Model",
-            })
-            .count(),
-        )
+        .poll(() => page.locator('[data-chat-model-option="openai/startup-model"]').count())
         .toBe(1);
       await gateway.emitChatFinal({ runId, text: "History race stayed visible." });
       await page

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -1,4 +1,3 @@
-import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import {
   chatSessionListResponse,
@@ -10,30 +9,6 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-
-function chatModelPicker(root: Locator) {
-  return root.locator("wa-select.chat-controls__model-picker").first();
-}
-
-function chatModelValue(root: Locator) {
-  return chatModelPicker(root).evaluate((element) =>
-    String((element as HTMLElement & { value?: string }).value),
-  );
-}
-
-async function selectChatModel(root: Locator, value: string) {
-  const picker = chatModelPicker(root);
-  await picker
-    .locator(`wa-option[value="${value}"]`)
-    .waitFor({ state: "attached", timeout: 10_000 });
-  await expect.poll(() => picker.isDisabled()).toBe(false);
-  await picker.evaluate(async (element, next) => {
-    const select = element as HTMLElement & { value: string; updateComplete: Promise<unknown> };
-    select.value = next;
-    await select.updateComplete;
-    select.dispatchEvent(new Event("change", { bubbles: true }));
-  }, value);
-}
 
 suite.define(() => {
   it("routes runtime-aware model commands through the server directive path", async () => {
@@ -88,8 +63,8 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}chat`);
       const main = page.getByRole("main");
-      await chatModelPicker(main).click();
-      const modelScroller = chatModelPicker(main).locator("wa-option").last();
+      await main.locator('[data-chat-model-select="true"]').click();
+      const modelScroller = main.locator(".chat-controls__model-options");
       await page.evaluate(() => {
         document.documentElement.style.overflowY = "auto";
         document.body.style.height = "1800px";
@@ -130,13 +105,23 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
 
       const main = page.getByRole("main");
-      const activePane = () => main.locator('openclaw-chat-pane[aria-hidden="false"]');
+      const openModelSelect = async () => {
+        const trigger = main.locator(
+          'openclaw-chat-pane[aria-hidden="false"] [data-chat-model-select="true"]',
+        );
+        await trigger.waitFor({ state: "visible", timeout: 10_000 });
+        return trigger;
+      };
       const selectModel = async (value: string) => {
-        await selectChatModel(activePane(), value);
+        const activePane = main.locator('openclaw-chat-pane[aria-hidden="false"]');
+        await activePane.locator('[data-chat-model-select="true"]').click();
+        const option = activePane.locator(`[data-chat-model-option="${value}"]`);
+        await option.waitFor({ state: "visible", timeout: 10_000 });
+        await option.click();
       };
 
-      await chatModelPicker(activePane()).waitFor({ state: "visible", timeout: 10_000 });
-      expect(await chatModelValue(activePane())).toBe("");
+      let modelSelect = await openModelSelect();
+      expect(await modelSelect.getAttribute("data-chat-select-value")).toBe("");
 
       await selectModel("bedrock/claude-opus-4.5");
       const patchRequest = await gateway.waitForRequest("sessions.patch");
@@ -144,7 +129,9 @@ suite.define(() => {
         key: "agent:main:session-a",
         model: "bedrock/claude-opus-4.5",
       });
-      expect(await chatModelValue(activePane())).toBe("bedrock/claude-opus-4.5");
+      expect(await modelSelect.getAttribute("data-chat-select-value")).toBe(
+        "bedrock/claude-opus-4.5",
+      );
 
       await page
         .locator(
@@ -154,8 +141,8 @@ suite.define(() => {
       await page.locator(".sidebar-recent-session--active").getByText("Session B").waitFor({
         timeout: 10_000,
       });
-      await chatModelPicker(activePane()).waitFor({ state: "visible", timeout: 10_000 });
-      expect(await chatModelValue(activePane())).toBe("");
+      modelSelect = await openModelSelect();
+      expect(await modelSelect.getAttribute("data-chat-select-value")).toBe("");
 
       await page
         .locator(
@@ -166,8 +153,10 @@ suite.define(() => {
         timeout: 10_000,
       });
 
-      await chatModelPicker(activePane()).waitFor({ state: "visible", timeout: 10_000 });
-      expect(await chatModelValue(activePane())).toBe("bedrock/claude-opus-4.5");
+      modelSelect = await openModelSelect();
+      expect(await modelSelect.getAttribute("data-chat-select-value")).toBe(
+        "bedrock/claude-opus-4.5",
+      );
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -243,12 +232,13 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}chat`);
       const main = page.getByRole("main");
-      const modelSelect = chatModelPicker(main);
+      const modelSelect = main.locator('[data-chat-model-select="true"]').first();
       await modelSelect.waitFor({ state: "visible", timeout: 10_000 });
       expect(await modelSelect.textContent()).toContain("Claude Opus 4.5");
-      expect(await chatModelValue(main)).toBe("");
+      expect(await modelSelect.getAttribute("data-chat-select-value")).toBe("");
 
-      await selectChatModel(main, "openai/gpt-5.5");
+      await modelSelect.click();
+      await main.locator('[data-chat-model-option="openai/gpt-5.5"]').click();
       const firstPatch = await gateway.waitForRequest("sessions.patch");
       expect(requireRecord(firstPatch.params)).toMatchObject({
         key: "agent:ops:session-a",
@@ -259,16 +249,20 @@ suite.define(() => {
       // Model selection closes immediately. Reopen and select the real default
       // catalog row to clear the session override.
       await modelSelect.click();
-      const defaultModel = modelSelect.locator('wa-option[value=""]');
+      const defaultModel = main.locator(
+        '[data-chat-model-option="anthropic/claude-opus-4-5"][data-chat-model-default="true"]',
+      );
+      await defaultModel.waitFor({ state: "visible", timeout: 10_000 });
       expect(await defaultModel.textContent()).toContain("Default");
-      await selectChatModel(main, "");
+      expect(await main.locator('[data-chat-model-option=""]').count()).toBe(0);
+      await defaultModel.click();
       const patches = await waitForRequests(gateway, "sessions.patch", 2);
       expect(requireRecord(patches[1]?.params)).toMatchObject({
         key: "agent:ops:session-a",
         model: null,
       });
       expect(await modelSelect.textContent()).toContain("Claude Opus 4.5");
-      expect(await chatModelValue(main)).toBe("");
+      expect(await modelSelect.getAttribute("data-chat-select-value")).toBe("");
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -355,7 +349,7 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
       const main = page.getByRole("main");
       const activePane = main.locator('openclaw-chat-pane[aria-hidden="false"]');
-      const modelSelect = chatModelPicker(activePane);
+      const modelSelect = activePane.locator('[data-chat-model-select="true"]');
       const effortSelect = activePane.locator('[data-chat-thinking-select="true"]');
       const thinkingSlider = activePane.locator('[data-chat-thinking-slider="true"]');
       const expectedThinkingValues = thinkingLevels.map((level) => level.id).join(",");
@@ -363,10 +357,13 @@ suite.define(() => {
       await modelSelect.waitFor({ state: "visible", timeout: 10_000 });
       expect(await modelSelect.textContent()).toContain("GPT-5.6 Sol");
       expect(await modelSelect.textContent()).not.toContain("@openai:");
-      await expect.poll(() => modelSelect.locator('wa-option[value=""]').count()).toBe(1);
-      expect((await modelSelect.locator("wa-option").allTextContents()).join(" ")).not.toContain(
-        "@openai:",
-      );
+      await modelSelect.click();
+      await expect
+        .poll(() => activePane.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').count())
+        .toBe(1);
+      expect(
+        (await main.locator("[data-chat-model-option]").allTextContents()).join(" "),
+      ).not.toContain("@openai:");
       await expect
         .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
         .toBe(expectedThinkingValues);
@@ -384,7 +381,10 @@ suite.define(() => {
       await page.locator(".sidebar-recent-session--active").getByText("Explicit Sol").waitFor({
         timeout: 10_000,
       });
-      await expect.poll(() => modelSelect.locator('wa-option[value=""]').count()).toBe(1);
+      await modelSelect.click();
+      await expect
+        .poll(() => activePane.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').count())
+        .toBe(1);
       await expect
         .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
         .toBe(expectedThinkingValues);
@@ -424,7 +424,8 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
 
       const main = page.getByRole("main");
-      await selectChatModel(main, "bedrock/claude-opus-4.5");
+      await main.locator('[data-chat-model-select="true"]').click();
+      await main.locator('[data-chat-model-option="bedrock/claude-opus-4.5"]').click();
       await gateway.waitForRequest("sessions.patch");
 
       const prompt = "send while the model save is pending";
@@ -487,7 +488,7 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
 
       const main = page.getByRole("main");
-      const modelPicker = chatModelPicker(main);
+      const modelPicker = main.locator('[data-chat-model-select="true"]').first();
       const effortPicker = main.locator('[data-chat-thinking-select="true"]').first();
       await effortPicker.click();
       const thinkingSlider = main.locator('[data-chat-thinking-slider="true"]');
@@ -526,17 +527,29 @@ suite.define(() => {
       await page.keyboard.press("Escape");
 
       await modelPicker.click();
+      const search = main.locator('[data-chat-model-search="true"]');
       await expect
-        .poll(() => modelPicker.locator('wa-option[value="anthropic/claude-fable-5"]').count())
-        .toBe(1);
+        .poll(() => search.evaluate((element) => element === document.activeElement))
+        .toBe(false);
+      await search.focus();
+      await search.fill("anthropic");
+      const anthropicModel = main.locator('[data-chat-model-option="anthropic/claude-fable-5"]');
+      await expect.poll(() => anthropicModel.isVisible()).toBe(true);
+      await expect
+        .poll(() =>
+          main.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').getAttribute("hidden"),
+        )
+        .toBe("");
       await expectRequestCountStable(gateway, "sessions.patch", 1);
-      await selectChatModel(main, "anthropic/claude-fable-5");
+      await search.press("Enter");
       const patches = await waitForRequests(gateway, "sessions.patch", 2);
       expect(requireRecord(patches[1]?.params)).toMatchObject({
         key: sessionKey,
         model: "anthropic/claude-fable-5",
       });
-      await expect.poll(() => chatModelValue(main)).toBe("anthropic/claude-fable-5");
+      await expect
+        .poll(() => main.locator(".chat-controls__model-picker").getAttribute("open"))
+        .toBe(null);
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -595,7 +608,8 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
 
       const main = page.getByRole("main");
-      await selectChatModel(main, "openai/gpt-5.6-sol");
+      await main.locator('[data-chat-model-select="true"]').click();
+      await main.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').click();
 
       const modelPatch = await gateway.waitForRequest("sessions.patch");
       expect(requireRecord(modelPatch.params)).toMatchObject({

--- a/ui/src/e2e/chat-only-model.e2e.test.ts
+++ b/ui/src/e2e/chat-only-model.e2e.test.ts
@@ -1,6 +1,5 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
@@ -27,19 +26,6 @@ const models = [
     supportsTools: true,
   },
 ];
-
-async function selectModel(picker: Locator, value: string) {
-  await picker
-    .locator(`wa-option[value="${value}"]`)
-    .waitFor({ state: "attached", timeout: 10_000 });
-  await expect.poll(() => picker.isDisabled()).toBe(false);
-  await picker.evaluate(async (element, next) => {
-    const select = element as HTMLElement & { value: string; updateComplete: Promise<unknown> };
-    select.value = next;
-    await select.updateComplete;
-    select.dispatchEvent(new Event("change", { bubbles: true }));
-  }, value);
-}
 
 function sessionsList(model: string, modelProvider: string) {
   return {
@@ -98,10 +84,12 @@ suite.define(() => {
 
       const main = page.getByRole("main");
       const composer = main.locator(".agent-chat__composer-shell");
-      const picker = composer.locator("wa-select.chat-controls__model-picker");
-      const badge = composer.locator(".chat-controls__model-capability-badge");
+      const picker = composer.locator('[data-chat-model-select="true"]');
+      const badge = picker.locator(".chat-controls__model-capability-badge");
 
+      await expect.poll(() => picker.getAttribute("data-chat-model-tools")).toBe("unavailable");
       await expect.poll(async () => (await badge.textContent())?.trim()).toBe("Chat only");
+      await expect.poll(() => picker.getAttribute("aria-label")).toContain("Chat only");
 
       if (proofDir) {
         await composer.screenshot({
@@ -111,8 +99,8 @@ suite.define(() => {
       }
 
       await picker.click();
-      const localOption = picker.locator('wa-option[value=""]');
-      const openAiOption = picker.locator('wa-option[value="openai/gpt-5.5"]');
+      const localOption = composer.locator('[data-chat-model-option="lmstudio/qwen3-8b"]');
+      const openAiOption = composer.locator('[data-chat-model-option="openai/gpt-5.5"]');
       await expect
         .poll(async () => (await localOption.textContent())?.replace(/\s+/g, " ").trim())
         .toContain("32.8k · Chat only");
@@ -128,13 +116,21 @@ suite.define(() => {
         });
       }
 
-      await selectModel(picker, "openai/gpt-5.5");
+      await openAiOption.click();
       const patch = await gateway.waitForRequest("sessions.patch");
       expect(patch.params).toMatchObject({ key: sessionKey, model: "openai/gpt-5.5" });
+      await expect.poll(() => picker.getAttribute("data-chat-model-tools")).toBe("available");
       await expect.poll(() => badge.count()).toBe(0);
 
-      await selectModel(picker, "");
-      await expect.poll(() => badge.count()).toBe(1);
+      const pickerDetails = composer.locator("details.chat-controls__model-picker");
+      if (!(await pickerDetails.evaluate((element: HTMLDetailsElement) => element.open))) {
+        await picker.click();
+      }
+      await localOption.click();
+      await expect.poll(() => picker.getAttribute("data-chat-model-tools")).toBe("unavailable");
+      if (await pickerDetails.evaluate((element: HTMLDetailsElement) => element.open)) {
+        await picker.click();
+      }
       await page.setViewportSize({ height: 844, width: 390 });
       await expect.poll(() => picker.isVisible()).toBe(true);
 
@@ -146,10 +142,13 @@ suite.define(() => {
         });
       }
 
-      await picker.click();
+      if (!(await pickerDetails.evaluate((element: HTMLDetailsElement) => element.open))) {
+        await picker.click();
+      }
+      const menu = composer.locator(".chat-controls__model-menu");
       await expect
         .poll(async () => {
-          const box = await localOption.boundingBox();
+          const box = await menu.boundingBox();
           return box !== null && box.x >= 0 && box.x + box.width <= 390;
         })
         .toBe(true);

--- a/ui/src/e2e/model-alias-display.e2e.test.ts
+++ b/ui/src/e2e/model-alias-display.e2e.test.ts
@@ -63,15 +63,15 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}chat`);
       const main = page.getByRole("main");
-      const picker = main.locator("wa-select.chat-controls__model-picker").first();
+      const picker = main.locator('[data-chat-model-select="true"]').first();
       await picker.waitFor({ state: "visible", timeout: 10_000 });
       await picker.click();
 
       const opus = main.locator(
-        'wa-option[value="anthropic/claude-opus-4-8"] .picker-select__label',
+        '[data-chat-model-option="anthropic/claude-opus-4-8"] .chat-controls__model-option-name',
       );
       const sonnet = main.locator(
-        'wa-option[value="anthropic/claude-sonnet-5"] .picker-select__label',
+        '[data-chat-model-option="anthropic/claude-sonnet-5"] .chat-controls__model-option-name',
       );
       await expect.poll(() => opus.textContent()).toBe("Opus 4.8 · opus");
       await expect.poll(() => sonnet.textContent()).toBe("Sonnet 5 · sonnet");
@@ -84,7 +84,7 @@ suite.define(() => {
       }
 
       const nvidia = main.locator(
-        'wa-option[value="nvidia/moonshotai/kimi-k2.5"] .picker-select__label',
+        '[data-chat-model-option="nvidia/moonshotai/kimi-k2.5"] .chat-controls__model-option-name',
       );
       await expect.poll(() => nvidia.textContent()).toBe("Kimi K2.5 (NVIDIA)");
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -118,9 +118,9 @@ suite.define(() => {
         )
         .toMatchObject({ params: { agentId: "main", limitPerHost: 1 } });
 
-      const cliGroup = page.locator("wa-select.new-session-page__target-picker");
-      await cliGroup.click();
-      await expect.poll(() => cliGroup.getAttribute("open")).toBe("");
+      await page.locator('[data-chat-model-select="true"]').click();
+      const cliGroup = page.locator('[data-chat-model-target-group="cliAgents"]');
+      await expect.poll(() => cliGroup.isVisible()).toBe(true);
       await pollLocatorText(cliGroup).toContain("CLI agents");
       await pollLocatorText(cliGroup).toContain("Claude Code");
       expect(await cliGroup.textContent()).not.toContain("History only");
@@ -132,12 +132,7 @@ suite.define(() => {
         });
       }
 
-      await cliGroup.evaluate(async (element) => {
-        const select = element as HTMLElement & { value: string; updateComplete: Promise<unknown> };
-        select.value = "claude";
-        await select.updateComplete;
-        select.dispatchEvent(new Event("change", { bubbles: true }));
-      });
+      await cliGroup.getByRole("option", { name: "Claude Code" }).click();
       await expect.poll(() => new URL(page.url()).searchParams.get("catalog")).toBe("claude");
       await expect
         .poll(async () =>
@@ -147,7 +142,7 @@ suite.define(() => {
         )
         .toMatchObject({ params: { agentId: "main", catalogId: "claude" } });
       await pollLocatorText(page.locator(".new-session-page__runtime")).toContain("Claude Code");
-      expect(await page.locator("wa-select.chat-controls__model-picker").count()).toBe(0);
+      expect(await page.locator('[data-chat-model-select="true"]').count()).toBe(0);
       if (captureCliAgentsProof) {
         await page.screenshot({
           animations: "disabled",
@@ -474,18 +469,18 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}new`);
       await gateway.waitForRequest("chat.metadata");
 
-      const modelSelect = page.locator("wa-select.chat-controls__model-picker");
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
       await expect.poll(() => modelSelect.textContent()).toContain("Models unavailable");
       await modelSelect.click();
       await expect
         .poll(() => page.locator('[data-chat-model-catalog-state="error"]').isVisible())
         .toBe(true);
-      expect(await modelSelect.locator("wa-option").count()).toBe(1);
+      expect(await page.locator("[data-chat-model-option]").count()).toBe(0);
 
       await page.locator('[data-chat-model-catalog-retry="true"]').click();
 
       await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
-      await expect.poll(() => modelSelect.locator("wa-option").count()).toBe(3);
+      await expect.poll(() => page.locator("[data-chat-model-option]").count()).toBe(3);
       expect(await page.locator('[data-chat-model-catalog-state="error"]').count()).toBe(0);
     } finally {
       await context.close();
@@ -530,15 +525,11 @@ suite.define(() => {
       await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
 
       const modelSelect = page.locator(
-        ".new-session-page__composer wa-select.chat-controls__model-picker",
+        '.new-session-page__composer [data-chat-model-select="true"]',
       );
       await modelSelect.click();
       await expect
-        .poll(() =>
-          modelSelect
-            .locator('wa-option[value="openai/gpt-5.6-luna"] .picker-select__label')
-            .textContent(),
-        )
+        .poll(() => page.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').textContent())
         .toContain(recoveredModel.name);
 
       expect(await gateway.getRequests("chat.metadata")).toEqual([
@@ -618,7 +609,7 @@ suite.define(() => {
       await pollLocatorText(runtime).toContain("Claude Code");
       expect(await runtime.getAttribute("title")).toBe(model);
       expect(await page.locator('.new-session-page__trigger[title="Agent"]').count()).toBe(0);
-      expect(await page.locator("wa-select.chat-controls__model-picker").count()).toBe(0);
+      expect(await page.locator('[data-chat-model-select="true"]').count()).toBe(0);
 
       await page.locator(".new-session-page__message").fill("use Claude Code");
       await page.getByRole("button", { name: "Start session" }).click();

--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -135,7 +135,7 @@ suite.define(() => {
       const heroBox = await page.locator(".agent-chat__welcome h2").boundingBox();
       const triggersBox = await page.locator(".new-session-page__triggers").boundingBox();
       const composerBox = await page.locator(".new-session-page__composer").boundingBox();
-      const modelBox = await page.locator("wa-select.chat-controls__model-picker").boundingBox();
+      const modelBox = await page.locator('[data-chat-model-select="true"]').boundingBox();
       const modelWrapperBox = await page
         .locator(".new-session-page__composer .chat-composer-model-control")
         .boundingBox();
@@ -159,7 +159,7 @@ suite.define(() => {
       ).toBe(1);
       expect(
         await page
-          .locator("wa-select.chat-controls__model-picker")
+          .locator('[data-chat-model-select="true"]')
           .evaluate((element) => element.closest(".agent-chat__composer-footer") != null),
       ).toBe(true);
       expect(modelWrapperBox?.x ?? 0).toBeGreaterThan(

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -33,30 +33,6 @@ const MODELS = [
   { id: "gpt-5.5", name: "GPT 5.5", provider: "openai" },
   { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
 ];
-
-function newSessionModelPicker(page: Page) {
-  return page.locator(".new-session-page__composer wa-select.chat-controls__model-picker");
-}
-
-function newSessionModelValue(page: Page) {
-  return newSessionModelPicker(page).evaluate((element) =>
-    String((element as HTMLElement & { value?: string }).value),
-  );
-}
-
-async function selectNewSessionModel(page: Page, value: string) {
-  const picker = newSessionModelPicker(page);
-  await picker
-    .locator(`wa-option[value="${value}"]`)
-    .waitFor({ state: "attached", timeout: 10_000 });
-  await expect.poll(() => picker.isDisabled()).toBe(false);
-  await picker.evaluate(async (element, next) => {
-    const select = element as HTMLElement & { value: string; updateComplete: Promise<unknown> };
-    select.value = next;
-    await select.updateComplete;
-    select.dispatchEvent(new Event("change", { bubbles: true }));
-  }, value);
-}
 const GIT_BRANCHES = {
   branches: [{ kind: "local", name: "main" }],
   defaultBranch: "main",
@@ -255,19 +231,38 @@ suite.define(() => {
         },
       });
       await page.goto(`${suite.server.baseUrl}new`);
-      const modelSelect = newSessionModelPicker(page);
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
       await modelSelect.waitFor();
       expect(
-        await page
-          .locator(".new-session-page__composer wa-select.chat-controls__model-picker")
-          .count(),
+        await page.locator('.new-session-page__composer [data-chat-model-select="true"]').count(),
       ).toBe(1);
       expect(
-        await page
-          .locator(".new-session-page__triggers wa-select.chat-controls__model-picker")
-          .count(),
+        await page.locator('.new-session-page__triggers [data-chat-model-select="true"]').count(),
       ).toBe(0);
-      await selectNewSessionModel(page, "anthropic/claude-sonnet-4-6");
+      await modelSelect.click();
+      const pickerOpen = () =>
+        modelSelect.evaluate(
+          (element) => element.closest("details")?.hasAttribute("open") ?? false,
+        );
+      const modelTriggerBox = await modelSelect.boundingBox();
+      const modelMenuBox = await page.locator(".chat-controls__model-menu").boundingBox();
+      expect(modelTriggerBox).not.toBeNull();
+      expect(modelMenuBox).not.toBeNull();
+      expect(modelMenuBox?.x ?? 0).toBeLessThanOrEqual(modelTriggerBox?.x ?? 0);
+      expect((modelMenuBox?.x ?? 0) + (modelMenuBox?.width ?? 0)).toBeLessThanOrEqual(
+        await page.evaluate(() => window.innerWidth),
+      );
+      await expect.poll(pickerOpen).toBe(true);
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+      // Model selection commits immediately and closes the model popover.
+      await expect.poll(pickerOpen).toBe(false);
+      await expect
+        .poll(() => modelSelect.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await modelSelect.click();
+      await expect.poll(pickerOpen).toBe(true);
+      await page.mouse.click(8, 8);
+      await expect.poll(pickerOpen).toBe(false);
       await page.locator(".new-session-page__message").fill("use this model");
       await page.getByRole("button", { name: "Start session" }).click();
 
@@ -279,17 +274,62 @@ suite.define(() => {
     });
   });
 
-  it("lets Web Awesome own model-picker keyboard dismissal", async () => {
+  it("separates model shortcuts from numeric search input by focus", async () => {
     await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
       await installMockGateway(page, { models: MODELS });
       await page.goto(`${suite.server.baseUrl}new`);
 
-      const modelSelect = newSessionModelPicker(page);
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      const picker = page.locator(".chat-controls__model-picker");
+      const search = page.locator('[data-chat-model-search="true"]');
+      const firstModel = page.locator('[data-chat-model-option="openai/gpt-5.5"]');
+      const secondModel = page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]');
 
       await modelSelect.click();
-      await expect.poll(() => modelSelect.getAttribute("open")).toBe("");
-      await page.keyboard.press("Escape");
-      await expect.poll(() => modelSelect.getAttribute("open")).toBe(null);
+      await expect.poll(() => picker.getAttribute("open")).toBe("");
+      await expect
+        .poll(() => modelSelect.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      const secondShortcut = secondModel.locator('[data-chat-model-shortcut-number="2"]');
+      await expect.poll(() => secondShortcut.count()).toBe(1);
+      const menuBoxBeforeFocus = await page.locator(".chat-controls__model-menu").boundingBox();
+      const actionBoxBeforeFocus = await secondModel
+        .locator(".chat-controls__model-option-action")
+        .boundingBox();
+      expect(menuBoxBeforeFocus).not.toBeNull();
+      expect(actionBoxBeforeFocus).not.toBeNull();
+      await expect
+        .poll(() => secondShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("1");
+
+      await search.focus();
+      await expect
+        .poll(() => search.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await expect
+        .poll(() => secondShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("0");
+      expect(await page.locator(".chat-controls__model-menu").boundingBox()).toEqual(
+        menuBoxBeforeFocus,
+      );
+      expect(
+        await secondModel.locator(".chat-controls__model-option-action").boundingBox(),
+      ).toEqual(actionBoxBeforeFocus);
+      await search.press("1");
+      await expect.poll(() => search.inputValue()).toBe("1");
+      await expect.poll(() => picker.getAttribute("open")).toBe("");
+
+      await search.fill("anthropic");
+      await expect.poll(() => firstModel.isVisible()).toBe(false);
+      await expect.poll(() => secondModel.isVisible()).toBe(true);
+      await modelSelect.focus();
+      const filteredShortcut = secondModel.locator('[data-chat-model-shortcut-number="1"]');
+      await expect
+        .poll(() => filteredShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("1");
+      await page.keyboard.press("1");
+      await expect.poll(() => picker.getAttribute("open")).toBe(null);
+      await expect.poll(() => modelSelect.textContent()).toContain("Claude Sonnet 4.6");
     });
   });
 
@@ -356,7 +396,9 @@ suite.define(() => {
       });
       await expect.poll(() => effortSelect.getAttribute("data-chat-thinking-value")).toBe("xhigh");
 
-      await selectNewSessionModel(page, "openai/gpt-5.6-sol");
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').click();
       await effortSelect.click();
 
       await expect
@@ -373,8 +415,7 @@ suite.define(() => {
         ),
       ).toBeCloseTo(83.33, 1);
 
-      await page.keyboard.press("Escape");
-      await expect.poll(() => page.locator(".chat-controls__effort-menu").isVisible()).toBe(false);
+      await effortSelect.click();
       await page.locator(".new-session-page__message").fill("keep the selected effort");
       await page.getByRole("button", { name: "Start session" }).click();
       const create = await gateway.waitForRequest("sessions.create");
@@ -407,7 +448,9 @@ suite.define(() => {
       await page.getByLabel("Worktree name").fill("remembered-task");
       await page.keyboard.press("Escape");
 
-      await selectNewSessionModel(page, "anthropic/claude-sonnet-4-6");
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
       const effortSelect = page.locator('[data-chat-thinking-select="true"]');
       await effortSelect.click();
       const thinkingSlider = page.locator('[data-chat-thinking-slider="true"]');
@@ -428,7 +471,9 @@ suite.define(() => {
         .poll(() => page.getByLabel("Worktree name").inputValue())
         .toBe("remembered-task");
       await page.keyboard.press("Escape");
-      await expect.poll(() => newSessionModelValue(page)).toBe("anthropic/claude-sonnet-4-6");
+      await expect
+        .poll(() => modelSelect.getAttribute("data-chat-select-value"))
+        .toBe("anthropic/claude-sonnet-4-6");
       await expect.poll(() => effortSelect.getAttribute("data-chat-thinking-value")).toBe("high");
       await captureUiProof(page, "new-session-preferences-restored.png");
 
@@ -642,7 +687,9 @@ suite.define(() => {
           .toBe(1);
 
         await gateway.deferNext("users.prefs.set");
-        await selectNewSessionModel(page, "");
+        const modelSelect = page.locator('[data-chat-model-select="true"]');
+        await modelSelect.click();
+        await page.locator('[data-chat-model-option="openai/gpt-5.5"]').click();
         await expect
           .poll(async () => (await gateway.getRequests("users.prefs.set")).length)
           .toBe(2);
@@ -724,7 +771,9 @@ suite.define(() => {
       await placeTrigger.click();
       await page.getByRole("button", { name: "Worktree" }).click();
       await page.keyboard.press("Escape");
-      await selectNewSessionModel(page, "anthropic/claude-sonnet-4-6");
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
 
       await navigateInApp(page, "chat");
       await waitForCommittedChatRoute(page);
@@ -759,7 +808,9 @@ suite.define(() => {
 
       await page.reload();
       await page.locator(".new-session-page__message").fill("keep both remembered choices");
-      await expect.poll(() => newSessionModelValue(page)).toBe("anthropic/claude-sonnet-4-6");
+      await expect
+        .poll(() => modelSelect.getAttribute("data-chat-select-value"))
+        .toBe("anthropic/claude-sonnet-4-6");
       await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("true");
       await expect.poll(() => start.isDisabled()).toBe(false);
       await start.click();
@@ -805,7 +856,9 @@ suite.define(() => {
         "openclaw-next",
       );
 
-      await selectNewSessionModel(page, "anthropic/claude-sonnet-4-6");
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
       const storedPreference = await readMainPreference(page);
       expect(storedPreference).toMatchObject({
         workspace: MOVED_WORKSPACE,

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -180,36 +180,6 @@ suite.define(() => {
       );
       expect(controlsOverflow).toBe(0);
 
-      const picker = newSessionModelPicker(page);
-      await picker.click();
-      await expect.poll(() => picker.getAttribute("open")).toBe("");
-      const optionLabelWidths = await picker.locator("wa-option").evaluateAll((options) =>
-        options.flatMap((option) => {
-          if (option.getBoundingClientRect().width === 0) {
-            return [];
-          }
-          const label = option.querySelector<HTMLElement>(".picker-select__label")!;
-          const probe = document.createElement("span");
-          probe.style.cssText = `position:fixed;visibility:hidden;width:8ch;font:${getComputedStyle(label).font}`;
-          document.body.append(probe);
-          const minimum = probe.getBoundingClientRect().width;
-          probe.remove();
-          return [
-            {
-              label: label.textContent?.trim(),
-              minimum,
-              width: label.getBoundingClientRect().width,
-            },
-          ];
-        }),
-      );
-      expect(optionLabelWidths.length).toBeGreaterThanOrEqual(2);
-      for (const entry of optionLabelWidths) {
-        expect(entry.width, JSON.stringify(entry)).toBeGreaterThanOrEqual(entry.minimum);
-      }
-      await captureUiProof(page, "mobile-model-picker-labels.png");
-      await picker.click();
-
       await attach.click();
       await expect.poll(() => takePhoto.isVisible()).toBe(true);
       await page.keyboard.press("Escape");

--- a/ui/src/e2e/session-suggestions.e2e.test.ts
+++ b/ui/src/e2e/session-suggestions.e2e.test.ts
@@ -99,14 +99,14 @@ suite.define(() => {
 
     await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
     const composer = page.locator(".agent-chat__composer-combobox textarea");
-    const modelPicker = page.locator("wa-select.chat-controls__model-picker");
+    const modelTrigger = page.locator(".chat-controls__model-trigger");
     const outsideTypingIndicator = page.locator(".agent-chat__typing-indicator--outside");
     await gateway.waitForRequest("session.suggestions.list");
     await expect(composer).toBeEnabled();
-    await modelPicker.waitFor();
-    const idleModelBox = await modelPicker.boundingBox();
+    await modelTrigger.waitFor();
+    const idleModelBox = await modelTrigger.boundingBox();
     if (idleModelBox === null) {
-      throw new Error("Expected the model picker before remote typing");
+      throw new Error("Expected the model trigger before remote typing");
     }
     await expect(outsideTypingIndicator).toHaveCount(0);
     await gateway.emitGatewayEvent("session.typing", {
@@ -119,7 +119,7 @@ suite.define(() => {
     });
     await expect(page.locator(".agent-chat__typing-text")).toHaveText("Owner is typing…");
     const [typingModelBox, typingIndicatorBox, composerShellBox] = await Promise.all([
-      modelPicker.boundingBox(),
+      modelTrigger.boundingBox(),
       outsideTypingIndicator.boundingBox(),
       page.locator(".agent-chat__composer-shell").boundingBox(),
     ]);

--- a/ui/src/pages/channels/view.pairing.test.ts
+++ b/ui/src/pages/channels/view.pairing.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   renderChannelPairingDetail,
   renderChannelPairingPrompt,
@@ -107,9 +107,21 @@ function createProps(overrides: Partial<ChannelsProps> = {}): ChannelsProps {
   };
 }
 
+// Rendered prompts mount <openclaw-modal-dialog> into document.body; leaked
+// containers keep an open dialog alive and poison later dialog-owning test
+// files in the same worker.
+const renderedContainers: HTMLDivElement[] = [];
+
+afterEach(() => {
+  for (const container of renderedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
 function renderInto(template: unknown): HTMLDivElement {
   const container = document.createElement("div");
   document.body.append(container);
+  renderedContainers.push(container);
   render(template as never, container);
   return container;
 }

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -50,6 +50,7 @@ import { invalidateChatMetadataCache, refreshPageChat } from "./chat-state-refre
 import { selectedChatSessionRow } from "./chat-state-route.ts";
 import { resetChatViewState } from "./chat-view-state.ts";
 import { dismissConfirmedActionPopovers } from "./components/chat-message.ts";
+import { clearChatModelSearchOnEscape } from "./components/chat-model-picker.ts";
 import { toggleSessionWorkspace } from "./components/chat-session-workspace.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
@@ -303,6 +304,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
       }
     }
 
+    clearChatModelSearchOnEscape(event);
     if (event.defaultPrevented || event.key !== "Escape") {
       return;
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2530,7 +2530,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           footer: rectFor(".agent-chat__composer-footer"),
           meta: rectFor(".agent-chat__composer-meta"),
           model: rectFor(".chat-controls__model-trigger"),
-          modelPicker: rectFor(".chat-controls__model-picker"),
           modelLabel: rectFor(".chat-controls__model-trigger .chat-controls__inline-select-label"),
           overrides: rectFor(".agent-chat__session-overrides-pill"),
           status: rectFor(".agent-chat__composer-run-status"),
@@ -2538,9 +2537,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         };
       });
 
-      expect(layout.controls.scrollWidth, JSON.stringify(layout)).toBeLessThanOrEqual(
-        layout.controls.clientWidth + 1,
-      );
+      expect(layout.controls.scrollWidth).toBeLessThanOrEqual(layout.controls.clientWidth + 1);
       for (const control of [
         layout.status,
         layout.overrides,
@@ -2557,7 +2554,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(trigger.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
         expect(trigger.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
       }
-      expect(layout.modelPicker.width).toBeGreaterThanOrEqual(138);
       expect(layout.modelLabel.scrollWidth).toBeLessThanOrEqual(layout.modelLabel.clientWidth + 1);
       for (const [left, right] of [
         [layout.status, layout.overrides],

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -291,17 +291,22 @@ function composerControlsHtml(crowded = false) {
       }
       <div class="chat-composer-model-control">
         <div class="chat-controls__session chat-controls__model chat-controls__model-settings">
-          <div class="chat-controls__model-control">
-            <div class="chat-controls__model-control-row">
-              <div class="model-picker">
-                <wa-select class="settings-select picker-select model-picker__select chat-controls__model-picker" style="display:block;width:100%;min-width:138px">
-                  <div class="chat-controls__inline-select-trigger chat-controls__model-trigger" data-chat-composer-model="true" aria-label="Chat model">
-                    <span class="chat-controls__inline-select-label">GPT-5.6 Luna</span>
-                  </div>
-                </wa-select>
-              </div>
+          <details class="chat-controls__inline-select chat-controls__model-picker">
+          <summary class="chat-controls__inline-select-trigger chat-controls__model-trigger" data-chat-composer-model="true" aria-label="Chat model">
+            <span class="chat-controls__inline-select-label">GPT-5.6 Luna</span>
+          </summary>
+          <div class="chat-controls__inline-select-menu chat-controls__model-menu">
+            <div class="chat-controls__model-search-wrap"><input class="chat-controls__model-search" placeholder="Search models" /></div>
+            <div class="chat-controls__model-options">
+              <button class="chat-controls__inline-select-option chat-controls__model-option chat-controls__inline-select-option--selected">Default model</button>
+              <button class="chat-controls__inline-select-option chat-controls__model-option">gpt-5.5</button>
+              <button class="chat-controls__inline-select-option chat-controls__model-option">claude-sonnet-4-6</button>
+              <button class="chat-controls__inline-select-option chat-controls__model-option">gpt-5.6-luna</button>
+              <button class="chat-controls__inline-select-option chat-controls__model-option">gpt-5.6-sol</button>
+              <button class="chat-controls__inline-select-option chat-controls__model-option">openrouter/auto</button>
             </div>
           </div>
+          </details>
           <details class="chat-controls__inline-select chat-controls__effort-picker">
           <summary class="chat-controls__inline-select-trigger chat-controls__effort-trigger" data-chat-composer-effort="true" aria-label="Effort">
             <span class="chat-controls__inline-select-label">High</span>
@@ -2423,6 +2428,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         const composer = await getBoundingBox(page, ".agent-chat__input");
         for (const picker of [
           {
+            menu: ".chat-controls__model-menu",
+            trigger: '[data-chat-composer-model="true"]',
+          },
+          {
             menu: ".chat-controls__effort-menu",
             trigger: '[data-chat-composer-effort="true"]',
           },
@@ -2475,14 +2484,14 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         });
       });
       await syncFixtureComposerPopoverAnchor(page);
-      await page.locator('[data-chat-composer-effort="true"]').evaluate((node) => {
+      await page.locator('[data-chat-composer-model="true"]').evaluate((node) => {
         node.parentElement?.setAttribute("open", "");
       });
       await waitForLayoutSettled(page);
       await syncFixtureComposerPopoverAnchor(page);
       await waitForLayoutSettled(page);
       const composer = await getBoundingBox(page, ".agent-chat__input");
-      const menu = await getBoundingBox(page, ".chat-controls__effort-menu");
+      const menu = await getBoundingBox(page, ".chat-controls__model-menu");
       const anchorEvidence = await page.locator(".agent-chat__input").evaluate((node) => ({
         anchorBottom: getComputedStyle(node).getPropertyValue("--chat-composer-popover-bottom"),
         layoutHeight: document.documentElement.clientHeight,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -543,28 +543,13 @@ function createOpenAiHeaderState(overrides: Parameters<typeof createChatHeaderSt
   });
 }
 
-function getChatModelSelect(container: Element): HTMLElement & { value: string } {
-  const select = container.querySelector<HTMLElement & { value: string }>(
-    "wa-select.chat-controls__model-picker",
-  );
+function getChatModelSelect(container: Element): HTMLElement {
+  const select = container.querySelector<HTMLElement>('[data-chat-model-select="true"]');
   expect(select).toBeInstanceOf(HTMLElement);
   if (!(select instanceof HTMLElement)) {
     throw new Error("Expected chat model control");
   }
   return select;
-}
-
-function getChatModelOption(container: Element, value: string): HTMLElement | null {
-  return container.querySelector(
-    `wa-select.chat-controls__model-picker wa-option[value="${value}"]`,
-  );
-}
-
-function changeChatModel(container: Element, value: string) {
-  const select = getChatModelSelect(container);
-  Object.defineProperty(select, "value", { configurable: true, value });
-  select.dispatchEvent(new Event("change", { bubbles: true }));
-  Reflect.deleteProperty(select, "value");
 }
 
 type ChatModelControlsProps = Parameters<typeof renderChatModelControls>[0];
@@ -5343,7 +5328,7 @@ describe("chat model controls", () => {
     const container = renderModelControls(state);
 
     const modelSelect = getChatModelSelect(container);
-    expect(modelSelect.hasAttribute("disabled")).toBe(true);
+    expect(modelSelect.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("shows an empty state instead of a configured default when no usable models exist", () => {
@@ -5354,9 +5339,7 @@ describe("chat model controls", () => {
     });
     const container = renderModelControls(state);
 
-    const options = container.querySelectorAll("wa-select.chat-controls__model-picker wa-option");
-    expect(options).toHaveLength(1);
-    expect(options[0]?.hasAttribute("disabled")).toBe(true);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     expect(
       container.querySelector('[data-chat-model-catalog-state="ready"]')?.textContent,
     ).toContain("No models available");
@@ -5367,12 +5350,12 @@ describe("chat model controls", () => {
     const onModelSelect = vi.fn(async () => true);
     const container = renderModelControls(state, { onModelSelect });
     const modelOption = Array.from(
-      container.querySelectorAll<HTMLElement>("wa-select.chat-controls__model-picker wa-option"),
-    ).find((option) => !option.hasAttribute("selected") && option.getAttribute("value"));
-    expect(modelOption).toBeInstanceOf(HTMLElement);
-    changeChatModel(container, modelOption?.getAttribute("value") ?? "");
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
+    ).find((button) => button.getAttribute("aria-selected") === "false");
+    expect(modelOption).toBeInstanceOf(HTMLButtonElement);
+    modelOption?.click();
 
-    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.getAttribute("value"), "main");
+    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.dataset.chatModelOption, "main");
   });
 
   it("keeps model enabled while write-only access disables effort controls", () => {
@@ -5389,28 +5372,31 @@ describe("chat model controls", () => {
     });
 
     const modelSelect = getChatModelSelect(container);
-    expect(modelSelect.hasAttribute("disabled")).toBe(false);
+    expect(modelSelect.getAttribute("aria-disabled")).toBe("false");
     expect(modelSelect.getAttribute("title")).not.toBe(reason);
     const modelOption = Array.from(
-      container.querySelectorAll<HTMLElement>("wa-select.chat-controls__model-picker wa-option"),
-    ).find((option) => !option.hasAttribute("selected") && option.getAttribute("value"));
-    changeChatModel(container, modelOption?.getAttribute("value") ?? "");
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
+    ).find((button) => button.getAttribute("aria-selected") === "false");
+    modelOption?.click();
     container.querySelector<HTMLButtonElement>("[data-chat-speed-toggle]")?.click();
     getThinkingSlider(container)?.dispatchEvent(new Event("change", { bubbles: true }));
 
     expect(onFastModeSelect).not.toHaveBeenCalled();
-    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.getAttribute("value"), "main");
+    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.dataset.chatModelOption, "main");
     expect(onThinkingSelect).not.toHaveBeenCalled();
   });
 
-  it("preserves the empty-string default override and clears an explicit override", () => {
+  it("marks the inherited default muted and resets an override from the provenance row", () => {
     const { state } = createChatHeaderState({
       model: null,
       models: createOpenAiModelCatalog(),
     });
     const container = renderModelControls(state);
 
-    expect(getChatModelOption(container, "")?.hasAttribute("selected")).toBe(true);
+    expect(
+      container.querySelector(".chat-controls__model-provenance-value--inherit"),
+    ).not.toBeNull();
+    expect(container.querySelector("[data-chat-model-reset]")).toBeNull();
 
     const onModelSelect = vi.fn(async () => true);
     renderModelControls(
@@ -5419,9 +5405,22 @@ describe("chat model controls", () => {
       container,
     );
 
-    expect(getChatModelOption(container, "")?.hasAttribute("selected")).toBe(false);
-    changeChatModel(container, "");
+    expect(container.querySelector(".chat-controls__model-provenance-value--inherit")).toBeNull();
+    const reset = container.querySelector<HTMLButtonElement>("[data-chat-model-reset]");
+    const modelSelect = getChatModelSelect(container);
+    const details = modelSelect.closest<HTMLDetailsElement>("details");
+    document.body.append(container);
+    if (details) {
+      details.open = true;
+    }
+    expect(reset).toBeInstanceOf(HTMLButtonElement);
+    expect(reset?.textContent?.trim()).toBe("Use default");
+    reset?.focus();
+    reset?.click();
     expect(onModelSelect).toHaveBeenCalledWith("", "main");
+    expect(details?.open).toBe(false);
+    expect(document.activeElement).toBe(modelSelect);
+    container.remove();
   });
 
   it("hides model choices for locked sessions while preserving reasoning and speed", () => {
@@ -5443,9 +5442,16 @@ describe("chat model controls", () => {
     });
 
     const modelSelect = getChatModelSelect(container);
-    expect(modelSelect.hasAttribute("disabled")).toBe(true);
-    expect(modelSelect.querySelectorAll("wa-option")).toHaveLength(1);
-    expect(modelSelect.querySelector("wa-option")?.textContent).toContain("Codex-controlled model");
+    expect(modelSelect.dataset.chatModelLocked).toBe("true");
+    expect(modelSelect.getAttribute("aria-disabled")).toBe("false");
+    expect(container.querySelector(".chat-controls__locked-model-value")?.textContent).toBe(
+      "Codex-controlled model",
+    );
+    expect(
+      container.querySelector(".chat-controls__inline-select-label")?.textContent,
+    ).not.toContain("GPT-5.5");
+    expect(container.querySelectorAll("[data-chat-model-provider]")).toHaveLength(0);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     expect(onModelSelect).not.toHaveBeenCalled();
 
     const slider = getThinkingSlider(container);
@@ -5492,7 +5498,10 @@ describe("chat model controls", () => {
       modelSelectionRuntimeId: runtimeId,
     });
 
-    expect(getChatModelSelect(container).querySelector("wa-option")?.textContent).toContain(
+    expect(container.querySelector(".chat-controls__locked-model-value")?.textContent).toBe(
+      expected,
+    );
+    expect(container.querySelector(".chat-controls__inline-select-label")?.textContent).toContain(
       expected,
     );
     if (runtimeId === "openclaw") {
@@ -5525,13 +5534,16 @@ describe("chat model controls", () => {
     state.chatStream = "Working";
     const onModelSelect = vi.fn(async () => true);
     const container = renderModelControls(state, { onModelSelect });
-    expect(getChatModelSelect(container).hasAttribute("disabled")).toBe(true);
-    changeChatModel(container, "openai/gpt-5.4");
+    const modelOption = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
+    ).find((button) => button.getAttribute("aria-selected") === "false");
+    expect(modelOption?.disabled).toBe(true);
+    modelOption?.click();
 
     expect(onModelSelect).not.toHaveBeenCalled();
   });
 
-  it("renders provider artwork and selects an exact model value", () => {
+  it("groups models and filters them with keyboard selection", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
@@ -5543,22 +5555,51 @@ describe("chat model controls", () => {
     });
     const onModelSelect = vi.fn(async () => true);
     const container = renderModelControls(state, { onModelSelect });
-    const options = Array.from(
-      container.querySelectorAll<HTMLElement>("wa-select.chat-controls__model-picker wa-option"),
+    document.body.append(container);
+
+    const providerHeadings = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-chat-model-provider]"),
     );
-    expect(options.map((option) => option.getAttribute("value"))).toEqual([
-      "",
-      "openai/gpt-5.5",
-      "anthropic/claude-sonnet-4-6",
-      "google/gemini-2.5-pro",
+    expect(providerHeadings.map((heading) => heading.textContent?.trim())).toEqual([
+      "OpenAI",
+      "Anthropic",
+      "Google",
     ]);
+    const anthropicModels = container.querySelector<HTMLElement>(
+      '[data-chat-model-provider-group="anthropic"]',
+    );
+    expect(anthropicModels?.textContent).toContain("Claude Sonnet 4.6");
+    const details = container.querySelector<HTMLDetailsElement>(".chat-controls__model-picker");
+    const search = container.querySelector<HTMLInputElement>("[data-chat-model-search]");
+    details!.open = true;
+    search!.value = "anth";
+    search!.dispatchEvent(new InputEvent("input", { bubbles: true }));
+
+    const visibleOptions = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
+    ).filter((option) => !option.hidden);
+    expect(visibleOptions.map((option) => option.dataset.chatModelOption)).toEqual([
+      "anthropic/claude-sonnet-4-6",
+    ]);
+    expect(visibleOptions[0]?.hasAttribute("data-chat-model-highlighted")).toBe(true);
     expect(
-      options.map((option) =>
-        option.querySelector("[data-provider-icon]")?.getAttribute("data-provider-icon"),
-      ),
-    ).toEqual(["codex", "codex", "claude", "gemini"]);
-    changeChatModel(container, "anthropic/claude-sonnet-4-6");
+      visibleOptions[0]
+        ?.querySelector("[data-chat-model-shortcut]")
+        ?.getAttribute("data-chat-model-shortcut-number"),
+    ).toBe("1");
+    expect(
+      visibleOptions[0]?.querySelector(".chat-controls__model-option-provider"),
+    ).not.toBeNull();
+
+    search!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    const highlighted = container.querySelector<HTMLButtonElement>("[data-chat-model-highlighted]");
+    expect(highlighted?.id).not.toBe("");
+    expect(search?.getAttribute("aria-activedescendant")).toBe(highlighted?.id);
+
+    search!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(onModelSelect).toHaveBeenCalledWith("anthropic/claude-sonnet-4-6", "main");
+    expect(details?.open).toBe(false);
+    container.remove();
   });
 
   it("groups legacy Codex model references under OpenAI", () => {
@@ -5572,11 +5613,14 @@ describe("chat model controls", () => {
     });
     const container = renderModelControls(state);
 
-    const options = container.querySelectorAll("wa-select.chat-controls__model-picker wa-option");
-    expect(options).toHaveLength(3);
+    const providerButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
+    );
+    expect(providerButtons.map((button) => button.textContent?.trim())).toEqual(["OpenAI"]);
     expect(
-      [...options].every((option) => option.querySelector('[data-provider-icon="codex"]')),
-    ).toBe(true);
+      container.querySelector<HTMLElement>('[data-chat-model-provider-group="openai"]')?.hidden,
+    ).toBe(false);
+    expect(container.querySelector('[data-chat-model-provider-group="codex"]')).toBeNull();
   });
 
   it("merges provider aliases into unique visible groups", () => {
@@ -5596,27 +5640,35 @@ describe("chat model controls", () => {
     });
     const container = renderModelControls(state);
 
-    const options = Array.from(
-      container.querySelectorAll("wa-select.chat-controls__model-picker wa-option"),
+    const providerButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
     );
-    expect(options.map((option) => option.textContent?.trim())).toEqual([
-      "Default (gpt-5 · openai)",
-      "Gemini 2.5 Pro",
-      "Gemini CLI",
-      "Sonnet",
-      "Kimi",
-      "GLM",
-      "Kimi K3",
-      "Kimi K2.7",
-      "Kimi K2.6",
-    ]);
+    const providerLabels = providerButtons.map((button) => button.textContent?.trim());
+    expect(providerLabels).toEqual(["Google", "OpenCode", "Moonshot AI"]);
+    expect(new Set(providerLabels).size).toBe(providerLabels.length);
     expect(
-      new Set(
-        options.map((option) =>
-          option.querySelector("[data-provider-icon]")?.getAttribute("data-provider-icon"),
-        ),
-      ),
-    ).toEqual(new Set(["codex", "gemini", "opencode", "kimi"]));
+      container.querySelector('[data-chat-model-provider-group="google"]')?.textContent,
+    ).toContain("Gemini CLI");
+    const openCodeModels = container.querySelector(
+      '[data-chat-model-provider-group="opencode"]',
+    )?.textContent;
+    expect(openCodeModels).toContain("Sonnet");
+    expect(openCodeModels).toContain("Kimi");
+    expect(openCodeModels).toContain("GLM");
+    expect(openCodeModels).not.toContain("OpenCode Sonnet");
+    expect(
+      container.querySelector('[data-chat-model-provider-group="google-gemini-cli"]'),
+    ).toBeNull();
+    expect(container.querySelector('[data-chat-model-provider-group="opencode-go"]')).toBeNull();
+    expect(container.querySelector('[data-chat-model-provider-group="opencode-zen"]')).toBeNull();
+    const moonshotModels = container.querySelector(
+      '[data-chat-model-provider-group="moonshot"]',
+    )?.textContent;
+    expect(moonshotModels).toContain("Kimi K3");
+    expect(moonshotModels).toContain("Kimi K2.7");
+    expect(moonshotModels).toContain("Kimi K2.6");
+    expect(container.querySelector('[data-chat-model-provider-group="moonshot-ai"]')).toBeNull();
+    expect(container.querySelector('[data-chat-model-provider-group="moonshotai"]')).toBeNull();
   });
 
   it("shows model context size inline without a redundant tooltip", () => {
@@ -5633,9 +5685,14 @@ describe("chat model controls", () => {
       ],
     });
     const container = renderModelControls(state);
-    const modelOption = getChatModelOption(container, "openai/gpt-5.6-sol");
+    const modelOption = container.querySelector<HTMLButtonElement>(
+      '[data-chat-model-option="openai/gpt-5.6-sol"]',
+    );
 
-    expect(modelOption?.querySelector(".picker-select__description")?.textContent).toBe("1M");
+    expect(modelOption?.querySelector(".chat-controls__model-option-meta")?.textContent).toBe("1M");
+    expect(
+      getChatModelSelect(container).querySelector(".chat-controls__trigger-meta")?.textContent,
+    ).toBe("1M");
     expect(modelOption?.closest("openclaw-tooltip")).toBeNull();
   });
 
@@ -5683,15 +5740,16 @@ describe("chat model controls", () => {
     });
     const container = renderModelControls(state);
     const metaFor = (value: string) =>
-      getChatModelOption(container, value)?.querySelector(".picker-select__description")
-        ?.textContent;
+      container.querySelector(
+        `[data-chat-model-option="${value}"] .chat-controls__model-option-meta`,
+      )?.textContent;
 
-    expect(metaFor("openai/gpt-5.6")).toBe("OpenClaw · 1M");
+    expect(metaFor("openai/gpt-5.6")).toBe("1M · OpenClaw");
     expect(metaFor("openai/gpt-5.6")).not.toContain("Codex");
-    expect(metaFor("openai/gpt-5.6-sol")).toBe("Codex · 1M");
+    expect(metaFor("openai/gpt-5.6-sol")).toBe("1M · Codex");
     // Known CLI runtime ids map to their product labels, not capitalized ids.
-    expect(metaFor("anthropic/claude-opus-4-5")).toBe("Claude CLI · 200k");
-    expect(metaFor("google/gemini-3-pro")).toBe("Gemini CLI · 1M");
+    expect(metaFor("anthropic/claude-opus-4-5")).toBe("200k · Claude CLI");
+    expect(metaFor("google/gemini-3-pro")).toBe("1M · Gemini CLI");
     // Implicitly resolved runtimes stay unlabeled; only operator-pinned
     // (source model/provider) rows carry the runtime meta.
     expect(metaFor("openai/gpt-5.6-terra")).toBe("1M");
@@ -5718,13 +5776,22 @@ describe("chat model controls", () => {
       ],
     });
     const container = renderModelControls(state);
+    const trigger = getChatModelSelect(container);
 
+    expect(trigger.dataset.chatModelTools).toBe("unavailable");
     expect(
-      getChatModelOption(container, "lmstudio/qwen3-8b")
-        ?.querySelector(".picker-select__description")
+      trigger.querySelector(".chat-controls__model-capability-badge")?.textContent?.trim(),
+    ).toBe("Chat only");
+    expect(trigger.getAttribute("aria-label")).toContain("Chat only");
+    expect(
+      container
+        .querySelector('[data-chat-model-option="lmstudio/qwen3-8b"]')
+        ?.querySelector(".chat-controls__model-option-meta")
         ?.textContent?.trim(),
     ).toBe("32.8k · Chat only");
-    expect(getChatModelOption(container, "openai/gpt-5.5")?.textContent).not.toContain("Chat only");
+    expect(
+      container.querySelector('[data-chat-model-option="openai/gpt-5.5"]')?.textContent,
+    ).not.toContain("Chat only");
   });
 
   it("shows canonical OpenAI model names instead of command aliases", () => {
@@ -5749,13 +5816,19 @@ describe("chat model controls", () => {
     });
     const container = renderModelControls(state);
 
-    expect(getChatModelOption(container, "openai/gpt-5.5")?.textContent?.trim()).toBe("GPT-5.5");
+    expect(
+      getChatModelSelect(container)
+        .querySelector(".chat-controls__inline-select-label")
+        ?.textContent?.trim(),
+    ).toBe("GPT-5.5");
     expect(
       getThinkingSelect(container)
         .querySelector(".chat-controls__inline-select-label")
         ?.textContent?.trim(),
     ).toBe("High");
-    expect(getChatModelOption(container, "openai/gpt-5.5")?.textContent).toContain("GPT-5.5");
+    expect(
+      container.querySelector('[data-chat-model-option="openai/gpt-5.5"]')?.textContent,
+    ).toContain("GPT-5.5");
   });
 
   it("marks the actual default model row and selects it when inherited", () => {
@@ -5783,14 +5856,22 @@ describe("chat model controls", () => {
     const container = document.createElement("div");
     renderModelControls(state, { modelOverrides: { main: null } }, container);
 
-    const defaultOptions = container.querySelectorAll(
-      'wa-select.chat-controls__model-picker wa-option[value=""]',
+    expect(
+      getChatModelSelect(container)
+        .querySelector(".chat-controls__inline-select-label")
+        ?.textContent?.trim(),
+    ).toBe("GPT-5.5");
+    const defaultOptions = container.querySelectorAll<HTMLButtonElement>(
+      '[data-chat-model-default="true"]',
     );
     expect(defaultOptions).toHaveLength(1);
     const defaultOption = defaultOptions[0];
-    expect(defaultOption?.hasAttribute("selected")).toBe(true);
+    expect(defaultOption?.dataset.chatModelOption).toBe("openai/gpt-5.5");
+    expect(defaultOption?.getAttribute("aria-selected")).toBe("true");
     expect(defaultOption?.textContent).toContain("GPT-5.5");
     expect(defaultOption?.textContent).toContain("Default");
+    expect(defaultOption?.querySelector(".chat-controls__inline-select-check")).not.toBeNull();
+    expect(container.querySelector('[data-chat-model-option=""]')).toBeNull();
   });
 
   it.each([
@@ -5799,14 +5880,16 @@ describe("chat model controls", () => {
       model: "gpt-5.4",
       models: createOpenAiModelCatalog(),
       sessionKey: "default-clear",
+      selected: "false",
     },
     {
       name: "clears an explicit override that matches the default model",
       model: "gpt-5.5",
       models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
       sessionKey: "explicit-default",
+      selected: "true",
     },
-  ])("$name", async ({ model, models, sessionKey }) => {
+  ])("$name", async ({ model, models, sessionKey, selected }) => {
     const { state } = createChatHeaderState({ model, modelProvider: "openai", models });
     state.sessionsResult = createSessionsListResult({
       defaultsModel: "gpt-5.5",
@@ -5821,12 +5904,15 @@ describe("chat model controls", () => {
       onModelSelect,
     });
 
-    const defaultOption = getChatModelOption(container, "");
-    expect(defaultOption).toBeInstanceOf(HTMLElement);
-    expect(defaultOption?.hasAttribute("selected")).toBe(false);
+    const defaultOption = container.querySelector<HTMLButtonElement>(
+      '[data-chat-model-option="openai/gpt-5.5"][data-chat-model-default="true"]',
+    );
+    expect(defaultOption).toBeInstanceOf(HTMLButtonElement);
+    expect(defaultOption?.getAttribute("aria-selected")).toBe(selected);
     expect(defaultOption?.textContent).toContain("Default");
-    expect(getChatModelOption(container, `openai/${model}`)?.hasAttribute("selected")).toBe(true);
-    changeChatModel(container, "");
+    const currentOption = container.querySelector<HTMLButtonElement>('[aria-selected="true"]');
+    expect(currentOption?.querySelector(".chat-controls__inline-select-check")).not.toBeNull();
+    defaultOption?.click();
 
     await waitForFast(() => {
       expect(onModelSelect).toHaveBeenCalledWith("", sessionKey);
@@ -5855,19 +5941,21 @@ describe("chat model controls", () => {
     });
     const container = renderModelControls(state);
 
-    const options = Array.from(
-      container.querySelectorAll("wa-select.chat-controls__model-picker wa-option"),
+    const providerButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
     );
-    expect(options.map((option) => option.textContent?.trim())).toEqual([
-      "Gemma 4 · google",
-      "Default (Gemma 4 · openrouter)",
-      "Gemma 4",
+    expect(providerButtons.map((button) => button.textContent?.trim())).toEqual([
+      "OpenRouter",
+      "Google",
     ]);
     expect(
-      options.map((option) =>
-        option.querySelector("[data-provider-icon]")?.getAttribute("data-provider-icon"),
-      ),
-    ).toEqual(["gemini", "openrouter", "openrouter"]);
+      container.querySelector<HTMLElement>('[data-chat-model-provider-group="google"]')
+        ?.textContent,
+    ).toContain("Gemma 4");
+    expect(
+      container.querySelector<HTMLElement>('[data-chat-model-provider-group="openrouter"]')
+        ?.textContent,
+    ).toContain("Gemma 4");
   });
 
   it("uses a unique catalog provider before an unrelated stale session hint", () => {
@@ -5886,10 +5974,14 @@ describe("chat model controls", () => {
       modelOverrides: { main: "moonshotai/kimi-k2.5" },
     });
 
-    const icon = getChatModelOption(container, "moonshotai/kimi-k2.5")?.querySelector(
-      ".provider-brand-icon--fallback",
-    );
-    expect(icon?.textContent?.trim()).toBe("N");
+    const providers = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
+    ).map((button) => button.dataset.chatModelProvider);
+    expect(providers).toContain("nvidia");
+    expect(providers).not.toContain("zai");
+    expect(
+      container.querySelector<HTMLElement>('[data-chat-model-provider-group="nvidia"]')?.hidden,
+    ).toBe(false);
   });
 
   it("renders reasoning as a slider and speed as a fast-mode toggle", () => {
@@ -5915,9 +6007,13 @@ describe("chat model controls", () => {
     expect(speedToggle?.getAttribute("aria-checked")).toBe("false");
     expect(speedToggle?.dataset.chatSpeedToggle).toBe("on");
     expect(
-      container.querySelector(
-        'wa-select.chat-controls__model-picker wa-option [data-provider-icon="codex"]',
-      ),
+      container.querySelector('[data-chat-model-select="true"] .chat-controls__provider-icon'),
+    ).toBeNull();
+    expect(
+      container.querySelector("[data-chat-model-option] .chat-controls__provider-icon"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-chat-model-provider="openai"] [data-provider-icon]'),
     ).not.toBeNull();
   });
 
@@ -5935,11 +6031,14 @@ describe("chat model controls", () => {
     });
 
     const modelOption = Array.from(
-      container.querySelectorAll<HTMLElement>("wa-select.chat-controls__model-picker wa-option"),
-    ).find((option) => !option.hasAttribute("selected") && option.getAttribute("value"));
-    expect(modelOption).toBeInstanceOf(HTMLElement);
-    changeChatModel(container, modelOption?.getAttribute("value") ?? "");
-    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.getAttribute("value"), "main");
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
+    ).find(
+      (button) =>
+        button.getAttribute("aria-selected") === "false" && button.dataset.chatModelOption !== "",
+    );
+    expect(modelOption).toBeInstanceOf(HTMLButtonElement);
+    modelOption?.click();
+    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.dataset.chatModelOption, "main");
 
     const slider = getThinkingSlider(container);
     expect(slider).toBeInstanceOf(HTMLInputElement);
@@ -6293,13 +6392,19 @@ describe("chat model controls", () => {
     };
     render(renderChatModelControls(props), container);
 
-    changeChatModel(container, "openai/gpt-5.4");
+    container
+      .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.4"]')
+      ?.click();
 
     await waitForFast(() => {
       expect(onModelSelect).toHaveBeenCalledWith("openai/gpt-5.4", "main");
     });
     render(renderChatModelControls(props), container);
-    expect(getChatModelOption(container, "openai/gpt-5.5")?.hasAttribute("selected")).toBe(true);
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.5"]')
+        ?.getAttribute("aria-selected"),
+    ).toBe("true");
   });
 
   it("keeps the speed toggle visible and disabled for unsupported providers", () => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5696,6 +5696,25 @@ describe("chat model controls", () => {
     expect(modelOption?.closest("openclaw-tooltip")).toBeNull();
   });
 
+  it("synthesizes a selectable row for a persisted override missing from the catalog", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.2-retired",
+      modelProvider: "openai",
+      models: [{ id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" }],
+    });
+    const container = renderModelControls(state);
+
+    const optionValues = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
+    ).map((option) => option.getAttribute("data-chat-model-option"));
+    const overrideValue = optionValues.find((value) => value?.includes("gpt-5.2-retired"));
+    expect(overrideValue).toBeDefined();
+    const overrideOption = container.querySelector<HTMLButtonElement>(
+      `[data-chat-model-option="${overrideValue}"]`,
+    );
+    expect(overrideOption?.querySelector(".chat-controls__inline-select-check")).not.toBeNull();
+  });
+
   it("distinguishes model rows that use different agent runtimes", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.6",

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -1,9 +1,6 @@
 // Chat-owned model, reasoning, and fast-mode picker orchestration.
-import { html, nothing } from "lit";
+import { html } from "lit";
 import type { ModelCatalogEntry, SessionsListResult } from "../../../api/types.ts";
-import { icons } from "../../../components/icons.ts";
-import { type ModelPickerOption, renderModelPicker } from "../../../components/model-picker.ts";
-import { formatRawProviderLabel, providerDisplayLabel } from "../../../components/provider-icon.ts";
 import { t } from "../../../i18n/index.ts";
 import { normalizeChatModelProviderId } from "../../../lib/chat/model-ref.ts";
 import {
@@ -15,15 +12,16 @@ import {
   resolveChatThinkingSelectState,
   type ChatThinkingTarget,
 } from "../../../lib/chat/thinking.ts";
-import { formatContextTokenCapacity } from "../../../lib/format.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { renderChatEffortPicker } from "./chat-effort-picker.ts";
+import {
+  renderChatModelPicker,
+  type ChatModelCatalogState,
+  type ChatModelPickerOption,
+  type ChatModelPickerTargetGroup,
+} from "./chat-model-picker.ts";
 
-export type ChatModelCatalogState = {
-  hasSnapshot: boolean;
-  onRetry?: () => void;
-  status: "idle" | "loading" | "refreshing" | "ready" | "error";
-};
+export type { ChatModelCatalogState } from "./chat-model-picker.ts";
 
 type ChatModelControlsProps = {
   activeRunId: string | null;
@@ -36,6 +34,7 @@ type ChatModelControlsProps = {
   modelOverrides?: Readonly<Record<string, string | null | undefined>>;
   modelSelectionLocked?: boolean;
   modelSelectionRuntimeId?: string;
+  modelPickerTargetGroups?: readonly ChatModelPickerTargetGroup[];
   modelSwitching: boolean;
   modelsLoading?: boolean;
   modelMutationDisabledReason?: string;
@@ -49,6 +48,7 @@ type ChatModelControlsProps = {
   thinkingSession?: ChatThinkingTarget;
   onFastModeSelect?: (value: ChatFastModeSelectValue, sessionKey: string) => unknown;
   onModelSelect?: (value: string, sessionKey: string) => unknown;
+  onModelPickerTargetSelect?: (groupId: string, value: string) => unknown;
   onRequestUpdate?: () => void;
   onThinkingSelect?: (value: string, sessionKey: string) => unknown;
 };
@@ -136,70 +136,9 @@ function resolveChatModelPickerLabel(
   return fallbackLabel;
 }
 
-function formatModelLabel(label: string, provider: string): string {
-  const prefixes = [formatRawProviderLabel(provider), providerDisplayLabel(provider)].toSorted(
-    (left, right) => right.length - left.length,
-  );
-  return prefixes.reduce(
-    (result, prefix) =>
-      result.toLowerCase().startsWith(`${prefix.toLowerCase()} `)
-        ? result.slice(prefix.length + 1)
-        : result,
-    label,
-  );
-}
-
-const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
-  "claude-cli": "Claude CLI",
-  codex: "Codex",
-  "codex-cli": "Codex",
-  "google-gemini-cli": "Gemini CLI",
-  openclaw: "OpenClaw",
-};
-
-function formatAgentRuntimeLabel(id: string): string {
-  const normalized = id.trim().toLowerCase();
-  return (
-    AGENT_RUNTIME_LABELS[normalized] ??
-    `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`
-  );
-}
-
-function renderModelCatalogState(state: ChatModelCatalogState, hasOptions: boolean) {
-  if (state.status === "ready" && hasOptions) {
-    return nothing;
-  }
-  const label =
-    state.status === "refreshing"
-      ? t("chat.modelControls.refreshingModels")
-      : state.status === "error"
-        ? state.hasSnapshot
-          ? t("chat.modelControls.modelsRefreshFailed")
-          : t("chat.modelControls.modelsUnavailable")
-        : state.status === "ready"
-          ? t("chat.modelControls.noModelsAvailable")
-          : t("chat.modelControls.loadingModels");
-  return html`
-    <div
-      class="chat-controls__model-catalog-state"
-      data-chat-model-catalog-state=${state.status}
-      aria-live="polite"
-    >
-      <span class="chat-controls__model-catalog-state-label">
-        ${state.status === "error" ? icons.alertTriangle : nothing}<span>${label}</span>
-      </span>
-      ${state.status === "error" && state.onRetry
-        ? html`<button
-            class="chat-controls__model-catalog-retry"
-            data-chat-model-catalog-retry="true"
-            type="button"
-            @click=${state.onRetry}
-          >
-            ${icons.refresh}<span>${t("common.retry")}</span>
-          </button>`
-        : nothing}
-    </div>
-  `;
+function formatPickerModelLabel(label: string): string {
+  const match = /^Default \((.+)\)$/u.exec(label);
+  return match?.[1] ?? label;
 }
 
 export function renderChatModelControls(props: ChatModelControlsProps) {
@@ -255,13 +194,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ? t("chat.modelControls.defaultWithModel", { model: canonicalDefaultLabel })
       : defaultLabel;
   const normalizedDefaultModel = defaultModel.trim().toLowerCase();
-  const defaultCatalogEntry = resolveChatModelCatalogEntry(defaultModel, props.modelCatalog);
-  const modelOptions: ModelPickerOption[] = selectOptions.map((option) => {
-    const catalogEntry = resolveChatModelCatalogEntry(option.value, props.modelCatalog);
+  const modelOptions: ChatModelPickerOption[] = selectOptions.map((option) => {
     const isDefault =
-      defaultSelectable &&
-      (option.value.trim().toLowerCase() === normalizedDefaultModel ||
-        (catalogEntry !== undefined && catalogEntry === defaultCatalogEntry));
+      defaultSelectable && option.value.trim().toLowerCase() === normalizedDefaultModel;
+    const catalogEntry = resolveChatModelCatalogEntry(option.value, props.modelCatalog);
     // Runtime meta labels only operator-pinned runtimes (models/provider config);
     // implicit/default resolution stays unlabeled so ordinary rows stay clean.
     const agentRuntime = catalogEntry?.agentRuntime;
@@ -269,53 +205,41 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       agentRuntime && (agentRuntime.source === "model" || agentRuntime.source === "provider")
         ? agentRuntime.id.trim()
         : undefined;
-    const provider = resolveChatModelProvider(
-      option.value,
-      props.modelCatalog,
-      "",
-      isDefault ? defaultProviderHint : option.value === currentOverride ? currentProviderHint : "",
-    );
-    const detail = [
-      agentRuntimeId ? formatAgentRuntimeLabel(agentRuntimeId) : "",
-      catalogEntry?.contextWindow ? formatContextTokenCapacity(catalogEntry.contextWindow) : "",
-      catalogEntry?.supportsTools === false ? t("chat.modelControls.chatOnly") : "",
-    ]
-      .filter(Boolean)
-      .join(" · ");
-    const label = isDefault
-      ? pickerDefaultLabel
-      : resolveChatModelPickerLabel(option.value, option.label, props.modelCatalog);
     return {
-      value: isDefault ? "" : option.value,
-      label: formatModelLabel(label, provider),
-      provider,
-      ...(detail ? { detail } : {}),
-    };
-  });
-  if (currentOverride && !modelOptions.some((option) => option.value === currentOverride)) {
-    const catalogEntry = resolveChatModelCatalogEntry(currentOverride, props.modelCatalog);
-    const detail = [
-      catalogEntry?.contextWindow ? formatContextTokenCapacity(catalogEntry.contextWindow) : "",
-      catalogEntry?.supportsTools === false ? t("chat.modelControls.chatOnly") : "",
-    ]
-      .filter(Boolean)
-      .join(" · ");
-    modelOptions.push({
-      value: currentOverride,
-      label: catalogEntry?.name.trim() || currentOverride,
+      commitValue: isDefault ? "" : option.value,
+      ...(agentRuntimeId ? { agentRuntimeId } : {}),
+      ...(catalogEntry?.contextWindow ? { contextWindow: catalogEntry.contextWindow } : {}),
+      ...(typeof catalogEntry?.supportsTools === "boolean"
+        ? { supportsTools: catalogEntry.supportsTools }
+        : {}),
+      isDefault,
+      value: option.value,
+      label: resolveChatModelPickerLabel(option.value, option.label, props.modelCatalog),
       provider: resolveChatModelProvider(
-        currentOverride,
+        option.value,
         props.modelCatalog,
         "",
-        currentProviderHint,
+        isDefault
+          ? defaultProviderHint
+          : option.value === currentOverride
+            ? currentProviderHint
+            : "",
       ),
-      ...(detail ? { detail } : {}),
-    });
-  }
+    };
+  });
   const lockedModelLabel =
     props.modelSelectionRuntimeId?.trim().toLowerCase() === "codex"
       ? t("chat.selectors.nativeCodexModel")
       : t("chat.selectors.lockedSessionModel");
+  const committedModelLabel =
+    props.modelSelectionLocked === true
+      ? lockedModelLabel
+      : (modelOptions.find((entry) => entry.value === currentOverride)?.label ??
+        resolveChatModelPickerLabel(
+          currentOverride,
+          currentOverride || pickerDefaultLabel,
+          props.modelCatalog,
+        ));
   const managedCatalog = props.modelCatalogState ?? {
     hasSnapshot: !props.modelsLoading,
     status: props.modelsLoading ? ("loading" as const) : ("ready" as const),
@@ -325,7 +249,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     ["idle", "loading", "refreshing"].includes(managedCatalog.status);
   const catalogErrorWithoutSnapshot =
     managedCatalog.status === "error" && !managedCatalog.hasSnapshot;
-  const catalogSnapshotEmpty = managedCatalog.hasSnapshot && selectOptions.length === 0;
+  const catalogSnapshotEmpty = managedCatalog.hasSnapshot && modelOptions.length === 0;
   const catalogTriggerStatus = catalogLoadingWithoutSnapshot
     ? t("chat.modelControls.loadingModels")
     : catalogErrorWithoutSnapshot
@@ -353,80 +277,25 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     commonDisabled ||
     effortMutationDisabled ||
     (thinking.options.length === 0 && (!showFastMode || fastMode.disabled));
-  const pickerOptions =
-    props.modelSelectionLocked === true
-      ? [
-          {
-            value: currentOverride,
-            label: lockedModelLabel,
-            ...(currentProviderHint ? { provider: currentProviderHint } : {}),
-          },
-        ]
-      : catalogLoadingWithoutSnapshot || catalogErrorWithoutSnapshot || catalogSnapshotEmpty
-        ? [
-            {
-              value: currentOverride,
-              label: catalogTriggerStatus ?? pickerDefaultLabel,
-              disabled: true,
-            },
-          ]
-        : modelOptions.length > 0
-          ? modelOptions.some((option) => option.value === "")
-            ? modelOptions
-            : [
-                {
-                  value: "",
-                  label: pickerDefaultLabel,
-                  ...(defaultProviderHint ? { provider: defaultProviderHint } : {}),
-                },
-                ...modelOptions,
-              ]
-          : [
-              {
-                value: currentOverride,
-                label: catalogTriggerStatus ?? pickerDefaultLabel,
-                disabled: true,
-              },
-            ];
-  const activeCatalogEntry = resolveChatModelCatalogEntry(
-    currentOverride || defaultModel,
-    props.modelCatalog,
-  );
-  const modelToolsUnavailable = activeCatalogEntry?.supportsTools === false;
   return html`
     <div class="chat-controls__session chat-controls__model chat-controls__model-settings">
-      <div class="chat-controls__model-control">
-        <div class="chat-controls__model-control-row">
-          ${modelToolsUnavailable
-            ? html`<span
-                class="chat-controls__model-capability-badge"
-                title=${t("chat.modelControls.chatOnlyHelp")}
-                >${icons.alertTriangle}<span>${t("chat.modelControls.chatOnly")}</span></span
-              >`
-            : nothing}
-          ${renderModelPicker({
-            label: t("chat.selectors.model"),
-            value: currentOverride,
-            options: pickerOptions,
-            disabled: modelDisabled || props.modelSelectionLocked === true,
-            title:
-              props.modelMutationDisabledReason ??
-              (props.modelSelectionLocked ? t("chat.selectors.modelLockedLabel") : undefined),
-            className: "chat-controls__model-picker",
-            placement: "top",
-            onChange: (next) => {
-              if (
-                next !== currentOverride &&
-                !modelDisabled &&
-                props.modelSelectionLocked !== true
-              ) {
-                void props.onModelSelect?.(next, props.sessionKey);
-              }
-            },
-          })}
-        </div>
-        ${renderModelCatalogState(managedCatalog, selectOptions.length > 0)}
-      </div>
+      ${renderChatModelPicker({
+        defaultModelLabel: formatPickerModelLabel(pickerDefaultLabel),
+        disabled: modelDisabled,
+        disabledReason: props.modelMutationDisabledReason,
+        modelCatalogState: managedCatalog,
+        modelSelectionLocked: props.modelSelectionLocked === true,
+        modelOptions,
+        targetGroups: props.modelPickerTargetGroups,
+        selectedModelValue: currentOverride,
+        sessionKey: props.sessionKey,
+        triggerModelLabel: formatPickerModelLabel(committedModelLabel),
+        triggerStatusLabel: catalogTriggerStatus,
+        onModelSelect: async (next, targetSessionKey) =>
+          props.onModelSelect?.(next, targetSessionKey),
+        onTargetSelect: props.onModelPickerTargetSelect,
+        onRequestUpdate: props.onRequestUpdate,
+      })}
       ${renderChatEffortPicker({
         disabled: effortDisabled,
         disabledReason: props.effortMutationDisabledReason,

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -227,6 +227,33 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ),
     };
   });
+  // A persisted session override can outlive the catalog (retired or
+  // temporarily unavailable model). Synthesize its row so the dialog still
+  // shows the selection and lets the operator move off it. An entirely empty
+  // catalog keeps its "no models" state instead of one orphaned row.
+  if (
+    currentOverride &&
+    modelOptions.length > 0 &&
+    !modelOptions.some((option) => option.value === currentOverride)
+  ) {
+    const catalogEntry = resolveChatModelCatalogEntry(currentOverride, props.modelCatalog);
+    modelOptions.push({
+      commitValue: currentOverride,
+      ...(catalogEntry?.contextWindow ? { contextWindow: catalogEntry.contextWindow } : {}),
+      ...(typeof catalogEntry?.supportsTools === "boolean"
+        ? { supportsTools: catalogEntry.supportsTools }
+        : {}),
+      isDefault: false,
+      value: currentOverride,
+      label: catalogEntry?.name.trim() || currentOverride,
+      provider: resolveChatModelProvider(
+        currentOverride,
+        props.modelCatalog,
+        "",
+        currentProviderHint,
+      ),
+    });
+  }
   const lockedModelLabel =
     props.modelSelectionRuntimeId?.trim().toLowerCase() === "codex"
       ? t("chat.selectors.nativeCodexModel")

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -1,0 +1,719 @@
+import { html, nothing } from "lit";
+import { repeat } from "lit/directives/repeat.js";
+import { icons } from "../../../components/icons.ts";
+import "../../../components/tooltip.ts";
+import {
+  formatRawProviderLabel,
+  providerDisplayLabel,
+  renderProviderBrandIcon,
+} from "../../../components/provider-icon.ts";
+import { t } from "../../../i18n/index.ts";
+import { formatContextTokenCapacity } from "../../../lib/format.ts";
+
+export type ChatModelCatalogState = {
+  hasSnapshot: boolean;
+  onRetry?: () => void;
+  status: "idle" | "loading" | "refreshing" | "ready" | "error";
+};
+
+export type ChatModelPickerOption = {
+  agentRuntimeId?: string;
+  commitValue: string;
+  contextWindow?: number;
+  isDefault: boolean;
+  label: string;
+  provider: string;
+  supportsTools?: boolean;
+  value: string;
+};
+
+export type ChatModelPickerTargetGroup = {
+  id: string;
+  label: string;
+  options: readonly { label: string; value: string }[];
+};
+
+// Known models.list runtime ids; mirrors src/status/agent-runtime-label.ts,
+// which cannot be imported here (it drags terminal sanitizers into the bundle).
+const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
+  "claude-cli": "Claude CLI",
+  codex: "Codex",
+  "codex-cli": "Codex",
+  "google-gemini-cli": "Gemini CLI",
+  openclaw: "OpenClaw",
+};
+
+function formatAgentRuntimeLabel(id: string): string {
+  const normalized = id.trim().toLowerCase();
+  return (
+    AGENT_RUNTIME_LABELS[normalized] ??
+    `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`
+  );
+}
+
+type ChatModelPickerParams = {
+  defaultModelLabel: string;
+  disabled: boolean;
+  disabledReason?: string;
+  modelCatalogState?: ChatModelCatalogState;
+  modelSelectionLocked: boolean;
+  modelOptions: ChatModelPickerOption[];
+  targetGroups?: readonly ChatModelPickerTargetGroup[];
+  selectedModelValue: string;
+  sessionKey: string;
+  triggerModelLabel: string;
+  triggerStatusLabel?: string;
+  onModelSelect: (value: string, sessionKey: string) => Promise<unknown>;
+  onTargetSelect?: (groupId: string, value: string) => unknown;
+  onRequestUpdate?: () => void;
+};
+
+function renderProviderIcon(provider: string) {
+  return renderProviderBrandIcon(provider, { className: "chat-controls__provider-icon" });
+}
+
+function formatModelLabel(option: ChatModelPickerOption): string {
+  const prefixes = [
+    formatRawProviderLabel(option.provider),
+    providerDisplayLabel(option.provider),
+  ].toSorted((left, right) => right.length - left.length);
+  for (const prefix of prefixes) {
+    if (option.label.toLowerCase().startsWith(`${prefix.toLowerCase()} `)) {
+      return option.label.slice(prefix.length + 1);
+    }
+  }
+  return option.label;
+}
+
+function pickerMenu(target: EventTarget | null): HTMLElement | null {
+  return target instanceof Element
+    ? target.closest<HTMLElement>(".chat-controls__model-menu")
+    : null;
+}
+
+function visibleModelRows(root: HTMLElement): HTMLButtonElement[] {
+  return [...root.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")]
+    .filter((row) => !row.hidden)
+    .toSorted(
+      (left, right) =>
+        Number(left.dataset.chatModelRank ?? left.dataset.chatModelIndex ?? 0) -
+        Number(right.dataset.chatModelRank ?? right.dataset.chatModelIndex ?? 0),
+    );
+}
+
+function ensureModelPickerIds(menu: HTMLElement): void {
+  const details = menu.closest<HTMLDetailsElement>(".chat-controls__model-picker");
+  const input = menu.querySelector<HTMLInputElement>("[data-chat-model-search]");
+  const listbox = menu.querySelector<HTMLElement>("[data-chat-model-list]");
+  if (!details || !input || !listbox) {
+    return;
+  }
+  const prefix = details.dataset.chatModelPickerId ?? `chat-model-picker-${crypto.randomUUID()}`;
+  details.dataset.chatModelPickerId = prefix;
+  listbox.id = `${prefix}-listbox`;
+  menu.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]").forEach((row, index) => {
+    row.id = `${prefix}-option-${index}`;
+  });
+  input.setAttribute("aria-controls", listbox.id);
+  input.setAttribute("aria-expanded", details.open ? "true" : "false");
+}
+
+function highlightModelRow(menu: HTMLElement, row: HTMLButtonElement | undefined): void {
+  menu.querySelectorAll<HTMLElement>("[data-chat-model-option]").forEach((candidate) => {
+    candidate.toggleAttribute("data-chat-model-highlighted", candidate === row);
+  });
+  const input = menu.querySelector<HTMLInputElement>("[data-chat-model-search]");
+  if (row?.id) {
+    input?.setAttribute("aria-activedescendant", row.id);
+  } else {
+    input?.removeAttribute("aria-activedescendant");
+  }
+}
+
+function updateModelShortcuts(menu: HTMLElement, rows: readonly HTMLButtonElement[]): void {
+  menu.querySelectorAll<HTMLElement>("[data-chat-model-shortcut]").forEach((shortcut) => {
+    shortcut.hidden = true;
+    shortcut.removeAttribute("data-chat-model-shortcut-number");
+  });
+  rows.slice(0, 9).forEach((row, index) => {
+    const shortcut = row.querySelector<HTMLElement>("[data-chat-model-shortcut]");
+    if (!shortcut) {
+      return;
+    }
+    shortcut.hidden = false;
+    shortcut.setAttribute("data-chat-model-shortcut-number", String(index + 1));
+  });
+}
+
+function modelMatchRank(row: HTMLButtonElement, query: string): number | null {
+  const model = row.dataset.chatModelName ?? "";
+  const provider = row.dataset.chatModelProviderLabel ?? "";
+  if (model.startsWith(query)) {
+    return 0;
+  }
+  if (model.includes(query)) {
+    return 1;
+  }
+  if (provider.startsWith(query)) {
+    return 2;
+  }
+  return provider.includes(query) ? 3 : null;
+}
+
+function updateModelSearch(input: HTMLInputElement): void {
+  const menu = pickerMenu(input);
+  if (!menu) {
+    return;
+  }
+  ensureModelPickerIds(menu);
+  const query = input.value.trim().toLocaleLowerCase();
+  menu.toggleAttribute("data-chat-model-filtering", Boolean(query));
+  const rows = [...menu.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")];
+  const matches: Array<{ row: HTMLButtonElement; score: number; index: number }> = [];
+  rows.forEach((row, index) => {
+    const score = query ? modelMatchRank(row, query) : 0;
+    row.hidden = score === null;
+    row.style.removeProperty("--chat-model-rank");
+    delete row.dataset.chatModelRank;
+    if (score !== null) {
+      matches.push({ row, score, index });
+    }
+  });
+  matches
+    .toSorted((left, right) => left.score - right.score || left.index - right.index)
+    .forEach(({ row }, rank) => {
+      row.dataset.chatModelRank = String(rank);
+      row.style.setProperty("--chat-model-rank", String(rank));
+    });
+  const visibleRows = visibleModelRows(menu);
+  updateModelShortcuts(menu, visibleRows);
+  const selected = visibleRows.find((row) => row.getAttribute("aria-selected") === "true");
+  highlightModelRow(menu, query ? visibleRows[0] : (selected ?? visibleRows[0]));
+  const empty = menu.querySelector<HTMLElement>("[data-chat-model-search-empty]");
+  if (empty) {
+    empty.hidden = !query || visibleRows.length > 0;
+  }
+}
+
+function resetModelSearch(details: HTMLDetailsElement): void {
+  const input = details.querySelector<HTMLInputElement>("[data-chat-model-search]");
+  if (!input) {
+    return;
+  }
+  input.value = "";
+  updateModelSearch(input);
+}
+
+export function clearChatModelSearchOnEscape(event: KeyboardEvent): boolean {
+  if (event.key !== "Escape") {
+    return false;
+  }
+  const input = event
+    .composedPath()
+    .find(
+      (target): target is HTMLInputElement =>
+        target instanceof HTMLInputElement && target.matches("[data-chat-model-search]"),
+    );
+  if (!input?.value) {
+    return false;
+  }
+  input.value = "";
+  updateModelSearch(input);
+  event.preventDefault();
+  event.stopPropagation();
+  return true;
+}
+
+function handleModelSearchKeydown(event: KeyboardEvent): void {
+  const input = event.currentTarget as HTMLInputElement;
+  const menu = pickerMenu(input);
+  if (!menu) {
+    return;
+  }
+  const rows = visibleModelRows(menu);
+  if (rows.length === 0) {
+    return;
+  }
+  if (event.key === "Enter") {
+    const highlighted = rows.find((row) => row.hasAttribute("data-chat-model-highlighted"));
+    if (highlighted) {
+      event.preventDefault();
+      highlighted.click();
+    }
+    return;
+  }
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+    return;
+  }
+  event.preventDefault();
+  const currentIndex = rows.findIndex((row) => row.hasAttribute("data-chat-model-highlighted"));
+  const offset = event.key === "ArrowDown" ? 1 : rows.length - 1;
+  const nextIndex = currentIndex < 0 ? 0 : (currentIndex + offset) % rows.length;
+  highlightModelRow(menu, rows[nextIndex]);
+  rows[nextIndex]?.scrollIntoView?.({ block: "nearest" });
+}
+
+function handleModelPickerKeydown(event: KeyboardEvent): void {
+  const details = event.currentTarget as HTMLDetailsElement;
+  if (!details.open || event.target instanceof HTMLInputElement || !/^[1-9]$/u.test(event.key)) {
+    return;
+  }
+  const row = visibleModelRows(details)[Number(event.key) - 1];
+  event.preventDefault();
+  row?.click();
+}
+
+function renderCatalogState(state: ChatModelCatalogState | undefined, hasOptions: boolean) {
+  if (!state || (state.status === "ready" && hasOptions)) {
+    return nothing;
+  }
+  const label =
+    state.status === "refreshing"
+      ? t("chat.modelControls.refreshingModels")
+      : state.status === "error"
+        ? state.hasSnapshot
+          ? t("chat.modelControls.modelsRefreshFailed")
+          : t("chat.modelControls.modelsUnavailable")
+        : state.status === "ready"
+          ? t("chat.modelControls.noModelsAvailable")
+          : t("chat.modelControls.loadingModels");
+  return html`
+    <div
+      class="chat-controls__model-catalog-state ${hasOptions
+        ? ""
+        : "chat-controls__model-catalog-state--empty"}"
+      data-chat-model-catalog-state=${state.status}
+      aria-live="polite"
+    >
+      <span class="chat-controls__model-catalog-state-label">
+        ${state.status === "error" ? icons.alertTriangle : nothing}
+        <span>${label}</span>
+      </span>
+      ${state.status === "error" && state.onRetry
+        ? html`
+            <button
+              class="chat-controls__model-catalog-retry"
+              data-chat-model-catalog-retry="true"
+              type="button"
+              @click=${(event: MouseEvent) => {
+                event.stopPropagation();
+                state.onRetry?.();
+              }}
+            >
+              ${icons.refresh}
+              <span>${t("common.retry")}</span>
+            </button>
+          `
+        : nothing}
+    </div>
+  `;
+}
+
+export function renderChatModelPicker(params: ChatModelPickerParams) {
+  const defaultModelOption = params.modelOptions.find((option) => option.isDefault);
+  const activeModelOption =
+    params.selectedModelValue === ""
+      ? defaultModelOption
+      : params.modelOptions.find((option) => option.value === params.selectedModelValue);
+  const modelToolsUnavailable = activeModelOption?.supportsTools === false;
+  const triggerTitle = [
+    params.triggerStatusLabel ?? params.triggerModelLabel,
+    modelToolsUnavailable ? t("chat.modelControls.chatOnly") : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const triggerMeta = activeModelOption?.contextWindow
+    ? formatContextTokenCapacity(activeModelOption.contextWindow)
+    : "";
+  const providerGroups = new Map<string, ChatModelPickerOption[]>();
+  for (const option of params.modelOptions) {
+    const existing = providerGroups.get(option.provider);
+    if (existing) {
+      existing.push(option);
+    } else {
+      providerGroups.set(option.provider, [option]);
+    }
+  }
+  const orderedProviderGroups = [...providerGroups];
+  const defaultProviderIndex = orderedProviderGroups.findIndex(
+    ([provider]) => provider === defaultModelOption?.provider,
+  );
+  if (defaultProviderIndex > 0) {
+    const [defaultGroup] = orderedProviderGroups.splice(defaultProviderIndex, 1);
+    if (defaultGroup) {
+      orderedProviderGroups.unshift(defaultGroup);
+    }
+  }
+  const orderedOptions = orderedProviderGroups.flatMap(([, options]) => options);
+  const optionIndex = new Map(orderedOptions.map((option, index) => [option.value, index]));
+  const targetGroups = params.targetGroups ?? [];
+  const targetOptionCount = targetGroups.reduce((count, group) => count + group.options.length, 0);
+  const hasOptions = params.modelOptions.length + targetOptionCount > 0;
+  const commitModel = (value: string) => {
+    if (params.modelSelectionLocked) {
+      return;
+    }
+    void params.onModelSelect(value, params.sessionKey).finally(() => params.onRequestUpdate?.());
+    params.onRequestUpdate?.();
+  };
+  const selectModel = (entry: ChatModelPickerOption, event: MouseEvent) => {
+    event.stopPropagation();
+    if (params.disabled || params.modelSelectionLocked) {
+      event.preventDefault();
+      return;
+    }
+    if (entry.commitValue !== params.selectedModelValue) {
+      commitModel(entry.commitValue);
+    }
+    const details = (event.currentTarget as HTMLElement).closest<HTMLDetailsElement>("details");
+    if (details) {
+      details.open = false;
+      details.querySelector<HTMLElement>("summary")?.focus();
+    }
+  };
+  const selectTarget = (groupId: string, value: string, event: MouseEvent) => {
+    event.stopPropagation();
+    if (params.disabled || params.modelSelectionLocked) {
+      event.preventDefault();
+      return;
+    }
+    params.onTargetSelect?.(groupId, value);
+    const details = (event.currentTarget as HTMLElement).closest<HTMLDetailsElement>("details");
+    if (details) {
+      details.open = false;
+      details.querySelector<HTMLElement>("summary")?.focus();
+    }
+  };
+  return html`
+    <details
+      class="chat-controls__inline-select chat-controls__model-picker"
+      @keydown=${handleModelPickerKeydown}
+      @toggle=${(event: Event) => {
+        const details = event.currentTarget as HTMLDetailsElement;
+        if (!details.open) {
+          resetModelSearch(details);
+          return;
+        }
+        queueMicrotask(() => {
+          const input = details.querySelector<HTMLInputElement>("[data-chat-model-search]");
+          if (input) {
+            updateModelSearch(input);
+          }
+        });
+      }}
+    >
+      <summary
+        class="chat-controls__inline-select-trigger chat-controls__model-trigger ${params.disabled
+          ? "chat-controls__inline-select-trigger--disabled"
+          : ""}"
+        data-chat-model-select="true"
+        data-chat-model-locked=${params.modelSelectionLocked ? "true" : "false"}
+        data-chat-select-value=${params.selectedModelValue}
+        data-chat-model-tools=${modelToolsUnavailable ? "unavailable" : "available"}
+        aria-label=${`${t("chat.selectors.model")}: ${triggerTitle}`}
+        aria-disabled=${params.disabled ? "true" : "false"}
+        title=${params.disabledReason ?? triggerTitle}
+        @click=${(event: MouseEvent) => {
+          if (params.disabled) {
+            event.preventDefault();
+            return;
+          }
+          (event.currentTarget as HTMLElement).focus({ preventScroll: true });
+        }}
+      >
+        ${modelToolsUnavailable
+          ? html`
+              <openclaw-tooltip .content=${t("chat.modelControls.chatOnlyHelp")}>
+                <span class="chat-controls__model-capability-badge" aria-hidden="true">
+                  ${icons.alertTriangle}
+                  <span>${t("chat.modelControls.chatOnly")}</span>
+                </span>
+              </openclaw-tooltip>
+            `
+          : nothing}
+        <span class="chat-controls__inline-select-label">
+          ${params.triggerStatusLabel ?? params.triggerModelLabel}
+        </span>
+        ${params.triggerStatusLabel || !triggerMeta
+          ? nothing
+          : html`<span class="chat-controls__trigger-meta">${triggerMeta}</span>`}
+      </summary>
+      <div
+        class="chat-controls__inline-select-menu chat-controls__model-menu"
+        aria-label=${t("chat.selectors.model")}
+      >
+        ${params.modelSelectionLocked
+          ? html`
+              <div
+                class="chat-controls__locked-model"
+                aria-label=${t("chat.selectors.modelLockedLabel")}
+              >
+                <span class="chat-controls__inline-select-section-label">
+                  ${t("chat.selectors.modelSection")}
+                </span>
+                <span class="chat-controls__locked-model-value">${params.triggerModelLabel}</span>
+                <span class="chat-controls__locked-model-badge">
+                  ${t("chat.selectors.modelLocked")}
+                </span>
+              </div>
+            `
+          : html`
+              <div class="chat-controls__model-search-wrap">
+                ${icons.search}
+                <input
+                  class="chat-controls__model-search"
+                  data-chat-model-search="true"
+                  type="search"
+                  role="combobox"
+                  aria-autocomplete="list"
+                  autocomplete="off"
+                  spellcheck="false"
+                  placeholder=${t("chat.modelControls.searchModels")}
+                  aria-label=${t("chat.modelControls.searchModels")}
+                  ?disabled=${params.disabled}
+                  @input=${(event: InputEvent) =>
+                    updateModelSearch(event.currentTarget as HTMLInputElement)}
+                  @keydown=${handleModelSearchKeydown}
+                />
+              </div>
+              ${renderCatalogState(params.modelCatalogState, params.modelOptions.length > 0)}
+              ${hasOptions
+                ? html`
+                    <div
+                      class="chat-controls__model-options"
+                      data-chat-model-list="true"
+                      role="listbox"
+                      aria-label=${t("chat.selectors.model")}
+                    >
+                      ${repeat(
+                        orderedProviderGroups,
+                        ([provider]) => provider,
+                        ([provider, options]) => html`
+                          <section
+                            class="chat-controls__provider-model-group"
+                            data-chat-model-provider-group=${provider}
+                            aria-label=${t("chat.modelControls.providerModels", {
+                              provider: providerDisplayLabel(provider),
+                            })}
+                          >
+                            <div
+                              class="chat-controls__provider-heading"
+                              data-chat-model-provider=${provider}
+                            >
+                              ${renderProviderIcon(provider)}
+                              <span>${providerDisplayLabel(provider)}</span>
+                            </div>
+                            ${repeat(
+                              options,
+                              (entry) => entry.value,
+                              (entry) => {
+                                const selected =
+                                  entry.value === params.selectedModelValue ||
+                                  (entry.isDefault && params.selectedModelValue === "");
+                                const modelLabel = formatModelLabel(entry);
+                                const modelMeta = [
+                                  entry.contextWindow
+                                    ? formatContextTokenCapacity(entry.contextWindow)
+                                    : "",
+                                  entry.supportsTools === false
+                                    ? t("chat.modelControls.chatOnly")
+                                    : "",
+                                  entry.agentRuntimeId
+                                    ? formatAgentRuntimeLabel(entry.agentRuntimeId)
+                                    : "",
+                                ]
+                                  .filter(Boolean)
+                                  .join(" · ");
+                                const index = optionIndex.get(entry.value) ?? 0;
+                                return html`
+                                  <button
+                                    class="chat-controls__inline-select-option chat-controls__model-option ${selected
+                                      ? "chat-controls__inline-select-option--selected"
+                                      : ""}"
+                                    data-chat-model-option=${entry.value}
+                                    data-chat-model-default=${entry.isDefault ? "true" : nothing}
+                                    data-chat-model-index=${index}
+                                    data-chat-model-name=${modelLabel.toLocaleLowerCase()}
+                                    data-chat-model-provider-label=${providerDisplayLabel(
+                                      entry.provider,
+                                    ).toLocaleLowerCase()}
+                                    role="option"
+                                    aria-selected=${selected ? "true" : "false"}
+                                    type="button"
+                                    ?disabled=${params.disabled}
+                                    @mouseenter=${(event: MouseEvent) => {
+                                      const menu = pickerMenu(event.currentTarget);
+                                      if (menu) {
+                                        highlightModelRow(
+                                          menu,
+                                          event.currentTarget as HTMLButtonElement,
+                                        );
+                                      }
+                                    }}
+                                    @click=${(event: MouseEvent) => selectModel(entry, event)}
+                                  >
+                                    <span class="chat-controls__model-option-provider">
+                                      ${renderProviderIcon(entry.provider)}
+                                    </span>
+                                    <span class="chat-controls__model-option-copy">
+                                      <span class="chat-controls__model-option-title">
+                                        <span class="chat-controls__model-option-name"
+                                          >${modelLabel}</span
+                                        >
+                                        ${entry.isDefault
+                                          ? html`<span
+                                              class="chat-controls__model-state-label chat-controls__model-state-label--default"
+                                              >${t("chat.modelControls.default")}</span
+                                            >`
+                                          : nothing}
+                                      </span>
+                                      ${modelMeta
+                                        ? html`<span class="chat-controls__model-option-meta"
+                                            >${modelMeta}</span
+                                          >`
+                                        : nothing}
+                                    </span>
+                                    <span class="chat-controls__model-option-action">
+                                      ${selected
+                                        ? html`<span
+                                            class="chat-controls__inline-select-check"
+                                            aria-hidden="true"
+                                            >${icons.check}</span
+                                          >`
+                                        : html`<kbd
+                                            data-chat-model-shortcut="true"
+                                            aria-hidden="true"
+                                            hidden
+                                          ></kbd>`}
+                                    </span>
+                                  </button>
+                                `;
+                              },
+                            )}
+                          </section>
+                        `,
+                      )}
+                      ${repeat(
+                        targetGroups,
+                        (group) => group.id,
+                        (group) => html`
+                          <section
+                            class="chat-controls__provider-model-group"
+                            data-chat-model-target-group=${group.id}
+                            aria-label=${group.label}
+                          >
+                            <div class="chat-controls__provider-heading">
+                              <span
+                                class="chat-controls__provider-icon chat-controls__target-icon"
+                                aria-hidden="true"
+                                >${icons.terminal}</span
+                              >
+                              <span>${group.label}</span>
+                            </div>
+                            ${repeat(
+                              group.options,
+                              (entry) => entry.value,
+                              (entry, targetIndex) => html`
+                                <button
+                                  class="chat-controls__inline-select-option chat-controls__model-option"
+                                  data-chat-model-option=${`target:${group.id}:${entry.value}`}
+                                  data-chat-model-target=${entry.value}
+                                  data-chat-model-index=${orderedOptions.length + targetIndex}
+                                  data-chat-model-name=${entry.label.toLocaleLowerCase()}
+                                  data-chat-model-provider-label=${group.label.toLocaleLowerCase()}
+                                  role="option"
+                                  aria-selected="false"
+                                  type="button"
+                                  ?disabled=${params.disabled}
+                                  @mouseenter=${(event: MouseEvent) => {
+                                    const menu = pickerMenu(event.currentTarget);
+                                    if (menu) {
+                                      highlightModelRow(
+                                        menu,
+                                        event.currentTarget as HTMLButtonElement,
+                                      );
+                                    }
+                                  }}
+                                  @click=${(event: MouseEvent) =>
+                                    selectTarget(group.id, entry.value, event)}
+                                >
+                                  <span
+                                    class="chat-controls__model-option-provider chat-controls__target-icon"
+                                    aria-hidden="true"
+                                    >${icons.terminal}</span
+                                  >
+                                  <span class="chat-controls__model-option-copy">
+                                    <span class="chat-controls__model-option-title">
+                                      <span class="chat-controls__model-option-name"
+                                        >${entry.label}</span
+                                      >
+                                    </span>
+                                  </span>
+                                  <span class="chat-controls__model-option-action">
+                                    <kbd
+                                      data-chat-model-shortcut="true"
+                                      aria-hidden="true"
+                                      hidden
+                                    ></kbd>
+                                  </span>
+                                </button>
+                              `,
+                            )}
+                          </section>
+                        `,
+                      )}
+                    </div>
+                    <div
+                      class="chat-controls__model-search-empty"
+                      data-chat-model-search-empty
+                      hidden
+                    >
+                      ${t("chat.modelControls.noMatchingModels")}
+                    </div>
+                    ${params.modelOptions.length > 0
+                      ? html`<footer class="chat-controls__model-provenance">
+                          ${params.selectedModelValue === ""
+                            ? html`<span class="chat-controls__model-provenance-value--inherit">
+                                ${t("chat.modelControls.usingDefault")}
+                              </span>`
+                            : html`
+                                <span>${t("chat.modelControls.sessionOverride")}</span>
+                                <openclaw-tooltip
+                                  .content=${t("chat.modelControls.resetToDefault", {
+                                    model: params.defaultModelLabel,
+                                  })}
+                                >
+                                  <button
+                                    class="chat-controls__model-reset"
+                                    data-chat-model-reset="true"
+                                    type="button"
+                                    ?disabled=${params.disabled}
+                                    @click=${(event: MouseEvent) => {
+                                      event.stopPropagation();
+                                      if (params.disabled) {
+                                        event.preventDefault();
+                                        return;
+                                      }
+                                      commitModel("");
+                                      const details = (
+                                        event.currentTarget as HTMLElement
+                                      ).closest<HTMLDetailsElement>("details");
+                                      if (details) {
+                                        details.open = false;
+                                        details.querySelector<HTMLElement>("summary")?.focus();
+                                      }
+                                    }}
+                                  >
+                                    ${t("chat.modelControls.useDefault")}
+                                  </button>
+                                </openclaw-tooltip>
+                              `}
+                        </footer>`
+                      : nothing}
+                  `
+                : nothing}
+            `}
+      </div>
+    </details>
+  `;
+}

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -82,28 +82,6 @@ function renderControl(
   return container;
 }
 
-function modelSelect(container: Element) {
-  return container.querySelector<HTMLElement & { value: string }>(
-    "wa-select.chat-controls__model-picker",
-  );
-}
-
-function modelOptions(container: Element) {
-  return container.querySelectorAll("wa-select.chat-controls__model-picker wa-option");
-}
-
-function modelOption(container: Element, value: string) {
-  return container.querySelector(
-    `wa-select.chat-controls__model-picker wa-option[value="${value}"]`,
-  );
-}
-
-function changePicker(select: HTMLElement & { value: string }, value: string) {
-  Object.defineProperty(select, "value", { configurable: true, value });
-  select.dispatchEvent(new Event("change", { bubbles: true }));
-  Reflect.deleteProperty(select, "value");
-}
-
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -121,7 +99,7 @@ describe("new-session model runtime", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     expect(request).not.toHaveBeenCalledWith("sessions.catalog.list", expect.anything());
     expect(
-      renderControl(control, context).querySelector("wa-select.new-session-page__target-picker"),
+      renderControl(control, context).querySelector("[data-chat-model-target-group]"),
     ).toBeNull();
   });
 
@@ -172,22 +150,14 @@ describe("new-session model runtime", () => {
     );
     await vi.waitFor(() => {
       const container = renderControl(control, context);
-      expect(container.querySelector("wa-select.new-session-page__target-picker")).not.toBeNull();
-      expect(
-        container.querySelector(
-          'wa-select.new-session-page__target-picker wa-option[value="anthropic"]',
-        ),
-      ).not.toBeNull();
+      expect(container.querySelector('[data-chat-model-target-group="cliAgents"]')).not.toBeNull();
+      expect(container.querySelector('[data-chat-model-target="anthropic"]')).not.toBeNull();
       expect(container.textContent).not.toContain("History only");
     });
 
-    const target = renderControl(control, context).querySelector<HTMLElement & { value: string }>(
-      "wa-select.new-session-page__target-picker",
-    );
-    expect(target).not.toBeNull();
-    if (target) {
-      changePicker(target, "anthropic");
-    }
+    renderControl(control, context)
+      .querySelector<HTMLButtonElement>('[data-chat-model-target="anthropic"]')
+      ?.click();
 
     expect(onCatalogTargetSelect).toHaveBeenCalledExactlyOnceWith("anthropic");
   });
@@ -247,10 +217,13 @@ describe("new-session model runtime", () => {
 
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     const container = renderControl(control, context);
-    expect(modelSelect(container)?.textContent).toContain("Loading models");
-    expect(modelSelect(container)?.hasAttribute("disabled")).toBe(true);
-    expect(modelOptions(container)).toHaveLength(1);
-    expect(modelOptions(container)[0]?.hasAttribute("disabled")).toBe(true);
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "Loading models",
+    );
+    expect(
+      container.querySelector('[data-chat-model-select="true"]')?.getAttribute("aria-disabled"),
+    ).toBe("true");
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     pending.resolve({ models: [] });
   });
 
@@ -269,7 +242,7 @@ describe("new-session model runtime", () => {
     });
 
     let container = renderControl(control, context, "main", null);
-    const loadingModelTrigger = modelSelect(container);
+    const loadingModelTrigger = container.querySelector('[data-chat-model-select="true"]');
     expect(loadingModelTrigger?.textContent).toContain("Loading models");
     expect(loadingModelTrigger?.textContent).not.toContain("Default model");
     expect(container.querySelector('[data-chat-thinking-select="true"]')?.textContent).toContain(
@@ -283,8 +256,14 @@ describe("new-session model runtime", () => {
       model: { primary: "openai/gpt-5.6-sol" },
       thinkingDefault: "high",
     });
-    expect(modelOption(container, "")?.textContent).toContain("GPT-5.6 Sol");
-    expect(modelSelect(container)?.textContent).toContain("GPT-5.6 Sol");
+    expect(
+      container.querySelector(
+        '[data-chat-model-option="openai/gpt-5.6-sol"][data-chat-model-default="true"]',
+      )?.textContent,
+    ).toContain("GPT-5.6 Sol");
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "GPT-5.6 Sol",
+    );
     const thinkingPicker = container.querySelector('[data-chat-thinking-select="true"]');
     expect(thinkingPicker).not.toBeNull();
     expect(thinkingPicker?.textContent).toContain("High");
@@ -314,7 +293,9 @@ describe("new-session model runtime", () => {
       id: "main",
       model: { primary: "openai/gpt-5.6-sol" },
     });
-    expect(modelSelect(container)?.textContent).toContain("GPT-5.6 Sol");
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "GPT-5.6 Sol",
+    );
     expect(container.querySelector('[data-chat-thinking-select="true"]')?.textContent).toContain(
       "Medium",
     );
@@ -365,8 +346,10 @@ describe("new-session model runtime", () => {
       ).toBe("error");
     });
     const container = renderControl(control, context);
-    expect(modelSelect(container)?.textContent).toContain("Models unavailable");
-    expect(modelOptions(container)).toHaveLength(1);
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "Models unavailable",
+    );
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     expect(container.querySelector('[data-chat-model-catalog-retry="true"]')).not.toBeNull();
   });
 
@@ -392,7 +375,11 @@ describe("new-session model runtime", () => {
       ?.click();
 
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(modelOptions(renderControl(control, context))).toHaveLength(3));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+      ).toHaveLength(3),
+    );
   });
 
   it("renders a successful empty catalog as an explicit empty result", async () => {
@@ -409,10 +396,12 @@ describe("new-session model runtime", () => {
           .querySelector("[data-chat-model-catalog-state]")
           ?.getAttribute("data-chat-model-catalog-state"),
       ).toBe("ready");
-      expect(modelSelect(container)?.textContent).toContain("No models available");
+      expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+        "No models available",
+      );
     });
     const container = renderControl(control, context);
-    expect(modelOptions(container)).toHaveLength(1);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     expect(container.querySelector('[data-chat-model-catalog-retry="true"]')).toBeNull();
   });
 
@@ -439,8 +428,10 @@ describe("new-session model runtime", () => {
       ).not.toBeNull(),
     );
     const container = renderControl(control, context);
-    expect(modelOptions(container)).toHaveLength(1);
-    expect(modelSelect(container)?.textContent).toContain("No models available");
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "No models available",
+    );
     expect(container.textContent).not.toContain("GPT-5.6 Luna");
   });
 
@@ -492,14 +483,18 @@ describe("new-session model runtime", () => {
     const control = new NewSessionModelControl(() => undefined);
 
     control.load(context, "main", true);
-    await vi.waitFor(() => expect(modelOptions(renderControl(control, context))).toHaveLength(2));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+      ).toHaveLength(2),
+    );
     request.mockReturnValueOnce(refresh.promise);
 
     control.load(context, "main", true);
 
     let container = renderControl(control, context);
     expect(container.querySelector('[data-chat-model-catalog-state="refreshing"]')).not.toBeNull();
-    expect(modelOptions(container)).toHaveLength(2);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(2);
 
     refresh.reject(new Error("refresh failed"));
     await vi.waitFor(() =>
@@ -508,7 +503,7 @@ describe("new-session model runtime", () => {
       ).not.toBeNull(),
     );
     container = renderControl(control, context);
-    expect(modelOptions(container)).toHaveLength(2);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(2);
     expect(container.textContent).toContain("Couldn’t refresh models");
 
     container.querySelector<HTMLButtonElement>('[data-chat-model-catalog-retry="true"]')?.click();
@@ -518,7 +513,9 @@ describe("new-session model runtime", () => {
         renderControl(control, context).querySelector("[data-chat-model-catalog-state]"),
       ).toBeNull(),
     );
-    expect(modelOptions(renderControl(control, context))).toHaveLength(2);
+    expect(
+      renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+    ).toHaveLength(2);
   });
 
   it("keeps stale same-agent data across reconnect invalidation until replacement arrives", async () => {
@@ -534,18 +531,32 @@ describe("new-session model runtime", () => {
     const control = new NewSessionModelControl(() => undefined);
 
     control.load(context, "main", true);
-    await vi.waitFor(() => expect(modelOption(renderControl(control, context), "")).not.toBeNull());
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="openai/gpt-5.6-luna"]',
+        ),
+      ).not.toBeNull(),
+    );
 
     control.invalidate(false);
     request.mockReturnValueOnce(reconnect.promise);
     control.load(context, "main", true);
 
-    expect(modelOption(renderControl(control, context), "")).not.toBeNull();
+    expect(
+      renderControl(control, context).querySelector(
+        '[data-chat-model-option="openai/gpt-5.6-luna"]',
+      ),
+    ).not.toBeNull();
     reconnect.resolve({ models: newModels });
-    await vi.waitFor(() => expect(modelOptions(renderControl(control, context))).toHaveLength(3));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+      ).toHaveLength(2),
+    );
     const container = renderControl(control, context);
-    expect(modelSelect(container)?.textContent).not.toContain("GPT-5.6 Luna");
-    expect(modelOption(container, "openai/gpt-5.6-sol")).not.toBeNull();
+    expect(container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]')).toBeNull();
+    expect(container.querySelector('[data-chat-model-option="openai/gpt-5.6-sol"]')).not.toBeNull();
   });
 
   it("clears the old catalog on agent switch and ignores the late old-agent result", async () => {
@@ -572,7 +583,9 @@ describe("new-session model runtime", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
     await vi.waitFor(() =>
       expect(
-        modelOption(renderControl(control, context, "research"), "anthropic/claude-sonnet-5"),
+        renderControl(control, context, "research").querySelector(
+          '[data-chat-model-option="anthropic/claude-sonnet-5"]',
+        ),
       ).not.toBeNull(),
     );
 
@@ -583,8 +596,10 @@ describe("new-session model runtime", () => {
     await Promise.resolve();
 
     const container = renderControl(control, context, "research");
-    expect(modelOption(container, "anthropic/claude-sonnet-5")).not.toBeNull();
-    expect(modelSelect(container)?.textContent).not.toContain("GPT-5.6 Luna");
+    expect(
+      container.querySelector('[data-chat-model-option="anthropic/claude-sonnet-5"]'),
+    ).not.toBeNull();
+    expect(container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]')).toBeNull();
   });
 
   it("coalesces equivalent concurrent metadata loads", async () => {
@@ -684,16 +699,16 @@ describe("new-session model runtime", () => {
     control.load(context, "main", true);
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledOnce();
-      expect(modelOption(renderControl(control, context), "demo/limited")).not.toBeNull();
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-option="demo/limited"]'),
+      ).not.toBeNull();
     });
     control.selected = "kimi/k3";
     control.thinkingLevel = "xhigh";
 
-    const picker = modelSelect(renderControl(control, context));
-    expect(picker).not.toBeNull();
-    if (picker) {
-      changePicker(picker, "demo/limited");
-    }
+    renderControl(control, context)
+      .querySelector<HTMLButtonElement>('[data-chat-model-option="demo/limited"]')
+      ?.click();
 
     expect(control.selected).toBe("demo/limited");
     expect(control.thinkingLevel).toBe("");

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -2,15 +2,12 @@ import {
   DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
   resolveGatewayStartupRetryAfterMs,
 } from "@openclaw/gateway-client/browser";
-import { html, nothing } from "lit";
 import type {
   SessionCatalog,
   SessionsCatalogListResult,
 } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { icons } from "../../components/icons.ts";
-import { renderPicker } from "../../components/select-picker.ts";
 import { t } from "../../i18n/index.ts";
 import {
   buildQualifiedChatModelValue,
@@ -603,31 +600,7 @@ export class NewSessionModelControl {
       thinkingDefault:
         options.agent?.thinkingDefault ?? sourceResult?.defaults.thinkingDefault ?? "medium",
     };
-    const targetPicker =
-      this.catalogTargets.length > 0
-        ? renderPicker({
-            label: t("newSession.cliAgentsGroup"),
-            value: "",
-            options: [
-              { value: "", label: t("newSession.cliAgentsGroup"), disabled: true },
-              ...this.catalogTargets.map(({ id, label }) => ({ value: id, label })),
-            ],
-            disabled: options.sending || snapshot?.phase !== "connected",
-            className: "new-session-page__target-picker",
-            renderLeading: (option) =>
-              option.value
-                ? html`<span class="new-session-page__target-icon" aria-hidden="true"
-                    >${icons.terminal}</span
-                  >`
-                : nothing,
-            onChange: (catalogId) => {
-              if (catalogId) {
-                this.onCatalogTargetSelect(catalogId);
-              }
-            },
-          })
-        : nothing;
-    return html`${targetPicker}${renderChatModelControls({
+    return renderChatModelControls({
       activeRunId: null,
       agentDefaultModel,
       connected: snapshot?.phase === "connected",
@@ -645,6 +618,16 @@ export class NewSessionModelControl {
             : this.metadataState.status,
       },
       modelOverrides: { [sessionKey]: this.selected },
+      modelPickerTargetGroups:
+        this.catalogTargets.length > 0
+          ? [
+              {
+                id: "cliAgents",
+                label: t("newSession.cliAgentsGroup"),
+                options: this.catalogTargets.map(({ id, label }) => ({ value: id, label })),
+              },
+            ]
+          : undefined,
       modelSwitching: false,
       sending: options.sending,
       sessionKey,
@@ -660,16 +643,19 @@ export class NewSessionModelControl {
         this.selected = selection.model;
         this.thinkingLevel = selection.thinkingLevel;
         this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
-        this.notify();
+      },
+      onModelPickerTargetSelect: (groupId, catalogId) => {
+        if (groupId === "cliAgents") {
+          this.onCatalogTargetSelect(catalogId);
+        }
       },
       onThinkingSelect: (value) => {
         this.selectionGeneration += 1;
         this.restoringPreference = false;
         this.thinkingLevel = value;
         this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
-        this.notify();
       },
       onRequestUpdate: this.notify,
-    })}`;
+    });
   }
 }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -16,6 +16,7 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/chat.css";
 import "../../styles/new-session.css";
+import { clearChatModelSearchOnEscape } from "../chat/components/chat-model-picker.ts";
 import { renderWelcomeState } from "../chat/components/chat-welcome.ts";
 import * as catalog from "./catalog-target.ts";
 import type { SubmissionOutcomeReason } from "./cloud-recovery-state.ts";
@@ -210,7 +211,8 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
     if (event.type === "keydown") {
       const keyEvent = event as KeyboardEvent;
-      if (keyEvent.key !== "Escape") {
+      clearChatModelSearchOnEscape(keyEvent);
+      if (keyEvent.defaultPrevented || keyEvent.key !== "Escape") {
         return;
       }
       const picker =

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3788,6 +3788,7 @@ button.chat-reply-preview--message:disabled {
     padding: 0 2px 0 4px;
   }
 
+  .agent-chat__input .chat-controls__model-menu,
   .agent-chat__input .chat-controls__effort-menu {
     box-sizing: border-box;
     position: fixed;
@@ -4300,50 +4301,8 @@ button.chat-reply-preview--message:disabled {
   gap: 4px;
 }
 
-.chat-controls__model-control {
-  display: grid;
-  min-width: min-content;
-  flex: 1 1 auto;
-}
-
-.chat-controls__model-control-row {
-  display: flex;
-  align-items: center;
-  min-width: min-content;
-}
-
-.chat-controls__model-control-row .model-picker {
-  min-width: min-content;
-  flex: 1 1 auto;
-}
-
-.chat-controls__model-control .model-picker {
-  gap: 0;
-}
-
-.chat-controls__model-picker::part(combobox) {
-  height: 30px;
-  min-height: 30px;
-  padding-inline: 8px;
-  border: 0;
-  background: transparent;
-}
-
-.chat-controls__model-picker:hover::part(combobox),
-.chat-controls__model-picker[open]::part(combobox) {
-  background: color-mix(in srgb, var(--text) 7%, transparent);
-}
-
-@media (max-width: 768px) {
-  .chat-controls__model-picker wa-option {
-    box-sizing: border-box;
-    width: 100%;
-    max-width: calc(100vw - 36px);
-  }
-
-  .chat-controls__model-picker .picker-select__copy {
-    max-width: calc(100vw - 84px);
-  }
+.chat-controls__model-settings .chat-controls__inline-select-trigger {
+  width: auto;
 }
 
 .chat-controls__inline-select {
@@ -4485,15 +4444,280 @@ button.chat-reply-preview--message:disabled {
   background: color-mix(in srgb, var(--text) 6%, transparent);
 }
 
+/* Model and effort are independent surfaces so either choice stays one focused
+   interaction without hiding the other pill's effective state. */
+.chat-controls__model-menu,
 .chat-controls__effort-menu {
   display: flex;
   flex-direction: column;
   gap: 0;
   padding: 0;
+  overflow: hidden;
+}
+
+.chat-controls__model-menu {
+  left: auto;
+  right: 0;
+  width: min(380px, calc(100vw - 24px));
+  max-height: min(440px, calc(100vh - 96px));
+}
+
+.chat-controls__effort-menu {
   left: auto;
   right: 0;
   width: min(330px, calc(100vw - 24px));
   overflow: hidden;
+}
+
+.chat-controls__model-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 8px;
+  padding: 0 9px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--card) 78%, transparent);
+}
+
+.chat-controls__model-search-wrap svg {
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+  flex: 0 0 auto;
+}
+
+.chat-controls__model-search {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+
+.chat-controls__model-search::placeholder {
+  color: var(--muted);
+}
+
+.chat-controls__locked-model {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--card) 78%, transparent);
+}
+
+.chat-controls__locked-model-value {
+  overflow: hidden;
+  flex: 1 1 auto;
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-controls__locked-model-badge {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: var(--radius-full);
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chat-controls__provider-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 9px 3px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Mask/brand-color rules live on .provider-brand-icon (components.css). */
+.chat-controls__provider-icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+}
+
+.chat-controls__provider-icon.provider-brand-icon--fallback {
+  font-size: 9px;
+}
+
+.chat-controls__target-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.chat-controls__model-options {
+  display: block;
+  min-width: 0;
+  padding: 0 7px 7px;
+  overflow-y: auto;
+  overscroll-behavior: none;
+}
+
+.chat-controls__provider-model-group {
+  display: grid;
+  gap: 2px;
+}
+
+.chat-controls__inline-select-section-label {
+  padding: 3px 6px 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chat-controls__model-menu[data-chat-model-filtering] .chat-controls__model-options {
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-controls__model-menu[data-chat-model-filtering] .chat-controls__provider-model-group {
+  display: contents;
+}
+
+.chat-controls__model-menu[data-chat-model-filtering] .chat-controls__provider-heading {
+  display: none;
+}
+
+.chat-controls__model-option {
+  order: var(--chat-model-rank, 0);
+  justify-content: flex-start;
+  gap: 8px;
+  min-height: 40px;
+  padding: 5px 8px;
+}
+
+/* display: flex above beats the UA [hidden] style; without this, filtered-out
+   rows keep rendering even though search marked them hidden. */
+.chat-controls__model-option[hidden] {
+  display: none;
+}
+
+.chat-controls__model-option[data-chat-model-highlighted] {
+  border-color: color-mix(in srgb, var(--border) 76%, transparent);
+  background: var(--bg-hover);
+}
+
+.chat-controls__model-option-provider {
+  display: none;
+}
+
+.chat-controls__model-menu[data-chat-model-filtering] .chat-controls__model-option-provider {
+  display: inline-flex;
+}
+
+.chat-controls__model-option-provider.chat-controls__target-icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+}
+
+.chat-controls__model-option-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  min-width: 22px;
+  margin-left: auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .chat-controls__model-option-action kbd {
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+}
+
+.chat-controls__model-search-wrap:focus-within
+  ~ .chat-controls__model-options
+  .chat-controls__model-option-action
+  kbd {
+  opacity: 0;
+}
+
+.chat-controls__model-option-action kbd::before {
+  content: attr(data-chat-model-shortcut-number);
+}
+
+.chat-controls__model-search-empty {
+  min-height: 80px;
+  padding: 24px 12px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.chat-controls__model-search-empty[hidden] {
+  display: none;
+}
+
+.chat-controls__model-option-copy {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.chat-controls__model-option-title,
+.chat-controls__model-option-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-controls__model-option-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.chat-controls__model-option-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-controls__model-state-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.chat-controls__model-state-label--default {
+  color: var(--muted);
+}
+
+.chat-controls__model-option-meta {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 450;
 }
 
 .chat-controls__reasoning-panel {
@@ -4515,6 +4739,22 @@ button.chat-reply-preview--message:disabled {
   justify-content: space-between;
   gap: 8px;
   min-width: 0;
+}
+
+.chat-controls__model-provenance {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  padding: 7px 10px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.chat-controls__model-provenance-value--inherit {
+  color: var(--muted);
 }
 
 .chat-controls__model-catalog-state {
@@ -4569,6 +4809,26 @@ button.chat-reply-preview--message:disabled {
   border-color: color-mix(in srgb, var(--text) 28%, var(--border));
   background: var(--bg-hover);
   outline: none;
+}
+
+.chat-controls__model-reset {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  padding: 0 7px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  cursor: var(--cursor-action);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.chat-controls__model-reset:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--border) 45%, transparent);
+  color: var(--text);
 }
 
 .chat-controls__reasoning-state {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3758,13 +3758,17 @@ button.chat-reply-preview--message:disabled {
   .agent-chat__composer-controls .chat-controls__model,
   .chat-composer-model-control {
     width: fit-content;
-    min-width: min-content;
+    min-width: 0;
     max-width: min(70vw, 100%);
     margin-left: 0;
   }
 
+  /* Reserve the readable model trigger, 44px effort target, and their gap;
+     keep the picker cluster right-aligned like desktop while transient status
+     text yields before either picker does. */
   .agent-chat__input .agent-chat__composer-controls .chat-composer-model-control {
     flex: 0 1 auto;
+    min-width: 138px;
   }
 
   .agent-chat__input .agent-chat__composer-controls .chat-controls__model-picker {
@@ -4291,7 +4295,7 @@ button.chat-reply-preview--message:disabled {
 
 .chat-controls__model {
   grid-area: model;
-  min-width: min-content;
+  min-width: 0;
   max-width: none;
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2783,8 +2783,11 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   white-space: nowrap;
 }
 
-/* Keycap hint, not content: fixed-width so letters and digits share one rail. */
-.session-menu__shortcut {
+/* Keycap hint, not content: the app's quiet mono shortcut idiom (see
+   .chat-question-panel__option kbd), fixed-width so letters and digits share
+   one rail beside the labels. */
+.session-menu__shortcut,
+.chat-controls__model-option-action kbd {
   flex: 0 0 auto;
   min-width: 12px;
   color: var(--muted);


### PR DESCRIPTION
## What Problem This Solves

Fixes a default-path UI regression where PR #122964 replaced the chat and new-session composers' rich model-picker dialog with the settings-style select. That split the composer into two plain dropdowns, removed search and provider grouping, and truncated the default model label.

## Why This Change Was Made

The composer picker is a distinct product surface: it combines model search, provider grouping, context and capability metadata, CLI-agent targets, and the session-override footer in one dialog. This partial revert restores that shipped composer experience while keeping #122964's channel-picker unification and shared model picker on the settings surfaces where that simpler control fits.

The restored `chat-model-picker.ts` is byte-identical to the parent of #122964's merge commit (`edcf1974838~1`). One additional bounded test-only change lets the responsive composer test wait for viewport resizing to settle before reading bounding boxes, removing grouped-run timing flakiness without changing product behavior.

## User Impact

Model picking on the default chat and new-session composers returns to a compact single trigger that opens the searchable, provider-grouped dialog. Talk, Memory, Session Observer, Automations, Agents, model defaults, Workboard, and other settings pages keep the unified settings picker. There are no config or protocol changes.

## Evidence

Provenance: partial revert of PR #122964 / commit [edcf1974838](https://github.com/openclaw/openclaw/commit/edcf1974838), limited to the composer model-picker regression while retaining its channel and settings unification.

### Chat composer

| Before: split plain selects | After: restored compact picker |
| --- | --- |
| ![Chat composer before](https://github.com/user-attachments/assets/c6a970ba-3681-4d3d-9731-cd6f93cbe285) | ![Chat composer after](https://github.com/user-attachments/assets/e6e82c26-3c55-4014-831c-8ce3dd64b63a) |

| Before: plain model select open | After: searchable grouped dialog open |
| --- | --- |
| ![Chat picker open before](https://github.com/user-attachments/assets/34130f78-879c-4ecb-89db-8afd051abd93) | ![Chat picker open after](https://github.com/user-attachments/assets/cc93db5d-6c78-4716-97b8-818da038adfa) |

### New-session composer

| Before: split plain selects | After: restored compact picker |
| --- | --- |
| ![New-session composer before](https://github.com/user-attachments/assets/f58cd2e4-cb52-4a1f-8724-a9ba209fec7d) | ![New-session composer after](https://github.com/user-attachments/assets/5fbd9d06-52b9-4c24-9d8f-2d04af85e88f) |

| Before: plain model select open | After: searchable grouped dialog open |
| --- | --- |
| ![New-session picker open before](https://github.com/user-attachments/assets/92af4352-fc49-4fe8-9a5e-97b5d46c0940) | ![New-session picker open after](https://github.com/user-attachments/assets/7716060a-3e08-4d28-986d-530a7591d64b) |

Focused proof:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/model-control.test.ts ui/src/components/model-picker.test.ts` — 3 files, 277 tests passed.
- `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts ui/src/e2e/chat-only-model.e2e.test.ts ui/src/e2e/new-session-page.places.e2e.test.ts ui/src/e2e/model-alias-display.e2e.test.ts` — 4 files, 24 tests passed.
- `node scripts/run-vitest.mjs ui/src/e2e/chat-composer-redesign.e2e.test.ts ui/src/e2e/chat-composer-accessory-focus.e2e.test.ts ui/src/e2e/session-suggestions.e2e.test.ts ui/src/e2e/chat-flow.follow-ups.e2e.test.ts ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts ui/src/pages/chat/chat-responsive.browser.test.ts` — 6 files, 47 tests passed.
- Post-rebase: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/model-control.test.ts` — 2 files, 275 tests passed.
- Inventory restoration commit [0be822e099c](https://github.com/openclaw/openclaw/commit/0be822e099ccdb8e42f021b6641158f87083b463): `node scripts/run-vitest.mjs ui/src/components/web-awesome-migration.node.test.ts` — 1 file, 3 tests passed.
- `node scripts/check-changed.mjs -- <all changed files>` — all selected lanes passed.
- `pnpm ui:i18n:baseline` — no diff; the `customModel` English key remains for the settings picker.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted or actionable findings; patch judged correct (0.98).

Production LOC is +1110/-269 and tests are +592/-399. The positive production delta restores the 719-line shipped picker deleted by #122964; it is regression restoration rather than a new parallel capability.

**AI-assisted:** Yes.

### CI dialog-leak diagnosis

- CI run [31685862983](https://github.com/openclaw/openclaw/actions/runs/31685862983) failed only `src/components/input-dialog.test.ts` (10 tests): a leaked open “Approve DM access” `<openclaw-modal-dialog>` from `ui/src/pages/channels/view.pairing.test.ts` poisoned the dialog-owning file in the same worker. Its `renderInto` helper appended containers to `document.body` without `afterEach` cleanup. This was a latent cross-test leak surfaced by the branch's changed test scheduling, not a behavior regression in the PR.
- Producer-owned fix: `view.pairing.test.ts` now tracks rendered containers and removes them in `afterEach`, restoring the repo test-hygiene invariant that global DOM state is cleaned and suites remain safe under `--isolate=false`.
- Causality proof in the original serial-worker execution order: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/channels/view.pairing.test.ts ui/src/components/input-dialog.test.ts`. Pre-fix: 1 shard failed with the exact CI signature. Post-fix: 2 files, 17/17 tests passed.

### Persisted override preservation

- The restored composer picker now ports #122964's synthesized-override row in `chat-model-controls.ts`: when a persisted session override is absent from a non-empty usable catalog, it remains a selectable row. The synthesis stays gated on a usable catalog so the true `No models available` empty state is preserved.
- Regression coverage: `chat-view.test.ts` now proves that a persisted override missing from the catalog is synthesized as a selectable row.
- Focused proof: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/model-control.test.ts` — 2 files, 276 tests passed.
- Fresh Codex autoreview after the override repair: clean, no accepted or actionable findings; patch judged correct (0.96).



### #123085 reconciliation

The final branch reconciles #123085 with the restored composer picker. The rebase had merged #123085's `wa-select` label-width mechanics into this restored dialog surface, removing the old trigger reservation in `chat/layout.css` and leaving a new-session label-width test block that referenced the unified-picker helper removed by the partial revert. Commit [55f06ec7ca5](https://github.com/openclaw/openclaw/commit/55f06ec7ca59a8a81e5ec20c31f5b2cc287ccbfc) restores `chat/layout.css` and `chat-responsive.browser.test.ts` to their exact pre-#122964 state and removes that composer-only label-width block from `new-session-page.workspace-memory.e2e.test.ts`. #123085's shared `select-picker.ts` fix and `new-session.css` line remain because the settings picker surfaces still use them.

- Focused proof: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts` — 2 shards, 13 tests passed.
- Fresh Codex autoreview of the reconciled branch: clean, no accepted or actionable findings; patch judged correct (0.98).
- Follow-up: #123085's label-width E2E coverage lost its composer venue when the shipped dialog was restored; it may be re-homed on a settings picker surface where the unified select still exists.
