### PR TITLE
chore(plugins): align install ownership fixtures

### DIFF
--- a/src/plugins/install-persistence.warning-sink.test.ts
+++ b/src/plugins/install-persistence.warning-sink.test.ts
@@ -10,6 +10,7 @@ import {
   pluginsCliRuntimeLogs,
   setInstalledPluginIndexInstallRecords,
 } from "../cli/plugins-cli-test-helpers.js";
+import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 
 const snapshot = {
   config: {},
@@ -33,15 +34,18 @@ describe("plugin install persistence warning audiences", () => {
     const warn = vi.fn();
     loadPluginManifestRegistryMock.mockReturnValue({
       plugins: [
-        {
-          id: "workboard",
-          manifestPath: "/tmp/workboard/openclaw.plugin.json",
-          configSchema: {
-            type: "object",
-            required: ["token"],
-            properties: { token: { type: "string" } },
+        recordPluginManifestInstallOwner(
+          {
+            id: "workboard",
+            manifestPath: `${install.installPath}/openclaw.plugin.json`,
+            configSchema: {
+              type: "object",
+              required: ["token"],
+              properties: { token: { type: "string" } },
+            },
           },
-        },
+          "workboard",
+        ),
       ],
       diagnostics: [],
     });
@@ -69,19 +73,22 @@ describe("plugin install persistence warning audiences", () => {
     const warning = 'Exclusive slot "memory" switched from "memory-core" to "workboard".';
     loadPluginManifestRegistryMock.mockReturnValue({
       plugins: [
-        {
-          id: "workboard",
-          kind: "memory",
-          channels: [],
-          providers: [],
-          cliBackends: [],
-          skills: [],
-          hooks: [],
-          origin: "config",
-          rootDir: "/tmp/workboard",
-          source: "/tmp/workboard/index.js",
-          manifestPath: "/tmp/workboard/openclaw.plugin.json",
-        },
+        recordPluginManifestInstallOwner(
+          {
+            id: "workboard",
+            kind: "memory",
+            channels: [],
+            providers: [],
+            cliBackends: [],
+            skills: [],
+            hooks: [],
+            origin: "config",
+            rootDir: install.installPath,
+            source: `${install.installPath}/index.js`,
+            manifestPath: `${install.installPath}/openclaw.plugin.json`,
+          },
+          "workboard",
+        ),
       ],
       diagnostics: [],
     });

--- a/src/plugins/installed-plugin-index-records.test.ts
+++ b/src/plugins/installed-plugin-index-records.test.ts
@@ -15,6 +15,7 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
+import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
   resolvePluginNpmGenerationProjectDir,
@@ -50,12 +51,15 @@ function createPluginCandidate(stateDir: string, pluginId: string): PluginCandid
     }),
     "utf8",
   );
-  return {
-    idHint: pluginId,
-    source,
-    rootDir,
-    origin: "global",
-  };
+  return recordPluginCandidateInstallOwner(
+    {
+      idHint: pluginId,
+      source,
+      rootDir,
+      origin: "global",
+    },
+    pluginId,
+  );
 }
 
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import type { PluginCandidate } from "./discovery.js";
+import { resolveInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import { buildInstalledPluginIndexRecords } from "./installed-plugin-index-record-builder.js";
 import {
   loadInstalledPluginIndexInstallRecordsSync,
@@ -96,22 +98,28 @@ function createPluginCandidate(params: {
   packageManifest?: OpenClawPackageManifest;
   format?: PluginCandidate["format"];
   bundleFormat?: PluginCandidate["bundleFormat"];
+  installOwner?: string;
 }): PluginCandidate {
-  return {
-    idHint: params.idHint ?? "demo",
-    source: params.format === "bundle" ? params.rootDir : path.join(params.rootDir, "index.ts"),
-    rootDir: params.rootDir,
-    origin: params.origin ?? "global",
-    format: params.format,
-    bundleFormat: params.bundleFormat,
-    packageName: params.packageName,
-    packageVersion: params.packageVersion,
-    packageDir: params.packageDir ?? params.rootDir,
-    packageManifest: params.packageManifest,
-  };
+  return recordPluginCandidateInstallOwner(
+    {
+      idHint: params.idHint ?? "demo",
+      source: params.format === "bundle" ? params.rootDir : path.join(params.rootDir, "index.ts"),
+      rootDir: params.rootDir,
+      origin: params.origin ?? "global",
+      format: params.format,
+      bundleFormat: params.bundleFormat,
+      packageName: params.packageName,
+      packageVersion: params.packageVersion,
+      packageDir: params.packageDir ?? params.rootDir,
+      packageManifest: params.packageManifest,
+    },
+    params.installOwner,
+  );
 }
 
-function createRichPluginFixture(params: { id?: string; packageVersion?: string } = {}) {
+function createRichPluginFixture(
+  params: { id?: string; packageVersion?: string; installOwner?: string } = {},
+) {
   const rootDir = makeTempDir();
   const id = params.id ?? "demo";
   writeRuntimeEntry(rootDir);
@@ -180,6 +188,7 @@ function createRichPluginFixture(params: { id?: string; packageVersion?: string 
           defaultChoice: "npm",
         },
       },
+      installOwner: params.installOwner,
     }),
   };
 }
@@ -247,6 +256,7 @@ describe("installed plugin index", () => {
       path: "package.json",
     });
     expectSha256(packageJson.hash);
+    expect(resolveInstalledPluginIndexInstallOwner(plugin)).toBeUndefined();
     expect(index.plugins[0]?.installRecord).toBeUndefined();
     expect(index.plugins[0]?.installRecordHash).toBeUndefined();
   });
