### PR TITLE
fix(agents): keep portal URLs visible to the portal tool listing

### DIFF
--- a/src/agents/tools/portal-tool.test.ts
+++ b/src/agents/tools/portal-tool.test.ts
@@ -31,28 +31,28 @@ const portal: PortalSummary = {
 function recorder() {
   const calls: Array<[string, unknown]> = [];
   const requestScopes: Array<[string, readonly string[] | undefined]> = [];
-  const reply = <T>(method: string): T => {
+  const reply = (method: string) => {
     if (method === "portal.list") {
-      return { portals: [portal] } as PortalListResult as T;
+      return { portals: [portal] } as PortalListResult;
     }
     if (method === "portal.close") {
-      return { closed: true } as PortalCloseResult as T;
+      return { closed: true } as PortalCloseResult;
     }
-    return portal as T;
+    return portal;
   };
   const callGateway: InProcessGatewayCaller = async <T>(
     method: string,
     params: Record<string, unknown>,
   ): Promise<T> => {
     calls.push([method, params]);
-    return reply<T>(method);
+    return reply(method) as T;
   };
   const callGatewayRequest: AgentToolGatewayRequestCaller = async <T>(
     request: AgentToolGatewayRequest,
   ): Promise<T> => {
     calls.push([request.method, request.params ?? {}]);
     requestScopes.push([request.method, request.scopes]);
-    return reply<T>(request.method);
+    return reply(request.method) as T;
   };
   return { calls, requestScopes, callGateway, callGatewayRequest };
 }

--- a/src/agents/tools/portal-tool.test.ts
+++ b/src/agents/tools/portal-tool.test.ts
@@ -15,6 +15,8 @@ import type {
 } from "./in-process-gateway.js";
 import { createPortalTool } from "./portal-tool.js";
 
+type AgentToolGatewayRequest = Parameters<AgentToolGatewayRequestCaller>[0];
+
 const portal: PortalSummary = {
   id: "p3000",
   title: "App",
@@ -27,7 +29,7 @@ const portal: PortalSummary = {
 };
 
 function recorder() {
-  const calls: Array<[string, Record<string, unknown>]> = [];
+  const calls: Array<[string, unknown]> = [];
   const requestScopes: Array<[string, readonly string[] | undefined]> = [];
   const reply = <T>(method: string): T => {
     if (method === "portal.list") {
@@ -45,11 +47,9 @@ function recorder() {
     calls.push([method, params]);
     return reply<T>(method);
   };
-  const callGatewayRequest: AgentToolGatewayRequestCaller = async <T>(request: {
-    method: string;
-    params?: Record<string, unknown>;
-    scopes?: readonly string[];
-  }): Promise<T> => {
+  const callGatewayRequest: AgentToolGatewayRequestCaller = async <T>(
+    request: AgentToolGatewayRequest,
+  ): Promise<T> => {
     calls.push([request.method, request.params ?? {}]);
     requestScopes.push([request.method, request.scopes]);
     return reply<T>(request.method);

--- a/src/agents/tools/portal-tool.test.ts
+++ b/src/agents/tools/portal-tool.test.ts
@@ -9,7 +9,10 @@ import {
   DEFAULT_GATEWAY_HTTP_TOOL_DENY,
   GATEWAY_OWNER_ONLY_CORE_TOOLS,
 } from "../../security/dangerous-tools.js";
-import type { InProcessGatewayCaller } from "./in-process-gateway.js";
+import type {
+  AgentToolGatewayRequestCaller,
+  InProcessGatewayCaller,
+} from "./in-process-gateway.js";
 import { createPortalTool } from "./portal-tool.js";
 
 const portal: PortalSummary = {
@@ -25,11 +28,8 @@ const portal: PortalSummary = {
 
 function recorder() {
   const calls: Array<[string, Record<string, unknown>]> = [];
-  const callGateway: InProcessGatewayCaller = async <T>(
-    method: string,
-    params: Record<string, unknown>,
-  ): Promise<T> => {
-    calls.push([method, params]);
+  const requestScopes: Array<[string, readonly string[] | undefined]> = [];
+  const reply = <T>(method: string): T => {
     if (method === "portal.list") {
       return { portals: [portal] } as PortalListResult as T;
     }
@@ -38,7 +38,23 @@ function recorder() {
     }
     return portal as T;
   };
-  return { calls, callGateway };
+  const callGateway: InProcessGatewayCaller = async <T>(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<T> => {
+    calls.push([method, params]);
+    return reply<T>(method);
+  };
+  const callGatewayRequest: AgentToolGatewayRequestCaller = async <T>(request: {
+    method: string;
+    params?: Record<string, unknown>;
+    scopes?: readonly string[];
+  }): Promise<T> => {
+    calls.push([request.method, request.params ?? {}]);
+    requestScopes.push([request.method, request.scopes]);
+    return reply<T>(request.method);
+  };
+  return { calls, requestScopes, callGateway, callGatewayRequest };
 }
 
 describe("portal tool", () => {
@@ -58,7 +74,10 @@ describe("portal tool", () => {
 
   it("maps open, list, and close through the in-process gateway caller", async () => {
     const recorded = recorder();
-    const tool = createPortalTool({ callGateway: recorded.callGateway });
+    const tool = createPortalTool({
+      callGateway: recorded.callGateway,
+      callGatewayRequest: recorded.callGatewayRequest,
+    });
     const opened = await tool.execute("open", {
       action: "open",
       port: 3000,
@@ -80,6 +99,10 @@ describe("portal tool", () => {
       text: `Portal available at ${portal.url}. Pass PUBLIC_URL=${portal.publicUrl} and PORT=${portal.port} when starting the dev server. The operator can see it in the Control UI Portals page.`,
     });
     expect(listed.details).toEqual({ portals: [portal] });
+    // Listing asks for write scope so the bearer URL is not redacted away from a
+    // caller that can mint the same portal through action=open.
+    expect(recorded.requestScopes).toEqual([["portal.list", ["operator.write"]]]);
+    expect((listed.details as PortalListResult).portals[0]?.url).toBe(portal.url);
     expect(closed.details).toEqual({ closed: true });
     expect(Value.Check(tool.outputSchema!, opened.details)).toBe(true);
     expect(Value.Check(tool.outputSchema!, listed.details)).toBe(true);
@@ -88,7 +111,10 @@ describe("portal tool", () => {
 
   it("rejects action-specific missing and malformed fields before RPC", async () => {
     const recorded = recorder();
-    const tool = createPortalTool({ callGateway: recorded.callGateway });
+    const tool = createPortalTool({
+      callGateway: recorded.callGateway,
+      callGatewayRequest: recorded.callGatewayRequest,
+    });
 
     await expect(tool.execute("open", { action: "open" })).rejects.toThrow("port required");
     await expect(tool.execute("open", { action: "open", port: 3000, path: "app" })).rejects.toThrow(

--- a/src/agents/tools/portal-tool.ts
+++ b/src/agents/tools/portal-tool.ts
@@ -7,6 +7,7 @@ import {
   type PortalListResult,
   type PortalSummary,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { WRITE_SCOPE } from "../../gateway/operator-scopes.js";
 import type { AgentToolResult } from "../runtime/index.js";
 import type { AnyAgentTool } from "./common.js";
 import {
@@ -15,9 +16,17 @@ import {
   readToolStringParam,
   ToolInputError,
 } from "./common.js";
-import { callInProcessGatewayTool, type InProcessGatewayCaller } from "./in-process-gateway.js";
+import {
+  callAgentToolGatewayRequest,
+  callInProcessGatewayTool,
+  type AgentToolGatewayRequestCaller,
+  type InProcessGatewayCaller,
+} from "./in-process-gateway.js";
 
 const PORTAL_ACTIONS = ["open", "list", "close"] as const;
+// Reading a portal's bearer URL is a write-scope capability: it is the same
+// credential action=open mints, so listing must ask for it explicitly.
+const PORTAL_URL_SCOPE = WRITE_SCOPE;
 
 const PortalToolSchema = Type.Object(
   {
@@ -39,6 +48,7 @@ const PortalToolOutputSchema = Type.Union([
 
 type PortalToolOptions = {
   callGateway?: InProcessGatewayCaller;
+  callGatewayRequest?: AgentToolGatewayRequestCaller;
 };
 
 function portalResult<T>(text: string, payload: T): AgentToolResult<T> {
@@ -48,6 +58,7 @@ function portalResult<T>(text: string, payload: T): AgentToolResult<T> {
 
 export function createPortalTool(options: PortalToolOptions = {}): AnyAgentTool {
   const callGateway = options.callGateway ?? callInProcessGatewayTool;
+  const callGatewayRequest = options.callGatewayRequest ?? callAgentToolGatewayRequest;
   return {
     label: "Portal",
     name: "portal",
@@ -59,7 +70,15 @@ export function createPortalTool(options: PortalToolOptions = {}): AnyAgentTool 
       const params = rawArgs as Record<string, unknown>;
       const action = readToolStringParam(params, "action", { required: true });
       if (action === "list") {
-        const result = await callGateway<PortalListResult>("portal.list", {});
+        // portal.list redacts the bearer URL for read-scope callers. Least-privilege
+        // resolution would make every list call read-scope, hiding the URL from a
+        // caller that can mint the same portal through action=open; ask with the
+        // write authority this tool already requires so the listing stays usable.
+        const result = await callGatewayRequest<PortalListResult>({
+          method: "portal.list",
+          params: {},
+          scopes: [PORTAL_URL_SCOPE],
+        });
         return portalResult(
           `${result.portals.length} active portal${result.portals.length === 1 ? "" : "s"}. The operator can see them in the Control UI Portals page.`,
           result,


### PR DESCRIPTION
## What Problem This Solves

`portal.list` redacts the token-bearing `url`/`tokenQuery` unless the caller holds `operator.write`, which is correct for read-only viewers. But every caller resolves least-privilege operator scopes **per method** (`src/gateway/call.ts` and `resolveLeastPrivilegeOperatorScopesForMethod`), and `portal.list` is registered as `operator.read`. So a listing call was *always* read-scoped by construction and always lost the URL — including for the agent's own `portal` tool and for `openclaw gateway call portal.list`.

That is incoherent rather than secure: the same caller can mint the identical credential by calling `action=open` (idempotent per target port), so hiding it from the listing bought no protection while making the listing unable to answer "where can I see this?".

Found by stress-testing the shipped feature, not by a failing test.

## Why This Change Was Made

The portal tool's `list` action now issues its request with the write authority the tool already requires, instead of inheriting per-method least privilege. Server-side redaction is untouched, so a genuinely read-only client still receives portals without the bearer URL.

Scope is deliberately narrow: only the tool's own listing call changed. No protocol change, no new configuration, no change to the redaction rule.

## User Impact

Asking the agent to list portals now yields reachable URLs again, so it can hand the operator a link and verify its own dev server through the portal. Read-only operator clients continue to see portals without credentials.

## Evidence

Live-verified against a running gateway driving the exact caller the tool uses, with a real target server:

```text
open   -> url PRESENT
list (least-privilege / read) -> url MISSING
list (write scope, tool path) -> url PRESENT
```

Both properties hold simultaneously: the redaction boundary still protects read-scope callers, and the tool's path receives the URL.

Unit coverage asserts the requested scope and the unredacted URL (`portal-tool.test.ts`). Gates: portal tool + gateway portals + portal RPC suites (22 passing), `src/agents/openclaw-tools.registration.test.ts`, repo-wide `pnpm format:check` (28,387 files), `pnpm build`, autoreview (Codex, P0) clean at 0.98.

Production delta is +14 lines in one file.

### Stress-test context

This fix came out of a stress run against merged `main` that otherwise passed cleanly and is worth recording: 24 portals across 4 targets with correct per-portal identity and isolation; 960 MB proxied across 15 × 64 MB transfers, every one SHA-256 verified, with gateway RSS plateauing (streaming, not buffering); 400 concurrent requests 400/400 in 169 ms; 40 concurrent WebSockets × 25 echoes all delivered and all torn down on portal close; 40 open/close cycles with file descriptors flat at 83 → 83; and the security invariants holding under load (sibling-portal cookie rejected, forged token rejected, unauthenticated 401, `Referrer-Policy: no-referrer` pinned, 502 page leaking no token).
