### PR TITLE
fix(gateway): suppress ambient channel auto-enable from env credentials

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -570,7 +570,7 @@ Example:
 
     The legacy per-channel `allow` key is migrated to `enabled` by `openclaw doctor --fix`.
 
-    If you only set `DISCORD_BOT_TOKEN` and do not create a `channels.discord` block, runtime fallback is `groupPolicy="allowlist"` (with a warning in logs), even if `channels.defaults.groupPolicy` is `open`.
+    Without a `channels.discord` block, the Gateway does not auto-start Discord from `DISCORD_BOT_TOKEN`. Once the block exists, `DISCORD_BOT_TOKEN` remains the default-account token fallback. Passing `--ambient-channels` opts into env-only auto-configuration; that path uses `groupPolicy="allowlist"` and logs a warning, even if `channels.defaults.groupPolicy` is `open`.
 
   </Tab>
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -573,7 +573,7 @@ openclaw config patch --file ./slack.socket.patch.json5 --dry-run
 openclaw config patch --file ./slack.socket.patch.json5
 ```
 
-        Env fallback (default account only):
+        Default-account credential fallback after `channels.slack` is configured:
 
 ```bash
 SLACK_APP_TOKEN=slack-app-token-example
@@ -1315,7 +1315,7 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
 
     Channel allowlist lives under `channels.slack.channels` and **must use stable Slack channel IDs** (for example `C12345678`) as config keys. Enterprise Grid org installs require `team:<team-id>:channel:<channel-id>` so policies cannot cross workspace boundaries.
 
-    Runtime note: if `channels.slack` is completely missing (env-only setup), runtime falls back to `groupPolicy="allowlist"` and logs a warning (even if `channels.defaults.groupPolicy` is set).
+    Without a `channels.slack` block, the Gateway does not auto-start Slack from `SLACK_*` environment variables. Once the block exists, those variables remain default-account credential fallbacks. Passing `--ambient-channels` opts into env-only auto-configuration; that path uses `groupPolicy="allowlist"` and logs a warning, even if `channels.defaults.groupPolicy` is set.
 
     Name/ID resolution:
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -75,8 +75,11 @@ openclaw gateway run   # equivalent, explicit form
 <ParamField path="--dev" type="boolean">
   Create a dev config + workspace if missing (skips `BOOTSTRAP.md`).
 </ParamField>
+<ParamField path="--ambient-channels" type="boolean">
+  Allow the Gateway to auto-configure channels from ambient environment variables. By default, channels require an explicit `channels.<id>` config block.
+</ParamField>
 <ParamField path="--dev-ambient-channels" type="boolean">
-  Allow a dev Gateway to auto-configure channels from ambient environment variables. Requires `--dev`.
+  Deprecated alias for `--ambient-channels`.
 </ParamField>
 <ParamField path="--reset" type="boolean">
   Reset dev config, credentials, sessions, and workspace. Requires `--dev`.

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -185,7 +185,7 @@ What this does:
    - Default identity: **C3-PO** (protocol droid).
    - `pnpm gateway:dev` also sets `OPENCLAW_SKIP_CHANNELS=1` to skip channel providers.
 
-Dev Gateways ignore ambient channel environment triggers by default, so credentials inherited from your shell do not connect the development instance to real channel services. Explicit `channels.<id>` configuration still works. Pass `--dev-ambient-channels` with `--dev` to restore ambient channel auto-configuration for that run.
+All Gateways ignore ambient channel environment triggers by default, so credentials inherited from the launching shell do not connect to channel services without explicit intent. A `channels.<id>` configuration block still enables that channel and can use environment variables for its credentials. Pass `--ambient-channels` to restore ambient channel auto-configuration for that run; `--dev-ambient-channels` remains as a deprecated alias.
 
 Reset flow (fresh start):
 

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -204,9 +204,9 @@ read_when:
 
     Replace `https://my-openclaw.fly.dev` with your real Fly app origin. Gateway startup seeds local Control UI origins from the runtime `--bind` and `--port` values so first boot can proceed before config exists, but browser access through Fly still needs the exact HTTPS origin listed in `gateway.controlUi.allowedOrigins`.
 
