### PR TITLE
fix(ui): make Control UI terminal readable in light mode

### DIFF
--- a/src/gateway/terminal/intro-banner.test.ts
+++ b/src/gateway/terminal/intro-banner.test.ts
@@ -25,9 +25,9 @@ describe("composeTerminalIntroBanner", () => {
     const banner = composeTerminalIntroBanner();
 
     expect(banner).toBe(
-      `\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[38;5;216m${EXPECTED_ART.join("\r\n")}\r\n\r\n\x1b[0m`,
+      `\r\n\x1b[33mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[91m${EXPECTED_ART.join("\r\n")}\r\n\r\n\x1b[0m`,
     );
-    expect(banner.startsWith("\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m")).toBe(true);
+    expect(banner.startsWith("\r\n\x1b[33mWelcome to the Claw.\x1b[0m")).toBe(true);
     expect(banner.endsWith("\r\n\r\n\x1b[0m")).toBe(true);
     expect(banner.replaceAll("\r\n", "")).not.toContain("\n");
   });

--- a/src/gateway/terminal/intro-banner.ts
+++ b/src/gateway/terminal/intro-banner.ts
@@ -22,8 +22,11 @@ const TERMINAL_INTRO_ART = [
 // Always full art: open-time request.cols is the pre-fit boot grid (the client
 // resizes immediately after open), so width gating keyed on it suppressed the
 // art on real, wide terminals.
+// ANSI-16 colors only: the server can't know the client's light/dark mode, and
+// fixed 256-color indices (223/216) bypass the client theme and vanish on light
+// backgrounds. Yellow/bright-red stay warm on dark and darken on light.
 export function composeTerminalIntroBanner(): string {
-  const headline = `\x1b[38;5;223mWelcome to the Claw.${RESET}`;
-  const art = `\x1b[38;5;216m${TERMINAL_INTRO_ART.join("\r\n")}\r\n\r\n`;
+  const headline = `\x1b[33mWelcome to the Claw.${RESET}`;
+  const art = `\x1b[91m${TERMINAL_INTRO_ART.join("\r\n")}\r\n\r\n`;
   return `\r\n${headline}\r\n\r\n${art}${RESET}`;
 }

--- a/ui/src/components/terminal/terminal-theme.ts
+++ b/ui/src/components/terminal/terminal-theme.ts
@@ -8,9 +8,10 @@ type TerminalTheme = NonNullable<
   NonNullable<CreateGhosttyTerminalOptions["terminalOptions"]>["theme"]
 >;
 
-// ANSI palette tuned to sit on the Control UI's near-black / near-white surfaces.
-// Shared 8 + bright 8; foreground/background/cursor are overridden per mode below.
-const ANSI = {
+// ANSI palettes tuned per mode: colors that read on the near-black surface sit
+// at 1.4-2.6:1 on the light surface, so light gets its own darkened set
+// (>=4.5:1 on #f7f8fa) instead of sharing the dark palette.
+const DARK_ANSI = {
   black: "#1b1e26",
   red: "#ff6b6b",
   green: "#4ec9a8",
@@ -27,6 +28,29 @@ const ANSI = {
   brightMagenta: "#d7a3d4",
   brightCyan: "#7bd3dd",
   brightWhite: "#ffffff",
+} as const;
+
+// Same hue identities as DARK_ANSI, darkened for the light surface. Bright
+// variants go darker than normal ones so bold/bright text stays emphatic
+// instead of washing out; brightWhite maps to the strongest ink, matching
+// the light-theme convention in Ghostty/iTerm paired themes.
+const LIGHT_ANSI = {
+  black: "#3a3f4b",
+  red: "#c62f3d",
+  green: "#177a5e",
+  yellow: "#8f6400",
+  blue: "#1e66d0",
+  magenta: "#94439c",
+  cyan: "#0f7487",
+  white: "#1b1e26",
+  brightBlack: "#5c6370",
+  brightRed: "#a3242f",
+  brightGreen: "#0f664e",
+  brightYellow: "#755200",
+  brightBlue: "#1a55ab",
+  brightMagenta: "#7c3382",
+  brightCyan: "#0c6070",
+  brightWhite: "#0a0c10",
 } as const;
 
 // Dark mirrors the claw tokens in styles/base.css (`--bg` #0e1015,
@@ -47,16 +71,14 @@ export function terminalTheme(mode: "dark" | "light"): TerminalTheme {
   const colors = terminalDynamicColors(mode);
   if (mode === "light") {
     return {
-      ...ANSI,
+      ...LIGHT_ANSI,
       ...colors,
       cursorAccent: "#f7f8fa",
-      selectionBackground: "rgba(90, 162, 255, 0.30)",
-      black: "#3a3f4b",
-      white: "#1b1e26",
+      selectionBackground: "rgba(30, 102, 208, 0.30)",
     };
   }
   return {
-    ...ANSI,
+    ...DARK_ANSI,
     ...colors,
     cursorAccent: "#0e1015",
     selectionBackground: "rgba(90, 162, 255, 0.32)",


### PR DESCRIPTION
## What Problem This Solves

The Control UI terminal is nearly unreadable in light mode. The light theme in `ui/src/components/terminal/terminal-theme.ts` re-mapped only black/white and reused the dark-background ANSI palette for the other 14 slots, leaving 1.4–2.6:1 WCAG contrast on the `#f7f8fa` surface (yellow 1.63, brightYellow 1.38, brightWhite 1.06 — white on white). On top of that, the gateway intro banner (`src/gateway/terminal/intro-banner.ts`) hardcoded 256-color indices 223/216 (pale tan/salmon), which bypass the client theme entirely, so the greeting and claw art washed out on light no matter what the palette said.

## Why This Change Was Made

Light backgrounds need darker ANSI colors — the same convention every paired terminal theme follows (Ghostty, iTerm). And the server can't know the client's color mode, so the banner must speak semantic ANSI-16 that the client theme renders per mode instead of fixed 256-color values.

- Light mode gets a dedicated `LIGHT_ANSI` palette with the same hue identities, all ≥4.95:1 on `#f7f8fa` (normal slots ~5.0–5.6, bright slots ~6.5–7.5). Bright variants go darker than normal ones so bold/bright text stays emphatic; brightWhite maps to the strongest ink.
- The banner emits ANSI-16 yellow (headline) and bright red (claw art): warm tan/salmon on dark (visually close to the previous fixed colors), dark gold/crimson on light.
- Dark mode palette is unchanged; light selection highlight follows the darker blue.

## User Impact

Operators using the Control UI in light mode get a readable terminal — prompt colors, `ls` output, and the intro banner all render at accessible contrast. Dark mode looks the same as before.

## Evidence

| | before | after |
|---|---|---|
| light | ![light before](https://github.com/user-attachments/assets/ed5a3c0f-7017-4064-be14-d76b66c24734) | ![light after](https://github.com/user-attachments/assets/d39c60cf-670a-416d-9ca5-696eff92b99a) |
| dark | ![dark before](https://github.com/user-attachments/assets/7c98c7f5-0ac0-422d-bbf7-2d77382d6a8b) | ![dark after](https://github.com/user-attachments/assets/474ee4a8-19ff-40bb-b556-5ada9ffdef23) |

Screenshots captured from the mocked Control UI dev server driving the real ghostty terminal runtime (`createIsolatedGhosttyTerminal` + `terminalTheme`), writing the exact banner bytes each revision's `composeTerminalIntroBanner` emits plus a representative ANSI-16 prompt/`ls` sample.

Validation:

- `node scripts/run-vitest.mjs src/gateway/terminal/intro-banner.test.ts` — green (asserts the new ANSI-16 escapes)
- `node scripts/check-changed.mjs` — exit 0 (format, lint, import cycles, guard lanes)
- Codex autoreview (`gpt-5.6-sol`, high): clean, "patch is correct (0.99)"

WCAG contrast on `#f7f8fa`, before → after: red 2.61→5.10, green 1.93→4.96, yellow 1.63→4.95, blue 2.46→5.11, magenta 2.62→5.58, cyan 2.23→5.11, brightRed 2.18→6.93, brightGreen 1.63→6.52, brightYellow 1.38→6.67, brightBlue 1.96→6.74, brightMagenta 1.96→7.45, brightCyan 1.62→6.76, brightWhite 1.06→18.42.
