### PR TITLE
fix(telegram): skip audio download in groups when disableAudioPreflight is set

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media.disable-audio-preflight.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.disable-audio-preflight.test.ts
@@ -1,0 +1,134 @@
+// Telegram tests cover the pre-download mention gate honoring
+// disableAudioPreflight for captionless voice notes in mention-gated groups.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { telegramBotDepsForTest } from "./bot.media.e2e.test-harness.js";
+import {
+  TELEGRAM_TEST_TIMINGS,
+  createBotHandlerWithOptions,
+  mockTelegramFileDownload,
+  watchTelegramFetch,
+} from "./bot.media.test-utils.js";
+
+vi.mock("./media-understanding.runtime.js", () => ({
+  transcribeFirstAudio: vi.fn(async () => "mock transcript"),
+}));
+
+type GroupConfig = Record<
+  string,
+  {
+    requireMention?: boolean;
+    disableAudioPreflight?: boolean;
+    topics?: Record<string, { disableAudioPreflight?: boolean }>;
+  }
+>;
+
+const originalGetRuntimeConfig = telegramBotDepsForTest.getRuntimeConfig;
+
+function setGroupConfig(groups: GroupConfig): void {
+  telegramBotDepsForTest.getRuntimeConfig = () =>
+    ({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "open",
+          groups,
+        },
+      },
+    }) as ReturnType<typeof originalGetRuntimeConfig>;
+}
+
+afterEach(() => {
+  telegramBotDepsForTest.getRuntimeConfig = originalGetRuntimeConfig;
+});
+
+function captionlessVoiceMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    message: {
+      message_id: 1,
+      chat: { id: -100123, type: "group" },
+      from: { id: 777, is_bot: false, first_name: "Ada" },
+      voice: { file_id: "voice-1" },
+      date: 1736380800,
+      ...overrides,
+    },
+    me: { username: "openclaw_bot" },
+    getFile: vi.fn(async () => ({ file_path: "voice/1.ogg" })),
+  };
+}
+
+describe("telegram inbound media pre-download mention gate", () => {
+  const INBOUND_MEDIA_TEST_TIMEOUT_MS = 90_000;
+
+  it(
+    "does not download captionless voice notes when disableAudioPreflight is enabled for the group",
+    async () => {
+      setGroupConfig({ "-100123": { requireMention: true, disableAudioPreflight: true } });
+      const { handler, replySpy } = await createBotHandlerWithOptions({});
+      const ctx = captionlessVoiceMessage();
+      const fetchSpy = watchTelegramFetch();
+      try {
+        await handler(ctx);
+        expect(ctx.getFile).not.toHaveBeenCalled();
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(replySpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    INBOUND_MEDIA_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "still downloads captionless voice notes for mention preflight when disableAudioPreflight is not set",
+    async () => {
+      setGroupConfig({ "-100123": { requireMention: true } });
+      const { handler } = await createBotHandlerWithOptions({});
+      const ctx = captionlessVoiceMessage();
+      const fetchSpy = mockTelegramFileDownload({
+        contentType: "audio/ogg",
+        bytes: new Uint8Array([0x4f, 0x67, 0x67, 0x53]), // "OggS"
+      });
+      try {
+        await handler(ctx);
+        expect(ctx.getFile).toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    INBOUND_MEDIA_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "downloads captionless voice notes when a topic-level disableAudioPreflight false override is set",
+    async () => {
+      setGroupConfig({
+        "-100123": {
+          requireMention: true,
+          disableAudioPreflight: true,
+          topics: { "5": { disableAudioPreflight: false } },
+        },
+      });
+      const { handler } = await createBotHandlerWithOptions({});
+      const ctx = captionlessVoiceMessage({
+        message_id: 3,
+        message_thread_id: 5,
+        is_topic_message: true,
+        chat: { id: -100123, type: "supergroup", is_forum: true },
+      });
+      const fetchSpy = mockTelegramFileDownload({
+        contentType: "audio/ogg",
+        bytes: new Uint8Array([0x4f, 0x67, 0x67, 0x53]), // "OggS"
+      });
+      try {
+        await handler(ctx);
+        expect(ctx.getFile).toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    INBOUND_MEDIA_TEST_TIMEOUT_MS,
+  );
+});

--- a/extensions/telegram/src/bot-handlers.inbound-media.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.ts
@@ -135,8 +135,12 @@ export function createTelegramInboundMedia({
       authorization;
     const textParts = getTelegramTextParts(msg);
     const documentMime = msg.document?.mime_type?.split(";")[0]?.trim().toLowerCase();
+    const disableAudioPreflight =
+      (authorization.topicConfig?.disableAudioPreflight ??
+        authorization.groupConfig?.disableAudioPreflight) === true;
     const mayNeedDownload =
       !textParts.text.trim() &&
+      !disableAudioPreflight &&
       Boolean(msg.audio ?? msg.voice ?? documentMime?.startsWith("audio/"));
     // Media-less messages have nothing to skip-download. They must reach the
     // canonical mention gate (bot-message-context.body), which records group


### PR DESCRIPTION
## Problem

In mention-gated Telegram groups (`requireMention: true`), every captionless voice note is **downloaded** via `getFile` + file fetch **before** the mention gate runs — even when the group has `disableAudioPreflight: true`.

The `disableAudioPreflight` flag only gates the preflight **transcription** step, not the **download**. The download happens even for messages that are subsequently skipped with `no-mention`, wasting bandwidth and failing loudly when the Telegram API is unreachable or slow.

Observed on OpenClaw 2026.6.10 and confirmed still present in 2026.7.1 and `main`.

## Root cause

In `bot-handlers.inbound-media.ts`, `resolveUnaddressedGroupMediaDisposition` treats captionless audio as "may need download for mention detection":

```ts
const mayNeedDownload =
  !textParts.text.trim() &&
  Boolean(msg.audio ?? msg.voice ?? documentMime?.startsWith("audio/"));
if (!isGroup || !hasInboundMedia(msg) || mayNeedDownload) {
  return "process"; // -> resolveMedia() downloads the file
}
```

Audio always returns `true`, so the disposition is always `"process"` and the file is downloaded, regardless of `disableAudioPreflight`.

## Fix

Honor `disableAudioPreflight` when deciding whether media may need to be downloaded for mention detection. When set, captionless audio falls through to the canonical mention gate (same as media-less messages) and the file is **not** downloaded:

```ts
const disableAudioPreflight =
  (authorization.topicConfig?.disableAudioPreflight ??
    authorization.groupConfig?.disableAudioPreflight) === true;
const mayNeedDownload =
  !textParts.text.trim() &&
  !disableAudioPreflight &&
  Boolean(msg.audio ?? msg.voice ?? documentMime?.startsWith("audio/"));
```

Messages that carry a text body are unaffected (they already returned early on text).

## Testing

- Manual: with `requireMention: true` + `disableAudioPreflight: true` on a group, captionless voice notes are no longer fetched; text-mention and reply-to-bot flows keep working.
- Existing Telegram test suite is unaffected (change is additive and mirrors the flag check already used in `bot-message-context.body.ts`).