### PR TITLE
fix(ci): prevent type-aware lint timeouts on constrained runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1890,7 +1890,7 @@ jobs:
               fi
               pnpm check:max-lines-ratchet --base "$base_ref"
               if [[ "${RATCHET_RELEASE_MERGE_TREE:-}" == "true" ]]; then
-                node --import tsx scripts/run-oxlint-shards.mts --only=core --only=extensions --split-core --threads=1
+                node --import tsx scripts/run-oxlint-shards.mts --only=core --only=extensions --threads=1
               fi
               ;;
             bun-launcher)
@@ -2501,15 +2501,16 @@ jobs:
               # i18n-tooling diff must run it. oxlint always runs.
               lint_args=(--threads=8)
               if [ "$RUNNER_BACKEND" = "github" ]; then
-                # Three dedicated hosted jobs own the split core stripes. Keep
+                # Five dedicated hosted jobs own the aggregated core Programs. Keep
                 # extension preparation, optional UI checks, and formatting in
-                # this fourth lane so each 4-core runner stays below ~6m.
+                # this sixth lane so each 4-core runner stays below ~6m.
                 lint_args=(--only=extensions --only=scripts --threads=1)
+                export GOMAXPROCS=2
               elif [ "$(nproc)" -lt 8 ]; then
-                # Fork PRs run on 4-core hosted runners with 16GB. Bound both
-                # the core process size and its threads so type-aware oxlint
-                # does not intermittently lose the runner under memory pressure.
-                lint_args=(--split-core --threads=1)
+                # Fork PRs build each semantic Program once. Bound both oxlint
+                # and its Go helper within the 4-core/16GB hosted runner.
+                lint_args=(--threads=1)
+                export GOMAXPROCS=2
               fi
               if [ "$RUN_CONTROL_UI_I18N" = "true" ] || [ "$RUN_UI_TESTS" = "true" ]; then
                 pnpm lint "${lint_args[@]}"
@@ -2613,8 +2614,8 @@ jobs:
               ;;
           esac
 
-  # The github/hybrid planner profile splits the serial core oxlint path across
-  # five deterministic hosted jobs. All-Blacksmith mode keeps one lint job.
+  # The github/hybrid planner profile aggregates core targets into five Programs
+  # across five hosted jobs. All-Blacksmith mode keeps one lint job.
   check-lint-hosted-core-shard:
     permissions:
       contents: read
@@ -2639,6 +2640,7 @@ jobs:
 
       - name: Run hosted core lint stripe
         env:
