### PR TITLE
fix(ui): surface non-default account in channel session labels (#123112)

### DIFF
--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -38,6 +38,36 @@ describe("resolveSessionDisplayName", () => {
     expect(resolveSessionDisplayName("agent:main:imessage:direct:+4912")).toBe("iMessage · +4912");
   });
 
+  it("surfaces a non-default account segment in DM labels", () => {
+    // per-account-channel-peer DM keys carry <channel>:<account>:direct:<id>;
+    // the raw key must never leak into the sidebar, and the account must be
+    // distinguishable at a glance from the default-account session.
+    expect(resolveSessionDisplayName("agent:main:telegram:cards:direct:42")).toBe(
+      "Telegram (cards) · 42",
+    );
+    expect(resolveSessionDisplayName("agent:main:telegram:cards:direct:491234567890")).toBe(
+      "Telegram (cards) · …567890",
+    );
+    expect(resolveSessionDisplayName("agent:main:signal:work:direct:+4912")).toBe(
+      "Signal (work) · +4912",
+    );
+  });
+
+  it("does not surface a default account segment in DM labels", () => {
+    expect(resolveSessionDisplayName("agent:main:telegram:default:direct:42")).toBe(
+      "Telegram · 42",
+    );
+  });
+
+  it("surfaces a non-default account segment in group labels", () => {
+    expect(resolveSessionDisplayName("agent:main:telegram:cards:group:-1001234567890")).toBe(
+      "Telegram (cards) Group",
+    );
+    expect(resolveSessionDisplayName("agent:main:telegram:group:-1001234567890")).toBe(
+      "Telegram Group",
+    );
+  });
+
   it("does not split UTF-16 surrogate pairs when shortening peer ids", () => {
     expect(resolveSessionDisplayName("agent:main:telegram:direct:12345😀67890")).toBe(
       "Telegram · …67890",

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -20,6 +20,9 @@ const CHANNEL_LABELS: Record<string, string> = {
 
 const KNOWN_CHANNEL_KEYS = Object.keys(CHANNEL_LABELS);
 
+/** Account segment value that session-key builders normalize absence to. */
+const DEFAULT_ACCOUNT_ID = "default";
+
 /** Raw peer ids stay out of the sidebar; keep a short recognizable tail only. */
 function shortenPeerId(identifier: string): string {
   const trimmed = identifier.trim();
@@ -147,28 +150,37 @@ function parseSessionKey(key: string): SessionKeyInfo {
     return { kind: "automation", prefix, fallbackName: prefix };
   }
 
-  // Direct chat: agent:<x>:<channel>:direct:<id>. Never render the raw peer
-  // id; the gateway sends origin-derived names, so this is a last resort.
-  const directMatch = key.match(/^agent:[^:]+:([^:]+):direct:(.+)$/);
+  // Direct chat: agent:<x>:<channel>[:<account>]:direct:<id>. Never render the
+  // raw peer id; the gateway sends origin-derived names, so this is a last
+  // resort. A non-default account segment (per-account-channel-peer DM scope)
+  // is surfaced so multi-account setups stay distinguishable at a glance.
+  const directMatch = key.match(/^agent:[^:]+:([^:]+)(?::([^:]+))?:direct:(.+)$/);
   if (directMatch) {
     const channel = directMatch[1];
-    const identifier = directMatch[2];
+    const account = directMatch[2];
+    const identifier = directMatch[3];
     if (!channel || !identifier) {
       return { prefix: "", fallbackName: key };
     }
     const channelLabel = CHANNEL_LABELS[channel] ?? capitalize(channel);
-    return { prefix: "", fallbackName: `${channelLabel} · ${shortenPeerId(identifier)}` };
+    const accountSuffix = account && account !== DEFAULT_ACCOUNT_ID ? ` (${account})` : "";
+    return {
+      prefix: "",
+      fallbackName: `${channelLabel}${accountSuffix} · ${shortenPeerId(identifier)}`,
+    };
   }
 
-  // Group chat: agent:<x>:<channel>:group:<id>.
-  const groupMatch = key.match(/^agent:[^:]+:([^:]+):group:(.+)$/);
+  // Group chat: agent:<x>:<channel>[:<account>]:group:<id>.
+  const groupMatch = key.match(/^agent:[^:]+:([^:]+)(?::([^:]+))?:group:(.+)$/);
   if (groupMatch) {
     const channel = groupMatch[1];
+    const account = groupMatch[2];
     if (!channel) {
       return { prefix: "", fallbackName: key };
     }
     const channelLabel = CHANNEL_LABELS[channel] ?? capitalize(channel);
-    return { prefix: "", fallbackName: `${channelLabel} Group` };
+    const accountSuffix = account && account !== DEFAULT_ACCOUNT_ID ? ` (${account})` : "";
+    return { prefix: "", fallbackName: `${channelLabel}${accountSuffix} Group` };
   }
 
   // Channel-prefixed keys like "telegram:123": durable session rows written by


### PR DESCRIPTION
## What Problem This Solves

With `channels.telegram.accounts.<default, cards>` configured, the default-account DM session key is `agent:main:telegram:direct:<chatId>` while a session reached through the `cards` account is `agent:main:telegram:cards:direct:<chatId>`. The Control UI's session display only understands the account-less shape, so the account-qualified key falls through `parseSessionKey` to the raw-key fallback and renders the full routing key (`telegram:cards:direct:42`) instead of a friendly label — while the default-account session renders `Telegram · 42`. Multi-account sessions are indistinguishable at a glance in the sidebar/session list, and the raw key structure leaks into the UI (exactly what the `shortenPeerId` design is meant to prevent). The same fall-through affects account-qualified group keys (`agent:main:telegram:cards:group:<id>`).

## Why

`ui/src/lib/session-display.ts` `parseSessionKey` matches direct DMs with `/^agent:[^:]+:([^:]+):direct:(.+)$/` and groups with `/^agent:[^:]+:([^:]+):group:(.+)$/`. The `per-account-channel-peer` DM scope (used for non-default accounts) inserts a normalized account segment between channel and kind: `agent:<agent>:<channel>:<accountId>:direct:<peerId>` (`src/routing/session-key.ts:238-242`). Neither regex accepts the optional account segment, so those keys skip the friendly direct/group branches entirely and fall through to the generic `agent:<x>:` branch (`session-display.ts:191-195`), which returns the raw remainder of the key. The channel grouping regex (`CHANNEL_SESSION_KEY_RE`) already tolerates the optional account segment — only the label path is broken.

## User Impact

- Non-default-account Telegram (and any other channel) sessions now render as `Telegram (cards) · 42` instead of the raw `telegram:cards:direct:42`, so sidebar/session-list rows are distinguishable at a glance and opaque routing keys stay out of the UI.
- The account id is surfaced only when it is not the default account; account-less keys and explicit `:default:` segments render exactly as before (`Telegram · 42`), so default setups see zero change.
- Group sessions get the same treatment (`Telegram (cards) Group`); account-less groups are unchanged.
- Behavior is limited to the display fallback path — labels, displayNames and derived titles set by the gateway still take precedence unchanged.

## Evidence

Pre-fix behavior, captured on `main` with the account-qualified key (raw key leaks; default session gets the friendly label):

```text
default: "Telegram · 42"
cards: "telegram:cards:direct:42"
cards channel info: {"channel":"telegram","channelSession":true}
```

Post-fix regression tests (`ui/src/lib/session-display.test.ts`, includes new cases for DM/group account labels, `:default:` suppression, and peer-id shortening with an account):

```text
✓  unit  src/lib/session-display.test.ts (17 tests) 13ms
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Related grouping suite unaffected:

```text
Test Files  1 passed (1)
      Tests  26 passed (26)
```

UI typecheck clean:

```text
$ pnpm tsgo:ui
EXIT=0 (0 "error TS" lines)
```

[AI-assisted] Implementation and evidence generated with agent tooling.
