### PR TITLE
fix(gateway): sessions cache serves pre-terminal rows forever after a run-end race

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -2,6 +2,7 @@ import type { SessionsListParams } from "../../../packages/gateway-protocol/src/
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import { readSessionIdentityMutationVersion } from "../../sessions/session-lifecycle-events.js";
+import { readSessionLifecyclePersistenceVersion } from "../session-lifecycle-state.js";
 import { isGatewayAdmin } from "../session-sharing.js";
 import { readSessionTitleProjectionUnavailableVersion } from "../session-transcript-title-reader.js";
 import type { SessionsListResult } from "../session-utils.types.js";
@@ -11,6 +12,7 @@ import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js
 
 type SessionListFence = {
   agentRunIndexVersion: number;
+  lifecyclePersistenceVersion: number;
   sessionIdentityMutationVersion: number;
   sessionsMutationVersion: number;
   titleProjectionUnavailableVersion: number;
@@ -29,6 +31,7 @@ const sessionListsByContext = new WeakMap<GatewayRequestContext, SessionListStat
 function readSessionListFence(context: GatewayRequestContext): SessionListFence {
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
+    lifecyclePersistenceVersion: readSessionLifecyclePersistenceVersion(),
     sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
     sessionsMutationVersion: readSessionsMutationVersion(context),
     titleProjectionUnavailableVersion: readSessionTitleProjectionUnavailableVersion(),
@@ -38,6 +41,7 @@ function readSessionListFence(context: GatewayRequestContext): SessionListFence 
 function matchesSessionListFence(value: SessionListFence, fence: SessionListFence): boolean {
   return (
     value.agentRunIndexVersion === fence.agentRunIndexVersion &&
+    value.lifecyclePersistenceVersion === fence.lifecyclePersistenceVersion &&
     value.sessionIdentityMutationVersion === fence.sessionIdentityMutationVersion &&
     value.sessionsMutationVersion === fence.sessionsMutationVersion &&
     value.titleProjectionUnavailableVersion === fence.titleProjectionUnavailableVersion

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -17,6 +17,7 @@ import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
 import type { GatewaySessionRow } from "../session-utils.types.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -239,6 +240,36 @@ describe("sessions.list single-flight", () => {
       expect(loader.calls).toHaveBeenCalledTimes(1);
 
       emitSessionsChanged(context, { reason: "test", sessionKey: "agent:main:active" });
+      await listSessions({ client, context, request });
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("invalidates a completed result after terminal lifecycle persistence lands", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+      const clock = vi.spyOn(Date, "now").mockReturnValue(60_400);
+
+      const first = await listSessions({ client, context, request });
+      clock.mockReturnValue(60_401);
+      expect(await listSessions({ client, context, request })).toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+
+      // The terminal entry write (status/endedAt/runtimeMs) commits after the
+      // run-index fence bumped at lifecycle end. A list computed in that
+      // window cached the pre-terminal row; the persistence fence evicts it.
+      await persistGatewaySessionLifecycleEvent({
+        sessionKey: "agent:main:active",
+        agentId: "main",
+        event: {
+          ts: 60_500,
+          runId: "run-terminal-fence",
+          data: { phase: "end", startedAt: 60_000, endedAt: 60_450 },
+        },
+      });
       await listSessions({ client, context, request });
       expect(loader.calls).toHaveBeenCalledTimes(2);
     });

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -298,6 +298,16 @@ function acceptsCronRunContinuationLifecycleEvent(params: {
   return Boolean(marker?.phase === "continuing" && runId && marker.ownerRunId === runId);
 }
 
+// sessions.list cache fence input. The terminal entry write (status/endedAt/
+// runtimeMs) commits asynchronously after the run-index fence already bumped
+// at lifecycle end; without its own fence a list computed in that window
+// caches the pre-terminal row indefinitely.
+let lifecyclePersistenceVersion = 0;
+
+export function readSessionLifecyclePersistenceVersion(): number {
+  return lifecyclePersistenceVersion;
+}
+
 export async function persistGatewaySessionLifecycleEvent(params: {
   sessionKey: string;
   agentId?: string;
@@ -360,4 +370,5 @@ export async function persistGatewaySessionLifecycleEvent(params: {
       requireWriteSuccess: true,
     },
   );
+  lifecyclePersistenceVersion += 1;
 }


### PR DESCRIPTION
## What Problem This Solves

A session can show the wrong status/duration in the sidebar indefinitely after a run ends. On lifecycle end, `server-chat.ts` clears run projections first (bumping the agent-run-index fence synchronously) and then starts the **async** terminal entry write (`persistGatewaySessionLifecycleEvent` patches status/endedAt/runtimeMs/lastRunError). A `sessions.list` landing between those two points sees `hasActiveRun:false` plus the pre-terminal entry — a cacheable, wrong row. The completed-result cache serves it forever: the async commit bumps no fence, and the post-persist `sessions.changed` is a raw broadcast whose triggered client refresh is answered from the same stale cache.

## Why This Change Was Made

Same structural class as #123253 (a projected-row input changing without a fence bump), fixed at the same owner boundary: the lifecycle persistence writer gets its own monotonic version, bumped when the entry commit lands, and the version joins the `sessions.list` fence alongside the run-index/identity/mutation/title versions. Any list cached during the race window is evicted the moment the terminal write commits — no per-call-site bookkeeping, and the existing broadcasts stay as the client nudge.

The observer-digest and subagent-status siblings from the same lane report share this fence class; they're follow-ups (different writers).

## User Impact

Session rows show the correct terminal status and runtime immediately after a run ends, even when a list request races the terminal write.

## Evidence

- Regression "invalidates a completed result after terminal lifecycle persistence lands": cached list must reload after `persistGatewaySessionLifecycleEvent` — fails pre-fix (stale cache served), passes post-fix.
- Suites green: sessions-read-cache (24), session-lifecycle-state, server-chat.agent-events. Typecheck `tsconfig.core.test.json` clean.
- Autoreview (codex/gpt-5.6-sol, high): clean, 0.98.
- Production LOC: +15 (version + accessor + fence field + comments); tests +31.

Found by the session list/roster lane of the web-UI QA campaign (highest-severity gateway finding: default-path silent wrong status).
