### PR TITLE
fix(logs): surface truncation when line limit drops records

### DIFF
--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -208,7 +208,9 @@ describe("logs cli", () => {
 
     expect(stdoutWrites.join("")).toContain("Log file:");
     expect(stdoutWrites.join("")).toContain("raw line");
-    expect(stderrWrites.join("")).toContain("Log tail truncated");
+    expect(stderrWrites.join("")).toContain(
+      "Log tail truncated (increase --limit or --max-bytes).",
+    );
     expect(stderrWrites.join("")).toContain("Log cursor reset");
   });
 

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -725,7 +725,7 @@ export function registerLogsCli(program: Command) {
           if (
             !emitJsonLine({
               type: "notice",
-              message: "Log tail truncated (increase --max-bytes).",
+              message: "Log tail truncated (increase --limit or --max-bytes).",
             })
           ) {
             return;
@@ -785,7 +785,7 @@ export function registerLogsCli(program: Command) {
           }
         }
         if (payload.truncated) {
-          if (!errorLine("Log tail truncated (increase --max-bytes).")) {
+          if (!errorLine("Log tail truncated (increase --limit or --max-bytes).")) {
             return;
           }
         }

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -85,6 +85,25 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines).toEqual(["old line", "recent one", "recent two"]);
   });
 
+  it("marks output truncated when the line limit omits complete records", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+
+    await fs.writeFile(file, "one\ntwo\nthree\n");
+    setLoggerOverride({ file });
+
+    const result = await readConfiguredLogTail({ limit: 2, maxBytes: 100 });
+
+    expect(result).toMatchObject({
+      cursor: 14,
+      size: 14,
+      lines: ["two", "three"],
+      truncated: true,
+      reset: false,
+    });
+  });
+
   it("falls back only within the active profile's rolling log family", async () => {
     const tempDir = tempDirs.make("openclaw-log-tail-");
     const missing = path.join(tempDir, "openclaw-dev-2026-01-22.log");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -138,6 +138,7 @@ async function readLogSlice(params: {
       lines = lines.slice(0, -1);
     }
     if (lines.length > limit) {
+      truncated = true;
       lines = lines.slice(lines.length - limit);
     }
 


### PR DESCRIPTION
Closes #123275

## What Problem This Solves

Fixes an issue where users tailing logs would receive only the newest records without a truncation signal when the configured line limit omitted older complete records.

## Why This Change Was Made

The log-tail reader now reports truncation for either byte-window or line-limit omissions while preserving the existing cursor and reset semantics. CLI notices now point operators to both relevant controls: `--limit` and `--max-bytes`.

## User Impact

Gateway and direct log-tail consumers can reliably detect incomplete history, and CLI users get an actionable explanation of how to request a larger tail.

## Evidence

- Regression RED on current `main`: the three-line fixture returned the expected two newest lines and EOF cursor, but reported `truncated: false`.
- `node scripts/run-vitest.mjs src/logging/log-tail.test.ts src/cli/logs-cli.test.ts` (44 tests passed)
- `pnpm exec oxfmt --check --threads=1 src/logging/log-tail.ts src/logging/log-tail.test.ts src/cli/logs-cli.ts src/cli/logs-cli.test.ts`
- Direct Oxlint check for the four changed files
- `pnpm tsgo:core`
- Repository autoreview: clean, no accepted/actionable findings
- `pnpm check:changed` could not enter code analysis because the local Crabbox binary failed its `--version`/`--help` sanity check.

AI-assisted: yes. I reviewed and understand the implementation and tests.


### Exact-head remote behavior proof

- Reviewed head: `5de47b4a1a0761a4e38a0805d073c104936823f9`
- Sanitized direct AWS Crabbox: public networking, no Tailscale, no instance profile, fresh temporary `HOME`, Node `24.15.0`, pnpm `11.15.1`.
- Focused exact-head tests: `44/44` passed; private-QA packaged build passed.
- Packaged Gateway/CLI contract proof: https://crabbox.openclaw.ai/portal/runs/run_75a4521b702d

```json
{
  "first": { "lineCount": 2, "truncated": true, "cursor": 305, "size": 305, "reset": false },
  "cursorTail": { "lineCount": 1, "appendedOnce": true, "noReplay": true },
  "cli": {
    "notice": "Log tail truncated (increase --limit or --max-bytes).",
    "markerObserved": true
  }
}
```

The repository `remote-log-tailing` scenario was also run on the same head: https://crabbox.openclaw.ai/portal/runs/run_7f2a30e67380. Its product output contained the new CLI notice, but the scenario failed its older marker assertion because two Gateway RPC audit records displaced the marker under `--limit 2`. The passing contract proof above suppresses those unrelated info-level audit records and exercises the same real packaged Gateway and CLI without changing the PR. This harness false negative is recorded here as a follow-up; it is not folded into this four-file fix.

### Current-main merge and history proof

- Current `main` checked: `e04dfd26e237cfc73afb20a5d58d707b0574cdb2`.
- A temporary no-commit three-way merge of this exact PR head onto that SHA completed cleanly.
- The merged result retained exactly the same four-file scope and numstat: production `+3/-2`, tests `+22/-1`; `git diff --check` passed.
- Focused tests on the merged result passed `44/44`.
- Current `main` still slices complete records to the line limit without first setting `truncated = true`; this PR repairs that producer boundary.
- The existing line-limit slice traces to `306fe841f54b4c11c93831d8aff3fabb619dd511` (`fix(cli): add local logs fallback`, April 4, 2026). The added truncation assignment remains authored by `yu-xin-c`.

The PR head is intentionally unchanged. Repository policy treats an otherwise clean behind-main branch as advisory, so this records the exact merge result instead of rebasing solely to refresh ancestry.
