### PR TITLE
fix(ci): stop killing healthy discord Vitest runs and repair partial runtime-env mocks

### DIFF
--- a/extensions/discord/src/gateway-logging.test.ts
+++ b/extensions/discord/src/gateway-logging.test.ts
@@ -2,10 +2,16 @@
 import { EventEmitter } from "node:events";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
-  logVerbose: vi.fn(),
-  warn: (message: string) => `warn:${message}`,
-}));
+// Suite runs isolate=false: a partial factory here poisons the shared module
+// cache for later files in the worker (#123025), so spread the real module.
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    logVerbose: vi.fn(),
+    warn: (message: string) => `warn:${message}`,
+  };
+});
 
 let logVerbose: typeof import("openclaw/plugin-sdk/runtime-env").logVerbose;
 let attachDiscordGatewayLogging: typeof import("./gateway-logging.js").attachDiscordGatewayLogging;

--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -70,10 +70,16 @@ vi.mock("openclaw/plugin-sdk/proxy-capture", () => ({
   resolveDebugProxySettings: () => ({ enabled: false }),
 }));
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
-  danger: (value: string) => value,
-  warn: (value: string) => value,
-}));
+// Suite runs isolate=false: a partial factory here poisons the shared module
+// cache for later files in the worker (#123025), so spread the real module.
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    danger: (value: string) => value,
+    warn: (value: string) => value,
+  };
+});
 
 describe("createDiscordGatewayPlugin", () => {
   let createDiscordGatewayPlugin: typeof import("./gateway-plugin.js").createDiscordGatewayPlugin;

--- a/extensions/discord/src/monitor/provider.startup.test.ts
+++ b/extensions/discord/src/monitor/provider.startup.test.ts
@@ -29,9 +29,15 @@ vi.mock("openclaw/plugin-sdk/dangerous-name-runtime", () => ({
   isDangerousNameMatchingEnabled: () => false,
 }));
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
-  danger: (value: string) => value,
-}));
+// Suite runs isolate=false: a partial factory here poisons the shared module
+// cache for later files in the worker (#123025), so spread the real module.
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    danger: (value: string) => value,
+  };
+});
 
 vi.mock("../proxy-request-client.js", () => ({
   DISCORD_REST_TIMEOUT_MS: 15_000,

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -81,6 +81,12 @@ export const VITEST_CONFIG_NO_OUTPUT_TIMEOUT_MS = new Map([
     DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS,
   ],
   ["test/vitest/vitest.infra.config.ts", DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS],
+  // Largest extension shard: silent transform/import startup was measured at
+  // ~210s on a loaded macOS host, so the 120s default kills healthy runs (#123025).
+  [
+    "test/vitest/vitest.extension-discord.config.ts",
+    DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS,
+  ],
   [GATEWAY_CORE_VITEST_CONFIG, DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS],
   [GATEWAY_SERVER_VITEST_CONFIG, DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS],
 ]);


### PR DESCRIPTION
## What Problem This Solves

Fixes #123025: the discord extension Vitest suite reliably died locally with `[vitest] no output for 120000ms; terminating stalled Vitest process group` (exit 143), and when given a longer budget it surfaced 4 real cross-file test failures (`No "logVerbose" export is defined on the "openclaw/plugin-sdk/runtime-env" mock`).

Two distinct root causes, both fixed here:

1. **Watchdog false positive.** The discord shard is the largest extension suite (221 files / 2763 tests). Its silent transform+import startup phase was measured at ~210s wall-clock on a loaded macOS host — past the wrapper's 120s default no-output timeout. `test/vitest/vitest.extension-discord.config.ts` was not in `VITEST_CONFIG_NO_OUTPUT_TIMEOUT_MS`, so healthy runs were killed mid-collection. It now gets the extra-long budget, same as the gateway-core/gateway-server/infra configs.
2. **Partial `vi.mock` factories poisoning the shared module cache.** The repo runs Vitest with `isolate: false` (`resolveVitestIsolation` is hard-off), so a bare factory like `vi.mock("openclaw/plugin-sdk/runtime-env", () => ({ danger: ... }))` leaves a module in the worker's cache that is missing every other export. Later files in the same worker that bind `logVerbose`/`sleepWithAbort` through `message-handler.process.test-harness.ts` then fail at import time. Three discord files violated the documented contract ("explicit vi.mock factories must export every binding prod touches"): `monitor/provider.startup.test.ts`, `gateway-logging.test.ts`, `monitor/gateway-plugin.test.ts`. They now spread `importOriginal` and override only what they stub.

## Why This Change Was Made

The suite stall was blocking local full-shard proof runs (it bit repeatedly during the landing of #122983) and was masking the mock-hygiene failures. CI passes today only because Linux startup slips under 120s and worker scheduling doesn't pair the poisoning files with the harness files — both are timing luck, not correctness.

## User Impact

Test-infra only; no runtime behavior change. Contributors and agents can run `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts --configLoader runner` locally and get a real verdict instead of a spurious exit-143 kill.

## Evidence

- **Pre-fix (main @ 8f0a71d475a):** default budget → `[vitest] no output for 120000ms; terminating stalled Vitest process group`, exit 143, zero output. With `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=600000`: suite runs but `Test Files 3 failed | 218 passed`, `Tests 4 failed | 2731 passed` — failures exactly in the files that import the shared harness after a poisoned worker cache (`message-handler.process.ack.test.ts`, `message-handler.process.room-events.test.ts`, `message-handler.process.abort-retry.test.ts`).
- **Post-fix:** same command, default env: `Test Files 221 passed (221)`, `Tests 2763 passed (2763)`.
- `test/scripts/run-vitest.test.ts` passes (its `it.each` over `VITEST_CONFIG_NO_OUTPUT_TIMEOUT_MS` validates the new entry's path).
- Production LOC delta: 6 lines in `scripts/run-vitest.mts` (map entry + comment); the rest is test files.

Follow-up (named, not in this PR): the bare-factory pattern on `openclaw/plugin-sdk/runtime-env` exists at ~17 more sites across other extensions (telegram, slack, line, imessage, …). Each is currently harmless because no sibling file in those shards binds the missing exports through a shared harness, but they are the same latent bug class under `isolate: false`.
