### PR TITLE
test(plugins): drop stale Google Meet source finding

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -32,7 +32,6 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
-  ["@openclaw/google-meet:dangerous-exec:src/node-host.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
   ["@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts", 2],
   ["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts", 1],


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/118451

## What Problem This Solves

Resolves a release-validation failure where the publishable-plugin security scan still required a reviewed `dangerous-exec` finding in Google Meet's source `node-host.ts`, even though that source no longer executes child processes.

Campaign fingerprint:

- Campaign: `20260813T134026Z-main_sha-daily-843017073cc2`
- Validation/tooling SHA: `843017073cc27b28c1926ea21808b4209620ee03`
- Rerun group: `all`
- Full Release Validation run: https://github.com/openclaw/openclaw/actions/runs/31706155558
- Failed job: `94470670448` (`Run plugin prerelease validation`)
- Failed job URL: https://github.com/openclaw/openclaw/actions/runs/31706155558/job/94470670448

The independent session-binding failure from the same campaign is separately owned by https://github.com/openclaw/openclaw/pull/123222.

## Why This Change Was Made

https://github.com/openclaw/openclaw/pull/118451 moved audio process ownership out of the Google Meet node host and into the shared meeting runtime, removing the `node:child_process` import and `spawnSync` call from `extensions/google-meet/src/node-host.ts`.

This PR removes only the stale required source finding. The conditional packaged-runtime review entry for `@openclaw/google-meet:dangerous-exec:dist/index.js` remains unchanged.

Exact delta: one test-only deletion, production `+0/-0`, tests `+0/-1`.

## User Impact

No runtime behavior changes. Release validation now reflects the current Google Meet source ownership without weakening the packaged-runtime security review.

## Evidence

- `node --import tsx scripts/check-plugin-npm-runtime-builds.mts --package extensions/google-meet` - built the Google Meet npm runtime successfully with three runtime entries.
- `node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts` - 1 file passed, 94 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- src/plugins/npm-install-security-scan.release.test.ts` - passed locally, including core-test typecheck and targeted lint.
- `pnpm format src/plugins/npm-install-security-scan.release.test.ts` - passed.
- `git diff --check` - passed.
- Exact diff: `src/plugins/npm-install-security-scan.release.test.ts` `+0/-1`.
- The packaged `@openclaw/google-meet:dangerous-exec:dist/index.js` review entry remains present.

Punchcard-Session: coral-river-orchard-59
