### PR TITLE
fix(codex): preserve legacy binding ownership on upgrade

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -209,6 +209,42 @@ describe("codex doctor contract", () => {
     expect(original.plugins.entries.codex.config).toHaveProperty("codexDynamicToolsProfile");
   });
 
+  it("uses the persisted system owner for legacy bindings in a multi-agent config", async () => {
+    const fixture = await createBindingMigrationFixture({
+      name: "session-current",
+      sessionIndex: {
+        "agent:main:session-1": {
+          sessionId: "session-current",
+          sessionFile: "session-current.jsonl",
+          updatedAt: 1,
+        },
+      },
+      threadId: "thread-1",
+    });
+    const params = {
+      ...fixture.params,
+      config: {
+        agents: {
+          ownership: "explicit" as const,
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { main: {}, ops: {} },
+        },
+      },
+    };
+
+    try {
+      await expect(fixture.migration.detectLegacyState(params)).resolves.toMatchObject({
+        preview: [expect.stringContaining("legacy sidecar")],
+      });
+      await expect(fixture.migration.migrateLegacyState(params)).resolves.toMatchObject({
+        changes: [expect.stringContaining("Migrated 1")],
+        warnings: [],
+      });
+    } finally {
+      await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("imports and archives shipped binding sidecars", async () => {
     const fixture = await createBindingMigrationFixture({
       name: "session-current",

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -42,6 +42,12 @@ type SessionSurface = {
   agentIds: Set<string>;
 };
 
+function resolveLegacyMigrationFallbackAgentId(
+  config: MigrationEnvironment["config"],
+): string | undefined {
+  return config.agents?.defaults?.systemAgent?.agentId?.trim() || undefined;
+}
+
 type LegacyBindingSource = {
   sidecarPath: string;
   transcriptPath: string;
@@ -147,7 +153,10 @@ async function collectSessionSurfaces(params: MigrationEnvironment): Promise<Ses
   }
 
   const legacyRoot = path.join(params.stateDir, "sessions");
-  const defaultAgentId = resolveSessionAgentIds({ config: params.config }).defaultAgentId;
+  const defaultAgentId = resolveSessionAgentIds({
+    config: params.config,
+    fallbackAgentId: resolveLegacyMigrationFallbackAgentId(params.config),
+  }).defaultAgentId;
   await add(legacyRoot, path.join(legacyRoot, "sessions.json"), defaultAgentId, true);
   return [...surfaces.values()].toSorted((a, b) => a.root.localeCompare(b.root));
 }
@@ -424,7 +433,9 @@ function resolveLegacyBindingOwnerAgentId(params: {
   return resolveSessionAgentIds({
     sessionKey: params.sessionKey,
     config: params.config,
-    ...(storeAgentId ? { agentId: storeAgentId } : {}),
+    ...(storeAgentId
+      ? { agentId: storeAgentId }
+      : { fallbackAgentId: resolveLegacyMigrationFallbackAgentId(params.config) }),
   }).sessionAgentId;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateways with multiple explicitly owned agents could fail startup during an upgrade because the Codex legacy-binding migration could not resolve the retired global session owner.

The failure is reproducible after the explicit-ownership migration persists `agents.defaults.systemAgent.agentId`: Codex sidecar detection throws `AGENT_SELECTION_REQUIRED`, startup records a migration warning, and gateway readiness is refused.

Forward-port of the focused Codex portion of #123167. Original commit and authorship preserved from `20b6021a9025515109ce6a06ba94a06df05f9b8f` by @steipete.

## Why This Change Was Made

The migration now uses the persisted system-agent owner as its explicit fallback for retired global Codex binding surfaces. It does not restore ambient default selection or guess among agents; current runtime ownership remains explicit.

## User Impact

Multi-agent gateways can complete startup migration after upgrading instead of entering a doctor/startup loop.

## Evidence

- Before fix: focused regression rejects with `AgentSelectionRequiredError` / `AGENT_SELECTION_REQUIRED` at `collectSessionSurfaces`.
- After fix: focused regression passes.
- Full `extensions/codex/doctor-contract-api.test.ts`: 28/28 passed.
- `oxfmt --check` and focused extension `oxlint`: passed.
- Direct sibling Codex inspection confirms OpenClaw owns this migration/agent mapping; Codex app-server resumes by thread id/history/path and has no OpenClaw agent-owner contract.
- Production LOC: +13/-2 (net +11) | Tests: +36/-0. The production addition centralizes the persisted migration fallback at both legacy-owner resolution sites.

Release note: fixes multi-agent gateway startup after explicit-ownership upgrades.