### PR TITLE
fix(ui): keep the chat header blend off the transcript scrollbar

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -12,6 +12,11 @@ openclaw-chat-page {
 
 .chat {
   --chat-thread-max-width: 48rem;
+  /* Half of the transcript's shared side gutter. .chat-thread keeps this strip
+     free on both edges so its scrollbar hugs the pane edge, so overlays that
+     paint across the thread (the header fade) must stop at it or they cover
+     the thumb. */
+  --chat-thread-gutter: 18px;
 
   position: relative;
   display: flex;
@@ -362,10 +367,10 @@ openclaw-chat-page {
 
 .chat-thread-inner {
   box-sizing: border-box;
-  /* 36px shared gutter plus the responsive side inset that used to be
+  /* Shared gutter plus the responsive side inset that used to be
      .chat-thread's horizontal padding (moved off the scroll container so
      overlay scrollbars sit flush at the pane edge). */
-  width: calc(100% - 36px - 2 * clamp(6px, 1vw, 12px));
+  width: calc(100% - 2 * var(--chat-thread-gutter) - 2 * clamp(6px, 1vw, 12px));
   max-width: var(--chat-thread-max-width);
   margin-inline: auto;
 }
@@ -373,7 +378,7 @@ openclaw-chat-page {
 .chat-inline-approval {
   box-sizing: border-box;
   flex: 0 0 auto;
-  width: calc(100% - 36px - 2 * clamp(6px, 1vw, 12px));
+  width: calc(100% - 2 * var(--chat-thread-gutter) - 2 * clamp(6px, 1vw, 12px));
   max-width: var(--chat-thread-max-width);
   margin: 8px auto;
 }

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -180,11 +180,16 @@
   overflow: hidden;
 }
 
+/* Header-to-transcript blend. It stops one thread gutter short of both pane
+   edges: the transcript's scrollbar lives in that strip, and a full-width
+   overlay paints over the thumb's top (it vanishes under the fade while
+   scrolling). Transcript content never enters the gutter, so nothing escapes
+   the blend. Both edges stay symmetric so RTL keeps the same clearance. */
 .chat-main__conversation::before {
   content: "";
   position: absolute;
   z-index: 2;
-  inset: 0 0 auto;
+  inset: 0 var(--chat-thread-gutter) auto;
   height: 24px;
   pointer-events: none;
   background: linear-gradient(to bottom, var(--chat-surface), transparent);


### PR DESCRIPTION
Closes #123307

## What Problem This Solves

Fixes an issue where users scrolling a Control UI chat transcript would see the scrollbar disappear near the top of the pane. The blend that softens the chat pane header into the transcript spans the full pane width, so it paints over the strip where the transcript's own scrollbar lives: the thumb fades out and vanishes under the header instead of staying visible across its whole track. It affects the default chat surface — single pane and split view, both themes.

## Why This Change Was Made

The blend is the right effect; its geometry was not. `.chat-thread` deliberately runs without horizontal padding and with `scrollbar-gutter: stable both-edges` so its scrollbar hugs the pane edge, and the blend is an absolutely positioned overlay above the scroll container, so a full-width overlay is guaranteed to cover the thumb (a scroll container's scrollbar cannot paint above a positioned sibling with a higher stacking order).

The fix keeps the blend and stops it one transcript gutter short of both pane edges. That gutter — the 18px each side that the transcript column already reserves — becomes a `--chat-thread-gutter` token on `.chat` so the overlay and the content column cannot drift apart. Transcript content is inset by at least 24px on each side, so nothing content-bearing escapes the blend; the strip left uncovered contains only the scrollbar and background painted in the same colour the gradient starts from, so the blend looks unchanged. Insets are symmetric so RTL layouts, where the scrollbar sits on the other edge, get the same clearance.

Alternatives considered and rejected: raising the scrollbar above the overlay is not expressible in CSS; masking the scroll container itself fades the thumb rather than sparing it; measuring the scrollbar width in JS adds startup work for a layout constant this stylesheet already owns.

## User Impact

The transcript scrollbar stays visible over its full track while scrolling, including directly under the pane header, so scroll position feedback is no longer lost at the top of the thread. The header-to-transcript blend itself is visually unchanged.

## Evidence

- Root cause traced in current `main` (`faa6202`): overlay owner `ui/src/styles/chat/sidebar.css:183` (`.chat-main__conversation::before`, `inset: 0 0 auto`, `z-index: 2`) painting above the scroll container `ui/src/styles/chat/layout.css:322` (`.chat-thread`, `scrollbar-gutter: stable both-edges`, no horizontal padding so the scrollbar hugs the pane edge). Regression introduced by #122220, which added the overlay.
- Diff is CSS-only: 2 files, +14/-4, of which 9 added lines are the invariant comments; a single new declaration (the shared gutter token). The two existing `36px` literals in the transcript column were replaced by `2 * var(--chat-thread-gutter)` (identical computed value) so the overlay and the content column stay in sync.
- Behaviour matrix reviewed against the changed rules — scroll at top / middle / bottom, hover on the thumb, light and dark themes, LTR and RTL, single pane and split view: the overlay geometry is theme- and state-independent (its colour comes from `--chat-surface`, which both themes define), so the only variable is horizontal coverage, which now excludes the scrollbar strip in every one of those states.

### Visual proof

Captured on a Crabbox AWS box (Linux, xfce desktop, headed Chrome) from a clean remote checkout of this PR's head, so nothing local influenced the result. The same fixture is rendered twice against the repository's own stylesheets: once with `chat/layout.css` + `chat/sidebar.css` read from `origin/main`, once from this PR's head, every other stylesheet read from `main` in both runs. The transcript sits at `scrollTop: 0`, which is where the thumb starts and where the header fade paints.

The crops below are the top of the scrollbar track at 5x — the strip the overlay covers.

| State | Light | Dark |
| --- | --- | --- |
| Before / after, top of the track | <img width="420" alt="Light theme: before, the fade washes out the scrollbar arrow and the top of the thumb; after, both paint at full strength and the fade stops short of the gutter" src="https://github.com/user-attachments/assets/4fe0acac-fba9-47a6-b6e7-aa6b8542ba59" /> | <img width="420" alt="Dark theme: before, the top of the thumb fades into the background; after, the thumb keeps full contrast across the fade band" src="https://github.com/user-attachments/assets/425de2fe-b191-4b91-a4e1-528e34777363" /> |

Before, the scrollbar's up-arrow and the first pixels of the thumb are washed into the gradient. After, both paint at full strength, and the fade's edge is visible stopping one gutter short of the pane edge.

The same two states at full pane, so the blend reads in context — the header still fades into the transcript exactly as before:

| Before | After |
| --- | --- |
| <img width="380" alt="Full chat pane, light theme, before: the header fade spans the whole pane width" src="https://github.com/user-attachments/assets/d71d8e18-6ef4-423b-8253-40a48b277e07" /> | <img width="380" alt="Full chat pane, light theme, after: the fade is visually unchanged while the scrollbar survives" src="https://github.com/user-attachments/assets/805d0e62-2255-4ce2-9692-a066d012a3ba" /> |

Read off the same rendered pages:

| | Before | After |
| --- | --- | --- |
| Overlay inset (left / right) | `0px` / `0px` | `18px` / `18px` |
| Overlay height | `24px` | `24px` |
| Overlay paints | yes | yes |
| Scrollbar gutter reserved per edge | 15px | 15px |

The 18px the fix clears exceeds the 15px the scroll container actually reserves, so the strip is cleared with room to spare in both themes. Pixel-differencing the before/after frames confirms the change is confined to the fade band and nothing else moved: the only differing rows are the 24px band under the header, peaking at a 120/255 delta in light and 92/255 in dark.

One thing the capture also settles: `--chat-surface` is declared only on `.chat-split-view__cell`, but every pane renders inside that cell (`ui/src/pages/chat/chat-page-pane-render.ts:53`), single-pane included — so the fade does paint on the default surface, and `overlayPaints` is true in all four runs.

### Remaining proof gap

No Vitest run accompanies this change: it is CSS-only with no test touched, and CI's UI lanes cover the stylesheets.


### Merge-result check (ClawSweeper rank-up move)

ClawSweeper's only rank-up move — confirm the visual result on the merge result or a rebased head — is resolved by evidence rather than a re-render, and its two "before merge" merge-risk items are answered by the same check.

The branch is behind main, and five commits touched these two stylesheets since merge-base `faa62024123c` (#123693, #123386, #123380, #122475, #123299). None of them touch a rule this PR owns: `.chat`, `.chat-thread-inner` (`width: calc(100% - 36px - 2 * clamp(6px, 1vw, 12px))`), `.chat-inline-approval` (same literal) and `.chat-main__conversation::before` (`inset: 0 0 auto`) are byte-identical on current `origin/main` and at the merge base. Main's drift is confined to unrelated rules — search-bar radius, composer popovers, attachment image button, inline-select menus, effort slider, and the `.chat-workbench` grid columns. The three-way merge therefore applies these hunks to unchanged context, so the merge result is behaviorally identical to the head the screenshots were captured from.

One risk not covered by the supplied screenshots was checked directly against source: `--chat-thread-gutter` is declared on `.chat`, so any consumer rendering outside that subtree would make the custom property invalid at computed-value time and drop the declaration to its initial value (`inset: auto`, collapsing the fade; `width: auto`, widening the transcript column). Every production consumer inherits it — `chat-view.ts:574-581` nests `.chat-main__conversation` and `.chat-inline-approval` under `<section class="card chat">`, and the only `.chat-thread-inner` render sites are `components/chat-thread.ts:93` and `components/chat-transcript-controller.ts:324` inside the same subtree.
