### PR TITLE
fix(ci): register run-attempt-state.test.ts in its vitest lane (main is red)

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -14,6 +14,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts",
+      "extensions/codex/src/app-server/run-attempt-state.test.ts",
       "extensions/codex/src/app-server/run-attempt.steering.test.ts",
       "extensions/codex/src/app-server/run-attempt.turn-watches.test.ts",
       "extensions/codex/src/app-server/run-attempt.usage-limits.test.ts",


### PR DESCRIPTION
## What Problem This Solves

CI on `main` (and every open PR) fails `checks-node-compact-large-4`: the full-suite test-file ownership audit (`test/vitest-projects-config.test.ts` "covers each normal full-suite test file exactly once") reports `extensions/codex/src/app-server/run-attempt-state.test.ts` as uncovered. The file landed in #123345 (`e04dfd26e23`) without being registered in any vitest lane.

## Why This Change Was Made

Smallest correct fix for red main per repo policy: register the file beside its `run-attempt-*` siblings in `test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts` (one line).

## User Impact

Unblocks CI for main and all open PRs; the new codex test actually runs in full suites.

## Evidence

- Repro: main CI run (checks-node-compact-large-4) fails with `+ ["extensions/codex/src/app-server/run-attempt-state.test.ts"]`; same failure on rebased PR heads.
- Post-fix, the audit no longer reports the file (verified locally; remaining local-only contract noise is a macOS artifact absent on Linux CI).