### PR TITLE
fix(release): allow ANSI in reusable job logs

### DIFF
--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -288,8 +288,12 @@ function findParentJobsAll(parentRunId, repository = DEFAULT_REPO) {
   return jobs;
 }
 
+function parentJobLogArgs(jobId, repository = DEFAULT_REPO) {
+  return ["api", `repos/${repository}/actions/jobs/${jobId}/logs`, "--allow-escape-sequences"];
+}
+
 function parentJobLog(jobId, repository = DEFAULT_REPO) {
-  return gh(["api", `repos/${repository}/actions/jobs/${jobId}/logs`]);
+  return gh(parentJobLogArgs(jobId, repository));
 }
 
 function normalizeOptionalRunId(value, label) {

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -288,12 +288,34 @@ function findParentJobsAll(parentRunId, repository = DEFAULT_REPO) {
   return jobs;
 }
 
-function parentJobLogArgs(jobId, repository = DEFAULT_REPO) {
-  return ["api", `repos/${repository}/actions/jobs/${jobId}/logs`, "--allow-escape-sequences"];
+function parentJobLogArgs(jobId, repository = DEFAULT_REPO, allowEscapeSequences = true) {
+  const args = ["api", `repos/${repository}/actions/jobs/${jobId}/logs`];
+  if (allowEscapeSequences) {
+    args.push("--allow-escape-sequences");
+  }
+  return args;
+}
+
+function isUnknownAllowEscapeSequencesFlag(error) {
+  if (typeof error !== "object" || error === null || !("stderr" in error)) {
+    return false;
+  }
+  const stderr = error.stderr;
+  return (
+    typeof stderr === "string" &&
+    stderr.replace(/\r\n?/gu, "\n").split("\n").includes("unknown flag: --allow-escape-sequences")
+  );
 }
 
 function parentJobLog(jobId, repository = DEFAULT_REPO) {
-  return gh(parentJobLogArgs(jobId, repository));
+  try {
+    return gh(parentJobLogArgs(jobId, repository));
+  } catch (error) {
+    if (!isUnknownAllowEscapeSequencesFlag(error)) {
+      throw error;
+    }
+    return gh(parentJobLogArgs(jobId, repository, false));
+  }
 }
 
 function normalizeOptionalRunId(value, label) {

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -165,6 +165,13 @@ process.stdout.write(readFileSync(process.env.ARCHIVE));
       expect(shimCalls).toContain(
         `"repos/openclaw/openclaw/compare/${workflowSha}...${verifierSha}?per_page=1&page=2"`,
       );
+      expect(shimCalls).toContain(
+        JSON.stringify([
+          "api",
+          `repos/openclaw/openclaw/actions/jobs/${fixture.parentJob.id}/logs`,
+          "--allow-escape-sequences",
+        ]),
+      );
       expect(shimCalls).not.toContain(`/actions/artifacts/${artifactId}/zip`);
       expect(plainCalls.trim()).toBe(
         JSON.stringify(["api", `repos/openclaw/openclaw/actions/artifacts/${artifactId}/zip`]),

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -182,6 +182,109 @@ process.stdout.write(readFileSync(process.env.ARCHIVE));
   });
 });
 
+function runParentJobLogProbe(shimBody: string) {
+  const root = mkdtempSync(join(tmpdir(), "release-ci-job-log-"));
+  const shimLog = join(root, "shim.log");
+  const shimGh = join(root, "gh");
+  writeFileSync(
+    shimGh,
+    `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.SHIM_LOG, JSON.stringify(args) + "\\n");
+${shimBody}
+`,
+  );
+  chmodSync(shimGh, 0o755);
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `import { createReleaseEvidenceClient } from ${JSON.stringify(pathToFileURL(resolve(SCRIPT)).href)};
+         try {
+           process.stdout.write(createReleaseEvidenceClient("owner/repo").getJobLog("123"));
+         } catch (error) {
+           process.stdout.write(JSON.stringify({
+             message: error instanceof Error ? error.message : String(error),
+             stderr: typeof error === "object" && error !== null && "stderr" in error
+               ? String(error.stderr)
+               : "",
+           }));
+           process.exitCode = 17;
+         }`,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${root}:${process.env.PATH ?? ""}`,
+          SHIM_LOG: shimLog,
+        },
+      },
+    );
+    return {
+      calls: readFileSync(shimLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+      result,
+    };
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+describe("parent job log compatibility", () => {
+  const flaggedArgs = ["api", "repos/owner/repo/actions/jobs/123/logs", "--allow-escape-sequences"];
+  const legacyArgs = ["api", "repos/owner/repo/actions/jobs/123/logs"];
+
+  it("uses one flagged call when gh supports raw escape-sequence output", () => {
+    const { calls, result } = runParentJobLogProbe(
+      'process.stdout.write("\\u001b[31mlog\\u001b[0m");',
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("\u001b[31mlog\u001b[0m");
+    expect(calls).toEqual([flaggedArgs]);
+  });
+
+  it("retries once without the flag for the exact legacy gh error", () => {
+    const { calls, result } = runParentJobLogProbe(`
+if (args.includes("--allow-escape-sequences")) {
+  process.stderr.write("unknown flag: --allow-escape-sequences\\n\\nUsage: gh api <endpoint> [flags]\\n");
+  process.exit(1);
+}
+process.stdout.write("\\u001b[31mlegacy log\\u001b[0m");
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("\u001b[31mlegacy log\u001b[0m");
+    expect(calls).toEqual([flaggedArgs, legacyArgs]);
+  });
+
+  it("propagates unrelated errors without retrying", () => {
+    const { calls, result } = runParentJobLogProbe(`
+process.stderr.write("error: unknown flag: --allow-escape-sequences\\n");
+process.exit(1);
+`);
+
+    expect(result.status).toBe(17);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining("Command failed: gh"),
+        stderr: "error: unknown flag: --allow-escape-sequences\n",
+      }),
+    );
+    expect(calls).toEqual([flaggedArgs]);
+  });
+});
+
 describe("runReleaseCiGh", () => {
   it("bounds each GitHub lookup with a timeout and SIGKILL", () => {
     const execFileSyncImpl = vi.fn(() => "result");


### PR DESCRIPTION
## What Problem This Solves

Reusable full-release validation rejected otherwise valid prior evidence when a GitHub Actions job log contained terminal escape sequences. The failed log read made the release workflow fall through into unnecessary heavy validation jobs.

## Why This Change Was Made

Allow terminal escape sequences only for the parent job-log API read. Older `gh` versions retry once without the flag only when stderr contains the exact unsupported-flag line; unrelated failures still propagate without retry. Other REST reads remain on their existing argv contract, and artifact ZIP downloads remain on the plain `gh` binary path.

## User Impact

Release operators can reuse exact validated evidence even when a child dispatch log contains ANSI output, avoiding a false-negative reuse decision and an unnecessary full validation rerun.

## Evidence

- Failure: full-release validation run https://github.com/openclaw/openclaw/actions/runs/31690790954 rejected run `31676494305` because the job-log response contained terminal escape sequences.
- `node scripts/run-vitest.mjs test/scripts/release-ci-summary.test.ts` - 50 passed, including modern, legacy fallback, and unrelated-error contracts.
- Live read of job `94372185605` with local `gh 2.93.0` exercised the legacy fallback and returned 50,744 bytes without stderr leakage.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/release-ci-summary.mjs` - passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/release-ci-summary.mjs test/scripts/release-ci-summary.test.ts` - passed.
- `git diff --check` - passed.

Changelog: none; internal release tooling only.
