### PR TITLE
fix(logs): report line-limit truncation

### DIFF
--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -208,7 +208,9 @@ describe("logs cli", () => {
 
     expect(stdoutWrites.join("")).toContain("Log file:");
     expect(stdoutWrites.join("")).toContain("raw line");
-    expect(stderrWrites.join("")).toContain("Log tail truncated");
+    expect(stderrWrites.join("")).toContain(
+      "Log tail truncated (increase --limit or --max-bytes).",
+    );
     expect(stderrWrites.join("")).toContain("Log cursor reset");
   });
 

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -725,7 +725,7 @@ export function registerLogsCli(program: Command) {
           if (
             !emitJsonLine({
               type: "notice",
-              message: "Log tail truncated (increase --max-bytes).",
+              message: "Log tail truncated (increase --limit or --max-bytes).",
             })
           ) {
             return;
@@ -785,7 +785,7 @@ export function registerLogsCli(program: Command) {
           }
         }
         if (payload.truncated) {
-          if (!errorLine("Log tail truncated (increase --max-bytes).")) {
+          if (!errorLine("Log tail truncated (increase --limit or --max-bytes).")) {
             return;
           }
         }

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -85,6 +85,26 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines).toEqual(["old line", "recent one", "recent two"]);
   });
 
+  it("reports truncation when the line limit omits complete records", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const content = "one\ntwo\nthree\n";
+
+    await fs.writeFile(file, content);
+    setLoggerOverride({ file });
+
+    const result = await readConfiguredLogTail({ limit: 2, maxBytes: 100 });
+
+    expect(result).toMatchObject({
+      lines: ["two", "three"],
+      cursor: Buffer.byteLength(content),
+      size: Buffer.byteLength(content),
+      truncated: true,
+      reset: false,
+    });
+  });
+
   it("falls back only within the active profile's rolling log family", async () => {
     const tempDir = tempDirs.make("openclaw-log-tail-");
     const missing = path.join(tempDir, "openclaw-dev-2026-01-22.log");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -138,6 +138,7 @@ async function readLogSlice(params: {
       lines = lines.slice(0, -1);
     }
     if (lines.length > limit) {
+      truncated = true;
       lines = lines.slice(lines.length - limit);
     }
 

--- a/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts
+++ b/test/e2e/qa-lab/runtime/remote-log-tailing-runtime.ts
@@ -100,7 +100,11 @@ export async function runRemoteLogTailing(repoRoot: string, outputRoot: string) 
       lines: string[];
       truncated: boolean;
     };
-    if (first.lines.length !== 2 || !first.lines.some((line) => line.includes("qa-line-three"))) {
+    if (
+      first.lines.length !== 2 ||
+      !first.lines.some((line) => line.includes("qa-line-three")) ||
+      !first.truncated
+    ) {
       throw new Error(`logs.tail did not honor limit: ${JSON.stringify(first)}`);
     }
     const bounded = (await gateway.call("logs.tail", { limit: 20, maxBytes: 96 })) as {


### PR DESCRIPTION
Closes #123275

## What Problem This Solves

Fixes an issue where `logs.tail` would silently omit older complete records when the line limit was exceeded while returning `truncated: false`. Because the returned cursor already advanced to EOF, CLI, Control UI, Android, diagnostics, and direct RPC consumers could not recover the skipped records.

## Why This Change Was Made

The canonical log-tail reader now marks the result truncated before applying its existing line-limit slice, matching its byte-limit behavior and the Linux journal sibling. Cursor, size, reset, partial-line, and byte-window semantics remain unchanged. CLI notices now name both recovery controls: `--limit` and `--max-bytes`.

## User Impact

Log consumers can trust `truncated` to mean any requested records were omitted, regardless of whether the byte bound or line bound caused it. Operators receive actionable guidance for increasing either limit.

## Evidence

- Tests-first reader regression failed before the repair: expected `truncated: true`, received `false`, while lines, EOF cursor `14`, size `14`, and reset state were otherwise correct.
- Log-tail owner tests: 5/5 passed.
- Logs CLI tests: 39/39 passed.
- QA remote log-tailing runtime tests: 2/2 passed.
- Source-blind CLI probe: `--limit 2` returned `two`/`three`, EOF cursor/size `14`, and the `--limit or --max-bytes` notice; `--limit 5` returned all records with no notice.
- The earlier exact CI failure was broken `main`: #123363 canonically registered `extensions/codex/src/app-server/run-attempt-state.test.ts`, and that repair is already present in the refreshed base.
- Full-suite Vitest ownership audit passed with no missing or duplicated files, and the Codex state test passed through the canonical attempt-extra project on the refreshed base.
- Upstream Codex was checked directly at `../codex/codex-rs/app-server-protocol/src/protocol/v2/turn.rs`; `TurnStartParams.input` retains its typed `Text`/`Skill`/`Mention` input contract, and this PR makes no Codex production change.
- Core, core-test, and root-test TypeScript checks passed.
- Targeted core/scripts lint, formatting, and `git diff --check` passed.
- Final integrated Codex autoreview: clean, no findings, confidence 0.99; TruffleHog clean.
- Refreshed against `origin/main` `d9d970240022c23bf0e31ce47c047a1576994d45`; exact reviewed head `a71bab813eab5ed8f5e766433f9ff8b20eb26860`.

Production delta: +3/-2, net +1. Tests/support: +28/-2, net +26.

AI-assisted: yes. The repair was reviewed against the reader, Gateway/CLI projections, UI/native consumers, diagnostics export, and journal sibling semantics.
