### PR TITLE
fix: cloud worker turns fail after dispatch

### DIFF
--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -1,8 +1,10 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  WorkerConnectRequestFrameSchema,
   WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE,
   WORKER_LAUNCH_V2_PROTOCOL_FEATURE,
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
@@ -52,6 +54,7 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import {
+  buildWorkerConnectParams,
   parseWorkerLaunchDescriptor,
   type WorkerLaunchDescriptor,
 } from "../../worker/launch-descriptor.js";
@@ -290,6 +293,7 @@ describe("worker turn launcher", () => {
         bundleHash: BUNDLE_HASH,
         openclawVersion: "2026.7.2",
         protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+        installKind: "bundle",
       },
       ownerEpoch: OWNER_EPOCH,
       teardownTerminalState: null,
@@ -683,7 +687,7 @@ describe("worker turn launcher", () => {
     expect(placements.get(SESSION_ID)).toMatchObject({ state: "active", turnClaim: null });
   });
 
-  it("carries a non-main placement identity while reporting keep-local conflicts", async () => {
+  it("round-trips the stored bootstrap receipt while reporting keep-local conflicts", async () => {
     let admissionWork: ExecutionIdentityAdmissionWork | undefined;
     cleanupAdmissionSink = configureExecutionIdentityAdmissionSink((work) => {
       admissionWork = work;
@@ -768,6 +772,18 @@ describe("worker turn launcher", () => {
           owner: "worker",
           runId: "run-worker-turn",
           ownerEpoch: OWNER_EPOCH,
+        });
+        const connectFrame = {
+          type: "req" as const,
+          id: "launch-validation",
+          method: "connect" as const,
+          params: buildWorkerConnectParams(request.descriptor),
+        };
+        expect(Value.Check(WorkerConnectRequestFrameSchema, connectFrame)).toBe(true);
+        expect(request.descriptor.admission.handshake).toEqual({
+          bundleHash: BUNDLE_HASH,
+          openclawVersion: "2026.7.2",
+          protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
         });
         descriptor = parseWorkerLaunchDescriptor(structuredClone(request.descriptor));
         expect(request.timeoutMs).toBe(5_000);

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -179,17 +179,19 @@ async function executeWorkerTurn(params: {
   const { placement, turn } = params;
   const modelRef = assertSupportedTurn(turn);
   const environment = params.environments.get(placement.environmentId);
+  const bootstrapReceipt = environment?.bootstrapReceipt;
   if (
     !environment ||
     environment.state !== "attached" ||
     environment.ownerEpoch !== placement.activeOwnerEpoch ||
-    environment.bootstrapReceipt?.bundleHash !== placement.workerBundleHash ||
+    !bootstrapReceipt ||
+    bootstrapReceipt.bundleHash !== placement.workerBundleHash ||
     environment.attachedSessionIds.length !== 1 ||
     environment.attachedSessionIds[0] !== placement.sessionId
   ) {
     throw new Error("Active worker placement does not match its attached environment");
   }
-  if (!supportsWorkerExecutionContextLaunch(environment.bootstrapReceipt)) {
+  if (!supportsWorkerExecutionContextLaunch(bootstrapReceipt)) {
     throw new Error(
       "Active worker bundle lacks the current execution-context capability; reprovision the worker before launch",
     );
@@ -319,6 +321,8 @@ async function executeWorkerTurn(params: {
     turn,
     turnClaim: params.turnClaim,
   });
+  // Project the wire handshake; the receipt also carries storage-only provenance.
+  const { bundleHash, openclawVersion, protocolFeatures } = bootstrapReceipt;
   const launchPlan = await fitLaunchDescriptorWithRuntimeIdentity({
     runtimeIdentity,
     messages: initialMessages,
@@ -332,7 +336,7 @@ async function executeWorkerTurn(params: {
           sessionId: placement.sessionId,
           ownerEpoch: placement.activeOwnerEpoch,
           rpcSetVersion: credential.rpcSetVersion,
-          handshake: environment.bootstrapReceipt,
+          handshake: { bundleHash, openclawVersion, protocolFeatures },
         },
         assignment: {
           agentId: placement.agentId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users dispatching a session to the default static-SSH cloud-worker path would see the placement become active, but every subsequent turn failed immediately with `Error: invalid worker launch descriptor`.

## Why This Change Was Made

The worker environment receipt now carries storage-only `installKind` provenance. The Gateway launch builder passed that richer stored receipt directly into the closed worker admission handshake, so `WorkerConnectRequestFrameSchema` rejected the extra field. This change projects only the three wire-contract fields (`bundleHash`, `openclawVersion`, and `protocolFeatures`) at the Gateway boundary; the parser remains strict and no compatibility path is added.

The launcher boundary test now uses a real persisted receipt with `installKind: "bundle"`, validates the generated connect frame, and reparses the real launch descriptor. This covers changes to both the Gateway builder and worker parser.

## User Impact

Cloud-worker turns on current `main` were completely broken after dispatch. The public-ingress and direct-connection work in #122578 and #122683 established the closed v3 launch contract; #122966 then added the storage-only receipt field that exposed the builder leak. After this fix, static-SSH placements can execute turns normally again.

## Evidence

Pre-fix live reproduction against the existing dev Gateway (four active localbox placements):

```text
session[1] Error: invalid worker launch descriptor
session[2] Error: invalid worker launch descriptor
session[3] Error: invalid worker launch descriptor
session[4] Error: invalid worker launch descriptor
```

Clause isolation:

```text
endpoint:true
withoutProvenance:true
withProvenance:false
parserWithoutProvenance:true
parserWithProvenance:false
```

Focused regression proof:

```text
$ node scripts/run-vitest.mjs src/worker/launch-descriptor.test.ts src/gateway/worker-environments/worker-turn-payload.test.ts src/gateway/worker-environments/worker-turn-launcher.test.ts
Test Files  3 passed (3)
Tests       58 passed (58)
```

Static/build proof:

```text
$ node scripts/run-oxlint.mjs src/gateway/worker-environments/worker-turn-launcher.ts src/gateway/worker-environments/worker-turn-launcher.test.ts
exit 0
$ node --import tsx scripts/build-all.mts
exit 0
$ git diff --check
exit 0
```

Live fixed-dist proof used a fresh state database, an isolated Gateway port, channels disabled, and the copied `localbox` profile:

```text
$ gateway call sessions.create …
{"ok":true}
$ gateway call sessions.dispatch …
{"ok":true,"state":"active"}
$ openclaw agent --session-key <redacted> --message "reply ok"
ok
$ gateway call sessions.reclaim …
{"ok":true,"state":"reclaimed"}
```

Autoreview: clean, no accepted or actionable findings. AI-assisted: yes.
