### PR TITLE
fix(onboard): import applies after runtime state initialization

### DIFF
--- a/src/wizard/setup.migration-import.test.ts
+++ b/src/wizard/setup.migration-import.test.ts
@@ -6,6 +6,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { listSetupMigrationOptions } from "./setup.migration-import.js";
 import {
   assertFreshSetupMigrationTarget,
+  buildSetupMigrationTargetSnapshot,
   inspectSetupMigrationFreshness,
   preserveSetupMigrationSecurityAcknowledgement,
 } from "./setup.migration-snapshot.js";
@@ -55,6 +56,27 @@ describe("setup migration import freshness", () => {
     });
 
     expect(result).toEqual({ fresh: true, reasons: [] });
+  });
+
+  it("ignores runtime state churn while still detecting workspace changes", async () => {
+    const root = tempRoots.make("openclaw-setup-migration-");
+    const stateDir = path.join(root, "state");
+    const workspaceDir = path.join(root, "workspace");
+    const initial = await buildSetupMigrationTargetSnapshot({
+      config: {},
+      stateDir,
+      workspaceDir,
+    });
+
+    await writeFile(path.join(stateDir, "state", "openclaw.sqlite"), "runtime database\n");
+    expect(await buildSetupMigrationTargetSnapshot({ config: {}, stateDir, workspaceDir })).toBe(
+      initial,
+    );
+
+    await writeFile(path.join(workspaceDir, "external.txt"), "concurrent write\n");
+    expect(
+      await buildSetupMigrationTargetSnapshot({ config: {}, stateDir, workspaceDir }),
+    ).not.toBe(initial);
   });
 
   it("preserves the first-launch acknowledgement across the lock-time config reread", () => {

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -28,6 +28,7 @@ import {
   inspectSetupMigrationFreshness,
   preserveSetupMigrationSecurityAcknowledgement,
   prepareSetupMigrationAttemptBoundary,
+  SetupMigrationTargetChangedError,
   withSetupMigrationTargetLock,
 } from "./setup.migration-snapshot.js";
 import {
@@ -544,7 +545,9 @@ export async function runSetupMigrationImport(params: {
         buildSetupMigrationPlanSourceSnapshot(plan),
       ]);
       if (currentTargetSnapshotHash !== planningTargetSnapshotHash) {
-        throw new Error("Migration target changed before promotion. Review it and retry.");
+        throw new SetupMigrationTargetChangedError(
+          "Migration target changed before promotion. Review it and retry.",
+        );
       }
       if (currentSourceSnapshotHash !== plannedSourceSnapshotHash) {
         throw new Error("Migration source changed before promotion. Review it and retry.");

--- a/src/wizard/setup.migration-promotion.ts
+++ b/src/wizard/setup.migration-promotion.ts
@@ -6,6 +6,7 @@ import { readDurableJsonFile, writeJsonAtomic } from "../infra/json-files.js";
 import { isNotFoundPathError } from "../infra/path-guards.js";
 import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
 import { hashSetupMigrationConfig } from "./setup.migration-canonical.js";
+import { SetupMigrationTargetChangedError } from "./setup.migration-snapshot.js";
 
 export const PROMOTION_JOURNAL_FILE = "onboarding-promotion.json";
 export const PROMOTION_JOURNAL_VERSION = 1;
@@ -358,7 +359,9 @@ export async function recordPromotionTargetState(component: PromotionComponent):
   }
   const stat = await fs.lstat(component.finalPath);
   if (!stat.isDirectory() || (await fs.readdir(component.finalPath)).length > 0) {
-    throw new Error(`Migration target changed before promotion: ${component.finalPath}`);
+    throw new SetupMigrationTargetChangedError(
+      `Migration target changed before promotion: ${component.finalPath}`,
+    );
   }
   component.targetWasEmptyDirectory = true;
   component.emptyTargetBackupPath = await reserveEmptyTargetBackupPath(component.finalPath);
@@ -370,7 +373,9 @@ export async function moveRecordedEmptyTarget(component: PromotionComponent): Pr
   }
   const entries = await fs.readdir(component.finalPath);
   if (entries.length > 0) {
-    throw new Error(`Migration target changed before promotion: ${component.finalPath}`);
+    throw new SetupMigrationTargetChangedError(
+      `Migration target changed before promotion: ${component.finalPath}`,
+    );
   }
   if (component.emptyTargetBackupPath) {
     await fs.rename(component.finalPath, component.emptyTargetBackupPath);

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -29,7 +29,6 @@ const MEANINGFUL_WORKSPACE_ENTRIES = [
   "skills",
 ] as const;
 const IMPORT_BLOCKING_STATE_ENTRIES = ["credentials", "sessions", "agents"] as const;
-const MIGRATION_TARGET_STATE_ENTRIES = [...IMPORT_BLOCKING_STATE_ENTRIES, "state"] as const;
 
 export class SetupTargetLockedError extends Error {
   readonly code = "setup_target_locked";
@@ -254,7 +253,7 @@ export async function buildSetupMigrationTargetSnapshot(params: {
   const targetConfig = buildSetupMigrationSnapshotConfig(params.config);
   hash.update(`config:${JSON.stringify(canonicalizeSetupMigrationValue(targetConfig))}\0`);
   await hashTargetPath(hash, params.workspaceDir, "workspace");
-  for (const entry of MIGRATION_TARGET_STATE_ENTRIES) {
+  for (const entry of IMPORT_BLOCKING_STATE_ENTRIES) {
     await hashTargetPath(hash, path.join(params.stateDir, entry), `state/${entry}`);
   }
   return hash.digest("hex");
@@ -306,7 +305,9 @@ export async function prepareSetupMigrationAttemptBoundary(params: {
     workspaceDir: params.workspaceDir,
   });
   if (currentTargetSnapshotHash !== params.expectedTargetSnapshotHash) {
-    throw new Error("Migration target changed while preparing the import. Review it and retry.");
+    throw new SetupMigrationTargetChangedError(
+      "Migration target changed while preparing the import. Review it and retry.",
+    );
   }
   const sourceSnapshotHash = await buildSetupMigrationPlanSourceSnapshot(params.plan);
   if (sourceSnapshotHash !== params.expectedSourceSnapshotHash) {
@@ -378,3 +379,4 @@ export function assertFreshSetupMigrationTarget(freshness: {
 }
 
 export class SetupMigrationFreshnessError extends Error {}
+export class SetupMigrationTargetChangedError extends Error {}

--- a/src/wizard/setup.migration-stage.ts
+++ b/src/wizard/setup.migration-stage.ts
@@ -14,7 +14,10 @@ import type {
   MigrationItem,
   MigrationPlan,
 } from "../plugins/types.js";
-import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  registerOpenClawAgentDatabase,
+  unregisterOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
 import {
   disposeOpenClawAgentDatabaseByPath,
   openOpenClawAgentDatabase,
@@ -37,6 +40,7 @@ import {
   type SetupMigrationPromotionContinuation,
   type SetupMigrationPromotionResume,
 } from "./setup.migration-promotion.js";
+import { SetupMigrationTargetChangedError } from "./setup.migration-snapshot.js";
 
 export { recoverSetupMigrationPromotion } from "./setup.migration-promotion.js";
 export type {
@@ -319,6 +323,7 @@ export async function createSetupMigrationStage(params: {
   });
   openOpenClawAgentDatabase({ agentId, env: stageEnv });
   let databasesDisposed = false;
+  let finalAgentDatabaseRegistered = false;
   let retainForRecovery = false;
 
   const disposeDatabases = () => {
@@ -328,13 +333,6 @@ export async function createSetupMigrationStage(params: {
     clearRuntimeAuthProfileStoreSnapshot(stagedAgentDir);
     const stagedAgentDatabasePath = path.join(stagedAgentDir, "openclaw-agent.sqlite");
     disposeOpenClawAgentDatabaseByPath(stagedAgentDatabasePath, { env: stageEnv });
-    // Verification may already close this handle. The staged registry still must
-    // publish the final path before its shared database is promoted.
-    registerOpenClawAgentDatabase({
-      agentId,
-      path: path.join(finalAgentDir, "openclaw-agent.sqlite"),
-      env: stageEnv,
-    });
     closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(stageEnv));
     databasesDisposed = true;
   };
@@ -367,9 +365,13 @@ export async function createSetupMigrationStage(params: {
       }
       const configBefore = await readConfigFile();
       if (hashSetupMigrationConfig(configBefore) !== hashSetupMigrationConfig(expectedConfig)) {
-        throw new Error("Migration config changed before promotion. Review it and retry.");
+        throw new SetupMigrationTargetChangedError(
+          "Migration config changed before promotion. Review it and retry.",
+        );
       }
       const configTarget = configs.getFinalConfig();
+      // Shared state is owned by the live runtime. Promote durable import artifacts,
+      // then merge the derived agent registry fact instead of replacing its database.
       const components: PromotionComponent[] = [
         {
           name: "workspace",
@@ -381,12 +383,6 @@ export async function createSetupMigrationStage(params: {
           name: "agent",
           stagedPath: stagedAgentDir,
           finalPath: finalAgentDir,
-          status: "staged",
-        },
-        {
-          name: "state",
-          stagedPath: path.join(stagedStateDir, "state"),
-          finalPath: path.join(params.stateDir, "state"),
           status: "staged",
         },
       ];
@@ -441,6 +437,14 @@ export async function createSetupMigrationStage(params: {
           }
           await fs.mkdir(path.dirname(component.finalPath), { recursive: true, mode: 0o700 });
           await fs.rename(component.stagedPath, component.finalPath);
+          if (component.name === "agent") {
+            registerOpenClawAgentDatabase({
+              agentId,
+              path: path.join(finalAgentDir, "openclaw-agent.sqlite"),
+              env: finalEnv,
+            });
+            finalAgentDatabaseRegistered = true;
+          }
           component.status = "promoted";
           await writePromotionJournal(journalPath, journal);
         }
@@ -471,6 +475,14 @@ export async function createSetupMigrationStage(params: {
       } catch (error) {
         if (retainForRecovery) {
           throw error;
+        }
+        if (finalAgentDatabaseRegistered) {
+          unregisterOpenClawAgentDatabase({
+            agentId,
+            path: path.join(finalAgentDir, "openclaw-agent.sqlite"),
+            env: finalEnv,
+          });
+          finalAgentDatabaseRegistered = false;
         }
         if (await rollbackComponents(journal.components)) {
           journal.status = "rolled-back";

--- a/src/wizard/setup.migration-transaction.test.ts
+++ b/src/wizard/setup.migration-transaction.test.ts
@@ -12,6 +12,10 @@ import type {
   MigrationProviderContext,
   MigrationProviderPlugin,
 } from "../plugins/types.js";
+import {
+  listOpenClawRegisteredAgentDatabases,
+  registerOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 
 const mocks = vi.hoisted(() => ({
@@ -392,6 +396,61 @@ describe("transactional setup migration import", () => {
       "Migration target changed before promotion",
     );
     await expect(fs.access(path.join(root, "workspace", "MEMORY.md"))).rejects.toThrow();
+  });
+
+  it("promotes while the live runtime state database changes during staged apply", async () => {
+    const root = tempRoots.make("openclaw-migration-transaction-");
+    const source = path.join(root, "source-memory.md");
+    const stateDir = path.join(root, "openclaw-state");
+    const liveEnv = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const runtimeDatabasePath = path.join(root, "runtime-agent.sqlite");
+    await fs.writeFile(source, "remember this\n", "utf8");
+    mocks.provider = provider({
+      source,
+      mutateDuringApply: async () => {
+        registerOpenClawAgentDatabase({
+          agentId: "runtime",
+          path: runtimeDatabasePath,
+          env: liveEnv,
+        });
+      },
+    });
+    const currentConfig = { value: {} };
+
+    await expect(runImport({ root, source, currentConfig })).resolves.toEqual({
+      kind: "no-imported-inference",
+    });
+
+    expect(await fs.readFile(path.join(root, "workspace", "MEMORY.md"), "utf8")).toBe(
+      "remember this\n",
+    );
+    expect(listOpenClawRegisteredAgentDatabases({ env: liveEnv })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ agentId: "main" }),
+        expect.objectContaining({ agentId: "runtime", path: runtimeDatabasePath }),
+      ]),
+    );
+  });
+
+  it("still aborts promotion when another writer changes the workspace", async () => {
+    const root = tempRoots.make("openclaw-migration-transaction-");
+    const source = path.join(root, "source-memory.md");
+    const externalFile = path.join(root, "workspace", "external.txt");
+    await fs.writeFile(source, "remember this\n", "utf8");
+    mocks.provider = provider({
+      source,
+      mutateDuringApply: async () => {
+        await fs.mkdir(path.dirname(externalFile), { recursive: true });
+        await fs.writeFile(externalFile, "concurrent write\n", "utf8");
+      },
+    });
+    const currentConfig = { value: {} };
+
+    await expect(runImport({ root, source, currentConfig })).rejects.toThrow(
+      "Migration target changed before promotion",
+    );
+    await expect(fs.access(path.join(root, "workspace", "MEMORY.md"))).rejects.toThrow();
+    expect(await fs.readFile(externalFile, "utf8")).toBe("concurrent write\n");
   });
 
   it("runs deferred activation only after promotion and keeps failures as warnings", async () => {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -19,7 +19,10 @@ import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { WizardCancelledError, type WizardPrompter, type WizardSelectParams } from "./prompts.js";
 import { runSetupWizard } from "./setup.js";
-import { SetupMigrationFreshnessError } from "./setup.migration-snapshot.js";
+import {
+  SetupMigrationFreshnessError,
+  SetupMigrationTargetChangedError,
+} from "./setup.migration-snapshot.js";
 
 type ResolveProviderPluginChoice =
   typeof import("../plugins/provider-auth-choice.runtime.js").resolveProviderPluginChoice;
@@ -1465,14 +1468,25 @@ describe("runSetupWizard", () => {
     expect(runSetupMemoryImportStep).not.toHaveBeenCalled();
   });
 
-  it("returns to setup mode after an interactive import freshness rejection", async () => {
-    const workspaceDir = await makeCaseDir("import-freshness-retry-");
-    listSetupMigrationOptions.mockResolvedValueOnce([{ providerId: "hermes", label: "Hermes" }]);
-    runSetupMigrationImport.mockRejectedValueOnce(
-      new SetupMigrationFreshnessError(
+  it.each([
+    {
+      label: "freshness rejection",
+      error: new SetupMigrationFreshnessError(
         "Migration import during onboarding requires a fresh OpenClaw setup.\nExisting setup:\n- state agents/ exists",
       ),
-    );
+      detail: "state agents/ exists",
+    },
+    {
+      label: "target change",
+      error: new SetupMigrationTargetChangedError(
+        "Migration target changed before promotion. Review it and retry.",
+      ),
+      detail: "Migration target changed before promotion",
+    },
+  ])("returns to setup mode after an interactive import $label", async ({ error, detail }) => {
+    const workspaceDir = await makeCaseDir("import-retry-");
+    listSetupMigrationOptions.mockResolvedValueOnce([{ providerId: "hermes", label: "Hermes" }]);
+    runSetupMigrationImport.mockRejectedValueOnce(error);
     const setupChoices: Array<"import:hermes" | "quickstart"> = ["import:hermes", "quickstart"];
     const select = vi.fn(async ({ message }: WizardSelectParams<unknown>) => {
       if (message === "Setup mode") {
@@ -1501,7 +1515,7 @@ describe("runSetupWizard", () => {
     expect(select.mock.calls.filter(([params]) => params.message === "Setup mode")).toHaveLength(2);
     expect(runSetupMigrationImport).toHaveBeenCalledOnce();
     expect(prompter.note).toHaveBeenCalledWith(
-      expect.stringContaining("state agents/ exists"),
+      expect.stringContaining(detail),
       "Existing config detected",
     );
     expect(finalizeSetupWizard).toHaveBeenCalledOnce();

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -28,7 +28,10 @@ import {
   listSetupMigrationOptions,
   runSetupMigrationImport,
 } from "./setup.migration-import.js";
-import { SetupMigrationFreshnessError } from "./setup.migration-snapshot.js";
+import {
+  SetupMigrationFreshnessError,
+  SetupMigrationTargetChangedError,
+} from "./setup.migration-snapshot.js";
 import { runSetupModelAuthStep, type SetupModelAuthCandidate } from "./setup.model-auth.js";
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
@@ -272,7 +275,10 @@ async function runSetupWizardOnce(
         continueOnboarding: true,
       });
     } catch (error) {
-      if (!(error instanceof SetupMigrationFreshnessError) || !flowFromPrompt) {
+      const canReturnToSetupMode =
+        error instanceof SetupMigrationFreshnessError ||
+        error instanceof SetupMigrationTargetChangedError;
+      if (!canReturnToSetupMode || !flowFromPrompt) {
         throw error;
       }
       await prompter.note(formatErrorMessage(error), t("wizard.setup.existingConfigTitle"));


### PR DESCRIPTION
Related: #122967
Related: #112798
Related: #122968

## What Problem This Solves

Fixes an issue where users applying a Codex, Claude, or Hermes import during classic onboarding would reach a correct migration preview, confirm it, and then have the wizard exit because its own runtime SQLite bookkeeping made the target appear to have changed.

AI-assisted; the implementation and evidence were reviewed against the snapshot, staging, promotion, lock, and provider ownership paths.

## Why This Change Was Made

The transactional snapshot continues to guard config, workspace content, credentials, sessions, and agents, but no longer hashes the live runtime-owned shared state database. Promotion now publishes the staged workspace and agent database while merging the final agent-registry fact into the live shared database instead of replacing the entire `state/` directory; rollback compensates that registry write.

The onboarding target lock makes a second onboarding/import against the same profile impossible, but it does not serialize ordinary config writers, workspace edits, or runtime database writers. The remaining target snapshot is therefore still meaningful for real import surfaces, while byte-hashing WAL-backed runtime state was redundant with the lock for onboarding peers and incompatible with legitimate runtime churn.

Genuine target changes now use a typed error. Menu-selected interactive imports show the reason and return to Setup mode, matching the #122967 freshness-rejection UX. Explicit `--flow import` / `--import-from` invocations still fail loudly instead of silently dropping requested automation.

Production LOC: **+51/-23 (net +28)**. Tests: **+103/-8 (net +95)**. The production growth is the typed retry UX plus rollback-safe logical registry merge that replaces unsafe whole-directory state promotion.

## User Impact

Fresh-profile onboarding imports now apply even when the wizard creates or updates `state/openclaw.sqlite` between preview and promotion. A real concurrent workspace, config, credentials, session, or agent change still blocks the transaction rather than overwriting it.

## Evidence

Pre-fix owner regressions failed for the intended reasons:

```text
setup.migration-import.test.ts: runtime state churn changed the target snapshot hash
setup.migration-transaction.test.ts: live state DB write rejected with "Migration target changed before promotion"
```

Exact head `d2d26e80456c1698a57161ffd573f936d6b13cc0`:

- `node scripts/run-vitest.mjs src/wizard/setup.migration-import.test.ts src/wizard/setup.migration-transaction.test.ts src/wizard/setup.migration-stage.test.ts src/wizard/setup.test.ts` — 4 files, 95 tests passed.
- `node scripts/check-changed.mjs` — passed the full delegated typecheck, format, core/extensions/scripts lint, dead-code, database-first, Plugin SDK, boundary, and import-cycle gates on Testbox `tbx_01kzx603re8m4gwhh9thm4a2jw` ([run](https://github.com/openclaw/openclaw/actions/runs/31685130777)).
- `pnpm build` — passed locally after installing the existing frozen lockfile dependencies.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.

Live built-CLI proof used only scratch profile `ip1`, port 19607, and a synthetic source; all scratch paths were moved to Trash afterward and the port was clear:

```text
OpenClaw 2026.8.1 (7235943)
[state/db] state database schema migration pending; verifying integrity first
Target workspace directory: /Users/steipete/.openclaw-ip1/workspace
Migration preview: codex
1 item, 0 conflicts, 0 sensitive items
Archive: config.toml
Apply this migration now? Yes
Migration applied
Migration complete. Continuing setup.
```

The archived `config.toml` byte-matched the source, and the live shared SQLite registry contained the promoted `main` agent database path. The synthetic rollout file was not claimed as imported: the current Codex provider produced a one-item plan containing only `archive:config.toml`, so no session item existed to verify.
