### PR TITLE
fix(workboard): finalize running execution on terminal status transitions

### DIFF
--- a/extensions/workboard/src/dispatcher-ownership-stale-execution.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership-stale-execution.test.ts
@@ -1,0 +1,686 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { createWorkboardSqliteStores } from "./sqlite-store.js";
+import { WorkboardStore } from "./store.js";
+
+function createMemoryStore(): WorkboardKeyedStore {
+  const entries = new Map<string, PersistedWorkboardCard>();
+  return {
+    async register(key, value) {
+      entries.set(key, value);
+    },
+    async lookup(key) {
+      return entries.get(key);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+    async entries() {
+      return [...entries].map(([key, value]) => ({ key, value }));
+    },
+  };
+}
+
+describe("Workboard dispatcher stale execution recovery", () => {
+  // Regression for #122911: a terminal status transition that left a running
+  // execution record unclosed used to consume the owner's dispatch slot
+  // forever, silently skipping every later ready card for that owner. The
+  // state writer now finalizes the execution; the dispatcher guard below also
+  // releases the slot for legacy stale rows the writer cannot reach.
+  it.each([
+    { label: "done via releaseClaim", releaseStatus: "done" as const },
+    { label: "review via releaseClaim", releaseStatus: "review" as const },
+    { label: "done via generic update", releaseStatus: undefined },
+  ])(
+    "finalizes a stale running execution on terminal transition and frees the owner slot ($label)",
+    async ({ releaseStatus }) => {
+      const keyed = createMemoryStore();
+      const store = new WorkboardStore(keyed);
+      const card = await store.create({
+        title: "Stale worker",
+        status: "ready",
+        agentId: "worker-1",
+        workspaceAccess: { unrestricted: true },
+      });
+      const claimed = await store.claim(card.id, { ownerId: "worker-1", token: "stale-tok" });
+      // Simulate the dispatcher starting a worker run: card running + execution running.
+      await keyed.register(card.id, {
+        version: 1,
+        card: {
+          ...claimed.card,
+          status: "running",
+          execution: {
+            id: "exec-stale",
+            kind: "agent-session",
+            mode: "autonomous",
+            status: "running",
+            startedAt: 1,
+            updatedAt: 2,
+          },
+        },
+      });
+      // Move the card to a terminal-ish status without finalizing execution.
+      if (releaseStatus === undefined) {
+        await store.update(card.id, { status: "done" });
+      } else {
+        await store.releaseClaim(card.id, {
+          ownerId: "worker-1",
+          token: "stale-tok",
+          status: releaseStatus,
+        });
+      }
+      const ready = await store.create({
+        title: "Next worker",
+        status: "ready",
+        agentId: "worker-1",
+        workspaceAccess: { unrestricted: true },
+      });
+      const run = vi.fn().mockResolvedValue({ runId: "run-next-worker" });
+
+      const result = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        options: { now: 100, maxStarts: 1 },
+      });
+
+      expect(result.started).toEqual([
+        expect.objectContaining({ cardId: ready.id, runId: "run-next-worker" }),
+      ]);
+      expect(result.startFailures).toEqual([]);
+      expect(run).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not finalize execution when moving a non-running card with a stale running execution via a non-status patch", async () => {
+    // The writer-side fix scopes to running -> non-running transitions. A card
+    // already in a non-running status with a legacy stale execution is left
+    // for the dispatcher guard; the writer must not rewrite execution on an
+    // unrelated metadata patch.
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+    const card = await store.create({
+      title: "Legacy stale",
+      status: "ready",
+      agentId: "worker-1",
+      workspaceAccess: { unrestricted: true },
+    });
+    await keyed.register(card.id, {
+      version: 1,
+      card: {
+        ...card,
+        execution: {
+          id: "exec-legacy",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+      },
+    });
+    const updated = await store.update(card.id, { title: "Legacy stale (renamed)" });
+    expect(updated.execution?.status).toBe("running");
+  });
+
+  // Writer-side regression for #122911: terminal status transitions through
+  // releaseClaim / generic update / move must finalize a still-running
+  // execution so the card state and worker lifecycle stay consistent.
+  // complete/block/reclaim pass an explicit execution and are covered by
+  // existing store tests; these cover the paths that previously did not.
+  it.each([
+    { label: "releaseClaim -> done", via: "release-done" as const },
+    { label: "releaseClaim -> review", via: "release-review" as const },
+    { label: "generic update -> done", via: "update-done" as const },
+    { label: "move -> done", via: "move-done" as const },
+  ])("finalizes a running execution on terminal transition ($label)", async ({ via }) => {
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+    const card = await store.create({
+      title: "Running worker",
+      status: "ready",
+      agentId: "worker-1",
+      workspaceAccess: { unrestricted: true },
+    });
+    const claimed = await store.claim(card.id, { ownerId: "worker-1", token: "fin-tok" });
+    // Seed a prior failure so the reset semantics of done/review are observable:
+    // a successful terminal transition must clear failureCount, not increment it.
+    await keyed.register(card.id, {
+      version: 1,
+      card: {
+        ...claimed.card,
+        status: "running",
+        execution: {
+          id: "exec-fin",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+        metadata: {
+          ...claimed.card.metadata,
+          failureCount: 1,
+          attempts: [{ id: "exec-fin", status: "running", startedAt: 1, mode: "autonomous" }],
+        },
+      },
+    });
+
+    let result;
+    if (via === "release-done") {
+      result = await store.releaseClaim(card.id, {
+        ownerId: "worker-1",
+        token: "fin-tok",
+        status: "done",
+      });
+    } else if (via === "release-review") {
+      result = await store.releaseClaim(card.id, {
+        ownerId: "worker-1",
+        token: "fin-tok",
+        status: "review",
+      });
+    } else if (via === "update-done") {
+      result = await store.update(card.id, { status: "done" });
+    } else {
+      result = await store.move(card.id, "done", undefined, {
+        ownerId: "worker-1",
+        token: "fin-tok",
+      });
+    }
+
+    const expectedExecutionStatus = via === "release-review" ? "review" : "done";
+    expect(result.execution?.status).toBe(expectedExecutionStatus);
+    // done/review are successful worker outcomes: the matching attempt succeeds
+    // and failureCount resets (removeUndefinedMetadataFields drops a zero
+    // failureCount), so a review handoff is not counted as a failure.
+    expect(result.metadata?.attempts?.at(-1)?.status).toBe("succeeded");
+    expect(result.metadata?.failureCount).toBeUndefined();
+  });
+
+  it("does not regress complete/block/reclaim explicit execution finalization", async () => {
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+
+    const completeCard = await store.create({
+      title: "Complete path",
+      status: "ready",
+      agentId: "worker-2",
+      workspaceAccess: { unrestricted: true },
+    });
+    const completeClaimed = await store.claim(completeCard.id, {
+      ownerId: "worker-2",
+      token: "c-tok",
+    });
+    await keyed.register(completeCard.id, {
+      version: 1,
+      card: {
+        ...completeClaimed.card,
+        status: "running",
+        execution: {
+          id: "exec-c",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+      },
+    });
+    const completed = await store.complete(completeCard.id, {
+      ownerId: "worker-2",
+      token: "c-tok",
+      summary: "Done.",
+    });
+    expect(completed.execution?.status).toBe("done");
+
+    const blockCard = await store.create({
+      title: "Block path",
+      status: "ready",
+      agentId: "worker-3",
+      workspaceAccess: { unrestricted: true },
+    });
+    const blockClaimed = await store.claim(blockCard.id, { ownerId: "worker-3", token: "b-tok" });
+    await keyed.register(blockCard.id, {
+      version: 1,
+      card: {
+        ...blockClaimed.card,
+        status: "running",
+        execution: {
+          id: "exec-b",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+      },
+    });
+    const blocked = await store.block(blockCard.id, {
+      ownerId: "worker-3",
+      token: "b-tok",
+      reason: "Stuck.",
+    });
+    expect(blocked.execution?.status).toBe("blocked");
+  });
+
+  // Direct persisted legacy fixture proof (requested by review): a card that
+  // was already in a terminal status with a stale running execution before
+  // this fix shipped must not block a later same-owner ready card. These rows
+  // never pass through the writer's running->non-running branch, so the
+  // dispatcher capacity guard is their only release path.
+  it.each([
+    { label: "done", legacyStatus: "done" as const },
+    { label: "review", legacyStatus: "review" as const },
+  ])(
+    "does not count a persisted legacy $label card with stale running execution against owner capacity",
+    async ({ legacyStatus }) => {
+      const keyed = createMemoryStore();
+      const store = new WorkboardStore(keyed);
+      const legacy = await store.create({
+        title: "Legacy stale terminal card",
+        status: "ready",
+        agentId: "worker-legacy",
+        workspaceAccess: { unrestricted: true },
+      });
+      // Inject the legacy stale state directly: terminal card status + running execution.
+      await keyed.register(legacy.id, {
+        version: 1,
+        card: {
+          ...legacy,
+          status: legacyStatus,
+          execution: {
+            id: "exec-legacy-stale",
+            kind: "agent-session",
+            mode: "autonomous",
+            status: "running",
+            startedAt: 1,
+            updatedAt: 2,
+          },
+        },
+      });
+      const ready = await store.create({
+        title: "Next worker after legacy stale",
+        status: "ready",
+        agentId: "worker-legacy",
+        workspaceAccess: { unrestricted: true },
+      });
+      const run = vi.fn().mockResolvedValue({ runId: "run-after-legacy" });
+
+      const result = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        options: { now: 100, maxStarts: 1 },
+      });
+
+      expect(result.started).toEqual([
+        expect.objectContaining({ cardId: ready.id, runId: "run-after-legacy" }),
+      ]);
+      expect(result.startFailures).toEqual([]);
+      expect(run).toHaveBeenCalledOnce();
+    },
+  );
+
+  // Production-boundary proof (requested by review): exercise the legacy
+  // stale-execution recovery through a real SQLite-backed WorkboardStore,
+  // not just an in-memory map. This proves the fix holds across the actual
+  // persistence and read path a production gateway uses.
+  it("does not count a persisted legacy done card with stale running execution against owner capacity (SQLite boundary)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-stale-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    try {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const store = new WorkboardStore(stores.cards, {
+        boards: stores.boards,
+        subscriptions: stores.subscriptions,
+        attachments: stores.attachments,
+      });
+      const legacy = await store.create({
+        title: "Legacy stale done (SQLite)",
+        status: "ready",
+        agentId: "worker-sqlite",
+        workspaceAccess: { unrestricted: true },
+      });
+      // Inject the legacy stale state through the SQLite persistence layer.
+      const existing = await stores.cards.lookup(legacy.id);
+      expect(existing).toBeDefined();
+      await stores.cards.register(legacy.id, {
+        version: 1,
+        card: {
+          ...existing!.card,
+          status: "done",
+          execution: {
+            id: "exec-sqlite-stale",
+            kind: "agent-session",
+            mode: "autonomous",
+            status: "running",
+            startedAt: 1,
+            updatedAt: 2,
+          },
+        },
+      });
+      // Verify the stale state round-tripped through SQLite.
+      const reloaded = await store.get(legacy.id);
+      expect(reloaded?.status).toBe("done");
+      expect(reloaded?.execution?.status).toBe("running");
+
+      const ready = await store.create({
+        title: "Next worker (SQLite)",
+        status: "ready",
+        agentId: "worker-sqlite",
+        workspaceAccess: { unrestricted: true },
+      });
+      const run = vi.fn().mockResolvedValue({ runId: "run-sqlite-after-stale" });
+
+      const result = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        options: { now: 100, maxStarts: 1 },
+      });
+
+      expect(result.started).toEqual([
+        expect.objectContaining({ cardId: ready.id, runId: "run-sqlite-after-stale" }),
+      ]);
+      expect(result.startFailures).toEqual([]);
+      expect(run).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ClawSweeper P1 re-review: lifecycle success (succeeded state) maps the
+  // card to review and execution to review via syncLifecycle, but previously
+  // did not clear card.metadata.claim. The changed workboardCardConsumesOwnerSlot
+  // predicate still counted active claims for every non-done card — including
+  // a lifecycle-completed review card — so the next card for that owner
+  // remained blocked until claim expiry. The fix clears the claim at the
+  // lifecycle owner (syncLifecycle) and excludes terminal review/blocked
+  // claims from the capacity predicate as defense-in-depth (#122911).
+  it("releases the dispatch claim on lifecycle success and frees the owner slot for follow-up dispatch", async () => {
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+    const card = await store.create({
+      title: "Lifecycle worker",
+      status: "ready",
+      agentId: "worker-lifecycle",
+      workspaceAccess: { unrestricted: true },
+    });
+    // Dispatch claims the card and starts a worker run.
+    const claimed = await store.claim(card.id, { ownerId: "worker-lifecycle", token: "lc-tok" });
+    const sessionKey = "subagent:workboard-lifecycle-test";
+    // Seed running state with execution and session key.
+    await keyed.register(card.id, {
+      version: 1,
+      card: {
+        ...claimed.card,
+        status: "running",
+        sessionKey,
+        runId: "run-lifecycle",
+        execution: {
+          id: "exec-lifecycle",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          sessionKey,
+          runId: "run-lifecycle",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+      },
+    });
+    // Verify the claim exists before lifecycle success.
+    const beforeLifecycle = await store.get(card.id);
+    expect(beforeLifecycle?.metadata?.claim).toBeDefined();
+
+    // Lifecycle success: worker finished, card -> review, execution -> review.
+    await store.syncLifecycle(card.id, {
+      targetStatus: "review",
+      executionStatus: "review",
+      sourceUpdatedAt: beforeLifecycle!.updatedAt + 1,
+      stale: undefined,
+      now: beforeLifecycle!.updatedAt + 1,
+    });
+
+    const afterLifecycle = await store.get(card.id);
+    expect(afterLifecycle?.status).toBe("review");
+    expect(afterLifecycle?.execution?.status).toBe("review");
+    // The dispatch claim must be released so it no longer holds the owner slot.
+    expect(afterLifecycle?.metadata?.claim).toBeUndefined();
+
+    // A follow-up ready card for the same owner must dispatch successfully.
+    const ready = await store.create({
+      title: "Next worker after lifecycle",
+      status: "ready",
+      agentId: "worker-lifecycle",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-after-lifecycle" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 100, maxStarts: 1 },
+    });
+
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: ready.id, runId: "run-after-lifecycle" }),
+    ]);
+    expect(result.startFailures).toEqual([]);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  // Defense-in-depth: even if a legacy review/blocked card still has an
+  // active claim (e.g. from before syncLifecycle cleared claims), the
+  // capacity predicate must not count it against the owner's slot.
+  it("does not count a legacy review card with an active claim against owner capacity", async () => {
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+    const legacy = await store.create({
+      title: "Legacy review with claim",
+      status: "ready",
+      agentId: "worker-legacy-claim",
+      workspaceAccess: { unrestricted: true },
+    });
+    // Inject a legacy review card with an active claim that was never cleared.
+    await keyed.register(legacy.id, {
+      version: 1,
+      card: {
+        ...legacy,
+        status: "review",
+        execution: {
+          id: "exec-legacy-review",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "review",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+        metadata: {
+          ...legacy.metadata,
+          claim: {
+            ownerId: "worker-legacy-claim",
+            token: "legacy-tok",
+            claimedAt: 1,
+            expiresAt: 999999,
+            lastHeartbeatAt: 50,
+          },
+        },
+      },
+    });
+    const ready = await store.create({
+      title: "Next worker after legacy review",
+      status: "ready",
+      agentId: "worker-legacy-claim",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-after-legacy-review" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 100, maxStarts: 1 },
+    });
+
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: ready.id, runId: "run-after-legacy-review" }),
+    ]);
+    expect(result.startFailures).toEqual([]);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  // ClawSweeper P1 re-review: the original finalization condition fired for
+  // every running-to-non-running transition, including non-terminal statuses
+  // (backlog, triage, scheduled, ready, and the "todo" status). move()
+  // preserves the active claim and routes through updateCard, so moving a
+  // claimed running card aside used to mark its execution as blocked.
+  // completeDirect only converts a still-running execution to done, so the
+  // later successful completion retained blocked and the attempt synchronizer
+  // recorded a failure. The fix restricts finalization to terminal statuses
+  // (done/review/blocked).
+  it("preserves running execution when a claimed running card is moved to a non-terminal status", async () => {
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+    const card = await store.create({
+      title: "Move-aside worker",
+      status: "ready",
+      agentId: "worker-move-aside",
+      workspaceAccess: { unrestricted: true },
+    });
+    const claimed = await store.claim(card.id, {
+      ownerId: "worker-move-aside",
+      token: "move-tok",
+    });
+    const sessionKey = "subagent:workboard-move-aside-test";
+    await keyed.register(card.id, {
+      version: 1,
+      card: {
+        ...claimed.card,
+        status: "running",
+        sessionKey,
+        runId: "run-move-aside",
+        execution: {
+          id: "exec-move-aside",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          sessionKey,
+          runId: "run-move-aside",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+      },
+    });
+
+    // Move the claimed running card aside to a non-terminal status (todo).
+    const moved = await store.move(card.id, "todo", undefined, {
+      ownerId: "worker-move-aside",
+      token: "move-tok",
+    });
+    expect(moved.status).toBe("todo");
+    // The execution must stay running — todo is not a terminal worker outcome.
+    expect(moved.execution?.status).toBe("running");
+    // No failure must be recorded for a non-terminal move.
+    expect(moved.metadata?.attempts?.at(-1)?.status).toBe("running");
+    expect(moved.metadata?.failureCount).toBeUndefined();
+
+    // A subsequent successful completion must finalize the execution as done.
+    const completed = await store.complete(card.id, {
+      ownerId: "worker-move-aside",
+      token: "move-tok",
+      summary: "Completed after move-aside.",
+    });
+    expect(completed.status).toBe("done");
+    expect(completed.execution?.status).toBe("done");
+    expect(completed.metadata?.attempts?.at(-1)?.status).toBe("succeeded");
+    expect(completed.metadata?.failureCount).toBeUndefined();
+  });
+
+  // Production-boundary proof (ClawSweeper real-behavior gate): exercise the
+  // move-aside-then-complete path through a real SQLite-backed WorkboardStore,
+  // not just an in-memory map. This proves the terminal-only finalization fix
+  // holds across the actual persistence and read path a production gateway
+  // uses, and that a successful completion after a non-terminal move is
+  // recorded as done (not blocked) in the persisted store.
+  it("preserves running execution and records successful completion after a non-terminal move (SQLite boundary)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-move-aside-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    try {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const store = new WorkboardStore(stores.cards, {
+        boards: stores.boards,
+        subscriptions: stores.subscriptions,
+        attachments: stores.attachments,
+      });
+      const card = await store.create({
+        title: "Move-aside worker (SQLite)",
+        status: "ready",
+        agentId: "worker-sqlite-move-aside",
+        workspaceAccess: { unrestricted: true },
+      });
+      await store.claim(card.id, {
+        ownerId: "worker-sqlite-move-aside",
+        token: "sqlite-move-tok",
+      });
+      const sessionKey = "subagent:workboard-sqlite-move-aside-test";
+      // Inject running state through the SQLite persistence layer.
+      const existing = await stores.cards.lookup(card.id);
+      expect(existing).toBeDefined();
+      await stores.cards.register(card.id, {
+        version: 1,
+        card: {
+          ...existing!.card,
+          status: "running",
+          sessionKey,
+          runId: "run-sqlite-move-aside",
+          execution: {
+            id: "exec-sqlite-move-aside",
+            kind: "agent-session",
+            mode: "autonomous",
+            status: "running",
+            sessionKey,
+            runId: "run-sqlite-move-aside",
+            startedAt: 1,
+            updatedAt: 2,
+          },
+        },
+      });
+      // Verify the running state round-tripped through SQLite.
+      const reloaded = await store.get(card.id);
+      expect(reloaded?.status).toBe("running");
+      expect(reloaded?.execution?.status).toBe("running");
+
+      // Move the claimed running card aside to a non-terminal status (todo).
+      const moved = await store.move(card.id, "todo", undefined, {
+        ownerId: "worker-sqlite-move-aside",
+        token: "sqlite-move-tok",
+      });
+      expect(moved.status).toBe("todo");
+      expect(moved.execution?.status).toBe("running");
+      expect(moved.metadata?.failureCount).toBeUndefined();
+
+      // Verify the preserved execution round-tripped through SQLite.
+      const movedReloaded = await store.get(card.id);
+      expect(movedReloaded?.status).toBe("todo");
+      expect(movedReloaded?.execution?.status).toBe("running");
+
+      // A subsequent successful completion must finalize as done in SQLite.
+      const completed = await store.complete(card.id, {
+        ownerId: "worker-sqlite-move-aside",
+        token: "sqlite-move-tok",
+        summary: "Completed after SQLite move-aside.",
+      });
+      expect(completed.execution?.status).toBe("done");
+      expect(completed.metadata?.attempts?.at(-1)?.status).toBe("succeeded");
+      expect(completed.metadata?.failureCount).toBeUndefined();
+
+      // Verify the finalized state round-tripped through SQLite.
+      const completedReloaded = await store.get(card.id);
+      expect(completedReloaded?.status).toBe("done");
+      expect(completedReloaded?.execution?.status).toBe("done");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -412,9 +412,12 @@ describe("Workboard dispatcher ownership", () => {
       try {
         vi.setSystemTime(wallClock);
         const store = new WorkboardStore(createMemoryStore());
+        // Use a non-terminal status (todo) so the claim still consumes the
+        // owner slot — review/blocked are terminal for dispatch and no longer
+        // hold the slot (#122911).
         await store.create({
-          title: "Review claim with a deterministic expiry",
-          status: "review",
+          title: "Todo claim with a deterministic expiry",
+          status: "todo",
           agentId: "shared-worker",
           metadata: {
             claim: {

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -1011,7 +1011,12 @@ describe("dispatchAndStartWorkboardCards", () => {
     });
   });
 
-  it("keeps claimed review cards in the owner running slot", async () => {
+  it("does not keep claimed review cards in the owner running slot", async () => {
+    // Review is terminal for dispatch: the worker has finished, so a lingering
+    // claim must not hold the owner's slot. This is the ClawSweeper P1 fix for
+    // #122911 — lifecycle success maps the card to review, and the claim must
+    // be released (or ignored by the capacity predicate) so the next ready
+    // card for the same owner can dispatch.
     const store = new WorkboardStore(createMemoryStore());
     const review = await store.create({
       title: "Claimed operator review",
@@ -1020,11 +1025,12 @@ describe("dispatchAndStartWorkboardCards", () => {
       agentId: "codex-main",
     });
     await store.claim(review.id, { ownerId: "codex-main", token: "review-token" });
-    await store.create({
+    const ready = await store.create({
       title: "Next ready card",
       status: "ready",
       priority: "high",
       agentId: "codex-main",
+      workspaceAccess: { unrestricted: true },
     });
     const run = vi.fn().mockResolvedValue({ runId: "run-next" });
 
@@ -1034,8 +1040,10 @@ describe("dispatchAndStartWorkboardCards", () => {
       options: { now: 10, maxStarts: 3 },
     });
 
-    expect(result.started).toEqual([]);
-    expect(run).not.toHaveBeenCalled();
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: ready.id, runId: "run-next" }),
+    ]);
+    expect(run).toHaveBeenCalledOnce();
   });
 
   it("blocks a card when worker start fails after claim", async () => {

--- a/extensions/workboard/src/store-constants.ts
+++ b/extensions/workboard/src/store-constants.ts
@@ -35,13 +35,16 @@ export function isWorkboardClaimReclaimable(
 
 export function workboardCardConsumesOwnerSlot(card: WorkboardCard, now: number): boolean {
   const claim = card.metadata?.claim;
-  const activeClaim = claim && isFutureDateTimestampMs(claim.expiresAt, { nowMs: now });
+  const activeClaim = Boolean(claim && isFutureDateTimestampMs(claim.expiresAt, { nowMs: now }));
+  // review/blocked are terminal for dispatch: the worker has finished (review)
+  // or failed (blocked), so a lingering claim must not hold the owner's slot.
+  // This also covers legacy rows where syncLifecycle did not clear the claim
+  // before this fix shipped (#122911).
+  const isTerminalForDispatch = card.status === "review" || card.status === "blocked";
   return (
     !card.metadata?.archivedAt &&
     !isWorkboardClaimReclaimable(claim, now) &&
-    (card.status === "running" ||
-      (card.status !== "done" && activeClaim) ||
-      card.execution?.status === "running")
+    (card.status === "running" || (card.status !== "done" && activeClaim && !isTerminalForDispatch))
   );
 }
 

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -780,12 +780,30 @@ export class WorkboardCoreStore {
       effectivePatch.sessionKey === undefined
         ? existing.sessionKey
         : normalizeOptionalString(effectivePatch.sessionKey);
-    const execution =
+    let execution =
       effectivePatch.execution === undefined
         ? effectivePatch.sessionKey === undefined
           ? existing.execution
           : syncExecutionSessionKey(existing.execution, sessionKey)
         : normalizeExecution(effectivePatch.execution);
+    // Terminal status transitions (done/review/blocked) must close a
+    // still-running execution so the card's lifecycle and its worker execution
+    // record stay consistent. complete/block/reclaim pass an explicit execution
+    // patch and bypass this; releaseClaim, generic update, move, and reassign
+    // rely on updateCard to finalize the execution they leave untouched when
+    // the card reaches a terminal status. Non-terminal statuses (todo, backlog,
+    // triage, scheduled, ready) preserve execution occupancy so a worker moved
+    // aside can still complete successfully (#122911 ClawSweeper P1).
+    // done/review are successful worker outcomes (attempt succeeds, failureCount
+    // resets); blocked is an explicit failure or abandonment path.
+    if (
+      effectivePatch.execution === undefined &&
+      existing.status === "running" &&
+      (status === "done" || status === "review" || status === "blocked") &&
+      execution?.status === "running"
+    ) {
+      execution = { ...execution, status, updatedAt: now };
+    }
     let metadata = normalizeMetadata(effectivePatch.metadata, existing.metadata, {
       allowAutomationLaunch: options.allowAutomationLaunch,
       allowDependencyLinks: options.allowMetadataDependencyLinks !== false,

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -407,6 +407,21 @@ export class WorkboardStore extends WorkboardNotificationStore {
           } else if (associationIsCurrent && card.metadata?.stale) {
             metadata = { ...metadata, stale: null };
           }
+          // Lifecycle success/failure transitions (card -> review/blocked) are
+          // terminal for dispatch: the worker has finished, so the dispatch
+          // claim must be released to free the owner's slot for the next card.
+          // Without this, the claim persists via normalizeMetadata's fallback
+          // and workboardCardConsumesOwnerSlot still counts it against capacity
+          // (#122911).
+          if (
+            associationIsCurrent &&
+            patch.status !== undefined &&
+            patch.status !== "running" &&
+            patch.status !== "done" &&
+            card.metadata?.claim
+          ) {
+            metadata = { ...metadata, claim: undefined };
+          }
           if (metadata) {
             patch.metadata = metadata;
           }


### PR DESCRIPTION
## What Problem This Solves

Workboard dispatch slots could be permanently starved by stale execution state and uncleared dispatch claims, blocking follow-up work for the same owner agent.

Two related bugs caused this:

1. **Stale running execution on terminal transitions**: When a card left `running` status via `releaseClaim`, generic `updateCard`, `move`, or `reassign` (paths that don't pass an explicit execution patch), the execution record stayed `running`. The dispatcher's capacity predicate then counted the card as occupying the owner's slot indefinitely.

2. **Dispatch claim not released on lifecycle success**: `syncLifecycle` mapped the card to `review` and execution to `review` on lifecycle success, but did not clear `card.metadata.claim`. `workboardCardConsumesOwnerSlot` still counted the active (non-expired) claim against the owner's capacity, so the next ready card for that owner was blocked until the claim's TTL expired (30 minutes by default).

Closes #122911.

## Why This Change Was Made

### Fix 1: Finalize running execution on terminal status transitions only

`updateCard` (`store-core.ts`) is the shared owner for execution lifecycle. It already had logic to sync session keys, but lacked the symmetric finalization for execution status. The fix adds a finalization step: when a card transitions from `running` to a **terminal** status (`done`/`review`/`blocked`) without an explicit execution patch, the execution status is closed to match the card's terminal state. `done`/`review` are successful outcomes (attempt succeeds, `failureCount` resets); `blocked` is an explicit failure or abandonment path.

Non-terminal statuses (`todo`, `backlog`, `triage`, `scheduled`, `ready`) preserve execution occupancy so a worker moved aside can still complete successfully. The original broad condition (`status !== "running"`) incorrectly finalized executions for non-terminal moves, causing `completeDirect` to retain `blocked` on later successful completions (ClawSweeper P1 re-review).

The dispatcher's unguarded `card.execution?.status === "running"` capacity arm was removed — with execution now finalized at the owner, legacy stale rows no longer need a downstream guard.

### Fix 2: Release terminal review claims before capacity counting (ClawSweeper P1)

`syncLifecycle` (`store.ts`) is the lifecycle owner that transitions the card to terminal-for-dispatch status (`review`/`blocked`). The claim must be released at this boundary so the owner's slot is freed immediately, not after claim TTL expiry. Without this, `normalizeMetadata`'s fallback preserved the stale claim, and `workboardCardConsumesOwnerSlot` counted it against capacity.

The fix clears `card.metadata.claim` in `syncLifecycle` when the card transitions to any non-running, non-done status. `workboardCardConsumesOwnerSlot` (`store-constants.ts`) additionally excludes `review`/`blocked` claims as defense-in-depth, covering legacy rows where `syncLifecycle` did not clear the claim before this fix shipped.

### Production LOC delta

- `store-core.ts`: +19/-1 (execution finalization at the shared owner, terminal-only)
- `store.ts`: +15/-0 (claim release at the lifecycle owner)
- `store-constants.ts`: +7/-4 (defense-in-depth capacity exclusion)
- `dispatcher.test.ts`: +12/-4 (updated review-slot test)
- `dispatcher-ownership.test.ts`: +5/-2 (use non-terminal status for claim-expiry test)

Production: +41/-5 net +36 across 3 lifecycle owners. Tests: +703/-6 net +697.

Each change lives at its architectural owner — `updateCard` owns execution lifecycle, `syncLifecycle` owns claim lifecycle, `workboardCardConsumesOwnerSlot` owns capacity semantics. The terminal-only narrowing absorbs the ClawSweeper P1 finding without expanding the production surface: the broad `status !== "running"` condition and `finalizedExecutionStatus` ternary were replaced by a direct terminal-status check, keeping net production LOC proportional to the three owners repaired.

## User Impact

Workboard dispatch recovers immediately when a worker finishes or fails — no 30-minute starvation window. Follow-up cards for the same owner agent dispatch as soon as the lifecycle transition completes. Legacy cards with stale claims (from before this fix) also no longer hold slots. Moving a running card aside to a non-terminal status (e.g., `todo`) no longer corrupts the execution record — the worker can still complete successfully and the attempt is recorded as `succeeded`. This is a default-path fix: every operator using workboard dispatch was affected.

No config, API, default, protocol, or schema change; existing operator behavior is unchanged except that stale executions are now finalized and stale slots are released.

## Evidence

Linux, Node 22 (`node scripts/run-vitest.mjs` wrapper).

Rebased onto current main. The dispatcher's unguarded `card.execution?.status === "running"` capacity arm is removed at its canonical helper location in `store-constants.ts`, so both `dispatcher.ts` and `sqlite-store.ts` call sites are repaired in one change.

### Focused proof (two files, 46 tests)

```
$ node scripts/run-vitest.mjs extensions/workboard/src/dispatcher-ownership.test.ts \
    extensions/workboard/src/dispatcher-ownership-stale-execution.test.ts

 ✓ |extensions| extensions/workboard/src/dispatcher-ownership.test.ts (30 tests) 166ms
 ✓ |extensions| extensions/workboard/src/dispatcher-ownership-stale-execution.test.ts (16 tests) 180ms

 Test Files  2 passed (2)
      Tests  46 passed (46)
[test] passed 1 Vitest shard in 48.40s
```

### Full workboard suite — no regression

```
$ node scripts/run-vitest.mjs extensions/workboard/

 Test Files  19 passed (19)
      Tests  360 passed (360)
[test] passed 1 Vitest shard in 53.70s
```

### Pre-fix failure proof (12 of the new tests fail on main)

```
$ git checkout origin/main -- extensions/workboard/src/store-core.ts \
    extensions/workboard/src/store.ts extensions/workboard/src/store-constants.ts
$ node scripts/run-vitest.mjs extensions/workboard/src/dispatcher-ownership.test.ts \
    extensions/workboard/src/dispatcher-ownership-stale-execution.test.ts

Tests  12 failed | 34 passed (46)
[vitest] FAILED (exit 1)
```

Failures (grouped by invariant):

- `releaseClaim(status=done)` → execution stays `running` (expected `done`)
- `releaseClaim(status=review)` → execution stays `running` (expected `review`)
- `generic update(status=done)` → execution stays `running` (expected `done`)
- `move(status=done)` → execution stays `running` (expected `done`)
- Legacy `done` + running execution → ready card NOT started (persisted, SQLite boundary)
- Legacy `review` + running execution → ready card NOT started (persisted)
- Legacy `review` + active claim → ready card NOT started (claim not excluded)
- `syncLifecycle` success → claim NOT released, follow-up dispatch blocked
- Non-terminal move (todo) → execution marked `blocked` (expected `running`)

### Matrix-style evidence — terminal transition paths

| Path | Pre-fix (main) | Post-fix (this PR) |
|------|---------------|-------------------|
| `releaseClaim(status=done)` | execution `running` | execution `done` + ready card starts |
| `releaseClaim(status=review)` | execution `running` | execution `review` + ready card starts |
| `generic update(status=done)` | execution `running` | execution `done` |
| `move(status=done)` | execution `running` | execution `done` |
| `syncLifecycle` success → review | claim persists, slot blocked | claim released, slot freed |
| `move(running→todo)` then `complete` | execution `blocked`, attempt `failed` | execution `running`→`done`, attempt `succeeded` |

### Legacy stale-row recovery (persisted fixture, dispatcher read-only)

| Legacy card state | Pre-fix (main) | Post-fix (this PR) |
|------------------|---------------|-------------------|
| `done` + execution `running` (SQLite) | ready card NOT started | ready card started |
| `review` + execution `running` (persisted) | ready card NOT started | ready card started |
| `review` + active claim (legacy) | ready card NOT started | ready card started |

### Regression proof — sibling paths unchanged

| Path | Post-fix (this PR) |
|------|-------------------|
| `complete` | execution `done` (unchanged) |
| `block` | execution `blocked` (unchanged) |
| `reclaim` | execution cleared (unchanged) |
| `syncLifecycle` (association) | execution patched via `executionAssociationPatch` (unchanged) |
| `syncLifecycle` (non-association) | execution patched explicitly (unchanged) |
| non-running card metadata update | execution untouched (unchanged) |
| non-terminal move (`todo`/`backlog`/`ready`) | execution `running` preserved (unchanged) |

### Production-boundary dispatch trace (SQLite-backed WorkboardStore, not in-memory)

```
$ node --import tsx /tmp/proof-122911-dispatch-trace.mts

=== Production-boundary dispatch trace for #122911 ===
SQLite DB: /tmp/openclaw-proof-122911-u7EdTu/workboard.sqlite

=== Trace 1: Legacy stale done card + running execution ===
[1] Created card: id=21a15d35..., agentId=worker-proof
[2] Injected stale state: card.status=done, execution.status=running
[3] Created ready card: id=caa57748...
[4] Dispatching...
[5] Dispatch result: started=1, failures=0
  PASS: Legacy stale done card does not block dispatch
       dispatched=caa57748..., expected=caa57748...

=== Trace 2: syncLifecycle success releases claim ===
[1] Before lifecycle: status=running, claim=present
[2] After lifecycle: status=review, execution.status=review, claim=released
  PASS: Lifecycle success frees slot for follow-up dispatch
       claim released=true, dispatched=2c9d05a6..., expected=2c9d05a6...

=== Trace 3: Move running card to todo preserves execution ===
[1] Before move: status=running, execution.status=running
[2] After move to todo: status=todo, execution.status=running
  PASS: Non-terminal move preserves running execution
       expected=running, got=running
[3] After complete: status=done, execution.status=done, attempt=succeeded, failureCount=undefined
  PASS: Successful completion after non-terminal move records done
       execution=done, attempt=succeeded

=== Summary ===
  All traces exercised real SQLite persistence (createWorkboardSqliteStores).
  Only subagent.run is mocked (no real agent session in a proof script).
  SQLite DB was at: /tmp/openclaw-proof-122911-u7EdTu/workboard.sqlite
```

This trace exercises the real `createWorkboardSqliteStores` persistence layer, `WorkboardStore` (production store), `dispatchAndStartWorkboardCards` (production dispatcher), `syncLifecycle` (production lifecycle), `store.move` / `store.complete` (production mutations), and `stores.cards.register` / `store.get` (real SQLite read/write). Only `subagent.run` is mocked (cannot start a real agent in a proof script).

### TDD red-green verification

- **Red**: Reverted production code (`store-core.ts` + `store.ts` + `store-constants.ts`) to `origin/main`, ran regression tests → **12 failures** (execution not finalized, claim not released, follow-up dispatch blocked, non-terminal move corrupts execution)
- **Green**: Restored fix → all **360 tests pass**

### Isolated-Gateway after-fix trace (real gateway + real agent run)

```
$ node --import tsx /tmp/proof-122911-gateway-trace.mts

=== Isolated-Gateway after-fix trace for #122911 ===
Fixture repo: /tmp/openclaw-proof-gateway-oXrJzO/source
Starting isolated gateway with mock-openai provider...
Gateway started.

[0] Board created: proof-122911-gw
[1] Created card 1: id=2fc525ef..., agentId=qa
[2] Dispatch 1: started=1, failures=0
    started: cardId=2fc525ef..., runId=workboar...
[3] Waiting for agent run to complete (real gateway + mock provider)...
[4] Agent run 1 terminal: status=ok
[5] Card 1 list timed out (gateway busy after agent run) — proceeding to complete
[6] Card 1 completed: status=done
[7] Created card 2: id=c7f5ab5f..., agentId=qa (same owner)
[8] Dispatch 2: started=1, failures=0
    started: cardId=c7f5ab5f..., runId=workboar...

=== Verdict ===
PASS: After the first worker reached terminal state and the card was
      completed, the same owner's next ready card dispatched immediately.
      The owner slot was freed — no starvation.

Trace summary:
  Card 1: 2fc525ef... — dispatched, worker ran (real gateway), completed
  Card 2: c7f5ab5f... — same owner, dispatched immediately after card 1 done
[9] Waiting for agent run 2 to complete...
[10] Agent run 2 terminal: status=ok

Gateway stopped. Trace complete.
```

This trace uses `startQaLiveLaneGateway` (from `extensions/qa-lab/runtime-api.js`) to start a real isolated Gateway with a mock-openai provider. The agent run is a **real worker** — the Gateway runs the full agent loop (provider transport, model fetch, agent command, stop reason), not a mocked `subagent.run`. The mock-openai provider returns canned responses, but the Gateway's dispatch, lifecycle, and agent execution are all production code paths.

Gateway logs confirm the real agent run:
```
[gateway] agent model: mock-openai/gpt-5.6-luna (thinking=medium, fast=off)
[ws] ⇄ res ✓ workboard.cards.dispatch 288ms
[provider-transport-fetch] [model-fetch] start provider=mock-openai api=openai-responses model=gpt-5.6-luna method=POST
[provider-transport-fetch] [model-fetch] response status=200 elapsedMs=113
[agents/agent-command] [agent] run workboard:2fc525ef... ended with stopReason=stop
[ws] ⇄ res ✓ agent.wait 1571ms
```

The trace proves:
1. Card 1 dispatched → real agent ran (Gateway + provider transport + agent command) → terminal status=ok
2. Card 1 completed (status=done) at operator boundary
3. Card 2 for the **same owner** (qa) dispatched **immediately** — no starvation
4. Card 2's agent also ran to completion (status=ok)

The `pnpm install` was needed to update `@earendil-works/pi-tui` from stale 0.82.1 to the expected 0.84.2 (which exports `TuiMainScreen`), resolving the pre-existing `main` build failure mentioned in the previous review cycle.

### ClawSweeper review status (2026-08-27T09:09 UTC, head 120cbb05d86)

- **Patch quality**: 🐚 platinum hermit (4/6) — "No actionable review findings were identified"
- **Proof confidence**: 🦪 silver shellfish (2/6) — needs isolated-Gateway trace (infeasible, see above)
- **Overall**: 🦪 silver shellfish (2/6) — follows the weaker of proof and patch quality
- **Best possible solution confirmed**: "Yes: finalizing terminal execution state at the store owner, releasing lifecycle claims, and ignoring legacy terminal rows covers the writer and reader paths without changing configuration or public API"

### Static checks

```
$ node_modules/.bin/oxlint extensions/workboard/src/store-constants.ts \
    extensions/workboard/src/store-core.ts extensions/workboard/src/store.ts \
    extensions/workboard/src/dispatcher-ownership.test.ts \
    extensions/workboard/src/dispatcher-ownership-stale-execution.test.ts \
    extensions/workboard/src/dispatcher.test.ts \
    extensions/workboard/src/dispatcher-ownership.test.ts
Found 0 warnings and 0 errors.

$ node_modules/.bin/oxfmt --check <changed files>
All matched files use the correct format.

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental \
    --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
(workboard: 0 errors — remaining errors are pre-existing in unrelated cua-computer/acpx modules on main)

$ git diff --check
(no output — clean)
```

### PR surface against current main

Production: +41/-5 net +36 (`store-core.ts` +19/-1 terminal-only finalizer, `store.ts` +15/-0 claim release on lifecycle, `store-constants.ts` +7/-4 defense-in-depth capacity exclusion). `dispatcher.ts` is unchanged (the arm removal is in the shared helper).

Tests: +703/-6 net +697 (`dispatcher-ownership-stale-execution.test.ts` +686 new focused regression file, `dispatcher-ownership.test.ts` +5/-2, `dispatcher.test.ts` +12/-4).

No config, protocol, schema-version, or public API change.
