### PR TITLE
test(browser): isolate native host fixture executable

### DIFF
--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -196,9 +196,10 @@ describe.runIf(process.platform !== "win32")("extension install ownership policy
       });
 
       expect(status.installedCopy).toMatchObject({ present: true, owned: true });
-      expect(status.registrations.find((entry) => entry.product === "chromium")?.state).toBe(
-        "owned",
-      );
+      expect(
+        status.registrations.find((entry) => entry.product === "chromium")?.state,
+        status.issues.join("\n"),
+      ).toBe("owned");
     } finally {
       lstatSpy.mockRestore();
       getuidSpy.mockRestore();

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -50,6 +50,11 @@ async function fixture(platform: NodeJS.Platform = "linux") {
   await fs.writeFile(path.join(bundledDir, "modules", "runtime.test.ts"), "throw new Error();\n");
   await fs.writeFile(path.join(bundledDir, "sidepanel.html"), "must not ship\n");
   await fs.writeFile(nativeHostPath, "export {};\n", { mode: 0o600 });
+  const privateNodePath = path.join(root, "node");
+  if (process.platform !== "win32") {
+    const nodeCommand = `'${process.execPath.replaceAll("'", `'"'"'`)}'`;
+    await fs.writeFile(privateNodePath, `#!/bin/sh\nexec ${nodeCommand} "$@"\n`, { mode: 0o700 });
+  }
   const deps = {
     platform,
     homeDir,
@@ -59,7 +64,7 @@ async function fixture(platform: NodeJS.Platform = "linux") {
       LOCALAPPDATA: path.join(homeDir, "AppData", "Local"),
     },
     nativeHostPath,
-    nodePath: process.execPath,
+    nodePath: process.platform === "win32" ? process.execPath : privateNodePath,
   };
   return { root, homeDir, stateDir, bundledDir, pluginRoot, nativeHostPath, deps };
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a hosted Browser shard fixture failure where native-host registration tests rejected the GitHub-hosted Node executable because it was group/world-writable.

## Why This Change Was Made

The fixture now uses a private `0700` POSIX wrapper that executes `process.execPath`, while Windows continues to use `process.execPath` directly. The original assertion also retains the native-host issue list as its failure diagnostic.

This is fixture-only. It does not change production behavior, ownership policy, retries, or timeouts.

## User Impact

No product behavior changes. Hosted Browser validation can exercise native-host registration without depending on the permission mode of the runner-managed Node installation.

## Evidence

- Original campaign Browser shard job: https://github.com/openclaw/openclaw/actions/runs/31707221815/job/94471020138
- Diagnostic Browser shard job: https://github.com/openclaw/openclaw/actions/runs/31709459301/job/94478619614
  - Proved `/opt/hostedtoolcache/node/24.18.0/x64/bin/node` was rejected as group/world-writable.
- Repaired hosted run: https://github.com/openclaw/openclaw/actions/runs/31710190508
- Repaired Browser shard job: https://github.com/openclaw/openclaw/actions/runs/31710190508/job/94484977623
  - `extension-install.test.ts`: 24 passed, 1 skipped, 0 failed.
  - All 7 prior native-host fixture failures are fixed.
  - The shard's only remaining failures are the two file-chooser timeout assertions independently owned by https://github.com/openclaw/openclaw/pull/123163.
- Focused local Browser config: 24 passed, 1 skipped.
- Targeted formatting, oxlint, diff, and temp-directory checks passed.

Production LOC: +0/-0  
Tests: +10/-4  
Files: 1

Punchcard-Session: silver-river-willow-y4
