### PR TITLE
fix(feishu): keep pre-tool text in streaming card replies

### DIFF
--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -6,15 +6,17 @@
 // HTTP fetch, so streaming-card entity calls are captured at the wire seam.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
 import {
+  createWireRecorder,
   deliveryTraceScenarios,
   expectDeliveryTraceMatchesGolden,
   runDeliveryTraceScenario,
   type DeliveryTraceInStep,
   type DeliveryTraceScenarioName,
+  type TraceEvent,
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { afterAll, afterEach, beforeAll, describe, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -319,7 +321,7 @@ function createRecordingCardKitFetch(): typeof fetch {
   ) as typeof fetch;
 }
 
-function makeTraceAccount(scenario: DeliveryTraceScenarioName): ResolvedFeishuAccount {
+function makeTraceAccount(scenario: string): ResolvedFeishuAccount {
   traceState.setupCount += 1;
   return {
     accountId: "main",
@@ -337,7 +339,12 @@ function makeTraceAccount(scenario: DeliveryTraceScenarioName): ResolvedFeishuAc
   };
 }
 
-function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenarioName) {
+type FeishuTraceHarness = {
+  created: ReturnType<CreateFeishuReplyDispatcher>;
+  options: ReturnType<CreateFeishuReplyDispatcher>["dispatcherOptions"];
+};
+
+function createFeishuTraceHarness(recorder: WireRecorder, scenario: string): FeishuTraceHarness {
   traceState.recordWireCall = recorder.recordWireCall;
   traceState.messageCount = 0;
   traceState.reactionCount = 0;
@@ -355,7 +362,11 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
     sendTarget: "oc-trace-chat",
     replyToMessageId: "om-inbound",
   });
-  const options = created.dispatcherOptions;
+  return { created, options: created.dispatcherOptions };
+}
+
+function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenarioName) {
+  const { created, options } = createFeishuTraceHarness(recorder, scenario);
 
   return async (step: DeliveryTraceInStep) => {
     switch (step.kind) {
@@ -419,4 +430,144 @@ describe("feishu delivery trace goldens", () => {
       });
     });
   }
