### PR TITLE
fix(slack): keep bound thread replies on the routed agent

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -101,6 +101,7 @@ describe("resolveSlackThreadContextData", () => {
 
     const result = await resolveSlackThreadContextData({
       ctx,
+      agentId: "main",
       account: createSlackTestAccount({ thread: { initialHistoryLimit: 20 } }),
       message: createThreadMessage(),
       isGroupDm: params.isGroupDm ?? false,
@@ -399,6 +400,7 @@ describe("resolveSlackThreadContextData", () => {
 
     const result = await resolveSlackThreadContextData({
       ctx,
+      agentId: "main",
       account: createSlackTestAccount({ thread: { initialHistoryLimit: 20 } }),
       message: createThreadMessage(),
       isGroupDm: false,
@@ -446,6 +448,7 @@ describe("resolveSlackThreadContextData", () => {
 
     const result = await resolveSlackThreadContextData({
       ctx,
+      agentId: "main",
       account: createSlackTestAccount({ thread: { initialHistoryLimit: 1 } }),
       message: createThreadMessage(),
       isGroupDm: false,
@@ -566,6 +569,7 @@ describe("resolveSlackThreadContextData", () => {
 
     const result = await resolveSlackThreadContextData({
       ctx,
+      agentId: "main",
       account: createSlackTestAccount({ thread: { initialHistoryLimit: 20 } }),
       message: createThreadMessage({
         channel: "D123",

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -1,5 +1,4 @@
 // Slack plugin module implements prepare thread context behavior.
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import {
   formatInboundEnvelope,
   resolveInboundSupplementalSenderAllowed,
@@ -59,7 +58,7 @@ type SlackSessionResetFreshness =
 type SlackSessionFreshnessRuntime = {
   session?: {
     resolveEntryResetFreshness?: (params: {
-      defaultAgentId?: string;
+      agentId: string;
       storePath?: string;
       sessionKey: string;
       sessionCfg?: OpenClawConfig["session"];
@@ -71,6 +70,7 @@ type SlackSessionFreshnessRuntime = {
 
 function resolveSlackThreadSessionFreshness(params: {
   ctx: SlackMonitorContext;
+  agentId: string;
   storePath: string;
   sessionKey: string;
 }): SlackSessionResetFreshness | undefined {
@@ -78,7 +78,7 @@ function resolveSlackThreadSessionFreshness(params: {
   // intentionally keeps non-context helpers untyped for external plugins.
   const runtime = params.ctx.channelRuntime as SlackSessionFreshnessRuntime | undefined;
   return runtime?.session?.resolveEntryResetFreshness?.({
-    defaultAgentId: resolveDefaultAgentId(params.ctx.cfg),
+    agentId: params.agentId,
     storePath: params.storePath,
     sessionKey: params.sessionKey,
     sessionCfg: params.ctx.cfg.session,
@@ -153,6 +153,7 @@ async function resolveSlackThreadUserMap(params: {
 
 export async function resolveSlackThreadContextData(params: {
   ctx: SlackMonitorContext;
+  agentId: string;
   account: ResolvedSlackAccount;
   message: SlackMessageEvent;
   isGroupDm: boolean;
@@ -187,6 +188,7 @@ export async function resolveSlackThreadContextData(params: {
     params.isThreadReply && params.threadTs
       ? resolveSlackThreadSessionFreshness({
           ctx: params.ctx,
+          agentId: params.agentId,
           storePath: params.storePath,
           sessionKey: params.sessionKey,
         })

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -12,6 +12,7 @@ import type { SlackChannelConfigEntries } from "../channel-config.js";
 import { createSlackMonitorContext } from "../context.js";
 
 export function createInboundSlackTestContext(params: {
+  accountId?: string;
   app?: App;
   cfg: OpenClawConfig;
   appClient?: App["client"];
@@ -25,7 +26,7 @@ export function createInboundSlackTestContext(params: {
 }) {
   return createSlackMonitorContext({
     cfg: params.cfg,
-    accountId: "default",
+    accountId: params.accountId ?? "default",
     botToken: "token",
     app: params.app ?? ({ client: params.appClient ?? {} } as App),
     runtime: {} as RuntimeEnv,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1,5 +1,6 @@
 // Slack tests cover prepare plugin behavior.
 import fs from "node:fs/promises";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { App } from "@slack/bolt";
 import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/channel-contract-testing";
@@ -1230,8 +1231,13 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
   });
 
-  function createThreadSlackCtx(params: { cfg: OpenClawConfig; replies: unknown }) {
+  function createThreadSlackCtx(params: {
+    accountId?: string;
+    cfg: OpenClawConfig;
+    replies: unknown;
+  }) {
     return createInboundSlackCtx({
+      accountId: params.accountId,
       cfg: params.cfg,
       appClient: { conversations: { replies: params.replies } } as App["client"],
       defaultRequireMention: false,
@@ -1239,9 +1245,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
   }
 
-  function createThreadAccount(): ResolvedSlackAccount {
+  function createThreadAccount(accountId = "default"): ResolvedSlackAccount {
     return {
-      accountId: "default",
+      accountId,
       enabled: true,
       identity: "bot",
       botTokenSource: "config",
@@ -3900,6 +3906,49 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     } finally {
       unregisterSessionBindingAdapter({ channel: "slack", accountId: "default", adapter });
     }
+  });
+
+  it("keeps account-bound thread freshness on the routed agent", async () => {
+    const { dir } = storeFixture.makeTmpStorePath();
+    const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
+    const expectedStorePath = path.join(dir, "foundation", "sessions.json");
+    const cfg = {
+      agents: { entries: { main: {}, foundation: {} } },
+      bindings: [
+        {
+          agentId: "foundation",
+          match: { channel: "slack", accountId: "foundation" },
+        },
+        { agentId: "main", match: { channel: "slack", accountId: "*" } },
+      ],
+      session: { store: storeTemplate },
+      channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+    } as OpenClawConfig;
+    const replies = vi.fn().mockResolvedValue({
+      messages: [{ text: "starter", user: "U2", ts: "100.000" }],
+      response_metadata: { next_cursor: "" },
+    });
+    const slackCtx = createThreadSlackCtx({
+      accountId: "foundation",
+      cfg,
+      replies,
+    });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createThreadAccount("foundation"),
+      createThreadReplyMessage({
+        text: "bound thread reply",
+        ts: "101.000",
+        thread_ts: "100.000",
+      }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.route.agentId).toBe("foundation");
+    expect(prepared.turn.storePath).toBe(expectedStorePath);
   });
 
   const threadRouteScenarios = [

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1606,6 +1606,7 @@ export async function prepareSlackMessage(params: {
     threadStarterMedia,
   } = await resolveSlackThreadContextData({
     ctx,
+    agentId: route.agentId,
     account,
     message,
     isGroupDm,


### PR DESCRIPTION
Related: #114009

## What Problem This Solves

Fixes an issue where Slack thread replies could fail with `AgentSelectionRequiredError` when an account binding routed the conversation to one agent but thread freshness still tried to resolve a retired ambient default in an explicit multi-agent configuration.

The failure happens before the thread event can be adopted, so retry-eligible events remain pending and later events in the same Slack conversation lane cannot advance.

## Why This Change Was Made

The Slack route already owns the authoritative agent for the message and uses it to choose the session store. This change carries that same routed agent into thread freshness and removes the separate default-agent lookup, keeping routing, storage, and freshness on one owner boundary. It adds no config, migration, fallback, or compatibility path.

The regression coverage constructs the account-specific context from the start and exercises the complete Slack thread preparation boundary with two keyed agents, no default marker, an account-specific binding, and a wildcard fallback binding.

## User Impact

Slack thread replies in explicit multi-agent installations continue through preparation under their configured account binding instead of failing because no global default agent exists. Existing configurations do not need to change.

## Evidence

- Pre-fix regression: the new full preparation test failed with `AgentSelectionRequiredError` at the stale default-agent lookup.
- Focused proof: `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts` — 177/177 passed.
- Changed gate: `node scripts/check-changed.mjs -- extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts extensions/slack/src/monitor/message-handler/prepare-thread-context.ts extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/prepare.ts` — passed via the documented local fallback after the remote backend was unavailable.
- `git diff --check` — clean.
- Fresh structured autoreview — clean, no accepted/actionable findings.
- Production LOC: +6/-3 (net +3). Tests: +56/-3. Test support: +2/-1.
- No live Slack mutation was performed. The defect is deterministic before channel I/O and is covered at the complete Slack preparation boundary.

AI-assisted; the implementation and ownership boundary were reviewed and understood.
