### PR TITLE
fix(ui): JSON summaries, JSON badge, and Tool sender label bypass i18n

### DIFF
--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -457,13 +457,6 @@
       "text": "NIP-05"
     },
     {
-      "count": 2,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/chat/components/chat-message-bubble.ts",
-      "text": "JSON"
-    },
-    {
       "count": 1,
       "kind": "html-text",
       "name": "text",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4846,6 +4846,10 @@ export const en: TranslationMap = {
     },
     codeBlock: {
       jsonLines: "JSON · {count} lines",
+      jsonBadge: "JSON",
+      jsonArrayItem: "Array ({count} item)",
+      jsonArrayItems: "Array ({count} items)",
+      jsonObjectKeys: "Object ({count} keys)",
     },
     workspaceConflict: {
       titleOne: "1 cloud workspace conflict",
@@ -5092,6 +5096,7 @@ export const en: TranslationMap = {
       showLess: "Show less",
       showMore: "Show more",
       unknownDate: "Unknown date",
+      toolSender: "Tool",
       voiceNote: "Voice note",
       duplicatesCollapsed: "{count} consecutive identical messages collapsed",
       contextFor: "Message context for {timestamp}",

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -511,7 +511,7 @@ export function renderGroupedMessage(
                             ?open=${Boolean(opts.autoExpandToolCalls)}
                           >
                             <summary class="chat-json-summary">
-                              <span class="chat-json-badge">JSON</span>
+                              <span class="chat-json-badge">${t("chat.codeBlock.jsonBadge")}</span>
                               <span class="chat-json-label"
                                 >${jsonSummaryLabel(jsonResult.parsed)}</span
                               >
@@ -575,7 +575,7 @@ export function renderGroupedMessage(
             ${jsonResult
               ? html`<details class="chat-json-collapse">
                   <summary class="chat-json-summary">
-                    <span class="chat-json-badge">JSON</span>
+                    <span class="chat-json-badge">${t("chat.codeBlock.jsonBadge")}</span>
                     <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
                   </summary>
                   <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -334,7 +334,7 @@ export function resolveMessageGroupSenderLabel(
     : normalizedRole === "assistant"
       ? (userLabel ?? assistantName)
       : normalizedRole === "tool"
-        ? "Tool"
+        ? t("chat.messages.toolSender")
         : group.messages.every((item) =>
               Boolean(workspaceResultConflictFromTranscript(item.message)),
             )

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -52,16 +52,19 @@ export function detectJson(text: string): { parsed: unknown; pretty: string } | 
 /** Build a short summary label for collapsed JSON (type + key count or array length). */
 export function jsonSummaryLabel(parsed: unknown): string {
   if (Array.isArray(parsed)) {
-    return `Array (${parsed.length} item${parsed.length === 1 ? "" : "s"})`;
+    return t(
+      parsed.length === 1 ? "chat.codeBlock.jsonArrayItem" : "chat.codeBlock.jsonArrayItems",
+      { count: String(parsed.length) },
+    );
   }
   if (parsed && typeof parsed === "object") {
     const keys = Object.keys(parsed as Record<string, unknown>);
     if (keys.length <= 4) {
       return `{ ${keys.join(", ")} }`;
     }
-    return `Object (${keys.length} keys)`;
+    return t("chat.codeBlock.jsonObjectKeys", { count: String(keys.length) });
   }
-  return "JSON";
+  return t("chat.codeBlock.jsonBadge");
 }
 
 export type MessageActionDetails = {


### PR DESCRIPTION
## What Problem This Solves

Three chat-surface strings bypass i18n and always render in English regardless of locale:
- `jsonSummaryLabel` (`ui/src/pages/chat/components/chat-message-markdown.ts`): "Object (7 keys)", "Array (2 items)", "JSON" on every collapsed pure-JSON assistant/tool message.
- The `chat-json-badge` literal "JSON" in `chat-message-bubble.ts` (2 sites).
- The tool sender label "Tool" in `chat-message-group.ts`.

The sibling key `chat.codeBlock.jsonLines` is already localized in 20+ locales; #115730's "localize remaining control surfaces" sweep missed these.

## Why This Change Was Made

All user-visible strings on this surface flow through `t()`. New keys: `chat.codeBlock.jsonBadge/jsonArrayItem/jsonArrayItems/jsonObjectKeys`, `chat.messages.toolSender`. The raw-copy i18n baseline shrinks by the two now-localized "JSON" badge entries (96→94), so re-introducing raw copies fails `ui:i18n:verify` — that's the structural regression guard for this class.

## User Impact

zh-CN/de/etc. users get localized JSON summaries, badge, and tool sender name once locale files pick up the keys (locale refresh flow owns translations; English behavior is byte-identical).

## Evidence

- `node --import tsx scripts/control-ui-i18n-verify.ts verify` green with the shrunk baseline (raw-copy entries 96→94); pre-fix, removing the baseline entries without the code change fails verify.
- Focused suite green: `node scripts/run-vitest.mjs run ui/src/pages/chat/components/chat-message.test.ts ui/src/i18n/` (183 + i18n tests).
- UI test typecheck green: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json`.
- Autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC: +9/−6 code, +6 i18n keys, −7 baseline JSON. English output unchanged (no behavior regression risk).
