### PR TITLE
fix(slack): keep queued messages recoverable during long turns

### DIFF
--- a/extensions/slack/src/monitor/ingress.test.ts
+++ b/extensions/slack/src/monitor/ingress.test.ts
@@ -211,12 +211,13 @@ function createReceiverEventWithBody(body: Record<string, unknown>): ReceiverEve
 function attachIngress(
   queue: ChannelIngressQueue<SlackIngressPayload>,
   processEvent: (event: ReceiverEvent) => Promise<void>,
+  options: { adoptionStallTimeoutMs?: number } = {},
 ) {
   const ingress = createSlackDurableIngress({
     accountId: "default",
     queue,
     pollIntervalMs: 60_000,
-    adoptionStallTimeoutMs: 5_000,
+    adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? 5_000,
   });
   const harness = createReceiverHarness();
   ingress.wrapReceiver(harness.receiver).init({ processEvent } as App);
@@ -298,6 +299,43 @@ describe("Slack durable ingress", () => {
       await ingress.waitForIdle();
 
       expect(order).toEqual(["ack-start", "ack-complete", "dispatch"]);
+      await ingress.stop();
+    });
+  });
+
+  it("keeps deferred Slack work recoverable while later channel events start", async () => {
+    await withQueue(async (queue) => {
+      const starts: string[] = [];
+      let adoptFirst: (() => void | Promise<void>) | undefined;
+      const processEvent = vi.fn(async (event: ReceiverEvent) => {
+        const eventId = (event.body as { event_id?: string }).event_id ?? "unknown";
+        starts.push(eventId);
+        const lifecycle = resolveSlackIngressTurnLifecycle(event.customProperties);
+        if (eventId === "Ev-deferred") {
+          adoptFirst = lifecycle?.onAdopted;
+          lifecycle?.onDeferred();
+          return;
+        }
+        await lifecycle?.onAdopted();
+      });
+      const { ingress, receive } = attachIngress(queue, processEvent, {
+        adoptionStallTimeoutMs: 25,
+      });
+      ingress.start();
+
+      await receive(createReceiverEvent("Ev-deferred"));
+      await vi.waitFor(() => expect(starts).toEqual(["Ev-deferred"]));
+      await receive(createReceiverEvent("Ev-next", undefined, { ts: "1700000000.000200" }));
+      await vi.waitFor(() => expect(starts).toEqual(["Ev-deferred", "Ev-next"]));
+      await new Promise<void>((resolve) => setTimeout(resolve, 75));
+
+      expect(await queue.listFailed?.()).toEqual([]);
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual(["Ev-deferred"]);
+
+      await adoptFirst?.();
+      await expect(queue.enqueue("Ev-deferred", {} as SlackIngressPayload)).resolves.toMatchObject({
+        kind: "completed",
+      });
       await ingress.stop();
     });
   });

