### PR TITLE
fix(ai): session cost understates gpt-5.5 priority (fast mode) turns by 20%

### DIFF
--- a/packages/ai/src/providers/openai-responses-service-tier-pricing.test.ts
+++ b/packages/ai/src/providers/openai-responses-service-tier-pricing.test.ts
@@ -1,0 +1,30 @@
+// Service-tier pricing has exactly one owner. A transport-local copy of this
+// table previously drifted (flat 2x priority while gpt-5.5 priority is 2.5x),
+// silently understating UI cost for managed-transport turns.
+import { describe, expect, it } from "vitest";
+import type { Usage } from "../types.js";
+import { applyResponsesServiceTierPricing } from "./openai-responses-shared.js";
+
+function usage(): Usage {
+  return {
+    input: 100,
+    output: 10,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 110,
+    cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.25, total: 3.75 },
+  };
+}
+
+describe("applyResponsesServiceTierPricing", () => {
+  it.each([
+    ["default tier keeps base pricing", undefined, "gpt-5.5", 3.75],
+    ["flex halves cost", "flex", "gpt-5.5", 1.875],
+    ["priority doubles cost for most models", "priority", "gpt-5.6-luna", 7.5],
+    ["priority is 2.5x for gpt-5.5", "priority", "gpt-5.5", 9.375],
+  ] as const)("%s", (_name, tier, modelId, expectedTotal) => {
+    const value = usage();
+    applyResponsesServiceTierPricing(value, tier, { id: modelId });
+    expect(value.cost.total).toBeCloseTo(expectedTotal, 10);
+  });
+});

--- a/packages/ai/src/transports/openai-responses-client.pricing.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.pricing.test.ts
@@ -1,0 +1,93 @@
+// The managed Responses transport must price usage through the canonical
+// model-aware service-tier helper. A transport-local flat table previously
+// drifted (2x while gpt-5.5 priority bills 2.5x) and understated UI cost.
+import type { Model } from "@openclaw/llm-core";
+import { describe, expect, it, vi } from "vitest";
+
+type SdkResponse = { data: AsyncIterable<unknown>; response: Response };
+
+const sseState = vi.hoisted(() => ({
+  outcomes: [] as Array<Error | SdkResponse>,
+}));
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    responses = {
+      create: () => {
+        const outcome = sseState.outcomes.shift() ?? new Error("Unexpected SSE request");
+        return {
+          withResponse: async () => {
+            if (outcome instanceof Error) {
+              throw outcome;
+            }
+            return outcome;
+          },
+        };
+      },
+    };
+  }
+  return { default: MockOpenAI, AzureOpenAI: MockOpenAI };
+});
+
+vi.mock("openai/resources/responses/ws.js", () => ({
+  ResponsesWS: function UnexpectedResponsesWS() {
+    throw new Error("pricing tests must not construct a WebSocket");
+  },
+}));
+
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+
+// Cost figures are per million tokens; usage below uses 1M input + 1M output
+// so the expected totals read directly off the multiplied unit prices.
+const model = {
+  id: "gpt-5.5",
+  name: "GPT 5.5",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 2, output: 10, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-responses">;
+
+function completedResponse(serviceTier: string): SdkResponse {
+  return {
+    data: (async function* () {
+      yield {
+        type: "response.completed",
+        response: {
+          id: "resp_priced",
+          status: "completed",
+          service_tier: serviceTier,
+          output: [
+            {
+              id: "msg_priced",
+              type: "message",
+              status: "completed",
+              role: "assistant",
+              content: [{ type: "output_text", text: "ok", annotations: [] }],
+            },
+          ],
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000, total_tokens: 2_000_000 },
+        },
+      };
+    })(),
+    response: new Response(null, { status: 200 }),
+  };
+}
+
+describe("managed Responses transport service-tier pricing", () => {
+  it("applies the canonical 2.5x gpt-5.5 priority multiplier to usage cost", async () => {
+    sseState.outcomes.push(completedResponse("priority"));
+    const stream = await createOpenAIResponsesTransportStreamFn()(
+      model,
+      { messages: [], tools: [] },
+      { apiKey: "test-key", sessionId: "session-pricing", transport: "sse" } as never,
+    );
+    const result = await stream.result();
+    // Base cost 2 + 10 = 12; gpt-5.5 priority is 2.5x = 30 (flat 2x would be 24).
+    expect(result.usage.cost.total).toBeCloseTo(30, 6);
+  });
+});

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -5,6 +5,7 @@ import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
 import { resolveAzureDeploymentNameFromMap } from "../providers/azure-deployment-map.js";
 import { isOpenAICompatibleAzureResponsesBaseUrl } from "../providers/azure-openai-responses-client-compat.js";
