### PR TITLE
fix(qa): prove scheduled cron scenarios fire naturally

### DIFF
--- a/qa/scenarios/scheduling/cron-natural-fire-no-duplicate.yaml
+++ b/qa/scenarios/scheduling/cron-natural-fire-no-duplicate.yaml
@@ -101,9 +101,13 @@ flow:
               timeoutMs:
                 expr: "liveTurnTimeoutMs(env, Math.max(60000, config.fireDelayMs + 45000))"
         - assert:
-            expr: "Date.now() >= scheduledAtMs"
+            expr: "Number.isSafeInteger(completedRun?.runAtMs) && completedRun.runAtMs >= scheduledAtMs"
             message:
-              expr: "`cron completed before scheduled time ${scheduledFor}`"
+              expr: "`cron actually started before its scheduled time ${scheduledFor}: ${JSON.stringify(completedRun)}`"
+        - assert:
+            expr: "Number.isSafeInteger(completedRun?.ts) && completedRun.ts >= runStartedAt && completedRun.ts >= completedRun.runAtMs"
+            message:
+              expr: "`expected the current naturally scheduled cron attempt's recorded completion, got ${JSON.stringify(completedRun)}`"
         - assert:
             expr: "completedRun?.status === 'ok'"
             message:

--- a/qa/scenarios/scheduling/cron-one-minute-ping.yaml
+++ b/qa/scenarios/scheduling/cron-one-minute-ping.yaml
@@ -7,14 +7,14 @@ scenario:
     primary:
       - automation.cron-rpcs
       - automation.chat-announce-delivery
-      - automation.agent-cron-tool
+      - automation.isolated-cron-execution
     secondary:
       - channels.qa-channel-final-reply
-  objective: Verify the agent can schedule a cron reminder one minute in the future and receive the follow-up in the QA channel.
+  objective: Verify a Gateway cron reminder scheduled one minute in the future fires naturally and delivers its follow-up through the QA channel.
   successCriteria:
-    - Agent schedules a cron reminder roughly one minute ahead.
-    - Reminder returns through qa-channel.
-    - Agent recognizes the reminder as part of the original task.
+    - Gateway stores a one-shot cron reminder roughly one minute ahead.
+    - The scheduler executes the reminder no earlier than its scheduled due time without forcing the job.
+    - The isolated agent turn returns the reminder marker through qa-channel.
   docsRefs:
     - docs/help/testing.md
     - docs/channels/qa-channel.md
@@ -23,7 +23,8 @@ scenario:
     - extensions/qa-lab/src/self-check.ts
   execution:
     kind: flow
-    summary: Verify the agent can schedule a cron reminder one minute in the future and receive the follow-up in the QA channel.
+    timeoutMs: 180000
+    summary: Schedule a one-minute Gateway cron reminder, wait for its natural timer, and verify qa-channel delivery.
     channel: qa-channel
     config:
       channelId: qa-room
@@ -78,7 +79,7 @@ flow:
             expr: response.id
       detailsExpr: scheduledAt
 
-    - name: forces the reminder through QA channel delivery
+    - name: waits for the natural reminder and QA channel delivery
       actions:
         - assert:
             expr: "Boolean(jobId)"
@@ -89,14 +90,8 @@ flow:
         - set: runStartedAt
           value:
             expr: "Date.now()"
-        - call: env.gateway.call
-          args:
-            - cron.run
-            - id:
-                ref: jobId
-              mode: force
-            - timeoutMs: 30000
         - call: waitForCronRunCompletion
+          saveAs: completedRun
           args:
             - callGateway:
                 expr: "env.gateway.call.bind(env.gateway)"
@@ -105,7 +100,19 @@ flow:
               afterTs:
                 ref: runStartedAt
               timeoutMs:
-                expr: liveTurnTimeoutMs(env, 45000)
+                expr: liveTurnTimeoutMs(env, 120000)
+        - assert:
+            expr: "Number.isSafeInteger(completedRun?.runAtMs) && completedRun.runAtMs >= new Date(scheduledAt).getTime()"
+            message:
+              expr: "`cron reminder actually started before its scheduled time ${scheduledAt}: ${JSON.stringify(completedRun)}`"
+        - assert:
+            expr: "Number.isSafeInteger(completedRun?.ts) && completedRun.ts >= runStartedAt && completedRun.ts >= completedRun.runAtMs"
+            message:
+              expr: "`expected the current scheduled cron attempt's recorded completion, got ${JSON.stringify(completedRun)}`"
+        - assert:
+            expr: "completedRun?.status === 'ok'"
+            message:
+              expr: "`expected a successful naturally scheduled reminder, got ${JSON.stringify(completedRun)}`"
         - call: waitForOutboundMessage
           saveAs: outbound
           args:


### PR DESCRIPTION
Related: #114492

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the natural cron QA scenarios could pass without proving that the scheduler started the job at or after its due time. The one-minute scenario also force-ran the job even though its stated purpose was to exercise a scheduled reminder.

## Why This Change Was Made

Both scenarios now wait for the scheduler-owned run and validate the recorded `runAtMs` and completion timestamp. The one-minute scenario's metadata now describes the Gateway and isolated-cron boundaries it actually exercises; the separate forced-run scenario remains unchanged.

## User Impact

No direct user-facing behavior changes. Cron regressions that execute a reminder early, match a stale completion, or require a forced run are now caught by the repo-backed QA suite.

## Evidence

- Exact head: `69d56a18dcb`.
- Focused catalog validation: `scenario-catalog.test.ts` passed **58/58** on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/31688929136)).
- Rebased executable QA proof: `cron-natural-fire-no-duplicate` and `cron-one-minute-ping` passed **2/2**, with **0 failed and 0 skipped**, against qa-channel + a real Gateway child + mock-openai ([run](https://github.com/openclaw/openclaw/actions/runs/31691190895)).
- Conservative changed gate: `pnpm check:changed` exited 0, including formatting, typecheck, lint, dependency/package guards, boundaries, and import cycles ([run](https://github.com/openclaw/openclaw/actions/runs/31689308193)).
- Fresh `autoreview --mode local`: no accepted/actionable findings; confidence **0.99**.
- Diff: two QA scenario files, **+28/-17**; production LOC delta **0**.
