### PR TITLE
refactor(ui): resolve duplicate stylesheet selectors and restore no-duplicate-selectors

### DIFF
--- a/config/stylelint.config.mjs
+++ b/config/stylelint.config.mjs
@@ -6,10 +6,6 @@ export default {
     // Cascade-order advice, not an error class; 400+ intentional hits in the
     // existing token/override cascade make it pure noise here.
     "no-descending-specificity": null,
-    // 17 pre-existing duplicates; merging them reorders the cascade and needs
-    // per-site visual proof. Tighten in a follow-up, keep new code honest via
-    // review until then.
-    "no-duplicate-selectors": null,
     // stylelint 17.14.1 knows display-mode as fullscreen | standalone |
     // minimal-ui | browser | picture-in-picture (lib/reference/mediaFeatures.mjs),
     // predating window-controls-overlay. Allow that one value only, so typos in
@@ -28,6 +24,14 @@ export default {
     {
       files: ["**/*.ts"],
       customSyntax: "postcss-lit",
+    },
+    {
+      files: ["ui/src/components/file-preview-modal.ts"],
+      rules: {
+        // Shortcut-key chrome is intentionally reopened beside the modal footer;
+        // keep every other selector in this Lit stylesheet enforced.
+        "no-duplicate-selectors": [true, { ignoreSelectors: [".kbd"] }],
+      },
     },
   ],
 };

--- a/config/stylelint.config.mjs
+++ b/config/stylelint.config.mjs
@@ -25,13 +25,5 @@ export default {
       files: ["**/*.ts"],
       customSyntax: "postcss-lit",
     },
-    {
-      files: ["ui/src/components/file-preview-modal.ts"],
-      rules: {
-        // Shortcut-key chrome is intentionally reopened beside the modal footer;
-        // keep every other selector in this Lit stylesheet enforced.
-        "no-duplicate-selectors": [true, { ignoreSelectors: [".kbd"] }],
-      },
-    },
   ],
 };

--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -105,12 +105,6 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       background: var(--bg-elevated);
     }
 
