### PR TITLE
fix(memory): ship wiki runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2020,6 +2020,7 @@
     "jszip": "3.10.1",
     "kysely": "0.29.4",
     "linkedom": "0.18.13",
+    "mdast-util-from-markdown": "2.0.3",
     "minimatch": "10.2.5",
     "ms": "2.1.3",
     "node-edge-tts": "1.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       linkedom:
         specifier: 0.18.13
         version: 0.18.13
+      mdast-util-from-markdown:
+        specifier: 2.0.3
+        version: 2.0.3(supports-color@10.2.2)
       minimatch:
         specifier: 10.2.5
         version: 10.2.5

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -744,9 +744,6 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
     return [formatInstalledDistFileScanLimitError("root dist", distFiles.limit)];
   }
   const missingImporters = new Map<string, Set<string>>();
-  const bundledExtensionRuntimeDependencyOwners =
-    collectBundledExtensionRuntimeDependencyOwners(packageRoot);
-
   for (const filePath of distFiles.files) {
     const fileStat = lstatSync(filePath);
     if (!fileStat.isFile() || fileStat.size > MAX_INSTALLED_ROOT_DIST_JS_BYTES) {
@@ -769,12 +766,7 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
         !dependencyName ||
         NODE_BUILTIN_MODULES.has(dependencyName) ||
         OPTIONAL_OR_EXTERNALIZED_RUNTIME_IMPORTS.has(dependencyName) ||
-        declaredRuntimeDeps.has(dependencyName) ||
-        isBundledExtensionOwnedRuntimeImport({
-          dependencyName,
-          ownersByDependency: bundledExtensionRuntimeDependencyOwners,
-          source,
-        })
+        declaredRuntimeDeps.has(dependencyName)
       ) {
         continue;
       }
@@ -790,35 +782,6 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
       return `installed package root is missing declared runtime dependency '${dependencyName}' for dist importers: ${importerList.join(", ")}. Add it to package.json dependencies/optionalDependencies.`;
     })
     .toSorted((left, right) => left.localeCompare(right));
-}
-
-function collectBundledExtensionRuntimeDependencyOwners(
-  packageRoot: string,
-): Map<string, Set<string>> {
-  const ownersByDependency = new Map<string, Set<string>>();
-  const { manifests } = readBundledExtensionPackageJsons(packageRoot);
-  for (const { id, manifest } of manifests) {
-    for (const dependencyName of collectRuntimeDependencySpecs(manifest).keys()) {
-      const owners = ownersByDependency.get(dependencyName) ?? new Set<string>();
-      owners.add(id);
-      ownersByDependency.set(dependencyName, owners);
-    }
-  }
-  return ownersByDependency;
-}
-
-function isBundledExtensionOwnedRuntimeImport(params: {
-  dependencyName: string;
-  ownersByDependency: Map<string, Set<string>>;
-  source: string;
-}): boolean {
-  const owners = params.ownersByDependency.get(params.dependencyName);
-  if (!owners) {
-    return false;
-  }
-  return [...owners].some((pluginId) =>
-    params.source.includes(`//#region extensions/${pluginId}/`),
-  );
 }
 
 export function resolveInstalledBinaryPath(prefixDir: string, platform = process.platform): string {

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1024,6 +1024,38 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
     }
   });
 
+  it("requires bundled extension imports to resolve from root dependencies", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writePackageFile(packageRoot, "package.json", {
+        version: "2026.8.1",
+        dependencies: {},
+      });
+      writePackageFile(packageRoot, "dist/extensions/memory-wiki/package.json", {
+        name: "@openclaw/memory-wiki",
+        dependencies: { "mdast-util-from-markdown": "2.0.3" },
+      });
+      mkdirSync(join(packageRoot, "dist"), { recursive: true });
+      writeFileSync(
+        join(packageRoot, "dist", "memory-wiki-runtime.js"),
+        [
+          "//#region extensions/memory-wiki/src/markdown.ts",
+          'import { fromMarkdown } from "mdast-util-from-markdown";',
+          "export { fromMarkdown };",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      expect(collectInstalledRootDependencyManifestErrors(packageRoot)).toEqual([
+        "installed package root is missing declared runtime dependency 'mdast-util-from-markdown' for dist importers: memory-wiki-runtime.js. Add it to package.json dependencies/optionalDependencies.",
+      ]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   it("accepts optional or externalized runtime imports", () => {
     const packageRoot = makeInstalledPackageRoot();
 


### PR DESCRIPTION
Fixes #122357.

## Root cause

Bundled plugin code is compiled into the root `dist` tree and plugin-local `node_modules` directories are removed during packaging. `memory-wiki` imports `mdast-util-from-markdown`, but the root package did not declare it. The postpublish verifier then exempted imports owned by bundled extension manifests, so the clean-install failure escaped release validation.

## Fix

- declare `mdast-util-from-markdown@2.0.3` in the root runtime dependencies;
- remove the bundled-extension exemption from installed root dependency verification;
- add a regression proving a bundled Memory Wiki import fails validation unless the root package declares it.

This keeps dependency ownership aligned with the existing internalized bundled-plugin runtime model and catches the defect generically for future bundled plugins.

## Verification

- `pnpm exec vitest run test/openclaw-npm-postpublish-verify.test.ts test/release-check.test.ts src/plugins/contracts/extension-runtime-dependencies.contract.test.ts`
- `pnpm format:check --no-error-on-unmatched-pattern -- package.json pnpm-lock.yaml scripts/openclaw-npm-postpublish-verify.ts test/openclaw-npm-postpublish-verify.test.ts`
- `pnpm deps:pins:check`
- `pnpm build`
- built-root `collectInstalledRootDependencyManifestErrors(process.cwd())` returned `[]`

Production LOC delta is net negative: the obsolete exemption and owner-mapping helper are removed.
