### PR TITLE
improve(ui): explain the Utility model setting

### DIFF
--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -20,6 +20,7 @@ const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? descri
 const NOW = Date.now();
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
 const artifactDir = path.resolve(".artifacts/control-ui-e2e/model-providers");
+const utilityHelpArtifactDir = path.resolve(".artifacts/control-ui-e2e/utility-model-help");
 const readinessArtifactDir = path.resolve(".artifacts/control-ui-e2e/models-provider-readiness");
 const redactedConfigValue = "[redacted]";
 const openaiInputValue = ["e2e", "test", "key"].join("-");
@@ -62,6 +63,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     if (recordVisuals) {
       await mkdir(artifactDir, { recursive: true });
+      await mkdir(utilityHelpArtifactDir, { recursive: true });
       await mkdir(readinessArtifactDir, { recursive: true });
     }
   });
@@ -321,6 +323,160 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       await expect.poll(async () => page.locator(".model-providers__row").count()).toBe(4);
     } finally {
       await context.close();
+    }
+  });
+
+  it("explains the utility model with accessible pointer, keyboard, and narrow-layout behavior", async () => {
+    for (const colorScheme of ["light", "dark"] as const) {
+      const context = await browser.newContext({
+        colorScheme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      });
+      const page = await context.newPage();
+      const config = {
+        agents: { defaults: { model: "openai/gpt-5.5" } },
+        models: { providers: { openai: providerConfig(redactedConfigValue) } },
+      };
+      await installMockGateway(page, {
+        models: [
+          { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true },
+          {
+            id: "gpt-5.6-luna",
+            name: "GPT-5.6 Luna",
+            provider: "openai",
+            available: true,
+          },
+        ],
+        methodResponses: {
+          "config.get": {
+            config,
+            sourceConfig: config,
+            hash: `utility-help-${colorScheme}`,
+            issues: [],
+            raw: JSON.stringify(config),
+            valid: true,
+          },
+          "models.authStatus": { ts: NOW, providers: [] },
+          "usage.status": { updatedAt: NOW, providers: [] },
+          "sessions.usage": { aggregates: { byProvider: [] } },
+        },
+      });
+
+      try {
+        await page.goto(`${server.baseUrl}settings/model-providers`);
+        await page.locator(".page-title", { hasText: "Models" }).first().waitFor();
+        const defaults = page.locator(".model-providers__defaults");
+        const utilityField = defaults.locator(".field").nth(1);
+        const utilityLabel = utilityField.locator(".model-providers__utility-label");
+        await utilityField.waitFor();
+        await expect
+          .poll(() => modelPickerValue(utilityField.locator("wa-select")))
+          .toBe("__openclaw_automatic_utility__");
+
+        if (recordVisuals) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(utilityHelpArtifactDir, `${colorScheme}-default-full.png`),
+          });
+          await utilityField.screenshot({
+            animations: "disabled",
+            path: path.join(utilityHelpArtifactDir, `${colorScheme}-default-crop.png`),
+          });
+        }
+
+        const helpButton = defaults.getByRole("button", { name: "About the utility model" });
+        await expect.poll(() => helpButton.count()).toBe(1);
+        expect(await helpButton.getAttribute("aria-haspopup")).toBe("dialog");
+
+        const defaultColor = await helpButton.evaluate((node) => getComputedStyle(node).color);
+        await helpButton.hover();
+        await expect
+          .poll(() => helpButton.evaluate((node) => getComputedStyle(node).color))
+          .not.toBe(defaultColor);
+
+        await helpButton.click();
+        const popover = page.locator("wa-popover.model-providers__utility-help-popover");
+        const popoverDialog = popover.locator("dialog");
+        const popoverBody = popover.locator('[part="body"]');
+        await expect.poll(() => popoverDialog.isVisible()).toBe(true);
+        await expect.poll(() => popover.textContent()).toContain("short background tasks");
+        await expect.poll(() => popover.textContent()).toContain("primary model provider");
+
+        if (recordVisuals) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(utilityHelpArtifactDir, `${colorScheme}-open-full.png`),
+          });
+          const labelBox = await utilityLabel.boundingBox();
+          const popoverBox = await popoverBody.boundingBox();
+          if (!labelBox || !popoverBox) {
+            throw new Error("expected utility label and help popover bounds");
+          }
+          const x = popoverBox.x;
+          const y = Math.max(0, labelBox.y - 4);
+          await page.screenshot({
+            animations: "disabled",
+            clip: {
+              x,
+              y,
+              width: popoverBox.width,
+              height: popoverBox.y + popoverBox.height - y,
+            },
+            path: path.join(utilityHelpArtifactDir, `${colorScheme}-open-crop.png`),
+          });
+        }
+
+        await page.locator(".page-title", { hasText: "Models" }).first().click();
+        await expect.poll(() => popoverDialog.isHidden()).toBe(true);
+
+        await helpButton.focus();
+        await page.keyboard.press("Tab");
+        await page.keyboard.press("Shift+Tab");
+        await expect
+          .poll(() => helpButton.evaluate((node) => node.matches(":focus-visible")))
+          .toBe(true);
+        await page.keyboard.press("Enter");
+        await expect.poll(() => popoverDialog.isVisible()).toBe(true);
+        await expect
+          .poll(() => popover.evaluate((node) => node.shadowRoot?.activeElement?.localName))
+          .toBe("dialog");
+        await page.keyboard.press("Escape");
+        await expect.poll(() => popoverDialog.isHidden()).toBe(true);
+        expect(new URL(page.url()).pathname).toBe("/settings/model-providers");
+        await expect
+          .poll(() => helpButton.evaluate((node) => node === document.activeElement))
+          .toBe(true);
+
+        await page.setViewportSize({ height: 844, width: 390 });
+        await utilityField.scrollIntoViewIfNeeded();
+        await helpButton.click();
+        await expect.poll(() => popoverDialog.isVisible()).toBe(true);
+        await expect
+          .poll(() =>
+            page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+          )
+          .toBe(true);
+        const mobilePopoverBox = await popoverBody.boundingBox();
+        if (!mobilePopoverBox) {
+          throw new Error("expected utility help popover bounds on mobile");
+        }
+        expect(mobilePopoverBox.x).toBeGreaterThanOrEqual(0);
+        expect(mobilePopoverBox.x + mobilePopoverBox.width).toBeLessThanOrEqual(390);
+
+        if (recordVisuals) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(utilityHelpArtifactDir, `${colorScheme}-mobile-open.png`),
+          });
+        }
+      } finally {
+        await context.close();
+      }
     }
   });
 

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -405,26 +405,41 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         await expect.poll(() => popover.textContent()).toContain("short background tasks");
         await expect.poll(() => popover.textContent()).toContain("primary model provider");
 