@@ -608,7 +618,7 @@ describe("installed plugin index", () => {
   });
 
   it("records explicit install records separately from package install intent", () => {
-    const fixture = createRichPluginFixture();
+    const fixture = createRichPluginFixture({ installOwner: "demo" });
 
     const index = loadInstalledPluginIndex({
       candidates: [fixture.candidate],
@@ -688,6 +698,7 @@ describe("installed plugin index", () => {
           rootDir: globalDir,
           idHint: "duplicate-demo",
           origin: "global",
+          installOwner: "duplicate-demo",
         }),
       ],
       installRecords: {
@@ -716,7 +727,7 @@ describe("installed plugin index", () => {
   });
 
   it("indexes npm plugin index records written before a process reload", () => {
-    const fixture = createRichPluginFixture();
+    const fixture = createRichPluginFixture({ installOwner: "demo" });
     const cfg = recordPluginInstall(
       {},
       {
@@ -765,7 +776,7 @@ describe("installed plugin index", () => {
   });
 
   it("indexes persisted plugin index records from an explicit state directory", async () => {
-    const fixture = createRichPluginFixture();
+    const fixture = createRichPluginFixture({ installOwner: "demo" });
     const stateDir = makeTempDir();
     await writePersistedInstalledPluginIndexInstallRecords(
       {
@@ -848,7 +859,7 @@ describe("installed plugin index", () => {
   });
 
   it("indexes local fallback plugin index records written before a process reload", () => {
-    const fixture = createRichPluginFixture();
+    const fixture = createRichPluginFixture({ installOwner: "demo" });
     const cfg = recordPluginInstall(
       {},
       {
@@ -883,7 +894,7 @@ describe("installed plugin index", () => {
   });
 
   it("does not treat package install intent as source invalidation", () => {
-    const fixture = createRichPluginFixture();
+    const fixture = createRichPluginFixture({ installOwner: "demo" });
     const previous = loadInstalledPluginIndex({
       candidates: [fixture.candidate],
       installRecords: {
@@ -912,7 +923,7 @@ describe("installed plugin index", () => {
   });
 
   it("treats plugin index changes as source invalidation", () => {
-    const fixture = createRichPluginFixture();
+    const fixture = createRichPluginFixture({ installOwner: "demo" });
     const previous = loadInstalledPluginIndex({
       candidates: [fixture.candidate],
       installRecords: {
@@ -1092,7 +1103,7 @@ describe("installed plugin index", () => {
   });
 
   it("diffs invalidation reasons for manifest, package, source, host, compat, and migration changes", () => {
-    const fixture = createRichPluginFixture();
+    const fixture = createRichPluginFixture({ installOwner: "demo" });
     const previous = loadInstalledPluginIndex({
       candidates: [fixture.candidate],
       config: {

--- a/src/plugins/management-service-featured.test.ts
+++ b/src/plugins/management-service-featured.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
+import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 
 const mocks = vi.hoisted(() => ({
   metadata: vi.fn(),
@@ -32,33 +34,45 @@ function metadataSnapshot(params: {
   const id = params.id ?? "workboard";
   const packageName =
     params.packageName === null ? undefined : (params.packageName ?? `@openclaw/${id}`);
-  const manifest = {
-    id,
-    name: params.name ?? "Workboard",
-    description: params.description ?? "Coordinate agent work in a shared board.",
-    catalog: { featured: params.featured ?? true, order: 10 },
-    ...(params.icon ? { icon: params.icon } : {}),
-    channels: [],
-    providers: [],
-    cliBackends: [],
-    skills: [],
-    hooks: [],
-    origin: params.origin ?? "bundled",
-    rootDir: `/tmp/${id}`,
-    source: `/tmp/${id}/index.ts`,
-    manifestPath: `/tmp/${id}/openclaw.plugin.json`,
-  };
+  const rootDir = `/tmp/${id}`;
+  const installOwner = params.installRecord ? id : undefined;
+  const manifest = recordPluginManifestInstallOwner(
+    {
+      id,
+      name: params.name ?? "Workboard",
+      description: params.description ?? "Coordinate agent work in a shared board.",
+      catalog: { featured: params.featured ?? true, order: 10 },
+      ...(params.icon ? { icon: params.icon } : {}),
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      origin: params.origin ?? "bundled",
+      rootDir,
+      source: `${rootDir}/index.ts`,
+      manifestPath: `${rootDir}/openclaw.plugin.json`,
+    },
+    installOwner,
+  );
+  const installRecord = params.installRecord
+    ? { ...params.installRecord, installPath: rootDir }
+    : undefined;
   return {
     index: {
       plugins: [
-        {
-          pluginId: id,
-          ...(packageName ? { packageName } : {}),
-          origin: params.origin ?? "bundled",
-          enabled: true,
-        },
+        recordInstalledPluginIndexInstallOwner(
+          {
+            pluginId: id,
+            ...(packageName ? { packageName } : {}),
+            origin: params.origin ?? "bundled",
+            rootDir,
+            enabled: true,
+          },
+          installOwner,
+        ),
       ],
-      installRecords: params.installRecord ? { [id]: params.installRecord } : {},
+      installRecords: installRecord ? { [id]: installRecord } : {},
     },
     byPluginId: new Map([[id, manifest]]),
     plugins: [manifest],

--- a/src/plugins/management-service.registry-refresh.test.ts
+++ b/src/plugins/management-service.registry-refresh.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
+import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 
 const mocks = vi.hoisted(() => ({
   clawhubInstall: vi.fn(),
@@ -78,26 +80,47 @@ function mockClawHubWorkboardInstall() {
   });
 }
 
-function metadataSnapshot(enabled: boolean) {
-  const manifest = {
-    id: "workboard",
-    name: "Workboard",
-    channels: [],
-    providers: [],
-    cliBackends: [],
-    skills: [],
-    hooks: [],
-    origin: "bundled",
-    rootDir: "/tmp/workboard",
-    source: "/tmp/workboard/index.ts",
-    manifestPath: "/tmp/workboard/openclaw.plugin.json",
-  };
+function metadataSnapshot(enabled: boolean, installed = false) {
+  const installOwner = installed ? "workboard" : undefined;
+  const manifest = recordPluginManifestInstallOwner(
+    {
+      id: "workboard",
+      name: "Workboard",
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      origin: "bundled",
+      rootDir: "/tmp/workboard",
+      source: "/tmp/workboard/index.ts",
+      manifestPath: "/tmp/workboard/openclaw.plugin.json",
+    },
+    installOwner,
+  );
   return {
     index: {
       plugins: [
-        { pluginId: "workboard", packageName: "@openclaw/workboard", origin: "bundled", enabled },
+        recordInstalledPluginIndexInstallOwner(
+          {
+            pluginId: "workboard",
+            packageName: "@openclaw/workboard",
+            origin: "bundled",
+            rootDir: "/tmp/workboard",
+            enabled,
+          },
+          installOwner,
+        ),
       ],
-      installRecords: {},
+      installRecords: installed
+        ? {
+            workboard: {
+              source: "clawhub",
+              spec: "clawhub:community/workboard",
+              installPath: "/tmp/workboard",
+            },
+          }
+        : {},
     },
     byPluginId: new Map([["workboard", manifest]]),
     plugins: [manifest],
@@ -169,7 +192,7 @@ describe("plugin management registry refresh", () => {
         return { plugins: { entries: { workboard: { enabled: false } } } };
       },
     );
-    mocks.metadata.mockReturnValue(metadataSnapshot(false));
+    mocks.metadata.mockReturnValue(metadataSnapshot(false, true));
 
     const result = await installManagedPlugin({
       request: { source: "clawhub", packageName: "community/workboard" },

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -6,6 +6,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
   readPersistedInstalledPluginIndex,
@@ -77,7 +78,11 @@ function hashFile(filePath: string): string {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
-function createCandidate(rootDir: string, pluginId = "demo"): PluginCandidate {
+function createCandidate(
+  rootDir: string,
+  pluginId = "demo",
+  installOwner?: string,
+): PluginCandidate {
   fs.writeFileSync(
     path.join(rootDir, "index.ts"),
     "throw new Error('runtime entry should not load while reading plugin registry');\n",
@@ -124,12 +129,15 @@ function createCandidate(rootDir: string, pluginId = "demo"): PluginCandidate {
     }),
     "utf8",
   );
-  return {
-    idHint: pluginId,
-    source: path.join(rootDir, "index.ts"),
-    rootDir,
-    origin: "global",
-  };
+  return recordPluginCandidateInstallOwner(
+    {
+      idHint: pluginId,
+      source: path.join(rootDir, "index.ts"),
+      rootDir,
+      origin: "global",
+    },
+    installOwner,
+  );
 }
 
 function createIndex(
@@ -558,15 +566,19 @@ describe("plugin registry facade", () => {
     const tempDir = makeTempDir();
     const rootDir = makeTempDir();
     const filePath = path.join(tempDir, "custom-registry.sqlite");
-    const env = hermeticEnv();
+    const env = hermeticEnv({
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: tempDir,
+    });
+    const installRecords = {
+      demo: { source: "npm" as const, spec: "demo@1.0.0", installPath: rootDir },
+    };
     const persisted = loadPluginRegistrySnapshot({
-      candidates: [createCandidate(rootDir)],
+      candidates: [createCandidate(rootDir, "demo", "demo")],
+      installRecords,
       env,
       preferPersisted: false,
     });
-    persisted.installRecords = {
-      demo: { source: "npm", spec: "demo@1.0.0", installPath: rootDir },
-    };
     await writePersistedInstalledPluginIndex(persisted, { filePath });
 
     const result = loadPluginRegistrySnapshotWithMetadata({ filePath, env });


### PR DESCRIPTION
Related: #123063

## What Problem This Solves

Keeps plugin install/index tests aligned with the authoritative install ownership ledger now used on `main`. Several fixtures still modeled installed plugins without recording ownership first, which made those tests exercise states the product no longer produces.

## Why This Change Was Made

The six affected test files now record install ownership before constructing ledger-backed plugin indexes and preserve an explicit unowned negative case. This is a maintainer-requested, test-only follow-up: no production code, scripts, configuration, or public behavior changes.

## User Impact

No user-visible runtime change. Maintainers get more accurate regression coverage for plugin install ownership, persistence, registry refresh, and management-service behavior.

## Evidence

- Exact head: `ece77a198f3d31e585608e916f0029c348323dbb`
- Focused plugin tests: 6 files, 109/109 passed
- `oxfmt --check` on all six changed files: passed
- `git diff --check`: passed
- `check-changed` exact-head Testbox gate: passed, including core-test typecheck and lint
- Local exact-head ClawSweeper: `nothing_found`; best solution: yes
- Exact-head branch autoreview: clean, 0.99 confidence, no accepted/actionable findings
- Scope: exactly six `src/plugins/*.test.ts` files; production delta `0`; tests `+170/-99`
- Representative bundled-plugin shard: deferred while shared capacity is reserved; not waived. Ordinary exact-head CI is requested on this PR.

AI-assisted: yes. I reviewed and understand the complete change and its test-only boundary.
