### PR TITLE
fix: doctor loops forever on legacy OAuth profiles with missing sidecars

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -782,6 +782,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
           email: "user@example.com",
           oauthRef: {
             source: "openclaw-credentials",
+            id: "0123456789abcdef0123456789abcdef",
             provider: "openai-codex",
           },
         },

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { listAuthProfileStoresRequiringMigration } from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import { resolveAuthProfileEligibility } from "../agents/auth-profiles/order.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/runtime-snapshots.js";
 import {
@@ -285,8 +287,9 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
           type: "oauth",
           provider: "openai",
           oauthRef: {
+            source: "openclaw-credentials",
             id: "0123456789abcdef0123456789abcdef",
-            provider: "openai",
+            provider: "openai-codex",
           },
         },
       },
@@ -305,16 +308,21 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       env: state.env,
     });
 
-    expect(result.warnings).toEqual([
-      expect.stringContaining("legacy OAuth sidecar profile"),
-      expect.stringContaining("no importable auth profiles or state"),
-      expect.stringContaining("Deferred shared legacy OAuth migration"),
-    ]);
-    expect(loadPersistedAuthProfileStore(state.agentDir())).toBeNull();
-    expect(fs.existsSync(authPath)).toBe(true);
-    expect(fs.existsSync(oauthPath)).toBe(true);
-    expectNoMigratedArchive(authPath);
-    expectNoMigratedArchive(oauthPath);
+    expect(result.warnings).toEqual([expect.stringContaining("legacy OAuth sidecar profile")]);
+    expect(
+      loadPersistedAuthProfileStore(state.agentDir())?.profiles["openai:default"],
+    ).toMatchObject({
+      type: "oauth",
+      provider: "openai",
+      oauthRef: {
+        source: "openclaw-credentials",
+        provider: "openai-codex",
+      },
+    });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(fs.existsSync(oauthPath)).toBe(false);
+    expectMigratedArchive(authPath);
+    expectMigratedArchive(oauthPath);
   });
 
   it("preserves state-only profile IDs while migrating shared OAuth", async () => {
@@ -701,7 +709,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     expect(fs.existsSync(authPath)).toBe(false);
   });
 
-  it("leaves unresolved legacy OAuth sidecar refs in JSON", async () => {
+  it("migrates unresolved legacy OAuth sidecar refs so startup can proceed cold", async () => {
     const state = await makeTestState();
     const authPath = await writeLegacyAuthProfilesJson(state, {
       version: 1,
@@ -711,8 +719,9 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
           provider: "openai",
           email: "user@example.com",
           oauthRef: {
+            source: "openclaw-credentials",
             id: "0123456789abcdef0123456789abcdef",
-            provider: "openai",
+            provider: "openai-codex",
           },
         },
       },
@@ -725,14 +734,36 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     });
 
     expect(result.detected).toEqual([authPath]);
-    expect(result.changes).toEqual([]);
+    expect(result.changes).toEqual([expect.stringContaining("Migrated auth profile JSON")]);
     expect(result.warnings).toEqual([
-      expect.stringContaining("legacy OAuth sidecar profile"),
-      expect.stringContaining("no importable auth profiles or state"),
+      expect.stringContaining("Migrated 1 legacy OAuth sidecar profile"),
     ]);
-    expect(loadPersistedAuthProfileStore(state.agentDir())).toBeNull();
-    expect(fs.existsSync(authPath)).toBe(true);
-    expectNoMigratedArchive(authPath);
+    expect(result.warnings[0]).toContain("re-authenticate");
+    const store = loadPersistedAuthProfileStore(state.agentDir());
+    expect(store?.profiles["openai:user@example.com"]).toMatchObject({
+      type: "oauth",
+      provider: "openai",
+      email: "user@example.com",
+      oauthRef: {
+        source: "openclaw-credentials",
+        provider: "openai-codex",
+      },
+    });
+    expect(
+      resolveAuthProfileEligibility({
+        store: store!,
+        provider: "openai",
+        profileId: "openai:user@example.com",
+      }),
+    ).toEqual({ eligible: false, reasonCode: "unresolved_ref" });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expectMigratedArchive(authPath);
+    expect(
+      listAuthProfileStoresRequiringMigration({
+        agentDirs: [state.agentDir()],
+        env: state.env,
+      }),
+    ).toEqual([]);
   });
 
   it("imports valid profiles when one legacy OAuth sidecar ref is unresolved", async () => {
@@ -750,8 +781,8 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
           provider: "openai",
           email: "user@example.com",
           oauthRef: {
-            id: "0123456789abcdef0123456789abcdef",
-            provider: "openai",
+            source: "openclaw-credentials",
+            provider: "openai-codex",
           },
         },
       },
