### PR TITLE
fix(cron): alert when topic delivery fails

### DIFF
--- a/src/gateway/server-cron-notifications.delivery-failure.test.ts
+++ b/src/gateway/server-cron-notifications.delivery-failure.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.types.js";
+import type { CronJob } from "../cron/types.js";
+import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
+
+const sendFailureNotificationAnnounce = vi.hoisted(() => vi.fn());
+
+vi.mock("../cron/delivery.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cron/delivery.js")>();
+  return { ...actual, sendFailureNotificationAnnounce };
+});
+
+import { dispatchGatewayCronFinishedNotifications } from "./server-cron-notifications.js";
+
+function createThreadedJob(withFailureDestination: boolean): CronJob {
+  return {
+    id: "cron-delivery-failure",
+    name: "threaded report",
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "report" },
+    delivery: {
+      mode: "announce",
+      channel: "telegram",
+      to: "-1001234567890",
+      threadId: 42,
+      ...(withFailureDestination
+        ? {
+            failureDestination: {
+              mode: "announce" as const,
+              channel: "telegram" as const,
+              to: "-1001234567890",
+            },
+          }
+        : {}),
+    },
+    state: {},
+  };
+}
+
+describe("cron primary delivery failure notifications", () => {
+  beforeEach(() => {
+    resetGatewayWorkAdmission();
+    sendFailureNotificationAnnounce.mockReset();
+    sendFailureNotificationAnnounce.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => resetGatewayWorkAdmission());
+
+  it("uses only an explicit failure destination", () => {
+    const evt = {
+      jobId: "cron-delivery-failure",
+      action: "finished" as const,
+      status: "ok" as const,
+      deliveryStatus: "not-delivered" as const,
+      deliveryError: "message thread not found",
+    };
+    const dispatch = (job: CronJob) =>
+      dispatchGatewayCronFinishedNotifications({
+        evt,
+        job,
+        deps: {} as CliDeps,
+        logger: { warn: vi.fn() },
+        resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+      });
+
+    dispatch(createThreadedJob(false));
+    expect(sendFailureNotificationAnnounce).not.toHaveBeenCalled();
+
+    dispatch(createThreadedJob(true));
+    expect(sendFailureNotificationAnnounce).toHaveBeenCalledOnce();
+    expect(sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toEqual({
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: undefined,
+      sessionKey: undefined,
+      inheritSessionThread: false,
+    });
+    expect(sendFailureNotificationAnnounce.mock.calls[0]?.[5]).toEqual({
+      text:
+        '⚠️ Automation "threaded report" delivery failed\n' +
+        "Check automation history for details.",
+    });
+  });
+});

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -153,13 +153,12 @@ function buildCronWebhookHeaders(webhookToken?: string): Record<string, string> 
 }
 
 function buildCronFailureWebhookPayload(params: { evt: CronEvent; job: CronJob }) {
-  const failureMessage = `Automation "${params.job.name}" failed: ${params.evt.error ?? "unknown error"}`;
   return {
     jobId: params.job.id,
     jobName: params.job.name,
-    message: failureMessage,
+    message: `Automation "${params.job.name}" ${params.evt.status === "error" ? "failed" : "delivery failed"}: ${params.evt.error ?? params.evt.deliveryError ?? "unknown error"}`,
     status: params.evt.status,
-    error: params.evt.error,
+    error: params.evt.error ?? params.evt.deliveryError,
     runAtMs: params.evt.runAtMs,
     durationMs: params.evt.durationMs,
     nextRunAtMs: params.evt.nextRunAtMs,
@@ -516,12 +515,16 @@ function dispatchCronFailureDestinationNotifications(params: {
   ssrfPolicy?: SsrFPolicy;
   globalFailureDestination?: CronFailureDestinationConfig;
 }): void {
-  if (params.evt.status !== "error" || !params.job || params.job.delivery?.bestEffort === true) {
+  if (!params.job || params.job.delivery?.bestEffort === true) {
     return;
   }
 
   const job = params.job;
   const failureDest = resolveFailureDestination(job, params.globalFailureDestination);
+  const deliveryFailed = params.evt.deliveryStatus === "not-delivered";
+  if (params.evt.status !== "error" && (!deliveryFailed || !failureDest)) {
+    return;
+  }
   const deliverySessionKey = resolveCronDeliverySessionKey(job);
   const failurePayload = buildCronFailureWebhookPayload({ evt: params.evt, job });
 
@@ -570,7 +573,7 @@ function dispatchCronFailureDestinationNotifications(params: {
         to: failureDest.to,
         accountId: failureDest.accountId,
         sessionKey: deliverySessionKey,
-        // Explicit failure routes keep run context without inheriting the primary topic.
+        // Explicit failure routes escape rejected primary delivery without inheriting its topic.
         inheritSessionThread: false,
       }
     : primaryPlan.mode === "announce" && primaryPlan.requested
@@ -588,7 +591,7 @@ function dispatchCronFailureDestinationNotifications(params: {
 
   const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(job.agentId);
   const failureAlertText = [
-    `Automation "${job.name}" failed`,
+    `Automation "${job.name}" ${params.evt.status === "error" ? "failed" : "delivery failed"}`,
     ...cronFailureDetailLines(job.state.lastErrorReason),
   ].join("\n");
   dispatchDetachedCronNotification({


### PR DESCRIPTION
Closes #121092

## What Problem This Solves

Fixes an issue where a successful cron run could lose its output to a dead Telegram topic without notifying the operator, even when an independent failure destination was configured.

## Why This Change Was Made

The cron finalizer correctly records a rejected primary send as `not-delivered` while keeping the run itself successful. Gateway failure notifications only considered failed runs, so that terminal delivery outcome skipped `delivery.failureDestination` entirely.

Treat `not-delivered` as notification-worthy only when an explicit alternate destination resolves. Primary topic sends remain fail-closed; no implicit base-chat fallback or Telegram-specific branch is added.

## Maintainer Direction

Maintainer confirms the explicit-alternate-route contract and authorizes landing after terminal exact-head CI. The branch is conflict-free; BEHIND-only drift does not trigger a rebase under the OpenClaw fast lane.

The exact-head local ClawSweeper review found zero code findings, security concerns, or maintainer decisions. Its final Rank-up move was to recheck queued exact-head CI before merge; the full exact-head workflow rerun owns that gate. Hosted suggestions to rebase for drift or attach tier-raising media are intentionally skipped: the fast lane forbids drift-only rebases and does not chase a review tier.

## User Impact

Operators can configure `delivery.failureDestination` to receive a clear delivery-failed alert outside a stale topic. Jobs without an explicit alternate route retain current fail-closed behavior.

## Evidence

- Regression test failed pre-fix with zero alternate sends, then passed after the owner-boundary repair.
- Focused Gateway suite: 54 passed.
- `pnpm tsgo` and `pnpm check:test-types` passed.
- Targeted Oxfmt, Oxlint, and `git diff --check` passed.
- Exact-head (`e0ba78980aaaa4b18a39b51dc6c0a8f594d9e284`) real-user Telegram recording exercised the changed path:
  - baseline user message `48584` received SUT reply `48585` in 3.299s;
  - successful command run; primary send to invalid topic `2147483647` returned `400 Bad Request: message thread not found`;
  - run history recorded `status=ok`, `deliveryStatus=not-delivered`, `delivered=false`;
  - configured threadless alternate route produced one SUT alert, message `48586` at 12.505s: `Automation "E2E final delivery failure alert e0ba789" delivery failed`;
  - recorded alert had no reply target and arrived on the base/general surface (`topicId=1`); provider request count remained 1 from the baseline turn;
  - stream totals: 2 SUT messages, 4 reaction events, 0 edits, 0 deletions.
