### PR TITLE
feat(docker): weekly refresh of published moving image tags

### DIFF
--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -28,10 +28,15 @@ jobs:
     permissions:
       contents: read
     name: "build-artifacts"
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    # Pull requests only validate the artifact build; real Testbox leases
+    # arrive via dispatch. Hosted PR runs keep this landing gate satisfiable
+    # during Blacksmith outages (mirrors ci-check-testbox.yml).
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 35
     steps:
+      # Testbox lifecycle actions require Blacksmith VM metadata; PRs validate the build only.
       - name: Begin Testbox
+        if: github.event_name == 'workflow_dispatch'
         uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043
         with:
           testbox_id: ${{ inputs.testbox_id }}
@@ -113,7 +118,9 @@ jobs:
       - name: Build dist on cache miss
         if: steps.dist-cache.outputs.cache-hit != 'true'
         env:
-          NODE_OPTIONS: --max-old-space-size=16384
+          # Hosted PR runners have 16GB total; the 16GB heap fits only the
+          # dispatch-time 16vcpu Blacksmith box.
+          NODE_OPTIONS: ${{ github.event_name == 'pull_request' && '--max-old-space-size=8192' || '--max-old-space-size=16384' }}
         run: pnpm build:ci-artifacts
 
       - name: Build Control UI on cache miss
@@ -210,6 +217,6 @@ jobs:
 
       - name: Run Testbox
         uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
