### PR TITLE
feat(ui): add fullscreen mode to Desktop preview

### DIFF
--- a/ui/src/components/desktop/desktop-panel-connection.ts
+++ b/ui/src/components/desktop/desktop-panel-connection.ts
@@ -1,0 +1,15 @@
+import type { DesktopObserveResult, WorkerDesktopAppId } from "@openclaw/gateway-protocol";
+
+export type DesktopAppId = WorkerDesktopAppId;
+export type DesktopCredentials = { username?: string; password?: string };
+
+export type PendingDesktopConnection = {
+  environmentId: string;
+  control: boolean;
+  observed?: DesktopObserveResult;
+  operationId: number;
+};
+
+export type ObservedDesktopConnection = PendingDesktopConnection & {
+  observed: DesktopObserveResult;
+};

--- a/ui/src/components/desktop/desktop-panel-fullscreen-controller.ts
+++ b/ui/src/components/desktop/desktop-panel-fullscreen-controller.ts
@@ -1,0 +1,116 @@
+import { html, type ReactiveController, type TemplateResult } from "lit";
+import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
+import type { OpenClawLitElement } from "../../lit/openclaw-element.ts";
+import { icons } from "../icons.ts";
+
+type DesktopPanelFullscreenOptions = {
+  section: () => HTMLElement | null;
+  onChange: () => void;
+};
+
+export class DesktopPanelFullscreenController implements ReactiveController {
+  active = false;
+  errorText: string | null = null;
+
+  private restoreFocus = false;
+  private readonly onFullscreenChange = () => this.handleFullscreenChange();
+
+  constructor(
+    private readonly host: OpenClawLitElement,
+    private readonly options: DesktopPanelFullscreenOptions,
+  ) {
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    document.addEventListener("fullscreenchange", this.onFullscreenChange);
+  }
+
+  hostDisconnected(): void {
+    document.removeEventListener("fullscreenchange", this.onFullscreenChange);
+    this.restoreFocus = false;
+    if (this.fullscreenElement() === this.options.section()) {
+      void document.exitFullscreen().catch(() => {});
+    }
+  }
+
+  renderButton(): TemplateResult {
+    const supported = this.supported();
+    const label = this.active
+      ? t("desktop.exitFullscreen")
+      : supported
+        ? t("desktop.enterFullscreen")
+        : t("desktop.fullscreenUnavailable");
+    return html`<openclaw-tooltip .content=${label}>
+      <button
+        class="bp-icon desktop-fullscreen-button"
+        type="button"
+        aria-label=${label}
+        aria-pressed=${this.active ? "true" : "false"}
+        aria-disabled=${supported ? "false" : "true"}
+        @click=${() => void this.toggle()}
+      >
+        <span class="desktop-fullscreen-icon" aria-hidden="true">
+          ${this.active ? icons.minimize : icons.maximize}
+        </span>
+      </button>
+    </openclaw-tooltip>`;
+  }
+
+  private fullscreenElement(): Element | null {
+    const shadowFullscreen =
+      this.host.renderRoot instanceof ShadowRoot ? this.host.renderRoot.fullscreenElement : null;
+    return shadowFullscreen ?? document.fullscreenElement;
+  }
+
+  private supported(): boolean {
+    return document.fullscreenEnabled && typeof Element.prototype.requestFullscreen === "function";
+  }
+
+  private handleFullscreenChange(): void {
+    const wasActive = this.active;
+    this.active = this.fullscreenElement() === this.options.section();
+    this.options.onChange();
+    this.host.requestUpdate();
+    if (wasActive && !this.active && this.restoreFocus) {
+      // Escape and browser controls exit outside the component. Restore focus so
+      // keyboard operators return to the control that changed the viewport.
+      void this.host.updateComplete.then(() => {
+        this.host.renderRoot
+          .querySelector<HTMLButtonElement>(".desktop-fullscreen-button")
+          ?.focus();
+        this.restoreFocus = false;
+      });
+    }
+  }
+
+  private async toggle(): Promise<void> {
+    this.setError(null);
+    if (this.active) {
+      try {
+        await document.exitFullscreen();
+      } catch (error) {
+        this.setError(t("desktop.errors.fullscreenFailed", { error: formatUiError(error) }));
+      }
+      return;
+    }
+    const section = this.options.section();
+    if (!section || !this.supported()) {
+      this.setError(t("desktop.fullscreenUnavailable"));
+      return;
+    }
+    this.restoreFocus = true;
+    try {
+      await section.requestFullscreen();
+    } catch (error) {
+      this.restoreFocus = false;
+      this.setError(t("desktop.errors.fullscreenFailed", { error: formatUiError(error) }));
+    }
+  }
+
+  private setError(errorText: string | null): void {
+    this.errorText = errorText;
+    this.host.requestUpdate();
+  }
+}

