### PR TITLE
fix(approvals): adopt native delivery receipts on replay

### DIFF
--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -49,6 +49,10 @@ export function createGatewayInstanceRuntime(
 ): GatewayInstanceRuntime {
   const approvalSubscribers = new Set<GatewayApprovalEventSubscriber>();
   const routeCoordinator = createApprovalNativeRouteCoordinator();
+  const approvalDeliveryReceipts = new Map<
+    string,
+    { approvalId: string; entry: unknown }
+  >();
   let closed = false;
 
   const assertDispatchAvailable = (method: string) => {
@@ -177,9 +181,27 @@ export function createGatewayInstanceRuntime(
         ),
       publishResolved: (kind, resolved) => {
         publish(kind, (subscriber) => subscriber.onResolved(resolved as GatewayApprovalResolved));
+        approvalDeliveryReceipts.forEach((receipt, key) => {
+          if (receipt.approvalId === (resolved as GatewayApprovalResolved).id) {
+            approvalDeliveryReceipts.delete(key);
+          }
+        });
       },
     },
     nativeApprovals: {
+      deliveryReceipts: {
+        read: (key) => approvalDeliveryReceipts.get(JSON.stringify(key))?.entry ?? null,
+        write: (key, entry) => {
+          assertDispatchAvailable("native approval delivery receipt write");
+          approvalDeliveryReceipts.set(JSON.stringify(key), {
+            approvalId: key.approvalId,
+            entry,
+          });
+        },
+        remove: (key) => {
+          approvalDeliveryReceipts.delete(JSON.stringify(key));
+        },
+      },
       request: async <T>(
         method: GatewayNativeApprovalMethod,
         payload: Record<string, unknown>,
@@ -232,6 +254,7 @@ export function createGatewayInstanceRuntime(
       closed = true;
       releaseRecoveryRuntime();
       approvalSubscribers.clear();
+      approvalDeliveryReceipts.clear();
       routeCoordinator.close();
     },
   };

--- a/src/infra/approval-gateway-runtime.types.ts
+++ b/src/infra/approval-gateway-runtime.types.ts
@@ -14,6 +14,20 @@ export type GatewayApprovalEventSubscriber = {
   onResolved: (resolved: GatewayApprovalResolved) => void;
 };
 
+export type GatewayNativeApprovalDeliveryReceiptKey = {
+  approvalId: string;
+  channel: string;
+  accountId: string;
+  targetKey: string;
+};
+
+/** Gateway-owned durable delivery state; intentionally not part of the public protocol. */
+export type GatewayNativeApprovalDeliveryReceipts = {
+  read: (key: GatewayNativeApprovalDeliveryReceiptKey) => unknown | null;
+  write: (key: GatewayNativeApprovalDeliveryReceiptKey, entry: unknown) => void;
+  remove: (key: GatewayNativeApprovalDeliveryReceiptKey) => void;
+};
+
 /** Gateway-owned authority and event transport for channel-native approval runtimes. */
 export type GatewayNativeApprovalRuntime = {
   request: <T = unknown>(
@@ -22,6 +36,7 @@ export type GatewayNativeApprovalRuntime = {
     options?: { clientDisplayName?: string },
   ) => Promise<T>;
   requestRoute: <T = unknown>(method: "send", params: Record<string, unknown>) => Promise<T>;
+  deliveryReceipts?: GatewayNativeApprovalDeliveryReceipts;
   routeCoordinator: ApprovalNativeRouteCoordinator;
   subscribe: (subscriber: GatewayApprovalEventSubscriber) => () => void;
 };

--- a/src/infra/approval-handler-runtime.test.ts
+++ b/src/infra/approval-handler-runtime.test.ts
@@ -1,5 +1,12 @@
 // Covers approval handler runtime adapter creation and lazy wiring.
 import { describe, expect, it, vi } from "vitest";
+import { withGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import type {
+  GatewayNativeApprovalDeliveryReceiptKey,
+  GatewayNativeApprovalDeliveryReceipts,
+  GatewayNativeApprovalRuntime,
+} from "./approval-gateway-runtime.types.js";
+import { createApprovalNativeRouteCoordinator } from "./approval-native-route-coordinator.js";
 import {
   createChannelApprovalNativeRuntimeAdapter,
   createChannelApprovalHandlerFromCapability,
@@ -84,6 +91,16 @@ function createTestApprovalHandler(capability: ApprovalCapability) {
     capability,
     ...TEST_HANDLER_PARAMS,
   });
+}
+
+function createTestDeliveryReceipts(): GatewayNativeApprovalDeliveryReceipts {
+  const entries = new Map<string, unknown>();
+  const keyOf = (key: GatewayNativeApprovalDeliveryReceiptKey) => JSON.stringify(key);
+  return {
+    read: (key) => entries.get(keyOf(key)) ?? null,
+    write: (key, entry) => entries.set(keyOf(key), entry),
+    remove: (key) => entries.delete(keyOf(key)),
+  };
 }
 
 type ApprovalHandlerRuntime = NonNullable<Awaited<ReturnType<typeof createTestApprovalHandler>>>;
@@ -234,6 +251,50 @@ describe("createChannelApprovalHandlerFromCapability", () => {
     expect(unbind?.binding).toEqual({ bindingId: "bound-1" });
     expect(unbind?.request).toBe(request);
     expect(buildResolvedResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("adopts a delivered entry when a handler replacement replays the pending approval", async () => {
+    const deliveryReceipts = createTestDeliveryReceipts();
+    const deliverPending = makeSequentialPendingDeliveryMock();
+    const buildResolvedResult = vi.fn().mockResolvedValue({ kind: "leave" });
+    const gatewayRuntime = {
+      deliveryReceipts,
+      routeCoordinator: createApprovalNativeRouteCoordinator(),
+    } as GatewayNativeApprovalRuntime;
+    const createHandler = async () =>
+      await withGatewayNativeApprovalRuntime(gatewayRuntime, () =>
+        createChannelApprovalHandlerFromCapability({
+          capability: makeNativeApprovalCapability({ deliverPending, buildResolvedResult }),
+          ...TEST_HANDLER_PARAMS,
+          accountId: "main",
+        }),
+      );
+    const request = makeExecApprovalRequest("exec:replacement-replay");
+
+    const first = expectApprovalRuntime(await createHandler());
+    await first.handleRequested(request);
+    await first.stop();
+
+    const replacement = expectApprovalRuntime(await createHandler());
+    await replacement.handleRequested(request);
+    await replacement.handleResolved({
+      id: request.id,
+      decision: "approved",
+      resolvedBy: "operator",
+    } as never);
+
+    expect(deliverPending).toHaveBeenCalledTimes(1);
+    expect(buildResolvedResult).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: { messageId: "1" } }),
+    );
+    expect(
+      deliveryReceipts.read({
+        approvalId: request.id,
+        channel: "test",
+        accountId: "main",
+        targetKey: "origin-chat",
+      }),
+    ).toBeNull();
   });
 
   it("continues finalization cleanup after one resolved entry unbind failure", async () => {

--- a/src/infra/approval-handler-runtime.ts
+++ b/src/infra/approval-handler-runtime.ts
@@ -1,5 +1,9 @@
 // Runtime contracts for approval handlers used by execution requests.
 import type {
+  GatewayNativeApprovalDeliveryReceiptKey,
+} from "./approval-gateway-runtime.types.js";
+import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import type {
   ChannelApprovalCapability,
   ChannelApprovalNativeAdapter,
 } from "../channels/plugins/types.adapters.js";
@@ -75,6 +79,7 @@ export type ChannelApprovalHandler<
 type WrappedPendingEntry = {
   entry: unknown;
   binding?: unknown;
+  receiptKey?: GatewayNativeApprovalDeliveryReceiptKey;
 };
 
 type ActiveApprovalEntries = {
@@ -456,6 +461,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
     return null;
   }
   const log = createSubsystemLogger(params.label);
+  const deliveryReceipts = getGatewayNativeApprovalRuntime()?.deliveryReceipts;
   const activeEntries = new Map<string, ActiveApprovalEntries>();
   let stopped = false;
   const resolveApprovalKind = nativeRuntime.resolveApprovalKind ?? resolveApprovalRequestKind;
@@ -519,21 +525,37 @@ export async function createChannelApprovalHandlerFromCapability(params: {
       deliverTarget: async ({
         plannedTarget,
         preparedTarget,
+        targetKey,
         request,
         approvalKind,
         pendingContent,
       }) => {
-        const entry = await nativeRuntime.transport.deliverPending({
-          ...baseContext,
-          plannedTarget,
-          preparedTarget,
-          request,
-          approvalKind,
-          view: pendingContent.view,
-          pendingPayload: pendingContent.payload,
-        });
+        const receiptKey =
+          deliveryReceipts && params.accountId
+            ? {
+                approvalId: request.id,
+                channel: params.channel,
+                accountId: params.accountId,
+                targetKey,
+              }
+            : undefined;
+        const adoptedEntry = receiptKey ? deliveryReceipts?.read(receiptKey) : null;
+        const entry =
+          adoptedEntry ??
+          (await nativeRuntime.transport.deliverPending({
+            ...baseContext,
+            plannedTarget,
+            preparedTarget,
+            request,
+            approvalKind,
+            view: pendingContent.view,
+            pendingPayload: pendingContent.payload,
+          }));
         if (!entry) {
           return null;
+        }
+        if (receiptKey && adoptedEntry === null) {
+          deliveryReceipts.write(receiptKey, entry);
         }
         if (stopped) {
           // onStopped fired between deliverPending and bindPending. The wrapped
@@ -584,6 +606,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
         const wrapped: WrappedPendingEntry = {
           entry,
           ...(binding === undefined || binding === null ? {} : { binding }),
+          ...(receiptKey ? { receiptKey } : {}),
         };
         const activeRequest = activeEntries.get(request.id) ?? {
           request,
@@ -676,6 +699,9 @@ export async function createChannelApprovalHandlerFromCapability(params: {
               result,
               phase: "resolved",
             });
+            if (wrapped.receiptKey) {
+              deliveryReceipts?.remove(wrapped.receiptKey);
+            }
           },
         });
       },
@@ -711,6 +737,9 @@ export async function createChannelApprovalHandlerFromCapability(params: {
               result,
               phase: "expired",
             });
+            if (wrapped.receiptKey) {
+              deliveryReceipts?.remove(wrapped.receiptKey);
+            }
           },
         });
       },

--- a/src/infra/approval-native-runtime-types.ts
+++ b/src/infra/approval-native-runtime-types.ts
@@ -27,6 +27,7 @@ export type ChannelNativeApprovalTransportSpec<
   deliverTarget: (params: {
     plannedTarget: ChannelApprovalNativePlannedTarget;
     preparedTarget: TPreparedTarget;
+    targetKey: string;
     request: TRequest;
     approvalKind: ChannelApprovalKind;
     pendingContent: TPendingContent;

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -59,6 +59,7 @@ export async function deliverApprovalRequestViaChannelNativePlan<
   deliverTarget: (params: {
     plannedTarget: ChannelApprovalNativePlannedTarget;
     preparedTarget: TPreparedTarget;
+    targetKey: string;
     request: TRequest;
   }) => TPendingEntry | null | Promise<TPendingEntry | null>;
   onDeliveryError?: (params: {
@@ -111,6 +112,7 @@ export async function deliverApprovalRequestViaChannelNativePlan<
       const entry = await params.deliverTarget({
         plannedTarget,
         preparedTarget: preparedTarget.target,
+        targetKey: preparedTarget.dedupeKey,
         request: params.request,
       });
       if (!entry) {


### PR DESCRIPTION
## What Problem This Solves

Replacing a native approval channel handler while an approval remains pending
can replay the pending event and create a second provider message for the same
approval destination.

## What Changed

The Gateway-instance native approval runtime now retains an opaque delivery
receipt keyed by approval, channel, account, and target. A replacement handler
adopts that entry instead of delivering again. Resolution removes the receipt,
and Gateway shutdown clears the lifecycle-owned map.

## Rationale

Pending approvals do not survive a full Gateway restart: a new runtime epoch
cancels prior-epoch rows. Therefore persistence, SQLite schema changes, Plugin
SDK serialization, and Gateway protocol changes are unnecessary. The smallest
correct owner is the existing Gateway-instance native approval runtime.

## Evidence

- Exact-base causal control at `c218187244e5e67a54401e8775c2919af58c9087`:
  13 existing tests passed and the new replacement-replay test failed as
  expected because `deliverPending` ran twice.
- Exact-head `src/infra/approval-handler-runtime.test.ts`: 14/14 pass at
  `a5863b40aecc6604f99a2ea39d78aa05709bf8cc` using Node 24.15 / SQLite 3.51.3.
- Adjacent native runtime/bootstrap suites: 47/47 pass; 61/61 focused head tests
  pass in total.
- The new case replaces the handler inside one Gateway lifecycle and asserts the
  pending delivery entry is adopted rather than delivered twice.
- `git diff --check`: pass.

## Current Verification Boundary

The exact causal and focused runtime evidence is green. The full repository
suite/build was not run; the six-file change is bounded to the native approval
runtime, handler bootstrap, instance lifecycle, and their focused tests. An
earlier system-Node attempt was NO VERDICT because its SQLite 3.51.2 failed
before test collection.

The change does not claim exactly-once delivery across an external provider
accepting a create request followed by a process crash before local receipt
recording. Full Gateway restart already terminates the old approval epoch.