### PR TITLE
fix(gateway): preserve local node ownership in describe

### DIFF
--- a/src/gateway/server-methods/nodes.read.test.ts
+++ b/src/gateway/server-methods/nodes.read.test.ts
@@ -1,0 +1,131 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import type { PairedDevice } from "../../infra/device-pairing.js";
+import { resolveNodePairingState } from "../../infra/device-pairing.js";
+import { NodeRegistry } from "../node-registry.js";
+import { nodeReadHandlers } from "./nodes.read.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const { listDevicePairingMock, resolveLocalNodeIdMock } = vi.hoisted(() => ({
+  listDevicePairingMock: vi.fn(),
+  resolveLocalNodeIdMock: vi.fn(),
+}));
+
+vi.mock("../../infra/device-pairing.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/device-pairing.js")>(
+    "../../infra/device-pairing.js",
+  );
+  return { ...actual, listDevicePairing: listDevicePairingMock };
+});
+
+vi.mock("../../node-host/local-id.js", () => ({
+  resolveLocalNodeId: resolveLocalNodeIdMock,
+}));
+
+function createPairedNode(nodeId: string): PairedDevice {
+  return {
+    deviceId: nodeId,
+    publicKey: `public-key-${nodeId}`,
+    roles: ["node"],
+    tokens: {
+      node: {
+        token: `token-${nodeId}`,
+        role: "node",
+        scopes: [],
+        createdAtMs: 1,
+      },
+    },
+    nodeSurface: {
+      displayName: nodeId,
+      caps: [],
+      commands: [],
+      createdAtMs: 1,
+      approvedAtMs: 1,
+    },
+    createdAtMs: 1,
+    approvedAtMs: 1,
+  };
+}
+
+function registerNode(registry: NodeRegistry, pairedNode: PairedDevice): void {
+  const pairingState = expectDefined(
+    resolveNodePairingState(pairedNode),
+    `${pairedNode.deviceId} pairing state`,
+  );
+  registry.register(
+    {
+      connId: `connection-${pairedNode.deviceId}`,
+      connect: {
+        client: {
+          id: "node-host",
+          version: "1.0.0",
+          platform: "linux",
+          mode: "node",
+          displayName: pairedNode.deviceId,
+        },
+        device: { id: pairedNode.deviceId },
+        scopes: [],
+      },
+    } as never,
+    {
+      pairingIdentity: pairingState.identity.key,
+      ...(pairingState.generation ? { pairingGeneration: pairingState.generation.key } : {}),
+    },
+  );
+}
+
+describe("node read projections", () => {
+  it("preserves Gateway-local ownership across list and describe", async () => {
+    const localNodeId = "local-node";
+    const remoteNodeId = "remote-node";
+    const pairedNodes = [createPairedNode(localNodeId), createPairedNode(remoteNodeId)];
+    const nodeRegistry = new NodeRegistry();
+    for (const pairedNode of pairedNodes) {
+      registerNode(nodeRegistry, pairedNode);
+    }
+    listDevicePairingMock.mockResolvedValue({ pending: [], paired: pairedNodes });
+    resolveLocalNodeIdMock.mockResolvedValue(localNodeId);
+
+    const client = {
+      connect: { scopes: ["operator.read"] },
+    } as GatewayRequestHandlerOptions["client"];
+    const context = {
+      logGateway: { warn: vi.fn() },
+      nodeRegistry,
+    } as unknown as GatewayRequestHandlerOptions["context"];
+
+    async function request(method: "node.list" | "node.describe", params: Record<string, unknown>) {
+      const respond = vi.fn();
+      await expectDefined(
+        nodeReadHandlers[method],
+        `${method} handler`,
+      )({
+        req: { type: "req", id: `request-${method}`, method, params },
+        params,
+        client,
+        isWebchatConnect: () => false,
+        respond,
+        context,
+      });
+      expect(respond).toHaveBeenCalledWith(true, expect.anything(), undefined);
+      return respond.mock.calls[0]?.[1];
+    }
+
+    const list = (await request("node.list", {})) as {
+      nodes: Array<{ nodeId: string; gatewayLocal?: boolean }>;
+    };
+    expect(list.nodes.filter((node) => node.gatewayLocal)).toEqual([
+      expect.objectContaining({ nodeId: localNodeId, gatewayLocal: true }),
+    ]);
+    expect(list.nodes.find((node) => node.nodeId === remoteNodeId)).not.toHaveProperty(
+      "gatewayLocal",
+    );
+
+    await expect(request("node.describe", { nodeId: localNodeId })).resolves.toEqual(
+      expect.objectContaining({ nodeId: localNodeId, gatewayLocal: true }),
+    );
+    await expect(request("node.describe", { nodeId: remoteNodeId })).resolves.not.toHaveProperty(
+      "gatewayLocal",
+    );
+  });
+});

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -16,7 +16,7 @@ import { resolveLocalNodeId } from "../../node-host/local-id.js";
 import type { NodeListNode } from "../../shared/node-list-types.js";
 import { replaceRemoteNodeSkills } from "../../skills/runtime/remote-skills.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../skills/runtime/remote.js";
