### PR TITLE
chore: restore current-main agent E2E baseline

### DIFF
--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -305,6 +305,7 @@ describe("subagent registry lifecycle error grace", () => {
       requesterTurnRunId,
       childSessionKey: `agent:main:subagent:${childSuffix}`,
       requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+      requesterAgentId: "main",
       requesterDisplayKey: MAIN_REQUESTER_DISPLAY_KEY,
       task,
       cleanup: "keep",


### PR DESCRIPTION
Related: #114492

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where the current-main agent E2E shard failed before reaching its intended assertions after explicit agent ownership, requester ownership, and embedded auth policy evolved.

This is a separate current-main CI baseline repair. It does not include or modify any #114492 split work.

## Why This Change Was Made

Align the two E2E harnesses with their current owner contracts: full module mocks expose the cooldown probe policy, unscoped multi-agent runs choose an explicit owner, sole-agent inference uses a sole-agent fixture, and subagent registrations record the authoritative requester agent.

No production path, product behavior, protocol, configuration, dependency, or SQLite surface changes.

## User Impact

No user-visible behavior changes. Maintainers regain a trustworthy current-main E2E signal for embedded runs and subagent requester settlement.

## Evidence

- Exact current-main head before repair: `600126acaa23d41644172b05399aabd5ac87264d`.
- Fresh Testbox reproduction, Actions `31688860064`: the exact two-file shard failed **25/33**; each file reproduced independently, excluding order contamination.
- Same exact two-file command after repair on Testbox `tbx_01kzx8tcv1atbcg7w3xzzrpc7c`: **33/33 passed**.
- Focused owner/sibling proof: auth-controller **19/19**, explicit session-agent selection **17/17**, requester-yield **12/12**; **48/48 passed**.
- Classified `coreTests` changed gate passed, including formatting, core-test typecheck, lint, dead-export, dependency, plugin-boundary, and repository ratchet checks.
- Fresh autoreview: Codex `gpt-5.6-sol` high, **no accepted/actionable findings**, patch-correct confidence **0.99**.
- Production LOC: **+0/-0**. Tests: **+20/-1**.
- Sibling Codex source checked at `2e1607ee2fa8099a233df7437adee5f16a741905`; this PR does not change Codex protocol/runtime behavior.
