### PR TITLE
fix(ui): keep limited-access banner clear of shell controls

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -59,7 +59,6 @@ const SCOPE_UPGRADE_BANNER_ELEMENT = {
 function renderScopeUpgradeBanner(
   host: ShellViewHost,
   snapshot: ApplicationContext["gateway"]["snapshot"],
-  chromeOffset: boolean,
 ) {
   const state = readScopeUpgradeAvailability(snapshot);
   if (state.phase === "hidden") {
@@ -80,7 +79,6 @@ function renderScopeUpgradeBanner(
     return html`<openclaw-device-scope-upgrade-banner
       .props=${{
         snapshot,
-        chromeOffset,
       }}
     ></openclaw-device-scope-upgrade-banner>`;
   }
@@ -506,7 +504,7 @@ export function renderApplicationShell(host: ShellViewHost) {
           : ""} ${activeRoute === "workboard" ? "content--workboard" : ""}"
         .tabIndex=${-1}
       >
-        ${renderScopeUpgradeBanner(host, gatewaySnapshot, !settingsTakeover && !mobileNavLayout)}
+        ${renderScopeUpgradeBanner(host, gatewaySnapshot)}
         ${gatewaySnapshot.hello?.deviceAuthMigration?.pending === true
           ? // The migration banner is registered by a rare-flow dynamic import after first render.
             customElements.get("openclaw-device-auth-migration-banner")

--- a/ui/src/app/device-scope-upgrade.runtime.ts
+++ b/ui/src/app/device-scope-upgrade.runtime.ts
@@ -130,7 +130,6 @@ export class ScopeUpgradeController {
 
 type ScopeUpgradeBannerProps = {
   snapshot: ApplicationGatewaySnapshot;
-  chromeOffset: boolean;
 };
 
 class ScopeUpgradeBanner extends OpenClawLightDomContentsElement {
@@ -186,7 +185,6 @@ class ScopeUpgradeBanner extends OpenClawLightDomContentsElement {
       class="callout ${state.phase === "error" || state.phase === "rejected"
         ? "danger"
         : "warn"} callout--action"
-      style=${props.chromeOffset ? "margin-left: 72px" : nothing}
       role="status"
     >
       <span class="callout__content">${text}</span>

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -32,6 +32,17 @@ const SCOPE_UPGRADE_METHODS = [
 const MANUAL_UPGRADE_GUIDANCE =
   "This browser has limited access. Manage it with openclaw devices on the Gateway or from Devices on an admin browser.";
 
+type BoundingBox = { x: number; y: number; width: number; height: number };
+
+function boxesIntersect(left: BoundingBox, right: BoundingBox): boolean {
+  return !(
+    left.x + left.width <= right.x ||
+    right.x + right.width <= left.x ||
+    left.y + left.height <= right.y ||
+    right.y + right.height <= left.y
+  );
+}
+
 let browser: Browser;
 let server: ControlUiE2eServer;
 const openContexts = new Set<BrowserContext>();
@@ -122,6 +133,10 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     await page.getByRole("button", { name: "Request admin" }).waitFor();
 
     await page.locator("#new-session-project-trigger").click();
+    const projectPopover = page.locator("wa-popover.new-session-page__project-popover");
+    await expect
+      .poll(() => projectPopover.evaluate((element) => element === document.activeElement))
+      .toBe(true);
     const browse = page.getByRole("button", { name: "Browse folders" });
     await expect.poll(() => browse.isDisabled()).toBe(true);
     await browse.focus();
@@ -187,7 +202,25 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       });
 
       await page.goto(`${server.baseUrl}chat`);
-      await page.getByText(MANUAL_UPGRADE_GUIDANCE, { exact: true }).waitFor();
+      const guidance = page.getByText(MANUAL_UPGRADE_GUIDANCE, { exact: true });
+      await guidance.waitFor();
+
+      const guidanceBox = await guidance.boundingBox();
+      const chromeControls = page.locator(".shell-chrome-controls__button");
+      expect(guidanceBox).not.toBeNull();
+      expect(await chromeControls.count()).toBe(2);
+      for (let index = 0; index < (await chromeControls.count()); index += 1) {
+        const control = chromeControls.nth(index);
+        const controlBox = await control.boundingBox();
+        expect(controlBox).not.toBeNull();
+        if (guidanceBox && controlBox) {
+          const label = await control.getAttribute("aria-label");
+          expect(
+            boxesIntersect(guidanceBox, controlBox),
+            `guidance ${JSON.stringify(guidanceBox)} intersects ${label} ${JSON.stringify(controlBox)}`,
+          ).toBe(false);
+        }
+      }
 
       expect(await page.getByRole("button", { name: "Request admin" }).count()).toBe(0);
       expect(await gateway.getRequests("device.scopes.requestUpgrade")).toHaveLength(0);

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -4,6 +4,7 @@ import { chromium, type Browser, type BrowserContext, type Page } from "playwrig
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
+  controlUiBundledSettingsStorageKey,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -28,6 +29,10 @@ const FULL_SCOPES = [
 const SCOPE_UPGRADE_METHODS = [
   "device.scopes.requestUpgrade",
   "device.scopes.waitUpgrade",
+] as const;
+const HIDDEN_WEB_CHROME_HOSTS = [
+  { collapsed: false, label: "native web chrome", rootClass: "openclaw-native-web-chrome" },
+  { collapsed: true, label: "collapsed native navigation", rootClass: "openclaw-native-nav" },
 ] as const;
 const MANUAL_UPGRADE_GUIDANCE =
   "This browser has limited access. Manage it with openclaw devices on the Gateway or from Devices on an admin browser.";
@@ -224,6 +229,56 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
 
       expect(await page.getByRole("button", { name: "Request admin" }).count()).toBe(0);
       expect(await gateway.getRequests("device.scopes.requestUpgrade")).toHaveLength(0);
+    },
+  );
+
+  it.each(HIDDEN_WEB_CHROME_HOSTS)(
+    "keeps manual guidance at the normal content inset with $label",
+    async ({ collapsed, rootClass }) => {
+      const context = await createContext();
+      await context.addInitScript(
+        ({ hostClass, settingsKey, startCollapsed }) => {
+          localStorage.setItem(settingsKey, JSON.stringify({ navCollapsed: startCollapsed }));
+          const stamp = () =>
+            document.documentElement.classList.add("openclaw-native-macos", hostClass);
+          if (document.documentElement) {
+            stamp();
+          } else {
+            document.addEventListener("DOMContentLoaded", stamp);
+          }
+        },
+        {
+          hostClass: rootClass,
+          settingsKey: controlUiBundledSettingsStorageKey(server.baseUrl),
+          startCollapsed: collapsed,
+        },
+      );
+      const page = await context.newPage();
+      await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "device.scopes.requestUpgrade"],
+        operatorScopes: LIMITED_SCOPES,
+      });
+
+      await page.goto(`${server.baseUrl}chat`);
+      const guidance = page.getByText(MANUAL_UPGRADE_GUIDANCE, { exact: true });
+      await guidance.waitFor();
+      if (collapsed) {
+        await expect
+          .poll(() => page.locator(".shell").getAttribute("class"))
+          .toContain("shell--nav-collapsed");
+      }
+      await expect.poll(() => page.locator(".shell-chrome-controls").isVisible()).toBe(false);
+
+      const contentBox = await page.locator(".content").boundingBox();
+      const calloutBox = await page.locator("openclaw-update-banner .callout").boundingBox();
+      const contentInset = await page
+        .locator(".content")
+        .evaluate((element) => Number.parseFloat(getComputedStyle(element).paddingLeft));
+      expect(contentBox).not.toBeNull();
+      expect(calloutBox).not.toBeNull();
+      if (contentBox && calloutBox) {
+        expect(calloutBox.x).toBe(contentBox.x + contentInset);
+      }
     },
   );
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -140,7 +140,13 @@
   display: none;
 }
 
