### PR TITLE
fix(ui): keep the GitHub mark on its label's line when chat wraps

### DIFF
--- a/ui/src/styles/chat-github-link-presentation.browser.test.ts
+++ b/ui/src/styles/chat-github-link-presentation.browser.test.ts
@@ -1,0 +1,178 @@
+// Control UI tests cover how GitHub links present in chat when a line wraps.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const describeGitHubLinkPresentation = canRunPlaywrightChromium(chromiumExecutablePath)
+  ? describe
+  : describe.skip;
+
+function readChatCss(): string {
+  return ["ui/src/styles/base.css", "ui/src/styles/chat/text.css"]
+    .map((file) => readStyleSheet(file))
+    .join("\n");
+}
+
+// The three shapes the parser can produce, all carrying the same mark:
+// a bare item URL whose label it rewrites to owner/repo#number, a bare URL to
+// any other GitHub path, and an authored label. Only the first two carry
+// markdown-bare-url, so the sweep covers both wrap regimes.
+const LINK_FORMS = [
+  {
+    className: "markdown-bare-url markdown-github-link",
+    id: "human-ref",
+    label: "openclaw/openclaw#123309",
+    lead: "then follow-up tracked in ",
+  },
+  {
+    className: "markdown-bare-url markdown-github-link",
+    id: "bare-url",
+    label: "https://github.com/openclaw/openclaw/blob/main/ui/src/styles/chat/text.css#L254",
+    lead: "then the owning rule lives at ",
+  },
+  {
+    className: "markdown-github-link",
+    id: "authored",
+    label: "the sibling chip rule",
+    lead: "then see ",
+  },
+] as const;
+
+function fixtureDocument(themeMode: "dark" | "light"): string {
+  const themeAttributes =
+    themeMode === "light" ? `data-theme="light" data-theme-mode="light"` : `data-theme="dark"`;
+  const columns = LINK_FORMS.map(
+    ({ className, id, label, lead }) => `
+      <div class="chat-text" id="column-${id}">Reproduce the failing run and read the notes
+        first, ${lead}<a id="${id}" class="${className}" href="https://github.com/openclaw/openclaw"
+        >${label}</a> before landing the fix.</div>`,
+  ).join("");
+  return `<!doctype html><html ${themeAttributes}><head><style>${readChatCss()}</style></head>
+    <body>${columns}</body></html>`;
+}
+
+type WrapSample = {
+  readonly columnWidth: number;
+  readonly fragments: number;
+  readonly labelStartsMarkLine: boolean;
+  readonly markLineTop: number;
+};
+
+// Sweeping the column instead of picking one width: the mark has to stay with
+// its label at every position the reference can land in, and a single tuned
+// width stops exercising the wrap boundary as soon as prose or font metrics move.
+async function probeWrap(
+  themeMode: "dark" | "light",
+): Promise<Record<string, readonly WrapSample[]>> {
+  const fixtureFile = path.join(fixtureDirectory, `${themeMode}.html`);
+  fs.writeFileSync(fixtureFile, fixtureDocument(themeMode), "utf8");
+  const page = await browser.newPage();
+  try {
+    await page.goto(`file://${fixtureFile}`);
+    return await page.evaluate(
+      (ids: readonly string[]) => {
+        const resolve = (selector: string) => {
+          const element = document.querySelector(selector);
+          if (!(element instanceof HTMLElement)) {
+            throw new Error(`Missing GitHub link fixture element for ${selector}`);
+          }
+          return element;
+        };
+        const samples: Record<string, WrapSample[]> = {};
+        for (const id of ids) {
+          const column = resolve(`#column-${id}`);
+          const link = resolve(`#${id}`);
+          const collected: WrapSample[] = [];
+          for (let columnWidth = 200; columnWidth <= 900; columnWidth += 4) {
+            column.style.width = `${columnWidth}px`;
+            // The mark is painted at the start of the link box, so the link box
+            // and the first label character sharing a line is exactly the
+            // invariant: the mark is never left behind on the previous line.
+            const linkStart = link.getClientRects()[0];
+            const labelRange = document.createRange();
+            const labelText = link.firstChild;
+            if (!labelText || !linkStart) {
+              throw new Error(`Missing label geometry for ${id}`);
+            }
+            labelRange.setStart(labelText, 0);
+            labelRange.setEnd(labelText, 1);
+            const labelStart = labelRange.getBoundingClientRect();
+            collected.push({
+              columnWidth,
+              fragments: link.getClientRects().length,
+              labelStartsMarkLine: Math.abs(labelStart.top - linkStart.top) < 2,
+              markLineTop: Math.round(linkStart.top),
+            });
+          }
+          samples[id] = collected;
+        }
+        return samples;
+      },
+      LINK_FORMS.map((form) => form.id),
+    );
+  } finally {
+    await page.close();
+  }
+}
+
+let browser: Browser;
+let fixtureDirectory: string;
+
+beforeAll(async () => {
+  if (!canRunPlaywrightChromium(chromiumExecutablePath)) {
+    return;
+  }
+  // Resolve the temp root: macOS hands back a /var symlink and the file:// URL
+  // must be the canonical path.
+  fixtureDirectory = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "chat-github-link-presentation-")),
+  );
+  browser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
+});
+
+afterAll(async () => {
+  await browser?.close();
+  if (fixtureDirectory) {
+    fs.rmSync(fixtureDirectory, { force: true, recursive: true });
+  }
+});
+
+describeGitHubLinkPresentation("chat GitHub link presentation", () => {
+  it.each(["light", "dark"] as const)(
+    "keeps the GitHub mark on its label's line at every column width in %s",
+    async (themeMode) => {
+      const samples = await probeWrap(themeMode);
+      for (const { id } of LINK_FORMS) {
+        const collected = samples[id] ?? [];
+        // Vacuity guard: the reference must actually move between lines across
+        // the sweep, or the assertion below passes on prose that never wraps.
+        expect(new Set(collected.map((sample) => sample.markLineTop)).size).toBeGreaterThan(1);
+        const stranded = collected.filter((sample) => !sample.labelStartsMarkLine);
+        expect({ id, stranded }).toEqual({ id, stranded: [] });
+      }
+    },
+  );
+
+  it("keeps GitHub links breaking across lines instead of moving whole", async () => {
+    const samples = await probeWrap("dark");
+    // The file-link chip answers the same invariant by making the whole anchor
+    // atomic. That is the wrong answer here: an atomic anchor never fragments,
+    // so a long URL would move to the next line rather than break inside it and
+    // leave the line it should have filled ragged. Both forms must still split.
+    for (const id of ["bare-url", "authored"]) {
+      const collected = samples[id] ?? [];
+      expect({ id, splits: collected.some((sample) => sample.fragments > 1) }).toEqual({
+        id,
+        splits: true,
+      });
+    }
+  });
+});

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -255,11 +255,13 @@
   --github-mark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.27-.01-1.17-.02-2.12-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.19 1.76 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.78 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.42-2.7 5.39-5.26 5.68.41.35.78 1.05.78 2.12 0 1.53-.01 2.76-.01 3.14 0 .3.21.67.8.55A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z'/%3E%3C/svg%3E");
 
   content: "";
