### PR TITLE
test(whatsapp): declare broadcast fixture owners

### DIFF
--- a/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
+++ b/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
@@ -18,6 +18,12 @@ import { createTestWebInboundMessage } from "./inbound/test-message.test-helper.
 
 installWebAutoReplyTestHomeHooks();
 
+const whatsappAccountOwner = (accountId = "default") =>
+  ({
+    agentId: "alfred",
+    match: { channel: "whatsapp", accountId },
+  }) satisfies NonNullable<OpenClawConfig["bindings"]>[number];
+
 describe("broadcast groups", () => {
   installWebAutoReplyUnitTestHooks();
 
@@ -47,6 +53,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner()],
       broadcast: {
         strategy: "sequential",
         "+1000": ["alfred", "baerbel"],
@@ -68,6 +75,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner()],
       broadcast: {
         strategy: "sequential",
         "123@g.us": ["alfred", "baerbel"],
@@ -157,6 +165,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner("work")],
       broadcast: {
         strategy: "sequential",
         "123@g.us": ["alfred", "baerbel"],
@@ -199,6 +208,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner()],
       broadcast: {
         strategy: "parallel",
         "+1000": ["alfred", "baerbel"],


### PR DESCRIPTION
## What Problem This Solves

Resolves a daily main-qualification failure where four WhatsApp broadcast-group fixtures configured multiple agents without declaring which agent owned the tested account. The fixtures stopped with `AgentSelectionRequiredError` before reaching their broadcast assertions.

## Why This Change Was Made

Adds one typed test helper for WhatsApp account-owner bindings and applies it only to the four failing multi-agent fixtures, including the named `work` account case. Runtime routing, ownership defaults, agent configuration, retry behavior, and assertions are unchanged.

## User Impact

No user-visible runtime change. WhatsApp qualification now exercises the intended broadcast behavior under the current explicit-owner routing contract.

## Evidence

- Campaign: `20260813T073118Z-main_sha-daily-6966301523a5`
- Before on `baf85e6868e67aebd12ef0e7b77774061fc9db2f`: 4 failed, 1 passed; all failures were `AgentSelectionRequiredError`.
- After focused proof on rebased head: 5 passed.
- Blacksmith Testbox `tbx_01kzxea4km23g7gtbjhtf227z4`: `pnpm test:extension whatsapp` passed 98 files and 1,333 tests.
- `node scripts/check-changed.mjs -- extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts`: passed via trusted-source local fallback after Blacksmith capacity blocked the delegated changed gate.
- `git diff --check`: passed.
- Structured autoreview: clean, no accepted/actionable findings.
- Production LOC: +0/-0. Tests: +10/-0.

Punchcard-Session: frost-orchard-lantern-ze
