### PR TITLE
improve(gateway): cut slow server test setup

### DIFF
--- a/src/gateway/plugin-metadata.test-helpers.ts
+++ b/src/gateway/plugin-metadata.test-helpers.ts
@@ -1,0 +1,79 @@
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+
+function ownerEntries(value: ReadonlyMap<string, readonly string[]>) {
+  return [...value].map(([id, owners]) => [id, [...owners]] as const);
+}
+
+/** Verifies the manifest-derived fields of a trimmed metadata fixture agree. */
+export function assertPluginMetadataSnapshotConsistency(snapshot: PluginMetadataSnapshot): void {
+  const plugins = snapshot.manifestRegistry.plugins;
+  const pluginIds = plugins.map((plugin) => plugin.id);
+  if (JSON.stringify(snapshot.plugins.map((plugin) => plugin.id)) !== JSON.stringify(pluginIds)) {
+    throw new Error("plugin metadata fixture registry and plugin list diverged");
+  }
+  if (snapshot.metrics.manifestPluginCount !== plugins.length) {
+    throw new Error("plugin metadata fixture manifest count diverged");
+  }
+  if (snapshot.metrics.indexPluginCount !== snapshot.index.plugins.length) {
+    throw new Error("plugin metadata fixture index count diverged");
+  }
+
+  const expectedProviderOwners = new Map<string, string[]>();
+  const expectedCliBackendOwners = new Map<string, string[]>();
+  const appendOwner = (owners: Map<string, string[]>, id: string, pluginId: string) => {
+    const existing = owners.get(id) ?? [];
+    if (!existing.includes(pluginId)) {
+      owners.set(id, [...existing, pluginId]);
+    }
+  };
+
+  for (const plugin of plugins) {
+    if (snapshot.byPluginId.get(plugin.id) !== plugin) {
+      throw new Error(`plugin metadata fixture lookup diverged for ${plugin.id}`);
+    }
+    const providers = new Set(plugin.providers);
+    const cliBackends = new Set(plugin.cliBackends);
+    const authRefs = new Set([
+      ...(plugin.providerAuthChoices ?? []).map((choice) => choice.choiceId),
+      ...(plugin.providerAuthChoices ?? []).flatMap((choice) => choice.deprecatedChoiceIds ?? []),
+    ]);
+
+    for (const provider of providers) {
+      appendOwner(expectedProviderOwners, provider, plugin.id);
+    }
+    for (const [alias, provider] of Object.entries(plugin.providerAuthAliases ?? {})) {
+      if (!providers.has(alias) || !providers.has(provider)) {
+        throw new Error(`plugin metadata fixture alias ${alias} is outside ${plugin.id} providers`);
+      }
+      appendOwner(expectedProviderOwners, alias, plugin.id);
+    }
+    for (const choice of plugin.providerAuthChoices ?? []) {
+      if (!providers.has(choice.provider)) {
+        throw new Error(
+          `plugin metadata fixture auth choice ${choice.choiceId} has an unknown provider`,
+        );
+      }
+    }
+    for (const backend of cliBackends) {
+      appendOwner(expectedCliBackendOwners, backend, plugin.id);
+    }
+    for (const ref of plugin.syntheticAuthRefs ?? []) {
+      if (!providers.has(ref) && !cliBackends.has(ref) && !authRefs.has(ref)) {
+        throw new Error(`plugin metadata fixture synthetic auth ref ${ref} has no owner`);
+      }
+    }
+  }
+
+  if (
+    JSON.stringify(ownerEntries(snapshot.owners.providers)) !==
+    JSON.stringify(ownerEntries(expectedProviderOwners))
+  ) {
+    throw new Error("plugin metadata fixture provider owners diverged");
+  }
+  if (
+    JSON.stringify(ownerEntries(snapshot.owners.cliBackends)) !==
+    JSON.stringify(ownerEntries(expectedCliBackendOwners))
+  ) {
+    throw new Error("plugin metadata fixture CLI backend owners diverged");
+  }
+}

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -11,11 +11,13 @@ import {
 } from "../../agents/auth-profiles.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
+import { assertPluginMetadataSnapshotConsistency } from "../plugin-metadata.test-helpers.js";
 import { modelsHandlers } from "./models.js";
 import type { RespondFn } from "./types.js";
 
@@ -34,8 +36,10 @@ const modelPluginMetadataSnapshot = vi.hoisted(() => {
           choiceId: "anthropic-cli",
           deprecatedChoiceIds: ["claude-cli"],
         },
+        { provider: "anthropic", method: "setup-token", choiceId: "setup-token" },
         { provider: "anthropic", method: "api-key", choiceId: "apiKey" },
       ],
+      modelSupport: { modelPrefixes: ["claude-"] },
       skills: [],
       hooks: [],
       origin: "bundled",
