### PR TITLE
fix(raft): report missing CLI in channel status

### DIFF
--- a/extensions/raft/src/channel.test.ts
+++ b/extensions/raft/src/channel.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { raftPlugin } from "./channel.js";
 
+const detectBinaryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/setup-tools")>()),
+  detectBinary: detectBinaryMock,
+}));
+
 describe("Raft channel plugin", () => {
+  beforeEach(() => {
+    detectBinaryMock.mockReset();
+  });
+
   it("declares a wake-only direct channel", () => {
     expect(raftPlugin.meta).toMatchObject({
       id: "raft",
@@ -13,4 +25,42 @@ describe("Raft channel plugin", () => {
     expect(raftPlugin.message).toBeUndefined();
     expect(raftPlugin.outbound).toBeUndefined();
   });
+
+  it.each([
+    {
+      detected: true,
+      expected: { ok: true, cliFound: true, error: null },
+    },
+    {
+      detected: false,
+      expected: {
+        ok: false,
+        cliFound: false,
+        error: "Raft CLI not found on the Gateway PATH",
+      },
+    },
+  ])(
+    "maps CLI detection to a coherent status outcome when detected=$detected",
+    async ({ detected, expected }) => {
+      detectBinaryMock.mockResolvedValueOnce(detected);
+      const cfg = {
+        channels: {
+          raft: {
+            profile: "test-profile",
+          },
+        },
+      } as OpenClawConfig;
+      const account = raftPlugin.config.resolveAccount(cfg, "default");
+
+      const result = await raftPlugin.status!.probeAccount!({
+        account,
+        timeoutMs: 1_000,
+        cfg,
+      });
+
+      expect(detectBinaryMock).toHaveBeenCalledOnce();
+      expect(detectBinaryMock).toHaveBeenCalledWith("raft");
+      expect(result).toEqual(expected);
+    },
+  );
 });

--- a/extensions/raft/src/channel.ts
+++ b/extensions/raft/src/channel.ts
@@ -19,9 +19,9 @@ import { raftChannelConfigSchema } from "./config-schema.js";
 import { startRaftGatewayAccount } from "./gateway.js";
 import { raftSetupPlugin } from "./setup.js";
 
-type RaftProbe = {
-  cliFound: boolean;
-};
+type RaftProbe =
+  | { ok: true; cliFound: true; error: null }
+  | { ok: false; cliFound: false; error: string };
 
 export const raftPlugin: ChannelPlugin<ResolvedRaftAccount, RaftProbe> = createChatChannelPlugin({
   base: {
@@ -61,9 +61,16 @@ export const raftPlugin: ChannelPlugin<ResolvedRaftAccount, RaftProbe> = createC
     status: createComputedAccountStatusAdapter<ResolvedRaftAccount, RaftProbe>({
       defaultRuntime: createDefaultChannelRuntimeState("default"),
       buildChannelSummary: ({ snapshot }) => buildBaseChannelStatusSummary(snapshot),
-      probeAccount: async () => ({
-        cliFound: await detectBinary("raft"),
-      }),
+      probeAccount: async () => {
+        const cliFound = await detectBinary("raft");
+        return cliFound
+          ? { ok: true, cliFound: true, error: null }
+          : {
+              ok: false,
+              cliFound: false,
+              error: "Raft CLI not found on the Gateway PATH",
+            };
+      },
       formatCapabilitiesProbe: ({ probe }) => [
         {
           text: `Raft CLI: ${probe.cliFound ? "found" : "missing"}`,


### PR DESCRIPTION
Closes #123137

## What Problem This Solves

Fixes an issue where Raft operators using the documented `openclaw channels status --probe` verification path would not receive a standard success or failure outcome when OpenClaw checked for the `raft` CLI. A missing binary could leave the account looking configured without the expected `probe failed` status or actionable account error.

## Why This Change Was Made

The Raft plugin now records its existing binary-detection fact as a coherent canonical probe outcome while preserving the shipped `cliFound` detail. The change stays plugin-local: shared status/Gateway consumers already understand `{ ok, error }`, and the discriminated result prevents contradictory success, CLI-presence, and error states.

## User Impact

Raft status checks now report `works` when the CLI is available and `probe failed` with `Raft CLI not found on the Gateway PATH` when it is missing. JSON and capability output continue to expose `cliFound` and the existing `Raft CLI: found/missing` detail.

## Evidence

- Tests-first regression failed before the producer repair: expected `{ ok: false, cliFound: false, error: "Raft CLI not found on the Gateway PATH" }`, received `{ cliFound: false }`.
- Focused Raft channel test: 3/3 passed after the repair.
- Targeted formatting and `git diff --check` passed.
- Final integrated Codex autoreview: clean, no findings, confidence 0.99; TruffleHog clean.
- Hosted changed gate passed on Testbox `tbx_01kzxc8p10w3mgwkpkc0e51ky6`; Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31693328937.
- Exact-head CI completed green: https://github.com/openclaw/openclaw/actions/runs/31693226030.

Production delta: +13/-6, net +7. Tests: +51/-1, net +50.

AI-assisted: yes. The implementation and regression were reviewed against the complete plugin/status owner path.
