### PR TITLE
fix(ui): prevent transcript search icon precision flake

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -760,8 +760,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(icons).toHaveLength(2);
       for (const icon of icons) {
         const box = await icon.boundingBox();
-        expect(box?.width).toBe(16);
-        expect(box?.height).toBe(16);
+        expect(box?.width).toBeCloseTo(16, 3);
+        expect(box?.height).toBeCloseTo(16, 3);
       }
       await input.focus();
       const outline = await input.evaluate((element) => {


### PR DESCRIPTION
Related: #123343

## What Problem This Solves

Fixes an issue where the Control UI test `keeps transcript search icons compact` could fail nondeterministically when Playwright returned an SVG bounding-box dimension as `16.000001907348633` instead of exact `16`.

The same test passed on the unchanged rerun, and the same `origin/main` SHA passed its Control UI check, confirming browser floating-point precision noise rather than a rendered-size regression.

## Why This Change Was Made

The assertion now checks both icon dimensions with a narrow `toBeCloseTo(16, 3)` tolerance at the observable geometry boundary. This accepts less than `0.0005px` of subpixel noise while still failing any meaningful compactness regression.

No sleeps, retries, timeout increases, production CSS changes, or broad assertion weakening were added. Sibling exact computed-size assertions were audited; they cover CSS strings, rounded dimensions, same-grid relational equality, or unrelated fixed controls without matching flake evidence, so they remain exact.

## User Impact

No user-visible behavior changes. Maintainers get a stable Control UI CI signal without masking real transcript-search icon sizing regressions.

AI-assisted: Codex performed the bounded implementation/audit, and the final diff received an independent Codex autoreview.

## Evidence

- Confirmed failure: CI run 31749708378, attempt 1, `checks-ui` — `16.000001907348633` versus exact `16` at `chat-responsive.browser.test.ts:764`.
- Unchanged rerun: CI run 31749708378, attempt 2, `checks-ui` passed.
- Control: `origin/main` SHA `b7b33149b06e6e371879c7a5f0846b68880226e2` passed `checks-ui` in run 31746060261.
- Focused proof:
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t "keeps transcript search icons compact"` — 1 passed, 85 skipped.
  - `./node_modules/.bin/oxfmt --check ui/src/pages/chat/chat-responsive.browser.test.ts` — passed.
  - `git diff --check` — passed.
  - `node scripts/check-changed.mjs --dry-run -- ui/src/pages/chat/chat-responsive.browser.test.ts` — classified as `coreTests` / UI test.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: `+0/-0`; tests: `+2/-2`.
