### PR TITLE
fix(gateway): preserve hook target on early failure

### DIFF
--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -541,37 +541,6 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
-  it("reports runtime-config failures as failed admission", async () => {
-    loadConfigMock.mockImplementationOnce(() => {
-      throw new Error("config exploded");
-    });
-
-    const result = await dispatchAgentHook(buildAgentPayload("Config", "hooks"));
-
-    expect(result).toMatchObject({
-      ok: false,
-      statusCode: 502,
-      error: "hook agent run failed before entering the agent runner",
-      runId: expect.any(String),
-    });
-    await waitForFast(() =>
-      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
-        "Hook Config (error): Error: config exploded",
-        { sessionKey: "main-session" },
-      ),
-    );
-    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
-    const wake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(wake).toMatchObject({
-      source: "hook",
-      intent: "immediate",
-      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
-      sessionKey: "main-session",
-    });
-    expect(wake.agentId).toBeUndefined();
-    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
-  });
-
   it("keeps cron admission details behind stable public errors", async () => {
     runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
       status: "error",
@@ -1018,57 +987,5 @@ describe("dispatchAgentHook trust handling", () => {
       agentId: "main",
     });
     expect(failureWake.sessionKey).toBeUndefined();
-  });
-
-  it("carries the config-resolved agent on a recovered global failure wake", async () => {
-    // Early config resolution fails before the event key resolves, so
-    // hookEventSessionKey is absent; recovery still yields the unscoped
-    // "global" sentinel. The failure wake must reuse the recovered key and
-    // attach the explicit agent so the queued failure event is consumed.
-    loadConfigMock.mockImplementationOnce(() => {
-      throw new Error("config exploded");
-    });
-    resolveMainSessionKeyMock.mockReturnValueOnce("global").mockReturnValueOnce("global");
-
-    const result = await dispatchAgentHook({
-      ...buildAgentPayload("Config"),
-      effectiveAgentId: "hooks",
-    });
-
-    expect(result).toMatchObject({
-      ok: false,
-      statusCode: 502,
-      error: "hook agent run failed before entering the agent runner",
-      runId: expect.any(String),
-    });
-    await waitForFast(() =>
-      expectOwnedSystemEvent("Hook Config (error): Error: config exploded", "hooks"),
-    );
-    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
-    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
-      source: "hook",
-      intent: "immediate",
-      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
-      agentId: "hooks",
-    });
-    expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
-  });
-
-  it("carries the fresh default agent on the recovered global failure wake when no agent is named", async () => {
-    loadConfigMock.mockImplementationOnce(() => {
-      throw new Error("config exploded");
-    });
-    resolveMainSessionKeyMock.mockReturnValueOnce("global").mockReturnValueOnce("global");
-
-    dispatchAgentHook(buildAgentPayload("Config"));
-
-    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
-    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
-      source: "hook",
-      intent: "immediate",
-      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
-      agentId: "main",
-    });
-    expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
 });

