### PR TITLE
fix(telegram): preserve bare URL query separators

### DIFF
--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -270,7 +270,14 @@ describe("markdownToTelegramRichBlocks", () => {
     const { blocks } = markdownToTelegramRichBlocks("**start https://example.com** end");
     const text = blocks[0] && blocks[0].type === "paragraph" ? blocks[0].text : "";
     expect(hasStyle(text, "bold")).toBe(true);
-    expect(collectUrls(text)).toEqual(["https://example.com"]);
+    expect(collectUrls(text)).toEqual([]);
+  });
+
+  it("leaves bare URL query separators to Telegram entity detection", () => {
+    const url = "https://example.com/wp-admin/post.php?post=100&action=edit";
+    const { blocks } = markdownToTelegramRichBlocks(url);
+
+    expect(blocks).toEqual([{ type: "paragraph", text: url }]);
   });
 
   it("emits pre blocks with fence language", () => {

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -104,11 +104,10 @@ function resolveTelegramLinkAction(
     return null;
   }
   const label = source.slice(link.start, link.end);
-  if (context.origin === "linkify" && isAutoLinkedFileRef(href, label)) {
-    // Bare file refs (README.md, openclaw.json) must render as code, not links:
-    // Telegram's server-side entity detection would otherwise re-linkify them
-    // and show spurious domain previews for TLD-like extensions.
-    return { kind: "code" };
+  if (context.origin === "linkify") {
+    // File refs need code to suppress false links. Other bare links stay plain
+    // because Telegram typed URLs escape query separators (observed 2026-08).
+    return isAutoLinkedFileRef(href, label) ? { kind: "code" } : null;
   }
   if (href.startsWith("#")) {
     // In-message fragments are RichTextAnchorLink, not RichTextUrl.


### PR DESCRIPTION
Fixes #102162.

## What problem this solves

Telegram rich messages changed a bare URL query separator from `&` to literal `&amp;` in the link target. The visible text stayed correct, but opening the link could reach the wrong URL.

## Root cause

The rich-block renderer wrapped parser-generated bare URLs in Bot API `RichTextUrl` nodes. A real Telegram DM returned that typed target with `&amp;`. The legacy `sendMessage` path returned the same URL with the raw `&`, which isolated the defect to typed rich URL handling.

## Fix

Leave parser-generated bare URLs as plain rich text and let Telegram's documented entity detection create the link. Authored Markdown links remain typed. File-like bare references remain code-formatted so Telegram does not turn them into false links.

Production delta: -1 line.

## Proof

- Pre-fix Telegram userbot: `messageRichMessage` returned `RichTextUrl.url=https://example.com/wp-admin/post.php?post=100&amp;action=edit`; the legacy negative control returned raw `&`.
- Regression test: failed before the fix because the block contained a typed `url`; passes after the fix with the exact bare URL as plain paragraph text.
- Focused Telegram rich-block tests: 108 passed.
- Changed gate: passed, including extension production and test typechecks, type-aware lint, dead-export scan, and runtime guards.
- Distill and Greybeard source passes: zero findings.
- Final-head Telegram userbot: one `messageRichMessage` reply, visible URL exact, TDLib `RichTextUrl.url` exact with raw `&`, zero `&amp;` hits, one provider request, and `operation=sendRichMessage`. No edit or deletion side effects.

AI-assisted: yes, implemented by Codex.
