### PR TITLE
fix(ui): dropped attachments that fail to read vanish with no visible outcome

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5389,6 +5389,7 @@ export const en: TranslationMap = {
     },
     attachments: {
       attachedFile: "Attached file",
+      readFailed: "Could not attach: {names}{more}",
       showInTextField: "Show in text field",
       outsideAllowedFolders: "Outside allowed folders",
       unavailable: "Unavailable",

--- a/ui/src/pages/chat/components/chat-attachments.test.ts
+++ b/ui/src/pages/chat/components/chat-attachments.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleChatAttachmentPaste } from "./chat-attachments.ts";
+
+vi.mock("../../../lib/toast.ts", () => ({ showToast: vi.fn() }));
+
+import { showToast } from "../../../lib/toast.ts";
+
+class StubFileReader {
+  static failNames = new Set<string>();
+  result: string | ArrayBuffer | null = null;
+  private listeners = new Map<string, Array<() => void>>();
+
+  addEventListener(type: string, listener: () => void) {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  removeEventListener() {}
+  abort() {}
+
+  readAsDataURL(file: File) {
+    queueMicrotask(() => {
+      if (StubFileReader.failNames.has(file.name)) {
+        this.emit("error");
+        return;
+      }
+      this.result = "data:image/png;base64,aGk=";
+      this.emit("load");
+    });
+  }
+
+  private emit(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener();
+    }
+  }
+}
+
+function pasteEventWithFiles(files: File[]): ClipboardEvent {
+  return {
+    preventDefault: () => {},
+    clipboardData: {
+      items: files.map((file) => ({
+        type: file.type,
+        getAsFile: () => file,
+      })),
+      getData: () => "",
+    },
+  } as unknown as ClipboardEvent;
+}
+
+describe("chat attachment read failures", () => {
+  const realFileReader = globalThis.FileReader;
+
+  beforeEach(() => {
+    vi.stubGlobal("FileReader", StubFileReader as unknown as typeof FileReader);
+    StubFileReader.failNames = new Set();
+  });
+
+  afterEach(() => {
+    vi.stubGlobal("FileReader", realFileReader);
+    vi.clearAllMocks();
+  });
+
+  it("names files whose read failed instead of dropping them silently", async () => {
+    StubFileReader.failNames = new Set(["bad.png"]);
+    const onAttachmentsChange = vi.fn();
+    handleChatAttachmentPaste(
+      pasteEventWithFiles([
+        new File(["ok"], "good.png", { type: "image/png" }),
+        new File(["broken"], "bad.png", { type: "image/png" }),
+      ]),
+      { attachments: [], onAttachmentsChange },
+    );
+    await vi.waitFor(() => {
+      expect(onAttachmentsChange).toHaveBeenCalled();
+    });
+    expect(vi.mocked(showToast)).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(showToast).mock.calls[0]?.[0]?.message;
+    expect(String(message)).toContain("bad.png");
+    // The successful sibling still attaches.
+    const attached = onAttachmentsChange.mock.calls[0]?.[0] as Array<{ fileName?: string }>;
+    expect(attached).toHaveLength(1);
+    expect(attached[0]?.fileName).toBe("good.png");
+  });
+
+  it("does not toast when every read succeeds", async () => {
+    const onAttachmentsChange = vi.fn();
+    handleChatAttachmentPaste(
+      pasteEventWithFiles([new File(["ok"], "good.png", { type: "image/png" })]),
+      { attachments: [], onAttachmentsChange },
+    );
+    await vi.waitFor(() => {
+      expect(onAttachmentsChange).toHaveBeenCalled();
+    });
+    expect(vi.mocked(showToast)).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/chat/components/chat-attachments.test.ts
+++ b/ui/src/pages/chat/components/chat-attachments.test.ts
@@ -79,7 +79,9 @@ describe("chat attachment read failures", () => {
     });
     expect(vi.mocked(showToast)).toHaveBeenCalledTimes(1);
     const message = vi.mocked(showToast).mock.calls[0]?.[0]?.message;
-    expect(String(message)).toContain("bad.png");
+    // The read-failure toast is a plain t() string, not a template.
+    expect(typeof message).toBe("string");
+    expect(message).toContain("bad.png");
     // The successful sibling still attaches.
     const attached = onAttachmentsChange.mock.calls[0]?.[0] as Array<{ fileName?: string }>;
     expect(attached).toHaveLength(1);

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -6,6 +6,7 @@ import "../../../components/tooltip.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import type { BrowserAnnotationAttachment, ChatAttachment } from "../../../lib/chat/chat-types.ts";
+import { showToast } from "../../../lib/toast.ts";
 import {
   generateAttachmentId,
   getChatAttachmentDataUrl,
@@ -295,14 +296,28 @@ async function appendAttachmentFiles(files: readonly File[], props: ChatAttachme
   }
   props.onPendingReadsChange?.(1);
   try {
-    const additions = (
-      await Promise.all(files.map((file) => readAttachmentFile(file, props)))
-    ).filter((attachment): attachment is ChatAttachment => attachment !== null);
+    const results = await Promise.all(files.map((file) => readAttachmentFile(file, props)));
+    const additions = results.filter(
+      (attachment): attachment is ChatAttachment => attachment !== null,
+    );
     if (props.readSignal?.aborted) {
       for (const attachment of additions) {
         releaseChatAttachmentPayload(attachment.id);
       }
       return;
+    }
+    // Unreadable drops (folders, permission-denied files) must not vanish
+    // silently: name what was skipped so the user knows it never attached.
+    const failed = results
+      .map((attachment, index) => (attachment === null ? files[index]?.name : undefined))
+      .filter((name): name is string => Boolean(name));
+    if (failed.length > 0) {
+      showToast({
+        message: t("chat.attachments.readFailed", {
+          names: failed.slice(0, 3).join(", "),
+          more: failed.length > 3 ? ` +${failed.length - 3}` : "",
+        }),
+      });
     }
     if (additions.length === 0) {
       return;


### PR DESCRIPTION
## What Problem This Solves

Dropping or pasting a file the browser cannot read (a folder drop, a permission-denied file, a vanished file handle) produced *nothing*: `readAttachmentFile` resolves `null` on FileReader `error`, and `appendAttachmentFiles` silently filtered those out (`ui/src/pages/chat/components/chat-attachments.ts`). The user drops a file, no chip appears, no message explains why — the worst bug class per the repo's Product Doctrine ("an action that produces nothing, with nothing explaining why").

## Why This Change Was Made

Every user action must end in a visible outcome or a recorded, intentional non-outcome. The failure fact is known exactly at the read boundary; surfacing it there via the existing `showToast` seam names what was skipped (up to 3 names + count) while successful siblings in the same batch still attach. Abort (composer reset/navigation) intentionally stays silent — the user cancelled.

## User Impact

Dropping a folder or unreadable file now shows "Could not attach: <names>" instead of nothing. Mixed batches attach the readable files and report the rest.

## Evidence

- Regression test fails pre-fix, passes post-fix (`git stash` verified): mixed paste with one failing FileReader must toast naming `bad.png` and still attach `good.png`; all-success paste must not toast.
- Focused suite green: `node scripts/run-vitest.mjs run ui/src/pages/chat/components/chat-attachments.test.ts`.
- UI test typecheck green: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json`; i18n verify green (`scripts/control-ui-i18n-verify.ts verify`).
- Autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC: +19/−3 (2 comment lines, 1 i18n string; failure-channel capability that cannot exist with fewer lines — the silent filter *was* the structure). Tests +103 (new file).
