### PR TITLE
fix: Codex Test & use completes from Model Setup

### DIFF
--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -62,6 +62,20 @@ describe("harness runtime plugins", () => {
     expect(pluginRegistry.agentHarnesses).toHaveLength(1);
   });
 
+  it("explains how to recover when the selected harness registration is missing", async () => {
+    await expect(
+      ensureSelectedAgentHarnessPlugin({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        agentHarnessRuntimeOverride: "codex",
+        workspaceDir: "/tmp/workspace",
+        pluginRegistry: createEmptyPluginRegistry(),
+      }),
+    ).rejects.toThrow(
+      'Agent harness runtime "codex" is unavailable because its plugin registration is missing from this prepared run. Enable or reinstall the plugin that provides this runtime, restart the Gateway, then retry.',
+    );
+  });
+
   it("force-activates a default-disabled harness owner selected for a run", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
       config: {},

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -131,6 +131,8 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
   }
 
   if (!params.pluginRegistry?.agentHarnesses.some((entry) => entry.harness.id === runtime)) {
-    throw new Error(`Agent harness runtime "${runtime}" is not present in the prepared registry.`);
+    throw new Error(
+      `Agent harness runtime "${runtime}" is unavailable because its plugin registration is missing from this prepared run. Enable or reinstall the plugin that provides this runtime, restart the Gateway, then retry.`,
+    );
   }
 }

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -54,10 +54,12 @@ export function prepareWorkspacePluginRegistries(
   runtimePluginRegistry?: PluginRegistry;
   inboundPluginRegistry?: PluginRegistry;
 } {
-  if (input.readOnly) {
+  // Read-only catalog owners stay runtime-free, but setup probes carry an exact harness selection.
+  // That selected registry must belong to the generation instead of leaking from an outer scope.
+  if (input.readOnly && !input.runtimePluginSelections) {
     return {};
   }
-  const inboundPluginRegistry = loadInboundRegistry?.(input);
+  const inboundPluginRegistry = input.readOnly ? undefined : loadInboundRegistry?.(input);
   const runtimePluginRegistry =
     input.runtimePluginSelections || !inboundPluginRegistry
       ? loadAgentRuntimePluginRegistryHandle({

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -48,6 +48,24 @@ describe("prepared model runtime snapshots", () => {
   it("keeps an isolated setup probe exact after a gateway replacement", async () => {
     mocks.configuredAgentIds = ["default"];
     const stagedConfig = { agents: { defaults: { model: "openai/gpt-5.6" } } };
+    const selectedPluginRegistry = createEmptyPluginRegistry();
+    selectedPluginRegistry.agentHarnesses.push({
+      pluginId: "codex",
+      source: "test",
+      harness: {
+        id: "codex",
+        label: "Codex",
+        supports: () => ({ supported: true }),
+        runAttempt: async () => {
+          throw new Error("unused");
+        },
+      },
+    });
+    mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation((params) =>
+      (params as { selections?: unknown }).selections
+        ? selectedPluginRegistry
+        : createEmptyPluginRegistry(),
+    );
     await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
     markPreparedModelRuntimeSnapshotsStale("test isolated probe replacement", {
       waitForReplacement: true,
@@ -58,6 +76,7 @@ describe("prepared model runtime snapshots", () => {
       agentDir: "/tmp/setup-probe-agent",
       inheritedAuthDir: "/tmp/setup-probe-agent",
       workspaceDir: "/tmp/setup-probe-workspace",
+      runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.6", runtime: "codex" }],
     });
     await Promise.resolve();
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(1);
@@ -72,6 +91,14 @@ describe("prepared model runtime snapshots", () => {
       agentDir: "/tmp/setup-probe-agent",
       workspaceDir: "/tmp/setup-probe-workspace",
     });
+    expect(lease.snapshot.pluginRegistry?.agentHarnesses.map((entry) => entry.harness.id)).toEqual([
+      "codex",
+    ]);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selections: [{ provider: "openai", modelId: "gpt-5.6", runtime: "codex" }],
+      }),
+    );
     lease.release();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Model Setup could detect authenticated Codex access on a fresh Gateway, but **Test & use** dead-ended before starting Codex.

The packaged Mac app reproduced this as:

> Connection failed. Agent harness runtime "codex" is not present in the prepared registry. Review the connection details, then retry.

The suggested remediation was also misleading because connection details were not the missing piece.

## Why This Change Was Made

Isolated read-only setup probes already carry the exact selected harness runtime, but prepared-runtime construction discarded every plugin registry for read-only generations. Exact-generation scoping correctly stopped inheriting an ambient registry, exposing that latent ownership gap as an empty prepared registry.

This change keeps ordinary read-only catalog owners runtime-free while preparing the model-selected plugin registry when a read-only run explicitly selects a plugin harness. The fix is generic to plugin harnesses, preserves exact-generation isolation, and does not special-case the dashboard or Codex. Genuinely missing registrations now explain that the plugin registration is absent and direct operators to enable or reinstall the plugin, restart the Gateway, and retry.

Provenance: commit 02272c345f3 made prepared generations scope an explicit empty registry instead of inheriting an outer registry. That isolation is correct; this PR completes the selected-runtime side of the contract. The guided CLI and Gateway use the same activation implementation, so an older CLI build could succeed through inherited staged scope while the packaged Gateway at 600126acaa2 exposed the missing generation-owned registry.

The upstream Codex protocol confirms that initialization and completion would proceed through `initialize`, `thread/start`, and `turn/start`; the pre-fix failure occurred before any of those requests:

- https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server-protocol/src/protocol/common.rs#L474-L489
- https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server-protocol/src/protocol/common.rs#L855-L860

## User Impact

Operators can use **Test & use** on a detected Codex subscription from a fresh Gateway. The candidate reaches a real completion and becomes the persisted default route instead of failing on missing prepared-registry state.

If a third-party harness really is missing from a prepared run, the error now names the missing plugin registration and gives a concrete recovery path.

Production LOC: +7/-3 (net +4) | Tests: +41/-0

The positive production delta is the lifecycle invariant comment plus the required actionable operator error; the registry decision itself replaces the existing read-only branch without adding a parallel activation path.

## Evidence

### Before: exact dashboard RPC pair on isolated profile `cpr1`, derived port 39991

`openclaw.setup.detect`:

```json
{
  "kind": "codex-cli",
  "modelRef": "openai/gpt-5.6-sol",
  "label": "Codex",
  "detail": "logged in · ChatGPT subscription",
  "credentials": true
}
```

`openclaw.setup.activate`:

```json
{
  "ok": false,
  "status": "unknown",
  "error": "Agent harness runtime \"codex\" is not present in the prepared registry."
}
```

### After: fixed dist, same profile and RPC pair

```json
{
  "ok": true,
  "modelRef": "openai/gpt-5.6-sol",
  "latencyMs": 12039,
  "lines": ["Inference verified: openai/gpt-5.6-sol"]
}
```

Gateway events showed the Codex harness selection, app-server lifecycle, assistant text `OK`, usage, and clean lifecycle completion. A source-blind persistence probe then returned:

```json
{
  "ok": true,
  "latencyMs": 6039,
  "modelRef": "openai/gpt-5.6-sol"
}
```

Subsequent detection reported `setupComplete: true` and `configuredModel: openai/gpt-5.6-sol`.

### Automated proof

- Regression test failed before the production edit because the isolated read-only snapshot had no plugin registry.
- `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.test.ts src/agents/harness/runtime-plugin.test.ts` — 55 passed.
- `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.inbound-registry.test.ts src/system-agent/setup-inference.test.ts` — 132 passed.
- `pnpm build` — passed.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31692477675
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.

The isolated Gateway was stopped after proof. Its profile state, validator workspace, and profile log were moved to Trash. The operator OpenClaw and Codex filesystem state was not mutated.