--- a/ui/src/components/desktop/desktop-panel-styles.ts
+++ b/ui/src/components/desktop/desktop-panel-styles.ts
@@ -14,6 +14,19 @@ export const desktopPanelStyles = css`
   .bp-title {
     min-width: 0;
   }
+  .bp-icon[aria-disabled="true"] {
+    opacity: 0.4;
+  }
+  .desktop-fullscreen-icon > svg {
+    width: 15px;
+    height: 15px;
+  }
+  .bp:fullscreen {
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
   .desktop-content {
     display: flex;
     flex: 1;

--- a/ui/src/components/desktop/desktop-panel-view.ts
+++ b/ui/src/components/desktop/desktop-panel-view.ts
@@ -1,5 +1,5 @@
 import type { EnvironmentSummary, WorkerDesktopAppId } from "@openclaw/gateway-protocol";
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../../i18n/index.ts";
 import { icons } from "../icons.ts";
 import { desktopAppIcon, desktopAppLabel } from "./desktop-app-presentation.ts";
@@ -8,6 +8,7 @@ import { desktopSourceForEnvironment } from "./desktop-source.ts";
 
 export function renderDesktopPanelHeader(options: {
   dock: "bottom" | "right";
+  fullscreenControl: TemplateResult;
   onClose: () => void;
   onDock: (dock: "bottom" | "right") => void;
 }) {
@@ -33,6 +34,7 @@ export function renderDesktopPanelHeader(options: {
         >
           ${icons.panelRightOpen}
         </button>
+        ${options.fullscreenControl}
         <button
           class="rail-header__action bp-icon"
           type="button"

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -3,7 +3,6 @@ import type {
   DesktopSource,
   EnvironmentSummary,
   EnvironmentsListResult,
-  WorkerDesktopAppId,
   WorkerDesktopLaunchResult,
 } from "@openclaw/gateway-protocol";
 import { html, nothing } from "lit";
@@ -21,7 +20,14 @@ import {
 import { DesktopClient, type DesktopConnectionHandle } from "./desktop-client.ts";
 import { desktopDocumentStyles } from "./desktop-document-styles.ts";
 import { renderDesktopDocumentView } from "./desktop-document-view.ts";
+import type {
+  DesktopAppId,
+  DesktopCredentials,
+  ObservedDesktopConnection,
+  PendingDesktopConnection,
+} from "./desktop-panel-connection.ts";
 import { desktopCredentialRequirement } from "./desktop-panel-credentials.ts";
+import { DesktopPanelFullscreenController } from "./desktop-panel-fullscreen-controller.ts";
 import { desktopPanelLauncherStyles } from "./desktop-panel-launcher-styles.ts";
 import { type DesktopPanelState, renderDesktopPanelRecovery } from "./desktop-panel-state.ts";
 import { desktopPanelStyles } from "./desktop-panel-styles.ts";
@@ -43,17 +49,7 @@ const panelLayout = createDockPanelLayout({
   defaultHeight: 420,
   defaultWidth: 560,
 });
-type DesktopAppId = WorkerDesktopAppId;
-type DesktopCredentials = { username?: string; password?: string };
-type PendingDesktopConnection = {
-  environmentId: string;
-  control: boolean;
-  observed?: DesktopObserveResult;
-  operationId: number;
-};
-type ObservedDesktopConnection = PendingDesktopConnection & { observed: DesktopObserveResult };
 const MOBILE_KEYBOARD_SENTINEL = "________________";
-
 /** `<openclaw-desktop-panel>` — dockable RFB access to Gateway desktop sources. */
 class OpenClawDesktopPanel extends OpenClawLitElement {
   @property({ attribute: false }) client: GatewayBrowserClient | null = null;
@@ -94,6 +90,11 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     layout: panelLayout,
     reservationPrefix: "desktop",
     isAvailable: () => this.available,
+    isFullscreen: () => this.fullscreenMode.active,
+  });
+  private readonly fullscreenMode = new DesktopPanelFullscreenController(this, {
+    section: () => this.renderRoot.querySelector<HTMLElement>("section.bp"),
+    onChange: () => this.dockLayout.syncReservation(),
   });
   private readonly onToggleRequest = (event: Event) => this.handleToggleRequest(event);
 
@@ -602,7 +603,10 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     if (!this.available) {
       return nothing;
     }
-    const notice = renderDesktopNotice(this.launchErrorText ?? this.errorText, this.noticeText);
+    const notice = renderDesktopNotice(
+      this.fullscreenMode.errorText ?? this.launchErrorText ?? this.errorText,
+      this.noticeText,
+    );
     const picker = renderDesktopPicker({
       environments: this.environments,
       loading: this.loading,
@@ -673,13 +677,17 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       return nothing;
     }
     const dock = this.dockLayout.dock;
-    const style =
-      dock === "bottom" ? `height:${this.dockLayout.height}px` : `width:${this.dockLayout.width}px`;
+    const style = this.fullscreenMode.active
+      ? ""
+      : dock === "bottom"
+        ? `height:${this.dockLayout.height}px`
+        : `width:${this.dockLayout.width}px`;
     return html`
       <section class="bp bp--${dock}" style=${style} aria-label=${t("desktop.title")}>
         ${this.dockLayout.renderResizer("bp", t("desktop.resize"))}
         ${renderDesktopPanelHeader({
           dock,
+          fullscreenControl: this.fullscreenMode.renderButton(),
           onDock: (nextDock) => this.dockLayout.setDock(nextDock),
           onClose: () => this.closePanel(),
         })}

