### PR TITLE
fix: auth-cold gateways hide all models and dead-end the operator

### DIFF
--- a/ui/src/components/web-awesome-migration.node.test.ts
+++ b/ui/src/components/web-awesome-migration.node.test.ts
@@ -53,6 +53,7 @@ describe("Web Awesome control ownership", () => {
       "components/command-palette.ts",
       "pages/chat/components/chat-composer-skill-menu.ts",
       "pages/chat/components/chat-composer-slash-menu.ts",
+      "pages/chat/components/chat-model-picker-options.ts",
       "pages/chat/components/chat-model-picker.ts",
     ]);
   });

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -668,6 +668,84 @@ suite.define(() => {
     });
   });
 
+  it("keeps an auth-cold configured catalog visible and blocks chat until setup", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const models = [
+        {
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
+          provider: "openai",
+          available: false,
+        },
+        {
+          id: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          provider: "openai",
+          available: false,
+        },
+      ];
+      const gateway = await installMockGateway(page, {
+        agentModel: "openai/gpt-5.6-sol",
+        models,
+        methodResponses: {
+          "sessions.list": {
+            count: 1,
+            defaults: {
+              contextTokens: 200_000,
+              model: "gpt-5.6-sol",
+              modelProvider: "openai",
+            },
+            path: "",
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                model: "gpt-5.6-sol",
+                modelProvider: "openai",
+                status: "done",
+                updatedAt: Date.now(),
+              },
+            ],
+            ts: Date.now(),
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("models.list");
+
+      const composer = page.locator(".agent-chat__input");
+      const picker = composer.locator("wa-select.chat-controls__model-picker");
+      const options = picker.locator("wa-option");
+      await expect.poll(() => options.count()).toBe(2);
+      await expect.poll(() => options.first().textContent()).toContain("Default (GPT-5.6 Sol)");
+      await expect.poll(() => options.first().textContent()).toContain("Sign-in needed");
+      await expect
+        .poll(() =>
+          options.evaluateAll((rows) => rows.every((row) => row.hasAttribute("disabled"))),
+        )
+        .toBe(true);
+      await expect
+        .poll(() => composer.locator(".chat-controls__model-catalog-state").textContent())
+        .toContain("Review the provider credential or sign-in, then retry");
+      await expect.poll(() => composer.locator("textarea").isDisabled()).toBe(true);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await picker.click();
+        await expect.poll(() => options.last().isVisible()).toBe(true);
+        await composer.screenshot({
+          animations: "disabled",
+          path: `${artifactDir}/auth-cold-model-picker.png`,
+        });
+        await picker.click();
+      }
+      await composer.locator('[data-chat-model-setup="true"]').click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
+    });
+  });
+
   it("loads agent-scoped startup models when the route switches sessions", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const workModel = {

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -661,9 +661,11 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator('[data-chat-model-provider-group="codex"]').count())
         .toBe(0);
-      // The advertised default is unavailable, so no usable catalog row is
-      // marked as the default and no synthetic empty row is introduced.
-      await expect.poll(() => composer.locator('[data-chat-model-default="true"]').count()).toBe(0);
+      // The advertised default is configured but unavailable, so its row stays
+      // visible and disabled while the usable model remains selectable.
+      const unavailableDefault = composer.locator('[data-chat-model-default="true"]');
+      await expect.poll(() => unavailableDefault.count()).toBe(1);
+      await expect.poll(() => unavailableDefault.getAttribute("disabled")).not.toBeNull();
       await expect.poll(() => composer.locator('[data-chat-model-option=""]').count()).toBe(0);
     });
   });
