### PR TITLE
fix(gateway): incognito session reset leaves other clients in a deleted chat pane

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -193,9 +193,11 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     }
     if ("incognitoDeleted" in result) {
       respond(true, { ok: true, key: result.key, deleted: true }, undefined);
+      // The session is gone, not reset: clients drop rows and navigate away
+      // only on "delete" (a non-delete reason merges a rowless no-op event).
       emitSessionsChanged(context, {
         sessionKey: result.key,
-        reason,
+        reason: "delete",
       });
       return;
     }

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -550,6 +550,32 @@ test("sessions.reset emits inferred selected global agent scope", async () => {
   });
 });
 
+test("sessions.reset of an incognito session broadcasts a delete, not a reset", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      "incognito-chat": sessionStoreEntry("sess-incognito", { incognito: true }),
+    },
+  });
+  const broadcast = vi.fn();
+  const reset = await directSessionReq<{ ok: true; key: string; deleted?: boolean }>(
+    "sessions.reset",
+    { key: "incognito-chat", reason: "reset" },
+    {
+      context: {
+        broadcastToConnIds: broadcast,
+        getSessionEventSubscriberConnIds: () => new Set(["conn-incognito"]),
+      },
+    },
+  );
+
+  expect(reset.ok).toBe(true);
+  expect(reset.payload?.deleted).toBe(true);
+  // The row is gone; only reason "delete" makes clients drop it and navigate away.
+  expect(broadcast.mock.calls[0]?.[0]).toBe("sessions.changed");
+  expect(broadcast.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ reason: "delete" }));
+});
+
 test("sessions.reset emits enriched session_end and session_start hooks", async () => {
   await createSessionStoreDir();
   await writeMainTranscriptSession({


### PR DESCRIPTION
## What Problem This Solves

Resetting an incognito session actually deletes it — `performGatewaySessionReset` runs the delete lifecycle and the RPC responds `{deleted: true}` — but the `sessions.reset` handler broadcast `sessions.changed` with the original `"reset"`/`"new"` reason (src/gateway/server-methods/sessions-mutations.ts). Clients remove rows and navigate away only on `reason: "delete"` (ui/src/lib/sessions/reconcile.ts:353-374 populates `deletedSessions`, which drives navigation in app-shell-navigation.ts). With a non-delete reason, `broadcastSessionsChanged` loads the now-deleted row, gets null, and emits a rowless event that merges as a no-op: another tab viewing the incognito session dead-ends in a deleted chat pane, and the sidebar row lingers on every other client until an unrelated refresh.

## Why This Change Was Made

The event must state what actually happened. `sessions.delete` already broadcasts `reason: "delete"` for the same terminal state; the incognito branch of reset reaches the identical outcome through a different door and must speak the same word. One-word fix at the broadcast site plus the invariant comment.

## User Impact

Deleting an incognito session via reset now clears it from all connected clients immediately and navigates viewers away, matching regular delete.

## Evidence

- Regression fails pre-fix, passes post-fix (`git stash` verified): incognito entry + `sessions.reset` must broadcast `sessions.changed` with `reason: "delete"` (pre-fix: `"reset"`).
- Focused suites green: `node scripts/run-vitest.mjs run src/gateway/server.sessions.reset-hooks.test.ts src/gateway/server-methods/sessions-mutations` (23 + suite tests).
- Core test typecheck green: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`.
- Autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC: +3/−1 (2 comment lines; code delta +1/−1). Tests +26.
