### PR TITLE
fix(gateway): automation badge never updates — cron changes bypass the sessions.list cache fence

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import { readSessionIdentityMutationVersion } from "../../sessions/session-lifecycle-events.js";
 import { readSessionTranscriptUpdateVersion } from "../../sessions/transcript-events.js";
+import { readSessionAutomationVersion } from "../session-automation-index.js";
 import { readSessionLifecyclePersistenceVersion } from "../session-lifecycle-state.js";
 import { isGatewayAdmin } from "../session-sharing.js";
 import { readSessionTitleProjectionUnavailableVersion } from "../session-transcript-title-reader.js";
@@ -14,6 +15,7 @@ import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js
 type SessionListFence = {
   agentRunIndexVersion: number;
   lifecyclePersistenceVersion: number;
+  sessionAutomationVersion: number;
   sessionIdentityMutationVersion: number;
   sessionsMutationVersion: number;
   sessionTranscriptUpdateVersion: number;
@@ -35,6 +37,7 @@ function readSessionListFence(context: GatewayRequestContext): SessionListFence 
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
     lifecyclePersistenceVersion: readSessionLifecyclePersistenceVersion(),
+    sessionAutomationVersion: readSessionAutomationVersion(),
     sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
     sessionsMutationVersion: readSessionsMutationVersion(context),
     // Rows embed transcript-derived previews/titles; a committed transcript
@@ -49,6 +52,7 @@ function matchesSessionListFence(value: SessionListFence, fence: SessionListFenc
   return (
     value.agentRunIndexVersion === fence.agentRunIndexVersion &&
     value.lifecyclePersistenceVersion === fence.lifecyclePersistenceVersion &&
+    value.sessionAutomationVersion === fence.sessionAutomationVersion &&
     value.sessionIdentityMutationVersion === fence.sessionIdentityMutationVersion &&
     value.sessionsMutationVersion === fence.sessionsMutationVersion &&
     value.sessionTranscriptUpdateVersion === fence.sessionTranscriptUpdateVersion &&

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -17,6 +17,7 @@ import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { bumpSessionAutomationVersion } from "../session-automation-index.js";
 import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
 import type { GatewaySessionRow } from "../session-utils.types.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
@@ -305,6 +306,28 @@ describe("sessions.list single-flight", () => {
       });
       const refreshed = await listSessions({ client, context, request });
       expect(refreshed).not.toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("invalidates a completed result when a cron automation binding changes", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+      const clock = vi.spyOn(Date, "now").mockReturnValue(60_400);
+
+      const first = await listSessions({ client, context, request });
+      clock.mockReturnValue(60_401);
+      expect(await listSessions({ client, context, request })).toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+
+      // Cron job add/remove/enable changes hasAutomation on projected rows but
+      // historically bumped only the automation memo, so cached lists served
+      // stale badges forever.
+      bumpSessionAutomationVersion();
+      await listSessions({ client, context, request });
       expect(loader.calls).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/gateway/session-automation-index.ts
+++ b/src/gateway/session-automation-index.ts
@@ -67,6 +67,12 @@ export function bumpSessionAutomationVersion(): void {
   sourceVersion += 1;
 }
 
+/** sessions.list cache fence input: hasAutomation is projected per row from
+ * this index, so cached lists are stale the moment a binding changes. */
+export function readSessionAutomationVersion(): number {
+  return sourceVersion;
+}
+
 function buildAutomationKeys(
   jobs: readonly CronJob[],
   cfg: OpenClawConfig,


### PR DESCRIPTION
## What Problem This Solves

Adding, removing, enabling, or retargeting an automation never updates the session list's automation badge. The cron scheduler broadcasts `sessions.changed` so clients refresh — but the refresh is answered from the `sessions.list` completed-result cache, which is guarded by four fence versions none of which the cron path bumps. A list with no active runs is cached indefinitely, so the stale `hasAutomation` badge persists until an unrelated session mutation happens to advance another fence.

## Why This Change Was Made

`hasAutomation` is projected per row from the session automation index (`sessionHasAutomation`), whose version bump (`bumpSessionAutomationVersion`, called on every cron job/store change) only invalidated the index's private memo. The list cache never saw it. The root-cause fix is to make the automation version a first-class input of the list fence, exactly like the agent-run-index and identity-mutation versions already are: any binding change invalidates every cached list atomically, with no per-call-site bookkeeping. The cron broadcasts stay as they are — they're the client nudge; the fence is the projection truth.

This is one instance of a broader class the roster lane mapped (raw `sessions.changed` broadcasts without a fence bump); the automation fence is the one with a clean single-owner fix. The terminal-persistence race and profile-rename siblings are noted for follow-up.

## User Impact

The automation badge on session rows updates immediately when automations are created, deleted, enabled, disabled, or retargeted.

## Evidence

- Regression "invalidates a completed result when a cron automation binding changes": cached list must reload after `bumpSessionAutomationVersion()` — fails pre-fix (stale cache served), passes post-fix.
- Suites green: sessions-read-cache (23), session-automation-index, sessions-read. Typecheck `tsconfig.core.test.json` clean.
- Autoreview (codex/gpt-5.6-sol, high): clean, 0.99.
- Production LOC: +10 (fence field + accessor + comments); tests +23.

Found by the session list/roster lane of the web-UI QA campaign.
