### PR TITLE
fix(nextcloud-talk): redact credentials in bot preflight error text

### DIFF
--- a/extensions/nextcloud-talk/src/bot-preflight.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.ts
@@ -1,5 +1,6 @@
 // Nextcloud Talk plugin module implements bot preflight behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonResponse,
@@ -134,11 +135,14 @@ export async function probeNextcloudTalkBotResponseFeature(params: {
           response,
           BOT_PREFLIGHT_ERROR_BODY_LIMIT_BYTES,
         ).catch(() => "");
+        // The probe sends Basic auth credentials; reflected upstream text must
+        // be sanitized independently of the operator's log-redaction setting.
+        const safeBody = body ? redactToolPayloadText(body) : "";
         return {
           ok: false,
           code: "api_error",
           status: response.status,
-          message: `Nextcloud Talk bot response feature probe failed (${response.status})${body ? `: ${body}` : ""}`,
+          message: `Nextcloud Talk bot response feature probe failed (${response.status})${safeBody ? `: ${safeBody}` : ""}`,
         };
       }
 


### PR DESCRIPTION
## What Problem This Solves

The Nextcloud Talk bot response feature probe sends Basic auth credentials (`Authorization: Basic <base64(user:password)>`) in the request header (line 122). When the probe receives a non-OK response, the error body text is read via `readResponseTextLimited` and included verbatim in the probe result message (line 141). If a self-hosted Nextcloud server (which may have debugging plugins that echo request headers) reflects the `Authorization` header in its error body, the Base64-encoded credentials leak into the probe result message.

This is the same class of credential-leak vulnerability that was fixed for Discord in PR #119536, where `redactToolPayloadText()` was applied to error response text. The Nextcloud Talk preflight was missed in that pass.

## Evidence

- Line 112-113: `const auth = Buffer.from(\`${credentials.apiUser}:${credentials.apiPassword}\`, "utf-8").toString("base64")`
- Line 122: `Authorization: \`Basic ${auth}\``
- Lines 133-141: error body is read and directly interpolated into the probe message without redaction
- The pattern `redactToolPayloadText(text)` is already established in:
  - `extensions/discord/src/api.ts` (PR #119536)
  - `extensions/github-copilot/embeddings.ts` (line 116-118)
- After the fix, the error body text is wrapped with `redactToolPayloadText()` before being included in the probe result message

## Changes

- Import `redactToolPayloadText` from `openclaw/plugin-sdk/logging-core`
- Apply `redactToolPayloadText()` to the error body text before including it in the probe result message

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] AI-assisted

<!-- This change was generated with AI assistance. -->