### PR TITLE
fix(release): recover installer gateway after migration convergence

### DIFF
--- a/scripts/docker/install-sh-e2e/run.sh
+++ b/scripts/docker/install-sh-e2e/run.sh
@@ -896,14 +896,19 @@ run_profile() {
 
   phase_mark_start "Start gateway ($profile)"
   GATEWAY_LOG="$workspace/gateway.log"
-  openclaw --profile "$profile" gateway --port "$port" --bind loopback >"$GATEWAY_LOG" 2>&1 &
-  GATEWAY_PID="$!"
+  GATEWAY_MIGRATION_CONVERGENCE_REFUSAL_PREFIX="OpenClaw plugin migration inputs changed during startup convergence;"
+  start_gateway() {
+    openclaw --profile "$profile" gateway --port "$port" --bind loopback >>"$GATEWAY_LOG" 2>&1 &
+    GATEWAY_PID="$!"
+  }
   cleanup_profile() {
     if kill -0 "$GATEWAY_PID" 2>/dev/null; then
       kill "$GATEWAY_PID" 2>/dev/null || true
       wait "$GATEWAY_PID" 2>/dev/null || true
     fi
   }
+  : >"$GATEWAY_LOG"
+  start_gateway
   trap cleanup_profile EXIT
   phase_mark_passed "Start gateway ($profile)"
 
@@ -914,17 +919,38 @@ run_profile() {
   TURN4_JSON="/tmp/agent-${profile}-4.json"
   HEALTH_JSON="/tmp/health-${profile}.json"
 
+  wait_for_gateway_health() {
+    for _ in $(seq 1 240); do
+      if openclaw --profile "$profile" health --timeout 5000 --json >/dev/null 2>&1; then
+        return 0
+      fi
+      if ! kill -0 "$GATEWAY_PID" 2>/dev/null; then
+        return 1
+      fi
+      sleep 0.25
+    done
+    openclaw --profile "$profile" health --timeout 60000 --json >"$HEALTH_JSON" 2>&1
+  }
+
   phase_mark_start "Wait for health ($profile)"
-  for _ in $(seq 1 240); do
-    if openclaw --profile "$profile" health --timeout 5000 --json >/dev/null 2>&1; then
-      break
+  if ! wait_for_gateway_health; then
+    # Doctor exits once after plugin migration convergence so the final inventory can restart cleanly.
+    # Retry only that exact, already-exited launch; other health failures remain release blockers.
+    if ! kill -0 "$GATEWAY_PID" 2>/dev/null &&
+      grep -Fq "$GATEWAY_MIGRATION_CONVERGENCE_REFUSAL_PREFIX" "$GATEWAY_LOG"; then
+      wait "$GATEWAY_PID" 2>/dev/null || true
+      echo "Restart gateway after migration convergence ($profile)"
+      start_gateway
+      if ! wait_for_gateway_health; then
+        echo "ERROR: gateway health failed ($profile, output=$HEALTH_JSON)" >&2
+        dump_profile_debug "$profile" "$HEALTH_JSON" >&2 || true
+        return 1
+      fi
+    else
+      echo "ERROR: gateway health failed ($profile, output=$HEALTH_JSON)" >&2
+      dump_profile_debug "$profile" "$HEALTH_JSON" >&2 || true
+      return 1
     fi
-    sleep 0.25
-  done
-  if ! openclaw --profile "$profile" health --timeout 60000 --json >"$HEALTH_JSON" 2>&1; then
-    echo "ERROR: gateway health failed ($profile, output=$HEALTH_JSON)" >&2
-    dump_profile_debug "$profile" "$HEALTH_JSON" >&2 || true
-    return 1
   fi
   phase_mark_passed "Wait for health ($profile)"
 

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -139,6 +139,94 @@ function normalizeInstallE2eAgentOutput(output: string) {
   }
 }
 
+function runInstallE2eMigrationConvergenceFixture() {
+  const root = tempDirs.make("openclaw-install-e2e-migration-convergence-");
+  const binDir = join(root, "bin");
+  const installerPath = join(root, "installer.sh");
+  const statePath = join(root, "gateway-attempts");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(installerPath, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+
+  writeFileSync(
+    join(binDir, "npm"),
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'if [[ "$*" == *"view openclaw@latest version"* ]]; then',
+      "  printf '2026.6.35\\n'",
+      'elif [[ "$*" == *"view openclaw versions --json"* ]]; then',
+      '  printf \'[\\"2026.6.34\\",\\"2026.6.35\\"]\\n\'',
+      "fi",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    join(binDir, "openclaw"),
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'if [[ "${1:-}" == "--version" ]]; then',
+      "  printf '2026.6.35\\n'",
+      "  exit 0",
+      "fi",
+      'if [[ "$*" == *onboard* ]]; then',
+      '  previous=""',
+      '  for argument in "$@"; do',
+      '    if [[ "$previous" == "--workspace" ]]; then',
+      '      mkdir -p "$argument"',
+      '      touch "$argument/AGENTS.md" "$argument/IDENTITY.md" "$argument/USER.md" "$argument/SOUL.md" "$argument/TOOLS.md"',
+      "      exit 0",
+      "    fi",
+      '    previous="$argument"',
+      "  done",
+      "fi",
+      'if [[ "$*" == *gateway* ]]; then',
+      '  attempts="$(cat "$FAKE_GATEWAY_ATTEMPTS" 2>/dev/null || printf 0)"',
+      "  attempts=$((attempts + 1))",
+      '  printf "%s\\n" "$attempts" >"$FAKE_GATEWAY_ATTEMPTS"',
+      '  if [[ "$attempts" == "1" ]]; then',
+      '    echo "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready." >&2',
+      "    exit 1",
+      "  fi",
+      "  while :; do sleep 1; done",
+      "fi",
+      'if [[ "$*" == *health* ]]; then',
+      '  attempts="$(cat "$FAKE_GATEWAY_ATTEMPTS" 2>/dev/null || printf 0)"',
+      '  if [[ "$attempts" -ge 2 ]]; then',
+      "    printf '{\\\"ok\\\":true}\\n'",
+      "    exit 0",
+      "  fi",
+      "  exit 1",
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  const result = spawnSync("bash", [INSTALL_E2E_RUNNER_PATH], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: 15_000,
+    env: {
+      ...process.env,
+      FAKE_GATEWAY_ATTEMPTS: statePath,
+      HOME: root,
+      OPENAI_API_KEY: "test-key",
+      OPENCLAW_E2E_MODELS: "openai",
+      OPENCLAW_INSTALL_E2E_AGENT_TOOL_SMOKE: "0",
+      OPENCLAW_INSTALL_E2E_SKIP_PREVIOUS: "1",
+      OPENCLAW_INSTALL_URL: `file://${installerPath}`,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
+  return {
+    attempts: existsSync(statePath) ? readFileSync(statePath, "utf8").trim() : undefined,
+    result,
+  };
+}
+
 function expectInstallDockerfileContract(
   dockerfilePath: string,
   runnerPath: string,
@@ -765,6 +853,14 @@ describe("install-sh E2E runner", () => {
     );
     expect(script).toContain('timeout --kill-after=15s "${AGENT_TURN_TIMEOUT_SECONDS}s"');
     expect(script).toContain('\\"timeoutSeconds\\":${OPENAI_PROVIDER_TIMEOUT_SECONDS}');
+  });
+
+  it("restarts an exited installer gateway once after migration convergence", () => {
+    const { attempts, result } = runInstallE2eMigrationConvergenceFixture();
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(attempts).toBe("2");
+    expect(result.stdout).toContain("Restart gateway after migration convergence (e2e-openai)");
   });
 
   it("normalizes agent JSON when structured lifecycle diagnostics follow the result", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the installer Docker release check can reject gateway readiness after plugin migration inputs converge during the first startup. The process has intentionally exited and requires one clean restart, but the harness previously waited for health and failed the release lane.

## Why This Change Was Made

The installer harness now recognizes only the documented migration-convergence refusal after the gateway has exited, then performs one fresh startup and repeats the same health check. Other exits, readiness failures, and a second refusal still fail. This matches the bounded recovery contract already used by the cross-OS release checks.

## User Impact

Release validation and installer smoke coverage recover from the expected one-time migration convergence restart without hiding generic gateway failures. No product configuration, package, tag, or publication surface changes.

## Evidence

- Failed release check: Docker package/update OpenAI reported the exact migration-convergence readiness refusal and closed the health connection.
- Root cause: src/commands/doctor-config-preflight.ts rejects readiness after migration inputs change so the next startup runs against final plugin/config state.
- Focused black-box fixture proves one exited refusal restarts once and only then reaches health: node scripts/run-vitest.mjs test/scripts/test-install-sh-docker.test.ts (57 passed).
- Shell syntax: bash -n scripts/docker/install-sh-e2e/run.sh.
- Formatting and whitespace: pnpm format:check -- scripts/docker/install-sh-e2e/run.sh test/scripts/test-install-sh-docker.test.ts; git diff --check.
- Fresh autoreview: .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/extended-stable/2026.6.33 (no actionable findings).