### PR TITLE
fix(codex): projected history no longer invokes skills

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import {
   fitCodexProjectedContextForTurnStart,
+  neutralizeCodexToolMentionsOutsideRange,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
 } from "./context-engine-projection.js";
@@ -208,6 +209,37 @@ describe("projectContextEngineAssemblyForCodex", () => {
 
     expect(result.promptText.length).toBeGreaterThan(60_000);
     expect(result.promptText).not.toContain("[truncated ");
+  });
+
+  it("neutralizes non-request tool mentions while preserving the current request", () => {
+    const currentRequest = "Use $current-skill for this request";
+    const promptText = [
+      "History: $example-manual and [$other-skill](skill://other/SKILL.md)",
+      "Shell context: cd $HOME/project && echo $custom_var",
+      `Current user request:\n${currentRequest}`,
+      "Hook context: $hook-skill",
+    ].join("\n");
+    const requestStart = promptText.indexOf(currentRequest);
+    const result = neutralizeCodexToolMentionsOutsideRange({
+      promptText,
+      preservedRange: { start: requestStart, end: requestStart + currentRequest.length },
+      contextRange: { start: 0, end: requestStart },
+      requestRange: { start: requestStart, end: requestStart + currentRequest.length },
+    });
+
+    expect(result.promptText).toContain("$\u200Bexample-manual");
+    expect(result.promptText).toContain("[$\u200Bother-skill](skill://other/SKILL.md)");
+    expect(result.promptText).toContain("cd $HOME/project && echo $\u200Bcustom_var");
+    expect(result.promptText).toContain("Hook context: $\u200Bhook-skill");
+    expect(result.promptText).not.toContain("$example-manual");
+    expect(result.promptText).not.toContain("$other-skill");
+    expect(result.promptText.slice(result.preservedRange.start, result.preservedRange.end)).toBe(
+      currentRequest,
+    );
+    expect(result.contextRange && result.promptText.slice(0, result.contextRange.end)).toContain(
+      "$\u200Bexample-manual",
+    );
+    expect(result.requestRange).toEqual(result.preservedRange);
   });
 
   it("fits projected context under the Codex turn input limit", () => {

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -10,6 +10,7 @@ type CodexContextProjection = {
   developerInstructionAddition?: string;
   promptText: string;
   promptContextRange?: CodexProjectedContextRange;
+  promptRequestRange: CodexProjectedContextRange;
   assembledMessages: AgentMessage[];
   prePromptMessageCount: number;
 };
@@ -37,6 +38,19 @@ const CODEX_TURN_START_TEXT_INPUT_MAX_CHARS = 1 << 20;
 const DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS = 20_000;
 const MIN_PROMPT_BUDGET_RATIO = 0.5;
 const MIN_PROMPT_BUDGET_TOKENS = 8_000;
+const CODEX_IGNORED_TOOL_MENTION_NAMES = new Set([
+  "HOME",
+  "LANG",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "XDG_CONFIG_HOME",
+]);
 
 /** Projects assembled OpenClaw context-engine messages into Codex prompt inputs. */
 export function projectContextEngineAssemblyForCodex(params: {
@@ -66,6 +80,10 @@ export function projectContextEngineAssemblyForCodex(params: {
     promptPrefix && boundedContext
       ? { start: promptPrefix.length, end: promptPrefix.length + boundedContext.length }
       : undefined;
+  const promptRequestRange = {
+    start: promptText.length - prompt.length,
+    end: promptText.length,
+  };
 
   return {
     ...(params.systemPromptAddition?.trim()
@@ -73,8 +91,59 @@ export function projectContextEngineAssemblyForCodex(params: {
       : {}),
     promptText,
     ...(promptContextRange ? { promptContextRange } : {}),
+    promptRequestRange,
     assembledMessages: params.assembledMessages,
     prePromptMessageCount: params.originalHistoryMessages.length,
+  };
+}
+
+/** Neutralizes Codex tool mentions outside the authenticated current-request span. */
+export function neutralizeCodexToolMentionsOutsideRange(params: {
+  promptText: string;
+  preservedRange: CodexProjectedContextRange;
+  contextRange?: CodexProjectedContextRange;
+  requestRange?: CodexProjectedContextRange;
+}): {
+  promptText: string;
+  preservedRange: CodexProjectedContextRange;
+  contextRange?: CodexProjectedContextRange;
+  requestRange?: CodexProjectedContextRange;
+} {
+  const preservedRange = normalizeProjectedContextRange(
+    params.preservedRange,
+    params.promptText.length,
+  );
+  if (!preservedRange) {
+    return params;
+  }
+  const prefix = params.promptText.slice(0, preservedRange.start);
+  const preserved = params.promptText.slice(preservedRange.start, preservedRange.end);
+  const suffix = params.promptText.slice(preservedRange.end);
+  const neutralizedPrefix = neutralizeCodexToolMentions(prefix);
+  const neutralizedSuffix = neutralizeCodexToolMentions(suffix);
+  const promptText = `${neutralizedPrefix}${preserved}${neutralizedSuffix}`;
+  const mapRange = (
+    range: CodexProjectedContextRange | undefined,
+  ): CodexProjectedContextRange | undefined => {
+    const normalized = normalizeProjectedContextRange(range, params.promptText.length);
+    if (!normalized) {
+      return undefined;
+    }
+    return {
+      start: mapNeutralizedOffset(params.promptText, preservedRange, normalized.start),
+      end: mapNeutralizedOffset(params.promptText, preservedRange, normalized.end),
+    };
+  };
+  const contextRange = mapRange(params.contextRange);
+  const requestRange = mapRange(params.requestRange);
+  return {
+    promptText,
+    preservedRange: {
+      start: neutralizedPrefix.length,
+      end: neutralizedPrefix.length + preserved.length,
+    },
+    ...(contextRange ? { contextRange } : {}),
+    ...(requestRange ? { requestRange } : {}),
   };
 }
 
@@ -240,6 +309,35 @@ function renderMessagesForCodexContext(
     })
     .filter((value): value is string => Boolean(value))
     .join("\n\n");
+}
+
+function neutralizeCodexToolMentions(text: string): string {
+  return text.replace(/\$([A-Za-z0-9_:-]+)/g, (match, name: string) => {
+    return CODEX_IGNORED_TOOL_MENTION_NAMES.has(name.toUpperCase()) ? match : `$\u200B${name}`;
+  });
+}
+
+function mapNeutralizedOffset(
+  promptText: string,
+  preservedRange: CodexProjectedContextRange,
+  offset: number,
+): number {
+  const prefixEnd = Math.min(offset, preservedRange.start);
+  const neutralizedPrefixLength = neutralizeCodexToolMentions(
+    promptText.slice(0, prefixEnd),
+  ).length;
+  if (offset <= preservedRange.start) {
+    return neutralizedPrefixLength;
+  }
+  const preservedLength = Math.min(offset, preservedRange.end) - preservedRange.start;
+  if (offset <= preservedRange.end) {
+    return neutralizedPrefixLength + preservedLength;
+  }
+  return (
+    neutralizedPrefixLength +
+    preservedLength +
+    neutralizeCodexToolMentions(promptText.slice(preservedRange.end, offset)).length
+  );
 }
 
 function renderMessageBody(

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -167,6 +167,7 @@ export async function prepareCodexAttemptContext(
   const promptState = {
     promptText: params.prompt,
     promptContextRange: undefined as CodexProjectedContextRange | undefined,
+    promptRequestRange: { start: 0, end: params.prompt.length } as CodexProjectedContextRange,
     developerInstructions: baseDeveloperInstructions,
     prePromptMessageCount: historyState.messages.length,
     contextEngineProjection: undefined as CodexContextEngineThreadBootstrapProjection | undefined,

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -14,6 +14,7 @@ import {
 } from "./attempt-context.js";
 import {
   fitCodexProjectedContextForTurnStart,
+  neutralizeCodexToolMentionsOutsideRange,
   projectContextEngineAssemblyForCodex,
   type CodexProjectedContextRange,
 } from "./context-engine-projection.js";
@@ -82,6 +83,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     });
     promptState.promptText = projection.promptText;
     promptState.promptContextRange = projection.promptContextRange;
+    promptState.promptRequestRange = projection.promptRequestRange;
     promptState.prePromptMessageCount = projection.prePromptMessageCount;
   };
   const applyActiveContextEngineProjection = async (
@@ -163,6 +165,9 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     promptState.promptContextRange = projectionDecision.project
       ? projection.promptContextRange
       : undefined;
+    promptState.promptRequestRange = projectionDecision.project
+      ? projection.promptRequestRange
+      : { start: 0, end: params.prompt.length };
     promptState.developerInstructions = joinPresentSections(
       baseDeveloperInstructions,
       projection.developerInstructionAddition,
@@ -182,8 +187,13 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
   }
   const codexModelInputHistoryMessages: typeof historyState.messages = [];
   const buildPromptFromCurrentInputs = async () => {
+    const inputPrompt = prependCurrentInboundContext(
+      promptState.promptText,
+      params.currentInboundContext,
+    );
+    const promptStateOffset = inputPrompt.length - promptState.promptText.length;
     const result = await resolveAgentHarnessBeforePromptBuildResult({
-      prompt: prependCurrentInboundContext(promptState.promptText, params.currentInboundContext),
+      prompt: inputPrompt,
       developerInstructions: promptState.developerInstructions,
       messages: structuredClone(historyState.messages),
       ctx: hookContext,
@@ -194,7 +204,17 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
         "Codex app-server cannot enforce before_prompt_build toolsAllow; use the embedded or Copilot runtime for turn-scoped tool policy.",
       );
     }
-    return result;
+    const currentRequestRange = result.promptInputRange
+      ? {
+          start:
+            result.promptInputRange.start +
+            promptStateOffset +
+            promptState.promptRequestRange.start,
+          end:
+            result.promptInputRange.start + promptStateOffset + promptState.promptRequestRange.end,
+        }
+      : undefined;
+    return { ...result, currentRequestRange };
   };
   const resolveShiftedPromptInputRange = (
     prompt: string,
@@ -259,6 +279,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
   const decorateCodexTurnPromptText = (promptBuildResult: {
     prompt: string;
     promptInputRange?: { start: number; end: number };
+    currentRequestRange?: { start: number; end: number };
   }) => {
     const turnPromptText = prependCodexOpenClawPromptContext(
       promptBuildResult.prompt,
@@ -274,22 +295,35 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       promptBuildResult.promptInputRange,
       turnPromptText,
     );
-    const preservedRange =
+    const currentRequestRange =
       resolveShiftedPromptInputRange(
         promptBuildResult.prompt,
-        promptBuildResult.promptInputRange,
+        promptBuildResult.currentRequestRange,
         turnPromptText,
       ) ??
       resolveCodexDeliveryHintPreservedInputRange({
         prompt: promptBuildResult.prompt,
-        promptInputRange: promptBuildResult.promptInputRange,
+        promptInputRange: promptBuildResult.currentRequestRange,
         decoratedPrompt: turnPromptText,
       });
+    const neutralized = currentRequestRange
+      ? neutralizeCodexToolMentionsOutsideRange({
+          promptText: turnPromptText,
+          preservedRange: currentRequestRange,
+          contextRange: projectedRanges?.contextRange,
+          requestRange: projectedRanges?.requestRange,
+        })
+      : {
+          promptText: turnPromptText,
+          contextRange: projectedRanges?.contextRange,
+          requestRange: currentRequestRange,
+          preservedRange: currentRequestRange,
+        };
     return fitCodexProjectedContextForTurnStart({
-      promptText: turnPromptText,
-      contextRange: projectedRanges?.contextRange,
-      requestRange: projectedRanges?.requestRange,
-      preservedRange,
+      promptText: neutralized.promptText,
+      contextRange: neutralized.contextRange,
+      requestRange: neutralized.requestRange,
+      preservedRange: neutralized.preservedRange,
     });
   };
   const firstPromptBuild = await buildPromptFromCurrentInputs();
@@ -370,6 +404,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     });
     promptState.promptText = projection.promptText;
     promptState.promptContextRange = projection.promptContextRange;
+    promptState.promptRequestRange = projection.promptRequestRange;
     promptState.prePromptMessageCount = projection.prePromptMessageCount;
     return true;
   };

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -277,7 +277,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     openFileBackedSessionManagerForTest(sessionFile, { sessionId: "session-1" }).appendMessage(
-      assistantMessage("existing context", Date.now()) as never,
+      assistantMessage("The user did not invoke $example-manual.", Date.now()) as never,
     );
     const openSpy = vi.spyOn(SessionManager, "open");
     const contextEngine = createContextEngine();
@@ -345,6 +345,8 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       "context-engine system",
     );
     expectRequestInputTextContains(harness, "OpenClaw assembled context for this turn:");
+    expectRequestInputTextContains(harness, "$\u200Bexample-manual");
+    expect(getRequestInputText(harness)).not.toContain("$example-manual");
 
     await harness.completeTurn();
     await run;
@@ -478,6 +480,8 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(inputText).toContain("current inbound context survives");
     expect(inputText).toContain("current prompt survives");
     expect(inputText).toContain("hook append marker");
+    expect(inputText).toContain("</conversation_context>");
+    expect(inputText).toContain("Current user request:");
 
     await harness.completeTurn();
     await run;
@@ -1783,7 +1787,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     params.currentInboundContext = {
       text: [
         "Conversation context (chronological, selected for current message):",
-        "#6474 Sun 2026-05-10 22:22 GMT+5:30 [reply target] OpenClaw: anchor REPLYCTX this is the old message",
+        "#6474 Sun 2026-05-10 22:22 GMT+5:30 [reply target] OpenClaw: anchor REPLYCTX mentioned $example-manual from $HOME",
         "#6498 Sun 2026-05-10 22:22 GMT+5:30 OpenClaw: filler REPLYCTX 23",
       ].join("\n"),
     };
@@ -1795,6 +1799,8 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(inputText).toContain("OpenClaw assembled context for this turn:");
     expect(inputText).toContain("Current user request:\nhello");
     expect(inputText).toContain("[reply target] OpenClaw: anchor REPLYCTX");
+    expect(inputText).toContain("$\u200Bexample-manual from $HOME");
+    expect(inputText).not.toContain("$example-manual");
     expect(inputText.trim().startsWith("Conversation context (chronological")).toBe(true);
 
     await harness.completeTurn();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2578,8 +2578,8 @@ describe("runCodexAppServerAttempt", () => {
       systemPrompt: "custom codex system",
       prependSystemContext: "pre system",
       appendSystemContext: "post system",
-      prependContext: "queued context",
-      appendContext: "tail context",
+      prependContext: "queued $example-manual context from $HOME",
+      appendContext: "tail $hook-skill context",
       toolsAllow: ["*"],
     }));
     initializeGlobalHookRunner(
@@ -2592,7 +2592,9 @@ describe("runCodexAppServerAttempt", () => {
     const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(assistantMessage("previous turn", Date.now()));
     const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    const params = createParams(sessionFile, workspaceDir);
+    params.prompt = "use $current-skill now";
+    const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
@@ -2607,7 +2609,7 @@ describe("runCodexAppServerAttempt", () => {
       },
       { runId?: string; sessionId?: string },
     ];
-    expect(hookInput.prompt).toBe("hello");
+    expect(hookInput.prompt).toBe("use $current-skill now");
     expect(hookInput.messages).toEqual([
       expect.objectContaining({
         role: "assistant",
@@ -2628,14 +2630,20 @@ describe("runCodexAppServerAttempt", () => {
       | { input?: Array<{ text?: string; text_elements?: unknown[]; type?: string }> }
       | undefined;
     expect(turnStartParams?.input).toEqual([
-      { type: "text", text: "queued context\n\nhello\n\ntail context", text_elements: [] },
+      {
+        type: "text",
+        text: "queued $\u200Bexample-manual context from $HOME\n\nuse $current-skill now\n\ntail $\u200Bhook-skill context",
+        text_elements: [],
+      },
     ]);
     expect(JSON.stringify(turnStartParams)).not.toContain("previous turn");
     const [llmInputPayload] = mockCall(llmInput, "llm_input") as [
       { historyMessages?: unknown[]; prompt?: string },
       unknown,
     ];
-    expect(llmInputPayload.prompt).toBe("queued context\n\nhello\n\ntail context");
+    expect(llmInputPayload.prompt).toBe(
+      "queued $\u200Bexample-manual context from $HOME\n\nuse $current-skill now\n\ntail $\u200Bhook-skill context",
+    );
     expect(llmInputPayload.historyMessages).toEqual([]);
     expect(JSON.stringify(llmInputPayload)).not.toContain("previous turn");
   });


### PR DESCRIPTION
Closes #122812

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Codex-backed agents could invoke an explicit-only skill when its `$skill-name` appeared only in projected conversation history, quoted inbound context, workspace context, or prompt-hook context rather than in the current user request.

## Why This Change Was Made

The Codex turn builder now tracks the authenticated current-request span through context projection, inbound metadata, prompt hooks, delivery metadata, and input-size fitting. Scanner-shaped tool mentions outside that span are made non-invocable while the current request remains unchanged; Codex's ignored environment variables such as `$HOME` remain intact.

This keeps the existing WebChat-only OpenClaw `$skill` reference contract unchanged and addresses the Codex provenance false positive without moving projected history into size-limited additional context.

## User Impact

Manual-only skills no longer run because their names appeared in earlier conversation or injected reference context. A `$skill-name` typed in the current request remains available to Codex's explicit skill handling.

## Evidence

- `pnpm exec vitest run extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/transcript-repair-runtime-contract.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts extensions/codex/src/app-server/run-attempt.test.ts --config vitest.config.ts` (187 tests passed)
- `pnpm exec oxfmt --check` on all six changed files
- `pnpm exec oxlint` on all six changed files
- `git diff --check`
- Independent final diff review found no unresolved actionable findings.
- `pnpm check:changed` was unavailable because the configured Testbox runner remained queued; the queued run was stopped without a result.
