### PR TITLE
fix(ui): keep session subtitles stable when opened

### DIFF
--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -85,7 +85,6 @@ describe("SidebarSessionNarrationController", () => {
         { ...runningRow("agent:main:failed"), hasActiveRun: false, status: "failed" },
         runningRow("agent:main:active"),
       ],
-      openSessionKey: "",
       agentId: "main",
     });
     await Promise.resolve();
@@ -113,7 +112,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -216,7 +214,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity,
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
     await Promise.resolve();
@@ -266,7 +263,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -299,7 +295,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -337,7 +332,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -370,7 +364,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -412,7 +405,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -450,7 +442,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -497,7 +488,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -557,7 +547,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -595,7 +584,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -636,7 +624,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -676,7 +663,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -732,7 +718,6 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
-      openSessionKey: "",
       agentId: "main",
     };
 
@@ -765,7 +750,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("global")],
-      openSessionKey: "",
     };
 
     controller.sync({ ...base, agentId: "main" });
@@ -802,7 +786,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 
@@ -852,7 +835,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity,
       source: firstSource,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
     controller.sync({
@@ -861,7 +843,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity,
       source: secondSource,
       rows: [],
-      openSessionKey: "",
       agentId: "main",
     });
     resolveFirst({ key: "agent:main:run", agentId: null });
@@ -871,28 +852,6 @@ describe("SidebarSessionNarrationController", () => {
       key: "agent:main:run",
       agentId: null,
     });
-  });
-
-  it("does not hand an old agent's global subscription to the open chat", async () => {
-    const subscribeMessages = vi.fn((key: string, options?: { agentId?: string | null }) =>
-      Promise.resolve({ key, agentId: options?.agentId ?? null }),
-    );
-    const unsubscribeMessages = vi.fn(() => Promise.resolve());
-    const source = { subscribeMessages, unsubscribeMessages } as unknown as SessionCapability;
-    const controller = new SidebarSessionNarrationController(() => undefined);
-    const base = {
-      enabled: true,
-      connected: true,
-      connectionIdentity: {},
-      source,
-      rows: [runningRow("global")],
-    };
-
-    controller.sync({ ...base, openSessionKey: "", agentId: "main" });
-    await Promise.resolve();
-    controller.sync({ ...base, openSessionKey: "global", agentId: "research" });
-
-    expect(unsubscribeMessages).toHaveBeenCalledWith({ key: "global", agentId: "main" });
   });
 
   it("keeps the newest sentence after a response exceeds the retained tail", async () => {
@@ -908,7 +867,6 @@ describe("SidebarSessionNarrationController", () => {
       connectionIdentity: {},
       source,
       rows: [runningRow("agent:main:run")],
-      openSessionKey: "",
       agentId: "main",
     });
 

--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -80,6 +80,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [
         { ...runningRow("agent:main:stale"), hasActiveRun: false, status: "running" },
         { ...runningRow("agent:main:failed"), hasActiveRun: false, status: "failed" },
@@ -111,6 +112,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -213,6 +215,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity,
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -262,6 +265,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -294,6 +298,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -331,6 +336,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -363,6 +369,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -404,6 +411,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -441,6 +449,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -487,6 +496,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -546,6 +556,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -583,6 +594,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -623,6 +635,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -662,6 +675,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -718,6 +732,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       agentId: "main",
     };
 
@@ -749,6 +764,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("global")],
     };
 
@@ -785,6 +801,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -834,6 +851,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity,
       source: firstSource,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });
@@ -842,6 +860,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity,
       source: secondSource,
+      openSessionKey: "",
       rows: [],
       agentId: "main",
     });
@@ -866,6 +885,7 @@ describe("SidebarSessionNarrationController", () => {
       connected: true,
       connectionIdentity: {},
       source,
+      openSessionKey: "",
       rows: [runningRow("agent:main:run")],
       agentId: "main",
     });

--- a/ui/src/components/app-sidebar-session-narration.ts
+++ b/ui/src/components/app-sidebar-session-narration.ts
@@ -59,6 +59,7 @@ export type SidebarNarrationSyncInput = {
   connectionIdentity: object | null;
   source: SessionCapability | null;
   rows: readonly SidebarRecentSession[];
+  openSessionKey: string;
   agentId: string;
 };
 