-  display: inline-block;
+  position: absolute;
+  inset-inline-start: 0;
+  /* vertical-align cannot reach an out-of-flow box, so the baseline shift it
+     used to carry becomes an offset from the first line box's top edge. */
+  top: 0.1em;
   width: 1em;
   height: 1em;
-  margin-inline-end: 0.3em;
-  vertical-align: -0.14em;
   background: currentColor;
   mask: var(--github-mark) center / contain no-repeat;
   -webkit-mask: var(--github-mark) center / contain no-repeat;
@@ -269,6 +271,13 @@
    signal and clutters dense URL text. Hover restores it as the affordance,
    like the file-link convention below. */
 .chat-text :where(a.markdown-github-link) {
+  /* The mark is painted out of flow with its space reserved here, so nothing
+     inside the anchor precedes the label: an in-flow atomic mark carries a soft
+     wrap opportunity after it, so a line could end on the mark alone. The anchor
+     stays inline so the bare-URL rule below can still fill the line a long URL
+     starts on; the file-link chip's `display: inline-block` could not. */
+  position: relative;
+  padding-inline-start: 1.3em; /* the mark's 1em box plus the 0.3em gap it had */
   text-decoration: none;
 }
 
@@ -277,10 +286,10 @@
 }
 
 /* The inherited `overflow-wrap: anywhere` breaks a word only once every other
-   option is gone, so a long URL is pushed whole onto the next line — stranding
-   the mark alone at the end of the previous one. Unconditional break points
-   make the URL fill the line it starts on; authored labels are excluded so
-   prose still wraps on word boundaries. */
+   option is gone, so a long URL is pushed whole onto the next line, leaving the
+   line it should have filled ragged. Unconditional break points make the URL
+   fill the line it starts on; authored labels are excluded so prose still wraps
+   on word boundaries. */
 .chat-text :where(a.markdown-bare-url) {
   line-break: anywhere;
 }

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -100,6 +100,7 @@ const nodeDrivenBrowserLayoutTests = [
   "src/pages/sessions/view.browser.test.ts",
   "src/styles/cursor-policy.browser.test.ts",
   "src/styles/chat-file-link-presentation.browser.test.ts",
+  "src/styles/chat-github-link-presentation.browser.test.ts",
   "src/styles/sr-only.browser.test.ts",
 ] as const;
 const mockRegistryUnitTests = [


### PR DESCRIPTION
Closes #123353

## What Problem This Solves

Fixes an issue where users reading a Control UI chat transcript would see a GitHub reference split across two lines, with the octocat mark left alone at the end of one line and the reference — `openclaw/openclaw#123309`, a URL, or an authored label — starting the next. The mark carries no meaning on its own, so the reference reads as two fragments.

It affects all three shapes the Markdown parser produces for `github.com` links, on the default path with no configuration involved, whenever a link lands near the right edge of a line — so narrow columns, split view, and mobile widths hit it most. Agents cite issues and PRs constantly, so these links are common in transcripts.

This is the sibling case named as follow-up work in #123309 and in #123310.

## Why This Change Was Made

The octocat is painted as a `::before` with `display: inline-block`. An atomic inline carries a soft wrap opportunity on both sides, so the line was always allowed to break between the mark and the label it marks; the anchor rule had never declared anything to prevent it. Bare URLs additionally carry `line-break: anywhere`, which narrows that window but does not close it — the break simply happens at the last opportunity that fits, and when only the mark fits, that opportunity is the one right after it.

The mark is now painted out of flow (`position: absolute`) and its space reserved by the anchor's own `padding-inline-start: 1.3em` — the mark's 1em box plus the 0.3em gap it previously carried as a margin. Nothing inside the anchor precedes the label any more, so no break opportunity exists between them; the only remaining one is before the whole reference. Spacing, size, color, and the `em` sizing that tracks `--chat-text-size` are unchanged.

**The sibling file-link fix could not be reused.** #123310 answers the same invariant for `a.markdown-file-link` by making the whole anchor atomic (`display: inline-block`). An atomic anchor never fragments, so a long bare URL would move to the next line whole instead of breaking inside it — the exact behavior `line-break: anywhere` exists to prevent. Measured over the same column sweep, that treatment raises the average unused space on the line preceding a bare URL from 8.4px to 210.1px (max 496.5px): it trades a stranded mark for a ragged column. Keeping the anchor inline and moving only the mark is what lets both invariants hold at once.

The comment on the `markdown-bare-url` rule is updated in the same change: it justified `line-break: anywhere` partly by the mark being stranded, which is no longer a consequence the rule has to defend against.

## User Impact

GitHub references in chat prose now keep their mark and their label on the same line, in every form and at every column width. Long URLs still fill the line they start on and break inside themselves, exactly as before. Nothing about clicking, hovering, the hovercard, copying, or the mark's colors, spacing, or size changes — a reference that fits on one line renders identically to before.

## Evidence

CSS-only change at the owning rule, plus a regression test. **Production LOC delta:** `ui/src/styles/chat/text.css` +16/-7 — 2 added declarations (`position`, `padding-inline-start`), 3 declarations swapped for 3 on the `::before` (`display`/`margin-inline-end`/`vertical-align` → `position`/`inset-inline-start`/`top`), and the rest comments for a non-obvious layout invariant. Tests: +178 in a new `ui/src/styles/chat-github-link-presentation.browser.test.ts`.

The test is a new file rather than an addition to `chat-file-link-presentation.browser.test.ts`: that suite is scoped to workspace file links, #123310 is currently open against it, and the surfaces assert different invariants — file chips must never fragment, GitHub links must always be able to.

**Real-browser proof.** The three link forms were rendered in Chrome against the shipped stylesheets (`ui/src/styles/base.css` + `ui/src/styles/chat/text.css`, unmodified and patched), sweeping a chat column from 200px to 900px in 4px steps and reading `getClientRects()` on each anchor.

Column widths where the mark is stranded on the previous line:

| Link form | Label | Before | After |
| --- | --- | --- | --- |
| Humanized item reference | `openclaw/openclaw#123309` | 252, 256, 496, 500 | none |
| Bare GitHub URL | `https://github.com/.../text.css#L254` | 272, 276, 516, 520 | none |
| Authored label | `the sibling chip rule` | 204, 208, 212, 216, 396, 400, 404, 408, 412 | none |

Unused space on the line preceding the reference, averaged across the sweep — the cost the atomic alternative would have charged:

| Link form | Before | After (this PR) | If made atomic |
| --- | --- | --- | --- |
| Humanized item reference | 10.1px | 10.5px | 59.1px |
| Bare GitHub URL | 8.4px | 8.6px | 210.1px |
| Authored label | 5.1px | 6.1px | 28.2px |

Before and after, both themes, at the column widths where each form strands the mark:

| | Before | After |
| --- | --- | --- |
| Light | <img width="400" alt="Light theme: the octocat mark stranded at the end of a line in all three GitHub link forms" src="https://github.com/user-attachments/assets/f8f8f1e8-9946-481b-8581-242464198879" /> | <img width="400" alt="Light theme: the mark kept on the same line as its label in all three forms" src="https://github.com/user-attachments/assets/7f418f48-6292-4752-9265-ded0443de038" /> |
| Dark | <img width="400" alt="Dark theme: the octocat mark stranded at the end of a line in all three GitHub link forms" src="https://github.com/user-attachments/assets/c9a4132b-fbe2-4bfc-9176-b43fbc33e0fd" /> | <img width="400" alt="Dark theme: the mark kept on the same line as its label in all three forms" src="https://github.com/user-attachments/assets/1bdd20e4-39b5-42ae-ab62-cc5b407fdeb4" /> |

Note in the "after" bare-URL panel that the URL still breaks mid-token to fill its line — the wrap regime is preserved, only the mark moved.

**Regression test.** `keeps the GitHub mark on its label's line at every column width` runs the same sweep in both themes and asserts, for each form, that the first character of the label shares a line with the start of the anchor box — which is where the mark is painted. That invariant needs no magic constant and fails on pre-fix code for the reason the issue reports: at the widths listed above the label's first line differs from the anchor's. A vacuity guard first asserts the reference actually changes lines across the sweep, so the test cannot pass on a fixture that never wraps. `keeps GitHub links breaking across lines instead of moving whole` asserts both the bare URL and the authored label still fragment, which is what would regress if this were ever "simplified" into the file-link chip's atomic treatment.

The probe logic in the test was executed against the real committed stylesheets before and after the patch: pre-fix it reports the stranded widths in the table above for all three forms; post-fix it reports none, with the vacuity and fragmentation guards satisfied in both cases.

**Validation run locally:** `oxfmt` (clean on both files) and `node scripts/run-oxlint.mjs ui/src/styles/chat-github-link-presentation.browser.test.ts` (exit 0).

**Known proof gap — declared:** the machine this was prepared on had under 500MB of free disk for most of the task, so the branch could not get its own dependency install and **the added Vitest browser test has not been executed by Vitest**; its probe was validated by running the identical measurement in Chrome against the same stylesheets, as described above. CI is the first Vitest execution of the new test.

**Follow-up observed, not fixed here:** the parser applies `markdown-bare-url` to an item URL and *then* rewrites its label to `owner/repo#number` (`ui/src/components/markdown-parser.ts:497` and `:516`), so a humanized reference keeps `line-break: anywhere` even though its label is no longer a URL — it can break as `openclaw/openc` / `law#123309`. That is a producer-side classification question, separate from this invariant, and is left alone rather than folded in blind.

## Landing review update — August 15, 2026

- Full PR head, current `main`, the complete chat stylesheet, Markdown parser ownership, sibling file-link behavior, scoped guidance, and relevant history were inspected.
- The earlier `checks-ui` failure was related: the new node-driven Chromium layout test was omitted from `nodeDrivenBrowserLayoutTests`, so Vite attempted to bundle Playwright and failed on its optional `kerberos` import. The test is now routed through the canonical node-driven layout lane.
- Focused Testbox proof is green: Actions run 31863845676 passed the GitHub-link test (3/3) and sibling file-link test (6/6). This supersedes the earlier declared Vitest execution gap.
- The +9 net production-line delta remains confined to the owning CSS rule and its invariant comments; no smaller atomic-link treatment preserves long-URL fragmentation.
- All ClawSweeper review points and Rank-up moves are addressed. No security, owner-boundary, or crash-consistency concern remains.
