### PR TITLE
fix(doctor): repeated no-op OAuth migration prompt and swallowed migration error cause

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -487,9 +487,12 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       env: state.env,
     });
 
-    expect(result.warnings).toContain(
-      "Failed to migrate shared legacy OAuth credentials; the source was left in place.",
-    );
+    // The warning must carry the underlying cause so the user can act on it.
+    expect(result.warnings).toEqual([
+      expect.stringMatching(
+        /^Failed to migrate shared legacy OAuth credentials; the source was left in place: .+/,
+      ),
+    ]);
     expect(fs.existsSync(oauthPath)).toBe(true);
     expectNoMigratedArchive(oauthPath);
     expect(readPersistedAuthProfileStoreRaw(state.agentDir())).toEqual(unreadableStore);

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1318,9 +1318,9 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   } else if (hasLegacyOAuth) {
     try {
       migrateLegacyOAuthFile({ oauthPath, env, now, result });
-    } catch {
+    } catch (err) {
       result.warnings.push(
-        `Failed to migrate shared legacy OAuth credentials; the source was left in place.`,
+        `Failed to migrate shared legacy OAuth credentials; the source was left in place: ${String(err)}`,
       );
     }
   }

--- a/src/commands/doctor-auth-oauth-sidecar.test.ts
+++ b/src/commands/doctor-auth-oauth-sidecar.test.ts
@@ -347,6 +347,25 @@ describe("maybeRepairLegacyOAuthSidecarProfiles", () => {
     expect(fs.existsSync(sidecarPath)).toBe(true);
   });
 
+  it("does not prompt when only unreferenced sidecars remain (guaranteed no-op)", async () => {
+    const state = await makeTestState();
+    await state.writeJson(
+      path.join("credentials", "auth-profiles", "cccccccccccccccccccccccccccccccc.json"),
+      {
+        version: 1,
+        profileId: "openai-codex:orphan",
+        provider: "openai-codex",
+        access: "orphaned-access-token",
+        refresh: "orphaned-refresh-token",
+      },
+    );
+
+    const prompter = makePrompter(true);
+    await maybeRepairLegacyOAuthSidecarProfiles({ cfg: {}, prompter });
+
+    expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
+  });
+
   it.runIf(process.platform !== "win32")(
     "scans symlinked state agents before treating sidecars as unreferenced",
     async () => {

--- a/src/commands/doctor-auth-oauth-sidecar.ts
+++ b/src/commands/doctor-auth-oauth-sidecar.ts
@@ -239,12 +239,16 @@ export async function maybeRepairLegacyOAuthSidecarProfiles(params: {
     );
   }
 
-  const shouldRepair = await params.prompter.confirmAutoFix({
-    message: "Migrate legacy Codex OAuth credentials now?",
-    initialValue: true,
-  });
-  if (!shouldRepair) {
-    return result;
+  // Unreferenced sidecars alone are informational: the store loop below never
+  // touches them, so prompting would confirm a guaranteed no-op on every run.
+  if (stores.length > 0) {
+    const shouldRepair = await params.prompter.confirmAutoFix({
+      message: "Migrate legacy Codex OAuth credentials now?",
+      initialValue: true,
+    });
+    if (!shouldRepair) {
+      return result;
+    }
   }
 
   const migratedSidecarsByRefId = new Map<string, string>();


### PR DESCRIPTION
## What Problem This Solves

Fixes two `openclaw doctor` auth-repair UX defects that never converge:

1. When only *unreferenced* legacy Codex OAuth sidecar credential files remain (the exact end-state the sidecar flow itself produces after archiving a store), interactive doctor prompted "Migrate legacy Codex OAuth credentials now?" on **every** run — but the repair loop intentionally never touches unreferenced sidecars, so answering "yes" was a guaranteed no-op, forever.
2. When the shared legacy `oauth.json` migration failed (unreadable SQLite store, lock contention, changed source), the warning said only "Failed to migrate shared legacy OAuth credentials; the source was left in place." — no cause, no next step, while gateway startup keeps directing the user back to `doctor --fix`.

## Why This Change Was Made

The confirm gate in `src/commands/doctor-auth-oauth-sidecar.ts` covered the informational unreferenced-sidecar report, not just actionable stores; gating the prompt on `stores.length > 0` matches what the repair loop can actually do. The swallowed error in `src/commands/doctor-auth-flat-profiles.ts` diverged from its own sibling handler a few lines above (per-candidate failures include `${String(err)}`); aligning restores one convention.

## User Impact

Operators with leftover sidecar files stop being nagged with a no-op prompt on every doctor run, and a failing shared-OAuth migration now names its cause so the user can act (fix permissions, retry, re-authenticate).

## Evidence

- New regression `does not prompt when only unreferenced sidecars remain` fails pre-fix (confirmAutoFix called) and passes post-fix; existing warning/no-touch expectations unchanged (9 passed).
- Strengthened shared-OAuth test asserts the warning now carries a cause suffix; full `doctor-auth-flat-profiles.test.ts` green (50 passed).
- Fresh autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC delta: sidecar +10/−6, flat-profiles +2/−2 (net +4 prod, all from the actionable-gate block replacing an unconditional prompt; no growth avoidable without losing the unreferenced-sidecar warning contract).
