### PR TITLE
improve: speed up focused model directive tests

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -28,7 +28,7 @@ const stickyModelMock = vi.hoisted(() => ({
   persistBestEffort: vi.fn(),
 }));
 const pluginPolicyMock = vi.hoisted(() => ({
-  channels: new Map<string, ChannelPlugin>(),
+  channels: new Map<string, Pick<ChannelPlugin, "id" | "commands">>(),
   thinkingProfiles: new Map<
     string,
     (context: ProviderDefaultThinkingPolicyContext) => ProviderThinkingProfile | null | undefined
@@ -906,7 +906,7 @@ describe("/model chat UX", () => {
       commands: {
         buildModelBrowseChannelData: () => ({ telegram: { inlineKeyboard: [] } }),
       },
-    } as ChannelPlugin);
+    });
 
     const reply = await resolveModelInfoReply({ surface: "telegram" });
 

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -5,11 +5,12 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
+import type {
+  ProviderDefaultThinkingPolicyContext,
+  ProviderThinkingProfile,
+} from "../../plugins/provider-thinking.types.js";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "../../sessions/model-overrides.js";
-
-vi.hoisted(() => {
-  vi.resetModules();
-});
 
 const authProfilesStoreMock = vi.hoisted(() => ({
   profiles: {} as Record<
@@ -25,6 +26,13 @@ const modelsCommandMock = vi.hoisted(() => ({
 }));
 const stickyModelMock = vi.hoisted(() => ({
   persistBestEffort: vi.fn(),
+}));
+const pluginPolicyMock = vi.hoisted(() => ({
+  channels: new Map<string, ChannelPlugin>(),
+  thinkingProfiles: new Map<
+    string,
+    (context: ProviderDefaultThinkingPolicyContext) => ProviderThinkingProfile | null | undefined
+  >(),
 }));
 
 function defaultModelsCommandReply() {
@@ -235,6 +243,14 @@ vi.mock("../../agents/provider-auth-aliases.js", () => ({
   resolveProviderIdForAuth: (provider: string) => provider,
 }));
 
+vi.mock("../../agents/cli-backends.js", () => ({
+  isCliRuntimeModelBackendForProvider: () => false,
+  listCliRuntimeModelBackendBindings: () => [],
+  listCliRuntimeProviderIds: () => [],
+  resolveCliRuntimeCanonicalProvider: () => undefined,
+  resolveCliRuntimeModelBackendBinding: () => undefined,
+}));
+
 vi.mock("../../agents/harness/selection.js", () => ({
   selectAgentHarness: () => ({ id: "openclaw" }),
   resolveAgentHarnessPolicy: ({
@@ -280,6 +296,20 @@ vi.mock("../../agents/runtime-plan/auth.js", () => ({
   }),
 }));
 
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: (id: string) => pluginPolicyMock.channels.get(id),
+}));
+
+vi.mock("../../plugins/provider-thinking.js", () => ({
+  resolveEffectiveThinkingProfile: ({
+    provider,
+    context,
+  }: {
+    provider: string;
+    context: ProviderDefaultThinkingPolicyContext;
+  }) => pluginPolicyMock.thinkingProfiles.get(provider)?.(context),
+}));
+
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -295,14 +325,10 @@ import {
   type InternalHookEvent,
 } from "../../hooks/internal-hooks.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
-import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
-import { setActivePluginRegistry } from "../../plugins/runtime.js";
-import type { ProviderPlugin } from "../../plugins/types.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { ElevatedLevel } from "../thinking.js";
 
 let handleDirectiveOnly: typeof import("./directive-handling.impl.js").handleDirectiveOnly;
-let cliBackendsTesting: typeof import("../../agents/cli-backends.test-support.js").testing;
 let maybeHandleModelDirectiveInfo: typeof import("./directive-handling.model.js").maybeHandleModelDirectiveInfo;
 let createModelVisibilityPolicy: typeof import("../../agents/model-visibility-policy.js").createModelVisibilityPolicy;
 let buildModelAliasIndex: typeof import("../../agents/model-selection.js").buildModelAliasIndex;
@@ -312,7 +338,6 @@ let applyInlineDirectiveOverrides: typeof import("./get-reply-directives-apply.j
 let createFastTestModelSelectionState: typeof import("./model-selection.js").createFastTestModelSelectionState;
 
 beforeAll(async () => {
-  ({ testing: cliBackendsTesting } = await import("../../agents/cli-backends.test-support.js"));
   ({ handleDirectiveOnly } = await import("./directive-handling.impl.js"));
   ({ maybeHandleModelDirectiveInfo } = await import("./directive-handling.model.js"));
   ({ createModelVisibilityPolicy } = await import("../../agents/model-visibility-policy.js"));
@@ -417,14 +442,22 @@ function createSessionEntry(overrides?: Partial<SessionEntry>): SessionEntry {
   };
 }
 
-function setDirectiveTestProviders(providers: ProviderPlugin[]): void {
-  const registry = createEmptyPluginRegistry();
-  registry.providers = providers.map((provider) => ({
-    pluginId: "test",
-    provider,
-    source: "test",
-  }));
-  setActivePluginRegistry(registry);
+function setDirectiveTestProviders(
+  providers: Array<{
+    id: string;
+    label?: string;
+    auth?: unknown[];
+    resolveThinkingProfile?: (
+      context: ProviderDefaultThinkingPolicyContext,
+    ) => ProviderThinkingProfile | null | undefined;
+  }>,
+): void {
+  pluginPolicyMock.thinkingProfiles.clear();
+  for (const provider of providers) {
+    if (provider.resolveThinkingProfile) {
+      pluginPolicyMock.thinkingProfiles.set(provider.id, provider.resolveThinkingProfile);
+    }
+  }
 }
 
 function setOpenAiRuntimeScopedUltraProvider(): void {
@@ -449,17 +482,8 @@ function setOpenAiRuntimeScopedUltraProvider(): void {
 
 beforeEach(() => {
   vi.useRealTimers();
-  cliBackendsTesting.setDepsForTest({
-    resolvePluginSetupRegistry: () => ({
-      providers: [],
-      cliBackends: [],
-      configMigrations: [],
-      autoEnableProbes: [],
-      diagnostics: [],
-    }),
-    resolveRuntimeCliBackends: () => [],
-  });
   setDirectiveTestProviders([]);
+  pluginPolicyMock.channels.clear();
   modelsCommandMock.resolveModelsCommandReply
     .mockReset()
     .mockResolvedValue(defaultModelsCommandReply());
@@ -480,8 +504,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cliBackendsTesting.resetDepsForTest();
   setDirectiveTestProviders([]);
+  pluginPolicyMock.channels.clear();
   clearRuntimeAuthProfileStoreSnapshots();
   clearInternalHooks();
 });
@@ -877,20 +901,12 @@ describe("/model chat UX", () => {
   );
 
   it("includes the thinking level in channel-specific model summaries", async () => {
-    const registry = createEmptyPluginRegistry();
-    registry.channels = [
-      {
-        pluginId: "test",
-        plugin: {
-          id: "telegram",
-          commands: {
-            buildModelBrowseChannelData: () => ({ telegram: { inlineKeyboard: [] } }),
-          },
-        },
-        source: "test",
+    pluginPolicyMock.channels.set("telegram", {
+      id: "telegram",
+      commands: {
+        buildModelBrowseChannelData: () => ({ telegram: { inlineKeyboard: [] } }),
       },
-    ] as never;
-    setActivePluginRegistry(registry);
+    } as ChannelPlugin);
 
     const reply = await resolveModelInfoReply({ surface: "telegram" });
 
@@ -2252,6 +2268,24 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
   });
 
   it("keeps xhigh when switching to OpenCode Claude Opus 4.7", async () => {
+    setDirectiveTestProviders([
+      {
+        id: "opencode",
+        resolveThinkingProfile: ({ modelId }) => ({
+          levels:
+            modelId === "claude-opus-4-7"
+              ? [
+                  { id: "off" },
+                  { id: "minimal" },
+                  { id: "low" },
+                  { id: "medium" },
+                  { id: "high" },
+                  { id: "xhigh" },
+                ]
+              : [{ id: "off" }],
+        }),
+      },
+    ]);
     const sessionEntry = createSessionEntry({ thinkingLevel: "xhigh" });
 
     const result = await runHandleCommand("/model opencode/claude-opus-4-7", {
@@ -2654,10 +2688,9 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(sessionEntry.thinkingLevel).toBe("medium");
   });
 
-  it.each([
-    ["openai", "gpt-5.5"],
-    ["openai", "gpt-5.5"],
-  ])("accepts xhigh for %s/%s when catalog marks reasoning support", async (provider, model) => {
+  it("accepts xhigh when the catalog marks reasoning support", async () => {
+    const provider = "openai";
+    const model = "gpt-5.5";
     setDirectiveTestProviders([
       {
         id: provider,


### PR DESCRIPTION
## What Problem This Solves

Focused development on model directives paid for plugin-registry, provider-policy, and CLI-backend runtime graphs even though this consumer suite only needs their boundary results. A fresh one-worker run took 64.09s and peaked at 1,445,180 KiB RSS.

## Why This Change Was Made

Replace those cold real imports with explicit leaf fakes that preserve the consumer-owned channel lookup, provider thinking-profile handoff, and CLI-runtime-empty contracts. Real registry, provider-policy, and CLI-backend behavior remains in their owner suites. Remove one literally duplicated `openai/gpt-5.5` table row.

No production behavior or production code changes.

## User Impact

Developers get materially faster focused feedback and lower memory use when changing model directive handling.

## Evidence

Matched Node 24.15.0, fresh module cache, one worker, actual auto-reply Vitest config:

| Metric | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Wall | 64.09s | 23.07s | 64.0% |
| Vitest | 63.06s | 22.24s | 64.7% |
| Test body | 53.88s | 12.96s | 75.9% |
| Max RSS | 1,445,180 KiB | 885,216 KiB | 38.7% |

Validation:
- changed suite: 106/106 passed at exact head
- same-worker shuffled consumer + thinking owner: 171/171 passed for seeds 123133 and 123134
- real provider-policy owner: 2/2 passed
- real channel-registry owner: 6/6 passed
- targeted Oxfmt and Oxlint passed
- `git diff --check` passed

The final fresh run had unchanged import time (7.50s) and nearly unchanged transform time; the measured win comes from removing repeated first-use registry/provider activation from the test body. The earlier matched run was faster still, so the table uses the more conservative final exact-head result.