-    The Discord token can come from either:
+    The `channels.discord` block above enables Discord. Its token can come from either:
 
-    - Environment variable `DISCORD_BOT_TOKEN` (recommended for secrets); no need to add it to config, the gateway reads it automatically
+    - Environment variable `DISCORD_BOT_TOKEN` (recommended for secrets); the configured default account reads it automatically
     - Config file `channels.discord.token`
 
     Restart to apply:

--- a/src/cli/gateway-cli/run-command.ts
+++ b/src/cli/gateway-cli/run-command.ts
@@ -45,10 +45,11 @@ export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks
     )
     .option("--dev", "Create a dev config + workspace if missing (no BOOTSTRAP.md)", false)
     .option(
-      "--dev-ambient-channels",
-      "Allow dev gateways to auto-configure channels from ambient environment variables",
+      "--ambient-channels",
+      "Allow the gateway to auto-configure channels from ambient environment variables",
       false,
     )
+    .option("--dev-ambient-channels", "Deprecated alias for --ambient-channels", false)
     .option(
       "--reset",
       "Reset dev config + credentials + sessions + workspace (requires --dev)",

--- a/src/cli/gateway-cli/run-options.ts
+++ b/src/cli/gateway-cli/run-options.ts
@@ -22,6 +22,7 @@ export type GatewayRunOpts = {
   rawStream?: boolean;
   rawStreamPath?: unknown;
   dev?: boolean;
+  ambientChannels?: boolean;
   devAmbientChannels?: boolean;
   reset?: boolean;
 };
@@ -42,6 +43,7 @@ const GATEWAY_RUN_BOOLEAN_KEYS = [
   "tailscaleResetOnExit",
   "allowUnconfigured",
   "dev",
+  "ambientChannels",
   "devAmbientChannels",
   "reset",
   "force",

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -515,31 +515,32 @@ describe("gateway run option collisions", () => {
     expect(runtimeErrors.join("\n")).toContain("Invalid --port. Use a port number from 1 to 65535");
   });
 
-  it("suppresses ambient channel triggers for dev gateways by default", async () => {
-    await runGatewayCli(["gateway", "run", "--allow-unconfigured", "--dev"]);
+  it.each([{ options: [] as string[] }, { options: ["--dev"] }])(
+    "suppresses ambient channel triggers by default with options %j",
+    async ({ options }) => {
+      await runGatewayCli(["gateway", "run", "--allow-unconfigured", ...options]);
 
-    expect(gatewayStartOptions().ambientEnvTriggers).toBe("suppress");
-  });
+      expect(gatewayStartOptions().ambientEnvTriggers).toBe("suppress");
+    },
+  );
 
-  it("allows ambient channel triggers with the explicit dev override", async () => {
-    await runGatewayCli([
-      "gateway",
-      "run",
-      "--allow-unconfigured",
-      "--dev",
-      "--dev-ambient-channels",
-    ]);
+  it.each([
+    {
+      label: "the primary subcommand flag",
+      argv: ["gateway", "run", "--allow-unconfigured", "--ambient-channels"],
+    },
+    {
+      label: "the inherited primary flag",
+      argv: ["gateway", "--ambient-channels", "run", "--allow-unconfigured"],
+    },
+    {
+      label: "the deprecated alias",
+      argv: ["gateway", "run", "--allow-unconfigured", "--dev-ambient-channels"],
+    },
+  ])("allows ambient channel triggers with $label", async ({ argv }) => {
+    await runGatewayCli(argv);
 
     expect(gatewayStartOptions().ambientEnvTriggers).toBe("allow");
-  });
-
-  it("rejects the ambient channel override outside dev mode", async () => {
-    await expect(
-      runGatewayCli(["gateway", "run", "--allow-unconfigured", "--dev-ambient-channels"]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(startGatewayServer).not.toHaveBeenCalled();
-    expect(runtimeErrors).toContain("Use --dev-ambient-channels with --dev.");
   });
 
   it("drops the pristine core fact when guarded config becomes stateful", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -694,16 +694,11 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
   installQaParentWatchdog();
   const isDevProfile = normalizeOptionalLowercaseString(process.env.OPENCLAW_PROFILE) === "dev";
   const devMode = Boolean(opts.dev) || isDevProfile;
-  // Dev gateways inherit the operator shell. Suppress ambient channel credentials so a
-  // development instance cannot silently connect to real channel services.
-  const devAmbientEnvTriggers = opts.devAmbientChannels ? "allow" : "suppress";
+  // Gateways inherit the launching shell, so suppress ambient channel credentials unless the
+  // operator explicitly allows them for this run.
+  const ambientEnvTriggers = opts.ambientChannels || opts.devAmbientChannels ? "allow" : "suppress";
   if (opts.reset && !devMode) {
     defaultRuntime.error("Use --reset with --dev.");
-    defaultRuntime.exit(1);
-    return;
-  }
-  if (opts.devAmbientChannels && !devMode) {
-    defaultRuntime.error("Use --dev-ambient-channels with --dev.");
     defaultRuntime.exit(1);
     return;
   }
@@ -1212,11 +1207,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
           ...(envSidecarStartupMode !== "start" ? { sidecarStartup: envSidecarStartupMode } : {}),
           ...(channelAutostartSuppression ? { channelAutostartSuppression } : {}),
           ...(channelAutostartSuppression ? { tryRecoverChannelAutostartSuppression } : {}),
-          ...(devMode
-            ? {
-                ambientEnvTriggers: devAmbientEnvTriggers,
-              }
-            : {}),
+          ambientEnvTriggers,
         });
       },
     });

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -366,7 +366,7 @@ describe("channel plugin blockers", () => {
     ]);
   });
 
