### PR TITLE
fix(skills): run scheduled collection reviews in auto mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Skill Workshop collection review:** carry and close the required prepared execution admission for scheduled collection reconciliation so autonomous reviews reach model dispatch instead of failing before execution. Fixes #123262. Thanks @woodym-dotcom.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Skill Workshop collection review:** carry and close the required prepared execution admission for scheduled collection reconciliation so autonomous reviews reach model dispatch instead of failing before execution. Fixes #123262. Thanks @woodym-dotcom.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAdmittedRunDelegatedAuthority,
+  resolvePreparedRunAdmission,
+  type AdmittedRunContext,
+} from "../../agents/admitted-run-context.js";
 import { createSkillWorkshopTool } from "../../agents/tools/skill-workshop-tool.js";
 import {
   createOpenClawTestState,
@@ -57,8 +62,14 @@ describe("skill collection review", () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "useful", description: "Useful reusable procedure" },
     ]);
+    let admittedRunContext: AdmittedRunContext | undefined;
     let reviewResult: unknown;
     runEmbeddedAgent.mockImplementation(async (params) => {
+      admittedRunContext = await resolvePreparedRunAdmission({
+        runId: params.runId,
+        runtimeKind: "embedded",
+        preparedRunAdmission: params.preparedRunAdmission,
+      });
       const tool = createSkillWorkshopTool({
         workspaceDir: params.workspaceDir,
         config: params.config,
@@ -95,6 +106,10 @@ describe("skill collection review", () => {
       onError,
     });
     expect(onError).not.toHaveBeenCalled();
+    expect(admittedRunContext?.operationalRunInstance.runId).toBe(
+      runEmbeddedAgent.mock.calls[0]?.[0]?.runId,
+    );
+    expect(getAdmittedRunDelegatedAuthority(admittedRunContext!)).toBeUndefined();
     expect(reviewResult).toMatchObject({ kept: ["useful"], written: [], dropped: [] });
     expect(runEmbeddedAgent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -235,7 +250,13 @@ describe("skill collection review", () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "useful", description: "Useful reusable procedure" },
     ]);
+    let admittedRunContext: AdmittedRunContext | undefined;
     runEmbeddedAgent.mockImplementation(async (params) => {
+      admittedRunContext = await resolvePreparedRunAdmission({
+        runId: params.runId,
+        runtimeKind: "embedded",
+        preparedRunAdmission: params.preparedRunAdmission,
+      });
       const tool = createSkillWorkshopTool({
         workspaceDir: params.workspaceDir,
         config: params.config,
@@ -261,6 +282,7 @@ describe("skill collection review", () => {
 
     expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledOnce();
+    expect(getAdmittedRunDelegatedAuthority(admittedRunContext!)).toBeUndefined();
   });
 
   it("reviews a same-model shared workspace without hiding every agent's skills", async () => {

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import { stableStringify } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -94,6 +95,7 @@ async function runSkillCollectionReview(params: {
   }
   const model = resolveCollectionReviewModel(params.config, params.agentId);
   const sessionId = randomUUID();
+  const runId = `${COLLECTION_REVIEW_SESSION_SEGMENT}:${randomUUID()}`;
   const sessionKey = `agent:${params.agentId}:${COLLECTION_REVIEW_SESSION_SEGMENT}:incognito-${sessionId}`;
   const collectionReconcile: SkillCollectionReconcileContext = {
     agentIds: [...(params.agentIds ?? [params.agentId])],
@@ -109,41 +111,52 @@ async function runSkillCollectionReview(params: {
     ),
   };
   const { runEmbeddedAgent } = await import("../../agents/embedded-agent.js");
-  await runEmbeddedAgent({
-    sessionId,
-    sessionKey,
-    sandboxSessionKey: sessionKey,
-    sessionManager: SessionManager.inMemory(params.workspaceDir),
-    agentId: params.agentId,
-    trigger: "cron",
-    lane: CommandLane.SkillWorkshopReview,
-    agentHarnessId: "openclaw",
-    agentHarnessRuntimeOverride: "openclaw",
-    workspaceDir: params.workspaceDir,
-    config: params.config,
-    prompt: buildCollectionReviewPrompt(skills),
-    provider: model.provider,
-    model: model.model,
-    ...(model.authProfileId
-      ? { authProfileId: model.authProfileId, authProfileIdSource: "user" as const }
-      : {}),
-    modelSelectionLocked: true,
-    modelFallbacksOverride: [],
-    timeoutMs: COLLECTION_REVIEW_TIMEOUT_MS,
-    runId: `${COLLECTION_REVIEW_SESSION_SEGMENT}:${randomUUID()}`,
-    toolsAllow: ["skill_workshop"],
-    skillWorkshopProposalOnly: true,
-    disableMessageTool: true,
-    disableTrajectory: true,
-    skillWorkshopCollectionReconcile: collectionReconcile,
-    skillWorkshopProposalEnv: params.env,
-    cleanupBundleMcpOnRunEnd: true,
-    bootstrapContextMode: "lightweight",
-    skillsSnapshot: { prompt: "", skills: [] },
-    verboseLevel: "off",
-    reasoningLevel: "off",
-    suppressToolErrorWarnings: true,
-  });
+  const preparedRunAdmission = prepareSystemAgentRunAdmission(
+    params.config,
+    runId,
+    params.agentId,
+    "skill-workshop.collection-review",
+  );
+  try {
+    await runEmbeddedAgent({
+      preparedRunAdmission,
+      sessionId,
+      sessionKey,
+      sandboxSessionKey: sessionKey,
+      sessionManager: SessionManager.inMemory(params.workspaceDir),
+      agentId: params.agentId,
+      trigger: "cron",
+      lane: CommandLane.SkillWorkshopReview,
+      agentHarnessId: "openclaw",
+      agentHarnessRuntimeOverride: "openclaw",
+      workspaceDir: params.workspaceDir,
+      config: params.config,
+      prompt: buildCollectionReviewPrompt(skills),
+      provider: model.provider,
+      model: model.model,
+      ...(model.authProfileId
+        ? { authProfileId: model.authProfileId, authProfileIdSource: "user" as const }
+        : {}),
+      modelSelectionLocked: true,
+      modelFallbacksOverride: [],
+      timeoutMs: COLLECTION_REVIEW_TIMEOUT_MS,
+      runId,
+      toolsAllow: ["skill_workshop"],
+      skillWorkshopProposalOnly: true,
+      disableMessageTool: true,
+      disableTrajectory: true,
+      skillWorkshopCollectionReconcile: collectionReconcile,
+      skillWorkshopProposalEnv: params.env,
+      cleanupBundleMcpOnRunEnd: true,
+      bootstrapContextMode: "lightweight",
+      skillsSnapshot: { prompt: "", skills: [] },
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      suppressToolErrorWarnings: true,
+    });
+  } finally {
+    preparedRunAdmission.close();
+  }
   if (!collectionReconcile.result) {
     throw new Error("Skill collection review ended without reconciling the collection.");
   }


### PR DESCRIPTION
Closes #123262

## What Problem This Solves

Fixes an issue where users with Skill Workshop autonomous mode enabled would have every scheduled collection review fail before model dispatch with `prepared execution context is unavailable or disagrees with the run`.

## Why This Change Was Made

The scheduled collection-review caller was missed when embedded side runs adopted mandatory execution admission in #120534. The runner correctly rejects an unadmitted execution; this caller now creates one system admission for its exact run ID, carries it into the embedded run, and closes its delegated authority in `finally`, matching the existing history-scan and experience-review ownership boundary.

The production delta is +13 lines: the added lifecycle ownership is required to preserve the run-admission security invariant. Tests add 22 lines and cover both normal completion and runner failure.

## User Impact

Daily autonomous Skill Workshop collection reconciliation can reach model dispatch again. Success and failure paths both release their run authority after the review finishes.

## Evidence

- Live Gateway logs on August 13, 2026 repeatedly showed the exact pre-dispatch failure for independent `clawblocker` and `blockdigest` workspaces; current source inspection traced both to the missing caller admission.
- `node scripts/run-vitest.mjs src/skills/workshop/collection-review.test.ts` — 11 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 node scripts/check-changed.mjs` — core, core-test, docs, typecheck, lint, and guard lanes passed.
- `git diff --check` — passed.
- Structured autoreview — clean, with no accepted or actionable findings.

Post-fix live deployment proof is intentionally not claimed here; the production Gateway remains on its manager-owned immutable release until this PR is independently verified and landed.
