### PR TITLE
fix: keep Control UI CI fixtures deterministic

### DIFF
--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -304,7 +304,7 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     const context = await createContext();
     const page = await context.newPage();
     await page.route(/device-scope-upgrade\.runtime(?:-[^/.]+)?\.(?:js|ts)/u, (route) =>
-      route.abort("failed"),
+      route.fulfill({ status: 503 }),
     );
     await installMockGateway(page, { operatorScopes: LIMITED_SCOPES });
 

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -717,9 +717,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(searchBar.height).toBeLessThan(64);
       expect(icons).toHaveLength(2);
       for (const icon of icons) {
-        const box = await icon.boundingBox();
-        expect(box?.width).toBe(16);
-        expect(box?.height).toBe(16);
+        const size = await icon.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { height: style.height, width: style.width };
+        });
+        expect(size).toEqual({ height: "16px", width: "16px" });
       }
       await input.focus();
       const outline = await input.evaluate((element) => {


### PR DESCRIPTION
## What Problem This Solves

Resolves two Control UI CI failures caused by test transport and browser-projection details rather than product regressions:

- a lazy banner-module failure fixture could consume the full test timeout after aborting its request during page navigation;
- Chromium could report a computed 16px search icon as `16.000001907348633` device-space pixels.

## Why This Change Was Made

The module fixture now returns HTTP 503, preserving a real dynamic-import rejection while completing the intercepted request deterministically. The icon test now asserts the browser's exact computed CSS width and height, the owner boundary for the 16px layout contract, instead of Playwright's floating-point bounding-box projection.

## User Impact

No product behavior changes. CI continues to verify the unavailable-module fallback and compact 16px search icons without transport-cancellation hangs or device-space rounding noise.

## Evidence

- Before: [main run 31732000025](https://github.com/openclaw/openclaw/actions/runs/31732000025) timed out in `keeps manual repair guidance when the banner module fails to load`.
- Before: [main run 31746060261](https://github.com/openclaw/openclaw/actions/runs/31746060261) received `16.000001907348633` for the 16px icon height.
- Full `device-scope-upgrade.e2e.test.ts`: 9 passed.
- Full `chat-responsive.browser.test.ts`: 86 passed.
- Changed-file formatting, oxlint, and `git diff --check` passed.
- Combined branch autoreview reported no actionable findings.

Production LOC: +0/-0 | Tests: +6/-4