+});
+
+// Same fixed epoch as runDeliveryTraceScenario. Not imported: the harness
+// keeps that constant private so shared goldens stay the only public contract.
+const CARDKIT_RECORDING_EPOCH_MS = Date.UTC(2026, 0, 1);
+const PRE_TOOL_STREAM_TEXT = "Step 1: Identify the task.";
+const POST_TOOL_FINAL_TEXT = "Step 4: Analyze the results.";
+const COMBINED_INDEPENDENT_FINALS = `${PRE_TOOL_STREAM_TEXT}\n\n${POST_TOOL_FINAL_TEXT}`;
+const CUMULATIVE_FIRST_SNAPSHOT = "```md\n完整回复第一段\n```";
+const CUMULATIVE_SECOND_SNAPSHOT = "```md\n完整回复第一段 + 第二段\n```";
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function recordedWirePayload(event: TraceEvent): Record<string, unknown> | undefined {
+  if (!isJsonRecord(event.data) || !isJsonRecord(event.data.payload)) {
+    return undefined;
+  }
+  return event.data.payload;
+}
+
+function cardContentWrites(events: readonly TraceEvent[]): string[] {
+  const writes: string[] = [];
+  for (const event of events) {
+    if (event.dir !== "out" || !event.kind.endsWith("/elements/content/content")) {
+      continue;
+    }
+    const content = recordedWirePayload(event)?.content;
+    if (typeof content === "string") {
+      writes.push(content);
+    }
+  }
+  return writes;
+}
+
+function closeSettingsSummary(events: readonly TraceEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event || event.dir !== "out" || !event.kind.endsWith("/settings")) {
+      continue;
+    }
+    const settings = recordedWirePayload(event)?.settings;
+    if (!isJsonRecord(settings) || !isJsonRecord(settings.config)) {
+      return undefined;
+    }
+    const summary = settings.config.summary;
+    if (!isJsonRecord(summary) || typeof summary.content !== "string") {
+      return undefined;
+    }
+    return summary.content;
+  }
+  return undefined;
+}
+
+function cardKitTextPayloads(events: readonly TraceEvent[]): unknown[] {
+  return events
+    .filter(
+      (event) =>
+        event.dir === "out" &&
+        (event.kind.endsWith("/elements/content/content") || event.kind.endsWith("/settings")),
+    )
+    .map((event) => ({ kind: event.kind, payload: recordedWirePayload(event) }));
+}
+
+async function runFeishuCardKitRecording(
+  scenario: string,
+  drive: (harness: FeishuTraceHarness) => Promise<void>,
+): Promise<TraceEvent[]> {
+  vi.useFakeTimers({ now: CARDKIT_RECORDING_EPOCH_MS });
+  try {
+    const recorder = createWireRecorder();
+    const harness = createFeishuTraceHarness(recorder, scenario);
+    await drive(harness);
+    await vi.advanceTimersByTimeAsync(0);
+    return recorder.finish();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+describe("feishu CardKit recording after independent assistant finals", () => {
+  it("retains both segments on the last content update and close", async () => {
+    const events = await runFeishuCardKitRecording(
+      "pretool-retain",
+      async ({ created, options }) => {
+        await options.onReplyStart?.();
+        created.replyOptions.onPartialReply?.({ text: PRE_TOOL_STREAM_TEXT });
+        await vi.advanceTimersByTimeAsync(300);
+        await created.delivery.deliver({ text: PRE_TOOL_STREAM_TEXT }, { kind: "final" });
+        await vi.advanceTimersByTimeAsync(0);
+        created.replyOptions.onAssistantMessageStart?.();
+        await created.delivery.deliver({ text: POST_TOOL_FINAL_TEXT }, { kind: "final" });
+        await vi.advanceTimersByTimeAsync(300);
+        await options.onIdle?.();
+        options.onCleanup?.();
+      },
+    );
+
+    const contentWrites = cardContentWrites(events);
+    const lastContent = contentWrites.at(-1);
+    const closeSummary = closeSettingsSummary(events);
+    if (process.env.OPENCLAW_TRACE_DUMP === "1") {
+      process.stdout.write(`${JSON.stringify(cardKitTextPayloads(events), null, 2)}\n`);
+    }
+
+    expect(contentWrites.length).toBeGreaterThan(0);
+    expect(lastContent).toBe(COMBINED_INDEPENDENT_FINALS);
+    expect(lastContent).toContain(PRE_TOOL_STREAM_TEXT);
+    expect(lastContent).toContain(POST_TOOL_FINAL_TEXT);
+    expect(closeSummary).toBeDefined();
+    expect(closeSummary).toContain("Step 1");
+    expect(closeSummary).toContain("Step 4");
+  });
+
+  it("replaces a same-message cumulative snapshot instead of appending", async () => {
+    const events = await runFeishuCardKitRecording(
+      "cumulative-replace",
+      async ({ created, options }) => {
+        await options.onReplyStart?.();
+        await created.delivery.deliver({ text: CUMULATIVE_FIRST_SNAPSHOT }, { kind: "final" });
+        await vi.advanceTimersByTimeAsync(300);
+        await created.delivery.deliver({ text: CUMULATIVE_SECOND_SNAPSHOT }, { kind: "final" });
+        await vi.advanceTimersByTimeAsync(300);
+        await options.onIdle?.();
+        options.onCleanup?.();
+      },
+    );
+
+    const contentWrites = cardContentWrites(events);
+    const lastContent = contentWrites.at(-1);
+    const closeSummary = closeSettingsSummary(events);
+    if (process.env.OPENCLAW_TRACE_DUMP === "1") {
+      process.stdout.write(`${JSON.stringify(cardKitTextPayloads(events), null, 2)}\n`);
+    }
+
+    expect(lastContent).toBe(CUMULATIVE_SECOND_SNAPSHOT);
+    expect(lastContent).not.toBe(`${CUMULATIVE_FIRST_SNAPSHOT}\n\n${CUMULATIVE_SECOND_SNAPSHOT}`);
+    expect(closeSummary).toBe(CUMULATIVE_SECOND_SNAPSHOT.replace(/\n/g, " ").trim());
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1065,6 +1065,31 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("keeps pre-tool streamed prose when an independent post-tool final arrives", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    const preToolText = "Step 1: Identify the task.";
+    const postToolText = "Step 4: Analyze the results.";
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: preToolText });
+    await options.deliver({ text: preToolText }, { kind: "final" });
+    result.replyOptions.onAssistantMessageStart?.();
+    await options.deliver({ text: postToolText }, { kind: "final" });
+    await options.onIdle?.();
+
+    const session = requireStreamingInstance(0);
+    const expectedCombined = `${preToolText}\n\n${postToolText}`;
+    expect(streamingUpdateTexts()).toContain(expectedCombined);
+    expect(session.closeWithResult).toHaveBeenCalledWith(expectedCombined, {
+      note: "Agent: agent",
+    });
+    expect(session.close).toHaveBeenCalledWith(expectedCombined, {
+      note: "Agent: agent",
+    });
+  });
+
   it("falls back to chunked text when an appended error exceeds the streaming limit", async () => {
     const runtime = getFeishuRuntimeMock();
     runtime.channel.text.resolveTextChunkLimit.mockReturnValue(20);

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -302,6 +302,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let lastSnapshotTextLength = 0;
   // Partial previews are replaceable; only committed final text may precede an error notice.
   let hasStreamingFinalText = false;
+  // A later assistant message is a new final, not a cumulative snapshot of the current card.
+  let carryStreamTextToNextFinal = false;
   const deliveredFinalTexts = new Set<string>();
   type ClosedStreamingSettlement = {
     result: FeishuReplyDeliveryResult;
@@ -506,6 +508,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     snapshotBaseText = "";
     lastSnapshotTextLength = 0;
     hasStreamingFinalText = false;
+    carryStreamTextToNextFinal = false;
   };
 
   const rememberClosedStreamingSettlement = (
@@ -1412,7 +1415,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "final") {
               // Final payloads can be cumulative snapshots or independent
               // notices. Preserve both when the latter arrives after an answer.
-              streamText = text;
+              streamText = mergeStreamingFinalText(streamText, text, carryStreamTextToNextFinal);
+              carryStreamTextToNextFinal = false;
               hasStreamingFinalText = true;
               snapshotBaseText = "";
               lastSnapshotTextLength = text.length;
@@ -1578,7 +1582,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         : undefined,
       onAssistantMessageStart: previewStreamingEnabled
-        ? () => updateStreamingStatusLine("", { startIfNeeded: false })
+        ? () => {
+            carryStreamTextToNextFinal = Boolean(streamText);
+            return updateStreamingStatusLine("", { startIfNeeded: false });
+          }
         : undefined,
       onCompactionStart: previewStreamingEnabled
         ? () => updateStreamingStatusLine("📦 **Compacting context...**")


### PR DESCRIPTION
Closes #84486

## What Problem This Solves

Fixes an issue where Feishu streaming card replies dropped the model's pre-tool text when a later independent final arrived after a tool call. Users only saw the post-tool answer.

## Why This Change Was Made

The streaming path assigned `streamText = text` on every final. That is correct for cumulative same-message snapshots. It is wrong after `onAssistantMessageStart`, when the next final is a new assistant message and not a prefix of the card.

The existing `mergeStreamingFinalText` helper now runs at that assignment only when a new assistant message started with card text already present. Cumulative snapshots still replace. Error finals still replace uncommitted previews.

This stays on that one overwrite. It does not change sibling Feishu card issues around tool-progress persistence, stale updates, or CLI commentary.

## User Impact

Feishu streaming cards keep the text shown before a tool call, then append the post-tool answer in the same card.

## Evidence

After-fix CardKit recording on this head. Real `createFeishuReplyDispatcher` and real `FeishuStreamingSession` (streaming-card owner). The only fake is the Lark SDK client plus CardKit HTTP fetch (`createRecordingLarkClient` / `createRecordingCardKitFetch`). No live Feishu account.

Sequence: pre-tool partial `Step 1: Identify the task.` then first final (same text) then `onAssistantMessageStart` then independent post-tool final `Step 4: Analyze the results.` then idle close.

Recorded last card update (text that would hit Feishu):

```json
{
  "kind": "PUT /cardkit/v1/cards/card-1/elements/content/content",
  "payload": {
    "content": "Step 1: Identify the task.\n\nStep 4: Analyze the results.",
    "sequence": 3,
    "uuid": "s_card-1_3"
  }
}
```

Recorded close. The card body was already the combined text, so close did not issue another content PUT. The close settings payload is the existing 50-char CardKit summary of that accepted body. Both segments are still present:

```json
{
  "kind": "PATCH /cardkit/v1/cards/card-1/settings",
  "payload": {
    "settings": {
      "config": {
        "streaming_mode": false,
        "summary": {
          "content": "Step 1: Identify the task.  Step 4: Analyze the..."
        }
      }
    },
    "sequence": 5,
    "uuid": "c_card-1_5"
  }
}
```

Accepted card body retained through close:

```
Step 1: Identify the task.

Step 4: Analyze the results.
```

Control, same card, no `onAssistantMessageStart`: first final ` ```md\n完整回复第一段\n``` ` then cumulative ` ```md\n完整回复第一段 + 第二段\n``` `. Last update and close replace. No double-print.

```json
{
  "kind": "PUT /cardkit/v1/cards/card-1/elements/content/content",
  "payload": {
    "content": "```md\n完整回复第一段 + 第二段\n```",
    "sequence": 3,
    "uuid": "s_card-1_3"
  }
}
```

```json
{
  "kind": "PATCH /cardkit/v1/cards/card-1/settings",
  "payload": {
    "settings": {
      "config": {
        "streaming_mode": false,
        "summary": {
          "content": "```md 完整回复第一段 + 第二段 ```"
        }
      }
    },
    "sequence": 5,
    "uuid": "c_card-1_5"
  }
}
```

Commands and results:

```
OPENCLAW_TRACE_DUMP=1 node scripts/run-vitest.mjs extensions/feishu/src/delivery-trace.test.ts -t "retains both segments|replaces a same-message"
# Test Files  1 passed (1)
# Tests  2 passed | 5 skipped (7)
# dumped payloads above are that run's stdout

node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts -t "keeps pre-tool streamed prose"
# pre-fix: FAIL, close kept only "Step 4: Analyze the results."
# post-fix: PASS

node scripts/run-vitest.mjs \
  extensions/feishu/src/delivery-trace.test.ts \
  extensions/feishu/src/reply-dispatcher.test.ts -t "keeps pre-tool streamed prose|coalesces cumulative final|retains both segments|replaces a same-message|records streaming-happy"
# Test Files  2 passed (2)
# Tests  5 passed | 127 skipped (132)
```

Production LOC: +9/-2 (net +7). Tests: delivery-trace CardKit recording plus the earlier dispatcher case.
The extra production lines record the assistant-message boundary so cumulative same-message finals keep replace-if-prefix behavior.