### PR TITLE
fix(release): print post-update config diagnostics

### DIFF
--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -467,6 +467,9 @@ if [ "$update_status" -ne 0 ]; then
   echo "openclaw update failed" >&2
   openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.err >&2
   openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json >&2
+  openclaw_e2e_maybe_timeout "$command_timeout" openclaw config validate --json >/tmp/openclaw-upgrade-survivor-post-update-validate.json 2>/tmp/openclaw-upgrade-survivor-post-update-validate.err || true
+  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.err >&2
+  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.json >&2
   exit "$update_status"
 fi
 if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3287,6 +3287,8 @@ if (starts === 1) {
     expectTextToIncludeAll(runner, [
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.err",
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json",
+      "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.err",
+      "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.json",
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-doctor.log",
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-status.err",
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-status.json",
@@ -3297,6 +3299,8 @@ if (starts === 1) {
 
     expect(runner).not.toContain("cat /tmp/openclaw-upgrade-survivor-update.err");
     expect(runner).not.toContain("cat /tmp/openclaw-upgrade-survivor-update.json");
+    expect(runner).not.toContain("cat /tmp/openclaw-upgrade-survivor-post-update-validate.err");
+    expect(runner).not.toContain("cat /tmp/openclaw-upgrade-survivor-post-update-validate.json");
     expect(runner).not.toContain("cat /tmp/openclaw-upgrade-survivor-doctor.log");
     expect(runner).not.toContain("cat /tmp/openclaw-upgrade-survivor-status.err");
     expect(runner).not.toContain("cat /tmp/openclaw-upgrade-survivor-status.json");


### PR DESCRIPTION
## What Problem This Solves

Published upgrade recovery reaches `post-plugin-doctor-invalid-config`, but the update command intentionally returns only a boolean from its fresh-process config validation. The release artifact therefore cannot show which config field remains invalid.

Observed on signed r22: https://github.com/openclaw/openclaw/actions/runs/31707767225

## Why This Change Was Made

When `openclaw update` fails, the trusted survivor immediately reruns `openclaw config validate --json` against the already-updated install and state, then prints both bounded stderr and JSON through the existing safe log helper. The original update status remains authoritative and unchanged.

## User Impact

Release validation failures identify the actual invalid config field instead of stopping at the generic `post-plugin-doctor-invalid-config` reason. Normal successful upgrades are unchanged.

## Evidence

- `bash -n scripts/e2e/upgrade-survivor-docker.sh`
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` — 194 passed
- Fresh structured autoreview — no accepted/actionable findings; secret scan clean

No changelog change is required; this is trusted release-harness diagnostics.
