### PR TITLE
fix(ui): chat links containing 'tail' get a stray presentation class

### DIFF
--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -50,6 +50,15 @@ describe("toSanitizedMarkdownHtml", () => {
     );
   });
 
+  it("does not stamp presentation classes on links whose href contains 'tail'", () => {
+    const fragment = htmlFragment(
+      toSanitizedMarkdownHtml("[tailscale docs](https://docs.openclaw.ai/tailscale)"),
+    );
+    const link = fragment.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://docs.openclaw.ai/tailscale");
+    expect(link?.classList.contains("chat-link-tail-blur")).toBe(false);
+  });
+
   it("strips unsupported citation control markers before display", () => {
     const html = toSanitizedMarkdownHtml(
       "v2026.5.20 release note citeturn2view0\n\nStill readable.",

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -1,4 +1,3 @@
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 // Control UI module implements markdown behavior.
 import DOMPurify from "dompurify";
 import { stripUnsupportedCitationControlMarkers } from "../../../src/shared/text/citation-control-markers.js";
@@ -318,7 +317,6 @@ const APP_RESOURCE_PATH_PREFIXES = [
   ["plugins", "diffs-language-pack"],
 ];
 const markdownCache = new Map<string, string>();
-const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
 
 function getCachedMarkdown(key: string): string | null {
   const cached = markdownCache.get(key);
@@ -469,9 +467,6 @@ function installHooks() {
 
     node.setAttribute("rel", "noreferrer noopener");
     node.setAttribute("target", "_blank");
-    if (normalizeLowercaseStringOrEmpty(href).includes("tail")) {
-      node.classList.add(TAIL_LINK_BLUR_CLASS);
-    }
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Removes a latent Control UI rendering foot-gun: every chat link whose URL contains the substring "tail" (for example `https://docs.openclaw.ai/tailscale`, any `/details/…` URL) was stamped with a `chat-link-tail-blur` CSS class by the markdown sanitizer hook.

## Why This Change Was Made

No stylesheet, script, or test anywhere in the repo consumes `chat-link-tail-blur` — the producer is orphaned (present since the original Control UI import 65e12328aa20, never with a consumer). It pollutes sanitized HTML and markdown cache entries, and the substring predicate `href.includes("tail")` could never be a correct presentation classifier: the day anyone adds a matching CSS rule, docs links across all transcripts blur. Link presentation classes have one canonical owner — the `web-link-classes` rule in `ui/src/components/markdown-parser.ts`, which classifies by parsed hostname. Deleting the orphan restores single ownership.

## User Impact

No visible change today (the class was dead output). Removes the risk of accidental future styling of unrelated links and slightly shrinks every cached rendered message.

## Evidence

- New regression test in `ui/src/components/markdown.test.ts` asserts a `/tailscale` docs link carries no `chat-link-tail-blur` class; fails on pre-fix code (1 failed), passes post-fix (91 passed).
- Fresh autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC delta: −6 (pure deletion), test +9.
