### PR TITLE
fix: prevent internal model reflections from reaching replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -326,7 +326,8 @@ export function splitTextIntoLaneSegments(
         ...(update.isReasoningSnapshot ? { isReasoningSnapshot: true } : {}),
       },
     })),
-    suppressedReasoningOnly: Boolean(split.reasoningText) && suppressReasoning && !split.answerText,
+    suppressedReasoningOnly:
+      isReasoning === true && !split.answerText && (suppressReasoning || !split.reasoningText),
   };
 }
 

--- a/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
@@ -188,6 +188,24 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("suppresses internal reflection when reasoning streams", async () => {
+    const { reasoningDraftStream } = setupDraftStreams({
+      answerMessageId: 2001,
+      reasoningMessageId: 3001,
+    });
+    mockTurn(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "<internal>private reflection</internal>", isReasoning: true },
+        { kind: "final" },
+      );
+    });
+
+    await dispatchWithContext({ context: createReasoningStreamContext() });
+
+    expect(reasoningDraftStream.update).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("routes typed reasoning-only finals to durable delivery when reasoning is persistent", async () => {
     loadSessionStore.mockReturnValue({
       s1: { reasoningLevel: "on" },

--- a/extensions/telegram/src/reasoning-lane-coordinator.test.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.test.ts
@@ -23,6 +23,10 @@ describe("splitTelegramReasoningText", () => {
     });
   });
 
+  it("suppresses internal reflection from explicitly typed reasoning", () => {
+    expect(splitTelegramReasoningText("<internal>private reflection</internal>", true)).toEqual({});
+  });
+
   it("ignores literal think tags inside inline code", () => {
     const text = "Use `<think>example</think>` literally.";
     expect(splitTelegramReasoningText(text)).toEqual({
@@ -39,6 +43,7 @@ describe("splitTelegramReasoningText", () => {
 
   it("does not emit partial reasoning tag prefixes", () => {
     expect(splitTelegramReasoningText("  <thi", true)).toStrictEqual({});
+    expect(splitTelegramReasoningText("  <int", true)).toStrictEqual({});
   });
 
   it("keeps visible Thinking-prefixed answers in the answer lane", () => {

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -29,11 +29,13 @@ const REASONING_TAG_PREFIXES = [
   "<think",
   "<thinking",
   "<thought",
+  "<internal",
   "<antthinking",
   "<mm:think",
   "</think",
   "</thinking",
   "</thought",
+  "</internal",
   "</antthinking",
   "</mm:think",
 ];
@@ -116,11 +118,13 @@ export function splitTelegramReasoningText(
 
   const taggedReasoning = extractThinkingFromTaggedStreamOutsideCode(text);
   const strippedAnswer = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
+  const reasoningText = taggedReasoning || strippedAnswer;
+  if (!reasoningText) {
+    return {};
+  }
 
   return {
-    reasoningText: markReasoningMessage(
-      formatReasoningMessage(taggedReasoning || strippedAnswer || text),
-    ),
+    reasoningText: markReasoningMessage(formatReasoningMessage(reasoningText)),
   };
 }
 

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
@@ -737,10 +737,17 @@ describe("createReasoningTagTextPartitioner", () => {
     expect(partitioner.flush()).toEqual([{ kind: "thinking", text: "outerinner" }]);
   });
 
-  it("keeps nested unclosed internal reflection private on flush", () => {
+  it("never emits nested unclosed internal reflection on flush", () => {
     const partitioner = createReasoningTagTextPartitioner();
 
     expect(partitioner.pushVisible("<thinking>outer<internal>private reflection")).toEqual([]);
-    expect(partitioner.flush()).toEqual([{ kind: "thinking", text: "outerprivate reflection" }]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("never emits closed internal reflection", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("<internal>private reflection</internal>")).toEqual([]);
+    expect(partitioner.flush()).toEqual([]);
   });
 });

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
@@ -736,4 +736,11 @@ describe("createReasoningTagTextPartitioner", () => {
     expect(partitioner.pushVisible("<think>outer<think>inner</think>")).toEqual([]);
     expect(partitioner.flush()).toEqual([{ kind: "thinking", text: "outerinner" }]);
   });
+
+  it("keeps nested unclosed internal reflection private on flush", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("<thinking>outer<internal>private reflection")).toEqual([]);
+    expect(partitioner.flush()).toEqual([{ kind: "thinking", text: "outerprivate reflection" }]);
+  });
 });

--- a/packages/markdown-core/src/reasoning-tag-parser.ts
+++ b/packages/markdown-core/src/reasoning-tag-parser.ts
@@ -12,6 +12,7 @@ export const REASONING_TAG_NAMES = [
   "thinking",
   "thought",
   "reasoning",
+  "internal",
   "antthinking",
   "antml:think",
   "antml:thinking",
@@ -32,6 +33,7 @@ type ReasoningTagMatch = {
   text: string;
   isClose: boolean;
   isSelfClosing: boolean;
+  canRecoverUnclosed: boolean;
 };
 
 type ReasoningTagScan = {
@@ -127,6 +129,7 @@ export function parseReasoningTagAt(
           text: text.slice(start, end),
           isClose,
           isSelfClosing: !isClose && lastSignificant === "/",
+          canRecoverUnclosed: partialName !== "internal",
         },
       };
     }
@@ -254,6 +257,7 @@ export type ReductionState = {
     content: string;
     openTag: string;
     protectedClose: boolean;
+    canRecoverUnclosed: boolean;
     visibleBefore: boolean;
   };
 };
@@ -306,6 +310,7 @@ export function reduceReasoningText(
       index: scannedTag.index + start,
       isClose: scannedTag.isClose,
       isSelfClosing: scannedTag.isSelfClosing,
+      canRecoverUnclosed: scannedTag.canRecoverUnclosed,
       text: scannedTag.text,
     };
     if (!isInsideCode(tag.index, codeSpans)) {
@@ -357,8 +362,12 @@ export function reduceReasoningText(
           content: "",
           openTag: tag.text,
           protectedClose: false,
+          canRecoverUnclosed: tag.canRecoverUnclosed,
           visibleBefore: state.visibleEver,
         };
+      } else if (state.pending) {
+        // Any nested private block makes the whole unclosed region private on flush.
+        state.pending.canRecoverUnclosed &&= tag.canRecoverUnclosed;
       }
       state.depth += 1;
       cursor = tagEnd;
@@ -394,9 +403,10 @@ export function reduceReasoningText(
   if (options.final && state.depth > 0 && state.pending) {
     const pending = state.pending;
     const recoverAsText =
-      options.mode === "static-preserve" ||
-      (options.mode === "static-strict" && !pending.visibleBefore && !pending.protectedClose) ||
-      (options.mode === "visible" && !pending.protectedClose);
+      pending.canRecoverUnclosed &&
+      (options.mode === "static-preserve" ||
+        (options.mode === "static-strict" && !pending.visibleBefore && !pending.protectedClose) ||
+        (options.mode === "visible" && !pending.protectedClose));
     if (recoverAsText) {
       const value =
         options.mode === "visible" && pending.visibleBefore

--- a/packages/markdown-core/src/reasoning-tag-parser.ts
+++ b/packages/markdown-core/src/reasoning-tag-parser.ts
@@ -33,7 +33,7 @@ type ReasoningTagMatch = {
   text: string;
   isClose: boolean;
   isSelfClosing: boolean;
-  canRecoverUnclosed: boolean;
+  isPrivate: boolean;
 };
 
 type ReasoningTagScan = {
@@ -129,7 +129,7 @@ export function parseReasoningTagAt(
           text: text.slice(start, end),
           isClose,
           isSelfClosing: !isClose && lastSignificant === "/",
-          canRecoverUnclosed: partialName !== "internal",
+          isPrivate: partialName === "internal",
         },
       };
     }
@@ -255,9 +255,9 @@ export type ReductionState = {
   visibleEver: boolean;
   pending?: {
     content: string;
+    containsPrivate: boolean;
     openTag: string;
     protectedClose: boolean;
-    canRecoverUnclosed: boolean;
     visibleBefore: boolean;
   };
 };
@@ -310,19 +310,20 @@ export function reduceReasoningText(
       index: scannedTag.index + start,
       isClose: scannedTag.isClose,
       isSelfClosing: scannedTag.isSelfClosing,
-      canRecoverUnclosed: scannedTag.canRecoverUnclosed,
+      isPrivate: scannedTag.isPrivate,
       text: scannedTag.text,
     };
     if (!isInsideCode(tag.index, codeSpans)) {
       tags.push(tag);
     }
   }
-  const hasCloseAfter: boolean[] = [];
+  const mustParseRemainder: boolean[] = [];
   if (options.scope === "leading") {
-    let seenClose = false;
+    let mustParse = false;
     for (let index = tags.length - 1; index >= 0; index -= 1) {
-      hasCloseAfter[index] = seenClose;
-      seenClose ||= tags[index]?.isClose === true;
+      mustParse ||= tags[index]?.isPrivate === true;
+      mustParseRemainder[index] = mustParse;
+      mustParse ||= tags[index]?.isClose === true;
     }
   }
   let cursor = start;
@@ -351,7 +352,7 @@ export function reduceReasoningText(
         state.depth === 0 &&
         options.scope === "leading" &&
         state.visibleEver &&
-        !hasCloseAfter[tagIndex]
+        !mustParseRemainder[tagIndex]
       ) {
         emit("text", text.slice(tag.index));
         cursor = text.length;
@@ -360,14 +361,14 @@ export function reduceReasoningText(
       if (state.depth === 0) {
         state.pending = {
           content: "",
+          containsPrivate: tag.isPrivate,
           openTag: tag.text,
           protectedClose: false,
-          canRecoverUnclosed: tag.canRecoverUnclosed,
           visibleBefore: state.visibleEver,
         };
       } else if (state.pending) {
-        // Any nested private block makes the whole unclosed region private on flush.
-        state.pending.canRecoverUnclosed &&= tag.canRecoverUnclosed;
+        // A nested private block makes the enclosing reasoning non-emitting.
+        state.pending.containsPrivate ||= tag.isPrivate;
       }
       state.depth += 1;
       cursor = tagEnd;
@@ -377,7 +378,9 @@ export function reduceReasoningText(
     if (state.depth > 0) {
       state.depth -= 1;
       if (state.depth === 0 && state.pending) {
-        emit("thinking", state.pending.content);
+        if (!state.pending.containsPrivate) {
+          emit("thinking", state.pending.content);
+        }
         state.pending = undefined;
       } else if (state.pending) {
         state.pending.protectedClose = true;
@@ -402,19 +405,20 @@ export function reduceReasoningText(
   append(text.slice(cursor));
   if (options.final && state.depth > 0 && state.pending) {
     const pending = state.pending;
-    const recoverAsText =
-      pending.canRecoverUnclosed &&
-      (options.mode === "static-preserve" ||
+    if (!pending.containsPrivate) {
+      const recoverAsText =
+        options.mode === "static-preserve" ||
         (options.mode === "static-strict" && !pending.visibleBefore && !pending.protectedClose) ||
-        (options.mode === "visible" && !pending.protectedClose));
-    if (recoverAsText) {
-      const value =
-        options.mode === "visible" && pending.visibleBefore
-          ? pending.openTag + pending.content
-          : pending.content;
-      emit("text", value);
-    } else {
-      emit("thinking", pending.content);
+        (options.mode === "visible" && !pending.protectedClose);
+      if (recoverAsText) {
+        const value =
+          options.mode === "visible" && pending.visibleBefore
+            ? pending.openTag + pending.content
+            : pending.content;
+        emit("text", value);
+      } else {
+        emit("thinking", pending.content);
+      }
     }
     state.depth = 0;
     state.pending = undefined;

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3808,6 +3808,13 @@ describe("message tool reasoning tag sanitization", () => {
     },
     {
       field: "message",
+      input: "<internal>private reflection</internal>Visible answer",
+      expected: "Visible answer",
+      target: "telegram:123",
+      channel: "telegram",
+    },
+    {
+      field: "message",
       input: "Thinking\n_internal plan_\n\nVisible answer",
       expected: "Visible answer",
       target: "telegram:123",

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -991,6 +991,12 @@ describe("sanitizeAssistantVisibleText", () => {
       "Before <think>literal tag text after",
     );
   });
+
+  it("never recovers unclosed internal reflection from final-answer prose", () => {
+    expect(
+      sanitizeAssistantFinalAnswerText("Visible prefix <thinking><internal>private reflection"),
+    ).toBe("Visible prefix");
+  });
 });
 
 describe("sanitizeAssistantVisibleTextWithProfile", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -39,6 +39,11 @@ describe("stripAssistantInternalScaffolding", () => {
       expected: "Visible",
     },
     {
+      name: "strips internal reflection tags",
+      input: ["<internal>", "private reflection", "</internal>", "Visible"].join("\n"),
+      expected: "Visible",
+    },
+    {
       name: "strips relevant-memories scaffolding blocks",
       input: [
         "<relevant-memories>",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -81,6 +81,16 @@ describe("stripReasoningTagsFromText", () => {
         input: "<think>first</think>A<think>second</think>B",
         expected: "AB",
       },
+      {
+        name: "strips internal reflection blocks",
+        input: "<internal>private reflection</internal>Visible answer.",
+        expected: "Visible answer.",
+      },
+      {
+        name: "never recovers nested unclosed internal reflection as visible text",
+        input: "<thinking>outer<internal>private reflection",
+        expected: "",
+      },
     ] as const)("$name", (testCase) => {
       expectStrippedCase(testCase);
     });
@@ -95,6 +105,10 @@ describe("stripReasoningTagsFromText", () => {
       {
         name: "preserves inline literal think tag documentation",
         input: "The `<think>` tag is used for reasoning. Don't forget the closing `</think>` tag.",
+      },
+      {
+        name: "preserves literal internal tag documentation",
+        input: "Use `<internal>private</internal>` literally.",
       },
       {
         name: "preserves xml fenced examples",
@@ -368,6 +382,12 @@ describe("stripReasoningTagsFromText", () => {
         name: "still strips fully closed reasoning blocks in preserve mode",
         input: "A <think>hidden</think> B",
         expected: "A  B",
+        opts: { mode: "preserve" as const },
+      },
+      {
+        name: "does not recover internal reflection in preserve mode",
+        input: "<internal>private reflection",
+        expected: "",
         opts: { mode: "preserve" as const },
       },
     ] as const)("$name", (testCase) => {


### PR DESCRIPTION
Closes #122623

## What Problem This Solves

Fixes an issue where Telegram replies could expose model-generated `<internal>` reflection text instead of sending only the visible answer.

## Why This Change Was Made

The shared reasoning parser now treats `<internal>` as private, keeps it non-emitting during streaming, and carries that rule through nested, incomplete blocks. Telegram also suppresses typed private-only payloads instead of falling back to raw text.

Canonical repair: this PR. It builds on #122650 and credits @wangyan2026 while replacing that channel-specific approach with the shared parser invariant.

## User Impact

Internal reflection stays hidden across channels. Literal tag examples in Markdown code remain visible.

## Evidence

- Before: the new regression run failed 3 assertions and returned the private `<internal>` payload through both parser and delivery sanitization boundaries.
- After: focused parser, automatic-delivery, streaming, message-tool, Telegram splitter, and dispatcher suites — 530 passed.
- `pnpm tsgo` — passed.
- `pnpm check:test-types` — passed.
- Local ClawSweeper run 3: 🐚 platinum hermit — patch correct, 0 findings, security cleared, no maintainer decision, 0 rank-up moves.
- Live before/after Telegram proof: the pre-fix private marker appeared as an ordinary reply; on PR head, the same private + visible fixture produced only `OPENCLAW_E2E_VISIBLE_123196` in the real-user DM event stream and Telegram Desktop. [Redacted trace](https://github.com/openclaw/openclaw/pull/123196#issuecomment-5281224982).
