### PR TITLE
fix(gateway): report draining during pending startup

### DIFF
--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -822,6 +822,24 @@ describe("gateway probe endpoints", () => {
           pendingReason: "plugin-convergence",
         });
 
+        gatewayDraining = true;
+        const drainingDuringStartup = await sendGatewayRequest(server, { path: "/startupz" });
+        expect(drainingDuringStartup.res.statusCode).toBe(503);
+        expect(JSON.parse(drainingDuringStartup.getBody())).toMatchObject({
+          ok: false,
+          status: "draining",
+          version: resolveRuntimeServiceVersion(process.env),
+          uptimeMs: expect.any(Number),
+        });
+
+        const drainingReadiness = await sendGatewayRequest(server, { path: "/readyz" });
+        expect(drainingReadiness.res.statusCode).toBe(503);
+        expect(JSON.parse(drainingReadiness.getBody())).toMatchObject({
+          ready: false,
+          failing: ["gateway-draining"],
+        });
+        gatewayDraining = false;
+
         startupPending = false;
         const started = await sendGatewayRequest(server, { path: "/startupz" });
         expect(started.res.statusCode).toBe(200);

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -43,6 +43,9 @@ const DEFAULT_READINESS_CACHE_TTL_MS = 1_000;
 export function createStartupChecker(deps: GatewayStartupStateDeps): StartupChecker {
   return (): StartupResult => {
     const uptimeMs = Date.now() - deps.startedAt;
+    if (deps.getGatewayDraining?.()) {
+      return { ok: false, status: "draining", uptimeMs };
+    }
     if (deps.getStartupPending?.()) {
       return {
         ok: false,
@@ -50,9 +53,6 @@ export function createStartupChecker(deps: GatewayStartupStateDeps): StartupChec
         uptimeMs,
         pendingReason: deps.getStartupPendingReason?.() ?? "startup-sidecars",
       };
-    }
-    if (deps.getGatewayDraining?.()) {
-      return { ok: false, status: "draining", uptimeMs };
     }
     return { ok: true, status: "started", uptimeMs };
   };


### PR DESCRIPTION
Closes #123203

## What Problem This Solves

Fixes an issue where Gateway startup/readiness probes would report `starting` instead of the terminal `draining` state when shutdown or restart began before startup sidecars completed.

## Why This Change Was Made

The shared startup checker now evaluates draining before startup-pending. This single owner decision updates both `/startupz` and `/readyz` without changing HTTP status codes, lifecycle producers, protocol shapes, configuration, storage, security boundaries, or channel readiness logic.

## User Impact

Operators and automation now see the actual terminal lifecycle state during an early shutdown: `/startupz` reports `draining`, and detailed `/readyz` reports `gateway-draining`. Basic admission behavior remains unchanged at HTTP 503.

## Evidence

- Tests-first HTTP regression failed before the repair: expected `draining`, received `starting` while both flags were true.
- Refreshed head: `db50e52095cf563c2eebff4f73f3232064e38bde`, rebased once onto captured `origin/main` `babba7124df69c886c2a1c98ee5b464ffc695f5b`; the task-owned commit replayed without conflict. GitHub currently reports the PR mergeable and not conflicting; later main movement is advisory and was not chased.
- `node scripts/run-vitest.mjs src/gateway/server-http.probe.test.ts src/gateway/server/readiness.test.ts`: 2 files, 55/55 tests passed.
- `./node_modules/.bin/oxfmt --check src/gateway/server/readiness.ts src/gateway/server-http.probe.test.ts`: passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server/readiness.ts src/gateway/server-http.probe.test.ts`: passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr-123204-rebase-core.tsbuildinfo`: passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr-123204-rebase-core-test.tsbuildinfo`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Source-aware Codex autoreview against `origin/main`: clean, no accepted/actionable findings, confidence 0.99; TruffleHog clean.
- Operator-visible HTTP contract: during the overlapping state, local `/startupz` returned 503 with `status: "draining"` and local `/readyz` returned 503 with `failing: ["gateway-draining"]`; clearing drain restored the existing startup/channel-state sequence.
- Fresh exact-head CI is green for `db50e52095cf563c2eebff4f73f3232064e38bde`: https://github.com/openclaw/openclaw/actions/runs/31745633632. One unrelated browser pixel-rounding flake (`15.999998092651367` versus `16`) passed on the failed-only retry; no source change was made. The prior `a416170148f457316f888b2a2fd7d95090b70ac7` CI run was infrastructure-cancelled before useful execution and is superseded by this exact-head run.

Production delta: +3/-3, net 0. Tests: +18.

AI-assisted: yes. The implementation and regression were reviewed against startup binding, drain lifecycle, readiness rendering, documented probe semantics, sibling readiness behavior, and the shared owner boundary.
