### PR TITLE
test(browser): align file chooser timeout assertions

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
@@ -70,7 +70,9 @@ describe("pw-tools-core", () => {
 
       expect(fc1.setFiles).not.toHaveBeenCalled();
       await vi.waitFor(() => {
-        expect(fc2.setFiles).toHaveBeenCalledWith([secondCanonicalPath]);
+        expect(fc2.setFiles).toHaveBeenCalledWith([secondCanonicalPath], {
+          timeout: 120_000,
+        });
       });
     } finally {
       await Promise.all([fs.rm(firstPath, { force: true }), fs.rm(secondPath, { force: true })]);

--- a/extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts
@@ -129,7 +129,9 @@ describe("pw-tools-core", () => {
         timeout: 120_000,
       });
       await vi.waitFor(() => {
-        expect(fileChooser.setFiles).toHaveBeenCalledWith([canonicalUploadPath]);
+        expect(fileChooser.setFiles).toHaveBeenCalledWith([canonicalUploadPath], {
+          timeout: 120_000,
+        });
       });
     } finally {
       await fs.rm(uploadPath, { force: true });


### PR DESCRIPTION
## What Problem This Solves

Resolves stale Browser test expectations that still asserted the pre-helper
`fileChooser.setFiles` call shape after file assignment began forwarding the
resolved timeout.

## Why This Change Was Made

The two affected expectations now include the existing 120-second default
timeout. This is test-only: no production behavior, workflow, dependency, or
release surface changes.

## User Impact

No user-visible behavior changes. The Browser regression tests now accurately
cover the timeout already passed by production code.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts` — 3 files, 25 tests passed.
- Repository autoreview: clean, no accepted or actionable findings.
- Targeted `oxfmt`, `git diff --check`, and delegated `check-changed` passed.
- Diff: two test files, `+6/-2`; production LOC `0`.

AI-assisted: yes. The patch and proof were reviewed against the repository
instructions and scoped Browser test contract.

Punchcard-Session: frost-orchard-lantern-ze
