### PR TITLE
fix(ci): run complete plugin tests for direct changes

### DIFF
--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -353,6 +353,15 @@ function createChangedExtensionConfigShards(extensionRoots: string[]) {
   });
 }
 
+function createChangedExtensionConfigShardsForPaths(changedPaths: string[], cwd: string) {
+  const relevantPaths = changedPaths.filter(
+    (changedPath) =>
+      changedPath.startsWith("extensions/") &&
+      (existsSync(path.join(cwd, changedPath)) || !isTestFileTarget(changedPath)),
+  );
+  return createChangedExtensionConfigShards(resolveChangedExtensionRoots(relevantPaths));
+}
+
 /**
  * The fail-safe cause leaves the non-extension diff's extension impact unbounded,
  * so whole extension configs are required; precise targets would under-cover.
@@ -362,19 +371,7 @@ export function createChangedExtensionFallbackShards(
   options: CwdOptions = {},
 ): ChangedNodeTestShard[] {
   const cwd = options.cwd ?? process.cwd();
-  const extensionPaths = changedPaths.filter((changedPath) =>
-    changedPath.startsWith("extensions/"),
-  );
-  if (extensionPaths.length === 0) {
-    return [];
-  }
-  const relevantPaths = extensionPaths.filter(
-    (changedPath) => existsSync(path.join(cwd, changedPath)) || !isTestFileTarget(changedPath),
-  );
-  if (relevantPaths.length === 0) {
-    return [];
-  }
-  return createChangedExtensionConfigShards(resolveChangedExtensionRoots(relevantPaths));
+  return createChangedExtensionConfigShardsForPaths(changedPaths, cwd);
 }
 
 /**
@@ -404,9 +401,13 @@ export function createChangedNodeTestShards(
   }
 
   const policyTargetsByPath = new Map(
-    livePaths.map((changedPath) => [changedPath, resolvePolicyTestTargets([changedPath])]),
+    livePaths
+      .filter((changedPath) => !changedPath.startsWith("extensions/"))
+      .map((changedPath) => [changedPath, resolvePolicyTestTargets([changedPath])]),
   );
-  const regularLivePaths = livePaths.filter((changedPath) => !isPolicyTestOwnedPath(changedPath));
+  const regularLivePaths = livePaths.filter(
+    (changedPath) => !changedPath.startsWith("extensions/") && !isPolicyTestOwnedPath(changedPath),
+  );
 
   // Workspace package consumers often use package specifiers, which the
   // relative import graph cannot connect back to the changed package source.
@@ -436,6 +437,7 @@ export function createChangedNodeTestShards(
   // Boundary-config targets run as regular nondist targets: the boundary
   // suite scans the checked-out tree and never consumes the built dist.
   const shards = [
+    ...createChangedExtensionConfigShardsForPaths(livePaths, cwd),
     ...createChangedTargetShards(targets, {
       checkName: "checks-node-changed",
       shardName: "changed",

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -283,6 +283,22 @@ describe("CI changed Node test plan", () => {
     ]);
   });
 
+  it.each([
+    {
+      changedPath: "extensions/browser/src/browser/cdp.helpers.test.ts",
+      config: "test/vitest/vitest.extension-browser.config.ts",
+    },
+    {
+      changedPath: "extensions/codex/src/session-upstream-marker.ts",
+      config: "test/vitest/vitest.extension-codex.config.ts",
+    },
+  ])("runs the whole owning extension config for $changedPath", ({ changedPath, config }) => {
+    const shards = createChangedNodeTestShards([changedPath]);
+
+    expect(shards).not.toBeNull();
+    expect(shards?.flatMap((shard) => shard.configs)).toContain(config);
+  });
+
   it("preserves Matrix process bounds in mixed package fallbacks", () => {
     const shards = createChangedExtensionFallbackShards([
       "packages/gateway-protocol/src/frame-guards.ts",
@@ -406,20 +422,19 @@ describe("CI changed Node test plan", () => {
     expect(new Set(targets).size).toBe(targets.length);
   });
 
-  it("serializes changed-test chunks that contain Memory Core integration tests", () => {
+  it("serializes the owning Memory Core extension config for direct changes", () => {
     const shards = createChangedNodeTestShards([
       "extensions/memory-core/src/memory/mmr.ts",
       "extensions/memory-core/src/memory/mmr.test.ts",
     ]);
     expect(shards).not.toBeNull();
-    const targetShards = shards?.filter((shard) => shard.targets) ?? [];
-    expect(targetShards.length).toBeGreaterThan(0);
-    expect(
-      targetShards
-        .filter((shard) =>
-          shard.targets?.some((target) => target.startsWith("extensions/memory-core/")),
-        )
-        .every((shard) => shard.planConcurrency === 1),
-    ).toBe(true);
+    expect(shards).toContainEqual({
+      checkName: "checks-node-changed-extensions-config",
+      configs: ["test/vitest/vitest.extension-memory.config.ts"],
+      planConcurrency: 1,
+      requiresDist: false,
+      runner: "blacksmith-8vcpu-ubuntu-2404",
+      shardName: "changed-extensions-config",
+    });
   });
 });


### PR DESCRIPTION
Related: #114506
Follow-up to #122885

## What Problem This Solves

Fixes an issue where directly changed plugin source or test files could pass pull request CI without running every test in that plugin's owning Vitest config.

PR #114506 demonstrates the escape: its successful CI run 31523897727 and final pre-merge run 31587436490 emitted only compact core Node shards, while the compact plan excluded the full plugin suite. PR #122885 added affected-plugin configs when precise targeting falls back, but precise extension plans could still omit colocated tests. PR #123282 exposed the stale Browser tests only because its package changes forced that fallback path; that PR separately owns those test repairs.

## Why This Change Was Made

The changed-node planner now treats plugin test ownership independently from precise core targeting. Every live `extensions/<id>` path adds the complete owning plugin Vitest config, while extension paths are removed from the precise import-graph target set. Non-plugin paths keep the existing precise behavior, and package, deletion, unresolved-path, Matrix chunking, and Memory Core serialization fallbacks remain unchanged.

## User Impact

There is no runtime or user-facing product change. Maintainers now get the complete affected plugin test config before merge for direct plugin changes, preventing omitted in-tree tests from first surfacing on `main` or an unrelated package-change PR.

## Evidence

- Historical selection: [CI run 31523897727](https://github.com/openclaw/openclaw/actions/runs/31523897727) passed with only `checks-node-compact-*` jobs and no Browser config; [run 31587436490](https://github.com/openclaw/openclaw/actions/runs/31587436490) likewise selected no Browser tests and failed `check-test-types` before #114506 merged.
- Config coverage proof: [job 94588320505](https://github.com/openclaw/openclaw/actions/runs/31742162194/job/94588320505) ran `vitest.extension-browser.config.ts`, including all three stale tests repaired by #123282.
- Pre-fix regression: `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts -t "runs the whole owning extension config"` failed 2/2 cases because the Browser and Codex configs were absent.
- Post-fix focused proof: `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts test/scripts/changed-lanes.test.ts` passed 178 tests.
- `./node_modules/.bin/oxfmt --check scripts/lib/ci-changed-node-test-plan.mts test/scripts/ci-changed-node-test-plan.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/lib/ci-changed-node-test-plan.mts`
- `git diff --check`
- Codex-backed autoreview: clean, no accepted/actionable findings.

AI-assisted: yes.
