### PR TITLE
docs(ui): record stylesheet policy in the Control UI guide

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -26,6 +26,15 @@ This directory owns Control UI-specific guidance that should not live in the rep
 - Icons: shared 24x24 Lucide icons go through `strokeIcon()` in `ui/src/components/icons-tools.ts` so stroke presentation attributes stay inline and render inside shadow roots. Icon bodies are `svg\`\``fragments, never`html\`\`` (wrong namespace renders nothing).
 - `pnpm lint:ui:lit` is an opt-in lit-analyzer diagnostic for template bindings (slow, ~9 min; known baseline of pre-existing findings). It is not a CI gate.
 
+## Stylesheet Policy
+
+- Colors: stylesheet colors flow through custom-property tokens defined in `ui/src/styles/base.css`; `color-no-hex` enforces this. Exempt surfaces (token definitions, `lobster-pet.css` sprite artwork, `--theme-chip-*` preview swatches) each carry a stated contract. Lit `css\`\`` templates are not yet gated — prefer tokens there too.
+- Breakpoints: `max-width` media conditions use the canonical ladder 400/560/640/768/900/1100/1320px (plus the 932×500 landscape-phone compound); stylelint's allowed-list enforces it. New thresholds round up to the next rung. Don't add rungs without updating the config comment and this note.
+- Duplicate selectors are lint errors; deliberate topic-section reopens use `stylelint-disable-next-line no-duplicate-selectors -- <reason>`.
+- Dead CSS: `node --import tsx scripts/audit-control-ui-dead-css.mts` reports class selectors with no production reference (AST-based, understands `X--${...}` stems and `classMap`). Advisory, not a gate — verify by hand before deleting; extend the script's stem detection rather than its allowlist when it misses a dynamic family.
+- Native CSS nesting: opportunistic only — nest when already rewriting a section; no conversion sweeps.
+- `@layer` is deliberately not used: the shared light-DOM stylesheet's precedence relies on import order plus specificity, page CSS imports lazily per component, and measured `no-descending-specificity` hits are within-file — layering the import manifest would flip unlayered-vs-layered precedence across ~48 lazily imported page files for no measured win. Revisit only with computed-style parity proof across all routes on the mocked dev server (PR #123156/#123160 show the evidence pattern).
+
 ## Live Verification
 
 - The Gateway serves the prebuilt bundle from `dist/control-ui`; editing `ui/src` changes nothing live until `pnpm ui:build`. Confirm the served `/assets/index-*.js` hash changed before trusting a live result.


### PR DESCRIPTION
## What Problem This Solves

The CSS-hygiene series (#123156 hex-token gate, #123160 breakpoint ladder, #123166 duplicate selectors, #123178 dead-CSS audit) added enforcement mechanisms and one deliberate non-decision (no `@layer`). None of that policy was written anywhere an agent or contributor working in `ui/src` would find it.

## Why This Change Was Made

`ui/AGENTS.md` gets a Stylesheet Policy section recording, tersely: the token-color contract and its three exempted surfaces, the canonical breakpoint ladder + round-up rule, the duplicate-selector disable convention, the dead-CSS audit command and its extend-the-script-not-the-allowlist rule, opportunistic-only nesting, and the measured rationale for not adopting `@layer` (within-file specificity hits; lazily imported page CSS would flip unlayered-vs-layered precedence across ~48 files) with the evidence bar for revisiting.

## User Impact

None (docs only). Keeps the four enforcement PRs from decaying into unexplained lint errors.

## Evidence

Docs-only diff; `git diff --check` clean. Policy content matches the shipped stylelint config and scripts landed in the four referenced PRs.
