### PR TITLE
fix(agents): reject unbound legacy session keys

### DIFF
--- a/src/agents/session-agent-binding.test.ts
+++ b/src/agents/session-agent-binding.test.ts
@@ -3,6 +3,41 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveBoundAgentIdForSession } from "./session-agent-binding.js";
 
 describe("resolveBoundAgentIdForSession", () => {
+  const multiAgentConfig = {
+    agents: { entries: { main: {}, research: {} } },
+  } satisfies OpenClawConfig;
+  const singleAgentConfig = {
+    agents: { entries: { main: {} } },
+  } satisfies OpenClawConfig;
+
+  it.each([
+    {
+      name: "an explicit agent id",
+      params: { config: multiAgentConfig, agentId: "research", sessionKey: "legacy-session" },
+      expected: "research",
+    },
+    {
+      name: "an agent-scoped key",
+      params: { config: multiAgentConfig, sessionKey: "agent:research:session:abc" },
+      expected: "research",
+    },
+    {
+      name: "the canonical main key",
+      params: { config: singleAgentConfig, sessionKey: "main" },
+      expected: "main",
+    },
+    {
+      name: "the configured main alias",
+      params: {
+        config: { ...singleAgentConfig, session: { mainKey: "inbox" } },
+        sessionKey: "inbox",
+      },
+      expected: "main",
+    },
+  ])("binds $name", ({ params, expected }) => {
+    expect(resolveBoundAgentIdForSession(params)).toBe(expected);
+  });
+
   it("binds a bare global key to the persisted fixed-store owner", () => {
     const config = {
       agents: {
@@ -14,5 +49,14 @@ describe("resolveBoundAgentIdForSession", () => {
     } satisfies OpenClawConfig;
 
     expect(resolveBoundAgentIdForSession({ config, sessionKey: "global" })).toBe("ops");
+  });
+
+  it("does not grant default-agent authority to an arbitrary unscoped key", () => {
+    expect(
+      resolveBoundAgentIdForSession({ config: singleAgentConfig, sessionKey: "legacy-session" }),
+    ).toBeUndefined();
+    expect(
+      resolveBoundAgentIdForSession({ config: multiAgentConfig, sessionKey: "legacy-session" }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/session-agent-binding.ts
+++ b/src/agents/session-agent-binding.ts
@@ -3,8 +3,13 @@
  *
  * Derives the trusted active agent from explicit agent ids, agent session keys, or configured main-session aliases.
  */
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
+import { resolvePersistedSessionStoreOwnerForKey } from "../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeMainKey, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
 
 /**
@@ -15,12 +20,23 @@ export function resolveBoundAgentIdForSession(params: {
   sessionKey?: string;
   agentId?: string;
 }): string | undefined {
-  if (!normalizeOptionalString(params.agentId) && !normalizeOptionalString(params.sessionKey)) {
+  const config = params.config ?? {};
+  const agentId = normalizeOptionalString(params.agentId);
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  if (!agentId && !sessionKey) {
     return undefined;
   }
-  return resolveSessionAgentId({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
-  });
+  if (agentId) {
+    return resolveSessionAgentId({ config, sessionKey, agentId });
+  }
+
+  const persistedOwner = resolvePersistedSessionStoreOwnerForKey(config, sessionKey);
+  const loweredSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
+  const mainKey = normalizeMainKey(config.session?.mainKey);
+  const hasTrustedBinding =
+    Boolean(parseAgentSessionKey(sessionKey)?.agentId) ||
+    persistedOwner.kind !== "none" ||
+    loweredSessionKey === "main" ||
+    loweredSessionKey === mainKey;
+  return hasTrustedBinding ? resolveSessionAgentId({ config, sessionKey }) : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where context-engine and plugin hooks with an arbitrary unscoped session key could inherit the default agent identity even though the key had no trusted agent binding.

This was the first product failure in the beta.2 plugin-prerelease run: https://github.com/openclaw/openclaw/actions/runs/31848220763

## Why This Change Was Made

The host-owned binding resolver now accepts only explicit agent IDs, agent-scoped keys, canonical or configured main-session aliases, and persisted fixed-store ownership. It delegates those trusted forms to the canonical session resolver so owner conflicts and retired fixed-store errors retain their existing behavior; arbitrary bare keys return no authority.

The general session resolver remains unchanged because its non-authority callers intentionally support default-agent selection.

Production LOC: `+23/-7` (net `+16`). Test LOC: `+44/-0`. The production growth restores the missing authority boundary while preserving the fixed-store ownership behavior introduced by the multi-agent refactor.

## User Impact

Context-engine and plugin LLM capabilities now fail closed when a session reference does not prove its agent owner. Explicit agent IDs, agent-scoped session keys, main aliases, and fixed-store sessions continue to work.

Release-note context: reject unbound legacy session keys when resolving agent-scoped runtime authority.

## Evidence

- Pre-fix reproduction: `node scripts/run-vitest.mjs src/agents/session-agent-binding.test.ts` failed when the arbitrary key reached the default-capable general resolver.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/agents/session-agent-binding.test.ts src/plugins/runtime/runtime-llm.runtime.test.ts` — 2 files, 36 tests passed.
- `pnpm format src/agents/session-agent-binding.ts src/agents/session-agent-binding.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- Heavy changed gate: Blacksmith Testbox was unavailable because the client is not installed. Direct AWS Crabbox `cbx_89c6dabe1325` passed the initial guards but lacked workspace dependencies; the single frozen-install retry on `cbx_3e691f7a9a93` stalled after installation and was stopped. Exact-head PR CI remains required.

Co-authored with Vincent Koc, preserving the original PR author's implementation credit.
