### PR TITLE
fix(ui): keep chat file links whole when a line wraps

### DIFF
--- a/ui/src/styles/chat-file-link-presentation.browser.test.ts
+++ b/ui/src/styles/chat-file-link-presentation.browser.test.ts
@@ -105,7 +105,18 @@ const SEPARATION_CASES = [
   },
 ] as const;
 
-function wrapFixtureDocument(themeMode: "dark" | "light"): string {
+// Both renderers paint the same parser output, so every wrap invariant has to
+// hold in each. The Detail Panel is the one that proves the chip owns its wrap
+// policy: .chat-text would hand it one by inheritance, .sidebar-markdown never
+// does, and the panel body hides horizontal overflow.
+const WRAP_CONTAINERS = ["chat-text", "sidebar-markdown"] as const;
+type WrapContainer = (typeof WRAP_CONTAINERS)[number];
+
+const WRAP_CASES = (["light", "dark"] as const).flatMap((themeMode) =>
+  WRAP_CONTAINERS.map((container) => ({ container, themeMode })),
+);
+
+function wrapFixtureDocument(themeMode: "dark" | "light", container: WrapContainer): string {
   const themeAttributes =
     themeMode === "light" ? `data-theme="light" data-theme-mode="light"` : `data-theme="dark"`;
   const separationLinks = SEPARATION_CASES.map(({ filePath, id, label, line }) => {
@@ -115,7 +126,7 @@ function wrapFixtureDocument(themeMode: "dark" | "light"): string {
         data-file-path="${filePath}"${lineAttribute}>${linkLabel}</a></p>`;
   }).join("\n");
   return `<!doctype html><html ${themeAttributes}><head><style>${readChatCss()}</style></head><body>
-    <div class="chat-text" id="column">
+    <div class="${container}" id="column">
       <ol><li>Reproduce the failing run, then read the harness entry point
         (<a id="wrap-chip" class="markdown-file-link" data-file-kind="code"
           data-file-path="test/harness.ts" data-file-line="182">harness.ts:182</a>)
@@ -134,6 +145,10 @@ type SeparationSample = {
   // away from it; on the same line it is only font-ascent noise.
   readonly glyphToLabelGapPx: number;
   readonly lineHeightPx: number;
+  // How far the painted label runs past the column's content edge. max-width
+  // caps the chip's box, not the text inside it, so the box measures clean while
+  // an unwrappable label still paints into the clipped region.
+  readonly labelOverflowPx: number;
   readonly wrapped: boolean;
 };
 
@@ -148,12 +163,15 @@ type WrapSample = {
 // Sweeping the column instead of hand-picking one width: the chip has to be
 // atomic at every position it can land in, and a single tuned width would stop
 // exercising the boundary as soon as the prose or the font metrics move.
-async function probeWrap(themeMode: "dark" | "light"): Promise<{
+async function probeWrap(
+  themeMode: "dark" | "light",
+  container: WrapContainer,
+): Promise<{
   readonly samples: readonly WrapSample[];
   readonly separation: readonly SeparationSample[];
 }> {
-  const fixtureFile = path.join(fixtureDirectory, `${themeMode}-wrap.html`);
-  fs.writeFileSync(fixtureFile, wrapFixtureDocument(themeMode), "utf8");
+  const fixtureFile = path.join(fixtureDirectory, `${themeMode}-${container}-wrap.html`);
+  fs.writeFileSync(fixtureFile, wrapFixtureDocument(themeMode, container), "utf8");
   const page = await browser.newPage();
   try {
     await page.goto(`file://${fixtureFile}`);
@@ -194,6 +212,7 @@ async function probeWrap(themeMode: "dark" | "light"): Promise<{
         // unsatisfiable. This failure is about the space beside the glyph.
         for (let columnWidth = 40; columnWidth <= 320; columnWidth += 4) {
           column.style.width = `${columnWidth}px`;
+          const columnRight = column.getBoundingClientRect().right;
           for (const { caseId, element } of separationChips) {
             const elementTop = element.getBoundingClientRect().top;
             const labelTextNode = element.firstChild;
@@ -204,12 +223,15 @@ async function probeWrap(themeMode: "dark" | "light"): Promise<{
             firstCharacterRange.setStart(labelTextNode, 0);
             firstCharacterRange.setEnd(labelTextNode, 1);
             const firstCharacterTop = firstCharacterRange.getBoundingClientRect().top;
+            const labelRange = document.createRange();
+            labelRange.selectNodeContents(labelTextNode);
             const lineHeightPx = Number.parseFloat(getComputedStyle(element).lineHeight);
             separation.push({
               caseId,
               columnWidth,
               glyphToLabelGapPx: firstCharacterTop - elementTop,
               lineHeightPx,
+              labelOverflowPx: labelRange.getBoundingClientRect().right - columnRight,
               wrapped: element.getBoundingClientRect().height > lineHeightPx * 1.3,
             });
           }
@@ -331,10 +353,10 @@ describeFileLinkPresentation("chat file link presentation", () => {
     },
   );
 
-  it.each(["light", "dark"] as const)(
-    "wraps a file link as one unit at every column width in %s",
-    async (themeMode) => {
-      const { samples } = await probeWrap(themeMode);
+  it.each(WRAP_CASES)(
+    "wraps a file link as one unit at every column width in $container/$themeMode",
+    async ({ container, themeMode }) => {
+      const { samples } = await probeWrap(themeMode, container);
       // Vacuity guard: the chip must actually change lines across the sweep, or
       // the assertion below would pass on a fixture that never wraps at all.
       expect(new Set(samples.map((sample) => Math.round(sample.chipTop))).size).toBeGreaterThan(1);
@@ -343,18 +365,23 @@ describeFileLinkPresentation("chat file link presentation", () => {
     },
   );
 
-  it.each(["light", "dark"] as const)(
-    "keeps an unshortened file label inside the column in %s",
-    async (themeMode) => {
-      const { samples } = await probeWrap(themeMode);
+  it.each(WRAP_CASES)(
+    "keeps an unshortened file label inside the column in $container/$themeMode",
+    async ({ container, themeMode }) => {
+      const { samples, separation } = await probeWrap(themeMode, container);
       // A label wider than the column wraps inside the chip rather than spilling
-      // past it; chat scroll containers set overflow-x: hidden, so an overflowing
+      // past it; both scroll containers set overflow-x: hidden, so an overflowing
       // chip would be clipped away instead of merely looking wide.
       const overflowing = samples.filter(
         (sample) => sample.longChipWidth > sample.columnWidth + 0.5,
       );
       expect(overflowing).toEqual([]);
       expect(samples.every((sample) => sample.longChipLineCount === 1)).toBe(true);
+      // The separation cases carry the labels with no `/` or `-` to break on, so
+      // only the chip's own wrap policy can keep them in the column. Inheriting
+      // one from .chat-text is not enough: .sidebar-markdown declares none.
+      const spilling = separation.filter((sample) => sample.labelOverflowPx > 0.5);
+      expect(spilling).toEqual([]);
     },
   );
 
@@ -363,10 +390,10 @@ describeFileLinkPresentation("chat file link presentation", () => {
   // cannot see that split. This compares the chip's top — where the glyph
   // paints, being first in the box — against the label's first character: same
   // line is font-ascent noise, a stranded glyph is a full line-height.
-  it.each(["light", "dark"] as const)(
-    "keeps the glyph attached to the label's first character in %s",
-    async (themeMode) => {
-      const { separation } = await probeWrap(themeMode);
+  it.each(WRAP_CASES)(
+    "keeps the glyph attached to the label's first character in $container/$themeMode",
+    async ({ container, themeMode }) => {
+      const { separation } = await probeWrap(themeMode, container);
       for (const testCase of SEPARATION_CASES) {
         const caseSamples = separation.filter((sample) => sample.caseId === testCase.id);
         expect(caseSamples.length).toBeGreaterThan(0);

--- a/ui/src/styles/chat-file-link-presentation.browser.test.ts
+++ b/ui/src/styles/chat-file-link-presentation.browser.test.ts
@@ -75,10 +75,9 @@ function fixtureDocument(themeMode: "dark" | "light"): string {
 // not shorten to a basename, which is the case that has to stay inside the column.
 const LONG_CHIP_PATH = "packages/gateway-protocol/src/session-transport-envelope.ts";
 
-// Separation cases for the glyph-attachment probe below. `unbroken` has no `/`,
-// `-`, or `_` for the line breaker to use as a natural break point, so it can
-// only wrap via the inherited `overflow-wrap: anywhere` — the exact condition
-// that starves the glyph's own line of a break opportunity (#123310 P2).
+// Cases for the glyph-attachment probe below. `unbroken` has no `/`, `-`, or `_`
+// to break on, so only the inherited `overflow-wrap: anywhere` can wrap it —
+// the condition that starves the glyph's own line of a break opportunity.
 const SEPARATION_CASES = [
   { filePath: "src/app.ts", id: "sep-short", label: "app.ts", line: undefined },
   {
@@ -115,10 +114,8 @@ function wrapFixtureDocument(themeMode: "dark" | "light"): string {
 type SeparationSample = {
   readonly caseId: (typeof SEPARATION_CASES)[number]["id"];
   readonly columnWidth: number;
-  // Positive when the glyph's line (the chip's own top) and the label's first
-  // character land on different lines — i.e. the glyph is stranded above a
-  // label that wrapped away from it, invisible to an inline-block chip's own
-  // getClientRects() (see chipLineCount below, always 1 for an atomic box).
+  // A full line-height means the glyph is stranded above a label that wrapped
+  // away from it; on the same line it is only font-ascent noise.
   readonly glyphToLabelGapPx: number;
   readonly lineHeightPx: number;
   readonly wrapped: boolean;
@@ -144,10 +141,9 @@ async function probeWrap(themeMode: "dark" | "light"): Promise<{
   const page = await browser.newPage();
   try {
     await page.goto(`file://${fixtureFile}`);
-    return await page.evaluate<{
-      samples: readonly WrapSample[];
-      separation: readonly SeparationSample[];
-    }>(
+    // No explicit type argument: a lone one binds `evaluate`'s `Arg` to `void`
+    // and the case ids arrive untyped. Inference reads both from the call.
+    return await page.evaluate(
       (caseIds) => {
         const resolve = (selector: string) => {
           const element = document.querySelector(selector);
@@ -177,11 +173,9 @@ async function probeWrap(themeMode: "dark" | "light"): Promise<{
             longChipWidth: longChip.getBoundingClientRect().width,
           });
         }
-        // Narrower, dedicated sweep for the glyph-attachment probe: a short
-        // basename like "app.ts" never wraps inside a realistic 220-900px chat
-        // column, so reusing that range here would make the case's vacuity guard
-        // unsatisfiable. The failure this guards is about the *tight* space
-        // directly beside the glyph, not the column at large.
+        // Its own narrower sweep: a short basename never wraps in a realistic
+        // 220-900px column, so that range would leave the vacuity guard below
+        // unsatisfiable. This failure is about the space beside the glyph.
         for (let columnWidth = 40; columnWidth <= 320; columnWidth += 4) {
           column.style.width = `${columnWidth}px`;
           for (const { caseId, element } of separationChips) {
@@ -348,17 +342,11 @@ describeFileLinkPresentation("chat file link presentation", () => {
     },
   );
 
-  // A file-link chip is `display: inline-block`, so it always reports exactly
-  // one client rect from the *outside* — the two tests above stay green even
-  // when the glyph splits from its label internally, because that split lives
-  // inside the chip's own atomic box. This closes that gap by comparing the
-  // chip's own top (where the glyph paints, since it is the first thing in the
-  // box) against the label's first character: on the same line the gap is only
-  // font-ascent noise; stranded on the next internal line it is a full
-  // line-height. Table-driven across a short basename (never has to wrap), an
-  // unbroken long basename (no `/`/`-`/`_` break points — only
-  // `overflow-wrap: anywhere` can wrap it, which is exactly what starves the
-  // glyph of a break opportunity), and a path carrying a `:line` suffix.
+  // An inline-block chip reports one client rect from the outside even when the
+  // glyph splits from its label inside its own box, so the two tests above
+  // cannot see that split. This compares the chip's top — where the glyph
+  // paints, being first in the box — against the label's first character: same
+  // line is font-ascent noise, a stranded glyph is a full line-height.
   it.each(["light", "dark"] as const)(
     "keeps the glyph attached to the label's first character in %s",
     async (themeMode) => {

--- a/ui/src/styles/chat-file-link-presentation.browser.test.ts
+++ b/ui/src/styles/chat-file-link-presentation.browser.test.ts
@@ -70,6 +70,73 @@ function fixtureDocument(themeMode: "dark" | "light"): string {
   </body></html>`;
 }
 
+// The reported scenario: a numbered list whose prose puts a parenthesized file
+// reference near the line edge. The second chip carries a label the parser could
+// not shorten to a basename, which is the case that has to stay inside the column.
+const LONG_CHIP_PATH = "packages/gateway-protocol/src/session-transport-envelope.ts";
+function wrapFixtureDocument(themeMode: "dark" | "light"): string {
+  const themeAttributes =
+    themeMode === "light" ? `data-theme="light" data-theme-mode="light"` : `data-theme="dark"`;
+  return `<!doctype html><html ${themeAttributes}><head><style>${readChatCss()}</style></head><body>
+    <div class="chat-text" id="column">
+      <ol><li>Reproduce the failing run, then read the harness entry point
+        (<a id="wrap-chip" class="markdown-file-link" data-file-kind="code"
+          data-file-path="test/harness.ts" data-file-line="182">harness.ts:182</a>)
+        before landing the fix.</li></ol>
+      <p><a id="long-chip" class="markdown-file-link" data-file-kind="code"
+        data-file-path="${LONG_CHIP_PATH}">${LONG_CHIP_PATH}</a></p>
+    </div>
+  </body></html>`;
+}
+
+type WrapSample = {
+  readonly chipLineCount: number;
+  readonly chipTop: number;
+  readonly columnWidth: number;
+  readonly longChipLineCount: number;
+  readonly longChipWidth: number;
+};
+
+// Sweeping the column instead of hand-picking one width: the chip has to be
+// atomic at every position it can land in, and a single tuned width would stop
+// exercising the boundary as soon as the prose or the font metrics move.
+async function probeWrap(themeMode: "dark" | "light"): Promise<readonly WrapSample[]> {
+  const fixtureFile = path.join(fixtureDirectory, `${themeMode}-wrap.html`);
+  fs.writeFileSync(fixtureFile, wrapFixtureDocument(themeMode), "utf8");
+  const page = await browser.newPage();
+  try {
+    await page.goto(`file://${fixtureFile}`);
+    return await page.evaluate<readonly WrapSample[]>(() => {
+      const resolve = (selector: string) => {
+        const element = document.querySelector(selector);
+        if (!(element instanceof HTMLElement)) {
+          throw new Error(`Missing wrap fixture element for ${selector}`);
+        }
+        return element;
+      };
+      const column = resolve("#column");
+      const chip = resolve("#wrap-chip");
+      const longChip = resolve("#long-chip");
+      const samples: WrapSample[] = [];
+      for (let columnWidth = 220; columnWidth <= 900; columnWidth += 4) {
+        column.style.width = `${columnWidth}px`;
+        samples.push({
+          // One client rect per line fragment: a chip split between its glyph and
+          // its label reports two, an atomic chip always reports one.
+          chipLineCount: chip.getClientRects().length,
+          chipTop: chip.getBoundingClientRect().top,
+          columnWidth,
+          longChipLineCount: longChip.getClientRects().length,
+          longChipWidth: longChip.getBoundingClientRect().width,
+        });
+      }
+      return samples;
+    });
+  } finally {
+    await page.close();
+  }
+}
+
 type StyleSnapshot = Record<(typeof CHIP_PROPERTIES)[number], string>;
 type PresentationProbe = {
   readonly chatGlyph: { readonly maskImage: string };
@@ -175,6 +242,33 @@ describeFileLinkPresentation("chat file link presentation", () => {
       expect(probed.panelFromCode).toEqual(probed.fromCode);
       expect(probed.panelGlyph).toEqual(probed.chatGlyph);
       expect(probed.panelGlyph.maskImage).toContain("svg");
+    },
+  );
+
+  it.each(["light", "dark"] as const)(
+    "wraps a file link as one unit at every column width in %s",
+    async (themeMode) => {
+      const samples = await probeWrap(themeMode);
+      // Vacuity guard: the chip must actually change lines across the sweep, or
+      // the assertion below would pass on a fixture that never wraps at all.
+      expect(new Set(samples.map((sample) => Math.round(sample.chipTop))).size).toBeGreaterThan(1);
+      const split = samples.filter((sample) => sample.chipLineCount !== 1);
+      expect(split).toEqual([]);
+    },
+  );
+
+  it.each(["light", "dark"] as const)(
+    "keeps an unshortened file label inside the column in %s",
+    async (themeMode) => {
+      const samples = await probeWrap(themeMode);
+      // A label wider than the column wraps inside the chip rather than spilling
+      // past it; chat scroll containers set overflow-x: hidden, so an overflowing
+      // chip would be clipped away instead of merely looking wide.
+      const overflowing = samples.filter(
+        (sample) => sample.longChipWidth > sample.columnWidth + 0.5,
+      );
+      expect(overflowing).toEqual([]);
+      expect(samples.every((sample) => sample.longChipLineCount === 1)).toBe(true);
     },
   );
 });

--- a/ui/src/styles/chat-file-link-presentation.browser.test.ts
+++ b/ui/src/styles/chat-file-link-presentation.browser.test.ts
@@ -87,6 +87,22 @@ const SEPARATION_CASES = [
     line: undefined,
   },
   { filePath: LONG_CHIP_PATH, id: "sep-path-with-line", label: LONG_CHIP_PATH, line: 182 },
+  // Far wider than any column below, so the label must wrap several times: the
+  // first cut has to land inside the label, never between glyph and first char.
+  {
+    filePath: `${"abcdefghij".repeat(24)}.ts`,
+    id: "sep-enormous",
+    label: `${"abcdefghij".repeat(24)}.ts`,
+    line: 7,
+  },
+  // Non-ASCII labels reach the chip through host-local hrefs, so the glyph has
+  // to stay attached to a first character the shortener never produced.
+  {
+    filePath: "~/repo/docs/spec.md",
+    id: "sep-cjk",
+    label: "文档/会话传输封装规范化适配器/协议架构第十七版/规范化器.ts",
+    line: 88,
+  },
 ] as const;
 
 function wrapFixtureDocument(themeMode: "dark" | "light"): string {

--- a/ui/src/styles/chat-file-link-presentation.browser.test.ts
+++ b/ui/src/styles/chat-file-link-presentation.browser.test.ts
@@ -74,9 +74,31 @@ function fixtureDocument(themeMode: "dark" | "light"): string {
 // reference near the line edge. The second chip carries a label the parser could
 // not shorten to a basename, which is the case that has to stay inside the column.
 const LONG_CHIP_PATH = "packages/gateway-protocol/src/session-transport-envelope.ts";
+
+// Separation cases for the glyph-attachment probe below. `unbroken` has no `/`,
+// `-`, or `_` for the line breaker to use as a natural break point, so it can
+// only wrap via the inherited `overflow-wrap: anywhere` — the exact condition
+// that starves the glyph's own line of a break opportunity (#123310 P2).
+const SEPARATION_CASES = [
+  { filePath: "src/app.ts", id: "sep-short", label: "app.ts", line: undefined },
+  {
+    filePath: "superlongfilenamewithoutanyslashesordashesorspacesatalljustonebigword.ts",
+    id: "sep-unbroken",
+    label: "superlongfilenamewithoutanyslashesordashesorspacesatalljustonebigword.ts",
+    line: undefined,
+  },
+  { filePath: LONG_CHIP_PATH, id: "sep-path-with-line", label: LONG_CHIP_PATH, line: 182 },
+] as const;
+
 function wrapFixtureDocument(themeMode: "dark" | "light"): string {
   const themeAttributes =
     themeMode === "light" ? `data-theme="light" data-theme-mode="light"` : `data-theme="dark"`;
+  const separationLinks = SEPARATION_CASES.map(({ filePath, id, label, line }) => {
+    const lineAttribute = line === undefined ? "" : ` data-file-line="${line}"`;
+    const linkLabel = line === undefined ? label : `${label}:${line}`;
+    return `<p><a id="${id}" class="markdown-file-link" data-file-kind="code"
+        data-file-path="${filePath}"${lineAttribute}>${linkLabel}</a></p>`;
+  }).join("\n");
   return `<!doctype html><html ${themeAttributes}><head><style>${readChatCss()}</style></head><body>
     <div class="chat-text" id="column">
       <ol><li>Reproduce the failing run, then read the harness entry point
@@ -85,9 +107,22 @@ function wrapFixtureDocument(themeMode: "dark" | "light"): string {
         before landing the fix.</li></ol>
       <p><a id="long-chip" class="markdown-file-link" data-file-kind="code"
         data-file-path="${LONG_CHIP_PATH}">${LONG_CHIP_PATH}</a></p>
+      ${separationLinks}
     </div>
   </body></html>`;
 }
+
+type SeparationSample = {
+  readonly caseId: (typeof SEPARATION_CASES)[number]["id"];
+  readonly columnWidth: number;
+  // Positive when the glyph's line (the chip's own top) and the label's first
+  // character land on different lines — i.e. the glyph is stranded above a
+  // label that wrapped away from it, invisible to an inline-block chip's own
+  // getClientRects() (see chipLineCount below, always 1 for an atomic box).
+  readonly glyphToLabelGapPx: number;
+  readonly lineHeightPx: number;
+  readonly wrapped: boolean;
+};
 
 type WrapSample = {
   readonly chipLineCount: number;
@@ -100,38 +135,79 @@ type WrapSample = {
 // Sweeping the column instead of hand-picking one width: the chip has to be
 // atomic at every position it can land in, and a single tuned width would stop
 // exercising the boundary as soon as the prose or the font metrics move.
-async function probeWrap(themeMode: "dark" | "light"): Promise<readonly WrapSample[]> {
+async function probeWrap(themeMode: "dark" | "light"): Promise<{
+  readonly samples: readonly WrapSample[];
+  readonly separation: readonly SeparationSample[];
+}> {
   const fixtureFile = path.join(fixtureDirectory, `${themeMode}-wrap.html`);
   fs.writeFileSync(fixtureFile, wrapFixtureDocument(themeMode), "utf8");
   const page = await browser.newPage();
   try {
     await page.goto(`file://${fixtureFile}`);
-    return await page.evaluate<readonly WrapSample[]>(() => {
-      const resolve = (selector: string) => {
-        const element = document.querySelector(selector);
-        if (!(element instanceof HTMLElement)) {
-          throw new Error(`Missing wrap fixture element for ${selector}`);
+    return await page.evaluate<{
+      samples: readonly WrapSample[];
+      separation: readonly SeparationSample[];
+    }>(
+      (caseIds) => {
+        const resolve = (selector: string) => {
+          const element = document.querySelector(selector);
+          if (!(element instanceof HTMLElement)) {
+            throw new Error(`Missing wrap fixture element for ${selector}`);
+          }
+          return element;
+        };
+        const column = resolve("#column");
+        const chip = resolve("#wrap-chip");
+        const longChip = resolve("#long-chip");
+        const separationChips = caseIds.map((caseId) => ({
+          caseId,
+          element: resolve(`#${caseId}`),
+        }));
+        const samples: WrapSample[] = [];
+        const separation: SeparationSample[] = [];
+        for (let columnWidth = 220; columnWidth <= 900; columnWidth += 4) {
+          column.style.width = `${columnWidth}px`;
+          samples.push({
+            // One client rect per line fragment: a chip split between its glyph and
+            // its label reports two, an atomic chip always reports one.
+            chipLineCount: chip.getClientRects().length,
+            chipTop: chip.getBoundingClientRect().top,
+            columnWidth,
+            longChipLineCount: longChip.getClientRects().length,
+            longChipWidth: longChip.getBoundingClientRect().width,
+          });
         }
-        return element;
-      };
-      const column = resolve("#column");
-      const chip = resolve("#wrap-chip");
-      const longChip = resolve("#long-chip");
-      const samples: WrapSample[] = [];
-      for (let columnWidth = 220; columnWidth <= 900; columnWidth += 4) {
-        column.style.width = `${columnWidth}px`;
-        samples.push({
-          // One client rect per line fragment: a chip split between its glyph and
-          // its label reports two, an atomic chip always reports one.
-          chipLineCount: chip.getClientRects().length,
-          chipTop: chip.getBoundingClientRect().top,
-          columnWidth,
-          longChipLineCount: longChip.getClientRects().length,
-          longChipWidth: longChip.getBoundingClientRect().width,
-        });
-      }
-      return samples;
-    });
+        // Narrower, dedicated sweep for the glyph-attachment probe: a short
+        // basename like "app.ts" never wraps inside a realistic 220-900px chat
+        // column, so reusing that range here would make the case's vacuity guard
+        // unsatisfiable. The failure this guards is about the *tight* space
+        // directly beside the glyph, not the column at large.
+        for (let columnWidth = 40; columnWidth <= 320; columnWidth += 4) {
+          column.style.width = `${columnWidth}px`;
+          for (const { caseId, element } of separationChips) {
+            const elementTop = element.getBoundingClientRect().top;
+            const labelTextNode = element.firstChild;
+            if (!labelTextNode) {
+              throw new Error(`Separation fixture ${caseId} has no label text node`);
+            }
+            const firstCharacterRange = document.createRange();
+            firstCharacterRange.setStart(labelTextNode, 0);
+            firstCharacterRange.setEnd(labelTextNode, 1);
+            const firstCharacterTop = firstCharacterRange.getBoundingClientRect().top;
+            const lineHeightPx = Number.parseFloat(getComputedStyle(element).lineHeight);
+            separation.push({
+              caseId,
+              columnWidth,
+              glyphToLabelGapPx: firstCharacterTop - elementTop,
+              lineHeightPx,
+              wrapped: element.getBoundingClientRect().height > lineHeightPx * 1.3,
+            });
+          }
+        }
+        return { samples, separation };
+      },
+      SEPARATION_CASES.map((testCase) => testCase.id),
+    );
   } finally {
     await page.close();
   }
@@ -248,7 +324,7 @@ describeFileLinkPresentation("chat file link presentation", () => {
   it.each(["light", "dark"] as const)(
     "wraps a file link as one unit at every column width in %s",
     async (themeMode) => {
-      const samples = await probeWrap(themeMode);
+      const { samples } = await probeWrap(themeMode);
       // Vacuity guard: the chip must actually change lines across the sweep, or
       // the assertion below would pass on a fixture that never wraps at all.
       expect(new Set(samples.map((sample) => Math.round(sample.chipTop))).size).toBeGreaterThan(1);
@@ -260,7 +336,7 @@ describeFileLinkPresentation("chat file link presentation", () => {
   it.each(["light", "dark"] as const)(
     "keeps an unshortened file label inside the column in %s",
     async (themeMode) => {
-      const samples = await probeWrap(themeMode);
+      const { samples } = await probeWrap(themeMode);
       // A label wider than the column wraps inside the chip rather than spilling
       // past it; chat scroll containers set overflow-x: hidden, so an overflowing
       // chip would be clipped away instead of merely looking wide.
@@ -269,6 +345,36 @@ describeFileLinkPresentation("chat file link presentation", () => {
       );
       expect(overflowing).toEqual([]);
       expect(samples.every((sample) => sample.longChipLineCount === 1)).toBe(true);
+    },
+  );
+
+  // A file-link chip is `display: inline-block`, so it always reports exactly
+  // one client rect from the *outside* — the two tests above stay green even
+  // when the glyph splits from its label internally, because that split lives
+  // inside the chip's own atomic box. This closes that gap by comparing the
+  // chip's own top (where the glyph paints, since it is the first thing in the
+  // box) against the label's first character: on the same line the gap is only
+  // font-ascent noise; stranded on the next internal line it is a full
+  // line-height. Table-driven across a short basename (never has to wrap), an
+  // unbroken long basename (no `/`/`-`/`_` break points — only
+  // `overflow-wrap: anywhere` can wrap it, which is exactly what starves the
+  // glyph of a break opportunity), and a path carrying a `:line` suffix.
+  it.each(["light", "dark"] as const)(
+    "keeps the glyph attached to the label's first character in %s",
+    async (themeMode) => {
+      const { separation } = await probeWrap(themeMode);
+      for (const testCase of SEPARATION_CASES) {
+        const caseSamples = separation.filter((sample) => sample.caseId === testCase.id);
+        expect(caseSamples.length).toBeGreaterThan(0);
+        // Vacuity guard: each case must actually wrap somewhere in the sweep, or
+        // the no-separation assertion below would pass on a chip that never
+        // reflows at all.
+        expect(caseSamples.some((sample) => sample.wrapped)).toBe(true);
+        const separated = caseSamples.filter(
+          (sample) => sample.glyphToLabelGapPx > sample.lineHeightPx / 2,
+        );
+        expect(separated).toEqual([]);
+      }
     },
   );
 });

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -366,19 +366,28 @@
    keeps it on the link color in every theme. Sized in em so it tracks
    --chat-text-size and the user's text-scale setting. The default glyph is the
    generic document; kinds below match components/file-kind.ts, whose icons are
-   the same Lucide set the file preview modal renders as SVG. */
+   the same Lucide set the file preview modal renders as SVG.
+   display stays `inline` rather than `inline-block`: an inline-block (or any
+   other atomic/replaced box) carries its own contingent line-break opportunity,
+   so when the label can't fit next to it, the UA pushes the *whole* label onto
+   the next line instead of letting overflow-wrap continue the run — stranding
+   the glyph alone on the line above (the bug the parent rule's max-width fix
+   left open). A non-atomic inline has no such boundary: the glyph and the
+   label's first character stay one unbreakable run, and overflow-wrap:anywhere
+   (inherited from .chat-text) still wraps the rest of a long label normally.
+   Sized via padding-inline-start + an explicit mask size instead of
+   width/height + contain, since non-replaced inline boxes ignore width/height. */
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link::before {
   --file-glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3Cline x1='16' x2='8' y1='13' y2='13'/%3E%3Cline x1='16' x2='8' y1='17' y2='17'/%3E%3Cline x1='10' x2='8' y1='9' y2='9'/%3E%3C/svg%3E");
 
   content: "";
-  display: inline-block;
-  width: 1em;
-  height: 1em;
+  display: inline;
+  padding-inline-start: 1em;
   margin-inline-end: 0.28em;
   vertical-align: -0.14em;
   background: currentColor;
-  mask: var(--file-glyph) center / contain no-repeat;
-  -webkit-mask: var(--file-glyph) center / contain no-repeat;
+  mask: var(--file-glyph) left center / 1em 1em no-repeat;
+  -webkit-mask: var(--file-glyph) left center / 1em 1em no-repeat;
 }
 
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link[data-file-kind="code"]::before {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -346,9 +346,14 @@
   text-decoration: none;
   /* Atomic: prose cannot break between the glyph and the label, or at a hyphen
      inside it. max-width keeps a label the parser could not shorten wrapping
-     inside the chip; the chat scroller's overflow-x: hidden would clip it. */
+     inside the chip; the chat scroller's overflow-x: hidden would clip it.
+     The wrap policy is declared here rather than inherited: .chat-text sets
+     overflow-wrap: anywhere but .sidebar-markdown sets no wrapping policy, so
+     an unbreakable label would size the capped box past the panel, whose body
+     hides horizontal overflow, and be clipped instead of wrapping. */
   display: inline-block;
   max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link:hover {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -344,12 +344,9 @@
      link pointer does not apply; they are content links and keep the hand. */
   cursor: pointer;
   text-decoration: none;
-  /* The glyph below is an atomic inline, so prose could end a line on the icon
-     and strand its label on the next. An atomic chip has no interior line box to
-     break, keeping one reference whole; prose still wraps around it. max-width
-     caps the shrink-to-fit width so a label the parser could not shorten below
-     the column wraps inside the chip instead of overflowing into the chat
-     scroller's overflow-x: hidden, which would clip it away. */
+  /* Atomic: prose cannot break between the glyph and the label, or at a hyphen
+     inside it. max-width keeps a label the parser could not shorten wrapping
+     inside the chip; the chat scroller's overflow-x: hidden would clip it. */
   display: inline-block;
   max-width: 100%;
 }
@@ -367,16 +364,9 @@
    --chat-text-size and the user's text-scale setting. The default glyph is the
    generic document; kinds below match components/file-kind.ts, whose icons are
    the same Lucide set the file preview modal renders as SVG.
-   display stays `inline` rather than `inline-block`: an inline-block (or any
-   other atomic/replaced box) carries its own contingent line-break opportunity,
-   so when the label can't fit next to it, the UA pushes the *whole* label onto
-   the next line instead of letting overflow-wrap continue the run — stranding
-   the glyph alone on the line above (the bug the parent rule's max-width fix
-   left open). A non-atomic inline has no such boundary: the glyph and the
-   label's first character stay one unbreakable run, and overflow-wrap:anywhere
-   (inherited from .chat-text) still wraps the rest of a long label normally.
-   Sized via padding-inline-start + an explicit mask size instead of
-   width/height + contain, since non-replaced inline boxes ignore width/height. */
+   Stays `inline`: an atomic box carries its own break opportunity and would push
+   a too-wide label whole to the next line, stranding the glyph. Inline boxes
+   ignore width/height, so 1em comes from padding-inline-start and a mask size. */
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link::before {
   --file-glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3Cline x1='16' x2='8' y1='13' y2='13'/%3E%3Cline x1='16' x2='8' y1='17' y2='17'/%3E%3Cline x1='10' x2='8' y1='9' y2='9'/%3E%3C/svg%3E");
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -344,6 +344,14 @@
      link pointer does not apply; they are content links and keep the hand. */
   cursor: pointer;
   text-decoration: none;
+  /* The glyph below is an atomic inline, so prose could end a line on the icon
+     and strand its label on the next. An atomic chip has no interior line box to
+     break, keeping one reference whole; prose still wraps around it. max-width
+     caps the shrink-to-fit width so a label the parser could not shorten below
+     the column wraps inside the chip instead of overflowing into the chat
+     scroller's overflow-x: hidden, which would clip it away. */
+  display: inline-block;
+  max-width: 100%;
 }
 
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link:hover {


### PR DESCRIPTION
Closes #123309

## What Problem This Solves

A workspace file reference in a Control UI chat transcript can split across two lines, so one reference reads as two fragments.

There are two ways it tears, and both are reproducible on the pre-fix CSS:

- **Mid-label**, the common case. Repository paths are kebab-case, and a hyphen is a line-break opportunity, so `chat-composer-attachments.test.ts:123` ends a line as `chat-composer-` and resumes on the next as `attachments.test.ts:123`.
- **On the glyph**, the narrow case. When the space left at the end of a line is wide enough for the file-type icon but not for the first hyphenated chunk after it, the line ends on the icon and the entire label starts the next line, leaving a mark that carries no meaning on its own.

It affects both chat surfaces that render file links: message bubbles and the Chat Detail Panel. It happens on the default path, with no configuration involved, whenever a file reference lands near the right edge of a line — so narrow columns, split view, and mobile widths hit it most.

## Why This Change Was Made

The chip is an inline anchor holding two things a line may break between: the file-type glyph, painted as a `::before` with `display: inline-block`, and the label text. An atomic inline carries a soft wrap opportunity on both sides, and the label carries its own opportunities at each hyphen, so the line was always allowed to break inside the reference; the chip rule had never declared anything to prevent it.

The chip is now an atomic inline itself (`display: inline-block`). An atomic inline has no interior line box for prose to break, so the whole reference moves to the next line together, while the wrap opportunities *around* the chip keep prose wrapping between words as before.

That atomicity has one accepted cost, measured in the stress run below rather than assumed: an atomic inline carries a wrap opportunity on *both* sides, so a trailing `,` or `)` can start the next line instead of staying with the chip — 12 of 40 punctuation-adjacent chips in the first width sweep, versus 0 before the change. It is cosmetic, and the obvious alternative is worse: `white-space: nowrap` on a non-atomic chip keeps the punctuation but sends 44 chips past the column edge into the chat scroller's `overflow-x: hidden`, where they are clipped instead of merely orphaned. Trading a rare orphaned bracket for never tearing a reference in half is the right way round.

`max-width: 100%` is the deliberate answer for the extreme case. Labels are shortened to the shortest distinguishing path suffix (`ui/src/components/file-kind.ts:117-142`), which has no length cap — colliding basenames keep leading segments, so a label can be wider than a narrow chat column. Capping the chip's shrink-to-fit width means such a label wraps *inside* the chip rather than overflowing the bubble; chat scroll containers set `overflow-x: hidden`, so an overflowing chip would be clipped away rather than merely looking wide. Trading a rare two-line chip for a silently truncated one is the wrong way round.

Making the chip atomic closes the mid-label tear but leaves the glyph case open one level down, now *inside* the chip: an `inline-block` `::before` carries its own break opportunity, so a label too wide for the space beside it wraps whole and strands the glyph on the line above. The glyph rule therefore drops to `display: inline`, which keeps the mark and the label's first character in one unbreakable run while the inherited `overflow-wrap: anywhere` still wraps the rest of a long label. Non-replaced inline boxes ignore `width`/`height`, so the 1em box now comes from `padding-inline-start` plus an explicit mask size instead of `width`/`height` with `contain`, at the same size and position.

Non-goal in this PR: the sibling GitHub-mark chip (`a.markdown-github-link::before`, `ui/src/styles/chat/text.css:254`) paints the same kind of atomic-inline mark and shares the invariant, but it cannot take this treatment unmodified. Bare GitHub URLs also carry `a.markdown-bare-url` with `line-break: anywhere` (`ui/src/styles/chat/text.css:284`) precisely so a long URL fills the line it starts on; making that chip atomic would push the whole URL to the next line instead. That sibling needs its own scoped handling and is named as follow-up work in #123309 rather than fixed blind here.

## User Impact

File references in chat prose now wrap as one unit: icon and label always stay together, and the chip moves to the next line whole instead of tearing in half. Nothing about clicking, hovering, copying, or the chip's colors and spacing changes. The glyph is painted through a different box model than before, but at the same 1em size and the same position, and the existing presentation assertions — chip property parity across both authoring syntaxes and both surfaces, and glyph mask equality — still hold.

## Evidence

CSS-only change at the owning rule, plus a regression test.

**Production LOC delta:** `ui/src/styles/chat/text.css` +13/-6, net +7 — six of those lines are the two three-line invariant comments, so the declarations themselves are net +1 (`display: inline-block` and `max-width: 100%` added on the chip; the glyph's `display`/`width`/`height` trio collapses to `display`/`padding-inline-start`, and the mask pair is rewritten in place). Tests: +204 in `ui/src/styles/chat-file-link-presentation.browser.test.ts`. The defect is a missing declaration on the rule that already owns chip presentation, so there is no structure for the fix to be absorbed into; the growth is the fix itself and the comments AGENTS.md requires for a non-obvious layout invariant.

### Before / after in the running Control UI

Captured from the Control UI chat, rendered by the mock-gateway e2e harness (`startControlUiE2eServer` + `installMockGateway`) at a 720px viewport. One assistant message, one real repository path, identical text on both sides:

> Coverage for the composer attachment regression lives in ui/src/pages/chat/components/chat-composer-attachments.test.ts:123 and it runs on every push.

Both runs are the same working tree. **Before** is this branch with only the `text.css` hunk reverted to its base; **after** is the branch head restored. The branch has since been rebased, so the base to revert against is now `38e0ae6ec85` (`git checkout 38e0ae6ec85 -- ui/src/styles/chat/text.css`); it was `2dcd47d4f45` when these captures were taken. Between those two bases the file-link rules changed only in `color` (`--accent` to `--link`, from #124274), so the wrapping geometry these captures measure is unaffected — the link hue in the images is the older token.

Before — the reference tears at a hyphen, `chat-composer-` ending one line and `attachments.test.ts:123` starting the next:

![before, light](https://github.com/user-attachments/assets/81010593-f71f-4805-b0c0-9a0262666979)

After — the reference moves to the next line whole:

![after, light](https://github.com/user-attachments/assets/08637d55-e74f-4d75-ad90-e11c6f33a10c)

Same pair in dark:

![before, dark](https://github.com/user-attachments/assets/6809abc2-0c97-46d8-a52f-bbbf4c057d29)

![after, dark](https://github.com/user-attachments/assets/827c2371-b9b4-4791-85da-aae8baac7f99)

In context, before and after:

![before, full window](https://github.com/user-attachments/assets/5f66a70f-b72a-4d19-a346-ef7d433a7bf9)

![after, full window](https://github.com/user-attachments/assets/c83342c3-b0e1-4ec2-bb6f-8561ec08c0c2)

**Measured, not just eyeballed.** The screenshots above are paired with `getClientRects()` on the chip anchor, which reports one rect per line box it occupies:

| | line boxes | rect widths | rect tops |
|---|---|---|---|
| before | 2 | `[123, 152]` | `[80, 101]` |
| after | 1 | `[275]` | `[99]` |

Identical numbers in light and dark. The `after` row is the whole point: one rect, and it sits at the lower line — the chip moved down intact rather than straddling both.

Sweeping the lead-in text against the pre-fix CSS reproduces all three break points and confirms the glyph case is real, not hypothetical: the first rect measures 123px (break after the second hyphen), then 52px (after the first hyphen), then **18px — the width of the glyph alone**, with the entire label pushed to the next line. Every one of them collapses to a single 275px rect after the fix.

**Regression test** — added to the existing file-link presentation browser suite rather than a new file. It renders the reported scenario and sweeps the column from 220px to 900px in 4px steps, in both themes:

- `wraps a file link as one unit at every column width` asserts `getClientRects().length === 1` for the chip at every sampled width. A vacuity guard first asserts the chip actually changes lines across the sweep, so the test cannot pass on a fixture that never wraps.
- `keeps an unshortened file label inside the column` uses a 58-character label the parser cannot shorten and asserts the chip never exceeds the column width, covering the `max-width` decision described above.
- `keeps the glyph attached to the label's first character` covers the case the two above cannot see: an `inline-block` chip reports one client rect from the outside even when the glyph splits from its label inside its own box, so this compares the chip's top against the label's first character across a dedicated 40-320px sweep. It is table-driven over a short basename, an unbroken long basename, a path carrying a `:line` suffix, a 240-character basename with nothing to break on, and a CJK label — the last two added after the stress run, since they are the cases where the label must wrap several times and the first cut is where a glyph would strand. Each case carries its own vacuity guard asserting the chip actually wraps somewhere in the sweep.

The suite was run both ways with `node scripts/run-vitest.mjs ui/src/styles/chat-file-link-presentation.browser.test.ts`:

- On the branch head: **12 passed**.
- With only the `text.css` hunk reverted to base: **6 failed, 6 passed** — all three regression pairs in both themes (`wraps a file link as one unit`, `keeps an unshortened file label inside the column`, and `keeps the glyph attached to the label's first character`).

So the tests fail on pre-fix code for the intended reason and pass on the fix.

### Stress test in the running Control UI

A fixture transcript built to break this rule rather than to look realistic, rendered by the Control UI mock harness (`scripts/control-ui-mock-dev.ts`) and driven with Playwright at 320/360/480/768/1200px in both themes. The fixture is a local harness transcript at the current head, not committed with this PR; the numbers below come from measuring the live DOM.

What it puts in front of the chip:

- a **430-character path, twelve segments deep**, and a **240-character basename with no `/`, `-`, `_`, or `.`** before its extension — far wider than every column tested, so the label has to wrap several times inside the chip;
- labels the workspace-path scanner can never produce, reached through host-local hrefs: **CJK**, **emoji**, **accented Latin**, **spaces**, and **percent-encoded** sequences;
- **24 chips in one paragraph** separated only by commas; a paragraph that is nothing but one giant chip; a giant chip followed immediately by a **one-character word**, to expose greedy line filling;
- chips inside a **blockquote**, a **three-level nested list**, and **table cells** — including a first column, which turns anywhere-breaking off;
- all three authoring syntaxes at brutal length, and a fenced block that must produce no chip.

46 chips per run, 10 runs per variant. Each chip is measured for whether the glyph shares a line box with the label's first character, whether the chip reports more than one client rect, whether it paints past its own cell or column, and whether anything made the document scroll sideways:

| | glyph stranded from label | chip torn in two | escaped its container | document scrolls sideways |
|---|---:|---:|---:|---:|
| before | **154** | **256** | 0 | none |
| **after (this PR)** | **0** | **0** | **0** | **none** |

Zero at 320px, and zero at every width above it, in both themes.

The 240-character unbreakable basename at 360px is the case worth looking at, because it is the one the fix has to survive: the label *must* wrap — no rule can make it fit — and the only question is where the first cut lands. Before, it lands between the glyph and the label, leaving the mark alone at the end of the previous line:

![brutal oversized, dark 360, before](https://github.com/user-attachments/assets/e2028909-8f49-4c66-aedd-584b241daa78)

After, the glyph and the first characters stay together and every cut lands inside the label body:

![brutal oversized, dark 360, after](https://github.com/user-attachments/assets/ead0dd5d-0ec4-4624-97a0-8b05c1782f41)

The character-set cases at 320px, the narrowest column tested. Before, the percent-encoded label leaves its glyph alone on a line of its own, and the greedy-line-filling case strands another:

![brutal charsets, dark 320, before](https://github.com/user-attachments/assets/9521e949-5203-4eb2-a2c7-0a4c9b6304e0)

After — CJK, emoji, accented, spaced, and percent-encoded labels all keep their glyph attached:

![brutal charsets, dark 320, after](https://github.com/user-attachments/assets/c0dce930-cc67-48d7-999b-2d47db938453)

Density and containers at 480px — 24 back-to-back chips, a blockquote, a three-level list, and a table — before, then after:

![brutal density, light 480, before](https://github.com/user-attachments/assets/8c27da5c-c181-4558-b0e6-6549d5227e27)

![brutal density, light 480, after](https://github.com/user-attachments/assets/e3dbbf18-7df9-4e3a-97e0-6c6eaa44addf)

The whole brutal fixture at desktop width:

![brutal window, light 1200, after](https://github.com/user-attachments/assets/e5cc1257-f4e7-472e-9d1a-3c8d64ecdffd)

**What the stress run did not find, and what it did.** No clipping, no layout blowout, and no horizontal scrolling at any width: a long path in a table cell widens the cell and the table scrolls on its own, which is that table's existing `overflow-x: auto` behavior and is unchanged by this PR. Two cosmetic consequences of an atomic chip are real and visible above: the trailing-punctuation detachment described earlier, and — only when an oversized chip lands inside a numbered list at a very narrow column — the list marker aligning against the chip's tall line box instead of the first text line. Both are the price of never tearing a reference in half; neither hides content.

**Proof scope:** local proof on macOS — the browser suite above, the paired captures, and the stress run — now backed by a cross-platform run. Exact-head CI is green on `2d8727db84c`: [run 31921356912](https://github.com/openclaw/openclaw/actions/runs/31921356912), with none failing. That was the open question here, since font metrics differ on Linux and the sweeps' vacuity guards are what would surface a fixture that stopped reaching the wrap boundary as a failure rather than a silent pass.