+import { applyResponsesServiceTierPricing } from "../providers/openai-responses-shared.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
 import { projectProviderError } from "../utils/provider-error.js";
 import {
@@ -31,7 +32,6 @@ import {
   type OpenAIResponsesOptions,
 } from "./openai-responses-contracts.js";
 import {
-  applyServiceTierPricing,
   logResponsesFailedNoDetails,
   ResponsesStreamFailure,
   safeDebugValue,
@@ -180,7 +180,10 @@ type ResponsesTransportExecutorOptions = {
   createResponseStream: (
     params: ResponsesStreamParams,
   ) => ReturnType<typeof createResponsesStreamWithEncryptedContentRetry>;
-  pricingOptions?: (options: OpenAIResponsesOptions | undefined) => ResponsesPricingOptions;
+  pricingOptions?: (
+    options: OpenAIResponsesOptions | undefined,
+    model: Model,
+  ) => ResponsesPricingOptions;
 };
 
 function createResponsesTransportExecutor(config: ResponsesTransportExecutorOptions): StreamFn {
@@ -456,7 +459,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         }
         try {
           const terminal = await processResponsesStream(responseStream, output, stream, model, {
-            ...config.pricingOptions?.(responsesOptions),
+            ...config.pricingOptions?.(responsesOptions, model),
             firstEventTimeoutMs:
               getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
             abortFirstEventStream: firstEvent.abort,
@@ -515,7 +518,13 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
     createClient: createOpenAIResponsesClient,
     buildRequest: buildOpenAIResponsesParams,
     createResponseStream: createResponsesStreamWithEncryptedContentRetry,
-    pricingOptions: (options) => ({ serviceTier: options?.serviceTier, applyServiceTierPricing }),
+    pricingOptions: (options, model) => ({
+      serviceTier: options?.serviceTier,
+      // One canonical service-tier pricing table; a transport-local copy drifted
+      // from provider pricing (gpt-5.5 priority 2.5x) and understated costs.
+      applyServiceTierPricing: (usage, serviceTier) =>
+        applyResponsesServiceTierPricing(usage, serviceTier, model),
+    }),
   });
 }
 

--- a/packages/ai/src/transports/openai-responses-debug.ts
+++ b/packages/ai/src/transports/openai-responses-debug.ts
@@ -2,10 +2,9 @@ import { createHash } from "node:crypto";
 import type { Api, Model } from "@openclaw/llm-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import { resolveModelPayloadDebugMode } from "./model-transport-debug.js";
 import { RESPONSE_FAILED_NO_DETAILS_MESSAGE } from "./openai-responses-contracts.js";
-import { log, type MutableAssistantOutput } from "./openai-transport-shared.js";
+import { log } from "./openai-transport-shared.js";
 import { redactIdentifier, redactSensitiveText } from "./transport-utils.js";
 
 function stringifyUnknown(value: unknown, fallback = ""): string {
@@ -16,33 +15,6 @@ function stringifyUnknown(value: unknown, fallback = ""): string {
     return String(value);
   }
   return fallback;
-}
-
-function getServiceTierCostMultiplier(serviceTier: ResponseCreateParamsStreaming["service_tier"]) {
-  switch (serviceTier) {
-    case "flex":
-      return 0.5;
-    case "priority":
-      return 2;
-    default:
-      return 1;
-  }
-}
-
-export function applyServiceTierPricing(
-  usage: MutableAssistantOutput["usage"],
-  serviceTier?: ResponseCreateParamsStreaming["service_tier"],
-): void {
-  const multiplier = getServiceTierCostMultiplier(serviceTier);
-  if (multiplier === 1) {
-    return;
-  }
-  usage.cost.input *= multiplier;
-  usage.cost.output *= multiplier;
-  usage.cost.cacheRead *= multiplier;
-  usage.cost.cacheWrite *= multiplier;
-  usage.cost.total =
-    usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 }
 
 export function safeDebugValue(value: unknown): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openai/gpt-5.5` with fast mode (priority service tier) through the managed Responses transport saw session cost understated by 20% in the Control UI and usage accounting.

## Why This Change Was Made

Two copies of the service-tier pricing table existed. The canonical `applyResponsesServiceTierPricing` (`packages/ai/src/providers/openai-responses-shared.ts:489`) learned the gpt-5.5 priority 2.5x multiplier in #117298; the transport-local copy in `packages/ai/src/transports/openai-responses-debug.ts` (split out earlier in b0525e1a70b6) kept a flat 2x and was the copy actually used by the mainline env-`OPENAI_API_KEY` path. This change deletes the drifted copy and delegates the transport's `pricingOptions` to the canonical model-aware helper, so pricing has exactly one owner. Azure intentionally remains tier-unpriced (it sets no `pricingOptions`), unchanged.

## User Impact

Cost shown for priority-tier gpt-5.5 turns on the managed transport now matches the provider's actual 2.5x billing, and matches what the package provider path already reported. Other models/tiers are unchanged.

## Evidence

- New table-driven test `packages/ai/src/providers/openai-responses-service-tier-pricing.test.ts` pins default/flex/priority multipliers including gpt-5.5 priority = 2.5x (previously untested anywhere).
- `openai-responses-client.continuation.test.ts` + transport activity tests green.
- Fresh autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.98)".
- Production LOC delta: net −19 (13+/4− client, 1+/29− debug), tests separate.
