### PR TITLE
fix(qa): keep Anthropic mock tool ids replay-stable

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
@@ -169,7 +169,7 @@ export function adaptAnthropicToolCallIds(events: StreamEvent[]): StreamEvent[] 
     if (existing) {
       return existing;
     }
-    const adapted = `toolu_${createHash("sha256").update(id).digest("hex").slice(0, 48)}`;
+    const adapted = `toolu${createHash("sha256").update(id).digest("hex").slice(0, 35)}`;
     adaptedIds.set(id, adapted);
     return adapted;
   };

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -6647,7 +6647,7 @@ Update and merge these partial structured summaries.`,
     const toolUseBlock = body.content.find((block) => block.type === "tool_use") as
       | { id: string; name: string; input: Record<string, unknown> }
       | undefined;
-    expect(toolUseBlock?.id).toMatch(/^toolu_[A-Za-z0-9_]+$/);
+    expect(toolUseBlock?.id).toMatch(/^toolu[a-f0-9]{35}$/);
     expect(toolUseBlock?.id.length).toBeLessThanOrEqual(64);
     expect(toolUseBlock?.name).toBe("read");
     expect(toolUseBlock?.input).toEqual({ path: "repo/docs/help/testing.md" });
@@ -6665,6 +6665,7 @@ Update and merge these partial structured summaries.`,
   it("preserves already-native Anthropic tool IDs while adapting shared generated IDs", () => {
     const nativeId = "toolu_native_123";
     const generatedId = "call_mock_read_generated_1";
+    const secondGeneratedId = "call_mock_read_generated_2";
     const events: StreamEvent[] = [
       {
         type: "response.output_item.added",
@@ -6690,6 +6691,7 @@ Update and merge these partial structured summaries.`,
           output: [
             { type: "function_call", name: "read", call_id: nativeId, arguments: "{}" },
             { type: "function_call", name: "read", call_id: generatedId, arguments: "{}" },
+            { type: "function_call", name: "read", call_id: secondGeneratedId, arguments: "{}" },
           ],
           usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
         },
@@ -6730,9 +6732,13 @@ Update and merge these partial structured summaries.`,
     });
 
     expect(callIds.filter((id) => id === nativeId)).toHaveLength(3);
-    expect(new Set(adaptedGeneratedIds).size).toBe(1);
+    expect(adaptedGeneratedIds.slice(0, 3)).toEqual(
+      Array.from({ length: 3 }, () => "toolu51ca7fb8ca8ab1910ae2815b4e69a38ac71"),
+    );
+    expect(adaptedGeneratedIds[3]).toMatch(/^toolu[a-f0-9]{35}$/);
+    expect(adaptedGeneratedIds[3]).not.toBe(adaptedGeneratedIds[0]);
     expect(repeatedGeneratedIds).toEqual(adaptedGeneratedIds);
-    expect(adaptedGeneratedIds[0]).toMatch(/^toolu_[A-Za-z0-9_]+$/);
+    expect(adaptedGeneratedIds[0]).toMatch(/^toolu[a-f0-9]{35}$/);
     expect(adaptedGeneratedIds[0]?.length).toBeLessThanOrEqual(64);
   });
 
@@ -6790,7 +6796,7 @@ Update and merge these partial structured summaries.`,
       if (!toolUse || typeof toolUse.id !== "string" || typeof toolUse.name !== "string") {
         throw new Error("Expected Anthropic tool_use block");
       }
-      expect(toolUse.id).toMatch(/^toolu_[A-Za-z0-9_]+$/);
+      expect(toolUse.id).toMatch(/^toolu[a-f0-9]{35}$/);
       expect(toolUse.id.length).toBeLessThanOrEqual(64);
       emittedToolUseIds.push(toolUse.id);
       return toolUse;
@@ -7838,7 +7844,7 @@ Update and merge these partial structured summaries.`,
       toolUseStart?.content_block,
       "Anthropic SSE tool_use content block",
     );
-    expect(toolUse.id).toMatch(/^toolu_[A-Za-z0-9_]+$/);
+    expect(toolUse.id).toMatch(/^toolu[a-f0-9]{35}$/);
     expect(String(toolUse.id).length).toBeLessThanOrEqual(64);
     const debug = requireRecord(await getJson(server, "/debug/last-request"), "debug request");
     expect(debug.plannedToolCallId).toBe(toolUse.id);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Anthropic QA scenarios could report false tool-call causality failures when generated mock IDs were normalized differently during replay.

## Why This Change Was Made

Generated mock Anthropic tool IDs now use the replay-stable canonical `toolu` plus 35-character SHA-256 form. Native `toolu_*` IDs remain unchanged.

## User Impact

No production user-visible behavior changes. Anthropic QA compaction and thread-memory scenarios now evaluate the intended runtime behavior instead of failing on mock-only ID formatting.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts`: 267/267 passed.
- Exact two-scenario QA proof on diff-identical predecessor `eb7a9ab16e5290398a6e7467707e3c5121c9fec3` (current head changes only the Punchcard trailer): `compaction-retry-mutating-tool` and `thread-memory-isolation` both passed.
- Evidence recorded provider `anthropic`, model `anthropic/claude-opus-4-8`, `live=false`, fixture `mock-openai`, and the exact tested SHA.
- Runtime artifacts synchronized through the isolated `@openclaw/ai` overlay; no TypeScript or bundled-plugin rebuild occurred.
- `node scripts/run-oxlint.mjs` for both changed files, `oxfmt --check`, and `git diff --check`: passed.

Punchcard-Session: frost-orchard-lantern-ze
