### PR TITLE
fix(codex): stop quoted context from triggering explicit skill mentions

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -71,6 +71,26 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(ordered.prePromptMessageCount).toBe(1);
   });
 
+  it("neutralizes explicit mention sigils in projected history but not the current request", () => {
+    const result = projectContextEngineAssemblyForCodex({
+      assembledMessages: [
+        textMessage("assistant", "The user did not invoke $example-manual."),
+        textMessage("user", "see [$other-skill](skill://other) and [@pkg](plugin://pkg@mp)"),
+      ],
+      originalHistoryMessages: [],
+      prompt: "run $current-skill now",
+    });
+
+    const context = result.promptText.slice(0, result.promptContextRange?.end);
+    // Codex byte-scans the whole turn text for `$name`; historical tokens must
+    // not survive in scannable form (codex-rs/skills/src/mentions.rs).
+    expect(context).not.toContain("$example-manual");
+    expect(context).toContain("＄example-manual");
+    expect(context).toContain("[＄other-skill](skill://other)");
+    expect(context).toContain("[＠pkg](plugin://pkg@mp)");
+    expect(result.promptText).toContain("Current user request:\nrun $current-skill now");
+  });
+
   it("frames projected history as reference data and omits tool payloads", () => {
     const result = projectContextEngineAssemblyForCodex({
       assembledMessages: [

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -38,6 +38,17 @@ const DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS = 20_000;
 const MIN_PROMPT_BUDGET_RATIO = 0.5;
 const MIN_PROMPT_BUDGET_TOKENS = 8_000;
 
+// Codex scans every turn text input byte-for-byte for explicit `$name` skill
+// mentions and `[@name](plugin://…)` links (codex-rs/skills/src/mentions.rs);
+// quoted history must never count as a current explicit invocation, so swap
+// the sigils to same-length fullwidth lookalikes (same technique as
+// escapeCodexChatText). Only the raw current request stays selectable.
+export function neutralizeCodexExplicitMentionSigils(text: string): string {
+  return text
+    .replace(/\$(?=[A-Za-z0-9_:-])/gu, "＄")
+    .replace(/\[@(?=[A-Za-z0-9_:-]+\]\()/gu, "[＠");
+}
+
 /** Projects assembled OpenClaw context-engine messages into Codex prompt inputs. */
 export function projectContextEngineAssemblyForCodex(params: {
   assembledMessages: AgentMessage[];
@@ -50,10 +61,12 @@ export function projectContextEngineAssemblyForCodex(params: {
   const prompt = params.prompt.trim();
   const contextMessages = dropDuplicateTrailingPrompt(params.assembledMessages, prompt);
   const maxRenderedContextChars = normalizeRenderedContextMaxChars(params.maxRenderedContextChars);
-  const renderedContext = renderMessagesForCodexContext(contextMessages, {
-    maxTextPartChars: resolveTextPartMaxChars(maxRenderedContextChars),
-    toolPayloadMode: params.toolPayloadMode ?? "elide",
-  });
+  const renderedContext = neutralizeCodexExplicitMentionSigils(
+    renderMessagesForCodexContext(contextMessages, {
+      maxTextPartChars: resolveTextPartMaxChars(maxRenderedContextChars),
+      toolPayloadMode: params.toolPayloadMode ?? "elide",
+    }),
+  );
   const boundedContext = renderedContext
     ? truncateOlderContext(renderedContext, maxRenderedContextChars)
     : undefined;

--- a/extensions/codex/src/app-server/run-attempt-state.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-state.test.ts
@@ -1,0 +1,21 @@
+// Codex tests cover run-attempt prompt state helpers.
+import { describe, expect, it } from "vitest";
+import { prependCurrentInboundContext } from "./run-attempt-state.js";
+
+describe("prependCurrentInboundContext", () => {
+  it("neutralizes explicit mention sigils in inbound context but not the prompt", () => {
+    const joined = prependCurrentInboundContext("run $current-skill now", {
+      text: "Quoted reply: please try $example-manual later",
+    });
+
+    expect(joined).toBe(
+      "Quoted reply: please try ＄example-manual later\n\nrun $current-skill now",
+    );
+  });
+
+  it("returns the prompt unchanged without inbound context", () => {
+    expect(prependCurrentInboundContext("run $current-skill now", undefined)).toBe(
+      "run $current-skill now",
+    );
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-state.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { CodexAppServerRpcError } from "./client.js";
+import { neutralizeCodexExplicitMentionSigils } from "./context-engine-projection.js";
 import { isJsonObject, type CodexServerNotification } from "./protocol.js";
 import type {
   CodexAppServerBindingIdentity,
@@ -136,8 +137,12 @@ export function prependCurrentInboundContext(
   prompt: string,
   context: EmbeddedRunAttemptParams["currentInboundContext"],
 ): string {
+  // Inbound context carries quoted replies and room backlog, not the raw
+  // current request; Codex must not resolve explicit mentions from it.
   const text = context?.text.trim();
-  return text ? [text, prompt].filter(Boolean).join("\n\n") : prompt;
+  return text
+    ? [neutralizeCodexExplicitMentionSigils(text), prompt].filter(Boolean).join("\n\n")
+    : prompt;
 }
 
 export function waitForCodexNotificationDispatchTurn(): Promise<void> {


### PR DESCRIPTION
Fixes #122812

## What Problem This Solves

Codex-backed agents could invoke a skill because its `$skill-name` token appeared in projected conversation history or quoted inbound context (reply quotes, room backlog) rather than in the raw current user message. Codex byte-scans every turn text input for explicit `$name` skill mentions and `[@name](plugin://...)` links (`codex-rs/skills/src/mentions.rs`, `codex-rs/skills/src/selection.rs:94-103`) with no quoting or code-fence awareness, and OpenClaw's Codex adapter packs projected history plus the current request into one `UserInput::Text` — so a historical `$example-manual` inside `<conversation_context>` was indistinguishable from a freshly typed one. Codex selected the skill and injected its full body, exactly the deterministic signature in the issue report.

## Why This Change Was Made

Codex's `UserInput` enum has no unscanned text variant, so the only correct owner for the fix is OpenClaw's projection boundary. The repo already has the canonical technique pointing the other direction: `escapeCodexChatText` (`extensions/codex/src/command-formatters.ts`) neutralizes mention triggers with fullwidth lookalikes so Codex output cannot ping channel users. This change mirrors it channel→Codex: `neutralizeCodexExplicitMentionSigils` swaps `$name` → `＄name` and `[@name](` → `[＠name](` inside the rendered `<conversation_context>` block (the single choke point shared by fresh-thread continuity, context-engine, and stale-binding-resume projections) and the inbound quoted-reply/room-backlog envelope. Fullwidth characters keep identical UTF-16 lengths, so no truncation/range math changes. The raw current request stays untouched: a `$skill` the user actually types this turn still resolves.

The other half of #122812 — external channels not resolving `$skill` at all — is the documented WebChat/Control-UI-only product contract (docs/tools/skills.md, feature commit 7fa95e2656aa) and is intentionally unchanged here, matching the ClawSweeper recommendation on the issue.

## User Impact

Codex-harness agents no longer falsely report that the user explicitly invoked a skill when the `$skill` token only exists in history, summaries, quoted replies, or room backlog. Genuine current-turn explicit mentions keep working.

## Evidence

- Both regression tests fail on pre-fix code (2 failed) and pass with the fix: `node scripts/run-vitest.mjs extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/run-attempt-state.test.ts` → 25 passed.
- `node scripts/check-changed.mjs` green (remote proof backend unreachable; local fallback per policy).
- Codex autoreview (gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Dependency contract verified directly in sibling Codex source at `91d6f48992ad` (`skills/src/selection.rs`, `skills/src/mentions.rs`, `protocol/src/user_input.rs`).
- Production LOC +18/−3 (tests +46): new invariant enforcement at a dependency boundary; Codex offers no unscanned input channel to absorb it net-neutral.

Supersedes the approach in #123311 for the reported defect; the cross-channel `$skill` expansion proposed there remains a separate product decision. Thanks @hannesrudolph for the report and the detailed provenance diagnosis.
