### PR TITLE
fix(ollama): redact API key in web search error response text

### DIFF
--- a/extensions/ollama/src/web-search-provider.runtime.ts
+++ b/extensions/ollama/src/web-search-provider.runtime.ts
@@ -1,11 +1,11 @@
 // Ollama web-search runtime implements provider integration.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   isNonSecretApiKeyMarker,
   normalizeOptionalSecretInput,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveEnvApiKey } from "openclaw/plugin-sdk/provider-auth-runtime";
-import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   enablePluginInConfig,

--- a/extensions/ollama/src/web-search-provider.runtime.ts
+++ b/extensions/ollama/src/web-search-provider.runtime.ts
@@ -233,8 +233,7 @@ async function runOllamaWebSearch(params: {
         // text must be sanitized independently of the operator's log-redaction
         // setting.
         const safeDetail = redactToolPayloadText(detail.text || "");
-        const message =
-          `Ollama web search failed (${response.status}): ${safeDetail}`.trim();
+        const message = `Ollama web search failed (${response.status}): ${safeDetail}`.trim();
         if (response.status === 404) {
           lastError = new Error(message);
           continue;

--- a/extensions/ollama/src/web-search-provider.runtime.ts
+++ b/extensions/ollama/src/web-search-provider.runtime.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalSecretInput,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveEnvApiKey } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   enablePluginInConfig,
@@ -228,8 +229,12 @@ async function runOllamaWebSearch(params: {
       }
       if (!response.ok) {
         const detail = await readResponseText(response, { maxBytes: 64_000 });
+        // Ollama Cloud requests carry a bearer API key; reflected upstream
+        // text must be sanitized independently of the operator's log-redaction
+        // setting.
+        const safeDetail = redactToolPayloadText(detail.text || "");
         const message =
-          `Ollama web search failed (${response.status}): ${detail.text || ""}`.trim();
+          `Ollama web search failed (${response.status}): ${safeDetail}`.trim();
         if (response.status === 404) {
           lastError = new Error(message);
           continue;


### PR DESCRIPTION
## What Problem This Solves

Ollama Cloud web search requests carry a bearer API key in the `Authorization` header (line 204: `headers.Authorization = \`Bearer ${attempt.apiKey}\``). When the search API returns a non-OK response, the error body text is read via `readResponseText` and included verbatim in the thrown error message (line 232). If the Ollama server (or a proxy) echoes request headers in its error body, the API key leaks into error messages and logs.

This is the same class of credential-leak vulnerability that was fixed for Discord in PR #119536, where `redactToolPayloadText()` was applied to error response text. The Ollama web search runtime was missed in that pass.

## Evidence

- Line 204: `headers.Authorization = \`Bearer ${attempt.apiKey}\``
- Lines 230-232: error body is read via `readResponseText` and directly interpolated into the error message without redaction
- The pattern `redactToolPayloadText(text)` is already established in:
  - `extensions/discord/src/api.ts` (PR #119536)
  - `extensions/github-copilot/embeddings.ts` (line 116-118)
  - `extensions/voice-call/src/providers/shared/response-body.ts` (uses `redactSensitiveText`)
- After the fix, the error body text is wrapped with `redactToolPayloadText()` before being included in the error message

## Changes

- Import `redactToolPayloadText` from `openclaw/plugin-sdk/logging-core`
- Apply `redactToolPayloadText()` to the error body text before including it in the error message

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] AI-assisted

<!-- This change was generated with AI assistance. -->