### PR TITLE
fix(update): skip unrelated enclosing git roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,7 +398,7 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
-- **Updater linked source installs:** keep probing past unrelated enclosing Git repositories so globally linked source checkouts update from the configured Git channel instead of falling back to a nonexistent npm tag.
+- **Updater linked source installs:** keep probing past unrelated enclosing Git repositories so globally linked source checkouts update from the configured Git channel instead of falling back to a nonexistent npm tag. (#123197) Thanks @RomneyDa.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,7 +398,6 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
-- **Updater linked source installs:** keep probing past unrelated enclosing Git repositories so globally linked source checkouts update from the configured Git channel instead of falling back to a nonexistent npm tag. (#123197) Thanks @RomneyDa.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,7 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
+- **Updater linked source installs:** keep probing past unrelated enclosing Git repositories so globally linked source checkouts update from the configured Git channel instead of falling back to a nonexistent npm tag.
 
 ## 2026.7.1
 

--- a/src/infra/update-runner-install-surface.ts
+++ b/src/infra/update-runner-install-surface.ts
@@ -64,13 +64,16 @@ export async function resolveGitRoot(
   runCommand: CommandRunner,
   candidates: string[],
   timeoutMs: number,
+  packageRoot?: string | null,
 ): Promise<string | null> {
   for (const dir of candidates) {
     const result = await runCommand(["git", "-C", dir, "rev-parse", "--show-toplevel"], {
       timeoutMs,
     }).catch(() => null);
     const root = result?.code === 0 ? result.stdout.trim() : "";
-    if (root) {
+    // A launcher may live inside an unrelated checkout (for example nvm).
+    // Keep probing until the Git root owns the discovered OpenClaw package.
+    if (root && (!packageRoot || updateInstallRootsMatch(root, packageRoot))) {
       return root;
     }
   }
@@ -117,10 +120,7 @@ export async function resolveUpdateInstallSurface(
   const candidates = buildStartDirs(opts);
   const packageRoot = await findPackageRoot(candidates);
 
-  let gitRoot = await resolveGitRoot(runCommand, candidates, timeoutMs);
-  if (gitRoot && packageRoot && !updateInstallRootsMatch(gitRoot, packageRoot)) {
-    gitRoot = null;
-  }
+  const gitRoot = await resolveGitRoot(runCommand, candidates, timeoutMs, packageRoot);
   if (gitRoot && !packageRoot) {
     return { kind: "missing", mode: "unknown", root: resolveUpdateInstallRoot(gitRoot) };
   }

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -302,6 +302,41 @@ describe("runGatewayUpdate", () => {
     },
   );
 
+  it("skips an unrelated enclosing git root before the OpenClaw checkout", async () => {
+    const versionManagerRoot = path.join(tempDir, "version-manager");
+    const binDir = path.join(versionManagerRoot, "bin");
+    const sourceRoot = path.join(tempDir, "source");
+    await Promise.all([
+      fs.mkdir(binDir, { recursive: true }),
+      fs.mkdir(sourceRoot, { recursive: true }),
+    ]);
+    await fs.writeFile(
+      path.join(sourceRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "1.0.0" }),
+      "utf8",
+    );
+
+    const { runner, calls } = createRunner({
+      [`git -C ${binDir} rev-parse --show-toplevel`]: { stdout: versionManagerRoot },
+      [`git -C ${sourceRoot} rev-parse --show-toplevel`]: { stdout: sourceRoot },
+    });
+
+    await expect(
+      resolveUpdateInstallSurface({
+        argv1: path.join(binDir, "openclaw"),
+        cwd: sourceRoot,
+        timeoutMs: 1000,
+        runCommand: runner,
+      }),
+    ).resolves.toMatchObject({
+      kind: "git",
+      mode: "git",
+      root: sourceRoot,
+      packageRoot: sourceRoot,
+    });
+    expect(calls).toContain(`git -C ${sourceRoot} rev-parse --show-toplevel`);
+  });
+
   async function setupUiIndex() {
     const uiIndexPath = path.join(tempDir, "dist", "control-ui", "index.html");
     await fs.mkdir(path.dirname(uiIndexPath), { recursive: true });

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -32,7 +32,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
   const candidates = buildStartDirs(opts);
   const pkgRoot = await findPackageRoot(candidates);
 
-  let gitRoot = await resolveGitRoot(runCommand, candidates, timeoutMs);
+  let gitRoot = await resolveGitRoot(runCommand, candidates, timeoutMs, pkgRoot);
   if (!gitRoot && pkgRoot) {
     const cwdRoot = normalizeDir(opts.cwd);
     if (
@@ -42,9 +42,6 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     ) {
       gitRoot = resolveUpdateInstallRoot(cwdRoot);
     }
-  }
-  if (gitRoot && pkgRoot && !updateInstallRootsMatch(gitRoot, pkgRoot)) {
-    gitRoot = null;
   }
   if (gitRoot && !pkgRoot) {
     return {
@@ -56,7 +53,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       durationMs: Date.now() - startedAt,
     };
   }
-  if (gitRoot && pkgRoot && updateInstallRootsMatch(gitRoot, pkgRoot)) {
+  if (gitRoot && pkgRoot) {
     return await updateGitCheckout({
       opts,
       gitRoot,


### PR DESCRIPTION
## Summary

- keep update Git-root discovery probing after an unrelated enclosing repository
- correlate the selected Git root with the discovered OpenClaw package root
- cover launchers installed beneath a version-manager checkout

## Root cause

The global launcher lives under the user's nvm checkout. The mutable updater accepted nvm as the first Git root, rejected it after discovering the actual OpenClaw package root, and then fell back to npm without probing the remaining source-checkout candidate. With the dev channel selected, that fallback attempted the nonexistent `openclaw@dev` registry tag.

## Verification

- regression reproduced before the fix: 1 failed, 71 passed
- `node scripts/run-vitest.mjs src/infra/update-runner.test.ts` (72 passed)
- `pnpm format:check --no-error-on-unmatched-pattern -- CHANGELOG.md src/infra/update-runner-install-surface.ts src/infra/update-runner.test.ts src/infra/update-runner.ts`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings

Production delta: -3 lines. Test delta: +35 lines.