@@ -47,6 +51,7 @@ const modelPluginMetadataSnapshot = vi.hoisted(() => {
       id: "byteplus",
       channels: [],
       providers: ["byteplus", "byteplus-plan"],
+      syntheticAuthRefs: [],
       providerAuthAliases: { "byteplus-plan": "byteplus" },
       providerAuthChoices: [
         { provider: "byteplus", method: "api-key", choiceId: "byteplus-api-key" },
@@ -63,8 +68,14 @@ const modelPluginMetadataSnapshot = vi.hoisted(() => {
       id: "github-copilot",
       channels: [],
       providers: ["github-copilot"],
+      syntheticAuthRefs: [],
       providerAuthChoices: [
         { provider: "github-copilot", method: "device", choiceId: "github-copilot" },
+        {
+          provider: "github-copilot",
+          method: "device-enterprise",
+          choiceId: "github-copilot-enterprise",
+        },
       ],
       cliBackends: [],
       skills: [],
@@ -85,6 +96,8 @@ const modelPluginMetadataSnapshot = vi.hoisted(() => {
       policyHash: "models-test-plugin-policy",
       generatedAtMs: 0,
       installRecords: {},
+      // A real isolated bundled snapshot has no installed-index rows; bundled
+      // manifest records remain the authoritative graph for this fixture.
       plugins: [],
       diagnostics: [],
     },
@@ -151,6 +164,7 @@ const withoutOpenAIEnvAuth = async <T>(run: () => Promise<T>): Promise<T> =>
 let modelsTestState: OpenClawTestState;
 
 beforeAll(async () => {
+  assertPluginMetadataSnapshotConsistency(modelPluginMetadataSnapshot as PluginMetadataSnapshot);
   modelsTestState = await createOpenClawTestState({
     layout: "state-only",
     prefix: "openclaw-models-list-",

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -2,7 +2,7 @@
 // validation errors, and protocol response shapes.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
@@ -12,9 +12,128 @@ import {
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withEnvAsync } from "../../test-utils/env.js";
-import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import { modelsHandlers } from "./models.js";
 import type { RespondFn } from "./types.js";
+
+const modelPluginMetadataSnapshot = vi.hoisted(() => {
+  const plugins = [
+    {
+      id: "anthropic",
+      channels: [],
+      providers: ["anthropic"],
+      cliBackends: ["claude-cli"],
+      syntheticAuthRefs: ["claude-cli"],
+      providerAuthChoices: [
+        {
+          provider: "anthropic",
+          method: "cli",
+          choiceId: "anthropic-cli",
+          deprecatedChoiceIds: ["claude-cli"],
+        },
+        { provider: "anthropic", method: "api-key", choiceId: "apiKey" },
+      ],
+      skills: [],
+      hooks: [],
+      origin: "bundled",
+      rootDir: "/test/anthropic",
+      source: "/test/anthropic/index.js",
+      manifestPath: "/test/anthropic/openclaw.plugin.json",
+    },
+    {
+      id: "byteplus",
+      channels: [],
+      providers: ["byteplus", "byteplus-plan"],
+      providerAuthAliases: { "byteplus-plan": "byteplus" },
+      providerAuthChoices: [
+        { provider: "byteplus", method: "api-key", choiceId: "byteplus-api-key" },
+      ],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      origin: "bundled",
+      rootDir: "/test/byteplus",
+      source: "/test/byteplus/index.js",
+      manifestPath: "/test/byteplus/openclaw.plugin.json",
+    },
+    {
+      id: "github-copilot",
+      channels: [],
+      providers: ["github-copilot"],
+      providerAuthChoices: [
+        { provider: "github-copilot", method: "device", choiceId: "github-copilot" },
+      ],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      origin: "bundled",
+      rootDir: "/test/github-copilot",
+      source: "/test/github-copilot/index.js",
+      manifestPath: "/test/github-copilot/openclaw.plugin.json",
+    },
+  ];
+  return {
+    policyHash: "models-test-plugin-policy",
+    index: {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash: "models-test-plugin-policy",
+      generatedAtMs: 0,
+      installRecords: {},
+      plugins: [],
+      diagnostics: [],
+    },
+    registryDiagnostics: [],
+    manifestRegistry: { plugins, diagnostics: [] },
+    plugins,
+    diagnostics: [],
+    byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
+    normalizePluginId: (pluginId: string) => pluginId,
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map([
+        ["anthropic", ["anthropic"]],
+        ["byteplus", ["byteplus"]],
+        ["byteplus-plan", ["byteplus"]],
+        ["github-copilot", ["github-copilot"]],
+      ]),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map([["claude-cli", ["anthropic"]]]),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+    metrics: {
+      registrySnapshotMs: 0,
+      manifestRegistryMs: 0,
+      ownerMapsMs: 0,
+      totalMs: 0,
+      indexPluginCount: 0,
+      manifestPluginCount: plugins.length,
+    },
+  };
+});
+
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/current-plugin-metadata-snapshot.js")>()),
+  getCurrentPluginMetadataSnapshot: () => modelPluginMetadataSnapshot,
+}));
+
+vi.mock("../../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/plugin-metadata-snapshot.js")>()),
+  loadPluginMetadataSnapshot: () => modelPluginMetadataSnapshot,
+  resolvePluginMetadataSnapshot: () => modelPluginMetadataSnapshot,
+}));
+
+vi.mock("../../plugins/provider-thinking.js", () => ({
+  resolveEffectiveThinkingProfile: () => undefined,
+}));
 
 const withoutOpenAIEnvAuth = async <T>(run: () => Promise<T>): Promise<T> =>
   await withEnvAsync(
@@ -28,6 +147,34 @@ const withoutOpenAIEnvAuth = async <T>(run: () => Promise<T>): Promise<T> =>
     },
     run,
   );
+
+let modelsTestState: OpenClawTestState;
+
+beforeAll(async () => {
+  modelsTestState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-models-list-",
+    agentEnv: "main",
+  });
+});
+
+afterAll(async () => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  await modelsTestState.cleanup();
+});
+
+async function withModelsTestState<T>(
+  options: NonNullable<Parameters<typeof createOpenClawTestState>[0]>,
+  run: (state: OpenClawTestState) => Promise<T>,
+): Promise<T> {
+  clearRuntimeAuthProfileStoreSnapshots();
+  await modelsTestState.writeAuthProfiles({ version: 1, profiles: {} });
+  try {
+    return await withEnvAsync(options.env ?? {}, () => run(modelsTestState));
+  } finally {
+    clearRuntimeAuthProfileStoreSnapshots();
+  }
+}
 
 function createDemoOAuthStore(params: { access: string; expires: number }) {
   return {
@@ -779,7 +926,7 @@ describe("models.list", () => {
 
   it("keeps keyless local provider wildcard discoveries visible with unknown availability", async () => {
     await withoutOpenAIEnvAuth(async () => {
-      await withOpenClawTestState(
+      await withModelsTestState(
         {
           layout: "state-only",
           prefix: "openclaw-models-list-local-wildcard-",
@@ -849,7 +996,7 @@ describe("models.list", () => {
 
   it("marks legacy OpenAI Codex aliases available through ChatGPT OAuth", async () => {
     await withoutOpenAIEnvAuth(async () => {
-      await withOpenClawTestState(
+      await withModelsTestState(
         {
           layout: "state-only",
           prefix: "openclaw-models-list-codex-alias-",
@@ -908,7 +1055,7 @@ describe("models.list", () => {
 
   it("marks catalog models available through their configured CLI runtime", async () => {
     await withEnvAsync({ ANTHROPIC_API_KEY: undefined }, async () => {
-      await withOpenClawTestState(
+      await withModelsTestState(
         {
           layout: "state-only",
           prefix: "openclaw-models-list-cli-runtime-",
@@ -1127,7 +1274,7 @@ describe("models.list", () => {
   });
 
   it("does not mark catalog rows available from expired OAuth profiles", async () => {
-    await withOpenClawTestState(
+    await withModelsTestState(
       {
         layout: "state-only",
         prefix: "openclaw-models-list-expired-profile-",
@@ -1169,7 +1316,7 @@ describe("models.list", () => {
   });
 
   it("uses refreshed persisted OAuth when the runtime auth snapshot is stale", async () => {
-    await withOpenClawTestState(
+    await withModelsTestState(
       {
         layout: "state-only",
         prefix: "openclaw-models-list-stale-runtime-profile-",
@@ -1227,7 +1374,7 @@ describe("models.list", () => {
   });
 
   it("marks env SecretRef-backed auth profiles available", async () => {
-    await withOpenClawTestState(
+    await withModelsTestState(
       {
         layout: "state-only",
         prefix: "openclaw-models-list-env-profile-",
@@ -1281,7 +1428,7 @@ describe("models.list", () => {
   });
 
   it("keeps non-env SecretRef-backed auth profile availability unknown", async () => {
-    await withOpenClawTestState(
+    await withModelsTestState(
       {
         layout: "state-only",
         prefix: "openclaw-models-list-file-profile-",
@@ -1346,7 +1493,7 @@ describe("models.list", () => {
     // Regression: the models.list availability checker loaded the auth store
     // for profile checks but did not pass it to the runtime availability check,
     // so inline provider keys in billing cooldown stayed browseable.
-    await withOpenClawTestState(
+    await withModelsTestState(
       {
         layout: "state-only",
         prefix: "openclaw-models-list-inline-cooldown-",
@@ -1420,7 +1567,7 @@ describe("models.list", () => {
   });
 
   it("uses an exact hydrated runtime profile SecretRef as read-only proof", async () => {
-    await withOpenClawTestState(
+    await withModelsTestState(
       {
         layout: "state-only",
         prefix: "openclaw-models-list-hydrated-file-profile-",
@@ -1514,7 +1661,7 @@ describe("models.list", () => {
       },
       { name: "managed-marker", apiKey: "secretref-managed" },
     ] as const) {
-      await withOpenClawTestState(
+      await withModelsTestState(
         {
           layout: "state-only",
           prefix: `openclaw-models-list-provider-${fixture.name}-profile-`,

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -1,12 +1,69 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   loadSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
-import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
+
+const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
+  policyHash: "sticky-model-test-empty-plugin-policy",
+  index: {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "sticky-model-test-empty-plugin-policy",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins: [],
+    diagnostics: [],
+  },
+  registryDiagnostics: [],
+  manifestRegistry: { plugins: [], diagnostics: [] },
+  plugins: [],
+  diagnostics: [],
+  byPluginId: new Map(),
+  normalizePluginId: (pluginId: string) => pluginId,
+  owners: {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  },
+  metrics: {
+    registrySnapshotMs: 0,
+    manifestRegistryMs: 0,
+    ownerMapsMs: 0,
+    totalMs: 0,
+    indexPluginCount: 0,
+    manifestPluginCount: 0,
+  },
+}));
+
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/current-plugin-metadata-snapshot.js")>()),
+  getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+}));
+
+vi.mock("../../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/plugin-metadata-snapshot.js")>()),
+  loadPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+  resolvePluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+}));
+
+vi.mock("../../plugins/provider-thinking.js", () => ({
+  resolveEffectiveThinkingProfile: () => undefined,
+}));
 
 const effects = vi.hoisted(() => ({
   info: vi.fn(),
@@ -44,6 +101,8 @@ const cfg = {
     ],
   },
 } satisfies OpenClawConfig;
+
+let openClawTestState: OpenClawTestState;
 
 function context(): GatewayRequestContext {
   return {
@@ -83,6 +142,10 @@ async function patchSession(params: Record<string, unknown>, scopes = ["operator
   return responses[0]!;
 }
 
+beforeAll(async () => {
+  openClawTestState = await createOpenClawTestState({ scenario: "minimal" });
+});
+
 beforeEach(() => {
   effects.info.mockReset();
   effects.warn.mockReset();
@@ -97,8 +160,9 @@ beforeEach(() => {
     );
 });
 
-afterEach(() => {
+afterAll(async () => {
   closeOpenClawAgentDatabasesForTest();
+  await openClawTestState.cleanup();
 });
 
 describe("sessions.patch sticky model persistence", () => {
@@ -108,88 +172,80 @@ describe("sessions.patch sticky model persistence", () => {
   ])(
     "persists an accepted model for the resolved $agentId agent",
     async ({ agentId, sessionKey }) => {
-      await withOpenClawTestState({ scenario: "minimal" }, async () => {
-        await upsertSessionEntryCore(
-          { agentId, sessionKey },
-          { sessionId: `session-${agentId}`, updatedAt: 1 },
-        );
-
-        const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" });
-
-        expect(response[0]).toBe(true);
-        await vi.waitFor(() => expect(effects.mutateConfigFileWithRetry).toHaveBeenCalledOnce());
-      });
-    },
-  );
-
-  it("keeps a write-scoped model switch session-only without persisting the configured default", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const sessionKey = "agent:main:dm:non-admin";
       await upsertSessionEntryCore(
-        { agentId: "main", sessionKey },
-        { sessionId: "session-non-admin", updatedAt: 1 },
+        { agentId, sessionKey },
+        { sessionId: `session-${agentId}`, updatedAt: 1 },
       );
-
-      const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" }, [
-        "operator.write",
-      ]);
-
-      expect(response[0]).toBe(true);
-      expect(loadSessionEntry({ agentId: "main", sessionKey })).toMatchObject({
-        providerOverride: "openai",
-        modelOverride: "gpt-5.6-sol",
-      });
-      expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
-    });
-  });
-
-  it("returns session success and warns when the sticky config write fails", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const sessionKey = "agent:main:dm:write-failure";
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey },
-        { sessionId: "session-write-failure", updatedAt: 1 },
-      );
-      effects.mutateConfigFileWithRetry.mockRejectedValueOnce(new Error("config write failed"));
 
       const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" });
 
       expect(response[0]).toBe(true);
-      expect(loadSessionEntry({ agentId: "main", sessionKey })).toMatchObject({
-        providerOverride: "openai",
-        modelOverride: "gpt-5.6-sol",
-      });
-      await vi.waitFor(() =>
-        expect(effects.warn).toHaveBeenCalledWith(
-          "failed sticky model persistence agentId=main model=openai/gpt-5.6-sol reason=config write failed",
-        ),
-      );
+      await vi.waitFor(() => expect(effects.mutateConfigFileWithRetry).toHaveBeenCalledOnce());
+    },
+  );
+
+  it("keeps a write-scoped model switch session-only without persisting the configured default", async () => {
+    const sessionKey = "agent:main:dm:non-admin";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-non-admin", updatedAt: 1 },
+    );
+
+    const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" }, [
+      "operator.write",
+    ]);
+
+    expect(response[0]).toBe(true);
+    expect(loadSessionEntry({ agentId: "main", sessionKey })).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-5.6-sol",
     });
+    expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+  });
+
+  it("returns session success and warns when the sticky config write fails", async () => {
+    const sessionKey = "agent:main:dm:write-failure";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-write-failure", updatedAt: 1 },
+    );
+    effects.mutateConfigFileWithRetry.mockRejectedValueOnce(new Error("config write failed"));
+
+    const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" });
+
+    expect(response[0]).toBe(true);
+    expect(loadSessionEntry({ agentId: "main", sessionKey })).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-5.6-sol",
+    });
+    await vi.waitFor(() =>
+      expect(effects.warn).toHaveBeenCalledWith(
+        "failed sticky model persistence agentId=main model=openai/gpt-5.6-sol reason=config write failed",
+      ),
+    );
   });
 
   it.each([
     { name: "omitted", patch: { label: "Sticky" } },
     { name: "cleared", patch: { model: null } },
     { name: "reset to the current default", patch: { model: "anthropic/claude-opus-4-6" } },
-  ])("does not persist when model is $name", async ({ patch }) => {
-    await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const sessionKey = "agent:main:dm:no-sticky";
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey },
-        {
-          sessionId: "session-main",
-          updatedAt: 1,
-          providerOverride: "openai",
-          modelOverride: "gpt-5.6-sol",
-          modelOverrideSource: "user",
-          modelOverrideRouteResolution: "resolved",
-        },
-      );
+  ])("does not persist when model is $name", async ({ name, patch }) => {
+    const sessionKey = `agent:main:dm:no-sticky-${name}`;
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey },
+      {
+        sessionId: `session-${name}`,
+        updatedAt: 1,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.6-sol",
+        modelOverrideSource: "user",
+        modelOverrideRouteResolution: "resolved",
+      },
+    );
 
-      const response = await patchSession({ key: sessionKey, ...patch });
+    const response = await patchSession({ key: sessionKey, ...patch });
 
-      expect(response[0]).toBe(true);
-      expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
-    });
+    expect(response[0]).toBe(true);
+    expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -30,6 +30,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/diagnostic-events.js";
 import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
+import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
+import { rebasePluginMetadataSnapshotManifestRegistry } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   isSessionWorkAdmissionActive,
@@ -40,6 +43,7 @@ import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { assertPluginMetadataSnapshotConsistency } from "./plugin-metadata.test-helpers.js";
 import {
   createDirectChatContext,
   createTextTranscriptEvent,
@@ -137,65 +141,78 @@ function createChatVisionModelCatalogSnapshot(): Awaited<
 type GatewayHarness = Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 type GatewaySocket = Awaited<ReturnType<GatewayHarness["openWs"]>>;
 let harness: GatewayHarness;
-const gatewayPluginMetadataSnapshot: PluginMetadataSnapshot = {
-  policyHash: "gateway-chat-test-plugin-policy",
-  index: {
-    version: 1,
-    hostContractVersion: "test",
-    compatRegistryVersion: "test",
-    migrationVersion: 1,
-    policyHash: "gateway-chat-test-plugin-policy",
-    generatedAtMs: 0,
-    installRecords: {},
+
+function createGatewayPluginMetadataSnapshot(config: OpenClawConfig): PluginMetadataSnapshot {
+  const policyHash = resolveInstalledPluginIndexPolicyHash(config);
+  const emptySnapshot: PluginMetadataSnapshot = {
+    policyHash,
+    index: {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash,
+      generatedAtMs: 0,
+      installRecords: {},
+      // Matches the real isolated bundled snapshot: no installed-index rows,
+      // with the selected bundled manifests supplied below.
+      plugins: [],
+      diagnostics: [],
+    },
+    registryDiagnostics: [],
+    manifestRegistry: { plugins: [], diagnostics: [] },
     plugins: [],
     diagnostics: [],
-  },
-  registryDiagnostics: [],
-  manifestRegistry: {
+    byPluginId: new Map(),
+    normalizePluginId: (pluginId) => pluginId,
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map(),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+    metrics: {
+      registrySnapshotMs: 0,
+      manifestRegistryMs: 0,
+      ownerMapsMs: 0,
+      totalMs: 0,
+      indexPluginCount: 0,
+      manifestPluginCount: 0,
+    },
+  };
+  return rebasePluginMetadataSnapshotManifestRegistry(emptySnapshot, {
     plugins: [
       {
         id: "openai",
         channels: [],
         providers: ["openai"],
         cliBackends: [],
+        syntheticAuthRefs: [],
         providerAuthChoices: [
           { provider: "openai", method: "oauth", choiceId: "openai" },
+          {
+            provider: "openai",
+            method: "device-code",
+            choiceId: "openai-device-code",
+          },
           { provider: "openai", method: "api-key", choiceId: "openai-api-key" },
         ],
-        modelSupport: { modelPrefixes: ["gpt-"] },
+        modelSupport: { modelPrefixes: ["gpt-", "o1", "o3", "o4"] },
         skills: [],
         hooks: [],
         origin: "bundled",
         rootDir: "/test/openai",
-        source: "/test/openai/index.js",
+        source: "/test/openai/index.ts",
         manifestPath: "/test/openai/openclaw.plugin.json",
       },
     ],
     diagnostics: [],
-  },
-  plugins: [],
-  diagnostics: [],
-  byPluginId: new Map(),
-  normalizePluginId: (pluginId) => pluginId,
-  owners: {
-    channels: new Map(),
-    channelConfigs: new Map(),
-    providers: new Map([["openai", ["openai"]]]),
-    modelCatalogProviders: new Map(),
-    cliBackends: new Map(),
-    setupProviders: new Map(),
-    commandAliases: new Map(),
-    contracts: new Map(),
-  },
-  metrics: {
-    registrySnapshotMs: 0,
-    manifestRegistryMs: 0,
-    ownerMapsMs: 0,
-    totalMs: 0,
-    indexPluginCount: 0,
-    manifestPluginCount: 1,
-  },
-};
+  });
+}
 const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 beforeAll(async () => {
@@ -1262,10 +1279,12 @@ describe("gateway server chat", () => {
         },
       },
       async (state) => {
+        let releasePluginMetadata: () => boolean = () => false;
         openDirectChatSession();
         try {
           const config = {
             agents: {
+              ownership: "explicit" as const,
               defaults: {
                 model: { primary: "openai/gpt-5.5" },
                 models: { "openai/gpt-5.5": {} },
@@ -1280,9 +1299,25 @@ describe("gateway server chat", () => {
             },
             talk: { agentId: "main" },
           };
-          testState.agentsConfig = config.agents;
           await state.writeConfig(config);
           clearConfigCache();
+          const pluginMetadataSnapshot = createGatewayPluginMetadataSnapshot(config);
+          assertPluginMetadataSnapshotConsistency(pluginMetadataSnapshot);
+          releasePluginMetadata = installTemporaryCurrentPluginMetadataSnapshot(
+            pluginMetadataSnapshot,
+            {
+              config,
+              compatibleConfigs: [config],
+              env: process.env,
+            },
+          ).release;
+          const persistedConfig = getRuntimeConfig();
+          expect(persistedConfig.auth?.order?.openai).toEqual([
+            "openai:api",
+            "openai:chatgpt",
+            "openai:expired",
+          ]);
+          testState.agentsConfig = persistedConfig.agents;
           await writeSessionStore({
             entries: {
               "agent:work:main": {
@@ -1385,14 +1420,14 @@ describe("gateway server chat", () => {
           const preparedAuthStoreByAgentId = new Map([
             [
               "main",
-              loadAuthProfileStoreForRuntime(resolveAgentDir(config, "main"), {
+              loadAuthProfileStoreForRuntime(resolveAgentDir(persistedConfig, "main"), {
                 readOnly: true,
               }),
             ],
             [
               "work",
-              loadAuthProfileStoreForRuntime(resolveAgentDir(config, "work"), {
-                inheritedAuthDir: resolveAgentDir(config, "main"),
+              loadAuthProfileStoreForRuntime(resolveAgentDir(persistedConfig, "work"), {
+                inheritedAuthDir: resolveAgentDir(persistedConfig, "main"),
                 readOnly: true,
               }),
             ],
@@ -1428,10 +1463,10 @@ describe("gateway server chat", () => {
               return existing;
             }
             const projector = createGatewayAgentModelCatalogProjector({
-              cfg: config,
+              cfg: persistedConfig,
               agentId,
               snapshot: catalogSnapshot,
-              metadataSnapshot: gatewayPluginMetadataSnapshot,
+              metadataSnapshot: pluginMetadataSnapshot,
               preparedAuthStore: preparedAuthStoreByAgentId.get(agentId),
               ...(profileId ? { preferredProfileId: profileId } : {}),
               ...(profileId && (profileSource === "user" || legacyUserProfile)
@@ -1446,7 +1481,7 @@ describe("gateway server chat", () => {
                 params: { view: "configured" },
                 preloadedCatalog: {
                   agentId,
-                  config,
+                  config: persistedConfig,
                   snapshot: catalogSnapshot,
                 },
                 preloadedOnly: true,
@@ -1466,10 +1501,10 @@ describe("gateway server chat", () => {
                 agentId: "work",
                 agentDir: "/tmp/chat-work-agent",
                 workspaceDir: "/tmp/chat-work-workspace",
-                config,
+                config: persistedConfig,
                 ...catalogSnapshot,
               }),
-            getRuntimeConfig: () => config,
+            getRuntimeConfig: () => persistedConfig,
             readChatStartupProjection: vi.fn(async ({ agentId, sessionEntry, includeSystem }) => {
               const [mainProjection, workProjection, sessionProjection] = await Promise.all([
                 projectAgent(context, "main"),
@@ -1485,7 +1520,7 @@ describe("gateway server chat", () => {
                 metadata: sessionProjection.metadata,
                 sessionModelCatalog: sessionProjection.modelCatalog,
                 defaultModelCatalog: mainProjection.modelCatalog,
-                agentsList: listAgentsForGateway(config, mainProjection.modelCatalog, {
+                agentsList: listAgentsForGateway(persistedConfig, mainProjection.modelCatalog, {
                   modelCatalogByAgentId: new Map([
                     ["main", mainProjection.modelCatalog],
                     ["work", workProjection.modelCatalog],
@@ -1495,17 +1530,11 @@ describe("gateway server chat", () => {
               };
             }),
           });
-          const persistedConfig = config;
-          expect(persistedConfig.auth?.order?.openai).toEqual([
-            "openai:api",
-            "openai:chatgpt",
-            "openai:expired",
-          ]);
           const expiredPreferenceEvaluation = await createGatewayAgentModelCatalogProjector({
             cfg: persistedConfig,
             agentId: "work",
             snapshot: catalogSnapshot,
-            metadataSnapshot: gatewayPluginMetadataSnapshot,
+            metadataSnapshot: pluginMetadataSnapshot,
             preferredProfileId: "openai:expired",
           }).evaluateEntry(subscriptionRoute, catalogSnapshot.routeVariants);
           expect(expiredPreferenceEvaluation).toMatchObject({
@@ -1598,6 +1627,7 @@ describe("gateway server chat", () => {
           preparedThinkingPolicy.fallback = "off";
           testState.agentsConfig = undefined;
           testState.sessionStorePath = undefined;
+          releasePluginMetadata();
         }
       },
     );

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -30,8 +30,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/diagnostic-events.js";
 import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
-import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
-import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
@@ -74,6 +73,7 @@ const restartRecoveryMocks = vi.hoisted(() => ({
     skipped: 0,
   })),
 }));
+const preparedThinkingPolicy = vi.hoisted(() => ({ fallback: "off" as "base" | "off" }));
 
 vi.mock(
   "../agents/main-session-recovery/main-session-restart-recovery.js",
@@ -89,6 +89,21 @@ vi.mock(
     };
   },
 );
+
+vi.mock("../plugins/provider-thinking.js", () => ({
+  resolveEffectiveThinkingProfile: (params: { context?: { reasoning?: boolean } }) => {
+    const offOnly =
+      params.context?.reasoning === false ||
+      (params.context?.reasoning === undefined && preparedThinkingPolicy.fallback === "off");
+    return offOnly
+      ? {
+          levels: [{ id: "off", label: "off" }],
+          defaultLevel: "off",
+          preserveWhenCatalogReasoningFalse: true,
+        }
+      : undefined;
+  },
+}));
 
 installGatewayTestHooks({ scope: "suite" });
 const FAST_WAIT_OPTS = { timeout: 2_000, interval: 1 } as const;
@@ -122,6 +137,65 @@ function createChatVisionModelCatalogSnapshot(): Awaited<
 type GatewayHarness = Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 type GatewaySocket = Awaited<ReturnType<GatewayHarness["openWs"]>>;
 let harness: GatewayHarness;
+const gatewayPluginMetadataSnapshot: PluginMetadataSnapshot = {
+  policyHash: "gateway-chat-test-plugin-policy",
+  index: {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "gateway-chat-test-plugin-policy",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins: [],
+    diagnostics: [],
+  },
+  registryDiagnostics: [],
+  manifestRegistry: {
+    plugins: [
+      {
+        id: "openai",
+        channels: [],
+        providers: ["openai"],
+        cliBackends: [],
+        providerAuthChoices: [
+          { provider: "openai", method: "oauth", choiceId: "openai" },
+          { provider: "openai", method: "api-key", choiceId: "openai-api-key" },
+        ],
+        modelSupport: { modelPrefixes: ["gpt-"] },
+        skills: [],
+        hooks: [],
+        origin: "bundled",
+        rootDir: "/test/openai",
+        source: "/test/openai/index.js",
+        manifestPath: "/test/openai/openclaw.plugin.json",
+      },
+    ],
+    diagnostics: [],
+  },
+  plugins: [],
+  diagnostics: [],
+  byPluginId: new Map(),
+  normalizePluginId: (pluginId) => pluginId,
+  owners: {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map([["openai", ["openai"]]]),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  },
+  metrics: {
+    registrySnapshotMs: 0,
+    manifestRegistryMs: 0,
+    ownerMapsMs: 0,
+    totalMs: 0,
+    indexPluginCount: 0,
+    manifestPluginCount: 1,
+  },
+};
 const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 beforeAll(async () => {
@@ -1188,7 +1262,6 @@ describe("gateway server chat", () => {
         },
       },
       async (state) => {
-        let releasePluginMetadata: () => boolean = () => false;
         openDirectChatSession();
         try {
           const config = {
@@ -1196,13 +1269,18 @@ describe("gateway server chat", () => {
               defaults: {
                 model: { primary: "openai/gpt-5.5" },
                 models: { "openai/gpt-5.5": {} },
+                heartbeat: { agentId: "main" },
+                sessionStore: { agentId: "main" },
+                systemAgent: { agentId: "main" },
               },
-              entries: { main: { default: true }, work: {} },
+              entries: { main: {}, work: {} },
             },
             auth: {
               order: { openai: ["openai:api", "openai:chatgpt", "openai:expired"] },
             },
+            talk: { agentId: "main" },
           };
+          testState.agentsConfig = config.agents;
           await state.writeConfig(config);
           clearConfigCache();
           await writeSessionStore({
@@ -1353,6 +1431,7 @@ describe("gateway server chat", () => {
               cfg: config,
               agentId,
               snapshot: catalogSnapshot,
+              metadataSnapshot: gatewayPluginMetadataSnapshot,
               preparedAuthStore: preparedAuthStoreByAgentId.get(agentId),
               ...(profileId ? { preferredProfileId: profileId } : {}),
               ...(profileId && (profileSource === "user" || legacyUserProfile)
@@ -1397,6 +1476,11 @@ describe("gateway server chat", () => {
                 projectAgent(context, "work"),
                 projectAgent(context, agentId, sessionEntry),
               ]);
+              preparedThinkingPolicy.fallback = sessionProjection.modelCatalog.some(
+                (entry) => entry.reasoning === true,
+              )
+                ? "base"
+                : "off";
               return {
                 metadata: sessionProjection.metadata,
                 sessionModelCatalog: sessionProjection.modelCatalog,
@@ -1411,15 +1495,7 @@ describe("gateway server chat", () => {
               };
             }),
           });
-          const persistedConfig = getRuntimeConfig();
-          // Direct handlers bypass Gateway startup, so publish its process-lifecycle handoff once.
-          // Otherwise every route projector rediscovers the full plugin metadata graph.
-          const pluginMetadata = resolvePluginMetadataSnapshot({ config, env: process.env });
-          releasePluginMetadata = installTemporaryCurrentPluginMetadataSnapshot(pluginMetadata, {
-            config,
-            compatibleConfigs: [persistedConfig],
-            env: process.env,
-          }).release;
+          const persistedConfig = config;
           expect(persistedConfig.auth?.order?.openai).toEqual([
             "openai:api",
             "openai:chatgpt",
@@ -1429,6 +1505,7 @@ describe("gateway server chat", () => {
             cfg: persistedConfig,
             agentId: "work",
             snapshot: catalogSnapshot,
+            metadataSnapshot: gatewayPluginMetadataSnapshot,
             preferredProfileId: "openai:expired",
           }).evaluateEntry(subscriptionRoute, catalogSnapshot.routeVariants);
           expect(expiredPreferenceEvaluation).toMatchObject({
@@ -1518,8 +1595,9 @@ describe("gateway server chat", () => {
             }
           }
         } finally {
+          preparedThinkingPolicy.fallback = "off";
+          testState.agentsConfig = undefined;
           testState.sessionStorePath = undefined;
-          releasePluginMetadata();
         }
       },
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI performance problem where three gateway test files dominated the slowest compact lanes: `agent-chat` was 220s and `gateway-methods` was 212s in green main run 31683213137.

## Why This Change Was Made

The slow files were body-bound rather than import-bound. The method suites repeatedly crossed cold plugin metadata/provider-policy and state-database boundaries even though they supply their own catalogs and auth fixtures. The chat suite already used one suite-level Gateway, but one direct startup-composition case reloaded broad plugin policy.

This keeps the single real cold Gateway composition proof, reuses suite-owned state for handler cases, and supplies trimmed metadata fixtures derived from a real bundled snapshot. The chat route test still serializes and reloads its config through `getRuntimeConfig()`; only the prepared metadata graph is injected. A shared invariant check keeps registry records, plugin lists, lookups, providers, aliases, auth choices, synthetic auth refs, CLI backends, owners, and counts aligned.

No production code changed, and every existing assertion and per-file test count remains intact.

## User Impact

No user-visible behavior changes. Gateway CI gets materially shorter feedback without reducing coverage.

## Evidence

CI context: green main run 31683213137 measured `server.chat.gateway-server-chat-b.test.ts` at 54.7s in the 220s `agent-chat` group, and the two method files at 49.8s and 46.9s in the 212s `gateway-methods` group.

Same profiled command before and after (`OPENCLAW_VITEST_IMPORT_DURATIONS=1 OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 node scripts/run-vitest.mjs <file>`), using Vitest's file duration to exclude unrelated global heavy-check queue time:

- `server.chat.gateway-server-chat-b.test.ts`: 51.03s -> 29.03s (43.1% faster), 98 tests unchanged; one suite-level Gateway spawn before and after.
- `sessions-mutations.sticky-model.test.ts`: 36.60s -> 3.76s (89.7% faster), 7 tests unchanged; zero Gateway spawns.
- `models.test.ts`: 42.70s -> 2.51s (94.1% faster), 30 tests unchanged; zero Gateway spawns.

Coverage-regression proof:

- Temporarily changed the runtime config loader to rewrite `auth.order.openai` locally. The chat route test failed at the persisted-order assertion with `corrupted-loader-order` instead of the three authored profiles. The corruption was removed before all passing proof and is absent from the diff.
- Built an isolated real bundled metadata snapshot, trimmed it to the providers used by these tests, and derived the committed fixture shape and invariants from that output.

Additional proof:

- All three touched files pass with unchanged counts.
- Adjacent model and session-mutation suites: 7 files, 130 tests passed in 16.22s.
- `node scripts/check-changed.mjs -- <changed files>`: green on Blacksmith Testbox, exit 0 (Actions run 31689840922).
- `git diff --check`: clean.
- Branch autoreview against `origin/main`: clean, no accepted/actionable findings.
- Production LOC: +0/-0. Test-only change.
