### PR TITLE
fix(ui): show one session activity indicator

### DIFF
--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -179,7 +179,7 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
     areUiSessionKeysEquivalent(host.getRouteSessionKey(), mainKey);
   const hasComposerDraft = host.hasSessionDraft(mainKey);
   const running = mainRow?.hasActiveRun === true;
-  const unread = mainRow?.unread === true && !active;
+  const unread = mainRow?.unread === true && !active && !running;
   // Home keeps its page/attention glyph leading and shares trailing activity with session rows.
   const homeGlyph = renderSessionGlyph({
     content:

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -180,6 +180,13 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
   const hasComposerDraft = host.hasSessionDraft(mainKey);
   const running = mainRow?.hasActiveRun === true;
   const unread = mainRow?.unread === true && !active && !running;
+  const hiddenUnread = mainRow?.unread === true && !active && running;
+  const homeLabel =
+    attentionLabel || hiddenUnread
+      ? [t("nav.home"), attentionLabel, hiddenUnread ? t("sessionsView.unread") : ""]
+          .filter(Boolean)
+          .join(" · ")
+      : undefined;
   // Home keeps its page/attention glyph leading and shares trailing activity with session rows.
   const homeGlyph = renderSessionGlyph({
     content:
@@ -201,7 +208,7 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
         preferenceDerivedFace: true,
       }).href}
       class="nav-item nav-item--home ${active ? "nav-item--active" : ""}"
-      aria-label=${attentionLabel ? `${t("nav.home")} · ${attentionLabel}` : nothing}
+      aria-label=${homeLabel ?? nothing}
       aria-current=${active ? "page" : nothing}
       @click=${(event: MouseEvent) => {
         if (!shouldHandleNavigationClick(event)) {

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -179,11 +179,16 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
     areUiSessionKeysEquivalent(host.getRouteSessionKey(), mainKey);
   const hasComposerDraft = host.hasSessionDraft(mainKey);
   const running = mainRow?.hasActiveRun === true;
-  const unread = mainRow?.unread === true && !active && !running;
-  const hiddenUnread = mainRow?.unread === true && !active && running;
+  const hasUnread = mainRow?.unread === true && !active;
+  const unread = hasUnread && !running;
   const homeLabel =
-    attentionLabel || hiddenUnread
-      ? [t("nav.home"), attentionLabel, hiddenUnread ? t("sessionsView.unread") : ""]
+    attentionLabel || (running && hasUnread)
+      ? [
+          t("nav.home"),
+          attentionLabel,
+          running ? t("sessionsView.activeRun") : "",
+          hasUnread ? t("sessionsView.unread") : "",
+        ]
           .filter(Boolean)
           .join(" · ")
       : undefined;

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -44,7 +44,6 @@ import {
   sessionAttentionSubtitle,
 } from "./session-attention-presentation.ts";
 import { renderSessionGlyph, renderSessionUnreadBadge } from "./session-glyph.ts";
-import { describeSessionTrailingState } from "./session-leading-indicator.ts";
 import { renderSessionRowBadges } from "./session-row-badges.ts";
 import type { SidebarAttentionSummary } from "./sidebar-attention.ts";
 import { formatSidebarBuildSubtitle } from "./sidebar-build-chip-format.ts";
@@ -181,11 +180,11 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
   const hasComposerDraft = host.hasSessionDraft(mainKey);
   const running = mainRow?.hasActiveRun === true;
   const unread = mainRow?.unread === true && !active;
+  const activeRunLabel = running ? t("sessionsView.activeRun") : "";
+  const unreadLabel = unread ? t("sessionsView.unread") : "";
   const homeDescription =
-    attentionLabel || (running && unread)
-      ? [attentionLabel, mainRow ? describeSessionTrailingState(mainRow, "none") : ""]
-          .filter(Boolean)
-          .join(" · ")
+    attentionLabel || (activeRunLabel && unreadLabel)
+      ? [attentionLabel, activeRunLabel, unreadLabel].filter(Boolean).join(" · ")
       : "";
   // Home keeps its page/attention glyph leading and shares trailing activity with session rows.
   const homeGlyph = renderSessionGlyph({

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -44,6 +44,7 @@ import {
   sessionAttentionSubtitle,
 } from "./session-attention-presentation.ts";
 import { renderSessionGlyph, renderSessionUnreadBadge } from "./session-glyph.ts";
+import { describeSessionTrailingState } from "./session-leading-indicator.ts";
 import { renderSessionRowBadges } from "./session-row-badges.ts";
 import type { SidebarAttentionSummary } from "./sidebar-attention.ts";
 import { formatSidebarBuildSubtitle } from "./sidebar-build-chip-format.ts";
@@ -179,19 +180,13 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
     areUiSessionKeysEquivalent(host.getRouteSessionKey(), mainKey);
   const hasComposerDraft = host.hasSessionDraft(mainKey);
   const running = mainRow?.hasActiveRun === true;
-  const hasUnread = mainRow?.unread === true && !active;
-  const unread = hasUnread && !running;
-  const homeLabel =
-    attentionLabel || (running && hasUnread)
-      ? [
-          t("nav.home"),
-          attentionLabel,
-          running ? t("sessionsView.activeRun") : "",
-          hasUnread ? t("sessionsView.unread") : "",
-        ]
+  const unread = mainRow?.unread === true && !active;
+  const homeDescription =
+    attentionLabel || (running && unread)
+      ? [attentionLabel, mainRow ? describeSessionTrailingState(mainRow, "none") : ""]
           .filter(Boolean)
           .join(" · ")
-      : undefined;
+      : "";
   // Home keeps its page/attention glyph leading and shares trailing activity with session rows.
   const homeGlyph = renderSessionGlyph({
     content:
@@ -199,7 +194,7 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
         ? html`<span class="nav-item__icon" aria-hidden="true">${icons.home}</span>`
         : renderSessionAttentionIcon(attention),
     running: false,
-    badge: unread ? renderSessionUnreadBadge() : nothing,
+    badge: unread && !running ? renderSessionUnreadBadge() : nothing,
   });
   return html`
     <a
@@ -213,7 +208,7 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
         preferenceDerivedFace: true,
       }).href}
       class="nav-item nav-item--home ${active ? "nav-item--active" : ""}"
-      aria-label=${homeLabel ?? nothing}
+      aria-label=${homeDescription ? `${t("nav.home")} · ${homeDescription}` : nothing}
       aria-current=${active ? "page" : nothing}
       @click=${(event: MouseEvent) => {
         if (!shouldHandleNavigationClick(event)) {

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -222,9 +222,14 @@ export function renderRecentSession(params: {
   const trailingDescription = session.isChild
     ? ""
     : describeSessionTrailingState(session, pullRequestState);
+  const childUnreadDescription =
+    session.isChild && running && session.unread ? t("sessionsView.unread") : "";
   const hasTrail = session.isChild && (session.runtimeMs != null || session.startedAt != null);
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
-  const stateId = trailingIndicator === nothing ? undefined : sidebarSessionStateId(session.key);
+  const stateId =
+    trailingIndicator === nothing && !childUnreadDescription
+      ? undefined
+      : sidebarSessionStateId(session.key);
   const openMenuFromEvent = (event: MouseEvent | KeyboardEvent) =>
     handleContextMenuEvent(
       event,
@@ -385,6 +390,9 @@ export function renderRecentSession(params: {
             </span>
           </span>
         </span>
+        ${childUnreadDescription
+          ? html`<span class="sr-only" id=${stateId}>${childUnreadDescription}</span>`
+          : nothing}
       </a>
       ${session.childSessionKeys.length > 0
         ? html`<button

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -220,16 +220,13 @@ export function renderRecentSession(params: {
       channelAvatarAuth,
     );
   const trailingDescription = session.isChild
-    ? ""
+    ? running && session.unread
+      ? t("sessionsView.unread")
+      : ""
     : describeSessionTrailingState(session, pullRequestState);
-  const childUnreadDescription =
-    session.isChild && running && session.unread ? t("sessionsView.unread") : "";
   const hasTrail = session.isChild && (session.runtimeMs != null || session.startedAt != null);
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
-  const stateId =
-    trailingIndicator === nothing && !childUnreadDescription
-      ? undefined
-      : sidebarSessionStateId(session.key);
+  const stateId = trailingDescription ? sidebarSessionStateId(session.key) : undefined;
   const openMenuFromEvent = (event: MouseEvent | KeyboardEvent) =>
     handleContextMenuEvent(
       event,
@@ -363,7 +360,9 @@ export function renderRecentSession(params: {
                 ),
               })}
               ${trailingIndicator === nothing
-                ? nothing
+                ? trailingDescription
+                  ? html`<span class="sr-only" id=${stateId}>${trailingDescription}</span>`
+                  : nothing
                 : html`<span class="session-row-aside">
                     <span
                       class="session-row-state"
@@ -390,9 +389,6 @@ export function renderRecentSession(params: {
             </span>
           </span>
         </span>
-        ${childUnreadDescription
-          ? html`<span class="sr-only" id=${stateId}>${childUnreadDescription}</span>`
-          : nothing}
       </a>
       ${session.childSessionKeys.length > 0
         ? html`<button

--- a/ui/src/components/session-attention-presentation.ts
+++ b/ui/src/components/session-attention-presentation.ts
@@ -41,16 +41,6 @@ export function sessionAttentionSubtitle(attention: SidebarSessionAttention): st
   }
 }
 
-export function renderSessionUnreadState(session: SidebarRecentSession) {
-  return !session.isChild && session.unread
-    ? html`<span
-        class="session-unread-dot sidebar-recent-session__unread"
-        role="img"
-        aria-label=${t("sessionsView.unread")}
-      ></span>`
-    : nothing;
-}
-
 export function renderSessionRunSpinner(showTitle = true) {
   return html`<span
     class="session-run-spinner sidebar-recent-session__state"
@@ -75,7 +65,13 @@ export function renderSessionState(session: SidebarRecentSession, showTitle = tr
     return renderSessionRunSpinner(showTitle);
   }
   if (!session.isChild) {
-    return renderSessionUnreadState(session);
+    return session.unread
+      ? html`<span
+          class="session-unread-dot sidebar-recent-session__unread"
+          role="img"
+          aria-label=${t("sessionsView.unread")}
+        ></span>`
+      : nothing;
   }
   const status = session.status;
   if (!status) {

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -32,7 +32,9 @@ function renderGlyphBadge(
   session: SidebarRecentSession,
   pullRequestState: SessionPullRequestIndicatorState,
 ): SessionGlyphContent {
-  if (session.unread) {
+  // The run ring owns transient activity while active; unread stays stored
+  // and returns as the glyph badge after the run ends.
+  if (session.unread && !session.hasActiveRun) {
     return renderSessionUnreadBadge();
   }
   if (pullRequestState === "none") {

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -5,7 +5,6 @@ import { icons } from "./icons.ts";
 import {
   renderSessionAttentionIcon,
   renderSessionState,
-  renderSessionUnreadState,
 } from "./session-attention-presentation.ts";
 import {
   renderSessionGlyph,
@@ -81,16 +80,10 @@ function renderSessionTrailingState(
   pullRequestState: SessionPullRequestIndicatorState,
 ) {
   const sessionState = renderSessionState(session, false);
-  const concurrentUnreadState = session.hasActiveRun ? renderSessionUnreadState(session) : nothing;
-  if (
-    pullRequestState === "none" &&
-    sessionState === nothing &&
-    concurrentUnreadState === nothing
-  ) {
+  if (pullRequestState === "none" && sessionState === nothing) {
     return nothing;
   }
-  return html`${renderPullRequestIndicator(pullRequestState, false)} ${sessionState}
-  ${concurrentUnreadState}`;
+  return html`${renderPullRequestIndicator(pullRequestState, false)} ${sessionState}`;
 }
 
 function renderPersistentSessionIcon(icon: string) {

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -32,8 +32,6 @@ function renderGlyphBadge(
   session: SidebarRecentSession,
   pullRequestState: SessionPullRequestIndicatorState,
 ): SessionGlyphContent {
-  // The run ring owns transient activity while active; unread stays stored
-  // and returns as the glyph badge after the run ends.
   if (session.unread && !session.hasActiveRun) {
     return renderSessionUnreadBadge();
   }

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -451,7 +451,7 @@ suite.define(() => {
       expect(layout.state.right).toBeLessThanOrEqual(layout.endcap.right);
       expect(layout.spinner.left).toBeGreaterThanOrEqual(layout.endcap.left);
       expect(layout.spinner.right).toBeLessThanOrEqual(layout.endcap.right);
-      expect(layout.atoms.length).toBeGreaterThanOrEqual(4);
+      expect(layout.atoms.length).toBeGreaterThanOrEqual(3);
       for (const atom of layout.atoms) {
         expect(atom.left).toBeGreaterThanOrEqual(layout.endcap.left);
         expect(atom.right).toBeLessThanOrEqual(layout.endcap.right);

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -364,19 +364,42 @@ suite.define(() => {
         .toBe(true);
       await expect.poll(() => state.locator(".session-run-spinner").isVisible()).toBe(true);
       await expect.poll(() => state.locator(".session-unread-dot").count()).toBe(0);
-      const [endcapBounds, openPullRequestBounds, spinnerBounds] = await Promise.all([
-        row.locator(".sidebar-recent-session__details-endcap").boundingBox(),
-        state.locator("[data-session-pr-state='open'] svg").boundingBox(),
-        state.locator(".session-run-spinner").boundingBox(),
-      ]);
-      if (!endcapBounds || !openPullRequestBounds || !spinnerBounds) {
-        throw new Error("Expected visible session state geometry");
-      }
-      for (const iconBounds of [openPullRequestBounds, spinnerBounds]) {
-        expect(iconBounds.x).toBeGreaterThanOrEqual(endcapBounds.x);
-        expect(iconBounds.x + iconBounds.width).toBeLessThanOrEqual(
-          endcapBounds.x + endcapBounds.width,
+      const stateLayout = await row.evaluate((element) => {
+        const endcap = element.querySelector<HTMLElement>(
+          ".sidebar-recent-session__details-endcap",
         );
+        const atoms = Array.from(
+          element.querySelectorAll<HTMLElement>(
+            ".session-row-state :is([data-session-pr-state='open'], .session-run-spinner)",
+          ),
+        );
+        if (!endcap || atoms.length !== 2) {
+          throw new Error("Expected visible session state geometry");
+        }
+        const layoutLeft = (node: HTMLElement) => {
+          let left = 0;
+          for (
+            let current: HTMLElement | null = node;
+            current;
+            current = current.offsetParent as HTMLElement | null
+          ) {
+            left += current.offsetLeft;
+          }
+          return left;
+        };
+        const endcapLeft = layoutLeft(endcap);
+        return {
+          endcapLeft,
+          endcapRight: endcapLeft + endcap.offsetWidth,
+          atoms: atoms.map((atom) => ({
+            left: layoutLeft(atom),
+            right: layoutLeft(atom) + atom.offsetWidth,
+          })),
+        };
+      });
+      for (const atom of stateLayout.atoms) {
+        expect(atom.left).toBeGreaterThanOrEqual(stateLayout.endcapLeft);
+        expect(atom.right).toBeLessThanOrEqual(stateLayout.endcapRight);
       }
       const link = row.locator(".sidebar-recent-session__link");
       const rowText = row.locator(".sidebar-recent-session__text");

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -363,17 +363,16 @@ suite.define(() => {
         .poll(() => state.locator("[data-session-pr-state='open']").isVisible())
         .toBe(true);
       await expect.poll(() => state.locator(".session-run-spinner").isVisible()).toBe(true);
-      await expect.poll(() => state.locator(".session-unread-dot").isVisible()).toBe(true);
-      const [endcapBounds, openPullRequestBounds, spinnerBounds, unreadBounds] = await Promise.all([
+      await expect.poll(() => state.locator(".session-unread-dot").count()).toBe(0);
+      const [endcapBounds, openPullRequestBounds, spinnerBounds] = await Promise.all([
         row.locator(".sidebar-recent-session__details-endcap").boundingBox(),
         state.locator("[data-session-pr-state='open'] svg").boundingBox(),
         state.locator(".session-run-spinner").boundingBox(),
-        state.locator(".session-unread-dot").boundingBox(),
       ]);
-      if (!endcapBounds || !openPullRequestBounds || !spinnerBounds || !unreadBounds) {
-        throw new Error("Expected visible combined session state geometry");
+      if (!endcapBounds || !openPullRequestBounds || !spinnerBounds) {
+        throw new Error("Expected visible session state geometry");
       }
-      for (const iconBounds of [openPullRequestBounds, spinnerBounds, unreadBounds]) {
+      for (const iconBounds of [openPullRequestBounds, spinnerBounds]) {
         expect(iconBounds.x).toBeGreaterThanOrEqual(endcapBounds.x);
         expect(iconBounds.x + iconBounds.width).toBeLessThanOrEqual(
           endcapBounds.x + endcapBounds.width,

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -331,7 +331,15 @@ describe("AppSidebar agent chip", () => {
         path: "",
         count: 1,
         defaults: { modelProvider: null, model: null, contextTokens: null },
-        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 5, hasActiveRun: true }],
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 5,
+            hasActiveRun: true,
+            unread: true,
+          },
+        ],
       },
       agentId: "main",
     });
@@ -345,9 +353,24 @@ describe("AppSidebar agent chip", () => {
     expect(spinner).not.toBeNull();
     expect(sidebar.querySelector(".nav-item--home .nav-item__icon")).not.toBeNull();
     expect(sidebar.querySelector(".nav-item--home .session-glyph__ring")).toBeNull();
+    expect(sidebar.querySelector(".nav-item--home .session-glyph__badge--unread")).toBeNull();
     expect(spinner?.getAttribute("role")).toBe("img");
     expect(spinner?.getAttribute("aria-label")).toBe("Active run");
     expect(spinner?.getAttribute("title")).toBe("Active run");
+
+    harness.publishList({
+      result: {
+        ts: 3,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 6, unread: true }],
+      },
+      agentId: "main",
+    });
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".nav-item--home .session-run-spinner")).toBeNull();
+    expect(sidebar.querySelector(".nav-item--home .session-glyph__badge--unread")).not.toBeNull();
   });
 
   it("uses the shared tooltip for the Home dashboard glyph", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -354,6 +354,14 @@ describe("AppSidebar session indicators", () => {
           kind: "direct",
           label: "Open PR child",
           updatedAt: 2,
+          hasActiveRun: true,
+          status: "running",
+          unread: true,
+          agentStatus: {
+            note: "Waiting for input",
+            attention: "key",
+            expiresAt: Date.now() + 60_000,
+          },
           worktree: { id: "wt-open", branch: "feature/open", repoRoot: "/repo" },
         },
         {
@@ -419,6 +427,14 @@ describe("AppSidebar session indicators", () => {
     expect(pinnedLead?.innerHTML).toBe(runningLead?.innerHTML);
     expect(pinnedLead?.querySelector("[data-session-pr-state]")).toBeNull();
     expect(pinnedRow?.querySelector(".session-row-state")).toBeNull();
+
+    const attentionLead = sidebar.querySelector(
+      `[data-session-key="${openPullRequestKey}"] .sidebar-session-indicator`,
+    );
+    expect(attentionLead?.querySelector('[data-session-attention="agent"]')).not.toBeNull();
+    expect(attentionLead?.querySelector(".session-glyph__ring")).not.toBeNull();
+    expect(attentionLead?.querySelector(".session-glyph__badge--unread")).toBeNull();
+    expect(attentionLead?.querySelector('[data-session-pr-state="open"]')).not.toBeNull();
   });
 
   it("prioritizes an active run over unread activity", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -421,7 +421,7 @@ describe("AppSidebar session indicators", () => {
     expect(pinnedRow?.querySelector(".session-row-state")).toBeNull();
   });
 
-  it("trails transient activity while keeping persistent status leading", async () => {
+  it("prioritizes an active run over unread activity", async () => {
     const keys = {
       plain: "agent:main:plain",
       forked: "agent:main:forked",
@@ -524,7 +524,7 @@ describe("AppSidebar session indicators", () => {
     ).not.toBeNull();
     expect(
       runningUnread?.querySelector(".session-row-aside > .session-row-state .session-unread-dot"),
-    ).not.toBeNull();
+    ).toBeNull();
 
     for (const key of [keys.unread, keys.runningUnread]) {
       const link = sidebar.querySelector(`[data-session-key="${key}"] a`);

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -246,13 +246,16 @@ describe("AppSidebar session indicators", () => {
     for (const row of result.sessions) {
       row.hasActiveRun = true;
       row.status = "running";
+      if (row.key === mainKey) {
+        row.unread = true;
+      }
     }
     const { sidebar } = await mountSidebar(
       createGatewayHarness({} as GatewayBrowserClient).gateway,
       sessions.sessions,
     );
     sidebar.activeRouteId = "chat";
-    sidebar.sessionKey = mainKey;
+    sidebar.sessionKey = workingKey;
     sidebar.outboxAttentionCountForSession = (sessionKey) => (sessionKey === mainKey ? 2 : 0);
     sidebar.hasSessionDraft = (sessionKey) => sessionKey === mainKey;
     sidebar.requestUpdate();
@@ -271,6 +274,8 @@ describe("AppSidebar session indicators", () => {
     expect(homeSpinner?.getAttribute("aria-label")).toBe(
       sessionSpinner?.getAttribute("aria-label"),
     );
+    expect(home?.querySelector(".session-unread-dot")).toBeNull();
+    expect(home?.getAttribute("aria-label")).toBe("Home · Unread");
     expect(
       home?.querySelector(".nav-item__state .session-row-badge--attention")?.textContent,
     ).toContain("2");
@@ -435,6 +440,14 @@ describe("AppSidebar session indicators", () => {
     expect(attentionLead?.querySelector(".session-glyph__ring")).not.toBeNull();
     expect(attentionLead?.querySelector(".session-glyph__badge--unread")).toBeNull();
     expect(attentionLead?.querySelector('[data-session-pr-state="open"]')).not.toBeNull();
+    const attentionLink = sidebar.querySelector(
+      `[data-session-key="${openPullRequestKey}"] .sidebar-recent-session__link`,
+    );
+    const attentionDescriptionId = attentionLink?.getAttribute("aria-describedby");
+    expect(attentionDescriptionId).toBe(
+      `sidebar-session-state-${encodeURIComponent(openPullRequestKey)}`,
+    );
+    expect(sidebar.querySelector(`[id="${attentionDescriptionId}"]`)?.textContent).toBe("Unread");
   });
 
   it("prioritizes an active run over unread activity", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -275,7 +275,7 @@ describe("AppSidebar session indicators", () => {
       sessionSpinner?.getAttribute("aria-label"),
     );
     expect(home?.querySelector(".session-unread-dot")).toBeNull();
-    expect(home?.getAttribute("aria-label")).toBe("Home · Unread");
+    expect(home?.getAttribute("aria-label")).toBe("Home · Active run · Unread");
     expect(
       home?.querySelector(".nav-item__state .session-row-badge--attention")?.textContent,
     ).toContain("2");


### PR DESCRIPTION
Running unread sessions could show a loading spinner and an unread dot at the same time. The duplicate visual state made it unclear which indicator mattered. This PR gives an active run visual precedence while keeping the stored unread fact available to screen readers. While running, the row shows only the spinner or ring and announces `Active run · Unread`; after completion, the unread dot returns.

## Change breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Implementation | 6 | +86 | -28 |
| Tests and fixtures | 2 | +37 | -15 |
| **Total** | **8** | **+123** | **-43** |

## Proof

The same running-and-unread state is used for each sidebar surface:

| State | Direct base | PR |
| --- | --- | --- |
| Running and unread | Spinner/ring and unread dot appear together | Only the spinner/ring is visible; accessible state is `Active run · Unread` |
| Finished and unread | Unread dot | Unread dot |

### Regular session row

<img width="237" height="30" alt="Running session row showing only the activity spinner" src="https://github.com/user-attachments/assets/2238ab19-98c8-4c31-8c5f-1a1aa657314b" />

<img width="237" height="30" alt="Finished session row showing the unread dot" src="https://github.com/user-attachments/assets/77781c46-a523-47a2-b81c-69fcbc41399e" />

https://github.com/user-attachments/assets/ed6d4574-6988-46a3-81f2-9e52996eee55

### Attention child

<img width="217" height="42" alt="Running attention child with run ring and no unread badge" src="https://github.com/user-attachments/assets/1b8095f9-a7a4-4284-ab8a-14356c309a5e" />

<img width="217" height="42" alt="Finished attention child with unread badge restored" src="https://github.com/user-attachments/assets/99657903-c5d8-44df-80ab-7512b078ea13" />

[Attention-child walkthrough](https://github.com/user-attachments/assets/744c9297-e6a1-4cc4-b6b1-fbaedb4a647b)

### Home

<img width="237" height="32" alt="Running Home row with spinner and no unread dot" src="https://github.com/user-attachments/assets/6b111bf4-aa6a-4044-b87c-cf9bbeffa3ff" />

<img width="237" height="32" alt="Finished Home row with unread dot restored" src="https://github.com/user-attachments/assets/1d12e21c-6dfd-4113-82c0-50e45014fadc" />

[Home walkthrough](https://github.com/user-attachments/assets/344e6d25-ea22-4381-9de2-ab5338fc667f)

These captures prove the unchanged visual rule. The latest follow-up changes only nonvisual unread semantics for Home and active child glyphs.

## How to verify

1. Render a regular row, attention child, or Home with both active-run and unread state.
2. Confirm only the spinner or ring is visible and the accessible description still includes `Unread`.
3. Finish the run without clearing unread state and confirm the unread dot returns.

Exact head: `3342d9d869567c0836cf8c081e45ed6362f58dd7`.