--- a/extensions/slack/src/monitor/ingress.ts
+++ b/extensions/slack/src/monitor/ingress.ts
@@ -299,6 +299,9 @@ export function createSlackDurableIngress(
     retention: "standard",
     appendRetryDelaysMs: [0],
     drain: {
+      // Reply-lane deferral has explicit adopt/fail/abandon settlement. Release
+      // channel ingress so one long agent turn cannot dead-letter unrelated Slack work.
+      deferredLaneOccupancy: "release-until-settled",
       resolveNonRetryableFailure: resolveSlackIngressNonRetryableFailure,
       // Shipped Slack rows did not store lanes, so replay still derives them from payloads.
       deriveLaneKey: (record) =>

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -48,7 +48,7 @@ export const DEFAULT_INGRESS_ADOPTION_STALL_MS = 5 * 60 * 1000;
 /** Bounded tombstone write retries — wedged ownership beats silent double-dispatch. */
 const INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS = 8;
 
-type DeferredLaneOccupancy = "hold" | "release";
+type DeferredLaneOccupancy = "hold" | "release" | "release-until-settled";
 
 export type CreateChannelIngressDrainOptions<
   TPayload,
@@ -83,7 +83,9 @@ export type CreateChannelIngressDrainOptions<
   claimLeaseMs?: number;
   /**
    * Whether a claimed event keeps occupying its ingress serialization lane after
-   * dispatch hands ownership to deferred work. Default "hold" (current behavior).
+   * dispatch hands ownership to deferred work. "release-until-settled" also lets
+   * the deferred lifecycle own its timeout instead of the ingress stall watchdog.
+   * Default "hold" (current behavior).
    */
   deferredLaneOccupancy?: DeferredLaneOccupancy;
   retryPolicy?: IngressRetryPolicyConfig;
@@ -457,9 +459,14 @@ export function createChannelIngressDrain<
         if (state.phase !== "dispatching") {
           return;
         }
-        // Deferred holds the claim; watchdog remains armed until adoption or abandon.
+        // Deferred always holds the durable claim until adoption or abandonment.
+        // A lifecycle-owned deferral has its own terminal callbacks, so the ingress
+        // watchdog must not dead-letter legitimate queued work before they run.
         state.phase = "deferred";
-        if (deferredLaneOccupancy === "release") {
+        if (deferredLaneOccupancy === "release-until-settled") {
+          clearStallTimer(state);
+        }
+        if (deferredLaneOccupancy !== "hold") {
           if (laneOwnerByKey.get(state.laneKey) === state) {
             laneOwnerByKey.delete(state.laneKey);
           }

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -79,6 +79,40 @@ describe("channel ingress drain watchdog", () => {
     });
   });
 
+  it("lets a released deferred lifecycle own settlement without a watchdog", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 40_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-lifecycle-owned", { text: "x" }, { laneKey: "l1" });
+      let adopt: (() => void | Promise<void>) | undefined;
+
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 1_000,
+        deferredLaneOccupancy: "release-until-settled",
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          adopt = lifecycle.onAdopted;
+          return { kind: "deferred" };
+        },
+      });
+
+      await drain.drainOnce();
+      await vi.waitFor(() => expect(drain.activeLaneKeys()).toEqual(new Set()));
+      clock += 60_000;
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(await queue.listFailed?.()).toEqual([]);
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual(["evt-lifecycle-owned"]);
+
+      await adopt?.();
+      await expect(queue.enqueue("evt-lifecycle-owned", { text: "x" })).resolves.toMatchObject({
+        kind: "completed",
+      });
+      drain.dispose();
+    });
+  });
+
   it("does not kill healthy long turns after adoption", async () => {
     await withTempState(async (stateDir) => {
       let clock = 20_000;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack users could receive no reply when their message was queued behind a long-running agent turn and remained deferred longer than the five-minute ingress adoption watchdog.

## Why This Change Was Made

Slack now releases its channel-level ingress lane after explicit reply-lane deferral and lets that deferred lifecycle settle the durable claim through adoption, failure, cancellation, or abandonment. Normal dispatch stalls retain the existing watchdog, and channel-ID migration ordering remains serialized before the reply-queue handoff.

AI-assisted.

## User Impact

Queued Slack messages remain recoverable during long tasks instead of being silently marked failed, while later channel events can proceed into their own reply lanes.

## Evidence

- Observed before the fix: an acknowledged Slack event was marked failed after exactly `300000ms` with `handler-timeout` while waiting behind a busy reply lane; the Slack connection stayed healthy and model requests returned HTTP 200.
- Regression proof: `node scripts/run-vitest.mjs src/channels/message/ingress-drain.test.ts src/channels/message/ingress-drain.watchdog.test.ts src/channels/message/ingress-drain-supersede.test.ts extensions/slack/src/monitor/ingress.test.ts` — 47 tests passed.
- Focused Oxlint passed for the changed core and Slack files.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions`, and `pnpm tsgo:extensions:test` passed.
- `pnpm plugin-sdk:surface:check` passed.
- `git diff --check` passed.
- Repository-wide changed-check reached an unrelated pre-existing doctor-contract failure affecting 32 bundled plugins; none of the reported plugins or files are changed here.
- The author explicitly opted out of the repository's external-model autoreview gate for this PR; normal PR review and CI remain requested.

Production LOC: +14/-4 (net +10) | Tests: +73/-1

The small production increase introduces an explicit lifecycle-owned deferral mode so Slack can preserve durable recovery without weakening the watchdog for ordinary ingress stalls.
