### PR TITLE
fix(slack): preserve bold formatting in normal replies

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1695,6 +1695,30 @@ describe("slackPlugin directory", () => {
 });
 
 describe("slackPlugin agentPrompt", () => {
+  it("teaches agents to author plain replies in standard Markdown", () => {
+    const hints = slackPlugin.agentPrompt?.inboundFormattingHints?.({
+      cfg: {
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+            appToken: "xapp-test",
+          },
+        },
+      },
+    });
+
+    expect(hints).toEqual({
+      text_markup: "markdown",
+      rules: [
+        "Write standard Markdown; OpenClaw converts it to Slack mrkdwn.",
+        "Bold uses **double asterisks**; italic uses *single asterisks*.",
+        "Links use [label](url).",
+        "Code blocks use triple backticks with an optional language identifier.",
+        "Markdown headings and lists are supported; pipe tables are converted according to the channel table mode.",
+      ],
+    });
+  });
+
   it("teaches agents to use typed presentation", () => {
     const hints = slackPlugin.agentPrompt?.messageToolHints?.({
       cfg: {

--- a/extensions/slack/src/shared.ts
+++ b/extensions/slack/src/shared.ts
@@ -51,13 +51,13 @@ export function createSlackPluginBase(params: {
     doctor: slackDoctor,
     agentPrompt: {
       inboundFormattingHints: () => ({
-        text_markup: "slack_mrkdwn",
+        text_markup: "markdown",
         rules: [
-          "Use Slack mrkdwn, not standard Markdown.",
-          "Bold uses *single asterisks*.",
-          "Links use <url|label>.",
-          "Code blocks use triple backticks without a language identifier.",
-          "Do not use markdown headings or pipe tables.",
+          "Write standard Markdown; OpenClaw converts it to Slack mrkdwn.",
+          "Bold uses **double asterisks**; italic uses *single asterisks*.",
+          "Links use [label](url).",
+          "Code blocks use triple backticks with an optional language identifier.",
+          "Markdown headings and lists are supported; pipe tables are converted according to the channel table mode.",
         ],
       }),
       messageToolHints: () => [

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -31,13 +31,13 @@ vi.mock("../../channels/plugins/registry-loaded.js", async (importOriginal) => (
             }) => {
               formattingHintCalls.push(params);
               return {
-                text_markup: "slack_mrkdwn",
+                text_markup: "markdown",
                 rules: [
-                  "Use Slack mrkdwn, not standard Markdown.",
-                  "Bold uses *single asterisks*.",
-                  "Links use <url|label>.",
-                  "Code blocks use triple backticks without a language identifier.",
-                  "Do not use markdown headings or pipe tables.",
+                  "Write standard Markdown; OpenClaw converts it to Slack mrkdwn.",
+                  "Bold uses **double asterisks**; italic uses *single asterisks*.",
+                  "Links use [label](url).",
+                  "Code blocks use triple backticks with an optional language identifier.",
+                  "Markdown headings and lists are supported; pipe tables are converted according to the channel table mode.",
                 ],
               };
             },
@@ -283,7 +283,7 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["sender_id"]).toBeUndefined();
   });
 
-  it("includes Slack mrkdwn response format hints for Slack chats and threads cfg", () => {
+  it("includes Markdown authoring hints for Slack chats and threads cfg", () => {
     formattingHintCalls.length = 0;
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(
@@ -304,13 +304,13 @@ describe("buildInboundMetaSystemPrompt", () => {
             config: { listAccountIds: () => [], resolveAccount: () => ({}) },
             agentPrompt: {
               inboundFormattingHints: () => ({
-                text_markup: "slack_mrkdwn",
+                text_markup: "markdown",
                 rules: [
-                  "Use Slack mrkdwn, not standard Markdown.",
-                  "Bold uses *single asterisks*.",
-                  "Links use <url|label>.",
-                  "Code blocks use triple backticks without a language identifier.",
-                  "Do not use markdown headings or pipe tables.",
+                  "Write standard Markdown; OpenClaw converts it to Slack mrkdwn.",
+                  "Bold uses **double asterisks**; italic uses *single asterisks*.",
+                  "Links use [label](url).",
+                  "Code blocks use triple backticks with an optional language identifier.",
+                  "Markdown headings and lists are supported; pipe tables are converted according to the channel table mode.",
                 ],
               }),
             },
@@ -336,13 +336,13 @@ describe("buildInboundMetaSystemPrompt", () => {
 
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["response_format"]).toEqual({
-      text_markup: "slack_mrkdwn",
+      text_markup: "markdown",
       rules: [
-        "Use Slack mrkdwn, not standard Markdown.",
-        "Bold uses *single asterisks*.",
-        "Links use <url|label>.",
-        "Code blocks use triple backticks without a language identifier.",
-        "Do not use markdown headings or pipe tables.",
+        "Write standard Markdown; OpenClaw converts it to Slack mrkdwn.",
+        "Bold uses **double asterisks**; italic uses *single asterisks*.",
+        "Links use [label](url).",
+        "Code blocks use triple backticks with an optional language identifier.",
+        "Markdown headings and lists are supported; pipe tables are converted according to the channel table mode.",
       ],
     });
     expect(formattingHintCalls).toEqual([{ cfg, accountId: "work" }]);
@@ -370,7 +370,7 @@ describe("buildInboundMetaSystemPrompt", () => {
 
     const payload = parseInboundMetaPayload(prompt);
     const responseFormat = payload["response_format"] as { text_markup?: string } | undefined;
-    expect(responseFormat?.text_markup).toBe("slack_mrkdwn");
+    expect(responseFormat?.text_markup).toBe("markdown");
     // Trusted metadata still identifies the system event; only authoring hints
     // follow the delivery channel.
     expect(payload["channel"]).toBe("heartbeat");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where normal Slack replies could show intended bold labels as italics, visible underscores, or plain text when the reply included bullet points and CJK punctuation.

## Why This Change Was Made

Slack's ordinary send, edit, and preview paths already parse standard Markdown and convert it to Slack mrkdwn, but the agent prompt told models to author those replies as native mrkdwn. This aligns the normal-reply contract with the existing renderer while leaving Block Kit and presentation fields on native Slack mrkdwn.

## User Impact

Bold labels, bullets, links, code fences, and other formatting in normal Slack replies are authored consistently and converted by the existing Slack renderer. Structured Block Kit content is unchanged.

## Evidence

- Added a Slack plugin contract test for the complete normal-reply formatting guidance.
- Updated inbound metadata tests to verify the Markdown contract for chats, threads, and system-event delivery.
- Focused verification: 4 files passed, 167 tests passed across 2 Vitest shards.
- Formatting hook and `git diff --check` passed.
- Independent review found no actionable issues.
- The repository autoreview command could not start because TruffleHog is not installed locally; PR CI remains the source of truth for the full project checks.