-    .kbd {
-      font-family: var(--mono);
-      border: 1px solid var(--border);
-      color: var(--muted);
-    }
-
     .body {
       flex: 1;
       display: grid;
@@ -399,8 +393,10 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
     }
 
     .kbd {
+      font-family: var(--mono);
       font-size: 10.5px;
       padding: 2px 6px;
+      border: 1px solid var(--border);
       border-radius: 4px;
       background: var(--bg-elevated);
       color: var(--text);

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -218,16 +218,13 @@ openclaw-activity-page {
 @media (max-width: 720px) {
   .activity-entry__meta {
     white-space: normal;
+    grid-column: 2;
+    justify-content: flex-start;
   }
 
   .activity-entry__summary {
     grid-template-columns: 18px minmax(0, 1fr);
     gap: var(--space-2);
-  }
-
-  .activity-entry__meta {
-    grid-column: 2;
-    justify-content: flex-start;
   }
 
   .activity-entry__body {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -753,6 +753,7 @@ openclaw-app {
    a page owns; installed/app-like windows are desktop chrome and keep the arrow.
    Controls consume --cursor-action rather than hardcoding a cursor, and real
    hyperlinks keep the UA pointer in every mode. */
+/* stylelint-disable-next-line no-duplicate-selectors -- cursor policy block, see comment above */
 :root {
   --cursor-action: pointer;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1449,9 +1449,6 @@ openclaw-chat-video-player {
   max-width: 100%;
   border-radius: 999px;
   font-size: 12px;
-}
-
-.chat-assistant-attachment-badge {
   padding: 3px 8px;
   background: color-mix(in srgb, var(--accent) 14%, transparent);
   color: var(--accent);
@@ -4266,6 +4263,7 @@ button.chat-reply-preview--message:disabled {
 .chat-controls__agent {
   min-width: 0;
   max-width: none;
+  grid-area: agent;
 }
 
 .chat-controls__session-row {
@@ -4287,10 +4285,6 @@ button.chat-reply-preview--message:disabled {
 .chat-controls__session-picker {
   grid-area: session;
   position: relative;
-}
-
-.chat-controls__agent {
-  grid-area: agent;
 }
 
 .chat-controls__model {
@@ -5158,8 +5152,12 @@ button.chat-reply-preview--message:disabled {
 .chat-controls__thinking {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 13px;
+  gap: 4px;
+  font-size: 12px;
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
 }
 
 /* Controls separator: the visible divider is the background; any glyph content
@@ -5205,17 +5203,6 @@ button.chat-reply-preview--message:disabled {
   font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.chat-controls__thinking {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 12px;
-  padding: 4px 10px;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
 }
 
 /* Light theme thinking indicator override */

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -128,11 +128,8 @@
   border-style: solid;
   background: color-mix(in srgb, var(--accent) 16%, transparent);
   color: var(--text-strong);
-}
-
-/* The bottom zone paints over the right zone's lower corner; keep the active
-   one on top so its label stays readable. */
-.chat-workbench__dock-zone--active {
+  /* The bottom zone paints over the right zone's lower corner; keep the active
+     one on top so its label stays readable. */
   z-index: 1;
 }
 
@@ -787,9 +784,6 @@ openclaw-chat-sidebar-region,
 
 .chat-workspace-rail__browser-caption {
   color: var(--muted);
-}
-
-.chat-workspace-rail__browser-caption {
   padding: 0 12px 6px;
   font-size: var(--control-ui-text-xs);
   line-height: 1.2;

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1032,9 +1032,6 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-}
-
-.chat-activity-group__icon {
   color: var(--muted);
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3711,12 +3711,6 @@ td.data-table-key-col {
   white-space: nowrap;
 }
 
-.btn--ghost {
-  background: transparent;
-  border-color: transparent;
-  color: var(--muted);
-}
-
 .btn--ghost:hover:not(:disabled) {
   background: var(--bg-hover);
   color: var(--text);

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -1029,6 +1029,7 @@
 }
 
 /* Web Awesome popup surfaces own positioning, dismissal, and focus. */
+/* stylelint-disable-next-line no-duplicate-selectors -- popover sizing stays with its Web Awesome part overrides */
 .cron-filter-popover {
   --max-width: min(280px, calc(100vw - 48px));
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -216,6 +216,7 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
    (settings-sidebar.ts). Below the drawer breakpoint the regular mobile
    shell stays in charge and the settings sidebar rides inside the drawer. */
 
+/* stylelint-disable-next-line no-duplicate-selectors -- settings navigation variable belongs with the takeover rules below */
 .shell {
   --shell-settings-nav-width: 288px;
 }
@@ -660,9 +661,6 @@ openclaw-settings-save-indicator {
 
 .settings-save-indicator__apply {
   border-radius: 999px;
-}
-
-.settings-save-indicator__apply {
   border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
   background: var(--accent-subtle);
   color: var(--text);
@@ -3355,9 +3353,6 @@ openclaw-tooltip.sidebar-hover-tooltip {
 .sidebar-hover-card__person-email {
   color: var(--muted);
   font-weight: 400;
-}
-
-.sidebar-hover-card__person-email {
   font-size: var(--control-ui-text-xs);
 }
 

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -47,12 +47,8 @@ openclaw-lobster-pet {
   -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;
   transition: left 1.15s ease-in-out;
-}
-
-/* Seeded glint tint rides its own variable, mapped here (before the palette
-   rules) so palette and offline class rules still out-cascade it on both
-   look surfaces. */
-.lobster-pet {
+  /* Seeded glint tint is mapped before the palette rules so palette and
+     offline class rules still out-cascade it on both look surfaces. */
   --lob-glint: var(--lob-glint-seed, #00e5cc);
 }
 

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -455,6 +455,14 @@ select.settings-select:not([multiple]) {
   min-height: var(--settings-control-height);
   box-sizing: border-box;
   align-items: stretch;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  max-width: 100%;
+  background: color-mix(in srgb, var(--bg) 80%, var(--bg-elevated) 20%);
+  border: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  border-radius: var(--radius-md);
+  padding: 2px;
 }
 
 .settings-segmented > .settings-segmented__btn {
@@ -494,17 +502,6 @@ wa-switch.settings-toggle {
   --wa-form-control-activated-color: var(--accent);
   --wa-color-focus: var(--ring);
   flex: none;
-}
-
-.settings-segmented {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 2px;
-  max-width: 100%;
-  background: color-mix(in srgb, var(--bg) 80%, var(--bg-elevated) 20%);
-  border: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
-  border-radius: var(--radius-md);
-  padding: 2px;
 }
 
 wa-radio-group.settings-segmented::part(form-control-label) {

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -60,6 +60,11 @@
   color: var(--accent);
   font-size: 11px;
   font-weight: 650;
+  flex: 0 1 auto;
+  max-width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .provider-usage-grid {
@@ -98,14 +103,6 @@
 .provider-usage-summary {
   color: var(--muted);
   font-size: 11px;
-}
-
-.provider-usage-plan {
-  flex: 0 1 auto;
-  max-width: 55%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .provider-usage-windows,
@@ -253,6 +250,8 @@
   position: relative;
   overflow: visible;
   z-index: 2;
+  display: grid;
+  gap: 16px;
 }
 
 .usage-header.pinned {
@@ -260,11 +259,6 @@
   top: 16px;
   z-index: 4;
   box-shadow: var(--shadow-md);
-}
-
-.usage-header {
-  display: grid;
-  gap: 16px;
 }
 
 .usage-header-row {
@@ -366,12 +360,6 @@
 .chart-toggle .toggle-btn:hover:not(.active) {
   background: var(--bg-hover);
   color: var(--text);
-}
-
-.chart-toggle .toggle-btn.active {
-  background: var(--accent-subtle);
-  border: none;
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .usage-date-range {

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -39,9 +39,6 @@
   justify-content: space-between;
   gap: 12px;
   align-items: center;
-}
-
-.workboard-toolbar {
   padding: 9px;
   border: 1px solid color-mix(in srgb, var(--border-strong) 56%, transparent);
   border-radius: 8px;
@@ -673,13 +670,6 @@
   --workboard-health-highlight-color: var(--warn);
 }
 
-.workboard-card--health-highlight::before {
-  background: var(--workboard-health-highlight-color);
-  inset: -1px auto -1px -1px;
-  width: 5px;
-  border-radius: 8px 0 0 8px;
-}
-
 .workboard-card--busy {
   opacity: 0.62;
 }
@@ -1198,6 +1188,9 @@
 
 .workboard-card--health-highlight::before {
   background: var(--workboard-health-highlight-color);
+  inset: -1px auto -1px -1px;
+  width: 5px;
+  border-radius: 8px 0 0 8px;
   box-shadow: 1px 0 0 color-mix(in srgb, var(--workboard-health-highlight-color) 52%, transparent);
 }
 


### PR DESCRIPTION
## What Problem This Solves

`config/stylelint.config.mjs` disabled `no-duplicate-selectors` with a comment naming it a follow-up: 17+ pre-existing duplicate selector blocks whose merging "reorders the cascade and needs per-site visual proof." Duplicate blocks are cascade hazards — a later reopen silently overrides an earlier edit, and review can't see it.

## Why This Change Was Made

Part 3 of the CSS-hygiene series (#123156, #123160). This is the named follow-up: every violation resolved site-by-site, the disable deleted, the rule restored to its recommended-preset error default.

Resolution per site, by reading both blocks and everything between them:
- **Merged** (14 sites): true duplicates where declarations were disjoint or the later winner was preserved — activity, settings segmented control, usage header/plan, workboard toolbar, chat layout/sidebar/tool-cards, lobster-pet, layout save-indicator/hover-card.
- **Deleted dead** (3 sites): `components.css` `.btn--ghost` reopen (identical declarations), `usage.css` chart-toggle `.active` block fully superseded by the two later equal-specificity blocks, `workboard.css` health-highlight `::before` geometry consolidated into the later block that already wins (verified the interleaved priority-stripe `::before` rules only touch `background`, which the health block already overrode at both positions — stripes behave identically).
- **Disable-next-line with stated reason** (3 sites): deliberate topic-organization reopens (`base.css` cursor-policy `:root` with its 4-line design comment, `cron.css` popover width token beside its `::part` theming, `layout.css` settings-nav variables beside the settings takeover section).
- One duplicate found in a Lit template during full-run validation (`file-preview-modal.ts` `.kbd`): merged the two blocks into one (footer block keeps `font-family: var(--mono)` + `border` from the deleted first block) rather than adding a config carve-out.

## User Impact

None — rendering-identical by construction, verified by screenshot parity. Net −56 LOC. New duplicate selectors now fail `pnpm lint:ui:styles`.

## Evidence

- `stylelint` full run (CSS + Lit templates): exit 0. Negative test: scratch duplicate fails (exit 2).
- Mocked dev server screenshot parity, origin/main vs branch, 9 routes × dark/light: all pages byte-identical except usage (fixture chart animation noise ≤0.00016 at 1% fuzz, matches same-tree control captures).

Workboard dark (health-highlight stripe + toolbar, both touched):

![workboard](https://github.com/user-attachments/assets/9d9c9c32-7c14-4653-8d93-5639b8b6eac6)

Usage dark (chart-toggle active state, dead block deleted):

![usage](https://github.com/user-attachments/assets/5cc85e53-7775-46c6-877b-060d17e6bd4c)

Autoreview (Codex/gpt-5.6-sol, branch mode): clean.
