### PR TITLE
fix(google-meet): validate OAuth token response against malformed envelopes

### DIFF
--- a/extensions/google-meet/src/oauth.test.ts
+++ b/extensions/google-meet/src/oauth.test.ts
@@ -299,4 +299,3 @@ describe("Google Meet OAuth", () => {
     ).rejects.toThrow("Google OAuth token response was missing access_token");
   });
 });
-

--- a/extensions/google-meet/src/oauth.test.ts
+++ b/extensions/google-meet/src/oauth.test.ts
@@ -244,4 +244,59 @@ describe("Google Meet OAuth", () => {
     ).rejects.toThrow(/timeout/i);
     expect(promptInput).not.toHaveBeenCalled();
   });
+
+  it("rejects a null OAuth token response as malformed", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("null", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      resolveGoogleMeetAccessToken({
+        clientId: "client-id",
+        refreshToken: "refresh-token",
+      }),
+    ).rejects.toThrow("Google OAuth token response was malformed");
+  });
+
+  it("rejects a primitive string OAuth token response as malformed", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response('"not-an-object"', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      resolveGoogleMeetAccessToken({
+        clientId: "client-id",
+        refreshToken: "refresh-token",
+      }),
+    ).rejects.toThrow("Google OAuth token response was malformed");
+  });
+
+  it("rejects an OAuth token response missing access_token", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ expires_in: 3600 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      resolveGoogleMeetAccessToken({
+        clientId: "client-id",
+        refreshToken: "refresh-token",
+      }),
+    ).rejects.toThrow("Google OAuth token response was missing access_token");
+  });
 });
+

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -92,11 +92,9 @@ async function executeGoogleTokenRequest(body: URLSearchParams): Promise<GoogleM
       const detail = await readGoogleApiErrorDetail(response);
       throw new Error(`Google OAuth token request failed (${response.status}): ${detail}`);
     }
-    const payload = await readProviderJsonResponse<unknown>(
-      response,
-      "Google OAuth token",
-      { maxBytes: GOOGLE_OAUTH_TOKEN_JSON_MAX_BYTES },
-    );
+    const payload = await readProviderJsonResponse<unknown>(response, "Google OAuth token", {
+      maxBytes: GOOGLE_OAUTH_TOKEN_JSON_MAX_BYTES,
+    });
     if (!isRecord(payload)) {
       throw new Error("Google OAuth token response was malformed");
     }
@@ -109,7 +107,9 @@ async function executeGoogleTokenRequest(body: URLSearchParams): Promise<GoogleM
       accessToken,
       expiresAt: resolveGoogleMeetTokenExpiresAt(payload.expires_in),
       refreshToken:
-        typeof payload.refresh_token === "string" ? payload.refresh_token.trim() || undefined : undefined,
+        typeof payload.refresh_token === "string"
+          ? payload.refresh_token.trim() || undefined
+          : undefined,
       scope: typeof payload.scope === "string" ? payload.scope.trim() || undefined : undefined,
       tokenType:
         typeof payload.token_type === "string" ? payload.token_type.trim() || undefined : undefined,

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { readGoogleApiErrorDetail } from "./google-api-errors.js";
 
 const GOOGLE_MEET_REDIRECT_URI = "http://localhost:8085/oauth2callback";
@@ -91,23 +92,27 @@ async function executeGoogleTokenRequest(body: URLSearchParams): Promise<GoogleM
       const detail = await readGoogleApiErrorDetail(response);
       throw new Error(`Google OAuth token request failed (${response.status}): ${detail}`);
     }
