### PR TITLE
fix(gateway): keep explicit-owner Control UI discovery working

### DIFF
--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -893,8 +893,24 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
 
     const cfg = context.getRuntimeConfig();
-    const modelCatalog = await readPreparedServerMethodModelCatalog(context);
+    const modelCatalogByAgentId =
+      cfg.agents?.ownership === "explicit"
+        ? new Map(
+            (
+              await Promise.all(
+                listAgentIds(cfg).map(async (agentId) => {
+                  const catalog = await readPreparedServerMethodModelCatalog(context, { agentId });
+                  return catalog ? ([[agentId, catalog]] as const) : [];
+                }),
+              )
+            ).flat(),
+          )
+        : undefined;
+    const modelCatalog = modelCatalogByAgentId
+      ? undefined
+      : await readPreparedServerMethodModelCatalog(context);
     const result = listAgentsForGateway(cfg, modelCatalog, {
+      ...(modelCatalogByAgentId ? { modelCatalogByAgentId } : {}),
       includeSystem: hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND),
     });
     respond(true, result, undefined);

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -100,6 +100,25 @@ test("agents.list reads published model facts without starting provider discover
   expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
 });
 
+test("agents.list reads model facts without an implicit owner", async () => {
+  await setAgentsConfig({ ownership: "explicit", entries: { ops: {}, research: {} } });
+  const readPreparedGatewayModelCatalog = vi.fn(async (params?: { agentId?: string }) => {
+    if (!params?.agentId) {
+      throw new Error("model catalog read has no explicit owner");
+    }
+    return [];
+  });
+
+  await expect(listAgentIdsViaRpc(false, { readPreparedGatewayModelCatalog })).resolves.toEqual([
+    "ops",
+    "research",
+  ]);
+  expect(readPreparedGatewayModelCatalog.mock.calls).toEqual([
+    [{ agentId: "ops" }],
+    [{ agentId: "research" }],
+  ]);
+});
+
 beforeEach(async () => {
   testState.agentConfig = undefined;
   testState.sessionStorePath = undefined;

--- a/src/system-agent/setup-inference-detect.ts
+++ b/src/system-agent/setup-inference-detect.ts
@@ -1,5 +1,9 @@
 import { normalizeOptionalAgentRuntimeId } from "../agents/agent-runtime-id.js";
-import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentEffectiveModelPrimary,
+  tryResolveLegacyCompatibilityAgentId,
+} from "../agents/agent-scope.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { resolveModelRuntimePolicy } from "../agents/model-runtime-policy.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
@@ -39,13 +43,17 @@ function resolveConfiguredCandidateKind(
   if (!modelRef) {
     return undefined;
   }
+  const agentId = tryResolveLegacyCompatibilityAgentId(config ?? {});
+  if (!agentId) {
+    return undefined;
+  }
   const ref = parseRef(modelRef);
   const runtime = normalizeOptionalAgentRuntimeId(
     resolveModelRuntimePolicy({
       config,
       provider: ref.provider,
       modelId: ref.model,
-      agentId: resolveDefaultAgentId(config ?? {}),
+      agentId,
     }).policy?.id,
   );
   if (runtime === "codex") {
@@ -55,6 +63,12 @@ function resolveConfiguredCandidateKind(
     return "claude-cli";
   }
   return undefined;
+}
+
+function hasConfiguredInference(config: Parameters<typeof resolveAgentEffectiveModelPrimary>[0]) {
+  return listAgentIds(config).some((agentId) =>
+    Boolean(resolveAgentEffectiveModelPrimary(config, agentId)),
+  );
 }
 
 /**
@@ -97,7 +111,7 @@ export async function listManualSetupInferenceOptions(
     workspace,
     // Derived from config only (no probing): a pre-existing default model must
     // keep classifying the install as configured even when scanning declined.
-    setupComplete: Boolean(resolveAgentEffectiveModelPrimary(cfg, resolveDefaultAgentId(cfg))),
+    setupComplete: hasConfiguredInference(cfg),
   };
 }
 
@@ -260,6 +274,6 @@ export async function detectSetupInference(
     recommendedInstalls: listRecommendedToolInstalls(),
     workspace,
     ...(configuredModel ? { configuredModel } : {}),
-    setupComplete: Boolean(configuredModel),
+    setupComplete: Boolean(configuredModel) || hasConfiguredInference(cfg),
   };
 }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -53,6 +53,7 @@ import {
   activateSetupInference as activateSetupInferenceImpl,
   type BoundVerifySetupInferenceResult,
   detectSetupInference,
+  listManualSetupInferenceOptions,
   listSetupInferenceAuthOptions,
   listSetupInferenceManualProviders,
   listSetupInferencePrepareOptions,
@@ -792,6 +793,53 @@ describe("detectSetupInference", () => {
     await expect(detectSetupInference()).rejects.toThrow(
       "OpenClaw config /tmp/openclaw.json is invalid (agents.defaults.model: Expected a model reference)",
     );
+  });
+
+  it("detects configured inference without an implicit roster owner", async () => {
+    const { readConfigFileSnapshot } = await import("../config/config.js");
+    const config = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { model: "openai/gpt-5.5" },
+        entries: { ops: {}, research: { model: "anthropic/claude-opus-4-8" } },
+      },
+    } satisfies OpenClawConfig;
+    vi.mocked(readConfigFileSnapshot).mockImplementationOnce(
+      mockConfigSnapshot(config, { includeMetadata: true }),
+    );
+
+    await expect(
+      detectSetupInference({
+        detectInferenceBackends: async () => [
+          {
+            kind: "existing-model",
+            modelRef: "openai/gpt-5.5",
+            label: "Current model",
+            detail: "openai/gpt-5.5 - already configured",
+            credentials: true,
+          },
+        ],
+        probeLocalCommand: vi.fn(async (command) => ({ command, found: false })),
+        resolveManifestProviderAuthChoices: () => [],
+      }),
+    ).resolves.toMatchObject({ setupComplete: true });
+  });
+
+  it("recognizes per-agent inference when manual setup has no implicit roster owner", async () => {
+    const { readConfigFileSnapshot } = await import("../config/config.js");
+    const config = {
+      agents: {
+        ownership: "explicit" as const,
+        entries: { ops: {}, research: { model: "anthropic/claude-opus-4-8" } },
+      },
+    } satisfies OpenClawConfig;
+    vi.mocked(readConfigFileSnapshot).mockImplementationOnce(
+      mockConfigSnapshot(config, { includeMetadata: true }),
+    );
+
+    await expect(
+      listManualSetupInferenceOptions({ resolveManifestProviderAuthChoices: () => [] }),
+    ).resolves.toMatchObject({ setupComplete: true });
   });
 
   it("lists text-inference key and token methods from provider manifests", () => {


### PR DESCRIPTION
## Summary

### High Level TLDR

Explicit-owner installations could make the Control UI fail while listing agents or detecting setup because those global reads still tried to select an implicit default agent. This change scopes model-catalog reads to each configured agent and determines configured inference across the explicit roster without inventing a default owner.

## What Problem This Solves

Fixes an issue where operators using `agents.ownership: "explicit"` could receive `AgentSelectionRequiredError` from `agents.list` and `openclaw.setup.detect`, preventing Control UI agent discovery and setup-state detection.

## Why This Change Was Made

`agents.list` keeps using lifecycle-published model facts, but now reads those facts once per configured owner and passes the resulting map through the existing gateway roster boundary. Setup detection now checks configured inference across the roster and only performs runtime-specific candidate deduplication when a legacy compatibility owner actually exists.

The legacy and sole-owner paths remain unchanged. This does not add provider discovery, fallback ownership, config, protocol, or persistence behavior.

## User Impact

Explicit-owner installations can load their agent roster and setup state without selecting a default agent. Each listed agent continues to receive its own prepared model and thinking metadata.

## Root Cause

Before this change, two global read paths still called APIs that require an owner:

- `agents.list` called `readPreparedServerMethodModelCatalog(context)` without `agentId`.
- setup discovery called `resolveDefaultAgentId` while classifying configured runtime candidates and checking whether setup was complete.

That works for legacy or sole-owner rosters, but explicit multi-agent rosters intentionally have no implicit owner. The owner resolver therefore correctly raised `AgentSelectionRequiredError`; the global callers were wrong to request an implicit owner.

The prepared-catalog read was retained because `agents.list` is expected to use lifecycle-published facts rather than starting provider discovery. The repair supplies the missing owner at that boundary instead of skipping model metadata.

## Verification

Regression tests were first applied to unmodified `b7b33149b06e6e371879c7a5f0846b68880226e2` and failed with `AgentSelectionRequiredError`:

```text
node scripts/run-vitest.mjs src/gateway/server-methods/sessions-read.test.ts
1 failed, 13 passed

node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts
2 failed, 127 passed
```

On exact head `99cd7e8aa3c9b6bf477775e038118d94095232e6`:

```text
node scripts/run-vitest.mjs src/gateway/server-methods/sessions-read.test.ts
14 passed

node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts
129 passed

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main \
  --parallel-tests 'node scripts/run-vitest.mjs src/gateway/server-methods/sessions-read.test.ts && node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts'
autoreview clean: no accepted/actionable findings reported

OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs
exit 0
```

The changed-file gate could not acquire a remote Testbox provider in this environment and used its documented local fallback. All selected local lanes passed.

Production delta is +35/-5 lines; tests are +67/-0. The production growth is the owner map needed to preserve published per-agent model facts plus one shared roster-wide configured-inference predicate. Skipping the catalog would be smaller but would regress model/thinking metadata for explicit rosters.

## Real behavior proof

The exact pre-fix RPC-path test rejects because the prepared catalog is read without an owner. On this head, the same RPC returns both explicit agents and records exactly two owner-qualified prepared reads:

```text
[{ agentId: "ops" }]
[{ agentId: "research" }]
```

The setup tests likewise reproduce both affected states: a shared configured model with no implicit owner, and a model configured only on one explicit agent. Both now return `setupComplete: true` without throwing.

Live aggregate deployment proof used stock base `67a1cdda0009c94dc53edf71f3054026cfc03ddd` with this PR applied as an overlay. After restart:

```text
agents.list
11 agents returned; every row retained model metadata; no owner-selection error

openclaw.setup.detect
setupComplete=true; configuredModel=openai/gpt-5.6-terra; no owner-selection error

gateway verbose health
ok=true; RPC reachable; Telegram connected and ready
```

Repeatable test-file performance check, same host and workload after warmup, three measured samples per tree using `/usr/bin/time -f '%e %M'`:

```text
baseline (failing):  6.46s / 1238608 KB, 6.42s / 1237624 KB, 6.39s / 1219276 KB
candidate (passing): 6.33s / 1249696 KB, 6.27s / 1227332 KB, 6.40s / 1222032 KB
```

No distinguishable test-file wall-time or peak-RSS regression was observed. This is a focused harness benchmark, not a live RPC latency measurement.

## What was not tested

- A live browser interaction was not performed; the deployed Gateway RPCs that back the affected Control UI surfaces were exercised directly.
- Remote Testbox execution was unavailable because no authenticated provider was ready; the full changed-file gate ran locally instead.
- Unrelated providers, channels, and setup mutations were not exercised.

## Evidence

The regression tests cover the original global entry points, assert that explicit ownership never falls back to an ownerless catalog read, and cover configured inference from both shared defaults and per-agent configuration.
