### PR TITLE
fix(agents): keep Codex turns working with request overrides

### DIFF
--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -131,9 +131,16 @@ Two secret-free provider-owned facts describe the selected route:
 
 Return `{ supported: false, reason }` when the harness cannot reproduce the
 prepared transport. Do not infer support by reading raw config after selection.
+Add `fallbackRuntime: "openclaw"` only when the built-in runtime can reproduce
+the exact prepared request without dropping authored behavior. Core then uses
+that fallback for explicit and persisted selections as well as multi-route
+retry sets. Leave it absent for provider, route, or authentication failures
+that must remain fail-closed.
+
 When auth preparation yields multiple retry routes, one harness must support
 all of them before dispatch. Implicit selection uses OpenClaw if no plugin can
-own the full set; an explicit or persisted plugin selection fails closed.
+own the full set; an explicit or persisted plugin selection fails closed unless
+the plugin declares the lossless OpenClaw fallback.
 
 ## Register a harness
 

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -316,8 +316,11 @@ describe("Codex agent harness supports()", () => {
         preparedAuth: { source: "harness" },
       },
     });
-    expect(result.supported).toBe(false);
-    expect(!result.supported ? result.reason : undefined).toContain("request transport overrides");
+    expect(result).toEqual({
+      supported: false,
+      reason: "Codex cannot reproduce authored request transport overrides",
+      fallbackRuntime: "openclaw",
+    });
   });
 
   it("rejects an OpenAI route without a provider compatibility declaration", () => {

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -183,6 +183,7 @@ export function createCodexAppServerAgentHarness(options: {
         return {
           supported: false,
           reason: "Codex cannot reproduce authored request transport overrides",
+          fallbackRuntime: "openclaw",
         };
       }
       const preparedAuth = ctx.modelProvider?.preparedAuth;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -2026,10 +2026,14 @@ describe("selectAgentHarness", () => {
     });
   });
 
-  it("rejects explicit Codex when agent request params cannot be reproduced", () => {
+  it("uses a harness-declared OpenClaw fallback for explicit request params", () => {
     const supports = vi.fn((ctx: Parameters<AgentHarness["supports"]>[0]) =>
       ctx.modelProvider?.requestTransportOverrides === "present"
-        ? { supported: false as const, reason: "authored request params are unsupported" }
+        ? {
+            supported: false as const,
+            reason: "authored request params are unsupported",
+            fallbackRuntime: "openclaw" as const,
+          }
         : { supported: true as const },
     );
     registerAgentHarness({
@@ -2039,20 +2043,30 @@ describe("selectAgentHarness", () => {
       runAttempt: vi.fn(async () => createAttemptResult("codex")),
     });
 
-    expect(() =>
+    expect(
       selectAgentHarness({
         provider: "openai",
-        modelId: "gpt-5.5",
+        modelId: "gpt-5.6-sol",
         modelProvider: {
           api: "openai-responses",
           baseUrl: "https://api.openai.com/v1",
           requestTransportOverrides: "none",
           runtimePolicy: { compatibleIds: ["openclaw", "codex"] },
         },
-        config: { agents: { defaults: { params: { store: false } } } },
-        agentHarnessRuntimeOverride: "codex",
-      }),
-    ).toThrow("authored request params are unsupported");
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "openai/gpt-5.6-sol": {
+                  params: { responsesServerCompaction: true },
+                  agentRuntime: { id: "codex" },
+                },
+              },
+            },
+          },
+        },
+      }).id,
+    ).toBe("openclaw");
     expect(supports).toHaveBeenCalledWith(
       expect.objectContaining({
         modelProvider: expect.objectContaining({ requestTransportOverrides: "present" }),
@@ -2363,6 +2377,33 @@ describe("selectAgentHarness", () => {
         ...pin,
       }),
     ).toThrow("prepared retry route is incompatible");
+  });
+
+  it.each([
+    ["explicit", { agentHarnessRuntimeOverride: "codex" }],
+    ["pinned", { agentHarnessId: "codex" }],
+  ] as const)("uses a declared fallback for a %s harness across prepared routes", (_label, pin) => {
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports: (ctx) =>
+        ctx.modelProvider?.requestTransportOverrides === "present"
+          ? { supported: false, fallbackRuntime: "openclaw" }
+          : { supported: true },
+      runAttempt: vi.fn(async () => createAttemptResult("codex")),
+    });
+
+    expect(
+      selectAgentHarnessForPreparedModelProviders({
+        provider: "openai",
+        modelId: "gpt-5.6-sol",
+        modelProviders: [
+          { requestTransportOverrides: "none" },
+          { requestTransportOverrides: "present" },
+        ],
+        ...pin,
+      }).id,
+    ).toBe("openclaw");
   });
 
   it.each([

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -134,6 +134,8 @@ type AgentHarnessSelectionDecision = {
     | "implicit_plugin_unavailable_openclaw"
     // Implicit Codex preference cannot reproduce the prepared transport, so OpenClaw handled it.
     | "implicit_plugin_unsupported_openclaw"
+    // The requested plugin declared OpenClaw as a lossless fallback for this prepared request.
+    | "plugin_declared_fallback_openclaw"
     // Provider-owned CLI runtime aliases have no agent harness plugin counterpart.
     | "cli_runtime_passthrough_openclaw"
     // Auto mode chose a registered plugin harness that supports the provider/model.
@@ -262,8 +264,8 @@ export function selectAgentHarnessForPreparedModelProviders(
   ) {
     return first?.harness ?? selectAgentHarness(selectionParams);
   }
-  // Only implicit/auto selection can produce different supported harnesses. One embedded
-  // runtime owns the complete retry set; explicit and pinned plugins fail during probing above.
+  // One embedded runtime owns the complete retry set. Auto selection and plugin-declared
+  // fallbacks may resolve individual prepared routes to different harnesses.
   return (
     decisions.find((decision) => decision.selectedHarnessId === "openclaw")?.harness ??
     createOpenClawAgentHarness()
@@ -312,7 +314,7 @@ function selectAgentHarnessDecision(
       } as AgentHarnessPolicy)
     : resolvedPolicy;
   // OpenClaw's built-in harness is intentionally not part of the plugin candidate list. Explicit plugin
-  // runtimes fail closed; only `auto` may route an unmatched turn to OpenClaw.
+  // runtimes fail closed unless the selected plugin declares OpenClaw as a lossless fallback.
   const pluginHarnesses = listPluginAgentHarnesses();
   const openClawHarness = createOpenClawAgentHarness();
   const runtime = policy.runtime;
@@ -364,6 +366,14 @@ function selectAgentHarnessDecision(
           harness: forced,
           policy,
           selectedReason: "forced_plugin",
+          candidates: listHarnessCandidates(pluginHarnesses),
+        });
+      }
+      if (support.fallbackRuntime === "openclaw") {
+        return buildSelectionDecision({
+          harness: openClawHarness,
+          policy: { ...policy, runtime: "openclaw" },
+          selectedReason: "plugin_declared_fallback_openclaw",
           candidates: listHarnessCandidates(pluginHarnesses),
         });
       }

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -46,7 +46,12 @@ export type AgentHarnessSupportContext = {
 
 export type AgentHarnessSupport =
   | { supported: true; priority?: number; reason?: string }
-  | { supported: false; reason?: string };
+  | {
+      supported: false;
+      reason?: string;
+      /** Lossless host fallback when this harness cannot reproduce the prepared request. */
+      fallbackRuntime?: "openclaw";
+    };
 
 type InternalEmbeddedRunAttemptParams =
   import("../embedded-agent-runner/run/types.js").EmbeddedRunAttemptParams;


### PR DESCRIPTION
Related: #118528

## What Problem This Solves

Fixes an issue where users with an explicit native harness route would have every agent turn fail before model execution when existing model or provider request parameters could not be reproduced by that harness. This remained possible after the narrow Doctor migration in #118738 because arbitrary authored request parameters cannot be removed losslessly.

The concrete upgrade-compatible configuration is an `openai/gpt-5.6-sol` model with `agentRuntime.id: "codex"` plus `responsesServerCompaction`. Current main throws `Requested agent harness "codex" does not support ...` instead of using the OpenClaw runtime that can honor the authored request.

## Why This Change Was Made

The agent-harness support contract now lets a plugin declare `fallbackRuntime: "openclaw"` on an unsupported result only when that fallback preserves the prepared request. Core honors that typed declaration for explicit and persisted selections and converges multi-route retry sets on one runtime.

The Codex plugin declares the fallback only for authored request transport overrides. Provider ownership, route compatibility, and prepared-auth failures retain the existing fail-closed behavior. This keeps core plugin-agnostic and avoids inferring safety from free-form error strings.

The managed Codex app-server is pinned to `0.147.0`. I inspected the matching upstream tag (`rust-v0.147.0`, commit `be6e8eac029b183056b7e4402879f15d2c85f61b`) directly: [`ThreadStartParams`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L57-L103) and [`TurnStartParams`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L71-L145) expose bounded native controls, not an arbitrary OpenClaw Responses-request override channel. Falling back is therefore the only lossless runtime repair for unknown authored parameters.

## User Impact

Agent turns no longer brick when an existing explicit Codex route also carries request parameters that only OpenClaw can reproduce. The turn transparently uses OpenClaw and preserves the authored request behavior. Unsupported native provider, route, authentication, and locked transcript cases remain fail-closed.

Release-note context: explicit Codex model routes with unsupported request parameters now self-heal through OpenClaw instead of failing every turn.

## Evidence

- Pre-fix regression: the focused selector test failed with `Requested agent harness "codex" does not support openai/gpt-5.6-sol (authored request params are unsupported).`
- `node scripts/run-vitest.mjs src/agents/harness/selection.test.ts` — 115 passed.
- `node scripts/run-vitest.mjs extensions/codex/harness.test.ts` — 32 passed.
- `pnpm plugin-sdk:surface:check` — passed; 0 forbidden package-exported subpaths.
- `pnpm check:changed` — passed locally after the remote check backend reported no ready provider; covered core/core-test/plugin/plugin-test typechecks, both lint lanes, formatting, import cycles, dead exports, plugin boundaries, and state/database guards.
- `git diff --check origin/main...HEAD` — clean.

## Scope and repair closeout

- Root cause: support probing had only `supported` plus a free-form reason, so explicit selections had no typed way to distinguish a lossless host fallback from an unsafe incompatibility and always threw.
- Architectural owner: the generic agent-harness support/selection contract; the Codex plugin owns when its transport rejection is recoverable.
- Canonical fix: one additive `fallbackRuntime` capability, consumed by the existing selector and documented in the Plugin SDK.
- Sibling behavior: auto/implicit fallback remains unchanged; unrelated Codex route/auth failures and every plugin that omits the declaration still fail closed; prepared retry sets and ordinary persisted pins are covered.
- Production delta: +20 / -4, net +16. The growth is the typed Plugin SDK capability and selector branch needed to make the safe state representable. Tests are +54 / -10, net +44; docs are +8 / -1, net +7.
- No config keys, migrations, dependencies, generated files, or runtime-specific policy were added to core.

- [x] AI-assisted
- [x] I understand the change and verified the affected owner boundaries.
