### PR TITLE
fix(release): validate frozen packages with trusted harness pnpm

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2353,7 +2353,7 @@ jobs:
           echo "Validating Docker E2E package tarball: $target"
           validator=(node scripts/check-openclaw-package-tarball.mjs)
           if [[ -n "${EXPECTED_PACKAGE_FILE_NAME// }" ]]; then
-            validator=(pnpm --dir .release-harness exec node scripts/check-openclaw-package-tarball.mjs)
+            validator=(bash -c 'cd .release-harness && pnpm exec node scripts/check-openclaw-package-tarball.mjs "$1"' --)
           fi
           started_at="$(date +%s)"
           timeout --foreground 5m "${validator[@]}" "$GITHUB_WORKSPACE/$target"

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -715,6 +715,11 @@ describe("release validation no-push transport", () => {
     expect(validatePackage.run).toContain("package/dist/build-info.json");
     expect(validatePackage.run).toContain('[[ "$package_source_sha" == "$SELECTED_SHA" ]]');
     expect(validatePackage.run).toContain("scripts/check-openclaw-package-tarball.mjs");
+    expect(validatePackage.run).toContain(
+      "cd .release-harness && pnpm exec node scripts/check-openclaw-package-tarball.mjs",
+    );
+    expect(validatePackage.run).toContain('"$GITHUB_WORKSPACE/$target"');
+    expect(validatePackage.run).not.toContain("pnpm --dir .release-harness");
     const targetedRun = step(
       job(workflow, "validate_docker_lanes"),
       "Run targeted Docker E2E lanes",


### PR DESCRIPTION
## What Problem This Solves

Fixes a release-validation failure when the trusted `main` harness validates a frozen candidate whose pnpm pin differs from `main`.

## Why This Change Was Made

The release harness already installs its own pinned pnpm. The validator now starts from that harness directory, so Corepack resolves the same pinned package manager before the validator receives the immutable candidate tarball path.

## User Impact

Release maintainers can validate older or extended-stable candidate packages with the current trusted release workflow even when their pnpm pins differ from `main`. This does not alter candidate bytes, release refs, tags, or npm state.

## Evidence

- Reproduces the failure from [Plugin Prerelease job 94457196850](https://github.com/openclaw/openclaw/actions/runs/31702691003/job/94457196850): Corepack selected frozen target pnpm 11.2.2 before `pnpm --dir .release-harness` applied the harness’s 11.15.1 directory, which pnpm correctly rejected.
- The failing job had already verified the downloaded artifact digest and immutable candidate tuple: source `fdc1c2e6c1b5f41d00edb2eb55244fa7c51f87dd`, version `2026.6.35`.
- `node scripts/run-vitest.mjs test/scripts/release-no-push-workflow.test.ts` (15 passed)
- `actionlint .github/workflows/openclaw-live-and-e2e-checks-reusable.yml`
- `node_modules/.bin/oxfmt --check test/scripts/release-no-push-workflow.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` — clean, no accepted/actionable findings.
