### PR TITLE
fix(ui): responsive layout test no longer flakes under load

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -594,14 +594,16 @@ async function waitForLayoutSettled(page: Page, selector: string): Promise<void>
   // content-visibility and container queries can defer descendant layout beyond
   // a fixed rAF pair. Measure the owning geometry until two frames agree.
   await page.evaluate(
-    async ({ maxFrames, selector }) => {
+    async ({ maxFrames, selector: targetSelector }) => {
       let previousGeometry: string | undefined;
       let stableFrames = 0;
       for (let frame = 0; frame < maxFrames; frame += 1) {
-        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-        const elements = [...document.querySelectorAll<HTMLElement>(selector)];
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+        const elements = [...document.querySelectorAll<HTMLElement>(targetSelector)];
         if (elements.length === 0) {
-          throw new Error(`No layout elements matched ${selector}`);
+          throw new Error(`No layout elements matched ${targetSelector}`);
         }
         const geometry = JSON.stringify(
           elements.map((element) => {
@@ -615,7 +617,7 @@ async function waitForLayoutSettled(page: Page, selector: string): Promise<void>
         }
         previousGeometry = geometry;
       }
-      throw new Error(`Layout did not stabilize for ${selector} within ${maxFrames} frames`);
+      throw new Error(`Layout did not stabilize for ${targetSelector} within ${maxFrames} frames`);
     },
     { maxFrames: 60, selector },
   );

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -590,14 +590,34 @@ async function closeBrowserPage(page: Page): Promise<void> {
   await page.close().catch(() => {});
 }
 
-async function waitForLayoutSettled(page: Page): Promise<void> {
-  // Raw DOM mutations skip Playwright's actionability wait. Allow style invalidation
-  // to land, then observe one stable frame before measuring viewport bounds.
+async function waitForLayoutSettled(page: Page, selector: string): Promise<void> {
+  // content-visibility and container queries can defer descendant layout beyond
+  // a fixed rAF pair. Measure the owning geometry until two frames agree.
   await page.evaluate(
-    () =>
-      new Promise<void>((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-      }),
+    async ({ maxFrames, selector }) => {
+      let previousGeometry: string | undefined;
+      let stableFrames = 0;
+      for (let frame = 0; frame < maxFrames; frame += 1) {
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        const elements = [...document.querySelectorAll<HTMLElement>(selector)];
+        if (elements.length === 0) {
+          throw new Error(`No layout elements matched ${selector}`);
+        }
+        const geometry = JSON.stringify(
+          elements.map((element) => {
+            const rect = element.getBoundingClientRect();
+            return [rect.x, rect.y, rect.width, rect.height];
+          }),
+        );
+        stableFrames = geometry === previousGeometry ? stableFrames + 1 : 1;
+        if (stableFrames >= 2) {
+          return;
+        }
+        previousGeometry = geometry;
+      }
+      throw new Error(`Layout did not stabilize for ${selector} within ${maxFrames} frames`);
+    },
+    { maxFrames: 60, selector },
   );
 }
 
@@ -1059,7 +1079,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await page.locator(".chat-split-view__cell").evaluate((cell) => {
         (cell as HTMLElement).style.width = "580px";
       });
-      await waitForLayoutSettled(page);
+      await waitForLayoutSettled(page, ".chat-pane__header, .chat-pane__close-pane");
       const intermediateHeader = await getBoundingBox(page, ".chat-pane__header");
       const intermediateClose = await getBoundingBox(page, ".chat-pane__close-pane");
       expect(intermediateClose.x + intermediateClose.width).toBeLessThanOrEqual(
@@ -1077,7 +1097,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await page.locator(".chat-split-view__cell").evaluate((cell) => {
         (cell as HTMLElement).style.width = "1000px";
       });
-      await waitForLayoutSettled(page);
+      await waitForLayoutSettled(page, ".chat-pane__header, .chat-pane__close-pane");
       const fullCompositionWidth = await page.locator(".chat-pane__header").evaluate((element) => {
         const headerElement = element as HTMLElement;
         headerElement.style.containerType = "normal";
@@ -1088,7 +1108,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         return width;
       });
       await setHeaderContentWidth(801);
-      await waitForLayoutSettled(page);
+      await waitForLayoutSettled(page, ".chat-pane__header, .chat-pane__close-pane");
       const transitionOverflow = await page.locator(".chat-pane__header").evaluate((element) => ({
         clientWidth: element.clientWidth,
         scrollWidth: element.scrollWidth,
@@ -1503,6 +1523,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           </div>
         </body></html>`,
       );
+      await waitForLayoutSettled(page, "[data-first-row], .chat-group-footer");
 
       const layout = await page.evaluate(() => {
         const first = document.querySelector<HTMLElement>("[data-first-row]")!;
@@ -1654,7 +1675,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             2,
           ),
         );
-        await waitForLayoutSettled(page);
+        await waitForLayoutSettled(page, ".agent-chat__composer-combobox > textarea");
         const wideHeight = (await textarea.boundingBox())?.height ?? 0;
 
         await page.setViewportSize({ width: 430, height: 800 });
@@ -2443,9 +2464,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           await page.locator(picker.trigger).evaluate((node) => {
             node.parentElement?.setAttribute("open", "");
           });
-          await waitForLayoutSettled(page);
+          await waitForLayoutSettled(page, `${picker.menu}, .agent-chat__input`);
           await syncFixtureComposerPopoverAnchor(page);
-          await waitForLayoutSettled(page);
+          await waitForLayoutSettled(page, `${picker.menu}, .agent-chat__input`);
           const menu = await getBoundingBox(page, picker.menu);
           const trigger = await getBoundingBox(page, picker.trigger);
           const footer = await getBoundingBox(page, ".agent-chat__composer-footer");
@@ -2487,9 +2508,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await page.locator('[data-chat-composer-model="true"]').evaluate((node) => {
         node.parentElement?.setAttribute("open", "");
       });
-      await waitForLayoutSettled(page);
+      await waitForLayoutSettled(page, ".chat-controls__model-menu, .agent-chat__input");
       await syncFixtureComposerPopoverAnchor(page);
-      await waitForLayoutSettled(page);
+      await waitForLayoutSettled(page, ".chat-controls__model-menu, .agent-chat__input");
       const composer = await getBoundingBox(page, ".agent-chat__input");
       const menu = await getBoundingBox(page, ".chat-controls__model-menu");
       const anchorEvidence = await page.locator(".agent-chat__input").evaluate((node) => ({


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent `chat-responsive.browser.test.ts` failure on slow GitHub-hosted runners where the virtual row's parent geometry is sampled before Chromium finishes the `content-visibility: auto` layout pass for its wrapped footer.

## Why This Change Was Made

The file's existing layout helper assumed two animation frames were always sufficient. It now watches the geometry relevant to each caller and returns only after two consecutive animation frames agree, with a 60-frame bound. The virtual-row assertion uses that helper before measuring and keeps its original numeric contract unchanged.

No production code, tolerances, or assertions changed. This PR is AI-assisted and has been reviewed with the repository autoreview workflow.

## User Impact

No product behavior changes. Maintainers get deterministic responsive-layout coverage without intermittent false failures under runner contention.

## Evidence

- Hosted flake provenance:
  - CI run 31725819298: `checks-ui` passed; this file passed all 86 tests and the affected case passed in 671 ms.
  - CI run 31733675477: `checks-ui` failed only the affected case with `expected 129.59375 to be less than or equal to 28`.
  - CI run 31725482479: `checks-ui` was skipped by change classification, so it is not counted as a passing execution of this file.
- Focused post-fix proof: a bounded five-iteration loop of `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` completed 5/5 green, with all 86 tests passing in every iteration. A separate initial post-fix run was also green.
- Pre-fix local characterization: the same full file completed 11 consecutive local runs, confirming the failure window is specific to the contended hosted environment rather than a deterministic assertion failure.
- `/Users/steipete/Projects/openclaw/node_modules/.bin/oxfmt --check ui/src/pages/chat/chat-responsive.browser.test.ts` passed.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.
- The scoped changed gate was dispatched to Testbox `tbx_01kzydb5c1epm140rmwxfe2nhq` but remained queued without executing for 3m44s; the owned lease was cancelled and stopped. Exact-head PR CI remains the hosted gate.

Screenshots are not applicable because this changes test synchronization only and does not alter rendered UI behavior.
