### PR TITLE
fix(ui): prevent untranslated keys from reaching Control UI

### DIFF
--- a/scripts/control-ui-i18n-verify.ts
+++ b/scripts/control-ui-i18n-verify.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import * as ts from "typescript";
 import {
   loadControlUiTranslationMemory,
   materializeControlUiLocaleCatalog,
@@ -11,6 +12,7 @@ import {
 import { CONTROL_UI_LOCALE_ENTRIES } from "./lib/control-ui-i18n-config.ts";
 import { syncControlUiRawCopyBaseline } from "./lib/control-ui-i18n-raw-copy.ts";
 import type { TranslationMap } from "./lib/control-ui-i18n-sync-plan.ts";
+import { collectSourceFileContents } from "./lib/source-file-scan-cache.mts";
 
 export type CatalogFallbackBaseline = {
   fallbacks: Record<string, string[]>;
@@ -25,6 +27,7 @@ const SOURCE_LOCALE_PATH = path.join(LOCALES_DIR, "en.ts");
 const ACTIVITY_SOURCE_LOCALE_PATH = path.join(LOCALES_DIR, "en-activity.ts");
 const FALLBACK_BASELINE_PATH = path.join(I18N_ASSETS_DIR, "catalog-fallbacks.json");
 const FALLBACK_BASELINE_VERSION = 1;
+const CONTROL_UI_TEST_FILE_PATTERN = /\.(?:test|browser\.test|node\.test)\.tsx?$/u;
 
 function compareStringArrays(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
@@ -153,6 +156,71 @@ export function analyzeControlUiCatalogs(
   return { errors, fallbacks };
 }
 
+export function verifyControlUiReferencedKeys(
+  sourceFlat: ReadonlyMap<string, string>,
+  sourceFiles: readonly { content: string; relativeFile: string }[],
+): { literalReferences: number; templatePrefixReferences: number } {
+  const sourceKeys = [...sourceFlat.keys()];
+  const errors: string[] = [];
+  let literalReferences = 0;
+  let templatePrefixReferences = 0;
+
+  for (const { content, relativeFile } of sourceFiles) {
+    const sourceFile = ts.createSourceFile(relativeFile, content, ts.ScriptTarget.Latest, true);
+    const reportMissing = (node: ts.Node, description: string) => {
+      const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+      errors.push(`${relativeFile}:${line}: ${description}`);
+    };
+    const verifyArgument = (rawArgument: ts.Expression): void => {
+      const argument = ts.isParenthesizedExpression(rawArgument)
+        ? rawArgument.expression
+        : ts.isAsExpression(rawArgument) || ts.isTypeAssertionExpression(rawArgument)
+          ? rawArgument.expression
+          : rawArgument;
+      if (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument)) {
+        literalReferences += 1;
+        if (!sourceFlat.has(argument.text)) {
+          reportMissing(argument, `missing English catalog key ${JSON.stringify(argument.text)}`);
+        }
+      } else if (ts.isTemplateExpression(argument)) {
+        templatePrefixReferences += 1;
+        const prefix = argument.head.text;
+        if (prefix && !sourceKeys.some((key) => key.startsWith(prefix))) {
+          reportMissing(argument, `missing English catalog subtree ${JSON.stringify(prefix)}`);
+        }
+      } else if (ts.isConditionalExpression(argument)) {
+        verifyArgument(argument.whenTrue);
+        verifyArgument(argument.whenFalse);
+      }
+    };
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "t" &&
+        node.arguments[0]
+      ) {
+        verifyArgument(node.arguments[0]);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      [
+        "control-ui referenced translation key verification failed.",
+        errors.slice(0, 50).join("\n"),
+        errors.length > 50 ? `...and ${errors.length - 50} more` : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return { literalReferences, templatePrefixReferences };
+}
+
 async function buildCatalogFallbackBaseline(
   options: {
     allowCatalogDrift?: boolean;
@@ -212,7 +280,18 @@ function printCatalogFallbackSummary(baseline: CatalogFallbackBaseline) {
 async function verifyControlUiSourceCatalogShape() {
   const sourceMap = await loadSourceLocaleMap();
   const sourceFlat = flattenControlUiCatalog(sourceMap, "en");
-  process.stdout.write(`control-ui-i18n: source: keys=${sourceFlat.size}\n`);
+  const sourceFiles = (
+    await collectSourceFileContents({
+      ignoredDirNames: new Set(["test-helpers"]),
+      repoRoot: ROOT,
+      scanExtensions: new Set([".ts", ".tsx"]),
+      scanRoots: ["ui/src"],
+    })
+  ).filter(({ relativeFile }) => !CONTROL_UI_TEST_FILE_PATTERN.test(relativeFile));
+  const referenced = verifyControlUiReferencedKeys(sourceFlat, sourceFiles);
+  process.stdout.write(
+    `control-ui-i18n: source: keys=${sourceFlat.size} literal_references=${referenced.literalReferences} template_prefix_references=${referenced.templatePrefixReferences}\n`,
+  );
 }
 
 export async function syncControlUiCatalogFallbackBaseline(options: {

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -15,6 +15,7 @@ import {
   analyzeControlUiCatalogs,
   flattenControlUiCatalog,
   formatControlUiCatalogFallbackDriftError,
+  verifyControlUiReferencedKeys,
 } from "../../scripts/control-ui-i18n-verify.ts";
 import {
   appendBoundedProcessOutput,
@@ -249,6 +250,29 @@ describe("control-ui-i18n process runner", () => {
   it("rejects invalid catalog leaf values", () => {
     expect(() => flattenControlUiCatalog({ group: { title: 42 } }, "fr")).toThrow(
       "fr:group.title must be a string or object",
+    );
+  });
+
+  it("rejects literal keys and template prefixes missing from the English catalog", () => {
+    const source = flattenControlUiCatalog(
+      { common: { ok: "OK" }, workboard: { status: { ready: "Ready" } } },
+      "en",
+    );
+    const content = [
+      't("common.ok");',
+      't("common.missing");',
+      "t(`workboard.status.${status}`);",
+      "t(`workboard.missing.${status}`);",
+    ].join("\n");
+
+    expect(() =>
+      verifyControlUiReferencedKeys(source, [{ content, relativeFile: "ui/src/pages/example.ts" }]),
+    ).toThrowError(
+      [
+        "control-ui referenced translation key verification failed.",
+        'ui/src/pages/example.ts:2: missing English catalog key "common.missing"',
+        'ui/src/pages/example.ts:4: missing English catalog subtree "workboard.missing."',
+      ].join("\n"),
     );
   });
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -8,6 +8,7 @@ export const en: TranslationMap = {
     ok: "OK",
     yes: "Yes",
     no: "No",
+    default: "Default",
     assistant: "Assistant",
     active: "Active",
     loading: "Loading…",


### PR DESCRIPTION
Related: #122964

## What Problem This Solves

Fixes an issue where Control UI contributors could reference a translation key that did not exist in the English catalog, causing every locale to render the raw key string. The Automations model picker exposed this as `common.default`.

## Why This Change Was Made

The existing keyless contributor verifier now checks production `ui/src` translation calls against the already-flattened English catalog. It validates literal keys exactly and dynamic template calls by their static catalog prefix, while leaving nonliteral lookup-table keys outside this focused pass. The missing shared `common.default` English entry is added so the affected picker renders “Default.”

## User Impact

The Automations model picker renders “Default” instead of `common.default`. Future missing literal translation keys and misspelled dynamic catalog prefixes fail `pnpm ui:i18n:verify` and the CI-gated Control UI lane before merge.

## Evidence

- Exact regression: removing `common.default` makes `pnpm ui:i18n:verify` exit 1 with `ui/src/pages/cron/view.ts:1259: missing English catalog key "common.default"`.
- Repaired tree: `pnpm ui:i18n:verify` exits 0 with 4,979 English keys, 5,624 literal references, and 48 dynamic template-prefix references.
- Focused synthetic regression covers both a missing literal key and missing dynamic subtree.
- `oxfmt` and focused `oxlint` checks pass for all changed files.
- Structured autoreview: clean, no accepted/actionable findings.

Production/tooling delta: +81/-1; test delta: +24/-0. The tooling growth is the requested referenced-key capability plus deterministic source discovery and actionable file/line diagnostics; no config or runtime fallback surface was added.