+        expect(
+          await popover.evaluate((node) => ({
+            distance: Reflect.get(node, "distance"),
+            placement: Reflect.get(node, "placement"),
+            skidding: Reflect.get(node, "skidding"),
+          })),
+        ).toEqual({ distance: 8, placement: "top", skidding: 0 });
+        const helpButtonBox = await helpButton.boundingBox();
+        const labelBox = await utilityLabel.boundingBox();
+        const popoverBox = await popoverBody.boundingBox();
+        if (!helpButtonBox || !labelBox || !popoverBox) {
+          throw new Error("expected utility label, help trigger, and popover bounds");
+        }
+        expect(popoverBox.y + popoverBox.height).toBeLessThan(helpButtonBox.y);
+        const helpButtonCenter = helpButtonBox.x + helpButtonBox.width / 2;
+        const popoverCenter = popoverBox.x + popoverBox.width / 2;
+        expect(Math.abs(helpButtonCenter - popoverCenter)).toBeLessThanOrEqual(1);
+
         if (recordVisuals) {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
             path: path.join(utilityHelpArtifactDir, `${colorScheme}-open-full.png`),
           });
-          const labelBox = await utilityLabel.boundingBox();
-          const popoverBox = await popoverBody.boundingBox();
-          if (!labelBox || !popoverBox) {
-            throw new Error("expected utility label and help popover bounds");
-          }
-          const x = popoverBox.x;
-          const y = Math.max(0, labelBox.y - 4);
+          const x = Math.min(labelBox.x, popoverBox.x);
+          const y = Math.max(0, popoverBox.y);
+          const right = Math.max(labelBox.x + labelBox.width, popoverBox.x + popoverBox.width);
+          const bottom = Math.max(labelBox.y + labelBox.height, popoverBox.y + popoverBox.height);
           await page.screenshot({
             animations: "disabled",
             clip: {
               x,
               y,
-              width: popoverBox.width,
-              height: popoverBox.y + popoverBox.height - y,
+              width: right - x,
+              height: bottom - y,
             },
             path: path.join(utilityHelpArtifactDir, `${colorScheme}-open-crop.png`),
           });

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -569,6 +569,13 @@
       "text": "exec host=gateway/node"
     },
     {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/model-providers/default-models-view.ts",
+      "text": "i"
+    },
+    {
       "count": 4,
       "kind": "html-text",
       "name": "text",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4134,6 +4134,11 @@ export const en: TranslationMap = {
       subtitle: "Choose the primary, ordered fallbacks, and utility model.",
       primary: "Default model",
       utility: "Utility model",
+      utilityHelpLabel: "About the utility model",
+      utilityHelpPurpose:
+        "Handles short background tasks such as generated titles, progress narration, and session summaries.",
+      utilityHelpAutomatic:
+        "Automatic uses the primary model provider's recommended small model when available. Generated titles otherwise use the primary model.",
       automatic: "Automatic (provider default)",
       disabled: "Disabled",
       savedSelection: "Saved selection",

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -105,7 +105,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
                 id=${UTILITY_MODEL_HELP_POPOVER_ID}
                 class="settings-section__help-popover model-providers__utility-help-popover"
                 for=${UTILITY_MODEL_HELP_ID}
-                placement="bottom-end"
+                placement="top"
                 @keydown=${claimUtilityHelpEscape}
               >
                 <div class="settings-section__help-panel">

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { renderModelPicker, type ModelPickerOption } from "../../components/model-picker.ts";
 import { renderSettingsSection } from "../../components/settings-ui.ts";
+import "../../components/web-awesome-popover.ts";
 import { t } from "../../i18n/index.ts";
 import { modelCatalogRef, type DefaultModelSelection, type ModelPickerEntry } from "./data.ts";
 
@@ -21,6 +22,9 @@ type DefaultModelsViewProps = {
 };
 
 const AUTOMATIC_UTILITY_VALUE = "__openclaw_automatic_utility__";
+const UTILITY_MODEL_PICKER_ID = "model-providers-utility-model";
+const UTILITY_MODEL_HELP_ID = "model-providers-utility-help";
+const UTILITY_MODEL_HELP_POPOVER_ID = "model-providers-utility-help-popover";
 
 function modelOptions(models: ModelPickerEntry[]): ModelPickerOption[] {
   const seen = new Set<string>();
@@ -38,6 +42,21 @@ function modelOptions(models: ModelPickerEntry[]): ModelPickerOption[] {
     });
   }
   return options.toSorted((a, b) => a.label.localeCompare(b.label));
+}
+
+function claimUtilityHelpEscape(event: KeyboardEvent): void {
+  const popover = event.currentTarget as HTMLElement & { open: boolean };
+  if (event.key !== "Escape" || !popover.open) {
+    return;
+  }
+  // The settings shortcut runs before Web Awesome's document listener. Claim
+  // Escape here, then restore focus after its dialog finishes closing.
+  event.preventDefault();
+  popover.addEventListener(
+    "wa-after-hide",
+    () => document.getElementById(UTILITY_MODEL_HELP_ID)?.focus({ preventScroll: true }),
+    { once: true },
+  );
 }
 
 export function renderDefaultModels(props: DefaultModelsViewProps) {
@@ -68,9 +87,36 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
             onChange: props.onPrimaryChange,
           })}
         </label>