--- a/src/gateway/server/hooks.early-failure.test.ts
+++ b/src/gateway/server/hooks.early-failure.test.ts
@@ -1,0 +1,128 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSystemEventOptionsOwnerAgentId } from "../../infra/system-event-ownership.js";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import { resolveHooksConfig } from "../hooks.js";
+
+const mocks = vi.hoisted(() => ({
+  enqueueSystemEvent: vi.fn(),
+  getRuntimeConfig: vi.fn<() => OpenClawConfig>(),
+  requestHeartbeat: vi.fn(),
+  runCronIsolatedAgentTurn: vi.fn(),
+}));
+
+vi.mock("../../config/io.js", () => ({
+  getRuntimeConfig: mocks.getRuntimeConfig,
+}));
+vi.mock("../../cron/isolated-agent.js", () => ({
+  runCronIsolatedAgentTurn: mocks.runCronIsolatedAgentTurn,
+}));
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeat: mocks.requestHeartbeat,
+}));
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: mocks.enqueueSystemEvent,
+}));
+
+const { createGatewayHooksRequestHandler } = await import("./hooks.js");
+
+function createConfig(global: boolean): OpenClawConfig {
+  return {
+    agents: { entries: { main: { default: true }, hooks: {} } },
+    hooks: { enabled: true, token: "hook-secret" },
+    ...(global ? { session: { scope: "global" } } : {}),
+  };
+}
+
+async function postAgentHook(global: boolean) {
+  const config = createConfig(global);
+  const hooksConfig = resolveHooksConfig(config);
+  if (!hooksConfig) {
+    throw new Error("expected resolved hooks config");
+  }
+  const handler = createGatewayHooksRequestHandler({
+    deps: {} as never,
+    getHooksConfig: () => hooksConfig,
+    getClientIpConfig: () => ({}),
+    bindHost: "127.0.0.1",
+    port: 18789,
+    logHooks: { warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() } as never,
+  });
+  const req = Object.assign(
+    Readable.from([JSON.stringify({ message: "Dispatch", name: "Recovery", agentId: "hooks" })]),
+    {
+      method: "POST",
+      url: "/hooks/agent",
+      headers: {
+        authorization: "Bearer hook-secret",
+        "content-type": "application/json",
+      },
+      socket: { remoteAddress: "127.0.0.1" },
+    },
+  ) as unknown as IncomingMessage;
+  let responseBody = "";
+  const res = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((chunk: string) => {
+      responseBody = chunk;
+    }),
+  } as unknown as ServerResponse;
+
+  mocks.getRuntimeConfig
+    .mockImplementationOnce(() => {
+      throw new Error("required system config unavailable");
+    })
+    .mockReturnValue(config);
+  expect(await handler(req, res)).toBe(true);
+  return { body: JSON.parse(responseBody) as unknown, status: res.statusCode };
+}
+
+describe("gateway hook early-failure recovery", () => {
+  beforeEach(() => {
+    resetGatewayWorkAdmission();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetGatewayWorkAdmission();
+  });
+
+  it.each([
+    { scope: "agent-scoped", eventSessionKey: "agent:hooks:main" },
+    { scope: "global", eventSessionKey: "global" },
+  ])("keeps the accepted agent authoritative for $scope recovery", async (testCase) => {
+    const global = testCase.scope === "global";
+    const response = await postAgentHook(global);
+
+    expect(response.status).toBe(502);
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: "hook agent run failed before entering the agent runner",
+      runId: expect.any(String),
+    });
+    expect(mocks.runCronIsolatedAgentTurn).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "Hook Recovery (error): Error: required system config unavailable",
+      { sessionKey: testCase.eventSessionKey },
+    );
+    const eventOptions = mocks.enqueueSystemEvent.mock.calls[0]?.[1] as object;
+    expect(resolveSystemEventOptionsOwnerAgentId(eventOptions)).toBe(global ? "hooks" : null);
+
+    expect(mocks.requestHeartbeat).toHaveBeenCalledWith({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
+      agentId: "hooks",
+      ...(global ? {} : { sessionKey: testCase.eventSessionKey }),
+    });
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+  });
+});

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -10,11 +10,7 @@ import { listAgentIds } from "../../agents/agent-scope.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { getRuntimeConfig } from "../../config/io.js";
-import {
-  canonicalizeMainSessionAlias,
-  resolveAgentMainSessionKey,
-  resolveMainSessionKeyFromConfig,
-} from "../../config/sessions.js";
+import { canonicalizeMainSessionAlias, resolveAgentMainSessionKey } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   CronAgentAdmissionDisposition,
@@ -333,7 +329,13 @@ export function createGatewayHooksRequestHandler(params: {
     };
     const reportHookFailure = (err: unknown) => {
       logHooks.warn(`hook agent failed: ${String(err)}`);
-      const eventSessionKey = hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
+      const eventTarget =
+        hookEventTarget ??
+        resolveHookEventTarget({
+          cfg: getRuntimeConfig(),
+          resolvedAgentId: value.effectiveAgentId,
+        });
+      const eventSessionKey = eventTarget.eventSessionKey;
       const isGlobalEvent = isUnscopedSessionKeySentinel(eventSessionKey);
       let heartbeatTarget: HookEventTarget["heartbeatTarget"];
       if (isGlobalEvent && hookEventTarget) {
@@ -343,13 +345,7 @@ export function createGatewayHooksRequestHandler(params: {
         }
         heartbeatTarget = { agentId: globalTerminalAgentId };
       } else {
-        heartbeatTarget =
-          hookEventTarget?.heartbeatTarget ??
-          (isGlobalEvent
-            ? {
-                agentId: value.effectiveAgentId,
-              }
-            : { sessionKey: eventSessionKey });
+        heartbeatTarget = eventTarget.heartbeatTarget;
       }
       const failureEventOptions = { sessionKey: eventSessionKey };
       enqueueSystemEvent(
@@ -448,10 +444,11 @@ export function createGatewayHooksRequestHandler(params: {
           }
           // The accepted agent is the stable owner. Global scope stays global;
           // other events keep that owner in their agent-qualified session key.
-          hookEventTarget = resolveHookEventTarget({
+          const eventTarget = resolveHookEventTarget({
             cfg,
             resolvedAgentId: agentId,
           });
+          hookEventTarget = eventTarget;
           const { runCronIsolatedAgentTurn } = await loadIsolatedAgentModule();
           // Lazy module loading is the last Gateway-owned async boundary before
           // cron preparation, so recheck the deadline after it settles.
@@ -516,8 +513,7 @@ export function createGatewayHooksRequestHandler(params: {
             });
           }
           if (shouldAnnounce) {
-            const eventSessionKey =
-              hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
+            const eventSessionKey = eventTarget.eventSessionKey;
             const isGlobalEvent = isUnscopedSessionKeySentinel(eventSessionKey);
             let announceEventOptions = { sessionKey: eventSessionKey };
             let heartbeatTarget: HookEventTarget["heartbeatTarget"];
@@ -532,9 +528,7 @@ export function createGatewayHooksRequestHandler(params: {
               );
               heartbeatTarget = { agentId: globalTerminalAgentId };
             } else {
-              heartbeatTarget = hookEventTarget?.heartbeatTarget ?? {
-                sessionKey: eventSessionKey,
-              };
+              heartbeatTarget = eventTarget.heartbeatTarget;
             }
             enqueueSystemEvent(`${prefix}: ${summary}`.trim(), announceEventOptions);
             if (value.wakeMode === "now") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an accepted Gateway agent hook could route or suppress its terminal recovery event for the wrong agent when runtime configuration failed before the hook event target was constructed.

The HTTP request had already resolved the authoritative `effectiveAgentId`, but the early-failure path rediscovered ambient default ownership instead of preserving that accepted target.

## Why This Change Was Made

The early-failure path now resolves its fallback hook event target with the already accepted effective agent. Normal terminal announcements reuse the event target built for the admitted run, removing the ambient main-session resolver from this Gateway owner boundary.

Global-scope behavior remains intentionally split: the event stays on the literal `global` key with owner metadata, while its heartbeat targets the accepted agent. Agent-scoped recovery uses the agent-qualified main session. Missing runtime configuration still fails closed with HTTP 502 and never starts the isolated runner.

## User Impact

Operators can expect hook failures to wake and report to the agent selected during request admission, including during an early runtime-configuration failure. For an explicit `hooks` agent, global recovery retains `hooks` ownership and scoped recovery targets `agent:hooks:main`.

## Evidence

- Before the fix, the handler regression failed because recovery received ambient `main-session` instead of `agent:hooks:main`.
- `node scripts/run-vitest.mjs src/gateway/server/hooks.early-failure.test.ts` — 2 passed.
- `node scripts/run-vitest.mjs src/gateway/server/hooks.agent-trust.test.ts src/gateway/server/hooks.terminal-target.test.ts src/gateway/server.hooks-admission.test.ts src/gateway/server.hooks.test.ts` — 63 passed.
- `node scripts/check-changed.mjs -- src/gateway/server/hooks.ts src/gateway/server/hooks.early-failure.test.ts src/gateway/server/hooks.agent-trust.test.ts` — all selected local fallback lanes passed, including core/test typecheck, lint, guards, cycles, and formatting. Remote providers were unavailable before execution, so this is explicitly local fallback proof.
- `git diff --check` — passed.
- Structured autoreview — clean, with no accepted/actionable findings.
- Production LOC: +13/-19 (net -6). Tests: +128/-83 (net +45).
- The transient configuration fault requires controlled injection. The regression exercises the real returned HTTP handler and proves the operator boundary (502 response, no isolated runner start, event ownership, and heartbeat target); it is not live external-channel proof.
- AI-assisted: yes.