-.shell:not(.shell--mobile-nav):not(.shell--settings)
+/* Reserve notice space only while the corresponding in-page chrome remains visible. */
+:is(
+    html:not(.openclaw-native-nav, .openclaw-native-web-chrome)
+      .shell:not(.shell--mobile-nav, .shell--settings),
+    html.openclaw-native-nav:not(.openclaw-native-web-chrome)
+      .shell:not(.shell--mobile-nav, .shell--nav-collapsed, .shell--settings)
+  )
   .content
   > :is(
     openclaw-update-banner,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -15,8 +15,9 @@
       var(--shell-chrome-control-size) + var(--shell-chrome-controls-gap) +
       var(--shell-chrome-controls-gap)
   );
-  --shell-floating-update-card-left: calc(
-    var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-collapsed-width) + 8px
+  --shell-chrome-safe-area-left: calc(
+    var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-collapsed-width) -
+      var(--shell-chrome-control-size) - var(--shell-chrome-controls-gap) + 8px
   );
   /* Desktop has no topbar row — the sidebar owns navigation. Narrow viewports
      (layout.mobile.css) and the chat split toolbar restore the row height. */
@@ -73,6 +74,9 @@
 .shell--nav-collapsed {
   grid-template-columns: 0 minmax(0, 1fr);
   --shell-nav-width: 0px;
+  --shell-chrome-safe-area-left: calc(
+    var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-collapsed-width) + 8px
+  );
 }
 
 /* Drawer shells keep the nav mounted offscreen; desktop collapse removes it. */