-        <label class="field">
-          <span>${t("modelProviders.defaults.utility")}</span>
+        <div class="field">
+          <span class="model-providers__utility-label">
+            <label for=${UTILITY_MODEL_PICKER_ID}>${t("modelProviders.defaults.utility")}</label>
+            <span class="settings-section__docs">
+              <button
+                id=${UTILITY_MODEL_HELP_ID}
+                type="button"
+                class="settings-section__help-button"
+                aria-label=${t("modelProviders.defaults.utilityHelpLabel")}
+                aria-controls=${UTILITY_MODEL_HELP_POPOVER_ID}
+                aria-haspopup="dialog"
+              >
+                <span aria-hidden="true">i</span>
+              </button>
+              <wa-popover
+                id=${UTILITY_MODEL_HELP_POPOVER_ID}
+                class="settings-section__help-popover model-providers__utility-help-popover"
+                for=${UTILITY_MODEL_HELP_ID}
+                placement="bottom-end"
+                @keydown=${claimUtilityHelpEscape}
+              >
+                <div class="settings-section__help-panel">
+                  <p>${t("modelProviders.defaults.utilityHelpPurpose")}</p>
+                  <p>${t("modelProviders.defaults.utilityHelpAutomatic")}</p>
+                </div>
+              </wa-popover>
+            </span>
+          </span>
           ${renderModelPicker({
+            id: UTILITY_MODEL_PICKER_ID,
             label: t("modelProviders.defaults.utility"),
             value: props.selection.utilityModel ?? AUTOMATIC_UTILITY_VALUE,
             options: [
@@ -86,7 +132,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
             onChange: (value) =>
               props.onUtilityChange(value === AUTOMATIC_UTILITY_VALUE ? null : value),
           })}
-        </label>
+        </div>
       </div>
       <div class="model-providers__fallbacks">
         <div class="model-providers__fallback-heading">

--- a/ui/src/styles/model-providers.css
+++ b/ui/src/styles/model-providers.css
@@ -165,6 +165,13 @@
   margin-top: 16px;
 }
 