@@ -160,14 +161,22 @@ export class SidebarSessionNarrationController {
       return;
     }
 
-    const candidates = input.rows
-      .map((row, index) => ({ row, index }))
-      .filter(({ row }) => row.hasActiveRun)
-      .toSorted(
-        (left, right) => rowRecency(right.row) - rowRecency(left.row) || left.index - right.index,
-      )
-      .slice(0, SIDEBAR_NARRATION_SUBSCRIPTION_LIMIT);
-    const nextDesired = new Set(candidates.map(({ row }) => row.key));
+    const openSessionKey = input.openSessionKey.trim();
+    const nextDesired = new Set<string>();
+    let backgroundSubscriptions = 0;
+    for (const row of input.rows.toSorted((left, right) => rowRecency(right) - rowRecency(left))) {
+      if (!row.hasActiveRun) {
+        continue;
+      }
+      const open = areUiSessionKeysEquivalent(row.key, openSessionKey);
+      if (!open && backgroundSubscriptions >= SIDEBAR_NARRATION_SUBSCRIPTION_LIMIT) {
+        continue;
+      }
+      nextDesired.add(row.key);
+      if (!open) {
+        backgroundSubscriptions += 1;
+      }
+    }
 
     for (const key of this.desiredKeys) {
       if (nextDesired.has(key)) {

--- a/ui/src/components/app-sidebar-session-narration.ts
+++ b/ui/src/components/app-sidebar-session-narration.ts
@@ -59,7 +59,6 @@ export type SidebarNarrationSyncInput = {
   connectionIdentity: object | null;
   source: SessionCapability | null;
   rows: readonly SidebarRecentSession[];
-  openSessionKey: string;
   agentId: string;
 };
 
@@ -163,10 +162,7 @@ export class SidebarSessionNarrationController {
 
     const candidates = input.rows
       .map((row, index) => ({ row, index }))
-      .filter(
-        ({ row }) =>
-          row.hasActiveRun && !areUiSessionKeysEquivalent(row.key, input.openSessionKey.trim()),
-      )
+      .filter(({ row }) => row.hasActiveRun)
       .toSorted(
         (left, right) => rowRecency(right.row) - rowRecency(left.row) || left.index - right.index,
       )

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -254,6 +254,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       connectionIdentity: gateway?.client ?? null,
       source: this.context?.sessions ?? null,
       rows: this.visibleNarrationRowsInOrder(),
+      openSessionKey: isSessionRouteId(this.activeRouteId) ? this.getRouteSessionKey() : "",
       agentId: this.selectedAgentIdForSessions(),
     };
   }

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -254,7 +254,6 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       connectionIdentity: gateway?.client ?? null,
       source: this.context?.sessions ?? null,
       rows: this.visibleNarrationRowsInOrder(),
-      openSessionKey: isSessionRouteId(this.activeRouteId) ? this.getRouteSessionKey() : "",
       agentId: this.selectedAgentIdForSessions(),
     };
   }

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -23,8 +23,103 @@ const sessionSecondRowProofDir = path.join(
   "control-ui-e2e",
   "session-status-second-row-implementation",
 );