--- a/ui/src/components/dock-layout-controller.ts
+++ b/ui/src/components/dock-layout-controller.ts
@@ -140,10 +140,10 @@ export class DockLayoutController<TDock extends DockPanelPlacement> implements R
   }
 
   syncReservation(): void {
-    if (this.isFullscreen() || this.options.reserveViewport === false) {
+    if (this.options.reserveViewport === false) {
       return;
     }
-    const visible = this.options.isAvailable() && this.open;
+    const visible = !this.isFullscreen() && this.options.isAvailable() && this.open;
     const root = document.documentElement.style;
     root.setProperty(
       `--oc-${this.options.reservationPrefix}-reserve-bottom`,

--- a/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
@@ -1,0 +1,369 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "desktop fullscreen",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
+});
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofStage = process.env.OPENCLAW_DESKTOP_FULLSCREEN_PROOF_STAGE ?? "after";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "desktop-fullscreen");
+
+function sessionsList() {
+  return {
+    count: 1,
+    defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+    path: "",
+    sessions: [
+      {
+        key: "main",
+        kind: "direct",
+        label: "Main",
+        placement: { state: "active" },
+        updatedAt: Date.now(),
+      },
+    ],
+    ts: Date.now(),
+  };
+}
+
+const workerDesktopEnvironment = {
+  id: "worker-desktop-1",
+  type: "worker",
+  status: "available",
+  desktop: true,
+  worker: {
+    providerId: "crabbox",
+    state: "attached",
+    ageMs: 1_000,
+    attachedSessionIds: ["agent:main:release-operations"],
+    tunnelStatus: "connected",
+    desktopApps: ["browser", "terminal"],
+  },
+} as const;
+
+async function openDesktopPanel(page: Page) {
+  await page.goto(`${suite.server.baseUrl}chat`);
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent("openclaw:command-palette-open"));
+  });
+  await page.getByRole("combobox", { name: "Search chats and commands…" }).waitFor();
+  await page.getByRole("option", { name: "Desktop", exact: true }).click();
+  const panel = page.locator("openclaw-desktop-panel");
+  await panel.locator("section[aria-label='Desktop']").waitFor();
+  return panel;
+}
+
+async function installRichDesktopClientFake(panel: import("playwright").Locator) {
+  await panel.evaluate((element) => {
+    type Options = {
+      onConnect?: () => void;
+      onDisconnect?: (detail: { code?: number; reason?: string }) => void;
+      target: HTMLElement;
+      viewOnly: boolean;
+    };
+    (
+      element as HTMLElement & {
+        desktopClientFactory: () => {
+          connect(options: Options): Promise<{ disconnect(): void }>;
+        };
+        triggerDesktopDisconnect?: () => void;
+      }
+    ).desktopClientFactory = () => ({
+      async connect(options) {
+        const screen = document.createElement("div");
+        screen.dataset.testid = "rich-desktop-screen";
+        screen.style.cssText = [
+          "aspect-ratio:16/10",
+          "background:linear-gradient(145deg,#172554,#0f766e)",
+          "border:1px solid rgba(255,255,255,.24)",
+          "border-radius:10px",
+          "box-shadow:0 20px 48px rgba(0,0,0,.35)",
+          "color:#f8fafc",
+          "display:grid",
+          "font:13px ui-sans-serif,system-ui",
+          "grid-template-rows:34px 1fr 28px",
+          "height:min(90%,620px)",
+          "margin:auto",
+          "overflow:hidden",
+          "width:min(90%,992px)",
+        ].join(";");
+        screen.innerHTML = `
+          <div style="align-items:center;background:rgba(15,23,42,.88);display:flex;gap:7px;padding:0 12px">
+            <span style="background:#fb7185;border-radius:50%;height:8px;width:8px"></span>
+            <span style="background:#fbbf24;border-radius:50%;height:8px;width:8px"></span>
+            <span style="background:#34d399;border-radius:50%;height:8px;width:8px"></span>
+            <strong style="margin-left:6px">Release operations · worker-desktop-1</strong>
+            <span style="margin-left:auto;opacity:.72">Secure observer</span>
+          </div>
+          <div style="display:grid;gap:14px;grid-template-columns:1.35fr .65fr;padding:18px">
+            <div style="background:rgba(15,23,42,.76);border:1px solid rgba(255,255,255,.16);border-radius:8px;padding:16px">
+              <div style="font-size:18px;font-weight:700;margin-bottom:12px">Production rollout</div>
+              <div style="background:#22c55e;border-radius:999px;height:7px;margin:10px 0;width:78%"></div>
+              <div style="display:grid;gap:8px;grid-template-columns:repeat(3,1fr);margin-top:18px">
+                <div style="background:rgba(255,255,255,.09);border-radius:7px;padding:12px">12 healthy</div>
+                <div style="background:rgba(255,255,255,.09);border-radius:7px;padding:12px">2 pending</div>
+                <div style="background:rgba(255,255,255,.09);border-radius:7px;padding:12px">0 failed</div>
+              </div>
+            </div>
+            <div style="background:rgba(15,23,42,.76);border:1px solid rgba(255,255,255,.16);border-radius:8px;padding:16px">
+              <strong>Live checks</strong>
+              <p>Gateway ✓</p><p>Desktop relay ✓</p><p>Browser session ✓</p>
+            </div>
+          </div>
+          <div style="align-items:center;background:rgba(15,23,42,.9);display:flex;justify-content:space-between;padding:0 12px">
+            <span>operator@worker-desktop-1</span><span>${options.viewOnly ? "View only" : "Control enabled"}</span>
+          </div>`;
+        options.target.replaceChildren(screen);
+        (
+          element as HTMLElement & { triggerDesktopDisconnect?: () => void }
+        ).triggerDesktopDisconnect = () =>
+          options.onDisconnect?.({ code: 1006, reason: "remote session ended" });
+        options.onConnect?.();
+        return { disconnect: () => screen.remove() };
+      },
+    });
+  });
+}
+
+async function setTheme(page: Page, theme: "dark" | "light") {
+  await page.emulateMedia({ colorScheme: theme });
+  await page.evaluate((nextTheme) => {
+    document.documentElement.dataset.themeMode = nextTheme;
+    document.documentElement.dataset.themeResolved = nextTheme;
+    document.documentElement.classList.toggle("wa-light", nextTheme === "light");
+    document.documentElement.classList.toggle("wa-dark", nextTheme === "dark");
+    document.documentElement.style.colorScheme = nextTheme;
+  }, theme);
+}
+
+async function captureDesktopProof(page: Page, panel: import("playwright").Locator, name: string) {
+  if (!captureUiProof) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    path: path.join(proofDir, `${proofStage}-${name}-context.png`),
+  });
+  await panel.locator(".bp-header").screenshot({
+    animations: "disabled",
+    path: path.join(proofDir, `${proofStage}-${name}-header.png`),
+  });
+  const connectionToolbar = panel.locator(".desktop-toolbar--connection");
+  if ((await connectionToolbar.count()) > 0) {
+    await connectionToolbar.screenshot({
+      animations: "disabled",
+      path: path.join(proofDir, `${proofStage}-${name}-controls.png`),
+    });
+  }
+}
+
+suite.define(() => {
+  it.each(["dark", "light"] as const)(
+    "keeps the active desktop surface mounted through fullscreen entry and exit in %s mode",
+    async (theme) => {
+      await suite.withPage(
+        {
+          colorScheme: theme,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1440 },
+        },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            featureMethods: ["desktop.observe", "environments.list"],
+            methodResponses: {
+              "sessions.list": sessionsList(),
+              "environments.list": { environments: [workerDesktopEnvironment] },
+              "desktop.observe": {
+                cases: [
+                  {
+                    match: {
+                      source: { kind: "environment", environmentId: "worker-desktop-1" },
+                      control: false,
+                    },
+                    response: {
+                      transport: "rfb",
+                      wsPath: "/desktop/observe?token=view",
+                      expiresAtMs: 60_000,
+                      control: false,
+                    },
+                  },
+                  {
+                    match: {
+                      source: { kind: "environment", environmentId: "worker-desktop-1" },
+                      control: true,
+                    },
+                    response: {
+                      transport: "rfb",
+                      wsPath: "/desktop/observe?token=control",
+                      expiresAtMs: 60_000,
+                      control: true,
+                    },
+                  },
+                ],
+              },
+            },
+          });
+          const panel = await openDesktopPanel(page);
+          await setTheme(page, theme);
+          await gateway.waitForRequest("environments.list");
+          await installRichDesktopClientFake(panel);
+          await panel.getByRole("button", { name: "Connect", exact: true }).click();
+          await panel.getByTestId("rich-desktop-screen").waitFor();
+
+          await captureDesktopProof(page, panel, `${theme}-default`);
+          expect(
+            await page.evaluate(() => ({
+              enabled: document.fullscreenEnabled,
+              requestType: typeof Element.prototype.requestFullscreen,
+            })),
+          ).toEqual({ enabled: true, requestType: "function" });
+          const fullscreenButton = panel.locator(".desktop-fullscreen-button");
+          expect(await fullscreenButton.getAttribute("aria-label")).toBe("Enter fullscreen");
+          await fullscreenButton.hover();
+          await captureDesktopProof(page, panel, `${theme}-hover`);
+          await fullscreenButton.focus();
+          await captureDesktopProof(page, panel, `${theme}-focus`);
+
+          const screen = panel.getByTestId("rich-desktop-screen");
+          const screenHandle = await screen.elementHandle();
+          await fullscreenButton.press("Enter");
+          await expect
+            .poll(() => fullscreenButton.getAttribute("aria-label"))
+            .toBe("Exit fullscreen");
+          expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
+          expect(
+            await screen.evaluate((element, original) => element === original, screenHandle),
+          ).toBe(true);
+          expect(await gateway.getRequests("desktop.observe")).toHaveLength(1);
+          expect(
+            await panel.getByRole("button", { name: "Take control", exact: true }).isVisible(),
+          ).toBe(true);
+          expect(
+            await panel.getByRole("button", { name: "Disconnect", exact: true }).isVisible(),
+          ).toBe(true);
+          const [stageBox, screenBox] = await Promise.all([
+            panel.locator(".desktop-stage").boundingBox(),
+            screen.boundingBox(),
+          ]);
+          if (!stageBox || !screenBox) {
+            throw new Error("Desktop fullscreen geometry is unavailable");
+          }
+          expect(Math.abs(screenBox.width / screenBox.height - 16 / 10)).toBeLessThan(0.02);
+          expect(screenBox.x).toBeGreaterThanOrEqual(stageBox.x);
+          expect(screenBox.y).toBeGreaterThanOrEqual(stageBox.y);
+          expect(screenBox.x + screenBox.width).toBeLessThanOrEqual(stageBox.x + stageBox.width);
+          expect(screenBox.y + screenBox.height).toBeLessThanOrEqual(stageBox.y + stageBox.height);
+          expect(
+            stageBox.width - screenBox.width > 20 || stageBox.height - screenBox.height > 20,
+          ).toBe(true);
+          await captureDesktopProof(page, panel, `${theme}-fullscreen`);
+
+          await panel.getByRole("button", { name: "Take control", exact: true }).click();
+          await expect
+            .poll(async () => (await gateway.getRequests("desktop.observe")).length)
+            .toBe(2);
+          expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
+          await panel.getByText("Control enabled", { exact: true }).waitFor();
+
+          // Escape and browser controls both exit through the fullscreenchange path.
+          await page.evaluate(() => document.exitFullscreen());
+          await expect.poll(() => page.evaluate(() => document.fullscreenElement)).toBeNull();
+          await expect
+            .poll(() => fullscreenButton.getAttribute("aria-label"))
+            .toBe("Enter fullscreen");
+          expect(
+            await fullscreenButton.evaluate(
+              (button) => button === (button.getRootNode() as ShadowRoot).activeElement,
+            ),
+          ).toBe(true);
+          await captureDesktopProof(page, panel, `${theme}-exit`);
+
+          await fullscreenButton.click();
+          await panel.getByRole("button", { name: "Disconnect", exact: true }).click();
+          await panel.getByText("Desktop sources", { exact: true }).waitFor();
+          expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
+          await panel.getByRole("button", { name: "Connect", exact: true }).click();
+          await panel.getByText("View only", { exact: true }).waitFor();
+          await panel.evaluate((element) => {
+            (
+              element as HTMLElement & { triggerDesktopDisconnect?: () => void }
+            ).triggerDesktopDisconnect?.();
+          });
+          await panel
+            .getByText("Desktop disconnected: remote session ended", { exact: true })
+            .waitFor();
+          expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
+          await captureDesktopProof(page, panel, `${theme}-disconnected-fullscreen`);
+          await fullscreenButton.click();
+          await expect.poll(() => page.evaluate(() => document.fullscreenElement)).toBeNull();
+        },
+      );
+    },
+  );
+
+  it("reports unavailable and denied fullscreen requests", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: ["desktop.observe", "environments.list"],
+        methodResponses: {
+          "sessions.list": sessionsList(),
+          "environments.list": { environments: [] },
+        },
+      });
+      const panel = await openDesktopPanel(page);
+      const button = panel.locator(".desktop-fullscreen-button");
+      await panel.locator("section.bp").evaluate((element) => {
+        element.requestFullscreen = () =>
+          Promise.reject(new DOMException("Fullscreen permission denied", "NotAllowedError"));
+      });
+      await button.click();
+      await panel
+        .getByRole("alert")
+        .filter({ hasText: "Could not change fullscreen mode: Fullscreen permission denied" })
+        .waitFor();
+
+      await page.evaluate(() => {
+        Object.defineProperty(document, "fullscreenEnabled", { configurable: true, value: false });
+      });
+      await panel.evaluate((element) =>
+        (element as HTMLElement & { requestUpdate(): void }).requestUpdate(),
+      );
+      await expect
+        .poll(() => button.getAttribute("aria-label"))
+        .toBe("Fullscreen is unavailable in this browser");
+      expect(await button.getAttribute("aria-disabled")).toBe("true");
+      await button.focus();
+      await button.press("Enter");
+      await panel
+        .getByRole("alert")
+        .filter({ hasText: "Fullscreen is unavailable in this browser" })
+        .waitFor();
+    });
+  });
+
+  it("exits fullscreen when the desktop panel unmounts", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: ["desktop.observe", "environments.list"],
+        methodResponses: {
+          "sessions.list": sessionsList(),
+          "environments.list": { environments: [] },
+        },
+      });
+      const panel = await openDesktopPanel(page);
+      await panel.locator(".desktop-fullscreen-button").click();
+      await expect.poll(() => page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
+      await panel.evaluate((element) => element.remove());
+      await expect.poll(() => page.evaluate(() => document.fullscreenElement)).toBeNull();
+    });
+  });
+});

