### PR TITLE
fix(ui): model picker opens while live catalog loads

### DIFF
--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -363,25 +363,19 @@ describe("refreshChat", () => {
     expect(requestUpdate).not.toHaveBeenCalled();
   });
 
-  it("uses explicit model discovery after startup metadata", async () => {
+  it("renders startup models while explicit model discovery continues", async () => {
     const startup = createDeferred<unknown>();
+    const liveModels = createDeferred<unknown>();
+    const requestUpdate = vi.fn();
     const host = makeChatHost({
       hello: {
         features: { methods: ["chat.metadata", "chat.startup"] },
       } as TestChatHost["hello"],
       requestHandlers: {
         "chat.startup": () => startup.promise,
-        "models.list": {
-          models: [
-            {
-              available: true,
-              id: "live-model",
-              name: "Live Model",
-              provider: "openai",
-            },
-          ],
-        },
+        "models.list": () => liveModels.promise,
       },
+      requestUpdate,
     });
 
     const refresh = refreshPageChat(asChatPageHost(host), {
@@ -412,15 +406,38 @@ describe("refreshChat", () => {
       expect(host.chatModelCatalog).toEqual([
         {
           available: true,
+          id: "startup-model",
+          name: "Startup Model",
+          provider: "openai",
+        },
+      ]),
+    );
+    expect(asChatPageHost(host).chatModelsLoading).toBe(false);
+    expect(requestUpdate).toHaveBeenCalled();
+    expect(host.request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
+    expect(host.request).toHaveBeenCalledWith("models.list", { view: "configured" });
+    expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
+
+    liveModels.resolve({
+      models: [
+        {
+          available: true,
+          id: "live-model",
+          name: "Live Model",
+          provider: "openai",
+        },
+      ],
+    });
+    await waitForFast(() =>
+      expect(host.chatModelCatalog).toEqual([
+        {
+          available: true,
           id: "live-model",
           name: "Live Model",
           provider: "openai",
         },
       ]),
     );
-    expect(host.request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
-    expect(host.request).toHaveBeenCalledWith("models.list", { view: "configured" });
-    expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
   });
 
   it("fills omitted startup metadata immediately and populates models and commands", async () => {

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -150,20 +150,12 @@ function applyChatMetadataResult(
   client: GatewayBrowserClient,
   agentId: string | null | undefined,
   result: ChatMetadataResult,
-  fields: { commands?: boolean; models?: boolean } = {},
 ): ChatMetadataApplyResult {
-  const models = fields.models === false ? undefined : applyModelCatalogResult(result.models);
+  const models = applyModelCatalogResult(result.models);
   if (models) {
     host.chatModelCatalog = models;
   }
-  const commandsApplied =
-    fields.commands === false
-      ? false
-      : applyRemoteSlashCommandsResult({
-          client,
-          agentId,
-          result,
-        });
+  const commandsApplied = applyRemoteSlashCommandsResult({ client, agentId, result });
   return { commands: commandsApplied, models: Boolean(models) };
 }
 
@@ -445,12 +437,18 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
           return;
         }
         rememberChatMetadata(client, agentId, metadata);
-        // Startup metadata stays on the published static catalog so opening chat never waits on
-        // provider discovery. The explicit models.list read below owns the live picker inventory.
-        const applied = applyChatMetadataResult(host, client, agentId, metadata, { models: false });
-        if (!applied.models || !applied.commands) {
-          await refreshMissingChatMetadata(request, applied, { refreshModelCatalog: true });
+        // Render the published snapshot immediately. Live discovery can refine availability, but
+        // it must not keep the picker blocked on provider latency.
+        const applied = applyChatMetadataResult(host, client, agentId, metadata);
+        if (applied.models) {
+          host.chatModelsLoading = false;
+          host.requestUpdate?.();
         }
+        await refreshMissingChatMetadata(
+          request,
+          { ...applied, models: false },
+          { refreshModelCatalog: true },
+        );
       } finally {
         if (ownsChatMetadataRequest(request)) {
           host.chatModelsLoading = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening chat left the model picker on “Loading models…” while live model discovery ran, even though `chat.startup` had already supplied a prepared model catalog. In observed Gateway runs, that unnecessary wait lasted 7.6–8.7 seconds.

## Why This Change Was Made

The Control UI now renders the prepared startup catalog immediately, clears the picker loading state, and requests a render. The existing explicit `models.list` refresh still runs and replaces the startup snapshot when live availability arrives, preserving unusable-model filtering without blocking the picker.

The fallback path for missing startup metadata is unchanged.

## User Impact

Users can open and use the model picker as soon as chat startup completes. A slow live provider catalog refresh no longer presents an empty spinner, and the picker still converges on the live availability result.

## Evidence

### Before — direct base `983af028cfd2`

<img width="1440" height="900" alt="Model picker blocked on live discovery on the direct base" src="https://github.com/user-attachments/assets/df1dd6b3-e282-4fde-ac8d-14b5cc5db1f9" />

**What this shows:** With `models.list` delayed by 8 seconds, the current base shows “Loading models…” and exposes no options even though startup supplied `Startup Snapshot`.

**State:** Direct base `983af028cfd2`, real Control UI at `/chat`, browser-side mock Gateway, 1440×900 viewport. The full viewport keeps the composer loading state visible in product context.

### Now — this branch

<img width="1440" height="900" alt="Startup model available while live model discovery remains pending" src="https://github.com/user-attachments/assets/8aa49920-32e9-4032-a51b-993921ea5dda" />

**What this shows:** With the identical delayed response, the branch opens immediately with `Startup Snapshot`; after the delayed response resolves, the live catalog replaces it.

**State:** PR head `d4e42cb81cc`, real Control UI at `/chat`, browser-side mock Gateway, 1440×900 viewport. The full viewport includes the open picker and composer context needed to distinguish the usable state. The post-capture head update only corrected the test host's static type; production code is byte-identical to the capture.

### How to verify

1. Open the supplied mocked Control UI fixture and immediately click the model button in the composer.
2. Confirm `Startup Snapshot` is selectable while `models.list` remains pending.
3. Wait for the delayed live response and reopen the picker; the live catalog replaces the startup snapshot.

### Checks

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts` — 289 passed.
- `pnpm tsgo:core:test` — passed.
- `pnpm tsgo:ui` — passed.
- Deterministic base/branch Playwright comparison — base: zero options and loading; branch: startup option visible while one `models.list` request remained pending.
- Public fixture Playwright check — startup option visible with the delayed live request still pending.
- `git diff --check` — passed.

### Implementation notes

- Production LOC: +13/-15 (net -2).
- Tests: +30/-13.
- No protocol, config, storage, or provider-runtime changes.
