### PR TITLE
fix(doctor): preserve upgrade ownership through metadata

### DIFF
--- a/scripts/lib/openclaw-test-state.mts
+++ b/scripts/lib/openclaw-test-state.mts
@@ -134,7 +134,10 @@ function scenarioConfig(scenario: string, options: TestStateOptions = {}) {
           },
           contextTokens: 64000,
           skills: ["memory"],
+          authInheritance: { agentId: "main" },
+          heartbeat: { agentId: "main" },
           sessionStore: { agentId: "main" },
+          systemAgent: { agentId: "main" },
         },
         entries: {
           main: {
@@ -157,6 +160,11 @@ function scenarioConfig(scenario: string, options: TestStateOptions = {}) {
           },
         },
       },
+      bindings: [
+        { agentId: "main", match: { channel: "discord", accountId: "*" } },
+        { agentId: "main", match: { channel: "telegram", accountId: "*" } },
+        { agentId: "main", match: { channel: "whatsapp", accountId: "*" } },
+      ],
       skills: {
         allowBundled: ["memory", "openclaw-testing"],
         limits: {
@@ -480,7 +488,16 @@ OPENCLAW_TEST_STATE_JSON
       "skills": [
         "memory"
       ],
+      "authInheritance": {
+        "agentId": "main"
+      },
+      "heartbeat": {
+        "agentId": "main"
+      },
       "sessionStore": {
+        "agentId": "main"
+      },
+      "systemAgent": {
         "agentId": "main"
       }
     },
@@ -507,6 +524,29 @@ OPENCLAW_TEST_STATE_JSON
       }
     }
   },
+  "bindings": [
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "discord",
+        "accountId": "*"
+      }
+    },
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "telegram",
+        "accountId": "*"
+      }
+    },
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "whatsapp",
+        "accountId": "*"
+      }
+    }
+  ],
   "skills": {
     "allowBundled": [
       "memory",

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -7,11 +7,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
+import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SpawnResult } from "../process/exec-result.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import {
+  applyWizardMetadata,
   formatControlUiSshHint,
   handleReset,
   moveToTrash,
@@ -932,6 +936,22 @@ describe("waitForGatewayReachable", () => {
     });
 
     expect(result).toEqual({ ok: false, detail: "connect failed: timeout" });
+  });
+});
+
+describe("applyWizardMetadata", () => {
+  it("preserves the migrated legacy owner across the config replacement", () => {
+    const cfg = migratePersistedImplicitMainRoster({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    }).config as OpenClawConfig;
+    expect(tryResolveLegacyCompatibilityAgentId(cfg)).toBe("main");
+
+    const result = applyWizardMetadata(cfg, { command: "doctor", mode: "local" });
+
+    expect(result).not.toBe(cfg);
+    expect(tryResolveLegacyCompatibilityAgentId(result)).toBe("main");
   });
 });
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -7,15 +7,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
-import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SpawnResult } from "../process/exec-result.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import {
-  applyWizardMetadata,
   formatControlUiSshHint,
   handleReset,
   moveToTrash,
@@ -936,22 +932,6 @@ describe("waitForGatewayReachable", () => {
     });
 
     expect(result).toEqual({ ok: false, detail: "connect failed: timeout" });
-  });
-});
-
-describe("applyWizardMetadata", () => {
-  it("preserves the migrated legacy owner across the config replacement", () => {
-    const cfg = migratePersistedImplicitMainRoster({
-      agents: {
-        list: [{ id: "main", default: true }, { id: "ops" }],
-      },
-    }).config as OpenClawConfig;
-    expect(tryResolveLegacyCompatibilityAgentId(cfg)).toBe("main");
-
-    const result = applyWizardMetadata(cfg, { command: "doctor", mode: "local" });
-
-    expect(result).not.toBe(cfg);
-    expect(tryResolveLegacyCompatibilityAgentId(result)).toBe("main");
   });
 });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -15,6 +15,7 @@ import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.
 import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
 import { printClawBanner } from "../cli/claw-banner.js";