--- a/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
@@ -170,9 +170,7 @@ suite.define(() => {
                     const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
                     for (let index = 0; index < pixels.length; index += 128) {
                       if (
-                        (pixels[index] ?? 0) +
-                          (pixels[index + 1] ?? 0) +
-                          (pixels[index + 2] ?? 0) >
+                        (pixels[index] ?? 0) + (pixels[index + 1] ?? 0) + (pixels[index + 2] ?? 0) >
                         0
                       ) {
                         return true;

--- a/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
@@ -195,10 +195,10 @@ suite.define(() => {
           if (!stageBox || !screenBox) {
             throw new Error("Desktop fullscreen geometry is unavailable");
           }
-          const framebuffer = await screen.evaluate((canvas) => ({
-            height: canvas.height,
-            width: canvas.width,
-          }));
+          const framebuffer = await screen.evaluate((element) => {
+            const canvas = element as HTMLCanvasElement;
+            return { height: canvas.height, width: canvas.width };
+          });
           expect(framebuffer.width).toBeGreaterThan(0);
           expect(framebuffer.height).toBeGreaterThan(0);
           expect(

--- a/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
@@ -4,9 +4,14 @@ import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { installScriptedRfbServer } from "./desktop-rfb-test-support.ts";
 
+const realVncWsUrl = process.env.OPENCLAW_DESKTOP_REAL_VNC_WS_URL?.trim() || null;
 const suite = createControlUiE2eSuite({
   name: "desktop fullscreen",
+  browserLaunchOptions: realVncWsUrl
+    ? { args: ["--disable-web-security", "--allow-running-insecure-content"] }
+    : undefined,
   startServerBeforeBrowser: true,
   unavailableMessage: (executablePath) =>
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
@@ -60,78 +65,6 @@ async function openDesktopPanel(page: Page) {
   return panel;
 }
 
-async function installRichDesktopClientFake(panel: import("playwright").Locator) {
-  await panel.evaluate((element) => {
-    type Options = {
-      onConnect?: () => void;
-      onDisconnect?: (detail: { code?: number; reason?: string }) => void;
-      target: HTMLElement;
-      viewOnly: boolean;
-    };
-    (
-      element as HTMLElement & {
-        desktopClientFactory: () => {
-          connect(options: Options): Promise<{ disconnect(): void }>;
-        };
-        triggerDesktopDisconnect?: () => void;
-      }
-    ).desktopClientFactory = () => ({
-      async connect(options) {
-        const screen = document.createElement("div");
-        screen.dataset.testid = "rich-desktop-screen";
-        screen.style.cssText = [
-          "aspect-ratio:16/10",
-          "background:linear-gradient(145deg,#172554,#0f766e)",
-          "border:1px solid rgba(255,255,255,.24)",
-          "border-radius:10px",
-          "box-shadow:0 20px 48px rgba(0,0,0,.35)",
-          "color:#f8fafc",
-          "display:grid",
-          "font:13px ui-sans-serif,system-ui",
-          "grid-template-rows:34px 1fr 28px",
-          "height:min(90%,620px)",
-          "margin:auto",
-          "overflow:hidden",
-          "width:min(90%,992px)",
-        ].join(";");
-        screen.innerHTML = `
-          <div style="align-items:center;background:rgba(15,23,42,.88);display:flex;gap:7px;padding:0 12px">
-            <span style="background:#fb7185;border-radius:50%;height:8px;width:8px"></span>
-            <span style="background:#fbbf24;border-radius:50%;height:8px;width:8px"></span>
-            <span style="background:#34d399;border-radius:50%;height:8px;width:8px"></span>
-            <strong style="margin-left:6px">Release operations · worker-desktop-1</strong>
-            <span style="margin-left:auto;opacity:.72">Secure observer</span>
-          </div>
-          <div style="display:grid;gap:14px;grid-template-columns:1.35fr .65fr;padding:18px">
-            <div style="background:rgba(15,23,42,.76);border:1px solid rgba(255,255,255,.16);border-radius:8px;padding:16px">
-              <div style="font-size:18px;font-weight:700;margin-bottom:12px">Production rollout</div>
-              <div style="background:#22c55e;border-radius:999px;height:7px;margin:10px 0;width:78%"></div>
-              <div style="display:grid;gap:8px;grid-template-columns:repeat(3,1fr);margin-top:18px">
-                <div style="background:rgba(255,255,255,.09);border-radius:7px;padding:12px">12 healthy</div>
-                <div style="background:rgba(255,255,255,.09);border-radius:7px;padding:12px">2 pending</div>
-                <div style="background:rgba(255,255,255,.09);border-radius:7px;padding:12px">0 failed</div>
-              </div>
-            </div>
-            <div style="background:rgba(15,23,42,.76);border:1px solid rgba(255,255,255,.16);border-radius:8px;padding:16px">
-              <strong>Live checks</strong>
-              <p>Gateway ✓</p><p>Desktop relay ✓</p><p>Browser session ✓</p>
-            </div>
-          </div>
-          <div style="align-items:center;background:rgba(15,23,42,.9);display:flex;justify-content:space-between;padding:0 12px">
-            <span>operator@worker-desktop-1</span><span>${options.viewOnly ? "View only" : "Control enabled"}</span>
-          </div>`;
-        options.target.replaceChildren(screen);
-        (
-          element as HTMLElement & { triggerDesktopDisconnect?: () => void }
-        ).triggerDesktopDisconnect = () =>
-          options.onDisconnect?.({ code: 1006, reason: "remote session ended" });
-        options.onConnect?.();
-        return { disconnect: () => screen.remove() };
-      },
-    });
-  });
-}
-
 async function setTheme(page: Page, theme: "dark" | "light") {
   await page.emulateMedia({ colorScheme: theme });
   await page.evaluate((nextTheme) => {
@@ -167,7 +100,7 @@ async function captureDesktopProof(page: Page, panel: import("playwright").Locat
 
 suite.define(() => {
   it.each(["dark", "light"] as const)(
-    "keeps the active desktop surface mounted through fullscreen entry and exit in %s mode",
+    "keeps the production noVNC canvas mounted through fullscreen entry and exit in %s mode",
     async (theme) => {
       await suite.withPage(
         {
@@ -179,6 +112,7 @@ suite.define(() => {
         async ({ page }) => {
           const gateway = await installMockGateway(page, {
             featureMethods: ["desktop.observe", "environments.list"],
+            webSocketPassthroughPrefixes: realVncWsUrl ? [realVncWsUrl] : [],
             methodResponses: {
               "sessions.list": sessionsList(),
               "environments.list": { environments: [workerDesktopEnvironment] },
@@ -191,7 +125,7 @@ suite.define(() => {
                     },
                     response: {
                       transport: "rfb",
-                      wsPath: "/desktop/observe?token=view",
+                      wsPath: realVncWsUrl ?? "/desktop/observe?token=view",
                       expiresAtMs: 60_000,
                       control: false,
                     },
@@ -203,7 +137,7 @@ suite.define(() => {
                     },
                     response: {
                       transport: "rfb",
-                      wsPath: "/desktop/observe?token=control",
+                      wsPath: realVncWsUrl ?? "/desktop/observe?token=control",
                       expiresAtMs: 60_000,
                       control: true,
                     },
@@ -215,9 +149,14 @@ suite.define(() => {
           const panel = await openDesktopPanel(page);
           await setTheme(page, theme);
           await gateway.waitForRequest("environments.list");
-          await installRichDesktopClientFake(panel);
+          if (!realVncWsUrl) {
+            // CI uses the canonical scripted RFB endpoint. Visual proof sets
+            // OPENCLAW_DESKTOP_REAL_VNC_WS_URL to a genuine VNC desktop.
+            await installScriptedRfbServer(page);
+          }
           await panel.getByRole("button", { name: "Connect", exact: true }).click();
-          await panel.getByTestId("rich-desktop-screen").waitFor();
+          const screen = panel.locator(".desktop-surface canvas");
+          await screen.waitFor();
 
           await captureDesktopProof(page, panel, `${theme}-default`);
           expect(
@@ -233,7 +172,6 @@ suite.define(() => {
           await fullscreenButton.focus();
           await captureDesktopProof(page, panel, `${theme}-focus`);
 
-          const screen = panel.getByTestId("rich-desktop-screen");
           const screenHandle = await screen.elementHandle();
           await fullscreenButton.press("Enter");
           await expect
@@ -257,7 +195,15 @@ suite.define(() => {
           if (!stageBox || !screenBox) {
             throw new Error("Desktop fullscreen geometry is unavailable");
           }
-          expect(Math.abs(screenBox.width / screenBox.height - 16 / 10)).toBeLessThan(0.02);
+          const framebuffer = await screen.evaluate((canvas) => ({
+            height: canvas.height,
+            width: canvas.width,
+          }));
+          expect(framebuffer.width).toBeGreaterThan(0);
+          expect(framebuffer.height).toBeGreaterThan(0);
+          expect(
+            Math.abs(screenBox.width / screenBox.height - framebuffer.width / framebuffer.height),
+          ).toBeLessThan(0.02);
           expect(screenBox.x).toBeGreaterThanOrEqual(stageBox.x);
           expect(screenBox.y).toBeGreaterThanOrEqual(stageBox.y);
           expect(screenBox.x + screenBox.width).toBeLessThanOrEqual(stageBox.x + stageBox.width);
@@ -272,7 +218,10 @@ suite.define(() => {
             .poll(async () => (await gateway.getRequests("desktop.observe")).length)
             .toBe(2);
           expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
-          await panel.getByText("Control enabled", { exact: true }).waitFor();
+          await panel.locator(".desktop-surface canvas").waitFor();
+          await expect
+            .poll(() => panel.getByRole("button", { name: "Take control", exact: true }).count())
+            .toBe(0);
 
           // Escape and browser controls both exit through the fullscreenchange path.
           await page.evaluate(() => document.exitFullscreen());
@@ -290,17 +239,6 @@ suite.define(() => {
           await fullscreenButton.click();
           await panel.getByRole("button", { name: "Disconnect", exact: true }).click();
           await panel.getByText("Desktop sources", { exact: true }).waitFor();
-          expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
-          await panel.getByRole("button", { name: "Connect", exact: true }).click();
-          await panel.getByText("View only", { exact: true }).waitFor();
-          await panel.evaluate((element) => {
-            (
-              element as HTMLElement & { triggerDesktopDisconnect?: () => void }
-            ).triggerDesktopDisconnect?.();
-          });
-          await panel
-            .getByText("Desktop disconnected: remote session ended", { exact: true })
-            .waitFor();
           expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
           await captureDesktopProof(page, panel, `${theme}-disconnected-fullscreen`);
           await fullscreenButton.click();

--- a/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
@@ -157,6 +157,33 @@ suite.define(() => {
           await panel.getByRole("button", { name: "Connect", exact: true }).click();
           const screen = panel.locator(".desktop-surface canvas");
           await screen.waitFor();
+          if (realVncWsUrl) {
+            await expect
+              .poll(
+                () =>
+                  screen.evaluate((element) => {
+                    const canvas = element as HTMLCanvasElement;
+                    const context = canvas.getContext("2d");
+                    if (!context || canvas.width === 0 || canvas.height === 0) {
+                      return false;
+                    }
+                    const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+                    for (let index = 0; index < pixels.length; index += 128) {
+                      if (
+                        (pixels[index] ?? 0) +
+                          (pixels[index + 1] ?? 0) +
+                          (pixels[index + 2] ?? 0) >
+                        0
+                      ) {
+                        return true;
+                      }
+                    }
+                    return false;
+                  }),
+                { timeout: 15_000 },
+              )
+              .toBe(true);
+          }
 
           await captureDesktopProof(page, panel, `${theme}-default`);
           expect(

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { installScriptedRfbServer } from "./desktop-rfb-test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "desktop source panel",
@@ -740,85 +741,9 @@ suite.define(() => {
         },
       });
       await page.goto(`${suite.server.baseUrl}chat`);
-      // Route desktop observe sockets to an in-page RFB 3.8 server (security
-      // None) so the production DesktopClient drives the real noVNC client.
-      await page.evaluate(() => {
-        const GatewaySocket = window.WebSocket;
-        class FakeRfbSocket extends EventTarget {
-          binaryType = "arraybuffer";
-          protocol = "";
-          readyState = 0;
-          onerror: ((event: Event) => void) | null = null;
-          onmessage: ((event: MessageEvent<ArrayBuffer>) => void) | null = null;
-          onopen: ((event: Event) => void) | null = null;
-          onclose: ((event: CloseEvent) => void) | null = null;
-          private handshake = 0;
-          constructor() {
-            super();
-            setTimeout(() => {
-              if (this.readyState !== 0) {
-                return;
-              }
-              this.readyState = 1;
-              this.onopen?.(new Event("open"));
-              this.deliver(new TextEncoder().encode("RFB 003.008\n"));
-            }, 0);
-          }
-          private deliver(bytes: Uint8Array<ArrayBuffer>): void {
-            setTimeout(() => {
-              if (this.readyState === 1) {
-                this.onmessage?.(new MessageEvent("message", { data: bytes.buffer }));
-              }
-            }, 0);
-          }
-          send(): void {
-            // Handshake replies are fixed-size, so respond by stage instead of
-            // parsing: version -> security types, choice -> ok, init -> ServerInit.
-            this.handshake += 1;
-            if (this.handshake === 1) {
-              this.deliver(new Uint8Array([1, 1]));
-            } else if (this.handshake === 2) {
-              this.deliver(new Uint8Array([0, 0, 0, 0]));
-            } else if (this.handshake === 3) {
-              const name = new TextEncoder().encode("fake-desktop");
-              const init = new Uint8Array(24 + name.length);
-              const view = new DataView(init.buffer);
-              view.setUint16(0, 800);
-              view.setUint16(2, 600);
-              init.set([32, 24, 0, 1], 4);
-              view.setUint16(8, 255);
-              view.setUint16(10, 255);
-              view.setUint16(12, 255);
-              init.set([16, 8, 0], 14);
-              view.setUint32(20, name.length);
-              init.set(name, 24);
-              this.deliver(init);
-            }
-          }
-          close(code = 1000, reason = ""): void {
-            if (this.readyState === 3) {
-              return;
-            }
-            this.readyState = 3;
-            const event = new CloseEvent("close", { code, reason });
-            this.onclose?.(event);
-            this.dispatchEvent(new CloseEvent("close", { code, reason }));
-          }
-        }
-        const RoutedSocket = function (url: string, protocols?: string | string[]) {
-          return url.includes("/desktop/observe")
-            ? new FakeRfbSocket()
-            : new GatewaySocket(url, protocols);
-        };
-        RoutedSocket.prototype = GatewaySocket.prototype;
-        Object.assign(RoutedSocket, {
-          CONNECTING: 0,
-          OPEN: 1,
-          CLOSING: 2,
-          CLOSED: 3,
-        });
-        window.WebSocket = RoutedSocket as unknown as typeof WebSocket;
-      });
+      // The production DesktopClient still owns noVNC; only the RFB endpoint
+      // is scripted here so this CI test remains deterministic.
+      await installScriptedRfbServer(page);
 
       await openDirectDesktop(page, "worker-desktop-1");
       const panel = page.locator("openclaw-desktop-panel");

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -823,7 +823,15 @@ suite.define(() => {
       await openDirectDesktop(page, "worker-desktop-1");
       const panel = page.locator("openclaw-desktop-panel");
       await panel.locator("section[aria-label='Desktop']").waitFor();
-      await panel.locator(".desktop-surface canvas").waitFor();
+      const canvas = panel.locator(".desktop-surface canvas");
+      await canvas.waitFor();
+      const canvasHandle = await canvas.elementHandle();
+      await panel.getByRole("button", { name: "Enter fullscreen", exact: true }).click();
+      await expect.poll(() => page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
+      expect(await canvas.evaluate((element, original) => element === original, canvasHandle)).toBe(
+        true,
+      );
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(1);
 
       const takeControl = panel.getByRole("button", { name: "Take control", exact: true });
       await takeControl.waitFor();
@@ -838,6 +846,9 @@ suite.define(() => {
       });
       await panel.locator(".desktop-surface canvas").waitFor();
       expect(await takeControl.count()).toBe(0);
+      expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
+      await panel.getByRole("button", { name: "Exit fullscreen", exact: true }).click();
+      await expect.poll(() => page.evaluate(() => document.fullscreenElement)).toBeNull();
     });
   });
 

--- a/ui/src/e2e/desktop-rfb-test-support.ts
+++ b/ui/src/e2e/desktop-rfb-test-support.ts
@@ -84,7 +84,7 @@ export async function installScriptedRfbServer(page: Page): Promise<void> {
     (
       window as typeof window & { triggerDesktopRfbDisconnect?: (reason: string) => void }
     ).triggerDesktopRfbDisconnect = (reason) => {
-      for (const socket of [...sockets]) {
+      for (const socket of sockets) {
         socket.close(1006, reason);
       }
     };

--- a/ui/src/e2e/desktop-rfb-test-support.ts
+++ b/ui/src/e2e/desktop-rfb-test-support.ts
@@ -1,0 +1,92 @@
+import type { Page } from "playwright";
+
+/** Install the scripted RFB 3.8 endpoint used by Desktop's canonical noVNC E2E. */
+export async function installScriptedRfbServer(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const GatewaySocket = window.WebSocket;
+    const sockets = new Set<FakeRfbSocket>();
+    class FakeRfbSocket extends EventTarget {
+      binaryType = "arraybuffer";
+      protocol = "";
+      readyState = 0;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent<ArrayBuffer>) => void) | null = null;
+      onopen: ((event: Event) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      private handshake = 0;
+      constructor() {
+        super();
+        sockets.add(this);
+        setTimeout(() => {
+          if (this.readyState !== 0) {
+            return;
+          }
+          this.readyState = 1;
+          this.onopen?.(new Event("open"));
+          this.deliver(new TextEncoder().encode("RFB 003.008\n"));
+        }, 0);
+      }
+      private deliver(bytes: Uint8Array<ArrayBuffer>): void {
+        setTimeout(() => {
+          if (this.readyState === 1) {
+            this.onmessage?.(new MessageEvent("message", { data: bytes.buffer }));
+          }
+        }, 0);
+      }
+      send(): void {
+        // Handshake replies are fixed-size, so respond by stage instead of
+        // parsing: version -> security types, choice -> ok, init -> ServerInit.
+        this.handshake += 1;
+        if (this.handshake === 1) {
+          this.deliver(new Uint8Array([1, 1]));
+        } else if (this.handshake === 2) {
+          this.deliver(new Uint8Array([0, 0, 0, 0]));
+        } else if (this.handshake === 3) {
+          const name = new TextEncoder().encode("scripted-desktop");
+          const init = new Uint8Array(24 + name.length);
+          const view = new DataView(init.buffer);
+          view.setUint16(0, 800);
+          view.setUint16(2, 600);
+          init.set([32, 24, 0, 1], 4);
+          view.setUint16(8, 255);
+          view.setUint16(10, 255);
+          view.setUint16(12, 255);
+          init.set([16, 8, 0], 14);
+          view.setUint32(20, name.length);
+          init.set(name, 24);
+          this.deliver(init);
+        }
+      }
+      close(code = 1000, reason = ""): void {
+        if (this.readyState === 3) {
+          return;
+        }
+        this.readyState = 3;
+        sockets.delete(this);
+        const event = new CloseEvent("close", { code, reason });
+        this.onclose?.(event);
+        this.dispatchEvent(new CloseEvent("close", { code, reason }));
+      }
+    }
+    const RoutedSocket = function (url: string, protocols?: string | string[]) {
+      return url.includes("/desktop/observe")
+        ? new FakeRfbSocket()
+        : new GatewaySocket(url, protocols);
+    };
+    RoutedSocket.prototype = GatewaySocket.prototype;
+    Object.assign(RoutedSocket, {
+      CONNECTING: 0,
+      OPEN: 1,
+      CLOSING: 2,
+      CLOSED: 3,
+    });
+    window.WebSocket = RoutedSocket as unknown as typeof WebSocket;
+    (
+      window as typeof window & { triggerDesktopRfbDisconnect?: (reason: string) => void }
+    ).triggerDesktopRfbDisconnect = (reason) => {
+      for (const socket of [...sockets]) {
+        socket.close(1006, reason);
+      }
+    };
+  });
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2019,6 +2019,9 @@ export const en: TranslationMap = {
     resize: "Resize desktop panel",
     dockBottom: "Dock to bottom",
     dockRight: "Dock to right",
+    enterFullscreen: "Enter fullscreen",
+    exitFullscreen: "Exit fullscreen",
+    fullscreenUnavailable: "Fullscreen is unavailable in this browser",
     pickerTitle: "Desktop sources",
     thisMachine: "This machine",
     refresh: "Refresh",
@@ -2052,6 +2055,7 @@ export const en: TranslationMap = {
     unknownReason: "unknown reason",
     errors: {
       listFailed: "Could not load desktop sources: {error}",
+      fullscreenFailed: "Could not change fullscreen mode: {error}",
       securityFailed: "Desktop security negotiation failed: {reason}",
     },
   },

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -266,6 +266,8 @@ export type ControlUiMockGatewayScenario = {
   historyMessages?: unknown[];
   /** Static payloads, parameter-matched cases, or call-ordered sequences. */
   methodResponses?: Record<string, unknown>;
+  /** URL prefixes that retain the browser's real WebSocket transport. */
+  webSocketPassthroughPrefixes?: string[];
   /** Replayed in-flight run snapshot served by chat.history and chat.startup. */
   inFlightRun?: {
     runId: string;
@@ -686,6 +688,7 @@ function normalizeScenario(
     omitFeatureMethods: scenario.omitFeatureMethods ?? false,
     historyMessages: scenario.historyMessages ?? [],
     methodResponses: scenario.methodResponses ?? {},
+    webSocketPassthroughPrefixes: scenario.webSocketPassthroughPrefixes ?? [],
     inFlightRun: scenario.inFlightRun ?? null,
     presenceUsers: scenario.presenceUsers ?? [],
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
@@ -742,6 +745,7 @@ function installControlUiMockGateway(
   },
   parseJson5: (raw: string) => unknown,
 ) {
+  const NativeWebSocket = window.WebSocket;
   type BrowserRequest = { id: string; method: string; params?: unknown };
   type BrowserFrame = {
     id?: unknown;
@@ -1962,7 +1966,23 @@ function installControlUiMockGateway(
   };
 
   (window as unknown as WindowWithGateway).openclawControlUiE2eGateway = exposed;
-  window.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  const RoutedWebSocket = function (url: string | URL, protocols?: string | string[]) {
+    const resolvedUrl = String(url);
+    if (scenario.webSocketPassthroughPrefixes.some((prefix) => resolvedUrl.startsWith(prefix))) {
+      return protocols === undefined
+        ? new NativeWebSocket(resolvedUrl)
+        : new NativeWebSocket(resolvedUrl, protocols);
+    }
+    return new MockWebSocket(resolvedUrl);
+  };
+  RoutedWebSocket.prototype = MockWebSocket.prototype;
+  Object.assign(RoutedWebSocket, {
+    CLOSED: MockWebSocket.CLOSED,
+    CLOSING: MockWebSocket.CLOSING,
+    CONNECTING: MockWebSocket.CONNECTING,
+    OPEN: MockWebSocket.OPEN,
+  });
+  window.WebSocket = RoutedWebSocket as unknown as typeof WebSocket;
   window.addEventListener("pagehide", () => {
     sessionMessageSubscriptions.clear();
     stopRepeatingSessionEvents();


### PR DESCRIPTION
Closes #122989

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

The Desktop preview is constrained by its dock. This PR adds a native element-fullscreen control to the existing panel without replacing the mounted noVNC surface. Take control, Disconnect, aspect ratio, letterboxing, browser Escape, focus restoration, visible failures, and unmount cleanup remain owned by the existing Desktop lifecycle.

No dependency, configuration, protocol, or startup system is added.

## Evidence correction and provenance

The first visual evidence published on this PR was invalid and has been withdrawn from this body. Its pixels came from a test-only HTML `div` created by `installRichDesktopClientFake`, including the invented “Release operations / Production rollout” dashboard. That fixture was introduced by this PR's first commit (`3a270825150`) and never existed on `main`. It did not exercise RFB.

The pre-existing test on `main` did instantiate production noVNC, but its RFB 3.8 peer was a scripted in-page WebSocket stub. It proved noVNC mounting and overlay hit testing, not a real VNC framebuffer. The test support is now named accordingly; no visual claim below relies on it.

The replacement visual proof is a genuine remote desktop pipeline on Crabbox/Daytona:

`Xvfb :99 (1024×640) → openbox + xterm → x11vnc :5900 → websockify :6080 → native Chromium WebSocket → production DesktopClient/@novnc/novnc canvas`

The Gateway control plane remains the repository's canonical `installMockGateway` harness. Only the desktop WebSocket is passed through to the real server. The displayed X11 terminal names the renderer and remote display so the framebuffer origin is visible in every connected screenshot.

Exact-head real-VNC run after integration with current `main`: https://crabbox.openclaw.ai/portal/runs/run_dda0cd2d5a5d — 4/4 focused fullscreen tests passed in Chromium. The test now waits for non-black framebuffer pixels in the production noVNC canvas before accepting screenshots. A separate Chromium WebSocket probe completed HTTP 101 and connected websockify to x11vnc (`run_f5c2d78b5e19`).

## State matrix

| State | Evidence |
| --- | --- |
| Disconnected | Source picker remains in the same fullscreen panel after Disconnect |
| Connecting | Existing connection lifecycle remains mounted in the panel |
| Connected / view only | Genuine x11vnc framebuffer, same canvas identity, Take control and Disconnect visible |
| Control enabled | Intentional control reconnect completes while fullscreen remains active |
| Hover / focus / keyboard | Canonical tooltip, visible focus, Enter activation |
| Fullscreen / external exit | Browser fullscreen state is authoritative; exit restores label and focus |
| Denied / unavailable | Visible alert, no silent failure |
| Unmount | Fullscreen cleanup passes |
| Themes | Light and dark connected, fullscreen, and disconnected states captured |

## Replacement screenshots — real X11/VNC framebuffer

| | Light | Dark |
| --- | --- | --- |
| Docked context | ![Light Desktop dock with a genuine X11 desktop served by x11vnc](https://github.com/user-attachments/assets/e8b6a636-5752-4f91-8ee6-e706436aa32a) | ![Dark Desktop dock with a genuine X11 desktop served by x11vnc](https://github.com/user-attachments/assets/5bca8b65-ba5e-4b96-af81-6dbe4ffbbf4e) |
| Docked header | ![Light Desktop header with fullscreen control](https://github.com/user-attachments/assets/5501838b-b398-4414-a230-b8333ca10396) | ![Dark Desktop header with fullscreen control](https://github.com/user-attachments/assets/56bd031c-b741-4d49-a56b-e2e75db67f95) |
| Native fullscreen | ![Light native fullscreen showing the genuine X11 framebuffer and letterboxing](https://github.com/user-attachments/assets/725e4867-a838-4e2f-9724-16ef91176300) | ![Dark native fullscreen showing the genuine X11 framebuffer and letterboxing](https://github.com/user-attachments/assets/0c8fc536-57ab-48fb-be30-6ff57a784fdc) |
| Fullscreen header | ![Light fullscreen header with exit control](https://github.com/user-attachments/assets/d7f20ae2-81ec-427a-a483-fe9b458c0b39) | ![Dark fullscreen header with exit control](https://github.com/user-attachments/assets/dbfce1d4-c662-4f87-b6e6-676acb508431) |

## Verification

- Exact-head real VNC visual run: 4/4 passed (`run_dda0cd2d5a5d`); 34 light/dark screenshots captured after visible framebuffer pixels arrived.
- Canonical mocked Desktop suite: 13/13 passed; corrected focused fullscreen suite: 4/4 passed remotely.
- The real framebuffer measured 1024×640; displayed canvas aspect and bounds preserve letterboxing.
- No second autoreview was run. The single previously authorized autoreview was clean.

Production LOC remains the fullscreen feature in the first commit. This correction removes the fabricated visual fixture and adds test-only routing that makes the real desktop socket bypass the canonical Gateway mock during remote visual proof.

## ClawSweeper disposition

- **Exact-head lint and test types — applied.** The reviewed lint and type findings remain fixed after the integration refresh. Commit `0c4e18f1a5e` applies canonical formatting to the framebuffer readiness gate; exact-head CI run `31754042737` completed green, including `openclaw/ci-gate`.
- **Refresh against current main — applied once for a material conflict.** After #122475 landed, a live merge-tree found conflicts in the Desktop header and dock-reservation owner. The branch was rebased once onto `f73b436f054`, preserving the canonical full-height rail header and suppressing only Desktop's existing viewport reservation while its element is fullscreen. The resulting merge-tree is clean.
- **Source-capable maintainer review — applied.** Repository-native review artifacts validated `0c4e18f1a5e` with zero findings, covering fullscreen cleanup, focus restoration, noVNC continuity, WebSocket routing, and current-main integration. This completes ClawSweeper's optional rank-up move.
- **Product decision — accepted.** Native element fullscreen is approved for landing as the Desktop preview's first-class large-view interaction.
