### PR TITLE
test(gateway): remove duplicate session-host projection

### DIFF
--- a/src/gateway/server-methods/environments.test.ts
+++ b/src/gateway/server-methods/environments.test.ts
@@ -218,7 +218,7 @@ afterEach(() => vi.restoreAllMocks());
 
 describe("environment gateway methods", () => {
   it("projects live node session-host capability without a worker service", async () => {
-    vi.mocked(isNodeRunnerSessionHost).mockReturnValue(true);
+    vi.mocked(isNodeRunnerSessionHost).mockImplementation(({ nodeId }) => nodeId === "node-live");
     const [ok, payload] = await callEnvironmentMethod("environments.list", {});
 
     expect(ok).toBe(true);
@@ -258,18 +258,6 @@ describe("environment gateway methods", () => {
         },
       ],
     });
-  });
-
-  it("marks only the current worker-build node as a session host", async () => {
-    vi.mocked(isNodeRunnerSessionHost).mockImplementation(({ nodeId }) => nodeId === "node-live");
-
-    const [ok, payload] = await callEnvironmentMethod("environments.list", {});
-
-    expect(ok).toBe(true);
-    const environments = (payload as { environments: Array<{ id: string; sessionHost?: boolean }> })
-      .environments;
-    expect(environments.find((entry) => entry.id === "node:node-live")?.sessionHost).toBe(true);
-    expect(environments.find((entry) => entry.id === "node:node-offline")?.sessionHost).toBe(false);
   });
 
   it("preserves never-connected and clean-disconnect history for offline nodes", async () => {


### PR DESCRIPTION
## What Problem This Solves

A newly landed `environments.list` test repeated the session-host projection already covered by the stronger full-response owner test immediately above it. Its fixture has only one connected node, so the separate assertion that the offline paired node is not a session host never exercises the session-host predicate.

## Why This Change Was Made

The retained full-response test now uses the node-ID-selective predicate from the later test. It continues to prove the complete environment projection:

- the connected `node-live` row is available and a session host;
- the paired-only `node-offline` row is unavailable and not a session host;
- the Gateway row and capabilities remain unchanged.

The strict-subset replay is deleted. No production or shared test-support code changes.

## User Impact

No user-visible behavior change. The same Gateway environment contract remains covered with one fewer duplicated setup and request.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/environments.test.ts`: 33/33 tests passed after rebasing onto current `main` and retaining its new offline-history regression.
- Exact changed-file plan passed locally: formatting, core test types, lint, dead-code, dependency, plugin-boundary, and policy guards. Remote delegation did not start because the selected local Crabbox binary failed its basic sanity probe.
- Structured autoreview passed with no actionable findings.
- `git diff --check` passed.
- Tests only: +1/-13, net -12.

AI-assisted: yes. The deletion was verified against the complete production owner, connected-node fixture, predicate owner, sibling status coverage, CI routing, and introduction history.