@@ -715,10 +717,15 @@ suite.define(() => {
       await gateway.waitForRequest("models.list");
 
       const composer = page.locator(".agent-chat__input");
-      const picker = composer.locator("wa-select.chat-controls__model-picker");
-      const options = picker.locator("wa-option");
+      const picker = composer.locator("details.chat-controls__model-picker");
+      const options = picker.locator(
+        "button[data-chat-model-option]:not([data-chat-model-target])",
+      );
+      await picker.locator("summary").click();
       await expect.poll(() => options.count()).toBe(2);
-      await expect.poll(() => options.first().textContent()).toContain("Default (GPT-5.6 Sol)");
+      await expect.poll(() => options.last().isVisible()).toBe(true);
+      await expect.poll(() => options.first().textContent()).toContain("GPT-5.6 Sol");
+      await expect.poll(() => options.first().textContent()).toContain("Default");
       await expect.poll(() => options.first().textContent()).toContain("Sign-in needed");
       await expect
         .poll(() =>
@@ -733,13 +740,10 @@ suite.define(() => {
 
       const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
       if (artifactDir) {
-        await picker.click();
-        await expect.poll(() => options.last().isVisible()).toBe(true);
         await composer.screenshot({
           animations: "disabled",
           path: `${artifactDir}/auth-cold-model-picker.png`,
         });
-        await picker.click();
       }
       await composer.locator('[data-chat-model-setup="true"]').click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CHAT_MODEL_CATALOG,
 } from "../../test-helpers/chat-model.ts";
 import {
+  isChatModelUnavailable,
   resolveChatFastModeSelectState,
   resolveChatModelOverrideValue,
   resolveChatModelSelectState,
@@ -180,7 +181,6 @@ describe("chat-model-select-state", () => {
 
     const resolved = resolveChatModelSelectState(state);
     expect(resolved.currentOverride).toBe("openai/gpt-5-mini");
-    expect(resolved.defaultSelectable).toBe(false);
     expect(resolved.options).toEqual([]);
   });
 
@@ -194,7 +194,6 @@ describe("chat-model-select-state", () => {
 
     const resolved = resolveChatModelSelectState(state);
     expect(resolved.currentOverride).toBe("openai/gpt-5-mini");
-    expect(resolved.defaultSelectable).toBe(false);
     expect(resolved.options).toEqual([]);
   });
 
@@ -215,7 +214,7 @@ describe("chat-model-select-state", () => {
     ]);
   });
 
-  it("omits unavailable catalog entries from picker options", () => {
+  it("keeps configured unavailable catalog entries visible but disabled", () => {
     const state = createChatModelState({
       chatModelCatalog: createModelCatalog(
         {
@@ -240,8 +239,14 @@ describe("chat-model-select-state", () => {
     });
 
     const resolved = resolveChatModelSelectState(state);
-    expect(resolved.defaultSelectable).toBe(true);
-    expect(resolved.options).toEqual([{ value: "openai/gpt-5.5", label: "GPT-5.5" }]);
+    expect(resolved.options).toEqual([
+      { value: "openai/gpt-5.5", label: "GPT-5.5" },
+      {
+        value: "codex/gpt-5.3-codex-spark",
+        label: "GPT-5.3 Codex Spark",
+        disabled: true,
+      },
+    ]);
   });
 
   it("keeps an available OpenAI route when an unavailable legacy route has the same model id", () => {
@@ -271,7 +276,6 @@ describe("chat-model-select-state", () => {
     const resolved = resolveChatModelSelectState(state);
     expect(resolved.currentOverride).toBe("openai/gpt-5.5");
     expect(resolved.defaultModel).toBe("openai/gpt-5.5");
-    expect(resolved.defaultSelectable).toBe(true);
     expect(resolved.options).toEqual([{ value: "openai/gpt-5.5", label: "GPT-5.5" }]);
   });
 
@@ -304,33 +308,37 @@ describe("chat-model-select-state", () => {
     expect(resolved.defaultModel).toBe("openai/gpt-5.5");
   });
 
-  it("does not reintroduce an unavailable current or default model", () => {
+  it("keeps an all-cold default identity visible as a disabled option", () => {
     const state = createChatModelState({
       chatModelCatalog: createModelCatalog(
         {
-          id: "gpt-5.5",
-          name: "GPT-5.5",
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
           provider: "openai",
-          available: true,
+          available: false,
         },
         {
-          id: "gpt-5.3-codex-spark",
-          name: "GPT-5.3 Codex Spark",
-          provider: "codex",
+          id: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          provider: "openai",
           available: false,
         },
       ),
       sessionsResult: createSessionsListResult({
-        model: "gpt-5.3-codex-spark",
+        model: "gpt-5.6-sol",
         modelProvider: "openai",
-        defaultsModel: "gpt-5.3-codex-spark",
+        defaultsModel: "gpt-5.6-sol",
         defaultsProvider: "openai",
       }),
     });
 
     const resolved = resolveChatModelSelectState(state);
-    expect(resolved.defaultSelectable).toBe(false);
-    expect(resolved.options).toEqual([{ value: "openai/gpt-5.5", label: "GPT-5.5" }]);
+    expect(resolved.defaultLabel).toBe("Default (GPT-5.6 Sol)");
+    expect(isChatModelUnavailable("gpt-5.6-sol", "openai", state.chatModelCatalog)).toBe(true);
+    expect(resolved.options).toEqual([
+      { value: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol", disabled: true },
+      { value: "openai/gpt-5.6-luna", label: "GPT-5.6 Luna", disabled: true },
+    ]);
   });
 
   it("supports fast mode for a default legacy Codex provider", () => {

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -6,7 +6,6 @@ import type {
   SessionsListResult,
 } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
-import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import {
   buildCatalogDisplayLookup,
   buildChatModelOptionFromLookup,
@@ -29,13 +28,12 @@ type ChatModelSelectStateInput = {
 type ChatModelSelectOption = {
   value: string;
   label: string;
+  disabled?: boolean;
 };
 
 type ChatModelSelectState = {
   currentOverride: string;
-  defaultSelectable: boolean;
   defaultModel: string;
-  defaultDisplay: string;
   defaultLabel: string;
   options: ChatModelSelectOption[];
 };
@@ -119,32 +117,21 @@ function normalizeChatModelAvailabilityKey(value: string): string {
   )}`;
 }
 
-function resolveAvailableChatModelValue(
-  value: string,
-  catalog: ModelCatalogEntry[],
-  displayLookup: ReturnType<typeof buildCatalogDisplayLookup>,
-): string {
+function resolveCatalogChatModelValue(value: string, options: ChatModelSelectOption[]): string {
   const exactValue = value.trim().toLowerCase();
   if (!exactValue) {
     return value;
   }
-  for (const entry of catalog) {
-    if (entry.available === false) {
-      continue;
-    }
-    const option = buildChatModelOptionFromLookup(entry, displayLookup);
-    if (option.value.trim().toLowerCase() === exactValue) {
-      return option.value;
-    }
-  }
   const normalizedValue = normalizeChatModelAvailabilityKey(value);
-  for (const entry of catalog) {
-    if (entry.available === false) {
-      continue;
-    }
-    const option = buildChatModelOptionFromLookup(entry, displayLookup);
-    if (normalizeChatModelAvailabilityKey(option.value) === normalizedValue) {
-      return option.value;
+  for (const disabled of [false, true]) {
+    const match = options.find(
+      (option) =>
+        Boolean(option.disabled) === disabled &&
+        (option.value.trim().toLowerCase() === exactValue ||
+          normalizeChatModelAvailabilityKey(option.value) === normalizedValue),
+    );
+    if (match) {
+      return match.value;
     }
   }
   return value;
@@ -156,19 +143,52 @@ function buildChatModelOptions(
 ): ChatModelSelectOption[] {
   const seen = new Set<string>();
   const options: ChatModelSelectOption[] = [];
+  const availableKeys = new Set(
+    catalog
+      .filter((entry) => entry.available !== false)
+      .map((entry) =>
+        normalizeChatModelAvailabilityKey(buildQualifiedChatModelValue(entry.id, entry.provider)),
+      ),
+  );
 
-  const addOption = (value: string, label?: string) => {
-    pushUniqueTrimmedSelectOption(options, seen, value, (trimmed) => label ?? trimmed);
-  };
-
-  for (const entry of catalog) {
-    if (entry.available === false) {
+  for (const entry of catalog.toSorted(
+    (left, right) =>
+      Number(left.available === false) - Number(right.available === false) ||
+      Number(left.provider.trim().toLowerCase() !== normalizeChatModelProviderId(left.provider)) -
+        Number(
+          right.provider.trim().toLowerCase() !== normalizeChatModelProviderId(right.provider),
+        ),
+  )) {
+    const option = buildChatModelOptionFromLookup(entry, displayLookup);
+    const value = option.value.trim();
+    const key = value.toLowerCase();
+    if (
+      !value ||
+      seen.has(key) ||
+      (entry.available === false &&
+        availableKeys.has(normalizeChatModelAvailabilityKey(option.value)))
+    ) {
       continue;
     }
-    const option = buildChatModelOptionFromLookup(entry, displayLookup);
-    addOption(option.value, option.label);
+    seen.add(key);
+    options.push({ ...option, ...(entry.available === false ? { disabled: true } : {}) });
   }
   return options;
+}
+
+export function isChatModelUnavailable(
+  model: string | null | undefined,
+  provider: string | null | undefined,
+  catalog: ModelCatalogEntry[],
+): boolean {
+  const value = resolvePreferredServerChatModelValue(model, provider, catalog);
+  const key = normalizeChatModelAvailabilityKey(value);
+  const matches = catalog.filter(
+    (entry) =>
+      normalizeChatModelAvailabilityKey(buildQualifiedChatModelValue(entry.id, entry.provider)) ===
+      key,
+  );
+  return matches.length > 0 && matches.every((entry) => entry.available === false);
 }
 
 export function resolveChatModelSelectState(
@@ -176,35 +196,23 @@ export function resolveChatModelSelectState(
 ): ChatModelSelectState {
   const catalog = state.chatModelCatalog ?? [];
   const displayLookup = buildCatalogDisplayLookup(
-    catalog.filter((entry) => entry.available !== false),
-  );
-  const currentOverride = resolveAvailableChatModelValue(
-    resolveChatModelOverrideValue(state),
-    catalog,
-    displayLookup,
-  );
-  const defaultModel = resolveAvailableChatModelValue(
-    resolveDefaultModelValue(state),
-    catalog,
-    displayLookup,
-  );
-  const defaultDisplay = formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup);
-  const options = buildChatModelOptions(catalog, displayLookup);
-  const defaultSelectable = Boolean(
-    defaultModel &&
-    options.some(
-      (option) =>
-        normalizeChatModelAvailabilityKey(option.value) ===
-        normalizeChatModelAvailabilityKey(defaultModel),
+    catalog.filter(
+      (entry) =>
+        entry.available !== false || isChatModelUnavailable(entry.id, entry.provider, catalog),
     ),
   );
+  const options = buildChatModelOptions(catalog, displayLookup);
+  const currentOverride = resolveCatalogChatModelValue(
+    resolveChatModelOverrideValue(state),
+    options,
+  );
+  const defaultModel = resolveCatalogChatModelValue(resolveDefaultModelValue(state), options);
+  const defaultLabel = formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup);
 
   return {
     currentOverride,
-    defaultSelectable,
     defaultModel,
-    defaultDisplay,
-    defaultLabel: defaultModel ? `Default (${defaultDisplay})` : "Default model",
+    defaultLabel: defaultModel ? `Default (${defaultLabel})` : "Default model",
     options,
   };
 }

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -10,6 +10,7 @@ import {
   resolveControlUiFollowUpMode,
   resolveControlUiServerQueueMode,
 } from "../../lib/chat/follow-up-mode.ts";
+import { isChatModelUnavailable } from "../../lib/chat/model-select-state.ts";
 import {
   isGatewayCapabilityAdvertised,
   isGatewayMethodAdvertised,
@@ -160,6 +161,11 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       (agent) => agent.id === currentAgentId,
     );
     const agentDefaultModel = selectedAgent?.model?.primary;
+    const modelUnavailable = isChatModelUnavailable(
+      selectedSession?.model ?? agentDefaultModel,
+      selectedSession?.modelProvider,
+      state.chatModelCatalog,
+    );
     const modelSetupRequired = requiresChatModelSetup({
       catalog: catalogKey !== null,
       connected: state.connected,
@@ -187,8 +193,9 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       selectedSession.sharingRole === "viewer" &&
       isGatewayMethodAdvertised(gatewaySnapshot, "session.suggestions.add") === true &&
       isGatewayMethodAdvertised(gatewaySnapshot, "session.suggestions.list") === true;
-    const disabledReason =
-      sessionParticipationBlocked && !suggestionViewer
+    const disabledReason = modelUnavailable
+      ? `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`
+      : sessionParticipationBlocked && !suggestionViewer
         ? t("chat.sessionSharing.readOnlyNotice")
         : null;
     const typingEnabled =
@@ -369,6 +376,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       canSend: catalogKey
         ? this.catalogSession?.canContinue === true
         : !modelSetupRequired &&
+          !modelUnavailable &&
           !selectedSessionArchived &&
           !restartRecoveryTombstoned &&
           (!sessionParticipationBlocked || suggestionViewer) &&
@@ -431,6 +439,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
             agentDefaultModel,
             modelAccess: mutationAccess.model,
             effortAccess: mutationAccess.effort,
+            onModelSetup: () => this.context.navigate("model-setup"),
           }),
       sessionWorkspace: catalogKey ? undefined : sessionWorkspace,
       backgroundTasks: catalogKey ? undefined : backgroundTasks,

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderChatPaneComposerControls } from "./chat-pane-session-controls.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 
@@ -22,6 +22,7 @@ describe("chat pane composer controls", () => {
       sessionsResult: null,
       chatStream: null,
     } as unknown as ChatPageHost;
+    const onModelSetup = vi.fn();
 
     render(
       renderChatPaneComposerControls({
@@ -30,6 +31,7 @@ describe("chat pane composer controls", () => {
         agentDefaultModel: undefined,
         modelAccess: { allowed: true, requiredScope: "operator.write" },
         effortAccess: { allowed: true, requiredScope: "operator.write" },
+        onModelSetup,
       }),
       container,
     );
@@ -38,5 +40,7 @@ describe("chat pane composer controls", () => {
       "chat-composer-model-control",
     ]);
     expect(container.querySelector('[data-chat-provider-usage="true"]')).toBeNull();
+    container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
+    expect(onModelSetup).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -44,8 +44,10 @@ export function renderChatPaneComposerControls(params: {
   agentDefaultModel: string | undefined;
   modelAccess: SessionMethodAccess;
   effortAccess: SessionMethodAccess;
+  onModelSetup: () => void;
 }) {
-  const { state, selectedSession, agentDefaultModel, modelAccess, effortAccess } = params;
+  const { state, selectedSession, agentDefaultModel, modelAccess, effortAccess, onModelSetup } =
+    params;
   return html`
     <div class="chat-composer-model-control">
       ${renderChatModelControls({
@@ -67,6 +69,7 @@ export function renderChatPaneComposerControls(params: {
         sessionsResult: state.sessionsResult,
         stream: state.chatStream,
         onRequestUpdate: () => state.requestUpdate?.(),
+        onModelSetup,
         onFastModeSelect: (next, targetSessionKey) =>
           effortAccess.allowed
             ? switchChatFastMode(state, next, targetSessionKey)

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5395,18 +5395,47 @@ describe("chat model controls", () => {
     expect(modelSelect.getAttribute("aria-disabled")).toBe("true");
   });
 
-  it("shows an empty state instead of a configured default when no usable models exist", () => {
+  it("shows disabled configured models and model setup when no model has authentication", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.6-sol",
       modelProvider: "openai",
-      models: [],
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
+          provider: "openai",
+          available: false,
+        },
+        {
+          id: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          provider: "openai",
+          available: false,
+        },
+      ],
     });
-    const container = renderModelControls(state);
+    const onModelSetup = vi.fn();
+    const container = renderModelControls(state, {
+      agentDefaultModel: "openai/gpt-5.6-sol",
+      onModelSetup,
+    });
 
-    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
+    const options = container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]");
+    expect([...options].map((option) => option.dataset.chatModelOption)).toEqual([
+      "openai/gpt-5.6-sol",
+      "openai/gpt-5.6-luna",
+    ]);
+    expect(options[0]?.textContent).toContain("GPT-5.6 Sol");
+    expect(options[0]?.textContent).toContain("Default");
+    expect([...options].every((option) => option.disabled)).toBe(true);
+    expect([...options].every((option) => option.textContent?.includes("Sign-in needed"))).toBe(
+      true,
+    );
     expect(
       container.querySelector('[data-chat-model-catalog-state="ready"]')?.textContent,
-    ).toContain("No models available");
+    ).toContain("Authentication failed. Review the provider credential or sign-in, then retry.");
+    container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
+    expect(onModelSetup).toHaveBeenCalledOnce();
   });
 
   it("applies a model selection immediately", () => {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -47,6 +47,7 @@ type ChatModelControlsProps = {
   thinkingDefaults?: SessionsListResult["defaults"];
   thinkingSession?: ChatThinkingTarget;
   onFastModeSelect?: (value: ChatFastModeSelectValue, sessionKey: string) => unknown;
+  onModelSetup?: () => void;
   onModelSelect?: (value: string, sessionKey: string) => unknown;
   onModelPickerTargetSelect?: (groupId: string, value: string) => unknown;
   onRequestUpdate?: () => void;
@@ -119,9 +120,16 @@ function resolveChatModelCatalogEntry(
     const provider = normalizeChatModelProviderId(candidate.provider);
     return `${provider}/${candidate.id.trim().toLowerCase()}` === normalizedValue;
   });
-  return (
-    matches.find((candidate) => candidate.provider.trim().toLowerCase() === "openai") ?? matches[0]
+  if (matches.length > 0) {
+    return (
+      matches.find((candidate) => candidate.provider.trim().toLowerCase() === "openai") ??
+      matches[0]
+    );
+  }
+  const idMatches = catalog.filter(
+    (candidate) => candidate.id.trim().toLowerCase() === normalizedValue,
   );
+  return idMatches.length === 1 ? idMatches[0] : undefined;
 }
 
 function resolveChatModelPickerLabel(
@@ -141,10 +149,13 @@ function formatPickerModelLabel(label: string): string {
   return match?.[1] ?? label;
 }
 
+function modelAuthenticationNeededText(): string {
+  return `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`;
+}
+
 export function renderChatModelControls(props: ChatModelControlsProps) {
   const {
     currentOverride,
-    defaultSelectable,
     defaultModel,
     defaultLabel,
     options: selectOptions,
@@ -184,6 +195,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   );
   const currentProviderHint = activeSession?.modelProvider ?? "";
   const defaultProviderHint = props.sessionsResult?.defaults?.modelProvider ?? "";
+  const defaultCatalogEntry = resolveChatModelCatalogEntry(defaultModel, props.modelCatalog);
   const canonicalDefaultLabel = resolveChatModelPickerLabel(
     defaultModel,
     defaultLabel,
@@ -195,9 +207,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       : defaultLabel;
   const normalizedDefaultModel = defaultModel.trim().toLowerCase();
   const modelOptions: ChatModelPickerOption[] = selectOptions.map((option) => {
-    const isDefault =
-      defaultSelectable && option.value.trim().toLowerCase() === normalizedDefaultModel;
     const catalogEntry = resolveChatModelCatalogEntry(option.value, props.modelCatalog);
+    const isDefault =
+      option.value.trim().toLowerCase() === normalizedDefaultModel ||
+      (catalogEntry !== undefined && catalogEntry === defaultCatalogEntry);
     // Runtime meta labels only operator-pinned runtimes (models/provider config);
     // implicit/default resolution stays unlabeled so ordinary rows stay clean.
     const agentRuntime = catalogEntry?.agentRuntime;
@@ -212,6 +225,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ...(typeof catalogEntry?.supportsTools === "boolean"
         ? { supportsTools: catalogEntry.supportsTools }
         : {}),
+      ...(option.disabled ? { disabled: true } : {}),
       isDefault,
       value: option.value,
       label: resolveChatModelPickerLabel(option.value, option.label, props.modelCatalog),
@@ -227,25 +241,26 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ),
     };
   });
-  // A persisted session override can outlive the catalog (retired or
-  // temporarily unavailable model). Synthesize its row so the dialog still
-  // shows the selection and lets the operator move off it. An entirely empty
-  // catalog keeps its "no models" state instead of one orphaned row.
+  const explicitOverride = props.modelOverrides?.[props.sessionKey];
+  const currentCatalogEntry = resolveChatModelCatalogEntry(currentOverride, props.modelCatalog);
   if (
-    currentOverride &&
-    modelOptions.length > 0 &&
+    typeof explicitOverride === "string" &&
+    explicitOverride.trim() &&
+    currentCatalogEntry &&
     !modelOptions.some((option) => option.value === currentOverride)
   ) {
-    const catalogEntry = resolveChatModelCatalogEntry(currentOverride, props.modelCatalog);
     modelOptions.push({
       commitValue: currentOverride,
-      ...(catalogEntry?.contextWindow ? { contextWindow: catalogEntry.contextWindow } : {}),
-      ...(typeof catalogEntry?.supportsTools === "boolean"
-        ? { supportsTools: catalogEntry.supportsTools }
+      ...(currentCatalogEntry.contextWindow
+        ? { contextWindow: currentCatalogEntry.contextWindow }
         : {}),
+      ...(typeof currentCatalogEntry.supportsTools === "boolean"
+        ? { supportsTools: currentCatalogEntry.supportsTools }
+        : {}),
+      ...(currentCatalogEntry.available === false ? { disabled: true } : {}),
       isDefault: false,
       value: currentOverride,
-      label: catalogEntry?.name.trim() || currentOverride,
+      label: currentCatalogEntry.name.trim() || currentOverride,
       provider: resolveChatModelProvider(
         currentOverride,
         props.modelCatalog,
@@ -254,6 +269,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ),
     });
   }
+  const pickerValue =
+    !explicitOverride && currentOverride.trim().toLowerCase() === defaultModel.trim().toLowerCase()
+      ? ""
+      : currentOverride;
   const lockedModelLabel =
     props.modelSelectionRuntimeId?.trim().toLowerCase() === "codex"
       ? t("chat.selectors.nativeCodexModel")
@@ -282,7 +301,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     : catalogErrorWithoutSnapshot
       ? t("chat.modelControls.modelsUnavailable")
       : catalogSnapshotEmpty
-        ? t("chat.modelControls.noModelsAvailable")
+        ? modelAuthenticationNeededText()
         : undefined;
   const busy =
     props.loading || props.sending || Boolean(props.activeRunId) || props.stream !== null;
@@ -314,10 +333,11 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
         modelSelectionLocked: props.modelSelectionLocked === true,
         modelOptions,
         targetGroups: props.modelPickerTargetGroups,
-        selectedModelValue: currentOverride,
+        selectedModelValue: pickerValue,
         sessionKey: props.sessionKey,
         triggerModelLabel: formatPickerModelLabel(committedModelLabel),
         triggerStatusLabel: catalogTriggerStatus,
+        onModelSetup: props.onModelSetup,
         onModelSelect: async (next, targetSessionKey) =>
           props.onModelSelect?.(next, targetSessionKey),
         onTargetSelect: props.onModelPickerTargetSelect,

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -244,23 +244,22 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   const explicitOverride = props.modelOverrides?.[props.sessionKey];
   const currentCatalogEntry = resolveChatModelCatalogEntry(currentOverride, props.modelCatalog);
   if (
-    typeof explicitOverride === "string" &&
-    explicitOverride.trim() &&
-    currentCatalogEntry &&
+    currentOverride &&
+    modelOptions.length > 0 &&
     !modelOptions.some((option) => option.value === currentOverride)
   ) {
     modelOptions.push({
       commitValue: currentOverride,
-      ...(currentCatalogEntry.contextWindow
+      ...(currentCatalogEntry?.contextWindow
         ? { contextWindow: currentCatalogEntry.contextWindow }
         : {}),
-      ...(typeof currentCatalogEntry.supportsTools === "boolean"
+      ...(typeof currentCatalogEntry?.supportsTools === "boolean"
         ? { supportsTools: currentCatalogEntry.supportsTools }
         : {}),
-      ...(currentCatalogEntry.available === false ? { disabled: true } : {}),
+      ...(currentCatalogEntry?.available === false ? { disabled: true } : {}),
       isDefault: false,
       value: currentOverride,
-      label: currentCatalogEntry.name.trim() || currentOverride,
+      label: currentCatalogEntry?.name.trim() || currentOverride,
       provider: resolveChatModelProvider(
         currentOverride,
         props.modelCatalog,

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -14,12 +14,11 @@ import {
 } from "../../../lib/chat/thinking.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { renderChatEffortPicker } from "./chat-effort-picker.ts";
-import {
-  renderChatModelPicker,
-  type ChatModelCatalogState,
-  type ChatModelPickerOption,
-  type ChatModelPickerTargetGroup,
-} from "./chat-model-picker.ts";
+import type {
+  ChatModelPickerOption,
+  ChatModelPickerTargetGroup,
+} from "./chat-model-picker-options.ts";
+import { renderChatModelPicker, type ChatModelCatalogState } from "./chat-model-picker.ts";
 
 export type { ChatModelCatalogState } from "./chat-model-picker.ts";
 

--- a/ui/src/pages/chat/components/chat-model-picker-options.ts
+++ b/ui/src/pages/chat/components/chat-model-picker-options.ts
@@ -7,7 +7,24 @@ import {
 } from "../../../components/provider-icon.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatContextTokenCapacity } from "../../../lib/format.ts";
-import type { ChatModelPickerOption, ChatModelPickerTargetGroup } from "./chat-model-picker.ts";
+
+export type ChatModelPickerOption = {
+  agentRuntimeId?: string;
+  commitValue: string;
+  contextWindow?: number;
+  disabled?: boolean;
+  isDefault: boolean;
+  label: string;
+  provider: string;
+  supportsTools?: boolean;
+  value: string;
+};
+
+export type ChatModelPickerTargetGroup = {
+  id: string;
+  label: string;
+  options: readonly { label: string; value: string }[];
+};
 
 // Known models.list runtime ids; mirrors src/status/agent-runtime-label.ts,
 // which cannot be imported here (it drags terminal sanitizers into the bundle).

--- a/ui/src/pages/chat/components/chat-model-picker-options.ts
+++ b/ui/src/pages/chat/components/chat-model-picker-options.ts
@@ -1,0 +1,155 @@
+import { html, nothing } from "lit";
+import { icons } from "../../../components/icons.ts";
+import {
+  formatRawProviderLabel,
+  providerDisplayLabel,
+  renderProviderBrandIcon,
+} from "../../../components/provider-icon.ts";
+import { t } from "../../../i18n/index.ts";
+import { formatContextTokenCapacity } from "../../../lib/format.ts";
+import type { ChatModelPickerOption, ChatModelPickerTargetGroup } from "./chat-model-picker.ts";
+
+// Known models.list runtime ids; mirrors src/status/agent-runtime-label.ts,
+// which cannot be imported here (it drags terminal sanitizers into the bundle).
+const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
+  "claude-cli": "Claude CLI",
+  codex: "Codex",
+  "codex-cli": "Codex",
+  "google-gemini-cli": "Gemini CLI",
+  openclaw: "OpenClaw",
+};
+
+function formatAgentRuntimeLabel(id: string): string {
+  const normalized = id.trim().toLowerCase();
+  return (
+    AGENT_RUNTIME_LABELS[normalized] ??
+    `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`
+  );
+}
+
+function formatModelLabel(option: ChatModelPickerOption): string {
+  const prefixes = [
+    formatRawProviderLabel(option.provider),
+    providerDisplayLabel(option.provider),
+  ].toSorted((left, right) => right.length - left.length);
+  for (const prefix of prefixes) {
+    if (option.label.toLowerCase().startsWith(`${prefix.toLowerCase()} `)) {
+      return option.label.slice(prefix.length + 1);
+    }
+  }
+  return option.label;
+}
+
+export function renderChatModelProviderIcon(provider: string) {
+  return renderProviderBrandIcon(provider, { className: "chat-controls__provider-icon" });
+}
+
+export function renderChatModelPickerOption(params: {
+  disabled: boolean;
+  entry: ChatModelPickerOption;
+  index: number;
+  selectedModelValue: string;
+  onHighlight: (row: HTMLButtonElement) => void;
+  onSelect: (entry: ChatModelPickerOption, event: MouseEvent) => void;
+}) {
+  const selected =
+    params.entry.value === params.selectedModelValue ||
+    (params.entry.isDefault && params.selectedModelValue === "");
+  const modelLabel = formatModelLabel(params.entry);
+  const modelMeta = [
+    params.entry.contextWindow ? formatContextTokenCapacity(params.entry.contextWindow) : "",
+    params.entry.supportsTools === false ? t("chat.modelControls.chatOnly") : "",
+    params.entry.agentRuntimeId ? formatAgentRuntimeLabel(params.entry.agentRuntimeId) : "",
+    params.entry.disabled ? t("modelSetup.candidates.signInNeeded") : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return html`
+    <button
+      class="chat-controls__inline-select-option chat-controls__model-option ${selected
+        ? "chat-controls__inline-select-option--selected"
+        : ""}"
+      data-chat-model-option=${params.entry.value}
+      data-chat-model-default=${params.entry.isDefault ? "true" : nothing}
+      data-chat-model-index=${params.index}
+      data-chat-model-name=${modelLabel.toLocaleLowerCase()}
+      data-chat-model-provider-label=${providerDisplayLabel(
+        params.entry.provider,
+      ).toLocaleLowerCase()}
+      role="option"
+      aria-selected=${selected ? "true" : "false"}
+      type="button"
+      ?disabled=${params.disabled || params.entry.disabled}
+      @mouseenter=${(event: MouseEvent) =>
+        params.onHighlight(event.currentTarget as HTMLButtonElement)}
+      @click=${(event: MouseEvent) => params.onSelect(params.entry, event)}
+    >
+      <span class="chat-controls__model-option-provider">
+        ${renderChatModelProviderIcon(params.entry.provider)}
+      </span>
+      <span class="chat-controls__model-option-copy">
+        <span class="chat-controls__model-option-title">
+          <span class="chat-controls__model-option-name">${modelLabel}</span>
+          ${params.entry.isDefault
+            ? html`<span
+                class="chat-controls__model-state-label chat-controls__model-state-label--default"
+                >${t("chat.modelControls.default")}</span
+              >`
+            : nothing}
+        </span>
+        ${modelMeta
+          ? html`<span class="chat-controls__model-option-meta">${modelMeta}</span>`
+          : nothing}
+      </span>
+      <span class="chat-controls__model-option-action">
+        ${selected
+          ? html`<span class="chat-controls__inline-select-check" aria-hidden="true"
+              >${icons.check}</span
+            >`
+          : html`<kbd data-chat-model-shortcut="true" aria-hidden="true" hidden></kbd>`}
+      </span>
+    </button>
+  `;
+}
+
+export function renderChatModelPickerTargetOption(params: {
+  disabled: boolean;
+  entry: ChatModelPickerTargetGroup["options"][number];
+  groupId: string;
+  groupLabel: string;
+  index: number;
+  onHighlight: (row: HTMLButtonElement) => void;
+  onSelect: (groupId: string, value: string, event: MouseEvent) => void;
+}) {
+  return html`
+    <button
+      class="chat-controls__inline-select-option chat-controls__model-option"
+      data-chat-model-option=${`target:${params.groupId}:${params.entry.value}`}
+      data-chat-model-target=${params.entry.value}
+      data-chat-model-index=${params.index}
+      data-chat-model-name=${params.entry.label.toLocaleLowerCase()}
+      data-chat-model-provider-label=${params.groupLabel.toLocaleLowerCase()}
+      role="option"
+      aria-selected="false"
+      type="button"
+      ?disabled=${params.disabled}
+      @mouseenter=${(event: MouseEvent) =>
+        params.onHighlight(event.currentTarget as HTMLButtonElement)}
+      @click=${(event: MouseEvent) => params.onSelect(params.groupId, params.entry.value, event)}
+    >
+      <span
+        class="chat-controls__model-option-provider chat-controls__target-icon"
+        aria-hidden="true"
+        >${icons.terminal}</span
+      >
+      <span class="chat-controls__model-option-copy">
+        <span class="chat-controls__model-option-title">
+          <span class="chat-controls__model-option-name">${params.entry.label}</span>
+        </span>
+      </span>
+      <span class="chat-controls__model-option-action">
+        <kbd data-chat-model-shortcut="true" aria-hidden="true" hidden></kbd>
+      </span>
+    </button>
+  `;
+}

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -9,30 +9,14 @@ import {
   renderChatModelPickerOption,
   renderChatModelPickerTargetOption,
   renderChatModelProviderIcon,
+  type ChatModelPickerOption,
+  type ChatModelPickerTargetGroup,
 } from "./chat-model-picker-options.ts";
 
 export type ChatModelCatalogState = {
   hasSnapshot: boolean;
   onRetry?: () => void;
   status: "idle" | "loading" | "refreshing" | "ready" | "error";
-};
-
-export type ChatModelPickerOption = {
-  agentRuntimeId?: string;
-  commitValue: string;
-  contextWindow?: number;
-  disabled?: boolean;
-  isDefault: boolean;
-  label: string;
-  provider: string;
-  supportsTools?: boolean;
-  value: string;
-};
-
-export type ChatModelPickerTargetGroup = {
-  id: string;
-  label: string;
-  options: readonly { label: string; value: string }[];
 };
 
 type ChatModelPickerParams = {

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -2,13 +2,14 @@ import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
-import {
-  formatRawProviderLabel,
-  providerDisplayLabel,
-  renderProviderBrandIcon,
-} from "../../../components/provider-icon.ts";
+import { providerDisplayLabel } from "../../../components/provider-icon.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatContextTokenCapacity } from "../../../lib/format.ts";
+import {
+  renderChatModelPickerOption,
+  renderChatModelPickerTargetOption,
+  renderChatModelProviderIcon,
+} from "./chat-model-picker-options.ts";
 
 export type ChatModelCatalogState = {
   hasSnapshot: boolean;
@@ -34,24 +35,6 @@ export type ChatModelPickerTargetGroup = {
   options: readonly { label: string; value: string }[];
 };
 
-// Known models.list runtime ids; mirrors src/status/agent-runtime-label.ts,
-// which cannot be imported here (it drags terminal sanitizers into the bundle).
-const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
-  "claude-cli": "Claude CLI",
-  codex: "Codex",
-  "codex-cli": "Codex",
-  "google-gemini-cli": "Gemini CLI",
-  openclaw: "OpenClaw",
-};
-
-function formatAgentRuntimeLabel(id: string): string {
-  const normalized = id.trim().toLowerCase();
-  return (
-    AGENT_RUNTIME_LABELS[normalized] ??
-    `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`
-  );
-}
-
 type ChatModelPickerParams = {
   defaultModelLabel: string;
   disabled: boolean;
@@ -69,23 +52,6 @@ type ChatModelPickerParams = {
   onTargetSelect?: (groupId: string, value: string) => unknown;
   onRequestUpdate?: () => void;
 };
-
-function renderProviderIcon(provider: string) {
-  return renderProviderBrandIcon(provider, { className: "chat-controls__provider-icon" });
-}
-
-function formatModelLabel(option: ChatModelPickerOption): string {
-  const prefixes = [
-    formatRawProviderLabel(option.provider),
-    providerDisplayLabel(option.provider),
-  ].toSorted((left, right) => right.length - left.length);
-  for (const prefix of prefixes) {
-    if (option.label.toLowerCase().startsWith(`${prefix.toLowerCase()} `)) {
-      return option.label.slice(prefix.length + 1);
-    }
-  }
-  return option.label;
-}
 
 function pickerMenu(target: EventTarget | null): HTMLElement | null {
   return target instanceof Element
@@ -412,6 +378,12 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
       details.querySelector<HTMLElement>("summary")?.focus();
     }
   };
+  const highlightOption = (row: HTMLButtonElement) => {
+    const menu = pickerMenu(row);
+    if (menu) {
+      highlightModelRow(menu, row);
+    }
+  };
   return html`
     <details
       class="chat-controls__inline-select chat-controls__model-picker"
@@ -533,96 +505,21 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                               class="chat-controls__provider-heading"
                               data-chat-model-provider=${provider}
                             >
-                              ${renderProviderIcon(provider)}
+                              ${renderChatModelProviderIcon(provider)}
                               <span>${providerDisplayLabel(provider)}</span>
                             </div>
                             ${repeat(
                               options,
                               (entry) => entry.value,
-                              (entry) => {
-                                const selected =
-                                  entry.value === params.selectedModelValue ||
-                                  (entry.isDefault && params.selectedModelValue === "");
-                                const modelLabel = formatModelLabel(entry);
-                                const modelMeta = [
-                                  entry.contextWindow
-                                    ? formatContextTokenCapacity(entry.contextWindow)
-                                    : "",
-                                  entry.supportsTools === false
-                                    ? t("chat.modelControls.chatOnly")
-                                    : "",
-                                  entry.agentRuntimeId
-                                    ? formatAgentRuntimeLabel(entry.agentRuntimeId)
-                                    : "",
-                                  entry.disabled ? t("modelSetup.candidates.signInNeeded") : "",
-                                ]
-                                  .filter(Boolean)
-                                  .join(" · ");
-                                const index = optionIndex.get(entry.value) ?? 0;
-                                return html`
-                                  <button
-                                    class="chat-controls__inline-select-option chat-controls__model-option ${selected
-                                      ? "chat-controls__inline-select-option--selected"
-                                      : ""}"
-                                    data-chat-model-option=${entry.value}
-                                    data-chat-model-default=${entry.isDefault ? "true" : nothing}
-                                    data-chat-model-index=${index}
-                                    data-chat-model-name=${modelLabel.toLocaleLowerCase()}
-                                    data-chat-model-provider-label=${providerDisplayLabel(
-                                      entry.provider,
-                                    ).toLocaleLowerCase()}
-                                    role="option"
-                                    aria-selected=${selected ? "true" : "false"}
-                                    type="button"
-                                    ?disabled=${params.disabled || entry.disabled}
-                                    @mouseenter=${(event: MouseEvent) => {
-                                      const menu = pickerMenu(event.currentTarget);
-                                      if (menu) {
-                                        highlightModelRow(
-                                          menu,
-                                          event.currentTarget as HTMLButtonElement,
-                                        );
-                                      }
-                                    }}
-                                    @click=${(event: MouseEvent) => selectModel(entry, event)}
-                                  >
-                                    <span class="chat-controls__model-option-provider">
-                                      ${renderProviderIcon(entry.provider)}
-                                    </span>
-                                    <span class="chat-controls__model-option-copy">
-                                      <span class="chat-controls__model-option-title">
-                                        <span class="chat-controls__model-option-name"
-                                          >${modelLabel}</span
-                                        >
-                                        ${entry.isDefault
-                                          ? html`<span
-                                              class="chat-controls__model-state-label chat-controls__model-state-label--default"
-                                              >${t("chat.modelControls.default")}</span
-                                            >`
-                                          : nothing}
-                                      </span>
-                                      ${modelMeta
-                                        ? html`<span class="chat-controls__model-option-meta"
-                                            >${modelMeta}</span
-                                          >`
-                                        : nothing}
-                                    </span>
-                                    <span class="chat-controls__model-option-action">
-                                      ${selected
-                                        ? html`<span
-                                            class="chat-controls__inline-select-check"
-                                            aria-hidden="true"
-                                            >${icons.check}</span
-                                          >`
-                                        : html`<kbd
-                                            data-chat-model-shortcut="true"
-                                            aria-hidden="true"
-                                            hidden
-                                          ></kbd>`}
-                                    </span>
-                                  </button>
-                                `;
-                              },
+                              (entry) =>
+                                renderChatModelPickerOption({
+                                  disabled: params.disabled,
+                                  entry,
+                                  index: optionIndex.get(entry.value) ?? 0,
+                                  selectedModelValue: params.selectedModelValue,
+                                  onHighlight: highlightOption,
+                                  onSelect: selectModel,
+                                }),
                             )}
                           </section>
                         `,
@@ -647,51 +544,16 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                             ${repeat(
                               group.options,
                               (entry) => entry.value,
-                              (entry, targetIndex) => html`
-                                <button
-                                  class="chat-controls__inline-select-option chat-controls__model-option"
-                                  data-chat-model-option=${`target:${group.id}:${entry.value}`}
-                                  data-chat-model-target=${entry.value}
-                                  data-chat-model-index=${orderedOptions.length + targetIndex}
-                                  data-chat-model-name=${entry.label.toLocaleLowerCase()}
-                                  data-chat-model-provider-label=${group.label.toLocaleLowerCase()}
-                                  role="option"
-                                  aria-selected="false"
-                                  type="button"
-                                  ?disabled=${params.disabled}
-                                  @mouseenter=${(event: MouseEvent) => {
-                                    const menu = pickerMenu(event.currentTarget);
-                                    if (menu) {
-                                      highlightModelRow(
-                                        menu,
-                                        event.currentTarget as HTMLButtonElement,
-                                      );
-                                    }
-                                  }}
-                                  @click=${(event: MouseEvent) =>
-                                    selectTarget(group.id, entry.value, event)}
-                                >
-                                  <span
-                                    class="chat-controls__model-option-provider chat-controls__target-icon"
-                                    aria-hidden="true"
-                                    >${icons.terminal}</span
-                                  >
-                                  <span class="chat-controls__model-option-copy">
-                                    <span class="chat-controls__model-option-title">
-                                      <span class="chat-controls__model-option-name"
-                                        >${entry.label}</span
-                                      >
-                                    </span>
-                                  </span>
-                                  <span class="chat-controls__model-option-action">
-                                    <kbd
-                                      data-chat-model-shortcut="true"
-                                      aria-hidden="true"
-                                      hidden
-                                    ></kbd>
-                                  </span>
-                                </button>
-                              `,
+                              (entry, targetIndex) =>
+                                renderChatModelPickerTargetOption({
+                                  disabled: params.disabled,
+                                  entry,
+                                  groupId: group.id,
+                                  groupLabel: group.label,
+                                  index: orderedOptions.length + targetIndex,
+                                  onHighlight: highlightOption,
+                                  onSelect: selectTarget,
+                                }),
                             )}
                           </section>
                         `,

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -20,6 +20,7 @@ export type ChatModelPickerOption = {
   agentRuntimeId?: string;
   commitValue: string;
   contextWindow?: number;
+  disabled?: boolean;
   isDefault: boolean;
   label: string;
   provider: string;
@@ -63,6 +64,7 @@ type ChatModelPickerParams = {
   sessionKey: string;
   triggerModelLabel: string;
   triggerStatusLabel?: string;
+  onModelSetup?: () => void;
   onModelSelect: (value: string, sessionKey: string) => Promise<unknown>;
   onTargetSelect?: (groupId: string, value: string) => unknown;
   onRequestUpdate?: () => void;
@@ -99,6 +101,10 @@ function visibleModelRows(root: HTMLElement): HTMLButtonElement[] {
         Number(left.dataset.chatModelRank ?? left.dataset.chatModelIndex ?? 0) -
         Number(right.dataset.chatModelRank ?? right.dataset.chatModelIndex ?? 0),
     );
+}
+
+function selectableModelRows(root: HTMLElement): HTMLButtonElement[] {
+  return visibleModelRows(root).filter((row) => !row.disabled);
 }
 
 function ensureModelPickerIds(menu: HTMLElement): void {
@@ -186,9 +192,10 @@ function updateModelSearch(input: HTMLInputElement): void {
       row.style.setProperty("--chat-model-rank", String(rank));
     });
   const visibleRows = visibleModelRows(menu);
-  updateModelShortcuts(menu, visibleRows);
-  const selected = visibleRows.find((row) => row.getAttribute("aria-selected") === "true");
-  highlightModelRow(menu, query ? visibleRows[0] : (selected ?? visibleRows[0]));
+  const selectableRows = selectableModelRows(menu);
+  updateModelShortcuts(menu, selectableRows);
+  const selected = selectableRows.find((row) => row.getAttribute("aria-selected") === "true");
+  highlightModelRow(menu, query ? selectableRows[0] : (selected ?? selectableRows[0]));
   const empty = menu.querySelector<HTMLElement>("[data-chat-model-search-empty]");
   if (empty) {
     empty.hidden = !query || visibleRows.length > 0;
@@ -230,7 +237,7 @@ function handleModelSearchKeydown(event: KeyboardEvent): void {
   if (!menu) {
     return;
   }
-  const rows = visibleModelRows(menu);
+  const rows = selectableModelRows(menu);
   if (rows.length === 0) {
     return;
   }
@@ -258,13 +265,18 @@ function handleModelPickerKeydown(event: KeyboardEvent): void {
   if (!details.open || event.target instanceof HTMLInputElement || !/^[1-9]$/u.test(event.key)) {
     return;
   }
-  const row = visibleModelRows(details)[Number(event.key) - 1];
+  const row = selectableModelRows(details)[Number(event.key) - 1];
   event.preventDefault();
   row?.click();
 }
 
-function renderCatalogState(state: ChatModelCatalogState | undefined, hasOptions: boolean) {
-  if (!state || (state.status === "ready" && hasOptions)) {
+function renderCatalogState(
+  state: ChatModelCatalogState | undefined,
+  hasOptions: boolean,
+  hasSelectableOptions: boolean,
+  onModelSetup?: () => void,
+) {
+  if (!state || (state.status === "ready" && hasSelectableOptions)) {
     return nothing;
   }
   const label =
@@ -275,7 +287,7 @@ function renderCatalogState(state: ChatModelCatalogState | undefined, hasOptions
           ? t("chat.modelControls.modelsRefreshFailed")
           : t("chat.modelControls.modelsUnavailable")
         : state.status === "ready"
-          ? t("chat.modelControls.noModelsAvailable")
+          ? `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`
           : t("chat.modelControls.loadingModels");
   return html`
     <div
@@ -302,6 +314,21 @@ function renderCatalogState(state: ChatModelCatalogState | undefined, hasOptions
             >
               ${icons.refresh}
               <span>${t("common.retry")}</span>
+            </button>
+          `
+        : nothing}
+      ${state.status === "ready" && !hasSelectableOptions && onModelSetup
+        ? html`
+            <button
+              class="chat-controls__model-catalog-retry"
+              data-chat-model-setup="true"
+              type="button"
+              @click=${(event: MouseEvent) => {
+                event.stopPropagation();
+                onModelSetup();
+              }}
+            >
+              ${t("modelSetup.connectionFailure.action")}
             </button>
           `
         : nothing}
@@ -349,6 +376,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
   const targetGroups = params.targetGroups ?? [];
   const targetOptionCount = targetGroups.reduce((count, group) => count + group.options.length, 0);
   const hasOptions = params.modelOptions.length + targetOptionCount > 0;
+  const hasSelectableModelOptions = params.modelOptions.some((option) => !option.disabled);
   const commitModel = (value: string) => {
     if (params.modelSelectionLocked) {
       return;
@@ -358,7 +386,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
   };
   const selectModel = (entry: ChatModelPickerOption, event: MouseEvent) => {
     event.stopPropagation();
-    if (params.disabled || params.modelSelectionLocked) {
+    if (params.disabled || params.modelSelectionLocked || entry.disabled) {
       event.preventDefault();
       return;
     }
@@ -476,7 +504,12 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                   @keydown=${handleModelSearchKeydown}
                 />
               </div>
-              ${renderCatalogState(params.modelCatalogState, params.modelOptions.length > 0)}
+              ${renderCatalogState(
+                params.modelCatalogState,
+                params.modelOptions.length > 0,
+                hasSelectableModelOptions,
+                params.onModelSetup,
+              )}
               ${hasOptions
                 ? html`
                     <div
@@ -521,6 +554,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                                   entry.agentRuntimeId
                                     ? formatAgentRuntimeLabel(entry.agentRuntimeId)
                                     : "",
+                                  entry.disabled ? t("modelSetup.candidates.signInNeeded") : "",
                                 ]
                                   .filter(Boolean)
                                   .join(" · ");
@@ -540,7 +574,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                                     role="option"
                                     aria-selected=${selected ? "true" : "false"}
                                     type="button"
-                                    ?disabled=${params.disabled}
+                                    ?disabled=${params.disabled || entry.disabled}
                                     @mouseenter=${(event: MouseEvent) => {
                                       const menu = pickerMenu(event.currentTarget);
                                       if (menu) {

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -200,6 +200,9 @@ export class DraftSubmissionFlow {
   }
 
   submitDisabledReason(): string | undefined {
+    if (this.place.modelControl.isModelUnavailable(this.place.selectedAgent())) {
+      return `${t("modelSetup.failure.auth")}. ${t("modelSetup.failureGuidance.auth")}`;
+    }
     const access = this.submissionAccess();
     return access.allowed ? undefined : access.reason;
   }
@@ -229,6 +232,7 @@ export class DraftSubmissionFlow {
       this.submittingValue ||
       this.gateway.preferenceLoading ||
       this.requiresModelSetup() ||
+      this.place.modelControl.isModelUnavailable(this.place.selectedAgent()) ||
       this.attachmentDraft.pendingReads > 0 ||
       (!pendingCloud && this.submissionOutcomeUnknownValue) ||
       (kind === "session" && !message && !hasAttachments) ||

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -382,8 +382,21 @@ describe("new-session model runtime", () => {
     );
   });
 
-  it("renders a successful empty catalog as an explicit empty result", async () => {
-    const { context, request } = contextWith([]);
+  it("renders an all-cold catalog as disabled intent with a setup action", async () => {
+    const { context, navigate, request } = contextWith([
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        available: false,
+      },
+      {
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "openai",
+        available: false,
+      },
+    ]);
     const control = new NewSessionModelControl(() => undefined);
 
     control.load(context, "main", true);
@@ -397,12 +410,26 @@ describe("new-session model runtime", () => {
           ?.getAttribute("data-chat-model-catalog-state"),
       ).toBe("ready");
       expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
-        "No models available",
+        "GPT-5.6 Luna",
       );
     });
     const container = renderControl(control, context);
-    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
+    const options = container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]");
+    expect(
+      control.isModelUnavailable({
+        id: "main",
+        model: { primary: "openai/gpt-5.6-luna" },
+      }),
+    ).toBe(true);
+    expect(options).toHaveLength(2);
+    expect(options[0]?.textContent).toContain("Sign-in needed");
+    expect([...options].every((option) => option.disabled)).toBe(true);
+    expect(container.textContent).toContain(
+      "Authentication failed. Review the provider credential or sign-in, then retry.",
+    );
     expect(container.querySelector('[data-chat-model-catalog-retry="true"]')).toBeNull();
+    container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
+    expect(navigate).toHaveBeenCalledWith("model-setup");
   });
 
   it("keeps a successful empty catalog explicit when its refresh fails", async () => {
@@ -419,7 +446,7 @@ describe("new-session model runtime", () => {
     request.mockReturnValueOnce(refresh.promise);
 
     control.load(context, "main", true);
-    expect(renderControl(control, context).textContent).toContain("No models available");
+    expect(renderControl(control, context).textContent).toContain("Authentication failed");
 
     refresh.reject(new Error("refresh failed"));
     await vi.waitFor(() =>
@@ -430,7 +457,7 @@ describe("new-session model runtime", () => {
     const container = renderControl(control, context);
     expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
-      "No models available",
+      "Authentication failed",
     );
     expect(container.textContent).not.toContain("GPT-5.6 Luna");
   });

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -15,7 +15,9 @@ function contextWith(
   featureMethods: string[] = [],
 ) {
   const request = vi.fn().mockResolvedValue({ models });
+  const navigate = vi.fn();
   const context = {
+    navigate,
     gateway: {
       snapshot: {
         phase: "connected",
@@ -36,7 +38,7 @@ function contextWith(
       },
     },
   } as unknown as ApplicationContext;
-  return { context, request };
+  return { context, navigate, request };
 }
 
 function startupUnavailableError(retryAfterMs = 250): GatewayRequestError {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -14,6 +14,7 @@ import {
   normalizeChatModelProviderId,
   resolvePreferredServerChatModelValue,
 } from "../../lib/chat/model-ref.ts";
+import { isChatModelUnavailable } from "../../lib/chat/model-select-state.ts";
 import { normalizeThinkingOptionValue } from "../../lib/chat/thinking.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
@@ -475,6 +476,13 @@ export class NewSessionModelControl {
 
   isRestoringPreference(): boolean {
     return this.restoringPreference;
+  }
+
+  isModelUnavailable(agent: GatewayAgentRow | undefined): boolean {
+    return (
+      this.metadataState.hasSnapshot &&
+      isChatModelUnavailable(this.selected || agent?.model?.primary, undefined, this.catalog)
+    );
   }
 
   private restorePreference(

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -655,6 +655,7 @@ export class NewSessionModelControl {
         this.thinkingLevel = value;
         this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
       },
+      onModelSetup: () => options.context?.navigate("model-setup"),
       onRequestUpdate: this.notify,
     });
   }


### PR DESCRIPTION
Closes #123080

## What Problem This Solves

Fixes an issue where a gateway with no working model authentication (fresh install pre-onboarding, expired or unmaterialized credentials) dead-ended the operator: the chat and new-session model pickers rendered empty with a bare "No models available" caption, hiding even the agent's configured default, with nothing pointing at authentication as the cause or the fix.

## Why This Change Was Made

The picker discarded every `available: false` catalog entry (#121852's noise reduction). Since the configured view contains declared models plus only *usable* discovered extras, hiding unavailable entries erased the operator's declared intent exactly when they needed it most. Configured cold models now stay visible — icon-bearing, disabled, annotated "Sign-in needed" — the resolved default remains identifiable, chat send and session start stay blocked while the selected model is cold, and both surfaces show actionable guidance with a link to Model Setup. Discovered/auth-backed extras keep their hidden-when-unusable behavior, preserving #121852 for healthy gateways. Duplicated catalog-resolution/fallback logic was absorbed in the same pass.

After (all-cold gateway):

![auth-cold picker with visible disabled models and setup affordance](https://github.com/user-attachments/assets/3811bd59-3d7f-43b9-ad7f-e5a59d62fad5)

## User Impact

An auth-cold gateway now tells you what is configured, what would run by default, why nothing is runnable, and where to fix it — instead of an empty select.

## Evidence

- Regression-first: 5 intended pre-fix failures across model-select-state, chat-view, and model-control suites; all pass post-fix.
- Focused proof: selector 26/26, chat view 243/243, chat pane 38/38, new-session control 32/32, draft submission 2/2, browser E2E harness pass with the screenshot above.
- Production LOC net 0 (+172/−172); tests +144.
- Browser proof used the deterministic mocked Gateway; live expired-credential path exercised manually during the investigation that produced #123080.

## Note: repairs red main in the same landing

At landing time, `main`'s `check-lint` was red: #123090 (deliberate partial revert restoring the composer model-picker dialog) reintroduced `ui/src/pages/chat/components/chat-model-picker.ts` at 729 lines, over the 700-line `max-lines` cap. Per repo policy this PR fixes that breakage in the same change: the option-row metadata/rendering moved to `chat-model-picker-options.ts` (picker 615 lines, sibling 155; no behavior change, no suppression). 302 focused tests pass post-split.