@@ -134,6 +138,17 @@
 
 .shell--mobile-nav .shell-chrome-controls {
   display: none;
+}
+
+.shell:not(.shell--mobile-nav):not(.shell--settings)
+  .content
+  > :is(
+    openclaw-update-banner,
+    openclaw-device-scope-upgrade-banner,
+    openclaw-device-auth-migration-banner
+  )
+  .callout {
+  margin-left: var(--shell-chrome-safe-area-left);
 }
 
 html.openclaw-native-macos .shell-chrome-controls {
@@ -1150,8 +1165,8 @@ openclaw-settings-save-indicator {
 
 /* Clear the collapsed three-button chrome cluster plus an 8px breathing gap. */
 .shell:not(.shell--mobile-nav) .sidebar-update-card--floating .sidebar-update-card {
-  width: min(360px, calc(100% - var(--shell-floating-update-card-left) - 16px));
-  margin-left: var(--shell-floating-update-card-left);
+  width: min(360px, calc(100% - var(--shell-chrome-safe-area-left) - 16px));
+  margin-left: var(--shell-chrome-safe-area-left);
 }
 
 /* Native hosts hide the web cluster; onboarding never mounts it. */


### PR DESCRIPTION
Related: #121459
Related: #123074

## What Problem This Solves

Fixes an issue where limited-access guidance in the Control UI could be obscured by the desktop shell's fixed Collapse sidebar and Open command palette controls at 1280x900. The persistent fallback path made visible by #123074 was especially affected; #123074 did not introduce the overlap.

## Why This Change Was Made

The desktop shell layout now owns one chrome-safe area for direct top-level notices, including the generic update/guidance notice, scope-upgrade notice, and device-auth-migration notice. This removes the scope-upgrade component's private 72px offset, preserves mobile/settings layouts, and reuses the same layout variable for the collapsed floating update card.

## User Impact

Limited-access guidance remains fully readable while Collapse sidebar and Open command palette stay available. When scope upgrade is actionable, the complete guidance and Request admin action remain readable with a 10px gap.

## Evidence

At 1280x900 before the fix, the guidance banner occupied x=278..1260 and its text x=295..1008.109, while the shell controls occupied x=268..300 and x=304..336. Text intersections measured 80px² and 512px²; banner intersections measured 704px² and 1024px².

After the fix, the guidance banner occupies x=364..1260 and its text x=381..1094.109, with zero banner or text intersections against either shell control. The actionable sibling also starts at x=364; its text ends at x=1126.625 and Request admin begins at x=1136.625, preserving a 10px gap and zero control intersections.

The regression was captured before the production edit: the focused E2E failed 2 tests and passed 5 for the intended geometry intersection. Final proof on the rebased head:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/device-scope-upgrade.e2e.test.ts` — 9/9 passed in 10.08s, including native web chrome and collapsed native navigation at the normal content inset. Before the native-host repair, both focused cases failed with an extra 106px/142px gutter.
- `cd ui && node ../scripts/run-vitest.mjs run --config vitest.config.ts --configLoader runner src/app/navigation-surface.browser.test.ts` — 1/1 passed in 1.27s.
- `node scripts/check-changed.mjs -- ui/src/app/app-shell-view.ts ui/src/app/device-scope-upgrade.runtime.ts ui/src/e2e/device-scope-upgrade.e2e.test.ts ui/src/styles/layout.css` — passed on the original head. Testbox authentication was unavailable, so the wrapper used its documented trusted-source local fallback; UI/core typecheck, lint, i18n, formatting, guards, and dead-code checks passed.
- Repository stylelint, `git diff --check`, and oxfmt passed.
- Fresh branch autoreview against `origin/main` reported no accepted/actionable findings. Source-blind visual validation passed all 5 observable clauses with no visible regressions; fixture identity was not inferable from screenshots alone and is covered by the deterministic E2E.
- Production LOC: +26/-9 (net +17). Tests: +89/-1 (net +88). The production growth centralizes the owner-boundary safe area, covers all direct desktop shell notice siblings, deletes the private per-component offset, and conditions the shared selector on actual in-page chrome visibility. The larger test delta is geometry coverage across ordinary web, native web chrome, and collapsed native navigation.

Landing also exposed unrelated red-main test flakiness. Exact-head CI run 31691547078 attempts 1 and 2 failed only `checks-ui-e2e (3/4)` because the background-task transcript comparison crossed a live elapsed-label tick (11s to 12s) with no substantive text change. A bounded local normalization of complete duration tokens passed the focused E2E once plus five consecutive serial runs (3/3 each), without a production seam. During the required rebase, current `main` already contained the equivalent canonical repair in d2afbd05ad0: the page clock is fixed for that E2E while timers keep running. The duplicate local test commit was therefore dropped. On the final rebased head, `ui/src/pages/chat/background-tasks.e2e.test.ts` passed 3/3 in 15.56s. This is test reliability repair inherited from `main`, not product behavior or additional PR production LOC.

Real-profile Chrome extension relay proof was unavailable after fail-closed retries. The deterministic mocked-Gateway flow in real Chromium is the primary visual proof for this shell-layout boundary.

### Before

![Limited-access guidance overlapping desktop shell controls](https://github.com/user-attachments/assets/44d148ec-587b-4a2a-a0e0-fa77bbe23b02)

### After

![Limited-access guidance clear of desktop shell controls](https://github.com/user-attachments/assets/e4f5aeff-78ad-4ccb-be76-9093c15a6290)

### Actionable

![Actionable limited-access banner with Request admin clear of desktop shell controls](https://github.com/user-attachments/assets/4868aec0-1619-49f8-baf7-b08b5d3a5a6f)

AI-assisted: yes. The author reviewed the implementation, regression coverage, rendered behavior, and validation results. No agent transcript is included.
