### PR TITLE
fix(mac): stop unbundled processes crashing on notification-center access

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36347,7 +36347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 102,
+      "line": 103,
       "path": "apps/macos/Sources/OpenClaw/PairingPromptSupport.swift",
       "source": "Device",
       "surface": "apple",
@@ -36355,7 +36355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 102,
+      "line": 103,
       "path": "apps/macos/Sources/OpenClaw/PairingPromptSupport.swift",
       "source": "Node",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
@@ -75,6 +75,8 @@ extension DashboardWindowController {
     }
 
     private func publishNotificationsStatus() async {
+        // Honest absence beats a fabricated status when the process is unbundled.
+        guard PermissionManager.notificationCenterAvailable else { return }
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         let permission = Self.notificationsPermissionLabel(for: settings.authorizationStatus)
         // Keep a global snapshot so late subscribers can read status without a bridge round-trip.

--- a/apps/macos/Sources/OpenClaw/NotificationManager.swift
+++ b/apps/macos/Sources/OpenClaw/NotificationManager.swift
@@ -15,6 +15,10 @@ struct NotificationManager {
     }()
 
     func send(title: String, body: String, sound: String?, priority: NotificationPriority? = nil) async -> Bool {
+        guard PermissionManager.notificationCenterAvailable else {
+            self.logger.warning("notification skipped: process has no bundle identity")
+            return false
+        }
         let center = UNUserNotificationCenter.current()
         let status = await center.notificationSettings()
         if status.authorizationStatus == .notDetermined {

--- a/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
+++ b/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
@@ -81,6 +81,7 @@ enum PairingPromptSupport {
     }
 
     static func notificationsAuthorized() async -> Bool {
+        guard PermissionManager.notificationCenterAvailable else { return false }
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         let status = settings.authorizationStatus
         return PermissionManager.isNotificationAuthorized(status: status)

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -24,6 +24,14 @@ enum CapabilityAuthorizationStatus: Equatable, Sendable {
 }
 
 enum PermissionManager {
+    /// UNUserNotificationCenter.current() aborts with NSInternalInconsistencyException
+    /// ("bundleProxyForCurrentProcess is nil") in unbundled processes such as
+    /// `swift build` dev binaries. Every notification-center call must check this
+    /// first so unbundled invocations degrade to not-granted instead of crashing.
+    static var notificationCenterAvailable: Bool {
+        Bundle.main.bundleIdentifier != nil
+    }
+
     static func isNotificationAuthorized(status: UNAuthorizationStatus) -> Bool {
         status == .authorized || status == .provisional
     }
@@ -75,6 +83,7 @@ enum PermissionManager {
     }
 
     private static func ensureNotifications(interactive: Bool) async -> Bool {
+        guard self.notificationCenterAvailable else { return false }
         let center = UNUserNotificationCenter.current()
         let settings = await center.notificationSettings()
         if self.isNotificationAuthorized(status: settings.authorizationStatus) {
@@ -213,6 +222,10 @@ enum PermissionManager {
         for cap in caps {
             switch cap {
             case .notifications:
+                guard self.notificationCenterAvailable else {
+                    results[cap] = .notGranted
+                    break
+                }
                 let center = UNUserNotificationCenter.current()
                 let settings = await center.notificationSettings()
                 results[cap] = self.isNotificationAuthorized(status: settings.authorizationStatus)


### PR DESCRIPTION
## What Problem This Solves

The Mac app hard-crashes (`abort trap: 6`) whenever a process without a bundle identity touches notifications. Live crash on 2026-08-13: a swift-build debug binary running onboarding aborted with `NSInternalInconsistencyException: bundleProxyForCurrentProcess is nil` at `PermissionManager.authorizationStatus` → `UNUserNotificationCenter currentNotificationCenter`, killing the app mid-"Getting things ready" (stack: PermissionManager.swift:216 → MacNodeModeCoordinator.swift:831/428/215).

## Why This Change Was Made

`UNUserNotificationCenter.current()` throws an uncatchable ObjC exception in unbundled processes. Five call sites invoked it unguarded (PermissionManager ×2, NotificationManager.send, DashboardWindowController.publishNotificationsStatus, PairingPromptSupport.notificationsAuthorized). One availability predicate (`PermissionManager.notificationCenterAvailable`, `Bundle.main.bundleIdentifier != nil`) now gates them all: permission checks report not-granted, sends log-and-skip, the dashboard snapshot stays honestly absent rather than fabricated. Packaged app behavior is unchanged (predicate is always true there).

## User Impact

Dev/unbundled invocations (swift build binaries, future tooling) no longer take down the whole app on the default onboarding path; they degrade to notifications-off. No behavior change for the shipped bundle.

## Evidence

- Pre-fix: raw `.build-local/debug/OpenClaw` with a fresh profile aborted within ~60s of onboarding (`Terminating app due to uncaught exception ... bundleProxyForCurrentProcess is nil`).
- Post-fix: identical invocation ran 90s+ through the same flow, zero `Terminating app` lines, then was cleanly stopped.
- `swift build -c debug --product OpenClaw`: green.
- Autoreview (`--mode uncommitted`): clean, no accepted/actionable findings (0.99).
