### PR TITLE
fix(ai): keep sessions usable with malformed reasoning history

### DIFF
--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -137,6 +137,30 @@ function responseMessage(id: string, text: string) {
 }
 
 describe("OpenAI Responses compaction replay", () => {
+  it.each(responseConverters)("$name skips invalid reasoning signatures", ({ convert }) => {
+    const invalidSignatures = [
+      ["truncated JSON", '{"type":"reasoning"'],
+      ["null", "null"],
+      ["array", "[]"],
+      ["wrong item type", '{"type":"message"}'],
+    ] as const;
+
+    for (const [caseName, thinkingSignature] of invalidSignatures) {
+      const input = convert({
+        messages: [
+          createAssistant([
+            { type: "thinking", thinking: "invalid", thinkingSignature },
+            { type: "text", text: "session continues" },
+          ]),
+        ],
+      });
+
+      expect(input, caseName).toEqual([
+        expect.objectContaining({ type: "message", role: "assistant" }),
+      ]);
+    }
+  });
+
   it("strips only exact compaction checkpoints with structural sharing", () => {
     const unchanged = createOutput();
     expect(stripCompactionReplayCheckpoint(unchanged)).toBe(unchanged);

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -362,13 +362,19 @@ function convertResponsesMessagesWithStyle(
             block.thinkingSignature &&
             (providerStyle || block.thinkingSignature.startsWith("{"))
           ) {
-            // Transport conversion skips openai-completions provenance tags; the provider
-            // conversion retains its shipped parse behavior for every non-empty signature.
-            const reasoningItem = JSON.parse(
-              block.thinkingSignature,
-            ) as ReplayableResponseReasoningItem;
+            // Persisted signatures are provider-owned data. Skip malformed or unrelated
+            // shapes so one corrupt history item cannot prevent the next request.
+            let reasoningItem: unknown;
+            try {
+              reasoningItem = JSON.parse(block.thinkingSignature);
+            } catch {
+              continue;
+            }
+            if (!isRecord(reasoningItem) || reasoningItem.type !== "reasoning") {
+              continue;
+            }
             const replayableReasoningItem = prepareOpenAIResponsesReasoningItemForReplay(
-              reasoningItem,
+              reasoningItem as ReplayableResponseReasoningItem,
               replayContext,
               readOpenAIResponsesReasoningReplayBlockMetadata(isRecord(block) ? block : {}),
               providerStyle ? { preserveUnattributedEncryptedContent: true } : undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing a Responses-provider session could have every later turn fail before the network request when persisted reasoning history contained malformed JSON or a non-reasoning JSON value.

## Why This Change Was Made

The shared Responses replay converter now catches JSON parse failures and accepts only non-array records tagged as `type: "reasoning"`. Invalid persisted signatures are skipped while valid reasoning items and later assistant content continue through the same provider- and transport-style replay paths.

## User Impact

Sessions with truncated, imported, edited, or otherwise incompatible reasoning signatures remain usable. Valid reasoning history replays as before.

## Evidence

### Release-shaped OCM behavior proof

Built and ran isolated package runtimes for the exact pre-fix parent `57e862980be` and PR head `1d15daec194`. Each runtime used an OCM-managed loopback gateway and a strict local OpenAI Responses-compatible endpoint with no credentials or real provider calls.

The harness created sessions through the gateway so OpenClaw persisted authentic encrypted reasoning signatures in SQLite. It then stopped the gateways, changed copied session signatures transactionally, verified SQLite integrity, restarted the gateways, and continued the same sessions through gateway WebSockets.

| Persisted signature | Before `57e862980be` | After `1d15daec194` |
|---|---|---|
| Truncated JSON | Continuation failed before provider egress | Continuation succeeded; malformed reasoning was omitted |
| Wrong-type object | Invalid replay item reached the endpoint and received HTTP 400 | Continuation succeeded; malformed reasoning was omitted |
| `null` | Already omitted; continuation succeeded | Continuation succeeded |
| Array | Already omitted; continuation succeeded | Continuation succeeded |
| Valid reasoning control | Encrypted reasoning replayed normally | Encrypted reasoning replayed normally |

Both provider- and transport-style converters were exercised. Successful post-fix requests retained assistant text and valid history. The valid control confirms the change does not disable reasoning replay.

Protocol cross-check: `openai/codex@97729885` defines Responses items as a `type`-tagged enum with a structured `Reasoning` variant in `codex-rs/protocol/src/models.rs:814-860`, and requests `reasoning.encrypted_content` in `codex-rs/core/src/client.rs:907`.

### Automated checks

- Pre-fix regression: `pnpm test packages/ai/src/transports/openai-responses-compaction-replay.test.ts` failed for both converter styles at the shared `JSON.parse` (2 failed, 38 passed). Blacksmith Testbox `tbx_01m08sy5kqas8gptk11brsbmyx`.
- Post-fix regression: the same command passed 40/40 tests, including truncated JSON, `null`, arrays, and wrong item types for both converter styles. Blacksmith Testbox `tbx_01m08t12nnkzt8817p80ng6bvk`: https://github.com/openclaw/openclaw/actions/runs/32071314320
- Changed-path gate: `pnpm check:changed` passed formatting, core and core-test typechecks, lint, import-cycle checks, and repository guards. Blacksmith Testbox `tbx_01m08t3bdcznfyydfwma51x5tb`: https://github.com/openclaw/openclaw/actions/runs/32071421182
- Bundled autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` exited 0; TruffleHog clean; no accepted/actionable findings.

AI-assisted maintainer rewrite. The original contributor remains the commit author.
