### PR TITLE
fix(ui): transcript search opens with matching corners

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -700,7 +700,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         <html>
           <head><style>${readUiCss()}</style></head>
           <body>
-            <section class="chat">
+            <section class="card chat">
               <div class="agent-chat__search-bar">
                 ${iconSvg()}
                 <input type="text" placeholder="Search messages" />
@@ -713,8 +713,28 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const searchBar = await getBoundingBox(page, ".agent-chat__search-bar");
       const icons = await page.locator(".agent-chat__search-bar svg").all();
       const input = page.locator(".agent-chat__search-bar input");
+      const cornerRadii = await page.locator(".chat").evaluate((chat) => {
+        const search = chat.querySelector<HTMLElement>(".agent-chat__search-bar");
+        if (!search) {
+          throw new Error("Expected transcript search bar");
+        }
+        const radii = (element: Element) => {
+          const style = getComputedStyle(element);
+          return [
+            style.borderTopLeftRadius,
+            style.borderTopRightRadius,
+            style.borderBottomRightRadius,
+            style.borderBottomLeftRadius,
+          ];
+        };
+        return { chat: radii(chat), search: radii(search) };
+      });
 
       expect(searchBar.height).toBeLessThan(64);
+      expect(cornerRadii).toEqual({
+        chat: ["0px", "0px", "0px", "0px"],
+        search: ["0px", "0px", "14px", "14px"],
+      });
       expect(icons).toHaveLength(2);
       for (const icon of icons) {
         const box = await icon.boundingBox();

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -146,12 +146,17 @@ openclaw-chat-page {
 
 /* Transcript search sits above the workbench. Keep the shared SVG icon from
    taking its intrinsic flex width and size the controls as compact chrome. */
+.chat:has(> .agent-chat__search-bar) {
+  border-radius: 0;
+}
+
 .agent-chat__search-bar {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
   border-bottom: 1px solid var(--border);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   background: var(--card);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening transcript search would see mismatched rounded corners between the search bar and the chat container.

## Why This Change Was Made

The chat container becomes square while transcript search is present, and the search bar owns the shared 14px bottom corners. The existing browser fixture now matches the real `.card.chat` markup and asserts the computed corner radii.

## User Impact

Transcript search now joins the chat workbench as one continuous surface instead of showing conflicting rounded edges.

## Evidence

- Regression proof against `origin/main`: the new assertion failed because the chat had four 14px corners while the search bar had four square corners.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` — 86 tests passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/styles/chat/layout.css` — passed.
- `pnpm exec stylelint --config config/stylelint.config.mjs ui/src/styles/chat/layout.css` — passed.
- Live managed Gateway served the worktree CSS, and the opened transcript-search state was visually verified.