@@ -774,19 +805,28 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
           provider: "openai",
           key: "sk-imported",
         },
+        "openai:user@example.com": {
+          type: "oauth",
+          provider: "openai",
+          email: "user@example.com",
+          oauthRef: {
+            source: "openclaw-credentials",
+            id: "0123456789abcdef0123456789abcdef",
+            provider: "openai-codex",
+          },
+        },
       },
-      order: { openai: ["openai:default"] },
+      order: { openai: ["openai:default", "openai:user@example.com"] },
       lastGood: { openai: "openai:default" },
     });
-    expect(fs.existsSync(authPath)).toBe(true);
-    expectNoMigratedArchive(authPath);
-    const remaining = JSON.parse(fs.readFileSync(authPath, "utf8"));
-    expect(remaining.profiles).toHaveProperty("openai:default");
-    expect(remaining.profiles).toHaveProperty("openai:user@example.com");
-    expect(remaining.order).toEqual({
-      openai: ["openai:default", "openai:user@example.com"],
-    });
-    expect(remaining.lastGood).toEqual({ openai: "openai:default" });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expectMigratedArchive(authPath);
+    expect(
+      listAuthProfileStoresRequiringMigration({
+        agentDirs: [state.agentDir()],
+        env: state.env,
+      }),
+    ).toEqual([]);
   });
 
   it("keeps existing SQLite credentials when importing stale JSON", async () => {
@@ -2031,7 +2071,7 @@ describe("legacy OpenAI auth profiles through the canonical migration owner", ()
     });
   });
 