+import { inheritLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
@@ -190,7 +191,7 @@ export function applyWizardMetadata(
 ): OpenClawConfig {
   const commit =
     normalizeOptionalString(process.env.GIT_COMMIT) ?? normalizeOptionalString(process.env.GIT_SHA);
-  return {
+  return inheritLegacyDefaultAgentId(cfg, {
     ...cfg,
     wizard: {
       ...cfg.wizard,
@@ -200,7 +201,7 @@ export function applyWizardMetadata(
       lastRunCommand: params.command,
       lastRunMode: params.mode,
     },
-  };
+  });
 }
 
 /** Formats the no-GUI SSH tunnel hint for opening the Control UI remotely. */

--- a/src/commands/onboard-helpers.wizard-metadata.test.ts
+++ b/src/commands/onboard-helpers.wizard-metadata.test.ts
@@ -1,0 +1,22 @@
+// Wizard metadata tests cover config provenance without losing migration ownership.
+import { describe, expect, it } from "vitest";
+import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
+import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applyWizardMetadata } from "./onboard-helpers.js";
+
+describe("applyWizardMetadata", () => {
+  it("preserves the migrated legacy owner across the config replacement", () => {
+    const cfg = migratePersistedImplicitMainRoster({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    }).config as OpenClawConfig;
+    expect(tryResolveLegacyCompatibilityAgentId(cfg)).toBe("main");
+
+    const result = applyWizardMetadata(cfg, { command: "doctor", mode: "local" });
+
+    expect(result).not.toBe(cfg);
+    expect(tryResolveLegacyCompatibilityAgentId(result)).toBe("main");
+  });
+});

--- a/test/scripts/openclaw-test-state.test.ts
+++ b/test/scripts/openclaw-test-state.test.ts
@@ -234,7 +234,17 @@ describe("scripts/lib/openclaw-test-state", () => {
         },
       });
       expect(payload.config.agents.ownership).toBe("explicit");
-      expect(payload.config.agents.defaults.sessionStore).toEqual({ agentId: "main" });
+      expect(payload.config.agents.defaults).toMatchObject({
+        authInheritance: { agentId: "main" },
+        heartbeat: { agentId: "main" },
+        sessionStore: { agentId: "main" },
+        systemAgent: { agentId: "main" },
+      });
+      expect(payload.config.bindings).toEqual([
+        { agentId: "main", match: { channel: "discord", accountId: "*" } },
+        { agentId: "main", match: { channel: "telegram", accountId: "*" } },
+        { agentId: "main", match: { channel: "whatsapp", accountId: "*" } },
+      ]);
       expect(Object.keys(payload.config.agents.entries)).toEqual(["main", "ops"]);
       expect(payload.config.agents).not.toHaveProperty("list");
       for (const agent of Object.values(payload.config.agents.entries)) {
@@ -286,7 +296,17 @@ describe("scripts/lib/openclaw-test-state", () => {
       ]);
       const upgradeConfig = JSON.parse(upgradeProbe.stdout);
       expect(upgradeConfig.agents.ownership).toBe("explicit");
-      expect(upgradeConfig.agents.defaults.sessionStore).toEqual({ agentId: "main" });
+      expect(upgradeConfig.agents.defaults).toMatchObject({
+        authInheritance: { agentId: "main" },
+        heartbeat: { agentId: "main" },
+        sessionStore: { agentId: "main" },
+        systemAgent: { agentId: "main" },
+      });
+      expect(upgradeConfig.bindings).toEqual([
+        { agentId: "main", match: { channel: "discord", accountId: "*" } },
+        { agentId: "main", match: { channel: "telegram", accountId: "*" } },
+        { agentId: "main", match: { channel: "whatsapp", accountId: "*" } },
+      ]);
       expect(Object.keys(upgradeConfig.agents.entries)).toEqual(["main", "ops"]);
       expect(upgradeConfig.agents).not.toHaveProperty("list");
       for (const agent of Object.values(upgradeConfig.agents.entries)) {


### PR DESCRIPTION
## What Problem This Solves

Exact signed r20 upgrade validation exposed one remaining ownership defect: Doctor correctly migrated a shipped legacy default agent, but `applyWizardMetadata` replaced the config object and dropped the WeakMap-backed compatibility owner. Later Doctor contributions then failed agent selection. The direct survivor fixture was separately under-specified: it declared explicit multi-agent ownership but did not explicitly assign ambient runtime roles.

## Why This Change Was Made

- Preserve retained legacy ownership across the wizard metadata object replacement with the existing `inheritLegacyDefaultAgentId` contract.
- Keep authored explicit configurations fail-closed; no fallback-to-main inference was added.
- Make the direct upgrade fixture fully explicit for heartbeat, system-agent, auth inheritance, fixed session-store ownership, and ambient channel bindings.

## User Impact

Published upgrades keep the shipped default-agent owner through Doctor config writes, plugin repair, and restart. Direct release fixtures model valid current multi-agent configuration instead of relying on retired implicit defaults.

## Evidence

- Pre-fix regression: `applyWizardMetadata` changed the retained owner from `main` to `undefined`.
- Focused proof: 244 assertions passed across onboard helpers, Doctor config/write flows, health contributions, default-role materialization, and JSON/shell fixture renderers.
- Fresh structured autoreview: no accepted/actionable findings; secret scan clean.
- Root cause observed in supported Release Checks run: https://github.com/openclaw/openclaw/actions/runs/31684777195
- Trusted-main session metadata harness repair landed separately as https://github.com/openclaw/openclaw/pull/123068

This PR signs the exact r21 tree on the isolated r20 base. It does not move canonical `release/2026.8.1`, generate changelog, tag, publish, or release.
