### PR TITLE
fix(matrix): guard malformed poll answers instead of throwing TypeError

### DIFF
--- a/extensions/matrix/src/matrix/poll-types.test.ts
+++ b/extensions/matrix/src/matrix/poll-types.test.ts
@@ -67,6 +67,32 @@ describe("parsePollStartContent", () => {
 
     expect(parsed?.maxSelections).toBe(2);
   });
+
+  it("drops malformed answers instead of throwing on sender-controlled content", () => {
+    const malformed: Array<[string, unknown]> = [
+      ["answers is a string", { question: { "m.text": "Q?" }, answers: "nope" }],
+      ["answers entries null", { question: { "m.text": "Q?" }, answers: [null] }],
+      [
+        "answer id non-string",
+        { question: { "m.text": "Q?" }, answers: [{ id: 42, "m.text": "a" }] },
+      ],
+    ];
+    for (const [label, poll] of malformed) {
+      expect(() => parsePollStart({ "m.poll.start": poll } as never), label).not.toThrow();
+      expect(parsePollStart({ "m.poll.start": poll } as never), label).toBeNull();
+    }
+  });
+
+  it("keeps well-formed answers when other entries are malformed", () => {
+    const parsed = parsePollStart({
+      "m.poll.start": {
+        question: { "m.text": "Lunch?" },
+        answers: [null, { id: "a1", "m.text": "Yes" }, { id: 42, "m.text": "dropped" }],
+      },
+    } as never);
+
+    expect(parsed?.answers).toEqual([{ id: "a1", text: "Yes" }]);
+  });
 });
 
 describe("buildPollStartContent", () => {

--- a/extensions/matrix/src/matrix/poll-types.test.ts
+++ b/extensions/matrix/src/matrix/poll-types.test.ts
@@ -76,6 +76,14 @@ describe("parsePollStartContent", () => {
         "answer id non-string",
         { question: { "m.text": "Q?" }, answers: [{ id: 42, "m.text": "a" }] },
       ],
+      [
+        "question text non-string",
+        { question: { "m.text": 42 }, answers: [{ id: "a1", "m.text": "a" }] },
+      ],
+      [
+        "answer text non-string",
+        { question: { "m.text": "Q?" }, answers: [{ id: "a1", "m.text": 42 }] },
+      ],
     ];
     for (const [label, poll] of malformed) {
       expect(() => parsePollStart({ "m.poll.start": poll } as never), label).not.toThrow();

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -141,11 +141,19 @@ export function parsePollStart(content: PollStartContent): ParsedPollStart | nul
     return null;
   }
 
-  const answers = poll.answers
-    .map((answer) => ({
-      id: answer.id,
-      text: getTextContent(answer).trim(),
-    }))
+  // Event content is sender-controlled JSON: the declared shape cannot be
+  // trusted, so guard the array and every entry before mapping. Malformed
+  // entries are dropped instead of throwing — a throw here would bubble up
+  // through thread/reply context building and silently drop the whole message.
+  const rawAnswers: unknown = poll.answers;
+  const answers = (Array.isArray(rawAnswers) ? rawAnswers : [])
+    .map((answer) => {
+      const candidate = answer as Partial<PollAnswer> | null | undefined;
+      return {
+        id: typeof candidate?.id === "string" ? candidate.id : "",
+        text: getTextContent(candidate ?? undefined).trim(),
+      };
+    })
     .filter((answer) => answer.id.trim().length > 0 && answer.text.length > 0);
   if (answers.length === 0) {
     return null;

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -120,11 +120,13 @@ export function isPollEventType(eventType: string): boolean {
   return (POLL_EVENT_TYPES as readonly string[]).includes(eventType);
 }
 
-function getTextContent(text?: TextContent): string {
-  if (!text) {
+function getTextContent(text?: unknown): string {
+  if (!text || typeof text !== "object") {
     return "";
   }
-  return text["m.text"] ?? text["org.matrix.msc1767.text"] ?? text.body ?? "";
+  const content = text as Record<string, unknown>;
+  const value = content["m.text"] ?? content["org.matrix.msc1767.text"] ?? content.body;
+  return normalizeOptionalString(value) ?? "";
 }
 
 export function parsePollStart(content: PollStartContent): ParsedPollStart | null {
@@ -136,7 +138,7 @@ export function parsePollStart(content: PollStartContent): ParsedPollStart | nul
     return null;
   }
 
-  const question = getTextContent(poll.question).trim();
+  const question = getTextContent(poll.question);
   if (!question) {
     return null;
   }
@@ -151,7 +153,7 @@ export function parsePollStart(content: PollStartContent): ParsedPollStart | nul
       const candidate = answer as Partial<PollAnswer> | null | undefined;
       return {
         id: typeof candidate?.id === "string" ? candidate.id : "",
-        text: getTextContent(candidate ?? undefined).trim(),
+        text: getTextContent(candidate),
       };
     })
     .filter((answer) => answer.id.trim().length > 0 && answer.text.length > 0);

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -8,7 +8,7 @@
  */
 
 import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/poll-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export const M_POLL_START = "m.poll.start" as const;
 const M_POLL_RESPONSE = "m.poll.response" as const;
@@ -121,11 +121,10 @@ export function isPollEventType(eventType: string): boolean {
 }
 
 function getTextContent(text?: unknown): string {
-  if (!text || typeof text !== "object") {
+  if (!isRecord(text)) {
     return "";
   }
-  const content = text as Record<string, unknown>;
-  const value = content["m.text"] ?? content["org.matrix.msc1767.text"] ?? content.body;
+  const value = text["m.text"] ?? text["org.matrix.msc1767.text"] ?? text.body;
   return normalizeOptionalString(value) ?? "";
 }
 
@@ -143,19 +142,14 @@ export function parsePollStart(content: PollStartContent): ParsedPollStart | nul
     return null;
   }
 
-  // Event content is sender-controlled JSON: the declared shape cannot be
-  // trusted, so guard the array and every entry before mapping. Malformed
-  // entries are dropped instead of throwing — a throw here would bubble up
-  // through thread/reply context building and silently drop the whole message.
+  // Sender-controlled event content can violate declared Matrix types; discard
+  // malformed answers here so context building never drops the whole message.
   const rawAnswers: unknown = poll.answers;
   const answers = (Array.isArray(rawAnswers) ? rawAnswers : [])
-    .map((answer) => {
-      const candidate = answer as Partial<PollAnswer> | null | undefined;
-      return {
-        id: typeof candidate?.id === "string" ? candidate.id : "",
-        text: getTextContent(candidate),
-      };
-    })
+    .map((answer) => ({
+      id: isRecord(answer) && typeof answer.id === "string" ? answer.id : "",
+      text: getTextContent(answer),
+    }))
     .filter((answer) => answer.id.trim().length > 0 && answer.text.length > 0);
   if (answers.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

fix(matrix): drop malformed poll answers in `parsePollStart` instead of throwing a `TypeError` that silently drops the whole message

## What Problem This Solves

The Matrix extension renders poll start events inside thread/reply context summaries. `parsePollStart` in `extensions/matrix/src/matrix/poll-types.ts` trusts the declared TypeScript shape of the event content:

```ts
const answers = poll.answers
  .map((answer) => ({ id: answer.id, text: getTextContent(answer).trim() }))
  .filter((answer) => answer.id.trim().length > 0 && answer.text.length > 0);
```

But Matrix event content is **sender-controlled JSON** (including from federated remote homeservers) — the declared shape cannot be trusted:

- `answers` not an array (e.g. a string) → `TypeError: poll.answers.map is not a function`
- array entries of `null` → `TypeError: Cannot read properties of null (reading 'id')`
- non-string `id` (e.g. a number) → `TypeError: answer.id.trim is not a function`

The throw path makes this a **persistent, remotely triggerable message drop**:

- `monitor/context-summary.ts` calls `parsePollStartContent` synchronously with no try/catch.
- It is reached from `monitor/thread-context.ts` (thread root summarization) and `monitor/reply-context.ts` (reply summarization) — both outside the `getEvent` `.catch`, which only covers network failures.
- The exception bubbles to the ingress top-level catch in `monitor/handler.ts`, which logs `matrix handler failed: TypeError ...` and **drops the entire message**.
- Worse: once a malformed poll exists as a thread root or a replied-to event, **every subsequent message in that thread / every reply to it** fails the same way — until the event is redacted. One malformed event from any room member (or a federated peer) turns into a lasting denial of context for that conversation branch.

**代码证据**: `extensions/matrix/src/matrix/poll-types.ts:144-149` (no `Array.isArray` guard, no entry shape check); `extensions/matrix/src/matrix/monitor/context-summary.ts:18` (unguarded synchronous call). Note the contrast with `fetchMatrixPollSnapshot`, whose call site in `monitor/handler-ingress-content.ts:104` explicitly wraps in `.catch` — the author knew this family of code can throw, but the synchronous context-summary entries were missed.

Trigger condition: any `m.poll.start` / `org.matrix.msc3381.poll.start` event with a structurally valid question but malformed `answers`, in a monitored room.

## Root Cause

- Present since the poll support landed in commit `bca2501c7f7` (2026-05-27), when `poll-types.ts` was added.
- Violated invariant: event content parsed at the message-ingestion hot path must be treated as untrusted input; parsing may reject the event (return null) but must never throw across the ingress boundary.
- The declared type `answers: PollAnswer[]` describes intent, not reality — there is no schema validation between the wire and this function.

## Why This Fix

- Option A: wrap the three call sites in try/catch. Works, but leaves the throw as the control flow and must be repeated at every future call site.
- Option B (chosen): make `parsePollStart` total — guard `Array.isArray(poll.answers)` and per-entry shape (`id` must be a string; entries tolerate null), drop malformed entries, and return `null` when nothing valid remains (the existing "no valid answers" path). The function already returns `null` for missing/empty questions, so this is consistent with its contract.
- Not chosen: full JSON-schema validation of poll events — correct but a much larger change; this fix removes the crash with minimal surface.

## User Impact

- Affected scenarios: Matrix rooms where any member (or federated remote) sends a poll start event with malformed `answers`; threads/replies involving such events.
- Before: the message (and every later message threading on or replying to the malformed poll) is silently dropped with only a `matrix handler failed` log line.
- After: malformed polls simply produce no poll summary; message processing continues normally. Well-formed polls are unaffected.
- Behavior change: malformed remote content degrades gracefully instead of poisoning the conversation branch.

## Evidence

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-matrix-poll-malformed.mjs
THROW answers is a string: TypeError: poll.answers.map is not a function
THROW answers entries null: TypeError: Cannot read properties of null (reading 'id')
THROW answer id non-string: TypeError: answer.id.trim is not a function
OK   valid poll: returned summary(1 answers)
RESULT: 3 case(s) THREW (bug present)
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-matrix-poll-malformed.mjs
OK   answers is a string: returned null
OK   answers entries null: returned null
OK   answer id non-string: returned null
OK   valid poll: returned summary(1 answers)
RESULT: ALL PASS
```

The proof calls the real exported `parsePollStartContent` from `extensions/matrix/src/matrix/poll-types.ts` (Node v24, tsx) with sender-controlled-shaped payloads. No mocks — pure parsing function executed directly.

## Tests and Validation

- `npx vitest run extensions/matrix/src/matrix/poll-types.test.ts` — 10/10 passed, including new regression tests: `drops malformed answers instead of throwing on sender-controlled content` (all three malformed shapes return null, no throw) and `keeps well-formed answers when other entries are malformed`.
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
