### PR TITLE
fix(discord): redact credentials in PluralKit API error text

### DIFF
--- a/extensions/discord/src/pluralkit.ts
+++ b/extensions/discord/src/pluralkit.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements pluralkit behavior.
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderJsonObjectResponse,
   readResponseTextLimited,
@@ -72,7 +73,10 @@ export async function fetchPluralKitMessageInfo(params: {
       const text = await readResponseTextLimited(res, PLURALKIT_ERROR_BODY_LIMIT_BYTES).catch(
         () => "",
       );
-      const detail = text.trim() ? `: ${text.trim()}` : "";
+      // PluralKit API requests may carry an authorization token; reflected
+      // upstream text must be sanitized independently of the operator's
+      // log-redaction setting.
+      const detail = text.trim() ? `: ${redactToolPayloadText(text.trim())}` : "";
       throw new Error(`PluralKit API failed (${res.status})${detail}`);
     }
     return (await readProviderJsonObjectResponse(res, "PluralKit message")) as PluralKitMessageInfo;


### PR DESCRIPTION
## What Problem This Solves

PluralKit API requests may carry an authorization token in the `Authorization` header (line 53: `headers.Authorization = params.config.token.trim()`). When the API returns a non-OK response, the error body text is read via `readResponseTextLimited` and included verbatim in the thrown error message (line 76). If the PluralKit API (or a proxy) echoes request headers in its error body, the authorization token leaks into error messages and logs.

This is the same class of credential-leak vulnerability that was fixed for Discord's main API in PR #119536, where `redactToolPayloadText()` was applied to error response text. The PluralKit integration helper was missed in that pass.

## Evidence

- Lines 72-76: error response text is read and directly interpolated into the error message without redaction
- The token is sent as `headers.Authorization = params.config.token.trim()` (line 53)
- The pattern `redactToolPayloadText(text)` is already established in:
  - `extensions/discord/src/api.ts` (PR #119536)
  - `extensions/github-copilot/embeddings.ts` (line 116-118)
- After the fix, the error body text is wrapped with `redactToolPayloadText()` before being included in the error message

## Changes

- Import `redactToolPayloadText` from `openclaw/plugin-sdk/logging-core`
- Apply `redactToolPayloadText()` to the error body text before including it in the error message

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] AI-assisted

<!-- This change was generated with AI assistance. -->