### PR TITLE
fix: keep task audit age check stable on slow CI

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -162,6 +162,8 @@ describe("tasks commands", () => {
   it("keeps audit JSON stable and sorts combined findings before limiting", async () => {
     await withTaskCommandStateDir(async () => {
       const now = Date.now();
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(now);
       createTaskRecord({
         runtime: "cli",
         ownerKey: "agent:main:main",
@@ -224,8 +226,7 @@ describe("tasks commands", () => {
         token: runningFlow.flowId,
         flow: jsonRoundTrip(runningFlow),
       });
-      expect(limitedFinding?.ageMs).toBeGreaterThanOrEqual(45 * 60_000);
-      expect(limitedFinding?.ageMs).toBeLessThan(45 * 60_000 + 1_000);
+      expect(limitedFinding?.ageMs).toBe(45 * 60_000);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI failure where the task-audit command test exceeded its one-second wall-clock allowance on a slower GitHub-hosted runner. Exact-main run 31736554642 observed an age of 2,701,602 ms while the assertion required less than 2,701,000 ms.

## Why This Change Was Made

The test now freezes only `Date` at the timestamp used to construct the task-flow records. Async timers and SQLite work remain real, preserving the reason broad fake timers were removed previously, while the observable audit age is asserted exactly instead of depending on runner speed.

## User Impact

No product behavior changes. CI now verifies the exact 45-minute audit age deterministically on both fast and slow runners.

## Evidence

- Before: [exact-main CI run 31736554642](https://github.com/openclaw/openclaw/actions/runs/31736554642) failed `tasks commands > keeps audit JSON stable and sorts combined findings before limiting` because setup and audit work crossed the one-second allowance.
- Focused regression: `node scripts/run-vitest.mjs src/commands/tasks.test.ts -t 'keeps audit JSON stable and sorts combined findings before limiting'` — 1 passed.
- Sibling coverage: `node scripts/run-vitest.mjs src/commands/tasks.test.ts` — 25 passed.
- Changed-file formatting, oxlint, and `git diff --check` passed.
- Autoreview reported no actionable findings.

Production LOC: +0/-0 | Tests: +3/-2
