### PR TITLE
fix(ui): keep question prompts from fading transcript content

### DIFF
--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -1,17 +1,5 @@
 .agent-chat__question-dock {
-  position: relative;
   min-width: 0;
-}
-
-.agent-chat__question-dock::before {
-  content: "";
-  position: absolute;
-  right: 0;
-  bottom: calc(100% - 1px);
-  left: 0;
-  height: 52px;
-  pointer-events: none;
-  background: linear-gradient(to top, var(--bg), transparent);
 }
 
 openclaw-chat-question-panel {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users answering a Control UI question would see transcript content immediately above the question card washed out by a gradient.

## Why This Change Was Made

The question panel now participates in normal composer flow, so its old overlap-masking gradient is no longer needed. This removes that pseudo-element and its unused positioning context while retaining the dock's width constraint.

## User Impact

Transcript activity and messages remain evenly visible above an open question card instead of fading into the page background.

## Evidence

- `pnpm exec stylelint --config config/stylelint.config.mjs ui/src/styles/chat/question-card.css`
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/question-flow.e2e.test.ts` — 11 passed
- Captured pending, answered, multi-select, terminal, live-edge scroll, and backscroll states under `.artifacts/control-ui-e2e/question-flow/`
- Live question prompt confirmed the transcript/card boundary renders cleanly
- Production LOC: +0/-12; tests: +0/-0
- Codex autoreview passed with no accepted or actionable findings

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted OpenClaw session transcript</summary>

```text
[user]
Reported an odd gradient immediately above the question prompt and asked for its cause and a fix.

[assistant]
Traced the artifact to a 52px question-dock pseudo-element that was retained after the panel moved into normal document flow. Recommended deleting the obsolete gradient and positioning context.

[user]
Asked to try the fix in a new worktree.

[assistant]
Created `fix/question-dock-gradient`, removed the stale CSS, and verified the change with focused stylelint, 11 question-flow E2E cases, and captured visual states.

[user]
Asked to load the worktree build and send a native question for live testing.

[assistant]
Built the Control UI and sent a native question prompt. The user confirmed the transcript/card boundary rendered cleanly.

[user]
Asked to open a pull request.

[assistant]
Reviewed the single-file deletion, confirmed no current-main conflict on the stylesheet, committed the change, and prepared the PR evidence.
```

</details>
<!-- agent-transcript:end -->
