### PR TITLE
fix: stop hosted UI and Gateway test flakes

### DIFF
--- a/src/gateway/portals/portal-service.test.ts
+++ b/src/gateway/portals/portal-service.test.ts
@@ -1,5 +1,4 @@
 import { request } from "node:http";
-import net from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { createGatewayPortalService, type GatewayPortalService } from "./portal-service.js";
 
@@ -25,17 +24,6 @@ async function getStatus(host: string, port: number, path: string): Promise<numb
     });
     req.once("error", reject);
     req.end();
-  });
-}
-
-async function expectConnectionRefused(port: number): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const socket = net.connect({ host: "127.0.0.1", port });
-    socket.once("connect", () => {
-      socket.destroy();
-      reject(new Error(`listener ${port} remained open`));
-    });
-    socket.once("error", () => resolve());
   });
 }
 
@@ -78,17 +66,25 @@ describe("gateway portal service", () => {
   it("closes idempotently and closes every portal on shutdown", async () => {
     const { service, httpServers } = makeService(["127.0.0.1"]);
     const first = await service.open({ targetPort: 3000 });
+    const firstServer = httpServers.at(-1);
     const second = await service.open({ targetPort: 4000 });
+    const secondServer = httpServers.at(-1);
+    expect(firstServer).toBeDefined();
+    expect(secondServer).toBeDefined();
 
     await service.close(first.id);
     await service.close(first.id);
     expect(service.list().map((entry) => entry.id)).toEqual([second.id]);
-    await expectConnectionRefused(first.listenPort);
+    // A closed ephemeral port can be reassigned immediately to a parallel test.
+    // Assert the owned Server instead of probing whichever listener now owns its port.
+    expect(firstServer?.listening).toBe(false);
+    expect(firstServer?.address()).toBeNull();
 
     await service.closeAll();
     expect(service.list()).toEqual([]);
     expect(httpServers).toEqual([]);
-    await expectConnectionRefused(second.listenPort);
+    expect(secondServer?.listening).toBe(false);
+    expect(secondServer?.address()).toBeNull();
   });
 
   it("removes every registered listener after a partial bind failure", async () => {

--- a/src/gateway/probe.device-auth-scope.test.ts
+++ b/src/gateway/probe.device-auth-scope.test.ts
@@ -77,6 +77,7 @@ vi.mock("ws", () => ({ WebSocket: ProbeWebSocket }));
 const { probeGateway } = await import("./probe.js");
 
 type ConnectFrame = {
+  id?: string;
   params?: {
     auth?: { token?: string; deviceToken?: string; password?: string };
     device?: { id?: string };
@@ -122,8 +123,20 @@ async function captureProbeConnectFrame(params: {
     throw new Error("missing probe connect frame");
   }
   const connect = JSON.parse(rawConnect) as ConnectFrame;
-  socket.emitClose(1008, "test complete");
+  socket.emitMessage(
+    JSON.stringify({
+      type: "res",
+      id: connect.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        auth: { role: "operator", scopes: ["operator.read"] },
+        server: { connId: "probe-scope-test", version: "test" },
+      },
+    }),
+  );
   await probePromise;
+  expect(socket.readyState).toBe(ProbeWebSocket.CLOSED);
   return connect;
 }
 

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -1,6 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Page, type Route } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -36,6 +36,7 @@ const HIDDEN_WEB_CHROME_HOSTS = [
 ] as const;
 const MANUAL_UPGRADE_GUIDANCE =
   "This browser has limited access. Manage it with openclaw devices on the Gateway or from Devices on an admin browser.";
+const BANNER_MODULE_ROUTE = /device-scope-upgrade\.runtime(?:-[^/.]+)?\.(?:js|ts)/u;
 
 type BoundingBox = { x: number; y: number; width: number; height: number };
 
@@ -77,6 +78,39 @@ async function createContext(): Promise<BrowserContext> {
   return context;
 }
 
+async function waitForLayoutSettled(page: Page, selector: string): Promise<void> {
+  // content-visibility, grid transitions, and lazy styles can defer layout beyond
+  // a fixed rAF pair. Measure the owning geometry until two frames agree.
+  await page.evaluate(
+    async ({ maxFrames, selector: targetSelector }) => {
+      let previousGeometry: string | undefined;
+      let stableFrames = 0;
+      for (let frame = 0; frame < maxFrames; frame += 1) {
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+        const elements = [...document.querySelectorAll<HTMLElement>(targetSelector)];
+        if (elements.length === 0) {
+          throw new Error(`No layout elements matched ${targetSelector}`);
+        }
+        const geometry = JSON.stringify(
+          elements.map((element) => {
+            const rect = element.getBoundingClientRect();
+            return [rect.x, rect.y, rect.width, rect.height];
+          }),
+        );
+        stableFrames = geometry === previousGeometry ? stableFrames + 1 : 1;
+        if (stableFrames >= 2) {
+          return;
+        }
+        previousGeometry = geometry;
+      }
+      throw new Error(`Layout did not stabilize for ${targetSelector} within ${maxFrames} frames`);
+    },
+    { maxFrames: 60, selector },
+  );
+}
+
 describeControlUiE2e("Control UI live device scope upgrade", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -107,10 +141,12 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       releaseBannerModule = resolve;
     });
     let heldBannerModule = false;
-    await page.route(/device-scope-upgrade\.runtime(?:-[^/.]+)?\.(?:js|ts)/u, async (route) => {
+    let bannerModuleRouteSettled: Promise<void> | undefined;
+    await page.route(BANNER_MODULE_ROUTE, async (route) => {
       if (!heldBannerModule) {
         heldBannerModule = true;
-        void bannerModuleRelease.then(() => route.continue());
+        bannerModuleRouteSettled = bannerModuleRelease.then(() => route.continue());
+        await bannerModuleRouteSettled;
         return;
       }
       await route.continue();
@@ -133,6 +169,7 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       await captureProof(page, "limited.png");
     } finally {
       releaseBannerModule();
+      await bannerModuleRouteSettled;
     }
     await navigation;
     await page.getByRole("button", { name: "Request admin" }).waitFor();
@@ -269,21 +306,20 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       }
       await expect.poll(() => page.locator(".shell-chrome-controls").isVisible()).toBe(false);
 
-      // Poll the geometry invariant: one-shot boundingBox reads can catch the
-      // nav-collapse transition mid-flight and report a stale callout offset.
-      await expect
-        .poll(async () => {
-          const contentBox = await page.locator(".content").boundingBox();
-          const calloutBox = await page.locator("openclaw-update-banner .callout").boundingBox();
-          if (!contentBox || !calloutBox) {
-            return Number.NaN;
-          }
-          const contentInset = await page
-            .locator(".content")
-            .evaluate((element) => Number.parseFloat(getComputedStyle(element).paddingLeft));
-          return calloutBox.x - contentBox.x - contentInset;
-        })
-        .toBe(0);
+      await waitForLayoutSettled(page, ".content, openclaw-update-banner .callout");
+      const calloutInsetDelta = await page.evaluate(() => {
+        const content = document.querySelector<HTMLElement>(".content");
+        const callout = document.querySelector<HTMLElement>("openclaw-update-banner .callout");
+        if (!content || !callout) {
+          throw new Error("Missing content or scope-upgrade callout after layout settled");
+        }
+        return (
+          callout.getBoundingClientRect().x -
+          content.getBoundingClientRect().x -
+          Number.parseFloat(getComputedStyle(content).paddingLeft)
+        );
+      });
+      expect(calloutInsetDelta).toBe(0);
     },
   );
 
@@ -308,17 +344,32 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
   it("keeps manual repair guidance when the banner module fails to load", async () => {
     const context = await createContext();
     const page = await context.newPage();
-    await page.route(/device-scope-upgrade\.runtime(?:-[^/.]+)?\.(?:js|ts)/u, (route) =>
-      route.abort("failed"),
-    );
+    let bannerModuleRejected = false;
+    const rejectBannerModule = async (route: Route) => {
+      // A network abort intentionally starts whole-document stale-chunk recovery,
+      // which is a different contract and can reload while this test tears down.
+      // Fail module evaluation instead so only the optional-banner fallback owns it.
+      await route.fulfill({
+        body: 'throw new Error("device scope banner module failed to evaluate");',
+        contentType: "application/javascript",
+        status: 200,
+      });
+      bannerModuleRejected = true;
+    };
+    await page.route(BANNER_MODULE_ROUTE, rejectBannerModule);
     await installMockGateway(page, { operatorScopes: LIMITED_SCOPES });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      const navigation = page.goto(`${server.baseUrl}chat`);
+      await expect.poll(() => bannerModuleRejected).toBe(true);
+      await navigation;
       await page.getByText(MANUAL_UPGRADE_GUIDANCE, { exact: true }).waitFor();
 
       expect(await page.getByRole("button", { name: "Request admin" }).count()).toBe(0);
     } finally {
+      // A failed dynamic import can be retried by a later shell render. Remove
+      // the route before closing so teardown cannot race a fresh intercepted request.
+      await page.unroute(BANNER_MODULE_ROUTE, rejectBannerModule);
       await page.close({ runBeforeUnload: false });
     }
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes recurring GitHub-hosted runner failures in the Control UI device-scope-upgrade E2E suite and the non-isolated Gateway core stripe. The flakes appeared as UI hook or test timeouts, a 20px banner-geometry mismatch, noisy post-test Gateway connect failures, and a portal listener reported open after shutdown.

## Why This Change Was Made

The UI test now awaits intercepted module routes, isolates optional-module evaluation failure from whole-document stale-chunk recovery, and measures settled layout from one atomic browser snapshot. Gateway tests complete the mocked probe handshake before the probe owns shutdown, while portal shutdown assertions follow the owned Node server objects instead of ephemeral port numbers that parallel tests can immediately reuse.

No production code changes. Production LOC: +0/-0. Tests and test support: +97/-37.

## User Impact

No user-visible product behavior changes. Hosted CI now validates the same UI and Gateway contracts without timing-, reload-, or ephemeral-port-dependent failures.

## Evidence

Failure provenance:

- Run [31725498058](https://github.com/openclaw/openclaw/actions/runs/31725498058): device-scope-upgrade cleanup hook timeout and 20px geometry mismatch.
- Run [31737316152](https://github.com/openclaw/openclaw/actions/runs/31737316152): failed-banner-module test timed out at 120 seconds.
- Run [31742781948 attempt 1](https://github.com/openclaw/openclaw/actions/runs/31742781948/attempts/1): repeated probe close diagnostics plus the portal listener assertion failure in the Gateway core stripe.

Before the final repair, the bounded UI loop reproduced both the 120-second test timeout and the 180-second context-cleanup timeout. The full Gateway core project reproduced `listener <port> remained open` with 1 failure out of 5,499 tests.

After the repair:

- Five consecutive green runs: `node scripts/run-vitest.mjs ui/src/e2e/device-scope-upgrade.e2e.test.ts` — 9/9 tests each run.
- Gateway owner and ordered sibling proof: 5 files, 62/62 tests green.
- Full non-isolated Gateway core proof: 333 files, 5,499/5,499 tests green.
- `node_modules/.bin/oxfmt --check` on all changed files: green.
- `git diff --check`: green.
- Pre-commit local-diff autoreview and post-commit branch autoreview: clean, no accepted/actionable findings.

Validation fallback: the trusted-source changed gate first requested Blacksmith Testbox, but the lease stayed queued for 3m53s and was canceled cleanly; the owned Crabbox fallback was unavailable because its broker was not authenticated. Per the repository Validation policy for unavailable remote backends, the heavier suites above ran locally and provide the gate evidence.
