### PR TITLE
fix(macos): onboarding appears ready with expired configured AI

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -24747,6 +24747,17 @@
       ]
     },
     {
+      "id": "native.apple.c4aa52c5646a434e",
+      "source": "Configured AI needs attention",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.c81b1c4da43da35d",
       "source": "Confirm",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/GatewayAutostartPolicy.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayAutostartPolicy.swift
@@ -5,6 +5,17 @@ enum GatewayAutostartPolicy {
         mode == .local && !paused
     }
 
+    @MainActor
+    static func activateGatewayForRecovery(
+        mode: AppState.ConnectionMode = AppStateStore.shared.connectionMode,
+        paused: Bool = AppStateStore.shared.isPaused,
+        activate: @MainActor () -> Void = { GatewayProcessManager.shared.setActive(true) }) -> Bool
+    {
+        guard self.shouldStartGateway(mode: mode, paused: paused) else { return false }
+        activate()
+        return true
+    }
+
     static func shouldEnsureLaunchAgent(
         mode: AppState.ConnectionMode,
         paused: Bool) -> Bool

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -64,6 +64,12 @@ actor GatewayConnection {
         }
     }
 
+    /// Opaque identity for one route and one physical websocket generation.
+    struct ServerIdentity: Equatable, Sendable {
+        fileprivate let routeGeneration: UInt64
+        fileprivate let socketGeneration: UInt64
+    }
+
     /// One connected Gateway server, not merely an endpoint configuration.
     /// A reconnect at the same URL creates a different lease.
     struct ServerLease: Sendable {
@@ -72,6 +78,17 @@ actor GatewayConnection {
         let route: Route
         fileprivate let socketGeneration: UInt64
         fileprivate let client: GatewayChannelActor
+
+        var identity: ServerIdentity {
+            ServerIdentity(
+                routeGeneration: self.route.generation,
+                socketGeneration: self.socketGeneration)
+        }
+    }
+
+    struct ServerSnapshotSubscription: Sendable {
+        let baseline: ServerIdentity?
+        let stream: AsyncStream<ServerIdentity>
     }
 
     enum Method: String {
@@ -167,6 +184,7 @@ actor GatewayConnection {
     private var lastRetiredSocketGeneration: UInt64?
 
     private var subscribers: [UUID: AsyncStream<GatewayPush>.Continuation] = [:]
+    private var serverSnapshotSubscribers: [UUID: AsyncStream<ServerIdentity>.Continuation] = [:]
     private var lastSnapshot: HelloOk?
     var canvasPluginSurfaceURL: String?
 
@@ -1188,15 +1206,12 @@ extension GatewayConnection {
             stateDir?.isEmpty == false ? stateDir : nil)
     }
 
-    func subscribe(
-        bufferingNewest: Int = 100,
-        replayLatestSnapshot: Bool = true) -> AsyncStream<GatewayPush>
-    {
+    func subscribe(bufferingNewest: Int = 100) -> AsyncStream<GatewayPush> {
         let id = UUID()
         let snapshot = self.lastSnapshot
         let connection = self
         return AsyncStream(bufferingPolicy: .bufferingNewest(bufferingNewest)) { continuation in
-            if replayLatestSnapshot, let snapshot {
+            if let snapshot {
                 continuation.yield(.snapshot(snapshot))
             }
             self.subscribers[id] = continuation
@@ -1206,8 +1221,36 @@ extension GatewayConnection {
         }
     }
 
+    /// Captures the current hello generation and registers future generations
+    /// in one actor turn, so reconnects cannot fall between inspection and subscription.
+    func subscribeServerSnapshots(bufferingNewest: Int = 1) -> ServerSnapshotSubscription {
+        let id = UUID()
+        let connection = self
+        let baseline = self.currentServerIdentity()
+        let stream = AsyncStream(
+            bufferingPolicy: .bufferingNewest(bufferingNewest))
+        { continuation in
+            self.serverSnapshotSubscribers[id] = continuation
+            continuation.onTermination = { @Sendable _ in
+                Task { await connection.removeServerSnapshotSubscriber(id) }
+            }
+        }
+        return ServerSnapshotSubscription(baseline: baseline, stream: stream)
+    }
+
     private func removeSubscriber(_ id: UUID) {
         self.subscribers[id] = nil
+    }
+
+    private func removeServerSnapshotSubscriber(_ id: UUID) {
+        self.serverSnapshotSubscribers[id] = nil
+    }
+
+    private func currentServerIdentity() -> ServerIdentity? {
+        guard self.lastSnapshot != nil, let socketGeneration = self.activeSocketGeneration else { return nil }
+        return ServerIdentity(
+            routeGeneration: self.routeGeneration,
+            socketGeneration: socketGeneration)
     }
 
     private func broadcast(_ push: GatewayPush) {
@@ -1219,6 +1262,11 @@ extension GatewayConnection {
             if let mainSessionKey = cachedMainSessionKey() {
                 Task { @MainActor in
                     WorkActivityStore.shared.setMainSessionKey(mainSessionKey)
+                }
+            }
+            if let identity = self.currentServerIdentity() {
+                for continuation in self.serverSnapshotSubscribers.values {
+                    continuation.yield(identity)
                 }
             }
         }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -98,6 +98,13 @@ actor GatewayConnection {
         let stream: AsyncStream<ServerIdentity>
     }
 
+    enum SharedEndpointRecovery: Sendable {
+        case localActivated
+        case localDenied
+        case remote
+        case unconfigured
+    }
+
     enum Method: String {
         case agent
         case status
@@ -151,6 +158,7 @@ actor GatewayConnection {
 
     private let endpointProvider: EndpointProvider
     private let supportsSharedEndpointRecovery: Bool
+    private let sharedEndpointRecovery: @Sendable () async -> SharedEndpointRecovery
     private let activationBindingKeyProvider: @Sendable () -> SymmetricKey?
     private let includeDeviceIdentity: Bool
     private let sessionProvider: SessionProvider
@@ -205,6 +213,8 @@ actor GatewayConnection {
     init(
         endpointProvider: @escaping EndpointProvider = GatewayConnection.defaultEndpointProvider,
         supportsSharedEndpointRecovery: Bool = true,
+        sharedEndpointRecovery: @escaping @Sendable () async -> SharedEndpointRecovery =
+            GatewayConnection.defaultSharedEndpointRecovery,
         activationBindingKeyProvider: @escaping @Sendable () -> SymmetricKey? =
             GatewayConnection.defaultActivationBindingKey,
         sessionBox: WebSocketSessionBox? = nil,
@@ -215,6 +225,7 @@ actor GatewayConnection {
     {
         self.endpointProvider = endpointProvider
         self.supportsSharedEndpointRecovery = supportsSharedEndpointRecovery
+        self.sharedEndpointRecovery = sharedEndpointRecovery
         self.activationBindingKeyProvider = activationBindingKeyProvider
         self.includeDeviceIdentity = true
         self.sessionProvider = Self.resolveSessionProvider(
@@ -241,6 +252,7 @@ actor GatewayConnection {
             try await EndpointSnapshot(config: configProvider(), routeAuthority: nil)
         }
         self.supportsSharedEndpointRecovery = false
+        self.sharedEndpointRecovery = { .unconfigured }
         self.activationBindingKeyProvider = activationBindingKeyProvider
         // Mock WebSocket routes do not exercise device authentication and must not
         // depend on the process-global persisted identity store.
@@ -257,6 +269,7 @@ actor GatewayConnection {
     {
         self.endpointProvider = testEndpointProvider
         self.supportsSharedEndpointRecovery = false
+        self.sharedEndpointRecovery = { .unconfigured }
         self.activationBindingKeyProvider = { GatewayConnection.testingActivationBindingKey }
         // Mock WebSocket routes do not exercise device authentication and must not
         // depend on the process-global persisted identity store.
@@ -340,15 +353,10 @@ actor GatewayConnection {
 
             // Auto-recover in local mode by spawning/attaching a gateway and retrying a few times.
             // Canvas interactions should "just work" even if the local gateway isn't running yet.
-            let mode = await MainActor.run { AppStateStore.shared.connectionMode }
+            let recovery = await self.sharedEndpointRecovery()
             try requireCurrentShutdownGeneration(shutdownGeneration)
-            switch mode {
-            case .local:
-                // Pause is an operator-owned stop, not a transport failure to heal.
-                // The shared policy check and activation stay atomic on MainActor.
-                guard await GatewayAutostartPolicy.activateGatewayForRecovery() else { throw error }
-                try requireCurrentShutdownGeneration(shutdownGeneration)
-
+            switch recovery {
+            case .localActivated:
                 let lastError: Error
                 do {
                     return try await self.retryRequest(
@@ -412,8 +420,26 @@ actor GatewayConnection {
 
                 try requireCurrentShutdownGeneration(shutdownGeneration)
                 throw lastError
-            case .unconfigured:
+            case .localDenied, .unconfigured:
                 throw error
+            }
+        }
+    }
+
+    private static func defaultSharedEndpointRecovery() async -> SharedEndpointRecovery {
+        await MainActor.run {
+            let state = AppStateStore.shared
+            switch state.connectionMode {
+            case .local:
+                // Pause is an operator-owned stop, not a transport failure to heal.
+                // Policy evaluation and activation stay atomic on MainActor.
+                return GatewayAutostartPolicy.activateGatewayForRecovery()
+                    ? .localActivated
+                    : .localDenied
+            case .remote:
+                return .remote
+            case .unconfigured:
+                return .unconfigured
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -68,6 +68,13 @@ actor GatewayConnection {
     struct ServerIdentity: Equatable, Sendable {
         fileprivate let routeGeneration: UInt64
         fileprivate let socketGeneration: UInt64
+
+        func covers(_ other: ServerIdentity) -> Bool {
+            if self.routeGeneration != other.routeGeneration {
+                return self.routeGeneration > other.routeGeneration
+            }
+            return self.socketGeneration >= other.socketGeneration
+        }
     }
 
     /// One connected Gateway server, not merely an endpoint configuration.

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -653,17 +653,18 @@ extension GatewayConnection {
     /// Captures the currently connected physical socket without probing or
     /// reconnecting. Queued mutations use this so waiting cannot retarget them.
     func captureServerLease() async -> ServerLease? {
-        guard let route = await self.captureRoute() else { return nil }
-        return await self.captureServerLease(ifCurrentRoute: route)
+        try? await self.captureRequiredServerLease()
     }
 
-    /// Freeze the physical socket that already owns a route-bound read.
-    func captureServerLease(ifCurrentRoute route: Route) async -> ServerLease? {
+    func captureRequiredServerLease() async throws -> ServerLease {
+        let route = try await self.captureRequiredRoute()
         guard let client = self.configuredConnection?.client,
               let socketGeneration = self.activeSocketGeneration
-        else { return nil }
+        else { throw OpenClawChatTransportSendError.notDispatched }
         let lease = ServerLease(route: route, socketGeneration: socketGeneration, client: client)
-        guard await self.isCurrentServerLease(lease) else { return nil }
+        guard await self.isCurrentServerLease(lease) else {
+            throw OpenClawChatTransportSendError.notDispatched
+        }
         return lease
     }
 

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -653,8 +653,13 @@ extension GatewayConnection {
     /// Captures the currently connected physical socket without probing or
     /// reconnecting. Queued mutations use this so waiting cannot retarget them.
     func captureServerLease() async -> ServerLease? {
-        guard let route = await self.captureRoute(),
-              let client = self.configuredConnection?.client,
+        guard let route = await self.captureRoute() else { return nil }
+        return await self.captureServerLease(ifCurrentRoute: route)
+    }
+
+    /// Freeze the physical socket that already owns a route-bound read.
+    func captureServerLease(ifCurrentRoute route: Route) async -> ServerLease? {
+        guard let client = self.configuredConnection?.client,
               let socketGeneration = self.activeSocketGeneration
         else { return nil }
         let lease = ServerLease(route: route, socketGeneration: socketGeneration, client: client)

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -344,7 +344,9 @@ actor GatewayConnection {
             try requireCurrentShutdownGeneration(shutdownGeneration)
             switch mode {
             case .local:
-                await MainActor.run { GatewayProcessManager.shared.setActive(true) }
+                // Pause is an operator-owned stop, not a transport failure to heal.
+                // The shared policy check and activation stay atomic on MainActor.
+                guard await GatewayAutostartPolicy.activateGatewayForRecovery() else { throw error }
                 try requireCurrentShutdownGeneration(shutdownGeneration)
 
                 let lastError: Error

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1188,12 +1188,15 @@ extension GatewayConnection {
             stateDir?.isEmpty == false ? stateDir : nil)
     }
 
-    func subscribe(bufferingNewest: Int = 100) -> AsyncStream<GatewayPush> {
+    func subscribe(
+        bufferingNewest: Int = 100,
+        replayLatestSnapshot: Bool = true) -> AsyncStream<GatewayPush>
+    {
         let id = UUID()
         let snapshot = self.lastSnapshot
         let connection = self
         return AsyncStream(bufferingPolicy: .bufferingNewest(bufferingNewest)) { continuation in
-            if let snapshot {
+            if replayLatestSnapshot, let snapshot {
                 continuation.yield(.snapshot(snapshot))
             }
             self.subscribers[id] = continuation

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -98,7 +98,7 @@ actor GatewayConnection {
         let stream: AsyncStream<ServerIdentity>
     }
 
-    enum SharedEndpointRecovery: Sendable {
+    private enum SharedEndpointRecovery: Sendable {
         case localActivated
         case localDenied
         case remote
@@ -158,7 +158,7 @@ actor GatewayConnection {
 
     private let endpointProvider: EndpointProvider
     private let supportsSharedEndpointRecovery: Bool
-    private let sharedEndpointRecovery: @Sendable () async -> SharedEndpointRecovery
+    private let activateGateway: @MainActor @Sendable () -> Void
     private let activationBindingKeyProvider: @Sendable () -> SymmetricKey?
     private let includeDeviceIdentity: Bool
     private let sessionProvider: SessionProvider
@@ -213,8 +213,9 @@ actor GatewayConnection {
     init(
         endpointProvider: @escaping EndpointProvider = GatewayConnection.defaultEndpointProvider,
         supportsSharedEndpointRecovery: Bool = true,
-        sharedEndpointRecovery: @escaping @Sendable () async -> SharedEndpointRecovery =
-            GatewayConnection.defaultSharedEndpointRecovery,
+        activateGateway: @escaping @MainActor @Sendable () -> Void = {
+            GatewayProcessManager.shared.setActive(true)
+        },
         activationBindingKeyProvider: @escaping @Sendable () -> SymmetricKey? =
             GatewayConnection.defaultActivationBindingKey,
         sessionBox: WebSocketSessionBox? = nil,
@@ -225,7 +226,7 @@ actor GatewayConnection {
     {
         self.endpointProvider = endpointProvider
         self.supportsSharedEndpointRecovery = supportsSharedEndpointRecovery
-        self.sharedEndpointRecovery = sharedEndpointRecovery
+        self.activateGateway = activateGateway
         self.activationBindingKeyProvider = activationBindingKeyProvider
         self.includeDeviceIdentity = true
         self.sessionProvider = Self.resolveSessionProvider(
@@ -252,7 +253,7 @@ actor GatewayConnection {
             try await EndpointSnapshot(config: configProvider(), routeAuthority: nil)
         }
         self.supportsSharedEndpointRecovery = false
-        self.sharedEndpointRecovery = { .unconfigured }
+        self.activateGateway = {}
         self.activationBindingKeyProvider = activationBindingKeyProvider
         // Mock WebSocket routes do not exercise device authentication and must not
         // depend on the process-global persisted identity store.
@@ -269,7 +270,7 @@ actor GatewayConnection {
     {
         self.endpointProvider = testEndpointProvider
         self.supportsSharedEndpointRecovery = false
-        self.sharedEndpointRecovery = { .unconfigured }
+        self.activateGateway = {}
         self.activationBindingKeyProvider = { GatewayConnection.testingActivationBindingKey }
         // Mock WebSocket routes do not exercise device authentication and must not
         // depend on the process-global persisted identity store.
@@ -426,14 +427,18 @@ actor GatewayConnection {
         }
     }
 
-    private static func defaultSharedEndpointRecovery() async -> SharedEndpointRecovery {
-        await MainActor.run {
+    private func sharedEndpointRecovery() async -> SharedEndpointRecovery {
+        let activateGateway = self.activateGateway
+        return await MainActor.run {
             let state = AppStateStore.shared
             switch state.connectionMode {
             case .local:
                 // Pause is an operator-owned stop, not a transport failure to heal.
                 // Policy evaluation and activation stay atomic on MainActor.
-                return GatewayAutostartPolicy.activateGatewayForRecovery()
+                return GatewayAutostartPolicy.activateGatewayForRecovery(
+                    mode: .local,
+                    paused: state.isPaused,
+                    activate: activateGateway)
                     ? .localActivated
                     : .localDenied
             case .remote:

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -653,18 +653,12 @@ extension GatewayConnection {
     /// Captures the currently connected physical socket without probing or
     /// reconnecting. Queued mutations use this so waiting cannot retarget them.
     func captureServerLease() async -> ServerLease? {
-        try? await self.captureRequiredServerLease()
-    }
-
-    func captureRequiredServerLease() async throws -> ServerLease {
-        let route = try await self.captureRequiredRoute()
-        guard let client = self.configuredConnection?.client,
+        guard let route = await self.captureRoute(),
+              let client = self.configuredConnection?.client,
               let socketGeneration = self.activeSocketGeneration
-        else { throw OpenClawChatTransportSendError.notDispatched }
+        else { return nil }
         let lease = ServerLease(route: route, socketGeneration: socketGeneration, client: client)
-        guard await self.isCurrentServerLease(lease) else {
-            throw OpenClawChatTransportSendError.notDispatched
-        }
+        guard await self.isCurrentServerLease(lease) else { return nil }
         return lease
     }
 

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -594,7 +594,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let state {
             let shouldWaitForConnection = state.connectionMode != .unconfigured
             if !shouldWaitForConnection, launchPlan.allowsAutomaticPresentation {
-                self.scheduleFirstRunOnboardingIfNeeded()
+                self.scheduleFirstRunOnboardingIfNeeded(state: state)
             }
             Task { @MainActor in
                 // Validate PATH selection before local startup. Existing installs may not
@@ -606,7 +606,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     mode: state.connectionMode,
                     paused: state.isPaused)
                 guard shouldWaitForConnection, launchPlan.allowsAutomaticPresentation else { return }
-                self.scheduleFirstRunOnboardingIfNeeded()
+                self.scheduleFirstRunOnboardingIfNeeded(state: state)
             }
         }
         TerminationSignalWatcher.shared.start()
@@ -730,20 +730,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             expectedRouteIdentity == currentRouteIdentity
     }
 
-    private func scheduleFirstRunOnboardingIfNeeded() {
-        let connectionMode = AppStateStore.shared.connectionMode
-        let expectedRouteIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity()
-        if connectionMode != .unconfigured, AppStateStore.shared.onboardingSeen {
+    func scheduleFirstRunOnboardingIfNeeded(
+        state: AppState = AppStateStore.shared,
+        scheduleOnboarding: @escaping @MainActor (AppState.ConnectionMode, String?) -> Void = { mode, routeIdentity in
+            AppDelegate.scheduleFirstRunOnboardingPresentation(
+                expectedConnectionMode: mode,
+                expectedRouteIdentity: routeIdentity)
+        })
+    {
+        let connectionMode = state.connectionMode
+        let expectedRouteIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity(state: state)
+        if connectionMode != .unconfigured, state.onboardingSeen {
             // Completion flags do not own any route's activation receipt.
             OnboardingController.markComplete()
             return
         }
-        self.scheduleFirstRunOnboardingPresentation(
-            expectedConnectionMode: connectionMode,
-            expectedRouteIdentity: expectedRouteIdentity)
+        scheduleOnboarding(connectionMode, expectedRouteIdentity)
     }
 
-    private func scheduleFirstRunOnboardingPresentation(
+    private static func scheduleFirstRunOnboardingPresentation(
         expectedConnectionMode: AppState.ConnectionMode,
         expectedRouteIdentity: String?)
     {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -594,9 +594,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let state {
             let shouldWaitForConnection = state.connectionMode != .unconfigured
             if !shouldWaitForConnection, launchPlan.allowsAutomaticPresentation {
-                Task { @MainActor in
-                    await self.scheduleFirstRunOnboardingIfNeeded(gatewayConnected: false)
-                }
+                self.scheduleFirstRunOnboardingIfNeeded()
             }
             Task { @MainActor in
                 // Validate PATH selection before local startup. Existing installs may not
@@ -608,8 +606,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     mode: state.connectionMode,
                     paused: state.isPaused)
                 guard shouldWaitForConnection, launchPlan.allowsAutomaticPresentation else { return }
-                await self.scheduleFirstRunOnboardingIfNeeded(
-                    gatewayConnected: ControlChannel.shared.state == .connected)
+                self.scheduleFirstRunOnboardingIfNeeded()
             }
         }
         TerminationSignalWatcher.shared.start()
@@ -721,36 +718,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.applicationTerminationReply(sender, true)
     }
 
-    @MainActor
-    static func shouldOpenDashboardInsteadOfOnboarding(
-        connectionMode: AppState.ConnectionMode,
-        onboardingSeen: Bool,
-        systemAgentResumePending: Bool,
-        gatewayConnected: Bool,
-        configuredInferenceModel: String?) -> Bool
-    {
-        let model = configuredInferenceModel?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return connectionMode != .unconfigured &&
-            !onboardingSeen &&
-            !systemAgentResumePending &&
-            gatewayConnected &&
-            model?.isEmpty == false
-    }
-
-    static func isCurrentFirstRunInferenceProbe(
-        expectedConnectionMode: AppState.ConnectionMode,
-        currentConnectionMode: AppState.ConnectionMode,
-        expectedRouteIdentity: String?,
-        currentRouteIdentity: String?,
-        gatewayRouteIsCurrent: Bool) -> Bool
-    {
-        expectedConnectionMode != .unconfigured &&
-            expectedConnectionMode == currentConnectionMode &&
-            expectedRouteIdentity != nil &&
-            expectedRouteIdentity == currentRouteIdentity &&
-            gatewayRouteIsCurrent
-    }
-
     static func shouldPresentScheduledFirstRunOnboarding(
         expectedConnectionMode: AppState.ConnectionMode,
         currentConnectionMode: AppState.ConnectionMode,
@@ -763,67 +730,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             expectedRouteIdentity == currentRouteIdentity
     }
 
-    private func scheduleFirstRunOnboardingIfNeeded(gatewayConnected: Bool) async {
+    private func scheduleFirstRunOnboardingIfNeeded() {
         let connectionMode = AppStateStore.shared.connectionMode
         let expectedRouteIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity()
-        var configuredInferenceModel: String?
-        if connectionMode != .unconfigured,
-           !AppStateStore.shared.onboardingSeen,
-           gatewayConnected
-        {
-            guard let route = await GatewayConnection.shared.captureRoute() else {
-                self.scheduleFirstRunOnboardingRecovery()
-                return
-            }
-            // Bind inference discovery to the connected route. A socket without a
-            // default-agent model cannot run OpenClaw and must stay in onboarding.
-            do {
-                configuredInferenceModel = try await GatewayConnection.shared.configuredInferenceModel(
-                    ifCurrentRoute: route)
-            } catch {
-                // A transient read failure is not evidence that inference is absent.
-                // Onboarding retries the same read without mutating on failure.
-                self.scheduleFirstRunOnboardingRecovery()
-                return
-            }
-            let gatewayRouteIsCurrent = await GatewayConnection.shared.isCurrentRoute(route)
-            let currentRouteIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity()
-            guard Self.isCurrentFirstRunInferenceProbe(
-                expectedConnectionMode: connectionMode,
-                currentConnectionMode: AppStateStore.shared.connectionMode,
-                expectedRouteIdentity: expectedRouteIdentity,
-                currentRouteIdentity: currentRouteIdentity,
-                gatewayRouteIsCurrent: gatewayRouteIsCurrent)
-            else {
-                self.scheduleFirstRunOnboardingRecovery()
-                return
-            }
-        }
-        let onboardingSeen = AppStateStore.shared.onboardingSeen
-        let systemAgentResumePending = OnboardingSystemAgentResumeStore.isPending(for: expectedRouteIdentity)
-        let shouldOpenDashboard = Self.shouldOpenDashboardInsteadOfOnboarding(
-            connectionMode: connectionMode,
-            onboardingSeen: onboardingSeen,
-            systemAgentResumePending: systemAgentResumePending,
-            gatewayConnected: gatewayConnected,
-            configuredInferenceModel: configuredInferenceModel)
-        if connectionMode != .unconfigured, onboardingSeen || shouldOpenDashboard {
+        if connectionMode != .unconfigured, AppStateStore.shared.onboardingSeen {
             // Completion flags do not own any route's activation receipt.
             OnboardingController.markComplete()
-            if shouldOpenDashboard {
-                self.openDashboardAction()
-            }
             return
         }
         self.scheduleFirstRunOnboardingPresentation(
             expectedConnectionMode: connectionMode,
             expectedRouteIdentity: expectedRouteIdentity)
-    }
-
-    private func scheduleFirstRunOnboardingRecovery() {
-        self.scheduleFirstRunOnboardingPresentation(
-            expectedConnectionMode: AppStateStore.shared.connectionMode,
-            expectedRouteIdentity: OnboardingSystemAgentResumeStore.selectedRouteIdentity())
     }
 
     private func scheduleFirstRunOnboardingPresentation(

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -594,7 +594,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let state {
             let shouldWaitForConnection = state.connectionMode != .unconfigured
             if !shouldWaitForConnection, launchPlan.allowsAutomaticPresentation {
-                self.scheduleFirstRunOnboardingIfNeeded(state: state)
+                Self.scheduleFirstRunOnboardingIfNeeded(state: state)
             }
             Task { @MainActor in
                 // Validate PATH selection before local startup. Existing installs may not
@@ -606,7 +606,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     mode: state.connectionMode,
                     paused: state.isPaused)
                 guard shouldWaitForConnection, launchPlan.allowsAutomaticPresentation else { return }
-                self.scheduleFirstRunOnboardingIfNeeded(state: state)
+                Self.scheduleFirstRunOnboardingIfNeeded(state: state)
             }
         }
         TerminationSignalWatcher.shared.start()
@@ -730,41 +730,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             expectedRouteIdentity == currentRouteIdentity
     }
 
-    func scheduleFirstRunOnboardingIfNeeded(
-        state: AppState = AppStateStore.shared,
-        scheduleOnboarding: @escaping @MainActor (AppState.ConnectionMode, String?) -> Void = { mode, routeIdentity in
-            AppDelegate.scheduleFirstRunOnboardingPresentation(
-                expectedConnectionMode: mode,
-                expectedRouteIdentity: routeIdentity)
-        })
+    static func scheduleFirstRunOnboardingIfNeeded(
+        state: AppState,
+        presenter: any FirstRunOnboardingPresenting = OnboardingController.shared)
     {
         let connectionMode = state.connectionMode
         let expectedRouteIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity(state: state)
         if connectionMode != .unconfigured, state.onboardingSeen {
             // Completion flags do not own any route's activation receipt.
-            OnboardingController.markComplete()
+            presenter.complete()
             return
         }
-        scheduleOnboarding(connectionMode, expectedRouteIdentity)
-    }
-
-    private static func scheduleFirstRunOnboardingPresentation(
-        expectedConnectionMode: AppState.ConnectionMode,
-        expectedRouteIdentity: String?)
-    {
         let seenVersion = AppDefaults.standard.integer(forKey: onboardingVersionKey)
-        let shouldShow = seenVersion < currentOnboardingVersion || !AppStateStore.shared.onboardingSeen
+        let shouldShow = seenVersion < currentOnboardingVersion || !state.onboardingSeen
         guard shouldShow else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-            let currentRouteIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity()
+            let currentRouteIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity(state: state)
             guard Self.shouldPresentScheduledFirstRunOnboarding(
-                expectedConnectionMode: expectedConnectionMode,
-                currentConnectionMode: AppStateStore.shared.connectionMode,
+                expectedConnectionMode: connectionMode,
+                currentConnectionMode: state.connectionMode,
                 expectedRouteIdentity: expectedRouteIdentity,
                 currentRouteIdentity: currentRouteIdentity,
-                onboardingSeen: AppStateStore.shared.onboardingSeen)
+                onboardingSeen: state.onboardingSeen)
             else { return }
-            OnboardingController.shared.show()
+            presenter.show()
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -528,13 +528,22 @@ enum OnboardingSystemAgentResumeStore {
 
 @MainActor
 protocol FirstRunOnboardingPresenting: AnyObject {
+    var presentsDashboardInsteadOfOnboarding: Bool { get }
     func complete()
+    func openDashboard()
+    func showOnboarding()
     func show()
 }
 
-enum FirstRunOnboardingDestination: Equatable {
-    case onboarding
-    case dashboard
+extension FirstRunOnboardingPresenting {
+    func show() {
+        guard self.presentsDashboardInsteadOfOnboarding else {
+            self.showOnboarding()
+            return
+        }
+        self.complete()
+        self.openDashboard()
+    }
 }
 
 @MainActor
@@ -547,6 +556,10 @@ final class OnboardingController: NSObject, NSWindowDelegate, FirstRunOnboarding
     /// setup mid-operation.
     var busyReason: String?
 
+    var presentsDashboardInsteadOfOnboarding: Bool {
+        ProcessInfo.processInfo.isNixMode
+    }
+
     static func markComplete() {
         AppDefaults.standard.set(true, forKey: onboardingSeenKey)
         AppDefaults.standard.set(currentOnboardingVersion, forKey: onboardingVersionKey)
@@ -558,17 +571,11 @@ final class OnboardingController: NSObject, NSWindowDelegate, FirstRunOnboarding
         Self.markComplete()
     }
 
-    static func firstRunDestination(isNixMode: Bool) -> FirstRunOnboardingDestination {
-        isNixMode ? .dashboard : .onboarding
+    func openDashboard() {
+        AppNavigationActions.openDashboard()
     }
 
-    func show() {
-        if Self.firstRunDestination(isNixMode: ProcessInfo.processInfo.isNixMode) == .dashboard {
-            // Nix mode is fully declarative; onboarding would suggest interactive setup that doesn't apply.
-            Self.markComplete()
-            AppNavigationActions.openDashboard()
-            return
-        }
+    func showOnboarding() {
         if let window {
             DockIconManager.shared.temporarilyShowDock()
             window.makeKeyAndOrderFront(nil)

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -527,7 +527,13 @@ enum OnboardingSystemAgentResumeStore {
 }
 
 @MainActor
-final class OnboardingController: NSObject, NSWindowDelegate {
+protocol FirstRunOnboardingPresenting: AnyObject {
+    func complete()
+    func show()
+}
+
+@MainActor
+final class OnboardingController: NSObject, NSWindowDelegate, FirstRunOnboardingPresenting {
     static let shared = OnboardingController()
     static let windowStyleMask: NSWindow.StyleMask = [.titled, .closable, .resizable, .fullSizeContentView]
     private var window: NSWindow?
@@ -541,6 +547,10 @@ final class OnboardingController: NSObject, NSWindowDelegate {
         AppDefaults.standard.set(currentOnboardingVersion, forKey: onboardingVersionKey)
         AppStateStore.shared.onboardingSeen = true
         DashboardManager.shared.handleOnboardingCompletion()
+    }
+
+    func complete() {
+        Self.markComplete()
     }
 
     func show() {
@@ -662,7 +672,6 @@ struct OnboardingView: View {
     let systemAgentDefaults: UserDefaults
     let aiSetupRouteIdentityProvider: @MainActor () -> String?
     let gatewaySelectionPersister: @MainActor () -> Bool
-    let configuredGatewayDashboardOpener: @MainActor () -> Void
     let dashboardOnboardingOpener: @MainActor () -> Void
 
     static let windowWidth: CGFloat = 630
@@ -843,9 +852,6 @@ struct OnboardingView: View {
         aiSetupRouteIdentityProvider: (@MainActor () -> String?)? = nil,
         configuredGatewayProbeTimeoutMs: Double = 15000,
         gatewaySelectionPersister: (@MainActor () -> Bool)? = nil,
-        configuredGatewayDashboardOpener: @escaping @MainActor () -> Void = {
-            AppNavigationActions.openDashboard()
-        },
         dashboardOnboardingOpener: @escaping @MainActor () -> Void = {
             AppNavigationActions.openDashboardOnboarding()
         })
@@ -859,7 +865,6 @@ struct OnboardingView: View {
         self.gatewaySelectionPersister = gatewaySelectionPersister ?? {
             state.syncGatewayConfigNow()
         }
-        self.configuredGatewayDashboardOpener = configuredGatewayDashboardOpener
         self.dashboardOnboardingOpener = dashboardOnboardingOpener
         _defaultsToLocalGateway = State(
             initialValue: !state.onboardingSeen && state.connectionMode == .unconfigured)

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -662,6 +662,7 @@ struct OnboardingView: View {
     let systemAgentDefaults: UserDefaults
     let aiSetupRouteIdentityProvider: @MainActor () -> String?
     let gatewaySelectionPersister: @MainActor () -> Bool
+    let configuredGatewayDashboardOpener: @MainActor () -> Void
     let dashboardOnboardingOpener: @MainActor () -> Void
 
     static let windowWidth: CGFloat = 630
@@ -842,6 +843,9 @@ struct OnboardingView: View {
         aiSetupRouteIdentityProvider: (@MainActor () -> String?)? = nil,
         configuredGatewayProbeTimeoutMs: Double = 15000,
         gatewaySelectionPersister: (@MainActor () -> Bool)? = nil,
+        configuredGatewayDashboardOpener: @escaping @MainActor () -> Void = {
+            AppNavigationActions.openDashboard()
+        },
         dashboardOnboardingOpener: @escaping @MainActor () -> Void = {
             AppNavigationActions.openDashboardOnboarding()
         })
@@ -855,6 +859,7 @@ struct OnboardingView: View {
         self.gatewaySelectionPersister = gatewaySelectionPersister ?? {
             state.syncGatewayConfigNow()
         }
+        self.configuredGatewayDashboardOpener = configuredGatewayDashboardOpener
         self.dashboardOnboardingOpener = dashboardOnboardingOpener
         _defaultsToLocalGateway = State(
             initialValue: !state.onboardingSeen && state.connectionMode == .unconfigured)

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -532,6 +532,11 @@ protocol FirstRunOnboardingPresenting: AnyObject {
     func show()
 }
 
+enum FirstRunOnboardingDestination: Equatable {
+    case onboarding
+    case dashboard
+}
+
 @MainActor
 final class OnboardingController: NSObject, NSWindowDelegate, FirstRunOnboardingPresenting {
     static let shared = OnboardingController()
@@ -553,10 +558,15 @@ final class OnboardingController: NSObject, NSWindowDelegate, FirstRunOnboarding
         Self.markComplete()
     }
 
+    static func firstRunDestination(isNixMode: Bool) -> FirstRunOnboardingDestination {
+        isNixMode ? .dashboard : .onboarding
+    }
+
     func show() {
-        if ProcessInfo.processInfo.isNixMode {
+        if Self.firstRunDestination(isNixMode: ProcessInfo.processInfo.isNixMode) == .dashboard {
             // Nix mode is fully declarative; onboarding would suggest interactive setup that doesn't apply.
             Self.markComplete()
+            AppNavigationActions.openDashboard()
             return
         }
         if let window {

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -99,7 +99,7 @@ final class OnboardingAISetupModel {
     @ObservationIgnored private var authSessionID: String?
     @ObservationIgnored private var authAttemptID = UUID()
     /// Only a just-completed provider flow may trust setupComplete without re-probing.
-    @ObservationIgnored private var providerAuthReconciliationPending = false
+    @ObservationIgnored private(set) var providerAuthReconciliationPending = false
 
     init(
         gateway: GatewayConnection = .shared,
@@ -235,11 +235,61 @@ final class OnboardingAISetupModel {
             pendingVerification = nil
         }
         guard isCurrentAttempt(context), !Task.isCancelled else { return .superseded }
-        if outcome == .freshSetupAllowed, isCurrentAttempt(context) {
-            self.resetForGatewayChange(clearPendingHandoff: false)
-            self.startIfNeeded()
+        return self.finishPendingVerificationOutcome(outcome, context: context)
+    }
+
+    /// Reuse a successful live turn from the exact configured-route probe when
+    /// a receipt appeared while that turn was in flight. Receipt ownership and
+    /// the route credential fingerprint remain mandatory; this only removes the
+    /// duplicate provider request.
+    @discardableResult
+    func reuseConfiguredInferenceVerification(
+        modelRef: String,
+        activationOwnershipFingerprint: String?) -> PendingVerificationOutcome
+    {
+        self.resumeConfiguredInference(modelRef: modelRef)
+        guard self.pendingActivationVerification,
+              let context = self.captureAttemptContext()
+        else { return .superseded }
+        if let ownershipFailure = self.pendingActivationOwnershipFailure(
+            context: context,
+            currentFingerprint: activationOwnershipFingerprint)
+        {
+            return self.finishPendingVerificationOutcome(ownershipFailure, context: context)
         }
-        return outcome
+        let outcome = self.acceptPendingConfiguredInferenceVerification(
+            modelRef: modelRef,
+            context: context)
+        return self.finishPendingVerificationOutcome(outcome, context: context)
+    }
+
+    /// Apply a failed turn from the same exact probe without immediately
+    /// spending another provider request. The receipt remains authoritative and
+    /// can retry after its activation window changes.
+    @discardableResult
+    func reuseConfiguredInferenceVerificationFailure(
+        modelRef: String,
+        status: String?,
+        error: String?,
+        activationOwnershipFingerprint: String?) -> PendingVerificationOutcome
+    {
+        self.resumeConfiguredInference(modelRef: modelRef)
+        guard self.pendingActivationVerification,
+              let context = self.captureAttemptContext()
+        else { return .superseded }
+        if let ownershipFailure = self.pendingActivationOwnershipFailure(
+            context: context,
+            currentFingerprint: activationOwnershipFingerprint)
+        {
+            return self.finishPendingVerificationOutcome(ownershipFailure, context: context)
+        }
+        self.phase = .ready
+        self.detectError = Self.failure(
+            label: "Configured AI",
+            status: status,
+            error: error)
+        let outcome = self.pendingVerificationFailureOutcome(context: context)
+        return self.finishPendingVerificationOutcome(outcome, context: context)
     }
 
     private func performPendingConfiguredInferenceVerification(
@@ -264,48 +314,14 @@ final class OnboardingAISetupModel {
               !Task.isCancelled,
               await self.gateway.isCurrentServerLease(lease)
         else { return .superseded }
-        if let activationOwner = pendingActivationOwner {
-            if activationOwner.isUnbound {
-                // Unbound receipts never resume across relaunch or verification
-                // retry; a fresh activation is the only safe continuation.
-                self.pendingActivationVerification = false
-                clearPendingHandoff(ifOwnedBy: context)
-                return .freshSetupAllowed
-            }
-            guard let currentFingerprint = await gateway.activationOwnershipFingerprint(
+        if self.pendingActivationOwner != nil {
+            let currentFingerprint = await gateway.activationOwnershipFingerprint(
                 ifCurrentServerLease: lease)
-            else {
-                self.phase = .ready
-                self.detectError = Self.transportFailure(
-                    "Secure storage is unavailable, so OpenClaw cannot verify which Gateway completed AI setup.")
-                return .notConnected
-            }
-            guard activationOwner.routeFingerprint == currentFingerprint else {
-                switch OnboardingSystemAgentResumeStore.pendingState(
-                    for: context.routeIdentity,
-                    defaults: self.defaults)
-                {
-                case let .activating(deadline), let .verified(deadline):
-                    // Replacement auth cannot verify this owner, but the old
-                    // activation may still mutate the same route. Keep its lease.
-                    self.pendingActivationVerification = false
-                    self.beginPendingActivationDeadlineWait(
-                        deadline: deadline,
-                        routeIdentity: context.routeIdentity)
-                    return .notConnected
-                case .activationExpired, .completed, .none:
-                    // No live mutation remains to overlap. Retire only this
-                    // owner, then let the replacement credentials start fresh.
-                    OnboardingSystemAgentResumeStore.clear(
-                        ifOwnedBy: context.routeIdentity,
-                        activationOwner: activationOwner,
-                        defaults: self.defaults)
-                    self.pendingActivationVerification = false
-                    self.phase = .ready
-                    self.detectError = Self.transportFailure(
-                        "The Gateway authentication changed while AI setup was finishing. Testing it again.")
-                    return .freshSetupAllowed
-                }
+            if let ownershipFailure = self.pendingActivationOwnershipFailure(
+                context: context,
+                currentFingerprint: currentFingerprint)
+            {
+                return ownershipFailure
             }
         }
         do {
@@ -320,54 +336,9 @@ final class OnboardingAISetupModel {
             else { return .superseded }
             let result = try JSONDecoder().decode(ActivateResult.self, from: data)
             if result.ok, let modelRef = result.modelRef {
-                let pendingState = OnboardingSystemAgentResumeStore.pendingState(
-                    for: context.routeIdentity,
-                    defaults: self.defaults)
-                switch pendingState {
-                case let .activating(deadline), let .verified(deadline):
-                    // This proves inference works, but not that the dropped
-                    // activation stopped mutating. Preserve its deadline.
-                    OnboardingSystemAgentResumeStore.markVerified(
-                        ifOwnedBy: context.routeIdentity,
-                        activationOwner: self.pendingActivationOwner,
-                        defaults: self.defaults)
-                    self.pendingActivationVerification = false
-                    self.detectError = nil
-                    self.beginPendingActivationDeadlineWait(
-                        deadline: deadline,
-                        routeIdentity: context.routeIdentity)
-                    return .notConnected
-                case .activationExpired, .none:
-                    if self.pendingActivationRequiresFreshActivation {
-                        self.pendingActivationVerification = false
-                        clearPendingHandoff(ifOwnedBy: context)
-                        return .freshSetupAllowed
-                    }
-                case .completed:
-                    guard let receiptOwner = self.pendingActivationOwner, !receiptOwner.isUnbound
-                    else {
-                        // Ownerless and unbound receipts carry no auth binding,
-                        // so they can belong to replaced credentials on this
-                        // route. Never let one authorize a handoff — repeat a
-                        // fresh activation instead.
-                        self.pendingActivationVerification = false
-                        clearPendingHandoff(ifOwnedBy: context)
-                        return .freshSetupAllowed
-                    }
-                    finishConnected(
-                        kind: "existing-model",
-                        activationOwner: self.pendingActivationOwner,
-                        requireExistingReceipt: true)
-                    if self.connected {
-                        return .connected
-                    }
-                    // The receipt owner changed while verification was in flight.
-                    // Adopt it only for a fresh verification; this result cannot attest it.
-                    self.retainCompletedReceiptForRetry(context: context)
-                    return .notConnected
-                }
-                self.acceptVerifiedPendingInference(modelRef: modelRef)
-                return self.connected ? .connected : .superseded
+                return self.acceptPendingConfiguredInferenceVerification(
+                    modelRef: modelRef,
+                    context: context)
             }
             self.phase = .ready
             self.detectError = Self.failure(
@@ -383,6 +354,117 @@ final class OnboardingAISetupModel {
             self.detectError = Self.transportFailure(error.localizedDescription)
             return self.pendingVerificationFailureOutcome(context: context)
         }
+    }
+
+    private func finishPendingVerificationOutcome(
+        _ outcome: PendingVerificationOutcome,
+        context: AttemptContext) -> PendingVerificationOutcome
+    {
+        if outcome == .freshSetupAllowed, self.isCurrentAttempt(context) {
+            self.resetForGatewayChange(clearPendingHandoff: false)
+            self.startIfNeeded()
+        }
+        return outcome
+    }
+
+    private func pendingActivationOwnershipFailure(
+        context: AttemptContext,
+        currentFingerprint: String?) -> PendingVerificationOutcome?
+    {
+        guard let activationOwner = self.pendingActivationOwner else { return nil }
+        if activationOwner.isUnbound {
+            // Unbound receipts never resume across relaunch or verification
+            // retry; a fresh activation is the only safe continuation.
+            self.pendingActivationVerification = false
+            self.clearPendingHandoff(ifOwnedBy: context)
+            return .freshSetupAllowed
+        }
+        guard let currentFingerprint else {
+            self.phase = .ready
+            self.detectError = Self.transportFailure(
+                "Secure storage is unavailable, so OpenClaw cannot verify which Gateway completed AI setup.")
+            return .notConnected
+        }
+        guard activationOwner.routeFingerprint == currentFingerprint else {
+            switch OnboardingSystemAgentResumeStore.pendingState(
+                for: context.routeIdentity,
+                defaults: self.defaults)
+            {
+            case let .activating(deadline), let .verified(deadline):
+                // Replacement auth cannot verify this owner, but the old
+                // activation may still mutate the same route. Keep its lease.
+                self.pendingActivationVerification = false
+                self.beginPendingActivationDeadlineWait(
+                    deadline: deadline,
+                    routeIdentity: context.routeIdentity)
+                return .notConnected
+            case .activationExpired, .completed, .none:
+                // No live mutation remains to overlap. Retire only this owner,
+                // then let the replacement credentials start fresh.
+                OnboardingSystemAgentResumeStore.clear(
+                    ifOwnedBy: context.routeIdentity,
+                    activationOwner: activationOwner,
+                    defaults: self.defaults)
+                self.pendingActivationVerification = false
+                self.phase = .ready
+                self.detectError = Self.transportFailure(
+                    "The Gateway authentication changed while AI setup was finishing. Testing it again.")
+                return .freshSetupAllowed
+            }
+        }
+        return nil
+    }
+
+    private func acceptPendingConfiguredInferenceVerification(
+        modelRef: String,
+        context: AttemptContext) -> PendingVerificationOutcome
+    {
+        let pendingState = OnboardingSystemAgentResumeStore.pendingState(
+            for: context.routeIdentity,
+            defaults: self.defaults)
+        switch pendingState {
+        case let .activating(deadline), let .verified(deadline):
+            // This proves inference works, but not that the dropped activation
+            // stopped mutating. Preserve its exact owner and deadline.
+            OnboardingSystemAgentResumeStore.markVerified(
+                ifOwnedBy: context.routeIdentity,
+                activationOwner: self.pendingActivationOwner,
+                defaults: self.defaults)
+            self.pendingActivationVerification = false
+            self.detectError = nil
+            self.beginPendingActivationDeadlineWait(
+                deadline: deadline,
+                routeIdentity: context.routeIdentity)
+            return .notConnected
+        case .activationExpired, .none:
+            if self.pendingActivationRequiresFreshActivation {
+                self.pendingActivationVerification = false
+                self.clearPendingHandoff(ifOwnedBy: context)
+                return .freshSetupAllowed
+            }
+        case .completed:
+            guard let receiptOwner = self.pendingActivationOwner, !receiptOwner.isUnbound
+            else {
+                // Ownerless and unbound receipts carry no auth binding, so they
+                // can belong to replaced credentials on this route.
+                self.pendingActivationVerification = false
+                self.clearPendingHandoff(ifOwnedBy: context)
+                return .freshSetupAllowed
+            }
+            self.finishConnected(
+                kind: "existing-model",
+                activationOwner: self.pendingActivationOwner,
+                requireExistingReceipt: true)
+            if self.connected {
+                return .connected
+            }
+            // The receipt owner changed while verification was in flight. Adopt
+            // it only for a fresh verification; this result cannot attest it.
+            self.retainCompletedReceiptForRetry(context: context)
+            return .notConnected
+        }
+        self.acceptVerifiedPendingInference(modelRef: modelRef)
+        return self.connected ? .connected : .superseded
     }
 
     private func pendingVerificationFailureOutcome(

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -169,6 +169,23 @@ final class OnboardingAISetupModel {
         self.detectError = detectError
     }
 
+    func recoverConfiguredGatewayVerification(
+        modelRef: String,
+        status: String?,
+        error: String?)
+    {
+        self.resetForGatewayChange(clearPendingHandoff: false)
+        self.updateConfiguredGatewayBlockerState(
+            .verificationFailed(ConfiguredGatewayVerificationFailure(
+                modelRef: modelRef,
+                status: status,
+                error: error)),
+            phase: .detecting,
+            detectError: nil)
+        self.started = true
+        self.scheduleDetection()
+    }
+
     /// Restore only the pending handoff state. A configured model label is not
     /// proof that the ambiguous activation completed or that inference works.
     func resumeConfiguredInference(modelRef: String) {
@@ -694,7 +711,9 @@ extension OnboardingAISetupModel {
                 }
                 return
             }
-            if let first = autoCandidateAfter(kind: nil) {
+            if self.configuredGatewayVerificationFailure != nil {
+                self.showManualEntry = self.candidates.isEmpty && !self.manualProviders.isEmpty
+            } else if let first = autoCandidateAfter(kind: nil) {
                 await self.activate(kind: first.kind, context: context)
             } else {
                 self.showManualEntry = !self.manualProviders.isEmpty
@@ -819,7 +838,7 @@ extension OnboardingAISetupModel {
             kind: kind,
             modelRef: candidate.modelRef,
             label: candidate.label,
-            tryNextCandidateOnFailure: true,
+            tryNextCandidateOnFailure: self.configuredGatewayVerificationFailure == nil,
             context: context)
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -169,23 +169,6 @@ final class OnboardingAISetupModel {
         self.detectError = detectError
     }
 
-    func recoverConfiguredGatewayVerification(
-        modelRef: String,
-        status: String?,
-        error: String?)
-    {
-        self.resetForGatewayChange(clearPendingHandoff: false)
-        self.updateConfiguredGatewayBlockerState(
-            .verificationFailed(ConfiguredGatewayVerificationFailure(
-                modelRef: modelRef,
-                status: status,
-                error: error)),
-            phase: .detecting,
-            detectError: nil)
-        self.started = true
-        self.scheduleDetection()
-    }
-
     /// Restore only the pending handoff state. A configured model label is not
     /// proof that the ambiguous activation completed or that inference works.
     func resumeConfiguredInference(modelRef: String) {

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -169,6 +169,15 @@ final class OnboardingAISetupModel {
         self.detectError = detectError
     }
 
+    func recoverConfiguredGatewayVerification(modelRef: String, status: String?, error: String?) {
+        self.resetForGatewayChange(clearPendingHandoff: false)
+        let failure = ConfiguredGatewayVerificationFailure(modelRef: modelRef, status: status, error: error)
+        self.updateConfiguredGatewayBlockerState(
+            .verificationFailed(failure), phase: .detecting, detectError: nil)
+        self.started = true
+        self.scheduleDetection()
+    }
+
     /// Restore only the pending handoff state. A configured model label is not
     /// proof that the ambiguous activation completed or that inference works.
     func resumeConfiguredInference(modelRef: String) {

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -66,7 +66,7 @@ final class OnboardingAISetupModel {
     private(set) var statuses: [String: CandidateStatus] = [:]
     private(set) var selectedKind: String?
     private(set) var detectError: Failure?
-    private(set) var pendingActivationVerification = false
+    var pendingActivationVerification = false
     private(set) var waitingForPendingActivationDeadline = false
     private(set) var configuredGatewayBlocker: ConfiguredGatewayBlocker?
     /// Set once every detected candidate failed; opens the manual key form.
@@ -74,8 +74,8 @@ final class OnboardingAISetupModel {
 
     var manualProviderID = ""
     var manualKey: String = ""
-    private(set) var manualTesting = false
-    private(set) var manualError: Failure?
+    var manualTesting = false
+    var manualError: Failure?
     var showManualEntry = false
 
     /// Called when a candidate connects so the page can advance.
@@ -84,17 +84,17 @@ final class OnboardingAISetupModel {
     /// activation lease. The view owns the route-bound, coalesced timer.
     var onPendingActivationDeadline: ((Date, String) -> Void)?
 
-    private let gateway: GatewayConnection
-    private let defaults: UserDefaults
+    let gateway: GatewayConnection
+    let defaults: UserDefaults
     private let routeIdentityProvider: @MainActor () -> String?
     private let connectionModeProvider: @MainActor () -> AppState.ConnectionMode
     private var started = false
     private var attemptToken = UUID()
     @ObservationIgnored private var pendingVerification: PendingVerification?
-    @ObservationIgnored private var pendingActivationOwner: OnboardingSystemAgentResumeStore.ActivationOwner?
+    @ObservationIgnored var pendingActivationOwner: OnboardingSystemAgentResumeStore.ActivationOwner?
     @ObservationIgnored private var completedHandoff: CompletedHandoff?
-    @ObservationIgnored private var pendingActivationRequiresFreshActivation = false
-    @ObservationIgnored private var serverLease: GatewayConnection.ServerLease?
+    @ObservationIgnored var pendingActivationRequiresFreshActivation = false
+    @ObservationIgnored private(set) var serverLease: GatewayConnection.ServerLease?
     @ObservationIgnored private var lastDetectedActivationState: PersistedActivationState?
     @ObservationIgnored private var authSessionID: String?
     @ObservationIgnored private var authAttemptID = UUID()
@@ -538,7 +538,7 @@ final class OnboardingAISetupModel {
         self.onPendingActivationDeadline?(deadline, routeIdentity)
     }
 
-    private func retainAmbiguousActivation(
+    func retainAmbiguousActivation(
         ifOwnedBy context: AttemptContext,
         activationOwner: OnboardingSystemAgentResumeStore.ActivationOwner,
         activationDeadline: Date)
@@ -821,19 +821,19 @@ extension OnboardingAISetupModel {
             supersededAttemptDeadline: supersededAttemptDeadline)
     }
 
-    private func beginAttemptContext(
+    func beginAttemptContext(
         supersededAttemptDeadline: Date? = nil) -> AttemptContext?
     {
         self.attemptToken = UUID()
         return self.captureAttemptContext(supersededAttemptDeadline: supersededAttemptDeadline)
     }
 
-    private func isCurrentAttempt(_ context: AttemptContext) -> Bool {
+    func isCurrentAttempt(_ context: AttemptContext) -> Bool {
         context.token == self.attemptToken &&
             self.routeIdentityProvider()?.trimmingCharacters(in: .whitespacesAndNewlines) == context.routeIdentity
     }
 
-    private func clearPendingHandoff(
+    func clearPendingHandoff(
         ifOwnedBy context: AttemptContext,
         activationOwner: OnboardingSystemAgentResumeStore.ActivationOwner? = nil)
     {
@@ -1581,134 +1581,6 @@ extension OnboardingAISetupModel {
 }
 
 extension OnboardingAISetupModel {
-    func submitManualKey() {
-        let key = self.manualKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let provider = selectedManualProvider, !key.isEmpty, !self.isBusy else { return }
-        guard let context = beginAttemptContext() else {
-            self.manualError = Self.transportFailure(
-                "No Gateway is selected. Select a Gateway, then try again.")
-            return
-        }
-        self.manualError = nil
-        self.manualTesting = true
-        Task { await self.submitManualKey(key: key, provider: provider, context: context) }
-    }
-
-    private func submitManualKey(
-        key: String,
-        provider: ManualProvider,
-        context: AttemptContext) async
-    {
-        defer {
-            if self.isCurrentAttempt(context) {
-                self.manualTesting = false
-            }
-        }
-        guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
-        guard let lease = serverLease,
-              await gateway.isCurrentServerLease(lease)
-        else {
-            let failure = Self.transportFailure(
-                "The Gateway connection changed. Check for AI accounts again.")
-            self.manualError = failure
-            self.requireFreshDetection(after: failure)
-            return
-        }
-        guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
-        let routeFingerprint = await gateway.activationOwnershipFingerprint(
-            ifCurrentServerLease: lease)
-        guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
-        let requestTimeoutMs = Self.activationRequestTimeoutMs(for: "api-key")
-        // Same keychain-unavailable degradation as detected candidates: an
-        // unbound lease keeps the ambiguity window without a resume receipt.
-        let activationOwner = routeFingerprint.map { fingerprint in
-            OnboardingSystemAgentResumeStore.ActivationOwner(
-                id: UUID().uuidString,
-                routeFingerprint: fingerprint)
-        } ?? .unbound()
-        self.pendingActivationOwner = activationOwner
-        self.pendingActivationRequiresFreshActivation = true
-        // Manual activation has the same persist-before-response ambiguity as
-        // detected candidates, so relaunch must inspect exact Gateway truth.
-        guard let activationDeadline = OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: context.routeIdentity,
-            activationOwner: activationOwner,
-            activationTimeoutMs: requestTimeoutMs,
-            defaults: defaults)
-        else {
-            self.manualError = Self.transportFailure(
-                "No Gateway is selected. Select a Gateway, then try again.")
-            return
-        }
-        guard !Task.isCancelled else {
-            self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
-            return
-        }
-        do {
-            let data = try await gateway.request(
-                method: "openclaw.setup.activate",
-                params: [
-                    "kind": AnyCodable("api-key"),
-                    "authChoice": AnyCodable(provider.id),
-                    "apiKey": AnyCodable(key),
-                ],
-                timeoutMs: requestTimeoutMs,
-                ifCurrentServerLease: lease)
-            let result = try JSONDecoder().decode(ActivateResult.self, from: data)
-            guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
-            guard await self.gateway.isCurrentServerLease(lease) else {
-                if result.ok,
-                   OnboardingSystemAgentResumeStore.markCompleted(
-                       ifOwnedBy: context.routeIdentity,
-                       activationOwner: activationOwner,
-                       defaults: self.defaults)
-                {
-                    self.pendingActivationVerification = true
-                    self.phase = .detecting
-                    _ = await self.verifyPendingConfiguredInference()
-                } else {
-                    self.pendingActivationVerification = false
-                    self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
-                    self.requireFreshDetection(after: Self.transportFailure(
-                        "The Gateway connection changed while AI setup was finishing. Check again."))
-                }
-                return
-            }
-            guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
-            if result.ok {
-                self.manualKey = ""
-                self.finishConnected(
-                    kind: "api-key",
-                    activationOwner: activationOwner)
-            } else {
-                self.pendingActivationVerification = false
-                self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
-                self.manualError = Self.failure(
-                    label: provider.label,
-                    status: result.status,
-                    error: result.error)
-            }
-        } catch {
-            guard self.isCurrentAttempt(context) else { return }
-            // A cancellation after request dispatch is ambiguous; keep the
-            // pending marker so relaunch reconciles against this exact route.
-            let failure = Self.transportFailure(error.localizedDescription)
-            self.manualError = failure
-            if Self.activationFailureIsDefinitive(error) {
-                self.pendingActivationVerification = false
-                self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
-                if await !(self.gateway.isCurrentServerLease(lease)) {
-                    self.requireFreshDetection(after: failure)
-                }
-            } else {
-                self.retainAmbiguousActivation(
-                    ifOwnedBy: context,
-                    activationOwner: activationOwner,
-                    activationDeadline: activationDeadline)
-            }
-        }
-    }
-
     /// A retired socket invalidates every candidate and provider record learned
     /// from that server generation. Preserve the error, but require a fresh
     /// detection lease before the user can dispatch another setup mutation.
@@ -1718,7 +1590,7 @@ extension OnboardingAISetupModel {
         self.detectError = failure
     }
 
-    private func finishConnected(
+    func finishConnected(
         kind: String,
         activationOwner: OnboardingSystemAgentResumeStore.ActivationOwner? = nil,
         requireExistingReceipt: Bool = false)

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -137,6 +137,12 @@ final class OnboardingAISetupModel {
             Task { await self.verifyPendingConfiguredInference() }
             return
         }
+        if self.providerAuthReconciliationPending {
+            self.phase = .detecting
+            self.detectError = nil
+            self.scheduleDetection()
+            return
+        }
         self.resetForGatewayChange()
         self.started = true
         self.phase = .detecting

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -1451,6 +1451,13 @@ extension OnboardingAISetupModel {
             let preparedModel = preparedModelRef?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             self.providerAuthReconciliationPending = self.providerWizardKind == .auth
+            if self.providerAuthReconciliationPending,
+               self.configuredGatewayVerificationFailure != nil
+            {
+                // Successful reauthentication supersedes the old verification
+                // failure; reconciliation now owns detection and its retries.
+                self.configuredGatewayBlocker = nil
+            }
             self.clearProviderAuth()
             if let preparedProvider,
                let preparedModel,

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupManualKey.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupManualKey.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+extension OnboardingAISetupModel {
+    func submitManualKey() {
+        let key = self.manualKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let provider = selectedManualProvider, !key.isEmpty, !self.isBusy else { return }
+        guard let context = beginAttemptContext() else {
+            self.manualError = Self.transportFailure(
+                "No Gateway is selected. Select a Gateway, then try again.")
+            return
+        }
+        self.manualError = nil
+        self.manualTesting = true
+        Task { await self.submitManualKey(key: key, provider: provider, context: context) }
+    }
+
+    private func submitManualKey(
+        key: String,
+        provider: ManualProvider,
+        context: AttemptContext) async
+    {
+        defer {
+            if self.isCurrentAttempt(context) {
+                self.manualTesting = false
+            }
+        }
+        guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
+        guard let lease = serverLease,
+              await gateway.isCurrentServerLease(lease)
+        else {
+            let failure = Self.transportFailure(
+                "The Gateway connection changed. Check for AI accounts again.")
+            self.manualError = failure
+            self.requireFreshDetection(after: failure)
+            return
+        }
+        guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
+        let routeFingerprint = await gateway.activationOwnershipFingerprint(
+            ifCurrentServerLease: lease)
+        guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
+        let requestTimeoutMs = Self.activationRequestTimeoutMs(for: "api-key")
+        // Same keychain-unavailable degradation as detected candidates: an
+        // unbound lease keeps the ambiguity window without a resume receipt.
+        let activationOwner = routeFingerprint.map { fingerprint in
+            OnboardingSystemAgentResumeStore.ActivationOwner(
+                id: UUID().uuidString,
+                routeFingerprint: fingerprint)
+        } ?? .unbound()
+        self.pendingActivationOwner = activationOwner
+        self.pendingActivationRequiresFreshActivation = true
+        // Manual activation has the same persist-before-response ambiguity as
+        // detected candidates, so relaunch must inspect exact Gateway truth.
+        guard let activationDeadline = OnboardingSystemAgentResumeStore.markPending(
+            routeIdentity: context.routeIdentity,
+            activationOwner: activationOwner,
+            activationTimeoutMs: requestTimeoutMs,
+            defaults: defaults)
+        else {
+            self.manualError = Self.transportFailure(
+                "No Gateway is selected. Select a Gateway, then try again.")
+            return
+        }
+        guard !Task.isCancelled else {
+            self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
+            return
+        }
+        do {
+            let data = try await gateway.request(
+                method: "openclaw.setup.activate",
+                params: [
+                    "kind": AnyCodable("api-key"),
+                    "authChoice": AnyCodable(provider.id),
+                    "apiKey": AnyCodable(key),
+                ],
+                timeoutMs: requestTimeoutMs,
+                ifCurrentServerLease: lease)
+            let result = try JSONDecoder().decode(ActivateResult.self, from: data)
+            guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
+            guard await self.gateway.isCurrentServerLease(lease) else {
+                if result.ok,
+                   OnboardingSystemAgentResumeStore.markCompleted(
+                       ifOwnedBy: context.routeIdentity,
+                       activationOwner: activationOwner,
+                       defaults: self.defaults)
+                {
+                    self.pendingActivationVerification = true
+                    self.phase = .detecting
+                    _ = await self.verifyPendingConfiguredInference()
+                } else {
+                    self.pendingActivationVerification = false
+                    self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
+                    self.requireFreshDetection(after: Self.transportFailure(
+                        "The Gateway connection changed while AI setup was finishing. Check again."))
+                }
+                return
+            }
+            guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
+            if result.ok {
+                self.manualKey = ""
+                self.finishConnected(
+                    kind: "api-key",
+                    activationOwner: activationOwner)
+            } else {
+                self.pendingActivationVerification = false
+                self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
+                self.manualError = Self.failure(
+                    label: provider.label,
+                    status: result.status,
+                    error: result.error)
+            }
+        } catch {
+            guard self.isCurrentAttempt(context) else { return }
+            // A cancellation after request dispatch is ambiguous; keep the
+            // pending marker so relaunch reconciles against this exact route.
+            let failure = Self.transportFailure(error.localizedDescription)
+            self.manualError = failure
+            if Self.activationFailureIsDefinitive(error) {
+                self.pendingActivationVerification = false
+                self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
+                if await !(self.gateway.isCurrentServerLease(lease)) {
+                    self.requireFreshDetection(after: failure)
+                }
+            } else {
+                self.retainAmbiguousActivation(
+                    ifOwnedBy: context,
+                    activationOwner: activationOwner,
+                    activationDeadline: activationDeadline)
+            }
+        }
+    }
+}
+

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupManualKey.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupManualKey.swift
@@ -84,7 +84,6 @@ extension OnboardingAISetupModel {
                        defaults: self.defaults)
                 {
                     self.pendingActivationVerification = true
-                    self.phase = .detecting
                     _ = await self.verifyPendingConfiguredInference()
                 } else {
                     self.pendingActivationVerification = false
@@ -129,4 +128,3 @@ extension OnboardingAISetupModel {
         }
     }
 }
-

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -201,8 +201,8 @@ extension OnboardingAISetupModel {
     /// OpenClaw rather than the existing-Gateway onboarding bypass.
     var ownsInferenceTransition: Bool {
         (self.phase == .detecting && self.configuredGatewayBlocker == nil) ||
-            self.phase == .testing || self.manualTesting || self.authBusy || self.connected ||
-            self.pendingActivationVerification
+            self.phase == .testing || self.manualTesting || self.providerWizardKind != nil ||
+            self.authBusy || self.connected || self.pendingActivationVerification
     }
 
     static func prepareOptions(

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -202,7 +202,8 @@ extension OnboardingAISetupModel {
     var ownsInferenceTransition: Bool {
         (self.phase == .detecting && self.configuredGatewayBlocker == nil) ||
             self.phase == .testing || self.manualTesting || self.providerWizardKind != nil ||
-            self.authBusy || self.connected || self.pendingActivationVerification
+            self.authBusy || self.providerAuthReconciliationPending || self.connected ||
+            self.pendingActivationVerification
     }
 
     static func prepareOptions(

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -182,6 +182,14 @@ struct OnboardingAISetupView: View {
                 secondaryTitle: card.secondaryTitle,
                 secondary: self.retryConfiguredGatewayProbe,
                 retry: self.returnToGatewayAuthentication)
+        } else if let verificationFailure = model.configuredGatewayVerificationFailure {
+            OnboardingErrorCard(
+                title: "Configured AI needs attention",
+                message: verificationFailure.presentation.summary,
+                details: verificationFailure.presentation.detail,
+                docsSlug: "start/onboarding",
+                retryTitle: "Try again",
+                retry: self.retryConfiguredGatewayProbe)
         } else if let detectError = model.detectError {
             OnboardingErrorCard(
                 title: self.model.configuredGatewayProbeUnavailable

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 
 /// Route-bound check used before onboarding starts creating inference config.
 /// A superseded result must never complete onboarding for the replacement Gateway.

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -110,7 +110,8 @@ final class OnboardingConfiguredGatewayProbe {
     func probe(
         connectionMode: AppState.ConnectionMode,
         attempt: Attempt,
-        routeIdentity: String? = nil) async -> Outcome
+        routeIdentity: String? = nil,
+        verifyConfiguredInference: Bool = true) async -> Outcome
     {
         guard self.isCurrent(attempt) else { return .superseded }
         self.activeProbeCount += 1
@@ -142,6 +143,11 @@ final class OnboardingConfiguredGatewayProbe {
             else { return .superseded }
             let boundRoute = BoundRoute(route: route, identity: routeIdentity)
             guard let model else { return .missing(route: boundRoute) }
+            // A pending activation receipt has its own route- and owner-bound
+            // verifier. Avoid paying for a second turn before reconciliation.
+            guard verifyConfiguredInference else {
+                return .configured(modelRef: model, route: boundRoute)
+            }
 
             guard let supportsVerification = await self.gateway.supportsServerMethod(
                 "openclaw.setup.verify",

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -118,7 +118,7 @@ final class OnboardingConfiguredGatewayProbe {
         guard connectionMode != .unconfigured else { return .unavailable }
         let lease: GatewayConnection.ServerLease
         do {
-            lease = try await self.gateway.captureRequiredServerLease()
+            lease = try await self.gateway.acquireServerLease()
         } catch {
             guard self.isCurrent(attempt) else { return .superseded }
             if connectionMode == .remote,

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -49,8 +49,8 @@ final class OnboardingConfiguredGatewayProbe {
     private var generation: UInt64 = 0
     private var scheduledProbeGenerations = Set<UInt64>()
     private var activeProbeGenerations = Set<UInt64>()
-    private var reconnectPending = false
-    private var snapshotAwaitingProbeLease: GatewayConnection.ServerLease?
+    private var observedServerIdentity: GatewayConnection.ServerIdentity?
+    private var pendingReconnectIdentity: GatewayConnection.ServerIdentity?
     private var reconnectHandler: (@MainActor () -> Void)?
     private var pendingActivationDeadlineTask: Task<Void, Never>?
     private var temporaryConnectionCheckDepth = 0
@@ -150,7 +150,7 @@ final class OnboardingConfiguredGatewayProbe {
             return .unavailable
         }
         guard self.isCurrent(attempt) else { return .superseded }
-        await self.registerProbeLease(lease)
+        self.registerProbeServer(lease.identity)
         let route = lease.route
         do {
             let agentsData = try await gateway.request(
@@ -182,7 +182,7 @@ final class OnboardingConfiguredGatewayProbe {
             }
             let verificationData: Data
             do {
-                verificationData = try await gateway.request(
+                verificationData = try await self.gateway.request(
                     method: "openclaw.setup.verify",
                     params: [:],
                     timeoutMs: self.verificationTimeoutMs,
@@ -242,32 +242,16 @@ final class OnboardingConfiguredGatewayProbe {
         self.reconnectHandler = onReconnect
         defer {
             self.reconnectHandler = nil
-            self.reconnectPending = false
-            self.snapshotAwaitingProbeLease = nil
+            self.pendingReconnectIdentity = nil
+            self.observedServerIdentity = nil
         }
-        // onboardingDidAppear owns the current cached snapshot. This stream
-        // observes only physical connections established after it subscribes.
-        let stream = await gateway.subscribe(
-            bufferingNewest: 1,
-            replayLatestSnapshot: false)
-        for await push in stream {
+        let subscription = await gateway.subscribeServerSnapshots(bufferingNewest: 1)
+        if let baseline = subscription.baseline {
+            self.consumeServerSnapshot(baseline, onReconnect: onReconnect)
+        }
+        for await identity in subscription.stream {
             guard !Task.isCancelled else { return }
-            guard case .snapshot = push else { continue }
-            // ServerLease validation includes the physical socket generation.
-            // Ignore the hello owned by this probe, but retain a newer socket
-            // until all work for the replaced lease has unwound.
-            if let lease = self.snapshotAwaitingProbeLease,
-               await self.gateway.isCurrentServerLease(lease)
-            {
-                self.snapshotAwaitingProbeLease = nil
-                self.reconnectPending = false
-                continue
-            }
-            guard !self.hasProbeWork else {
-                self.reconnectPending = true
-                continue
-            }
-            onReconnect()
+            self.consumeServerSnapshot(identity, onReconnect: onReconnect)
         }
     }
 
@@ -275,24 +259,32 @@ final class OnboardingConfiguredGatewayProbe {
         !self.scheduledProbeGenerations.isEmpty || !self.activeProbeGenerations.isEmpty
     }
 
-    private func registerProbeLease(_ lease: GatewayConnection.ServerLease) async {
-        guard await self.gateway.isCurrentServerLease(lease) else { return }
-        if self.reconnectPending {
-            // A snapshot received before lease acquisition belongs to the same
-            // physical socket now covered by this probe.
-            self.reconnectPending = false
-            self.snapshotAwaitingProbeLease = nil
-        } else {
-            // Push delivery is intentionally asynchronous to connect. Remember
-            // the lease until its hello arrives after a fast probe completes.
-            self.snapshotAwaitingProbeLease = lease
+    private func registerProbeServer(_ identity: GatewayConnection.ServerIdentity) {
+        self.observedServerIdentity = identity
+        if self.pendingReconnectIdentity == identity {
+            self.pendingReconnectIdentity = nil
         }
+    }
+
+    private func consumeServerSnapshot(
+        _ identity: GatewayConnection.ServerIdentity,
+        onReconnect: @escaping @MainActor () -> Void)
+    {
+        guard identity != self.observedServerIdentity else { return }
+        // Admission and ordinary push delivery can expose the same socket.
+        // Record it before starting work so that socket schedules only one probe.
+        self.observedServerIdentity = identity
+        guard !self.hasProbeWork else {
+            self.pendingReconnectIdentity = identity
+            return
+        }
+        onReconnect()
     }
 
     private func finishProbe(_ attempt: Attempt) {
         self.activeProbeGenerations.remove(attempt.generation)
-        guard !self.hasProbeWork, self.reconnectPending else { return }
-        self.reconnectPending = false
+        guard !self.hasProbeWork, self.pendingReconnectIdentity != nil else { return }
+        self.pendingReconnectIdentity = nil
         self.reconnectHandler?()
     }
 }

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -261,7 +261,9 @@ final class OnboardingConfiguredGatewayProbe {
 
     private func registerProbeServer(_ identity: GatewayConnection.ServerIdentity) {
         self.observedServerIdentity = identity
-        if self.pendingReconnectIdentity == identity {
+        if let pendingReconnectIdentity,
+           identity.covers(pendingReconnectIdentity)
+        {
             self.pendingReconnectIdentity = nil
         }
     }

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -15,7 +15,7 @@ final class OnboardingConfiguredGatewayProbe {
 
     enum Outcome: Equatable {
         case configured(modelRef: String, route: BoundRoute)
-        case verificationFailed(status: String?, error: String?, route: BoundRoute)
+        case verificationFailed(modelRef: String, status: String?, error: String?, route: BoundRoute)
         case missing(route: BoundRoute)
         case authIssue(RemoteGatewayAuthIssue)
         case unavailable
@@ -23,7 +23,7 @@ final class OnboardingConfiguredGatewayProbe {
 
         var boundRoute: BoundRoute? {
             switch self {
-            case let .configured(_, route), let .verificationFailed(_, _, route), let .missing(route):
+            case let .configured(_, route), let .verificationFailed(_, _, _, route), let .missing(route):
                 route
             case .authIssue, .unavailable, .superseded:
                 nil
@@ -116,9 +116,9 @@ final class OnboardingConfiguredGatewayProbe {
         self.activeProbeCount += 1
         defer { self.finishProbe() }
         guard connectionMode != .unconfigured else { return .unavailable }
-        let route: GatewayConnection.Route
+        let lease: GatewayConnection.ServerLease
         do {
-            route = try await self.gateway.captureRequiredRoute()
+            lease = try await self.gateway.captureRequiredServerLease()
         } catch {
             guard self.isCurrent(attempt) else { return .superseded }
             if connectionMode == .remote,
@@ -129,23 +129,20 @@ final class OnboardingConfiguredGatewayProbe {
             return .unavailable
         }
         guard self.isCurrent(attempt) else { return .superseded }
+        let route = lease.route
         do {
-            let model = try await gateway.configuredInferenceModel(
-                ifCurrentRoute: route,
-                timeoutMs: self.timeoutMs)
-            guard await self.gateway.isCurrentRoute(route),
+            let agentsData = try await gateway.request(
+                method: GatewayConnection.Method.agentsList.rawValue,
+                params: [:],
+                timeoutMs: self.timeoutMs,
+                ifCurrentServerLease: lease)
+            let model = try GatewayConnection.decodeConfiguredInferenceModel(agentsData)
+            guard await self.gateway.isCurrentServerLease(lease),
                   self.isCurrent(attempt)
             else { return .superseded }
             let boundRoute = BoundRoute(route: route, identity: routeIdentity)
             guard let model else { return .missing(route: boundRoute) }
 
-            // Bind method negotiation and inference to the socket that owned
-            // agents.list. A reconnect or credential replacement supersedes it.
-            guard let lease = await self.gateway.captureServerLease(ifCurrentRoute: route) else {
-                guard self.isCurrent(attempt) else { return .superseded }
-                return .unavailable
-            }
-            guard self.isCurrent(attempt) else { return .superseded }
             guard let supportsVerification = await self.gateway.supportsServerMethod(
                 "openclaw.setup.verify",
                 ifCurrentServerLease: lease),
@@ -169,17 +166,18 @@ final class OnboardingConfiguredGatewayProbe {
                 from: verificationData)
             guard verification.ok else {
                 return .verificationFailed(
+                    modelRef: model,
                     status: verification.status,
                     error: verification.error,
                     route: boundRoute)
             }
             return .configured(modelRef: model, route: boundRoute)
         } catch is CancellationError {
-            return .superseded
+            guard self.isCurrent(attempt) else { return .superseded }
+            return await self.gateway.isCurrentServerLease(lease) ? .superseded : .unavailable
         } catch {
-            guard await self.gateway.isCurrentRoute(route),
-                  self.isCurrent(attempt)
-            else { return .superseded }
+            guard self.isCurrent(attempt) else { return .superseded }
+            guard await self.gateway.isCurrentServerLease(lease) else { return .unavailable }
             if connectionMode == .remote,
                let authIssue = RemoteGatewayAuthIssue(error: error)
             {

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -170,11 +170,25 @@ final class OnboardingConfiguredGatewayProbe {
             guard supportsVerification else {
                 return .configured(modelRef: model, verification: nil, route: boundRoute)
             }
-            let verificationData = try await gateway.request(
-                method: "openclaw.setup.verify",
-                params: [:],
-                timeoutMs: self.verificationTimeoutMs,
-                ifCurrentServerLease: lease)
+            let verificationData: Data
+            do {
+                verificationData = try await gateway.request(
+                    method: "openclaw.setup.verify",
+                    params: [:],
+                    timeoutMs: self.verificationTimeoutMs,
+                    ifCurrentServerLease: lease)
+            } catch {
+                guard let response = error as? GatewayResponseError,
+                      response.method == "openclaw.setup.verify",
+                      response.missingScope == "operator.admin"
+                else { throw error }
+                guard await self.gateway.isCurrentServerLease(lease),
+                      self.isCurrent(attempt)
+                else { return .superseded }
+                // Released Gateways advertised this method while requiring admin.
+                // Persisted macOS device grants can be write-only after an upgrade.
+                return .configured(modelRef: model, verification: nil, route: boundRoute)
+            }
             guard await self.gateway.isCurrentServerLease(lease),
                   self.isCurrent(attempt)
             else { return .superseded }

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -47,8 +47,10 @@ final class OnboardingConfiguredGatewayProbe {
     private let timeoutMs: Double
     private let verificationTimeoutMs: Double
     private var generation: UInt64 = 0
-    private var activeProbeCount = 0
+    private var scheduledProbeGenerations = Set<UInt64>()
+    private var activeProbeGenerations = Set<UInt64>()
     private var reconnectPending = false
+    private var snapshotAwaitingProbeLease: GatewayConnection.ServerLease?
     private var reconnectHandler: (@MainActor () -> Void)?
     private var pendingActivationDeadlineTask: Task<Void, Never>?
     private var temporaryConnectionCheckDepth = 0
@@ -67,7 +69,11 @@ final class OnboardingConfiguredGatewayProbe {
     /// order, decides which selected Gateway owns the result.
     func beginProbe() -> Attempt {
         self.generation &+= 1
-        return Attempt(generation: self.generation)
+        let attempt = Attempt(generation: self.generation)
+        // Only the newest queued attempt can still start; active superseded
+        // attempts remain tracked until their route-bound work unwinds.
+        self.scheduledProbeGenerations = [attempt.generation]
+        return attempt
     }
 
     func isCurrent(_ attempt: Attempt) -> Bool {
@@ -91,6 +97,7 @@ final class OnboardingConfiguredGatewayProbe {
 
     func invalidate() {
         self.generation &+= 1
+        self.scheduledProbeGenerations.removeAll()
         self.pendingActivationDeadlineTask?.cancel()
         self.pendingActivationDeadlineTask = nil
     }
@@ -125,9 +132,10 @@ final class OnboardingConfiguredGatewayProbe {
         routeIdentity: String? = nil,
         verifyConfiguredInference: Bool = true) async -> Outcome
     {
+        self.scheduledProbeGenerations.remove(attempt.generation)
         guard self.isCurrent(attempt) else { return .superseded }
-        self.activeProbeCount += 1
-        defer { self.finishProbe() }
+        self.activeProbeGenerations.insert(attempt.generation)
+        defer { self.finishProbe(attempt) }
         guard connectionMode != .unconfigured else { return .unavailable }
         let lease: GatewayConnection.ServerLease
         do {
@@ -142,6 +150,7 @@ final class OnboardingConfiguredGatewayProbe {
             return .unavailable
         }
         guard self.isCurrent(attempt) else { return .superseded }
+        await self.registerProbeLease(lease)
         let route = lease.route
         do {
             let agentsData = try await gateway.request(
@@ -234,15 +243,27 @@ final class OnboardingConfiguredGatewayProbe {
         defer {
             self.reconnectHandler = nil
             self.reconnectPending = false
+            self.snapshotAwaitingProbeLease = nil
         }
-        let stream = await gateway.subscribe(bufferingNewest: 1)
+        // onboardingDidAppear owns the current cached snapshot. This stream
+        // observes only physical connections established after it subscribes.
+        let stream = await gateway.subscribe(
+            bufferingNewest: 1,
+            replayLatestSnapshot: false)
         for await push in stream {
             guard !Task.isCancelled else { return }
             guard case .snapshot = push else { continue }
-            // captureRoute can create the socket whose hello produced this
-            // snapshot. Coalesce it until that route-bound check finishes so a
-            // real reconnect is never lost behind the in-flight request.
-            guard self.activeProbeCount == 0 else {
+            // ServerLease validation includes the physical socket generation.
+            // Ignore the hello owned by this probe, but retain a newer socket
+            // until all work for the replaced lease has unwound.
+            if let lease = self.snapshotAwaitingProbeLease,
+               await self.gateway.isCurrentServerLease(lease)
+            {
+                self.snapshotAwaitingProbeLease = nil
+                self.reconnectPending = false
+                continue
+            }
+            guard !self.hasProbeWork else {
                 self.reconnectPending = true
                 continue
             }
@@ -250,9 +271,27 @@ final class OnboardingConfiguredGatewayProbe {
         }
     }
 
-    private func finishProbe() {
-        self.activeProbeCount -= 1
-        guard self.activeProbeCount == 0, self.reconnectPending else { return }
+    private var hasProbeWork: Bool {
+        !self.scheduledProbeGenerations.isEmpty || !self.activeProbeGenerations.isEmpty
+    }
+
+    private func registerProbeLease(_ lease: GatewayConnection.ServerLease) async {
+        guard await self.gateway.isCurrentServerLease(lease) else { return }
+        if self.reconnectPending {
+            // A snapshot received before lease acquisition belongs to the same
+            // physical socket now covered by this probe.
+            self.reconnectPending = false
+            self.snapshotAwaitingProbeLease = nil
+        } else {
+            // Push delivery is intentionally asynchronous to connect. Remember
+            // the lease until its hello arrives after a fast probe completes.
+            self.snapshotAwaitingProbeLease = lease
+        }
+    }
+
+    private func finishProbe(_ attempt: Attempt) {
+        self.activeProbeGenerations.remove(attempt.generation)
+        guard !self.hasProbeWork, self.reconnectPending else { return }
         self.reconnectPending = false
         self.reconnectHandler?()
     }

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -13,9 +13,18 @@ final class OnboardingConfiguredGatewayProbe {
         let identity: String?
     }
 
+    struct VerificationProof: Equatable {
+        let activationOwnershipFingerprint: String?
+    }
+
     enum Outcome: Equatable {
-        case configured(modelRef: String, route: BoundRoute)
-        case verificationFailed(modelRef: String, status: String?, error: String?, route: BoundRoute)
+        case configured(modelRef: String, verification: VerificationProof?, route: BoundRoute)
+        case verificationFailed(
+            modelRef: String,
+            status: String?,
+            error: String?,
+            verification: VerificationProof,
+            route: BoundRoute)
         case missing(route: BoundRoute)
         case authIssue(RemoteGatewayAuthIssue)
         case unavailable
@@ -23,7 +32,9 @@ final class OnboardingConfiguredGatewayProbe {
 
         var boundRoute: BoundRoute? {
             switch self {
-            case let .configured(_, route), let .verificationFailed(_, _, _, route), let .missing(route):
+            case let .configured(_, _, route),
+                 let .verificationFailed(_, _, _, _, route),
+                 let .missing(route):
                 route
             case .authIssue, .unavailable, .superseded:
                 nil
@@ -146,7 +157,7 @@ final class OnboardingConfiguredGatewayProbe {
             // A pending activation receipt has its own route- and owner-bound
             // verifier. Avoid paying for a second turn before reconciliation.
             guard verifyConfiguredInference else {
-                return .configured(modelRef: model, route: boundRoute)
+                return .configured(modelRef: model, verification: nil, route: boundRoute)
             }
 
             guard let supportsVerification = await self.gateway.supportsServerMethod(
@@ -157,7 +168,7 @@ final class OnboardingConfiguredGatewayProbe {
             // Released Gateways predate the live verifier. Preserve their
             // config-only handoff until they are upgraded.
             guard supportsVerification else {
-                return .configured(modelRef: model, route: boundRoute)
+                return .configured(modelRef: model, verification: nil, route: boundRoute)
             }
             let verificationData = try await gateway.request(
                 method: "openclaw.setup.verify",
@@ -175,9 +186,15 @@ final class OnboardingConfiguredGatewayProbe {
                     modelRef: model,
                     status: verification.status,
                     error: verification.error,
+                    verification: VerificationProof(
+                        activationOwnershipFingerprint: lease.route.activationOwnershipFingerprint),
                     route: boundRoute)
             }
-            return .configured(modelRef: model, route: boundRoute)
+            return .configured(
+                modelRef: model,
+                verification: VerificationProof(
+                    activationOwnershipFingerprint: lease.route.activationOwnershipFingerprint),
+                route: boundRoute)
         } catch is CancellationError {
             guard self.isCurrent(attempt) else { return .superseded }
             return await self.gateway.isCurrentServerLease(lease) ? .superseded : .unavailable

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -169,55 +169,10 @@ final class OnboardingConfiguredGatewayProbe {
             guard verifyConfiguredInference else {
                 return .configured(modelRef: model, verification: nil, route: boundRoute)
             }
-
-            guard let supportsVerification = await self.gateway.supportsServerMethod(
-                "openclaw.setup.verify",
-                ifCurrentServerLease: lease),
-                self.isCurrent(attempt)
-            else { return .superseded }
-            // Released Gateways predate the live verifier. Preserve their
-            // config-only handoff until they are upgraded.
-            guard supportsVerification else {
-                return .configured(modelRef: model, verification: nil, route: boundRoute)
-            }
-            let verificationData: Data
-            do {
-                verificationData = try await self.gateway.request(
-                    method: "openclaw.setup.verify",
-                    params: [:],
-                    timeoutMs: self.verificationTimeoutMs,
-                    ifCurrentServerLease: lease)
-            } catch {
-                guard let response = error as? GatewayResponseError,
-                      response.method == "openclaw.setup.verify",
-                      response.missingScope == "operator.admin"
-                else { throw error }
-                guard await self.gateway.isCurrentServerLease(lease),
-                      self.isCurrent(attempt)
-                else { return .superseded }
-                // Released Gateways advertised this method while requiring admin.
-                // Persisted macOS device grants can be write-only after an upgrade.
-                return .configured(modelRef: model, verification: nil, route: boundRoute)
-            }
-            guard await self.gateway.isCurrentServerLease(lease),
-                  self.isCurrent(attempt)
-            else { return .superseded }
-            let verification = try JSONDecoder().decode(
-                OnboardingAISetupModel.ActivateResult.self,
-                from: verificationData)
-            guard verification.ok else {
-                return .verificationFailed(
-                    modelRef: model,
-                    status: verification.status,
-                    error: verification.error,
-                    verification: VerificationProof(
-                        activationOwnershipFingerprint: lease.route.activationOwnershipFingerprint),
-                    route: boundRoute)
-            }
-            return .configured(
-                modelRef: model,
-                verification: VerificationProof(
-                    activationOwnershipFingerprint: lease.route.activationOwnershipFingerprint),
+            return try await self.verifyConfiguredModel(
+                model,
+                lease: lease,
+                attempt: attempt,
                 route: boundRoute)
         } catch is CancellationError {
             guard self.isCurrent(attempt) else { return .superseded }
@@ -236,6 +191,60 @@ final class OnboardingConfiguredGatewayProbe {
 
     func isCurrent(_ route: BoundRoute) async -> Bool {
         await self.gateway.isCurrentRoute(route.route)
+    }
+
+    private func verifyConfiguredModel(
+        _ model: String,
+        lease: GatewayConnection.ServerLease,
+        attempt: Attempt,
+        route: BoundRoute) async throws -> Outcome
+    {
+        guard let supportsVerification = await self.gateway.supportsServerMethod(
+            "openclaw.setup.verify",
+            ifCurrentServerLease: lease),
+            self.isCurrent(attempt)
+        else { return .superseded }
+        // Released Gateways predate the live verifier. Preserve their
+        // config-only handoff until they are upgraded.
+        guard supportsVerification else {
+            return .configured(modelRef: model, verification: nil, route: route)
+        }
+        let verificationData: Data
+        do {
+            verificationData = try await self.gateway.request(
+                method: "openclaw.setup.verify",
+                params: [:],
+                timeoutMs: self.verificationTimeoutMs,
+                ifCurrentServerLease: lease)
+        } catch {
+            guard let response = error as? GatewayResponseError,
+                  response.method == "openclaw.setup.verify",
+                  response.missingScope == "operator.admin"
+            else { throw error }
+            guard await self.gateway.isCurrentServerLease(lease),
+                  self.isCurrent(attempt)
+            else { return .superseded }
+            // Released Gateways advertised this method while requiring admin.
+            // Persisted macOS device grants can be write-only after an upgrade.
+            return .configured(modelRef: model, verification: nil, route: route)
+        }
+        guard await self.gateway.isCurrentServerLease(lease),
+              self.isCurrent(attempt)
+        else { return .superseded }
+        let verification = try JSONDecoder().decode(
+            OnboardingAISetupModel.ActivateResult.self,
+            from: verificationData)
+        let proof = VerificationProof(
+            activationOwnershipFingerprint: lease.route.activationOwnershipFingerprint)
+        guard verification.ok else {
+            return .verificationFailed(
+                modelRef: model,
+                status: verification.status,
+                error: verification.error,
+                verification: proof,
+                route: route)
+        }
+        return .configured(modelRef: model, verification: proof, route: route)
     }
 
     func consumeReconnects(onReconnect: @escaping @MainActor () -> Void) async {

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -15,6 +15,7 @@ final class OnboardingConfiguredGatewayProbe {
 
     enum Outcome: Equatable {
         case configured(modelRef: String, route: BoundRoute)
+        case verificationFailed(status: String?, error: String?, route: BoundRoute)
         case missing(route: BoundRoute)
         case authIssue(RemoteGatewayAuthIssue)
         case unavailable
@@ -22,7 +23,7 @@ final class OnboardingConfiguredGatewayProbe {
 
         var boundRoute: BoundRoute? {
             switch self {
-            case let .configured(_, route), let .missing(route):
+            case let .configured(_, route), let .verificationFailed(_, _, route), let .missing(route):
                 route
             case .authIssue, .unavailable, .superseded:
                 nil
@@ -32,6 +33,7 @@ final class OnboardingConfiguredGatewayProbe {
 
     private let gateway: GatewayConnection
     private let timeoutMs: Double
+    private let verificationTimeoutMs: Double
     private var generation: UInt64 = 0
     private var activeProbeCount = 0
     private var reconnectPending = false
@@ -41,10 +43,12 @@ final class OnboardingConfiguredGatewayProbe {
 
     init(
         gateway: GatewayConnection = .shared,
-        timeoutMs: Double = 15000)
+        timeoutMs: Double = 15000,
+        verificationTimeoutMs: Double = 150_000)
     {
         self.gateway = gateway
         self.timeoutMs = timeoutMs
+        self.verificationTimeoutMs = verificationTimeoutMs
     }
 
     /// Allocate before queuing async work so user-event order, not Task start
@@ -125,8 +129,6 @@ final class OnboardingConfiguredGatewayProbe {
             return .unavailable
         }
         guard self.isCurrent(attempt) else { return .superseded }
-        let boundRoute = BoundRoute(route: route, identity: routeIdentity)
-
         do {
             let model = try await gateway.configuredInferenceModel(
                 ifCurrentRoute: route,
@@ -134,9 +136,43 @@ final class OnboardingConfiguredGatewayProbe {
             guard await self.gateway.isCurrentRoute(route),
                   self.isCurrent(attempt)
             else { return .superseded }
-            guard let model = model?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !model.isEmpty
-            else { return .missing(route: boundRoute) }
+            let boundRoute = BoundRoute(route: route, identity: routeIdentity)
+            guard let model else { return .missing(route: boundRoute) }
+
+            // Bind method negotiation and inference to the socket that owned
+            // agents.list. A reconnect or credential replacement supersedes it.
+            guard let lease = await self.gateway.captureServerLease(ifCurrentRoute: route) else {
+                guard self.isCurrent(attempt) else { return .superseded }
+                return .unavailable
+            }
+            guard self.isCurrent(attempt) else { return .superseded }
+            guard let supportsVerification = await self.gateway.supportsServerMethod(
+                "openclaw.setup.verify",
+                ifCurrentServerLease: lease),
+                self.isCurrent(attempt)
+            else { return .superseded }
+            // Released Gateways predate the live verifier. Preserve their
+            // config-only handoff until they are upgraded.
+            guard supportsVerification else {
+                return .configured(modelRef: model, route: boundRoute)
+            }
+            let verificationData = try await gateway.request(
+                method: "openclaw.setup.verify",
+                params: [:],
+                timeoutMs: self.verificationTimeoutMs,
+                ifCurrentServerLease: lease)
+            guard await self.gateway.isCurrentServerLease(lease),
+                  self.isCurrent(attempt)
+            else { return .superseded }
+            let verification = try JSONDecoder().decode(
+                OnboardingAISetupModel.ActivateResult.self,
+                from: verificationData)
+            guard verification.ok else {
+                return .verificationFailed(
+                    status: verification.status,
+                    error: verification.error,
+                    route: boundRoute)
+            }
             return .configured(modelRef: model, route: boundRoute)
         } catch is CancellationError {
             return .superseded

--- a/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
@@ -64,23 +64,6 @@ extension OnboardingAISetupModel {
             detectError: nil)
     }
 
-    func recoverConfiguredGatewayVerification(
-        modelRef: String,
-        status: String?,
-        error: String?)
-    {
-        self.resetForGatewayChange(clearPendingHandoff: false)
-        self.updateConfiguredGatewayBlockerState(
-            .verificationFailed(ConfiguredGatewayVerificationFailure(
-                modelRef: modelRef,
-                status: status,
-                error: error)),
-            phase: .detecting,
-            detectError: nil)
-        self.started = true
-        self.scheduleDetection()
-    }
-
     func enterGatewayAuthBlocker(_ issue: RemoteGatewayAuthIssue) {
         self.resetForGatewayChange(clearPendingHandoff: false)
         self.updateConfiguredGatewayBlockerState(

--- a/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
@@ -1,7 +1,21 @@
 extension OnboardingAISetupModel {
+    struct ConfiguredGatewayVerificationFailure: Equatable {
+        let modelRef: String
+        let status: String?
+        let error: String?
+
+        var presentation: Failure {
+            OnboardingAISetupModel.failure(
+                label: "Configured AI",
+                status: self.status,
+                error: self.error)
+        }
+    }
+
     enum ConfiguredGatewayBlocker: Equatable {
         case unavailable
         case authentication(RemoteGatewayAuthIssue)
+        case verificationFailed(ConfiguredGatewayVerificationFailure)
     }
 
     var configuredGatewayProbeUnavailable: Bool {
@@ -11,6 +25,11 @@ extension OnboardingAISetupModel {
     var configuredGatewayAuthIssue: RemoteGatewayAuthIssue? {
         guard case let .authentication(issue) = self.configuredGatewayBlocker else { return nil }
         return issue
+    }
+
+    var configuredGatewayVerificationFailure: ConfiguredGatewayVerificationFailure? {
+        guard case let .verificationFailed(failure) = self.configuredGatewayBlocker else { return nil }
+        return failure
     }
 
     func showConfiguredGatewayProbeUnavailable() {

--- a/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
@@ -64,6 +64,23 @@ extension OnboardingAISetupModel {
             detectError: nil)
     }
 
+    func recoverConfiguredGatewayVerification(
+        modelRef: String,
+        status: String?,
+        error: String?)
+    {
+        self.resetForGatewayChange(clearPendingHandoff: false)
+        self.updateConfiguredGatewayBlockerState(
+            .verificationFailed(ConfiguredGatewayVerificationFailure(
+                modelRef: modelRef,
+                status: status,
+                error: error)),
+            phase: .detecting,
+            detectError: nil)
+        self.started = true
+        self.scheduleDetection()
+    }
+
     func enterGatewayAuthBlocker(_ issue: RemoteGatewayAuthIssue) {
         self.resetForGatewayChange(clearPendingHandoff: false)
         self.updateConfiguredGatewayBlockerState(

--- a/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
@@ -34,7 +34,6 @@ extension OnboardingAISetupModel {
 
     func showConfiguredGatewayProbeUnavailable() {
         guard !self.ownsInferenceTransition ||
-            self.configuredGatewayBlocker != nil ||
             self.waitingForPendingActivationDeadline
         else { return }
         // Retire stale candidates and `started` state. A later successful
@@ -50,7 +49,6 @@ extension OnboardingAISetupModel {
 
     func showConfiguredGatewayAuthIssue(_ issue: RemoteGatewayAuthIssue) {
         guard !self.ownsInferenceTransition ||
-            self.configuredGatewayBlocker != nil ||
             self.waitingForPendingActivationDeadline
         else { return }
         self.enterGatewayAuthBlocker(issue)

--- a/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingGatewayAuthBlocker.swift
@@ -4,7 +4,7 @@ extension OnboardingAISetupModel {
         let status: String?
         let error: String?
 
-        var presentation: Failure {
+        @MainActor var presentation: Failure {
             OnboardingAISetupModel.failure(
                 label: "Configured AI",
                 status: self.status,

--- a/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
@@ -108,6 +108,36 @@ extension OnboardingView {
         }
     }
 
+    func resumeVerifiedPendingSystemAgent(
+        modelRef: String,
+        activationOwnershipFingerprint: String?)
+    {
+        self.prepareSystemAgentHandoff()
+        self.aiSetup.reuseConfiguredInferenceVerification(
+            modelRef: modelRef,
+            activationOwnershipFingerprint: activationOwnershipFingerprint)
+        if let page = self.pageOrder.firstIndex(of: self.aiPageIndex) {
+            self.currentPage = page
+        }
+    }
+
+    func resumeFailedPendingSystemAgent(
+        modelRef: String,
+        status: String?,
+        error: String?,
+        activationOwnershipFingerprint: String?)
+    {
+        self.prepareSystemAgentHandoff()
+        self.aiSetup.reuseConfiguredInferenceVerificationFailure(
+            modelRef: modelRef,
+            status: status,
+            error: error,
+            activationOwnershipFingerprint: activationOwnershipFingerprint)
+        if let page = self.pageOrder.firstIndex(of: self.aiPageIndex) {
+            self.currentPage = page
+        }
+    }
+
     func waitForPendingInferenceSetup() {
         self.prepareSystemAgentHandoff()
         if let page = pageOrder.firstIndex(of: aiPageIndex) {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
@@ -169,4 +169,19 @@ extension OnboardingView {
         aiSetup.resetForGatewayChange(clearPendingHandoff: false)
         aiSetup.startIfNeeded()
     }
+
+    func resumeConfiguredGatewayVerificationRecovery(
+        modelRef: String,
+        status: String?,
+        error: String?)
+    {
+        self.prepareSystemAgentHandoff()
+        if let page = pageOrder.firstIndex(of: aiPageIndex) {
+            currentPage = page
+        }
+        aiSetup.recoverConfiguredGatewayVerification(
+            modelRef: modelRef,
+            status: status,
+            error: error)
+    }
 }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -185,118 +185,157 @@ extension OnboardingView {
 
             switch outcome {
             case let .configured(modelRef, _):
-                switch pendingState {
-                case .activating, .activationExpired, .completed:
-                    // A live setup/verification already owns this marker. A
-                    // reconnect must not downgrade connected state or fork a
-                    // second resume operation.
-                    guard !self.aiSetup.connected else { return }
-                    self.resumePendingSystemAgent(modelRef: modelRef)
-                    return
-                case .verified:
-                    // Inference was observed, but the dropped activation can
-                    // still be mutating until the same durable deadline.
-                    self.waitForPendingInferenceSetup()
-                    return
-                case .none:
-                    // A concurrent probe can clear an expired marker while
-                    // the dispatched activation is still returning. Keep the
-                    // setup-owned handoff, and prove inference on this route.
-                    if self.aiSetup.pendingActivationVerification {
-                        self.resumePendingSystemAgent(modelRef: modelRef)
-                        return
-                    }
-                }
-                guard Self.shouldOpenConfiguredGatewayDashboard(
-                    onboardingVisible: self.onboardingVisible,
-                    expectedMode: expectedMode,
-                    currentMode: self.state.connectionMode,
+                self.handleConfiguredGatewayProbeSuccess(
+                    modelRef: modelRef,
+                    pendingState: pendingState,
                     systemAgentResumePending: systemAgentResumePending,
-                    setupOwnsInferenceTransition: self.aiSetup.ownsInferenceTransition)
-                else { return }
-                self.onboardingVisible = false
-                self.configuredGatewayProbe.invalidate()
-                OnboardingController.markComplete()
-                OnboardingController.shared.close()
-                AppNavigationActions.openDashboard()
+                    expectedMode: expectedMode)
             case let .verificationFailed(modelRef, status, error, _):
-                // A configured model is not usable when its live turn fails.
-                // An ambiguous activation receipt retains mutation ownership;
-                // otherwise recovery may list choices but never auto-activate one.
-                guard !self.aiSetup.ownsInferenceTransition ||
-                    self.aiSetup.configuredGatewayVerificationFailure != nil
-                else { return }
-                switch pendingState {
-                case .activating, .completed:
-                    self.resumePendingSystemAgent(modelRef: modelRef)
-                case .verified:
-                    self.waitForPendingInferenceSetup()
-                case .activationExpired:
-                    guard expectedPendingState != .none,
-                          let expectedRouteIdentity,
-                          OnboardingSystemAgentResumeStore.clear(
-                              ifOwnedBy: expectedRouteIdentity,
-                              activationOwner: expectedActivationOwner,
-                              defaults: self.systemAgentDefaults)
-                    else { return }
-                    self.resumeConfiguredGatewayVerificationRecovery(
-                        modelRef: modelRef,
-                        status: status,
-                        error: error)
-                case .none:
-                    if self.aiSetup.pendingActivationVerification {
-                        self.resumePendingSystemAgent(modelRef: modelRef)
-                        return
-                    }
-                    // A receipt visible before this request was cleared by a
-                    // concurrent owner. Its completion path, not this stale
-                    // failure, decides when replacement setup is safe.
-                    guard expectedPendingState == .none else { return }
-                    self.resumeConfiguredGatewayVerificationRecovery(
-                        modelRef: modelRef,
-                        status: status,
-                        error: error)
-                }
+                self.handleConfiguredGatewayVerificationFailure(
+                    modelRef: modelRef,
+                    status: status,
+                    error: error,
+                    pendingState: pendingState,
+                    expectedPendingState: expectedPendingState,
+                    expectedRouteIdentity: expectedRouteIdentity,
+                    expectedActivationOwner: expectedActivationOwner)
             case .missing:
-                // A route-bound activation/verification can complete while the
-                // earlier agents.list request is suspended. Never let that
-                // stale absence reset connected inference or its handoff marker.
-                guard !self.aiSetup.connected else { return }
-                switch pendingState {
-                case .activating, .verified:
-                    // A dropped activation may still be committing. Keep this
-                    // route read-only until its durable maximum deadline.
-                    self.waitForPendingInferenceSetup()
-                    return
-                case .activationExpired, .completed:
-                    // The absence result was dispatched for the receipt visible
-                    // at probe start. A replacement attempt owns its own retry.
-                    guard expectedPendingState != .none,
-                          let expectedRouteIdentity,
-                          OnboardingSystemAgentResumeStore.clear(
-                              ifOwnedBy: expectedRouteIdentity,
-                              activationOwner: expectedActivationOwner,
-                              defaults: self.systemAgentDefaults)
-                    else { return }
-                    self.resumePendingInferenceSetup()
-                    return
-                case .none:
-                    break
-                }
-                if startAISetupWhenMissing,
-                   knownAISetupPage || self.activePageIndex == self.aiPageIndex
-                {
-                    if self.aiSetup.configuredGatewayVerificationFailure != nil {
-                        self.resumePendingInferenceSetup()
-                    } else {
-                        self.aiSetup.startIfNeeded()
-                    }
-                }
+                self.handleMissingConfiguredGatewayInference(
+                    pendingState: pendingState,
+                    expectedPendingState: expectedPendingState,
+                    expectedRouteIdentity: expectedRouteIdentity,
+                    expectedActivationOwner: expectedActivationOwner,
+                    startAISetupWhenMissing: startAISetupWhenMissing,
+                    knownAISetupPage: knownAISetupPage)
             case .unavailable, .authIssue:
                 self.showConfiguredGatewayProbeBlocker(outcome)
             case .superseded:
                 break
             }
+        }
+    }
+
+    private func handleConfiguredGatewayProbeSuccess(
+        modelRef: String,
+        pendingState: OnboardingSystemAgentResumeStore.PendingState,
+        systemAgentResumePending: Bool,
+        expectedMode: AppState.ConnectionMode)
+    {
+        switch pendingState {
+        case .activating, .activationExpired, .completed:
+            // A live setup/verification already owns this marker. A reconnect
+            // must not downgrade connected state or fork a second resume operation.
+            guard !self.aiSetup.connected else { return }
+            self.resumePendingSystemAgent(modelRef: modelRef)
+            return
+        case .verified:
+            // Inference was observed, but the dropped activation can still be
+            // mutating until the same durable deadline.
+            self.waitForPendingInferenceSetup()
+            return
+        case .none:
+            // A concurrent probe can clear an expired marker while the dispatched
+            // activation is still returning. Keep its handoff and prove inference.
+            if self.aiSetup.pendingActivationVerification {
+                self.resumePendingSystemAgent(modelRef: modelRef)
+                return
+            }
+        }
+        guard Self.shouldOpenConfiguredGatewayDashboard(
+            onboardingVisible: self.onboardingVisible,
+            expectedMode: expectedMode,
+            currentMode: self.state.connectionMode,
+            systemAgentResumePending: systemAgentResumePending,
+            setupOwnsInferenceTransition: self.aiSetup.ownsInferenceTransition)
+        else { return }
+        self.onboardingVisible = false
+        self.configuredGatewayProbe.invalidate()
+        OnboardingController.markComplete()
+        OnboardingController.shared.close()
+        AppNavigationActions.openDashboard()
+    }
+
+    private func handleConfiguredGatewayVerificationFailure(
+        modelRef: String,
+        status: String?,
+        error: String?,
+        pendingState: OnboardingSystemAgentResumeStore.PendingState,
+        expectedPendingState: OnboardingSystemAgentResumeStore.PendingState,
+        expectedRouteIdentity: String?,
+        expectedActivationOwner: OnboardingSystemAgentResumeStore.ActivationOwner?)
+    {
+        // A configured model is not usable when its live turn fails. An ambiguous
+        // activation receipt retains mutation ownership; other recovery is read-only.
+        guard !self.aiSetup.ownsInferenceTransition ||
+            self.aiSetup.configuredGatewayVerificationFailure != nil
+        else { return }
+        switch pendingState {
+        case .activating, .completed:
+            self.resumePendingSystemAgent(modelRef: modelRef)
+        case .verified:
+            self.waitForPendingInferenceSetup()
+        case .activationExpired:
+            guard expectedPendingState != .none,
+                  let expectedRouteIdentity,
+                  OnboardingSystemAgentResumeStore.clear(
+                      ifOwnedBy: expectedRouteIdentity,
+                      activationOwner: expectedActivationOwner,
+                      defaults: self.systemAgentDefaults)
+            else { return }
+            self.resumeConfiguredGatewayVerificationRecovery(
+                modelRef: modelRef,
+                status: status,
+                error: error)
+        case .none:
+            if self.aiSetup.pendingActivationVerification {
+                self.resumePendingSystemAgent(modelRef: modelRef)
+                return
+            }
+            // A receipt visible before this request was cleared by a concurrent
+            // owner. Its completion path, not this stale failure, owns replacement.
+            guard expectedPendingState == .none else { return }
+            self.resumeConfiguredGatewayVerificationRecovery(
+                modelRef: modelRef,
+                status: status,
+                error: error)
+        }
+    }
+
+    private func handleMissingConfiguredGatewayInference(
+        pendingState: OnboardingSystemAgentResumeStore.PendingState,
+        expectedPendingState: OnboardingSystemAgentResumeStore.PendingState,
+        expectedRouteIdentity: String?,
+        expectedActivationOwner: OnboardingSystemAgentResumeStore.ActivationOwner?,
+        startAISetupWhenMissing: Bool,
+        knownAISetupPage: Bool)
+    {
+        // A route-bound transition can complete while agents.list is suspended.
+        // Never let that stale absence reset connected inference or its receipt.
+        guard !self.aiSetup.connected else { return }
+        switch pendingState {
+        case .activating, .verified:
+            self.waitForPendingInferenceSetup()
+            return
+        case .activationExpired, .completed:
+            guard expectedPendingState != .none,
+                  let expectedRouteIdentity,
+                  OnboardingSystemAgentResumeStore.clear(
+                      ifOwnedBy: expectedRouteIdentity,
+                      activationOwner: expectedActivationOwner,
+                      defaults: self.systemAgentDefaults)
+            else { return }
+            self.resumePendingInferenceSetup()
+            return
+        case .none:
+            break
+        }
+        guard startAISetupWhenMissing,
+              knownAISetupPage || self.activePageIndex == self.aiPageIndex
+        else { return }
+        if self.aiSetup.configuredGatewayVerificationFailure != nil {
+            self.resumePendingInferenceSetup()
+        } else {
+            self.aiSetup.startIfNeeded()
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -219,6 +219,11 @@ extension OnboardingView {
                 OnboardingController.markComplete()
                 OnboardingController.shared.close()
                 AppNavigationActions.openDashboard()
+            case .verificationFailed:
+                // A configured model is not usable when its live turn fails.
+                // Keep onboarding open and expose the existing provider sign-in
+                // and credential recovery choices.
+                self.resumePendingInferenceSetup()
             case .missing:
                 // A route-bound activation/verification can complete while the
                 // earlier agents.list request is suspended. Never let that
@@ -270,7 +275,7 @@ extension OnboardingView {
             // Authentication is actionable at the Gateway page and never
             // evidence that Gateway-owned inference setup is missing.
             self.aiSetup.showConfiguredGatewayAuthIssue(issue)
-        case .configured, .missing, .superseded:
+        case .configured, .verificationFailed, .missing, .superseded:
             assertionFailure("Expected a configured Gateway probe blocker")
         }
     }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -219,11 +219,44 @@ extension OnboardingView {
                 OnboardingController.markComplete()
                 OnboardingController.shared.close()
                 AppNavigationActions.openDashboard()
-            case .verificationFailed:
+            case let .verificationFailed(modelRef, status, error, _):
                 // A configured model is not usable when its live turn fails.
-                // Keep onboarding open and expose the existing provider sign-in
-                // and credential recovery choices.
-                self.resumePendingInferenceSetup()
+                // An ambiguous activation receipt retains mutation ownership;
+                // otherwise recovery may list choices but never auto-activate one.
+                guard !self.aiSetup.ownsInferenceTransition ||
+                    self.aiSetup.configuredGatewayVerificationFailure != nil
+                else { return }
+                switch pendingState {
+                case .activating, .completed:
+                    self.resumePendingSystemAgent(modelRef: modelRef)
+                case .verified:
+                    self.waitForPendingInferenceSetup()
+                case .activationExpired:
+                    guard expectedPendingState != .none,
+                          let expectedRouteIdentity,
+                          OnboardingSystemAgentResumeStore.clear(
+                              ifOwnedBy: expectedRouteIdentity,
+                              activationOwner: expectedActivationOwner,
+                              defaults: self.systemAgentDefaults)
+                    else { return }
+                    self.resumeConfiguredGatewayVerificationRecovery(
+                        modelRef: modelRef,
+                        status: status,
+                        error: error)
+                case .none:
+                    if self.aiSetup.pendingActivationVerification {
+                        self.resumePendingSystemAgent(modelRef: modelRef)
+                        return
+                    }
+                    // A receipt visible before this request was cleared by a
+                    // concurrent owner. Its completion path, not this stale
+                    // failure, decides when replacement setup is safe.
+                    guard expectedPendingState == .none else { return }
+                    self.resumeConfiguredGatewayVerificationRecovery(
+                        modelRef: modelRef,
+                        status: status,
+                        error: error)
+                }
             case .missing:
                 // A route-bound activation/verification can complete while the
                 // earlier agents.list request is suspended. Never let that
@@ -253,7 +286,11 @@ extension OnboardingView {
                 if startAISetupWhenMissing,
                    knownAISetupPage || self.activePageIndex == self.aiPageIndex
                 {
-                    self.aiSetup.startIfNeeded()
+                    if self.aiSetup.configuredGatewayVerificationFailure != nil {
+                        self.resumePendingInferenceSetup()
+                    } else {
+                        self.aiSetup.startIfNeeded()
+                    }
                 }
             case .unavailable, .authIssue:
                 self.showConfiguredGatewayProbeBlocker(outcome)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -169,7 +169,8 @@ extension OnboardingView {
             let outcome = await self.configuredGatewayProbe.probe(
                 connectionMode: expectedMode,
                 attempt: probeAttempt,
-                routeIdentity: expectedRouteIdentity)
+                routeIdentity: expectedRouteIdentity,
+                verifyConfiguredInference: expectedPendingState == .none)
             guard await self.isCurrentConfiguredGatewayProbeOutcome(
                 outcome,
                 attempt: probeAttempt,
@@ -188,6 +189,7 @@ extension OnboardingView {
                 self.handleConfiguredGatewayProbeSuccess(
                     modelRef: modelRef,
                     pendingState: pendingState,
+                    expectedPendingState: expectedPendingState,
                     systemAgentResumePending: systemAgentResumePending,
                     expectedMode: expectedMode)
             case let .verificationFailed(modelRef, status, error, _):
@@ -218,6 +220,7 @@ extension OnboardingView {
     private func handleConfiguredGatewayProbeSuccess(
         modelRef: String,
         pendingState: OnboardingSystemAgentResumeStore.PendingState,
+        expectedPendingState: OnboardingSystemAgentResumeStore.PendingState,
         systemAgentResumePending: Bool,
         expectedMode: AppState.ConnectionMode)
     {
@@ -240,6 +243,10 @@ extension OnboardingView {
                 self.resumePendingSystemAgent(modelRef: modelRef)
                 return
             }
+            // A receipt that existed before agents.list was allowed to defer
+            // live verification to reconciliation. If another owner cleared it,
+            // this config-only result cannot authorize a dashboard handoff.
+            guard expectedPendingState == .none else { return }
         }
         guard Self.shouldOpenConfiguredGatewayDashboard(
             onboardingVisible: self.onboardingVisible,
@@ -266,9 +273,7 @@ extension OnboardingView {
     {
         // A configured model is not usable when its live turn fails. An ambiguous
         // activation receipt retains mutation ownership; other recovery is read-only.
-        guard !self.aiSetup.ownsInferenceTransition ||
-            self.aiSetup.configuredGatewayVerificationFailure != nil
-        else { return }
+        guard !self.aiSetup.ownsInferenceTransition else { return }
         switch pendingState {
         case .activating, .completed:
             self.resumePendingSystemAgent(modelRef: modelRef)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -260,7 +260,7 @@ extension OnboardingView {
         self.configuredGatewayProbe.invalidate()
         OnboardingController.markComplete()
         OnboardingController.shared.close()
-        AppNavigationActions.openDashboard()
+        self.configuredGatewayDashboardOpener()
     }
 
     private func reconcilePendingSystemAgent(

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -185,22 +185,22 @@ extension OnboardingView {
             self.schedulePendingActivationRecheckIfNeeded(pendingState)
 
             switch outcome {
-            case let .configured(modelRef, _):
+            case let .configured(modelRef, verification, _):
                 self.handleConfiguredGatewayProbeSuccess(
                     modelRef: modelRef,
+                    verification: verification,
                     pendingState: pendingState,
                     expectedPendingState: expectedPendingState,
                     systemAgentResumePending: systemAgentResumePending,
                     expectedMode: expectedMode)
-            case let .verificationFailed(modelRef, status, error, _):
+            case let .verificationFailed(modelRef, status, error, verification, _):
                 self.handleConfiguredGatewayVerificationFailure(
                     modelRef: modelRef,
                     status: status,
                     error: error,
+                    verification: verification,
                     pendingState: pendingState,
-                    expectedPendingState: expectedPendingState,
-                    expectedRouteIdentity: expectedRouteIdentity,
-                    expectedActivationOwner: expectedActivationOwner)
+                    expectedPendingState: expectedPendingState)
             case .missing:
                 self.handleMissingConfiguredGatewayInference(
                     pendingState: pendingState,
@@ -219,6 +219,7 @@ extension OnboardingView {
 
     private func handleConfiguredGatewayProbeSuccess(
         modelRef: String,
+        verification: OnboardingConfiguredGatewayProbe.VerificationProof?,
         pendingState: OnboardingSystemAgentResumeStore.PendingState,
         expectedPendingState: OnboardingSystemAgentResumeStore.PendingState,
         systemAgentResumePending: Bool,
@@ -229,7 +230,7 @@ extension OnboardingView {
             // A live setup/verification already owns this marker. A reconnect
             // must not downgrade connected state or fork a second resume operation.
             guard !self.aiSetup.connected else { return }
-            self.resumePendingSystemAgent(modelRef: modelRef)
+            self.reconcilePendingSystemAgent(modelRef: modelRef, verification: verification)
             return
         case .verified:
             // Inference was observed, but the dropped activation can still be
@@ -240,7 +241,7 @@ extension OnboardingView {
             // A concurrent probe can clear an expired marker while the dispatched
             // activation is still returning. Keep its handoff and prove inference.
             if self.aiSetup.pendingActivationVerification {
-                self.resumePendingSystemAgent(modelRef: modelRef)
+                self.reconcilePendingSystemAgent(modelRef: modelRef, verification: verification)
                 return
             }
             // A receipt that existed before agents.list was allowed to defer
@@ -262,35 +263,45 @@ extension OnboardingView {
         AppNavigationActions.openDashboard()
     }
 
+    private func reconcilePendingSystemAgent(
+        modelRef: String,
+        verification: OnboardingConfiguredGatewayProbe.VerificationProof?)
+    {
+        if let verification {
+            self.resumeVerifiedPendingSystemAgent(
+                modelRef: modelRef,
+                activationOwnershipFingerprint: verification.activationOwnershipFingerprint)
+        } else {
+            self.resumePendingSystemAgent(modelRef: modelRef)
+        }
+    }
+
     private func handleConfiguredGatewayVerificationFailure(
         modelRef: String,
         status: String?,
         error: String?,
+        verification: OnboardingConfiguredGatewayProbe.VerificationProof,
         pendingState: OnboardingSystemAgentResumeStore.PendingState,
-        expectedPendingState: OnboardingSystemAgentResumeStore.PendingState,
-        expectedRouteIdentity: String?,
-        expectedActivationOwner: OnboardingSystemAgentResumeStore.ActivationOwner?)
+        expectedPendingState: OnboardingSystemAgentResumeStore.PendingState)
     {
         // A configured model is not usable when its live turn fails. An ambiguous
         // activation receipt retains mutation ownership; other recovery is read-only.
         guard !self.aiSetup.ownsInferenceTransition else { return }
         switch pendingState {
         case .activating, .completed:
-            self.resumePendingSystemAgent(modelRef: modelRef)
+            self.resumeFailedPendingSystemAgent(
+                modelRef: modelRef,
+                status: status,
+                error: error,
+                activationOwnershipFingerprint: verification.activationOwnershipFingerprint)
         case .verified:
             self.waitForPendingInferenceSetup()
         case .activationExpired:
-            guard expectedPendingState != .none,
-                  let expectedRouteIdentity,
-                  OnboardingSystemAgentResumeStore.clear(
-                      ifOwnedBy: expectedRouteIdentity,
-                      activationOwner: expectedActivationOwner,
-                      defaults: self.systemAgentDefaults)
-            else { return }
-            self.resumeConfiguredGatewayVerificationRecovery(
+            self.resumeFailedPendingSystemAgent(
                 modelRef: modelRef,
                 status: status,
-                error: error)
+                error: error,
+                activationOwnershipFingerprint: verification.activationOwnershipFingerprint)
         case .none:
             if self.aiSetup.pendingActivationVerification {
                 self.resumePendingSystemAgent(modelRef: modelRef)
@@ -316,7 +327,7 @@ extension OnboardingView {
     {
         // A route-bound transition can complete while agents.list is suspended.
         // Never let that stale absence reset connected inference or its receipt.
-        guard !self.aiSetup.connected else { return }
+        guard !self.aiSetup.ownsInferenceTransition else { return }
         switch pendingState {
         case .activating, .verified:
             self.waitForPendingInferenceSetup()

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -260,7 +260,7 @@ extension OnboardingView {
         self.configuredGatewayProbe.invalidate()
         OnboardingController.markComplete()
         OnboardingController.shared.close()
-        self.configuredGatewayDashboardOpener()
+        AppNavigationActions.openDashboard()
     }
 
     private func reconcilePendingSystemAgent(

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -217,7 +217,8 @@ struct DashboardManagerGatewayTargetTests {
         #expect(catalogReads == 1)
     }
 
-    @Test func `primary window configuration retains resolved TLS policy`() async throws {
+    @Test(.appStateStoreIsolated)
+    func `primary window configuration retains resolved TLS policy`() async throws {
         let state = AppStateStore.shared
         let originalMode = state.connectionMode
         state.connectionMode = .remote
@@ -288,7 +289,8 @@ struct DashboardManagerGatewayTargetTests {
         #expect(!DashboardManager._testTargetIsAvailable(.profile("removed"), in: [primary]))
     }
 
-    @Test func `opening primary creates isolated auxiliary window`() async throws {
+    @Test(.appStateStoreIsolated)
+    func `opening primary creates isolated auxiliary window`() async throws {
         let state = AppStateStore.shared
         let originalMode = state.connectionMode
         state.connectionMode = .local

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
@@ -73,7 +73,7 @@ struct ExecApprovalsUIRollbackTests {
         }
     }
 
-    @Test
+    @Test(.appStateStoreIsolated)
     func `settings recover after initial approvals read is unavailable`() async throws {
         try await self.withTempStateDir { stateDir in
             _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { agent in
@@ -112,7 +112,7 @@ struct ExecApprovalsUIRollbackTests {
         }
     }
 
-    @Test
+    @Test(.appStateStoreIsolated)
     func `defaults mutation refreshes quick mode through app state owner`() async throws {
         try await self.withTempStateDir { _ in
             _ = try ExecApprovalsStore.updateDefaults { defaults in

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayAutostartPolicyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayAutostartPolicyTests.swift
@@ -10,6 +10,18 @@ struct GatewayAutostartPolicyTests {
         #expect(!GatewayAutostartPolicy.shouldStartGateway(mode: .unconfigured, paused: false))
     }
 
+    @MainActor
+    @Test func `paused first-run recovery does not activate gateway`() {
+        var activationCount = 0
+        let activated = GatewayAutostartPolicy.activateGatewayForRecovery(
+            mode: .local,
+            paused: true,
+            activate: { activationCount += 1 })
+
+        #expect(!activated)
+        #expect(activationCount == 0)
+    }
+
     @Test func `ensures launch agent when local and not attach only`() {
         #expect(GatewayAutostartPolicy.shouldEnsureLaunchAgent(
             mode: .local,

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
@@ -108,6 +108,20 @@ struct GatewayConnectionTests {
         await conn.shutdown()
     }
 
+    @Test func `server lease does not retarget an existing route after credential replacement`() async throws {
+        let session = self.makeSession()
+        let (conn, cfg) = try makeConnection(session: session, token: "a")
+        let route = try #require(await conn.captureRequiredRoute())
+
+        let lease = try #require(await conn.captureServerLease(ifCurrentRoute: route))
+        cfg.setToken("b")
+
+        #expect(await conn.captureServerLease(ifCurrentRoute: route) == nil)
+        #expect(await conn.isCurrentServerLease(lease) == false)
+        #expect(session.snapshotMakeCount() == 1)
+        await conn.shutdown()
+    }
+
     @Test func `disconnected server lease rejects before dispatch`() async throws {
         let session = self.makeSession(serverCapabilities: ["openclaw-setup-model-ref"])
         let (conn, _) = try makeConnection(session: session)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
@@ -108,15 +108,13 @@ struct GatewayConnectionTests {
         await conn.shutdown()
     }
 
-    @Test func `server lease does not retarget an existing route after credential replacement`() async throws {
+    @Test func `server lease does not retarget after credential replacement`() async throws {
         let session = self.makeSession()
         let (conn, cfg) = try makeConnection(session: session, token: "a")
-        let route = try #require(await conn.captureRequiredRoute())
+        let lease = try await conn.captureRequiredServerLease()
 
-        let lease = try #require(await conn.captureServerLease(ifCurrentRoute: route))
         cfg.setToken("b")
 
-        #expect(await conn.captureServerLease(ifCurrentRoute: route) == nil)
         #expect(await conn.isCurrentServerLease(lease) == false)
         #expect(session.snapshotMakeCount() == 1)
         await conn.shutdown()

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
@@ -111,7 +111,7 @@ struct GatewayConnectionTests {
     @Test func `server lease does not retarget after credential replacement`() async throws {
         let session = self.makeSession()
         let (conn, cfg) = try makeConnection(session: session, token: "a")
-        let lease = try await conn.captureRequiredServerLease()
+        let lease = try await conn.acquireServerLease()
 
         cfg.setToken("b")
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
@@ -6,6 +6,19 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayConnectionTests {
+    private func waitForReplacementServer(
+        _ connection: GatewayConnection,
+        after identity: GatewayConnection.ServerIdentity) async -> GatewayConnection.ServerLease?
+    {
+        for _ in 0..<400 {
+            if let lease = await connection.captureServerLease(), lease.identity != identity {
+                return lease
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return nil
+    }
+
     private func makeConnection(
         session: GatewayTestWebSocketSession,
         token: String? = nil) throws -> (GatewayConnection, ConfigSource)
@@ -139,6 +152,37 @@ struct GatewayConnectionTests {
         #expect(session.snapshotMakeCount() == 1)
         #expect(session.latestTask()?.snapshotSendCount() == 2)
         await conn.shutdown()
+    }
+
+    @Test func `server identity coverage follows replacement order`() async throws {
+        let session = self.makeSession()
+        let (connection, _) = try self.makeConnection(session: session)
+        let pendingB = try await connection.acquireServerLease()
+
+        let pendingBSocket = try #require(session.latestTask())
+        for _ in 0..<400 where !pendingBSocket.hasPendingReceiveHandler() {
+            await Task.yield()
+        }
+        #expect(pendingBSocket.hasPendingReceiveHandler())
+        pendingBSocket.emitReceiveFailure()
+        let acquiredC = try #require(await self.waitForReplacementServer(
+            connection,
+            after: pendingB.identity))
+
+        let acquiredCSocket = try #require(session.latestTask())
+        for _ in 0..<400 where !acquiredCSocket.hasPendingReceiveHandler() {
+            await Task.yield()
+        }
+        #expect(acquiredCSocket.hasPendingReceiveHandler())
+        acquiredCSocket.emitReceiveFailure()
+        let newerD = try #require(await self.waitForReplacementServer(
+            connection,
+            after: acquiredC.identity))
+
+        #expect(acquiredC.identity.covers(pendingB.identity)) // Acquired C retires pending B.
+        #expect(!acquiredC.identity.covers(newerD.identity)) // Acquired C retains newer D.
+        #expect(newerD.identity.covers(acquiredC.identity))
+        await connection.shutdown()
     }
 
     @Test func `server lease preserves caller cancellation after dispatch`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
@@ -157,15 +157,6 @@ struct MenuContentSmokeTests {
         #expect(replies == [true])
     }
 
-    @Test func `connected configured gateway stays in onboarding until live verification`() {
-        #expect(AppDelegate.shouldPresentScheduledFirstRunOnboarding(
-            expectedConnectionMode: .remote,
-            currentConnectionMode: .remote,
-            expectedRouteIdentity: "remote:id:gateway-a",
-            currentRouteIdentity: "remote:id:gateway-a",
-            onboardingSeen: false))
-    }
-
     @Test func `delayed first run presentation is cancelled by later completion`() {
         #expect(!AppDelegate.shouldPresentScheduledFirstRunOnboarding(
             expectedConnectionMode: .remote,

--- a/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
@@ -157,81 +157,13 @@ struct MenuContentSmokeTests {
         #expect(replies == [true])
     }
 
-    @Test func `connected configured gateway with inference opens dashboard instead of onboarding`() {
-        for mode in [AppState.ConnectionMode.local, .remote] {
-            let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
-                connectionMode: mode,
-                onboardingSeen: false,
-                systemAgentResumePending: false,
-                gatewayConnected: true,
-                configuredInferenceModel: " openai/gpt-5.5 ")
-
-            #expect(shouldOpen)
-        }
-    }
-
-    @Test func `connected configured gateway without inference keeps onboarding`() {
-        for model in [String?.none, "", "   "] {
-            let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
-                connectionMode: .remote,
-                onboardingSeen: false,
-                systemAgentResumePending: false,
-                gatewayConnected: true,
-                configuredInferenceModel: model)
-
-            #expect(!shouldOpen)
-        }
-    }
-
-    @Test func `disconnected configured gateway keeps onboarding recovery`() {
-        let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
-            connectionMode: .remote,
-            onboardingSeen: false,
-            systemAgentResumePending: false,
-            gatewayConnected: false,
-            configuredInferenceModel: "openai/gpt-5.5")
-
-        #expect(!shouldOpen)
-    }
-
-    @Test func `stored connection mode without a pending handoff still opens dashboard`() {
-        let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
-            connectionMode: .local,
-            onboardingSeen: false,
-            systemAgentResumePending: false,
-            gatewayConnected: true,
-            configuredInferenceModel: "openai/gpt-5.5")
-
-        #expect(shouldOpen)
-    }
-
-    @Test func `pending OpenClaw handoff survives relaunch and keeps onboarding`() {
-        let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
-            connectionMode: .local,
-            onboardingSeen: false,
-            systemAgentResumePending: true,
-            gatewayConnected: true,
-            configuredInferenceModel: "openai/gpt-5.5")
-
-        #expect(!shouldOpen)
-    }
-
-    @Test func `first run inference result rejects selected gateway drift`() {
-        #expect(!AppDelegate.isCurrentFirstRunInferenceProbe(
-            expectedConnectionMode: .remote,
-            currentConnectionMode: .remote,
-            expectedRouteIdentity: "remote:id:gateway-a",
-            currentRouteIdentity: "remote:id:gateway-b",
-            gatewayRouteIsCurrent: true))
-    }
-
-    @Test func `first run inference result accepts matching selected gateway and route`() {
-        #expect(AppDelegate.isCurrentFirstRunInferenceProbe(
+    @Test func `connected configured gateway stays in onboarding until live verification`() {
+        #expect(AppDelegate.shouldPresentScheduledFirstRunOnboarding(
             expectedConnectionMode: .remote,
             currentConnectionMode: .remote,
             expectedRouteIdentity: "remote:id:gateway-a",
             currentRouteIdentity: "remote:id:gateway-a",
-            gatewayRouteIsCurrent: true))
+            onboardingSeen: false))
     }
 
     @Test func `delayed first run presentation is cancelled by later completion`() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -649,18 +649,13 @@ private struct AISetupHarness {
 @MainActor
 private final class FirstRunGatewayTestPresenter: FirstRunOnboardingPresenting {
     private let makeView: @MainActor () -> OnboardingView
-    let presentsDashboardInsteadOfOnboarding: Bool
+    let presentsDashboardInsteadOfOnboarding = false
     private(set) var completionCount = 0
-    private(set) var openDashboardCount = 0
     private(set) var showCount = 0
     private(set) var view: OnboardingView?
     private(set) var probeTask: Task<Void, Never>?
 
-    init(
-        presentsDashboardInsteadOfOnboarding: Bool = false,
-        makeView: @escaping @MainActor () -> OnboardingView)
-    {
-        self.presentsDashboardInsteadOfOnboarding = presentsDashboardInsteadOfOnboarding
+    init(makeView: @escaping @MainActor () -> OnboardingView) {
         self.makeView = makeView
     }
 
@@ -668,9 +663,7 @@ private final class FirstRunGatewayTestPresenter: FirstRunOnboardingPresenting {
         self.completionCount += 1
     }
 
-    func openDashboard() {
-        self.openDashboardCount += 1
-    }
+    func openDashboard() {}
 
     func showOnboarding() {
         self.showCount += 1
@@ -822,16 +815,43 @@ private func setupAdmissionBusyResponse(id: String) -> Data {
 @Suite(.serialized)
 @MainActor
 struct OnboardingAISetupTests {
-    @Test func `nix first run presenter hands off to dashboard`() {
-        let presenter = FirstRunGatewayTestPresenter(
-            presentsDashboardInsteadOfOnboarding: true,
-            makeView: { fatalError("Nix first run must not present onboarding") })
+    @Test func `nix first run presenter opens a dashboard outcome`() async {
+        let defaults = AppDefaults.standard
+        let nixModeKey = "openclaw.nixMode"
+        let previousDefaults: [(String, Any?)] = [
+            (nixModeKey, defaults.object(forKey: nixModeKey)),
+            (onboardingSeenKey, defaults.object(forKey: onboardingSeenKey)),
+            (onboardingVersionKey, defaults.object(forKey: onboardingVersionKey)),
+        ]
+        let state = AppStateStore.shared
+        let previousConnectionMode = state.connectionMode
+        let previousOnboardingSeen = state.onboardingSeen
+        let dashboard = DashboardManager.shared
+        dashboard.close()
+        defer {
+            dashboard.close()
+            state.connectionMode = previousConnectionMode
+            state.onboardingSeen = previousOnboardingSeen
+            for (key, value) in previousDefaults {
+                if let value {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+        }
+        defaults.set(true, forKey: nixModeKey)
+        state.connectionMode = .unconfigured
+        state.onboardingSeen = false
 
+        let presenter = OnboardingController()
         presenter.show()
+        for _ in 0..<400 where dashboard._testController()?.isWindowOpen != true {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
 
-        #expect(presenter.completionCount == 1)
-        #expect(presenter.openDashboardCount == 1)
-        #expect(presenter.showCount == 0)
+        #expect(state.onboardingSeen)
+        #expect(dashboard._testController()?.isWindowOpen == true)
     }
 
     @Test func `first run verifies configured gateway before opening dashboard`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -393,6 +393,16 @@ private func wizardProgressResponse(id: String, sessionID: String, message: Stri
         """.utf8)
 }
 
+private func wizardInputResponse(id: String, sessionID: String) -> Data {
+    Data(
+        """
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "sessionId":"\(sessionID)","done":false,"status":"running",
+          "step":{"id":"code","type":"text","message":"Paste the authorization code"}}}
+        """
+        .utf8)
+}
+
 private func wizardDoneResponse(
     id: String,
     sessionID: String,
@@ -814,6 +824,72 @@ struct OnboardingAISetupTests {
         #expect(view.aiSetup.configuredGatewayVerificationFailure?.error == "expired login")
     }
 
+    @Test func `reconnect probe preserves active provider reauthentication`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyAuthReconnect"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list": configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect": reauthenticationDetectedSetupResponse(id: request.id)
+                case "openclaw.setup.auth.start":
+                    wizardInputResponse(
+                        id: request.id,
+                        sessionID: request.params["sessionId"] as? String ?? "auth-session")
+                default: nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: [
+                        "openclaw.setup.verify",
+                        "openclaw.setup.auth.start",
+                    ]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+        view.onboardingVisible = true
+
+        let initialProbe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await initialProbe.value
+        _ = await waitForAISetupRequests(harness.recorder, count: 3)
+        await settleQueuedAISetupTasks()
+
+        let option = try #require(view.aiSetup.authOptions.first)
+        view.aiSetup.startProviderAuth(option)
+        _ = await waitForAISetupRequests(harness.recorder, count: 4)
+        await settleQueuedAISetupTasks()
+        let authSessionID = try #require(view.aiSetup._test_authSessionID)
+        #expect(view.aiSetup.activeAuthOption?.id == option.id)
+        #expect(!view.aiSetup.authBusy)
+        #expect(view.aiSetup.ownsInferenceTransition)
+
+        // Reconnect snapshots enter through this same route-bound probe.
+        let reconnectProbe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await reconnectProbe.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 6)
+        await settleQueuedAISetupTasks()
+
+        #expect(requests.methods.suffix(2) == [
+            "agents.list",
+            "openclaw.setup.verify",
+        ])
+        #expect(!requests.methods.contains("wizard.cancel"))
+        #expect(view.aiSetup.activeAuthOption?.id == option.id)
+        #expect(view.aiSetup._test_authSessionID == authSessionID)
+        #expect(view.aiSetup.ownsInferenceTransition)
+    }
+
     @Test(arguments: [false, true])
     func `failed configured verification preserves activation receipt`(
         completed: Bool) async throws
@@ -851,12 +927,11 @@ struct OnboardingAISetupTests {
 
         let probe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
         await probe.value
-        let requests = await waitForAISetupRequests(harness.recorder, count: 3)
+        let requests = await waitForAISetupRequests(harness.recorder, count: 2)
         await settleQueuedAISetupTasks()
 
         #expect(requests.methods == [
             "agents.list",
-            "openclaw.setup.verify",
             "openclaw.setup.verify",
         ])
         #expect(!requests.methods.contains("openclaw.setup.detect"))

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1036,9 +1036,12 @@ struct OnboardingAISetupTests {
         view.aiSetup.startProviderAuth(try #require(view.aiSetup.authOptions.first))
         _ = await waitForAISetupRequests(harness.recorder, count: 5)
         await settleQueuedAISetupTasks()
+        #expect(view.aiSetup.configuredGatewayVerificationFailure == nil)
         #expect(view.aiSetup.detectError != nil)
         #expect(view.aiSetup.ownsInferenceTransition)
 
+        // This is the visible detection-error card's Try again action once
+        // successful sign-in retires the configured-verification card.
         view.aiSetup.retryFromScratch()
         _ = await waitForAISetupRequests(harness.recorder, count: 6)
         for _ in 0..<400 where !view.aiSetup.connected {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -272,7 +272,9 @@ private func reauthenticationDetectedSetupResponse(id: String) -> Data {
     Data(
         """
         {"type":"res","id":"\(id)","ok":true,"payload":{
-          "candidates":[],"manualProviders":[],
+          "candidates":[{"kind":"claude-cli","label":"Claude Code","detail":"signed in",
+            "modelRef":"anthropic/claude-opus-4-8","credentials":true}],
+          "manualProviders":[],
           "authOptions":[{"id":"openai:oauth","brandId":"openai","label":"OpenAI",
             "hint":"Sign in with OpenAI","kind":"oauth","featured":true}],
           "prepareOptions":[],"workspace":"/tmp/openclaw-workspace",
@@ -803,8 +805,119 @@ struct OnboardingAISetupTests {
             "openclaw.setup.detect",
         ])
         #expect(view.aiSetup.phase == .ready)
+        #expect(view.aiSetup.candidates.map(\.kind) == ["claude-cli"])
         #expect(view.aiSetup.authOptions.map(\.id) == ["openai:oauth"])
         #expect(!view.aiSetup.connected)
+        #expect(!requests.methods.contains("openclaw.setup.activate"))
+        #expect(view.aiSetup.configuredGatewayVerificationFailure?.modelRef == "openai/gpt-5.5")
+        #expect(view.aiSetup.configuredGatewayVerificationFailure?.status == "auth")
+        #expect(view.aiSetup.configuredGatewayVerificationFailure?.error == "expired login")
+    }
+
+    @Test(arguments: [false, true])
+    func `failed configured verification preserves activation receipt`(
+        completed: Bool) async throws
+    {
+        let defaults = try #require(isolatedAISetupDefaults(
+            prefix: "OnboardingConfiguredVerifyReceipt-\(completed)"))
+        markPending(defaults, for: "local", timeoutMs: 30000)
+        if completed {
+            #expect(markCompleted(defaults, for: "local"))
+        }
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list": configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                default: nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+
+        let probe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await probe.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 3)
+        await settleQueuedAISetupTasks()
+
+        #expect(requests.methods == [
+            "agents.list",
+            "openclaw.setup.verify",
+            "openclaw.setup.verify",
+        ])
+        #expect(!requests.methods.contains("openclaw.setup.detect"))
+        #expect(!requests.methods.contains("openclaw.setup.activate"))
+        #expect(view.aiSetup.pendingActivationVerification)
+        if completed {
+            #expect(pendingState(defaults) == .completed)
+        } else {
+            #expect(isPending(defaults))
+        }
+    }
+
+    @Test func `failed configured verification retry may enter ordinary missing setup`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyMissingRetry"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, recorder in
+                switch request.method {
+                case "agents.list":
+                    let count = await recorder.snapshot().methods.filter { $0 == "agents.list" }.count
+                    return count == 1
+                        ? configuredModelResponse(id: request.id)
+                        : missingConfiguredModelResponse(id: request.id)
+                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect": reauthenticationDetectedSetupResponse(id: request.id)
+                default: nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+
+        let failedProbe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await failedProbe.value
+        _ = await waitForAISetupRequests(harness.recorder, count: 3)
+        let retry = try #require(view.retryConfiguredGatewayProbe())
+        await retry.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 5)
+        await settleQueuedAISetupTasks()
+
+        #expect(requests.methods == [
+            "agents.list",
+            "openclaw.setup.verify",
+            "openclaw.setup.detect",
+            "agents.list",
+            "openclaw.setup.detect",
+        ])
+        #expect(view.aiSetup.configuredGatewayVerificationFailure == nil)
+        #expect(view.aiSetup.phase == .ready)
     }
 
     @Test func `candidate failure keeps friendly summary and exact detail`() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -812,6 +812,11 @@ private func setupAdmissionBusyResponse(id: String) -> Data {
 @Suite(.serialized)
 @MainActor
 struct OnboardingAISetupTests {
+    @Test func `nix first run presenter hands off to dashboard`() {
+        #expect(OnboardingController.firstRunDestination(isNixMode: true) == .dashboard)
+        #expect(OnboardingController.firstRunDestination(isNixMode: false) == .onboarding)
+    }
+
     @Test func `first run verifies configured gateway before opening dashboard`() async throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingFirstRunVerifyTests"))
         let url = try #require(URL(string: "ws://localhost:18789"))
@@ -860,6 +865,83 @@ struct OnboardingAISetupTests {
         ])
         #expect(presenter.view?.aiSetup.configuredGatewayVerificationFailure?.status == "auth")
         presenter.view?.onboardingDidDisappear()
+    }
+
+    @Test func `cold hello does not repeat verification and real reconnect does`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingColdHelloSingleFlight"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let initialVerificationGate = AISetupRequestGate()
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list":
+                    return configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify":
+                    await initialVerificationGate.wait()
+                    return rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect":
+                    return reauthenticationDetectedSetupResponse(id: request.id)
+                default:
+                    return nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+        let reconnectConsumer = Task {
+            await view.configuredGatewayProbe.consumeReconnects {
+                view.probeConfiguredGatewayForDashboard(knownVisible: true)
+            }
+        }
+        defer {
+            reconnectConsumer.cancel()
+            view.onboardingDidDisappear()
+        }
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        let initialProbe = try #require(view.onboardingDidAppear())
+        await initialVerificationGate.waitUntilStarted()
+        await initialVerificationGate.release()
+        await initialProbe.value
+        _ = await waitForAISetupRequests(harness.recorder, count: 3)
+        await settleQueuedAISetupTasks()
+        var requests = await harness.recorder.snapshot()
+
+        #expect(requests.methods.filter { $0 == "agents.list" }.count == 1)
+        #expect(requests.methods.filter { $0 == "openclaw.setup.verify" }.count == 1)
+
+        let firstSocket = try #require(harness.session.latestTask())
+        for _ in 0..<200 where !firstSocket.hasPendingReceiveHandler() {
+            await Task.yield()
+        }
+        firstSocket.emitReceiveFailure()
+        for _ in 0..<400 {
+            requests = await harness.recorder.snapshot()
+            if requests.methods.filter({ $0 == "openclaw.setup.verify" }).count == 2 {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        await settleQueuedAISetupTasks()
+        requests = await harness.recorder.snapshot()
+
+        #expect(harness.session.snapshotMakeCount() == 2)
+        #expect(requests.methods.filter { $0 == "agents.list" }.count == 2)
+        #expect(requests.methods.filter { $0 == "openclaw.setup.verify" }.count == 2)
     }
 
     @Test func `failed configured route verification exposes provider reauthentication`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -908,8 +908,8 @@ struct OnboardingAISetupTests {
             url: url,
             handler: { _, request, _ in
                 switch request.method {
-                case "agents.list": configuredModelResponse(id: request.id)
-                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "agents.list": return configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": return rejectedSetupVerificationResponse(id: request.id)
                 case "openclaw.setup.detect":
                     if detections.claim() == 0 {
                         return reauthenticationDetectedSetupResponse(id: request.id)
@@ -917,10 +917,10 @@ struct OnboardingAISetupTests {
                     await reconciliationGate.wait()
                     return persistedDetectedSetupResponse(id: request.id)
                 case "openclaw.setup.auth.start":
-                    wizardDoneResponse(
+                    return wizardDoneResponse(
                         id: request.id,
                         sessionID: request.params["sessionId"] as? String ?? "auth-session")
-                default: nil
+                default: return nil
                 }
             },
             receiveHook: { task, receiveIndex in
@@ -977,8 +977,8 @@ struct OnboardingAISetupTests {
             url: url,
             handler: { _, request, _ in
                 switch request.method {
-                case "agents.list": configuredModelResponse(id: request.id)
-                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "agents.list": return configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": return rejectedSetupVerificationResponse(id: request.id)
                 case "openclaw.setup.detect":
                     switch detections.claim() {
                     case 0:
@@ -1122,13 +1122,13 @@ struct OnboardingAISetupTests {
             url: url,
             handler: { _, request, _ in
                 switch request.method {
-                case "agents.list": configuredModelResponse(id: request.id)
+                case "agents.list": return configuredModelResponse(id: request.id)
                 case "openclaw.setup.verify":
                     await verificationGate.wait()
                     return verificationSucceeds
                         ? verifiedSetupResponse(id: request.id)
                         : rejectedSetupVerificationResponse(id: request.id)
-                default: nil
+                default: return nil
                 }
             },
             receiveHook: { task, receiveIndex in

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -775,6 +775,64 @@ private func setupAdmissionBusyResponse(id: String) -> Data {
 @Suite(.serialized)
 @MainActor
 struct OnboardingAISetupTests {
+    @Test func `first run verifies configured gateway before opening dashboard`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingFirstRunVerifyTests"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list": configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect": reauthenticationDetectedSetupResponse(id: request.id)
+                default: nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let appState = AppState(preview: true)
+        appState.connectionMode = .local
+        appState.onboardingSeen = false
+        let delegate = AppDelegate()
+        var launchEvents: [String] = []
+        var probeTask: Task<Void, Never>?
+        var launchedView: OnboardingView?
+        var dashboardOpenCount = 0
+
+        delegate.scheduleFirstRunOnboardingIfNeeded(state: appState) { mode, routeIdentity in
+            launchEvents.append("onboarding")
+            let view = OnboardingView(
+                state: appState,
+                aiSetupGateway: harness.gateway,
+                systemAgentDefaults: defaults,
+                aiSetupRouteIdentityProvider: { routeIdentity },
+                gatewaySelectionPersister: { true },
+                configuredGatewayDashboardOpener: { dashboardOpenCount += 1 })
+            #expect(mode == .local)
+            launchedView = view
+            probeTask = view.onboardingDidAppear()
+        }
+
+        let firstRunProbe = try #require(probeTask)
+        await firstRunProbe.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 2)
+        await settleQueuedAISetupTasks()
+
+        #expect(launchEvents == ["onboarding"])
+        #expect(Array(requests.methods.prefix(2)) == [
+            "agents.list",
+            "openclaw.setup.verify",
+        ])
+        #expect(dashboardOpenCount == 0)
+        launchedView?.onboardingDidDisappear()
+    }
+
     @Test func `failed configured route verification exposes provider reauthentication`() async throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyRecovery"))
         let url = try #require(URL(string: "ws://localhost:18789"))

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -824,14 +824,21 @@ struct OnboardingAISetupTests {
         #expect(view.aiSetup.configuredGatewayVerificationFailure?.error == "expired login")
     }
 
-    @Test func `reconnect probe preserves active provider reauthentication`() async throws {
+    @Test(arguments: [false, true])
+    func `reconnect probe preserves active provider reauthentication`(
+        missingModel: Bool) async throws
+    {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyAuthReconnect"))
         let url = try #require(URL(string: "ws://localhost:18789"))
+        let agentsResponses = AISetupSocketGeneration()
         let harness = AISetupHarness(
             url: url,
             handler: { _, request, _ in
                 switch request.method {
-                case "agents.list": configuredModelResponse(id: request.id)
+                case "agents.list":
+                    missingModel && agentsResponses.claim() > 0
+                        ? missingConfiguredModelResponse(id: request.id)
+                        : configuredModelResponse(id: request.id)
                 case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
                 case "openclaw.setup.detect": reauthenticationDetectedSetupResponse(id: request.id)
                 case "openclaw.setup.auth.start":
@@ -877,17 +884,89 @@ struct OnboardingAISetupTests {
         // Reconnect snapshots enter through this same route-bound probe.
         let reconnectProbe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
         await reconnectProbe.value
-        let requests = await waitForAISetupRequests(harness.recorder, count: 6)
+        let requests = await waitForAISetupRequests(
+            harness.recorder,
+            count: missingModel ? 5 : 6)
         await settleQueuedAISetupTasks()
 
-        #expect(requests.methods.suffix(2) == [
-            "agents.list",
-            "openclaw.setup.verify",
-        ])
+        let expectedReconnectMethods = missingModel
+            ? ["agents.list"]
+            : ["agents.list", "openclaw.setup.verify"]
+        #expect(requests.methods.suffix(expectedReconnectMethods.count) == expectedReconnectMethods)
         #expect(!requests.methods.contains("wizard.cancel"))
         #expect(view.aiSetup.activeAuthOption?.id == option.id)
         #expect(view.aiSetup._test_authSessionID == authSessionID)
         #expect(view.aiSetup.ownsInferenceTransition)
+    }
+
+    @Test func `provider auth reconciliation retains ownership across reconnect`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingProviderAuthReconcileReconnect"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let detections = AISetupSocketGeneration()
+        let reconciliationGate = AISetupRequestGate()
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list": configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect":
+                    if detections.claim() == 0 {
+                        return reauthenticationDetectedSetupResponse(id: request.id)
+                    }
+                    await reconciliationGate.wait()
+                    return persistedDetectedSetupResponse(id: request.id)
+                case "openclaw.setup.auth.start":
+                    wizardDoneResponse(
+                        id: request.id,
+                        sessionID: request.params["sessionId"] as? String ?? "auth-session")
+                default: nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: [
+                        "openclaw.setup.verify",
+                        "openclaw.setup.auth.start",
+                    ]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+        view.onboardingVisible = true
+
+        let initialProbe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await initialProbe.value
+        _ = await waitForAISetupRequests(harness.recorder, count: 3)
+        await settleQueuedAISetupTasks()
+
+        view.aiSetup.startProviderAuth(try #require(view.aiSetup.authOptions.first))
+        await reconciliationGate.waitUntilStarted()
+        #expect(view.aiSetup.activeAuthOption == nil)
+        #expect(view.aiSetup.ownsInferenceTransition)
+
+        let reconnectProbe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await reconnectProbe.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 7)
+        #expect(requests.methods.suffix(2) == [
+            "agents.list",
+            "openclaw.setup.verify",
+        ])
+        #expect(!view.aiSetup.connected)
+        #expect(view.aiSetup.ownsInferenceTransition)
+
+        await reconciliationGate.release()
+        for _ in 0..<400 where !view.aiSetup.connected {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(view.aiSetup.connected)
     }
 
     @Test(arguments: [false, true])
@@ -941,6 +1020,78 @@ struct OnboardingAISetupTests {
             #expect(pendingState(defaults) == .completed)
         } else {
             #expect(isPending(defaults))
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `receipt created during configured verification reuses the live result`(
+        verificationSucceeds: Bool) async throws
+    {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyMidflightReceipt"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let verificationGate = AISetupRequestGate()
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list": configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify":
+                    await verificationGate.wait()
+                    return verificationSucceeds
+                        ? verifiedSetupResponse(id: request.id)
+                        : rejectedSetupVerificationResponse(id: request.id)
+                default: nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+        view.onboardingVisible = true
+        let route = try #require(await harness.gateway.captureRoute())
+        let activationOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
+            id: "midflight-receipt",
+            routeFingerprint: try #require(route.activationOwnershipFingerprint))
+
+        let probe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await verificationGate.waitUntilStarted()
+        markPending(
+            defaults,
+            for: "local",
+            owner: activationOwner,
+            timeoutMs: 30000)
+        await verificationGate.release()
+        await probe.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 2)
+        await settleQueuedAISetupTasks()
+
+        #expect(requests.methods == [
+            "agents.list",
+            "openclaw.setup.verify",
+        ])
+        #expect(storedActivationOwner(defaults) == activationOwner)
+        if verificationSucceeds {
+            guard case .verified = pendingState(defaults) else {
+                Issue.record("expected the exact mid-flight receipt to retain verified ownership")
+                return
+            }
+            #expect(view.aiSetup.waitingForPendingActivationDeadline)
+        } else {
+            guard case .activating = pendingState(defaults) else {
+                Issue.record("expected the failed turn to retain the exact activation receipt")
+                return
+            }
+            #expect(view.aiSetup.pendingActivationVerification)
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -882,7 +882,7 @@ struct OnboardingAISetupTests {
                         ? configuredModelResponse(id: request.id)
                         : missingConfiguredModelResponse(id: request.id)
                 case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
-                case "openclaw.setup.detect": reauthenticationDetectedSetupResponse(id: request.id)
+                case "openclaw.setup.detect": detectedSetupResponse(id: request.id)
                 default: nil
                 }
             },

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -815,7 +815,8 @@ private func setupAdmissionBusyResponse(id: String) -> Data {
 @Suite(.serialized)
 @MainActor
 struct OnboardingAISetupTests {
-    @Test func `nix first run presenter opens a dashboard outcome`() async {
+    @Test(.appStateStoreIsolated)
+    func `nix first run presenter opens a dashboard outcome`() async {
         let defaults = AppDefaults.standard
         let nixModeKey = "openclaw.nixMode"
         let previousDefaults: [(String, Any?)] = [

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -881,9 +881,9 @@ struct OnboardingAISetupTests {
                     return count == 1
                         ? configuredModelResponse(id: request.id)
                         : missingConfiguredModelResponse(id: request.id)
-                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
-                case "openclaw.setup.detect": detectedSetupResponse(id: request.id)
-                default: nil
+                case "openclaw.setup.verify": return rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect": return detectedSetupResponse(id: request.id)
+                default: return nil
                 }
             },
             receiveHook: { task, receiveIndex in

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -969,6 +969,89 @@ struct OnboardingAISetupTests {
         #expect(view.aiSetup.connected)
     }
 
+    @Test func `provider auth reconciliation retry preserves successful sign-in`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingProviderAuthReconcileRetry"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let detections = AISetupSocketGeneration()
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list": configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect":
+                    switch detections.claim() {
+                    case 0:
+                        return reauthenticationDetectedSetupResponse(id: request.id)
+                    case 1:
+                        return unavailableGatewayResponse(id: request.id)
+                    default:
+                        let response = String(
+                            decoding: persistedDetectedSetupResponse(id: request.id),
+                            as: UTF8.self)
+                            .replacingOccurrences(
+                                of: #""credentials":false"#,
+                                with: #""credentials":true"#)
+                        return Data(response.utf8)
+                    }
+                case "openclaw.setup.auth.start":
+                    return wizardDoneResponse(
+                        id: request.id,
+                        sessionID: request.params["sessionId"] as? String ?? "auth-session")
+                case "openclaw.setup.activate":
+                    return successfulActivationResponse(
+                        id: request.id,
+                        modelRef: "claude-cli/claude-opus-4-8",
+                        latencyMs: 42)
+                default:
+                    return nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: [
+                        "openclaw.setup.verify",
+                        "openclaw.setup.auth.start",
+                        "openclaw.setup.activate",
+                    ],
+                    capabilities: ["openclaw-setup-model-ref"]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+        view.onboardingVisible = true
+
+        let initialProbe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await initialProbe.value
+        _ = await waitForAISetupRequests(harness.recorder, count: 3)
+        await settleQueuedAISetupTasks()
+
+        view.aiSetup.startProviderAuth(try #require(view.aiSetup.authOptions.first))
+        _ = await waitForAISetupRequests(harness.recorder, count: 5)
+        await settleQueuedAISetupTasks()
+        #expect(view.aiSetup.detectError != nil)
+        #expect(view.aiSetup.ownsInferenceTransition)
+
+        view.aiSetup.retryFromScratch()
+        _ = await waitForAISetupRequests(harness.recorder, count: 6)
+        for _ in 0..<400 where !view.aiSetup.connected {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        await settleQueuedAISetupTasks()
+        let requests = await harness.recorder.snapshot()
+
+        #expect(view.aiSetup.connected)
+        #expect(requests.methods.filter { $0 == "openclaw.setup.detect" }.count == 3)
+        #expect(!requests.methods.contains("openclaw.setup.activate"))
+    }
+
     @Test(arguments: [false, true])
     func `failed configured verification preserves activation receipt`(
         completed: Bool) async throws
@@ -1006,13 +1089,15 @@ struct OnboardingAISetupTests {
 
         let probe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
         await probe.value
-        let requests = await waitForAISetupRequests(harness.recorder, count: 2)
+        _ = await waitForAISetupRequests(harness.recorder, count: 2)
         await settleQueuedAISetupTasks()
+        let requests = await harness.recorder.snapshot()
 
         #expect(requests.methods == [
             "agents.list",
             "openclaw.setup.verify",
         ])
+        #expect(requests.methods.filter { $0 == "openclaw.setup.verify" }.count == 1)
         #expect(!requests.methods.contains("openclaw.setup.detect"))
         #expect(!requests.methods.contains("openclaw.setup.activate"))
         #expect(view.aiSetup.pendingActivationVerification)
@@ -1072,13 +1157,15 @@ struct OnboardingAISetupTests {
             timeoutMs: 30000)
         await verificationGate.release()
         await probe.value
-        let requests = await waitForAISetupRequests(harness.recorder, count: 2)
+        _ = await waitForAISetupRequests(harness.recorder, count: 2)
         await settleQueuedAISetupTasks()
+        let requests = await harness.recorder.snapshot()
 
         #expect(requests.methods == [
             "agents.list",
             "openclaw.setup.verify",
         ])
+        #expect(requests.methods.filter { $0 == "openclaw.setup.verify" }.count == 1)
         #expect(storedActivationOwner(defaults) == activationOwner)
         if verificationSucceeds {
             guard case .verified = pendingState(defaults) else {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -646,6 +646,43 @@ private struct AISetupHarness {
     }
 }
 
+@MainActor
+private final class FirstRunGatewayTestPresenter: FirstRunOnboardingPresenting {
+    private let makeView: @MainActor () -> OnboardingView
+    private(set) var completionCount = 0
+    private(set) var showCount = 0
+    private(set) var view: OnboardingView?
+    private(set) var probeTask: Task<Void, Never>?
+
+    init(makeView: @escaping @MainActor () -> OnboardingView) {
+        self.makeView = makeView
+    }
+
+    func complete() {
+        self.completionCount += 1
+    }
+
+    func show() {
+        self.showCount += 1
+        let view = self.makeView()
+        self.view = view
+        self.probeTask = view.onboardingDidAppear()
+    }
+}
+
+@MainActor
+private func waitForFirstRunProbe(
+    _ presenter: FirstRunGatewayTestPresenter) async throws -> Task<Void, Never>
+{
+    for _ in 0..<200 {
+        if let probeTask = presenter.probeTask {
+            return probeTask
+        }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+    return try #require(presenter.probeTask)
+}
+
 private func makeAISetupSession(
     recorder: AISetupRequestRecorder,
     indeterminateActivationAfterDispatch: Bool = false,
@@ -799,38 +836,30 @@ struct OnboardingAISetupTests {
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         appState.onboardingSeen = false
-        let delegate = AppDelegate()
-        var launchEvents: [String] = []
-        var probeTask: Task<Void, Never>?
-        var launchedView: OnboardingView?
-        var dashboardOpenCount = 0
-
-        delegate.scheduleFirstRunOnboardingIfNeeded(state: appState) { mode, routeIdentity in
-            launchEvents.append("onboarding")
-            let view = OnboardingView(
+        let routeIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity(state: appState)
+        let presenter = FirstRunGatewayTestPresenter {
+            OnboardingView(
                 state: appState,
                 aiSetupGateway: harness.gateway,
                 systemAgentDefaults: defaults,
                 aiSetupRouteIdentityProvider: { routeIdentity },
-                gatewaySelectionPersister: { true },
-                configuredGatewayDashboardOpener: { dashboardOpenCount += 1 })
-            #expect(mode == .local)
-            launchedView = view
-            probeTask = view.onboardingDidAppear()
+                gatewaySelectionPersister: { true })
         }
 
-        let firstRunProbe = try #require(probeTask)
+        AppDelegate.scheduleFirstRunOnboardingIfNeeded(state: appState, presenter: presenter)
+        let firstRunProbe = try await waitForFirstRunProbe(presenter)
         await firstRunProbe.value
         let requests = await waitForAISetupRequests(harness.recorder, count: 2)
         await settleQueuedAISetupTasks()
 
-        #expect(launchEvents == ["onboarding"])
+        #expect(presenter.showCount == 1)
+        #expect(presenter.completionCount == 0)
         #expect(Array(requests.methods.prefix(2)) == [
             "agents.list",
             "openclaw.setup.verify",
         ])
-        #expect(dashboardOpenCount == 0)
-        launchedView?.onboardingDidDisappear()
+        #expect(presenter.view?.aiSetup.configuredGatewayVerificationFailure?.status == "auth")
+        presenter.view?.onboardingDidDisappear()
     }
 
     @Test func `failed configured route verification exposes provider reauthentication`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -649,12 +649,18 @@ private struct AISetupHarness {
 @MainActor
 private final class FirstRunGatewayTestPresenter: FirstRunOnboardingPresenting {
     private let makeView: @MainActor () -> OnboardingView
+    let presentsDashboardInsteadOfOnboarding: Bool
     private(set) var completionCount = 0
+    private(set) var openDashboardCount = 0
     private(set) var showCount = 0
     private(set) var view: OnboardingView?
     private(set) var probeTask: Task<Void, Never>?
 
-    init(makeView: @escaping @MainActor () -> OnboardingView) {
+    init(
+        presentsDashboardInsteadOfOnboarding: Bool = false,
+        makeView: @escaping @MainActor () -> OnboardingView)
+    {
+        self.presentsDashboardInsteadOfOnboarding = presentsDashboardInsteadOfOnboarding
         self.makeView = makeView
     }
 
@@ -662,7 +668,11 @@ private final class FirstRunGatewayTestPresenter: FirstRunOnboardingPresenting {
         self.completionCount += 1
     }
 
-    func show() {
+    func openDashboard() {
+        self.openDashboardCount += 1
+    }
+
+    func showOnboarding() {
         self.showCount += 1
         let view = self.makeView()
         self.view = view
@@ -813,8 +823,15 @@ private func setupAdmissionBusyResponse(id: String) -> Data {
 @MainActor
 struct OnboardingAISetupTests {
     @Test func `nix first run presenter hands off to dashboard`() {
-        #expect(OnboardingController.firstRunDestination(isNixMode: true) == .dashboard)
-        #expect(OnboardingController.firstRunDestination(isNixMode: false) == .onboarding)
+        let presenter = FirstRunGatewayTestPresenter(
+            presentsDashboardInsteadOfOnboarding: true,
+            makeView: { fatalError("Nix first run must not present onboarding") })
+
+        presenter.show()
+
+        #expect(presenter.completionCount == 1)
+        #expect(presenter.openDashboardCount == 1)
+        #expect(presenter.showCount == 0)
     }
 
     @Test func `first run verifies configured gateway before opening dashboard`() async throws {
@@ -940,6 +957,91 @@ struct OnboardingAISetupTests {
         requests = await harness.recorder.snapshot()
 
         #expect(harness.session.snapshotMakeCount() == 2)
+        #expect(requests.methods.filter { $0 == "agents.list" }.count == 2)
+        #expect(requests.methods.filter { $0 == "openclaw.setup.verify" }.count == 2)
+    }
+
+    @Test func `late reconnect subscription observes the replacement server`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingLateReconnectSubscription"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let initialVerificationGate = AISetupRequestGate()
+        let verificationAttempts = AISetupSocketGeneration()
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list":
+                    return configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify":
+                    guard verificationAttempts.claim() > 0 else {
+                        await initialVerificationGate.wait()
+                        return nil
+                    }
+                    return rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect":
+                    return reauthenticationDetectedSetupResponse(id: request.id)
+                default:
+                    return nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let state = AppState(preview: true)
+        state.connectionMode = .local
+        let view = harness.view(
+            state: state,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+        defer { view.onboardingDidDisappear() }
+
+        let initialProbe = try #require(view.onboardingDidAppear())
+        await initialVerificationGate.waitUntilStarted()
+        let initialServer = try #require(await harness.gateway.captureServerLease())
+        let firstSocket = try #require(harness.session.latestTask())
+        for _ in 0..<200 where !firstSocket.hasPendingReceiveHandler() {
+            await Task.yield()
+        }
+        firstSocket.emitReceiveFailure()
+
+        var replacementServer: GatewayConnection.ServerLease?
+        for _ in 0..<400 {
+            if let candidate = await harness.gateway.captureServerLease(),
+               candidate.identity != initialServer.identity
+            {
+                replacementServer = candidate
+                break
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        _ = try #require(replacementServer)
+        #expect(harness.session.snapshotMakeCount() == 2)
+
+        let reconnectConsumer = Task {
+            await view.configuredGatewayProbe.consumeReconnects {
+                view.probeConfiguredGatewayForDashboard(knownVisible: true)
+            }
+        }
+        defer { reconnectConsumer.cancel() }
+        await initialVerificationGate.release()
+        await initialProbe.value
+
+        var requests = await harness.recorder.snapshot()
+        for _ in 0..<400 {
+            if requests.methods.filter({ $0 == "openclaw.setup.verify" }).count == 2 {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+            requests = await harness.recorder.snapshot()
+        }
+        await settleQueuedAISetupTasks()
+        requests = await harness.recorder.snapshot()
+
         #expect(requests.methods.filter { $0 == "agents.list" }.count == 2)
         #expect(requests.methods.filter { $0 == "openclaw.setup.verify" }.count == 2)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -268,6 +268,18 @@ private func detectedSetupResponse(
         """.utf8)
 }
 
+private func reauthenticationDetectedSetupResponse(id: String) -> Data {
+    Data(
+        """
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "candidates":[],"manualProviders":[],
+          "authOptions":[{"id":"openai:oauth","brandId":"openai","label":"OpenAI",
+            "hint":"Sign in with OpenAI","kind":"oauth","featured":true}],
+          "prepareOptions":[],"workspace":"/tmp/openclaw-workspace",
+          "configuredModel":"openai/gpt-5.5","setupComplete":true}}
+        """.utf8)
+}
+
 private func successfulEmptyResponse(id: String) -> Data {
     Data(#"{"type":"res","id":"\#(id)","ok":true,"payload":{}}"#.utf8)
 }
@@ -751,6 +763,50 @@ private func setupAdmissionBusyResponse(id: String) -> Data {
 @Suite(.serialized)
 @MainActor
 struct OnboardingAISetupTests {
+    @Test func `failed configured route verification exposes provider reauthentication`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyRecovery"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list": configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify": rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect": reauthenticationDetectedSetupResponse(id: request.id)
+                default: nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let appState = AppState(preview: true)
+        appState.connectionMode = .local
+        let view = harness.view(
+            state: appState,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
+        view.onboardingVisible = true
+
+        let probe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await probe.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 3)
+        await settleQueuedAISetupTasks()
+
+        #expect(Array(requests.methods.prefix(3)) == [
+            "agents.list",
+            "openclaw.setup.verify",
+            "openclaw.setup.detect",
+        ])
+        #expect(view.aiSetup.phase == .ready)
+        #expect(view.aiSetup.authOptions.map(\.id) == ["openai:oauth"])
+        #expect(!view.aiSetup.connected)
+    }
+
     @Test func `candidate failure keeps friendly summary and exact detail`() {
         let failure = OnboardingAISetupModel.failure(
             label: "Codex CLI",

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -367,10 +367,11 @@ struct OnboardingConfiguredGatewayProbeTests {
 
         let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
 
-        guard case let .verificationFailed(status, error, _) = outcome else {
+        guard case let .verificationFailed(modelRef, status, error, _) = outcome else {
             Issue.record("expected configured inference verification failure")
             return
         }
+        #expect(modelRef == "openai/gpt-5.5")
         #expect(status == "auth")
         #expect(error == "expired login")
     }
@@ -403,6 +404,42 @@ struct OnboardingConfiguredGatewayProbeTests {
             }
             return false
         }())
+    }
+
+    @Test func `configured probe does not splice a reconnecting socket`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: {
+                return GatewayTestWebSocketTask(
+                    sendHook: { task, message, sendIndex in
+                        guard sendIndex > 0,
+                              let request = onboardingProbeRequest(from: message),
+                              request.method == "agents.list"
+                        else { return }
+                        task.emitReceiveSuccessOnce(.data(onboardingAgentsResponse(id: request.id)))
+                        while !task.hasPendingReceiveHandler() {
+                            await Task.yield()
+                        }
+                        task.emitReceiveFailure()
+                    },
+                    receiveHook: { task, receiveIndex in
+                        if receiveIndex == 0 {
+                            return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                        }
+                        return .data(GatewayWebSocketTestSupport.connectOkData(
+                            id: task.snapshotConnectRequestID() ?? "connect",
+                            methods: ["openclaw.setup.verify"]))
+                    })
+            })
+
+        let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
+
+        #expect({
+            if case .unavailable = outcome { return true }
+            return false
+        }())
+        #expect(fixture.session.snapshotMakeCount() >= 1)
     }
 
     @Test func `route replacement supersedes live verification`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-import OpenClawKit
 import Testing
 @testable import OpenClaw
+@testable import OpenClawKit
 
 private actor OnboardingProbeGatewayConfig {
     private var token = "route-a"

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -622,7 +622,8 @@ struct OnboardingConfiguredGatewayProbeTests {
         }())
     }
 
-    @Test func `paused local first-run probe does not recover the gateway`() async throws {
+    @Test(.appStateStoreIsolated)
+    func `paused local first-run probe does not recover the gateway`() async throws {
         let url = try #require(URL(string: "ws://127.0.0.1:18789"))
         let stateDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("openclaw-onboarding-probe-\(UUID().uuidString)", isDirectory: true)
@@ -657,7 +658,9 @@ struct OnboardingConfiguredGatewayProbeTests {
         let probe = OnboardingConfiguredGatewayProbe(gateway: gateway, timeoutMs: 1)
 
         let outcome = try await DeviceIdentityStore.withStateDirectory(stateDir) {
-            await runOnboardingProbe(probe, connectionMode: .local)
+            let outcome = await runOnboardingProbe(probe, connectionMode: .local)
+            await gateway.shutdown()
+            return outcome
         }
 
         #expect({

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -201,6 +201,83 @@ private func onboardingProbeAuthFailureTaskFactory() -> GatewayTestWebSocketSess
     }
 }
 
+private func onboardingProbeRequest(
+    from message: URLSessionWebSocketTask.Message) -> (id: String, method: String)?
+{
+    let data: Data? = switch message {
+    case let .data(data): data
+    case let .string(string): string.data(using: .utf8)
+    @unknown default: nil
+    }
+    guard let data,
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let id = object["id"] as? String,
+          let method = object["method"] as? String
+    else { return nil }
+    return (id: id, method: method)
+}
+
+private func onboardingVerifyResponse(
+    id: String,
+    ok: Bool,
+    status: String? = nil,
+    error: String? = nil) -> Data
+{
+    let statusJSON = status.map { #", "status":"\#($0)""# } ?? ""
+    let errorJSON = error.map { #", "error":"\#($0)""# } ?? ""
+    return Data("""
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "ok":\(ok),"modelRef":"openai/gpt-5.5"\(statusJSON)\(errorJSON)}}
+        """
+        .utf8)
+}
+
+private enum OnboardingVerifyReply: Sendable {
+    case verified
+    case rejected
+    case transportFailure
+}
+
+private func onboardingVerifyTaskFactory(
+    reply: OnboardingVerifyReply,
+    advertiseVerifyMethod: Bool = true,
+    beforeVerifyReply: (@Sendable () async -> Void)? = nil) -> GatewayTestWebSocketSession.TaskFactory
+{
+    {
+        GatewayTestWebSocketTask(
+            sendHook: { task, message, sendIndex in
+                guard sendIndex > 0,
+                      let request = onboardingProbeRequest(from: message)
+                else { return }
+                guard request.method == "openclaw.setup.verify" else {
+                    task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: request.id)))
+                    return
+                }
+                await beforeVerifyReply?()
+                switch reply {
+                case .verified:
+                    task.emitReceiveSuccess(.data(onboardingVerifyResponse(id: request.id, ok: true)))
+                case .rejected:
+                    task.emitReceiveSuccess(.data(onboardingVerifyResponse(
+                        id: request.id,
+                        ok: false,
+                        status: "auth",
+                        error: "expired login")))
+                case .transportFailure:
+                    task.emitReceiveFailure()
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: advertiseVerifyMethod ? ["openclaw.setup.verify"] : []))
+            })
+    }
+}
+
 @MainActor
 private struct OnboardingProbeFixture {
     let session: GatewayTestWebSocketSession
@@ -270,6 +347,102 @@ private func isMissing(_ outcome: OnboardingConfiguredGatewayProbe.Outcome) -> B
 @Suite(.serialized)
 @MainActor
 struct OnboardingConfiguredGatewayProbeTests {
+    @Test func `configured route must pass live verification`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(reply: .verified))
+
+        let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
+
+        #expect(configuredModel(outcome) == "openai/gpt-5.5")
+        #expect(fixture.session.latestTask()?.snapshotSendCount() == 3)
+    }
+
+    @Test func `failed live verification stays in onboarding`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(reply: .rejected))
+
+        let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
+
+        guard case let .verificationFailed(status, error, _) = outcome else {
+            Issue.record("expected configured inference verification failure")
+            return
+        }
+        #expect(status == "auth")
+        #expect(error == "expired login")
+    }
+
+    @Test func `gateway without live verification keeps config-only handoff`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(
+                reply: .verified,
+                advertiseVerifyMethod: false))
+
+        let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
+
+        #expect(configuredModel(outcome) == "openai/gpt-5.5")
+        #expect(fixture.session.latestTask()?.snapshotSendCount() == 2)
+    }
+
+    @Test func `live verification transport failure is unavailable`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(reply: .transportFailure))
+
+        let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
+
+        #expect({
+            if case .unavailable = outcome {
+                return true
+            }
+            return false
+        }())
+    }
+
+    @Test func `route replacement supersedes live verification`() async throws {
+        let config = OnboardingProbeGatewayConfig()
+        let gate = OnboardingProbeGate()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let probe = onboardingProbeFixture(
+            url: url,
+            tokenProvider: { await config.snapshotToken() },
+            taskFactory: onboardingVerifyTaskFactory(
+                reply: .verified,
+                beforeVerifyReply: { await gate.wait() })).probe
+
+        let attempt = probe.beginProbe()
+        let result = Task { await probe.probe(connectionMode: .remote, attempt: attempt) }
+        await gate.waitUntilStarted()
+        await config.setToken("route-b")
+        await gate.release()
+
+        #expect(await result.value == .superseded)
+    }
+
+    @Test func `invalidation supersedes live verification`() async throws {
+        let gate = OnboardingProbeGate()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let probe = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(
+                reply: .verified,
+                beforeVerifyReply: { await gate.wait() })).probe
+
+        let attempt = probe.beginProbe()
+        let result = Task { await probe.probe(connectionMode: .remote, attempt: attempt) }
+        await gate.waitUntilStarted()
+        probe.invalidate()
+        await gate.release()
+
+        #expect(await result.value == .superseded)
+    }
+
     @Test func `reachable gateway uses its configured default agent model`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
         let fixture = onboardingProbeFixture(

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -80,6 +80,15 @@ private actor OnboardingProbeMethodRecorder {
     }
 }
 
+@MainActor
+private final class OnboardingProbeGatewayActivationRecorder {
+    private(set) var count = 0
+
+    func activate() {
+        self.count += 1
+    }
+}
+
 private actor OnboardingProbeConfigReadGate {
     private let blockedRead: Int
     private var readCount = 0
@@ -615,6 +624,22 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `paused local first-run probe does not recover the gateway`() async throws {
         let url = try #require(URL(string: "ws://127.0.0.1:18789"))
+        let stateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-onboarding-probe-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+
+        let state = AppStateStore.shared
+        let originalMode = state.connectionMode
+        let originalPaused = state.isPaused
+        state.connectionMode = .local
+        state.isPaused = true
+        defer {
+            state.connectionMode = originalMode
+            state.isPaused = originalPaused
+        }
+
+        let activation = OnboardingProbeGatewayActivationRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(receiveHook: { _, _ in
                 throw URLError(.cannotConnectToHost)
@@ -626,11 +651,14 @@ struct OnboardingConfiguredGatewayProbeTests {
                     config: (url: url, token: nil, password: nil),
                     routeAuthority: nil)
             },
-            sharedEndpointRecovery: { .localDenied },
+            activateGateway: { activation.activate() },
+            activationBindingKeyProvider: { nil },
             sessionBox: WebSocketSessionBox(session: session))
         let probe = OnboardingConfiguredGatewayProbe(gateway: gateway, timeoutMs: 1)
 
-        let outcome = await runOnboardingProbe(probe, connectionMode: .local)
+        let outcome = try await DeviceIdentityStore.withStateDirectory(stateDir) {
+            await runOnboardingProbe(probe, connectionMode: .local)
+        }
 
         #expect({
             if case .unavailable = outcome {
@@ -639,6 +667,7 @@ struct OnboardingConfiguredGatewayProbeTests {
                 false
             }
         }())
+        #expect(activation.count == 0)
         #expect(session.snapshotMakeCount() == 1)
         #expect(session.latestTask()?.snapshotSendCount() == 0)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -771,7 +771,7 @@ struct OnboardingConfiguredGatewayProbeTests {
         #expect(await result.value == .superseded)
     }
 
-    @Test func `snapshot during active probe is delivered after probe completion`() async throws {
+    @Test func `snapshot owned by active probe is not reported as reconnect`() async throws {
         let gate = OnboardingProbeGate()
         let url = try #require(URL(string: "ws://example.invalid"))
         let fixture = onboardingProbeFixture(url: url, beforeReply: { await gate.wait() })
@@ -791,14 +791,9 @@ struct OnboardingConfiguredGatewayProbeTests {
         #expect(reconnectCount == 0)
         await gate.release()
         #expect(await configuredModel(result.value) == "openai/gpt-5.5")
-        for _ in 0..<100 {
-            if reconnectCount > 0 {
-                break
-            }
-            await Task.yield()
-        }
+        for _ in 0..<100 { await Task.yield() }
 
-        #expect(reconnectCount == 1)
+        #expect(reconnectCount == 0)
     }
 
     @Test func `invalidated onboarding probe cannot complete the replacement selection`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -353,7 +353,7 @@ private func runOnboardingProbe(
 private func configuredModel(
     _ outcome: OnboardingConfiguredGatewayProbe.Outcome) -> String?
 {
-    guard case let .configured(modelRef, _) = outcome else { return nil }
+    guard case let .configured(modelRef, _, _) = outcome else { return nil }
     return modelRef
 }
 
@@ -392,7 +392,7 @@ struct OnboardingConfiguredGatewayProbeTests {
 
         let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
 
-        guard case let .verificationFailed(modelRef, status, error, _) = outcome else {
+        guard case let .verificationFailed(modelRef, status, error, _, _) = outcome else {
             Issue.record("expected configured inference verification failure")
             return
         }
@@ -609,7 +609,7 @@ struct OnboardingConfiguredGatewayProbeTests {
             connectionMode: .remote,
             attempt: attempt,
             routeIdentity: "remote:id:gateway-a")
-        guard case let .configured(_, route) = outcome else {
+        guard case let .configured(_, _, route) = outcome else {
             Issue.record("expected configured route")
             return
         }
@@ -633,7 +633,7 @@ struct OnboardingConfiguredGatewayProbeTests {
             connectionMode: .remote,
             attempt: firstAttempt,
             routeIdentity: "remote:id:gateway-a")
-        guard case let .configured(_, firstRoute) = first else {
+        guard case let .configured(_, _, firstRoute) = first else {
             Issue.record("expected first configured route")
             return
         }
@@ -644,7 +644,7 @@ struct OnboardingConfiguredGatewayProbeTests {
             connectionMode: .remote,
             attempt: secondAttempt,
             routeIdentity: "remote:id:gateway-b")
-        guard case let .configured(_, secondRoute) = second else {
+        guard case let .configured(_, _, secondRoute) = second else {
             Issue.record("expected replacement configured route")
             return
         }
@@ -681,10 +681,11 @@ struct OnboardingConfiguredGatewayProbeTests {
     @Test func `invalidation during final success route validation supersedes result`() async throws {
         let configGate = OnboardingProbeConfigReadGate(blockedRead: 4)
         let url = try #require(URL(string: "ws://example.invalid"))
+        let recorder = OnboardingProbeMethodRecorder()
         let fixture = onboardingProbeFixture(
             url: url,
-            tokenProvider: { await configGate.snapshotToken() })
-        let session = fixture.session
+            tokenProvider: { await configGate.snapshotToken() },
+            recorder: recorder)
         let probe = fixture.probe
 
         let attempt = probe.beginProbe()
@@ -694,17 +695,18 @@ struct OnboardingConfiguredGatewayProbeTests {
         await configGate.release()
 
         #expect(await result.value == .superseded)
-        #expect(session.latestTask()?.snapshotSendCount() == 2)
+        #expect(await recorder.snapshot() == ["health", "agents.list"])
     }
 
     @Test func `invalidation during final error route validation supersedes result`() async throws {
         let configGate = OnboardingProbeConfigReadGate(blockedRead: 3)
         let url = try #require(URL(string: "ws://example.invalid"))
+        let recorder = OnboardingProbeMethodRecorder()
         let fixture = onboardingProbeFixture(
             url: url,
             tokenProvider: { await configGate.snapshotToken() },
-            reply: .error)
-        let session = fixture.session
+            reply: .error,
+            recorder: recorder)
         let probe = fixture.probe
 
         let attempt = probe.beginProbe()
@@ -714,7 +716,7 @@ struct OnboardingConfiguredGatewayProbeTests {
         await configGate.release()
 
         #expect(await result.value == .superseded)
-        #expect(session.latestTask()?.snapshotSendCount() == 2)
+        #expect(await recorder.snapshot() == ["health", "agents.list"])
     }
 
     @Test func `route replacement supersedes an in-flight probe failure`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -613,6 +613,36 @@ struct OnboardingConfiguredGatewayProbeTests {
         }())
     }
 
+    @Test func `paused local first-run probe does not recover the gateway`() async throws {
+        let url = try #require(URL(string: "ws://127.0.0.1:18789"))
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(receiveHook: { _, _ in
+                throw URLError(.cannotConnectToHost)
+            })
+        })
+        let gateway = GatewayConnection(
+            endpointProvider: {
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: url, token: nil, password: nil),
+                    routeAuthority: nil)
+            },
+            sharedEndpointRecovery: { .localDenied },
+            sessionBox: WebSocketSessionBox(session: session))
+        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway, timeoutMs: 1)
+
+        let outcome = await runOnboardingProbe(probe, connectionMode: .local)
+
+        #expect({
+            if case .unavailable = outcome {
+                true
+            } else {
+                false
+            }
+        }())
+        #expect(session.snapshotMakeCount() == 1)
+        #expect(session.latestTask()?.snapshotSendCount() == 0)
+    }
+
     @Test func `route replacement supersedes an in-flight configured model result`() async throws {
         let config = OnboardingProbeGatewayConfig()
         let gate = OnboardingProbeGate()

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -246,9 +246,16 @@ private func onboardingVerifyResponse(
         .utf8)
 }
 
+private func onboardingLegacyVerifyScopeResponse(id: String) -> Data {
+    Data(
+        #"{"type":"res","id":"\#(id)","ok":false,"error":{"code":"INVALID_REQUEST","message":"missing scope: operator.admin"}}"#
+            .utf8)
+}
+
 private enum OnboardingVerifyReply: Sendable {
     case verified
     case rejected
+    case legacyAdminScopeRequired
     case transportFailure
 }
 
@@ -279,6 +286,8 @@ private func onboardingVerifyTaskFactory(
                         ok: false,
                         status: "auth",
                         error: "expired login")))
+                case .legacyAdminScopeRequired:
+                    task.emitReceiveSuccess(.data(onboardingLegacyVerifyScopeResponse(id: request.id)))
                 case .transportFailure:
                     task.emitReceiveFailure()
                 }
@@ -415,6 +424,30 @@ struct OnboardingConfiguredGatewayProbeTests {
 
         #expect(configuredModel(outcome) == "openai/gpt-5.5")
         #expect(await recorder.snapshot() == ["health", "agents.list"])
+    }
+
+    @Test func `legacy admin-scoped verifier keeps config-only handoff`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let recorder = OnboardingProbeMethodRecorder()
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(
+                reply: .legacyAdminScopeRequired,
+                recorder: recorder))
+
+        let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
+
+        guard case let .configured(modelRef, verification, _) = outcome else {
+            Issue.record("expected legacy config-only handoff")
+            return
+        }
+        #expect(modelRef == "openai/gpt-5.5")
+        #expect(verification == nil)
+        #expect(await recorder.snapshot() == [
+            "health",
+            "agents.list",
+            "openclaw.setup.verify",
+        ])
     }
 
     @Test func `live verification transport failure is unavailable`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -68,6 +68,18 @@ private actor OnboardingProbeGate {
     }
 }
 
+private actor OnboardingProbeMethodRecorder {
+    private var methods: [String] = []
+
+    func record(_ method: String) {
+        self.methods.append(method)
+    }
+
+    func snapshot() -> [String] {
+        self.methods
+    }
+}
+
 private actor OnboardingProbeConfigReadGate {
     private let blockedRead: Int
     private var readCount = 0
@@ -161,23 +173,25 @@ private enum OnboardingProbeReply: Sendable {
 
 private func onboardingProbeTaskFactory(
     reply: OnboardingProbeReply = .configured,
-    beforeReply: (@Sendable () async -> Void)? = nil) -> GatewayTestWebSocketSession.TaskFactory
+    beforeReply: (@Sendable () async -> Void)? = nil,
+    recorder: OnboardingProbeMethodRecorder? = nil) -> GatewayTestWebSocketSession.TaskFactory
 {
     {
         GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-            guard sendIndex > 0 else { return }
+            guard sendIndex > 0,
+                  let request = onboardingProbeRequest(from: message)
+            else { return }
+            await recorder?.record(request.method)
             switch reply {
             case let .agents(defaultAgentID, model):
-                guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
                 await beforeReply?()
                 task.emitReceiveSuccess(.data(onboardingAgentsResponse(
-                    id: id,
+                    id: request.id,
                     defaultAgentID: defaultAgentID,
                     model: model)))
             case .error:
-                guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
                 await beforeReply?()
-                task.emitReceiveSuccess(.data(onboardingProbeErrorResponse(id: id)))
+                task.emitReceiveSuccess(.data(onboardingProbeErrorResponse(id: request.id)))
             case .failure:
                 await beforeReply?()
                 task.emitReceiveFailure()
@@ -241,7 +255,8 @@ private enum OnboardingVerifyReply: Sendable {
 private func onboardingVerifyTaskFactory(
     reply: OnboardingVerifyReply,
     advertiseVerifyMethod: Bool = true,
-    beforeVerifyReply: (@Sendable () async -> Void)? = nil) -> GatewayTestWebSocketSession.TaskFactory
+    beforeVerifyReply: (@Sendable () async -> Void)? = nil,
+    recorder: OnboardingProbeMethodRecorder? = nil) -> GatewayTestWebSocketSession.TaskFactory
 {
     {
         GatewayTestWebSocketTask(
@@ -249,6 +264,7 @@ private func onboardingVerifyTaskFactory(
                 guard sendIndex > 0,
                       let request = onboardingProbeRequest(from: message)
                 else { return }
+                await recorder?.record(request.method)
                 guard request.method == "openclaw.setup.verify" else {
                     task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: request.id)))
                     return
@@ -291,10 +307,14 @@ private func onboardingProbeFixture(
     tokenProvider: @escaping @Sendable () async -> String? = { nil },
     reply: OnboardingProbeReply = .configured,
     beforeReply: (@Sendable () async -> Void)? = nil,
+    recorder: OnboardingProbeMethodRecorder? = nil,
     taskFactory: GatewayTestWebSocketSession.TaskFactory? = nil) -> OnboardingProbeFixture
 {
     let session = GatewayTestWebSocketSession(
-        taskFactory: taskFactory ?? onboardingProbeTaskFactory(reply: reply, beforeReply: beforeReply))
+        taskFactory: taskFactory ?? onboardingProbeTaskFactory(
+            reply: reply,
+            beforeReply: beforeReply,
+            recorder: recorder))
     let gateway = GatewayConnection(
         configProvider: {
             await (url: url, token: tokenProvider(), password: nil)
@@ -349,14 +369,19 @@ private func isMissing(_ outcome: OnboardingConfiguredGatewayProbe.Outcome) -> B
 struct OnboardingConfiguredGatewayProbeTests {
     @Test func `configured route must pass live verification`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
+        let recorder = OnboardingProbeMethodRecorder()
         let fixture = onboardingProbeFixture(
             url: url,
-            taskFactory: onboardingVerifyTaskFactory(reply: .verified))
+            taskFactory: onboardingVerifyTaskFactory(reply: .verified, recorder: recorder))
 
         let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
 
         #expect(configuredModel(outcome) == "openai/gpt-5.5")
-        #expect(fixture.session.latestTask()?.snapshotSendCount() == 3)
+        #expect(await recorder.snapshot() == [
+            "health",
+            "agents.list",
+            "openclaw.setup.verify",
+        ])
     }
 
     @Test func `failed live verification stays in onboarding`() async throws {
@@ -378,16 +403,18 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `gateway without live verification keeps config-only handoff`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
+        let recorder = OnboardingProbeMethodRecorder()
         let fixture = onboardingProbeFixture(
             url: url,
             taskFactory: onboardingVerifyTaskFactory(
                 reply: .verified,
-                advertiseVerifyMethod: false))
+                advertiseVerifyMethod: false,
+                recorder: recorder))
 
         let outcome = await runOnboardingProbe(fixture.probe, connectionMode: .remote)
 
         #expect(configuredModel(outcome) == "openai/gpt-5.5")
-        #expect(fixture.session.latestTask()?.snapshotSendCount() == 2)
+        #expect(await recorder.snapshot() == ["health", "agents.list"])
     }
 
     @Test func `live verification transport failure is unavailable`() async throws {
@@ -482,15 +509,17 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `reachable gateway uses its configured default agent model`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
+        let recorder = OnboardingProbeMethodRecorder()
         let fixture = onboardingProbeFixture(
             url: url,
-            reply: .agents(defaultAgentID: "work", model: "openai/gpt-5.5"))
+            reply: .agents(defaultAgentID: "work", model: "openai/gpt-5.5"),
+            recorder: recorder)
         let session = fixture.session
         let probe = fixture.probe
 
         #expect(await configuredModel(runOnboardingProbe(probe, connectionMode: .remote)) == "openai/gpt-5.5")
         #expect(session.snapshotMakeCount() == 1)
-        #expect(session.latestTask()?.snapshotSendCount() == 2)
+        #expect(await recorder.snapshot() == ["health", "agents.list"])
     }
 
     @Test func `gateway without a default agent model stays in onboarding`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/TestIsolation.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TestIsolation.swift
@@ -133,3 +133,26 @@ extension Trait where Self == ExecApprovalsStateIsolationTrait {
         Self()
     }
 }
+
+struct AppStateStoreIsolationTrait: TestTrait, TestScoping {
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void) async throws
+    {
+        await TestIsolationLock.shared.acquire()
+        do {
+            try await function()
+            await TestIsolationLock.shared.release()
+        } catch {
+            await TestIsolationLock.shared.release()
+            throw error
+        }
+    }
+}
+
+extension Trait where Self == AppStateStoreIsolationTrait {
+    static var appStateStoreIsolated: Self {
+        Self()
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGlobalSettingsSyncTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGlobalSettingsSyncTests.swift
@@ -98,7 +98,8 @@ struct VoiceWakeGlobalSettingsSyncTests {
         return previous
     }
 
-    @Test func `applies voice wake changed event to app state`() async {
+    @Test(.appStateStoreIsolated)
+    func `applies voice wake changed event to app state`() async {
         let previous = await applyTriggersAndCapturePrevious(["before"])
         let evt = self.voiceWakeChangedEvent(payload: OpenClawProtocol.AnyCodable(["triggers": [
             "openclaw",
@@ -115,7 +116,8 @@ struct VoiceWakeGlobalSettingsSyncTests {
         }
     }
 
-    @Test func `ignores voice wake changed event with invalid payload`() async {
+    @Test(.appStateStoreIsolated)
+    func `ignores voice wake changed event with invalid payload`() async {
         let previous = await applyTriggersAndCapturePrevious(["before"])
         let evt = self.voiceWakeChangedEvent(payload: OpenClawProtocol.AnyCodable(["unexpected": 123]))
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -46,10 +46,13 @@ has no macOS app asset, use the newest one that does, or build from source with
    macOS permissions any time from **Settings → Permissions**.
 
 If the app reaches an existing Gateway whose default agent has a configured
-model, it treats that Gateway as already set up, skips provider onboarding and
-OpenClaw, and opens the dashboard. If the Gateway cannot connect or its
-default agent has no model, inference onboarding remains available for
-recovery.
+model, it asks that model for a live reply before opening the dashboard. A
+failed check keeps onboarding open with retry, provider sign-in, model choice,
+and API-key recovery options; OpenClaw does not replace the configured model
+until you choose one of those options. Gateways from before the live-check
+method was introduced retain the config-only handoff until they are upgraded.
+If the Gateway cannot connect or its default agent has no model, inference
+onboarding remains available for recovery.
 
 For the CLI/Gateway setup path, use [Getting started](/start/getting-started).
 For permission recovery, use [macOS permissions](/platforms/mac/permissions).

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -49,8 +49,9 @@ If the app reaches an existing Gateway whose default agent has a configured
 model, it asks that model for a live reply before opening the dashboard. A
 failed check keeps onboarding open with retry, provider sign-in, model choice,
 and API-key recovery options; OpenClaw does not replace the configured model
-until you choose one of those options. Gateways from before the live-check
-method was introduced retain the config-only handoff until they are upgraded.
+until you choose one of those options. Older Gateways without the current
+write-scoped live-check method—including releases that expose it only to
+admin-scoped clients—retain the config-only handoff until they are upgraded.
 If the Gateway cannot connect or its default agent has no model, inference
 onboarding remains available for recovery.
 

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -71,9 +71,12 @@ Where does the **Gateway** run?
   itself. Existing compatible installations are reused.
 </Step>
 <Step title="Connect your AI">
-  A connected Gateway that already has a configured agent model skips this
-  page entirely and opens the normal agent UI. OpenClaw and provider setup
-  only run for a fresh or incomplete Gateway.
+  A connected current Gateway that already has a configured agent model first
+  runs one live model check. A successful check skips this page and opens the
+  normal agent UI; a failed check stays here with retry, sign-in, model, and
+  API-key recovery choices. Older Gateways without the live-check method keep
+  the configuration-only handoff until they are upgraded. OpenClaw and provider
+  setup run for a fresh, incomplete, or failed Gateway route.
 
 Once the Gateway is ready, onboarding looks for AI access you already have:
 a Claude Code or Codex login, `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`, or a

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -74,9 +74,10 @@ Where does the **Gateway** run?
   A connected current Gateway that already has a configured agent model first
   runs one live model check. A successful check skips this page and opens the
   normal agent UI; a failed check stays here with retry, sign-in, model, and
-  API-key recovery choices. Older Gateways without the live-check method keep
-  the configuration-only handoff until they are upgraded. OpenClaw and provider
-  setup run for a fresh, incomplete, or failed Gateway route.
+  API-key recovery choices. Older Gateways without the current write-scoped
+  live-check method—including releases that expose it only to admin-scoped
+  clients—keep the configuration-only handoff until they are upgraded. OpenClaw
+  and provider setup run for a fresh, incomplete, or failed Gateway route.
 
 Once the Gateway is ready, onboarding looks for AI access you already have:
 a Claude Code or Codex login, `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`, or a

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -132,8 +132,19 @@ describe("method scope resolution", () => {
     ["conversations.send", ["operator.admin"]],
     ["conversations.turn", ["operator.admin"]],
     ["conversations.turn.cancel", ["operator.admin"]],
+    ["openclaw.setup.verify", ["operator.write"]],
   ])("resolves least-privilege scopes for %s", (method, expected) => {
     expect(resolveLeastPrivilegeOperatorScopesForMethod(method)).toEqual(expected);
+  });
+
+  it("allows existing Mac device grants to verify configured inference", () => {
+    expect(
+      authorizeOperatorScopesForMethod("openclaw.setup.verify", [
+        "operator.read",
+        "operator.write",
+        "operator.approvals",
+      ]),
+    ).toEqual({ allowed: true });
   });
 
   it("leaves node-only pending drain outside operator scopes", () => {

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -137,13 +137,13 @@ describe("method scope resolution", () => {
     expect(resolveLeastPrivilegeOperatorScopesForMethod(method)).toEqual(expected);
   });
 
-  it("allows existing Mac device grants to verify configured inference", () => {
+  it("keeps bounded setup verification within existing write-turn authority", () => {
+    const existingMacScopes = ["operator.read", "operator.write", "operator.approvals"];
+    expect(authorizeOperatorScopesForMethod("openclaw.setup.verify", existingMacScopes)).toEqual({
+      allowed: true,
+    });
     expect(
-      authorizeOperatorScopesForMethod("openclaw.setup.verify", [
-        "operator.read",
-        "operator.write",
-        "operator.approvals",
-      ]),
+      authorizeOperatorScopesForMethod("agent", existingMacScopes, { message: "hello" }),
     ).toEqual({ allowed: true });
   });
 

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -407,8 +407,8 @@ const CORE_GATEWAY_METHOD_SPECS = [
   // sessions.files.* trusted-operator read domain.
   ["sessions.diff", "sessions-diff", "operator.read", "<=2026.7"],
   // Additive protocol methods append here to preserve existing advertised indices.
-  // Runs a live inference turn and can spend provider tokens, but does not
-  // mutate Gateway configuration.
+  // Match ordinary write-scoped agent turns: the caller cannot select a model,
+  // tools are disabled, output is capped at 32 tokens, and config/auth stay read-only.
   ["openclaw.setup.verify", "system-agent", "operator.write", "<=2026.7"],
   // Cloud-worker mutations depend on the loaded provider registry and owned
   // reconciler, so advertise them early but gate dispatch until sidecars are ready.

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -407,7 +407,9 @@ const CORE_GATEWAY_METHOD_SPECS = [
   // sessions.files.* trusted-operator read domain.
   ["sessions.diff", "sessions-diff", "operator.read", "<=2026.7"],
   // Additive protocol methods append here to preserve existing advertised indices.
-  ["openclaw.setup.verify", "system-agent", "operator.admin", "<=2026.7"],
+  // Runs a live inference turn and can spend provider tokens, but does not
+  // mutate Gateway configuration.
+  ["openclaw.setup.verify", "system-agent", "operator.write", "<=2026.7"],
   // Cloud-worker mutations depend on the loaded provider registry and owned
   // reconciler, so advertise them early but gate dispatch until sidecars are ready.
   [


### PR DESCRIPTION
Closes #121825

## What Problem This Solves

Fixes an issue where macOS users onboarding with an existing Gateway could be sent to the dashboard even though the configured AI login was expired or otherwise unable to complete a model turn. The first chat then failed before any assistant reply, leaving the user to infer that reauthentication was required.

## Why This Change Was Made

The configured-Gateway handoff now uses the existing `openclaw.setup.verify` live inference check before reporting current Gateways ready. Model discovery, method negotiation, and verification stay bound to one physical Gateway socket; a failed check preserves its actionable error in onboarding and lists recovery choices without automatically replacing the configured model. Existing Mac device grants can call the read-only verifier with `operator.write`, while older Gateways that do not advertise the method retain their existing configuration-only handoff.

## User Impact

Expired or migrated credentials are caught during onboarding instead of on the first chat message. Users stay in AI setup with retry, sign-in, model-selection, and API-key recovery options, and OpenClaw does not change their configured model until they explicitly choose a replacement. Healthy current Gateways perform one bounded live model check before dashboard handoff; older Gateways remain compatible.

## Evidence

### Packaged macOS behavior on the PR head

Both scenarios used the packaged `OpenClaw.app` built from `e03bd734690af13dadbb3a368c4c90137d63e500`; the app bundle's embedded commit matched that exact PR head. Each run used an isolated named profile, its own loopback port, and an app-owned current Gateway. The profile, Gateway service, and copied auth state were removed after each run. The locally assembled app was ad-hoc signed for this proof.

Healthy OpenAI OAuth route (`openai/gpt-5.3-codex-spark`):

```json
{"ok":true,"latencyMs":3101,"modelRef":"openai/gpt-5.3-codex-spark"}
```

- The live verifier completed a real model turn.
- macOS persisted `onboardingSeen=true` and opened the native Dashboard.
- The captured Dashboard showed the configured GPT-5.3 Codex Spark model ready for chat.

Expired copy of the same OpenAI OAuth profile:

```json
{"ok":false,"status":"auth","code":"token_expired"}
```

- The Gateway reported a 401 OAuth refresh failure with explicit reauthentication guidance.
- macOS kept `onboardingSeen=false`; Finish remained disabled.
- The native onboarding UI showed `Configured AI needs attention` and `login didn’t work. Sign in again, then retry`, with retry and provider sign-in recovery choices.

This directly exercises the linked reporter path: a configured model plus unusable migrated/expired credentials no longer authorizes the dashboard handoff, while the same packaged app still completes onboarding for a healthy configured route.

### Supporting validation

- The macOS `OpenClaw` Swift product built successfully on this head, and the packaged app was reassembled with the matching embedded commit.
- The existing regression coverage exercises the cold connection, one-socket lease binding, successful verification, structured auth failure, recovery without automatic activation, pending activation ownership, transport failure, route/socket replacement, invalidation, and older-Gateway fallback.
- The repository's previously recorded relevant Vitest shards passed: 282 tests passed and 37 skipped across macOS packaging, Gateway, infrastructure, daemon, and tooling projects.
- `git diff --check` passed on the clean PR worktree.
- Local focused Swift test execution was stopped because the unsigned test host requested access to the user's login Keychain; no password was supplied. The packaged-app proof above used the isolated profile that was explicitly authenticated for this run.
