### PR TITLE
fix(gateway): transcript commits leave sessions.list cache serving stale previews

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -2,6 +2,7 @@ import type { SessionsListParams } from "../../../packages/gateway-protocol/src/
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import { readSessionIdentityMutationVersion } from "../../sessions/session-lifecycle-events.js";
+import { readSessionTranscriptUpdateVersion } from "../../sessions/transcript-events.js";
 import { readSessionLifecyclePersistenceVersion } from "../session-lifecycle-state.js";
 import { isGatewayAdmin } from "../session-sharing.js";
 import { readSessionTitleProjectionUnavailableVersion } from "../session-transcript-title-reader.js";
@@ -15,6 +16,7 @@ type SessionListFence = {
   lifecyclePersistenceVersion: number;
   sessionIdentityMutationVersion: number;
   sessionsMutationVersion: number;
+  sessionTranscriptUpdateVersion: number;
   titleProjectionUnavailableVersion: number;
   workerPlacementDiskSpaceVersion: number;
 };
@@ -35,6 +37,9 @@ function readSessionListFence(context: GatewayRequestContext): SessionListFence 
     lifecyclePersistenceVersion: readSessionLifecyclePersistenceVersion(),
     sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
     sessionsMutationVersion: readSessionsMutationVersion(context),
+    // Rows embed transcript-derived previews/titles; a committed transcript
+    // write without a session mutation must still invalidate reuse.
+    sessionTranscriptUpdateVersion: readSessionTranscriptUpdateVersion(),
     titleProjectionUnavailableVersion: readSessionTitleProjectionUnavailableVersion(),
     workerPlacementDiskSpaceVersion: context.workerPlacementDiskSpaceReader?.version() ?? 0,
   };
@@ -46,6 +51,7 @@ function matchesSessionListFence(value: SessionListFence, fence: SessionListFenc
     value.lifecyclePersistenceVersion === fence.lifecyclePersistenceVersion &&
     value.sessionIdentityMutationVersion === fence.sessionIdentityMutationVersion &&
     value.sessionsMutationVersion === fence.sessionsMutationVersion &&
+    value.sessionTranscriptUpdateVersion === fence.sessionTranscriptUpdateVersion &&
     value.titleProjectionUnavailableVersion === fence.titleProjectionUnavailableVersion &&
     value.workerPlacementDiskSpaceVersion === fence.workerPlacementDiskSpaceVersion
   );

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -54,6 +54,7 @@ vi.mock("../session-utils.js", async (importOriginal) => {
 
 const { sessionReadHandlers } = await import("./sessions-read.js");
 const { emitSessionsChanged } = await import("./session-change-event.js");
+const { emitSessionTranscriptUpdate } = await import("../../sessions/transcript-events.js");
 
 function identifiedClient(profileId: string): GatewayClient {
   return {
@@ -282,6 +283,28 @@ describe("sessions.list single-flight", () => {
         },
       });
       await listSessions({ client, context, request });
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("invalidates a completed result after a committed transcript update", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+      const clock = vi.spyOn(Date, "now").mockReturnValue(60_400);
+
+      const first = await listSessions({ client, context, request });
+      clock.mockReturnValue(60_401);
+
+      // A transcript commit changes row previews/derived titles without any
+      // session-entry mutation; serving the cached page would hide it forever.
+      emitSessionTranscriptUpdate({
+        target: { agentId: "main", sessionId: "main-active", sessionKey: "agent:main:active" },
+      });
+      const refreshed = await listSessions({ client, context, request });
+      expect(refreshed).not.toBe(first);
       expect(loader.calls).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -3,7 +3,7 @@ import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coerc
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { parseAgentSessionKey } from "../routing/session-key.js";
-import { resolveGlobalSet } from "../shared/global-singleton.js";
+import { resolveGlobalSet, resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 /** Storage-neutral identity for the session transcript that changed. */
 type SessionTranscriptUpdateTarget = {
@@ -49,6 +49,16 @@ const INTERNAL_SESSION_TRANSCRIPT_LISTENERS = resolveGlobalSet<InternalSessionTr
   "close-and-restart",
 );
 
+const SESSION_TRANSCRIPT_UPDATE_STATE = resolveGlobalSingleton(
+  Symbol.for("openclaw.sessionTranscriptUpdateState"),
+  () => ({ version: 0 }),
+);
+
+/** Monotonic fence for projections that embed transcript-derived fields (previews, titles). */
+export function readSessionTranscriptUpdateVersion(): number {
+  return SESSION_TRANSCRIPT_UPDATE_STATE.version;
+}
+
 /** Registers a listener for normalized session transcript updates. */
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
   SESSION_TRANSCRIPT_LISTENERS.add(listener);
@@ -73,6 +83,9 @@ export function emitSessionTranscriptUpdate(update: InternalSessionTranscriptUpd
   if (!nextUpdate) {
     return;
   }
+  // Commit-then-broadcast: a subscriber's refetch races the sessions.list
+  // cache, so the fence must advance before any listener can observe the write.
+  SESSION_TRANSCRIPT_UPDATE_STATE.version += 1;
   const publicUpdate = projectPublicSessionTranscriptUpdate(nextUpdate);
   if (publicUpdate) {
     emitPublicSessionTranscriptUpdate(publicUpdate);


### PR DESCRIPTION
## What Problem This Solves

`sessions.list` completed results are cached behind a fence of monotonic versions (identity, session mutation, run index, title projection). But transcript commits — new messages persisted to a session — reach subscribed clients through the raw transcript-update broadcast path (`src/gateway/server-session-events.ts` → `sessions.changed` / `session.message`), which bumps **no** fence version; only `emitSessionsChanged` advances `sessionsMutationVersion`. A list page cached moments before a message commit therefore stays "valid": clients refetching on `sessions.changed` get the cached rows with stale `lastMessagePreview`/derived titles until some unrelated session mutation finally bumps a fence.

This is the third instance of the same structural class this campaign fixed on the cron path (#123253, `sessionAutomationVersion`) and the lifecycle persistence path (#123259, `lifecyclePersistenceVersion`): a broadcast without a fence bump makes the "refetch on change" contract serve the pre-change snapshot.

## Why This Change Was Made

Record facts where they happen: the transcript event emitter is the single choke point every transcript writer already flows through (`emitSessionTranscriptUpdate` in `src/sessions/transcript-events.ts`). It now owns a monotonic `sessionTranscriptUpdateVersion`, advanced **before** listeners run (commit-then-broadcast — a subscriber's refetch must never race ahead of the invalidation), and the sessions.list fence includes it.

## User Impact

Session list previews and derived titles update on the next fetch after a message lands, instead of freezing at the cached snapshot until an unrelated mutation.

## Evidence

- Regression fails pre-fix, passes post-fix (`git stash` verified): cached list + `emitSessionTranscriptUpdate` → refetch must rebuild (`loader.calls === 2`); pre-fix serves the cached page.
- Suites green: `node scripts/run-vitest.mjs run src/gateway/server-methods/sessions-read-cache.test.ts src/sessions/` (2 shards).
- Core test typecheck green: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`.
- Autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.98)".
- Production LOC: +20/−1 (7 comment lines; the fence input + its owner). Tests +23.
