### PR TITLE
fix(codex): preserve explicit migration ownership

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -61,13 +61,16 @@ function openBindingStore(env: NodeJS.ProcessEnv) {
 
 async function createBindingMigrationFixture(options: {
   binding?: Record<string, unknown>;
+  legacySharedRoot?: boolean;
   name: string;
   sessionIndex?: Record<string, unknown>;
   threadId: string;
 }) {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-"));
   const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
-  const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+  const sessionsDir = options.legacySharedRoot
+    ? path.join(stateDir, "sessions")
+    : path.join(stateDir, "agents", "main", "sessions");
   const storePath = path.join(sessionsDir, "sessions.json");
   const transcriptPath = path.join(sessionsDir, `${options.name}.jsonl`);
   const sidecarPath = `${transcriptPath}.codex-app-server.json`;
@@ -289,6 +292,82 @@ describe("codex doctor contract", () => {
     await expect(
       fs.readFile(fixture.storePath, "utf8").then(JSON.parse),
     ).resolves.not.toHaveProperty("agent:main:session-1.agentHarnessId");
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
+
+  it("preserves ambiguous shared-root bindings for explicit multi-agent configs", async () => {
+    const fixture = await createBindingMigrationFixture({
+      legacySharedRoot: true,
+      name: "explicit-owner",
+      sessionIndex: {
+        legacy: {
+          sessionId: "explicit-owner",
+          sessionFile: "explicit-owner.jsonl",
+          updatedAt: 1,
+        },
+      },
+      threadId: "thread-explicit-owner",
+    });
+    const params = {
+      ...fixture.params,
+      config: {
+        agents: { ownership: "explicit" as const, entries: { main: {}, ops: {} } },
+      },
+    };
+
+    await expect(fixture.migration.detectLegacyState(params)).resolves.toMatchObject({
+      preview: [expect.stringContaining("legacy sidecar")],
+    });
+    const result = await fixture.migration.migrateLegacyState(params);
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("session ownership is indeterminate"),
+    ]);
+    await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).rejects.toThrow();
+    await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
+
+  it("keeps an agent-scoped shared-root binding with its explicit owner", async () => {
+    const sessionKey = "agent:ops:legacy";
+    const fixture = await createBindingMigrationFixture({
+      legacySharedRoot: true,
+      name: "explicit-ops-owner",
+      sessionIndex: {
+        [sessionKey]: {
+          sessionId: "explicit-ops-owner",
+          sessionFile: "explicit-ops-owner.jsonl",
+          updatedAt: 1,
+        },
+      },
+      threadId: "thread-explicit-ops-owner",
+    });
+    const params = {
+      ...fixture.params,
+      config: {
+        agents: { ownership: "explicit" as const, entries: { main: {}, ops: {} } },
+      },
+    };
+
+    await expect(fixture.migration.migrateLegacyState(params)).resolves.toMatchObject({
+      changes: [expect.stringContaining("Migrated 1")],
+      warnings: [],
+    });
+    await expect(
+      openBindingStore(fixture.env).lookup(
+        bindingStoreKey({
+          kind: "session",
+          agentId: "ops",
+          sessionId: "explicit-ops-owner",
+          sessionKey,
+        }),
+      ),
+    ).resolves.toMatchObject({ sessionId: "explicit-ops-owner" });
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
 
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -101,7 +101,12 @@ async function collectSessionSurfaces(params: MigrationEnvironment): Promise<Ses
   const { resolveStorePath } = await import("openclaw/plugin-sdk/session-store-runtime");
   const surfaces = new Map<string, SessionSurface>();
   const stateRoot = await canonicalPathFromExistingAncestor(params.stateDir);
-  const add = async (root: string, storePath: string, agentId: string, scan: boolean) => {
+  const add = async (
+    root: string,
+    storePath: string,
+    agentId: string | undefined,
+    scan: boolean,
+  ) => {
     const canonicalRoot = await canonicalPathFromExistingAncestor(root);
     const surface = surfaces.get(canonicalRoot) ?? {
       root: canonicalRoot,
@@ -113,7 +118,9 @@ async function collectSessionSurfaces(params: MigrationEnvironment): Promise<Ses
     // A store's configured path defines how relative sessionFile locators are
     // resolved. Keep it intact; canonicalize only when deduplicating aliases.
     surface.storePaths.add(path.resolve(storePath));
-    surface.agentIds.add(agentId);
+    if (agentId) {
+      surface.agentIds.add(agentId);
+    }
     surfaces.set(canonicalRoot, surface);
   };
 
@@ -147,8 +154,11 @@ async function collectSessionSurfaces(params: MigrationEnvironment): Promise<Ses
   }
 
   const legacyRoot = path.join(params.stateDir, "sessions");
-  const defaultAgentId = resolveSessionAgentIds({ config: params.config }).defaultAgentId;
-  await add(legacyRoot, path.join(legacyRoot, "sessions.json"), defaultAgentId, true);
+  const legacyOwner = tryResolveLegacyBindingOwnerAgentId({
+    sessionKey: "",
+    config: params.config,
+  });
+  await add(legacyRoot, path.join(legacyRoot, "sessions.json"), legacyOwner, true);
   return [...surfaces.values()].toSorted((a, b) => a.root.localeCompare(b.root));
 }
 
@@ -336,11 +346,15 @@ async function collectBindingOwners(
     const sessionsDir = path.dirname(storePath);
     for (const { sessionKey, entry } of index.entries) {
       const sessionId = entry.sessionId;
-      const agentId = resolveLegacyBindingOwnerAgentId({
+      const agentId = tryResolveLegacyBindingOwnerAgentId({
         sessionKey,
         config: params.config,
         storeAgentIds: storeAgentIds.get(storePath),
       });
+      if (!agentId) {
+        failures.push(`session index ${storePath} has an ambiguous owner for ${sessionKey}`);
+        continue;
+      }
       let legacyTranscriptPath: string;
       let canonicalLegacyTranscriptPath: string;
       try {
@@ -426,6 +440,19 @@ function resolveLegacyBindingOwnerAgentId(params: {
     config: params.config,
     ...(storeAgentId ? { agentId: storeAgentId } : {}),
   }).sessionAgentId;
+}
+
+function tryResolveLegacyBindingOwnerAgentId(
+  params: Parameters<typeof resolveLegacyBindingOwnerAgentId>[0],
+): string | undefined {
+  try {
+    return resolveLegacyBindingOwnerAgentId(params);
+  } catch (error) {
+    if ((error as { code?: unknown }).code === "AGENT_SELECTION_REQUIRED") {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 function copyBindingForSession(stored: MigratedBindingRow, sessionId: string): MigratedBindingRow {


### PR DESCRIPTION
Closes #123326

AI-assisted: yes

## What Problem This Solves

Fixes an issue where an explicit multi-agent installation could enter a supervised Gateway crash loop while the bundled Codex plugin checked for legacy app-server thread-binding state. The migration required an implicit default agent before it scanned the legacy shared sessions root, even when no sidecar existed. Molty reproduced this on every restart and never opened its Gateway listener.

## Why This Change Was Made

Legacy shared-root discovery is now owner-neutral. Agent-scoped keys still resolve to their exact configured agent, while genuinely ambiguous bare legacy keys are retained with a migration warning rather than assigned to an invented owner. The fix remains inside the Codex plugin's doctor/migration boundary and does not alter runtime session routing, config, protocol, or SQLite schema.

## User Impact

Explicit multi-agent Gateways can start normally when Codex has no legacy sidecars to migrate. Existing agent-scoped sidecars remain migratable, and ambiguous bare legacy state remains preserved for operator-guided repair instead of being silently reassigned.

## Evidence

- Production reproduction: Molty reached more than 798 systemd restarts with no listener. Its clean source and build stamps matched `0926d56cbf90a8f50d0f0e2b36b5fd4af9e2be44`; startup failed with `AgentSelectionRequiredError` while detecting Codex app-server thread bindings.
- Read-only production inspection found zero Codex legacy sidecars, confirming the crash occurred before discovery.
- Pre-fix regression proof: `preserves ambiguous shared-root bindings for explicit multi-agent configs` failed with the exact `AGENT_SELECTION_REQUIRED` exception.
- Focused test: `node scripts/run-vitest.mjs extensions/codex/doctor-contract-api.test.ts` — 29/29 passed.
- Full changed gate passed: doctor contract closure/declaration tests, extension/test typechecks, targeted lint, database-first storage guard, runtime sidecar loader guard, and import-cycle check.
- Structured autoreview: clean, no accepted/actionable findings.
- Production LOC: +27 net; test LOC: +79 net.
- No UI or visual surface changed, so screenshots are not applicable. Live Molty startup/channel/model proof will follow immediately after merge and deployment.
