### PR TITLE
fix(ui): do not call a portal unreachable when policy refused the probe

### DIFF
--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -1,6 +1,18 @@
 // Anthropic OAuth tests cover token exchange and refresh behavior.
-import { get } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const startOAuthLoopbackCallbackServer = vi.hoisted(() =>
+  vi.fn<
+    typeof import("../../../infra/oauth-loopback-callback.js").startOAuthLoopbackCallbackServer
+  >(),
+);
+
+vi.mock("../../../infra/oauth-loopback-callback.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../infra/oauth-loopback-callback.js")>();
+  startOAuthLoopbackCallbackServer.mockImplementation(actual.startOAuthLoopbackCallbackServer);
+  return { ...actual, startOAuthLoopbackCallbackServer };
+});
+
 import { anthropicOAuthProvider } from "./anthropic.js";
 
 const ANTHROPIC_REDIRECT_URI = "http://localhost:53692/callback";
@@ -17,16 +29,6 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
 });
-
-async function getLocalCallback(url: string): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const request = get(url, (response) => {
-      response.resume();
-      response.once("end", resolve);
-    });
-    request.once("error", reject);
-  });
-}
 
 describe("Anthropic OAuth token responses", () => {
   it("cancels provider login before opening the OAuth flow", async () => {
@@ -45,6 +47,11 @@ describe("Anthropic OAuth token responses", () => {
   it("does not open the OAuth flow after cancellation during setup", async () => {
     const controller = new AbortController();
     const onAuth = vi.fn();
+    const close = vi.fn(async () => undefined);
+    startOAuthLoopbackCallbackServer.mockResolvedValueOnce({
+      waitForCallback: vi.fn(),
+      close,
+    });
     const loginPromise = anthropicOAuthProvider.login({
       onAuth,
       onPrompt: vi.fn(async () => "unused-code"),
@@ -55,6 +62,7 @@ describe("Anthropic OAuth token responses", () => {
 
     await expect(loginPromise).rejects.toThrow("Login cancelled");
     expect(onAuth).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
   });
 
   it("does not echo token payload values when refresh JSON parsing fails", async () => {
@@ -139,6 +147,14 @@ describe("Anthropic OAuth callback host", () => {
 
   it("binds IPv4 loopback while keeping Anthropic's registered localhost redirect", async () => {
     vi.stubEnv("OPENCLAW_OAUTH_CALLBACK_HOST", "127.0.0.1");
+    startOAuthLoopbackCallbackServer.mockImplementationOnce(async (params) => ({
+      waitForCallback: async () => ({
+        type: "authorization_code" as const,
+        code: "authorization-code",
+        state: params.expectedState,
+      }),
+      close: async () => undefined,
+    }));
     const tokenExchange = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (typeof init?.body !== "string") {
         throw new Error("token exchange did not send a JSON string body");
@@ -154,45 +170,34 @@ describe("Anthropic OAuth callback host", () => {
       );
     });
     vi.stubGlobal("fetch", tokenExchange);
-    let callback: Promise<void> | undefined;
 
     const credentials = await anthropicOAuthProvider.login({
       onAuth: ({ url }) => {
         const authorizationUrl = new URL(url);
         expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(ANTHROPIC_REDIRECT_URI);
-        const state = authorizationUrl.searchParams.get("state");
-        if (!state) {
-          throw new Error("authorization URL did not include OAuth state");
-        }
-        callback = getLocalCallback(
-          `http://127.0.0.1:53692/callback?code=authorization-code&state=${state}`,
-        );
+        expect(authorizationUrl.searchParams.get("state")).toBeTruthy();
       },
       onPrompt: async () => {
         throw new Error("callback server did not receive the authorization code");
       },
     });
 
-    if (!callback) {
-      throw new Error("authorization callback request was not started");
-    }
-    await callback;
+    expect(startOAuthLoopbackCallbackServer).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUrl: ANTHROPIC_REDIRECT_URI, bindHostname: "127.0.0.1" }),
+    );
     expect(credentials).toMatchObject({ access: "access-token", refresh: "refresh-token" });
     expect(tokenExchange).toHaveBeenCalledOnce();
   });
 
   it("settles an OAuth error callback immediately", async () => {
     vi.stubEnv("OPENCLAW_OAUTH_CALLBACK_HOST", "127.0.0.1");
-    let callback: Promise<void> | undefined;
+    startOAuthLoopbackCallbackServer.mockResolvedValueOnce({
+      waitForCallback: async () => ({ type: "oauth_error", error: "access_denied" }),
+      close: async () => undefined,
+    });
     const login = anthropicOAuthProvider.login({
       onAuth: ({ url }) => {
-        const state = new URL(url).searchParams.get("state");
-        if (!state) {
-          throw new Error("authorization URL did not include OAuth state");
-        }
-        callback = getLocalCallback(
-          `http://127.0.0.1:53692/callback?error=access_denied&state=${state}`,
-        );
+        expect(new URL(url).searchParams.get("state")).toBeTruthy();
       },
       onPrompt: async () => {
         throw new Error("error callback did not settle the listener");
@@ -200,6 +205,5 @@ describe("Anthropic OAuth callback host", () => {
     });
 
     await expect(login).rejects.toThrow("Anthropic OAuth error: access_denied");
-    await callback;
   });
 });

--- a/ui/src/pages/chat/components/chat-attachments.test.ts
+++ b/ui/src/pages/chat/components/chat-attachments.test.ts
@@ -2,10 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleChatAttachmentPaste } from "./chat-attachments.ts";
 
-vi.mock("../../../lib/toast.ts", () => ({ showToast: vi.fn() }));
-
-import { showToast } from "../../../lib/toast.ts";
-
 class StubFileReader {
   static failNames = new Set<string>();
   result: string | ArrayBuffer | null = null;
@@ -52,16 +48,18 @@ function pasteEventWithFiles(files: File[]): ClipboardEvent {
 }
 
 describe("chat attachment read failures", () => {
-  const realFileReader = globalThis.FileReader;
+  let toastHost: HTMLElementTagNameMap["openclaw-toast-host"];
 
   beforeEach(() => {
     vi.stubGlobal("FileReader", StubFileReader as unknown as typeof FileReader);
     StubFileReader.failNames = new Set();
+    toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
   });
 
   afterEach(() => {
-    vi.stubGlobal("FileReader", realFileReader);
-    vi.clearAllMocks();
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
   });
 
   it("names files whose read failed instead of dropping them silently", async () => {
@@ -77,11 +75,8 @@ describe("chat attachment read failures", () => {
     await vi.waitFor(() => {
       expect(onAttachmentsChange).toHaveBeenCalled();
     });
-    expect(vi.mocked(showToast)).toHaveBeenCalledTimes(1);
-    const message = vi.mocked(showToast).mock.calls[0]?.[0]?.message;
-    // The read-failure toast is a plain t() string, not a template.
-    expect(typeof message).toBe("string");
-    expect(message).toContain("bad.png");
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain("bad.png");
     // The successful sibling still attaches.
     const attached = onAttachmentsChange.mock.calls[0]?.[0] as Array<{ fileName?: string }>;
     expect(attached).toHaveLength(1);
@@ -97,6 +92,7 @@ describe("chat attachment read failures", () => {
     await vi.waitFor(() => {
       expect(onAttachmentsChange).toHaveBeenCalled();
     });
-    expect(vi.mocked(showToast)).not.toHaveBeenCalled();
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
   });
 });

--- a/ui/src/pages/portals/portal-reachability.test.ts
+++ b/ui/src/pages/portals/portal-reachability.test.ts
@@ -14,7 +14,7 @@ describe("probePortalReachable", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(probePortalReachable("https://gateway.example.test:43123/app")).resolves.toBe(
-      true,
+      "reachable",
     );
     expect(fetchMock).toHaveBeenCalledWith(
       "https://gateway.example.test:43123/app",
@@ -22,7 +22,7 @@ describe("probePortalReachable", () => {
     );
   });
 
-  it("returns false when the reachability deadline aborts the request", async () => {
+  it("reports unreachable when the reachability deadline aborts the request", async () => {
     const controller = new AbortController();
     const timeoutMock = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
     vi.stubGlobal(
@@ -46,7 +46,45 @@ describe("probePortalReachable", () => {
     const result = probePortalReachable("https://gateway.example.test:43123/app");
     controller.abort(new DOMException("Timed out", "TimeoutError"));
 
-    await expect(result).resolves.toBe(false);
+    await expect(result).resolves.toBe("unreachable");
     expect(timeoutMock).toHaveBeenCalledWith(4_000);
+  });
+
+  it("reports blocked, not unreachable, when CSP refuses the probe", async () => {
+    // A refused connection says nothing about the portal: frames obey frame-src,
+    // so the preview must still be attempted rather than declared unreachable.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        const violation = new Event("securitypolicyviolation") as Event & {
+          blockedURI?: string;
+        };
+        violation.blockedURI = "http://127.0.0.1:42065";
+        document.dispatchEvent(violation);
+        return Promise.reject(new TypeError("Failed to fetch"));
+      }),
+    );
+
+    await expect(probePortalReachable("http://127.0.0.1:42065/?openclaw_portal=abc")).resolves.toBe(
+      "blocked",
+    );
+  });
+
+  it("keeps unrelated policy violations from masking an unreachable portal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        const violation = new Event("securitypolicyviolation") as Event & {
+          blockedURI?: string;
+        };
+        violation.blockedURI = "inline";
+        document.dispatchEvent(violation);
+        return Promise.reject(new TypeError("Failed to fetch"));
+      }),
+    );
+
+    await expect(probePortalReachable("http://127.0.0.1:42065/?openclaw_portal=abc")).resolves.toBe(
+      "unreachable",
+    );
   });
 });

--- a/ui/src/pages/portals/portal-reachability.ts
+++ b/ui/src/pages/portals/portal-reachability.ts
@@ -1,13 +1,52 @@
 const PORTAL_REACHABILITY_TIMEOUT_MS = 4_000;
 
-export async function probePortalReachable(url: string): Promise<boolean> {
+/**
+ * `blocked` means the probe never reached the network: Content Security Policy
+ * refused the connection, so the result says nothing about the portal. Frames
+ * obey `frame-src`, not `connect-src`, so a blocked probe must never be
+ * reported to the operator as an unreachable portal.
+ */
+export type PortalReachability = "reachable" | "unreachable" | "blocked";
+
+function isProbeViolation(event: SecurityPolicyViolationEvent, target: URL): boolean {
+  try {
+    return new URL(event.blockedURI).origin === target.origin;
+  } catch {
+    // Keyword blockedURI values ("inline", "eval") never describe this fetch.
+    return false;
+  }
+}
+
+export async function probePortalReachable(url: string): Promise<PortalReachability> {
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return "unreachable";
+  }
+  let blocked = false;
+  const onViolation = (event: Event) => {
+    if (isProbeViolation(event as SecurityPolicyViolationEvent, target)) {
+      blocked = true;
+    }
+  };
+  // Callable outside a DOM (tests, any non-browser import): without a document
+  // there is no violation signal, so the probe stays reachable/unreachable.
+  const violationTarget = typeof document === "undefined" ? undefined : document;
+  violationTarget?.addEventListener("securitypolicyviolation", onViolation);
   try {
     await fetch(url, {
       mode: "no-cors",
       signal: AbortSignal.timeout(PORTAL_REACHABILITY_TIMEOUT_MS),
     });
-    return true;
+    return "reachable";
   } catch {
-    return false;
+    // The violation event and the fetch rejection race; let the event land.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    return blocked ? "blocked" : "unreachable";
+  } finally {
+    violationTarget?.removeEventListener("securitypolicyviolation", onViolation);
   }
 }

--- a/ui/src/pages/portals/portals-page.test.ts
+++ b/ui/src/pages/portals/portals-page.test.ts
@@ -6,7 +6,9 @@ import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { resolvePortalUrl } from "./portal-url.ts";
 
-const probePortalReachable = vi.hoisted(() => vi.fn<() => Promise<boolean>>());
+const probePortalReachable = vi.hoisted(() =>
+  vi.fn<() => Promise<"reachable" | "unreachable" | "blocked">>(),
+);
 
 vi.mock("./portal-reachability.ts", () => ({ probePortalReachable }));
 
@@ -87,7 +89,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
-  probePortalReachable.mockReset().mockResolvedValue(true);
+  probePortalReachable.mockReset().mockResolvedValue("reachable");
 });
 
 describe("PortalsPage", () => {
@@ -144,7 +146,7 @@ describe("PortalsPage", () => {
   });
 
   it("shows an unreachable notice without mounting the iframe and retries", async () => {
-    probePortalReachable.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    probePortalReachable.mockResolvedValueOnce("unreachable").mockResolvedValueOnce("reachable");
     const source = createContext(["portal.list", "portal.close"], async (method) => {
       if (method === "portal.list") {
         return { portals: [portal] } satisfies PortalListResult;
@@ -171,6 +173,19 @@ describe("PortalsPage", () => {
 
     await vi.waitFor(() => expect(page.querySelector("iframe")).not.toBeNull());
     expect(probePortalReachable).toHaveBeenCalledTimes(2);
+  });
+
+  it("still mounts the preview when policy blocks the probe", async () => {
+    // A CSP-refused probe never reached the network, so it must not be reported
+    // as an unreachable portal: frames obey frame-src and can still load.
+    probePortalReachable.mockResolvedValue("blocked");
+    const source = createContext(["portal.list", "portal.close"], async () => ({
+      portals: [portal],
+    }));
+    const page = await mountPage(source.context);
+
+    await vi.waitFor(() => expect(page.querySelector("iframe")).not.toBeNull());
+    expect(page.textContent).not.toContain("Portal not reachable from this browser");
   });
 
   it("shows the empty prompts and an unsupported note without calling the method", async () => {

--- a/ui/src/pages/portals/portals-page.ts
+++ b/ui/src/pages/portals/portals-page.ts
@@ -17,7 +17,7 @@ import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gatew
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import { probePortalReachable } from "./portal-reachability.ts";
+import { probePortalReachable, type PortalReachability } from "./portal-reachability.ts";
 import { resolvePortalUrl } from "./portal-url.ts";
 import "./portals.css";
 
@@ -26,7 +26,7 @@ const PORTAL_FRAME_SANDBOX =
 
 type PortalProbeState = {
   key: string;
-  status: "probing" | "reachable" | "unreachable";
+  status: "probing" | PortalReachability;
 };
 
 class PortalsPage extends OpenClawLightDomElement {
@@ -44,7 +44,7 @@ class PortalsPage extends OpenClawLightDomElement {
   private requestGeneration = 0;
   private portalSetRevision = 0;
   private portalProbeGeneration = 0;
-  private readonly portalProbeCache = new Map<string, boolean>();
+  private readonly portalProbeCache = new Map<string, PortalReachability>();
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
     invalidateRequests: () => this.resetGatewayState(),
@@ -135,16 +135,16 @@ class PortalsPage extends OpenClawLightDomElement {
     }
     const cached = force ? undefined : this.portalProbeCache.get(key);
     if (cached !== undefined) {
-      this.portalProbeState = { key, status: cached ? "reachable" : "unreachable" };
+      this.portalProbeState = { key, status: cached };
       return;
     }
 
     const generation = ++this.portalProbeGeneration;
     this.portalProbeState = { key, status: "probing" };
-    void probePortalReachable(url).then((reachable) => {
-      this.portalProbeCache.set(key, reachable);
+    void probePortalReachable(url).then((reachability) => {
+      this.portalProbeCache.set(key, reachability);
       if (generation === this.portalProbeGeneration && this.portalProbeState?.key === key) {
-        this.portalProbeState = { key, status: reachable ? "reachable" : "unreachable" };
+        this.portalProbeState = { key, status: reachability };
       }
     });
   }


### PR DESCRIPTION
## What Problem This Solves

The Portals page probes a portal with `fetch` before mounting its preview, and treated any failure as "Portal not reachable from this browser". A Content Security Policy refusal fails exactly like a dead port, so a perfectly reachable portal was reported as unreachable and its preview was replaced by an error notice.

The CSP `connect-src` allowance is derived server-side from the request `Host`, while the page builds portal URLs from the hostname the browser actually used. Those disagree whenever something rewrites `Host` — the Control UI reached *through* a portal (the proxy rewrites `Host` to the loopback target), or a reverse proxy that sets its own `Host`.

Found while running a dev gateway on a cloud box and reaching its Control UI through a portal. The browser console showed the refusal for a portal `curl` could reach from the same machine:

```text
Connecting to 'http://127.0.0.1:42065/?openclaw_portal=…' violates the following
Content Security Policy directive: "connect-src 'self' ws: wss: data:
https://api.openai.com https://tweakcn.com http://localhost:* https://localhost:*"
```

## Why This Change Was Made

- `probePortalReachable` now returns `reachable | unreachable | blocked`. A CSP refusal is detected through the `securitypolicyviolation` event (matched by origin, so unrelated `inline`/`eval` violations cannot mask a genuinely dead portal) and reported as `blocked`.
- The page mounts the preview for `blocked` as well as `reachable`. Frames obey `frame-src` (`'self' http: https:`), not `connect-src`, so a refused probe says nothing about whether the frame can load — asserting unreachability from it is simply wrong.

No Content Security Policy change ships here: an earlier revision widened `connect-src` to the loopback spellings so real detection survived a `Host`/hostname mismatch, but the tri-state fallback already produces the correct result, so the extra policy surface was dropped.

The branch initially also carried the unrelated browser-geometry assertion repair that had blocked this PR's CI twice. That repair landed on `main` before the final rebase, so the duplicate change was dropped and is not part of this PR.

After the required rebase, exact-head CI exposed an unrelated provider OAuth unit-test collision on a registered fixed callback port. Per repository landing policy, this PR now keeps provider mapping and lifecycle assertions behind the shared callback-owner mock while leaving real socket coverage with the shared callback owner, which uses OS-assigned test ports.

A later merge-ref refresh exposed an unrelated Control UI test whose module mock depended on full-suite import order. The test now verifies the actual rendered toast host—the user-visible owner boundary—instead of observing a mock that could be disconnected from the already-loaded production module.

Current `main` then assigned the same app-server attempt-state test to two Vitest lanes. This PR linked the in-flight #123365 and waited instead of duplicating it; while waiting, #123349 removed the duplicate from `main`, and this branch rebased onto that canonical repair.

The reachability notice still appears for genuinely unreachable portals, which is the case it was added for.

## User Impact

A reachable portal is no longer hidden behind a "not reachable" error, and the misleading claim is gone. Operators behind a Host-rewriting proxy, or viewing the Control UI through a portal, get the working preview.

## Evidence

- `ui/src/pages/portals` — 10 tests pass, including a new regression asserting the preview mounts when the probe is blocked. Verified it **fails against the pre-fix logic** (`expected null not to be null`, i.e. no iframe) rather than only passing after the change.
- New probe tests cover both directions: a CSP violation matching the probe origin yields `blocked`; an unrelated `inline` violation still yields `unreachable`.
- `src/gateway/control-ui-csp.test.ts` — 19 tests pass (unchanged file, run as a guard against the reverted policy edit).
- Provider OAuth unit coverage — 8 tests passed in 10 consecutive focused runs after removing the duplicate fixed-port socket dependency; the shared callback owner retained and passed all 10 real-network tests.
- Attachment failure UI coverage — the focused test passes, and the two-file import-order slice passed 10 consecutive runs with 252 tests per run after replacing the order-dependent module mock with a rendered-toast assertion.
- Duplicate attempt-state lane ownership — no duplicate patch here; rebased onto the canonical `main` repair from #123349 after waiting on the linked in-flight #123365.
- `pnpm format:check` clean (28,451 files), `pnpm ui:i18n:verify` clean, autoreview clean at 0.99.

Production: +49/-10 across two files (net +39). Tests: +104/-51.
