### PR TITLE
fix(ui): make active visibility pill distinct from its hover state

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1494,6 +1494,7 @@ async function createChatPickerScenario(
       "sessions.patchMany",
       "sessions.catalog.list",
       "sessions.catalog.read",
+      "sessions.create",
       "system.info",
       "terminal.open",
     ],

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -78,10 +78,13 @@ openclaw-new-session-page {
   opacity: 1;
 }
 
-/* Active mode stays readable without hover; inactive revealed pills keep the
-   muted resting color until directly hovered. */
-.new-session-page__visibility--active {
-  color: var(--text);
+/* Active mode must read as toggled-on even while hovered: hover on an
+   inactive pill already shows a neutral fill, so active gets an accent
+   tint to stay distinguishable under the cursor. */
+.new-session-page__visibility--active,
+.new-session-page__visibility--active:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
 }
 
 .new-session-page__visibility:disabled {


### PR DESCRIPTION
## What Problem This Solves

Clicking the Draft/Incognito visibility pill in the new-session composer produced no perceptible visual change: hovering an inactive pill already applies a neutral fill plus full-strength text, while the active (toggled-on) state only changed text color. Since the cursor is on the button at the moment of the click, "on" and "off" rendered nearly pixel-identical and operators could not tell whether the toggle took effect.

## Why This Change Was Made

The active state needs its own visual identity that survives hover. The fix gives `--active` an accent-tinted pill background with accent text/icon, applied both at rest and while hovered, mirroring the accent-active treatment already used elsewhere in the Control UI (e.g. selected config cards). The mock harness now also advertises `sessions.create` so the new-session visibility pills render enabled there, matching what operators see against a real Gateway (same rationale as the existing comment about session context-menu rows).

## User Impact

Toggling Draft or Incognito on now flips the pill to a clearly tinted accent state under the cursor; toggling off visibly returns it to the muted treatment. No behavior change — CSS only, plus mock-harness method advertisement.

## Evidence

Captured on the mocked Control UI dev server (`scripts/control-ui-mock-dev.ts`) with Playwright, element screenshots of the composer. Mock fixture data only.

Before — hovering the inactive pill:

![before hover inactive](https://github.com/user-attachments/assets/82231e2f-f66a-4c76-be12-f173d8103402)

Before — pill **active** and hovered (indistinguishable from the shot above; the bug):

![before active hovered](https://github.com/user-attachments/assets/4ac751a4-0a53-4265-9fae-0175ae575524)

After — pill active and hovered:

![after active hovered](https://github.com/user-attachments/assets/3727e5a6-6312-46ee-81e9-a47311422d6a)

After — pill active at rest:

![after active rest](https://github.com/user-attachments/assets/d4caf390-22aa-49e7-b552-2fcce42ebd30)

Validation: `stylelint` clean on `ui/src/styles/new-session.css`; Codex autoreview (`gpt-5.6-sol`, high) clean — "no accepted/actionable findings".
