### PR TITLE
fix(release): preserve upgrade diagnostic probe

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -72,6 +72,8 @@ update_restart_seconds=""
 BASELINE_INSTALL_LOG="$ARTIFACT_ROOT/baseline-install.log"
 UPDATE_JSON="$ARTIFACT_ROOT/update.json"
 UPDATE_ERR="$ARTIFACT_ROOT/update.err"
+POST_UPDATE_VALIDATE_JSON="$ARTIFACT_ROOT/post-update-validate.json"
+POST_UPDATE_VALIDATE_ERR="$ARTIFACT_ROOT/post-update-validate.err"
 DOCTOR_LOG="$ARTIFACT_ROOT/doctor.log"
 BASELINE_DOCTOR_LOG="$ARTIFACT_ROOT/baseline-doctor.log"
 GATEWAY_LOG="$ARTIFACT_ROOT/gateway.log"
@@ -1386,11 +1388,18 @@ update_candidate() {
   if [ "$ROOT_MANAGED_VPS" != "1" ]; then
     update_env+=(OPENCLAW_ALLOW_ROOT=1)
   fi
-  if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" "${update_env[@]}" openclaw "${update_args[@]}" >"$UPDATE_JSON" 2>"$UPDATE_ERR"; then
+  local update_status=0
+  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" "${update_env[@]}" openclaw "${update_args[@]}" >"$UPDATE_JSON" 2>"$UPDATE_ERR" || update_status=$?
+  if [ "$update_status" -ne 0 ]; then
     echo "openclaw update failed" >&2
-    openclaw_e2e_print_log "$UPDATE_ERR" >&2
-    openclaw_e2e_print_log "$UPDATE_JSON" >&2
-    return 1
+    local validate_status=0
+    openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw config validate --json >"$POST_UPDATE_VALIDATE_JSON" 2>"$POST_UPDATE_VALIDATE_ERR" || validate_status=$?
+    echo "post-update config validation probe status=$validate_status" >&2
+    openclaw_e2e_print_log "$POST_UPDATE_VALIDATE_ERR" >&2 || true
+    openclaw_e2e_print_log "$POST_UPDATE_VALIDATE_JSON" >&2 || true
+    openclaw_e2e_print_log "$UPDATE_ERR" >&2 || true
+    openclaw_e2e_print_log "$UPDATE_JSON" >&2 || true
+    return "$update_status"
   fi
   if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
     update_end="$(node -e "process.stdout.write(String(Date.now()))")"

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -465,11 +465,13 @@ update_status=$?
 set -e
 if [ "$update_status" -ne 0 ]; then
   echo "openclaw update failed" >&2
-  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.err >&2
-  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json >&2
-  openclaw_e2e_maybe_timeout "$command_timeout" openclaw config validate --json >/tmp/openclaw-upgrade-survivor-post-update-validate.json 2>/tmp/openclaw-upgrade-survivor-post-update-validate.err || true
-  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.err >&2
-  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.json >&2
+  validate_status=0
+  openclaw_e2e_maybe_timeout "$command_timeout" openclaw config validate --json >/tmp/openclaw-upgrade-survivor-post-update-validate.json 2>/tmp/openclaw-upgrade-survivor-post-update-validate.err || validate_status=$?
+  echo "post-update config validation probe status=$validate_status" >&2
+  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.err >&2 || true
+  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.json >&2 || true
+  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.err >&2 || true
+  openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json >&2 || true
   exit "$update_status"
 fi
 if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3297,7 +3297,7 @@ if (starts === 1) {
       "update_status=$?",
       'if [ "$update_status" -ne 0 ]; then',
       'echo "openclaw update failed" >&2',
-      'openclaw config validate --json >/tmp/openclaw-upgrade-survivor-post-update-validate.json',
+      "openclaw config validate --json >/tmp/openclaw-upgrade-survivor-post-update-validate.json",
       'echo "post-update config validation probe status=$validate_status" >&2',
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.err >&2 || true",
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.json >&2 || true",
@@ -3306,7 +3306,7 @@ if (starts === 1) {
       'exit "$update_status"',
     ]);
     expectTextToIncludeInOrder(publishedRunner, [
-      'local update_status=0',
+      "local update_status=0",
       'openclaw "${update_args[@]}" >"$UPDATE_JSON" 2>"$UPDATE_ERR" || update_status=$?',
       'if [ "$update_status" -ne 0 ]; then',
       'echo "openclaw update failed" >&2',

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -185,6 +185,15 @@ function expectTextToIncludeAll(text: string, snippets: readonly string[]): void
   }
 }
 
+function expectTextToIncludeInOrder(text: string, snippets: readonly string[]): void {
+  let offset = 0;
+  for (const snippet of snippets) {
+    const index = text.indexOf(snippet, offset);
+    expect(index).toBeGreaterThanOrEqual(offset);
+    offset = index + snippet.length;
+  }
+}
+
 function extractUpgradeSurvivorSupervisor(script: string): string {
   const match = script.match(
     /cat >"\$supervisor_script" <<'SUPERVISOR'\n(?<source>[\s\S]*?)\nSUPERVISOR/u,
@@ -3283,6 +3292,32 @@ if (starts === 1) {
   it("bounds upgrade survivor failure log diagnostics", () => {
     const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
     const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+
+    expectTextToIncludeInOrder(runner, [
+      "update_status=$?",
+      'if [ "$update_status" -ne 0 ]; then',
+      'echo "openclaw update failed" >&2',
+      'openclaw config validate --json >/tmp/openclaw-upgrade-survivor-post-update-validate.json',
+      'echo "post-update config validation probe status=$validate_status" >&2',
+      "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.err >&2 || true",
+      "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-post-update-validate.json >&2 || true",
+      "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.err >&2 || true",
+      "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json >&2 || true",
+      'exit "$update_status"',
+    ]);
+    expectTextToIncludeInOrder(publishedRunner, [
+      'local update_status=0',
+      'openclaw "${update_args[@]}" >"$UPDATE_JSON" 2>"$UPDATE_ERR" || update_status=$?',
+      'if [ "$update_status" -ne 0 ]; then',
+      'echo "openclaw update failed" >&2',
+      'openclaw config validate --json >"$POST_UPDATE_VALIDATE_JSON"',
+      'echo "post-update config validation probe status=$validate_status" >&2',
+      'openclaw_e2e_print_log "$POST_UPDATE_VALIDATE_ERR" >&2 || true',
+      'openclaw_e2e_print_log "$POST_UPDATE_VALIDATE_JSON" >&2 || true',
+      'openclaw_e2e_print_log "$UPDATE_ERR" >&2 || true',
+      'openclaw_e2e_print_log "$UPDATE_JSON" >&2 || true',
+      'return "$update_status"',
+    ]);
 
     expectTextToIncludeAll(runner, [
       "openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.err",

--- a/test/vitest/vitest.bundled.config.ts
+++ b/test/vitest/vitest.bundled.config.ts
@@ -30,8 +30,12 @@ const bundledUnitExcludePatterns = unitTestAdditionalExcludePatterns.filter(
     ),
 );
 
-export default createUnitVitestConfigWithOptions(process.env, {
-  includePatterns: bundledPluginDependentUnitTestFiles,
-  extraExcludePatterns: bundledUnitExcludePatterns,
-  name: "bundled",
-});
+export function createBundledVitestConfig(env: Record<string, string | undefined> = process.env) {
+  return createUnitVitestConfigWithOptions(env, {
+    includePatterns: bundledPluginDependentUnitTestFiles,
+    extraExcludePatterns: bundledUnitExcludePatterns,
+    name: "bundled",
+  });
+}
+
+export default createBundledVitestConfig();

--- a/test/vitest/vitest.contracts-channel-config.config.ts
+++ b/test/vitest/vitest.contracts-channel-config.config.ts
@@ -4,11 +4,13 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(
-  channelConfigContractPatterns,
-  process.env,
-  process.argv,
-  {
+export function createContractsChannelConfigVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+  argv: string[] = process.argv,
+) {
+  return createContractsVitestConfig(channelConfigContractPatterns, env, argv, {
     name: "contracts-channel-config",
-  },
-);
+  });
+}
+
+export default createContractsChannelConfigVitestConfig();

--- a/test/vitest/vitest.contracts-channel-registry.config.ts
+++ b/test/vitest/vitest.contracts-channel-registry.config.ts
@@ -4,11 +4,13 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(
-  channelRegistryContractPatterns,
-  process.env,
-  process.argv,
-  {
+export function createContractsChannelRegistryVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+  argv: string[] = process.argv,
+) {
+  return createContractsVitestConfig(channelRegistryContractPatterns, env, argv, {
     name: "contracts-channel-registry",
-  },
-);
+  });
+}
+
+export default createContractsChannelRegistryVitestConfig();

--- a/test/vitest/vitest.contracts-channel-session.config.ts
+++ b/test/vitest/vitest.contracts-channel-session.config.ts
@@ -4,11 +4,13 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(
-  channelSessionContractPatterns,
-  process.env,
-  process.argv,
-  {
+export function createContractsChannelSessionVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+  argv: string[] = process.argv,
+) {
+  return createContractsVitestConfig(channelSessionContractPatterns, env, argv, {
     name: "contracts-channel-session",
-  },
-);
+  });
+}
+
+export default createContractsChannelSessionVitestConfig();

--- a/test/vitest/vitest.contracts-channel-surface.config.ts
+++ b/test/vitest/vitest.contracts-channel-surface.config.ts
@@ -4,11 +4,13 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(
-  channelSurfaceContractPatterns,
-  process.env,
-  process.argv,
-  {
+export function createContractsChannelSurfaceVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+  argv: string[] = process.argv,
+) {
+  return createContractsVitestConfig(channelSurfaceContractPatterns, env, argv, {
     name: "contracts-channel-surface",
-  },
-);
+  });
+}
+
+export default createContractsChannelSurfaceVitestConfig();

--- a/test/vitest/vitest.contracts-plugin.config.ts
+++ b/test/vitest/vitest.contracts-plugin.config.ts
@@ -1,6 +1,13 @@
 // Vitest contracts plugin config wires the contracts plugin test shard.
 import { createContractsVitestConfig, pluginContractPatterns } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(pluginContractPatterns, process.env, process.argv, {
-  name: "contracts-plugin",
-});
+export function createContractsPluginVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+  argv: string[] = process.argv,
+) {
+  return createContractsVitestConfig(pluginContractPatterns, env, argv, {
+    name: "contracts-plugin",
+  });
+}
+
+export default createContractsPluginVitestConfig();

--- a/ui/src/app/route-transition.test.ts
+++ b/ui/src/app/route-transition.test.ts
@@ -5,7 +5,10 @@ function testDocumentWithOutlet(animate = vi.fn()) {
   const outlet = document.createElement("openclaw-router-outlet") as HTMLElement & {
     updateComplete: Promise<void>;
   };
-  outlet.updateComplete = Promise.resolve();
+  Object.defineProperty(outlet, "updateComplete", {
+    configurable: true,
+    value: Promise.resolve(),
+  });
   outlet.animate = animate;
   document.body.append(outlet);
   return {


### PR DESCRIPTION
## What Problem This Solves

Signed r22 run https://github.com/openclaw/openclaw/actions/runs/31745739282 showed published/root upgrade lanes bypassed the outer diagnostic and silently collapsed the update status.

## Why This Change Was Made

Repair both survivor runners: probe first; print marker/status; emit bounded safe logs; preserve the original update status.

## User Impact

Release validation now exposes exact post-update config errors; successful upgrades are unchanged.

## Evidence

- `bash -n scripts/e2e/upgrade-survivor-docker.sh` — passed
- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh` — passed
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` — 194 focused tests passed
- `git diff --check origin/main...HEAD` — passed
- Fresh structured autoreview of `origin/main...HEAD` — clean, with no accepted/actionable findings

No changelog is needed because this is trusted release tooling/test support.
