### PR TITLE
fix: keep global channel events scoped to their agent

### DIFF
--- a/extensions/discord/src/monitor.test.ts
+++ b/extensions/discord/src/monitor.test.ts
@@ -909,7 +909,10 @@ const { enqueueSystemEventSpy, resolveAgentRouteMock } = vi.hoisted(() => ({
 }));
 
 const channelRuntimeModule = await import("openclaw/plugin-sdk/system-event-runtime");
-vi.spyOn(channelRuntimeModule, "enqueueSystemEvent").mockImplementation(enqueueSystemEventSpy);
+vi.spyOn(channelRuntimeModule, "enqueueRoutedSystemEvent").mockImplementation(
+  (text, route, options) =>
+    enqueueSystemEventSpy(text, { ...options, sessionKey: route.sessionKey }) as boolean,
+);
 
 const routingModule = await import("openclaw/plugin-sdk/routing");
 vi.spyOn(routingModule, "resolveAgentRoute").mockImplementation(resolveAgentRouteMock);

--- a/extensions/discord/src/monitor/agent-components.deps.runtime.ts
+++ b/extensions/discord/src/monitor/agent-components.deps.runtime.ts
@@ -1,3 +1,3 @@
 // Discord plugin module implements agent componentseps behavior.
-export { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+export { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 export { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";

--- a/extensions/discord/src/monitor/agent-components.system-controls.ts
+++ b/extensions/discord/src/monitor/agent-components.system-controls.ts
@@ -21,7 +21,7 @@ import {
   type AgentComponentContext,
   type AgentComponentMessageInteraction,
 } from "./agent-components-helpers.js";
-import { enqueueSystemEvent } from "./agent-components.deps.runtime.js";
+import { enqueueRoutedSystemEvent } from "./agent-components.deps.runtime.js";
 
 type AgentSystemControlParams = {
   ctx: AgentComponentContext;
@@ -96,8 +96,7 @@ async function runAgentSystemControlInteraction(params: AgentSystemControlParams
   const eventText = params.formatEventText({ componentId, username, userId });
   logDebug(`${params.label}: enqueuing event for channel ${channelId}: ${eventText}`);
 
-  enqueueSystemEvent(eventText, {
-    sessionKey: route.sessionKey,
+  enqueueRoutedSystemEvent(eventText, route, {
     // The immutable interaction ID identifies one occurrence, preserving repeat clicks while
     // deduplicating gateway replays of that same occurrence.
     contextKey: `${params.contextKeyPrefix}:${channelId}:${componentId}:${userId}:${params.interaction.id}`,

--- a/extensions/discord/src/monitor/listeners.presence.test.ts
+++ b/extensions/discord/src/monitor/listeners.presence.test.ts
@@ -13,7 +13,7 @@ import { DiscordPresenceBaselineCache } from "./presence-transition-cache.js";
 
 const mocks = vi.hoisted(() => ({
   canViewDiscordGuildChannel: vi.fn(async () => true),
-  enqueueSystemEvent: vi.fn(() => true),
+  enqueueSystemEvent: vi.fn((_text: unknown, _options: Record<string, unknown>) => true),
   requestHeartbeat: vi.fn(),
   resolveAgentRoute: vi.fn(() => ({
     agentId: "molty",
@@ -26,7 +26,16 @@ vi.mock("openclaw/plugin-sdk/heartbeat-runtime", () => ({
 }));
 vi.mock("openclaw/plugin-sdk/routing", () => ({ resolveAgentRoute: mocks.resolveAgentRoute }));
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
-  enqueueSystemEvent: mocks.enqueueSystemEvent,
+  enqueueRoutedSystemEvent: (
+    text: unknown,
+    route: { agentId: unknown; sessionKey: unknown },
+    options: Record<string, unknown>,
+  ) =>
+    mocks.enqueueSystemEvent(text, {
+      ...options,
+      agentId: route.agentId,
+      sessionKey: route.sessionKey,
+    }),
 }));
 vi.mock("../send.permissions.js", () => ({
   canViewDiscordGuildChannel: mocks.canViewDiscordGuildChannel,
@@ -136,6 +145,7 @@ describe("DiscordPresenceListener", () => {
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
       expect.stringContaining('user_id="user-1"'),
       expect.objectContaining({
+        agentId: "molty",
         sessionKey: "agent:molty:discord:channel:channel-1",
         deliveryContext: {
           channel: "discord",

--- a/extensions/discord/src/monitor/listeners.reactions.ts
+++ b/extensions/discord/src/monitor/listeners.reactions.ts
@@ -2,7 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import {
   ChannelType,
   type Client,
@@ -500,8 +500,7 @@ async function handleDiscordReactionEvent(
         },
         parentPeer: parentPeerId ? { kind: "channel", id: parentPeerId } : undefined,
       });
-      enqueueSystemEvent(text, {
-        sessionKey: route.sessionKey,
+      enqueueRoutedSystemEvent(text, route, {
         contextKey,
       });
     };

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -4,7 +4,7 @@ import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import {
   type Client,
   type DiscordMessageDispatchData,
@@ -373,8 +373,7 @@ export class DiscordPresenceListener extends PresenceUpdateListener {
         return;
       }
 
-      const queued = enqueueSystemEvent(presenceEvent.text, {
-        sessionKey: route.sessionKey,
+      const queued = enqueueRoutedSystemEvent(presenceEvent.text, route, {
         contextKey: `discord:presence-online:${this.params.accountId}:${data.guild_id}:${userId}`,
         deliveryContext: {
           channel: "discord",

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -20,7 +20,7 @@ import { logDebug } from "openclaw/plugin-sdk/logging-core";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { getChildLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { resolveDefaultDiscordAccountId } from "../accounts.js";
 import { ChannelType, MessageType, type User } from "../internal/discord.js";
 import {
@@ -750,8 +750,7 @@ export async function preflightDiscordMessage(
   const systemText = resolveDiscordSystemEvent(message, systemLocation);
   if (systemText) {
     logDebug(`[discord-preflight] drop: system event`);
-    enqueueSystemEvent(systemText, {
-      sessionKey: effectiveRoute.sessionKey,
+    enqueueRoutedSystemEvent(systemText, effectiveRoute, {
       contextKey: `discord:system:${messageChannelId}:${message.id}`,
     });
     return null;

--- a/extensions/discord/src/test-support/component-runtime.ts
+++ b/extensions/discord/src/test-support/component-runtime.ts
@@ -161,7 +161,11 @@ vi.mock("../interactive-dispatch.js", () => {
 
 vi.mock("../monitor/agent-components.deps.runtime.js", () => {
   return {
-    enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+    enqueueRoutedSystemEvent: (
+      text: unknown,
+      route: { sessionKey: unknown },
+      options: Record<string, unknown>,
+    ) => enqueueSystemEventMock(text, { ...options, sessionKey: route.sessionKey }),
     readSessionUpdatedAt: (...args: unknown[]) => readSessionUpdatedAtMock(...args),
     resolveStorePath: (...args: unknown[]) => resolveStorePathMock(...args),
   };

--- a/extensions/discord/src/voice/membership.ts
+++ b/extensions/discord/src/voice/membership.ts
@@ -1,7 +1,7 @@
 // Discord plugin module owns voice-session participant membership events.
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import {
   collectDiscordVoiceParticipants,
@@ -234,7 +234,7 @@ export class DiscordVoiceMembershipTracker {
 
   private publish(entry: VoiceSessionEntry, text: string): boolean {
     try {
-      return enqueueSystemEvent(text, this.eventOptions(entry));
+      return enqueueRoutedSystemEvent(text, entry.route, this.eventOptions(entry));
     } catch (err) {
       this.logFailure(entry, err);
       return false;
@@ -276,12 +276,10 @@ export class DiscordVoiceMembershipTracker {
   }
 
   private eventOptions(entry: VoiceSessionEntry): {
-    sessionKey: string;
     contextKey: string;
     replace: true;
   } {
     return {
-      sessionKey: entry.route.sessionKey,
       contextKey: `discord:voice-membership:${this.accountId}:${entry.guildId}`,
       replace: true,
     };

--- a/extensions/discord/src/voice/voice-test-mocks.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-mocks.test-support.ts
@@ -282,7 +282,11 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
 });
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
-  enqueueSystemEvent: enqueueSystemEventMock,
+  enqueueRoutedSystemEvent: (
+    text: unknown,
+    route: { sessionKey: unknown },
+    options: Record<string, unknown>,
+  ) => enqueueSystemEventMock(text, { ...options, sessionKey: route.sessionKey }),
 }));
 
 vi.mock("openclaw/plugin-sdk/realtime-voice", async () => {

--- a/extensions/slack/src/monitor/config.runtime.ts
+++ b/extensions/slack/src/monitor/config.runtime.ts
@@ -4,7 +4,6 @@ export { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-na
 export {
   readSessionUpdatedAt,
   resolveChannelResetConfig,
-  resolveSessionKey,
   resolveStorePath,
   updateLastRoute,
 } from "openclaw/plugin-sdk/session-store-runtime";

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -194,29 +194,32 @@ describe("createSlackMonitorContext isChannelAllowed", () => {
   });
 });
 
-describe("createSlackMonitorContext resolveSlackSystemEventSessionKey", () => {
+describe("createSlackMonitorContext resolveSlackSystemEventRoute", () => {
   it("routes threaded interaction events to the Slack thread session", () => {
     const ctx = createTestContext();
 
     expect(
-      ctx.resolveSlackSystemEventSessionKey({
+      ctx.resolveSlackSystemEventRoute({
         channelId: "C_THREAD",
         channelType: "channel",
         senderId: "U_CLICKER",
         threadTs: "1712345678.123456",
       }),
-    ).toBe("agent:main:slack:channel:c_thread:thread:1712345678.123456");
+    ).toEqual({
+      agentId: "main",
+      sessionKey: "agent:main:slack:channel:c_thread:thread:1712345678.123456",
+    });
   });
 
   it("routes channel-less direct interactions to the sender session", () => {
     const ctx = createTestContext({ dmScope: "per-channel-peer" });
 
     expect(
-      ctx.resolveSlackSystemEventSessionKey({
+      ctx.resolveSlackSystemEventRoute({
         channelType: "im",
         senderId: "U_SHORTCUT",
       }),
-    ).toBe("agent:main:slack:direct:u_shortcut");
+    ).toEqual({ agentId: "main", sessionKey: "agent:main:slack:direct:u_shortcut" });
   });
 
   it("routes typeless system events through an event-carried mpDM type", () => {
@@ -224,39 +227,51 @@ describe("createSlackMonitorContext resolveSlackSystemEventSessionKey", () => {
     ctx.rememberSlackChannelType("C0MPDM42", "mpim");
 
     expect(
-      ctx.resolveSlackSystemEventSessionKey({
+      ctx.resolveSlackSystemEventRoute({
         channelId: "C0MPDM42",
         senderId: "U_ACTOR",
       }),
-    ).toBe("agent:main:slack:group:c0mpdm42");
+    ).toEqual({ agentId: "main", sessionKey: "agent:main:slack:group:c0mpdm42" });
   });
 
   it("partitions enterprise channel system events by workspace", () => {
     const ctx = createTestContext();
     const resolveForTeam = (teamId: string) =>
-      ctx.resolveSlackSystemEventSessionKey({
+      ctx.resolveSlackSystemEventRoute({
         channelId: "C_SHARED",
         channelType: "channel",
         senderId: "U_ACTOR",
         eventScope: createEnterpriseEventScope(teamId),
       });
 
-    expect(resolveForTeam("T111")).toBe("agent:main:slack:channel:team:t111:channel:c_shared");
-    expect(resolveForTeam("T222")).toBe("agent:main:slack:channel:team:t222:channel:c_shared");
+    expect(resolveForTeam("T111")).toEqual({
+      agentId: "main",
+      sessionKey: "agent:main:slack:channel:team:t111:channel:c_shared",
+    });
+    expect(resolveForTeam("T222")).toEqual({
+      agentId: "main",
+      sessionKey: "agent:main:slack:channel:team:t222:channel:c_shared",
+    });
   });
 
   it("partitions enterprise main DM system events by workspace", () => {
     const ctx = createTestContext({ dmScope: "main" });
     const resolveForTeam = (teamId: string) =>
-      ctx.resolveSlackSystemEventSessionKey({
+      ctx.resolveSlackSystemEventRoute({
         channelId: "D_SHARED",
         channelType: "im",
         senderId: "U_SHARED",
         eventScope: createEnterpriseEventScope(teamId),
       });
 
-    expect(resolveForTeam("T111")).toBe("agent:main:main:account:default:team:t111");
-    expect(resolveForTeam("T222")).toBe("agent:main:main:account:default:team:t222");
+    expect(resolveForTeam("T111")).toEqual({
+      agentId: "main",
+      sessionKey: "agent:main:main:account:default:team:t111",
+    });
+    expect(resolveForTeam("T222")).toEqual({
+      agentId: "main",
+      sessionKey: "agent:main:main:account:default:team:t222",
+    });
   });
 });
 

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -37,7 +37,7 @@ import {
   type SlackSuggestedPromptsInput,
   updateSlackSuggestedPrompts,
 } from "./suggested-prompts.js";
-import { createSlackSystemEventSessionKeyResolver } from "./system-event-session.js";
+import { createSlackSystemEventRouteResolver } from "./system-event-session.js";
 
 export {
   buildSlackAssistantThreadMetadata,
@@ -110,13 +110,13 @@ export type SlackMonitorContext = {
 
   logger: ReturnType<typeof getChildLogger>;
   shouldDropMismatchedSlackEvent: (body: unknown) => boolean;
-  resolveSlackSystemEventSessionKey: (params: {
+  resolveSlackSystemEventRoute: (params: {
     channelId?: string | null;
     channelType?: string | null;
     senderId?: string | null;
     threadTs?: string | null;
     eventScope?: SlackEventScope;
-  }) => string;
+  }) => { agentId: string; sessionKey: string };
   isChannelAllowed: (params: {
     teamId?: string;
     channelId?: string;
@@ -277,12 +277,11 @@ export function createSlackMonitorContext(params: {
     return id ? readLruMapEntry(channelCache, scopedKey(id, eventScope))?.info.type : undefined;
   };
 
-  const resolveSlackSystemEventSessionKey = createSlackSystemEventSessionKeyResolver({
+  const resolveSlackSystemEventRoute = createSlackSystemEventRouteResolver({
     cfg: params.cfg,
     accountId: params.accountId,
     getTeamId: () => ctx.teamId,
     mainKey: params.mainKey,
-    sessionScope: params.sessionScope,
     threadInheritParent: params.threadInheritParent,
     recallSlackChannelType,
   });
@@ -544,7 +543,7 @@ export function createSlackMonitorContext(params: {
     mediaMaxBytes: params.mediaMaxBytes,
     logger,
     shouldDropMismatchedSlackEvent,
-    resolveSlackSystemEventSessionKey,
+    resolveSlackSystemEventRoute,
     isChannelAllowed,
     resolveChannelName,
     rememberSlackChannelType,

--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -12,7 +12,11 @@ let registerSlackChannelIdChangedEvent: typeof import("./channels.js").registerS
 let createSlackSystemEventTestHarness: typeof import("./system-event-test-harness.js").createSlackSystemEventTestHarness;
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+  enqueueRoutedSystemEvent: (
+    text: unknown,
+    route: { sessionKey: unknown },
+    options: Record<string, unknown>,
+  ) => enqueueSystemEventMock(text, { ...options, sessionKey: route.sessionKey }),
 }));
 vi.mock("openclaw/plugin-sdk/channel-config-writes", () => ({
   resolveChannelConfigWrites: () => true,
@@ -111,10 +115,12 @@ describe("registerSlackChannelEvents", () => {
       enterpriseId: "E_GRID",
     };
     const resolveSessionKey = vi.fn(
-      (input: Parameters<typeof ctx.resolveSlackSystemEventSessionKey>[0]) =>
-        `session:${input.eventScope?.teamId ?? "workspace"}`,
+      (input: Parameters<typeof ctx.resolveSlackSystemEventRoute>[0]) => ({
+        agentId: "main",
+        sessionKey: `session:${input.eventScope?.teamId ?? "workspace"}`,
+      }),
     );
-    ctx.resolveSlackSystemEventSessionKey = resolveSessionKey;
+    ctx.resolveSlackSystemEventRoute = resolveSessionKey;
 
     const cases = [
       {

--- a/extensions/slack/src/monitor/events/channels.ts
+++ b/extensions/slack/src/monitor/events/channels.ts
@@ -7,7 +7,7 @@ import {
 } from "openclaw/plugin-sdk/config-mutation";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger, warn } from "openclaw/plugin-sdk/runtime-env";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { migrateSlackChannelConfig } from "../../channel-migration.js";
 import { resolveSlackChannelLabel } from "../channel-config.js";
 import type { SlackMonitorContext } from "../context.js";
@@ -48,13 +48,12 @@ export function registerSlackChannelEvents(params: {
       channelId: paramsLocal.channelId,
       channelName: paramsLocal.channelName,
     });
-    const sessionKey = ctx.resolveSlackSystemEventSessionKey({
+    const route = ctx.resolveSlackSystemEventRoute({
       channelId: paramsLocal.channelId,
       channelType: "channel",
       eventScope: paramsLocal.eventScope,
     });
-    enqueueSystemEvent(`Slack channel ${paramsLocal.kind}: ${label}.`, {
-      sessionKey,
+    enqueueRoutedSystemEvent(`Slack channel ${paramsLocal.kind}: ${label}.`, route, {
       contextKey: `slack:channel:${paramsLocal.eventScope ? `${paramsLocal.eventScope.teamId}:` : ""}${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}:${paramsLocal.eventId}`,
     });
   };

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -15,7 +15,7 @@ import {
   normalizeOptionalString,
   normalizeUniqueTrimmedStringList,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { decodeSlackApprovalAction, type SlackApprovalAction } from "../../approval-actions.js";
 import { isSlackApprovalAuthorizedSender } from "../../approval-auth.js";
 import { isSlackExecApprovalAuthorizedSender } from "../../exec-approvals.js";
@@ -974,7 +974,7 @@ function enqueueSlackBlockActionEvent(params: {
   params.ctx.runtime.log?.(
     `slack:interaction action=${params.parsed.actionId} type=${params.parsed.actionSummary.actionType ?? "unknown"} user=${params.parsed.userId} channel=${params.parsed.channelId}`,
   );
-  const sessionKey = params.ctx.resolveSlackSystemEventSessionKey({
+  const route = params.ctx.resolveSlackSystemEventRoute({
     channelId: params.parsed.channelId,
     channelType: params.auth.channelType,
     senderId: params.parsed.userId,
@@ -990,8 +990,7 @@ function enqueueSlackBlockActionEvent(params: {
     normalizeOptionalString(params.parsed.typedActionWithText.action_ts) ??
       params.parsed.typedBody.trigger_id,
   ].filter(Boolean);
-  const queued = enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
-    sessionKey,
+  const queued = enqueueRoutedSystemEvent(params.formatSystemEvent(eventPayload), route, {
     contextKey: contextParts.join(":"),
     deliveryContext: {
       channel: "slack",
@@ -1005,7 +1004,8 @@ function enqueueSlackBlockActionEvent(params: {
       source: "hook",
       intent: "immediate",
       reason: "hook:slack-interaction",
-      sessionKey,
+      agentId: route.agentId,
+      sessionKey: route.sessionKey,
       heartbeat: { target: "last" },
     });
   }

--- a/extensions/slack/src/monitor/events/interactions.modal.ts
+++ b/extensions/slack/src/monitor/events/interactions.modal.ts
@@ -1,7 +1,8 @@
 // Slack plugin module implements interactions.modal behavior.
 import type { AllMiddlewareArgs } from "@slack/bolt";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { dispatchSlackPluginInteractiveHandler } from "../../interactive-dispatch.js";
 import { parseSlackModalPrivateMetadata } from "../../modal-metadata.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
@@ -130,10 +131,14 @@ function resolveModalSessionRouting(params: {
   metadata: ReturnType<typeof parseSlackModalPrivateMetadata>;
   userId?: string;
   eventScope?: SlackEventScope;
-}): { sessionKey: string; channelId?: string; channelType?: string } {
+}): { agentId: string; sessionKey: string; channelId?: string; channelType?: string } {
   const metadata = params.metadata;
-  if (metadata.sessionKey && !params.eventScope) {
+  const metadataAgentId = metadata.sessionKey
+    ? resolveAgentIdFromSessionKey(metadata.sessionKey)
+    : undefined;
+  if (metadata.sessionKey && metadataAgentId && !params.eventScope) {
     return {
+      agentId: metadataAgentId,
       sessionKey: metadata.sessionKey,
       channelId: metadata.channelId,
       channelType: metadata.channelType,
@@ -141,7 +146,7 @@ function resolveModalSessionRouting(params: {
   }
   const routing = metadata.channelId
     ? {
-        sessionKey: params.ctx.resolveSlackSystemEventSessionKey({
+        ...params.ctx.resolveSlackSystemEventRoute({
           channelId: metadata.channelId,
           channelType: metadata.channelType,
           senderId: params.userId,
@@ -151,7 +156,7 @@ function resolveModalSessionRouting(params: {
         channelType: metadata.channelType,
       }
     : {
-        sessionKey: params.ctx.resolveSlackSystemEventSessionKey({
+        ...params.ctx.resolveSlackSystemEventRoute({
           channelType: "im",
           senderId: params.userId,
           eventScope: params.eventScope,
@@ -445,10 +450,10 @@ async function emitSlackModalLifecycleEvent(params: {
       })
     : undefined;
 
-  const queued = enqueueSystemEvent(
+  const queued = enqueueRoutedSystemEvent(
     params.formatSystemEvent({ ...eventPayload, ...pluginEventFields }),
+    sessionRouting,
     {
-      sessionKey: sessionRouting.sessionKey,
       contextKey: [params.contextPrefix, params.teamId, callbackId, viewId, userId]
         .filter(Boolean)
         .join(":"),
@@ -464,6 +469,7 @@ async function emitSlackModalLifecycleEvent(params: {
       source: "hook",
       intent: "immediate",
       reason: "hook:slack-interaction",
+      agentId: sessionRouting.agentId,
       sessionKey: sessionRouting.sessionKey,
       heartbeat: { target: "last" },
     });

--- a/extensions/slack/src/monitor/events/interactions.shortcuts.ts
+++ b/extensions/slack/src/monitor/events/interactions.shortcuts.ts
@@ -6,7 +6,7 @@ import type {
   SlackShortcutMiddlewareArgs,
 } from "@slack/bolt";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
 import { resolveSlackDeferredActionTarget } from "../deferred-action-routing.js";
@@ -103,7 +103,7 @@ async function handleSlackShortcut(params: {
     messageText: messageBody?.message.text,
     responseUrl: messageBody?.response_url,
   };
-  const sessionKey = params.ctx.resolveSlackSystemEventSessionKey({
+  const route = params.ctx.resolveSlackSystemEventRoute({
     channelId,
     channelType: auth.channelType,
     senderId: userId,
@@ -125,8 +125,7 @@ async function handleSlackShortcut(params: {
   params.ctx.runtime.log?.(
     `slack:interaction ${interactionType} callback=${callbackId} user=${userId} channel=${channelId ?? "direct"}`,
   );
-  const queued = enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
-    sessionKey,
+  const queued = enqueueRoutedSystemEvent(params.formatSystemEvent(eventPayload), route, {
     contextKey,
     deliveryContext: {
       channel: "slack",
@@ -140,7 +139,8 @@ async function handleSlackShortcut(params: {
       source: "hook",
       intent: "immediate",
       reason: "hook:slack-interaction",
-      sessionKey,
+      agentId: route.agentId,
+      sessionKey: route.sessionKey,
       heartbeat: { target: "last" },
     });
   }

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -76,7 +76,11 @@ vi.mock("openclaw/plugin-sdk/system-event-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/system-event-runtime")>();
   return {
     ...actual,
-    enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+    enqueueRoutedSystemEvent: (
+      text: unknown,
+      route: { sessionKey: unknown },
+      options: Record<string, unknown>,
+    ) => enqueueSystemEventMock(text, { ...options, sessionKey: route.sessionKey }),
   };
 });
 
@@ -354,7 +358,10 @@ function createContext(overrides?: {
     client: listenerClient,
   };
   const runtimeLog = vi.fn();
-  const resolveSessionKey = vi.fn().mockReturnValue("agent:ops:slack:channel:C1");
+  const resolveSessionKey = vi.fn().mockReturnValue({
+    agentId: "ops",
+    sessionKey: "agent:ops:slack:channel:C1",
+  });
   const isChannelAllowed = vi
     .fn<
       (params: {
@@ -406,7 +413,7 @@ function createContext(overrides?: {
     isChannelAllowed,
     resolveUserName,
     resolveChannelName,
-    resolveSlackSystemEventSessionKey: resolveSessionKey,
+    resolveSlackSystemEventRoute: resolveSessionKey,
   };
   return {
     ctx,
@@ -1307,6 +1314,7 @@ describe("registerSlackInteractionEvents", () => {
       source: "hook",
       intent: "immediate",
       reason: "hook:slack-interaction",
+      agentId: "ops",
       sessionKey: "agent:ops:slack:channel:C1",
       heartbeat: { target: "last" },
     });
@@ -3177,6 +3185,7 @@ describe("registerSlackInteractionEvents", () => {
       source: "hook",
       intent: "immediate",
       reason: "hook:slack-interaction",
+      agentId: "ops",
       sessionKey: "agent:ops:slack:channel:C1",
       heartbeat: { target: "last" },
     });
@@ -4001,6 +4010,7 @@ describe("registerSlackInteractionEvents", () => {
       source: "hook",
       intent: "immediate",
       reason: "hook:slack-interaction",
+      agentId: "main",
       sessionKey: "agent:main:slack:channel:C99",
       heartbeat: { target: "last" },
     });

--- a/extensions/slack/src/monitor/events/members.test.ts
+++ b/extensions/slack/src/monitor/events/members.test.ts
@@ -10,7 +10,11 @@ let initSlackHarness: typeof import("./system-event-test-harness.js").createSlac
 type MemberOverrides = import("./system-event-test-harness.js").SlackSystemEventTestOverrides;
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => memberMocks.enqueue(...args),
+  enqueueRoutedSystemEvent: (
+    text: unknown,
+    route: { sessionKey: unknown },
+    options: Record<string, unknown>,
+  ) => memberMocks.enqueue(text, { ...options, sessionKey: route.sessionKey }),
 }));
 type MemberHandler = import("./system-event-test-harness.js").SlackSystemEventHandler;
 
@@ -193,12 +197,14 @@ describe("registerSlackMemberEvents", () => {
     const resolveChannelName = vi.fn(harness.ctx.resolveChannelName);
     const resolveUserName = vi.fn(harness.ctx.resolveUserName);
     const resolveSessionKey = vi.fn(
-      (input: Parameters<typeof harness.ctx.resolveSlackSystemEventSessionKey>[0]) =>
-        `session:${input.eventScope?.teamId ?? "workspace"}`,
+      (input: Parameters<typeof harness.ctx.resolveSlackSystemEventRoute>[0]) => ({
+        agentId: "main",
+        sessionKey: `session:${input.eventScope?.teamId ?? "workspace"}`,
+      }),
     );
     harness.ctx.resolveChannelName = resolveChannelName;
     harness.ctx.resolveUserName = resolveUserName;
-    harness.ctx.resolveSlackSystemEventSessionKey = resolveSessionKey;
+    harness.ctx.resolveSlackSystemEventRoute = resolveSessionKey;
     registerSlackMemberEvents({ ctx: harness.ctx });
     const handler = harness.getHandler("member_joined_channel");
     if (!handler) {

--- a/extensions/slack/src/monitor/events/members.ts
+++ b/extensions/slack/src/monitor/events/members.ts
@@ -2,7 +2,7 @@
 import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from "@slack/bolt";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { SlackSystemEventAuthRetryError } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackMemberChannelEvent } from "../types.js";
@@ -56,10 +56,10 @@ export function registerSlackMemberEvents(params: {
       }
       const userInfo = payload.user ? await ctx.resolveUserName(payload.user, eventScope) : {};
       const userLabel = userInfo?.name ?? payload.user ?? "someone";
-      enqueueSystemEvent(
+      enqueueRoutedSystemEvent(
         `Slack: ${userLabel} ${paramsLocal.verb} ${ingressContext.channelLabel}.`,
+        ingressContext.route,
         {
-          sessionKey: ingressContext.sessionKey,
           contextKey: `slack:member:${eventScope ? `${eventScope.teamId}:` : ""}${paramsLocal.verb}:${channelId ?? "unknown"}:${payload.user ?? "unknown"}:${paramsLocal.eventId}`,
         },
       );

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -42,7 +42,11 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
 });
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
+  enqueueRoutedSystemEvent: (
+    text: unknown,
+    route: { sessionKey: unknown },
+    options: Record<string, unknown>,
+  ) => messageQueueMock(text, { ...options, sessionKey: route.sessionKey }),
 }));
 vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -11,7 +11,7 @@ import {
   asOptionalRecord as asRecord,
   normalizeOptionalString as asString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { noteSlackDraftConversationMessage } from "../../draft-message-boundaries.js";
 import type { SlackAppMentionEvent, SlackMessageEvent } from "../../types.js";
 import { normalizeSlackChannelType } from "../channel-type.js";
@@ -300,10 +300,13 @@ export function registerSlackMessageEvents(params: {
         if (!ingressContext) {
           return;
         }
-        enqueueSystemEvent(subtypeHandler.describe(ingressContext.channelLabel), {
-          sessionKey: ingressContext.sessionKey,
-          contextKey: `${subtypeHandler.contextKey(message)}:${body.event_id}`,
-        });
+        enqueueRoutedSystemEvent(
+          subtypeHandler.describe(ingressContext.channelLabel),
+          ingressContext.route,
+          {
+            contextKey: `${subtypeHandler.contextKey(message)}:${body.event_id}`,
+          },
+        );
         return;
       }
 

--- a/extensions/slack/src/monitor/events/pins.test.ts
+++ b/extensions/slack/src/monitor/events/pins.test.ts
@@ -8,7 +8,11 @@ let buildPinHarness: typeof import("./system-event-test-harness.js").createSlack
 type PinOverrides = import("./system-event-test-harness.js").SlackSystemEventTestOverrides;
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => pinEnqueueMock(...args),
+  enqueueRoutedSystemEvent: (
+    text: unknown,
+    route: { sessionKey: unknown },
+    options: Record<string, unknown>,
+  ) => pinEnqueueMock(text, { ...options, sessionKey: route.sessionKey }),
 }));
 type PinHandler = import("./system-event-test-harness.js").SlackSystemEventHandler;
 
@@ -175,12 +179,14 @@ describe("registerSlackPinEvents", () => {
     const resolveChannelName = vi.fn(harness.ctx.resolveChannelName);
     const resolveUserName = vi.fn(harness.ctx.resolveUserName);
     const resolveSessionKey = vi.fn(
-      (input: Parameters<typeof harness.ctx.resolveSlackSystemEventSessionKey>[0]) =>
-        `session:${input.eventScope?.teamId ?? "workspace"}`,
+      (input: Parameters<typeof harness.ctx.resolveSlackSystemEventRoute>[0]) => ({
+        agentId: "main",
+        sessionKey: `session:${input.eventScope?.teamId ?? "workspace"}`,
+      }),
     );
     harness.ctx.resolveChannelName = resolveChannelName;
     harness.ctx.resolveUserName = resolveUserName;
-    harness.ctx.resolveSlackSystemEventSessionKey = resolveSessionKey;
+    harness.ctx.resolveSlackSystemEventRoute = resolveSessionKey;
     registerSlackPinEvents({ ctx: harness.ctx });
     const handler = harness.getHandler("pin_added") as PinHandler | null;
     if (!handler) {

--- a/extensions/slack/src/monitor/events/pins.ts
+++ b/extensions/slack/src/monitor/events/pins.ts
@@ -2,7 +2,7 @@
 import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from "@slack/bolt";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackPinEvent } from "../types.js";
 import {
@@ -65,10 +65,10 @@ async function handleSlackPinEvent(params: {
     const userLabel = userInfo?.name ?? payload.user ?? "someone";
     const itemType = payload.item?.type ?? "item";
     const messageId = payload.item?.message?.ts ?? payload.event_ts;
-    enqueueSystemEvent(
+    enqueueRoutedSystemEvent(
       `Slack: ${userLabel} ${action} a ${itemType} in ${ingressContext.channelLabel}.`,
+      ingressContext.route,
       {
-        sessionKey: ingressContext.sessionKey,
         contextKey: `slack:pin:${eventScope ? `${eventScope.teamId}:` : ""}${contextKeySuffix}:${channelId ?? "unknown"}:${messageId ?? "unknown"}:${eventId}`,
       },
     );

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -9,7 +9,11 @@ type SlackSystemEventTestOverrides =
   import("./system-event-test-harness.js").SlackSystemEventTestOverrides;
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => reactionQueueMock(...args),
+  enqueueRoutedSystemEvent: (
+    text: unknown,
+    route: { sessionKey: unknown },
+    options: Record<string, unknown>,
+  ) => reactionQueueMock(text, { ...options, sessionKey: route.sessionKey }),
 }));
 type ReactionHandler = import("./system-event-test-harness.js").SlackSystemEventHandler;
 
@@ -296,8 +300,10 @@ describe("registerSlackReactionEvents", () => {
   it("passes sender context when resolving reaction session keys", async () => {
     reactionQueueMock.mockClear();
     const harness = createSlackSystemEventTestHarness();
-    const resolveSessionKey = vi.fn().mockReturnValue("agent:ops:main");
-    harness.ctx.resolveSlackSystemEventSessionKey = resolveSessionKey;
+    const resolveSessionKey = vi
+      .fn()
+      .mockReturnValue({ agentId: "ops", sessionKey: "agent:ops:main" });
+    harness.ctx.resolveSlackSystemEventRoute = resolveSessionKey;
     registerSlackReactionEvents({ ctx: harness.ctx });
     const handler = requireReactionHandler(
       harness.getHandler("reaction_added") as ReactionHandler | null,
@@ -326,12 +332,14 @@ describe("registerSlackReactionEvents", () => {
     const resolveChannelName = vi.fn(harness.ctx.resolveChannelName);
     const resolveUserName = vi.fn(harness.ctx.resolveUserName);
     const resolveSessionKey = vi.fn(
-      (input: Parameters<typeof harness.ctx.resolveSlackSystemEventSessionKey>[0]) =>
-        `session:${input.eventScope?.teamId ?? "workspace"}`,
+      (input: Parameters<typeof harness.ctx.resolveSlackSystemEventRoute>[0]) => ({
+        agentId: "main",
+        sessionKey: `session:${input.eventScope?.teamId ?? "workspace"}`,
+      }),
     );
     harness.ctx.resolveChannelName = resolveChannelName;
     harness.ctx.resolveUserName = resolveUserName;
-    harness.ctx.resolveSlackSystemEventSessionKey = resolveSessionKey;
+    harness.ctx.resolveSlackSystemEventRoute = resolveSessionKey;
     registerSlackReactionEvents({ ctx: harness.ctx });
     const handler = requireReactionHandler(
       harness.getHandler("reaction_added") as ReactionHandler | null,

--- a/extensions/slack/src/monitor/events/reactions.ts
+++ b/extensions/slack/src/monitor/events/reactions.ts
@@ -2,7 +2,7 @@
 import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from "@slack/bolt";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { allowListMatches, normalizeAllowListLower } from "../allow-list.js";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackEventScope } from "../event-scope.js";
@@ -101,8 +101,7 @@ export function registerSlackReactionEvents(params: {
       const authorLabel = authorInfo?.name ?? event.item_user;
       const baseText = `Slack reaction ${action}: :${emojiLabel}: by ${actorLabel} in ${ingressContext.channelLabel} msg ${item.ts}`;
       const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
-      enqueueSystemEvent(text, {
-        sessionKey: ingressContext.sessionKey,
+      enqueueRoutedSystemEvent(text, ingressContext.route, {
         contextKey: `slack:reaction:${eventScope ? `${eventScope.teamId}:` : ""}${action}:${item.channel}:${item.ts}:${event.user}:${emojiLabel}:${eventId}`,
       });
     } catch (err) {

--- a/extensions/slack/src/monitor/events/system-event-context.ts
+++ b/extensions/slack/src/monitor/events/system-event-context.ts
@@ -8,7 +8,7 @@ import { resolveSlackEventScope, type SlackEventScope } from "../event-scope.js"
 
 type SlackAuthorizedSystemEventContext = {
   channelLabel: string;
-  sessionKey: string;
+  route: { agentId: string; sessionKey: string };
 };
 
 export async function authorizeAndResolveSlackSystemEventContext(params: {
@@ -39,7 +39,7 @@ export async function authorizeAndResolveSlackSystemEventContext(params: {
     channelId,
     channelName: auth.channelName,
   });
-  const sessionKey = ctx.resolveSlackSystemEventSessionKey({
+  const route = ctx.resolveSlackSystemEventRoute({
     channelId,
     channelType: auth.channelType,
     senderId,
@@ -47,7 +47,7 @@ export async function authorizeAndResolveSlackSystemEventContext(params: {
   });
   return {
     channelLabel,
-    sessionKey,
+    route,
   };
 }
 

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -61,7 +61,7 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
     resolveUserName: async (userId: string) => ({
       name: overrides?.userNames?.[userId] ?? "alice",
     }),
-    resolveSlackSystemEventSessionKey: () => "agent:main:main",
+    resolveSlackSystemEventRoute: () => ({ agentId: "main", sessionKey: "agent:main:main" }),
   } as unknown as SlackMonitorContext;
 
   return {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -85,7 +85,11 @@ vi.mock("openclaw/plugin-sdk/system-event-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/system-event-runtime")>();
   return {
     ...actual,
-    enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+    enqueueRoutedSystemEvent: (
+      text: unknown,
+      route: { sessionKey: unknown },
+      options: Record<string, unknown>,
+    ) => enqueueSystemEventMock(text, { ...options, sessionKey: route.sessionKey }),
   };
 });
 
@@ -4805,7 +4809,10 @@ describe("prepareSlackMessage sender prefix", () => {
       mediaMaxBytes: 1000,
       logger: { info: vi.fn(), warn: vi.fn() },
       shouldDropMismatchedSlackEvent: () => false,
-      resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",
+      resolveSlackSystemEventRoute: () => ({
+        agentId: "main",
+        sessionKey: "agent:main:slack:channel:c1",
+      }),
       isChannelAllowed: () => true,
       resolveChannelName: async () => ({ name: "general", type: "channel" }),
       resolveUserName: async () => ({ name: "Alice" }),

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -36,7 +36,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveSlackReplyToMode } from "../../account-reply-mode.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
@@ -1497,10 +1497,13 @@ export async function prepareSlackMessage(params: {
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
 
-  enqueueSystemEvent(inboundLabel, {
-    sessionKey,
-    contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
-  });
+  enqueueRoutedSystemEvent(
+    inboundLabel,
+    { ...route, sessionKey },
+    {
+      contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
+    },
+  );
 
   const envelopeFrom =
     resolveConversationLabel({

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -357,12 +357,13 @@ describe("normalizeSlackChannelType", () => {
   });
 });
 
-describe("resolveSlackSystemEventSessionKey", () => {
+describe("resolveSlackSystemEventRoute", () => {
   it("defaults missing channel_type to channel sessions", () => {
     const ctx = createSlackMonitorContext(baseParams());
-    expect(ctx.resolveSlackSystemEventSessionKey({ channelId: "C123" })).toBe(
-      "agent:main:slack:channel:c123",
-    );
+    expect(ctx.resolveSlackSystemEventRoute({ channelId: "C123" })).toEqual({
+      agentId: "main",
+      sessionKey: "agent:main:slack:channel:c123",
+    });
   });
 
   it("uses the configured default agent for fallback system-event sessions", () => {
@@ -372,9 +373,10 @@ describe("resolveSlackSystemEventSessionKey", () => {
         agents: { list: [{ id: "ops", default: true }] },
       },
     });
-    expect(ctx.resolveSlackSystemEventSessionKey({ channelId: "C123" })).toBe(
-      "agent:ops:slack:channel:c123",
-    );
+    expect(ctx.resolveSlackSystemEventRoute({ channelId: "C123" })).toEqual({
+      agentId: "ops",
+      sessionKey: "agent:ops:slack:channel:c123",
+    });
   });
 
   it("routes channel system events through account bindings", () => {
@@ -393,9 +395,9 @@ describe("resolveSlackSystemEventSessionKey", () => {
         ],
       },
     });
-    expect(
-      ctx.resolveSlackSystemEventSessionKey({ channelId: "C123", channelType: "channel" }),
-    ).toBe("agent:ops:slack:channel:c123");
+    expect(ctx.resolveSlackSystemEventRoute({ channelId: "C123", channelType: "channel" })).toEqual(
+      { agentId: "ops", sessionKey: "agent:ops:slack:channel:c123" },
+    );
   });
 
   it("routes DM system events through direct-peer bindings when sender is known", () => {
@@ -416,12 +418,12 @@ describe("resolveSlackSystemEventSessionKey", () => {
       },
     });
     expect(
-      ctx.resolveSlackSystemEventSessionKey({
+      ctx.resolveSlackSystemEventRoute({
         channelId: "D123",
         channelType: "im",
         senderId: "U123",
       }),
-    ).toBe("agent:ops-dm:main");
+    ).toEqual({ agentId: "ops-dm", sessionKey: "agent:ops-dm:main" });
   });
 });
 

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -111,6 +111,7 @@ describe("Slack presence monitor", () => {
     expect(enqueue).toHaveBeenCalledOnce();
     expect(enqueue).toHaveBeenCalledWith(
       expect.stringContaining("retrieve relevant memory and wiki context"),
+      expect.objectContaining({ agentId: "main", sessionKey: "agent:main:slack:channel:D123" }),
       expect.objectContaining({
         deliveryContext: {
           channel: "slack",
@@ -179,8 +180,8 @@ describe("Slack presence monitor", () => {
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.stringContaining('channel_id="CNEW"'),
+      expect.objectContaining({ agentId: "main", sessionKey: "session:new" }),
       expect.objectContaining({
-        sessionKey: "session:new",
         deliveryContext: expect.objectContaining({
           to: "channel:CNEW",
           threadId: "2.000",
@@ -227,6 +228,7 @@ describe("Slack presence monitor", () => {
     expect(enqueue).toHaveBeenCalledTimes(2);
     expect(enqueue).toHaveBeenCalledWith(
       expect.stringContaining('team_id="T11111111"'),
+      expect.objectContaining({ agentId: "main" }),
       expect.objectContaining({
         deliveryContext: expect.objectContaining({
           to: "team:T11111111:user:U12345678",
@@ -235,6 +237,7 @@ describe("Slack presence monitor", () => {
     );
     expect(enqueue).toHaveBeenCalledWith(
       expect.stringContaining('team_id="T22222222"'),
+      expect.objectContaining({ agentId: "main" }),
       expect.objectContaining({
         deliveryContext: expect.objectContaining({
           to: "team:T22222222:user:U12345678",

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -3,7 +3,7 @@ import { type WebClient, WebAPIRateLimitedError } from "@slack/web-api";
 import type { SlackAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatSlackTarget } from "../target-parsing.js";
 import type { PreparedSlackMessage } from "./message-handler/types.js";
@@ -146,7 +146,7 @@ export function createSlackPresenceMonitor(params: {
   log?: (message: string) => void;
   error?: (message: string) => void;
   nowMs?: () => number;
-  enqueue?: typeof enqueueSystemEvent;
+  enqueue?: typeof enqueueRoutedSystemEvent;
   wake?: typeof requestHeartbeat;
 }): SlackPresenceMonitor {
   const resolveClient = params.resolveClient ?? (() => params.client);
@@ -156,7 +156,7 @@ export function createSlackPresenceMonitor(params: {
   const targets = new Map<string, PresenceTarget>();
   const presenceByUser = new Map<string, Presence>();
   const nowMs = params.nowMs ?? Date.now;
-  const enqueue = params.enqueue ?? enqueueSystemEvent;
+  const enqueue = params.enqueue ?? enqueueRoutedSystemEvent;
   const wake = params.wake ?? requestHeartbeat;
   let pollOffset = 0;
   let timer: NodeJS.Timeout | undefined;
@@ -250,8 +250,7 @@ export function createSlackPresenceMonitor(params: {
     if (!reserved) {
       return;
     }
-    const queued = enqueue(formatSlackPresenceEvent(target, userId), {
-      sessionKey: target.sessionKey,
+    const queued = enqueue(formatSlackPresenceEvent(target, userId), target, {
       contextKey: `slack:presence-active:${params.accountId}:${workspaceKey}:${userId}`,
       deliveryContext: {
         channel: "slack",

--- a/extensions/slack/src/monitor/system-event-session.ts
+++ b/extensions/slack/src/monitor/system-event-session.ts
@@ -1,12 +1,14 @@
 // Slack plugin module owns session routing for non-message events.
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
-import type { OpenClawConfig, SessionScope } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveRuntimeConversationBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
-import { resolveAgentRoute, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
+import {
+  resolveAgentRoute,
+  resolveThreadSessionKeys,
+  type ResolvedAgentRoute,
+} from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SlackMessageEvent } from "../types.js";
 import { normalizeSlackChannelType } from "./channel-type.js";
-import { resolveSessionKey } from "./config.runtime.js";
 import type { SlackEventScope } from "./event-scope.js";
 import {
   qualifySlackConversationId,
@@ -22,12 +24,13 @@ type SlackSystemEventSessionKeyParams = {
   eventScope?: SlackEventScope;
 };
 
-export function createSlackSystemEventSessionKeyResolver(params: {
+type SlackSystemEventRoute = Pick<ResolvedAgentRoute, "agentId" | "sessionKey">;
+
+export function createSlackSystemEventRouteResolver(params: {
   cfg: OpenClawConfig;
   accountId: string;
   getTeamId: () => string;
   mainKey: string;
-  sessionScope: SessionScope;
   threadInheritParent: boolean;
   recallSlackChannelType: (
     channelId: string | null | undefined,
@@ -45,10 +48,15 @@ export function createSlackSystemEventSessionKeyResolver(params: {
     );
     const isDirectMessage = channelType === "im";
     if (!channelId && (!isDirectMessage || !senderId)) {
-      return params.mainKey;
+      const route = resolveAgentRoute({
+        cfg: params.cfg,
+        channel: "slack",
+        accountId: params.accountId,
+        teamId: event.eventScope?.teamId ?? params.getTeamId(),
+      });
+      return { agentId: route.agentId, sessionKey: params.mainKey };
     }
-    const isGroup = channelType === "mpim";
-    const routeSessionKey = resolveSlackSystemEventRouteSessionKey({
+    const route = resolveSlackSystemEventRoute({
       cfg: params.cfg,
       accountId: params.accountId,
       teamId: params.getTeamId(),
@@ -59,42 +67,14 @@ export function createSlackSystemEventSessionKeyResolver(params: {
       threadTs: event.threadTs,
       eventScope: event.eventScope,
     });
-    if (routeSessionKey) {
-      return routeSessionKey;
+    if (route) {
+      return route;
     }
-
-    const from = isDirectMessage
-      ? `slack:${channelId || senderId}`
-      : isGroup
-        ? `slack:group:${channelId}`
-        : `slack:channel:${channelId}`;
-    const fallbackFrom = event.eventScope
-      ? `slack:${qualifySlackRoutePeerId({
-          id: isDirectMessage ? senderId : channelId,
-          kind: isDirectMessage ? "user" : "channel",
-          eventScope: event.eventScope,
-        })}`
-      : from;
-    const legacySessionKey = resolveSessionKey(
-      params.sessionScope,
-      {
-        From: fallbackFrom,
-        ChatType: isDirectMessage ? "direct" : isGroup ? "group" : "channel",
-        Provider: "slack",
-      },
-      params.mainKey,
-      resolveDefaultAgentId(params.cfg),
-    );
-    const threadTs = normalizeOptionalString(event.threadTs);
-    return resolveThreadSessionKeys({
-      baseSessionKey: legacySessionKey,
-      threadId: threadTs,
-      parentSessionKey: threadTs && params.threadInheritParent ? legacySessionKey : undefined,
-    }).sessionKey;
+    throw new Error("Slack system event route requires a peer");
   };
 }
 
-function resolveSlackSystemEventRouteSessionKey(params: {
+function resolveSlackSystemEventRoute(params: {
   cfg: OpenClawConfig;
   accountId: string;
   teamId: string;
@@ -104,81 +84,74 @@ function resolveSlackSystemEventRouteSessionKey(params: {
   senderId: string;
   threadTs?: string | null;
   eventScope?: SlackEventScope;
-}): string | undefined {
+}): SlackSystemEventRoute | undefined {
   const isDirectMessage = params.channelType === "im";
   const peerId = isDirectMessage ? params.senderId : params.channelId;
   if (!peerId) {
     return undefined;
   }
 
-  try {
-    const peerKind = isDirectMessage
-      ? "direct"
-      : params.channelType === "mpim"
-        ? "group"
-        : "channel";
-    let route = resolveAgentRoute({
-      cfg: params.cfg,
-      channel: "slack",
-      accountId: params.accountId,
-      teamId: params.eventScope?.teamId ?? params.teamId,
-      peer: {
-        kind: peerKind,
-        id: qualifySlackRoutePeerId({
-          id: peerId,
-          kind: isDirectMessage ? "user" : "channel",
-          eventScope: params.eventScope,
-        }),
-      },
-    });
-    if (params.eventScope && isDirectMessage && route.dmScope === "main") {
-      const sessionKey = resolveSlackEnterpriseMainDmSessionKey({
-        baseSessionKey: route.sessionKey,
-        accountId: params.accountId,
+  const peerKind = isDirectMessage ? "direct" : params.channelType === "mpim" ? "group" : "channel";
+  let route = resolveAgentRoute({
+    cfg: params.cfg,
+    channel: "slack",
+    accountId: params.accountId,
+    teamId: params.eventScope?.teamId ?? params.teamId,
+    peer: {
+      kind: peerKind,
+      id: qualifySlackRoutePeerId({
+        id: peerId,
+        kind: isDirectMessage ? "user" : "channel",
         eventScope: params.eventScope,
-      });
-      route = { ...route, sessionKey, mainSessionKey: sessionKey };
-    }
-
-    const threadTs = normalizeOptionalString(params.threadTs);
-    const baseConversationId = qualifySlackConversationId(
-      isDirectMessage ? `user:${params.senderId}` : params.channelId,
-      params.eventScope,
-    );
-    const threadBindingRoute =
-      !params.eventScope && threadTs
-        ? resolveRuntimeConversationBindingRoute({
-            route,
-            conversation: {
-              channel: "slack",
-              accountId: params.accountId,
-              conversationId: threadTs,
-              parentConversationId: baseConversationId,
-            },
-          })
-        : null;
-    const runtimeRoute = params.eventScope
-      ? { route, bindingRecord: null, boundSessionKey: undefined }
-      : threadBindingRoute?.boundSessionKey || threadBindingRoute?.bindingRecord
-        ? threadBindingRoute
-        : resolveRuntimeConversationBindingRoute({
-            route,
-            conversation: {
-              channel: "slack",
-              accountId: params.accountId,
-              conversationId: baseConversationId,
-            },
-          });
-    if (runtimeRoute.boundSessionKey) {
-      return runtimeRoute.route.sessionKey;
-    }
-    return resolveThreadSessionKeys({
-      baseSessionKey: runtimeRoute.route.sessionKey,
-      threadId: threadTs,
-      parentSessionKey:
-        threadTs && params.threadInheritParent ? runtimeRoute.route.sessionKey : undefined,
-    }).sessionKey;
-  } catch {
-    return undefined;
+      }),
+    },
+  });
+  if (params.eventScope && isDirectMessage && route.dmScope === "main") {
+    const sessionKey = resolveSlackEnterpriseMainDmSessionKey({
+      baseSessionKey: route.sessionKey,
+      accountId: params.accountId,
+      eventScope: params.eventScope,
+    });
+    route = { ...route, sessionKey, mainSessionKey: sessionKey };
   }
+
+  const threadTs = normalizeOptionalString(params.threadTs);
+  const baseConversationId = qualifySlackConversationId(
+    isDirectMessage ? `user:${params.senderId}` : params.channelId,
+    params.eventScope,
+  );
+  const threadBindingRoute =
+    !params.eventScope && threadTs
+      ? resolveRuntimeConversationBindingRoute({
+          route,
+          conversation: {
+            channel: "slack",
+            accountId: params.accountId,
+            conversationId: threadTs,
+            parentConversationId: baseConversationId,
+          },
+        })
+      : null;
+  const runtimeRoute = params.eventScope
+    ? { route, bindingRecord: null, boundSessionKey: undefined }
+    : threadBindingRoute?.boundSessionKey || threadBindingRoute?.bindingRecord
+      ? threadBindingRoute
+      : resolveRuntimeConversationBindingRoute({
+          route,
+          conversation: {
+            channel: "slack",
+            accountId: params.accountId,
+            conversationId: baseConversationId,
+          },
+        });
+  if (runtimeRoute.boundSessionKey) {
+    return runtimeRoute.route;
+  }
+  const sessionKey = resolveThreadSessionKeys({
+    baseSessionKey: runtimeRoute.route.sessionKey,
+    threadId: threadTs,
+    parentSessionKey:
+      threadTs && params.threadInheritParent ? runtimeRoute.route.sessionKey : undefined,
+  }).sessionKey;
+  return { agentId: runtimeRoute.route.agentId, sessionKey };
 }

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-system-events.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import { enqueueRoutedSystemEvent } from "../plugin-sdk/system-event-runtime.js";
 import { isCronSystemEvent } from "./heartbeat-events-filter.js";
 import {
   resolveSystemEventOwnerAgentId,
@@ -701,6 +702,29 @@ describe("system events (session routing)", () => {
       ["Hook finished", "beta"],
       ["Later alpha event", "alpha"],
     ]);
+  });
+
+  it("keeps routed global Slack and Discord events isolated by route owner", async () => {
+    const slackRoute = { agentId: "alpha", sessionKey: "global" };
+    const discordRoute = { agentId: "beta", sessionKey: "global" };
+    enqueueRoutedSystemEvent("Slack event for alpha", slackRoute);
+    enqueueRoutedSystemEvent("Discord event for beta", discordRoute);
+
+    const alpha = await drainFormattedEvents("global", { agentId: "alpha" });
+    expect(alpha).toContain("Slack event for alpha");
+    expect(alpha).not.toContain("Discord event for beta");
+    expect(peekSystemEvents("global")).toEqual(["Discord event for beta"]);
+
+    const beta = await drainFormattedEvents("global", { agentId: "beta" });
+    expect(beta).toContain("Discord event for beta");
+    expect(peekSystemEvents("global")).toStrictEqual([]);
+  });
+
+  it("rejects routed system events without an owner", () => {
+    expect(() =>
+      enqueueRoutedSystemEvent("Unbound event", { agentId: " ", sessionKey: "global" }),
+    ).toThrow("route.agentId");
+    expect(peekSystemEvents("global")).toStrictEqual([]);
   });
 
   it("replaces only the matching owner slot", () => {

--- a/src/plugin-sdk/system-event-runtime.ts
+++ b/src/plugin-sdk/system-event-runtime.ts
@@ -1,5 +1,27 @@
 // Narrow system event enqueue/peek helper surface without the broad infra-runtime barrel.
 
+import { withSystemEventOwner } from "../infra/system-event-ownership.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+
+type RoutedSystemEventOptions = Omit<Parameters<typeof enqueueSystemEvent>[1], "sessionKey">;
+type RoutedSystemEventRoute = { agentId: string; sessionKey: string };
+
+export function enqueueRoutedSystemEvent(
+  text: string,
+  route: RoutedSystemEventRoute,
+  options: RoutedSystemEventOptions = {},
+): boolean {
+  if (!route.agentId.trim()) {
+    throw new Error("routed system events require route.agentId");
+  }
+  // Literal global keys carry no owner identity, so bind the resolved route owner
+  // before enqueueing into the shared transient queue.
+  return enqueueSystemEvent(
+    text,
+    withSystemEventOwner({ ...options, sessionKey: route.sessionKey }, route.agentId),
+  );
+}
+
 export {
   enqueueSystemEvent,
   peekSystemEventEntries,


### PR DESCRIPTION
Closes #123315

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where multi-agent installations using global session scope could deliver Slack or Discord system events to a sibling agent after the producer had already selected the correct route.

## Why This Change Was Made

Introduce one narrow Plugin SDK enqueue seam that binds the resolved route owner through the existing system-event metadata, migrate both bundled channel producers, and make Slack retain the full route instead of falling back to a default. Literal-global queue semantics stay intact; genuinely unbound routes still fail explicitly.

## User Impact

Slack and Discord system notifications remain scoped to the agent selected by routing, including when both agents share the literal `global` queue. Operators do not need to configure a global default to make already-routed events work.

## Evidence

- Pre-fix real queue call-shape reproduction showed alpha consumed beta's event.
- Real two-agent global queue regression now leaves beta's event queued until beta drains it.
- 13 files / 496 focused tests passed; the final changed Discord file passed 29/29 after tightening.
- Complete changed-surface gate green; production build green; all 144 public Plugin SDK subpaths verified.
- Structured autoreview clean.
- Production: +176/-180, net -4 LOC. Tests: +157/-53, net +104. Test support: +11/-3, net +8.
- Remote proof caveat: two Daytona attempts were infrastructure-blocked, first by missing hydrated workspace modules and then by disk exhaustion during dependency installation. The trusted local full fallback passed; exact-head hosted CI is the landing proof.
- No live Slack or Discord mutation was performed; the defect is before external channel delivery and is proven through the real queue boundary plus focused producer tests.
- AI-assisted: yes. No transcript attached.