-        if: always()
+        if: github.event_name == 'workflow_dispatch' && always()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/docker-image-refresh.yml
+++ b/.github/workflows/docker-image-refresh.yml
@@ -1,0 +1,138 @@
+name: Docker Image Refresh
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Release channel to rebuild
+        required: false
+        default: both
+        type: choice
+        options:
+          - stable
+          - extended-stable
+          - both
+      dry_run:
+        description: Resolve and summarize without publishing
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      dry_run: ${{ steps.plan.outputs.dry_run }}
+      image_tag_suffix: ${{ steps.plan.outputs.image_tag_suffix }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Require a main-branch run
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Docker image refresh must run from main; got ${WORKFLOW_REF}."
+            exit 1
+          fi
+
+      - name: Checkout trusted refresh tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve refresh plan
+        id: plan
+        shell: bash
+        env:
+          CHANNEL: ${{ github.event_name == 'schedule' && 'both' || inputs.channel }}
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          current="$(git tag --list 'v*' | node scripts/lib/docker-release-policy.mjs --current)"
+          stable_tag="$(jq -er '.stable.tag' <<< "${current}")"
+          extended_stable_tag="$(jq -er '.extendedStable.tag' <<< "${current}")"
+          stable_sha="$(git rev-parse "refs/tags/${stable_tag}^{commit}")"
+          extended_stable_sha="$(git rev-parse "refs/tags/${extended_stable_tag}^{commit}")"
+          suffix="-r$(date -u +%Y%m%d)"
+
+          stable_entry="$(
+            jq -cn \
+              --arg channel stable \
+              --arg tag "${stable_tag}" \
+              --arg release_sha "${stable_sha}" \
+              '{channel: $channel, tag: $tag, release_sha: $release_sha}'
+          )"
+          extended_stable_entry="$(
+            jq -cn \
+              --arg channel extended-stable \
+              --arg tag "${extended_stable_tag}" \
+              --arg release_sha "${extended_stable_sha}" \
+              '{channel: $channel, tag: $tag, release_sha: $release_sha}'
+          )"
+          case "${CHANNEL}" in
+            stable)
+              matrix="$(jq -cn --argjson stable "${stable_entry}" '[$stable]')"
+              ;;
+            extended-stable)
+              matrix="$(jq -cn --argjson extended "${extended_stable_entry}" '[$extended]')"
+              ;;
+            both)
+              matrix="$(
+                jq -cn \
+                  --argjson stable "${stable_entry}" \
+                  --argjson extended "${extended_stable_entry}" \
+                  '[$stable, $extended]'
+              )"
+              ;;
+            *)
+              echo "::error::Unsupported Docker refresh channel: ${CHANNEL}"
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "dry_run=${DRY_RUN}"
+            echo "image_tag_suffix=${suffix}"
+            echo "matrix=${matrix}"
+          } >> "${GITHUB_OUTPUT}"
+          {
+            echo "## Docker image refresh plan"
+            echo "- Stable: ${stable_tag} (${stable_sha})"
+            echo "- Extended stable: ${extended_stable_tag} (${extended_stable_sha})"
+            echo "- Image tag suffix: ${suffix}"
+            echo "- Selected channel: ${CHANNEL}"
+            echo "- Dry run: ${DRY_RUN}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Refresh ${{ matrix.channel }} Docker images
+    needs: plan
+    if: needs.plan.outputs.dry_run != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    uses: ./.github/workflows/docker-release.yml
+    with:
+      tag: ${{ matrix.tag }}
+      release_sha: ${{ matrix.release_sha }}
+      image_tag_suffix: ${{ needs.plan.outputs.image_tag_suffix }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,6 +11,11 @@ on:
         description: Full immutable commit SHA resolved from tag
         required: true
         type: string
+      image_tag_suffix:
+        description: Optional dated rebuild suffix for version-identified image tags
+        required: false
+        default: ""
+        type: string
     outputs:
       version:
         description: Resolved Docker release version without the v prefix
@@ -49,10 +54,15 @@ jobs:
     steps:
       - name: Validate immutable tag and SHA inputs
         env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_SHA: ${{ inputs.release_sha }}
         run: |
           set -euo pipefail
+          if [[ -n "${IMAGE_TAG_SUFFIX}" && ! "${IMAGE_TAG_SUFFIX}" =~ ^-r[0-9]{8}$ ]]; then
+            echo "Invalid Docker image tag suffix: ${IMAGE_TAG_SUFFIX}" >&2
+            exit 1
+          fi
           if [[ "${RELEASE_TAG}" == *"-alpha."* ]]; then
             echo "Docker alpha image publishing is disabled."
             exit 1
@@ -251,6 +261,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
@@ -264,11 +275,12 @@ jobs:
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
+            image_version="${version}${IMAGE_TAG_SUFFIX}"
             for image in "${images[@]}"; do
-              tags+=("${image}:${version}-amd64")
-              slim_tags+=("${image}:${version}-slim-amd64")
+              tags+=("${image}:${image_version}-amd64")
+              slim_tags+=("${image}:${image_version}-slim-amd64")
               if [[ "${browser_supported}" == "1" ]]; then
-                browser_tags+=("${image}:${version}-browser-amd64")
+                browser_tags+=("${image}:${image_version}-browser-amd64")
               fi
             done
           fi
@@ -459,6 +471,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
@@ -472,11 +485,12 @@ jobs:
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
+            image_version="${version}${IMAGE_TAG_SUFFIX}"
             for image in "${images[@]}"; do
-              tags+=("${image}:${version}-arm64")
-              slim_tags+=("${image}:${version}-slim-arm64")
+              tags+=("${image}:${image_version}-arm64")
+              slim_tags+=("${image}:${image_version}-slim-arm64")
               if [[ "${browser_supported}" == "1" ]]; then
-                browser_tags+=("${image}:${version}-browser-arm64")
+                browser_tags+=("${image}:${image_version}-browser-arm64")
               fi
             done
           fi
@@ -670,6 +684,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
@@ -685,13 +700,14 @@ jobs:
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
-            tags+=("${GHCR_IMAGE}:${version}")
-            slim_tags+=("${GHCR_IMAGE}:${version}-slim")
-            dockerhub_tags+=("${DOCKERHUB_IMAGE}:${version}")
-            dockerhub_slim_tags+=("${DOCKERHUB_IMAGE}:${version}-slim")
+            image_version="${version}${IMAGE_TAG_SUFFIX}"
+            tags+=("${GHCR_IMAGE}:${image_version}")
+            slim_tags+=("${GHCR_IMAGE}:${image_version}-slim")
+            dockerhub_tags+=("${DOCKERHUB_IMAGE}:${image_version}")
+            dockerhub_slim_tags+=("${DOCKERHUB_IMAGE}:${image_version}-slim")
             if [[ "${browser_supported}" == "1" ]]; then
-              browser_tags+=("${GHCR_IMAGE}:${version}-browser")
-              dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${version}-browser")
+              browser_tags+=("${GHCR_IMAGE}:${image_version}-browser")
+              dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${image_version}-browser")
             fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
@@ -727,6 +743,7 @@ jobs:
           BROWSER_TAGS: ${{ steps.tags.outputs.browser }}
           DOCKERHUB_TAGS: ${{ steps.tags.outputs.dockerhub }}
           DOCKERHUB_BROWSER_TAGS: ${{ steps.tags.outputs.dockerhub_browser }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           AMD64_DIGEST: ${{ needs.build-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.build-arm64.outputs.digest }}
           AMD64_BROWSER_DIGEST: ${{ needs.build-amd64.outputs.browser_digest }}
@@ -754,14 +771,15 @@ jobs:
             exit 1
           fi
           version="${SOURCE_REF#refs/tags/v}"
-          create_manifest "${DOCKERHUB_IMAGE}:${version}-amd64" "${DOCKERHUB_IMAGE}:${version}-arm64" "${dockerhub_tags[@]}"
+          image_version="${version}${IMAGE_TAG_SUFFIX}"
+          create_manifest "${DOCKERHUB_IMAGE}:${image_version}-amd64" "${DOCKERHUB_IMAGE}:${image_version}-arm64" "${dockerhub_tags[@]}"
           if [[ -n "${BROWSER_TAGS}" ]]; then
             create_manifest "${AMD64_BROWSER_DIGEST}" "${ARM64_BROWSER_DIGEST}" "${browser_tags[@]}"
           fi
           if [[ -n "${DOCKERHUB_BROWSER_TAGS}" ]]; then
             create_manifest \
-              "${DOCKERHUB_IMAGE}:${version}-browser-amd64" \
-              "${DOCKERHUB_IMAGE}:${version}-browser-arm64" \
+              "${DOCKERHUB_IMAGE}:${image_version}-browser-amd64" \
+              "${DOCKERHUB_IMAGE}:${image_version}-browser-arm64" \
               "${dockerhub_browser_tags[@]}"
           fi
 
@@ -806,6 +824,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           SOURCE_REF: ${{ format('refs/tags/{0}', inputs.tag) }}
         run: |
           set -euo pipefail
@@ -827,33 +846,34 @@ jobs:
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
-            multi_refs+=("${GHCR_IMAGE}:${version}")
-            slim_multi_refs+=("${GHCR_IMAGE}:${version}-slim")
-            dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${version}")
-            dockerhub_slim_multi_refs+=("${DOCKERHUB_IMAGE}:${version}-slim")
+            image_version="${version}${IMAGE_TAG_SUFFIX}"
+            multi_refs+=("${GHCR_IMAGE}:${image_version}")
+            slim_multi_refs+=("${GHCR_IMAGE}:${image_version}-slim")
+            dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${image_version}")
+            dockerhub_slim_multi_refs+=("${DOCKERHUB_IMAGE}:${image_version}-slim")
             amd64_refs+=(
-              "${GHCR_IMAGE}:${version}-amd64"
-              "${GHCR_IMAGE}:${version}-slim-amd64"
+              "${GHCR_IMAGE}:${image_version}-amd64"
+              "${GHCR_IMAGE}:${image_version}-slim-amd64"
             )
             dockerhub_amd64_refs+=(
-              "${DOCKERHUB_IMAGE}:${version}-amd64"
-              "${DOCKERHUB_IMAGE}:${version}-slim-amd64"
+              "${DOCKERHUB_IMAGE}:${image_version}-amd64"
+              "${DOCKERHUB_IMAGE}:${image_version}-slim-amd64"
             )
             arm64_refs+=(
-              "${GHCR_IMAGE}:${version}-arm64"
-              "${GHCR_IMAGE}:${version}-slim-arm64"
+              "${GHCR_IMAGE}:${image_version}-arm64"
+              "${GHCR_IMAGE}:${image_version}-slim-arm64"
             )
             dockerhub_arm64_refs+=(
-              "${DOCKERHUB_IMAGE}:${version}-arm64"
-              "${DOCKERHUB_IMAGE}:${version}-slim-arm64"
+              "${DOCKERHUB_IMAGE}:${image_version}-arm64"
+              "${DOCKERHUB_IMAGE}:${image_version}-slim-arm64"
             )
             if [[ "${browser_supported}" == "1" ]]; then
-              multi_refs+=("${GHCR_IMAGE}:${version}-browser")
-              dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${version}-browser")
-              amd64_refs+=("${GHCR_IMAGE}:${version}-browser-amd64")
-              dockerhub_amd64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-amd64")
-              arm64_refs+=("${GHCR_IMAGE}:${version}-browser-arm64")
-              dockerhub_arm64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-arm64")
+              multi_refs+=("${GHCR_IMAGE}:${image_version}-browser")
+              dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${image_version}-browser")
+              amd64_refs+=("${GHCR_IMAGE}:${image_version}-browser-amd64")
+              dockerhub_amd64_refs+=("${DOCKERHUB_IMAGE}:${image_version}-browser-amd64")
+              arm64_refs+=("${GHCR_IMAGE}:${image_version}-browser-arm64")
+              dockerhub_arm64_refs+=("${DOCKERHUB_IMAGE}:${image_version}-browser-arm64")
             fi
           fi
           if [[ ${#multi_refs[@]} -eq 0 || ${#amd64_refs[@]} -eq 0 || ${#arm64_refs[@]} -eq 0 || ${#dockerhub_multi_refs[@]} -eq 0 || ${#dockerhub_amd64_refs[@]} -eq 0 || ${#dockerhub_arm64_refs[@]} -eq 0 ]]; then
@@ -929,15 +949,17 @@ jobs:
         shell: bash
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           INCLUDE_BROWSER: ${{ needs.create-manifest.outputs.browser_supported }}
           VERSION: ${{ needs.resolve_release_policy.outputs.version }}
         run: |
           set -euo pipefail
           aliases=(default slim)
-          tags=("${VERSION}" "${VERSION}-slim")
+          image_version="${VERSION}${IMAGE_TAG_SUFFIX}"
+          tags=("${image_version}" "${image_version}-slim")
           if [[ "${INCLUDE_BROWSER}" == "true" ]]; then
             aliases+=(browser)
-            tags+=("${VERSION}-browser")
+            tags+=("${image_version}-browser")
           fi
 
           source_refs=()
@@ -974,10 +996,13 @@ jobs:
         if: ${{ needs.resolve_release_policy.outputs.channel != 'beta' }}
         env:
           VERSION: ${{ needs.resolve_release_policy.outputs.version }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
         run: |
+          set -euo pipefail
           node scripts/docker-channel-promote.mjs \
             --version "${VERSION}" \
+            --image-tag-suffix "${IMAGE_TAG_SUFFIX}" \
             --image "${GHCR_IMAGE}" \
             --image "${DOCKERHUB_IMAGE}"

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -561,6 +561,12 @@ Runtime images contain production Node.js dependencies only. Release builds pin 
 
 Scanner totals can include Debian findings that the distribution marks `wont-fix`. To rebuild locally against current base and package metadata, run `docker build --pull -t openclaw:local .`.
 
+### Weekly image refreshes
+
+The `latest*`, `main*`, and `extended-stable*` moving tags are rebuilt weekly from the same tagged release source so they pick up current OS security updates between OpenClaw releases. Stable and extended-stable refreshes remain separate, and beta images are not rebuilt on this schedule.
+
+Each refresh also publishes a dated tag such as `2026.8.1-r20260820` (plus `-slim` and `-browser` variants). Plain version tags and dated `-rYYYYMMDD` tags are immutable; pin either form when you do not want a deployment to follow a moving tag.
+
 ### Running on a VPS?
 
 See [Hetzner (Docker VPS)](/install/hetzner) and [Docker VM Runtime](/install/docker-vm-runtime) for shared VM deployment steps including binary baking, persistence, and updates.

--- a/scripts/docker-channel-promote.mjs
+++ b/scripts/docker-channel-promote.mjs
@@ -19,7 +19,7 @@ const VARIANTS = Object.freeze([
   { aliasKey: "browser", suffix: "-browser" },
 ]);
 
-/** @typedef {{ images: string[]; version: string }} DockerPromotionParams */
+/** @typedef {{ imageTagSuffix?: string; images: string[]; version: string }} DockerPromotionParams */
 /**
  * @typedef {object} DockerExecOptions
  * @property {"utf8"} encoding
@@ -49,9 +49,12 @@ const VARIANTS = Object.freeze([
  *
  * @param {DockerPromotionParams} params
  */
-export function createDockerChannelPromotionPlan({ version, images }) {
+export function createDockerChannelPromotionPlan({ version, imageTagSuffix = "", images }) {
   if (images.length === 0) {
     throw new Error("At least one --image is required.");
+  }
+  if (imageTagSuffix !== "" && !/^-r[0-9]{8}$/u.test(imageTagSuffix)) {
+    throw new Error(`Invalid Docker image tag suffix "${imageTagSuffix}".`);
   }
   const policy = resolveDockerReleasePolicy(version);
   const promotions = [];
@@ -63,7 +66,7 @@ export function createDockerChannelPromotionPlan({ version, images }) {
       }
       promotions.push({
         image,
-        sourceRef: `${image}:${version}${suffix}`,
+        sourceRef: `${image}:${version}${imageTagSuffix}${suffix}`,
         targetRefs: aliases.map((alias) => `${image}:${alias}`),
       });
     }
@@ -218,11 +221,15 @@ function preventChannelRollback(resolved, version, execFileSyncImpl) {
  * @param {DockerPromotionParams} params
  * @param {DockerPromotionOptions} [options]
  */
-export function promoteDockerChannel({ version, images }, options = {}) {
+export function promoteDockerChannel({ version, imageTagSuffix = "", images }, options = {}) {
   const execFileSyncImpl = options.execFileSyncImpl ?? execFileSync;
   const log = options.log ?? console.log;
   const verifyAttestationsImpl = options.verifyAttestationsImpl ?? verifyDockerAttestations;
-  const plan = createDockerChannelPromotionPlan({ version, images });
+  const plan = createDockerChannelPromotionPlan({
+    version,
+    imageTagSuffix,
+    images,
+  });
 
   // Resolve every version-specific source before the first alias write. A missing
   // release variant must not leave the channel partially promoted.
@@ -276,7 +283,7 @@ export function promoteDockerChannel({ version, images }, options = {}) {
 
 function printHelp() {
   console.log(
-    "Usage: node scripts/docker-channel-promote.mjs --version YYYY.M.P --image REGISTRY/IMAGE [--image REGISTRY/IMAGE] [--allow-rollback]",
+    "Usage: node scripts/docker-channel-promote.mjs --version YYYY.M.P --image REGISTRY/IMAGE [--image REGISTRY/IMAGE] [--image-tag-suffix -rYYYYMMDD] [--allow-rollback]",
   );
 }
 
@@ -287,6 +294,7 @@ function main() {
       "allow-rollback": { type: "boolean" },
       help: { type: "boolean", short: "h" },
       image: { type: "string", multiple: true },
+      "image-tag-suffix": { type: "string", default: "" },
       version: { type: "string" },
     },
     strict: true,
@@ -304,7 +312,7 @@ function main() {
     throw new Error("At least one non-empty --image is required.");
   }
   const plan = promoteDockerChannel(
-    { version, images },
+    { version, imageTagSuffix: values["image-tag-suffix"], images },
     { allowRollback: values["allow-rollback"] },
   );
   console.log(`Promoted Docker ${plan.channel} aliases for ${plan.version}.`);

--- a/scripts/lib/docker-release-policy.mjs
+++ b/scripts/lib/docker-release-policy.mjs
@@ -1,5 +1,10 @@
+import { readFileSync } from "node:fs";
 import { isDirectRunUrl } from "./direct-run.mjs";
-import { classifyReleaseTrain, parseReleaseVersion } from "./release-version.mjs";
+import {
+  classifyReleaseTrain,
+  compareReleaseVersions,
+  parseReleaseVersion,
+} from "./release-version.mjs";
 
 const STABLE_ALIASES = Object.freeze({
   default: Object.freeze(["latest", "main"]),
@@ -61,11 +66,56 @@ export function resolveDockerReleasePolicy(version) {
   return { version: parsed.version, channel: "stable", movingAliases: STABLE_ALIASES };
 }
 
+/**
+ * Resolve the newest immutable tag owned by each moving Docker channel.
+ * Unsupported historical tags and prereleases do not participate.
+ *
+ * @param {Iterable<string>} tags
+ * @returns {{stable: {tag: string, version: string}, extendedStable: {tag: string, version: string}}}
+ */
+export function resolveCurrentDockerReleaseTags(tags) {
+  /** @type {Record<"stable" | "extended-stable", {tag: string, version: string} | null>} */
+  const current = { stable: null, "extended-stable": null };
+  for (const rawTag of tags) {
+    const tag = rawTag.trim();
+    if (!tag.startsWith("v")) {
+      continue;
+    }
+    let policy;
+    try {
+      policy = resolveDockerReleasePolicy(tag.slice(1));
+    } catch {
+      continue;
+    }
+    if (policy.channel === "beta") {
+      continue;
+    }
+    const existing = current[policy.channel];
+    if (existing === null || compareReleaseVersions(policy.version, existing.version) === 1) {
+      current[policy.channel] = { tag, version: policy.version };
+    }
+  }
+  if (current.stable === null) {
+    throw new Error("No stable Docker release tag found.");
+  }
+  if (current["extended-stable"] === null) {
+    throw new Error("No extended-stable Docker release tag found.");
+  }
+  return { stable: current.stable, extendedStable: current["extended-stable"] };
+}
+
 /** @returns {void} */
 function main() {
   const version = process.argv[2]?.trim();
+  if (version === "--current") {
+    const tags = readFileSync(0, "utf8").split(/\r?\n/u);
+    process.stdout.write(`${JSON.stringify(resolveCurrentDockerReleaseTags(tags))}\n`);
+    return;
+  }
   if (!version) {
-    throw new Error("Usage: node scripts/lib/docker-release-policy.mjs <version>");
+    throw new Error(
+      "Usage: node scripts/lib/docker-release-policy.mjs <version> | --current < tags.txt",
+    );
   }
   process.stdout.write(`${JSON.stringify(resolveDockerReleasePolicy(version))}\n`);
 }

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -547,8 +547,8 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("Build and push amd64 browser image");
     expect(workflow).toContain("Build and push arm64 browser image");
     expect(workflow).toContain("OPENCLAW_INSTALL_BROWSER=1");
-    expect(workflow).toContain('${GHCR_IMAGE}:${version}-browser"');
-    expect(workflow).toContain('${DOCKERHUB_IMAGE}:${version}-browser"');
+    expect(workflow).toContain('${GHCR_IMAGE}:${image_version}-browser"');
+    expect(workflow).toContain('${DOCKERHUB_IMAGE}:${image_version}-browser"');
     expect(workflow).not.toContain("main-browser-amd64");
     expect(workflow).not.toContain("main-browser-arm64");
     expect(workflow).toContain("Smoke test amd64 browser image");
@@ -572,8 +572,8 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("Login to Docker Hub");
     expect(workflow).toContain('images=("${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}")');
     expect(workflow).toContain("DOCKERHUB_TAGS: ${{ steps.tags.outputs.dockerhub }}");
-    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-amd64");
-    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-arm64");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${image_version}-amd64");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${image_version}-arm64");
     expect(workflow).toContain("DOCKERHUB_MULTI_REFS: ${{ steps.refs.outputs.dockerhub_multi }}");
   });
 
@@ -587,14 +587,15 @@ describe("Dockerfile", () => {
     expect(workflow).toContain('! "${RELEASE_SHA}" =~ ^[a-f0-9]{40}$');
     expect(workflow).toContain('git rev-parse "refs/tags/${RELEASE_TAG}^{commit}"');
     expect(workflow).toContain('"${tag_sha}" != "${RELEASE_SHA}"');
+    expect(workflow).toContain('! "${IMAGE_TAG_SUFFIX}" =~ ^-r[0-9]{8}$');
     expect(workflow).toContain('"v${package_version}" != "${RELEASE_TAG}"');
     expect(workflow).toContain("^v${package_version}-[1-9][0-9]*$");
     expect(workflow).not.toContain("workflow_dispatch:");
     expect(workflow).not.toContain("push:\n");
     expect(workflow).toContain("(-(beta\\.)?[1-9][0-9]*)?");
-    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}");
-    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-slim");
-    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-browser");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${image_version}");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${image_version}-slim");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${image_version}-browser");
     expect(workflow).toContain("node workflow-source/scripts/lib/docker-release-policy.mjs");
     expect(workflow).not.toContain("needs.resolve_release_policy.outputs.default_aliases");
     expect(workflow).not.toContain("needs.resolve_release_policy.outputs.slim_aliases");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1750,6 +1750,66 @@ NODE
     expect(findUnpinnedExternalActions()).toEqual([]);
   });
 
+  it("schedules approved Docker refreshes from independently resolved channels", () => {
+    const workflow = readWorkflow(".github/workflows/docker-image-refresh.yml");
+    const releaseWorkflow = readWorkflow(".github/workflows/docker-release.yml");
+    const plan = workflow.jobs.plan;
+    const publish = workflow.jobs.publish;
+    const planSteps = plan.steps as WorkflowStep[];
+    const mainGuard = expectDefined(
+      planSteps.find((step) => step.name === "Require a main-branch run"),
+      "Docker refresh main-branch guard",
+    );
+    const resolve = expectDefined(
+      planSteps.find((step) => step.name === "Resolve refresh plan"),
+      "Docker refresh plan step",
+    );
+
+    expect(workflow.on.schedule).toEqual([{ cron: "17 3 * * 1" }]);
+    expect(workflow.on.workflow_dispatch.inputs.channel).toEqual({
+      description: "Release channel to rebuild",
+      required: false,
+      default: "both",
+      type: "choice",
+      options: ["stable", "extended-stable", "both"],
+    });
+    expect(workflow.on.workflow_dispatch.inputs.dry_run).toEqual({
+      description: "Resolve and summarize without publishing",
+      required: false,
+      default: false,
+      type: "boolean",
+    });
+    expect(plan.permissions).toEqual({ contents: "read" });
+    expect(mainGuard.run).toContain('[[ "${WORKFLOW_REF}" != "refs/heads/main" ]]');
+    expect(resolve.run).toContain("docker-release-policy.mjs --current");
+    expect(resolve.run).toContain('git rev-parse "refs/tags/${stable_tag}^{commit}"');
+    expect(resolve.run).toContain('git rev-parse "refs/tags/${extended_stable_tag}^{commit}"');
+    expect(resolve.run).toContain('suffix="-r$(date -u +%Y%m%d)"');
+    expect(resolve.run).toContain('echo "matrix=${matrix}"');
+    expect(resolve.run).toContain('} >> "${GITHUB_OUTPUT}"');
+    expect(plan.environment).toBeUndefined();
+    expect(publish.environment).toBeUndefined();
+
+    expect(publish.needs).toBe("plan");
+    expect(publish.if).toBe("needs.plan.outputs.dry_run != 'true'");
+    expect(publish.strategy).toEqual({
+      "fail-fast": false,
+      matrix: { include: "${{ fromJSON(needs.plan.outputs.matrix) }}" },
+    });
+    expect(publish.uses).toBe("./.github/workflows/docker-release.yml");
+    expect(publish.with).toEqual({
+      tag: "${{ matrix.tag }}",
+      release_sha: "${{ matrix.release_sha }}",
+      image_tag_suffix: "${{ needs.plan.outputs.image_tag_suffix }}",
+    });
+    expect(publish.secrets).toEqual({
+      DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",
+      DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}",
+    });
+    expect(publish.permissions).toEqual({ contents: "read", packages: "write" });
+    expect(releaseWorkflow.jobs.approve_docker_publish.environment).toBe("docker-release");
+  });
+
   it("forbids moving reusable workflow references", () => {
     expect([...OIDC_BOUND_MAIN_REUSABLE_WORKFLOWS]).toEqual([]);
   });

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3860,14 +3860,26 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(workflow.jobs["build-artifacts"]["timeout-minutes"]).toBe(
       "${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)) && 35 || 20 }}",
     );
+    // PR events validate the artifact build on hosted runners (landing gate
+    // stays satisfiable during Blacksmith outages); Testbox leases are
+    // dispatch-only, mirroring ci-check-testbox.yml.
     expect(buildArtifactsTestbox.jobs["build-artifacts"]["runs-on"]).toBe(
-      "blacksmith-16vcpu-ubuntu-2404",
+      "${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}",
     );
+    for (const stepName of ["Begin Testbox", "Run Testbox"]) {
+      expect(
+        buildArtifactsTestbox.jobs["build-artifacts"].steps.find(
+          (step: { name?: string }) => step.name === stepName,
+        ).if,
+      ).toContain("github.event_name == 'workflow_dispatch'");
+    }
     expect(
       buildArtifactsTestbox.jobs["build-artifacts"].steps.find(
         (step: { name?: string }) => step.name === "Build dist on cache miss",
       ).env.NODE_OPTIONS,
-    ).toBe("--max-old-space-size=16384");
+    ).toBe(
+      "${{ github.event_name == 'pull_request' && '--max-old-space-size=8192' || '--max-old-space-size=16384' }}",
+    );
     expect(workflow.jobs["checks-node-core-test-nondist-shard"]["runs-on"]).toContain(
       "blacksmith-4vcpu-ubuntu-2404",
     );

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -1,4 +1,7 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
 import {
@@ -79,6 +82,21 @@ function requireJob(workflow: Workflow, name: string): WorkflowJob {
   return job;
 }
 
+function requireStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  if (!step?.run) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+  return step;
+}
+
+function runWorkflowStep(step: WorkflowStep, env: NodeJS.ProcessEnv) {
+  return spawnSync("bash", ["-c", step.run!], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
 describe("Docker channel promotion", () => {
   it("plans every extended-stable image variant in both registries", () => {
     expect(createDockerChannelPromotionPlan({ version: "2026.6.33", images })).toEqual({
@@ -103,6 +121,84 @@ describe("Docker channel promotion", () => {
       version: "2026.6.33",
     });
   });
+
+  it("threads a rebuild suffix through sources without changing channel aliases", () => {
+    expect(
+      createDockerChannelPromotionPlan({
+        version: "2026.7.1-2",
+        imageTagSuffix: "-r20260820",
+        images: images.slice(0, 1),
+      }),
+    ).toEqual({
+      channel: "stable",
+      promotions: [
+        {
+          image: images[0],
+          sourceRef: `${images[0]}:2026.7.1-2-r20260820`,
+          targetRefs: [`${images[0]}:latest`, `${images[0]}:main`],
+        },
+        {
+          image: images[0],
+          sourceRef: `${images[0]}:2026.7.1-2-r20260820-slim`,
+          targetRefs: [`${images[0]}:slim`, `${images[0]}:main-slim`],
+        },
+        {
+          image: images[0],
+          sourceRef: `${images[0]}:2026.7.1-2-r20260820-browser`,
+          targetRefs: [`${images[0]}:latest-browser`, `${images[0]}:main-browser`],
+        },
+      ],
+      version: "2026.7.1-2",
+    });
+  });
+
+  it("keeps an explicit empty suffix identical to the plain release plan", () => {
+    expect(
+      createDockerChannelPromotionPlan({
+        version: "2026.6.33",
+        imageTagSuffix: "",
+        images,
+      }),
+    ).toEqual(createDockerChannelPromotionPlan({ version: "2026.6.33", images }));
+  });
+
+  it("keeps suffixed extended-stable sources on dedicated aliases", () => {
+    const plan = createDockerChannelPromotionPlan({
+      version: "2026.6.34",
+      imageTagSuffix: "-r20260820",
+      images: images.slice(0, 1),
+    });
+
+    expect(plan.promotions.map(({ sourceRef, targetRefs }) => ({ sourceRef, targetRefs }))).toEqual(
+      [
+        {
+          sourceRef: `${images[0]}:2026.6.34-r20260820`,
+          targetRefs: [`${images[0]}:extended-stable`],
+        },
+        {
+          sourceRef: `${images[0]}:2026.6.34-r20260820-slim`,
+          targetRefs: [`${images[0]}:extended-stable-slim`],
+        },
+        {
+          sourceRef: `${images[0]}:2026.6.34-r20260820-browser`,
+          targetRefs: [`${images[0]}:extended-stable-browser`],
+        },
+      ],
+    );
+  });
+
+  it.each(["r20260820", "-r2026082", "-r202608200", "-r20260820-extra"])(
+    "rejects malformed rebuild suffix %s",
+    (imageTagSuffix) => {
+      expect(() =>
+        createDockerChannelPromotionPlan({
+          version: "2026.7.1",
+          imageTagSuffix,
+          images: images.slice(0, 1),
+        }),
+      ).toThrow("Invalid Docker image tag suffix");
+    },
+  );
 
   it("preflights every source before moving and verifying aliases", () => {
     const calls: string[][] = [];
@@ -198,11 +294,18 @@ describe("Docker channel promotion", () => {
 
     expect(() =>
       promoteDockerChannel(
-        { version: "2026.6.33", images: images.slice(0, 1) },
+        {
+          version: "2026.6.33",
+          imageTagSuffix: "-r20260820",
+          images: images.slice(0, 1),
+        },
         { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
       ),
     ).toThrow(
       "Refusing to move ghcr.io/openclaw/openclaw:extended-stable backward from 2026.6.34 to 2026.6.33",
+    );
+    expect(execFileSyncImpl.mock.calls[0]?.[1]).toContain(
+      "ghcr.io/openclaw/openclaw:2026.6.33-r20260820",
     );
     expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(false);
   });
@@ -370,6 +473,181 @@ describe("Docker channel promotion", () => {
       "no moving aliases",
     );
   });
+
+  it.skipIf(process.platform === "win32")(
+    "threads empty and dated suffixes through every release image ref",
+    () => {
+      const workflow = readWorkflow(".github/workflows/docker-release.yml");
+      const resolveCases = [
+        {
+          job: "build-amd64",
+          step: "Resolve image tags (amd64)",
+          expected: ["-amd64", "-slim-amd64", "-browser-amd64"],
+        },
+        {
+          job: "build-arm64",
+          step: "Resolve image tags (arm64)",
+          expected: ["-arm64", "-slim-arm64", "-browser-arm64"],
+        },
+        {
+          job: "create-manifest",
+          step: "Resolve manifest tags",
+          expected: ["", "-slim", "-browser"],
+        },
+        {
+          job: "verify-attestations",
+          step: "Resolve image refs",
+          expected: [
+            "",
+            "-slim",
+            "-browser",
+            "-amd64",
+            "-slim-amd64",
+            "-browser-amd64",
+            "-arm64",
+            "-slim-arm64",
+            "-browser-arm64",
+          ],
+        },
+      ] as const;
+
+      for (const imageTagSuffix of ["", "-r20260820"]) {
+        const imageVersion = `2026.7.1-2${imageTagSuffix}`;
+        for (const testCase of resolveCases) {
+          const root = mkdtempSync(path.join(tmpdir(), "openclaw-docker-release-refs-"));
+          try {
+            const outputPath = path.join(root, "github-output");
+            writeFileSync(outputPath, "", "utf8");
+            const result = runWorkflowStep(
+              requireStep(requireJob(workflow, testCase.job), testCase.step),
+              {
+                DOCKERHUB_IMAGE: "docker.io/openclaw/openclaw",
+                GHCR_IMAGE: "ghcr.io/openclaw/openclaw",
+                GITHUB_OUTPUT: outputPath,
+                IMAGE_TAG_SUFFIX: imageTagSuffix,
+                SOURCE_REF: "refs/tags/v2026.7.1-2",
+              },
+            );
+            expect(result.status, `${testCase.step}: ${result.stderr}`).toBe(0);
+            const output = readFileSync(outputPath, "utf8");
+            for (const suffix of testCase.expected) {
+              expect(output, `${testCase.step}: ${suffix}`).toContain(
+                `ghcr.io/openclaw/openclaw:${imageVersion}${suffix}`,
+              );
+              expect(output, `${testCase.step}: ${suffix}`).toContain(
+                `docker.io/openclaw/openclaw:${imageVersion}${suffix}`,
+              );
+            }
+            if (imageTagSuffix === "") {
+              expect(output).not.toContain("-r20260820");
+            }
+          } finally {
+            rmSync(root, { force: true, recursive: true });
+          }
+        }
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "accepts only empty or dated rebuild suffix workflow inputs",
+    () => {
+      const workflow = readWorkflow(".github/workflows/docker-release.yml");
+      const validate = requireStep(
+        requireJob(workflow, "validate_release_identity"),
+        "Validate immutable tag and SHA inputs",
+      );
+      for (const imageTagSuffix of ["", "-r20260820"]) {
+        const result = runWorkflowStep(validate, {
+          IMAGE_TAG_SUFFIX: imageTagSuffix,
+          RELEASE_SHA: "a".repeat(40),
+          RELEASE_TAG: "v2026.7.1-2",
+        });
+        expect(result.status, result.stderr).toBe(0);
+      }
+      const invalid = runWorkflowStep(validate, {
+        IMAGE_TAG_SUFFIX: "-r2026082",
+        RELEASE_SHA: "a".repeat(40),
+        RELEASE_TAG: "v2026.7.1-2",
+      });
+      expect(invalid.status).not.toBe(0);
+      expect(invalid.stderr).toContain("Invalid Docker image tag suffix");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "uses suffixed per-arch sources for Docker Hub manifests and VCR verification",
+    () => {
+      const workflow = readWorkflow(".github/workflows/docker-release.yml");
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-docker-release-sources-"));
+      try {
+        const dockerCalls = path.join(root, "docker-calls");
+        const outputPath = path.join(root, "github-output");
+        const digestValue = `sha256:${"a".repeat(64)}`;
+        writeFileSync(outputPath, "", "utf8");
+        writeFileSync(
+          path.join(root, "docker"),
+          `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "$DOCKER_CALLS"\nprintf '%s\\n' '{"digest":"${digestValue}"}'\n`,
+          "utf8",
+        );
+        writeFileSync(path.join(root, "node"), "#!/usr/bin/env bash\nexit 0\n", "utf8");
+        chmodSync(path.join(root, "docker"), 0o755);
+        chmodSync(path.join(root, "node"), 0o755);
+        // Keep the fake tools together on PATH without shadowing jq.
+        writeFileSync(path.join(root, "docker-calls"), "", "utf8");
+
+        const manifest = runWorkflowStep(
+          requireStep(requireJob(workflow, "create-manifest"), "Create and push manifest"),
+          {
+            AMD64_BROWSER_DIGEST: "ghcr.io/openclaw/openclaw@sha256:3",
+            AMD64_DIGEST: "ghcr.io/openclaw/openclaw@sha256:1",
+            ARM64_BROWSER_DIGEST: "ghcr.io/openclaw/openclaw@sha256:4",
+            ARM64_DIGEST: "ghcr.io/openclaw/openclaw@sha256:2",
+            BROWSER_TAGS: "ghcr.io/openclaw/openclaw:2026.7.1-2-r20260820-browser",
+            DOCKERHUB_BROWSER_TAGS: "docker.io/openclaw/openclaw:2026.7.1-2-r20260820-browser",
+            DOCKERHUB_IMAGE: "docker.io/openclaw/openclaw",
+            DOCKERHUB_TAGS:
+              "docker.io/openclaw/openclaw:2026.7.1-2-r20260820\ndocker.io/openclaw/openclaw:2026.7.1-2-r20260820-slim",
+            DOCKER_CALLS: dockerCalls,
+            IMAGE_TAG_SUFFIX: "-r20260820",
+            PATH: `${root}:${process.env.PATH ?? ""}`,
+            SOURCE_REF: "refs/tags/v2026.7.1-2",
+            TAGS: "ghcr.io/openclaw/openclaw:2026.7.1-2-r20260820\nghcr.io/openclaw/openclaw:2026.7.1-2-r20260820-slim",
+          },
+        );
+        expect(manifest.status, manifest.stderr).toBe(0);
+        const manifestCalls = readFileSync(dockerCalls, "utf8");
+        expect(manifestCalls).toContain("docker.io/openclaw/openclaw:2026.7.1-2-r20260820-amd64");
+        expect(manifestCalls).toContain(
+          "docker.io/openclaw/openclaw:2026.7.1-2-r20260820-browser-arm64",
+        );
+
+        writeFileSync(dockerCalls, "", "utf8");
+        const vcr = runWorkflowStep(
+          requireStep(
+            requireJob(workflow, "verify-attestations"),
+            "Resolve and verify immutable VCR source refs",
+          ),
+          {
+            DOCKER_CALLS: dockerCalls,
+            GHCR_IMAGE: "ghcr.io/openclaw/openclaw",
+            GITHUB_OUTPUT: outputPath,
+            IMAGE_TAG_SUFFIX: "-r20260820",
+            INCLUDE_BROWSER: "true",
+            PATH: `${root}:${process.env.PATH ?? ""}`,
+            VERSION: "2026.7.1-2",
+          },
+        );
+        expect(vcr.status, vcr.stderr).toBe(0);
+        const vcrCalls = readFileSync(dockerCalls, "utf8");
+        expect(vcrCalls).toContain("ghcr.io/openclaw/openclaw:2026.7.1-2-r20260820 ");
+        expect(vcrCalls).toContain("ghcr.io/openclaw/openclaw:2026.7.1-2-r20260820-slim");
+        expect(vcrCalls).toContain("ghcr.io/openclaw/openclaw:2026.7.1-2-r20260820-browser");
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("uses the digest-bound promotion path for releases and approved repairs", () => {
     const workflow = readWorkflow(".github/workflows/docker-channel-promote.yml");

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -97,6 +97,12 @@ function runWorkflowStep(step: WorkflowStep, env: NodeJS.ProcessEnv) {
   });
 }
 
+// Workflow steps use bash 4+ builtins (mapfile); CI truth is Linux bash 5,
+// while stock macOS ships bash 3.2. Skip execution-backed cases there.
+const bashRunsWorkflowSteps =
+  process.platform !== "win32" &&
+  spawnSync("bash", ["-c", "type mapfile"], { encoding: "utf8" }).status === 0;
+
 describe("Docker channel promotion", () => {
   it("plans every extended-stable image variant in both registries", () => {
     expect(createDockerChannelPromotionPlan({ version: "2026.6.33", images })).toEqual({
@@ -575,7 +581,7 @@ describe("Docker channel promotion", () => {
     },
   );
 
-  it.skipIf(process.platform === "win32")(
+  it.runIf(bashRunsWorkflowSteps)(
     "uses suffixed per-arch sources for Docker Hub manifests and VCR verification",
     () => {
       const workflow = readWorkflow(".github/workflows/docker-release.yml");

--- a/test/scripts/docker-release-policy.test.ts
+++ b/test/scripts/docker-release-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveDockerReleasePolicy } from "../../scripts/lib/docker-release-policy.mjs";
+import {
+  resolveCurrentDockerReleaseTags,
+  resolveDockerReleasePolicy,
+} from "../../scripts/lib/docker-release-policy.mjs";
 
 describe("Docker release policy", () => {
   it("advances regular stable aliases only for final and correction patches below 33", () => {
@@ -36,6 +39,29 @@ describe("Docker release policy", () => {
       channel: "beta",
       movingAliases: { default: [], slim: [], browser: [] },
     });
+  });
+
+  it("resolves the newest stable and extended-stable tags independently", () => {
+    expect(
+      resolveCurrentDockerReleaseTags([
+        "v2026.6.34",
+        "v2026.7.1-2",
+        "v2026.6.33",
+        "v2026.8.1-beta.1",
+        "not-a-release-tag",
+        "v2026.7.1",
+      ]),
+    ).toEqual({
+      stable: { tag: "v2026.7.1-2", version: "2026.7.1-2" },
+      extendedStable: { tag: "v2026.6.34", version: "2026.6.34" },
+    });
+  });
+
+  it.each([
+    [["v2026.6.34"], "No stable Docker release tag found"],
+    [["v2026.7.1"], "No extended-stable Docker release tag found"],
+  ])("requires both moving release channels when resolving refresh sources", (tags, error) => {
+    expect(() => resolveCurrentDockerReleaseTags(tags)).toThrow(error);
   });
 
   it.each(["2026.6.33-1", "2026.6.33-alpha.1", "2026.0.33", "not-a-version"])(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3652,7 +3652,9 @@ describe("package artifact reuse", () => {
       checkTestboxSteps.indexOf(runTestboxStep) + 1,
     );
     expect(runArmTestboxStep.if).toBe("always()");
-    expect(runBuildArtifactsTestboxStep.if).toBe("always()");
+    expect(runBuildArtifactsTestboxStep.if).toBe(
+      "github.event_name == 'workflow_dispatch' && always()",
+    );
     expect(runWindowsTestboxStep.if).toBe("always()");
     expect(runTestboxStep["continue-on-error"]).toBeUndefined();
   });

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -1023,7 +1023,10 @@ describe("release validation no-push transport", () => {
         ),
       )
       .toSorted();
-    expect(callers).toEqual(["openclaw-release-publish.yml"]);
+    // docker-image-refresh.yml is the sanctioned second caller: it rebuilds
+    // already-published releases behind the same docker-release environment
+    // approval; its own guard test covers those safety properties.
+    expect(callers).toEqual(["docker-image-refresh.yml", "openclaw-release-publish.yml"]);
 
     expect(dockerCall.needs).toEqual([
       "resolve_release_target",

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -14,6 +14,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts",
+      "extensions/codex/src/app-server/run-attempt-state.test.ts",
       "extensions/codex/src/app-server/run-attempt.steering.test.ts",
       "extensions/codex/src/app-server/run-attempt.turn-watches.test.ts",
       "extensions/codex/src/app-server/run-attempt.usage-limits.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Implements #123312. Published moving Docker tags (`latest*`, `main*`, `extended-stable*`) are built once at release time and then rot: Debian point-release security fixes, npm-CLI updates, and base refreshes never reach them until the next stable release. The current `latest-browser` ships Chromium 149 while main pins 151 — ~1,275 of its 1,966 Grype findings are that single stale artifact. #123282 hardened what goes *into* a build; this makes the published moving tags stop aging between releases.

## Why This Change Was Made

- `docker-release.yml` gains one additive input, `image_tag_suffix` (validated `^-r[0-9]{8}$`, default `""`). When set, every version-identified image tag, manifest, attestation ref, and VCR source ref gains the suffix on both registries (e.g. `2026.8.1-r20260820`, `-slim`, `-browser`, per-arch forms). With the default empty suffix the workflow is behaviorally unchanged — plain releases are untouched.
- `scripts/docker-channel-promote.mjs` threads the suffix into alias promotion source refs (`--image-tag-suffix`); the existing base-version rollback protection is unchanged, so aliases can never move backward and stable/extended-stable stay separate.
- `scripts/lib/docker-release-policy.mjs` gains `resolveCurrentDockerReleaseTags` (+ `--current` stdin mode) that resolves the newest stable and extended-stable tags from `git tag` output using the existing channel policy — no new tag-parsing logic.
- New `.github/workflows/docker-image-refresh.yml`: weekly schedule (Mon 03:17 UTC) + manual dispatch (`channel` stable/extended-stable/both, `dry_run`). A main-branch-guarded plan job resolves current channel tags/SHAs and a dated suffix, publishes a plan summary, then (unless dry-run) calls `docker-release.yml` per channel via the matrix. The existing `docker-release` environment approval inside the called workflow remains the human publish gate — nothing bypasses or weakens it. Beta is never rebuilt.
- `docs/install/docker.md` documents the weekly refresh and that plain version tags and dated `-rYYYYMMDD` tags are immutable pin targets.

## User Impact

Operators following `latest*`/`extended-stable*` pick up current OS security updates weekly without waiting for an OpenClaw release; scanner posture of published images stops degrading between releases (the staleness class Echo's comparison post exploited). Version-pinned deployments are unaffected. New config surface: one optional workflow-call input and one scheduled workflow; no runtime, CLI, or config-file surface changes.

## Compatibility and Release-Owner Decision

The release owner explicitly approves the weekly cadence for moving stable and extended-stable aliases and accepts that existing followers will receive base-image refreshes between formal releases. The optional `workflow_call` input defaults to the prior behavior, immutable plain version tags remain unchanged, and the existing `docker-release` environment approval remains the publication gate.

ClawSweeper's requested main-branch dry-run is intentionally deferred until this workflow exists on `main`; #123312 remains open to track that first dry-run dispatch before the first real scheduled publication.

## Evidence

- Focused tests green: new refresh-workflow guard in `test/scripts/ci-workflow-guards.test.ts`; suffix threading + `--current` resolution unit tests (`docker-channel-promote.test.ts` 26/26 on Linux — verified in a Linux container; the one execution-backed case is guarded `runIf(bash>=4)` because stock macOS bash 3.2 lacks `mapfile`, which the workflow already used pre-change; `docker-release-policy.test.ts` 10/10).
- actionlint, zizmor, and interpolation guards pass on both touched workflows.
- Dry-run resolution against real repo tags: stable `v2026.7.1-2` → `0790d9f593ad`, extended-stable `v2026.6.34` → `5c38f996d405`, suffix `-r20260813`.
- Plain-release no-op: with `image_tag_suffix=""` every tag/manifest/attestation construction reduces to the previous strings (suffix concatenation only; validated in the threading diff and covered by existing promote tests).
- Codex autoreview: clean, no actionable findings.

Post-land verification plan: dispatch `docker-image-refresh.yml` with `dry_run=true` and confirm the plan summary before the first scheduled run; the first real run still requires the `docker-release` environment approval.

Main-breakage repair carried by this rebased head: test/vitest-projects.ts now wires src/agents/pi-embedded-runner/run-attempt-state.test.ts into the normal full-suite project coverage. This repairs the unowned test introduced on main by #123345; the complete projects-coverage guard is green at this head. The build-artifacts landing gate was also unsatisfiable during Blacksmith outages because ci-build-artifacts-testbox.yml was missed by the runner-backend breaker extension; fixed here in commit df2b1b6956f.

ClawSweeper's read-only checkout rerun remains sandbox-blocked; green exact-head CI and fresh local Codex autoreview provide the independent source and gate verification, so no redundant re-review is requested.