-  it("does not rebind unresolved sidecar accounts when another Codex account migrates", async () => {
+  it("canonicalizes unresolved sidecar accounts while keeping them cold", async () => {
     const state = await makeTestState();
     const storePath = path.join(state.sessionsDir(), "sessions.json");
     const readySessionKey = "agent:main:main";
@@ -2089,7 +2129,7 @@ describe("legacy OpenAI auth profiles through the canonical migration owner", ()
       authProfileIdMap: profileIdMap,
     });
 
-    expect(result.repairedSessions).toBe(1);
+    expect(result.repairedSessions).toBe(2);
     expect(
       loadSessionEntry({ storePath, sessionKey: readySessionKey, env: state.env }),
     ).toMatchObject({
@@ -2098,9 +2138,17 @@ describe("legacy OpenAI auth profiles through the canonical migration owner", ()
     expect(
       loadSessionEntry({ storePath, sessionKey: pendingSessionKey, env: state.env }),
     ).toMatchObject({
-      authProfileOverride: "openai-codex:pending",
+      authProfileOverride: "openai:pending",
       authProfileOverrideSource: "user",
     });
+    const coldStore = loadPersistedAuthProfileStore(state.agentDir());
+    expect(
+      resolveAuthProfileEligibility({
+        store: coldStore!,
+        provider: "openai",
+        profileId: "openai:pending",
+      }),
+    ).toEqual({ eligible: false, reasonCode: "missing_credential" });
   });
 
   it("repairs an already-migrated selected account from its verified auth archive", async () => {
@@ -2265,6 +2313,7 @@ describe("legacy OpenAI auth profiles through the canonical migration owner", ()
             provider: "openai-codex",
             accountId: "failed-different-account",
             oauthRef: {
+              source: "openclaw-credentials",
               id: "0123456789abcdef0123456789abcdef",
               provider: "openai-codex",
             },
@@ -2326,8 +2375,8 @@ describe("legacy OpenAI auth profiles through the canonical migration owner", ()
       shouldRepair: true,
       authProfileIdMap: profileIdMap,
     });
-    expect(repair.repairedSessions).toBe(3);
-    for (const agentId of ["main", "inherited", "dedup"]) {
+    expect(repair.repairedSessions).toBe(4);
+    for (const agentId of ["main", "failed", "inherited", "dedup"]) {
       expect(
         loadSessionEntry({
           storePath: path.join(state.sessionsDir(agentId), "sessions.json"),
@@ -2339,15 +2388,16 @@ describe("legacy OpenAI auth profiles through the canonical migration owner", ()
         authProfileOverrideSource: "user",
       });
     }
-    expect(
-      loadSessionEntry({
-        storePath: path.join(state.sessionsDir("failed"), "sessions.json"),
-        sessionKey: "agent:failed:main",
-        env: state.env,
-      }),
-    ).toMatchObject({
-      authProfileOverride: "openai-codex:shared",
-      authProfileOverrideSource: "user",
+    expect(loadPersistedAuthProfileStore(state.agentDir("failed"))?.profiles).toMatchObject({
+      "openai:shared": {
+        type: "oauth",
+        provider: "openai",
+        accountId: "failed-different-account",
+        oauthRef: {
+          source: "openclaw-credentials",
+          provider: "openai-codex",
+        },
+      },
     });
   });
 

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -618,80 +618,6 @@ function formatMissingAuthProfileSqliteVerification(params: {
   return parts.length > 0 ? parts.join("; ") : null;
 }
 
-function filterRawAuthProfileState(
-  raw: Record<string, unknown>,
-  shouldKeepProfileId: (profileId: string) => boolean,
-): void {
-  if (isRecord(raw.order)) {
-    for (const [provider, profileIds] of Object.entries(raw.order)) {
-      if (!Array.isArray(profileIds)) {
-        continue;
-      }
-      const kept = profileIds.filter(
-        (profileId): profileId is string =>
-          typeof profileId === "string" && shouldKeepProfileId(profileId),
-      );
-      if (kept.length > 0) {
-        raw.order[provider] = kept;
-      } else {
-        delete raw.order[provider];
-      }
-    }
-    if (Object.keys(raw.order).length === 0) {
-      delete raw.order;
-    }
-  }
-  if (isRecord(raw.lastGood)) {
-    for (const [provider, profileId] of Object.entries(raw.lastGood)) {
-      if (typeof profileId !== "string" || !shouldKeepProfileId(profileId)) {
-        delete raw.lastGood[provider];
-      }
-    }
-    if (Object.keys(raw.lastGood).length === 0) {
-      delete raw.lastGood;
-    }
-  }
-  if (isRecord(raw.usageStats)) {
-    for (const profileId of Object.keys(raw.usageStats)) {
-      if (!shouldKeepProfileId(profileId)) {
-        delete raw.usageStats[profileId];
-      }
-    }
-    if (Object.keys(raw.usageStats).length === 0) {
-      delete raw.usageStats;
-    }
-  }
-}
-
-function pruneRawAuthProfileIds(raw: unknown, profileIds: ReadonlySet<string>): void {
-  if (!isRecord(raw) || !isRecord(raw.profiles)) {
-    return;
-  }
-  for (const profileId of profileIds) {
-    delete raw.profiles[profileId];
-  }
-  filterRawAuthProfileState(raw, (profileId) => !profileIds.has(profileId));
-}
-
-function pickRawAuthProfileIds(
-  raw: unknown,
-  profileIds: ReadonlySet<string>,
-): Record<string, unknown> | null {
-  if (!isRecord(raw) || !isRecord(raw.profiles)) {
-    return null;
-  }
-  const profiles = Object.fromEntries(
-    Object.entries(raw.profiles).filter(([profileId]) => profileIds.has(profileId)),
-  );
-  if (Object.keys(profiles).length === 0) {
-    return null;
-  }
-  const next = structuredClone(raw);
-  next.profiles = profiles;
-  filterRawAuthProfileState(next, (profileId) => profileIds.has(profileId));
-  return next;
-}
-
 function collectUnresolvedLegacyOAuthSidecarProfileIds(raw: unknown): string[] {
   if (!isRecord(raw) || !isRecord(raw.profiles)) {
     return [];
@@ -971,7 +897,7 @@ function migrateLockedLegacyOAuthFile(params: {
  * Imports legacy auth profile JSON and state files into the per-agent SQLite store.
  *
  * JSON files are verified and atomically renamed to timestamped archives only after import.
- * OAuth profiles that still depend on unresolved sidecar secrets remain as a migration input.
+ * OAuth profiles that still depend on missing sidecar secrets migrate as unavailable ref-only rows.
  */
 export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   cfg: OpenClawConfig;
@@ -1099,17 +1025,10 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       const unresolvedSidecarProfileIds = new Set(
         collectUnresolvedLegacyOAuthSidecarProfileIds(rawStore),
       );
-      const unresolvedSidecarRawStore =
+      const unresolvedSidecarWarning =
         unresolvedSidecarProfileIds.size > 0
-          ? pickRawAuthProfileIds(rawStore, unresolvedSidecarProfileIds)
-          : null;
-      if (unresolvedSidecarProfileIds.size > 0) {
-        // Sidecar-backed OAuth entries cannot move into SQLite until their secret material exists.
-        pruneRawAuthProfileIds(rawStore, unresolvedSidecarProfileIds);
-        result.warnings.push(
-          `Left ${unresolvedSidecarProfileIds.size} legacy OAuth sidecar profile${unresolvedSidecarProfileIds.size === 1 ? "" : "s"} in ${shortenHomePath(candidate.authPath)}; rerun ${formatCliCommand("openclaw doctor --fix")} after sidecar migration or re-authenticate those profiles.`,
-        );
-      }
+          ? `Migrated ${unresolvedSidecarProfileIds.size} legacy OAuth sidecar profile${unresolvedSidecarProfileIds.size === 1 ? "" : "s"} from ${shortenHomePath(candidate.authPath)} into SQLite as configured-unavailable without credentials; re-authenticate ${unresolvedSidecarProfileIds.size === 1 ? "this profile" : "these profiles"} to restore access.`
+          : undefined;
       const awsSdkMarkerStore =
         isRecord(rawStore) && isRecord(rawStore.profiles)
           ? resolveAwsSdkAuthProfileMarkerStore(candidate)
@@ -1154,7 +1073,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         !hasAuthProfileState(state) &&
         !awsSdkMarkerStore
       ) {
-        if (!unresolvedSidecarRawStore && sourceReceipts.length > 0) {
+        if (sourceReceipts.length > 0) {
           const archived = sourceReceipts.map((receipt) => {
             finalizeAuthProfileMigrationSource(receipt, "archived-unparsed", {
               sourceLocked: true,
@@ -1162,7 +1081,8 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
             return receipt.archivePath;
           });
           result.warnings.push(
-            `Archived unparseable auth profile input without import for ${shortenHomePath(candidate.authPath)} (${archived.map(shortenHomePath).join(", ")}).`,
+            unresolvedSidecarWarning ??
+              `Archived unparseable auth profile input without import for ${shortenHomePath(candidate.authPath)} (${archived.map(shortenHomePath).join(", ")}).`,
           );
           continue;
         }
@@ -1354,11 +1274,8 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
           receipt.expectedStateSha256 = expectedStateSha256;
         }
       }
-      const archivalReceipts = unresolvedSidecarRawStore
-        ? sourceReceipts.filter((receipt) => receipt.sourcePath !== candidate.authPath)
-        : sourceReceipts;
       assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
-      const archives = archivalReceipts.map((receipt) =>
+      const archives = sourceReceipts.map((receipt) =>
         archiveVerifiedAuthProfileSource(receipt, true),
       );
       const archiveText =
@@ -1368,6 +1285,9 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       result.changes.push(
         `Migrated auth profile JSON for ${shortenHomePath(candidate.authPath)} into SQLite (${archiveText}).`,
       );
+      if (unresolvedSidecarWarning) {
+        result.warnings.push(unresolvedSidecarWarning);
+      }
       if (openAIProviderRepair !== null) {
         result.changes.push(
           `Migrated ${openAIProviderRepair} OpenAI Codex auth profile(s) in ${shortenHomePath(candidate.authPath)} to provider "openai".`,

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -928,8 +928,9 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
   });
 
-  it("blocks gateway readiness when startup migrations leave warnings", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+  it("blocks gateway readiness when state migration warnings outlive the startup checkpoint", async () => {
+    needsStateMigrationCheckpoint.mockReturnValue(true);
+    needsStartupMigrationCheckpoint.mockReturnValue(false);
     autoMigrateLegacyStateDir.mockResolvedValueOnce({
       migrated: false,
       skipped: false,

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -666,23 +666,21 @@ export async function runDoctorConfigPreflight(
       });
     }
     if (gatewayStartupCheckpointRequired) {
-      if (shouldRecordStartupCheckpoint) {
-        if (startupMigrationWarnings.length > 0) {
-          throwStartupMigrationRefusal(
-            formatStartupMigrationFailure({
-              warnings: startupMigrationWarnings,
-              blockers: [],
-            }),
-          );
-        }
-        if (!snapshot.valid) {
-          throwStartupMigrationRefusal(
-            formatStartupMigrationFailure({
-              warnings: [],
-              blockers: ['OpenClaw config is invalid; run "openclaw doctor --fix" before startup.'],
-            }),
-          );
-        }
+      if (startupMigrationWarnings.length > 0) {
+        throwStartupMigrationRefusal(
+          formatStartupMigrationFailure({
+            warnings: startupMigrationWarnings,
+            blockers: [],
+          }),
+        );
+      }
+      if (shouldRecordStartupCheckpoint && !snapshot.valid) {
+        throwStartupMigrationRefusal(
+          formatStartupMigrationFailure({
+            warnings: [],
+            blockers: ['OpenClaw config is invalid; run "openclaw doctor --fix" before startup.'],
+          }),
+        );
       }
       // This state is established before the first Gateway plugin load and remains
       // fixed for the boot. Refresh it on every process start because migration


### PR DESCRIPTION
## What Problem This Solves

Fixes an operator dead-end loop: a legacy `auth-profiles.json` containing an OAuth profile whose sidecar state is missing made the gateway refuse startup with "run `openclaw doctor --fix`" — while doctor completed successfully, deliberately left that profile in the legacy file, and told the operator to rerun doctor. The instruction loop never terminated; the gateway never started. Hit in practice when restoring partial backups or copying an agent directory between installs.

Also fixes boot-to-boot inconsistency where the same startup-migration warning was non-fatal on one boot and blocked readiness on the next (fatality depended on whether the startup checkpoint needed renewal).

## Why This Change Was Made

Doctor pruned unresolved OAuth profiles before SQLite import and retained the legacy JSON, so the gateway's migration preflight kept demanding doctor forever. Doctor now migrates ref-only OAuth profiles into SQLite as configured-unavailable rows carrying no credential material (they can never authorize anything; re-authentication is the terminating action, and the warning says so), then archives the legacy JSON so the preflight stops firing. The whole pre-import pruning machinery became dead and was deleted. Migration warnings now deterministically block readiness whenever gateway startup migrations run, instead of depending on checkpoint state.

## User Impact

`openclaw doctor --fix` always converges: after one run the gateway starts, cold profiles are visible as needing re-authentication, and no instruction loop remains. Startup behavior is the same on every boot given the same state.

## Evidence

- Regression-first: pre-fix, the auth test failed because the legacy JSON survived doctor, and the checkpoint test failed because readiness resolved inconsistently; both pass post-fix.
- Auth migration suite 50 passed; startup migration suite 30 passed; lifecycle preflight suite 6 passed.
- Synthetic end-to-end state: source file removed, one archive created, no credential material stored, migrated profile ineligible to authorize, startup preflight clear.
- Production LOC net −82 (tests +51).
