### PR TITLE
fix: explicit agent ownership no longer breaks system surfaces

### DIFF
--- a/extensions/google-meet/src/runtime.owner-selection.test.ts
+++ b/extensions/google-meet/src/runtime.owner-selection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+import { meetRuntime } from "./test-support/fixtures.test-helpers.js";
+
+describe("Google Meet runtime owner selection", () => {
+  it("starts with an explicit realtime agent in a multi-agent config", () => {
+    const logger = { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() };
+
+    expect(() =>
+      meetRuntime({ realtime: { agentId: "work" } }, logger, {
+        agents: {
+          ownership: "explicit",
+          list: [{ id: "main" }, { id: "work" }],
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -94,7 +94,6 @@ const nowIso = () => new Date().toISOString();
 
 export class GoogleMeetRuntime {
   readonly #createdBrowserTabs = new Map<string, string>();
-  readonly #agentId: string;
   readonly #voiceCallGateway: VoiceCallGateway;
   readonly #sessions: GoogleMeetSessionRuntime;
 
@@ -107,7 +106,6 @@ export class GoogleMeetRuntime {
     },
   ) {
     const adapter = GOOGLE_MEET_PLATFORM_ADAPTER;
-    this.#agentId = resolveDefaultAgentId(params.fullConfig);
     this.#voiceCallGateway = createVoiceCallGateway(params);
     this.#sessions = new MeetingSessionRuntime({
       logger: params.logger,
@@ -146,9 +144,7 @@ export class GoogleMeetRuntime {
         url: adapter.urls.validateAndNormalize(request.url),
         transport: resolveTransport(request.transport, params.config),
         mode: resolveMode(request.mode, params.config),
-        agentId: normalizeAgentId(
-          request.agentId ?? params.config.realtime.agentId ?? this.#agentId,
-        ),
+        agentId: this.#resolveAgentId(request.agentId),
       }),
       createSession: ({ resolved, createdAt }): GoogleMeetSession =>
         createMeetingSession({ platform: adapter, config: params.config, resolved, createdAt }),
@@ -292,8 +288,7 @@ export class GoogleMeetRuntime {
   #probeContext(): GoogleMeetRuntimeProbeContext {
     return {
       config: this.params.config,
-      resolveAgentId: (request) =>
-        normalizeAgentId(request.agentId ?? this.params.config.realtime.agentId ?? this.#agentId),
+      resolveAgentId: (request) => this.#resolveAgentId(request.agentId),
       list: () => this.list(),
       join: async (request) => await this.join(request),
       isReusable: (session, resolved) => this.#sessions.isReusableSession(session, resolved),
@@ -301,6 +296,14 @@ export class GoogleMeetRuntime {
       refreshHealth: (sessionId) => this.#sessions.refreshHealth(sessionId),
       refreshCaptionHealth: async (session) => await this.#sessions.refreshCaptionHealth(session),
     };
+  }
+
+  #resolveAgentId(requestedAgentId?: string): string {
+    return normalizeAgentId(
+      requestedAgentId ??
+        this.params.config.realtime.agentId ??
+        resolveDefaultAgentId(this.params.fullConfig),
+    );
   }
 
   async #joinTransport(

--- a/extensions/google-meet/src/test-support/fixtures.test-helpers.ts
+++ b/extensions/google-meet/src/test-support/fixtures.test-helpers.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MeetingRealtimeAudioEngineHealth } from "openclaw/plugin-sdk/meeting-runtime";
 import { vi } from "vitest";
 import { resolveGoogleMeetConfig } from "../config.js";
@@ -195,10 +196,11 @@ export function meetAudioBridge(stop = vi.fn(async () => {})) {
 export function meetRuntime(
   config: Parameters<typeof resolveGoogleMeetConfig>[0],
   logger: ConstructorParameters<typeof GoogleMeetRuntime>[0]["logger"],
+  fullConfig: OpenClawConfig = {},
 ) {
   return new GoogleMeetRuntime({
     config: resolveGoogleMeetConfig(config),
-    fullConfig: {} as never,
+    fullConfig,
     runtime: {} as never,
     logger,
   });

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -22,11 +22,7 @@ import type {
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
 import { isModelSelectionLocked } from "../sessions/model-overrides.js";
 import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
-import {
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentDir,
-  resolveSessionAgentId,
-} from "./agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles/external-cli-auth-selection.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -739,7 +735,6 @@ export async function runBtwSideQuestion(
     config: params.cfg,
     agentId: requestedAgentId,
     agentDir: params.agentDir,
-    inheritedAuthDir: resolveDefaultAgentDir(params.cfg),
     workspaceDir: requestedWorkspaceDir,
     // Gateway-published owners are keyed with this flag, so a gateway-hosted
     // request that omits it can never match one.

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -102,6 +102,7 @@ export const resolveSessionAgentIdsMock = vi.fn(() => ({
   defaultAgentId: "main",
   sessionAgentId: "main",
 }));
+export const resolveDefaultAgentDirMock = vi.fn(() => "/tmp/agents/main/agent");
 export const estimateTokensMock = vi.fn((_message?: unknown) => 10);
 export const resolveAgentHarnessPolicyMock = vi.fn(() => ({ runtime: "openclaw" }));
 function createSelectedAgentHarnessMock(params: {
@@ -566,6 +567,8 @@ export function resetCompactHooksHarnessMocks(): void {
   hookRunner.runAfterCompaction.mockResolvedValue(undefined);
 
   acquireAgentRunPreparedModelRuntimeMock.mockClear();
+  resolveDefaultAgentDirMock.mockReset();
+  resolveDefaultAgentDirMock.mockReturnValue("/tmp/agents/main/agent");
   getCurrentPluginMetadataSnapshotMock.mockReset();
   getCurrentPluginMetadataSnapshotMock.mockReturnValue(emptyPluginMetadataSnapshot);
 
@@ -973,7 +976,7 @@ export async function loadCompactHooksHarness(): Promise<{
     resolveAgentConfig: vi.fn(() => undefined),
     resolveAgentDir: vi.fn((_cfg: unknown, agentId: string) => `/tmp/agents/${agentId}/agent`),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp"),
-    resolveDefaultAgentDir: vi.fn(() => "/tmp/agents/main/agent"),
+    resolveDefaultAgentDir: resolveDefaultAgentDirMock,
     resolveDefaultAgentId: vi.fn(() => "main"),
     resolveAgentIdFromSessionKey: vi.fn(
       (sessionKey: string) => sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main",

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -39,6 +39,7 @@ import {
   resolveProviderEntryApiKeyProfileReferenceMock,
   resolveContextWindowInfoMock,
   resolveContextEngineMock,
+  resolveDefaultAgentDirMock,
   resolveEffectiveCompactionModeMock,
   resolveEmbeddedAgentStreamFnMock,
   resolveMemorySearchConfigMock,
@@ -673,6 +674,40 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
 
     expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
       expect.objectContaining({ config: {}, workspaceDir: "/tmp/workspace" }),
+    );
+  });
+
+  it("does not require an implicit default owner for direct compaction", async () => {
+    resolveDefaultAgentDirMock.mockImplementation(() => {
+      throw new Error("ambiguous default agent");
+    });
+    resolveSessionAgentIdsMock.mockReturnValue({
+      defaultAgentId: "marie-clawndo",
+      sessionAgentId: "marie-clawndo",
+    });
+
+    const result = await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        agentId: "marie-clawndo",
+        config: {
+          agents: {
+            ownership: "explicit",
+            list: [{ id: "main" }, { id: "marie-clawndo" }],
+          },
+        },
+        sessionKey: "agent:marie-clawndo:dashboard:session-1",
+        sessionTarget: {
+          agentId: "marie-clawndo",
+          sessionId: TEST_SESSION_ID,
+          sessionKey: "agent:marie-clawndo:dashboard:session-1",
+          storePath: "/tmp/sessions.json",
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "marie-clawndo" }),
     );
   });
 
@@ -2502,6 +2537,40 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       preparedModelRuntime: snapshot,
       skipAgentDiscovery: true,
     });
+  });
+
+  it("does not require an implicit default owner for queued compaction", async () => {
+    resolveDefaultAgentDirMock.mockImplementation(() => {
+      throw new Error("ambiguous default agent");
+    });
+    resolveSessionAgentIdsMock.mockReturnValue({
+      defaultAgentId: "marie-clawndo",
+      sessionAgentId: "marie-clawndo",
+    });
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        agentId: "marie-clawndo",
+        config: {
+          agents: {
+            ownership: "explicit",
+            list: [{ id: "main" }, { id: "marie-clawndo" }],
+          },
+        },
+        sessionKey: "agent:marie-clawndo:dashboard:session-1",
+        sessionTarget: {
+          agentId: "marie-clawndo",
+          sessionId: TEST_SESSION_ID,
+          sessionKey: "agent:marie-clawndo:dashboard:session-1",
+          storePath: "/tmp/sessions.json",
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "marie-clawndo" }),
+    );
   });
 
   it("disposes the context engine once when route materialization rejects", async () => {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -23,7 +23,7 @@ import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generati
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { resolveUserPath } from "../../utils.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
-import { resolveAgentDir, resolveDefaultAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
+import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
 import { isRecoverableNativeHarnessBindingFailure } from "../harness/compaction-recovery.js";
 import { maybeCompactAgentHarnessSession } from "../harness/compaction.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
@@ -339,7 +339,6 @@ async function compactEmbeddedAgentSessionImpl(
     config: params.config ?? {},
     agentId: agentIds.sessionAgentId,
     agentDir,
-    inheritedAuthDir: resolveDefaultAgentDir(params.config ?? {}),
     workspaceDir: resolvedWorkspaceDir,
     ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
     runtimePluginSelections: [

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -10,7 +10,6 @@ import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentDir,
   resolveRunModelFallbacksOverride,
   resolveSessionAgentIds,
 } from "../agent-scope.js";
@@ -219,7 +218,6 @@ export async function compactEmbeddedAgentSessionDirect(
     config: requestedParams.config ?? {},
     agentId: requestedAgentIds.sessionAgentId,
     agentDir: requestedAgentDir,
-    inheritedAuthDir: resolveDefaultAgentDir(requestedParams.config ?? {}),
     workspaceDir: requestedWorkspaceDir,
     preserveWorkspaceDirOnRefresh: requestedWorkspaceDir !== canonicalWorkspaceDir,
     ...(requestedParams.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),

--- a/src/agents/embedded-agent-runner/model-resolution.ts
+++ b/src/agents/embedded-agent-runner/model-resolution.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveDefaultAgentDir } from "../agent-scope.js";
 import type { AuthProfileCredential } from "../auth-profiles/types.js";
 import {
   prepareModelRuntimeSnapshot,
@@ -67,7 +66,6 @@ export async function resolveTieredModel(params: {
     (await prepareModelRuntimeSnapshot({
       config,
       agentDir: params.agentDir,
-      inheritedAuthDir: resolveDefaultAgentDir(config),
       workspaceDir: params.workspaceDir,
     }));
   return (

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -15,12 +15,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { extractModelCompat } from "../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { normalizeProviderTransportWithPlugin } from "../plugins/provider-runtime.js";
-import {
-  resolveAgentDir,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentDir,
-  resolveSessionAgentId,
-} from "./agent-scope.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import { resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
 import { resolveModel, resolveModelAsync } from "./embedded-agent-runner/model.js";
@@ -295,7 +290,6 @@ export async function resolveEffectiveToolInventoryRuntimeModelContextAsync(
     agentId,
     agentDir,
     config: params.cfg,
-    inheritedAuthDir: resolveDefaultAgentDir(params.cfg),
     workspaceDir,
   });
   try {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -19,7 +19,6 @@ import {
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
 import { loadWebMediaRaw } from "../../media/web-media.js";
 import { resolveUserPath } from "../../utils.js";
-import { resolveDefaultAgentDir } from "../agent-scope.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { abortable } from "../embedded-agent-runner/run/abortable.js";
 import { applySecretRefHeaderSentinels } from "../model-auth.js";
@@ -175,7 +174,6 @@ async function runPdfPrompt(params: {
       agentDir: params.agentDir,
       ...(params.agentId ? { agentId: params.agentId } : {}),
       config: requestedCfg ?? {},
-      inheritedAuthDir: resolveDefaultAgentDir(requestedCfg ?? {}),
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     });
     try {

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -441,6 +441,44 @@ describe("handleCompactCommand", () => {
     );
   });
 
+  it("keeps the selected agent when compacting an ambiguous global session", async () => {
+    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+    });
+    resolveSessionAgentIdMock.mockReturnValue("marie-clawndo");
+    const cfg = {
+      agents: {
+        entries: {
+          main: {},
+          "marie-clawndo": {},
+        },
+      },
+    } as OpenClawConfig;
+
+    await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", cfg),
+        agentId: "marie-clawndo",
+        sessionKey: "global",
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+        },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(resolveSessionAgentIdMock).toHaveBeenCalledWith({
+      sessionKey: "global",
+      config: cfg,
+      agentId: "marie-clawndo",
+    });
+    expect(requireCompactEmbeddedAgentSessionCall().sessionTarget).toMatchObject({
+      agentId: "marie-clawndo",
+    });
+  });
+
   it("uses the resolved command store for compaction", async () => {
     vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
       ok: true,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -225,7 +225,11 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     }
   }
   const sessionAgentId = params.sessionKey
-    ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+    ? resolveSessionAgentId({
+        sessionKey: params.sessionKey,
+        config: params.cfg,
+        agentId: params.agentId,
+      })
     : (params.agentId ?? "main");
   const currentAgentId = params.agentId ?? "main";
   const sessionAgentDir =

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -239,10 +239,10 @@ describe("warnIfModelConfigLooksOff", () => {
 
     await warnIfModelConfigLooksOff(config, prompter);
 
-    expect(loadModelCatalog).toHaveBeenCalledWith(
-      expect.objectContaining({ config, inheritedAuthDir: expect.any(String) }),
-      { force: true, provenance: "explicit" },
-    );
+    expect(loadModelCatalog).toHaveBeenCalledWith(expect.objectContaining({ config }), {
+      force: true,
+      provenance: "explicit",
+    });
   });
 
   it("publishes validation catalogs for the selected agent", async () => {

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -185,7 +185,6 @@ export async function warnIfModelConfigLooksOff(
                 (options?.agentId
                   ? resolveAgentDir(config, options.agentId)
                   : resolveDefaultAgentDir(config)),
-              inheritedAuthDir: resolveDefaultAgentDir(config),
               workspaceDir: resolveAgentWorkspaceDir(config, validationAgentId),
             },
             { force: true, provenance: "explicit" },

--- a/src/commands/onboard-agent-target.ts
+++ b/src/commands/onboard-agent-target.ts
@@ -37,6 +37,11 @@ export function resolveOnboardingAgentTarget(
   };
 }
 
+/** Resolve the configured System Agent as the owner of onboarding effects. */
+export function resolveSystemAgentOnboardingTarget(config: OpenClawConfig): OnboardingAgentTarget {
+  return resolveOnboardingAgentTarget(config, config.agents?.defaults?.systemAgent?.agentId);
+}
+
 export async function ensureOnboardingAgentWorkspace(
   target: OnboardingAgentTarget,
   runtime: RuntimeEnv,

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -396,7 +396,6 @@ describe("worker inference provider runtime", () => {
     expect(runtime.acquireRuntimeLease).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "runtime-agent",
-        inheritedAuthDir: expect.any(String),
       }),
     );
     const [streamModel, streamContext, streamOptions] = runtime.stream.mock.calls[0] ?? [];

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -12,7 +12,6 @@ import {
   resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
@@ -397,7 +396,6 @@ async function resolveApprovedModel(params: {
     config,
     agentId: target.agentId,
     agentDir: resolveAgentDir(config, target.agentId),
-    inheritedAuthDir: resolveDefaultAgentDir(config),
   });
   const runtimeSnapshot = runtimeLease.snapshot;
   try {

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -1,5 +1,5 @@
 // Resolves image-capable model metadata and credential-bound runtime auth.
-import { resolveAgentWorkspaceDir, resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveModelAsync } from "../agents/embedded-agent-runner/model.js";
 import { isMinimaxVlmModel } from "../agents/minimax-vlm.js";
 import {
@@ -222,7 +222,6 @@ export async function resolveImageRuntime(
         agentDir: params.agentDir,
         ...(params.agentId ? { agentId: params.agentId } : {}),
         config: params.cfg ?? {},
-        inheritedAuthDir: resolveDefaultAgentDir(params.cfg ?? {}),
         ...(runtimeParams.workspaceDir ? { workspaceDir: runtimeParams.workspaceDir } : {}),
       });
   let leaseRetained = false;

--- a/src/system-agent/hosted-setup.runtime.ts
+++ b/src/system-agent/hosted-setup.runtime.ts
@@ -126,7 +126,7 @@ export async function runHostedSkillsSetup(
   beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
   runtime?: RuntimeEnv,
 ): Promise<HostedSetupCompletion> {
-  const [{ setupSkills }, { resolveOnboardingAgentTarget }] = await Promise.all([
+  const [{ setupSkills }, { resolveSystemAgentOnboardingTarget }] = await Promise.all([
     import("../commands/onboard-skills.js"),
     import("../commands/onboard-agent-target.js"),
   ]);
@@ -137,7 +137,7 @@ export async function runHostedSkillsSetup(
     run: async ({ baseConfig, runtime: setupRuntime }) => ({
       nextConfig: await setupSkills(
         baseConfig,
-        resolveOnboardingAgentTarget(baseConfig).workspaceDir,
+        resolveSystemAgentOnboardingTarget(baseConfig).workspaceDir,
         setupRuntime,
         prompter,
         { beforePersistentEffect: async () => await beforePersistentApply(setupRuntime) },
@@ -220,8 +220,8 @@ export async function runHostedMemoryImport(
   beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
   onProviderOutcome: (outcome: MemoryImportProviderOutcome) => void,
 ): Promise<HostedMemoryImportOutcome> {
-  const [{ resolveAgentWorkspaceDir, resolveDefaultAgentId }, { readSetupConfigFileSnapshot }] =
-    await Promise.all([import("../agents/agent-scope.js"), loadSetupShared()]);
+  const [{ readSetupConfigFileSnapshot }, { resolveSystemAgentOnboardingTarget }] =
+    await Promise.all([loadSetupShared(), import("../commands/onboard-agent-target.js")]);
   const snapshot = await readSetupConfigFileSnapshot();
   if (!snapshot.exists || !snapshot.valid || !snapshot.hash) {
     throw new Error(
@@ -230,8 +230,7 @@ export async function runHostedMemoryImport(
   }
   const baseHash = snapshot.hash;
   const config = snapshot.config;
-  const agentId = resolveDefaultAgentId(config);
-  const workspace = resolveAgentWorkspaceDir(config, agentId);
+  const { agentId, workspaceDir: workspace } = resolveSystemAgentOnboardingTarget(config);
   try {
     if (!(await stat(workspace)).isDirectory()) {
       return { status: "workspace-missing", providers: [], workspace };
@@ -248,6 +247,7 @@ export async function runHostedMemoryImport(
   const runtime = createHostedWizardRuntime(defaultRuntime);
   return await runSetupMemoryImportStep({
     config,
+    agentId,
     prompter,
     runtime,
     beforeApply: async () => {

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -1,4 +1,5 @@
 // Shared execution helpers keep the public dispatcher small and reviewable.
+import { tryResolveLegacyCompatibilityAgentId } from "../agents/agent-scope-config.js";
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import type { ConfigSetOptions } from "../cli/config-set-input.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -348,7 +349,6 @@ async function isDefaultAgentListPath(segments: readonly string[]): Promise<bool
     return true;
   }
   const { readConfigFileSnapshot } = await loadConfigModule();
-  const { resolveDefaultAgentId } = await import("../agents/agent-scope.js");
   const snapshot = await readConfigFileSnapshot();
   if (!snapshot.exists || !snapshot.valid) {
     return true;
@@ -360,8 +360,10 @@ async function isDefaultAgentListPath(segments: readonly string[]): Promise<bool
     // Unknown or id-less entry: cannot prove it is off the default route.
     return true;
   }
-  const defaultAgentId = resolveDefaultAgentId(config ?? {});
-  return normalizeAgentId(entry.id) === normalizeAgentId(defaultAgentId);
+  const defaultAgentId =
+    config?.agents?.defaults?.systemAgent?.agentId?.trim() ??
+    (config ? tryResolveLegacyCompatibilityAgentId(config) : undefined);
+  return !defaultAgentId || normalizeAgentId(entry.id) === normalizeAgentId(defaultAgentId);
 }
 
 export async function assertConfigWriteDoesNotBypassInferenceVerification(
@@ -562,11 +564,11 @@ export async function executeSetDefaultModel(
       const { applySystemAgentModelSelection, createSystemAgentModelSelectionUpdater } =
         await import("./setup-apply.js");
       const targetAgentId = operation.agentId;
+      const snapshot = await readConfigFileSnapshot();
       // Route projection and the live probes below all take the same optional
       // agent scope, so a per-agent selection is verified against that agent's
       // route with the exact rigor the default route gets.
       const projectRoute = (config: OpenClawConfig) => projectInferenceRoute(config, targetAgentId);
-      const snapshot = await readConfigFileSnapshot();
       const stagedConfig = await applySystemAgentModelSelection({
         config: snapshot.sourceConfig,
         model: operation.model,

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -824,11 +824,15 @@ describe("parseSystemAgentOperation", () => {
     expect(runConfigSet).not.toHaveBeenCalled();
   });
 
-  it("still blocks per-agent routing writes that hit the default agent", async () => {
+  it("still blocks per-agent routing writes that hit the system agent owner", async () => {
     const tempDir = opTempDirs.make("openclaw-default-agent-route-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     mockConfig.setConfig({
-      agents: { list: [{ id: "main", default: true }, { id: "helper" }] },
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        list: [{ id: "main" }, { id: "helper" }],
+      },
     });
     const { runtime } = createSystemAgentTestRuntime();
     const runConfigSet = vi.fn(async () => {});

--- a/src/system-agent/overview.test.ts
+++ b/src/system-agent/overview.test.ts
@@ -43,11 +43,12 @@ describe("loadSystemAgentOverview", () => {
   it("summarizes config, agents, model, tools, and gateway", async () => {
     const runtimeConfig: OpenClawConfig = {
       agents: {
-        defaults: { model: { primary: "openai/gpt-5.2" } },
-        list: [
-          { id: "main", default: true },
-          { id: "work", name: "Work" },
-        ],
+        ownership: "explicit",
+        defaults: {
+          model: { primary: "openai/gpt-5.2" },
+          systemAgent: { agentId: "main" },
+        },
+        list: [{ id: "main" }, { id: "work", name: "Work" }],
       },
       gateway: { port: 19001 },
     };

--- a/src/system-agent/overview.ts
+++ b/src/system-agent/overview.ts
@@ -1,9 +1,6 @@
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 // OpenClaw overview gathers config, agent, tool, docs, source, and gateway status.
-import {
-  listAgentEntries,
-  resolveAgentEffectiveModelPrimary,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+import { listAgentEntries, resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import {
   OPENCLAW_DOCS_URL,
   OPENCLAW_SOURCE_URL,
@@ -91,8 +88,7 @@ function issueMessages(snapshot: ConfigFileSnapshot): string[] {
   });
 }
 
-function buildAgentSummaries(cfg: OpenClawConfig): SystemAgentSummary[] {
-  const defaultAgentId = resolveDefaultAgentId(cfg);
+function buildAgentSummaries(cfg: OpenClawConfig, defaultAgentId: string): SystemAgentSummary[] {
   const entries = listAgentEntries(cfg);
   if (entries.length === 0) {
     return [
@@ -150,7 +146,7 @@ export async function loadSystemAgentOverview(
   const readSnapshot = deps.readConfigFileSnapshot ?? readConfigFileSnapshot;
   const snapshot = await readSnapshot();
   const cfg = snapshot.runtimeConfig ?? snapshot.sourceConfig ?? {};
-  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const defaultAgentId = resolveSystemAgentTargetAgentId(cfg);
   const defaultModel =
     resolveAgentEffectiveModelPrimary(cfg, defaultAgentId) ??
     resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model);
@@ -192,7 +188,7 @@ export async function loadSystemAgentOverview(
       issues: issueMessages(snapshot),
       hash: snapshot.hash ?? null,
     },
-    agents: buildAgentSummaries(cfg),
+    agents: buildAgentSummaries(cfg, defaultAgentId),
     defaultAgentId,
     defaultModel,
     tools: {

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -1,7 +1,7 @@
 // Applies OpenClaw's conversational setup: config, workspace files, gateway.
 import { isDeepStrictEqual } from "node:util";
 import { listAgentEntries, toAgentEntriesRecord } from "../agents/agent-scope-config.js";
-import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
+import { resolveSystemAgentOnboardingTarget as resolveSystemTarget } from "../commands/onboard-agent-target.js";
 import type { FirstOnboardingAgent } from "../commands/onboard-agent.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import {
@@ -339,7 +339,7 @@ export async function applySystemAgentSetup(
       expectedAgentDir: guardedExpectedAgentDir,
       expectedModelRef,
       resolveAgentDir: guardModules[0].resolveAgentDir,
-      resolveDefaultAgentId: guardModules[0].resolveDefaultAgentId,
+      resolveDefaultAgentId: (currentConfig) => resolveSystemTarget(currentConfig).agentId,
       resolveDefaultModelForAgent: guardModules[1].resolveDefaultModelForAgent,
     });
   };
@@ -494,9 +494,11 @@ export async function applySystemAgentSetup(
       preserveWorkspace,
     });
     if (model) {
+      const targetAgentId = candidate.agents?.defaults?.systemAgent?.agentId;
       candidate = await applySystemAgentModelSelection({
         config: candidate,
         model,
+        ...(targetAgentId ? { targetAgentId } : {}),
         ...(agentRuntimeId ? { agentRuntimeId } : {}),
         ...(authProfileId ? { authProfileId } : {}),
       });
@@ -567,7 +569,7 @@ export async function applySystemAgentSetup(
           if (assertCommitPreconditions) {
             assertCommitPreconditions(currentSnapshot.sourceConfig);
             if (
-              resolveUserPath(resolveOnboardingAgentTarget(finalizedConfig).workspaceDir) !==
+              resolveUserPath(resolveSystemTarget(finalizedConfig).workspaceDir) !==
               resolveUserPath(workspace)
             ) {
               throw new Error(
@@ -590,7 +592,7 @@ export async function applySystemAgentSetup(
   if (!settings) {
     throw new Error("OpenClaw setup committed without resolved Gateway settings.");
   }
-  const onboardingTarget = resolveOnboardingAgentTarget(nextConfig);
+  const onboardingTarget = resolveSystemTarget(nextConfig);
   const effectiveWorkspace = onboardingTarget.workspaceDir;
   if (verifiedRoute) {
     const afterRead = await readConfigFileSnapshotWithPluginMetadata();
@@ -646,8 +648,7 @@ export async function applySystemAgentSetup(
     }
   };
 
-  const { resolveDefaultAgentId } = await import("../agents/agent-scope.js");
-  const effectiveAgentId = resolveDefaultAgentId(nextConfig);
+  const effectiveAgentId = onboardingTarget.agentId;
   const workspaceResult = await runCommittedFollowUp(
     async () =>
       await onboardHelpers.ensureWorkspaceAndSessions(effectiveWorkspace, runtime, {

--- a/src/system-agent/setup-recovery.ts
+++ b/src/system-agent/setup-recovery.ts
@@ -1,5 +1,5 @@
 // Machine-local onboarding recovery owns receipt identity and completion validation.
-import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
+import { resolveSystemAgentOnboardingTarget } from "../commands/onboard-agent-target.js";
 import { readConfigFileSnapshot, withConfigMutationExclusive } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -41,7 +41,7 @@ export async function completeLocalSetupRecovery(params: {
       lockedSourceConfig.wizard?.securityAcknowledgedAt !== params.owner.securityAcknowledgedAt ||
       sourceConfig.wizard?.securityAcknowledgedAt !== params.owner.securityAcknowledgedAt ||
       resolveUserPath(
-        resolveOnboardingAgentTarget(snapshot.runtimeConfig ?? snapshot.config).workspaceDir,
+        resolveSystemAgentOnboardingTarget(snapshot.runtimeConfig ?? snapshot.config).workspaceDir,
       ) !== params.owner.workspace
     ) {
       throw new Error("The onboarding configuration changed before setup could complete.");

--- a/src/system-agent/system-agent.test-helpers.ts
+++ b/src/system-agent/system-agent.test-helpers.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import { resolveCliBackendConfig } from "../agents/cli-backends.js";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 // OpenClaw test helpers build runtime environments for rescue tests.
@@ -152,7 +152,7 @@ export function expectSystemAgentAuditRecord(
 export async function createSystemAgentVerifiedInferenceTestFixture(
   config: OpenClawConfig,
 ): Promise<SystemAgentVerifiedInferenceTestFixture> {
-  const routeAgentId = resolveDefaultAgentId(config);
+  const routeAgentId = resolveSystemAgentTargetAgentId(config);
   const selection = resolveSimpleCompletionSelectionForAgent({
     cfg: config,
     agentId: routeAgentId,

--- a/src/wizard/setup.memory-import.ts
+++ b/src/wizard/setup.memory-import.ts
@@ -51,6 +51,7 @@ async function showSkipHint(prompter: WizardPrompter): Promise<void> {
 
 export async function runSetupMemoryImportStep(params: {
   config: OpenClawConfig;
+  agentId?: string;
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   /** Recheck host authority at the copy boundary; onboarding intentionally omits this hook. */
@@ -58,7 +59,7 @@ export async function runSetupMemoryImportStep(params: {
   /** Observe completed provider attempts without changing onboarding behavior. */
   onProviderOutcome?: (outcome: MemoryImportProviderOutcome) => void;
 }): Promise<SetupMemoryImportOutcome> {
-  const agentId = resolveDefaultAgentId(params.config);
+  const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const providers = listMemoryMigrationProviders(params.config);
   if (providers.length === 0) {
     return { status: "nothing-to-import", providers: [] };

--- a/ui/src/e2e/skills-owner-selection.e2e.test.ts
+++ b/ui/src/e2e/skills-owner-selection.e2e.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Skills owner selection",
+  startServerBeforeBrowser: true,
+});
+
+suite.define(() => {
+  it("scopes every initial Skills status request to the displayed default agent", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "agents.list": {
+            agents: [
+              { id: "main", identity: { name: "Main" }, name: "Main" },
+              { id: "research", identity: { name: "Research" }, name: "Research" },
+            ],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [],
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}skills`);
+      await gateway.waitForRequest("skills.status");
+      await expect
+        .poll(() => gateway.getRequests("skills.status"))
+        .toEqual([expect.objectContaining({ params: { agentId: "main" } })]);
+      await page.getByText("No skills found.").waitFor();
+    });
+  });
+});

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -49,7 +49,7 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn<T
         }
       },
     },
-    skillsAgentId: null,
+    skillsAgentId: "main",
     skillsAgentRevision: 0,
     skillsLoading: false,
     skillsReport: null,
@@ -113,6 +113,15 @@ function mockSkillMutationRequests(
 }
 
 describe("loadSkills", () => {
+  it("does not issue an ownerless status request", async () => {
+    const { state, request } = createState();
+    state.skillsAgentId = null;
+
+    await loadSkills(state);
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("does not request ClawHub verdicts when no installed skills are linked", async () => {
     const { state, request } = createState();
     request.mockResolvedValueOnce({
@@ -124,7 +133,7 @@ describe("loadSkills", () => {
     await loadSkills(state);
 
     expect(request).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenCalledWith("skills.status", {});
+    expect(request).toHaveBeenCalledWith("skills.status", { agentId: "main" });
     expect(state.clawhubVerdicts).toEqual({});
     expect(state.clawhubVerdictsError).toBeNull();
   });
@@ -179,8 +188,8 @@ describe("loadSkills", () => {
     await loadSkills(state);
 
     expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenNthCalledWith(1, "skills.status", {});
-    expect(request).toHaveBeenNthCalledWith(2, "skills.securityVerdicts", {});
+    expect(request).toHaveBeenNthCalledWith(1, "skills.status", { agentId: "main" });
+    expect(request).toHaveBeenNthCalledWith(2, "skills.securityVerdicts", { agentId: "main" });
     expect(state.clawhubVerdicts).toEqual({
       [clawhubVerdictKey({
         registry: "https://clawhub.ai",
@@ -760,7 +769,7 @@ describe("skill mutations", () => {
     await refresh;
 
     expect(request).toHaveBeenCalledOnce();
-    expect(request).toHaveBeenCalledWith("skills.status", {});
+    expect(request).toHaveBeenCalledWith("skills.status", { agentId: "main" });
     expect(state.skillOperation).toBeNull();
   });
 
@@ -827,6 +836,7 @@ describe("skill mutations", () => {
       expectedRequest: [
         "skills.install",
         {
+          agentId: "main",
           name: "GitHub",
           installId: "install-123",
           dangerouslyForceUnsafeInstall: true,
@@ -1301,6 +1311,7 @@ describe("skill mutations", () => {
     );
 
     expect(request).toHaveBeenNthCalledWith(2, "skills.install", {
+      agentId: "main",
       source: "clawhub",
       slug: "github",
       version: "1.2.3",
@@ -1365,7 +1376,7 @@ describe("skill mutations", () => {
 });
 
 describe("reconcileSkillsAgentId", () => {
-  it("resets a deleted selected agent without releasing its active operation", () => {
+  it("selects the roster default after the selected agent is deleted", () => {
     const { state } = createState();
     state.skillsAgentId = "deleted";
     state.skillsReport = {
@@ -1382,7 +1393,7 @@ describe("reconcileSkillsAgentId", () => {
       agents: [{ id: "main" }],
     });
 
-    expect(state.skillsAgentId).toBeNull();
+    expect(state.skillsAgentId).toBe("main");
     expect(state.skillsAgentRevision).toBe(1);
     expect(state.skillsReport).toBeNull();
     expect(state.skillOperation).toEqual({ kind: "clawhub", ref: "calendar" });

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -198,11 +198,6 @@ function currentSkillCardCacheKey(state: SkillsState, skillKey: string): string 
   return skill ? skillCardCacheKey(skill) : undefined;
 }
 
-function skillsAgentParams(agentId: string | null | undefined): { agentId?: string } {
-  const normalized = agentId?.trim();
-  return normalized ? { agentId: normalized } : {};
-}
-
 function stateSkillsAgentParams(state: Pick<SkillsState, "skillsAgentId">): { agentId?: string } {
   const agentId = state.skillsAgentId?.trim();
   return agentId ? { agentId } : {};
@@ -210,9 +205,9 @@ function stateSkillsAgentParams(state: Pick<SkillsState, "skillsAgentId">): { ag
 
 export async function loadSkillStatusReport(
   client: GatewayBrowserClient,
-  agentId: string | null | undefined,
+  agentId: string,
 ): Promise<SkillStatusReport | undefined> {
-  return client.request<SkillStatusReport | undefined>("skills.status", skillsAgentParams(agentId));
+  return client.request<SkillStatusReport | undefined>("skills.status", { agentId });
 }
 
 type SkillsAgentScope = {
@@ -284,13 +279,15 @@ export function reconcileSkillsAgentId(
   state: SkillsState,
   agentsList: AgentsListResult | null | undefined,
 ) {
-  if (
-    agentsList &&
-    state.skillsAgentId &&
-    !agentsList.agents.some((agent) => agent.id === state.skillsAgentId)
-  ) {
-    setSkillsAgentId(state, null);
+  if (!agentsList) {
+    return;
   }
+  const selectedAgentId = agentsList.agents.some((agent) => agent.id === state.skillsAgentId)
+    ? state.skillsAgentId
+    : agentsList.agents.some((agent) => agent.id === agentsList.defaultId)
+      ? agentsList.defaultId
+      : null;
+  setSkillsAgentId(state, selectedAgentId);
 }
 
 export async function loadSkills(
@@ -301,8 +298,10 @@ export async function loadSkills(
   },
 ) {
   const client = state.client;
+  const agentId = state.skillsAgentId?.trim();
   if (
     !client ||
+    !agentId ||
     !state.connected ||
     state.skillsLoading ||
     (state.skillOperation && state.skillOperation !== options?.operation)
@@ -321,7 +320,7 @@ export async function loadSkills(
   state.skillsLoading = true;
   state.skillsError = null;
   try {
-    const res = await loadSkillStatusReport(client, state.skillsAgentId);
+    const res = await loadSkillStatusReport(client, agentId);
     if (!isCurrent()) {
       return;
     }

--- a/ui/src/pages/gateway-source-replacement.test.ts
+++ b/ui/src/pages/gateway-source-replacement.test.ts
@@ -464,6 +464,24 @@ describe("gateway source replacement across reconnect with a reused client", () 
     expect(request).not.toHaveBeenCalled();
   });
 
+  it("loads initial skills for the roster's selected agent", async () => {
+    const request = vi.fn(async () => ({ skills: [] }));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const agentsList = {
+      defaultId: "main",
+      agents: [{ id: "main" }, { id: "research" }],
+    };
+    const page = createPage(
+      "openclaw-skills-page",
+      contextWithClient(client, { connected: true, agentsList }),
+    );
+
+    document.body.append(page);
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("skills.status", { agentId: "main" }),
+    );
+  });
+
   it("rejects skills route data from an earlier same-client gateway epoch", async () => {
     const freshReport = { skills: [{ skillKey: "fresh" }] } as unknown as SkillsRouteData["report"];
     const request = vi.fn(async (method: string) =>

--- a/ui/src/pages/route-provenance.test.ts
+++ b/ui/src/pages/route-provenance.test.ts
@@ -188,13 +188,18 @@ describe("route preload gateway provenance", () => {
   });
 
   it("keeps skills provenance from before its async preload", async () => {
-    const client = {
-      request: vi.fn(async () => ({ skills: [] })),
-    } as unknown as GatewayBrowserClient;
+    const requestMethod = vi.fn(async () => ({ skills: [] }));
+    const client = { request: requestMethod } as unknown as GatewayBrowserClient;
     const originalSnapshot = snapshot(client, true);
     const mutable = mutableGateway(originalSnapshot);
     const gateway = mutable.gateway;
-    const agentsReady = deferred<null>();
+    const agentsList = {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "global" as const,
+      agents: [{ id: "main" }, { id: "research" }],
+    };
+    const agentsReady = deferred<typeof agentsList>();
     const agents = {
       ensureList: vi.fn(() => agentsReady.promise),
     } as unknown as ApplicationContext["agents"];
@@ -204,9 +209,11 @@ describe("route preload gateway provenance", () => {
     } as unknown as ApplicationContext);
 
     mutable.replaceSnapshot(snapshot(client, false));
-    agentsReady.resolve(null);
+    agentsReady.resolve(agentsList);
     const data = await request;
 
+    expect(requestMethod).toHaveBeenCalledWith("skills.status", { agentId: "main" });
+    expect(data.selectedAgentId).toBe("main");
     expect(data.gateway).toBe(gateway);
     expect(data.gatewaySnapshot).toBe(originalSnapshot);
     expect(data.agents).toBe(agents);

--- a/ui/src/pages/skills/route.ts
+++ b/ui/src/pages/skills/route.ts
@@ -25,23 +25,32 @@ async function loadSkillsRouteData(context: ApplicationContext): Promise<SkillsR
 
   let error: string | null = null;
   let agentsList: SkillsRouteData["agentsList"] = null;
+  let selectedAgentId: string | null = null;
   let report: SkillsRouteData["report"] = null;
   try {
-    agentsList = await agents.ensureList();
+    const loadedAgentsList = await agents.ensureList();
+    agentsList = loadedAgentsList;
+    selectedAgentId = loadedAgentsList?.agents.some(
+      (agent) => agent.id === loadedAgentsList.defaultId,
+    )
+      ? loadedAgentsList.defaultId
+      : null;
   } catch (err) {
     error = formatUiError(err);
   }
-  try {
-    report = (await loadSkillStatusReport(client, null)) ?? null;
-  } catch (err) {
-    error ??= formatUiError(err);
+  if (selectedAgentId) {
+    try {
+      report = (await loadSkillStatusReport(client, selectedAgentId)) ?? null;
+    } catch (err) {
+      error ??= formatUiError(err);
+    }
   }
   return {
     gateway,
     gatewaySnapshot,
     agents,
     agentsList,
-    selectedAgentId: null,
+    selectedAgentId,
     report,
     error,
   };

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -127,6 +127,7 @@ class SkillsPage extends OpenClawLightDomElement {
     (agents) => {
       const cleanup = agents.subscribe(() => {
         this.reconcileAgentState();
+        this.ensureInitialData();
         this.requestUpdate();
       });
       this.reconcileAgentState();
@@ -228,9 +229,13 @@ class SkillsPage extends OpenClawLightDomElement {
       return;
     }
     const agents = this.context.agents.state;
-    if (!agents.agentsList && !agents.agentsLoading) {
-      void this.loadAgents();
+    if (!agents.agentsList) {
+      if (!agents.agentsLoading) {
+        void this.loadAgents();
+      }
+      return;
     }
+    this.reconcileAgentState();
     if (!this.skillsReport && !this.skillsLoading) {
       void loadSkills(this);
     }
@@ -254,6 +259,7 @@ class SkillsPage extends OpenClawLightDomElement {
     }
     if (this.context.agents === agentsSource) {
       this.reconcileAgentState();
+      this.ensureInitialData();
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with multiple explicitly owned agents could see Custodian, Skills, setup, or Google Meet fail by asking for a retired implicit default agent instead of using the owner already selected by configuration or UI state.

## Why This Change Was Made

The affected paths now resolve the authoritative System Agent, route, or UI-selected agent once and carry that ID through subsequent work. Skills status requests cannot be emitted without an agent owner, and Google Meet defers legacy fallback resolution until neither request nor plugin configuration supplies an owner.

## User Impact

Operators can use Custodian and the Skills page with explicit multi-agent ownership without an `AgentSelectionRequiredError`. System Agent setup and recovery consistently affect the configured System Agent owner, while Google Meet honors its configured realtime agent without first requiring an implicit default.

## Evidence

- Reproduced the original Custodian failure with an explicit System Agent owner and two-agent roster before the repair.
- Reproduced the Skills failure as a successful agent-scoped `skills.status` request followed by an ownerless request that overwrote the page; the request producer now requires `agentId`.
- Operator live verification confirmed Custodian and Skills load successfully from the rebuilt Control UI bundle.
- `src/system-agent/setup-inference.test.ts`: 127/127 passed after rebasing onto current `main`.
- `src/system-agent/operations.test.ts`: 59/59 passed.
- Focused Control UI tests: 69/69 passed.
- Google Meet owner-selection regression: 1/1 passed.
- Scoped formatting and `git diff --check` passed.
- Final autoreview: clean, no accepted/actionable findings.

Production LOC: +132/-95 (net +37) | Tests/test support: +136/-26

The mocked browser regression is included for CI; local Blacksmith capacity was unavailable during the earlier live-debug pass.