+          GOMAXPROCS: "2"
           OPENCLAW_LOCAL_CHECK: "0"
         run: >-
           node --import tsx scripts/run-oxlint-shards.mts

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -89,6 +89,8 @@ const repositoryScriptEntries = [
   "scripts/qa-coverage-report.ts!",
   "scripts/qa-parity-report.ts!",
   "scripts/resolve-frozen-codex-live-suite.mjs!",
+  // Changed-file checks invoke this targeted UI Stylelint entrypoint by path.
+  "scripts/run-stylelint.mts!",
   "scripts/secrets/openclaw-bws-resolver.mjs!",
   "scripts/sqlite-session-entry-cache-lifetime-proof.ts!",
   "scripts/sync-labels.ts!",

--- a/package.json
+++ b/package.json
@@ -1637,7 +1637,7 @@
     "lint:apps": "pnpm lint:swift",
     "lint:auth:no-pairing-store-group": "node --import tsx scripts/check-no-pairing-store-group-auth.mts",
     "lint:auth:pairing-account-scope": "node --import tsx scripts/check-pairing-account-scope.mts",
-    "lint:core": "node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core",
+    "lint:core": "node --import tsx scripts/run-oxlint-shards.mts --only=core",
     "lint:docker-e2e": "node --import tsx scripts/check-docker-e2e-boundaries.mts",
     "lint:kysely": "node --import tsx scripts/check-kysely-guardrails.mts",
     "lint:docs": "pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc",

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -117,9 +117,10 @@ const TARGETED_LINT_PATH_LIMIT = 8;
 const LINTABLE_CORE_PATH_RE = /^(?:src|ui|packages)\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_EXTENSION_PATH_RE = /^extensions\/[^/]+\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_SCRIPT_PATH_RE = /^scripts\/.+\.[cm]?[jt]sx?$/u;
+const LINTABLE_UI_STYLE_PATH_RE = /^ui\/src\/.+\.(?:css|ts)$/u;
 const MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE = /^(?:docs\/|README\.md$|.*\.mdx?$)/u;
 const CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
-  /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$/u;
+  /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$|^ui\/src\/.+\.css$/u;
 const EXTENSION_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
   /^(?:test\/scripts\/|\.github\/workflows\/ci\.yml$)/u;
 const SCRIPT_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
@@ -524,6 +525,7 @@ export function createChangedCheckPlan(
     fallbackName: string,
     fallbackArgs: string[],
     ignoredPaths?: Set<string>,
+    fallbackWithoutTargets = true,
   ) => {
     const candidatePaths = ignoredPaths
       ? result.paths.filter((changedPath) => !ignoredPaths.has(changedPath))
@@ -545,8 +547,10 @@ export function createChangedCheckPlan(
     }
 
     if (targetedCommands.length === 0) {
-      addLint(fallbackName, fallbackArgs);
-      return false;
+      if (fallbackWithoutTargets) {
+        addLint(fallbackName, fallbackArgs);
+      }
+      return !fallbackWithoutTargets;
     }
     for (const command of targetedCommands) {
       addCommand(command.name, command.bin, command.args, command.env);
@@ -772,9 +776,30 @@ export function createChangedCheckPlan(
   }
 
   if (lanes.core || lanes.coreTests || lanes.ui) {
-    addTargetedLint(createTargetedCoreLintCommand, LINTABLE_CORE_PATH_RE, "lint core", [
-      "lint:core",
-    ]);
+    addTargetedLint(
+      createTargetedCoreLintCommand,
+      LINTABLE_CORE_PATH_RE,
+      "lint core",
+      ["lint:core"],
+      undefined,
+      lanes.core,
+    );
+  }
+  if (lanes.ui) {
+    const targets = result.paths
+      .filter(
+        (changedPath) => LINTABLE_UI_STYLE_PATH_RE.test(changedPath) && existsSync(changedPath),
+      )
+      .toSorted((left, right) => left.localeCompare(right));
+    for (let offset = 0; offset < targets.length; offset += TARGETED_LINT_PATH_LIMIT) {
+      const batch = targets.slice(offset, offset + TARGETED_LINT_PATH_LIMIT);
+      addCommand(
+        batch.length === 1 ? "lint UI changed style file" : "lint UI changed style files",
+        "node",
+        ["--import", "tsx", "scripts/run-stylelint.mts", ...batch],
+        baseEnv,
+      );
+    }
   }
   if (
     lanes.liveDockerTooling &&

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -776,13 +776,23 @@ export function createChangedCheckPlan(
   }
 
   if (lanes.core || lanes.coreTests || lanes.ui) {
+    // CSS is covered by targeted Stylelint below. Other non-Oxlint core/UI
+    // inputs keep the full lane so changed checks do not silently drop lint.
+    const fallbackWithoutTargets = result.paths.some((changedPath) => {
+      const surface = getChangedPathFacts(changedPath).surface;
+      return (
+        (surface === "source" || surface === "package" || surface === "ui") &&
+        !CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath) &&
+        !MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath)
+      );
+    });
     addTargetedLint(
       createTargetedCoreLintCommand,
       LINTABLE_CORE_PATH_RE,
       "lint core",
       ["lint:core"],
       undefined,
-      lanes.core,
+      fallbackWithoutTargets,
     );
   }
   if (lanes.ui) {

--- a/scripts/lib/local-heavy-check-runtime.mts
+++ b/scripts/lib/local-heavy-check-runtime.mts
@@ -143,6 +143,21 @@ function hasOxlintFormatArg(args: string[]) {
   );
 }
 
+/** Apply the shared memory and scheduler limits for Go-backed check helpers. */
+function applyThrottledGoRuntimeEnv(env: Env, hostResources: Resources) {
+  if (!env.GOMAXPROCS) {
+    env.GOMAXPROCS = String(
+      Math.min(DEFAULT_LOCAL_GO_MAX_PROCS, Math.max(1, hostResources.logicalCpuCount)),
+    );
+  }
+  if (!env.GOGC) {
+    env.GOGC = DEFAULT_LOCAL_GO_GC;
+  }
+  if (!env.GOMEMLIMIT) {
+    env.GOMEMLIMIT = DEFAULT_LOCAL_GO_MEMORY_LIMIT;
+  }
+}
+
 /** Apply local tsgo defaults for declaration skipping, caching, throttling, and profiling. */
 export function applyLocalTsgoPolicy(args: string[], env: Env, hostResources: Resources) {
   const nextEnv = { ...env };
@@ -170,18 +185,7 @@ export function applyLocalTsgoPolicy(args: string[], env: Env, hostResources: Re
   if (shouldThrottleLocalHeavyChecks(nextEnv, resolvedHostResources, "auto")) {
     insertBeforeSeparator(nextArgs, "--singleThreaded");
     insertBeforeSeparator(nextArgs, "--checkers", "1");
-
-    if (!nextEnv.GOMAXPROCS) {
-      nextEnv.GOMAXPROCS = String(
-        Math.min(DEFAULT_LOCAL_GO_MAX_PROCS, Math.max(1, resolvedHostResources.logicalCpuCount)),
-      );
-    }
-    if (!nextEnv.GOGC) {
-      nextEnv.GOGC = DEFAULT_LOCAL_GO_GC;
-    }
-    if (!nextEnv.GOMEMLIMIT) {
-      nextEnv.GOMEMLIMIT = DEFAULT_LOCAL_GO_MEMORY_LIMIT;
-    }
+    applyThrottledGoRuntimeEnv(nextEnv, resolvedHostResources);
   }
   if (nextEnv.OPENCLAW_TSGO_PPROF_DIR && !hasFlag(nextArgs, "--pprofDir")) {
     insertBeforeSeparator(nextArgs, "--pprofDir", nextEnv.OPENCLAW_TSGO_PPROF_DIR);
@@ -211,12 +215,8 @@ export function applyLocalOxlintPolicy(args: string[], env: Env, hostResources: 
     if (!hasFlag(nextArgs, "--threads")) {
       insertBeforeSeparator(nextArgs, "--threads=1");
     }
-    if (!nextEnv.GOGC) {
-      nextEnv.GOGC = DEFAULT_LOCAL_GO_GC;
-    }
-    if (!nextEnv.GOMEMLIMIT) {
-      nextEnv.GOMEMLIMIT = DEFAULT_LOCAL_GO_MEMORY_LIMIT;
-    }
+    // Oxlint's thread flag does not govern the Go tsgolint helper.
+    applyThrottledGoRuntimeEnv(nextEnv, hostResources);
   }
 
   return { env: nextEnv, args: nextArgs };

--- a/scripts/run-oxlint-shards.mts
+++ b/scripts/run-oxlint-shards.mts
@@ -438,10 +438,7 @@ export function filterOxlintShards<T extends { name: string }>(shards: T[], only
 }
 
 /** Aggregate one deterministic, disjoint stripe into a single core Program. */
-export function selectCoreOxlintStripe(
-  shards: OxlintShard[],
-  stripe: CoreStripe | undefined,
-) {
+export function selectCoreOxlintStripe(shards: OxlintShard[], stripe: CoreStripe | undefined) {
   if (!stripe) {
     return shards;
   }
@@ -451,6 +448,9 @@ export function selectCoreOxlintStripe(
   const targets = shards
     .filter((_, index) => index % stripe.total === stripe.index - 1)
     .flatMap((shard) => shard.args.slice(2));
+  if (targets.length === 0) {
+    return [];
+  }
   return [
     {
       name: `core:stripe:${stripe.index}`,

--- a/scripts/run-oxlint-shards.mts
+++ b/scripts/run-oxlint-shards.mts
@@ -437,9 +437,9 @@ export function filterOxlintShards<T extends { name: string }>(shards: T[], only
   );
 }
 
-/** Select one deterministic, disjoint stripe of split core lint targets. */
-export function selectCoreOxlintStripe<T extends { name: string }>(
-  shards: T[],
+/** Aggregate one deterministic, disjoint stripe into a single core Program. */
+export function selectCoreOxlintStripe(
+  shards: OxlintShard[],
   stripe: CoreStripe | undefined,
 ) {
   if (!stripe) {
@@ -448,7 +448,15 @@ export function selectCoreOxlintStripe<T extends { name: string }>(
   if (shards.length === 0 || shards.some((shard) => !shard.name.startsWith("core:"))) {
     throw new Error("--core-stripe requires a non-empty core-only shard selection");
   }
-  return shards.filter((_, index) => index % stripe.total === stripe.index - 1);
+  const targets = shards
+    .filter((_, index) => index % stripe.total === stripe.index - 1)
+    .flatMap((shard) => shard.args.slice(2));
+  return [
+    {
+      name: `core:stripe:${stripe.index}`,
+      args: ["--tsconfig", CORE_TS_CONFIG, ...targets],
+    },
+  ];
 }
 
 export function shouldPrepareExtensionPackageBoundaryArtifactsForShards(

--- a/scripts/run-stylelint.mts
+++ b/scripts/run-stylelint.mts
@@ -1,0 +1,19 @@
+// Runs Stylelint through the linked-worktree-aware repository toolchain.
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import {
+  ensureRepoToolNodeModulesLink,
+  resolveRepoToolBinPath,
+} from "./lib/local-heavy-check-runtime.mts";
+
+const stylelintPath = resolveRepoToolBinPath("stylelint");
+ensureRepoToolNodeModulesLink(stylelintPath);
+const result = spawnSync(
+  stylelintPath,
+  ["--config", path.resolve("config", "stylelint.config.mjs"), ...process.argv.slice(2)],
+  { env: process.env, stdio: "inherit" },
+);
+if (result.error) {
+  throw result.error;
+}
+process.exitCode = result.status ?? 1;

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -902,7 +902,7 @@ describe("scripts/changed-lanes", () => {
     {
       name: "routes the UI production config to UI prod and core test lanes",
       path: "tsconfig.ui.json",
-      expected: { includes: ["tsgo:ui", "tsgo:core:test"], excludes: [] },
+      expected: { includes: ["tsgo:ui", "tsgo:core:test", "lint:core"], excludes: [] },
     },
   ])("$name", ({ path: changedPath, expected }) => {
     const result = detectChangedLanes([changedPath]);
@@ -917,6 +917,18 @@ describe("scripts/changed-lanes", () => {
     for (const command of expected.excludes) {
       expect(commands).not.toContain(command);
     }
+  });
+
+  it("falls back to core lint for a non-lintable core test asset", () => {
+    const result = detectChangedLanes([
+      "packages/ai/test/fixtures/provider-transport-parity/openai-success.snap.txt",
+    ]);
+    const commands = createChangedCheckPlan(result, {
+      env: { PATH: "/usr/bin" },
+    }).commands.map((command) => command.args[0]);
+
+    expectLanes(result.lanes, { coreTests: true });
+    expect(commands).toContain("lint:core");
   });
 
   it.each(["scripts/control-ui-i18n.ts", "scripts/lib/example.ts", "tsconfig.scripts.json"])(

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -809,6 +809,39 @@ describe("scripts/changed-lanes", () => {
 
   it.each([
     {
+      name: "mixed UI TypeScript and CSS",
+      paths: ["ui/src/app-routes.ts", "ui/src/styles/base.css"],
+      oxlintTargets: ["ui/src/app-routes.ts"],
+      stylelintTargets: ["ui/src/app-routes.ts", "ui/src/styles/base.css"],
+    },
+    {
+      name: "UI CSS only",
+      paths: ["ui/src/styles/base.css"],
+      oxlintTargets: [],
+      stylelintTargets: ["ui/src/styles/base.css"],
+    },
+  ])("targets style lint for $name without broad core lint", (testCase) => {
+    const plan = createChangedCheckPlan(detectChangedLanes(testCase.paths), {
+      env: { PATH: "/usr/bin" },
+    });
+
+    expect(plan.commands.map((command) => command.args[0])).not.toContain("lint:core");
+    const oxlint = plan.commands.find((command) => command.name.startsWith("lint core changed"));
+    if (testCase.oxlintTargets.length === 0) {
+      expect(oxlint).toBeUndefined();
+    } else {
+      expect(oxlint?.args.slice(3)).toEqual(testCase.oxlintTargets);
+    }
+    expect(
+      plan.commands.find((command) => command.name.startsWith("lint UI changed style")),
+    ).toMatchObject({
+      bin: "node",
+      args: ["--import", "tsx", "scripts/run-stylelint.mts", ...testCase.stylelintTargets],
+    });
+  });
+
+  it.each([
+    {
       owner: "core",
       paths: [
         "src/gateway/node-registry.ts",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5588,7 +5588,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(checkShardRun).toContain('if [ "$RUNNER_BACKEND" = "github" ]; then');
     expect(checkShardRun).toContain("lint_args=(--only=extensions --only=scripts --threads=1)");
     expect(checkShardRun).toContain('elif [ "$(nproc)" -lt 8 ]; then');
-    expect(checkShardRun).toContain("lint_args=(--split-core --threads=1)");
+    expect(checkShardRun).toContain("lint_args=(--threads=1)");
+    expect(checkShardRun).not.toContain("lint_args=(--split-core --threads=1)");
+    expect(checkShardRun.match(/export GOMAXPROCS=2/gu)).toHaveLength(2);
     expect(checkShardRun).toContain('pnpm lint "${lint_args[@]}"');
     expect(checkShardRun).toContain(
       'node --import tsx scripts/run-oxlint-shards.mts "${lint_args[@]}"',
@@ -5600,6 +5602,10 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "max-parallel": 5,
       matrix: { stripe: [1, 2, 3, 4, 5] },
     });
+    expect(
+      hostedCoreLint.steps.find((step: WorkflowStep) => step.name === "Run hosted core lint stripe")
+        .env.GOMAXPROCS,
+    ).toBe("2");
     expect(
       hostedCoreLint.steps.find((step: WorkflowStep) => step.name === "Run hosted core lint stripe")
         .run,
@@ -5708,7 +5714,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       'if [[ "${RATCHET_RELEASE_MERGE_TREE:-}" == "true" ]]; then',
     );
     expect(checksFastRun.run).toContain(
-      "node --import tsx scripts/run-oxlint-shards.mts --only=core --only=extensions --split-core --threads=1",
+      "node --import tsx scripts/run-oxlint-shards.mts --only=core --only=extensions --threads=1",
     );
     expect(checksFastRun.run).not.toContain(
       "node scripts/run-oxlint.mjs src ui/src packages extensions",

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -1,6 +1,7 @@
 // Local Heavy Check Runtime tests cover local heavy check runtime script behavior.
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -326,6 +327,7 @@ describe("local-heavy-check-runtime", () => {
       "error",
       "--threads=1",
     ]);
+    expect(env.GOMAXPROCS).toBe("2");
     expect(env.GOGC).toBe("30");
     expect(env.GOMEMLIMIT).toBe("3GiB");
   });
@@ -341,6 +343,7 @@ describe("local-heavy-check-runtime", () => {
       "error",
       "--threads=1",
     ]);
+    expect(env.GOMAXPROCS).toBe("2");
     expect(env.GOGC).toBe("30");
     expect(env.GOMEMLIMIT).toBe("3GiB");
   });
@@ -348,7 +351,7 @@ describe("local-heavy-check-runtime", () => {
   it("honors an explicit oxlint thread count", () => {
     const { args, env } = applyLocalOxlintPolicy(
       ["--threads=8"],
-      makeEnv({ GOGC: "80", GOMEMLIMIT: "5GiB" }),
+      makeEnv({ GOMAXPROCS: "3", GOGC: "80", GOMEMLIMIT: "5GiB" }),
       ROOMY_HOST,
     );
 
@@ -360,8 +363,43 @@ describe("local-heavy-check-runtime", () => {
       "--report-unused-disable-directives-severity",
       "error",
     ]);
+    expect(env.GOMAXPROCS).toBe("3");
     expect(env.GOGC).toBe("80");
     expect(env.GOMEMLIMIT).toBe("5GiB");
+  });
+
+  it("passes the throttled Go concurrency limit to the oxlint child", () => {
+    const cwd = createTempDir("openclaw-oxlint-go-limit-");
+    const binDir = path.join(cwd, "node_modules", ".bin");
+    const capturePath = path.join(cwd, "gomaxprocs.txt");
+    const oxlintPath = path.join(binDir, "oxlint");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(
+      oxlintPath,
+      "#!/usr/bin/env node\nrequire('node:fs').writeFileSync(process.env.CAPTURE_PATH, process.env.GOMAXPROCS || '');\n",
+      "utf8",
+    );
+    fs.chmodSync(oxlintPath, 0o755);
+    const env = {
+      ...process.env,
+      CAPTURE_PATH: capturePath,
+      OPENCLAW_LOCAL_CHECK: "1",
+      OPENCLAW_LOCAL_CHECK_MODE: "throttled",
+      OPENCLAW_OXLINT_SKIP_LOCK: "1",
+      OPENCLAW_OXLINT_SKIP_PREPARE: "1",
+    };
+    delete env.GOMAXPROCS;
+
+    const result = spawnSync(
+      process.execPath,
+      [path.resolve("scripts/run-oxlint.mjs"), "--tsconfig", "config/tsconfig/oxlint.core.json"],
+      { cwd, encoding: "utf8", env },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.readFileSync(capturePath, "utf8")).toBe(
+      String(Math.min(2, Math.max(1, os.availableParallelism()))),
+    );
   });
 
   it("allows forcing full-speed oxlint runs on roomy hosts", () => {

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -380,7 +380,7 @@ describe("local-heavy-check-runtime", () => {
       "utf8",
     );
     fs.chmodSync(oxlintPath, 0o755);
-    const env = {
+    const env: NodeJS.ProcessEnv = {
       ...process.env,
       CAPTURE_PATH: capturePath,
       OPENCLAW_LOCAL_CHECK: "1",

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -242,7 +242,7 @@ describe("run-oxlint", () => {
     expect(packageJson.scripts.check).toBe("node --import tsx scripts/check.mts");
     expect(packageJson.scripts.lint).toBe("node --import tsx scripts/run-lint.mts");
     expect(packageJson.scripts["lint:core"]).toBe(
-      "node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core",
+      "node --import tsx scripts/run-oxlint-shards.mts --only=core",
     );
     expect(packageJson.scripts.check).not.toContain(
       "node --import tsx scripts/prepare-extension-package-boundary-artifacts.mts",
@@ -536,7 +536,7 @@ describe("run-oxlint", () => {
     expect(parsed.oxlintArgs).toEqual(["--max-warnings", "0"]);
   });
 
-  it("partitions split core lint targets into deterministic disjoint stripes", () => {
+  it("aggregates split core targets into deterministic disjoint Programs", () => {
     const shards = createOxlintShards({
       cwd: "/repo",
       splitCore: true,
@@ -549,16 +549,15 @@ describe("run-oxlint", () => {
     }).filter((shard) => shard.name.startsWith("core:"));
     const stripes = [1, 2, 3].map((index) => selectCoreOxlintStripe(shards, { index, total: 3 }));
 
-    expect(
-      stripes
-        .flat()
-        .map((shard) => shard.name)
-        .toSorted(),
-    ).toEqual(shards.map((shard) => shard.name).toSorted());
-    expect(new Set(stripes.flat().map((shard) => shard.name))).toHaveProperty(
-      "size",
-      shards.length,
-    );
+    expect(stripes.map((stripe) => stripe.map((shard) => shard.name))).toEqual([
+      ["core:stripe:1"],
+      ["core:stripe:2"],
+      ["core:stripe:3"],
+    ]);
+    const stripeTargets = stripes.flatMap(([stripe]) => stripe?.args.slice(2) ?? []);
+    const sourceTargets = shards.flatMap((shard) => shard.args.slice(2));
+    expect(stripeTargets.toSorted()).toEqual(sourceTargets.toSorted());
+    expect(new Set(stripeTargets)).toHaveProperty("size", sourceTargets.length);
     expect(() =>
       selectCoreOxlintStripe(createOxlintShards({ cwd: "/repo" }), { index: 1, total: 2 }),
     ).toThrow("--core-stripe requires a non-empty core-only shard selection");

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -558,6 +558,7 @@ describe("run-oxlint", () => {
     const sourceTargets = shards.flatMap((shard) => shard.args.slice(2));
     expect(stripeTargets.toSorted()).toEqual(sourceTargets.toSorted());
     expect(new Set(stripeTargets)).toHaveProperty("size", sourceTargets.length);
+    expect(selectCoreOxlintStripe(shards, { index: 6, total: 6 })).toEqual([]);
     expect(() =>
       selectCoreOxlintStripe(createOxlintShards({ cwd: "/repo" }), { index: 1, total: 2 }),
     ).toThrow("--core-stripe requires a non-empty core-only shard selection");


### PR DESCRIPTION
## What

Targets changed UI CSS and TypeScript files during local lint. Hosted core lint keeps three parallel jobs, but each job aggregates its target stripe into one Oxlint invocation and one tsgolint Program.

## Why

A CSS path was neither an Oxlint target nor a neutral path, so CSS-only and mixed UI changes fell back to full core lint. CI then split the core tree by top-level directory. Each child used the same broad tsconfig and rebuilt the same TypeScript Program, which pushed a two-file UI pull request past the 20-minute timeout.

## Changes

- Target changed UI files with Stylelint
- Keep CSS neutral to targeted Oxlint
- Aggregate hosted core targets into three Programs
- Build each local core Program once
- Cap tsgolint Go workers on constrained hosts
- Register the Stylelint launcher with Knip

## Testing

- CSS-only dry run schedules only targeted Stylelint
- Mixed dry run schedules targeted Oxlint and Stylelint
- Targeted Stylelint passes for `ui/src/styles/base.css`
- 241 planner, runner, and runtime tests pass
- 2 focused workflow guard tests pass
- Exact-head `check-test-types` passes in 3m10s
- Exact-head `check-dependencies` passes in 4m10s
- Exact-head `check-lint` passes in 4m57s
- Three core stripes pass in 1m24s to 1m28s
- Exact-head `actionlint` passes
- Formatting and `git diff --check` pass

Incident evidence: https://github.com/openclaw/openclaw/actions/runs/31740687629/job/94583397386?pr=123299