### PR TITLE
fix(ui): escape tool-policy glob patterns correctly in the Control UI

### DIFF
--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -13,7 +13,9 @@ import {
 import {
   buildAgentContext,
   formatBytes,
+  isAllowedByPolicy,
   listSelectableAgents,
+  matchesList,
   normalizeAgentLabel,
   normalizeAgentTargetLabel,
   resolveEffectiveModelFallbacks,
@@ -425,5 +427,30 @@ describe("buildAgentContext", () => {
 
     expect(context.identityName).toBe("大颖");
     expect(context.identityAvatar).toBe("⚙️");
+  });
+});
+
+describe("tool policy glob matching", () => {
+  it("matches trailing-star globs against dotted tool names", () => {
+    expect(matchesList("exec.command", ["exec*"])).toBe(true);
+    expect(matchesList("exec", ["exec*"])).toBe(true);
+    expect(matchesList("web_search", ["web_*"])).toBe(true);
+    expect(matchesList("web_search", ["exec*"])).toBe(false);
+  });
+
+  it("treats regex metacharacters in patterns literally", () => {
+    expect(matchesList("a.b", ["a.b"])).toBe(true);
+    expect(matchesList("axb", ["a.b"])).toBe(false);
+    expect(matchesList("foo.bar", ["foo*.bar"])).toBe(true);
+    expect(matchesList("fooX.bar", ["foo*.bar"])).toBe(true);
+    expect(matchesList("fooXbar", ["foo*.bar"])).toBe(false);
+    expect(matchesList("fooXbaz", ["foo*.bar"])).toBe(false);
+  });
+
+  it("applies deny globs in isAllowedByPolicy", () => {
+    expect(isAllowedByPolicy("web_search", { deny: ["web_*"] })).toBe(false);
+    expect(isAllowedByPolicy("exec.command", { deny: ["web_*"] })).toBe(true);
+    expect(isAllowedByPolicy("exec.command", { allow: ["exec*"] })).toBe(true);
+    expect(isAllowedByPolicy("web_fetch", { allow: ["exec*"] })).toBe(false);
   });
 });

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -9,6 +9,7 @@ import {
   normalizeToolPolicyName,
   resolveToolProfilePolicy,
 } from "../../../../src/agents/tool-policy-shared.js";