-  it("suppresses ambient-only package env blockers for dev gateway startup", () => {
+  it("suppresses ambient-only package env blockers for gateway startup", () => {
     mockManifestPlugins([
       plugin("discord", {
         packageChannel: createPackageChannelEnv("discord", ["DISCORD_FAKE_TEST_TRIGGER"]),

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2191,11 +2191,11 @@ describe("server-channels auto restart", () => {
     expect(manager.getAutostartSuppression()).toBeNull();
     expect(startAccount).not.toHaveBeenCalled();
     expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default?.lastError).toBe(
-      "ambient channel credentials suppressed for dev gateway",
+      "ambient channel credentials suppressed; configure the channel or start the gateway with --ambient-channels",
     );
   });
 
-  it("suppresses ambient dev channel autostart while allowing manual starts", async () => {
+  it("suppresses ambient channel autostart while allowing manual starts", async () => {
     const startAccount = vi.fn(async (_ctx: ChannelGatewayContext<TestAccount>) => {});
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager({
@@ -2205,7 +2205,7 @@ describe("server-channels auto restart", () => {
     await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
     expect(startAccount).not.toHaveBeenCalled();
     expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default?.lastError).toBe(
-      "ambient channel credentials suppressed for dev gateway",
+      "ambient channel credentials suppressed; configure the channel or start the gateway with --ambient-channels",
     );
 
     await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, { manual: true });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -534,7 +534,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       for (const id of accountIds) {
         setStoppedRuntime(channelId, id, {
           restartPending: false,
-          lastError: "ambient channel credentials suppressed for dev gateway",
+          lastError:
+            "ambient channel credentials suppressed; configure the channel or start the gateway with --ambient-channels",
         });
       }
       return;

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -132,7 +132,7 @@ export async function prepareGatewayServerBootstrap(input: {
 
   const minimalTestGateway =
     isVitestRuntimeEnv() && process.env.OPENCLAW_TEST_MINIMAL_GATEWAY === "1";
-  const ambientEnvTriggers = opts.ambientEnvTriggers ?? "allow";
+  const ambientEnvTriggers = opts.ambientEnvTriggers ?? "suppress";
 
   // Ensure all default port derivations (browser/canvas) see the actual runtime port.
   process.env.OPENCLAW_GATEWAY_PORT = String(port);

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -152,7 +152,7 @@ describe("gateway startup log", () => {
     ]);
   });
 
-  it("logs one dev suppression notice without an ambient configured-channel warning", async () => {
+  it("logs one suppression notice without an ambient configured-channel warning", async () => {
     const manifestRecords = [
       createManifestRecord({
         id: "discord",
@@ -185,7 +185,7 @@ describe("gateway startup log", () => {
 
     expect(warn.mock.calls).toEqual([
       [
-        "dev gateway suppressed ambient channel auto-configuration for 1 channel: discord. Use --dev-ambient-channels to re-enable ambient channel triggers.",
+        "gateway suppressed ambient channel auto-configuration for 1 channel: discord. Configure channels.<id> (openclaw channels add <id>) to enable the channel, or pass --ambient-channels to allow ambient env credentials.",
       ],
     ]);
     expect(warn.mock.calls.flat().join("\n")).not.toContain("channels.discord is configured");

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -256,9 +256,10 @@ function formatSuppressedAmbientChannelsStartupWarning(channelIds: readonly stri
     sanitizeForLog(channelId),
   );
   return (
-    `dev gateway suppressed ambient channel auto-configuration for ${safeChannelIds.length} ` +
+    `gateway suppressed ambient channel auto-configuration for ${safeChannelIds.length} ` +
     `${safeChannelIds.length === 1 ? "channel" : "channels"}: ${safeChannelIds.join(", ")}. ` +
-    "Use --dev-ambient-channels to re-enable ambient channel triggers."
+    "Configure channels.<id> (openclaw channels add <id>) to enable the channel, or pass " +
+    "--ambient-channels to allow ambient env credentials."
   );
 }
 

--- a/src/gateway/server-startup-minimal-boot.test.ts
+++ b/src/gateway/server-startup-minimal-boot.test.ts
@@ -3,7 +3,10 @@
 // gateway boot tests do) hides startup work that materializes plugin runtime,
 // which is exactly how a startup stall shipped green while hanging every
 // ui-e2e suite that boots a minimal test gateway.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetConfigRuntimeState } from "../config/runtime-snapshot.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { getFreePort } from "../test-utils/ports.js";
 
@@ -12,7 +15,56 @@ import { getFreePort } from "../test-utils/ports.js";
 // surfacing on unrelated UI PRs.
 const BOOT_BUDGET_MS = 90_000;
 
+afterEach(() => {
+  resetConfigRuntimeState();
+  clearCurrentPluginMetadataSnapshot();
+});
+
 describe("gateway minimal boot smoke", () => {
+  it("suppresses ambient channel triggers when the server option is omitted", async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "gateway-bootstrap-ambient-default",
+      layout: "home",
+      env: {
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    const token = "gateway-bootstrap-test-token";
+    await state.writeConfig({ gateway: { auth: { mode: "token", token } }, plugins: {} });
+    state.applyEnv();
+
+    try {
+      const { prepareGatewayServerBootstrap } = await import("./server-startup-bootstrap.js");
+      const log = createSubsystemLogger("gateway/bootstrap-test");
+      const bootstrap = await prepareGatewayServerBootstrap({
+        port,
+        opts: {
+          auth: { mode: "token", token },
+          bind: "loopback",
+          controlUiEnabled: false,
+          sidecarStartup: "defer",
+        },
+        log,
+        logSecrets: log,
+        loadWorkerEnvironmentStartupModule: async () =>
+          await import("./server-worker-environment-startup.js"),
+        formatRuntimeGatewayAuthTokenWarning: () => "unused",
+      });
+
+      expect(bootstrap.ambientEnvTriggers).toBe("suppress");
+    } finally {
+      await state.cleanup();
+    }
+  });
+
   it("boots a minimal test gateway within budget", { timeout: BOOT_BUDGET_MS }, async () => {
     const port = await getFreePort();
     const state = await createOpenClawTestState({


### PR DESCRIPTION
# What Problem This Solves

A gateway with no channel configuration could auto-enable channels purely from ambient host environment credentials inherited from the launching shell, and then mutate remote service state owned by the operator's real deployment. Observed on a scratch-profile gateway (`plugins: {}`, no `channels.*` config) started from a shell carrying the operator's env: Discord and SMS auto-enabled from `DISCORD_BOT_TOKEN` / `TWILIO_*`, and the Discord channel's native slash-command reconciliation deleted remote slash-command registrations belonging to the operator's production bot (`extensions/discord/src/internal/command-deploy.ts` deletes every remote global command not in its desired set; Telegram similarly runs `deleteWebhook`/`setWebhook` and a full command-menu clear at startup).

# Why This Change Was Made

PR #112011 already built the suppression machinery (`ambientEnvTriggers: "allow" | "suppress"` across presence detection, activation planning, autostart, startup logging) but scoped it to `--dev` gateways only; production gateways defaulted to `"allow"` (`src/gateway/server-startup-bootstrap.ts`). The incident gateway ran a scratch profile, not `--dev`, so it got the production default.

Zero-config env-only activation is not the documented contract: every documented flow (`openclaw channels add --use-env`, onboarding, Docker, Fly) writes `channels.<id>.enabled: true` and uses env only as the default-account secret source ("Each channel starts automatically when its config section exists" — docs/gateway/config-channels.md). So the fix flips the default: ambient env-only channel presence no longer activates channels on any gateway. Explicit `channels.<id>` config still activates exactly as documented, and env vars still supply the default-account token for configured channels.

The opt-in is generalized: `openclaw gateway run --ambient-channels` restores ambient auto-configuration in any mode; `--dev-ambient-channels` remains as a deprecated alias. Startup logs the suppressed channel ids once and names the enablement path (`openclaw channels add <id>` / `channels.<id>.enabled: true` / `--ambient-channels`).

# User Impact

- A gateway whose config has no channels no longer adopts shell/env credentials, connects to live services, or mutates remote state (slash commands, webhooks, command menus). This closes the silent cross-deployment destruction path.
- Operators using the documented flows are unaffected: `channels.<id>` config sections keep working, including env-var token fallback for the default account.
- The undocumented "env var alone starts the channel" behavior now requires `--ambient-channels` (or a one-line `channels.<id>.enabled: true`). The startup warning states this when ambient-only credentials are detected.
- Sibling channels are covered by the same generic seam: Discord/Telegram/Slack via channel env prefixes, SMS via manifest `configuredState.env` triggers — both are `AMBIENT_ENV_SOURCES` in the presence policy; no per-channel code changed.

# Evidence

- Production LOC delta: **-4** (+15/-19); tests +53; docs +3. The fix generalizes and deletes the dev-only gating rather than adding a new path.
- New regression test (`src/gateway/server-startup-minimal-boot.test.ts`): `prepareGatewayServerBootstrap` with the ambient option omitted resolves `ambientEnvTriggers: "suppress"` — fails on pre-fix code (default was `"allow"`).
- CLI seam tests (`src/cli/gateway-cli/run.option-collisions.test.ts`): default suppress with and without `--dev`; `--ambient-channels` (subcommand + inherited parent form) and the deprecated `--dev-ambient-channels` alias both resolve to `"allow"`; removed the obsolete dev-only-rejection test.
- Focused suites green: `channel-plugin-ids` (170), `run.option-collisions` (74), `server-startup-minimal-boot` (2), `server-startup-plugins` (26), `server-startup-log` (14), `server-channels` (95), `channel-plugin-blockers` (34) via `node scripts/run-vitest.mjs`.
- `node scripts/check-changed.mjs`: delegated to Blacksmith Testbox, exit 0 (lease stopped cleanly).
- Source-blind CLI validation: `--help` shows both flags; default launch suppresses Discord (excluded from loaded plugins, suppression warning logged); `--ambient-channels` loads Discord without the warning.
- Autoreview (Codex): clean, no accepted/actionable findings.
- Known cosmetic follow-up: an earlier pre-suppression planning log line ("Discord configured, enabled automatically") still prints before the suppressed-channel warning; the channel is not loaded or started. Left as-is (outside the enablement seam).
