### PR TITLE
fix(mattermost): redact credentials in error response text

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -3,6 +3,7 @@ import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-i
 import { collectErrorGraphCandidates } from "openclaw/plugin-sdk/error-runtime";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import { responseWithRelease } from "openclaw/plugin-sdk/fetch-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonResponse,
@@ -148,18 +149,20 @@ async function readMattermostSuccessText(res: Response, path: string): Promise<s
 export async function readMattermostError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
   const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
+  let detail: string;
   if (contentType.includes("application/json")) {
     try {
       const data = JSON.parse(text) as { message?: string } | undefined;
-      if (data?.message) {
-        return data.message;
-      }
-      return JSON.stringify(data);
+      detail = data?.message ?? JSON.stringify(data);
     } catch {
-      return text;
+      detail = text;
     }
+  } else {
+    detail = text;
   }
-  return text;
+  // Mattermost API requests carry a bearer token; reflected upstream text must
+  // be sanitized independently of the operator's log-redaction setting.
+  return redactToolPayloadText(detail);
 }
 
 export function createMattermostClient(params: {


### PR DESCRIPTION
## What Problem This Solves

Mattermost API requests carry a bearer token in the `Authorization` header. The `readMattermostError` helper in `extensions/mattermost/src/mattermost/client.ts` reads untrusted error-response text and returns it verbatim. If a self-hosted or misbehaving Mattermost server echoes request headers (including the `Authorization: Bearer <token>` header) in its error body, the bearer token leaks into error messages and logs.

This is the same class of credential-leak vulnerability that was fixed for Discord in PR #119536, where `redactToolPayloadText()` was applied to error response text. The Mattermost extension was missed in that pass.

## Evidence

- The `readMattermostError` function (line 148) reads error response text via `readResponseTextLimited` without any redaction
- The returned text flows directly into `throw new Error(...)` at the call sites (e.g. line 248: `Mattermost API ${res.status} ${res.statusText}: ${detail || "unknown error"}`)
- The pattern `redactToolPayloadText(await readResponseTextLimited(...))` is already established in:
  - `extensions/discord/src/api.ts` (PR #119536)
  - `extensions/github-copilot/embeddings.ts` (line 116-118)
  - `extensions/voice-call/src/providers/shared/response-body.ts` (uses `redactSensitiveText`)
- After the fix, `readMattermostError` applies `redactToolPayloadText()` to the final return value, ensuring any reflected credentials are sanitized

## Changes

- Import `redactToolPayloadText` from `openclaw/plugin-sdk/logging-core`
- Apply `redactToolPayloadText()` to the return value of `readMattermostError`

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] AI-assisted

<!-- This change was generated with AI assistance. -->