+import { escapeRegExp } from "../../../../src/shared/regexp.js";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -658,7 +659,7 @@ function compilePattern(pattern: string): CompiledPattern {
   if (!normalized.includes("*")) {
     return { kind: "exact", value: normalized };
   }
-  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
+  const escaped = escapeRegExp(normalized);
   return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
 }
 

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -4,6 +4,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 // Control UI module implements session display behavior.
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { escapeRegExp } from "../../../src/shared/regexp.js";
 import { t } from "../i18n/index.ts";
 
 const CHANNEL_LABELS: Record<string, string> = {
@@ -219,7 +220,7 @@ export function resolveSessionDisplayName(
       kind === "automation"
         ? rawName.replace(/^cron(\s+job)?:\s*/i, "").trim() || rawName
         : rawName;
-    const prefixPattern = new RegExp(`^${prefix.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\s*`, "i");
+    const prefixPattern = new RegExp(`^${escapeRegExp(prefix)}\\s*`, "i");
     if (kind === "subagent" && options.includeSubagentPrefix === false) {
       return name.replace(prefixPattern, "").trim() || fallbackName;
     }


### PR DESCRIPTION
## Summary

fix(ui): escape tool-policy glob patterns correctly in the Control UI so the agents panel matches what the gateway actually enforces

## What Problem This Solves

The Control UI agents panel compiles tool-policy glob patterns (`allow`/`deny`/`alsoAllow`, e.g. `exec*`, `web_*`) into regular expressions to display which tools are allowed or denied. The escape step uses a malformed character class:

```ts
// ui/src/lib/agents/display.ts
const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
```

The intended idiom is `/[.*+?^${}()|[\]\\]/g` (used correctly in 60+ places across the repo, including `src/shared/regexp.ts` and the gateway-side `src/agents/glob-pattern.ts`). Here the last three tokens are transposed (`[\\]\\]` instead of `[\]\\]`), so the regex actually matches "special char + `\` + `]`" — a three-character sequence that **never occurs in normal glob patterns**. Consequences:

- Regex escaping never happens: `escaped === normalized`.
- `replaceAll("\\*", ".*")` looks for a literal `\*`, which also never occurs (the `*` was never escaped), so no glob-to-regex conversion happens either.
- The final "compiled regex" is just the raw glob text anchored with `^...$`.

**代码证据**: `ui/src/lib/agents/display.ts:645` (and the same typo at `ui/src/lib/session-display.ts:222`).

Measured with the real function (see proof below):

- `matchesList("exec.command", ["exec*"])` → **false** (gateway: allowed) — `*` becomes a quantifier on `c`, so `^exec*$` matches `exe`/`exec` but nothing with a suffix.
- `matchesList("web_search", { deny: ["web_*"] })` → shown as **allowed** (gateway: denied).
- `foo*.bar` compiles to `^foo*.bar$` where `.` is regex any-char, so it also matches `fooXbar` — **over-matching**.

Trigger condition: any tool policy containing `*` (a documented, common pattern) viewed in the agents panel Tools/Skills page.

## Root Cause

- Introduced with the Control UI refactor in commit `65e12328aa2` (2026-07-04); the typo has been there since the file was created. `display.test.ts` had zero coverage of `matchesList`/`isAllowedByPolicy`, which is why it went unnoticed.
- Violated invariant: the UI's policy display must agree with the gateway's enforcement semantics (`src/agents/glob-pattern.ts`, which escapes correctly). A security-policy UI that disagrees with enforcement is worse than no UI.

## Why This Fix

- Option A: correct the character class in place (`[\]\\]`). Works, but keeps a third handwritten copy of the idiom — exactly how this typo happened.
- Option B (chosen): reuse the shared `escapeRegExp` from `src/shared/regexp.js`, already imported by other UI modules (`chat/heartbeat-display.ts`, `chat-thread-items.ts`). One canonical implementation, no chance of re-transposing. The escaped `\*` is then converted to `.*` by the existing `replaceAll`, preserving current glob semantics exactly.
- The same typo in `session-display.ts:222` (prefix stripping for session names) is fixed the same way; it is currently latent (built-in prefixes contain no regex metacharacters) but would throw on `new RegExp` for any locale whose translation contains `[`/`(`.

## User Impact

- Affected scenarios: agents panel Tools/Skills display for any agent whose tool policy uses `*` globs.
- Before: allow/deny states shown in the UI can be the opposite of what the gateway enforces — e.g. a user who configured `deny: ["web_*"]` sees `web_search` as "allowed" and may loosen a policy that was actually working.
- After: the panel renders the same verdicts as the gateway.
- Behavior change: display-only; no enforcement path changes.

## Real Behavior Proof

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-ui-tool-policy-glob.mjs
FAIL matchesList(exec.command, ["exec*"]) = false (expected true) [trailing-star glob matches dotted child]
FAIL matchesList(web_search, ["web_*"]) = false (expected true) [underscore glob]
FAIL matchesList(fooX.bar, ["foo*.bar"]) = false (expected true) [glob middle with literal dot]
FAIL matchesList(fooXbar, ["foo*.bar"]) = true (expected false) [glob still requires literal dot]
FAIL isAllowedByPolicy(web_search, {deny:["web_*"]}) = true (expected false) [deny glob enforced]
RESULT: 5 FAILURES (bug present)
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-ui-tool-policy-glob.mjs
PASS matchesList(exec.command, ["exec*"]) = true
PASS matchesList(web_search, ["web_*"]) = true
PASS matchesList(fooX.bar, ["foo*.bar"]) = true
PASS matchesList(fooXbar, ["foo*.bar"]) = false
PASS isAllowedByPolicy(web_search, {deny:["web_*"]}) = false
RESULT: ALL PASS
```

The proof imports the real `matchesList`/`isAllowedByPolicy` from `ui/src/lib/agents/display.ts` (Node v24, tsx) — no mocks.

## Tests and Validation

- `npx vitest run ui/src/lib/agents/display.test.ts ui/src/lib/session-display.test.ts` — 43/43 passed, including a new `tool policy glob matching` block: trailing-star globs, literal-metacharacter handling, and deny-glob enforcement.
- `npx oxlint --deny=warn` on all changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
