### PR TITLE
fix: keep search icon size check stable across browsers

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -759,9 +759,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       });
       expect(icons).toHaveLength(2);
       for (const icon of icons) {
-        const box = await icon.boundingBox();
-        expect(box?.width).toBe(16);
-        expect(box?.height).toBe(16);
+        const size = await icon.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { height: style.height, width: style.width };
+        });
+        expect(size).toEqual({ height: "16px", width: "16px" });
       }
       await input.focus();
       const outline = await input.evaluate((element) => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI failure where Chromium reported a 16px transcript-search icon as `16.000001907348633` device-space pixels. The exact equality assertion failed even though the rendered CSS contract remained 16px.

## Why This Change Was Made

The test now reads the browser's computed CSS width and height, which is the owner boundary for this layout contract, and asserts both remain exactly `16px`. This avoids treating harmless floating-point conversion in Playwright's bounding-box projection as a product regression without relaxing the icon-size requirement.

## User Impact

No product behavior changes. CI continues to enforce compact 16px search icons consistently across browser rendering environments.

## Evidence

- Before: [exact-main CI run 31746060261](https://github.com/openclaw/openclaw/actions/runs/31746060261) failed `keeps transcript search icons compact` because Playwright returned `16.000001907348633` for the 16px height.
- Focused regression: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t 'keeps transcript search icons compact'` — 1 passed.
- Sibling coverage: full `chat-responsive.browser.test.ts` — 86 passed.
- Changed-file formatting, oxlint, and `git diff --check` passed.
- Autoreview reported no actionable findings.

Production LOC: +0/-0 | Tests: +5/-3
