### PR TITLE
fix(google-meet): redact credentials in API error response text

### DIFF
--- a/extensions/google-meet/src/google-api-errors.ts
+++ b/extensions/google-meet/src/google-api-errors.ts
@@ -1,4 +1,5 @@
 // Google Meet plugin module implements google api errors behavior.
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 
 const REAUTH_HINT = "Re-run `openclaw googlemeet auth login` and store the refreshed oauth block.";
@@ -9,7 +10,11 @@ function scopeText(scopes: readonly string[]): string {
 }
 
 export async function readGoogleApiErrorDetail(response: Response): Promise<string> {
-  return await readResponseTextLimited(response, GOOGLE_API_ERROR_BODY_LIMIT_BYTES);
+  // Google API requests carry an OAuth bearer token; reflected upstream text
+  // must be sanitized independently of the operator's log-redaction setting.
+  return redactToolPayloadText(
+    await readResponseTextLimited(response, GOOGLE_API_ERROR_BODY_LIMIT_BYTES),
+  );
 }
 
 export async function googleApiError(params: {


### PR DESCRIPTION
## What Problem This Solves

Google API requests carry an OAuth bearer token in the `Authorization` header. The `readGoogleApiErrorDetail` helper in `extensions/google-meet/src/google-api-errors.ts` reads untrusted error-response text and returns it verbatim. If a Google API endpoint (or an intermediary proxy) echoes request headers in its error body, the OAuth bearer token leaks into error messages and logs.

This is the same class of credential-leak vulnerability that was fixed for Discord in PR #119536, where `redactToolPayloadText()` was applied to error response text. The Google Meet extension was missed in that pass.

## Evidence

- The `readGoogleApiErrorDetail` function (line 11-13) returns `readResponseTextLimited(...)` directly without any redaction
- The returned text flows into `new Error(...)` at line 25: `${params.prefix} failed (${params.response.status}): ${detail}${scopeHint}`
- The caller `googleApiError` is used by `gmeet_calendar.ts` and `gmeet_oauth.ts`, both of which send `Authorization: Bearer ${accessToken}` headers
- The pattern `redactToolPayloadText(await readResponseTextLimited(...))` is already established in:
  - `extensions/discord/src/api.ts` (PR #119536)
  - `extensions/github-copilot/embeddings.ts` (line 116-118, 261-263)
- After the fix, `readGoogleApiErrorDetail` wraps the return value with `redactToolPayloadText()`

## Changes

- Import `redactToolPayloadText` from `openclaw/plugin-sdk/logging-core`
- Apply `redactToolPayloadText()` to the return value of `readGoogleApiErrorDetail`

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] AI-assisted

<!-- This change was generated with AI assistance. -->