-import { createKnownNodeCatalog, listKnownNodes } from "../node-catalog.js";
+import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
 import { isNodeRunnerSessionHost, updateNodeRunnerInventory } from "../node-registry-private.js";
 import type { NodeSession } from "../node-registry.js";
 import {
@@ -79,6 +79,7 @@ function currentSessionHostNodeIds(params: {
 async function listNodesForClient(params: {
   client: GatewayClient | null;
   context: GatewayRequestContext;
+  nodeId?: string;
   pairedDevices: Awaited<ReturnType<typeof listDevicePairing>>["paired"];
   pairedNodes: ReturnType<typeof projectNodePairing>["paired"];
   pendingNodes: ReturnType<typeof projectNodePairing>["pending"];
@@ -101,7 +102,10 @@ async function listNodesForClient(params: {
     );
     return null;
   });
-  const nodes = listKnownNodes(catalog).map((node) =>
+  const catalogNodes = params.nodeId
+    ? [getKnownNode(catalog, params.nodeId)].filter(isVisibleNode)
+    : listKnownNodes(catalog);
+  const nodes = catalogNodes.map((node) =>
     node.nodeId === localNodeId ? Object.assign({}, node, { gatewayLocal: true }) : node,
   );
   if (nodeInvokePolicy.canReadPendingNodePairing(params.client)) {
@@ -295,12 +299,13 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
       const nodes = await listNodesForClient({
         client,
         context,
+        nodeId: id,
         pairedDevices: devicePairing.paired,
         pairedNodes: nodePairing.paired,
         pendingNodes: nodePairing.pending,
         connectedNodes,
       });
-      const node = nodes.find((candidate) => candidate.nodeId === id);
+      const node = nodes[0];
       if (!node) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
         return;

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -16,7 +16,7 @@ import { resolveLocalNodeId } from "../../node-host/local-id.js";
 import type { NodeListNode } from "../../shared/node-list-types.js";
 import { replaceRemoteNodeSkills } from "../../skills/runtime/remote-skills.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../skills/runtime/remote.js";
-import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
+import { createKnownNodeCatalog, listKnownNodes } from "../node-catalog.js";
 import { isNodeRunnerSessionHost, updateNodeRunnerInventory } from "../node-registry-private.js";
 import type { NodeSession } from "../node-registry.js";
 import {
@@ -76,16 +76,18 @@ function currentSessionHostNodeIds(params: {
   );
 }
 
-function listNodesForClient(params: {
+async function listNodesForClient(params: {
   client: GatewayClient | null;
+  context: GatewayRequestContext;
   pairedDevices: Awaited<ReturnType<typeof listDevicePairing>>["paired"];
   pairedNodes: ReturnType<typeof projectNodePairing>["paired"];
   pendingNodes: ReturnType<typeof projectNodePairing>["pending"];
   connectedNodes: readonly NodeSession[];
-  localNodeId: string | null;
-  nodeRegistry: GatewayRequestContext["nodeRegistry"];
-}): NodeListNode[] {
-  const sessionHostNodeIds = currentSessionHostNodeIds(params);
+}): Promise<NodeListNode[]> {
+  const sessionHostNodeIds = currentSessionHostNodeIds({
+    connectedNodes: params.connectedNodes,
+    nodeRegistry: params.context.nodeRegistry,
+  });
   const catalog = createKnownNodeCatalog({
     pairedDevices: params.pairedDevices,
     pairedNodes: params.pairedNodes,
@@ -93,8 +95,14 @@ function listNodesForClient(params: {
     connectedNodes: params.connectedNodes,
     sessionHostNodeIds,
   });
+  const localNodeId = await resolveLocalNodeId().catch((error: unknown) => {
+    params.context.logGateway.warn(
+      `failed to resolve same-install node-host identity: ${formatErrorMessage(error)}`,
+    );
+    return null;
+  });
   const nodes = listKnownNodes(catalog).map((node) =>
-    node.nodeId === params.localNodeId ? Object.assign({}, node, { gatewayLocal: true }) : node,
+    node.nodeId === localNodeId ? Object.assign({}, node, { gatewayLocal: true }) : node,
   );
   if (nodeInvokePolicy.canReadPendingNodePairing(params.client)) {
     return nodes;
@@ -250,20 +258,13 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
       const devicePairing = await listDevicePairing();
       const nodePairing = projectNodePairing(devicePairing.paired);
       const connectedNodes = listCurrentConnectedNodes(context, devicePairing.paired);
-      const localNodeId = await resolveLocalNodeId().catch((error: unknown) => {
-        context.logGateway.warn(
-          `failed to resolve same-install node-host identity: ${formatErrorMessage(error)}`,
-        );
-        return null;
-      });
-      const nodes = listNodesForClient({
+      const nodes = await listNodesForClient({
         client,
+        context,
         pairedDevices: devicePairing.paired,
         pairedNodes: nodePairing.paired,
         pendingNodes: nodePairing.pending,
         connectedNodes,
-        localNodeId,
-        nodeRegistry: context.nodeRegistry,
       });
       const activeNodeId = context.nodeRegistry.getActiveNode(connectedNodes)?.nodeId;
       const nodesWithPresence = activeNodeId
@@ -291,23 +292,15 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
       const devicePairing = await listDevicePairing();
       const nodePairing = projectNodePairing(devicePairing.paired);
       const connectedNodes = listCurrentConnectedNodes(context, devicePairing.paired);
-      const catalog = createKnownNodeCatalog({
+      const nodes = await listNodesForClient({
+        client,
+        context,
         pairedDevices: devicePairing.paired,
         pairedNodes: nodePairing.paired,
         pendingNodes: nodePairing.pending,
         connectedNodes,
-        sessionHostNodeIds: currentSessionHostNodeIds({
-          connectedNodes,
-          nodeRegistry: context.nodeRegistry,
-        }),
       });
-      const catalogNode = getKnownNode(catalog, id);
-      const node =
-        catalogNode && nodeInvokePolicy.canReadPendingNodePairing(client)
-          ? catalogNode
-          : catalogNode
-            ? safeNodeReadProjection(catalogNode, nodeReadCallerDeviceId(client))
-            : null;
+      const node = nodes.find((candidate) => candidate.nodeId === id);
       if (!node) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
         return;


### PR DESCRIPTION
Closes #123162

## What Problem This Solves

Fixes an issue where `node.describe` would omit `gatewayLocal: true` for the Gateway's canonical node-host installation even though `node.list` reported the fact for the same node and client. Consumers could classify one node differently depending on which read RPC they used.

## Why This Change Was Made

The existing client-safe node projection now owns local-node resolution and is shared by both list and describe. Describe retains a targeted catalog lookup, then uses the same Gateway-local marker and pending-node authorization/redaction projection as list. This removes describe's duplicate visibility policy while preserving current-main `sessionHost` projection, active-node projection, unknown-node errors, local-ID warning behavior, and remote-node behavior.

## User Impact

CLI, app, plugin, and agent-tool consumers can rely on `node.list` and `node.describe` to agree on Gateway-local ownership. Only the canonical local node is marked; remote nodes remain unmarked.

## Evidence

- Rebased once onto `origin/main` at `67a1cdda0009c94dc53edf71f3054026cfc03ddd`; refreshed exact head: `1ea06598172464d46e238964364dba8f0e8ca3cd`.
- Tests-first handler regression failed before the repair because `node.describe(local)` lacked `gatewayLocal` while `node.list(local)` included it.
- `node scripts/run-vitest.mjs src/gateway/server-methods/nodes.read.test.ts src/gateway/server.node-pairing-diagnostics-authz.test.ts` — 2 files, 3/3 tests passed.
- `node scripts/run-vitest.mjs src/gateway/node-catalog.test.ts` — 1 file, 17/17 tests passed, including current-main session-host catalog behavior.
- `./node_modules/.bin/oxfmt --check src/gateway/server-methods/nodes.read.ts src/gateway/server-methods/nodes.read.test.ts` — passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-methods/nodes.read.ts src/gateway/server-methods/nodes.read.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr-123165-core.tsbuildinfo` — passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr-123165-core-test.tsbuildinfo` — passed.
- Fresh final branch autoreview against `origin/main`: clean, no findings, confidence 0.97; TruffleHog clean.
- Exact-head CI on superseded head `6e40d15a3de1e260d303957a5424996cbb32c9e9` executed after preflight recovery and found one related `check-dependencies` failure: `getKnownNode` had become a test-only export. The current head retains targeted production lookup through the shared projection; focused proof and final review were rerun. Fresh exact-head CI on `1ea06598172464d46e238964364dba8f0e8ca3cd` is the landing gate.
- Earlier exact-head CI attempts before preflight recovery were infrastructure/capacity cancellations before useful execution and are superseded.

Production delta: +26/-28, net -2. Tests: +131.

AI-assisted: yes. The implementation and regression were reviewed against the complete node-read, pairing, registry, catalog, authorization, and current-main session-host owner path.
