### PR TITLE
fix(test): restore bounded Vitest silence watchdog

### DIFF
--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -81,12 +81,6 @@ export const VITEST_CONFIG_NO_OUTPUT_TIMEOUT_MS = new Map([
     DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS,
   ],
   ["test/vitest/vitest.infra.config.ts", DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS],
-  // Largest extension shard: silent transform/import startup was measured at
-  // ~210s on a loaded macOS host, so the 120s default kills healthy runs (#123025).
-  [
-    "test/vitest/vitest.extension-discord.config.ts",
-    DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS,
-  ],
   [GATEWAY_CORE_VITEST_CONFIG, DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS],
   [GATEWAY_SERVER_VITEST_CONFIG, DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS],
 ]);


### PR DESCRIPTION
Related: #123131

## What Problem This Solves

Resolves a problem where the Discord extension Vitest config received a 40-minute no-output allowance as part of an otherwise unrelated mock repair, weakening the script runner's bounded stall detection.

## Why This Change Was Made

Restores the prior 120-second default by removing only the Discord-specific timeout-map entry. The three runtime-env mock fixes from #123131 remain unchanged. The plugin-prerelease extension batch invokes `pnpm exec vitest run` directly and does not use this watchdog.

## User Impact

No production user impact. Test tooling again terminates silent Discord extension runs after the standard bounded interval.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/run-vitest.test.ts test/scripts/test-extension.test.ts test/scripts/plugin-prerelease-test-plan.test.ts`: 266 tests passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/run-vitest.mts`: passed.
- `node scripts/check-changed.mjs -- scripts/run-vitest.mts`: passed on Testbox.
- Exact prior code restored: `scripts/run-vitest.mts` matches the parent of #123131.
- Production LOC: +0/-6. Tests: +0/-0.
- AI-assisted: yes.

Punchcard-Session: frost-orchard-lantern-ze
