### PR TITLE
fix(ui): re-clicking the active nav item stacks duplicate history entries (Back appears dead)

### DIFF
--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -162,7 +162,7 @@ function routerHistoryLocation(location: ReturnType<RouterHistory["location"]>, 
   };
 }
 
-function sameRouteLocation(left: RouteLocation, right: RouteLocation): boolean {
+export function sameRouteLocation(left: RouteLocation, right: RouteLocation): boolean {
   return (
     left.pathname === right.pathname && left.search === right.search && left.hash === right.hash
   );

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -616,6 +616,40 @@ describe("normalizeInitialApplicationLocation", () => {
     }
   });
 
+  it("replaces instead of pushing when re-navigating to the active location", async () => {
+    const previousSettings = loadSettings();
+    const previousUrl = window.location.href;
+    saveSettings({
+      ...previousSettings,
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+    });
+    window.history.replaceState({}, "", "/");
+    const runtime = bootstrapApplication({ sessionPathBuilderReady: Promise.resolve() });
+    const pushState = vi.spyOn(window.history, "pushState");
+    const replaceState = vi.spyOn(window.history, "replaceState");
+
+    try {
+      await runtime.start();
+      await runtime.context.navigateAndWait("about");
+      expect(pushState).toHaveBeenCalledWith({}, "", "/settings/about");
+      pushState.mockClear();
+      replaceState.mockClear();
+
+      // Re-clicking the active nav item: no new history entry, Back stays live.
+      await runtime.context.navigateAndWait("about");
+
+      expect(pushState).not.toHaveBeenCalled();
+      expect(replaceState).toHaveBeenCalledWith({}, "", "/settings/about");
+    } finally {
+      pushState.mockRestore();
+      replaceState.mockRestore();
+      runtime.stop();
+      saveSettings(previousSettings);
+      window.history.replaceState({}, "", previousUrl);
+    }
+  });
+
   it("does not restart routing after stop wins the session-path loader race", async () => {
     const previousSettings = loadSettings();
     const previousUrl = window.location.href;

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -5,6 +5,7 @@ import {
   createApplicationRouter,
   locationForRoute,
   routeIdFromPath,
+  sameRouteLocation,
   startApplicationRouter,
   type ApplicationRouter,
   type RouteId,
@@ -460,18 +461,28 @@ export function bootstrapApplication(
   const cancelPendingGatewayConnection = () => {
     pendingGatewayConnection = null;
   };
-  const navigateAndWait = (routeId: RouteId, options?: ApplicationNavigationOptions) => {
+  const navigateWithMode = (
+    routeId: RouteId,
+    options: ApplicationNavigationOptions | undefined,
+    requested: "push" | "replace",
+  ) => {
     const location = routeLocation(routeId, options);
     // Preserve pre-start navigation exactly as the fire-and-forget entry point does.
     if (!routerStarted) {
-      pendingRouterStartNavigation = { routeId, location, mode: "push" };
+      pendingRouterStartNavigation = { routeId, location, mode: requested };
     }
-    const navigationPromise = router.navigate(routeId, context, { history: "push" }, location);
+    // Re-clicking the active nav item must not stack identical history
+    // entries: Back would appear dead until every duplicate is popped.
+    const samePage = routerStarted && sameRouteLocation(history.location(), location);
+    const historyMode = samePage ? "replace" : requested;
+    const navigationPromise = router.navigate(routeId, context, { history: historyMode }, location);
     void navigationPromise.catch((error: unknown) => {
       console.error("[openclaw] route navigation failed", error);
     });
     return navigationPromise;
   };
+  const navigateAndWait = (routeId: RouteId, options?: ApplicationNavigationOptions) =>
+    navigateWithMode(routeId, options, "push");
   const context: ApplicationContext<RouteId> = {
     basePath,
     gateway,
@@ -498,15 +509,7 @@ export function bootstrapApplication(
     },
     navigateAndWait,
     replace: (routeId, options) => {
-      const location = routeLocation(routeId, options);
-      if (!routerStarted) {
-        pendingRouterStartNavigation = { routeId, location, mode: "replace" };
-      }
-      void router
-        .navigate(routeId, context, { history: "replace" }, location)
-        .catch((error: unknown) => {
-          console.error("[openclaw] route replacement failed", error);
-        });
+      void navigateWithMode(routeId, options, "replace");
     },
     revalidate: (routeId) => router.revalidate(context, routeId),
     preload: (routeId, options) => router.preloadLocation(routeLocation(routeId, options), context),


### PR DESCRIPTION
## What Problem This Solves

Clicking the sidebar/nav item for the page you are already on pushes an identical history entry every time. A user who clicks "Chat" three times while sitting on /chat then has to press Back three extra times before anything visibly happens — Back appears dead. uirouter always applies the requested history mode before its same-match short-circuit, so every duplicate click lands in `window.history`.

## Why This Change Was Made

Root cause is in the Control UI navigation owner, not the router: `navigateAndWait` hardcoded `history: "push"` for every navigation, including no-op re-navigations to the current location. The fix computes the mode at that owner — when the router is started and the computed target equals the current history location (via the existing `sameRouteLocation` helper, now exported), push downgrades to replace. `context.replace` previously duplicated the whole navigate body with a hardcoded mode; it now flows through the same `navigateWithMode` owner, deleting the parallel copy.

## User Impact

Browser Back works after re-clicking the active nav item. No behavior change for real route changes (still push) or explicit replaces.

## Evidence

- Regression test `ui/src/app/bootstrap.test.ts` "replaces instead of pushing when re-navigating to the active location": fails pre-fix (pushState called twice), passes post-fix (second navigation calls replaceState, no pushState).
- Focused suites green: `ui/src/app/bootstrap.test.ts` (32), `ui/src/app-navigation.test.ts` + `ui/src/app-routes.test.ts` + `ui/src/pages/new-session/draft-submission-flow.test.ts` (79).
- Typecheck: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json` clean.
- Autoreview (codex/gpt-5.6-sol, high): clean, 0.99, no actionable findings.
- Production LOC: +15/−12 in bootstrap.ts (net +3, absorbed the duplicated replace body), +1/−1 export in app-routes.ts; tests +34.

Reproduced live during the web-UI QA campaign (dev gateway, real Control UI session).
