### PR TITLE
fix(android): drain queued messages on pre-branch gateways

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1404,7 +1404,11 @@ class NodeRuntime private constructor(
           prepareMainSessionKey(resolveAgentIdFromMainSessionKey(hello.mainSessionKey))
         // Create/adopt before history refresh; this keeps the first connected read on the
         // device-owned session without changing the shipped key or its existing transcript.
-        chat.onGatewayConnected(mainSessionBinding(mainSessionKey))
+        chat.onGatewayConnected(
+          mainSessionBinding(mainSessionKey),
+          hello.methods,
+          hello.serverVersion,
+        )
         refreshGatewayControlPage()
         updateStatus {
           operatorConnectionProblem = null

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.GatewayModelSummary
 import ai.openclaw.app.gateway.GatewayLoadedImage
 import ai.openclaw.app.gateway.GatewayLoadedMedia
 import ai.openclaw.app.gateway.GatewayMediaKind
+import ai.openclaw.app.gateway.GatewayMethod
 import ai.openclaw.app.gateway.GatewayRequestDefinitiveFailure
 import ai.openclaw.app.gateway.GatewayRequestNotEnqueued
 import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
@@ -60,6 +61,14 @@ private val QUESTION_REFRESH_RETRY_DELAYS_MS = longArrayOf(1_000L, 2_000L, 4_000
 private val SWARM_REFRESH_RETRY_DELAYS_MS = longArrayOf(1_000L, 2_000L, 4_000L)
 private const val SUBAGENT_ACTIVITY_RETENTION_MS = 60_000L
 private const val SESSION_EDITOR_MAX_BASE64_CHARS = ((OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES + 2) / 3) * 4
+
+// The correction tag source reports 2026.7.1; its published npm artifact reports 2026.7.1-2.
+private val LEGACY_GATEWAY_VERSIONS_WITHOUT_SESSION_BRANCHES =
+  setOf(
+    "2026.7.1",
+    "2026.7.1-1",
+    "2026.7.1-2",
+  )
 private val MANAGED_MEDIA_PATH_REGEX =
   Regex("^/api/chat/media/outgoing/[^/]+/([0-9a-fA-F-]{36})/full(?:\\?.*)?$")
 
@@ -394,6 +403,8 @@ class ChatController internal constructor(
   private val _sessionBranchSwitching = MutableStateFlow(false)
   val sessionBranchSwitching: StateFlow<Boolean> = _sessionBranchSwitching.asStateFlow()
 
+  @Volatile private var sessionBranchListingSupport = SessionBranchListingSupport.Unknown
+
   private val sessionBranchesRefreshGeneration = AtomicLong(0)
   private val sessionBranchSwitchGeneration = AtomicLong(0)
   private val sessionBranchSwitchClaimed = AtomicBoolean(false)
@@ -562,6 +573,7 @@ class ChatController internal constructor(
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
     retireMainSessionReadiness()
+    sessionBranchListingSupport = SessionBranchListingSupport.Unknown
     reconciledOutboxBranchScopes.clear()
     ambiguousMutationReconciliationStates.clear()
     synchronized(outboxSessionMutationEventLock) {
@@ -677,6 +689,31 @@ class ChatController internal constructor(
     adoptionJob.start()
   }
 
+  /** Records branch capability evidence from the same hello that owns this connection. */
+  internal fun onGatewayConnected(
+    mainSession: MainSessionBinding,
+    gatewayMethods: Set<String>,
+    gatewayVersion: String?,
+  ) {
+    val nextSupport =
+      when {
+        GatewayMethod.SessionsBranchesList.rawValue in gatewayMethods ->
+          SessionBranchListingSupport.Available
+        gatewayVersion?.trim() in LEGACY_GATEWAY_VERSIONS_WITHOUT_SESSION_BRANCHES ->
+          SessionBranchListingSupport.Unavailable
+        else -> SessionBranchListingSupport.Unknown
+      }
+    if (sessionBranchListingSupport != nextSupport) {
+      sessionBranchesRefreshGeneration.incrementAndGet()
+      _sessionBranchesLoading.value = false
+      if (nextSupport == SessionBranchListingSupport.Unavailable) {
+        _sessionBranches.value = emptyList()
+      }
+    }
+    sessionBranchListingSupport = nextSupport
+    onGatewayConnected(mainSession)
+  }
+
   private fun refreshConnectedGateway() {
     refreshQuestions()
     if (!restoreRunStateOnReconnect) {
@@ -722,6 +759,7 @@ class ChatController internal constructor(
       // Outbox rows are gateway-scoped too; the next publish repopulates them for the new scope.
       _outboxItems.value = emptyList()
       _outboxPresentationRestored.value = commandOutbox == null
+      sessionBranchListingSupport = SessionBranchListingSupport.Unknown
       reconciledOutboxBranchScopes.clear()
       ambiguousMutationReconciliationStates.clear()
       synchronized(outboxSessionMutationEventLock) {
@@ -1168,6 +1206,12 @@ class ChatController internal constructor(
     ReadOnly,
     Reconcile,
     FinalizeMutation,
+  }
+
+  private enum class SessionBranchListingSupport {
+    Unknown,
+    Available,
+    Unavailable,
   }
 
   /** Rewinds the current transcript at one canonical history entry. */
@@ -1643,7 +1687,7 @@ class ChatController internal constructor(
     return outbox.branchState(gatewayId, snapshot.outboxScope())
   }
 
-  private suspend fun requestSessionBranches(snapshot: SessionActionSnapshot): List<SessionBranch> =
+  private suspend fun requestSessionBranches(snapshot: SessionActionSnapshot): List<SessionBranch>? =
     requestSessionBranches(
       gatewayId = snapshot.gatewayScope?.gatewayId,
       sessionKey = snapshot.sessionKey,
@@ -1654,7 +1698,8 @@ class ChatController internal constructor(
     gatewayId: String?,
     sessionKey: String,
     ownerAgentId: String,
-  ): List<SessionBranch> {
+  ): List<SessionBranch>? {
+    if (sessionBranchListingSupport == SessionBranchListingSupport.Unavailable) return null
     val params =
       buildJsonObject {
         put("sessionKey", JsonPrimitive(sessionKey))
@@ -1726,7 +1771,15 @@ class ChatController internal constructor(
     val generation = sessionBranchesRefreshGeneration.incrementAndGet()
     if (isCurrentSessionAction(snapshot)) _sessionBranchesLoading.value = true
     return try {
-      val branches = requestSessionBranches(snapshot)
+      val branches =
+        requestSessionBranches(snapshot)
+          ?: return when {
+            purpose == BranchRefreshPurpose.FinalizeMutation -> false
+            previousState?.needsReconciliation == true -> false
+            previousState?.switchPendingSinceMs != null -> false
+            commandOutbox?.supportsBranchCoordination != true -> true
+            else -> markOutboxBranchReconciled(snapshot.gatewayScope, snapshot.outboxScope())
+          }
       if (!isCurrentSessionAction(snapshot) || generation != sessionBranchesRefreshGeneration.get()) return false
       val activeLeaf = if (branches.isEmpty()) null else activeBranchLeafEntryId(branches) ?: return false
       val outbox = commandOutbox
@@ -4820,6 +4873,12 @@ class ChatController internal constructor(
             sessionKey = sessionKey,
             ownerAgentId = branchScope.ownerAgentId,
           )
+        if (branches == null) {
+          if (!state.needsReconciliation && state.switchPendingSinceMs == null) {
+            markOutboxBranchReconciled(flushScope, branchScope)
+          }
+          continue
+        }
         val activeLeaf = if (branches.isEmpty()) null else activeBranchLeafEntryId(branches) ?: continue
         if (
           outbox.reconcileBranchScope(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -61,18 +61,27 @@ private val QUESTION_REFRESH_RETRY_DELAYS_MS = longArrayOf(1_000L, 2_000L, 4_000
 private val SWARM_REFRESH_RETRY_DELAYS_MS = longArrayOf(1_000L, 2_000L, 4_000L)
 private const val SUBAGENT_ACTIVITY_RETENTION_MS = 60_000L
 private const val SESSION_EDITOR_MAX_BASE64_CHARS = ((OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES + 2) / 3) * 4
-
-// The correction tag source reports 2026.7.1; its published npm artifact reports 2026.7.1-2.
-private val LEGACY_GATEWAY_VERSIONS_WITHOUT_SESSION_BRANCHES =
-  setOf(
-    "2026.7.1",
-    "2026.7.1-1",
-    "2026.7.1-2",
-  )
+private val GATEWAY_VERSION_PATTERN = Regex("^(\\d{4})\\.(\\d+)\\.(\\d+)(?:-([0-9A-Za-z.-]+))?$")
+private val GATEWAY_SESSION_BRANCH_BETA_PATTERN = Regex("^beta\\.(\\d+)$")
 private val MANAGED_MEDIA_PATH_REGEX =
   Regex("^/api/chat/media/outgoing/[^/]+/([0-9a-fA-F-]{36})/full(?:\\?.*)?$")
 
 internal fun chatOutboxQueueFailureText(): NativeText = ChatController.queueFailureText()
+
+/** Returns true only for a well-formed Gateway version known to predate session branches. */
+internal fun gatewayPredatesSessionBranches(rawVersion: String?): Boolean {
+  val match = GATEWAY_VERSION_PATTERN.matchEntire(rawVersion?.trim().orEmpty()) ?: return false
+  val year = match.groupValues[1].toIntOrNull() ?: return false
+  val month = match.groupValues[2].toIntOrNull() ?: return false
+  val patch = match.groupValues[3].toIntOrNull() ?: return false
+  when {
+    year != 2026 -> return year < 2026
+    month != 7 -> return month < 7
+    patch != 2 -> return patch < 2
+  }
+  val beta = GATEWAY_SESSION_BRANCH_BETA_PATTERN.matchEntire(match.groupValues[4]) ?: return false
+  return (beta.groupValues[1].toIntOrNull() ?: return false) < 4
+}
 
 // Capture before suspend points; both fields must still match before gateway data reaches UI state.
 internal data class ChatCacheScope(
@@ -699,7 +708,7 @@ class ChatController internal constructor(
       when {
         GatewayMethod.SessionsBranchesList.rawValue in gatewayMethods ->
           SessionBranchListingSupport.Available
-        gatewayVersion?.trim() in LEGACY_GATEWAY_VERSIONS_WITHOUT_SESSION_BRANCHES ->
+        gatewayPredatesSessionBranches(gatewayVersion) ->
           SessionBranchListingSupport.Unavailable
         else -> SessionBranchListingSupport.Unknown
       }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -112,6 +112,173 @@ class ChatControllerBranchCoordinationTest {
     }
 
   @Test
+  fun legacyGatewayWithoutBranchApiDrainsAnOrdinaryQueuedMessage() =
+    runTest {
+      enqueue("legacy queued")
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":{}}""")
+      gateway.respondWith("chat.history", historyResponse("session-main", emptyList()))
+      gateway.respond("sessions.branches.list") {
+        error("stable Gateway 2026.7.1-2 does not advertise this method")
+      }
+      gateway.respondChatSend("started")
+      val controller = controller(gateway, StandardTestDispatcher(testScheduler))
+      runCurrent()
+      controller.awaitOutboxRestore()
+      controller.onGatewayConnected(
+        MainSessionBinding("main", "OpenClaw Android"),
+        emptySet(),
+        "2026.7.1",
+      )
+      runCurrent()
+      controller.handleGatewayEvent("health", null)
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(2_000) {
+          while (gateway.callCount("chat.send") == 0) {
+            runCurrent()
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      assertEquals(0, gateway.callCount("sessions.branches.list"))
+      assertEquals(1, gateway.callCount("chat.send"))
+    }
+
+  @Test
+  fun firstLegacyGatewayCorrectionWithoutBranchApiDrainsAnOrdinaryQueuedMessage() =
+    runTest {
+      enqueue("first correction queued")
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":{}}""")
+      gateway.respondWith("chat.history", historyResponse("session-main", emptyList()))
+      gateway.respond("sessions.branches.list") {
+        error("Gateway 2026.7.1-1 does not implement this method")
+      }
+      gateway.respondChatSend("started")
+      val controller = controller(gateway, StandardTestDispatcher(testScheduler))
+      runCurrent()
+      controller.awaitOutboxRestore()
+      controller.onGatewayConnected(
+        MainSessionBinding("main", "OpenClaw Android"),
+        emptySet(),
+        "2026.7.1-1",
+      )
+      runCurrent()
+      controller.handleGatewayEvent("health", null)
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(2_000) {
+          while (gateway.callCount("chat.send") == 0) {
+            runCurrent()
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      assertEquals(0, gateway.callCount("sessions.branches.list"))
+      assertEquals(1, gateway.callCount("chat.send"))
+    }
+
+  @Test
+  fun legacyGatewayWithoutBranchApiKeepsAmbiguousBranchStateParked() =
+    runTest {
+      val branchScope = ChatOutboxScope("main", "main")
+      assertTrue(outbox.demoteSessionMutationToReconciliation("gateway-a", branchScope))
+      enqueue("ambiguous queued")
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":{}}""")
+      gateway.respondWith("chat.history", historyResponse("session-main", emptyList()))
+      gateway.respondChatSend("started")
+      val controller = controller(gateway, StandardTestDispatcher(testScheduler))
+      runCurrent()
+      controller.awaitOutboxRestore()
+      controller.onGatewayConnected(
+        MainSessionBinding("main", "OpenClaw Android"),
+        emptySet(),
+        "2026.7.1-2",
+      )
+      runCurrent()
+      controller.handleGatewayEvent("health", null)
+      runCurrent()
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        kotlinx.coroutines.delay(200)
+      }
+
+      assertTrue(outbox.branchState("gateway-a", branchScope)?.needsReconciliation == true)
+      assertEquals(0, gateway.callCount("sessions.branches.list"))
+      assertEquals(0, gateway.callCount("chat.send"))
+    }
+
+  @Test
+  fun advertisedBranchApiStillReconcilesBeforeQueuedDelivery() =
+    runTest {
+      enqueue("branch-aware queued")
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":{}}""")
+      gateway.respondWith("chat.history", historyResponse("session-main", emptyList()))
+      gateway.respondWith("sessions.branches.list", """{"branches":[]}""")
+      gateway.respondChatSend("started")
+      val controller = controller(gateway, StandardTestDispatcher(testScheduler))
+      runCurrent()
+      controller.awaitOutboxRestore()
+      controller.onGatewayConnected(
+        MainSessionBinding("main", "OpenClaw Android"),
+        setOf("sessions.branches.list"),
+        "2026.7.4",
+      )
+      runCurrent()
+      controller.handleGatewayEvent("health", null)
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(2_000) {
+          while (gateway.callCount("chat.send") == 0) {
+            runCurrent()
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      assertTrue(gateway.callCount("sessions.branches.list") >= 1)
+      assertEquals(1, gateway.callCount("chat.send"))
+    }
+
+  @Test
+  fun omittedBranchAdvertisementOnUnknownGatewayStillProbesBeforeQueuedDelivery() =
+    runTest {
+      enqueue("unadvertised branch-aware queued")
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":{}}""")
+      gateway.respondWith("chat.history", historyResponse("session-main", emptyList()))
+      gateway.respondWith("sessions.branches.list", """{"branches":[]}""")
+      gateway.respondChatSend("started")
+      val controller = controller(gateway, StandardTestDispatcher(testScheduler))
+      runCurrent()
+      controller.awaitOutboxRestore()
+      controller.onGatewayConnected(
+        MainSessionBinding("main", "OpenClaw Android"),
+        emptySet(),
+        "2026.7.4",
+      )
+      runCurrent()
+      controller.handleGatewayEvent("health", null)
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(2_000) {
+          while (gateway.callCount("chat.send") == 0) {
+            runCurrent()
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      assertTrue(gateway.callCount("sessions.branches.list") >= 1)
+      assertEquals(1, gateway.callCount("chat.send"))
+    }
+
+  @Test
   fun rewindParksAnEnqueueThatRacesInsideTheMutationLease() =
     runTest {
       val gateway = ScriptedGateway(json)

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -112,6 +112,39 @@ class ChatControllerBranchCoordinationTest {
     }
 
   @Test
+  fun sessionBranchVersionBoundaryFailsClosedOutsideKnownPreIntroductionVersions() {
+    val preIntroductionVersions =
+      listOf(
+        "2025.12.31",
+        "2026.6.10",
+        "2026.7.1",
+        "2026.7.1-1",
+        "2026.7.1-2",
+        "2026.7.1-beta.6",
+        "2026.7.2-beta.1",
+        "2026.7.2-beta.3",
+      )
+    for (version in preIntroductionVersions) {
+      assertTrue(version, gatewayPredatesSessionBranches(version))
+    }
+    val unknownOrCapableVersions =
+      listOf(
+        null,
+        "",
+        "unknown",
+        "v2026.7.1",
+        "2026.7.2-alpha.1",
+        "2026.7.2-beta.4",
+        "2026.7.2-beta.7",
+        "2026.7.2",
+        "2026.8.0",
+      )
+    for (version in unknownOrCapableVersions) {
+      assertFalse(version, gatewayPredatesSessionBranches(version))
+    }
+  }
+
+  @Test
   fun legacyGatewayWithoutBranchApiDrainsAnOrdinaryQueuedMessage() =
     runTest {
       enqueue("legacy queued")


### PR DESCRIPTION
Fixes #123242.

## What Problem This Solves

Android's durable outbox reconciles `sessions.branches.list` before `chat.send`. On protocol-compatible gateways that predate session branches, an operator-scoped client can receive `missing scope: operator.admin` for that unknown method before dispatch, so an otherwise Ready chat stays queued forever.

This change:

- treats an advertised `sessions.branches.list` as authoritative positive capability evidence;
- classifies well-formed Gateway versions before the branch API introduction (`2026.7.2-beta.4`) as branchless;
- skips branch reconciliation only for ordinary queued messages on those known older gateways;
- keeps ambiguous rewind/switch state parked rather than risking delivery on the wrong branch;
- continues probing malformed, unknown, and beta.4-or-newer gateways when the method is merely omitted from the conservative advertisement list.

No gateway scope is widened and no admin grant is required.

## Evidence

The same Android candidate was tested against official npm `openclaw@2026.7.1-2` with a local Ollama/Gemma model on both a Pixel 10 Pro XL and an Android Studio emulator.

| Pixel before (unmodified Play app) | Pixel after (side-by-side candidate) |
| --- | --- |
| ![Ready but queued](https://github.com/saari-co/public-oss-proof-assets/releases/download/openclaw-123242-v1/openclaw-123242-pixel-before-queued.png) | ![Exact reply delivered](https://github.com/saari-co/public-oss-proof-assets/releases/download/openclaw-123242-v1/openclaw-123242-pixel-after-exact-reply.png) |

![Emulator exact reply delivered](https://github.com/saari-co/public-oss-proof-assets/releases/download/openclaw-123242-v1/openclaw-123242-emulator-after-exact-reply.png)

The Pixel returned `ANDROID_XL_GEMMA_LEGACY_GATEWAY_OK`; the emulator independently returned `ANDROID_EMULATOR_GEMMA_LEGACY_GATEWAY_OK`. Both replies persisted after force-stop/reopen. The existing Play install remained installed and unchanged.

Media is crop-only, sanitized, and hash-documented in the [immutable proof release](https://github.com/saari-co/public-oss-proof-assets/releases/tag/openclaw-123242-v1).

Validation command:

```
ANDROID_HOME=/Users/bobbybones/Library/Android/sdk \
JAVA_HOME=/Users/bobbybones/Library/Java/JavaVirtualMachines/jbr-21.0.11/Contents/Home \
./gradlew :app:testPlayDebugUnitTest :app:ktlintCheck :app:lintPlayDebug :app:assemblePlayDebug
```

Result on rebased head `dea145ca06353c206e1482b8156bfe808bebe049`: `BUILD SUCCESSFUL` (120 tasks, 1m17s).

Focused coverage includes:

- the released `2026.7.1`, `2026.7.1-1`, and `2026.7.1-2` identities;
- the pre-introduction `2026.7.2-beta.1` through beta.3 boundary;
- beta.4/newer, malformed, and unknown versions remaining conservative;
- advertised branch support still reconciling before delivery;
- ordinary legacy delivery draining without a branch RPC;
- ambiguous branch mutation state remaining parked.