### PR TITLE
fix(codex): resume parent after terminal subagent fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.
 - **Updater plugin convergence:** keep pre-plugin doctor passes from installing configured plugins before the updater's plugin sweep, while preserving the final post-plugin migration pass and preventing ambient update-phase state from leaking into fresh doctor processes.

--- a/extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts
@@ -130,7 +130,7 @@ describe("buildCodexLifecycleTerminalMeta", () => {
 });
 
 describe("Codex terminal dynamic-tool release", () => {
-  it("fences unconsumed steering before interrupting a successful yield", async () => {
+  it("completes a successful yield before native interrupt completion", async () => {
     const harness = createTerminalReleaseHarness();
 
     harness.controller.scheduleTurnReleaseAfterTerminalDynamicTool(terminalYieldResult(true));
@@ -145,13 +145,17 @@ describe("Codex terminal dynamic-tool release", () => {
       { timeoutMs: 5_000 },
     );
     expect(harness.order.indexOf("cancel")).toBeLessThan(harness.order.indexOf("turn/interrupt"));
-    expect(harness.state.completed).toBe(false);
-    expect(harness.resolveCompletion).not.toHaveBeenCalled();
+    expect(harness.state.completed).toBe(true);
+    expect(harness.resolveCompletion).toHaveBeenCalledOnce();
 
     harness.completeTurn();
-    await vi.waitFor(() => expect(harness.resolveCompletion).toHaveBeenCalledOnce());
+    harness.controller.scheduleTurnReleaseAfterTerminalDynamicTool(terminalYieldResult(true));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
-    expect(harness.state.completed).toBe(true);
+    expect(harness.request).toHaveBeenCalledOnce();
+    expect(harness.resolveCompletion).toHaveBeenCalledOnce();
   });
 
   it("keeps steering open when the yield result fails", async () => {

--- a/extensions/codex/src/app-server/run-attempt-lifecycle-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-lifecycle-controller.ts
@@ -73,9 +73,8 @@ export function createCodexAttemptLifecycleController(
     // Interrupt drops accepted pending input. Reject unconsumed steering first so
     // completion delivery can use its fallback path instead of reporting success.
     turnRuntime.steeringQueueRef.current?.cancel();
-    void turnRuntime
-      .interruptTurn(value.call.turnId, { locallyCompleted: true })
-      .then(turnRuntime.completeTurn);
+    void turnRuntime.interruptTurn(value.call.turnId, { locallyCompleted: true });
+    turnRuntime.completeTurn();
   };
   const scheduleTerminalDynamicToolReleaseCheck = () => {
     if (

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -234,6 +234,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       wakeParams({ settledEntry: children[1] }),
     );
     await vi.waitFor(() => expect(deliverSpy).toHaveBeenCalledOnce());
+    await wakeB;
     releaseDeliveries();
     await expect(Promise.all([wakeA, wakeB])).resolves.toEqual(
       expect.arrayContaining([true, false]),

--- a/src/agents/subagents/registry/subagent-registry-run-launch.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-launch.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../tasks/detached-task-runtime.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../../utils/delivery-context.types.js";
+import { resolveSubagentRequesterAgentId } from "../../subagent-requester-owner.js";
 import { updateSwarmCollectorCompletion } from "../swarm/swarm-collector.js";
 import { normalizeSubagentRunState } from "./subagent-delivery-state.js";
 import { SUBAGENT_ENDED_REASON_ERROR } from "./subagent-lifecycle-events.js";
@@ -125,7 +126,7 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
       requesterOrigin,
       progressOrigin: registerParams.progressOrigin,
       requesterDisplayKey: registerParams.requesterDisplayKey,
-      requesterAgentId: registerParams.requesterAgentId,
+      requesterAgentId: resolveSubagentRequesterAgentId(cfg, registerParams),
       task: registerParams.task,
       taskName: registerParams.taskName,
       cleanup: registerParams.cleanup,
@@ -202,7 +203,7 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
         label: registerParams.label,
         task: registerParams.task,
         agentId: registerParams.agentId,
-        requesterAgentId: registerParams.requesterAgentId,
+        requesterAgentId: resolveSubagentRequesterAgentId(cfg, registerParams),
         deliveryStatus:
           registerParams.expectsCompletionMessage === false ? "not_applicable" : "pending",
       } as const;

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -363,6 +363,7 @@ describe("gateway agent handler", () => {
       expectRecordFields(run, {
         controllerSessionKey: "agent:work:main",
         requesterSessionKey: requester.sessionKey,
+        requesterAgentId: "main",
         requesterDisplayKey: requester.sessionKey,
         requesterOrigin: requester.origin,
         label: "plugin:memory-core",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a parent agent using Codex could remain parked after a successful terminal `sessions_yield` during subagent fan-out, even after its children completed.

Two independent lifecycle gaps combined:

1. Codex turn completion was chained behind the best-effort native interrupt watcher, so a committed terminal tool result could leave local attempt completion unresolved.
2. Fresh subagent registry rows preserved an optional requester owner instead of materializing the canonical owner, so strict owner-scoped requester settlement could miss otherwise matching children.

## Why This Change Was Made

After the terminal dynamic-tool response flushes, Codex now cancels pending steering, starts the native interrupt, and immediately invokes the existing idempotent local completion path. Late native `turn/completed` events and duplicate releases remain exactly once.

Subagent launch now resolves `requesterAgentId` through the existing canonical owner resolver before persisting both the registry and detached-task records. Existing explicit-owner precedence is unchanged. The concurrency test adds only a synchronization barrier so both settles are admitted before delivery is released.

No protocol, schema, config, selector, timeout, scenario, or requester-delivery semantics changed.

## User Impact

Codex parents reliably resume after terminal subagent fan-out, including owner-scoped requester settlement, without waiting for native interrupt completion.

## Evidence

- `extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts`: 5 passed
- `src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts`: 35 passed
- `src/agents/subagent-requester-owner.test.ts`: 2 passed
- `src/agents/subagents/registry/subagent-registry.test.ts`: 148 passed
- `src/gateway/server-methods/agent.test.ts`: 278 passed
- Blacksmith Testbox focused run: https://github.com/openclaw/openclaw/actions/runs/31689443627
- Delegated `check-changed`: passed, including formatting, typechecks, lint, import-cycle, plugin-boundary, and database-first guards: https://github.com/openclaw/openclaw/actions/runs/31689489678
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: passed
- Exact `subagent-fanout-synthesis` runtime-pair QA: `openclaw=pass`, `codex=pass`, 1/1 scenario passed, 0 skipped/failed
- Runtime-pair validator: passed with no Codex-native harness gap
- `qa-evidence.json`: 2,191 bytes, SHA-256 `6c99b362fd7fe663afee5b4997eefe5be6b4bb23d71ce4fc3a19f35097a4f3f2`
- Blacksmith Testbox build/QA run: https://github.com/openclaw/openclaw/actions/runs/31690533131
- `git diff --check`: passed
- Production delta: net zero (`Codex -1`, registry owner materialization +1)
- Exact-head local autoreview: clean, no accepted/actionable findings
- Exact-head local ClawSweeper: functional patch correct, proof sufficient, security cleared, high confidence

Local ClawSweeper's only P3 rank-up suggestion was to remove the changelog entry. That move is intentionally skipped because the owner-reviewed execution scope explicitly requires one concise changelog line for this operationally meaningful fix.

Dependency contract rechecked against `@openai/codex` `rust-v0.147.0`: dynamic-tool responses are submitted back to the core handler before the item completes; `turn/interrupt` is request/notification lifecycle work that eventually emits `turn/completed`. Relevant upstream files: `codex-rs/protocol/src/dynamic_tools.rs`, `codex-rs/app-server/src/dynamic_tools.rs`, `codex-rs/core/src/tools/handlers/dynamic.rs`, `codex-rs/app-server/src/request_processors/turn_processor.rs`, and `codex-rs/app-server/README.md`.

AI-assisted: yes. The implementation, dependency contract, scope, and evidence were manually verified.

<!-- Punchcard-Receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaWEFQUFZBNkI2RVI1WDMzOE1KN0U3OAB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl8zODZGRjVCMzQxQTI2NzQzQjJDREEzMEY0RAB3cmtfMDFLWldaMjI0SllOODFHWjkwWTQ1UEs2V1gAc2VzXzAxS1pYOVdCRFRBWkRHUDhCUTU2S0VNVjBGAHF1aWV0LXdvcmtzaG9wLXJpdmVyLWU1AG9wZW5jbGF3L29wZW5jbGF3AAAxMjMxMjQAZjA5NzU1OGZmMTRlZWQ2OTJlOGJkOTI0N2QxNTY0ODk2NTRjOTVlYzc4MTE1N2EwYjdmMTUxNmZlZDUwYWZmZQBzaWduaW5nLXYxAGtrZ3NjcWwxS3lkNUZYVkR5OTVzMWhqa0RjeGlSOFNUaWstR0hxbWFELXg5cTY1RzVBbnJwWkxQeGZJVEpCLXhvdHI1S043TkNPSnY2Qnc2b1k1dUJRADIwMjYtMDgtMTNUMTA6Mjk6MjEuODk4WgA.D4xZaoZLovE2dG2wyllSrLPqv8D7RVUuk7e5sKF6Oed3hqSvZCTRQ4mzViEUE1ULXUfsX_iIEqswXWvWzqMODA -->
