### PR TITLE
fix(codex): prevent restart loop in explicit multi-agent setups

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -188,7 +188,11 @@ describe("codex doctor contract", () => {
 
     await expect(migration.migrateLegacyState(params)).resolves.toEqual({
       changes: [],
-      warnings: [expect.stringContaining("has no agent owner for legacy")],
+      warnings: [
+        expect.stringContaining(
+          "Multiple agents are configured, but session agent resolution has no explicit owner. Pass an agentId, an agent-scoped session key, or a prepared fallbackAgentId.",
+        ),
+      ],
     });
     await expect(fs.access(sidecarPath)).resolves.toBeUndefined();
 

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -123,6 +123,78 @@ afterEach(() => {
 });
 
 describe("codex doctor contract", () => {
+  it("skips retired binding discovery without an implicit agent owner", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    await fs.mkdir(path.join(stateDir, "sessions"));
+    const params = {
+      config: {
+        agents: {
+          ownership: "explicit" as const,
+          entries: { main: {}, ops: {} },
+        },
+      },
+      env,
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: createDoctorContext(env),
+    };
+    const migration = stateMigrations[0];
+    if (!migration) {
+      throw new Error("missing Codex binding migration");
+    }
+
+    await expect(migration.detectLegacyState(params)).resolves.toBeNull();
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
+
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("retains an unscoped retired binding whose agent owner is ambiguous", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sessionsDir = path.join(stateDir, "sessions");
+    const transcriptPath = path.join(sessionsDir, "legacy.jsonl");
+    const sidecarPath = `${transcriptPath}.codex-app-server.json`;
+    await fs.mkdir(sessionsDir);
+    await fs.writeFile(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({ legacy: { sessionId: "legacy", sessionFile: "legacy.jsonl" } }),
+    );
+    await fs.writeFile(transcriptPath, `${JSON.stringify({ type: "session", id: "legacy" })}\n`);
+    await fs.writeFile(
+      sidecarPath,
+      JSON.stringify({ schemaVersion: 2, threadId: "thread-legacy" }),
+    );
+    const migration = stateMigrations[0];
+    if (!migration) {
+      throw new Error("missing Codex binding migration");
+    }
+    const params = {
+      config: {
+        agents: {
+          ownership: "explicit" as const,
+          entries: { main: {}, ops: {} },
+        },
+      },
+      env,
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: createDoctorContext(env),
+    };
+
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [],
+      warnings: [expect.stringContaining("has no agent owner for legacy")],
+    });
+    await expect(fs.access(sidecarPath)).resolves.toBeUndefined();
+
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
   it("reports the retired dynamic tools profile config key", () => {
     expect(
       legacyConfigRules[0]?.match({

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -101,7 +101,12 @@ async function collectSessionSurfaces(params: MigrationEnvironment): Promise<Ses
   const { resolveStorePath } = await import("openclaw/plugin-sdk/session-store-runtime");
   const surfaces = new Map<string, SessionSurface>();
   const stateRoot = await canonicalPathFromExistingAncestor(params.stateDir);
-  const add = async (root: string, storePath: string, agentId: string, scan: boolean) => {
+  const add = async (
+    root: string,
+    storePath: string,
+    agentId: string | undefined,
+    scan: boolean,
+  ) => {
     const canonicalRoot = await canonicalPathFromExistingAncestor(root);
     const surface = surfaces.get(canonicalRoot) ?? {
       root: canonicalRoot,
@@ -113,7 +118,9 @@ async function collectSessionSurfaces(params: MigrationEnvironment): Promise<Ses
     // A store's configured path defines how relative sessionFile locators are
     // resolved. Keep it intact; canonicalize only when deduplicating aliases.
     surface.storePaths.add(path.resolve(storePath));
-    surface.agentIds.add(agentId);
+    if (agentId) {
+      surface.agentIds.add(agentId);
+    }
     surfaces.set(canonicalRoot, surface);
   };
 
@@ -147,8 +154,9 @@ async function collectSessionSurfaces(params: MigrationEnvironment): Promise<Ses
   }
 
   const legacyRoot = path.join(params.stateDir, "sessions");
-  const defaultAgentId = resolveSessionAgentIds({ config: params.config }).defaultAgentId;
-  await add(legacyRoot, path.join(legacyRoot, "sessions.json"), defaultAgentId, true);
+  // The retired global store has no intrinsic agent owner. Resolve ownership
+  // from an indexed session key only if a sidecar actually exists.
+  await add(legacyRoot, path.join(legacyRoot, "sessions.json"), undefined, true);
   return [...surfaces.values()].toSorted((a, b) => a.root.localeCompare(b.root));
 }
 
@@ -336,11 +344,17 @@ async function collectBindingOwners(
     const sessionsDir = path.dirname(storePath);
     for (const { sessionKey, entry } of index.entries) {
       const sessionId = entry.sessionId;
-      const agentId = resolveLegacyBindingOwnerAgentId({
-        sessionKey,
-        config: params.config,
-        storeAgentIds: storeAgentIds.get(storePath),
-      });
+      let agentId: string;
+      try {
+        agentId = resolveLegacyBindingOwnerAgentId({
+          sessionKey,
+          config: params.config,
+          storeAgentIds: storeAgentIds.get(storePath),
+        });
+      } catch {
+        failures.push(`session index ${storePath} has no agent owner for ${sessionKey}`);
+        continue;
+      }
       let legacyTranscriptPath: string;
       let canonicalLegacyTranscriptPath: string;
       try {

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -351,8 +351,19 @@ async function collectBindingOwners(
           config: params.config,
           storeAgentIds: storeAgentIds.get(storePath),
         });
-      } catch {
-        failures.push(`session index ${storePath} has no agent owner for ${sessionKey}`);
+      } catch (error) {
+        // Ambiguous legacy ownership is operator-repairable; unexpected resolver
+        // failures must still abort Doctor instead of being mislabeled.
+        if (
+          !(error instanceof Error) ||
+          !("code" in error) ||
+          error.code !== "AGENT_SELECTION_REQUIRED"
+        ) {
+          throw error;
+        }
+        failures.push(
+          `session index ${storePath} has no agent owner for ${sessionKey}: ${error.message}`,
+        );
         continue;
       }
       let legacyTranscriptPath: string;


### PR DESCRIPTION
Production LOC: +34/-9 (net +25) | Tests: +76/-0

## What Problem This Solves

Fixes an issue where explicit multi-agent installations could enter a permanent Gateway restart loop after updating because Codex legacy binding discovery required an implicit agent owner even when there were no retired bindings to migrate.

## Why This Change Was Made

The retired global binding store has no intrinsic agent owner, so discovery now records that surface without inventing one and resolves ownership only from an indexed session key when a sidecar actually exists. Ambiguous real sidecars are retained with an actionable Doctor warning instead of crashing discovery or being attributed to an arbitrary agent.

This is the best fix because the migration owns legacy sidecar discovery and archival. Adding a default agent or weakening the shared explicit-owner resolver would reintroduce the ambient ownership behavior that PR #114388 intentionally removed.

Provenance: clearly made visible by PR #114388 (`1ca60fbc3a3`, authored and merged by @steipete on 2026-08-12), which correctly made multi-agent owner selection explicit but exposed this migration's unconditional default-agent lookup.

## User Impact

Operators with explicit multi-agent ownership can start the Gateway normally after updating. Existing ambiguous legacy Codex sidecars remain intact for operator review; the migration does not guess their agent owner.

## Evidence

- Captured the pre-fix regression: the new explicit-multi-agent test rejected with `AgentSelectionRequiredError` at `collectSessionSurfaces`.
- Focused Codex Doctor suite: 29/29 tests pass.
- Plugin Doctor contract suites: 5/5 tests pass.
- Formatting, focused extension lint, `git diff --check`, and a full production build pass.
- Live same-patch proof: the previously crash-looping Gateway reached `ready`, deep RPC succeeded, verbose health returned `ok: true`, Slack reconnected, and systemd remained at zero restarts.
- Codex dependency contract inspected at `openai/codex@6851fae57cf7`: `thread/start`, `thread/resume`, and `thread/read` retain thread identity in `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`; this repair changes only OpenClaw's retired-sidecar discovery before app-server protocol use.
- Hosted `check:changed` could not be started from this host because neither a working Crabbox nor Blacksmith client is installed. Normal exact-head PR CI remains pending.
### Exact-head upgrade proof (`20541bc305c`)

The fixtures use isolated synthetic state/config, two explicitly configured agents (`main` and `ops`), no credentials, and no live user sessions.

```text
$ openclaw gateway run --port 19091 --auth none --bind loopback --verbose
OpenClaw 2026.8.1 (20541bc)
[gateway] ready
[heartbeat] started

$ OPENCLAW_GATEWAY_PORT=19091 openclaw health --json --verbose
{
  "ok": true,
  "configReload": { "hotReloadStatus": "active" },
  "agents": [
    { "agentId": "main", "sessions": { "count": 0 } },
    { "agentId": "ops", "sessions": { "count": 0 } }
  ]
}
[ws] ⇄ res ✓ health 292ms
```

An isolated upgrade fixture with one real ambiguous retired sidecar preserves the file and completes Doctor with an actionable warning:

```text
$ openclaw doctor --fix --non-interactive --yes
Left 1 Codex binding sidecar(s) in place because session ownership is indeterminate:
session index <redacted-state>/sessions/sessions.json has no agent owner for legacy:
Multiple agents are configured, but session agent resolution has no explicit owner.
Pass an agentId, an agent-scoped session key, or a prepared fallbackAgentId.
Doctor complete.

$ test -f <redacted-state>/sessions/legacy.jsonl.codex-app-server.json
AMBIGUOUS_SIDECAR_PRESERVED=yes
```

Final exact-head focused suite: 29/29 passed. The synthetic Gateway remained RPC-healthy after readiness. It also emitted the previously separated nonfatal system-agent prewarm owner warning; that ambient-owner path is outside this migration and did not affect health.

The +25 production delta is the owner-boundary implementation: the retired global surface becomes explicitly ownerless until indexed session data can establish ownership, the expected `AGENT_SELECTION_REQUIRED` result is converted into the actionable retention warning, and unexpected resolver errors still propagate. Moving this policy into the shared resolver or inventing a default agent would weaken explicit ownership rather than remove code from the migration owner.


<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":11,"user":5,"assistant":5,"toolCalls":27,"toolOutputsDropped":27,"web":0,"redactions":2,"omittedUnsafe":0,"rawEntries":28}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

I just updated my openclaw from git, but it's no longer starting up. Can you investigate and see if there's a way to fix it?

[assistant]
I’m using the OpenClaw debugging workflow first, then the live-updater workflow because this is a post-`git` startup failure on the managed checkout. I’ll inspect the service, logs, checkout state, and exact failing startup path before changing anything.

The first boundary check is now split three ways: service/log evidence, checkout/build provenance, and the exact update delta. I’m also checking the live process myself so any consequential conclusion is independently verified.

The failure is concrete: startup entered a restart loop because a startup migration could not resolve an agent owner, then the update/build briefly left `dist` incomplete (`index.js` and a generated chunk were missing). A fresh exact-HEAD build appeared at 16:35 UTC and the service is currently running; I’m checking whether it is genuinely RPC-ready or merely alive under systemd.

The exact-HEAD build did not solve it: the gateway is still cycling (127 restarts), and RPC is refused while each process performs startup work. The persistent blocker is the Codex thread-binding migration’s missing agent owner, so I’m tracing that migration and its dependency contract before deciding whether `doctor --fix` is safe or whether the update introduced a code bug.

[assistant]
Continuing with full local permissions. The strongest current hypothesis is a startup-migration bug, not bad user state: the Codex migration asks for a default agent before it has established that any legacy binding file exists, so a valid multi-agent setup with no implicit default can fail every startup even when there is nothing to migrate. I’ll verify that against the exact configured agent shape, upstream Codex source, and a pre-fix regression test before changing code.

The sibling Codex source is now present and confirms thread identity is app-server protocol state (`thread/start`, `thread/resume`, `thread/read`); this crash happens earlier, entirely in OpenClaw’s retired sidecar discovery. Because the repair needs a regression test, I’m also applying the repository’s test-audit gate before authoring it.

The offending change is now pinned to `1ca60fbc3a3` (“make multi-agent ownership explicit”), pulled in by today’s update. The old Codex migration assumed “default means first agent”; the new resolver correctly rejects that ambiguity, exposing the migration’s unconditional owner lookup. I’m adding one owner-boundary regression: an explicit multi-agent install with no retired Codex sidecars must produce a clean no-op migration, not block gateway readiness. It requires no test-only production seam.

The regression failed on pre-fix code for the exact production reason and now passes. I also covered the sibling case: if a real retired global sidecar has only a bare, ambiguous session key, doctor preserves it and reports the missing owner instead of crashing or guessing. Next I’m rebuilding with the service stopped so `dist` cannot be observed half-written, then I’ll restart and require deep RPC plus verbose health.

The build command outlived its first output window and is still running; I caught that before accepting the transient service start and stopped the gateway again. I’m leaving it stopped until the build writes all three provenance stamps and `dist/index.js`, avoiding the same half-built-module race seen during the original update.

The gateway is repaired and genuinely ready now: PID `438273`, zero restarts, deep RPC succeeds, verbose health returns `ok: true`, both Slack accounts are connected, and the interrupted main session was recovered. I’m doing the required pre-ship review and diff/LOC audit now; one separate nonfatal warning remains in outgoing-media cleanup under explicit multi-agent ownership, which I’ll record as a follow-up unless review shows it belongs in this repair.

Fixed. OpenClaw is running and RPC-healthy again.

- Root cause: the new explicit multi-agent ownership logic made the Codex legacy-state migration demand a default agent even when there were no bindings to migrate.
- Repair: deferred ownership resolution and safely retained genuinely ambiguous legacy bindings: `extensions/codex/src/migration/session-binding-sidecars.ts:98`, `extensions/codex/src/migration/session-binding-sidecars.ts:344`.
- Added regressions: `extensions/codex/doctor-contract-api.test.ts:126`.
- Rebuilt `dist`, restarted systemd, and verified deep RPC plus verbose health. Current service has zero restarts; Slack is connected.
- Passed: 29 Codex migration tests, 5 doctor-contract tests, formatting, lint, full build, and runtime health.
- Production delta: +14 lines; tests: +72 lines. Growth implements explicit migration ownership and safe ambiguity reporting.
- Upstream Codex contract checked at commit `6851fae57cf7`: `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:58`, `:326`, `:1487`.

The source patch is currently uncommitted in the checkout. A separate nonfatal regression remains: some ambient operations such as outgoing-media cleanup and unscoped setup/model requests now require an explicit agent owner. It does not prevent startup, but deserves a follow-up repair.

Structured autoreview could not run because TruffleHog is not installed; direct review and all listed validation passed.

[user]
Should this be a PR or an issue for openclaw?

[assistant]
This should be a PR: the startup bug is reproduced, root-caused, fixed, and covered by regression tests.

Use a focused PR for the Codex migration repair. Separately file an issue for the broader explicit-owner regressions affecting outgoing-media cleanup and unscoped Gateway requests—they’re related to the same upstream refactor but belong to different owners and need wider investigation.

The PR should be prepared from a separate branch/worktree, not directly from this live `main` checkout.

[user]
can you prepare a PR for me?

[assistant]
I’ll prepare this as a focused draft PR using the repository’s PR-maintainer workflow. Because this checkout is the live `main` mirror, I’ll first move the existing patch into a separate working checkout, then run the required pre-PR gates, add the redacted agent transcript, commit, push, and open the PR without disturbing the running gateway.

I’m also using Gitcrawl for the required duplicate/already-fixed preflight before publication. I’ll keep the PR focused on the startup migration; the broader unscoped-owner failures will not be bundled into it.

The isolated branch is ready and matches the live repair byte-for-byte. Dependencies installed cleanly. I’m using the OpenClaw testing workflow for the PR gates now; it decides the focused local checks versus hosted Testbox work and keeps heavy validation off the live gateway host.

Focused proof is green in the isolated checkout. The hosted changed gate could not start because this host has neither a working Crabbox nor Blacksmith client; structured autoreview is likewise blocked because TruffleHog is absent and that workflow forbids auto-installing it. I’ll preserve those explicit proof gaps in the draft PR while letting normal PR CI provide the heavy exact-head validation.

A high-confidence local session transcript was found. Would you like me to include a redacted transcript in the PR body? It helps reviewers and can make the PR easier to prioritize; I can also generate a local HTML preview before insertion. I’ll continue pushing the branch and drafting the normal PR body while you decide.

Direct push is correctly denied because `zack-maxima` lacks write access to `openclaw/openclaw`. I’m switching the branch publication to your fork and will target the upstream `main` branch from there.

The branch is committed and pushed to your fork. The draft PR body is ready.

Before I create it: include the redacted agent transcript, preview it locally first, or omit it?

[user]
yeah we can include it

[assistant]
I’ll include the sanitized transcript without opening a preview. The agent-transcript workflow will remove prompts, reasoning, raw tool output, credentials, and unrelated turns; I’ll inspect the rendered Markdown before using it in the draft PR.

[tool summary]
1 read, 26 other; raw tool outputs dropped: 27
````

</details>
<!-- agent-transcript:end -->