+const subtitleStabilityProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "sidebar-subtitle-stability",
+);
 
 suite.define(() => {
+  it("keeps a running subtitle and row height stable when its session is opened", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(subtitleStabilityProofDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: subtitleStabilityProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const proofVideo = page.video();
+    const firstKey = "agent:main:session-a";
+    const secondKey = "agent:main:session-b";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([
+          {
+            key: firstKey,
+            kind: "direct",
+            label: "First running session",
+            updatedAt: 2,
+            activeRunIds: ["run-first"],
+            hasActiveRun: true,
+            status: "running",
+          },
+          {
+            key: secondKey,
+            kind: "direct",
+            label: "Second running session",
+            updatedAt: 1,
+            activeRunIds: ["run-second"],
+            hasActiveRun: true,
+            status: "running",
+          },
+        ]),
+      },
+      sessionKey: firstKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const secondRow = page.locator(`.sidebar-recent-session[data-session-key="${secondKey}"]`);
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.messages.subscribe")).some(
+            (request) => request.params.key === secondKey,
+          ),
+        )
+        .toBe(true);
+      await gateway.emitGatewayEvent("agent", {
+        sessionKey: secondKey,
+        runId: "run-second",
+        stream: "tool",
+        data: { name: "bash" },
+      });
+      await secondRow.getByText("Using bash").waitFor();
+      const heightBefore = await secondRow.evaluate((row) => row.getBoundingClientRect().height);
+      if (captureUiProofEnabled) {
+        await page.waitForTimeout(800);
+        await secondRow.screenshot({
+          path: path.join(subtitleStabilityProofDir, "01-running-before-open.png"),
+        });
+      }
+
+      await secondRow.locator("a.sidebar-recent-session__link").click();
+      await expect.poll(() => secondRow.getAttribute("class")).toContain("--active");
+      await secondRow.getByText("Using bash").waitFor();
+      const heightAfter = await secondRow.evaluate((row) => row.getBoundingClientRect().height);
+
+      expect(heightAfter).toBe(heightBefore);
+      if (captureUiProofEnabled) {
+        await page.waitForTimeout(800);
+        await secondRow.screenshot({
+          path: path.join(subtitleStabilityProofDir, "02-running-after-open.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+      if (proofVideo) {
+        await proofVideo.saveAs(
+          path.join(subtitleStabilityProofDir, "sidebar-subtitle-stability.webm"),
+        );
+      }
+    }
+  });
+
   it("replaces an intermediate running subtitle with the unread final digest", async () => {
     if (captureUiProofEnabled) {
       await mkdir(terminalMetadataProofDir, { recursive: true });

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   expectDefined,
   installMockGateway,
   pauseVirtualClock,
+  requireRecord,
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
@@ -79,7 +80,7 @@ suite.define(() => {
       await expect
         .poll(async () =>
           (await gateway.getRequests("sessions.messages.subscribe")).some(
-            (request) => request.params.key === secondKey,
+            (request) => requireRecord(request.params).key === secondKey,
           ),
         )
         .toBe(true);

--- a/ui/src/test-helpers/app-sidebar-cases/narration.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/narration.ts
@@ -182,7 +182,7 @@ describe("AppSidebar live narration", () => {
     ).toBeNull();
   });
 
-  it("skips the open chat subscription and resubscribes background runs after reconnect", async () => {
+  it("leases open and background running sessions again after reconnect", async () => {
     const openKey = "agent:main:open";
     const backgroundKey = "agent:main:background";
     const gateway = createGatewayHarness({} as GatewayBrowserClient);
@@ -197,21 +197,27 @@ describe("AppSidebar live narration", () => {
     sidebar.connected = true;
     await sidebar.updateComplete;
 
-    await waitForFast(() => expect(sessions.subscribeMessages).toHaveBeenCalledTimes(1));
-    expect(sessions.subscribeMessages).toHaveBeenLastCalledWith(backgroundKey, {
+    await waitForFast(() => expect(sessions.subscribeMessages).toHaveBeenCalledTimes(2));
+    expect(sessions.subscribeMessages).toHaveBeenCalledWith(openKey, {
+      agentId: undefined,
+    });
+    expect(sessions.subscribeMessages).toHaveBeenCalledWith(backgroundKey, {
       agentId: undefined,
     });
 
     gateway.publish({ phase: "stopped" });
     sidebar.connected = false;
     await sidebar.updateComplete;
-    await waitForFast(() => expect(sessions.unsubscribeMessages).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(sessions.unsubscribeMessages).toHaveBeenCalledTimes(2));
 
     gateway.publish({ phase: "connected" });
     sidebar.connected = true;
     await sidebar.updateComplete;
-    await waitForFast(() => expect(sessions.subscribeMessages).toHaveBeenCalledTimes(2));
-    expect(sessions.subscribeMessages).toHaveBeenLastCalledWith(backgroundKey, {
+    await waitForFast(() => expect(sessions.subscribeMessages).toHaveBeenCalledTimes(4));
+    expect(sessions.subscribeMessages).toHaveBeenNthCalledWith(3, backgroundKey, {
+      agentId: undefined,
+    });
+    expect(sessions.subscribeMessages).toHaveBeenNthCalledWith(4, openKey, {
       agentId: undefined,
     });
   });

--- a/ui/src/test-helpers/app-sidebar-cases/narration.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/narration.ts
@@ -159,6 +159,26 @@ describe("AppSidebar live narration", () => {
     expect(sessions.subscribeMessages.mock.calls.at(-1)?.[0]).toBe(keys[0]);
   });
 
+  it("keeps six background subscriptions when the open session is also running", async () => {
+    const keys = Array.from({ length: 7 }, (_, index) => `agent:main:run-${index + 1}`);
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    const sessions = createSessionsHarness("main", keys);
+    sessions.publishList({
+      result: sessionsResult(keys.map((key, index) => runningRow(key, index + 1))),
+      agentId: "main",
+    });
+    const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+    sidebar.activeRouteId = "chat";
+    sidebar.sessionKey = keys[0]!;
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+
+    await waitForFast(() => expect(sessions.subscribeMessages).toHaveBeenCalledTimes(7));
+    expect(sessions.subscribeMessages.mock.calls.map(([key]) => key)).toEqual(
+      expect.arrayContaining(keys),
+    );
+  });
+
   it("stays inert when the synced preference is off", async () => {
     const key = "agent:main:quiet";
     const gateway = createGatewayHarness({} as GatewayBrowserClient);
@@ -214,11 +234,11 @@ describe("AppSidebar live narration", () => {
     sidebar.connected = true;
     await sidebar.updateComplete;
     await waitForFast(() => expect(sessions.subscribeMessages).toHaveBeenCalledTimes(4));
-    expect(sessions.subscribeMessages).toHaveBeenNthCalledWith(3, backgroundKey, {
-      agentId: undefined,
-    });
-    expect(sessions.subscribeMessages).toHaveBeenNthCalledWith(4, openKey, {
-      agentId: undefined,
-    });
+    expect(sessions.subscribeMessages.mock.calls.slice(2)).toEqual(
+      expect.arrayContaining([
+        [backgroundKey, { agentId: undefined }],
+        [openKey, { agentId: undefined }],
+      ]),
+    );
   });
 });


### PR DESCRIPTION
## New behavior

Opening a running session no longer makes its live sidebar subtitle disappear or collapse the row. The selected row keeps showing its current activity—for example, **Using bash**—while the sidebar still maintains its six-session background narration quota.

## Exact-head behavior proof

Captured after the safe rebase at exact PR head `3f35195ce5f38f085904dfd0878b445df1b5a60c`. The behavior-level mocked-Gateway scenario waits for the second running row to show **Using bash**, selects that same row, and asserts that both the subtitle and measured row height remain unchanged.

| Before selecting the running row | After the same click |
| --- | --- |
| <img width="229" height="45" alt="Exact PR head before selection: Second running session shows Using bash" src="https://github.com/user-attachments/assets/3173d6a4-364b-437b-8ec9-33655b0fd4a1" /> | <img width="229" height="45" alt="Exact PR head after selection: Second running session still shows Using bash at the same height" src="https://github.com/user-attachments/assets/e478f4d3-97ff-43f4-bf6e-bfdc14bdb002" /> |

**What this shows:** Only the active-row chrome changes. The two-line subtitle remains visible and the row does not shift height.

### Paced interaction

https://github.com/user-attachments/assets/3a44b925-cd67-4330-902d-c48841c6680f

**What this shows:** The exact-head row starts with **Using bash**, receives the click, becomes active, and retains the same subtitle and height. The 5.12-second video is cropped to the sidebar interaction and excludes account details.

**State:** Control UI with a mocked Gateway fixture containing two running sessions; 1280×900 source viewport; no production Gateway or live user data.

## How to verify

1. Open the Control UI with two running sessions in the sidebar.
2. Wait for the second session to show a live activity subtitle such as **Using bash**.
3. Select that session row.
4. Confirm the subtitle remains visible and the row height does not change.
5. Confirm six other running sessions can still retain background narration subscriptions.

## Implementation notes

The sidebar narration controller keeps the active running session in its narration candidates while counting the six background rows separately. The existing shared, reference-counted subscription coordinator lets the open chat and sidebar share one session-message subscription, so subtitle stability does not create a duplicate Gateway subscription.

## Focused verification

- Narration controller lifecycle tests: 21 passed.
- Sidebar presentation browser scenarios: 5 passed.
- File-scoped formatting and Oxlint: passed.
- `git diff --check`: passed.
