### PR TITLE
feat(auth): explicit shared auth store seam

### DIFF
--- a/src/agents/agent-delete-safety.test.ts
+++ b/src/agents/agent-delete-safety.test.ts
@@ -1,0 +1,32 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isSharedAuthStoreOwner } from "./agent-delete-safety.js";
+
+describe("shared auth store deletion safety", () => {
+  const sharedAuthDbPath = path.join(os.tmpdir(), "shared-auth", "openclaw-agent.sqlite");
+  const otherAgentAuthDbPath = path.join(os.tmpdir(), "other-auth", "openclaw-agent.sqlite");
+
+  it.each([
+    {
+      name: "blocks the legacy-main database owner",
+      ownership: { location: "legacy-main" } as const,
+      agentAuthDbPath: sharedAuthDbPath,
+      expected: true,
+    },
+    {
+      name: "allows a non-owner agent database",
+      ownership: { location: "legacy-main" } as const,
+      agentAuthDbPath: otherAgentAuthDbPath,
+      expected: false,
+    },
+    {
+      name: "follows state-db ownership instead of a legacy-main path match",
+      ownership: { location: "state-db" } as const,
+      agentAuthDbPath: sharedAuthDbPath,
+      expected: false,
+    },
+  ])("$name", ({ ownership, agentAuthDbPath, expected }) => {
+    expect(isSharedAuthStoreOwner({ ownership, agentAuthDbPath, sharedAuthDbPath })).toBe(expected);
+  });
+});

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -5,7 +5,25 @@ import { lowercasePreservingWhitespace } from "@openclaw/normalization-core/stri
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { isSameOpenClawAgentDatabasePath } from "../state/openclaw-agent-db-registry.js";
 import { listAgentEntries, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import type { SharedAuthStoreOwnership } from "./auth-profiles/path-resolve.js";
+
+/** True when deleting this agent database would remove the legacy shared auth store. */
+export function isSharedAuthStoreOwner(params: {
+  ownership: SharedAuthStoreOwnership;
+  agentAuthDbPath: string;
+  sharedAuthDbPath: string;
+}): boolean {
+  return (
+    params.ownership.location === "legacy-main" &&
+    isSameOpenClawAgentDatabasePath(params.agentAuthDbPath, params.sharedAuthDbPath)
+  );
+}
+
+export function formatSharedAuthStoreOwnerDeleteError(agentId: string): string {
+  return `Agent "${agentId}" owns the legacy shared auth store and cannot be deleted. Run openclaw doctor --fix to migrate shared auth, then retry.`;
+}
 
 function normalizeWorkspacePathForComparison(input: string): string {
   const resolved = path.resolve(input.replaceAll("\0", ""));

--- a/src/agents/auth-profiles/legacy-source-diagnostic.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { resolveOAuthDir } from "../../config/paths.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { shortenHomePath } from "../../utils.js";
-import { resolveSharedAuthStoreDir, resolveSharedAuthStorePath } from "./path-resolve.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 
 const AUTH_PROFILE_MIGRATION_REQUIRED_CODE = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
@@ -44,7 +44,7 @@ export function listLegacyAuthProfileSources(params: {
     { kind: "auth-state", path: path.join(agentDir, "auth-state.json") },
     { kind: "legacy-auth", path: path.join(agentDir, "auth.json") },
   ];
-  const sharedMainDir = resolveSharedAuthStoreDir(params.env);
+  const sharedMainDir = path.dirname(resolveSharedAuthStorePath(params.env));
   if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
     candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
   }
@@ -98,7 +98,7 @@ function listStartupLegacyAuthProfileSources(params: {
   sources: LegacyAuthProfileSource[];
   credentialSources: LegacyAuthProfileSource[];
 }> {
-  const sharedMainDir = resolveSharedAuthStoreDir(params.env);
+  const sharedMainDir = path.dirname(resolveSharedAuthStorePath(params.env));
   return [...new Set([...params.agentDirs, sharedMainDir])].map((agentDir) => {
     const sources = listLegacyAuthProfileSources({ agentDir, env: params.env });
     return { agentDir, sources, credentialSources: sources.filter(isCredentialSource) };

--- a/src/agents/auth-profiles/legacy-source-diagnostic.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { resolveOAuthDir } from "../../config/paths.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { shortenHomePath } from "../../utils.js";
-import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
+import { resolveSharedAuthStoreDir, resolveSharedAuthStorePath } from "./path-resolve.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 
 const AUTH_PROFILE_MIGRATION_REQUIRED_CODE = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
@@ -25,8 +25,12 @@ export function resolveLegacyOAuthPath(env: NodeJS.ProcessEnv = process.env): st
   return path.join(resolveOAuthDir(env), "oauth.json");
 }
 
+function resolveAuthProfileOwnerPath(agentDir?: string): string {
+  return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
+}
+
 function resolveAgentDir(agentDir?: string): string {
-  return path.dirname(resolveAuthProfileDatabasePath(agentDir));
+  return path.dirname(resolveAuthProfileOwnerPath(agentDir));
 }
 
 /** Detects retired auth files by name only; runtime code must never read their contents. */
@@ -40,7 +44,7 @@ export function listLegacyAuthProfileSources(params: {
     { kind: "auth-state", path: path.join(agentDir, "auth-state.json") },
     { kind: "legacy-auth", path: path.join(agentDir, "auth.json") },
   ];
-  const sharedMainDir = resolveSharedMainAuthAgentDir(params.env);
+  const sharedMainDir = resolveSharedAuthStoreDir(params.env);
   if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
     candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
   }
@@ -94,7 +98,7 @@ function listStartupLegacyAuthProfileSources(params: {
   sources: LegacyAuthProfileSource[];
   credentialSources: LegacyAuthProfileSource[];
 }> {
-  const sharedMainDir = resolveSharedMainAuthAgentDir(params.env);
+  const sharedMainDir = resolveSharedAuthStoreDir(params.env);
   return [...new Set([...params.agentDirs, sharedMainDir])].map((agentDir) => {
     const sources = listLegacyAuthProfileSources({ agentDir, env: params.env });
     return { agentDir, sources, credentialSources: sources.filter(isCredentialSource) };
@@ -138,7 +142,7 @@ export class AuthProfileMigrationRequiredError extends Error {
   readonly sourceKinds: LegacyAuthProfileSourceKind[];
 
   constructor(params: { agentDir?: string; sources: readonly LegacyAuthProfileSource[] }) {
-    const ownerId = shortenHomePath(resolveAuthProfileDatabasePath(params.agentDir));
+    const ownerId = shortenHomePath(resolveAuthProfileOwnerPath(params.agentDir));
     const sourceKinds = [...new Set(params.sources.map((source) => source.kind))].toSorted();
     super(
       `Auth profile store ${ownerId} requires legacy credential migration; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
@@ -155,7 +159,7 @@ export class AuthProfileStoreUnreadableError extends Error {
 
   constructor(agentDir?: string) {
     super(
-      `Auth profile store ${shortenHomePath(resolveAuthProfileDatabasePath(agentDir))} is unreadable; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
+      `Auth profile store ${shortenHomePath(resolveAuthProfileOwnerPath(agentDir))} is unreadable; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
     );
     this.name = "AuthProfileStoreUnreadableError";
   }
@@ -171,7 +175,7 @@ export function warnLegacyAuthProfileSourcesIgnored(params: {
   if (params.sources.length === 0) {
     return;
   }
-  const databasePath = resolveAuthProfileDatabasePath(params.agentDir);
+  const databasePath = resolveAuthProfileOwnerPath(params.agentDir);
   if (warnedLegacySourceDatabases.has(databasePath)) {
     return;
   }
@@ -188,17 +192,17 @@ export function markAuthProfileMigrationRequired(
   agentDir: string | undefined,
   error: AuthProfileMigrationRequiredError,
 ): void {
-  const databasePath = resolveAuthProfileDatabasePath(agentDir);
+  const databasePath = resolveAuthProfileOwnerPath(agentDir);
   migrationRequiredByDatabase.set(databasePath, error);
 }
 
 export function clearAuthProfileMigrationRequired(agentDir?: string): void {
-  const databasePath = resolveAuthProfileDatabasePath(agentDir);
+  const databasePath = resolveAuthProfileOwnerPath(agentDir);
   migrationRequiredByDatabase.delete(databasePath);
 }
 
 export function assertAuthProfileMigrationReady(agentDir?: string): void {
-  const databasePath = resolveAuthProfileDatabasePath(agentDir);
+  const databasePath = resolveAuthProfileOwnerPath(agentDir);
   const error = migrationRequiredByDatabase.get(databasePath);
   if (error) {
     // The activated secrets snapshot for this owner is empty. Only an explicit

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -30,6 +30,7 @@ import {
   shouldBootstrapFromExternalCliCredential,
   shouldReplaceStoredOAuthCredential,
 } from "./oauth-shared.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { resolveOAuthRefreshLockPath } from "./paths.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import {
@@ -503,7 +504,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
     const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
-    const authPath = resolveAuthProfileDatabasePath(ownerAgentDir);
+    const authPath = ownerAgentDir
+      ? resolveAuthProfileDatabasePath(ownerAgentDir)
+      : resolveSharedAuthStorePath();
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
 
     try {
@@ -673,7 +676,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           }
         }
         if (ownerAgentDir) {
-          const mainPath = resolveAuthProfileDatabasePath(undefined);
+          const mainPath = resolveSharedAuthStorePath();
           if (mainPath !== authPath) {
             await mirrorRefreshedCredentialIntoMainStore({
               profileId: params.profileId,

--- a/src/agents/auth-profiles/path-resolve.shared-store.test.ts
+++ b/src/agents/auth-profiles/path-resolve.shared-store.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeConfigMachineState } from "../../state/config-machine-state.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  resolveOpenClawStateSqliteDir,
+  resolveOpenClawStateSqlitePath,
+} from "../../state/openclaw-state-db.paths.js";
+
+const tempDirs = new Set<string>();
+
+async function makeStateEnv(): Promise<NodeJS.ProcessEnv> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-shared-auth-store-"));
+  tempDirs.add(stateDir);
+  return { ...process.env, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_AGENT_DIR: undefined };
+}
+
+describe("shared auth store path resolution", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await Promise.all(
+      [...tempDirs].map(async (stateDir) => {
+        await fs.rm(stateDir, { recursive: true, force: true });
+        tempDirs.delete(stateDir);
+      }),
+    );
+  });
+
+  it("keeps the absent ownership record pinned to the shipped legacy-main path", async () => {
+    const env = await makeStateEnv();
+    const { resolveSharedAuthStoreDir, resolveSharedAuthStorePath } =
+      await import("./path-resolve.js");
+    const { resolveSharedMainAuthAgentDir } = await import("./shared-main-dir.js");
+    const legacyDir = resolveSharedMainAuthAgentDir(env);
+
+    expect(resolveSharedAuthStoreDir(env)).toBe(legacyDir);
+    expect(resolveSharedAuthStorePath(env)).toBe(path.join(legacyDir, "openclaw-agent.sqlite"));
+
+    writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env });
+
+    expect(resolveSharedAuthStoreDir(env)).toBe(legacyDir);
+    expect(resolveSharedAuthStorePath(env)).toBe(path.join(legacyDir, "openclaw-agent.sqlite"));
+  });
+
+  it("resolves a preexisting state-db ownership record", async () => {
+    const env = await makeStateEnv();
+    writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env });
+    const { resolveSharedAuthStoreDir, resolveSharedAuthStorePath } =
+      await import("./path-resolve.js");
+
+    expect(resolveSharedAuthStoreDir(env)).toBe(resolveOpenClawStateSqliteDir(env));
+    expect(resolveSharedAuthStorePath(env)).toBe(resolveOpenClawStateSqlitePath(env));
+  });
+
+  it("rejects a malformed ownership record instead of guessing a store", async () => {
+    const env = await makeStateEnv();
+    writeConfigMachineState("auth.sharedStore", { location: "legacy-main", extra: true }, { env });
+    const { resolveSharedAuthStorePath } = await import("./path-resolve.js");
+
+    expect(() => resolveSharedAuthStorePath(env)).toThrow("auth.sharedStore is invalid");
+  });
+});

--- a/src/agents/auth-profiles/path-resolve.shared-store.test.ts
+++ b/src/agents/auth-profiles/path-resolve.shared-store.test.ts
@@ -1,19 +1,13 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { writeConfigMachineState } from "../../state/config-machine-state.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import {
-  resolveOpenClawStateSqliteDir,
-  resolveOpenClawStateSqlitePath,
-} from "../../state/openclaw-state-db.paths.js";
 
-const tempDirs = new Set<string>();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-async function makeStateEnv(): Promise<NodeJS.ProcessEnv> {
-  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-shared-auth-store-"));
-  tempDirs.add(stateDir);
+function makeStateEnv(): NodeJS.ProcessEnv {
+  const stateDir = tempDirs.make("openclaw-shared-auth-store-");
   return { ...process.env, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_AGENT_DIR: undefined };
 }
 
@@ -22,18 +16,12 @@ describe("shared auth store path resolution", () => {
     vi.resetModules();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     closeOpenClawStateDatabaseForTest();
-    await Promise.all(
-      [...tempDirs].map(async (stateDir) => {
-        await fs.rm(stateDir, { recursive: true, force: true });
-        tempDirs.delete(stateDir);
-      }),
-    );
   });
 
   it("keeps the absent ownership record pinned to the shipped legacy-main path", async () => {
-    const env = await makeStateEnv();
+    const env = makeStateEnv();
     const { resolveSharedAuthStoreDir, resolveSharedAuthStorePath } =
       await import("./path-resolve.js");
     const { resolveSharedMainAuthAgentDir } = await import("./shared-main-dir.js");
@@ -43,26 +31,57 @@ describe("shared auth store path resolution", () => {
     expect(resolveSharedAuthStorePath(env)).toBe(path.join(legacyDir, "openclaw-agent.sqlite"));
 
     writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env });
+    const aliasEnv = {
+      ...env,
+      OPENCLAW_STATE_DIR: path.join(env.OPENCLAW_STATE_DIR ?? "", "."),
+    };
 
-    expect(resolveSharedAuthStoreDir(env)).toBe(legacyDir);
-    expect(resolveSharedAuthStorePath(env)).toBe(path.join(legacyDir, "openclaw-agent.sqlite"));
+    expect(resolveSharedAuthStoreDir(aliasEnv)).toBe(legacyDir);
+    expect(resolveSharedAuthStorePath(aliasEnv)).toBe(
+      path.join(legacyDir, "openclaw-agent.sqlite"),
+    );
   });
 
-  it("resolves a preexisting state-db ownership record", async () => {
-    const env = await makeStateEnv();
+  it("fails closed when the ownership record says state-db", async () => {
+    const env = makeStateEnv();
     writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env });
-    const { resolveSharedAuthStoreDir, resolveSharedAuthStorePath } =
-      await import("./path-resolve.js");
+    const {
+      resolveSharedAuthStoreDir,
+      resolveSharedAuthStoreOwnership,
+      resolveSharedAuthStorePath,
+    } = await import("./path-resolve.js");
 
-    expect(resolveSharedAuthStoreDir(env)).toBe(resolveOpenClawStateSqliteDir(env));
-    expect(resolveSharedAuthStorePath(env)).toBe(resolveOpenClawStateSqlitePath(env));
+    expect(resolveSharedAuthStoreOwnership(env)).toEqual({ location: "state-db" });
+    for (const resolvePath of [resolveSharedAuthStoreDir, resolveSharedAuthStorePath]) {
+      try {
+        resolvePath(env);
+        throw new Error("expected relocated shared auth resolution to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toMatchObject({
+          name: "SharedAuthStoreRelocatedUnsupportedError",
+          code: "SHARED_AUTH_STORE_RELOCATED_UNSUPPORTED",
+          action: "openclaw doctor --fix",
+          location: "state-db",
+          message: expect.stringContaining("this build cannot serve it"),
+        });
+      }
+    }
   });
 
-  it("rejects a malformed ownership record instead of guessing a store", async () => {
-    const env = await makeStateEnv();
-    writeConfigMachineState("auth.sharedStore", { location: "legacy-main", extra: true }, { env });
-    const { resolveSharedAuthStorePath } = await import("./path-resolve.js");
+  it("caches ownership independently for each canonical state root", async () => {
+    const firstEnv = makeStateEnv();
+    const secondEnv = makeStateEnv();
+    const { resolveSharedAuthStoreOwnership } = await import("./path-resolve.js");
+    expect(resolveSharedAuthStoreOwnership(firstEnv)).toEqual({ location: "legacy-main" });
 
-    expect(() => resolveSharedAuthStorePath(env)).toThrow("auth.sharedStore is invalid");
+    writeConfigMachineState(
+      "auth.sharedStore",
+      { location: "legacy-main", extra: true },
+      { env: secondEnv },
+    );
+
+    expect(() => resolveSharedAuthStoreOwnership(secondEnv)).toThrow("auth.sharedStore is invalid");
+    expect(resolveSharedAuthStoreOwnership(firstEnv)).toEqual({ location: "legacy-main" });
   });
 });

--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -6,18 +6,31 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveStateDir } from "../../config/paths.js";
 import { readConfigMachineState } from "../../state/config-machine-state.js";
-import {
-  resolveOpenClawStateSqliteDir,
-  resolveOpenClawStateSqlitePath,
-} from "../../state/openclaw-state-db.paths.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
 
 const SHARED_AUTH_STORE_STATE_KEY = "auth.sharedStore";
+const SHARED_AUTH_STORE_OWNERSHIP_CACHE_LIMIT = 256;
 
 export type SharedAuthStoreOwnership = { location: "legacy-main" } | { location: "state-db" };
 
-let sharedAuthStoreOwnership: SharedAuthStoreOwnership | undefined;
+// Explicit env callers can address another state root in the same process.
+// Pin each root once so later row changes require an owner-controlled restart.
+const sharedAuthStoreOwnershipByDatabasePath = new Map<string, SharedAuthStoreOwnership>();
+
+class SharedAuthStoreRelocatedUnsupportedError extends Error {
+  readonly code = "SHARED_AUTH_STORE_RELOCATED_UNSUPPORTED" as const;
+  readonly action = "openclaw doctor --fix" as const;
+  readonly location = "state-db" as const;
+
+  constructor() {
+    super(
+      "Shared auth store is recorded as relocated, but this build cannot serve it; run openclaw doctor --fix.",
+    );
+    this.name = "SharedAuthStoreRelocatedUnsupportedError";
+  }
+}
 
 function parseSharedAuthStoreOwnership(value: unknown): SharedAuthStoreOwnership {
   if (value === undefined) {
@@ -39,24 +52,34 @@ function parseSharedAuthStoreOwnership(value: unknown): SharedAuthStoreOwnership
 export function resolveSharedAuthStoreOwnership(
   env: NodeJS.ProcessEnv = process.env,
 ): SharedAuthStoreOwnership {
-  sharedAuthStoreOwnership ??= parseSharedAuthStoreOwnership(
-    readConfigMachineState<unknown>(SHARED_AUTH_STORE_STATE_KEY, { env }),
+  const databasePath = path.resolve(resolveOpenClawStateSqlitePath(env));
+  const cached = sharedAuthStoreOwnershipByDatabasePath.get(databasePath);
+  if (cached) {
+    return cached;
+  }
+  if (sharedAuthStoreOwnershipByDatabasePath.size >= SHARED_AUTH_STORE_OWNERSHIP_CACHE_LIMIT) {
+    throw new Error(
+      "Shared auth store ownership cache exceeded its process root limit; restart OpenClaw.",
+    );
+  }
+  const ownership = parseSharedAuthStoreOwnership(
+    readConfigMachineState<unknown>(SHARED_AUTH_STORE_STATE_KEY, { env, path: databasePath }),
   );
-  return sharedAuthStoreOwnership;
+  sharedAuthStoreOwnershipByDatabasePath.set(databasePath, ownership);
+  return ownership;
 }
 
-/** Resolve the directory containing the shared auth store. */
+/** Resolve the legacy agent directory containing the shared auth store. */
 export function resolveSharedAuthStoreDir(env: NodeJS.ProcessEnv = process.env): string {
-  return resolveSharedAuthStoreOwnership(env).location === "state-db"
-    ? resolveOpenClawStateSqliteDir(env)
-    : resolveSharedMainAuthAgentDir(env);
+  return path.dirname(resolveSharedAuthStorePath(env));
 }
 
-/** Resolve the shared auth store database path. */
+/** Resolve the shared auth database path, failing closed for unserved relocation. */
 export function resolveSharedAuthStorePath(env: NodeJS.ProcessEnv = process.env): string {
-  return resolveSharedAuthStoreOwnership(env).location === "state-db"
-    ? resolveOpenClawStateSqlitePath(env)
-    : path.join(resolveSharedMainAuthAgentDir(env), "openclaw-agent.sqlite");
+  if (resolveSharedAuthStoreOwnership(env).location === "state-db") {
+    throw new SharedAuthStoreRelocatedUnsupportedError();
+  }
+  return path.join(resolveSharedMainAuthAgentDir(env), "openclaw-agent.sqlite");
 }
 
 /** Resolve the user-facing auth profile database path. */

--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -3,19 +3,75 @@
  * Centralizes canonical SQLite display paths and cross-agent OAuth refresh lock paths.
  */
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveStateDir } from "../../config/paths.js";
+import { readConfigMachineState } from "../../state/config-machine-state.js";
+import {
+  resolveOpenClawStateSqliteDir,
+  resolveOpenClawStateSqlitePath,
+} from "../../state/openclaw-state-db.paths.js";
 import { resolveUserPath } from "../../utils.js";
-import { resolveAuthProfileDatabasePath } from "./sqlite.js";
+import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
+
+const SHARED_AUTH_STORE_STATE_KEY = "auth.sharedStore";
+
+export type SharedAuthStoreOwnership = { location: "legacy-main" } | { location: "state-db" };
+
+let sharedAuthStoreOwnership: SharedAuthStoreOwnership | undefined;
+
+function parseSharedAuthStoreOwnership(value: unknown): SharedAuthStoreOwnership {
+  if (value === undefined) {
+    return { location: "legacy-main" };
+  }
+  if (
+    isRecord(value) &&
+    Object.keys(value).length === 1 &&
+    (value.location === "legacy-main" || value.location === "state-db")
+  ) {
+    return { location: value.location };
+  }
+  throw new Error(
+    `Config machine state ${SHARED_AUTH_STORE_STATE_KEY} is invalid; run openclaw doctor --fix.`,
+  );
+}
+
+/** Resolve the process-stable owner of the shared auth store. */
+export function resolveSharedAuthStoreOwnership(
+  env: NodeJS.ProcessEnv = process.env,
+): SharedAuthStoreOwnership {
+  sharedAuthStoreOwnership ??= parseSharedAuthStoreOwnership(
+    readConfigMachineState<unknown>(SHARED_AUTH_STORE_STATE_KEY, { env }),
+  );
+  return sharedAuthStoreOwnership;
+}
+
+/** Resolve the directory containing the shared auth store. */
+export function resolveSharedAuthStoreDir(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveSharedAuthStoreOwnership(env).location === "state-db"
+    ? resolveOpenClawStateSqliteDir(env)
+    : resolveSharedMainAuthAgentDir(env);
+}
+
+/** Resolve the shared auth store database path. */
+export function resolveSharedAuthStorePath(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveSharedAuthStoreOwnership(env).location === "state-db"
+    ? resolveOpenClawStateSqlitePath(env)
+    : path.join(resolveSharedMainAuthAgentDir(env), "openclaw-agent.sqlite");
+}
 
 /** Resolve the user-facing auth profile database path. */
 export function resolveAuthStorePathForDisplay(agentDir?: string): string {
-  const pathname = resolveAuthProfileDatabasePath(agentDir);
+  const pathname = agentDir
+    ? path.join(resolveUserPath(agentDir), "openclaw-agent.sqlite")
+    : resolveSharedAuthStorePath();
   return pathname.startsWith("~") ? pathname : resolveUserPath(pathname);
 }
 
 /** Resolve the user-facing auth state database path. */
 export function resolveAuthStatePathForDisplay(agentDir?: string): string {
-  const pathname = resolveAuthProfileDatabasePath(agentDir);
+  const pathname = agentDir
+    ? path.join(resolveUserPath(agentDir), "openclaw-agent.sqlite")
+    : resolveSharedAuthStorePath();
   return pathname.startsWith("~") ? pathname : resolveUserPath(pathname);
 }
 

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -33,6 +33,7 @@ import {
   getRuntimeAuthProfileStoreCredentialMutationToken,
   getRuntimeAuthProfileStoreCredentialsRevision,
   getRuntimeAuthProfileStoreStateMutationToken,
+  listRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "./runtime-snapshots.js";
 import { resolveAuthProfileDatabasePath, runAuthProfileWriteTransaction } from "./sqlite.js";
@@ -796,6 +797,69 @@ describe("promoteAuthProfileInOrder", () => {
         ).toBeUndefined();
       },
       { clearOAuthDir: true },
+    );
+  });
+
+  it("restores an exactly owned derived snapshot under its custom database key", async () => {
+    await withAuthProfileTestState(
+      "openclaw-auth-custom-key-rollback-",
+      async ({ agentDirFor }) => {
+        const derivedAgentDir = agentDirFor("custom-key");
+        const databasePath = path.join(derivedAgentDir, "custom.sqlite");
+        saveAuthProfileStore({
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            "openai:baseline": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-baseline",
+            },
+          },
+        });
+        const capturedRuntime = loadAuthProfileStoreForRuntime(derivedAgentDir);
+        replaceRuntimeAuthProfileStoreSnapshots([
+          { databasePath, agentDir: derivedAgentDir, store: capturedRuntime },
+        ]);
+        const snapshot = captureAuthProfileStorePersistenceSnapshot();
+        const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+          snapshot,
+          store: {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "openai:temporary": {
+                type: "api_key",
+                provider: "openai",
+                key: "sk-temporary",
+              },
+            },
+          },
+        });
+
+        expect(committed.publishRuntimeSnapshots()).toBe(true);
+        expect(listRuntimeAuthProfileStoreSnapshots()).toEqual([
+          expect.objectContaining({
+            databasePath,
+            store: expect.objectContaining({
+              profiles: expect.objectContaining({
+                "openai:temporary": expect.objectContaining({ key: "sk-temporary" }),
+              }),
+            }),
+          }),
+        ]);
+
+        restoreAuthProfileStorePersistenceSnapshot(snapshot, committed.owned);
+
+        expect(listRuntimeAuthProfileStoreSnapshots()).toEqual([
+          expect.objectContaining({
+            databasePath,
+            store: expect.objectContaining({
+              profiles: expect.objectContaining({
+                "openai:baseline": expect.objectContaining({ key: "sk-baseline" }),
+              }),
+            }),
+          }),
+        ]);
+      },
     );
   });
 

--- a/src/agents/auth-profiles/runtime-materializations.ts
+++ b/src/agents/auth-profiles/runtime-materializations.ts
@@ -122,6 +122,11 @@ export function clearRuntimeAuthMaterializations(agentDir?: string): void {
   materializations.delete(ownerKey(agentDir));
 }
 
+/** Clears materializations for an already resolved canonical auth database owner. */
+export function clearRuntimeAuthMaterializationsAtDatabasePath(databasePath: string): void {
+  materializations.delete(databasePath);
+}
+
 export function clearAllRuntimeAuthMaterializations(): void {
   materializations.clear();
 }

--- a/src/agents/auth-profiles/runtime-materializations.ts
+++ b/src/agents/auth-profiles/runtime-materializations.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 
 /** Secret-free proof that one exact provider/model transport completed with usable auth. */
@@ -24,7 +25,7 @@ const materializations = new Map<string, RuntimeAuthMaterialization[]>();
 const listeners = new Set<RuntimeAuthMaterializationMutationListener>();
 
 function ownerKey(agentDir?: string): string {
-  return resolveAuthProfileDatabasePath(agentDir);
+  return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
 }
 
 function notify(agentDir?: string): void {

--- a/src/agents/auth-profiles/runtime-snapshots.test.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.test.ts
@@ -3,6 +3,7 @@
  * Verifies snapshots are cloned and isolated across agent-specific stores.
  */
 
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -17,6 +18,7 @@ import {
   getPreparedRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreCredentialsRevision,
+  listRuntimeAuthProfileStoreSnapshots,
   noteRuntimeAuthProfileStorePersistedMutation,
   registerRuntimeAuthProfileStoreMutationListener,
   replaceRuntimeAuthProfileStoreSnapshots,
@@ -66,6 +68,29 @@ function expectOpenAICodexSnapshotCredential(
 }
 
 describe("runtime auth profile snapshots", () => {
+  it("carries the canonical database identity through snapshot enumeration", () => {
+    const databasePath = "/tmp/openclaw-auth-runtime-enumeration/custom.sqlite";
+    const store = createStore("enumerated");
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        databasePath,
+        agentDir: "/tmp/projected-agent-dir-must-not-own-identity",
+        store,
+      },
+    ]);
+    try {
+      expect(listRuntimeAuthProfileStoreSnapshots()).toEqual([
+        {
+          databasePath,
+          agentDir: path.dirname(databasePath),
+          store,
+        },
+      ]);
+    } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
+    }
+  });
+
   it("marks default-owner materializations as inherited mutations", () => {
     const listener = vi.fn();
     const unregister = registerRuntimeAuthMaterializationMutationListener(listener);

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -10,6 +10,7 @@ import { mergeAuthProfileStores } from "./persisted.js";
 import {
   clearAllRuntimeAuthMaterializations,
   clearRuntimeAuthMaterializations,
+  clearRuntimeAuthMaterializationsAtDatabasePath,
 } from "./runtime-materializations.js";
 import { closeAuthProfileReadPool, resolveAuthProfileDatabasePath } from "./sqlite.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
@@ -316,7 +317,7 @@ export function replaceRuntimeAuthProfileStoreSnapshots(
   );
   for (const key of new Set([...runtimeAuthStoreSnapshots.keys(), ...next.keys()])) {
     if (authProfilesChanged(runtimeAuthStoreSnapshots.get(key), next.get(key))) {
-      clearRuntimeAuthMaterializations(path.dirname(key));
+      clearRuntimeAuthMaterializationsAtDatabasePath(key);
     }
   }
   recordChangedSnapshotRevisions(entries);
@@ -364,18 +365,17 @@ export function clearRuntimeAuthProfileStoreSnapshotCore(agentDir?: string): boo
   }
   advanceRuntimeAuthStoreSnapshotsRevision();
   runtimeAuthStoreSnapshots.delete(key);
-  clearRuntimeAuthMaterializations(agentDir);
+  clearRuntimeAuthMaterializationsAtDatabasePath(key);
   runtimeAuthStoreSnapshotRevisions.delete(key);
   notifyRuntimeAuthStoreMutation(agentDir);
   return true;
 }
 
-/** Stores a cloned runtime auth profile snapshot for an agent dir. */
-export function setRuntimeAuthProfileStoreSnapshot(
+function setRuntimeAuthProfileStoreSnapshotAtKey(
   store: RuntimeAuthProfileStore,
-  agentDir?: string,
+  key: string,
+  agentDir: string | undefined,
 ): void {
-  const key = resolveRuntimeStoreKey(agentDir);
   const credentialsChanged = !isDeepStrictEqual(
     credentialState(
       runtimeAuthStoreSnapshots.has(key) ? [[key, runtimeAuthStoreSnapshots.get(key)!]] : [],
@@ -387,7 +387,7 @@ export function setRuntimeAuthProfileStoreSnapshot(
   }
   const previousStore = runtimeAuthStoreSnapshots.get(key);
   if (authProfilesChanged(previousStore, store)) {
-    clearRuntimeAuthMaterializations(agentDir);
+    clearRuntimeAuthMaterializationsAtDatabasePath(key);
   }
   const ownerChanged = !isDeepStrictEqual(ownerState(previousStore), ownerState(store));
   const snapshotChanged = !isDeepStrictEqual(previousStore, store);
@@ -399,6 +399,23 @@ export function setRuntimeAuthProfileStoreSnapshot(
   if (ownerChanged) {
     notifyRuntimeAuthStoreMutation(agentDir);
   }
+}
+
+/** Stores a cloned runtime auth profile snapshot for an agent dir. */
+export function setRuntimeAuthProfileStoreSnapshot(
+  store: RuntimeAuthProfileStore,
+  agentDir?: string,
+): void {
+  setRuntimeAuthProfileStoreSnapshotAtKey(store, resolveRuntimeStoreKey(agentDir), agentDir);
+}
+
+/** Stores a cloned snapshot under an already resolved canonical database owner. */
+export function setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+  store: RuntimeAuthProfileStore,
+  databasePath: string,
+  agentDir?: string,
+): void {
+  setRuntimeAuthProfileStoreSnapshotAtKey(store, databasePath, agentDir);
 }
 
 /**
@@ -548,10 +565,14 @@ export function getRuntimeAuthProfileStoreCredentialsRevision(): number {
 
 /** Process-local generation for one exact runtime snapshot rollback owner. */
 export function getRuntimeAuthProfileStoreSnapshotRevision(agentDir?: string): number {
-  return (
-    runtimeAuthStoreSnapshotRevisions.get(resolveRuntimeStoreKey(agentDir)) ??
-    runtimeAuthStoreSnapshotsRevision
-  );
+  return getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(resolveRuntimeStoreKey(agentDir));
+}
+
+/** Process-local generation for an already resolved canonical snapshot owner. */
+export function getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(
+  databasePath: string,
+): number {
+  return runtimeAuthStoreSnapshotRevisions.get(databasePath) ?? runtimeAuthStoreSnapshotsRevision;
 }
 
 const testing = {

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -30,6 +30,12 @@ let evictedOwnerMutationFloor = 0;
 const MAX_PERSISTED_MUTATION_OWNERS = 256;
 const MAX_PERSISTED_MUTATION_PROFILES_PER_OWNER = 256;
 
+type RuntimeAuthProfileStoreSnapshotEntry = {
+  databasePath?: string;
+  agentDir?: string;
+  store: RuntimeAuthProfileStore;
+};
+
 type PersistedMutationRecord = {
   credentialRevision: number;
   credentialRevisionKnown: boolean;
@@ -155,11 +161,9 @@ function ownerState(
   };
 }
 
-function replaceChangesOwner(
-  entries: Array<{ agentDir?: string; store: RuntimeAuthProfileStore }>,
-): boolean {
+function replaceChangesOwner(entries: RuntimeAuthProfileStoreSnapshotEntry[]): boolean {
   const next = new Map(
-    entries.map((entry) => [resolveRuntimeStoreKey(entry.agentDir), entry.store] as const),
+    entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
   );
   const currentState = Array.from(
     runtimeAuthStoreSnapshots,
@@ -171,20 +175,16 @@ function replaceChangesOwner(
   return !isDeepStrictEqual(currentState, nextState);
 }
 
-function replaceChangesCredentials(
-  entries: Array<{ agentDir?: string; store: RuntimeAuthProfileStore }>,
-): boolean {
+function replaceChangesCredentials(entries: RuntimeAuthProfileStoreSnapshotEntry[]): boolean {
   const next = new Map(
-    entries.map((entry) => [resolveRuntimeStoreKey(entry.agentDir), entry.store] as const),
+    entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
   );
   return !isDeepStrictEqual(credentialState(runtimeAuthStoreSnapshots), credentialState(next));
 }
 
-function recordChangedSnapshotRevisions(
-  entries: Array<{ agentDir?: string; store: RuntimeAuthProfileStore }>,
-): boolean {
+function recordChangedSnapshotRevisions(entries: RuntimeAuthProfileStoreSnapshotEntry[]): boolean {
   const next = new Map(
-    entries.map((entry) => [resolveRuntimeStoreKey(entry.agentDir), entry.store] as const),
+    entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
   );
   const keys = new Set([...runtimeAuthStoreSnapshots.keys(), ...next.keys()]);
   let changed = false;
@@ -207,6 +207,14 @@ function recordChangedSnapshotRevisions(
 // and per-agent stores do not overwrite each other.
 function resolveRuntimeStoreKey(agentDir?: string): string {
   return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
+}
+
+function resolveRuntimeSnapshotEntryKey(entry: {
+  databasePath?: string;
+  agentDir?: string;
+}): string {
+  // Enumeration already owns the canonical key; never reconstruct it from a projected directory.
+  return entry.databasePath ?? resolveRuntimeStoreKey(entry.agentDir);
 }
 
 function notifyRuntimeAuthStoreMutation(agentDir?: string): void {
@@ -263,12 +271,14 @@ export function getPreparedRuntimeAuthProfileStoreSnapshotCore(
   return requested ?? inherited;
 }
 
-/** Lists cloned live snapshots for transactional rollback composition. */
+/** Lists cloned snapshots while preserving their canonical database identity. */
 export function listRuntimeAuthProfileStoreSnapshots(): Array<{
+  databasePath: string;
   agentDir: string;
   store: RuntimeAuthProfileStore;
 }> {
   return Array.from(runtimeAuthStoreSnapshots, ([key, store]) => ({
+    databasePath: key,
     agentDir: path.dirname(key),
     store: cloneAuthProfileStore(store),
   }));
@@ -294,7 +304,7 @@ export function hasAnyRuntimeAuthProfileStoreSource(agentDir?: string): boolean 
 
 /** Replaces all runtime auth profile snapshots with cloned entries. */
 export function replaceRuntimeAuthProfileStoreSnapshots(
-  entries: Array<{ agentDir?: string; store: AuthProfileStore }>,
+  entries: Array<{ databasePath?: string; agentDir?: string; store: AuthProfileStore }>,
 ): void {
   const credentialsChanged = replaceChangesCredentials(entries);
   const ownerChanged = replaceChangesOwner(entries);
@@ -302,7 +312,7 @@ export function replaceRuntimeAuthProfileStoreSnapshots(
     runtimeAuthStoreCredentialsRevision += 1;
   }
   const next = new Map(
-    entries.map((entry) => [resolveRuntimeStoreKey(entry.agentDir), entry.store] as const),
+    entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
   );
   for (const key of new Set([...runtimeAuthStoreSnapshots.keys(), ...next.keys()])) {
     if (authProfilesChanged(runtimeAuthStoreSnapshots.get(key), next.get(key))) {
@@ -313,7 +323,7 @@ export function replaceRuntimeAuthProfileStoreSnapshots(
   runtimeAuthStoreSnapshots.clear();
   for (const entry of entries) {
     runtimeAuthStoreSnapshots.set(
-      resolveRuntimeStoreKey(entry.agentDir),
+      resolveRuntimeSnapshotEntryKey(entry),
       cloneAuthProfileStore(entry.store),
     );
   }

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -5,6 +5,7 @@ import path from "node:path";
  */
 import { isDeepStrictEqual } from "node:util";
 import { cloneAuthProfileStore } from "./clone.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { mergeAuthProfileStores } from "./persisted.js";
 import {
   clearAllRuntimeAuthMaterializations,
@@ -205,7 +206,7 @@ function recordChangedSnapshotRevisions(
 // Runtime snapshots are keyed by the canonical database path so default-agent
 // and per-agent stores do not overwrite each other.
 function resolveRuntimeStoreKey(agentDir?: string): string {
-  return resolveAuthProfileDatabasePath(agentDir);
+  return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
 }
 
 function notifyRuntimeAuthStoreMutation(agentDir?: string): void {

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -4,6 +4,7 @@
  */
 import { evaluateStoredCredentialEligibility } from "./credential-state.js";
 import { hasLegacyAuthProfileCredentialSource } from "./legacy-source-diagnostic.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { coercePersistedAuthProfileStore } from "./persisted.js";
 import {
   getRuntimeAuthProfileStoreSnapshotCore,
@@ -100,8 +101,10 @@ export function hasAnyAuthProfileStoreSource(agentDir?: string): boolean {
     return true;
   }
 
-  const authPath = resolveAuthProfileDatabasePath(agentDir);
-  const mainAuthPath = resolveAuthProfileDatabasePath();
+  const authPath = agentDir
+    ? resolveAuthProfileDatabasePath(agentDir)
+    : resolveSharedAuthStorePath();
+  const mainAuthPath = resolveSharedAuthStorePath();
   if (
     agentDir &&
     authPath !== mainAuthPath &&

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -29,7 +29,7 @@ import {
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../../state/openclaw-state-db.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveRegisteredAgentIdForDir } from "../agent-dir-registry.js";
-import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
 
 type AuthProfileDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -47,13 +47,6 @@ type AuthProfileReadPoolCloseScope =
   | { kind: "database"; databasePath: string }
   | { kind: "root"; rootPath: string };
 
-function resolveAgentDir(agentDir?: string): string {
-  if (agentDir) {
-    return resolveUserPath(agentDir);
-  }
-  return resolveSharedMainAuthAgentDir();
-}
-
 function inferAgentIdFromDir(agentDir: string): string {
   const normalized = path.normalize(agentDir);
   if (path.basename(normalized) === "agent") {
@@ -68,7 +61,15 @@ function inferAgentIdFromDir(agentDir: string): string {
 // The auth database lives in the agent dir and shares the openclaw-agent schema
 // so auth store/state can move with the rest of agent-local durable state.
 function resolveAuthProfileDatabaseOptions(agentDir?: string) {
-  const dir = resolveAgentDir(agentDir);
+  if (!agentDir) {
+    const pathname = resolveSharedAuthStorePath();
+    const dir = path.dirname(pathname);
+    return {
+      agentId: resolveRegisteredAgentIdForDir(dir) ?? inferAgentIdFromDir(dir),
+      path: pathname,
+    };
+  }
+  const dir = resolveUserPath(agentDir);
   return {
     agentId: resolveRegisteredAgentIdForDir(dir) ?? inferAgentIdFromDir(dir),
     path: path.join(dir, "openclaw-agent.sqlite"),
@@ -76,17 +77,17 @@ function resolveAuthProfileDatabaseOptions(agentDir?: string) {
 }
 
 /** Resolves the SQLite database path that stores auth profiles for an agent dir. */
-export function resolveAuthProfileDatabasePath(agentDir?: string): string {
+export function resolveAuthProfileDatabasePath(agentDir: string): string {
   return resolveAuthProfileDatabaseOptions(agentDir).path;
 }
 
 /** Resolves the durable agent owner expected for an auth-profile database. */
-export function resolveAuthProfileDatabaseOwnerId(agentDir?: string): string {
+export function resolveAuthProfileDatabaseOwnerId(agentDir: string): string {
   return resolveAuthProfileDatabaseOptions(agentDir).agentId;
 }
 
 /** Resolves the SQLite database and sidecar paths used by auth profiles. */
-export function resolveAuthProfileDatabaseFilePaths(agentDir?: string): string[] {
+export function resolveAuthProfileDatabaseFilePaths(agentDir: string): string[] {
   return resolveSqliteDatabaseFilePaths(resolveAuthProfileDatabasePath(agentDir));
 }
 
@@ -286,7 +287,10 @@ export function inspectPersistedAuthProfileStoreRaw(
   if (database) {
     return inspectAuthProfileJsonCell(database.db, "store");
   }
-  return inspectAuthProfileJsonCellReadOnly(resolveAuthProfileDatabasePath(agentDir), "store");
+  return inspectAuthProfileJsonCellReadOnly(
+    resolveAuthProfileDatabaseOptions(agentDir).path,
+    "store",
+  );
 }
 
 /** Distinguishes an absent auth-state row from state that could not be read. */
@@ -297,7 +301,10 @@ export function inspectPersistedAuthProfileStateRaw(
   if (database) {
     return inspectAuthProfileJsonCell(database.db, "state");
   }
-  return inspectAuthProfileJsonCellReadOnly(resolveAuthProfileDatabasePath(agentDir), "state");
+  return inspectAuthProfileJsonCellReadOnly(
+    resolveAuthProfileDatabaseOptions(agentDir).path,
+    "state",
+  );
 }
 
 /** Reads the raw persisted secrets-store payload without coercing the schema. */
@@ -317,7 +324,7 @@ export function readPersistedAuthProfileStoreRaw(
     return parseJsonCell(row?.store_json);
   }
   const result = inspectAuthProfileJsonCellReadOnly(
-    resolveAuthProfileDatabasePath(agentDir),
+    resolveAuthProfileDatabaseOptions(agentDir).path,
     "store",
   );
   return result.status === "readable" ? result.raw : null;
@@ -340,7 +347,7 @@ export function readPersistedAuthProfileStateRaw(
     return parseJsonCell(row?.state_json);
   }
   const result = inspectAuthProfileJsonCellReadOnly(
-    resolveAuthProfileDatabasePath(agentDir),
+    resolveAuthProfileDatabaseOptions(agentDir).path,
     "state",
   );
   return result.status === "readable" ? result.raw : null;

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -50,10 +50,12 @@ import {
   getPreparedRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreSnapshotRevision,
+  getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath,
   noteRuntimeAuthProfileStorePersistedMutation,
   listRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
+  setRuntimeAuthProfileStoreSnapshotAtDatabasePath,
 } from "./runtime-snapshots.js";
 import {
   deletePersistedAuthProfileStoreRaw,
@@ -1446,8 +1448,9 @@ function saveAuthProfileStoreInTransaction(
             next: refreshed,
             existing: derived.store,
           });
-          setRuntimeAuthProfileStoreSnapshot(
+          setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
             mergeRuntimeExternalProfileReferences({ next: materialized, existing: derived.store }),
+            derived.databasePath,
             derived.agentDir,
           );
         }
@@ -1461,8 +1464,9 @@ function saveAuthProfileStoreInTransaction(
         next: refreshed,
         existing: derived.store,
       });
-      setRuntimeAuthProfileStoreSnapshot(
+      setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
         mergeRuntimeExternalProfileReferences({ next: materialized, existing: derived.store }),
+        derived.databasePath,
         derived.agentDir,
       );
     }
@@ -1548,7 +1552,7 @@ function captureRuntimeAuthProfileStorePersistenceSnapshot(
   const mainAuthPath = resolveSharedAuthPath();
   return {
     runtimeCaptured: true,
-    runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevision(agentDir),
+    runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(capturedAuthPath),
     runtimeStore: getRuntimeAuthProfileStoreSnapshot(agentDir),
     derivedRuntimeStores:
       capturedAuthPath === mainAuthPath
@@ -1558,7 +1562,8 @@ function captureRuntimeAuthProfileStorePersistenceSnapshot(
               databasePath,
               agentDir: derivedAgentDir,
               store,
-              runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevision(derivedAgentDir),
+              runtimeRevision:
+                getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(databasePath),
             }))
         : [],
   };
@@ -1607,17 +1612,15 @@ function recordRuntimeAuthProfileStorePublicationEdge(
 
 function replaceRuntimeAuthProfileStoreSnapshot(
   store: AuthProfileStore | undefined,
-  agentDir?: string,
+  agentDir: string | undefined,
+  databasePath: string,
 ): void {
   if (store) {
-    setRuntimeAuthProfileStoreSnapshot(store, agentDir);
+    setRuntimeAuthProfileStoreSnapshotAtDatabasePath(store, databasePath, agentDir);
     return;
   }
-  const replacedAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
   replaceRuntimeAuthProfileStoreSnapshots(
-    listRuntimeAuthProfileStoreSnapshots().filter(
-      (entry) => entry.databasePath !== replacedAuthPath,
-    ),
+    listRuntimeAuthProfileStoreSnapshots().filter((entry) => entry.databasePath !== databasePath),
   );
 }
 
@@ -1633,6 +1636,7 @@ function rebuildRuntimeAuthProfileStoreSnapshot(
   agentDir: string | undefined,
   existing: AuthProfileStore,
   predecessor?: AuthProfileStore,
+  databasePath?: string,
 ): void {
   const refreshed = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
   const currentMaterialized = preserveResolvedSecretBackedCredentials({
@@ -1646,7 +1650,11 @@ function rebuildRuntimeAuthProfileStoreSnapshot(
       })
     : currentMaterialized;
   const rebuilt = mergeRuntimeExternalProfileReferences({ next: materialized, existing });
-  setRuntimeAuthProfileStoreSnapshot(rebuilt, agentDir);
+  if (databasePath) {
+    setRuntimeAuthProfileStoreSnapshotAtDatabasePath(rebuilt, databasePath, agentDir);
+  } else {
+    setRuntimeAuthProfileStoreSnapshot(rebuilt, agentDir);
+  }
 }
 
 /** Capture both persisted auth rows under one database lock. */
@@ -1751,6 +1759,7 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
   const rowsFullyOwned = params.credentialsOwned && params.stateOwned;
   const rowsRestored = params.credentialsRestored || params.stateRestored;
   const reconcileOne = (
+    databasePath: string,
     agentDir: string | undefined,
     snapshotStore: AuthProfileStore | undefined,
     snapshotRuntimeRevision: number | undefined,
@@ -1770,11 +1779,11 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
       runtimeRevisionAtSaveEdge === runtimeRevisionBeforePublication &&
       currentRuntimeRevision === ownedRuntimeRevision;
     if (rowsFullyOwned && runtimeGenerationOwned && isDeepStrictEqual(currentStore, ownedStore)) {
-      replaceRuntimeAuthProfileStoreSnapshot(snapshotStore, agentDir);
+      replaceRuntimeAuthProfileStoreSnapshot(snapshotStore, agentDir, databasePath);
     } else if (rowsRestored && currentStore) {
       // Current overlays win, while the predecessor can still supply materialized
       // values for final keyRefs that the candidate temporarily removed.
-      rebuildRuntimeAuthProfileStoreSnapshot(agentDir, currentStore, snapshotStore);
+      rebuildRuntimeAuthProfileStoreSnapshot(agentDir, currentStore, snapshotStore, databasePath);
     }
   };
 
@@ -1786,6 +1795,7 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
     params.currentRuntimeStores.map((entry) => [entry.databasePath, entry]),
   );
   reconcileOne(
+    restoredAuthPath,
     params.agentDir,
     params.snapshot.runtimeStore,
     params.snapshot.runtimeRevision,
@@ -1824,6 +1834,7 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
     const snapshotEntry = snapshotDerived.get(pathname);
     const ownedEntry = ownedDerived.get(pathname);
     reconcileOne(
+      pathname,
       currentEntry.agentDir,
       snapshotEntry?.store,
       snapshotEntry?.runtimeRevision,
@@ -1890,10 +1901,14 @@ export function restoreAuthProfileStorePersistenceSnapshot(
           databasePath,
           agentDir: runtimeAgentDir,
           store,
-          runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevision(runtimeAgentDir),
+          runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(databasePath),
         }),
       );
-      const currentRuntimeRevision = getRuntimeAuthProfileStoreSnapshotRevision(agentDir);
+      const currentRuntimePath = agentDir
+        ? resolveAgentAuthPath(agentDir)
+        : resolveSharedAuthPath();
+      const currentRuntimeRevision =
+        getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(currentRuntimePath);
       if (credentialsRestored || stateRestored) {
         noteRuntimeAuthProfileStorePersistedMutation(agentDir, {
           credentialsChanged: credentialsRestored,

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -38,6 +38,7 @@ import {
   shouldUseMainOwnerForLocalOAuthCredential,
   type PersistedAuthProfileStores,
 } from "./ownership.js";
+import { resolveSharedAuthStorePath as resolveSharedAuthPath } from "./path-resolve.js";
 import {
   buildPersistedAuthProfileSecretsStore,
   loadPersistedAuthProfileStore,
@@ -59,16 +60,13 @@ import {
   inspectPersistedAuthProfileStoreRaw,
   readPersistedAuthProfileStoreRaw,
   readPersistedAuthProfileStateRaw,
-  resolveAuthProfileDatabasePath,
+  resolveAuthProfileDatabasePath as resolveAgentAuthPath,
   runAuthProfileWriteTransaction,
   writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
 } from "./sqlite.js";
 import { buildPersistedAuthProfileState, loadPersistedAuthProfileState } from "./state.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
-
-// Runtime identity is the canonical per-agent database, never a retired JSON filename.
-const resolveAuthStorePath = resolveAuthProfileDatabasePath;
 
 type LoadAuthProfileStoreOptions = {
   allowKeychainPrompt?: boolean;
@@ -247,7 +245,8 @@ function loadPersistedAuthProfileStores(
   database?: OpenClawAgentDatabase,
 ): PersistedAuthProfileStores {
   const localStore = loadPersistedAuthProfileStore(agentDir, database ? { database } : undefined);
-  const isMainStore = resolveAuthStorePath(agentDir) === resolveAuthStorePath();
+  const localAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
+  const isMainStore = localAuthPath === resolveSharedAuthPath();
   return {
     isMainStore,
     localStore,
@@ -280,8 +279,10 @@ function resolveRuntimeAuthProfileStore(
   agentDir?: string,
   options?: Pick<LoadAuthProfileStoreOptions, "allowKeychainPrompt" | "inheritedAuthDir">,
 ): AuthProfileStore | null {
-  const mainKey = resolveAuthStorePath(options?.inheritedAuthDir);
-  const requestedKey = resolveAuthStorePath(agentDir);
+  const mainKey = options?.inheritedAuthDir
+    ? resolveAgentAuthPath(options.inheritedAuthDir)
+    : resolveSharedAuthPath();
+  const requestedKey = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
   const mainStore = getRuntimeAuthProfileStoreSnapshotCore(options?.inheritedAuthDir);
   const requestedStore = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
 
@@ -1044,8 +1045,12 @@ export function loadAuthProfileStoreForRuntime(
   const effectiveAgentDir = resolveRuntimeAuthProfileAgentDir(agentDir);
   const effectiveOptions = resolveRuntimeAuthProfileLoadOptions(options);
   const store = loadAuthProfileStoreForAgent(effectiveAgentDir, effectiveOptions);
-  const authPath = resolveAuthStorePath(effectiveAgentDir);
-  const mainAuthPath = resolveAuthStorePath(effectiveOptions?.inheritedAuthDir);
+  const authPath = effectiveAgentDir
+    ? resolveAgentAuthPath(effectiveAgentDir)
+    : resolveSharedAuthPath();
+  const mainAuthPath = effectiveOptions?.inheritedAuthDir
+    ? resolveAgentAuthPath(effectiveOptions.inheritedAuthDir)
+    : resolveSharedAuthPath();
   const externalCli = resolveExternalCliOverlayOptions(effectiveOptions);
   if (!effectiveAgentDir || authPath === mainAuthPath) {
     return setRuntimeLocalProfileMetadata(
@@ -1108,8 +1113,12 @@ export function loadAuthProfileStoreWithoutExternalProfiles(
       : {}),
   };
   const store = loadAuthProfileStoreForAgent(effectiveAgentDir, options);
-  const authPath = resolveAuthStorePath(effectiveAgentDir);
-  const mainAuthPath = resolveAuthStorePath(options.inheritedAuthDir);
+  const authPath = effectiveAgentDir
+    ? resolveAgentAuthPath(effectiveAgentDir)
+    : resolveSharedAuthPath();
+  const mainAuthPath = options.inheritedAuthDir
+    ? resolveAgentAuthPath(options.inheritedAuthDir)
+    : resolveSharedAuthPath();
   if (!effectiveAgentDir || authPath === mainAuthPath) {
     return setRuntimeLocalProfileMetadata(
       stripRuntimeExternalProfileMetadata(store),
@@ -1207,8 +1216,12 @@ export function ensureAuthProfileStoreWithoutExternalProfiles(
     });
   }
   const store = loadAuthProfileStoreForAgent(effectiveAgentDir, effectiveOptions);
-  const authPath = resolveAuthStorePath(effectiveAgentDir);
-  const mainAuthPath = resolveAuthStorePath(effectiveOptions.inheritedAuthDir);
+  const authPath = effectiveAgentDir
+    ? resolveAgentAuthPath(effectiveAgentDir)
+    : resolveSharedAuthPath();
+  const mainAuthPath = effectiveOptions.inheritedAuthDir
+    ? resolveAgentAuthPath(effectiveOptions.inheritedAuthDir)
+    : resolveSharedAuthPath();
   if (!effectiveAgentDir || authPath === mainAuthPath) {
     return stripRuntimeExternalProfileMetadata(store);
   }
@@ -1239,8 +1252,9 @@ export function findPersistedAuthProfileCredential(params: {
     return requestedProfile;
   }
 
-  const requestedPath = resolveAuthStorePath(agentDir);
-  const mainPath = resolveAuthStorePath(resolveRuntimeAuthProfileAgentDir());
+  const requestedPath = resolveAgentAuthPath(agentDir);
+  const mainAgentDir = resolveRuntimeAuthProfileAgentDir();
+  const mainPath = mainAgentDir ? resolveAgentAuthPath(mainAgentDir) : resolveSharedAuthPath();
   if (requestedPath === mainPath) {
     return requestedProfile;
   }
@@ -1263,9 +1277,9 @@ export function resolvePersistedAuthProfileOwnerAgentDir(params: {
     return undefined;
   }
   const requestedStore = loadPersistedAuthProfileStore(agentDir);
-  const requestedPath = resolveAuthStorePath(agentDir);
+  const requestedPath = resolveAgentAuthPath(agentDir);
   const mainAgentDir = resolveRuntimeAuthProfileAgentDir();
-  const mainPath = resolveAuthStorePath(mainAgentDir);
+  const mainPath = mainAgentDir ? resolveAgentAuthPath(mainAgentDir) : resolveSharedAuthPath();
   if (requestedPath === mainPath) {
     return undefined;
   }
@@ -1292,8 +1306,11 @@ export function ensureAuthProfileStoreForLocalUpdate(agentDir?: string): AuthPro
   const effectiveAgentDir = resolveRuntimeAuthProfileAgentDir(agentDir);
   const options: LoadAuthProfileStoreOptions = { syncExternalCli: false };
   const store = loadAuthProfileStoreForAgent(effectiveAgentDir, options);
-  const authPath = resolveAuthStorePath(effectiveAgentDir);
-  const mainAuthPath = resolveAuthStorePath(resolveRuntimeAuthProfileAgentDir());
+  const authPath = effectiveAgentDir
+    ? resolveAgentAuthPath(effectiveAgentDir)
+    : resolveSharedAuthPath();
+  const mainAgentDir = resolveRuntimeAuthProfileAgentDir();
+  const mainAuthPath = mainAgentDir ? resolveAgentAuthPath(mainAgentDir) : resolveSharedAuthPath();
   if (!effectiveAgentDir || authPath === mainAuthPath) {
     return store;
   }
@@ -1342,8 +1359,8 @@ function saveAuthProfileStoreInTransaction(
   database: OpenClawAgentDatabase,
   publishFromSuppliedStore = false,
 ): () => void {
-  const savedAuthPath = resolveAuthStorePath(agentDir);
-  const mainAuthPath = resolveAuthStorePath();
+  const savedAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
+  const mainAuthPath = resolveSharedAuthPath();
   const savesMainStore = savedAuthPath === mainAuthPath;
   const loadedPersistedStores = loadPersistedAuthProfileStores(agentDir, database);
   const persistedStores: PersistedAuthProfileStores = {
@@ -1399,7 +1416,7 @@ function saveAuthProfileStoreInTransaction(
     // overlays at the publication edge so post-commit refreshes are retained.
     const derivedSnapshots = savesMainStore
       ? listRuntimeAuthProfileStoreSnapshots().filter(
-          (entry) => resolveAuthStorePath(entry.agentDir) !== mainAuthPath,
+          (entry) => resolveAgentAuthPath(entry.agentDir) !== mainAuthPath,
         )
       : [];
     if (credentialsChanged || stateChanged) {
@@ -1521,8 +1538,8 @@ function captureRuntimeAuthProfileStorePersistenceSnapshot(
   AuthProfileStorePersistenceSnapshot,
   "runtimeCaptured" | "runtimeRevision" | "runtimeStore" | "derivedRuntimeStores"
 > {
-  const capturedAuthPath = resolveAuthStorePath(agentDir);
-  const mainAuthPath = resolveAuthStorePath(undefined);
+  const capturedAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
+  const mainAuthPath = resolveSharedAuthPath();
   return {
     runtimeCaptured: true,
     runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevision(agentDir),
@@ -1530,7 +1547,7 @@ function captureRuntimeAuthProfileStorePersistenceSnapshot(
     derivedRuntimeStores:
       capturedAuthPath === mainAuthPath
         ? listRuntimeAuthProfileStoreSnapshots()
-            .filter((entry) => resolveAuthStorePath(entry.agentDir) !== mainAuthPath)
+            .filter((entry) => resolveAgentAuthPath(entry.agentDir) !== mainAuthPath)
             .map(({ agentDir: derivedAgentDir, store }) => ({
               agentDir: derivedAgentDir,
               store,
@@ -1583,10 +1600,10 @@ function replaceRuntimeAuthProfileStoreSnapshot(
     setRuntimeAuthProfileStoreSnapshot(store, agentDir);
     return;
   }
-  const replacedAuthPath = resolveAuthStorePath(agentDir);
+  const replacedAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
   replaceRuntimeAuthProfileStoreSnapshots(
     listRuntimeAuthProfileStoreSnapshots().filter(
-      (entry) => resolveAuthStorePath(entry.agentDir) !== replacedAuthPath,
+      (entry) => resolveAgentAuthPath(entry.agentDir) !== replacedAuthPath,
     ),
   );
 }
@@ -1741,10 +1758,12 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
     }
   };
 
-  const restoredAuthPath = resolveAuthStorePath(params.agentDir);
-  const mainAuthPath = resolveAuthStorePath(undefined);
+  const restoredAuthPath = params.agentDir
+    ? resolveAgentAuthPath(params.agentDir)
+    : resolveSharedAuthPath();
+  const mainAuthPath = resolveSharedAuthPath();
   const currentRuntimeStores = new Map(
-    params.currentRuntimeStores.map((entry) => [resolveAuthStorePath(entry.agentDir), entry]),
+    params.currentRuntimeStores.map((entry) => [resolveAgentAuthPath(entry.agentDir), entry]),
   );
   reconcileOne(
     params.agentDir,
@@ -1762,25 +1781,25 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
   }
   const snapshotDerived = new Map(
     (params.snapshot.derivedRuntimeStores ?? []).map((entry) => [
-      resolveAuthStorePath(entry.agentDir),
+      resolveAgentAuthPath(entry.agentDir),
       entry,
     ]),
   );
   const ownedDerived = new Map(
     (params.owned.derivedRuntimeStores ?? []).map((entry) => [
-      resolveAuthStorePath(entry.agentDir),
+      resolveAgentAuthPath(entry.agentDir),
       entry,
     ]),
   );
   const saveEdgeDerivedRevisions = new Map(
     (params.owned.derivedRuntimeRevisionsAtSaveEdge ?? []).map((entry) => [
-      resolveAuthStorePath(entry.agentDir),
+      resolveAgentAuthPath(entry.agentDir),
       entry.runtimeRevision,
     ]),
   );
   const publicationEdgeDerivedRevisions = new Map(
     (params.owned.derivedRuntimeRevisionsBeforePublication ?? []).map((entry) => [
-      resolveAuthStorePath(entry.agentDir),
+      resolveAgentAuthPath(entry.agentDir),
       entry.runtimeRevision,
     ]),
   );

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1416,7 +1416,7 @@ function saveAuthProfileStoreInTransaction(
     // overlays at the publication edge so post-commit refreshes are retained.
     const derivedSnapshots = savesMainStore
       ? listRuntimeAuthProfileStoreSnapshots().filter(
-          (entry) => resolveAgentAuthPath(entry.agentDir) !== mainAuthPath,
+          (entry) => entry.databasePath !== mainAuthPath,
         )
       : [];
     if (credentialsChanged || stateChanged) {
@@ -1516,12 +1516,18 @@ type AuthProfileStorePersistenceSnapshot = {
   runtimeRevisionBeforePublication?: number;
   runtimeStore?: AuthProfileStore;
   derivedRuntimeStores?: Array<{
+    databasePath: string;
     agentDir: string;
     store: AuthProfileStore;
     runtimeRevision?: number;
   }>;
-  derivedRuntimeRevisionsAtSaveEdge?: Array<{ agentDir: string; runtimeRevision: number }>;
+  derivedRuntimeRevisionsAtSaveEdge?: Array<{
+    databasePath: string;
+    agentDir: string;
+    runtimeRevision: number;
+  }>;
   derivedRuntimeRevisionsBeforePublication?: Array<{
+    databasePath: string;
     agentDir: string;
     runtimeRevision: number;
   }>;
@@ -1547,8 +1553,9 @@ function captureRuntimeAuthProfileStorePersistenceSnapshot(
     derivedRuntimeStores:
       capturedAuthPath === mainAuthPath
         ? listRuntimeAuthProfileStoreSnapshots()
-            .filter((entry) => resolveAgentAuthPath(entry.agentDir) !== mainAuthPath)
-            .map(({ agentDir: derivedAgentDir, store }) => ({
+            .filter((entry) => entry.databasePath !== mainAuthPath)
+            .map(({ agentDir: derivedAgentDir, databasePath, store }) => ({
+              databasePath,
               agentDir: derivedAgentDir,
               store,
               runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevision(derivedAgentDir),
@@ -1586,7 +1593,13 @@ function recordRuntimeAuthProfileStorePublicationEdge(
     owned.derivedRuntimeRevisionsBeforePublication = runtime.derivedRuntimeStores.flatMap(
       (entry) =>
         typeof entry.runtimeRevision === "number"
-          ? [{ agentDir: entry.agentDir, runtimeRevision: entry.runtimeRevision }]
+          ? [
+              {
+                databasePath: entry.databasePath,
+                agentDir: entry.agentDir,
+                runtimeRevision: entry.runtimeRevision,
+              },
+            ]
           : [],
     );
   }
@@ -1603,7 +1616,7 @@ function replaceRuntimeAuthProfileStoreSnapshot(
   const replacedAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
   replaceRuntimeAuthProfileStoreSnapshots(
     listRuntimeAuthProfileStoreSnapshots().filter(
-      (entry) => resolveAgentAuthPath(entry.agentDir) !== replacedAuthPath,
+      (entry) => entry.databasePath !== replacedAuthPath,
     ),
   );
 }
@@ -1681,7 +1694,13 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
     owned.derivedRuntimeRevisionsAtSaveEdge = runtimeAtSaveEdge.derivedRuntimeStores?.flatMap(
       (entry) =>
         typeof entry.runtimeRevision === "number"
-          ? [{ agentDir: entry.agentDir, runtimeRevision: entry.runtimeRevision }]
+          ? [
+              {
+                databasePath: entry.databasePath,
+                agentDir: entry.agentDir,
+                runtimeRevision: entry.runtimeRevision,
+              },
+            ]
           : [],
     );
     publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
@@ -1719,6 +1738,7 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
   credentialsRestored: boolean;
   stateRestored: boolean;
   currentRuntimeStores: Array<{
+    databasePath: string;
     agentDir: string;
     store: AuthProfileStore;
     runtimeRevision: number;
@@ -1763,7 +1783,7 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
     : resolveSharedAuthPath();
   const mainAuthPath = resolveSharedAuthPath();
   const currentRuntimeStores = new Map(
-    params.currentRuntimeStores.map((entry) => [resolveAgentAuthPath(entry.agentDir), entry]),
+    params.currentRuntimeStores.map((entry) => [entry.databasePath, entry]),
   );
   reconcileOne(
     params.agentDir,
@@ -1780,26 +1800,20 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
     return;
   }
   const snapshotDerived = new Map(
-    (params.snapshot.derivedRuntimeStores ?? []).map((entry) => [
-      resolveAgentAuthPath(entry.agentDir),
-      entry,
-    ]),
+    (params.snapshot.derivedRuntimeStores ?? []).map((entry) => [entry.databasePath, entry]),
   );
   const ownedDerived = new Map(
-    (params.owned.derivedRuntimeStores ?? []).map((entry) => [
-      resolveAgentAuthPath(entry.agentDir),
-      entry,
-    ]),
+    (params.owned.derivedRuntimeStores ?? []).map((entry) => [entry.databasePath, entry]),
   );
   const saveEdgeDerivedRevisions = new Map(
     (params.owned.derivedRuntimeRevisionsAtSaveEdge ?? []).map((entry) => [
-      resolveAgentAuthPath(entry.agentDir),
+      entry.databasePath,
       entry.runtimeRevision,
     ]),
   );
   const publicationEdgeDerivedRevisions = new Map(
     (params.owned.derivedRuntimeRevisionsBeforePublication ?? []).map((entry) => [
-      resolveAgentAuthPath(entry.agentDir),
+      entry.databasePath,
       entry.runtimeRevision,
     ]),
   );
@@ -1872,7 +1886,8 @@ export function restoreAuthProfileStorePersistenceSnapshot(
       // Main credential mutation lineage invalidates derived snapshots. Capture
       // them first so exact-owned entries can restore and newer entries rebuild.
       const currentRuntimeStores = listRuntimeAuthProfileStoreSnapshots().map(
-        ({ agentDir: runtimeAgentDir, store }) => ({
+        ({ agentDir: runtimeAgentDir, databasePath, store }) => ({
+          databasePath,
           agentDir: runtimeAgentDir,
           store,
           runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevision(runtimeAgentDir),

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -17,6 +17,7 @@ import {
   type AuthProfileStore,
 } from "../agents/auth-profiles.js";
 import { AuthProfileStoreUnreadableError } from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import {
   inspectPersistedAuthProfileStoreRaw,
@@ -256,7 +257,7 @@ export async function agentsAddCommand(
       const sourceAgentDir = resolveAgentDir(cfg, defaultAgentId);
       const sourceAuthPath = resolveAuthProfileDatabasePath(sourceAgentDir);
       const destAuthPath = resolveAuthProfileDatabasePath(agentDir);
-      const mainAuthPath = resolveAuthProfileDatabasePath();
+      const mainAuthPath = resolveSharedAuthStorePath();
       const sameAuthPath =
         normalizeLowercaseStringOrEmpty(path.resolve(sourceAuthPath)) ===
         normalizeLowercaseStringOrEmpty(path.resolve(destAuthPath));

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,10 +1,19 @@
 // Implements agent deletion with gateway delegation and local cleanup fallback.
-import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
+import {
+  findOverlappingWorkspaceAgentIds,
+  formatSharedAuthStoreOwnerDeleteError,
+  isSharedAuthStoreOwner,
+} from "../agents/agent-delete-safety.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   tryResolveSoleAgentId,
 } from "../agents/agent-scope.js";
+import {
+  resolveSharedAuthStoreOwnership,
+  resolveSharedAuthStorePath,
+} from "../agents/auth-profiles/path-resolve.js";
+import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import { resolveLegacyInheritedAuthAgentId } from "../agents/legacy-inherited-auth-dir.js";
 import {
   prepareLegacyWorkspaceStateReset,
@@ -26,7 +35,7 @@ import {
   isGatewayCredentialsRequiredError,
   isGatewayTransportError,
 } from "../gateway/call.js";
-import { LEGACY_IMPLICIT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -104,10 +113,15 @@ export async function agentsDeleteCommand(
   if (agentId !== input) {
     runtime.log(`Normalized agent id to "${agentId}".`);
   }
-  // agents/main/agent also owns the shipped shared legacy auth store.
-  // Keep main undeletable until named agents make auth-store ownership explicit.
-  if (agentId === LEGACY_IMPLICIT_AGENT_ID) {
-    runtime.error(`"${LEGACY_IMPLICIT_AGENT_ID}" cannot be deleted.`);
+  const agentDir = resolveAgentDir(cfg, agentId);
+  if (
+    isSharedAuthStoreOwner({
+      ownership: resolveSharedAuthStoreOwnership(),
+      agentAuthDbPath: resolveAuthProfileDatabasePath(agentDir),
+      sharedAuthDbPath: resolveSharedAuthStorePath(),
+    })
+  ) {
+    runtime.error(formatSharedAuthStoreOwnerDeleteError(agentId));
     runtime.exit(1);
     return;
   }
@@ -150,7 +164,6 @@ export async function agentsDeleteCommand(
   }
 
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const agentDir = resolveAgentDir(cfg, agentId);
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
   const result = pruneAgentConfig(cfg, agentId);
 

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -231,7 +231,9 @@ describe("agents delete command", () => {
 
       expect(gatewayMocks.callGateway).not.toHaveBeenCalled();
       expect(configMocks.replaceConfigFile).not.toHaveBeenCalled();
-      expect(runtime.error).toHaveBeenCalledWith('"main" cannot be deleted.');
+      expect(runtime.error).toHaveBeenCalledWith(
+        'Agent "main" owns the legacy shared auth store and cannot be deleted. Run openclaw doctor --fix to migrate shared auth, then retry.',
+      );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expectSessionStore(cfg, sessions, "main");
     });

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -19,10 +19,7 @@ import {
   hasMatchingOAuthIdentity,
 } from "../agents/auth-profiles/oauth-shared.js";
 import { isInheritedMainOAuthCredentialFromStores } from "../agents/auth-profiles/ownership.js";
-import {
-  resolveSharedAuthStoreDir,
-  resolveSharedAuthStorePath,
-} from "../agents/auth-profiles/path-resolve.js";
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import {
   applyLegacyAuthStore,
   coerceLegacyAuthStore,
@@ -812,7 +809,7 @@ function migrateLockedLegacyOAuthFile(params: {
   now: () => number;
   result: LegacyFlatAuthProfileRepairResult;
 }): void {
-  const mainAgentDir = resolveSharedAuthStoreDir(params.env);
+  const mainAgentDir = path.dirname(resolveSharedAuthStorePath(params.env));
   const targetDatabasePath = resolveAuthProfileDatabasePath(mainAgentDir);
   const receipt = prepareAuthProfileSourceReceipt({
     pathname: params.oauthPath,
@@ -1188,7 +1185,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
               database,
             );
             const loaded = loadMigratedStore(candidate.agentDir, { database });
-            const mainAgentDir = resolveSharedAuthStoreDir(params.env);
+            const mainAgentDir = path.dirname(resolveSharedAuthStorePath(params.env));
             const persistedStores = {
               isMainStore:
                 resolveMigrationTargetDatabasePath(candidate.agentDir) ===
@@ -1313,7 +1310,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       releaseSources?.();
     }
   }
-  const sharedMainAgentDir = resolveSharedAuthStoreDir(env);
+  const sharedMainAgentDir = path.dirname(resolveSharedAuthStorePath(env));
   const sharedMainCredentialSourceRemains = [
     resolveAuthStorePath(sharedMainAgentDir),
     resolveLegacyAuthStorePath(sharedMainAgentDir),

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -20,6 +20,10 @@ import {
 } from "../agents/auth-profiles/oauth-shared.js";
 import { isInheritedMainOAuthCredentialFromStores } from "../agents/auth-profiles/ownership.js";
 import {
+  resolveSharedAuthStoreDir,
+  resolveSharedAuthStorePath,
+} from "../agents/auth-profiles/path-resolve.js";
+import {
   applyLegacyAuthStore,
   coerceLegacyAuthStore,
   coercePersistedAuthProfileStore,
@@ -27,7 +31,6 @@ import {
   parseLegacyCredentialEntry,
 } from "../agents/auth-profiles/persisted.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/runtime-snapshots.js";
-import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
@@ -79,6 +82,10 @@ type AuthProfileSqliteMigrationCandidate = AuthProfileRepairCandidate & {
   statePath: string;
   legacyPath: string;
 };
+
+function resolveMigrationTargetDatabasePath(agentDir?: string): string {
+  return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
+}
 
 type AwsSdkProfileMarker = {
   profileId: string;
@@ -805,7 +812,7 @@ function migrateLockedLegacyOAuthFile(params: {
   now: () => number;
   result: LegacyFlatAuthProfileRepairResult;
 }): void {
-  const mainAgentDir = resolveSharedMainAuthAgentDir(params.env);
+  const mainAgentDir = resolveSharedAuthStoreDir(params.env);
   const targetDatabasePath = resolveAuthProfileDatabasePath(mainAgentDir);
   const receipt = prepareAuthProfileSourceReceipt({
     pathname: params.oauthPath,
@@ -997,7 +1004,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         fs.mkdirSync(path.dirname(pathname), { recursive: true });
       }
       releaseSources = acquireAuthProfileMigrationSourceLocks(candidateSourcePaths);
-      const targetDatabasePath = resolveAuthProfileDatabasePath(candidate.agentDir);
+      const targetDatabasePath = resolveMigrationTargetDatabasePath(candidate.agentDir);
       let sourceReceipts = candidateSourcePaths.filter(fs.existsSync).map((pathname) =>
         prepareAuthProfileSourceReceipt({
           pathname,
@@ -1181,14 +1188,14 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
               database,
             );
             const loaded = loadMigratedStore(candidate.agentDir, { database });
-            const mainAgentDir = resolveSharedMainAuthAgentDir(params.env);
+            const mainAgentDir = resolveSharedAuthStoreDir(params.env);
             const persistedStores = {
               isMainStore:
-                resolveAuthProfileDatabasePath(candidate.agentDir) ===
+                resolveMigrationTargetDatabasePath(candidate.agentDir) ===
                 resolveAuthProfileDatabasePath(mainAgentDir),
               localStore: loaded,
               mainStore:
-                resolveAuthProfileDatabasePath(candidate.agentDir) ===
+                resolveMigrationTargetDatabasePath(candidate.agentDir) ===
                 resolveAuthProfileDatabasePath(mainAgentDir)
                   ? loaded
                   : loadPersistedAuthProfileStore(mainAgentDir),
@@ -1306,7 +1313,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       releaseSources?.();
     }
   }
-  const sharedMainAgentDir = resolveSharedMainAuthAgentDir(env);
+  const sharedMainAgentDir = resolveSharedAuthStoreDir(env);
   const sharedMainCredentialSourceRemains = [
     resolveAuthStorePath(sharedMainAgentDir),
     resolveLegacyAuthStorePath(sharedMainAgentDir),
@@ -1742,7 +1749,7 @@ function recoverArchivedOpenAICodexAuthProfileIdMap(params: {
           path.resolve(report.archivePath) !== path.resolve(archive.path) ||
           typeof report.targetDatabasePath !== "string" ||
           path.resolve(report.targetDatabasePath) !==
-            path.resolve(resolveAuthProfileDatabasePath(candidate.agentDir)) ||
+            path.resolve(resolveMigrationTargetDatabasePath(candidate.agentDir)) ||
           !isRecord(report.expectedProfileSha256)
         ) {
           continue;

--- a/src/commands/doctor-auth-legacy-paths.ts
+++ b/src/commands/doctor-auth-legacy-paths.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
-import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
+import { resolveSharedAuthStoreDir } from "../agents/auth-profiles/path-resolve.js";
 import { resolveUserPath } from "../utils.js";
 
 function resolveLegacyAuthAgentDir(agentDir?: string): string {
-  return agentDir ? resolveUserPath(agentDir) : resolveSharedMainAuthAgentDir();
+  return agentDir ? resolveUserPath(agentDir) : resolveSharedAuthStoreDir();
 }
 
 export function resolveLegacyAuthProfilesPath(agentDir?: string): string {

--- a/src/commands/doctor-model-catalog-credentials.ts
+++ b/src/commands/doctor-model-catalog-credentials.ts
@@ -6,9 +6,9 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
+import { resolveSharedAuthStoreDir } from "../agents/auth-profiles/path-resolve.js";
 import { mergeAuthProfileStores } from "../agents/auth-profiles/persisted.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
-import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
@@ -230,7 +230,7 @@ export async function maybeMigrateModelCatalogCredentials(params: {
   const warnings: string[] = [];
   const env = params.env ?? process.env;
   const stateDir = resolveStateDir(env);
-  const mainAgentDir = resolveSharedMainAuthAgentDir(env);
+  const mainAgentDir = resolveSharedAuthStoreDir(env);
   const discoveredAgentDirs = listAgentModelsJsonPaths(params.cfg, stateDir, env).map(
     (modelsPath) => path.dirname(modelsPath),
   );

--- a/src/commands/doctor-model-catalog-credentials.ts
+++ b/src/commands/doctor-model-catalog-credentials.ts
@@ -6,7 +6,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
-import { resolveSharedAuthStoreDir } from "../agents/auth-profiles/path-resolve.js";
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import { mergeAuthProfileStores } from "../agents/auth-profiles/persisted.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
@@ -230,7 +230,7 @@ export async function maybeMigrateModelCatalogCredentials(params: {
   const warnings: string[] = [];
   const env = params.env ?? process.env;
   const stateDir = resolveStateDir(env);
-  const mainAgentDir = resolveSharedAuthStoreDir(env);
+  const mainAgentDir = path.dirname(resolveSharedAuthStorePath(env));
   const discoveredAgentDirs = listAgentModelsJsonPaths(params.cfg, stateDir, env).map(
     (modelsPath) => path.dirname(modelsPath),
   );

--- a/src/commands/doctor/shared/codex-route-session-repair.ts
+++ b/src/commands/doctor/shared/codex-route-session-repair.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString as normalizeString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentDir } from "../../../agents/agent-scope.js";
@@ -6,7 +7,7 @@ import {
   areOAuthCredentialsEquivalent,
   hasMatchingOAuthIdentity,
 } from "../../../agents/auth-profiles/oauth-shared.js";
-import { resolveSharedAuthStoreDir } from "../../../agents/auth-profiles/path-resolve.js";
+import { resolveSharedAuthStorePath } from "../../../agents/auth-profiles/path-resolve.js";
 import {
   loadPersistedAuthProfileStore,
   parseLegacyCredentialEntry,
@@ -332,7 +333,8 @@ function resolveVerifiedSessionAuthProfileIdMap(params: {
   const agentDir = resolveAgentDir(params.cfg, params.agentId, params.env);
   const localProfiles = loadPersistedAuthProfileStore(agentDir)?.profiles ?? {};
   const mainProfiles =
-    loadPersistedAuthProfileStore(resolveSharedAuthStoreDir(params.env))?.profiles ?? {};
+    loadPersistedAuthProfileStore(path.dirname(resolveSharedAuthStorePath(params.env)))?.profiles ??
+    {};
   const localLegacyAuthPath = resolveLegacyAuthProfilesPath(agentDir);
   const localLegacySourceExists = fs.existsSync(localLegacyAuthPath);
   const localLegacySource = localLegacySourceExists

--- a/src/commands/doctor/shared/codex-route-session-repair.ts
+++ b/src/commands/doctor/shared/codex-route-session-repair.ts
@@ -6,11 +6,11 @@ import {
   areOAuthCredentialsEquivalent,
   hasMatchingOAuthIdentity,
 } from "../../../agents/auth-profiles/oauth-shared.js";
+import { resolveSharedAuthStoreDir } from "../../../agents/auth-profiles/path-resolve.js";
 import {
   loadPersistedAuthProfileStore,
   parseLegacyCredentialEntry,
 } from "../../../agents/auth-profiles/persisted.js";
-import { resolveSharedMainAuthAgentDir } from "../../../agents/auth-profiles/shared-main-dir.js";
 import {
   applySessionEntryReplacements,
   listSessionEntriesForCanonicalRepair,
@@ -332,7 +332,7 @@ function resolveVerifiedSessionAuthProfileIdMap(params: {
   const agentDir = resolveAgentDir(params.cfg, params.agentId, params.env);
   const localProfiles = loadPersistedAuthProfileStore(agentDir)?.profiles ?? {};
   const mainProfiles =
-    loadPersistedAuthProfileStore(resolveSharedMainAuthAgentDir(params.env))?.profiles ?? {};
+    loadPersistedAuthProfileStore(resolveSharedAuthStoreDir(params.env))?.profiles ?? {};
   const localLegacyAuthPath = resolveLegacyAuthProfilesPath(agentDir);
   const localLegacySourceExists = fs.existsSync(localLegacyAuthPath);
   const localLegacySource = localLegacySourceExists

--- a/src/commands/doctor/shared/stale-auth-order.ts
+++ b/src/commands/doctor/shared/stale-auth-order.ts
@@ -7,11 +7,11 @@ import {
   resolveAuthProfileEligibility,
   resolveAuthProfileOrder,
 } from "../../../agents/auth-profiles/order.js";
+import { resolveSharedAuthStoreDir } from "../../../agents/auth-profiles/path-resolve.js";
 import {
   coercePersistedAuthProfileStore,
   mergeAuthProfileStores,
 } from "../../../agents/auth-profiles/persisted.js";
-import { resolveSharedMainAuthAgentDir } from "../../../agents/auth-profiles/shared-main-dir.js";
 import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
@@ -297,7 +297,7 @@ function loadConfiguredAgentAuthStores(
   }
   // Every secondary agent inherits the legacy main store at runtime, even when
   // `agents.list` names a different default agent.
-  const mainAgentDir = path.resolve(resolveSharedMainAuthAgentDir(env));
+  const mainAgentDir = path.resolve(resolveSharedAuthStoreDir(env));
   const activeAgentDirs = new Set<string>();
   const expectedAgentIdsByDir = new Map<string, Set<string>>();
   const addExpectedAgentDir = (agentDir: string, agentId: string) => {

--- a/src/commands/doctor/shared/stale-auth-order.ts
+++ b/src/commands/doctor/shared/stale-auth-order.ts
@@ -7,7 +7,7 @@ import {
   resolveAuthProfileEligibility,
   resolveAuthProfileOrder,
 } from "../../../agents/auth-profiles/order.js";
-import { resolveSharedAuthStoreDir } from "../../../agents/auth-profiles/path-resolve.js";
+import { resolveSharedAuthStorePath } from "../../../agents/auth-profiles/path-resolve.js";
 import {
   coercePersistedAuthProfileStore,
   mergeAuthProfileStores,
@@ -297,7 +297,7 @@ function loadConfiguredAgentAuthStores(
   }
   // Every secondary agent inherits the legacy main store at runtime, even when
   // `agents.list` names a different default agent.
-  const mainAgentDir = path.resolve(resolveSharedAuthStoreDir(env));
+  const mainAgentDir = path.dirname(resolveSharedAuthStorePath(env));
   const activeAgentDirs = new Set<string>();
   const expectedAgentIdsByDir = new Map<string, Set<string>>();
   const addExpectedAgentDir = (agentDir: string, agentId: string) => {

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -13,8 +13,8 @@ import {
   areOAuthCredentialsEquivalent,
   isSafeToAdoptMainStoreOAuthIdentity,
 } from "../../../agents/auth-profiles/oauth-shared.js";
+import { resolveSharedAuthStoreDir } from "../../../agents/auth-profiles/path-resolve.js";
 import { loadPersistedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
-import { resolveSharedMainAuthAgentDir } from "../../../agents/auth-profiles/shared-main-dir.js";
 import { updateAuthProfileStoreWithLock } from "../../../agents/auth-profiles/store.js";
 import type { AuthProfileStore, OAuthCredential } from "../../../agents/auth-profiles/types.js";
 import { resolveStateDir } from "../../../config/paths.js";
@@ -113,7 +113,7 @@ export async function scanStaleOAuthProfileShadows(params: {
 }): Promise<StaleOAuthProfileShadow[]> {
   const env = params.env ?? process.env;
   const now = params.now ?? Date.now();
-  const mainAgentDir = resolveSharedMainAuthAgentDir(env);
+  const mainAgentDir = resolveSharedAuthStoreDir(env);
   const mainAuthPath = path.resolve(resolveAuthStorePath(mainAgentDir));
   const mainStore = loadPersistedAuthProfileStore(mainAgentDir);
   if (!mainStore) {
@@ -294,7 +294,7 @@ export async function repairStaleOAuthProfileShadows(params: {
     byAgentDir.set(hit.agentDir, existing);
   }
   for (const [agentDir, agentHits] of byAgentDir) {
-    const mainStore = loadPersistedAuthProfileStore(resolveSharedMainAuthAgentDir(env));
+    const mainStore = loadPersistedAuthProfileStore(resolveSharedAuthStoreDir(env));
     if (!mainStore) {
       continue;
     }

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -13,7 +13,7 @@ import {
   areOAuthCredentialsEquivalent,
   isSafeToAdoptMainStoreOAuthIdentity,
 } from "../../../agents/auth-profiles/oauth-shared.js";
-import { resolveSharedAuthStoreDir } from "../../../agents/auth-profiles/path-resolve.js";
+import { resolveSharedAuthStorePath } from "../../../agents/auth-profiles/path-resolve.js";
 import { loadPersistedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
 import { updateAuthProfileStoreWithLock } from "../../../agents/auth-profiles/store.js";
 import type { AuthProfileStore, OAuthCredential } from "../../../agents/auth-profiles/types.js";
@@ -113,7 +113,7 @@ export async function scanStaleOAuthProfileShadows(params: {
 }): Promise<StaleOAuthProfileShadow[]> {
   const env = params.env ?? process.env;
   const now = params.now ?? Date.now();
-  const mainAgentDir = resolveSharedAuthStoreDir(env);
+  const mainAgentDir = path.dirname(resolveSharedAuthStorePath(env));
   const mainAuthPath = path.resolve(resolveAuthStorePath(mainAgentDir));
   const mainStore = loadPersistedAuthProfileStore(mainAgentDir);
   if (!mainStore) {
@@ -294,7 +294,7 @@ export async function repairStaleOAuthProfileShadows(params: {
     byAgentDir.set(hit.agentDir, existing);
   }
   for (const [agentDir, agentHits] of byAgentDir) {
-    const mainStore = loadPersistedAuthProfileStore(resolveSharedAuthStoreDir(env));
+    const mainStore = loadPersistedAuthProfileStore(path.dirname(resolveSharedAuthStorePath(env)));
     if (!mainStore) {
       continue;
     }

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -58,7 +58,9 @@ const mocks = vi.hoisted(() => ({
   cronRemoveAgentJobsTransactional: vi.fn(
     async (_agentId: string, commit: () => Promise<unknown>) => await commit(),
   ),
-  resolveAgentDir: vi.fn((_cfg?: unknown, _agentId?: string) => "/agents/test-agent"),
+  resolveAgentDir: vi.fn((_cfg?: unknown, agentId?: string) =>
+    agentId === "main" ? "/agents/main/agent" : "/agents/test-agent",
+  ),
   resolveAgentWorkspaceDir: vi.fn((_cfg?: unknown, _agentId?: string) => "/workspace/test-agent"),
   resolveSessionTranscriptsDirForAgent: vi.fn((_agentId?: string) => "/transcripts/test-agent"),
   listAgentsForGateway: vi.fn(() => ({
@@ -172,6 +174,14 @@ vi.mock("../../commands/agents.config.js", () => ({
   pruneAgentConfig: mocks.pruneAgentConfig,
 }));
 
+vi.mock("../../agents/auth-profiles/path-resolve.js", async () => ({
+  ...(await vi.importActual<typeof import("../../agents/auth-profiles/path-resolve.js")>(
+    "../../agents/auth-profiles/path-resolve.js",
+  )),
+  resolveSharedAuthStoreOwnership: () => ({ location: "legacy-main" }),
+  resolveSharedAuthStorePath: () => "/resolved/agents/main/agent/openclaw-agent.sqlite",
+}));
+
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: () => ["main"],
   listAgentEntries: mocks.listAgentEntries,
@@ -241,6 +251,8 @@ vi.mock("../../state/agent-deletion-journal.js", () => ({
 }));
 
 vi.mock("../../state/openclaw-agent-db-registry.js", () => ({
+  isSameOpenClawAgentDatabasePath: (left: string, right: string) =>
+    path.resolve(left) === path.resolve(right),
   unregisterOpenClawAgentDatabase: mocks.unregisterOpenClawAgentDatabase,
 }));
 
@@ -1265,6 +1277,9 @@ describe("agents.update", () => {
 describe("agents.delete", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveAgentDir.mockImplementation((_cfg?: unknown, agentId?: string) =>
+      agentId === "main" ? "/agents/main/agent" : "/agents/test-agent",
+    );
     mocks.fsLstat.mockResolvedValue({
       isSymbolicLink: () => false,
     } as unknown as import("node:fs").Stats);
@@ -2922,7 +2937,8 @@ describe("agents.delete", () => {
     });
     await promise;
 
-    expectRespondErrorContaining(respond, "cannot be deleted");
+    expectRespondErrorContaining(respond, "owns the legacy shared auth store");
+    expectRespondErrorContaining(respond, "openclaw doctor --fix");
     expect(mocks.writeConfigFile).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -20,7 +20,11 @@ import {
   validateAgentsUpdateParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { createAgent } from "../../agents/agent-create.js";
-import { findOverlappingWorkspaceAgentIds } from "../../agents/agent-delete-safety.js";
+import {
+  findOverlappingWorkspaceAgentIds,
+  formatSharedAuthStoreOwnerDeleteError,
+  isSharedAuthStoreOwner,
+} from "../../agents/agent-delete-safety.js";
 import {
   isPathOwnedByAnotherRegisteredAgent,
   normalizeAgentDirRegistryPath,
@@ -40,6 +44,11 @@ import {
   resolveAgentWorkspaceDir,
   tryResolveSoleAgentId,
 } from "../../agents/agent-scope.js";
+import {
+  resolveSharedAuthStoreOwnership,
+  resolveSharedAuthStorePath,
+} from "../../agents/auth-profiles/path-resolve.js";
+import { resolveAuthProfileDatabasePath } from "../../agents/auth-profiles/sqlite.js";
 import {
   createAgentIdentityConfig,
   mergeIdentityMarkdownContent,
@@ -79,7 +88,7 @@ import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
-import { LEGACY_IMPLICIT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import {
   readAgentDeletionJournal,
   type AgentDeletionJournalCleanupPath,
@@ -333,6 +342,16 @@ type AgentDeletePathOutcome =
   | { failed: AgentDeleteFailedPath };
 
 class AgentCleanupIdentityMismatchError extends Error {}
+class AgentSharedAuthStoreOwnerError extends Error {}
+
+function agentOwnsSharedAuthStore(cfg: OpenClawConfig, agentId: string): boolean {
+  const agentDir = resolveAgentDir(cfg, agentId);
+  return isSharedAuthStoreOwner({
+    ownership: resolveSharedAuthStoreOwnership(),
+    agentAuthDbPath: resolveAuthProfileDatabasePath(agentDir),
+    sharedAuthDbPath: resolveSharedAuthStorePath(),
+  });
+}
 
 function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcome {
   const reason = error instanceof Error && error.message ? error.message : String(error);
@@ -1011,13 +1030,11 @@ export const agentsHandlers: GatewayRequestHandlers = {
 
     const cfg = context.getRuntimeConfig();
     const agentId = normalizeAgentId(params.agentId);
-    // agents/main/agent also owns the shipped shared legacy auth store.
-    // Keep main undeletable until named agents make auth-store ownership explicit.
-    if (agentId === LEGACY_IMPLICIT_AGENT_ID) {
+    if (agentOwnsSharedAuthStore(cfg, agentId)) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `"${LEGACY_IMPLICIT_AGENT_ID}" cannot be deleted`),
+        errorShape(ErrorCodes.INVALID_REQUEST, formatSharedAuthStoreOwnerDeleteError(agentId)),
       );
       return;
     }
@@ -1059,6 +1076,9 @@ export const agentsHandlers: GatewayRequestHandlers = {
       const result = await withConfigMutationExclusive(async (lockedConfig) => {
         let lockedJournal = readAgentDeletionJournal(agentId);
         const configured = isConfiguredAgent(lockedConfig, agentId);
+        if (agentOwnsSharedAuthStore(lockedConfig, agentId)) {
+          throw new AgentSharedAuthStoreOwnerError(formatSharedAuthStoreOwnerDeleteError(agentId));
+        }
         if (!configured && (!lockedJournal || lockedJournal.cleanupCompleted)) {
           throw new AgentConfigPreconditionError(`agent "${agentId}" not found`);
         }
@@ -1479,6 +1499,10 @@ export const agentsHandlers: GatewayRequestHandlers = {
       });
       respond(true, result, undefined);
     } catch (error) {
+      if (error instanceof AgentSharedAuthStoreOwnerError) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
+        return;
+      }
       if (error instanceof AgentConfigPreconditionError) {
         respondAgentNotFound(respond, agentId);
         return;

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -7,6 +7,7 @@ import { registerResolvedAgentDir } from "../agents/agent-dir-registry.js";
 import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { loadAuthProfileStoreForSecretsRuntime } from "../agents/auth-profiles.js";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import {
   coercePersistedAuthProfileStore,
   loadPersistedAuthProfileStore,
@@ -770,7 +771,9 @@ async function validateProjectedSecretsState(params: {
       // whole-runtime check.
       includeAuthStoreRefs: params.write || params.authStoreByPath.size > 0,
       loadAuthStore: (agentDir?: string) => {
-        const storePath = resolveUserPath(resolveAuthProfileDatabasePath(agentDir));
+        const storePath = resolveUserPath(
+          agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath(),
+        );
         const override = authStoreLookup.get(storePath);
         if (override) {
           return (

--- a/src/secrets/auth-store-paths.ts
+++ b/src/secrets/auth-store-paths.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope.js";
+import { resolveSharedAuthStoreDir } from "../agents/auth-profiles/path-resolve.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -13,7 +14,12 @@ export function listAuthProfileStoreAgentDirs(config: OpenClawConfig, stateDir: 
   const paths = new Set<string>();
   // Scope default auth store discovery to the provided stateDir instead of
   // ambient process env, so scans do not include unrelated host-global stores.
-  paths.add(path.join(resolveUserPath(stateDir), "agents", "main", "agent"));
+  const scopedEnv = {
+    ...process.env,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_AGENT_DIR: undefined,
+  };
+  paths.add(resolveSharedAuthStoreDir(scopedEnv));
 
   const agentsRoot = path.join(resolveUserPath(stateDir), "agents");
   if (fs.existsSync(agentsRoot)) {
@@ -28,7 +34,7 @@ export function listAuthProfileStoreAgentDirs(config: OpenClawConfig, stateDir: 
   // Configured agent dirs may live outside stateDir; include them after state-dir discovery.
   for (const agentId of listAgentIds(config)) {
     if (agentId === "main") {
-      paths.add(path.join(resolveUserPath(stateDir), "agents", "main", "agent"));
+      paths.add(resolveSharedAuthStoreDir(scopedEnv));
       continue;
     }
     const agentDir = resolveAgentDir(config, agentId);

--- a/src/secrets/auth-store-paths.ts
+++ b/src/secrets/auth-store-paths.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope.js";
-import { resolveSharedAuthStoreDir } from "../agents/auth-profiles/path-resolve.js";
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -19,7 +19,7 @@ export function listAuthProfileStoreAgentDirs(config: OpenClawConfig, stateDir: 
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_AGENT_DIR: undefined,
   };
-  paths.add(resolveSharedAuthStoreDir(scopedEnv));
+  paths.add(path.dirname(resolveSharedAuthStorePath(scopedEnv)));
 
   const agentsRoot = path.join(resolveUserPath(stateDir), "agents");
   if (fs.existsSync(agentsRoot)) {
@@ -34,7 +34,7 @@ export function listAuthProfileStoreAgentDirs(config: OpenClawConfig, stateDir: 
   // Configured agent dirs may live outside stateDir; include them after state-dir discovery.
   for (const agentId of listAgentIds(config)) {
     if (agentId === "main") {
-      paths.add(resolveSharedAuthStoreDir(scopedEnv));
+      paths.add(path.dirname(resolveSharedAuthStorePath(scopedEnv)));
       continue;
     }
     const agentDir = resolveAgentDir(config, agentId);

--- a/src/secrets/runtime-auth-profile-owner.ts
+++ b/src/secrets/runtime-auth-profile-owner.ts
@@ -1,4 +1,5 @@
 /** Stable SecretRef owner identity for one agent-scoped auth profile. */
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 
 /** Tuple encoding distinguishes agents and avoids path/profile separator collisions. */
@@ -6,5 +7,8 @@ export function resolveAuthProfileSecretOwnerId(params: {
   agentDir?: string;
   profileId: string;
 }): string {
-  return JSON.stringify([resolveAuthProfileDatabasePath(params.agentDir), params.profileId]);
+  const storePath = params.agentDir
+    ? resolveAuthProfileDatabasePath(params.agentDir)
+    : resolveSharedAuthStorePath();
+  return JSON.stringify([storePath, params.profileId]);
 }

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -1,13 +1,12 @@
 /** Detects when secrets runtime preparation can safely use a fast path. */
 import { existsSync } from "node:fs";
-import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { resolveLegacyInheritedAuthDir } from "../agents/legacy-inherited-auth-dir.js";
-import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
@@ -104,16 +103,9 @@ function hasCandidateAuthProfileStoreSources(params: {
   agentDirs?: string[];
 }): boolean {
   const candidateDirs = resolveCandidateAgentDirs(params);
-  // The shipped no-argument auth store remains fixed at agents/main/agent.
-  const mainAgentDir = path.join(
-    resolveStateDir(params.env as NodeJS.ProcessEnv),
-    "agents",
-    "main",
-    "agent",
-  );
   return (
     candidateDirs.some((agentDir) => hasCandidateAuthProfileStoreSource(agentDir)) ||
-    hasCandidateAuthProfileStoreSource(mainAgentDir)
+    existsSync(resolveSharedAuthStorePath(params.env as NodeJS.ProcessEnv))
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's shared auth base is still stored inside the legacy `agents/main/agent/openclaw-agent.sqlite` database, but runtime callers identify it indirectly through an omitted agent-directory argument. That makes auth-store ownership implicit and forces agent deletion to protect the literal `main` id rather than the database that actually owns shared credentials.

## Why This Change Was Made

This introduces one process-stable shared-auth ownership record in existing `config_machine_state`, with the closed locations `legacy-main` and `state-db`. Missing state defaults to `legacy-main`, which resolves byte-for-byte to the shipped path. This build validates and records `state-db` but deliberately cannot serve it: path resolution fails closed with a typed doctor error before any per-agent store API can receive a shared-state pathname. The change adds no writer, schema change, fallback reader, dual write, or auth-data movement.

All current implicit shared-store consumers now start from the canonical database-path resolver, and the ambiguous no-argument resolver has been deleted. The per-agent database resolver requires an explicit agent directory. Agent deletion protects the legacy owner selected by the record using the canonical agent-database identity matcher; the separate sole-agent and H2-1 `authInheritance.agentId` guards remain unchanged. Runtime snapshot enumeration also carries its canonical database key through replacement and rollback instead of reconstructing identity from a projected parent directory.

## User Impact

There is no user-visible auth behavior change in this slice. Existing installs resolve the same effective auth stores for every agent. The internal seam makes the shared store owner explicit for H2.2, and deletion errors now explain that the legacy shared auth store is the reason an owning agent cannot be removed and point to `openclaw doctor --fix`.

## Evidence

- `node scripts/check-changed.mjs --dry-run`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs` — green local fallback after the selected Blacksmith Testbox remained queued without a run URL; includes core production/test tsgo, targeted lint, dead exports, import cycles, database-first checks, and schema-version guard at v7.
- Full `check:test-types` tsgo expansion green: core tests, extension tests, and root tests.
- Unfiltered auth-profile suites: 48 files, 590 tests passed.
- Unfiltered changed doctor/secrets suites: 7 files, 309 tests passed.
- Focused fail-closed/cache/snapshot proof: 3 files, 44 tests passed.
- Focused custom-key publication/rollback proof: 2 files, 42 tests passed.
- Earlier unchanged CLI/Gateway deletion proof on this branch: 4 files, 119 tests passed.
- Production LOC: +417/-167 (net +250); tests: +229/-3 (net +226). The production growth is the explicit shared-store ownership boundary, fail-closed relocation contract, and canonical snapshot identity carried across the full current caller set.

AI-assisted implementation under the Peter-approved H2 design; behavior and proof were inspected before publication.
