### PR TITLE
fix(update): honor stored dev channel for package installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 Docs: https://docs.openclaw.ai
 
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Updater stored dev routing:** continue no-flag updates from package installs through the configured dev git checkout instead of resolving the nonexistent npm `dev` tag. Fixes #123073. Thanks @galli-personal.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.
 - **Updater plugin convergence:** keep pre-plugin doctor passes from installing configured plugins before the updater's plugin sweep, while preserving the final post-plugin migration pass and preventing ambient update-phase state from leaking into fresh doctor processes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 Docs: https://docs.openclaw.ai
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6751,6 +6751,32 @@ describe("update-cli", () => {
     expectNoSideEffects(runRestartScript, runDaemonRestart);
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
+  it("uses the stored dev channel to continue a package-to-git update", async () => {
+    const tempDir = createCaseDir("openclaw-update-package-root");
+    mockPackageInstallStatus(tempDir);
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      parsed: { update: { channel: "dev" } },
+      resolved: { update: { channel: "dev" } } as OpenClawConfig,
+      sourceConfig: { update: { channel: "dev" } } as OpenClawConfig,
+      runtimeConfig: { update: { channel: "dev" } } as OpenClawConfig,
+      config: { update: { channel: "dev" } } as OpenClawConfig,
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue(
+      makeOkUpdateResult({
+        mode: "git",
+        root: path.join(tempDir, "..", "openclaw"),
+        after: { version: "2026.4.10" },
+      }),
+    );
+    mockNoopPostUpdatePluginConvergence();
+
+    await updateCommand({ yes: true, restart: false });
+
+    expect(vi.mocked(runGatewayUpdate)).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "dev" }),
+    );
+  });
   it("explains why git updates cannot run with edited files", async () => {
     vi.mocked(defaultRuntime.log).mockClear();
     vi.mocked(defaultRuntime.error).mockClear();

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -258,7 +258,7 @@ async function updateCommandInternal(
     });
     return;
   }
-  const switchToGit = requestedChannel === "dev" && installKind !== "git";
+  const switchToGit = selectedChannel === "dev" && installKind !== "git";
   const switchToPackage =
     requestedChannel !== null && requestedChannel !== "dev" && installKind === "git";
   const updateInstallKind = switchToGit ? "git" : switchToPackage ? "package" : installKind;


### PR DESCRIPTION
Fixes #123073

## What Problem This Solves

After a package-installed user switched to the `dev` channel, a later no-flag `openclaw update --yes` loaded the persisted `update.channel: dev` but kept the package install mode. The updater then tried to resolve the nonexistent npm `dev` tag instead of continuing through the configured git checkout.

## Why This Change Was Made

The explicit `--channel dev` path already switches package installs to git. The stored channel is the same effective user choice, so install-mode selection now follows `selectedChannel` rather than only the current invocation's `requestedChannel`.

## Scope

- Route a package install with stored `dev` and no `--channel` through the existing git update path.
- Preserve explicit `--channel dev`, stable, extended-stable, beta, and existing git-install behavior.
- Do not change package-manager bootstrap logic; current main already resolves/bootstrap pnpm for git worktrees.

## Evidence

### Real Behavior Proof

Built and packaged this branch with the repository's self-contained package path, installed the resulting `openclaw-2026.8.1.tgz` into an isolated npm prefix, and configured an isolated state directory:

```text
$ openclaw config set update.channel dev
Updated update.channel. Restart the gateway to apply.
```

The installed package CLI then received no `--channel`:

```text
$ openclaw update --dry-run --json
{
  "installKind": "package",
  "mode": "git",
  "updateInstallKind": "git",
  "switchToGit": true,
  "requestedChannel": null,
  "storedChannel": "dev",
  "effectiveChannel": "dev",
  "actions": [
    "Switch install mode from package to git checkout (dev channel)"
  ]
}
```

A non-dry-run invocation of the same installed CLI entered the real git updater: it cloned the isolated target checkout, created the candidate preflight worktree, and invoked `pnpm install --ignore-scripts` there. This proves the package-to-git dispatch without touching the operator's real OpenClaw state or service.

## Failing-First Regression Proof

New test: `uses the stored dev channel to continue a package-to-git update`

Before the production change on current main:

```text
AssertionError: expected "vi.fn()" to be called with arguments:
[ ObjectContaining {"channel": "dev"} ]

Number of calls: 0
Tests  1 failed | 240 skipped
```

After the change:

```text
Tests  1 passed | 240 skipped
```

The focused adjacent update-routing set also passes, including the review-found `--tag latest` override case, which remains on the package path while stored-dev no-flag updates use git.

## Validation

- named failing-first test — pass
- focused explicit-dev, stored-dev, one-off-tag, and dirty-git routing cases — pass
- `pnpm tsgo:core` — pass
- `pnpm tsgo:core:test` — pass
- targeted `oxfmt --check` — pass
- `git diff --check` — pass
- `pnpm build` — pass
- self-contained package integrity check — pass

The full update CLI file has 42 pre-existing Windows-host failures on both this branch and a pristine detached current-main worktree; this branch adds one passing test (199 passed vs 198 passed), with the same 42 failures in both runs.

## Risk and Rollback

Risk is limited to no-tag install-mode selection when the effective channel is `dev`; explicit one-off tags remain on the package path. Rollback is the one-line condition change plus its regression test/changelog entry.

Thanks @galli-personal for the report and the secondary no-flag routing reproduction.