### PR TITLE
fix: keep automation delivery owned in multi-agent fleets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Multi-agent automation delivery:** preserve the admitted agent owner through outbound channel bootstrap and durable replay so heartbeat and cron results use the correct agent workspace instead of failing ambient-agent selection.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Multi-agent automation delivery:** preserve the admitted agent owner through outbound channel bootstrap and durable replay so heartbeat and cron results use the correct agent workspace instead of failing ambient-agent selection.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -548,7 +548,7 @@ Periodic heartbeat runs.
 - `every`: duration string (ms/s/m/h). Default: `30m` (API-key auth) or `1h` (OAuth auth). Set to `0m` to disable.
 - `agentId`: explicit owner for ambient heartbeat runs when no `agents.entries.*.heartbeat` block exists. A shared heartbeat block without `agentId` keeps the existing all-agent enrollment behavior.
 - Cadence is written into a system-owned cron monitor row. Run `openclaw doctor --fix` to materialize a missing or stale row. If cron is disabled, scheduled heartbeats do not run and the gateway logs a startup warning.
-- The heartbeat object is strict. Its supported fields are `every`, `activeHours`, `model`, `session`, `target`, `directPolicy`, `to`, `accountId`, `prompt`, `timeoutSeconds`, `lightContext`, and `isolatedSession`.
+- The heartbeat object is strict. Its supported fields are `agentId`, `every`, `activeHours`, `model`, `session`, `target`, `directPolicy`, `to`, `accountId`, `prompt`, `timeoutSeconds`, `lightContext`, and `isolatedSession`.
 - `timeoutSeconds`: maximum time in seconds allowed for a heartbeat agent turn before it is aborted. Leave unset to use `agents.defaults.timeoutSeconds` when set, otherwise the heartbeat cadence capped at 600 seconds.
 - `directPolicy`: direct/DM delivery policy. `allow` (default) permits direct-target delivery. `block` suppresses direct-target delivery and emits `reason=dm-blocked`.
 - `target`: `owner` (default) sends only to a direct-message identity from `commands.ownerAllowFrom` or channel `allowFrom`. `last` explicitly follows the latest conversation, including groups. `none` keeps results internal.

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -178,6 +178,7 @@ export async function deliverInboundReplyWithMessageSendContextCore(
   try {
     support = await resolveOutboundDurableFinalDeliverySupport({
       cfg: params.cfg,
+      agentId: params.agentId,
       channel,
       requirements: requiredCapabilities,
     });

--- a/src/cron/isolated-agent/delivery-target.runtime.ts
+++ b/src/cron/isolated-agent/delivery-target.runtime.ts
@@ -18,6 +18,7 @@ export { resolveFirstBoundAccountId } from "../../routing/bound-account-read.js"
 export async function resolveChannelTargetForDelivery(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
+  agentId: string;
   input: string;
   accountId?: string | null;
 }): Promise<{ ok: true; target: ResolvedMessagingTarget } | { ok: false; error: Error }> {
@@ -26,6 +27,7 @@ export async function resolveChannelTargetForDelivery(params: {
   resolveOutboundChannelPlugin({
     channel: params.channel,
     cfg: params.cfg,
+    agentId: params.agentId,
     allowBootstrap: true,
   });
   try {
@@ -60,6 +62,7 @@ export async function resolveOutboundSessionRouteForDelivery(params: {
   resolveOutboundChannelPlugin({
     channel: params.channel,
     cfg: params.cfg,
+    agentId: params.agentId,
     allowBootstrap: true,
   });
   return await resolveOutboundSessionRoute(params);
@@ -69,11 +72,13 @@ export async function resolveOutboundSessionRouteForDelivery(params: {
 export function channelCanResolveOutboundSessionRoute(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
+  agentId: string;
 }): boolean {
   return Boolean(
     resolveOutboundChannelPlugin({
       channel: params.channel,
       cfg: params.cfg,
+      agentId: params.agentId,
       allowBootstrap: true,
     })?.messaging?.resolveOutboundSessionRoute,
   );

--- a/src/cron/isolated-agent/delivery-target.runtime.ts
+++ b/src/cron/isolated-agent/delivery-target.runtime.ts
@@ -24,7 +24,7 @@ export async function resolveChannelTargetForDelivery(params: {
 }): Promise<{ ok: true; target: ResolvedMessagingTarget } | { ok: false; error: Error }> {
   // Delivery may be the first channel touch after startup; allow bootstrap so
   // plugin config and account metadata are available before target resolution.
-  resolveOutboundChannelPlugin({
+  const plugin = resolveOutboundChannelPlugin({
     channel: params.channel,
     cfg: params.cfg,
     agentId: params.agentId,
@@ -37,6 +37,7 @@ export async function resolveChannelTargetForDelivery(params: {
       input: params.input,
       accountId: params.accountId,
       unknownTargetMode: "normalized",
+      plugin,
     });
   } catch (err) {
     return {
@@ -59,13 +60,13 @@ export async function resolveOutboundSessionRouteForDelivery(params: {
 }): Promise<OutboundSessionRoute | null> {
   // Route lookup also bootstraps the plugin so canonical thread/session mapping
   // matches the send-time channel runtime.
-  resolveOutboundChannelPlugin({
+  const plugin = resolveOutboundChannelPlugin({
     channel: params.channel,
     cfg: params.cfg,
     agentId: params.agentId,
     allowBootstrap: true,
   });
-  return await resolveOutboundSessionRoute(params);
+  return await resolveOutboundSessionRoute({ ...params, plugin });
 }
 
 /** Returns whether a channel can canonicalize outbound cron delivery sessions. */

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -345,6 +345,7 @@ export async function resolveDeliveryTarget(
   const targetResolution = await deliveryTargetRuntime.resolveChannelTargetForDelivery({
     cfg,
     channel,
+    agentId,
     input: toCandidate,
     accountId,
   });
@@ -402,6 +403,7 @@ export async function resolveDeliveryTarget(
   const routeCanCanonicalizeTarget = deliveryTargetRuntime.channelCanResolveOutboundSessionRoute({
     cfg,
     channel,
+    agentId,
   });
   const routeShouldCanonicalizeTarget =
     route && (route.threadId !== undefined || route.to !== routeTargetCandidate);

--- a/src/infra/outbound/account-scoped-conversation-bindings.test.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   createAccountScopedConversationBindingManager,
@@ -12,6 +13,13 @@ type TestBindingKind = "subagent" | "acp";
 const stateKey = Symbol("openclaw.accountScopedConversationBindingExpiry.test");
 const startedAt = 1_700_000_000_000;
 const baseCfg = {
+  session: { threadBindings: { idleHours: 1, maxAgeHours: 0 } },
+} satisfies OpenClawConfig;
+const explicitFleetCfg = {
+  agents: {
+    ownership: "explicit",
+    entries: { ops: {}, research: {} },
+  },
   session: { threadBindings: { idleHours: 1, maxAgeHours: 0 } },
 } satisfies OpenClawConfig;
 
@@ -76,6 +84,22 @@ describe("account-scoped conversation binding expiry", () => {
     expect(manager.listBySessionKey(binding.targetSessionKey)).toEqual([]);
     expect(service.resolveByConversation(conversation)).toBeNull();
     expect(service.listBySession(binding.targetSessionKey)).toEqual([]);
+  });
+
+  it("uses an agent-scoped target without resolving an ambient fleet owner", () => {
+    const manager = createManager({ cfg: explicitFleetCfg });
+
+    expect(
+      bindConversation(manager, { targetSessionKey: "agent:ops:subagent:child" }).agentId,
+    ).toBe("ops");
+  });
+
+  it("still requires an owner for an unscoped target in an explicit fleet", () => {
+    const manager = createManager({ cfg: explicitFleetCfg });
+
+    expect(() => bindConversation(manager, { targetSessionKey: "subagent:child" })).toThrow(
+      AgentSelectionRequiredError,
+    );
   });
 
   it("enforces maximum age even when activity refreshes the idle deadline", () => {

--- a/src/infra/outbound/account-scoped-conversation-bindings.test.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   createAccountScopedConversationBindingManager,
@@ -13,13 +12,6 @@ type TestBindingKind = "subagent" | "acp";
 const stateKey = Symbol("openclaw.accountScopedConversationBindingExpiry.test");
 const startedAt = 1_700_000_000_000;
 const baseCfg = {
-  session: { threadBindings: { idleHours: 1, maxAgeHours: 0 } },
-} satisfies OpenClawConfig;
-const explicitFleetCfg = {
-  agents: {
-    ownership: "explicit",
-    entries: { ops: {}, research: {} },
-  },
   session: { threadBindings: { idleHours: 1, maxAgeHours: 0 } },
 } satisfies OpenClawConfig;
 
@@ -84,22 +76,6 @@ describe("account-scoped conversation binding expiry", () => {
     expect(manager.listBySessionKey(binding.targetSessionKey)).toEqual([]);
     expect(service.resolveByConversation(conversation)).toBeNull();
     expect(service.listBySession(binding.targetSessionKey)).toEqual([]);
-  });
-
-  it("uses an agent-scoped target without resolving an ambient fleet owner", () => {
-    const manager = createManager({ cfg: explicitFleetCfg });
-
-    expect(
-      bindConversation(manager, { targetSessionKey: "agent:ops:subagent:child" }).agentId,
-    ).toBe("ops");
-  });
-
-  it("still requires an owner for an unscoped target in an explicit fleet", () => {
-    const manager = createManager({ cfg: explicitFleetCfg });
-
-    expect(() => bindConversation(manager, { targetSessionKey: "subagent:child" })).toThrow(
-      AgentSelectionRequiredError,
-    );
   });
 
   it("enforces maximum age even when activity refreshes the idle deadline", () => {
@@ -187,5 +163,20 @@ describe("account-scoped conversation binding expiry", () => {
     expect(manager.unbindConversation(binding.conversationId)?.targetSessionKey).toBe(
       binding.targetSessionKey,
     );
+  });
+
+  it("derives the binding owner from an agent-scoped target before consulting defaults", () => {
+    const manager = createManager({
+      cfg: {
+        agents: { list: [{ id: "main" }, { id: "molty" }] },
+        session: { threadBindings: { idleHours: 1, maxAgeHours: 0 } },
+      },
+    });
+
+    const binding = bindConversation(manager, {
+      targetSessionKey: "agent:molty:subagent:binding-owner",
+    });
+
+    expect(binding.agentId).toBe("molty");
   });
 });

--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -8,7 +8,12 @@ import {
   resolveThreadBindingMaxAgeMsForChannel,
 } from "../../channels/thread-bindings-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { normalizeAccountId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import {
+  normalizeAccountId,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../../routing/session-key.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import {
   registerSessionBindingAdapter,
@@ -71,6 +76,13 @@ function getState<TKind extends string>(
 
 function resolveBindingKey(accountId: string, conversationId: string): string {
   return `${accountId}:${conversationId}`;
+}
+
+function resolveBindingAgentId(cfg: OpenClawConfig, sessionKey: string): string {
+  const parsedAgentId = parseAgentSessionKey(sessionKey)?.agentId;
+  return parsedAgentId
+    ? normalizeAgentId(parsedAgentId)
+    : resolveAgentIdFromSessionKey(sessionKey, resolveDefaultAgentId(cfg));
 }
 
 function toSessionBindingRecord<TKind extends string>(params: {
@@ -196,10 +208,7 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
           typeof metadata?.agentId === "string" && metadata.agentId.trim()
             ? metadata.agentId.trim()
             : (existingLocal?.agentId ??
-              resolveAgentIdFromSessionKey(
-                normalizedTargetSessionKey,
-                resolveDefaultAgentId(params.cfg),
-              )),
+              resolveBindingAgentId(params.cfg, normalizedTargetSessionKey)),
         label:
           typeof metadata?.label === "string" && metadata.label.trim()
             ? metadata.label.trim()

--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -1,5 +1,5 @@
 import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 // Account-scoped conversation binding managers adapt channel-local thread maps
 // into the shared session binding service.
 import { resolveThreadBindingConversationIdFromBindingId } from "../../channels/thread-binding-id.js";
@@ -8,12 +8,7 @@ import {
   resolveThreadBindingMaxAgeMsForChannel,
 } from "../../channels/thread-bindings-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  normalizeAccountId,
-  normalizeAgentId,
-  parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
-} from "../../routing/session-key.js";
+import { normalizeAccountId } from "../../routing/session-key.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import {
   registerSessionBindingAdapter,
@@ -76,13 +71,6 @@ function getState<TKind extends string>(
 
 function resolveBindingKey(accountId: string, conversationId: string): string {
   return `${accountId}:${conversationId}`;
-}
-
-function resolveBindingAgentId(cfg: OpenClawConfig, sessionKey: string): string {
-  const parsedAgentId = parseAgentSessionKey(sessionKey)?.agentId;
-  return parsedAgentId
-    ? normalizeAgentId(parsedAgentId)
-    : resolveAgentIdFromSessionKey(sessionKey, resolveDefaultAgentId(cfg));
 }
 
 function toSessionBindingRecord<TKind extends string>(params: {
@@ -205,10 +193,13 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
         targetKind: params.toStoredTargetKind(targetKind),
         targetSessionKey: normalizedTargetSessionKey,
         agentId:
-          typeof metadata?.agentId === "string" && metadata.agentId.trim()
+          (typeof metadata?.agentId === "string" && metadata.agentId.trim()
             ? metadata.agentId.trim()
-            : (existingLocal?.agentId ??
-              resolveBindingAgentId(params.cfg, normalizedTargetSessionKey)),
+            : existingLocal?.agentId) ??
+          resolveSessionAgentId({
+            config: params.cfg,
+            sessionKey: normalizedTargetSessionKey,
+          }),
         label:
           typeof metadata?.label === "string" && metadata.label.trim()
             ? metadata.label.trim()

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -187,6 +187,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     resolveOutboundChannelPlugin({
       channel: resolvedChannel,
       cfg: params.cfg,
+      agentId: params.agentId,
       allowBootstrap: true,
     });
   if (!plugin) {

--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -1,6 +1,7 @@
 // Covers lazy outbound channel bootstrap, retry guards, auto-enable config, and
 // send-capable active registry short-circuiting.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
@@ -24,7 +25,8 @@ vi.mock("../../plugins/loader.js", () => ({
 
 const { bootstrapOutboundChannelPlugin, resetOutboundChannelBootstrapStateForTests } =
   await import("./channel-bootstrap.runtime.js");
-const { resolveOutboundDurableFinalDeliverySupport } = await import("./deliver-channel.js");
+const { resolveChannelOutboundDirectiveOptions, resolveOutboundDurableFinalDeliverySupport } =
+  await import("./deliver-channel.js");
 
 const discordConfig = {
   channels: {
@@ -35,6 +37,19 @@ const discordConfig = {
 const updatedDiscordConfig = {
   channels: {
     discord: { enabled: true },
+  },
+} satisfies OpenClawConfig;
+
+const explicitFleetDiscordConfig = {
+  agents: {
+    ownership: "explicit",
+    entries: {
+      ops: { workspace: "/tmp/openclaw-ops" },
+      research: { workspace: "/tmp/openclaw-research" },
+    },
+  },
+  channels: {
+    discord: {},
   },
 } satisfies OpenClawConfig;
 
@@ -67,6 +82,71 @@ describe("bootstrapOutboundChannelPlugin", () => {
     });
 
     expect(loaderMocks.loadPluginRegistryHandle).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the admitted agent workspace during outbound preparation", async () => {
+    installDiscordSetupShell();
+    const handle = createEmptyPluginRegistry();
+    handle.channels = [
+      {
+        pluginId: "discord",
+        plugin: {
+          id: "discord",
+          meta: {},
+          outbound: {
+            extractMarkdownImages: true,
+            sendText: async () => ({ messageId: "1" }),
+          },
+        },
+        source: "runtime",
+      },
+    ] as never;
+    loaderMocks.loadPluginRegistryHandle.mockReturnValue(handle);
+
+    await expect(
+      resolveChannelOutboundDirectiveOptions({
+        channel: "discord",
+        cfg: explicitFleetDiscordConfig,
+        agentId: "ops",
+      }),
+    ).resolves.toEqual({ extractMarkdownImages: true });
+
+    expect(loaderMocks.resolveDiscoverableScopedChannelPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/openclaw-ops" }),
+    );
+  });
+
+  it("still rejects ownerless bootstrap in an explicit multi-agent fleet", () => {
+    installDiscordSetupShell();
+
+    expect(() =>
+      bootstrapOutboundChannelPlugin({
+        channel: "discord",
+        cfg: explicitFleetDiscordConfig,
+      }),
+    ).toThrow(AgentSelectionRequiredError);
+  });
+
+  it("caches bootstrap outcomes per admitted agent", () => {
+    installDiscordSetupShell();
+    loaderMocks.loadPluginRegistryHandle.mockReturnValue(createEmptyPluginRegistry());
+
+    bootstrapOutboundChannelPlugin({
+      channel: "discord",
+      cfg: explicitFleetDiscordConfig,
+      agentId: "ops",
+    });
+    bootstrapOutboundChannelPlugin({
+      channel: "discord",
+      cfg: explicitFleetDiscordConfig,
+      agentId: "research",
+    });
+
+    expect(loaderMocks.loadPluginRegistryHandle).toHaveBeenCalledTimes(2);
+    expect(loaderMocks.resolveDiscoverableScopedChannelPluginIds).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ workspaceDir: "/tmp/openclaw-research" }),
+    );
   });
 
   it("skips bootstrap when the selected channel entry can already send", () => {

--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -27,9 +27,8 @@ const { bootstrapOutboundChannelPlugin, resetOutboundChannelBootstrapStateForTes
   await import("./channel-bootstrap.runtime.js");
 const { resolveChannelOutboundDirectiveOptions, resolveOutboundDurableFinalDeliverySupport } =
   await import("./deliver-channel.js");
-const { resolveChannelTargetForDelivery, resolveOutboundSessionRouteForDelivery } = await import(
-  "../../cron/isolated-agent/delivery-target.runtime.js"
-);
+const { resolveChannelTargetForDelivery, resolveOutboundSessionRouteForDelivery } =
+  await import("../../cron/isolated-agent/delivery-target.runtime.js");
 
 const discordConfig = {
   channels: {

--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -27,6 +27,9 @@ const { bootstrapOutboundChannelPlugin, resetOutboundChannelBootstrapStateForTes
   await import("./channel-bootstrap.runtime.js");
 const { resolveChannelOutboundDirectiveOptions, resolveOutboundDurableFinalDeliverySupport } =
   await import("./deliver-channel.js");
+const { resolveChannelTargetForDelivery, resolveOutboundSessionRouteForDelivery } = await import(
+  "../../cron/isolated-agent/delivery-target.runtime.js"
+);
 
 const discordConfig = {
   channels: {
@@ -147,6 +150,61 @@ describe("bootstrapOutboundChannelPlugin", () => {
       2,
       expect.objectContaining({ workspaceDir: "/tmp/openclaw-research" }),
     );
+  });
+
+  it("carries the admitted agent runtime into cron target and session resolution", async () => {
+    installDiscordSetupShell();
+    const resolveTarget = vi.fn(async () => ({
+      to: "channel:ops",
+      kind: "channel" as const,
+      source: "directory" as const,
+    }));
+    const resolveOutboundSessionRoute = vi.fn(() => ({
+      sessionKey: "agent:ops:discord:channel:ops",
+      baseSessionKey: "agent:ops:discord:channel:ops",
+      recipientSessionExact: true as const,
+      peer: { kind: "channel" as const, id: "ops" },
+      chatType: "channel" as const,
+      from: "discord:channel:ops",
+      to: "channel:ops",
+    }));
+    const handle = createEmptyPluginRegistry();
+    handle.channels = [
+      {
+        pluginId: "discord",
+        plugin: {
+          id: "discord",
+          meta: {},
+          outbound: { sendText: async () => ({ messageId: "1" }) },
+          messaging: {
+            targetResolver: { resolveTarget },
+            resolveOutboundSessionRoute,
+          },
+        },
+        source: "runtime",
+      },
+    ] as never;
+    loaderMocks.loadPluginRegistryHandle.mockReturnValue(handle);
+
+    await expect(
+      resolveChannelTargetForDelivery({
+        cfg: explicitFleetDiscordConfig,
+        channel: "discord",
+        agentId: "ops",
+        input: "ops",
+      }),
+    ).resolves.toMatchObject({ ok: true, target: { to: "channel:ops" } });
+    await expect(
+      resolveOutboundSessionRouteForDelivery({
+        cfg: explicitFleetDiscordConfig,
+        channel: "discord",
+        agentId: "ops",
+        target: "channel:ops",
+      }),
+    ).resolves.toMatchObject({ sessionKey: "agent:ops:discord:channel:ops" });
+
+    expect(resolveTarget).toHaveBeenCalledTimes(1);
+    expect(resolveOutboundSessionRoute).toHaveBeenCalledTimes(1);
   });
 
   it("skips bootstrap when the selected channel entry can already send", () => {

--- a/src/infra/outbound/channel-bootstrap.runtime.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.ts
@@ -10,6 +10,7 @@ import { loadPluginRegistryHandle } from "../../plugins/loader.js";
 import type { PluginChannelRegistration } from "../../plugins/registry-types.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { getActivePluginRegistry, getActivePluginRegistryVersion } from "../../plugins/runtime.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import { pruneMapToMaxSize } from "../map-size.js";
 
 const MAX_BOOTSTRAP_CONFIG_GENERATIONS = 64;
@@ -19,12 +20,12 @@ const bootstrapRegistriesByConfig = new Map<string, Map<string, PluginRegistry |
 
 function cacheBootstrapOutcome(
   registries: Map<string, PluginRegistry | null>,
-  channel: string,
+  key: string,
   outcome: PluginRegistry | null,
 ): void {
   // Reinsert every outcome, including null, so reads and writes share LRU ordering.
-  registries.delete(channel);
-  registries.set(channel, outcome);
+  registries.delete(key);
+  registries.set(key, outcome);
   pruneMapToMaxSize(registries, MAX_BOOTSTRAP_CHANNEL_OUTCOMES_PER_CONFIG);
 }
 
@@ -83,6 +84,7 @@ function resolveSendCapableRegistry(
 export function bootstrapOutboundChannelPlugin(params: {
   channel: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
 }): PluginRegistry | undefined {
   const cfg = params.cfg;
   if (!cfg) {
@@ -95,16 +97,21 @@ export function bootstrapOutboundChannelPlugin(params: {
     return activeSendRegistry;
   }
 
+  // Outbound callers already know the admitted run owner. Preserve it here so
+  // explicit fleets do not fall back to forbidden ambient-agent selection.
+  const agentId = params.agentId?.trim()
+    ? normalizeAgentId(params.agentId)
+    : resolveDefaultAgentId(cfg);
+  const outcomeKey = `${agentId}\0${params.channel}`;
   const registries = resolveBootstrapRegistries(cfg);
-  const cachedRegistry = registries.get(params.channel);
+  const cachedRegistry = registries.get(outcomeKey);
   if (cachedRegistry !== undefined) {
-    cacheBootstrapOutcome(registries, params.channel, cachedRegistry);
+    cacheBootstrapOutcome(registries, outcomeKey, cachedRegistry);
     return resolveSendCapableRegistry(cachedRegistry, params.channel);
   }
 
   const autoEnabled = applyPluginAutoEnable({ config: cfg });
-  const defaultAgentId = resolveDefaultAgentId(autoEnabled.config);
-  const workspaceDir = resolveAgentWorkspaceDir(autoEnabled.config, defaultAgentId);
+  const workspaceDir = resolveAgentWorkspaceDir(autoEnabled.config, agentId);
   const pluginIds = resolveDiscoverableScopedChannelPluginIds({
     config: autoEnabled.config,
     activationSourceConfig: cfg,
@@ -131,6 +138,6 @@ export function bootstrapOutboundChannelPlugin(params: {
   } catch {
     // Best-effort bootstrap; the caller reports the unavailable channel.
   }
-  cacheBootstrapOutcome(registries, params.channel, sendRegistry ?? null);
+  cacheBootstrapOutcome(registries, outcomeKey, sendRegistry ?? null);
   return sendRegistry;
 }

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -31,6 +31,7 @@ function getOutboundRuntimeRegistry(): PluginRegistry | null {
 function normalizeOutboundChannelForResolution(params: {
   channel: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   allowBootstrap?: boolean;
 }): {
   channel?: string;
@@ -63,6 +64,7 @@ function normalizeOutboundChannelForResolution(params: {
   const bootstrapRegistry = bootstrapOutboundChannelPlugin({
     channel: normalized,
     cfg: params.cfg,
+    agentId: params.agentId,
   });
   const bootstrappedRuntimePlugin = resolveActivatedOutboundPluginFromRuntimeRegistry(
     normalized,
@@ -193,6 +195,7 @@ function resolveActivatedOutboundPluginFromRuntimeRegistry(
 export function resolveOutboundChannelPlugin(params: {
   channel: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   allowBootstrap?: boolean;
 }): ChannelPlugin | undefined {
   const {
@@ -229,7 +232,11 @@ export function resolveOutboundChannelPlugin(params: {
     return undefined;
   }
 
-  const registry = bootstrapOutboundChannelPlugin({ channel: normalized, cfg: params.cfg });
+  const registry = bootstrapOutboundChannelPlugin({
+    channel: normalized,
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
   return resolveRuntimeOutboundPluginCandidate({
     loaded: resolveLoaded(),
     runtime: resolveActivatedOutboundPluginFromRuntimeRegistry(normalized, registry),
@@ -243,6 +250,7 @@ export function resolveOutboundChannelPlugin(params: {
 export function resolveOutboundChannelMessageAdapter(params: {
   channel: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   allowBootstrap?: boolean;
 }): ChannelMessageAdapterShape | undefined {
   const {
@@ -264,7 +272,11 @@ export function resolveOutboundChannelMessageAdapter(params: {
   if (current || params.allowBootstrap !== true || didBootstrap) {
     return current;
   }
-  const registry = bootstrapOutboundChannelPlugin({ channel: normalized, cfg: params.cfg });
+  const registry = bootstrapOutboundChannelPlugin({
+    channel: normalized,
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
   return (
     resolveSendCapableMessageAdapter(getLoadedChannelPlugin(normalized)) ??
     resolveValueFromRuntimeRegistry(normalized, resolveSendCapableMessageAdapter, registry) ??

--- a/src/infra/outbound/deferred-delivery-admission.ts
+++ b/src/infra/outbound/deferred-delivery-admission.ts
@@ -7,10 +7,12 @@ import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
 
 export function resolveDeferredDeliveryAdmission(
   params: ChannelMessageDeferredDeliveryAdmissionContext,
+  owner?: { agentId?: string },
 ): ChannelMessageDeferredDeliveryAdmissionResult {
   const adapter = resolveOutboundChannelMessageAdapter({
     channel: params.channel,
     cfg: params.cfg,
+    agentId: owner?.agentId,
     allowBootstrap: true,
   });
   return adapter?.durableFinal?.admitDeferredDelivery?.(params) ?? { status: "allowed" };

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -41,6 +41,7 @@ const loadChannelBootstrapRuntime = createLazyRuntimeModule(
 );
 export async function resolveChannelOutboundDirectiveOptions(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   channel: string;
 }): Promise<{ extractMarkdownImages?: boolean }> {
   const { outbound } = await loadBootstrappedOutboundAdapter(params);
@@ -63,6 +64,7 @@ export async function createChannelHandler(params: ChannelHandlerParams): Promis
 
 async function loadBootstrappedOutboundAdapter(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   channel: string;
 }): Promise<{ outbound?: ChannelOutboundAdapter; pluginRegistry?: PluginRegistry }> {
   let outbound = await loadChannelOutboundAdapter(params.channel);
@@ -73,6 +75,7 @@ async function loadBootstrappedOutboundAdapter(params: {
   const pluginRegistry = bootstrapOutboundChannelPlugin({
     channel: params.channel,
     cfg: params.cfg,
+    agentId: params.agentId,
   });
   outbound = pluginRegistry?.channels.find((entry) => entry.plugin.id === params.channel)?.plugin
     .outbound;
@@ -157,6 +160,7 @@ async function runChannelMessageSendWithLifecycle<
 
 export async function resolveOutboundDurableFinalDeliverySupport(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   channel: string;
   requirements?: DurableFinalDeliveryRequirements;
 }): Promise<OutboundDurableDeliverySupport> {

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -122,6 +122,8 @@ export type PlatformSendRoute = {
 
 export type ChannelHandlerParams = {
   cfg: OpenClawConfig;
+  /** Admitted run owner for agent-scoped channel runtime discovery. */
+  agentId?: string;
   channel: string;
   to: string;
   accountId?: string;

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -72,6 +72,7 @@ export async function deliverOutboundPayloadsCore(
   const createHandler = (mediaSources: readonly string[]) =>
     createChannelHandler({
       cfg,
+      agentId: params.session?.agentId,
       channel,
       to,
       deps,

--- a/src/infra/outbound/deliver-prepare.ts
+++ b/src/infra/outbound/deliver-prepare.ts
@@ -48,6 +48,7 @@ function throwIfPreparationAborted(
 async function createPreparationHandler(params: DeliverOutboundPayloadsParams) {
   return await createChannelHandler({
     cfg: params.cfg,
+    agentId: params.session?.agentId,
     channel: params.channel,
     to: params.to,
     deps: params.deps,
@@ -121,6 +122,7 @@ export async function prepareOutboundPayloadBatch(
 ): Promise<PreparedOutboundBatch> {
   const directiveOptions = await resolveChannelOutboundDirectiveOptions({
     cfg: params.cfg,
+    agentId: params.session?.agentId,
     channel: params.channel,
   });
   const plan = createOutboundPayloadPlan(params.payloads, {

--- a/src/infra/outbound/deliver-queue.ts
+++ b/src/infra/outbound/deliver-queue.ts
@@ -137,13 +137,16 @@ async function runOutboundDeliveryWithQueue(
     );
   }
   if (params.deferredDeliveryAdmissionPassed !== true) {
-    const admission = resolveDeferredDeliveryAdmission({
-      cfg: params.cfg,
-      channel,
-      to,
-      accountId: params.accountId,
-      phase: "live",
-    });
+    const admission = resolveDeferredDeliveryAdmission(
+      {
+        cfg: params.cfg,
+        channel,
+        to,
+        accountId: params.accountId,
+        phase: "live",
+      },
+      { agentId: params.session?.agentId },
+    );
     if (admission.status === "permanent_rejection") {
       emitPreQueueFailure();
       throw new Error(admission.reason);
@@ -225,6 +228,7 @@ async function runOutboundDeliveryWithQueue(
     delete requirements.messageSendingHooks;
     const support = await resolveOutboundDurableFinalDeliverySupport({
       cfg: params.cfg,
+      agentId: params.session?.agentId,
       channel,
       requirements,
     });

--- a/src/infra/outbound/delivery-queue-reconciliation.ts
+++ b/src/infra/outbound/delivery-queue-reconciliation.ts
@@ -23,6 +23,7 @@ type UnknownSendQueueEntry = {
   replyToMode?: ReplyToMode;
   threadId?: string | number | null;
   silent?: boolean;
+  session?: { agentId?: string };
 };
 
 export function buildUnknownSendContext(params: {
@@ -64,6 +65,7 @@ export async function reconcileUnknownQueuedDelivery(params: {
   const adapter = resolveOutboundChannelMessageAdapter({
     channel: params.entry.channel,
     cfg: params.cfg,
+    agentId: params.entry.session?.agentId,
     allowBootstrap: true,
   });
   if (adapter?.durableFinal?.capabilities?.reconcileUnknownSend !== true) {

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -345,13 +345,16 @@ async function applyRecoveryDeliveryAdmission(params: {
   stateDir?: string;
   logLabel: string;
 }): Promise<"allowed" | "failed" | "not_pending"> {
-  const admission = resolveDeferredDeliveryAdmission({
-    cfg: params.cfg,
-    channel: params.entry.channel,
-    to: params.entry.to,
-    accountId: params.entry.accountId,
-    phase: "recovery",
-  });
+  const admission = resolveDeferredDeliveryAdmission(
+    {
+      cfg: params.cfg,
+      channel: params.entry.channel,
+      to: params.entry.to,
+      accountId: params.entry.accountId,
+      phase: "recovery",
+    },
+    { agentId: params.entry.session?.agentId },
+  );
   if (admission.status === "allowed") {
     return "allowed";
   }
@@ -395,6 +398,7 @@ async function runUnknownSendTerminalCleanup(params: {
   const adapter = resolveOutboundChannelMessageAdapter({
     channel: params.entry.channel,
     cfg: params.cfg,
+    agentId: params.entry.session?.agentId,
     allowBootstrap: true,
   });
   const cleanup = adapter?.durableFinal?.afterUnknownSendTerminal;
@@ -519,6 +523,7 @@ async function runReconciledSentCommitHooks(params: {
   const adapter = resolveOutboundChannelMessageAdapter({
     channel: params.entry.channel,
     cfg: params.cfg,
+    agentId: params.entry.session?.agentId,
     allowBootstrap: true,
   });
   const afterCommit = adapter?.send?.lifecycle?.afterCommit;

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -245,6 +245,7 @@ function deriveRequiredMessageSendCapabilities(params: {
 
 async function assertRequiredMessageSendDurability(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   channel: Exclude<string, "none">;
   payloads: ReplyPayload[];
   replyToId?: string | null;
@@ -253,6 +254,7 @@ async function assertRequiredMessageSendDurability(params: {
 }): Promise<void> {
   const support = await resolveOutboundDurableFinalDeliverySupport({
     cfg: params.cfg,
+    agentId: params.agentId,
     channel: params.channel,
     requirements: deriveRequiredMessageSendCapabilities(params),
   });
@@ -384,6 +386,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     if (requireUnknownSendReconciliation) {
       await assertRequiredMessageSendDurability({
         cfg,
+        agentId: params.agentId,
         channel: outboundChannel,
         payloads: normalizedPayloads,
         replyToId: params.replyToId,


### PR DESCRIPTION
Related: #77700

AI-assisted: yes

## What Problem This Solves

Fixes an issue where heartbeat and isolated cron runs owned by a configured agent could finish successfully but fail while delivering their result in an explicit multi-agent fleet. The final delivery path discarded the admitted agent owner and attempted ambient default-agent selection, producing `AGENT_SELECTION_REQUIRED` after the model had already completed its work.

## Why This Change Was Made

Outbound preparation, channel handler creation, durability checks, channel resolution, and durable recovery now carry the existing session `agentId` into lazy channel bootstrap. Bootstrap uses that owner only for agent-scoped workspace discovery and keys cached outcomes by owner plus channel; genuinely ownerless calls still fail closed. The same owner invariant now avoids eagerly resolving a default agent when an account-scoped conversation binding already contains an agent-scoped session key.

The production growth (+91/-29, net +62) is the typed ownership boundary needed to keep live delivery and persisted replay on the same admitted agent. Tests are +105/-1; docs/changelog are +2/-1.

## User Impact

Operators with explicit multi-agent ownership can receive heartbeat and cron results from the correct agent workspace. Delivery replay and reconciliation keep the original owner after a restart, and ownerless operations remain selection errors rather than silently choosing another agent.

## Evidence

- Live clawstudio logs showed an owned cron session complete normally, followed by `AgentSelectionRequiredError` during final delivery.
- Frozen pre-fix source `2a70d849e8a8bde3d66562bc441d96fb95388baf` plus the new regressions: 3 intended failures, including the exact outbound-preparation stack through `resolveChannelOutboundDirectiveOptions` and `channel-bootstrap.runtime.ts`.
- Fixed head `59ead899663c945772864400d805b021d25d05fc`: 6 focused files, 345 tests passed across outbound bootstrap, durable queue recovery, agent delivery, account-scoped bindings, and cron delivery targeting.
- Classified changed gate passed: core production/test typechecks, lint, formatting, dead exports, import cycles, and repository guards.
- `pnpm check:docs` passed: formatting, Markdown lint, MDX, glossary, 6,482 internal links with 0 broken, and config examples.
- `git diff --check` passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local` returned no accepted/actionable findings (overall correct 0.96).

Proof gap: no source-blind live send was run for this head. Blacksmith Testbox `tbx_01kzy4sxqr5s80etyrvt4qtd84` remained queued for 3m56s and was stopped; the owned AWS fallback was unavailable because this host has no managed Crabbox broker login. The deterministic owner-boundary regression and all classified checks are green, but they are not presented as live channel proof.
