### PR TITLE
feat(ui): separate channel conversations in the sidebar

### DIFF
--- a/src/gateway/session-groups.test.ts
+++ b/src/gateway/session-groups.test.ts
@@ -69,6 +69,7 @@ describe("session groups catalog", () => {
         "category: Alpha ",
         "groups",
         "groups",
+        "channels",
         "catalog:",
         "catalog:codex",
         "pinned",
@@ -83,6 +84,7 @@ describe("session groups catalog", () => {
       "category:Beta",
       "category:Alpha",
       "groups",
+      "channels",
     ]);
 
     putSessionGroups(["Beta", "Alpha"], undefined, env);
@@ -92,6 +94,7 @@ describe("session groups catalog", () => {
       "category:Beta",
       "category:Alpha",
       "groups",
+      "channels",
     ]);
   });
 

--- a/src/gateway/session-groups.ts
+++ b/src/gateway/session-groups.ts
@@ -81,7 +81,12 @@ function normalizeSidebarSectionOrder(
   for (const raw of sectionOrder) {
     const sectionId = raw.trim();
     let canonical: string | null = null;
-    if (sectionId === "ungrouped" || sectionId === "groups" || sectionId === "work") {
+    if (
+      sectionId === "ungrouped" ||
+      sectionId === "groups" ||
+      sectionId === "channels" ||
+      sectionId === "work"
+    ) {
       canonical = sectionId;
     } else if (sectionId.startsWith("category:")) {
       const name = normalizeOptionalString(sectionId.slice("category:".length));

--- a/ui/src/components/app-sidebar-channel-section-controller.ts
+++ b/ui/src/components/app-sidebar-channel-section-controller.ts
@@ -1,0 +1,64 @@
+import { isSessionRouteId } from "../app-route-paths.ts";
+import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
+import type { SessionOrganizerController } from "./session-organizer-controller.ts";
+
+type SidebarChannelSectionHost = {
+  activeRouteId?: string;
+  sessionOrganizer: SessionOrganizerController;
+  findSidebarSessionByKey(sessionKey: string): SidebarRecentSession | undefined;
+  getRouteSessionKey(): string;
+  requestUpdate(): void;
+};
+
+/** Keeps default-collapsed channel chats reachable when one becomes active. */
+export class SidebarChannelSectionController {
+  private dismissedAutoExpandedKey: string | null = null;
+
+  constructor(private readonly host: SidebarChannelSectionHost) {}
+
+  get collapsedSections(): ReadonlySet<string> {
+    const stored = this.host.sessionOrganizer.collapsedSessionSections;
+    if (!stored.has("channels")) {
+      return stored;
+    }
+    const activeKey = this.activeChannelKey();
+    if (!activeKey || activeKey === this.dismissedAutoExpandedKey) {
+      return stored;
+    }
+    const effective = new Set(stored);
+    effective.delete("channels");
+    return effective;
+  }
+
+  toggle(sectionId: string): void {
+    if (sectionId !== "channels") {
+      this.host.sessionOrganizer.toggleSection(sectionId);
+      return;
+    }
+    const activeKey = this.activeChannelKey();
+    const storedCollapsed = this.host.sessionOrganizer.collapsedSessionSections.has(sectionId);
+    if (!this.collapsedSections.has(sectionId)) {
+      this.dismissedAutoExpandedKey = activeKey;
+      if (storedCollapsed) {
+        this.host.requestUpdate();
+      } else {
+        this.host.sessionOrganizer.toggleSection(sectionId);
+      }
+      return;
+    }
+    this.dismissedAutoExpandedKey = null;
+    this.host.sessionOrganizer.toggleSection(sectionId);
+  }
+
+  resetDismissedAutoExpansion(): void {
+    this.dismissedAutoExpandedKey = null;
+  }
+
+  private activeChannelKey(): string | null {
+    if (!isSessionRouteId(this.host.activeRouteId)) {
+      return null;
+    }
+    const routeKey = this.host.getRouteSessionKey();
+    return this.host.findSidebarSessionByKey(routeKey)?.channelSession ? routeKey : null;
+  }
+}

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -61,14 +61,24 @@ function renderSessionSection(params: {
   // zonedVisibleSections removes pinned rows; AppSidebar renders them through
   // renderPinnedSidebarSession, so every section here has a header.
   const collapsed = host.collapsedSessionSections.has(section.id);
-  const label = section.groups
-    ? t("chat.sidebar.groups")
-    : section.work
-      ? t("chat.sidebar.coding")
-      : group
-        ? group
-        : t("chat.sidebar.threads");
-  const zone = section.groups ? "groups" : section.work ? "coding" : group ? "category" : "threads";
+  const label = section.channels
+    ? t("chat.sidebar.channels")
+    : section.groups
+      ? t("chat.sidebar.groups")
+      : section.work
+        ? t("chat.sidebar.coding")
+        : group
+          ? group
+          : t("chat.sidebar.threads");
+  const zone = section.channels
+    ? "channels"
+    : section.groups
+      ? "groups"
+      : section.work
+        ? "coding"
+        : group
+          ? "category"
+          : "threads";
   // Collapsed Coding still signals live runs so background work stays visible.
   const collapsedRunningDot =
     collapsed &&
@@ -77,6 +87,8 @@ function renderSessionSection(params: {
   const collapsedAttentionDot =
     collapsed &&
     section.rows.some((row) => rowDemandsVisibility(row, RowVisibilityReason.Attention));
+  const collapsedUnreadDot =
+    collapsed && section.channels && section.rows.some((row) => row.unread);
   const newSessionAccess = host.readNewSessionAccess();
   const groupWriteAccess = host.readSessionMutationAccess({
     method: "sessions.groups.put",
@@ -154,6 +166,14 @@ function renderSessionSection(params: {
                   role="img"
                   aria-label=${t("sessionsView.attentionRequired")}
                   title=${t("sessionsView.attentionRequired")}
+                ></span>`
+              : nothing}
+            ${collapsedUnreadDot
+              ? html`<span
+                  class="session-unread-dot sidebar-session-group-unread"
+                  role="img"
+                  aria-label=${t("sessionsView.unread")}
+                  title=${t("sessionsView.unread")}
                 ></span>`
               : nothing}
           </button>

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -22,6 +22,7 @@ import {
   resolveUiDefaultAgentId,
 } from "../lib/sessions/session-key.ts";
 import { AppSidebarBase } from "./app-sidebar-base.ts";
+import { SidebarChannelSectionController } from "./app-sidebar-channel-section-controller.ts";
 import { adoptedCatalogSessionKeys } from "./app-sidebar-session-catalogs.ts";
 import {
   applySidebarSessionCreatorFilter,
@@ -125,6 +126,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
 
   private sessionSelectionAnchor: string | null = null;
   private collapsedActiveRouteKey: string | null = null;
+  protected readonly channelSection = new SidebarChannelSectionController(this);
   private readonly runtimeSampledAtByRow = new WeakMap<GatewaySessionRow, number>();
   private readonly attention = new SessionAttentionController(this);
 
@@ -139,9 +141,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     return this.context;
   }
 
-  get collapsedSessionSections(): ReadonlySet<string> {
-    return this.sessionOrganizer.collapsedSessionSections;
-  }
+  toggleSidebarSection = (sectionId: string) => this.channelSection.toggle(sectionId);
 
   dismissTransientMenus(): boolean {
     return this.sidebarMenus.dismissTransientMenus();
@@ -198,6 +198,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const activeRouteKey = isSessionRouteId(this.activeRouteId) ? this.getRouteSessionKey() : "";
     if (activeRouteKey !== this.collapsedActiveRouteKey) {
       this.collapsedActiveRouteKey = activeRouteKey;
+      this.channelSection.resetDismissedAutoExpansion();
       if (this.collapsedActiveChildSessionKeys.size > 0) {
         this.collapsedActiveChildSessionKeys = new Set();
       }
@@ -341,7 +342,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
         this.sessionsStatusFilter === "archived"
           ? []
           : this.sessionData.sessionCatalogs.map((catalog) => catalog.id),
-      collapsedSections: this.collapsedSessionSections,
+      collapsedSections: this.channelSection.collapsedSections,
       hideEmptyCreatorFilteredGroup: (category, rowCount) =>
         this.hideEmptyCreatorFilteredGroup(category, rowCount),
       visibleSessionLimits: this.sessionData.visibleSessionLimits,

--- a/ui/src/components/app-sidebar-session-types.test.ts
+++ b/ui/src/components/app-sidebar-session-types.test.ts
@@ -2,11 +2,14 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  loadStoredCollapsedSessionSections,
   loadStoredHiddenSessionCatalogIds,
   loadStoredSidebarSessionStatusFilter,
   setStoredSessionCatalogHidden,
   storeSidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
+
+const COLLAPSED_SECTIONS_STORAGE_KEY = "openclaw:sidebar:sessions:collapsed-sections";
 
 // getSafeLocalStorage only accepts an own value property under Vitest, so the
 // jsdom getter-backed localStorage must be replaced with a plain mock.
@@ -54,6 +57,18 @@ describe("sidebar session status preference", () => {
     expect(loadStoredSidebarSessionStatusFilter()).toBe("archived");
     storeSidebarSessionStatusFilter("all");
     expect(loadStoredSidebarSessionStatusFilter()).toBe("all");
+  });
+});
+
+describe("collapsed sidebar section preference", () => {
+  it("defaults fresh Channels closed without changing a legacy saved preference", () => {
+    expect([...loadStoredCollapsedSessionSections()]).toEqual(["channels", "work"]);
+
+    localStorage.setItem(
+      COLLAPSED_SECTIONS_STORAGE_KEY,
+      JSON.stringify(["category:Research", "work"]),
+    );
+    expect([...loadStoredCollapsedSessionSections()]).toEqual(["category:Research", "work"]);
   });
 });
 

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -261,9 +261,8 @@ export function loadStoredCollapsedSessionSections(): ReadonlySet<string> {
   try {
     const raw = getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_COLLAPSED_SECTIONS_STORAGE_KEY);
     if (raw == null) {
-      // First run: the Coding zone starts collapsed so dev sessions stay muted
-      // until the user opts in; expanding persists an empty entry for "work".
-      return new Set(["work"]);
+      // First run: noisy automatic zones start collapsed until the user opts in.
+      return new Set(["channels", "work"]);
     }
     const parsed: unknown = JSON.parse(raw);
     return new Set(
@@ -272,7 +271,7 @@ export function loadStoredCollapsedSessionSections(): ReadonlySet<string> {
         : [],
     );
   } catch {
-    return new Set(["work"]);
+    return new Set(["channels", "work"]);
   }
 }
 

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -321,7 +321,11 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   }
 
   toggleSection(sectionId: string): void {
-    this.sessionOrganizer.toggleSection(sectionId);
+    this.toggleSidebarSection(sectionId);
+  }
+
+  get collapsedSessionSections(): ReadonlySet<string> {
+    return this.channelSection.collapsedSections;
   }
 
   handleSessionListDragOver(event: DragEvent): void {

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -16,6 +16,7 @@ import {
   writeSidebarRouteDragData,
 } from "../lib/sessions/drag.ts";
 import {
+  categoryClearReturnsToChannels,
   categoryClearReturnsToGroups,
   type SidebarSessionsGrouping,
 } from "../lib/sessions/grouping.ts";
@@ -597,8 +598,11 @@ export class SessionOrganizerController implements ReactiveController {
       return true;
     }
     return (
-      sectionId === "groups" &&
-      Boolean(session && categoryClearReturnsToGroups(session, this.host.sessionsGrouping))
+      session !== undefined &&
+      ((sectionId === "groups" &&
+        categoryClearReturnsToGroups(session, this.host.sessionsGrouping)) ||
+        (sectionId === "channels" &&
+          categoryClearReturnsToChannels(session, this.host.sessionsGrouping)))
     );
   }
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4963,6 +4963,7 @@ export const en: TranslationMap = {
       serverUpdatedRefresh: "Refresh for full capabilities",
       threads: "Sessions",
       groups: "Groups",
+      channels: "Channels",
       coding: "Coding",
       noSessionsForAgent: "No sessions found for this agent",
       catalogViewOptions: "View options",

--- a/ui/src/lib/sessions/custom-groups.test.ts
+++ b/ui/src/lib/sessions/custom-groups.test.ts
@@ -20,12 +20,13 @@ describe("session group catalog readers", () => {
           "",
           42,
           "work",
+          " channels ",
           "category: Alpha ",
           " catalog: codex ",
           "catalog:",
         ],
       }),
-    ).toEqual(["work", "category:Alpha", "catalog:codex"]);
+    ).toEqual(["work", "channels", "category:Alpha", "catalog:codex"]);
     expect(readSidebarSectionOrder({})).toEqual([]);
   });
 });

--- a/ui/src/lib/sessions/custom-groups.ts
+++ b/ui/src/lib/sessions/custom-groups.ts
@@ -2,7 +2,7 @@
 // Catalog storage and member updates live on the gateway (sessions.groups.*);
 // the SessionCapability mirrors the catalog into state.groups.
 
-const BUILT_IN_SESSION_SECTION_IDS = new Set(["ungrouped", "groups", "work"]);
+const BUILT_IN_SESSION_SECTION_IDS = new Set(["ungrouped", "groups", "channels", "work"]);
 
 export function readSessionCustomGroupNames(payload: unknown): string[] {
   const groups = (payload as { groups?: Array<{ name?: unknown }> } | null)?.groups;

--- a/ui/src/lib/sessions/grouping.test.ts
+++ b/ui/src/lib/sessions/grouping.test.ts
@@ -12,13 +12,14 @@ import {
 } from "./grouping.ts";
 
 describe("groupSidebarSessionRows", () => {
-  it("orders pinned, categories, threads, groups, then coding while preserving row order", () => {
+  it("orders pinned, categories, threads, groups, channels, then coding", () => {
     const rows = [
       row({ key: "z-1", category: "Zulu" }),
       row({ key: "p-1", pinned: true, category: "Alpha" }),
       row({ key: "a-1", category: "Alpha" }),
       row({ key: "u-1" }),
       row({ key: "g-1", kind: "group" }),
+      row({ key: "ch-1", channelSession: true }),
       row({ key: "wt-1", workSession: true }),
       row({ key: "a-2", category: "Alpha" }),
     ];
@@ -31,35 +32,42 @@ describe("groupSidebarSessionRows", () => {
       "category:Zulu",
       "ungrouped",
       "groups",
+      "channels",
       "work",
     ]);
     expect(sections[1]?.rows.map((item) => item.key)).toEqual(["a-1", "a-2"]);
     expect(sections[3]?.rows.map((item) => item.key)).toEqual(["u-1"]);
     expect(sections[4]?.groups).toBe(true);
     expect(sections[4]?.rows.map((item) => item.key)).toEqual(["g-1"]);
-    expect(sections[5]?.work).toBe(true);
-    expect(sections[5]?.rows.map((item) => item.key)).toEqual(["wt-1"]);
+    expect(sections[5]?.channels).toBe(true);
+    expect(sections[5]?.rows.map((item) => item.key)).toEqual(["ch-1"]);
+    expect(sections[6]?.work).toBe(true);
+    expect(sections[6]?.rows.map((item) => item.key)).toEqual(["wt-1"]);
   });
 
-  it("folds DM channel sessions into threads and group kinds into the groups zone", () => {
+  it("separates every message-channel shape after explicit custom groups", () => {
     const sections = groupSidebarSessionRows([
       { ...row({ key: "tg-dm" }), channel: "telegram", channelSession: true },
       { ...row({ key: "dash-1" }) },
       { ...row({ key: "wa-group", kind: "group" }), channel: "whatsapp", channelSession: true },
-      // Explicit user category beats smart group/coding classification.
-      { ...row({ key: "grouped-tg", kind: "group" }), category: "Project X" },
+      // Explicit user category beats smart channel/group classification.
+      {
+        ...row({ key: "grouped-tg", kind: "group" }),
+        category: "Project X",
+        channelSession: true,
+      },
       { ...row({ key: "acp-1" }), acpSession: true },
     ]);
 
     expect(sections.map((section) => section.id)).toEqual([
       "category:Project X",
       "ungrouped",
-      "groups",
+      "channels",
       "work",
     ]);
     expect(sections[0]?.rows.map((item) => item.key)).toEqual(["grouped-tg"]);
-    expect(sections[1]?.rows.map((item) => item.key)).toEqual(["tg-dm", "dash-1"]);
-    expect(sections[2]?.rows.map((item) => item.key)).toEqual(["wa-group"]);
+    expect(sections[1]?.rows.map((item) => item.key)).toEqual(["dash-1"]);
+    expect(sections[2]?.rows.map((item) => item.key)).toEqual(["tg-dm", "wa-group"]);
     expect(sections[3]?.rows.map((item) => item.key)).toEqual(["acp-1"]);
   });
 
@@ -77,9 +85,10 @@ describe("groupSidebarSessionRows", () => {
       "pinned",
       "ungrouped",
       "groups",
+      "channels",
       "work",
     ]);
-    expect(sections[1]?.rows.map((item) => item.key)).toEqual(["tg"]);
+    expect(sections[3]?.rows.map((item) => item.key)).toEqual(["tg"]);
   });
 
   it("always emits threads and coding so the renderer can host fallbacks and catalogs", () => {
@@ -214,6 +223,7 @@ describe("normalizeSessionSectionOrder", () => {
       "category:Beta",
       "ungrouped",
       "groups",
+      "channels",
       "work",
     ]);
   });
@@ -224,7 +234,7 @@ describe("normalizeSessionSectionOrder", () => {
         ["ungrouped", "category:Alpha", "groups", "category:Beta", "work"],
         ["Alpha", "Beta"],
       ),
-    ).toEqual(["ungrouped", "category:Alpha", "groups", "category:Beta", "work"]);
+    ).toEqual(["ungrouped", "category:Alpha", "groups", "channels", "category:Beta", "work"]);
   });
 
   it("inserts a new category before the first built-in section", () => {
@@ -233,7 +243,7 @@ describe("normalizeSessionSectionOrder", () => {
         ["category:Alpha", "ungrouped", "groups", "work"],
         ["Alpha", "Beta"],
       ),
-    ).toEqual(["category:Alpha", "category:Beta", "ungrouped", "groups", "work"]);
+    ).toEqual(["category:Alpha", "category:Beta", "ungrouped", "groups", "channels", "work"]);
   });
 
   it("drops stale category tokens", () => {
@@ -242,7 +252,7 @@ describe("normalizeSessionSectionOrder", () => {
         ["category:Stale", "category:Alpha", "ungrouped", "groups", "work"],
         ["Alpha"],
       ),
-    ).toEqual(["category:Alpha", "ungrouped", "groups", "work"]);
+    ).toEqual(["category:Alpha", "ungrouped", "groups", "channels", "work"]);
   });
 
   it("appends unseen catalogs after coding and drops disappeared catalogs", () => {
@@ -252,7 +262,7 @@ describe("normalizeSessionSectionOrder", () => {
         [],
         ["claude", "codex"],
       ),
-    ).toEqual(["catalog:codex", "ungrouped", "groups", "work", "catalog:claude"]);
+    ).toEqual(["catalog:codex", "ungrouped", "groups", "channels", "work", "catalog:claude"]);
   });
 
   it("drops invalid and duplicate tokens", () => {
@@ -261,7 +271,7 @@ describe("normalizeSessionSectionOrder", () => {
         ["category:Stale", "bogus", "category:", "ungrouped", "ungrouped", "category:Alpha"],
         ["Alpha"],
       ),
-    ).toEqual(["ungrouped", "groups", "work", "category:Alpha"]);
+    ).toEqual(["ungrouped", "groups", "channels", "work", "category:Alpha"]);
   });
 
   it("reinserts a missing built-in after its default predecessor", () => {
@@ -270,7 +280,7 @@ describe("normalizeSessionSectionOrder", () => {
         ["category:Alpha", "ungrouped", "category:Beta", "work"],
         ["Alpha", "Beta"],
       ),
-    ).toEqual(["category:Alpha", "ungrouped", "groups", "category:Beta", "work"]);
+    ).toEqual(["category:Alpha", "ungrouped", "groups", "channels", "category:Beta", "work"]);
   });
 });
 

--- a/ui/src/lib/sessions/grouping.test.ts
+++ b/ui/src/lib/sessions/grouping.test.ts
@@ -228,13 +228,19 @@ describe("normalizeSessionSectionOrder", () => {
     ]);
   });
 
-  it("honors stored positions", () => {
-    expect(
-      normalizeSessionSectionOrder(
-        ["ungrouped", "category:Alpha", "groups", "category:Beta", "work"],
-        ["Alpha", "Beta"],
-      ),
-    ).toEqual(["ungrouped", "category:Alpha", "groups", "channels", "category:Beta", "work"]);
+  it("adds Channels to a pre-Channels order without moving saved sections", () => {
+    const stored = ["ungrouped", "category:Alpha", "groups", "category:Beta", "work"];
+    const upgraded = normalizeSessionSectionOrder(stored, ["Alpha", "Beta"]);
+
+    expect(upgraded).toEqual([
+      "ungrouped",
+      "category:Alpha",
+      "groups",
+      "channels",
+      "category:Beta",
+      "work",
+    ]);
+    expect(upgraded.filter((sectionId) => sectionId !== "channels")).toEqual(stored);
   });
 
   it("inserts a new category before the first built-in section", () => {

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -25,16 +25,25 @@ export type SessionRowGroup = {
 };
 
 export type SidebarSessionSection<Row> = {
-  id: "pinned" | "ungrouped" | "groups" | "work" | `category:${string}` | `catalog:${string}`;
+  id:
+    | "pinned"
+    | "ungrouped"
+    | "groups"
+    | "channels"
+    | "work"
+    | `category:${string}`
+    | `catalog:${string}`;
   category?: string;
   /** Built-in smart group-conversation section (kind "group" rows). */
   groups?: boolean;
+  /** Built-in smart section for conversations owned by message channels. */
+  channels?: boolean;
   /** Built-in smart coding section (worktree/exec-node/ACP sessions). */
   work?: boolean;
   rows: Row[];
 };
 
-const DEFAULT_SESSION_SECTION_ORDER = ["ungrouped", "groups", "work"] as const;
+const DEFAULT_SESSION_SECTION_ORDER = ["ungrouped", "groups", "channels", "work"] as const;
 
 export function normalizeSessionSectionOrder(
   stored: readonly string[],
@@ -199,6 +208,8 @@ type SidebarGroupableRow = {
   workSession?: boolean;
   /** ACP-backed harness session (Coding zone). */
   acpSession?: boolean;
+  /** Session created for a concrete external message-channel conversation. */
+  channelSession?: boolean;
 };
 
 /** Clearing the manual category reveals the built-in Groups destination. */
@@ -210,17 +221,32 @@ export function categoryClearReturnsToGroups(
     grouping === "category" &&
     row.pinned !== true &&
     Boolean(row.category?.trim()) &&
-    row.kind === "group"
+    row.kind === "group" &&
+    row.channelSession !== true
+  );
+}
+
+/** Clearing the manual category reveals the built-in Channels destination. */
+export function categoryClearReturnsToChannels(
+  row: SidebarGroupableRow,
+  grouping: SidebarSessionsGrouping,
+): boolean {
+  return (
+    grouping === "category" &&
+    row.pinned !== true &&
+    Boolean(row.category?.trim()) &&
+    row.channelSession === true
   );
 }
 
 /**
  * Zone partition: pinned, named categories (persisted `knownGroups` order,
  * new ones alphabetical), threads ("ungrouped" — the agent's chat sessions),
- * group conversations, then coding (worktree/exec-node/ACP). An explicit user
- * category wins over the smart group/coding classification so manual curation
- * sticks. `grouping: "none"` only disables categories; the kind-based Groups
- * and Coding zones always split so chat threads stay readable. The coding
+ * group conversations, message-channel conversations, then coding
+ * (worktree/exec-node/ACP). An explicit user category wins over every smart
+ * classification so manual curation sticks. `grouping: "none"` only disables
+ * categories; the Groups, Channels, and Coding zones always split so chat
+ * threads stay readable. The coding
  * section is always emitted (even empty) so its ordered position remains a
  * stable sibling of any catalog sections. Groups also stays visible while a
  * categorized group row can deterministically return there.
@@ -238,6 +264,7 @@ export function groupSidebarSessionRows<Row extends SidebarGroupableRow>(
   const pinned: Row[] = [];
   const threads: Row[] = [];
   const groups: Row[] = [];
+  const channels: Row[] = [];
   const coding: Row[] = [];
   const categories = new Map<string, Row[]>();
   if (grouping === "category") {
@@ -261,6 +288,10 @@ export function groupSidebarSessionRows<Row extends SidebarGroupableRow>(
       } else {
         categories.set(category, [row]);
       }
+      continue;
+    }
+    if (row.channelSession === true) {
+      channels.push(row);
       continue;
     }
     if (row.kind === "group") {
@@ -296,6 +327,10 @@ export function groupSidebarSessionRows<Row extends SidebarGroupableRow>(
   const hasGroupsReturnTarget = rows.some((row) => categoryClearReturnsToGroups(row, grouping));
   if (groups.length > 0 || hasGroupsReturnTarget) {
     orderedSections.push({ id: "groups", groups: true, rows: groups });
+  }
+  const hasChannelsReturnTarget = rows.some((row) => categoryClearReturnsToChannels(row, grouping));
+  if (channels.length > 0 || hasChannelsReturnTarget) {
+    orderedSections.push({ id: "channels", channels: true, rows: channels });
   }
   orderedSections.push({ id: "work", work: true, rows: coding });
   const catalogIds = [

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1615,6 +1615,10 @@ body.update-dialog-open .sidebar-update-card__status {
   box-shadow: 0 0 6px color-mix(in srgb, var(--warn) 48%, transparent);
 }
 
+.sidebar-session-group-unread {
+  margin-left: 4px;
+}
+
 .sidebar-session-catalog-load-more {
   display: block;
   width: calc(100% - var(--sidebar-lead) - 10px);

--- a/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
@@ -361,7 +361,7 @@ describe("AppSidebar group section ordering", () => {
     await waitForFast(() =>
       expect(harness.groupsPut).toHaveBeenCalledWith(
         ["Alpha", "Beta"],
-        ["category:Alpha", "ungrouped", "groups", "category:Beta", "work"],
+        ["category:Alpha", "ungrouped", "groups", "channels", "category:Beta", "work"],
       ),
     );
   });
@@ -374,7 +374,7 @@ describe("AppSidebar group section ordering", () => {
     await waitForFast(() =>
       expect(harness.groupsPut).toHaveBeenCalledWith(
         ["Beta", "Alpha"],
-        ["category:Beta", "ungrouped", "groups", "category:Alpha", "work"],
+        ["category:Beta", "ungrouped", "groups", "channels", "category:Alpha", "work"],
       ),
     );
   });
@@ -389,7 +389,7 @@ describe("AppSidebar group section ordering", () => {
     await waitForFast(() =>
       expect(harness.groupsPut).toHaveBeenCalledWith(
         ["Beta", "Alpha"],
-        ["category:Beta", "ungrouped", "groups", "category:Alpha", "work"],
+        ["category:Beta", "ungrouped", "groups", "channels", "category:Alpha", "work"],
       ),
     );
     await Promise.resolve();

--- a/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
@@ -200,7 +200,15 @@ describe("AppSidebar section reordering", () => {
     await waitForFast(() =>
       expect(harness.groupsPut).toHaveBeenCalledWith(
         ["Gamma", "Alpha", "Beta"],
-        ["category:Gamma", "category:Alpha", "category:Beta", "ungrouped", "groups", "work"],
+        [
+          "category:Gamma",
+          "category:Alpha",
+          "category:Beta",
+          "ungrouped",
+          "groups",
+          "channels",
+          "work",
+        ],
       ),
     );
   });
@@ -217,7 +225,10 @@ describe("AppSidebar section reordering", () => {
     dispatchDragEvent(threadsSection, "drop", dataTransfer);
 
     await waitForFast(() =>
-      expect(harness.groupsPut).toHaveBeenCalledWith([], ["work", "ungrouped", "groups"]),
+      expect(harness.groupsPut).toHaveBeenCalledWith(
+        [],
+        ["work", "ungrouped", "groups", "channels"],
+      ),
     );
   });
 
@@ -264,7 +275,7 @@ describe("AppSidebar section reordering", () => {
     await waitForFast(() =>
       expect(harness.groupsPut).toHaveBeenCalledWith(
         [],
-        ["work", "ungrouped", "groups", "catalog:codex"],
+        ["work", "ungrouped", "groups", "channels", "catalog:codex"],
       ),
     );
   });
@@ -283,7 +294,7 @@ describe("AppSidebar section reordering", () => {
     await waitForFast(() =>
       expect(harness.groupsPut).toHaveBeenCalledWith(
         [],
-        ["ungrouped", "groups", "catalog:codex", "work"],
+        ["ungrouped", "groups", "channels", "catalog:codex", "work"],
       ),
     );
   });

--- a/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
@@ -12,7 +12,15 @@ describe("AppSidebar session section visibility", () => {
   it("paginates each expanded section independently", async () => {
     const threadKeys = Array.from({ length: 12 }, (_, index) => `agent:main:thread-${index}`);
     const categoryKeys = Array.from({ length: 12 }, (_, index) => `agent:main:alpha-${index}`);
-    const sessions = createSessionsHarness("main", [...threadKeys, ...categoryKeys]);
+    const channelKeys = Array.from(
+      { length: 12 },
+      (_, index) => `agent:main:telegram:direct:${index}`,
+    );
+    const sessions = createSessionsHarness("main", [
+      ...threadKeys,
+      ...categoryKeys,
+      ...channelKeys,
+    ]);
     const result = sessions.sessions.state.result;
     if (!result) {
       throw new Error("expected session list fixture");
@@ -27,20 +35,81 @@ describe("AppSidebar session section visibility", () => {
     const { sidebar } = await mountSidebar(gateway, sessions.sessions);
     const category = sidebar.querySelector('[data-session-section="category:Alpha"]');
     const threads = sidebar.querySelector('[data-session-section="ungrouped"]');
+    const channels = sidebar.querySelector('[data-session-section="channels"]');
 
     expect(category?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
     expect(threads?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
+    expect(channels?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
     expect(category?.querySelector('[aria-label="Show more"]')).not.toBeNull();
     expect(threads?.querySelector('[aria-label="Show more"]')).not.toBeNull();
-    expect(sidebar.querySelectorAll(".sidebar-session-pagination")).toHaveLength(2);
+    expect(channels?.querySelector('[aria-label="Show more"]')).not.toBeNull();
+    expect(sidebar.querySelectorAll(".sidebar-session-pagination")).toHaveLength(3);
 
-    threads?.querySelector<HTMLButtonElement>('[aria-label="Show more"]')?.click();
+    channels?.querySelector<HTMLButtonElement>('[aria-label="Show more"]')?.click();
     await sidebar.updateComplete;
 
     expect(category?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
-    expect(threads?.querySelectorAll(".sidebar-recent-session")).toHaveLength(12);
+    expect(threads?.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
+    expect(channels?.querySelectorAll(".sidebar-recent-session")).toHaveLength(12);
     expect(category?.querySelector('[aria-label="Show more"]')).not.toBeNull();
-    expect(threads?.querySelector('[aria-label="Show more"]')).toBeNull();
+    expect(threads?.querySelector('[aria-label="Show more"]')).not.toBeNull();
+    expect(channels?.querySelector('[aria-label="Show more"]')).toBeNull();
+  });
+
+  it("starts Channels collapsed, surfaces unread, and reveals an active channel session", async () => {
+    localStorage.removeItem("openclaw:sidebar:sessions:collapsed-sections");
+    const firstChannelKey = "agent:main:telegram:direct:alice";
+    const secondChannelKey = "agent:main:discord:channel:operations";
+    const harness = createSessionsHarness("main", [
+      "agent:main:main",
+      "agent:main:dashboard:local",
+      firstChannelKey,
+      secondChannelKey,
+    ]);
+    const firstChannel = harness.sessions.state.result?.sessions.find(
+      (row) => row.key === firstChannelKey,
+    );
+    if (!firstChannel) {
+      throw new Error("expected channel session fixture");
+    }
+    firstChannel.unread = true;
+
+    const { sidebar } = await mountSidebar(
+      createGateway({} as GatewayBrowserClient),
+      harness.sessions,
+    );
+    sidebar.activeRouteId = "chat";
+    await sidebar.updateComplete;
+
+    let channels = sidebar.querySelector('[data-session-section="channels"]');
+    expect(channels?.querySelector('[aria-label="Channels"]')?.getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+    expect(channels?.querySelector(".sidebar-session-group-unread")).not.toBeNull();
+    expect(channels?.querySelector(".sidebar-recent-session")).toBeNull();
+
+    sidebar.sessionKey = firstChannelKey;
+    await sidebar.updateComplete;
+    channels = sidebar.querySelector('[data-session-section="channels"]');
+    expect(channels?.querySelector('[aria-label="Channels"]')?.getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    expect(channels?.querySelector(`[data-session-key="${firstChannelKey}"]`)).not.toBeNull();
+
+    channels?.querySelector<HTMLButtonElement>('[aria-label="Channels"]')?.click();
+    await sidebar.updateComplete;
+    channels = sidebar.querySelector('[data-session-section="channels"]');
+    expect(channels?.querySelector('[aria-label="Channels"]')?.getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+
+    sidebar.sessionKey = secondChannelKey;
+    await sidebar.updateComplete;
+    channels = sidebar.querySelector('[data-session-section="channels"]');
+    expect(channels?.querySelector('[aria-label="Channels"]')?.getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    expect(channels?.querySelector(`[data-session-key="${secondChannelKey}"]`)).not.toBeNull();
   });
 
   it("keeps global thread actions when every unpinned thread has a custom group", async () => {

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -588,8 +588,8 @@ export function setupSidebarTest() {
       configurable: true,
       value: createStorageMock(),
     });
-    // The Coding zone defaults to collapsed on first run; most cases assert its
-    // contents, so start expanded. Collapse-specific tests override this value.
+    // Channels and Coding default collapsed; most cases assert section contents,
+    // so start expanded. Collapse-specific tests override this value.
     localStorage.setItem("openclaw:sidebar:sessions:collapsed-sections", JSON.stringify([]));
   });
 


### PR DESCRIPTION
## New behavior

Channel-owned conversations now live in a dedicated **Channels** sidebar section instead of competing with normal session groups. Channels has its own collapsed and unread state, independent pagination, and active-session visibility.

## How it works

Channel classification is shared between Gateway grouping and Control UI grouping. A dedicated sidebar controller owns Channels expansion, pagination, unread state, and active-session inclusion, while explicit pins and custom groups keep precedence.

## Rebased proof attestation

- Current head: `0f8741ea828d5ba6da2b72da33671149978a4836`
- Direct base: `f0076b0ca63bbc543d151f6f362f7f9783d637d2`
- Previous proof head: `94c219409e8c052e2acead66abed8572468199fb`

Both PR commits were rebased onto the direct base without conflicts. `git range-diff` reports both pre-rebase and post-rebase commits as identical (`=`). The second commit adds CI-only upgrade-contract tests for existing saved section order and collapse preferences; it changes no production or rendered UI code. The existing GitHub-hosted screenshots and recording therefore remain representative of the current exact head.

## UI proof

The proof pack contains four 1280×900 staging captures and a paced interaction recording.

### Collapsed unread state

<img width="1280" height="900" alt="Collapsed Channels section preserving its unread indicator" src="https://github.com/user-attachments/assets/d6de00f7-73b3-4ede-9ef0-a1e0d040de99" />

The Channels section is collapsed while its unread indicator remains visible.

### Expanded Channels section

<img width="1280" height="900" alt="Expanded Channels section with channel-owned conversations separated from normal groups" src="https://github.com/user-attachments/assets/b3044ae4-cdff-4410-b2c5-e1d6522e57bc" />

Channel-owned conversations are separated from normal groups under their own heading.

### Independent pagination

<img width="1280" height="900" alt="Independent channel pagination" src="https://github.com/user-attachments/assets/1de86463-4c74-4f29-950c-d041b74f2ba2" />

Loading more channel conversations does not consume or reorder the normal session list budget.

### Active channel visibility

<img width="1280" height="900" alt="Active channel conversation remains visible" src="https://github.com/user-attachments/assets/f52837a9-4ce4-4c9b-92b8-7f5deea7aa40" />

The active channel conversation remains visible in Channels even when normal list limits apply.

### Interaction recording

https://github.com/user-attachments/assets/f4b0655d-09e2-45d6-bbb9-fc4568390f01

The paced recording demonstrates collapse and unread behavior, expansion, independent pagination, and active-row visibility in sequence.

## How to verify

1. Open the Control UI with both normal and channel-owned conversations.
2. Confirm channel-owned conversations appear only under **Channels**.
3. Collapse Channels and confirm unread state remains visible.
4. Expand it and paginate channel conversations; confirm normal groups keep their own pagination budget.
5. Open a channel conversation and confirm the active row remains visible.

## Exact-head checks

- Gateway section-order tests: 8 passed.
- Session grouping and custom-group tests: 28 passed.
- Sidebar integration tests: 253 passed.
- Saved collapse-preference contract tests: 6 passed.
- Pre-Channels section-order upgrade contract tests: 26 passed.
- Changed-file Oxlint, CSS lint, formatting, Control UI i18n verification, and `git diff --check` passed.
- Pre/post-rebase `git range-diff`: identical feature patch (`=`).

The unrelated `test/vitest-projects-config.test.ts` ownership check currently fails on this exact head and on the direct base because `extensions/codex/src/app-server/run-attempt-state.test.ts` is assigned to two Vitest configs. This PR does not modify that test or either config.

Broad memory-heavy `tsgo` and `tsgolint` runs were intentionally omitted; exact-head CI owns those repository-wide gates.

## Safety

- No Gateway protocol or configuration surface changes.
- The rebase did not change the feature patch; the exact-head follow-up is test-only.
- No unrelated workspace files are included.
