### PR TITLE
fix(gateway): models.list returns empty forever while chat works (owner binding-flag mismatch)

### DIFF
--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -97,10 +97,13 @@ describe("prepared model runtime owner selection", () => {
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
   });
 
-  it("resolves a gateway-published owner only for requests carrying the binding flag", async () => {
+  it("resolves a gateway-published owner for readers that omit the binding flag", async () => {
     // Gateway startup publishes configured owners with allowGatewaySubagentBinding,
-    // and that flag is part of the owner key. A request that omits it matches no
-    // owner, and standalone activation stays refused while the lifecycle is active.
+    // a publication-time build capability. Readers (models.list, catalog loads)
+    // cannot know it, so an absent flag is a wildcard in fallback resolution;
+    // requiring equality made every flagless read miss the configured owner and
+    // rebuild a live ephemeral catalog per request. A reader that explicitly
+    // demands binding still never receives a non-binding owner.
     mocks.configuredAgentIds = ["default"];
     const config = retainLegacyDefaultAgentId(
       { agents: { defaults: { model: "openai/gpt-5.5" }, entries: { default: {} } } },
@@ -123,9 +126,31 @@ describe("prepared model runtime owner selection", () => {
     await expect(
       loadPreparedModelRuntimeSnapshot({ ...request, allowGatewaySubagentBinding: true }),
     ).resolves.toMatchObject({ config });
-    await expect(loadPreparedModelRuntimeSnapshot(request)).rejects.toThrow(
-      "prepared model runtime owner was not published",
+    await expect(loadPreparedModelRuntimeSnapshot(request)).resolves.toMatchObject({ config });
+  });
+
+  it("does not resolve a binding-demanding reader against a non-binding owner", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = retainLegacyDefaultAgentId(
+      { agents: { defaults: { model: "openai/gpt-5.5" }, entries: { default: {} } } },
+      "default",
     );
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      catalogMode: "static",
+      gatewayLifecycle: true,
+      defaultWorkspaceDir: "/tmp/gateway-launch-workspace",
+    });
+
+    await expect(
+      prepareModelRuntimeSnapshot({
+        config,
+        agentId: "default",
+        agentDir: "/tmp/unused-agent",
+        inheritedAuthDir: "/tmp/unused-agent",
+        workspaceDir: "/tmp/gateway-launch-workspace",
+        allowGatewaySubagentBinding: true,
+      }),
+    ).rejects.toThrow("prepared model runtime owner was not published");
   });
 
   it("reuses the configured owner for its prepared plugin harness selections", async () => {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -289,7 +289,13 @@ export function resolvePublishedOwner(
       owner.input.inheritedAuthDir === input.inheritedAuthDir &&
       owner.input.readOnly === input.readOnly &&
       owner.input.skipCredentials === input.skipCredentials &&
-      owner.input.allowGatewaySubagentBinding === input.allowGatewaySubagentBinding &&
+      // Binding is a publication-time build capability readers cannot know;
+      // absent (= undefined after normalization) is a wildcard like the
+      // clauses below. Requiring equality made every flagless gateway reader
+      // (models.list, catalog loads) miss the configured owner and silently
+      // rebuild a live ephemeral catalog per request.
+      (input.allowGatewaySubagentBinding === undefined ||
+        owner.input.allowGatewaySubagentBinding === input.allowGatewaySubagentBinding) &&
       (input.runtimePluginSelections === undefined ||
         JSON.stringify(owner.input.runtimePluginSelections) ===
           JSON.stringify(input.runtimePluginSelections)) &&

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -125,18 +125,9 @@ function captureGenerationFacts(deps: ChatMetadataRuntimeDeps): PreparedGenerati
   const config = deps.getConfig();
   const agents = listAgentIds(config).map((rawAgentId): PreparedAgentFacts => {
     const agentId = normalizeAgentId(rawAgentId);
-    const owner =
-      deps.getPreparedOwner({
-        agentId,
-        config,
-        readOnly: true,
-        allowGatewaySubagentBinding: true,
-      }) ??
-      deps.getPreparedOwner({
-        agentId,
-        config,
-        readOnly: true,
-      });
+    // Flagless resolution reaches the configured owner regardless of its
+    // publication-time gateway-binding capability.
+    const owner = deps.getPreparedOwner({ agentId, config, readOnly: true });
     if (!owner) {
       throw new ChatMetadataSnapshotUnavailableError(
         `prepared chat metadata owner is unavailable for agent "${agentId}"`,


### PR DESCRIPTION
## What Problem This Solves

The Control UI composer permanently shows "No models available" (model/thinking/effort pickers dead) while chat itself works fine. `models.list` returns `{"models":[]}` on every call; `view=all` takes ~73 seconds. The gateway also burns CPU rebuilding a full live model catalog from scratch on every models.list / attachment / session-create request. Doctrine-class silent failure: the UI dead-ends contradicting real capability, with only a one-time debug log explaining why.

## Why This Change Was Made

Owner-identity mismatch. Gateway startup publishes the configured prepared-model owner for each agent with `allowGatewaySubagentBinding: true`, which entered the owner key in #117587. Catalog readers (`server-model-catalog.ts` and every consumer of `loadGatewayModelCatalogSnapshot`) resolve flagless. `resolvePublishedOwner`'s configured-owner fallback — designed exactly for readers that don't know launch facts — treats `workspaceDir`, `env`, and `runtimePluginSelections` as wildcards when absent, but required exact equality on the binding flag. Result: every read missed the published catalog, fell to a fresh **live** ephemeral rebuild (750 ms browse race → empty; ephemeral owner deleted on lease release, so it repeats forever).

The tell: chat metadata already worked around this same seam with a dual lookup (with-flag then without, #119369). This fixes the seam at its owner instead: absent flag = wildcard in the fallback, mirroring the adjacent clauses. A reader that explicitly demands binding still never resolves a non-binding owner (`true !== false` fails). The chat-metadata dual-lookup workaround is deleted.

## User Impact

The composer model picker works. models.list responds instantly from the prepared catalog instead of rebuilding live per request. The startup "chat metadata refresh failed" warn class loses its second trigger. Affected siblings all recover through the same owner: chat-send-attachments, sessions-create, sessions-patch-engine, nodes.event, optional-model-catalog, session-utils-model.

## Evidence

- **Live before/after**: two gateways from the same state dir (OpenAI API key, agent `main`, model openai/gpt-5.6-luna). Unfixed baseline (2278ca6952ea): `gateway call models.list` → `{"models": []}`. This branch's dist: `{"models":[{"id":"gpt-5.6-luna","provider":"openai","available":true}]}`.
- Regression `prepared-model-runtime.owner-selection.test.ts` "resolves a gateway-published owner for readers that omit the binding flag": fails pre-fix (owner not published), passes post-fix. New sibling test pins that a binding-demanding reader never resolves a non-binding owner.
- Suites green: prepared-model-runtime* + prepared-model-catalog* + chat-metadata-runtime (7 files, 130 tests).
- Typecheck `tsconfig.core.test.json` clean. Autoreview (codex/gpt-5.6-sol, high): clean, 0.98.
- Production LOC: owner.ts +7/−1 (comment-heavy; logic is one wildcard clause), chat-metadata-runtime.ts +3/−12. Net −3 production.

Found and root-caused during the web-UI QA campaign (dev gateway, real Control UI sessions).


### UI before/after (same state dir, real Control UI, OpenAI key)

Before (baseline gateway, composer dead):

![No models available](https://github.com/user-attachments/assets/35777047-0b48-4208-855f-7be0cb636db4)

After (this branch's dist, picker shows GPT-5.6 Luna):

![GPT-5.6 Luna available](https://github.com/user-attachments/assets/9ae59d16-e247-4910-9631-d6f4172c4231)
