### PR TITLE
fix(ci): allow GitHub-hosted npm preflight

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: false
         type: boolean
+      use_github_hosted_runners:
+        description: Use GitHub-hosted Ubuntu for npm preflight
+        required: false
+        default: false
+        type: boolean
       preflight_run_id:
         description: Existing successful preflight workflow run id to promote without rebuilding
         required: false
@@ -76,7 +81,7 @@ jobs:
   preflight_openclaw_npm:
     if: ${{ inputs.preflight_only }}
     # Preflight builds the full release package before publish; ubuntu-latest can OOM in tsdown.
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     steps:

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -13,7 +13,7 @@ type Step = {
   uses?: string;
   with?: Record<string, string>;
 };
-type Job = { environment?: string; steps?: Step[] };
+type Job = { environment?: string; "runs-on"?: string; steps?: Step[] };
 type Workflow = {
   on?: {
     workflow_dispatch?: {
@@ -27,6 +27,12 @@ type Workflow = {
         };
         plugin_npm_run_id?: { required?: boolean; type?: string };
         release_candidate_branch?: { default?: string; required?: boolean; type?: string };
+        use_github_hosted_runners?: {
+          default?: boolean;
+          description?: string;
+          required?: boolean;
+          type?: string;
+        };
       };
     };
   };
@@ -75,6 +81,19 @@ describe("minimal npm extended-stable workflow", () => {
     ]) {
       expect(raw).not.toContain(forbidden);
     }
+  });
+
+  it("allows an explicit default-off GitHub-hosted preflight runner", () => {
+    const parsed = workflow();
+    expect(parsed.on?.workflow_dispatch?.inputs?.use_github_hosted_runners).toEqual({
+      default: false,
+      description: "Use GitHub-hosted Ubuntu for npm preflight",
+      required: false,
+      type: "boolean",
+    });
+    expect(parsed.jobs?.preflight_openclaw_npm?.["runs-on"]).toBe(
+      "${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}",
+    );
   });
 
   it("binds intentional Plugin SDK release changes to the reported digest", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release tooling blocker where npm validation-only preflight runs can remain unassigned during a Blacksmith outage, with no operator-selected runner fallback.

Observed examples:

- https://github.com/openclaw/openclaw/actions/runs/31696399280
- https://github.com/openclaw/openclaw/actions/runs/31699345580

## Why This Change Was Made

Adds a default-off `use_github_hosted_runners` workflow-dispatch input and uses it only to select the `preflight_openclaw_npm` runner. Existing dispatches remain on `blacksmith-16vcpu-ubuntu-2404`; an operator can explicitly select GitHub-hosted `ubuntu-24.04` when Blacksmith capacity is unavailable.

No publish behavior, product code, release artifact, or frozen release SHA changes.

## User Impact

Release operators can unblock npm preflight validation during a Blacksmith outage without changing the default runner or touching the frozen release candidate.

Production LOC: +6/-1 (workflow capability, net +5) | Tests: +20/-1

## Evidence

- `node scripts/run-vitest.mjs test/scripts/openclaw-npm-extended-stable-workflow.test.ts` - 14 passed
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` - 115 passed, 2 skipped
- `node scripts/run-vitest.mjs test/openclaw-npm-postpublish-verify.test.ts` - 47 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts -t '^(?!.*executes shared release candidate identity validation with its JSON input).*$'` - 190 passed, 1 excluded
- Full package-acceptance execution was attempted twice; the existing `executes shared release candidate identity validation with its JSON input` fixture hung in `shared-image-artifact.sh verify-upload` both times and was the only excluded case.
- `node --import tsx scripts/check-workflows.mts` - zizmor passed; no direct input interpolation in composite run blocks
- `./node_modules/.bin/oxfmt --check .github/workflows/openclaw-npm-release.yml test/scripts/openclaw-npm-extended-stable-workflow.test.ts`
- `./node_modules/.bin/oxlint test/scripts/openclaw-npm-extended-stable-workflow.test.ts`
- `git diff --check`
- Local structured autoreview: clean, no accepted/actionable findings