+.model-providers__utility-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  width: fit-content;
+}
+
 .model-providers__fallbacks {
   margin-top: 16px;
 }


### PR DESCRIPTION
Closes #122982

## What Problem This Solves

The Models settings page names the Utility model and offers an Automatic value, but does not explain what the model handles or how Automatic is resolved. Operators therefore have to infer whether changing it affects normal chat responses.

## Why This Change Was Made

This PR adds the existing accessible information-popover pattern beside the Utility model label. The short copy reflects the runtime contract: the utility model handles generated titles, progress narration, and session summaries; Automatic prefers the primary provider's recommended small model when available, while generated titles can fall back to the primary model.

The popover stays within the existing model-picker and settings-help ownership. It opens by pointer or keyboard, closes on outside interaction or Escape, and returns focus to its trigger after Escape without navigating away from Settings.

## User Impact

Operators can understand the Utility model's role and the Automatic choice in place, without leaving model configuration or mistaking it for the primary chat model.

## Evidence

### Before — full Models context

| Light | Dark |
| --- | --- |
| ![Models settings in light theme before the Utility model help affordance](https://github.com/user-attachments/assets/6aad4987-e9ea-4ad0-bb10-9c93fa6c333f) | ![Models settings in dark theme before the Utility model help affordance](https://github.com/user-attachments/assets/20f4d0f1-44b1-4fb8-8a39-fd42d7913f64) |

### Before — Utility model label crop

| Light | Dark |
| --- | --- |
| ![Utility model label in light theme before the information control](https://github.com/user-attachments/assets/6a9cef54-2e32-4bff-9765-465143a864bb) | ![Utility model label in dark theme before the information control](https://github.com/user-attachments/assets/5643c60f-726e-4649-9025-903f67d1718e) |

### After — full Models context

| Light | Dark |
| --- | --- |
| ![Models settings in light theme with the Utility model popover anchored above its trigger](https://github.com/user-attachments/assets/fa3bfad7-10ef-4e71-8e20-fa69699cfb3f) | ![Models settings in dark theme with the Utility model popover anchored above its trigger](https://github.com/user-attachments/assets/6a0a8893-a3cc-4119-97c5-565d4b6e6424) |

### After — label and popover crop

| Light | Dark |
| --- | --- |
| ![Utility model information popover and centered arrow in light theme](https://github.com/user-attachments/assets/1fcbe222-191b-4f73-8414-90821f410cdc) | ![Utility model information popover and centered arrow in dark theme](https://github.com/user-attachments/assets/174efa52-050c-4d22-a2b7-e73e76cf1683) |

### After — mobile and overflow

| Light | Dark |
| --- | --- |
| ![Utility model information popover shifted within a 390 px light viewport](https://github.com/user-attachments/assets/5ecabe6b-49fd-4000-8f1f-f705795bed56) | ![Utility model information popover shifted within a 390 px dark viewport](https://github.com/user-attachments/assets/b8cfb06d-5687-444a-a0d1-f4ebda5c43ee) |

### Interaction matrix

| State | Light | Dark |
| --- | --- | --- |
| Default | Information control sits beside the label | Information control sits beside the label |
| Hover | Existing help-control hover treatment is visible | Existing help-control hover treatment is visible |
| Focus | Keyboard focus ring is visible | Keyboard focus ring is visible |
| Open | Pointer and Enter open the canonical popover | Pointer and Enter open the canonical popover |
| Close | Outside interaction and Escape close it; Escape restores trigger focus and remains on Models | Outside interaction and Escape close it; Escape restores trigger focus and remains on Models |
| Overflow | Popover remains inside the viewport | Popover remains inside the viewport |
| Mobile | Verified at 390 px without horizontal page overflow | Verified at 390 px without horizontal page overflow |

### Validation

- `ui/src/pages/model-providers/view.test.ts`: 33 passed
- `ui/src/e2e/model-providers.e2e.test.ts`: 5 passed, including pointer, keyboard, focus restoration, theme, and mobile/overflow coverage
- Placement proof on the refreshed head: preferred `top`, Web Awesome defaults `distance=8` and `skidding=0`, trigger/popover center alignment, and viewport fallback at 390 px
- Changed-surface formatting, localization verification, lint, type checks, and focused checks passed

### Review disposition

- Escape interaction: no separate code change. The Settings shortcut respects the claimed event, Web Awesome closes the popover, and the focused E2E verifies route and focus restoration.
- Source inspection: completed across the scoped policies, owner, sibling interaction, history, test support, and Web Awesome contract.
- Latest ClawSweeper P1/P2: skip — both describe the review host’s read-only inspection failure, not a code defect; maintainer source inspection and canonical remote E2E cover the requested event and contract checks.\n- Rank-up move: applied through latest-head source inspection and focused Control UI interaction proof; no additional code finding remained.

Production delta: +61 / -3 lines. Test coverage: +156 lines. Generated localization baseline: +7 lines.


### Exact-head source and dependency-contract review (ClawSweeper rank-up move)

ClawSweeper's rank-up move and its two P1 merge-risk items were blocked by a sandbox failure, not by anything in the diff. Both are now discharged by direct inspection.

**Dependency contract — `@awesome.me/webawesome` 3.10.0** (pinned at `ui/package.json:12`, registered route-locally by `ui/src/components/web-awesome-popover.ts`). Read from the installed package, not from docs or memory:

- `dist/components/popover/popover.d.ts` confirms the three surfaces this PR uses: `open: boolean`, the documented `wa-after-hide` event ("Emitted after the popover has hidden and all animations are complete"), and `for: string | null`, documented as requiring "an interactive/focusable element such as a button" — satisfied, the anchor is a real `<button>`.
- `dist/chunks/chunk.GSYA32IS.js` (the `WaPopover` implementation) shows the popover opens a **non-modal** dialog via `dialog.show()`, never `showModal()`. A non-modal `<dialog>` has no native Escape/cancel behavior, so Escape is owned entirely by the component's own `document` keydown listener — and that listener is registered inside `handleOpenChange()`, i.e. only once the popover opens.

That last detail is what makes this fix necessary and correctly ordered. The settings shortcut in `ui/src/app/app-shell-chrome.ts` is registered at shell mount, therefore *before* Web Awesome's listener, and it bails at line 360 (`if (event.defaultPrevented) { return; }`) before reaching the settings-takeover branch at line 364 that calls `host.exitSettings()`. Without intervention, Escape inside the popover would exit the entire settings takeover. Binding `@keydown` on the `wa-popover` element means the handler runs before any document listener, so `preventDefault()` lands in time for that guard; `stopPropagation()` is deliberately not called, so Web Awesome's own handler still runs and closes the popover. Restoring focus on `wa-after-hide` is ordering rather than duplication: Web Awesome focuses the anchor synchronously, but the non-modal dialog's close can move focus afterwards.

One edge case is accepted rather than left silent: when `isTopDismissible` is false, Escape is claimed while Web Awesome declines to close. That is only reachable with a stacked dismissible layer that would itself own Escape.

**Merge result.** Per-file commits on `origin/main` since merge base `14882ac44dcd`: `default-models-view.ts` 0, `model-providers.css` 0, `model-providers.e2e.test.ts` 0, `raw-copy-baseline.json` 0, `en.ts` 9. Every behavior-carrying file has zero drift, and in `en.ts` the insertion region is intact on main (`utility: "Utility model"` immediately followed by `automatic:`), so the three-way merge adds the five new keys cleanly alongside main's other new strings. The merge result is behaviorally identical to the reviewed head.

**Non-blocking a11y nit**, recorded rather than requested here: the help button carries `aria-label`, `aria-controls` and `aria-haspopup="dialog"` but never `aria-expanded`, and Web Awesome does not manage that attribute either (its implementation sets no aria attributes on the anchor). The gap belongs to the shared `settings-section__help-button` pattern, so the coherent fix belongs where that pattern is owned rather than in this one instance.