-    const payload = await readProviderJsonResponse<{
-      access_token?: string;
-      expires_in?: number;
-      refresh_token?: string;
-      scope?: string;
-      token_type?: string;
-    }>(response, "Google OAuth token", { maxBytes: GOOGLE_OAUTH_TOKEN_JSON_MAX_BYTES });
-    const accessToken = payload.access_token?.trim();
+    const payload = await readProviderJsonResponse<unknown>(
+      response,
+      "Google OAuth token",
+      { maxBytes: GOOGLE_OAUTH_TOKEN_JSON_MAX_BYTES },
+    );
+    if (!isRecord(payload)) {
+      throw new Error("Google OAuth token response was malformed");
+    }
+    const accessToken =
+      typeof payload.access_token === "string" ? payload.access_token.trim() : undefined;
     if (!accessToken) {
       throw new Error("Google OAuth token response was missing access_token");
     }
     return {
       accessToken,
       expiresAt: resolveGoogleMeetTokenExpiresAt(payload.expires_in),
-      refreshToken: payload.refresh_token?.trim() || undefined,
-      scope: payload.scope?.trim() || undefined,
-      tokenType: payload.token_type?.trim() || undefined,
+      refreshToken:
+        typeof payload.refresh_token === "string" ? payload.refresh_token.trim() || undefined : undefined,
+      scope: typeof payload.scope === "string" ? payload.scope.trim() || undefined : undefined,
+      tokenType:
+        typeof payload.token_type === "string" ? payload.token_type.trim() || undefined : undefined,
     };
   } finally {
     await release();


### PR DESCRIPTION
## What Problem This Solves

Google Meet OAuth token exchange could throw a raw TypeError when a successful token response body was null or a non-record value instead of the expected JSON object. The crash occurred at `payload.access_token` because the parsed JSON was accessed without first verifying it was an object.

## Why This Change Was Made

The `readProviderJsonResponse` call used a typed generic (`{ access_token?: string; ... }`) that assumed the parsed JSON was always an object. At runtime, a null or primitive response would pass through, and `payload.access_token` would throw `TypeError: Cannot read properties of null (reading 'access_token')`.

Following the same pattern as the OpenRouter video catalog fix (PR #111637), the handler now:
1. Reads the response as `unknown` via `readProviderJsonResponse<unknown>`
2. Validates the payload with `isRecord()` before accessing any property
3. Uses explicit `typeof` checks for string fields (`access_token`, `refresh_token`, `scope`, `token_type`)
4. `expires_in` is passed to `resolveGoogleMeetTokenExpiresAt` which already accepts `unknown`

## User Impact

Google Meet OAuth token exchange continues to work normally for well-formed responses. A malformed response now produces a clear error message ("Google OAuth token response was malformed") instead of a raw TypeError stack trace. This is especially important during OAuth setup flows where users may encounter unexpected proxy or network responses.

## Evidence

- Before fix: A null Google OAuth token success body would crash with `TypeError: Cannot read properties of null (reading 'access_token')` at `payload.access_token`.
- After fix: `isRecord(payload)` returns `false` for null, and a clear "malformed response" error is thrown instead.
- All five response fields (`access_token`, `expires_in`, `refresh_token`, `scope`, `token_type`) are accessed only after the `isRecord` check.
- `isRecord` is imported from `openclaw/plugin-sdk/string-coerce-runtime`, the same module used by other providers.
- All 53 CI checks pass on the latest commit (`7ae5dc6`), including `check-lint` and `check-test-types`. The only failing check is `label`, a transient GitHub labeling automation issue unrelated to code quality.

## Regression Test Plan

Added 3 regression tests to `extensions/google-meet/src/oauth.test.ts` (commit `7ae5dc6`):

1. **`rejects a null OAuth token response as malformed`** — sends `null` as the JSON token response body, verifies the error "Google OAuth token response was malformed" is thrown instead of a TypeError.
2. **`rejects a primitive string OAuth token response as malformed`** — sends `"not-an-object"` as the JSON token response body, verifies the same malformed-response error.
3. **`rejects an OAuth token response missing access_token`** — sends `{ expires_in: 3600 }` without `access_token`, verifies the error "Google OAuth token response was missing access_token" is thrown.

These tests cover both the malformed response path (null/primitive body) and the missing-field path (object without access_token), proving the fix handles edge cases without breaking normal OAuth token exchange.

## Root Cause

The `readProviderJsonResponse<T>` function parses JSON but does not guarantee the result is an object. The typed generic `T` created a false assumption that the parsed value would always match the expected shape. Without a runtime `isRecord()` guard, property access on `null` or primitives threw `TypeError`.
