### PR TITLE
fix(gateway): prevent targetless events from waking the wrong agent

### DIFF
--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
   resolveSoleAgentId,
+  resolveSystemAgentTargetAgentId,
   tryResolveDefaultAgentId,
   tryResolveSoleAgentId,
 } from "./agent-scope-config.js";
@@ -52,6 +53,23 @@ describe("agent roster resolution", () => {
     };
     expect(() => resolveDefaultAgentId(duplicateDefaults)).toThrow(AgentSelectionRequiredError);
     expect(tryResolveDefaultAgentId(duplicateDefaults)).toBeUndefined();
+  });
+
+  it("requires an explicit system owner when a roster has multiple agents", () => {
+    expect(
+      resolveSystemAgentTargetAgentId({
+        agents: {
+          defaults: { systemAgent: { agentId: "ops" } },
+          entries: { main: { default: true }, ops: {} },
+        },
+      }),
+    ).toBe("ops");
+    expect(resolveSystemAgentTargetAgentId({ agents: { entries: { ops: {} } } })).toBe("ops");
+    expect(() =>
+      resolveSystemAgentTargetAgentId({
+        agents: { entries: { main: { default: true }, ops: {} } },
+      }),
+    ).toThrow("Set agents.defaults.systemAgent.agentId");
   });
 
   it("resolves defaults only for the rosterless implicit main agent", () => {

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -231,11 +231,10 @@ export function resolveSystemAgentTargetAgentId(
     return normalizeAgentId(configuredAgentId);
   }
   return normalizeAgentId(
-    tryResolveLegacyCompatibilityAgentId(cfg) ??
-      resolveDefaultAgentId(cfg, {
-        surface: "system-agent consult routing",
-        hint: "Set agents.defaults.systemAgent.agentId or pass an explicit consult agent id.",
-      }),
+    resolveSoleAgentId(cfg, {
+      surface: "system-agent consult routing",
+      hint: "Set agents.defaults.systemAgent.agentId or pass an explicit consult agent id.",
+    }),
   );
 }
 

--- a/src/commands/doctor/shared/default-agent-role-materialization.test.ts
+++ b/src/commands/doctor/shared/default-agent-role-materialization.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { listAgentEntries, resolveDefaultAgentId } from "../../../agents/agent-scope-config.js";
-import { resolveSystemAgentTargetAgentId } from "../../../agents/agent-scope-config.js";
+import {
+  AgentSelectionRequiredError,
+  listAgentEntries,
+  resolveDefaultAgentId,
+  resolveSystemAgentTargetAgentId,
+} from "../../../agents/agent-scope-config.js";
 import { materializeLegacyDefaultAgentRoles } from "../../../config/legacy.default-agent-roles.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveCronJobEffectiveAgentId } from "../../../cron/agent-id.js";
@@ -19,7 +23,7 @@ function materializeDefaultAgentRoles(cfg: OpenClawConfig) {
 type SurfaceSnapshot = {
   channel: { agentId: string; sessionKey: string };
   heartbeat: string[];
-  consult: string;
+  consult: string | null;
   voice: string;
   cron: string;
   cli: string;
@@ -36,7 +40,16 @@ function snapshotSurfaces(cfg: OpenClawConfig): SurfaceSnapshot {
   return {
     channel: { agentId: channel.agentId, sessionKey: channel.sessionKey },
     heartbeat: resolveHeartbeatAgents(cfg).map((entry) => entry.agentId),
-    consult: resolveSystemAgentTargetAgentId(cfg),
+    consult: (() => {
+      try {
+        return resolveSystemAgentTargetAgentId(cfg);
+      } catch (error) {
+        if (error instanceof AgentSelectionRequiredError) {
+          return null;
+        }
+        throw error;
+      }
+    })(),
     voice: resolveTalkTargetAgentId(cfg),
     cron: resolveCronJobEffectiveAgentId({}, defaultAgentId),
     cli: defaultAgentId,
@@ -85,7 +98,9 @@ describe("default agent role materialization", () => {
   it.each(fixtures)("preserves all ambient surface routing for $name", ({ config }) => {
     const before = snapshotSurfaces(config);
     const result = materializeDefaultAgentRoles(config);
-    expect(snapshotSurfaces(result.config)).toEqual(before);
+    expect(snapshotSurfaces(result.config)).toEqual(
+      before.consult === null ? { ...before, consult: resolveDefaultAgentId(config) } : before,
+    );
 
     const second = materializeDefaultAgentRoles(result.config);
     expect(second.changes).toEqual([]);

--- a/src/cron/isolated-agent.delivery-awareness.test.ts
+++ b/src/cron/isolated-agent.delivery-awareness.test.ts
@@ -5,7 +5,12 @@ import "./isolated-agent.mocks.js";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveDefaultSessionStorePath } from "../config/sessions.js";
-import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
+import { selectAgentSystemEvents } from "../infra/system-event-ownership.js";
+import {
+  peekSystemEventEntries,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "../infra/system-events.js";
 import { createCliDeps, mockAgentPayloads } from "./isolated-agent.delivery.test-helpers.js";
 import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
 import { makeCfg, makeJob, withTempCronHome } from "./isolated-agent.test-harness.js";
@@ -116,6 +121,9 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
       expect(result.status).toBe("ok");
       expect(result.delivered).toBe(true);
       expect(peekSystemEvents("global")).toEqual(["global cron digest"]);
+      const globalEvents = peekSystemEventEntries("global");
+      expect(selectAgentSystemEvents(globalEvents, "main")).toHaveLength(1);
+      expect(selectAgentSystemEvents(globalEvents, "other")).toEqual([]);
     });
   });
 

--- a/src/cron/isolated-agent/delivery-dispatch-awareness.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-awareness.ts
@@ -6,7 +6,6 @@ import { resolveSessionWorkStartError } from "../../config/sessions/lifecycle.js
 import {
   canonicalizeMainSessionAlias,
   resolveAgentMainSessionKey,
-  resolveMainSessionKey,
 } from "../../config/sessions/main-session.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -16,6 +15,7 @@ import type {
   SourceDeliveryOutcome,
   SourceDeliveryVisibleDelivery,
 } from "../../infra/outbound/source-delivery-plan.js";
+import { withSystemEventOwner } from "../../infra/system-event-ownership.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { parseThreadSessionSuffix } from "../../routing/session-key.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
@@ -74,7 +74,7 @@ export function resolveCronAwarenessMainSessionKey(params: {
   agentId: string;
 }): string {
   return params.cfg.session?.scope === "global"
-    ? resolveMainSessionKey(params.cfg)
+    ? "global"
     : resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId });
 }
 
@@ -178,20 +178,26 @@ export async function queueCronAwarenessSystemEvent(params: {
       agentId: params.agentId,
     });
     if (params.queueMainSession) {
-      enqueueSystemEvent(params.text, {
-        sessionKey: mainSessionKey,
-        contextKey: params.deliveryIdempotencyKey,
-      });
+      enqueueSystemEvent(
+        params.text,
+        withSystemEventOwner(
+          { sessionKey: mainSessionKey, contextKey: params.deliveryIdempotencyKey },
+          params.agentId,
+        ),
+      );
     }
     const targetSessionKey = params.targetSessionKey;
     const shouldQueueTargetSession =
       targetSessionKey &&
       (!isSameSessionKey(targetSessionKey, mainSessionKey) || !params.queueMainSession);
     if (shouldQueueTargetSession) {
-      enqueueSystemEvent(params.targetText ?? formatTargetCronDeliveryAwarenessText(params.text), {
-        sessionKey: targetSessionKey,
-        contextKey: params.deliveryIdempotencyKey,
-      });
+      enqueueSystemEvent(
+        params.targetText ?? formatTargetCronDeliveryAwarenessText(params.text),
+        withSystemEventOwner(
+          { sessionKey: targetSessionKey, contextKey: params.deliveryIdempotencyKey },
+          params.agentId,
+        ),
+      );
     }
   } catch (err) {
     await logCronDeliveryWarn(

--- a/src/cron/service/wake.ts
+++ b/src/cron/service/wake.ts
@@ -31,7 +31,7 @@ export function wake(
     text: string;
     /**
      * Internal session key to enqueue the system event against. When omitted,
-     * the dep's default (heartbeat / main) is used — wakes from a non-main
+     * the dep resolves the configured system-agent target — wakes from a non-main
      * session would otherwise route to the wrong place. Callers wiring an
      * agent-tool `wake` should thread the resolved session key (e.g. from
      * `cron-tool`'s `resolveInternalSessionKey`) so the event lands on the
@@ -59,8 +59,8 @@ export function wake(
   // Carry the originating session's channel-correct delivery context (e.g. the
   // bound Telegram topic/thread) so a wake routes back into that thread instead
   // of the chat root. Only attempt this when an origin session is targeted; a
-  // no-origin wake keeps the exact pre-fix `enqueueSystemEvent(text, undefined)`
-  // shape so its default-sessionKey binding still kicks in.
+  // A no-origin wake keeps the empty option shape so the Gateway adapter can
+  // resolve the current system-agent owner and session atomically.
   const originDeliveryContext =
     sessionKey || agentId
       ? state.deps.resolveOriginDeliveryContext?.({ sessionKey, agentId })

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -2682,6 +2682,33 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("routes a targetless cron wake through the configured system agent", () => {
+    const cfg = {
+      ...createCronConfig("server-cron-system-owner-wake"),
+      agents: {
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { main: { default: true }, ops: {} },
+      },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: () => {} });
+    try {
+      expect(state.cron.wake({ mode: "now", text: "system wake" })).toEqual({ ok: true });
+
+      const enqueueCall = lastMockCall(enqueueSystemEventMock, "enqueue system event");
+      const wakeCall = lastMockCall(requestHeartbeatMock, "request heartbeat");
+      expect(enqueueCall?.[1]).toMatchObject({ sessionKey: "agent:ops:main" });
+      expect(wakeCall?.[0]).toMatchObject({
+        source: "manual",
+        agentId: "ops",
+        sessionKey: "agent:ops:main",
+      });
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("forwards cron system events to the resolved session", () => {
     const cfg = createCronConfig("server-cron-system-event");
     loadConfigMock.mockReturnValue(cfg);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -16,6 +16,7 @@ import {
   canonicalizeMainSessionAlias,
   resolveAgentIdFromSessionKey,
   resolveAgentMainSessionKey,
+  resolveSystemMainSessionTarget,
 } from "../config/sessions.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import {
@@ -451,6 +452,10 @@ export function buildGatewayCronService(params: {
     if (opts?.preserveUntargeted && !requestedAgentId && !requestedSessionKey) {
       return { runtimeConfig: getRuntimeConfig(), agentId: undefined, sessionKey: undefined };
     }
+    if (!requestedAgentId && !requestedSessionKey) {
+      const runtimeConfig = getRuntimeConfig();
+      return { runtimeConfig, ...resolveSystemMainSessionTarget(runtimeConfig) };
+    }
 
     // Derive from canonical agent-prefixed keys only. Relative keys intentionally
     // fall through to the configured default instead of hardcoding "main".
@@ -743,18 +748,20 @@ export function buildGatewayCronService(params: {
     sessionStorePath,
     enqueueSystemEvent: (text, opts) => {
       const { agentId, sessionKey } = resolveCronTarget(opts);
-      if (!sessionKey) {
-        throw new Error("Cron system event target did not resolve a session key.");
+      if (!agentId || !sessionKey) {
+        throw new Error("Cron system event target did not resolve an owner and session key.");
       }
-      const eventOptions = {
-        sessionKey,
-        contextKey: opts?.contextKey,
-        deliveryContext: opts?.deliveryContext,
-      };
-      if (sessionKey === "global" && agentId) {
-        withSystemEventOwner(eventOptions, agentId);
-      }
-      const remove = enqueueSystemEventWithReceipt(text, eventOptions);
+      const remove = enqueueSystemEventWithReceipt(
+        text,
+        withSystemEventOwner(
+          {
+            sessionKey,
+            contextKey: opts?.contextKey,
+            deliveryContext: opts?.deliveryContext,
+          },
+          agentId,
+        ),
+      );
       return remove ? { accepted: true, remove } : { accepted: false };
     },
     resolveOriginDeliveryContext: (opts) => {
@@ -771,7 +778,10 @@ export function buildGatewayCronService(params: {
       return resolveCronStoredDeliveryContext({ cfg: runtimeConfig, sessionKey });
     },
     requestHeartbeat: (opts) => {
-      const { agentId, sessionKey } = resolveCronTarget({ ...opts, preserveUntargeted: true });
+      const { agentId, sessionKey } = resolveCronTarget({
+        ...opts,
+        preserveUntargeted: opts?.source !== "manual",
+      });
       requestHeartbeat({
         source: opts?.source ?? "cron",
         intent: opts?.intent ?? "event",

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -7,6 +7,7 @@ export { sendDurableMessageBatchCore } from "../channels/message/runtime.js";
 export { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 export { agentCommandFromIngress } from "../commands/agent.js";
 export { getRuntimeConfig } from "../config/io.js";
+export { resolveSystemMainSessionTarget } from "../config/sessions/main-session.js";
 export { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 export { loadOrCreateProcessDeviceIdentity } from "../infra/device-identity.js";
 export { requestHeartbeat } from "../infra/heartbeat-wake.js";
@@ -17,6 +18,7 @@ export {
   registerApnsRegistration,
 } from "../infra/push-apns.js";
 export { enqueueSystemEvent } from "../infra/system-events.js";
+export { withSystemEventOwner } from "../infra/system-event-ownership.js";
 export { deleteMediaBuffer } from "../media/store.js";
 export { normalizeMainKey } from "../routing/session-key.js";
 export { defaultRuntime } from "../runtime.js";

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -104,12 +104,17 @@ const runtimeMocks = vi.hoisted(() => ({
   loadOrCreateProcessDeviceIdentity: loadOrCreateProcessDeviceIdentityMock,
   loadSessionEntry: vi.fn((sessionKey: string) => buildSessionLookup(sessionKey)),
   upsertSessionEntryCore: vi.fn(),
+  withSystemEventOwner: vi.fn((options: object) => options),
   normalizeChannelId: normalizeChannelIdMock,
   normalizeMainKey: vi.fn((key?: string | null) => key?.trim() || "agent:main:main"),
   normalizeRpcAttachmentsToChatAttachments: vi.fn((attachments?: unknown[]) => attachments ?? []),
   parseMessageWithAttachments: parseMessageWithAttachmentsMock,
   registerApnsRegistration: registerApnsRegistrationMock,
   requestHeartbeat: vi.fn(),
+  resolveSystemMainSessionTarget: vi.fn(() => ({
+    agentId: "ops",
+    sessionKey: "agent:ops:main",
+  })),
   resolveChatAttachmentMaxBytes: vi.fn(() => 20 * 1024 * 1024),
   resolveGatewayModelSupportsImages: vi.fn(
     async ({
@@ -929,6 +934,7 @@ describe("voice transcript events", () => {
     upsertSessionEntryMock.mockClear();
     loadSessionEntryMock.mockClear();
     loadSessionEntryMock.mockImplementation((sessionKey: string) => buildSessionLookup(sessionKey));
+    runtimeMocks.resolveSystemMainSessionTarget.mockClear();
     agentCommandMock.mockResolvedValue({ status: "ok" } as never);
     upsertSessionEntryMock.mockImplementation(async (_scope, patch) => patch);
   });
@@ -1456,16 +1462,17 @@ describe("notifications changed events", () => {
 
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       "Notification posted (node=node-n1 key=notif-1 package=com.example.chat): Message - Ping from Alex",
-      {
-        sessionKey: "node-node-n1",
+      expect.objectContaining({
+        sessionKey: "agent:ops:main",
         contextKey: "notification:notif-1",
-      },
+      }),
     );
     expect(requestHeartbeatMock).toHaveBeenCalledWith({
       source: "notifications-event",
       intent: "event",
       reason: "notifications-event",
-      sessionKey: "node-node-n1",
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
     });
   });
 
@@ -1482,17 +1489,36 @@ describe("notifications changed events", () => {
 
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       "Notification removed (node=node-n2 key=notif-2 package=com.example.mail)",
-      {
-        sessionKey: "node-node-n2",
+      expect.objectContaining({
+        sessionKey: "agent:ops:main",
         contextKey: "notification:notif-2",
-      },
+      }),
     );
     expect(requestHeartbeatMock).toHaveBeenCalledWith({
       source: "notifications-event",
       intent: "event",
       reason: "notifications-event",
-      sessionKey: "node-node-n2",
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
     });
+  });
+
+  it("records non-delivery when a targetless notification has no system owner", async () => {
+    const warn = vi.fn();
+    runtimeMocks.resolveSystemMainSessionTarget.mockImplementationOnce(() => {
+      throw new Error("Set agents.defaults.systemAgent.agentId");
+    });
+
+    await handleNodeEvent({ ...buildCtx(), logGateway: { warn } }, "node-unowned", {
+      event: "notifications.changed",
+      payloadJSON: JSON.stringify({ change: "posted", key: "notif-unowned" }),
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "notification event not delivered node=node-unowned: Set agents.defaults.systemAgent.agentId",
+    );
   });
 
   it("wakes heartbeat on payload sessionKey when provided", async () => {
@@ -1525,6 +1551,7 @@ describe("notifications changed events", () => {
       payloadJSON: JSON.stringify({
         change: "posted",
         key: "notif-5",
+        sessionKey: "node-node-n5",
       }),
     });
 

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -45,6 +45,7 @@ import {
   parseMessageWithAttachments,
   registerApnsRegistration,
   requestHeartbeat,
+  resolveSystemMainSessionTarget,
   resolveChatAttachmentMaxBytes,
   resolveGatewayModelSupportsImages,
   resolveOutboundTarget,
@@ -53,6 +54,7 @@ import {
   persistInboundImagesForTranscript,
   sendDurableMessageBatchCore,
   upsertSessionEntryCore,
+  withSystemEventOwner,
 } from "./server-node-events.runtime.js";
 
 const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
@@ -881,7 +883,19 @@ export const handleNodeEvent = async (
         return undefined;
       }
       const key = keyRaw;
-      const sessionKeyRaw = normalizeOptionalString(obj.sessionKey) ?? `node-${nodeId}`;
+      const requestedSessionKey = normalizeOptionalString(obj.sessionKey);
+      let target: { sessionKey: string; agentId?: string };
+      try {
+        target = requestedSessionKey
+          ? { sessionKey: requestedSessionKey }
+          : resolveSystemMainSessionTarget(getRuntimeConfig());
+      } catch (error) {
+        ctx.logGateway.warn(
+          `notification event not delivered node=${nodeId}: ${formatErrorMessage(error)}`,
+        );
+        return undefined;
+      }
+      const sessionKeyRaw = target.sessionKey;
       const { canonicalKey: sessionKey, entry } = loadSessionEntry(sessionKeyRaw);
       if (resolveAgentHarnessSessionContextError(sessionKey, entry)) {
         return undefined;
@@ -903,15 +917,20 @@ export const handleNodeEvent = async (
         }
       }
 
-      const queued = enqueueSystemEvent(summary, {
+      const eventOptions = {
         sessionKey,
         contextKey: `notification:${keyRaw}`,
-      });
+      };
+      const queued = enqueueSystemEvent(
+        summary,
+        target.agentId ? withSystemEventOwner(eventOptions, target.agentId) : eventOptions,
+      );
       if (queued) {
         requestHeartbeat({
           source: "notifications-event",
           intent: "event",
           reason: "notifications-event",
+          ...(target.agentId ? { agentId: target.agentId } : {}),
           sessionKey,
         });
       }

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { RestartSentinelPayload } from "../infra/restart-sentinel.js";
+import { resolveSystemEventOptionsOwnerAgentId } from "../infra/system-event-ownership.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -75,28 +76,29 @@ const mocks = vi.hoisted(() => {
     clearRestartSentinelIfRevision: vi.fn(async () => true),
     formatRestartSentinelMessage: vi.fn(() => "restart message"),
     summarizeRestartSentinel: vi.fn(() => "restart summary"),
-    resolveMainSessionKeyFromConfig: vi.fn(() => "agent:main:main"),
+    resolveSystemMainSessionTarget: vi.fn(() => ({
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
+    })),
     parseSessionThreadInfo: vi.fn(
       (): { baseSessionKey: string | null | undefined; threadId: string | undefined } => ({
         baseSessionKey: null,
         threadId: undefined,
       }),
     ),
-    loadSessionEntry: vi.fn(
-      (): LoadedSessionEntry => ({
-        cfg: {},
-        agentId: "main",
-        entry: {
-          sessionId: "agent:main:main",
-          updatedAt: 0,
-        },
-        store: {},
-        storePath: "/tmp/sessions.json",
-        canonicalKey: "agent:main:main",
-        storeKeys: ["agent:main:main"],
-        legacyKey: undefined,
-      }),
-    ),
+    loadSessionEntry: vi.fn<(sessionKey: string) => LoadedSessionEntry>((sessionKey) => ({
+      cfg: {},
+      agentId: "main",
+      entry: {
+        sessionId: sessionKey,
+        updatedAt: 0,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: sessionKey,
+      storeKeys: [sessionKey],
+      legacyKey: undefined,
+    })),
     deliveryContextFromSession: vi.fn(
       ():
         | { channel?: string; to?: string; accountId?: string; threadId?: string | number }
@@ -232,9 +234,11 @@ vi.mock("../config/sessions/transcript.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
-  resolveMainSessionKeyFromConfig: mocks.resolveMainSessionKeyFromConfig,
+  resolveSystemMainSessionTarget: mocks.resolveSystemMainSessionTarget,
   resolveSessionStorePathCore: vi.fn(() => "/tmp/sessions.json"),
 }));
+
+vi.mock("../config/io.js", () => ({ getRuntimeConfig: vi.fn(() => ({})) }));
 
 vi.mock("../config/sessions/thread-info.js", () => ({
   parseSessionThreadInfoFast: mocks.parseSessionThreadInfo,
@@ -573,18 +577,15 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.parseSessionThreadInfo.mockReset();
     mocks.parseSessionThreadInfo.mockReturnValue({ baseSessionKey: null, threadId: undefined });
     mocks.loadSessionEntry.mockReset();
-    mocks.loadSessionEntry.mockReturnValue({
+    mocks.loadSessionEntry.mockImplementation((sessionKey: string) => ({
       cfg: {},
-      entry: {
-        sessionId: "agent:main:main",
-        updatedAt: 0,
-      },
+      entry: { sessionId: sessionKey, updatedAt: 0 },
       store: {},
       storePath: "/tmp/sessions.json",
-      canonicalKey: "agent:main:main",
-      storeKeys: ["agent:main:main"],
+      canonicalKey: sessionKey,
+      storeKeys: [sessionKey],
       legacyKey: undefined,
-    });
+    }));
     mocks.deliveryContextFromSession.mockReset();
     mocks.deliveryContextFromSession.mockReturnValue(undefined);
     mocks.getChannelPlugin.mockReset();
@@ -648,6 +649,11 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.clearRestartSentinelIfRevision.mockResolvedValue(true);
     mocks.formatRestartSentinelMessage.mockClear();
     mocks.summarizeRestartSentinel.mockClear();
+    mocks.resolveSystemMainSessionTarget.mockReset();
+    mocks.resolveSystemMainSessionTarget.mockReturnValue({
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
+    });
     mocks.recordInboundSessionAndDispatchReply.mockReset();
     mocks.recordInboundSessionAndDispatchReply.mockResolvedValue(undefined);
     mocks.logInfo.mockClear();
@@ -2680,18 +2686,20 @@ describe("scheduleRestartSentinelWake", () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
 
     expect(mocks.clearRestartSentinelIfRevision).toHaveBeenCalledWith(123);
-    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
-      sessionKey: "agent:main:main",
-    });
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "restart message",
+      expect.objectContaining({ sessionKey: "agent:ops:main" }),
+    );
     expect(mocks.requestHeartbeat).toHaveBeenCalledWith({
       source: "restart-sentinel",
       intent: "immediate",
       reason: "wake",
-      sessionKey: "agent:main:main",
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
     });
   });
 
-  it("durably wakes the main session when the sentinel has no sessionKey", async () => {
+  it("durably wakes the configured system-agent session when the sentinel has no sessionKey", async () => {
     mocks.readRestartSentinel.mockResolvedValue({
       payload: {
         message: "restart message",
@@ -2700,16 +2708,67 @@ describe("scheduleRestartSentinelWake", () => {
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
-    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
-      sessionKey: "agent:main:main",
-    });
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "restart message",
+      expect.objectContaining({ sessionKey: "agent:ops:main" }),
+    );
     expect(mocks.requestHeartbeat).toHaveBeenCalledWith({
       source: "restart-sentinel",
       intent: "immediate",
       reason: "wake",
-      sessionKey: "agent:main:main",
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
     });
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("preserves system-agent ownership for a targetless global wake", async () => {
+    mocks.resolveSystemMainSessionTarget.mockReturnValue({
+      agentId: "ops",
+      sessionKey: "global",
+    });
+    mocks.readRestartSentinel.mockResolvedValue({
+      version: 1,
+      revision: 123,
+      payload: { kind: "restart", status: "ok", ts: 123, message: "restart message" },
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    const eventOptions = mocks.enqueueSystemEvent.mock.calls[0]?.[1];
+    expect(eventOptions).toMatchObject({ sessionKey: "global" });
+    expect(resolveSystemEventOptionsOwnerAgentId(eventOptions as object)).toBe("ops");
+    expect(mocks.requestHeartbeat).toHaveBeenCalledWith({
+      source: "restart-sentinel",
+      intent: "immediate",
+      reason: "wake",
+      agentId: "ops",
+      sessionKey: "global",
+    });
+  });
+
+  it("records targetless non-delivery when system-agent ownership is missing", async () => {
+    mocks.resolveSystemMainSessionTarget.mockImplementation(() => {
+      throw new Error(
+        "Multiple agents are configured, but system-agent consult routing has no explicit owner. Set agents.defaults.systemAgent.agentId or pass an explicit consult agent id.",
+      );
+    });
+    mocks.readRestartSentinel.mockResolvedValue({
+      version: 1,
+      revision: 123,
+      payload: { kind: "restart", status: "ok", ts: 123, message: "restart message" },
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.clearRestartSentinelIfRevision).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
+    expect(mocks.logWarn).toHaveBeenCalledWith("startup task failed", {
+      source: "restart-sentinel",
+      reason: expect.stringContaining("Set agents.defaults.systemAgent.agentId"),
+    });
   });
 
   it("warns when continuation cannot run because the restart sentinel has no sessionKey", async () => {
@@ -2725,15 +2784,16 @@ describe("scheduleRestartSentinelWake", () => {
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
-    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
-      sessionKey: "agent:main:main",
-    });
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "restart message",
+      expect.objectContaining({ sessionKey: "agent:ops:main" }),
+    );
     expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
     expect(mocks.logWarn.mock.calls).toEqual([
       [
         "restart summary: continuation skipped: restart sentinel sessionKey unavailable",
         {
-          sessionKey: "agent:main:main",
+          sessionKey: "agent:ops:main",
           continuationKind: "agentTurn",
         },
       ],

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -13,7 +13,8 @@ import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.
 import { recordInboundSession } from "../channels/session.js";
 import { dispatchAssembledChannelTurn } from "../channels/turn/lifecycle.js";
 import type { CliDeps } from "../cli/deps.types.js";
-import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
+import { getRuntimeConfig } from "../config/io.js";
+import { resolveSystemMainSessionTarget } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/thread-info.js";
 import { formatErrorMessage, toErrorObject } from "../infra/errors.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
@@ -42,6 +43,7 @@ import {
   type SessionDeliveryRecoveryLogger,
   type SessionDeliveryRoute,
 } from "../infra/session-delivery-queue.js";
+import { withSystemEventOwner } from "../infra/system-event-ownership.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { isPendingControlPlaneUpdateRestartSentinel } from "../infra/update-control-plane-sentinel.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -103,6 +105,7 @@ function hasRoutableDeliveryContext(context?: {
 function enqueueRestartSentinelWake(
   message: string,
   sessionKey: string,
+  agentId?: string,
   deliveryContext?: {
     channel?: string;
     to?: string;
@@ -110,11 +113,18 @@ function enqueueRestartSentinelWake(
     threadId?: string | number;
   },
 ) {
-  enqueueSystemEvent(message, {
+  const eventOptions = {
     sessionKey,
     ...(deliveryContext ? { deliveryContext } : {}),
+  };
+  enqueueSystemEvent(message, agentId ? withSystemEventOwner(eventOptions, agentId) : eventOptions);
+  requestHeartbeat({
+    source: "restart-sentinel",
+    intent: "immediate",
+    reason: "wake",
+    ...(agentId ? { agentId } : {}),
+    sessionKey,
   });
-  requestHeartbeat({ source: "restart-sentinel", intent: "immediate", reason: "wake", sessionKey });
 }
 
 async function waitForRetry(delayMs: number) {
@@ -196,10 +206,11 @@ export async function deliverQueuedSessionDelivery(params: {
 }) {
   const queuedEntry = resolveCorrelatedSubagentDelivery(params.entry);
   const { cfg, entry, storePath, canonicalKey } = loadSessionEntry(queuedEntry.sessionKey);
-  const queuedDeliveryContext = resolveQueuedSessionDeliveryContext(queuedEntry);
+  const deliveryContext = resolveQueuedSessionDeliveryContext(queuedEntry);
 
   if (queuedEntry.kind === "systemEvent") {
-    enqueueRestartSentinelWake(queuedEntry.text, canonicalKey, queuedDeliveryContext);
+    const { agentId, text } = queuedEntry;
+    enqueueRestartSentinelWake(text, canonicalKey, agentId, deliveryContext);
     return;
   }
 
@@ -213,12 +224,12 @@ export async function deliverQueuedSessionDelivery(params: {
       expectedSessionId: queuedEntry.expectedSessionId,
       actualSessionId: entry?.sessionId ?? null,
     });
-    enqueueRestartSentinelWake(queuedEntry.message, canonicalKey, queuedDeliveryContext);
+    enqueueRestartSentinelWake(queuedEntry.message, canonicalKey, undefined, deliveryContext);
     return;
   }
 
   if (!queuedEntry.route) {
-    enqueueRestartSentinelWake(queuedEntry.message, canonicalKey, queuedDeliveryContext);
+    enqueueRestartSentinelWake(queuedEntry.message, canonicalKey, undefined, deliveryContext);
     return;
   }
 
@@ -344,6 +355,7 @@ export async function deliverQueuedSessionDelivery(params: {
 
 function buildQueuedRestartContinuation(params: {
   sessionKey: string;
+  agentId?: string;
   continuation: RestartSentinelContinuation;
   route?: SessionDeliveryRoute;
   expectedSessionId?: string | undefined;
@@ -367,6 +379,7 @@ function buildQueuedRestartContinuation(params: {
     return {
       kind: "systemEvent",
       sessionKey: params.sessionKey,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
       text: params.continuation.text,
       ...(params.deliveryContext ? { deliveryContext: params.deliveryContext } : {}),
       idempotencyKey,
@@ -505,10 +518,12 @@ async function loadRestartSentinelStartupTask(params: {
         }
         return { status: "ran" as const };
       }
-      const mainSessionKey = resolveMainSessionKeyFromConfig();
+      const systemTarget = resolveSystemMainSessionTarget(getRuntimeConfig());
+      const mainSessionKey = systemTarget.sessionKey;
       const wakeQueueId = await enqueueSessionDelivery(
         buildQueuedRestartContinuation({
           sessionKey: mainSessionKey,
+          agentId: systemTarget.agentId,
           continuation: { kind: "systemEvent", text: message },
           revision: sentinelRevision,
           idempotencyKey: `restart-sentinel-wake:${mainSessionKey}:${sentinelRevision}`,

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -15,7 +15,7 @@ import {
 } from "../config/io.js";
 import { normalizeStateDirEnv } from "../config/paths.js";
 import { captureConfigOverrideApplier } from "../config/runtime-overrides.js";
-import { resolveMainSessionKey } from "../config/sessions.js";
+import { resolveSystemMainSessionTarget } from "../config/sessions.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef } from "../config/types.secrets.js";
@@ -30,9 +30,11 @@ import {
   setDiagnosticsEnabledForProcess,
 } from "../infra/diagnostic-events.js";
 import { isVitestRuntimeEnv, logAcceptedEnvOption } from "../infra/env.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { prepareGatewayAgentCliShim } from "../infra/openclaw-cli-shim.js";
 import { readGatewayRestartHandoffSync } from "../infra/restart-handoff.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
+import { withSystemEventOwner } from "../infra/system-event-ownership.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
@@ -201,10 +203,16 @@ export async function prepareGatewayServerBootstrap(input: {
     message: string,
     cfg: OpenClawConfig,
   ) => {
-    enqueueSystemEvent(`[${code}] ${message}`, {
-      sessionKey: resolveMainSessionKey(cfg),
-      contextKey: code,
-    });
+    const text = `[${code}] ${message}`;
+    try {
+      const target = resolveSystemMainSessionTarget(cfg);
+      enqueueSystemEvent(
+        text,
+        withSystemEventOwner({ sessionKey: target.sessionKey, contextKey: code }, target.agentId),
+      );
+    } catch (error) {
+      logSecrets.warn(`${text} not delivered: ${formatErrorMessage(error)}`);
+    }
   };
   const { createRuntimeSecretsActivator } = await startupConfigModulePromise;
   const activateRuntimeSecrets = createRuntimeSecretsActivator({

--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -11,13 +11,21 @@ import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProviderCore } from "../agents/model-auth.js";
 import { resolveSandboxContext } from "../agents/sandbox/context.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { selectAgentSystemEvents } from "../infra/system-event-ownership.js";
+import {
+  peekSystemEventEntries,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "../infra/system-events.js";
 import { resolveAuthProfileSecretOwnerId } from "../secrets/runtime-auth-profile-owner.js";
 import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime.js";
-import { withEnvAsync } from "../test-utils/env.js";
+import { deleteTestEnvValue, withEnvAsync } from "../test-utils/env.js";
 import {
+  connectWebchatClient,
   getGatewayTestPort,
   installGatewayTestHooks,
+  rpcReq,
   startTestGatewayServer,
   testState,
 } from "./test-helpers.js";
@@ -131,6 +139,47 @@ describe("Gateway startup SecretRef owner isolation", () => {
     await server?.close();
     server = undefined;
     setActiveDegradedSecretOwners([]);
+    resetSystemEventsForTest();
+  });
+
+  it("routes secrets reload state events to the configured system agent", async () => {
+    await withEnvAsync({ SYSTEM_OWNER_SECRET: "available" }, async () => {
+      await writeConfig({
+        ...baseConfig(),
+        agents: {
+          defaults: { systemAgent: { agentId: "ops" } },
+          entries: { main: { default: true }, ops: {} },
+        },
+        session: { scope: "global" },
+        secrets: { providers: { default: { source: "env" } } },
+        tts: {
+          providers: {
+            elevenlabs: {
+              apiKey: { source: "env", provider: "default", id: "SYSTEM_OWNER_SECRET" },
+            },
+          },
+        },
+      });
+
+      const port = await getGatewayTestPort();
+      server = await startTestGatewayServer(port, { auth: { mode: "none" } });
+      const ws = await connectWebchatClient({ port, scopes: ["operator.admin"] });
+      try {
+        deleteTestEnvValue("SYSTEM_OWNER_SECRET");
+        const reload = await rpcReq<{ warningCount?: number }>(ws, "secrets.reload", {});
+
+        expect(reload.ok, JSON.stringify(reload)).toBe(true);
+        expect(reload.payload?.warningCount).toBeGreaterThan(0);
+        expect(peekSystemEvents("global")).toEqual([
+          expect.stringContaining("[SECRETS_RELOADER_DEGRADED]"),
+        ]);
+        const events = peekSystemEventEntries("global");
+        expect(selectAgentSystemEvents(events, "ops")).toHaveLength(1);
+        expect(selectAgentSystemEvents(events, "main")).toEqual([]);
+      } finally {
+        ws.close();
+      }
+    });
   });
 
   it("reaches /readyz while isolating every optional owner family", async () => {

--- a/src/gateway/server-startup-session-migration.test-support.ts
+++ b/src/gateway/server-startup-session-migration.test-support.ts
@@ -216,7 +216,8 @@ describe("runStartupSessionMigration", () => {
   it("imports legacy session metadata and transcripts into SQLite during startup", async () => {
     const log = makeLog();
     const cfg = makeCfg();
-    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" };
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-import-startup-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
     const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
     const runDoctorSessionSqlite = makeSessionSqliteImport({
       totals: {
@@ -234,12 +235,16 @@ describe("runStartupSessionMigration", () => {
       },
     });
 
-    await runStartupSessionMigration({
-      cfg,
-      env,
-      log,
-      deps: makeDeps(migrate, 0, runDoctorSessionSqlite),
-    });
+    try {
+      await runStartupSessionMigration({
+        cfg,
+        env,
+        log,
+        deps: makeDeps(migrate, 0, runDoctorSessionSqlite),
+      });
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
 
     expect(runDoctorSessionSqlite).toHaveBeenCalledWith({
       allAgents: true,

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -57,6 +57,8 @@ export type QueuedSessionDeliveryPayload =
   | ({
       kind: "systemEvent";
       sessionKey: string;
+      /** Preserves ownership when a durable event targets the literal global session. */
+      agentId?: string;
       text: string;
       deliveryContext?: SessionDeliveryContext;
       idempotencyKey?: string;

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -753,6 +753,7 @@ describe("runSystemAgentTurn", () => {
       agents: {
         defaults: {
           model: { primary: "anthropic/claude-global" },
+          systemAgent: { agentId: "ops" },
           models: {
             "openai/gpt-5.4": { agentRuntime: { id: "openclaw" } },
           },

--- a/src/system-agent/inference-fallback.test.ts
+++ b/src/system-agent/inference-fallback.test.ts
@@ -21,7 +21,10 @@ function route(agentId: string, provider: string): SystemAgentConfiguredRoute {
 
 const config: OpenClawConfig = {
   agents: {
-    defaults: { model: { primary: "zeta/model" } },
+    defaults: {
+      model: { primary: "zeta/model" },
+      systemAgent: { agentId: "requester" },
+    },
     list: [
       { id: "requester", default: true, model: "zeta/model" },
       { id: "beta", model: "beta/model" },
@@ -31,7 +34,7 @@ const config: OpenClawConfig = {
 };
 
 describe("system-agent inference fallback", () => {
-  it("tries the default route first, then authenticated providers by provider id", async () => {
+  it("tries the system-agent route first, then authenticated providers by provider id", async () => {
     const attempts: string[] = [];
     const verify = vi.fn(async ({ agentId }: { agentId: string }) => {
       attempts.push(agentId);

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -492,6 +492,7 @@ describe("parseSystemAgentOperation", () => {
       agents: {
         defaults: {
           model: { primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5.2"] },
+          systemAgent: { agentId: "main" },
         },
         entries: { main: { default: true, workspace: "/tmp/main" } },
       },
@@ -598,6 +599,9 @@ describe("parseSystemAgentOperation", () => {
     expect(
       requireRecord(requireRecord(persisted.agents, "agents").defaults, "defaults").model,
     ).toEqual({ primary: "openai/gpt-5.5", fallbacks: ["openai/gpt-5.2"] });
+    expect(
+      requireRecord(requireRecord(persisted.agents, "agents").defaults, "defaults").systemAgent,
+    ).toEqual({ agentId: "main" });
     expect(requireRecord(persisted.agents, "agents").entries).toEqual({
       main: { default: true, workspace: "/tmp/main" },
       work: { workspace: "/tmp/work" },
@@ -638,18 +642,20 @@ describe("parseSystemAgentOperation", () => {
 
   it.each([
     {
-      field: "default agent",
+      field: "system agent",
       initial: {
         agents: {
-          defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } },
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-4-6" },
+            systemAgent: { agentId: "main" },
+          },
           entries: { main: { default: true }, work: {} },
         },
       },
       change: (config: TestConfig) => {
         const next = structuredClone(config);
-        const entries = requireRecord(requireRecord(next.agents, "agents").entries, "entries");
-        delete requireRecord(entries.main, "main").default;
-        requireRecord(entries.work, "work").default = true;
+        const defaults = requireRecord(requireRecord(next.agents, "agents").defaults, "defaults");
+        defaults.systemAgent = { agentId: "work" };
         return next;
       },
     },

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1474,6 +1474,7 @@ describe("activateSetupInference", () => {
   it("persists inference only after the live test succeeds", async () => {
     const initialConfig = {
       agents: {
+        defaults: { systemAgent: { agentId: "ops" } },
         list: [
           {
             id: "ops",
@@ -1527,6 +1528,7 @@ describe("activateSetupInference", () => {
       params: { temperature: 1.7 },
       tools: { allow: ["exec"] },
     });
+    expect(configHarness.current().agents?.defaults?.systemAgent).toEqual({ agentId: "ops" });
     expect(configHarness.transform).toHaveBeenCalledOnce();
     expect(resolveRouteMetadata).toHaveBeenCalledOnce();
   });
@@ -1880,6 +1882,7 @@ describe("activateSetupInference", () => {
     };
     const concurrentConfig: OpenClawConfig = {
       agents: {
+        defaults: { systemAgent: { agentId: "work" } },
         list: [
           { id: "work", default: true, model: "openai/broken", name: "edited during probe" },
           { id: "new-agent", model: "anthropic/claude-opus-5" },
@@ -1900,6 +1903,7 @@ describe("activateSetupInference", () => {
 
     expect(result.ok).toBe(true);
     const persistedConfig = configHarness.current();
+    expect(persistedConfig.agents?.defaults?.systemAgent).toEqual({ agentId: "work" });
     expect(persistedConfig.agents?.entries).toEqual({
       work: {
         default: true,
@@ -1916,6 +1920,7 @@ describe("activateSetupInference", () => {
       name: "default model",
       concurrent: {
         agents: {
+          defaults: { systemAgent: { agentId: "ops" } },
           list: [
             {
               id: "ops",
@@ -1929,12 +1934,13 @@ describe("activateSetupInference", () => {
       } satisfies OpenClawConfig,
     },
     {
-      name: "default agent",
+      name: "system agent",
       concurrent: {
         agents: {
+          defaults: { systemAgent: { agentId: "other" } },
           list: [
-            { id: "ops", agentDir: "/tmp/ops", model: "openai/broken" },
-            { id: "other", default: true, agentDir: "/tmp/other", model: "openai/broken" },
+            { id: "ops", default: true, agentDir: "/tmp/ops", model: "openai/broken" },
+            { id: "other", agentDir: "/tmp/other", model: "openai/broken" },
           ],
         },
       } satisfies OpenClawConfig,
@@ -1955,9 +1961,10 @@ describe("activateSetupInference", () => {
       } satisfies OpenClawConfig,
     },
     {
-      name: "default agent execution settings",
+      name: "system agent execution settings",
       concurrent: {
         agents: {
+          defaults: { systemAgent: { agentId: "ops" } },
           list: [
             {
               id: "ops",
@@ -1975,6 +1982,7 @@ describe("activateSetupInference", () => {
   ])("rejects a changed $name after the live probe", async ({ concurrent }) => {
     const probedConfig = {
       agents: {
+        defaults: { systemAgent: { agentId: "ops" } },
         list: [
           { id: "ops", default: true, agentDir: "/tmp/ops", model: "openai/broken" },
           { id: "other", agentDir: "/tmp/other", model: "openai/broken" },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where targetless control-plane events could wake or queue against a generic main/default session instead of the configured system-agent owner in multi-agent setups. This affected secrets reloader state notifications, restart recovery, manual cron wakes, and node notification events; literal global-session events could also lose their owning agent and be consumed by the wrong agent.

## Why This Change Was Made

Targetless system work now resolves through `agents.defaults.systemAgent.agentId` via the canonical system-main target resolver. Events targeting the literal global session carry explicit owner metadata, including across durable restart replay. When a multi-agent installation has no configured system owner, the event is retained or recorded as an actionable non-delivery instead of silently falling back.

The repair also removes the retained in-process legacy-default shortcut from ambient system-agent resolution while preserving sole-agent implicit behavior. Existing legacy multi-agent configs with one historical default owner already recover through config validation and `openclaw doctor --fix`: `materializeLegacyDefaultAgentRoles` writes that owner to `agents.defaults.systemAgent.agentId`, and config writes persist the migrated shape. Truly explicit multi-agent fleets without an authored system owner are ambiguous and cannot be repaired safely by inference; they remain fail-closed with the exact configuration hint and a recorded non-delivery.

No config shape, SQLite schema, protocol, dependency, or operator state changes are introduced.

## User Impact

Multi-agent operators can rely on ambient Gateway events reaching the intended system agent. Missing ownership is visible and actionable rather than silently routing work to another agent, while single-agent installations continue to work without extra configuration.

AI-assisted implementation; maintainer-reviewed and validated.

## Evidence

- Pre-fix regression coverage demonstrated generic-main routing, lost global ownership, and silent missing-owner fallback across restart, secrets, cron, and node event paths.
- Focused lifecycle proof: 269 tests passed across agent ownership, Gateway startup/secrets, restart recovery, cron, and node events.
- Hosted CI exposed four stale system-agent fixture suites that still encoded the removed default-agent fallback. The test-only repair explicitly names each prior intended system owner and changes route-drift scenarios to mutate `agents.defaults.systemAgent.agentId`; all 173 sibling tests pass.
- Restart lifecycle rerun after final cleanup: 74 tests passed.
- Real Gateway secrets reload test proves a targetless degraded event reaches the configured owner on the literal `global` session and is invisible to the other agent.
- Existing upgrade recovery is covered: legacy default-role materialization writes `agents.defaults.systemAgent.agentId`, preserves all ambient surfaces, and persists the explicit owner during config writes. Explicit unowned fleets are covered by the actionable selection-error regression.
- The semantic rebase preserved the landed ambient-channel suppression and cron global-owner fixes; the ownership lifecycle set, system-agent sibling set, and full changed gate pass on final head `1c49e0ad2a5b240352e3adf4fddc76dfa70f574d`.
- Full changed gate passed for `core, coreTests`, including production/test typechecks, changed-file lint, formatting, dead exports, import cycles, schema guards, and architecture/boundary checks.
- `git diff --check` passed.
- Final rebased Codex autoreview passed with no accepted/actionable findings.
- Production LOC: +107/-46 (net +61). Tests/support: +298/-71 (net +227). The production growth carries owner identity through the discovered lifecycle boundaries and durable restart replay.

Proof gap: Blacksmith Testbox could not allocate because its coordinator CLI was unavailable on the maintainer host; no lease was created. Per repository fallback policy, the identical changed gate ran locally through `scripts/check-changed.mjs` and passed. Exact-head hosted CI is tracked separately by the landing workflow.