### PR TITLE
fix(gateway): first-use session category leaves group catalogs stale on all clients

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -130,12 +130,16 @@ function client(scopes: string[]): GatewayClient {
   };
 }
 
-async function patchSession(params: Record<string, unknown>, scopes = ["operator.admin"]) {
+async function patchSession(
+  params: Record<string, unknown>,
+  scopes = ["operator.admin"],
+  requestContext = context(),
+) {
   const responses: Parameters<RespondFn>[] = [];
   await sessionMutationHandlers["sessions.patch"]?.({
     params,
     client: client(scopes),
-    context: context(),
+    context: requestContext,
     respond: (...response: Parameters<RespondFn>) => responses.push(response),
   } as never);
   expect(responses).toHaveLength(1);
@@ -183,6 +187,47 @@ describe("sessions.patch sticky model persistence", () => {
       await vi.waitFor(() => expect(effects.mutateConfigFileWithRetry).toHaveBeenCalledOnce());
     },
   );
+
+  it("emits a groups invalidation when a patch first registers a category", async () => {
+    const sessionKey = "agent:main:dm:category-groups";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-category-groups", updatedAt: 1 },
+    );
+    const broadcast = vi.fn();
+    const subscribedContext = {
+      ...context(),
+      broadcastToConnIds: broadcast,
+      getSessionEventSubscriberConnIds: () => new Set(["conn-groups"]),
+    } as unknown as GatewayRequestContext;
+
+    const first = await patchSession(
+      { key: sessionKey, category: "Fresh Category" },
+      ["operator.admin"],
+      subscribedContext,
+    );
+    expect(first[0]).toBe(true);
+    const groupsEvents = broadcast.mock.calls.filter(
+      (call) =>
+        call[0] === "sessions.changed" && (call[1] as { reason?: string }).reason === "groups",
+    );
+    expect(groupsEvents).toHaveLength(1);
+
+    // Re-assigning an already-registered category is not a catalog mutation.
+    broadcast.mockClear();
+    const second = await patchSession(
+      { key: sessionKey, category: "Fresh Category" },
+      ["operator.admin"],
+      subscribedContext,
+    );
+    expect(second[0]).toBe(true);
+    expect(
+      broadcast.mock.calls.filter(
+        (call) =>
+          call[0] === "sessions.changed" && (call[1] as { reason?: string }).reason === "groups",
+      ),
+    ).toHaveLength(0);
+  });
 
   it("keeps a write-scoped model switch session-only without persisting the configured default", async () => {
     const sessionKey = "agent:main:dm:non-admin";

--- a/src/gateway/server-methods/sessions-patch-engine.ts
+++ b/src/gateway/server-methods/sessions-patch-engine.ts
@@ -584,7 +584,11 @@ async function executeSessionPatchMutations(params: {
 
   const category = params.patch.category;
   if (patched && typeof category === "string" && category.trim()) {
-    ensureSessionGroupRegistered(category);
+    // A first-use category is a group-catalog mutation: clients reload the
+    // catalog only on reason "groups" (the sessions.groups.* siblings emit it).
+    if (ensureSessionGroupRegistered(category)) {
+      emitSessionsChanged(params.context, { reason: "groups" });
+    }
   }
   if (callerCanManageCron && archivedSessionKeys.size > 0) {
     try {

--- a/src/gateway/session-groups.ts
+++ b/src/gateway/session-groups.ts
@@ -186,11 +186,12 @@ export function putSessionGroups(
 export function ensureSessionGroupRegistered(
   name: string,
   env: NodeJS.ProcessEnv = process.env,
-): void {
+): boolean {
   const normalized = normalizeOptionalString(name);
   if (!normalized) {
-    return;
+    return false;
   }
+  let inserted = false;
   runOpenClawStateWriteTransaction(
     ({ db }) => {
       const kysely = kyselyFor(db);
@@ -201,6 +202,7 @@ export function ensureSessionGroupRegistered(
       if (existing) {
         return;
       }
+      inserted = true;
       const maxRow = executeSqliteQuerySync(
         db,
         kysely.selectFrom("session_groups").select("position").orderBy("position", "desc").limit(1),
@@ -216,6 +218,7 @@ export function ensureSessionGroupRegistered(
     },
     { env },
   );
+  return inserted;
 }
 
 function renameCatalogEntry(from: string, to: string, env: NodeJS.ProcessEnv): void {


### PR DESCRIPTION
## What Problem This Solves

Assigning a session category via `sessions.patch` registers the group in the SQLite catalog (`ensureSessionGroupRegistered`, src/gateway/session-groups.ts) but broadcasts only the per-row `reason: "patch"` event. Clients invalidate and reload the group catalog exclusively on `sessions.changed {reason: "groups"}` — the contract every `sessions.groups.*` handler honors (sessions-groups.ts:45,67,94; consumer at ui/src/lib/sessions/index.ts:427-429).

Consequence: after a CLI- or agent-driven category assignment, connected Control UI clients keep a stale `state.groups`. The section renders only while a live row still carries the category; once the last member is archived or deleted, the group silently vanishes from sidebars while `sessions.groups.list` still returns it — until a page reload.

## Why This Change Was Made

Record facts where they happen: the catalog write knows whether it inserted. `ensureSessionGroupRegistered` now returns that fact, and the single caller emits the `groups` invalidation exactly when a first-use category actually mutates the catalog — repeated assignments of an existing category stay silent, matching the siblings' semantics.

## User Impact

Custom session groups created implicitly through category assignment now appear in (and survive in) every connected client's sidebar without a reload.

## Evidence

- Regression fails pre-fix, passes post-fix (`git stash` verified): first-use category via the sessions.patch handler must broadcast exactly one `reason: "groups"` event; re-assigning the registered category must broadcast none.
- Sibling suites green: `node scripts/run-vitest.mjs run src/gateway/sessions-patch.test.ts src/gateway/session-groups` + the sticky-model handler suite (8 tests).
- Core test typecheck green: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`.
- Autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.98)".
- Production LOC: +10/−3 (2 comment lines). Tests +47/−2.
