### PR TITLE
fix(doctor): migrate skill workshop proposals under multi-agent configs without a default marker

### DIFF
--- a/src/commands/doctor-skill-workshop-sqlite.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.test.ts
@@ -389,4 +389,74 @@ describe("doctor Skill Workshop SQLite migration", () => {
     ]);
     await expect(fs.access(path.join(ambiguousDir, "proposal.json"))).resolves.toBeUndefined();
   });
+
+  it("migrates a proposal under a multi-agent config without a default marker", async () => {
+    // Regression for BUG-055: configuredAgentIds previously called the deprecated
+    // resolveDefaultAgentId, which throws AgentSelectionRequiredError whenever more
+    // than one agent is configured without a sole default marker. That crash escaped
+    // migrateProposal as a per-proposal warning, silently skipping every legacy
+    // proposal during `openclaw doctor` repair.
+    const mainWorkspace = await tempDirs.make("openclaw-workshop-multi-main-");
+    const otherWorkspace = await tempDirs.make("openclaw-workshop-multi-other-");
+    const proposalId = "multi-agent-workshop-20260813-1234567890";
+    const proposalDir = path.join(testState.stateDir, "skill-workshop", "proposals", proposalId);
+    const targetDir = path.join(otherWorkspace, "skills", "multi-agent-workshop");
+    const now = "2026-08-13T00:00:00.000Z";
+    const content = renderProposalMarkdown({
+      name: "multi-agent-workshop",
+      description: "Migrate under a multi-agent config with no default marker",
+      content: "# Multi-Agent Workshop\n\nOwner inferred from workspace.\n",
+      date: now,
+    });
+    const record: SkillProposalRecord = {
+      schema: SKILL_WORKSHOP_SCHEMA,
+      id: proposalId,
+      kind: "create",
+      status: "pending",
+      title: "Create Multi-Agent Workshop",
+      description: "Migrate under a multi-agent config with no default marker",
+      createdAt: now,
+      updatedAt: now,
+      createdBy: "cli",
+      // No origin.agentId or origin.sessionKey: forces inferOwnerAgentId through the
+      // configuredAgentIds + workspace-match path that previously crashed.
+      origin: { runId: "multi-agent-run" },
+      originRunIds: ["multi-agent-run"],
+      originRunMutationCounts: { "multi-agent-run": 1 },
+      proposedVersion: "v1",
+      draftFile: "PROPOSAL.md",
+      draftHash: hashSkillProposalContent(content),
+      target: {
+        skillName: "Multi-Agent Workshop",
+        skillKey: "multi-agent-workshop",
+        skillDir: targetDir,
+        skillFile: path.join(targetDir, "SKILL.md"),
+        source: "openclaw-workspace",
+      },
+      scan: {
+        state: "clean",
+        scannedAt: now,
+        critical: 0,
+        warn: 0,
+        info: 0,
+        findings: [],
+      },
+    };
+    await fs.mkdir(proposalDir, { recursive: true });
+    await fs.writeFile(path.join(proposalDir, "proposal.json"), JSON.stringify(record), "utf8");
+    await fs.writeFile(path.join(proposalDir, "PROPOSAL.md"), content, "utf8");
+
+    const result = await migrateLegacySkillWorkshopProposals({
+      config: {
+        agents: {
+          entries: {
+            main: { workspace: mainWorkspace },
+            other: { workspace: otherWorkspace },
+          },
+        },
+      },
+    });
+    expect(result).toMatchObject({ detected: 1, migrated: 1, warnings: [] });
+    await expect(fs.access(path.join(proposalDir, "proposal.json"))).rejects.toThrow();
+  });
 });

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
+  tryResolveSoleAgentId,
 } from "../agents/agent-scope.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -51,9 +51,7 @@ function proposalWorkspace(record: SkillProposalRecord): string {
 }
 
 function configuredAgentIds(config: OpenClawConfig): string[] {
-  return [
-    ...new Set([resolveDefaultAgentId(config), ...listAgentIds(config)].map(normalizeAgentId)),
-  ];
+  return [...new Set(listAgentIds(config).map(normalizeAgentId))];
 }
 
 function inferOwnerAgentId(params: {
@@ -69,7 +67,7 @@ function inferOwnerAgentId(params: {
     try {
       return resolveAgentIdFromSessionKey(
         params.record.origin.sessionKey,
-        resolveDefaultAgentId(params.config),
+        tryResolveSoleAgentId(params.config),
       );
     } catch {
       // Fall through to the workspace and single-agent evidence below.


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor` repair silently skipped every legacy Skill Workshop proposal when more than one agent was configured without a sole default marker. This PR makes the migration run to completion by inferring the owning agent from workspace evidence instead of crashing on default-agent resolution.

- **Problem**: `configuredAgentIds` in `src/commands/doctor-skill-workshop-sqlite.ts` called the deprecated `resolveDefaultAgentId(config)`, which throws `AgentSelectionRequiredError` whenever multiple agents are configured without a single `default: true` marker. The throw escaped `migrateProposal` and was caught by `migrateLegacySkillWorkshopProposals`'s per-proposal `catch`, which converted it into a warning — so `migrated` stayed `0` and every legacy proposal was silently skipped during `openclaw doctor` repair, with the legacy JSON sidecars left on disk.
- **Solution**: drop `resolveDefaultAgentId` from `configuredAgentIds` (its return value is always a subset of `listAgentIds`, so it was redundant once de-duplicated) and switch `inferOwnerAgentId`'s session-key fallback to `tryResolveSoleAgentId` (returns `undefined` instead of throwing; the existing `try/catch` fall-through preserves behavior).
- **What changed**:
  - `src/commands/doctor-skill-workshop-sqlite.ts` — import `tryResolveSoleAgentId` instead of `resolveDefaultAgentId`; `configuredAgentIds` now returns `[...new Set(listAgentIds(config).map(normalizeAgentId))]`; session-key fallback uses `tryResolveSoleAgentId`.
  - `src/commands/doctor-skill-workshop-sqlite.test.ts` — new regression test "migrates a proposal under a multi-agent config without a default marker".
- **What did NOT change**: the SQLite import path, rollback verification, legacy JSON removal, and the single-agent / legacy-empty-config behavior (still resolved via `listAgentIds`'s `LEGACY_IMPLICIT_AGENT_ID` fallback).

## Why This Change Was Made

The deprecated `resolveDefaultAgentId` is the wrong tool for a migration that already enumerates all configured agents: it exists to pick *one* owner for ambient work and throws when no sole owner exists. `configuredAgentIds` only needed the full roster, which `listAgentIds` already returns. Prefixing `resolveDefaultAgentId` into the `Set` contributed nothing (its result is always a member of `listAgentIds`) while turning every multi-agent-without-default repair into a silent no-op.

- **Best fix**: yes — removing the redundant throwing call is strictly better than wrapping it in `try/catch`, because the call had no effect on the returned set.
- **Alternative**: wrap `resolveDefaultAgentId` in `try/catch` and fall back to `listAgentIds`. Rejected — it preserves a useless deprecated call and hides the intent.
- **Risk**: none expected. `resolveDefaultAgentId(config)`'s return value is always either the sole default-marked agent or `resolveSoleAgentId`'s result — both are already present in `listAgentIds(config)`, so the `Set` output is identical for every config that did not previously throw. The session-key fallback change is behavior-preserving: `resolveAgentIdFromSessionKey`'s second parameter is `configuredDefaultAgentId?: string` (optional), and when no session-key agent id and no sole default exist it throws, which the surrounding `try/catch` already swallows to fall through to the workspace-match path.

This aligns with the merged fix in #123045 (`fix(doctor): stop after failed config migration writes`), which replaced `resolveDefaultAgentId` with `tryResolveSoleAgentId` across `doctor-core-checks` for the same class of regression. That PR did not touch `doctor-skill-workshop-sqlite.ts`; this PR covers the remaining Doctor path.

## User Impact

Operators running `openclaw doctor` on an explicit multi-agent installation (no single `default: true` agent) now get their legacy Skill Workshop proposals migrated into shared SQLite as intended, instead of the migration silently producing zero migrations and leaving stale `skill-workshop/proposals/*/proposal.json` sidecars behind. Single-agent and legacy configurations are unaffected.

## Evidence

- **Real environment tested**: Linux x86_64, Node v22.22.3, branch `fix/doctor-skill-workshop-multagent-crash-bug-055`, base `843017073cc`, head `804ebf5861e`.
- **Live command verification** — direct `node`/`tsx` exercise of the changed primitive against three multi-agent configs (proof script replicates `configuredAgentIds` from origin/main source and runs the real `agent-scope` module):

  ```console
  $ node --import tsx -e '<replicated configuredAgentIds + 3 multi-agent configs>'
  === PRE-FIX behavior (origin/main configuredAgentIds) ===
  CRASH [multi-agent, NO default marker] -> AgentSelectionRequiredError: Multiple agents are configured, but this operation has no explicit owner. ...
         listAgentIds alone        -> ["alpha","beta"]
         tryResolveSoleAgentId     -> undefined
  CRASH [multi-agent, TWO defaults]      -> AgentSelectionRequiredError: Multiple agents are configured, ...
         listAgentIds alone        -> ["alpha","beta"]
  CRASH [multi-agent, ownership explicit]-> AgentSelectionRequiredError: Multiple agents are configured, ...
         listAgentIds alone        -> ["alpha","beta"]
  SUMMARY: 3/3 configs CRASH on origin/main configuredAgentIds
  ```

  Post-fix (same primitive with the fix applied):

  ```console
  === POST-FIX behavior ===
  PASS  [multi-agent, NO default marker] -> ["alpha","beta"]
  PASS  [multi-agent, TWO defaults]      -> ["alpha","beta"]
  PASS  [multi-agent, ownership explicit]-> ["alpha","beta"]
  PASS  [single agent (regression)]      -> ["solo"]
  PASS  [legacy empty config (regression)] -> ["main"]
  SUMMARY (POST-FIX): 0/5 configs crash (expect 0)
  ```

- **Behavior matrix**:

  ```text
  input form                              => pre-fix result                              => post-fix result
  multi-agent, no default marker          => throw AgentSelectionRequiredError           => ["alpha","beta"]
  multi-agent, two defaults               => throw AgentSelectionRequiredError           => ["alpha","beta"]
  multi-agent, ownership explicit         => throw AgentSelectionRequiredError           => ["alpha","beta"]
  single agent (default marker)           => ["solo"] (ok)                               => ["solo"] (unchanged)
  legacy empty config {}                  => ["main"] (ok)                               => ["main"] (unchanged)
  ```

- **Pre-fix (source reverted via `git stash push -- src/commands/doctor-skill-workshop-sqlite.ts`, test kept)** — the new regression test fails on unmodified origin/main, proving it guards the real bug:

  ```console
  $ npx vitest run src/commands/doctor-skill-workshop-sqlite.test.ts -t "migrates a proposal under a multi-agent config without a default marker"
   FAIL  doctor Skill Workshop SQLite migration > migrates a proposal under a multi-agent config without a default marker
   AssertionError: expected { changes: [], …(3) } to match object { detected: 1, migrated: 1, …(1) }
   - Expected
   + Received
     {
       "detected": 1,
   -   "migrated": 1,
   -   "warnings": [],
   +   "migrated": 0,
   +   "warnings": [
   +     "Failed to migrate Skill Workshop proposal multi-agent-workshop-20260813-1234567890: AgentSelectionRequiredError: Multiple agents are configured, but this operation has no explicit owner. ...",
   +   ],
     }
    Test Files  1 failed (1)
         Tests  1 failed | 3 skipped (4)
  ```

- **Evidence after fix**:

  ```console
  $ npx vitest run src/commands/doctor-skill-workshop-sqlite.test.ts
   Test Files  1 passed (1)
        Tests  4 passed (4)
  ```

- **Observed result after fix**: the multi-agent-without-default config now migrates the proposal (`detected: 1, migrated: 1, warnings: []`) and removes the legacy `proposal.json` sidecar, instead of emitting an `AgentSelectionRequiredError` warning and leaving the sidecar on disk.
- **What was not tested**: an end-to-end `openclaw doctor` CLI run against a real multi-agent state directory (the migration function is exercised directly via its public entry point with a real on-disk proposal dir and SQLite state, which is the same surface the CLI calls).
- **Open PR collision check**: searched open PRs by topic (`doctor-skill-workshop-sqlite`, `configuredAgentIds`) and scanned changed-file lists; no open PR touches `src/commands/doctor-skill-workshop-sqlite.ts`. The related canonical PR #123045 (merged) fixed the same `resolveDefaultAgentId → tryResolveSoleAgentId` regression in `doctor-core-checks` but did not cover this file — not a duplicate.

### Regression test plan

- Existing path covered by pre-existing test `"imports verified sidecars, preserves review artifacts, and removes legacy JSON"` (multi-agent *with* a default marker — unchanged, still passes).
- New path covered by new test `"migrates a proposal under a multi-agent config without a default marker"` (multi-agent *without* a default marker; owner inferred from workspace match).
- Edge case `origin.sessionKey` present without a sole default: handled by `tryResolveSoleAgentId` returning `undefined`, `resolveAgentIdFromSessionKey` throwing, and the existing `try/catch` falling through to workspace matching — behavior identical to pre-fix for configs that did not crash.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude Code (glm-5.2 model)
- Prompts / session excerpts: Local `local-code-analysis` skill `fix:BUG-055` flow — root-cause analysis of `configuredAgentIds` calling deprecated `resolveDefaultAgentId`, alignment with merged #123045, node proof + pre-fix/post-fix vitest guard. Full session available on request.
- Confirmed understanding of code changes: Yes — every line of the diff is explained in "Why This Change Was Made"; the redundancy of `resolveDefaultAgentId` in the `Set` and the behavior-preserving nature of the session-key fallback switch are both justified.
- autoreview: N/A (no local autoreview skill run).
