### PR TITLE
fix: stabilize exact-main time and loopback isolation

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -162,6 +162,8 @@ describe("tasks commands", () => {
   it("keeps audit JSON stable and sorts combined findings before limiting", async () => {
     await withTaskCommandStateDir(async () => {
       const now = Date.now();
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(now);
       createTaskRecord({
         runtime: "cli",
         ownerKey: "agent:main:main",
@@ -224,8 +226,7 @@ describe("tasks commands", () => {
         token: runningFlow.flowId,
         flow: jsonRoundTrip(runningFlow),
       });
-      expect(limitedFinding?.ageMs).toBeGreaterThanOrEqual(45 * 60_000);
-      expect(limitedFinding?.ageMs).toBeLessThan(45 * 60_000 + 1_000);
+      expect(limitedFinding?.ageMs).toBe(45 * 60_000);
     });
   });
 

--- a/src/gateway/server-http.device-pairing-join.test.ts
+++ b/src/gateway/server-http.device-pairing-join.test.ts
@@ -1,4 +1,5 @@
 // Real Gateway lifecycle proof for admin mint -> public single-use join exchange.
+import { Agent, fetch } from "undici";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { WebSocket } from "ws";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -22,6 +23,7 @@ type JoinSetupResult = {
 
 let harness: Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 let adminSocket: WebSocket;
+let httpDispatcher: Agent;
 
 beforeAll(async () => {
   testState.gatewayAuth = {
@@ -34,6 +36,7 @@ beforeAll(async () => {
     },
   };
   harness = await createGatewaySuiteHarness();
+  httpDispatcher = new Agent({ connections: 1 });
   adminSocket = await harness.openWs();
   const connected = await connectReq(adminSocket, {
     token: "secret",
@@ -46,6 +49,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   adminSocket?.close();
+  await httpDispatcher?.close();
   await harness?.close();
 });
 
@@ -66,8 +70,14 @@ function shortcodeFromUrl(joinUrl: string): string {
   return new URL(joinUrl).pathname.split("/").at(-1) ?? "";
 }
 
-async function readJson(response: Response): Promise<unknown> {
+async function readJson(response: Awaited<ReturnType<typeof fetch>>): Promise<unknown> {
   return JSON.parse(await response.text()) as unknown;
+}
+
+async function fetchJoinUrl(url: string) {
+  // Other Gateway suites replace the process-wide Undici dispatcher. Keep this
+  // real loopback route bound to its own client so cross-suite mocks cannot claim it.
+  return await fetch(url, { dispatcher: httpDispatcher });
 }
 
 describe("Gateway device join route", () => {
@@ -84,7 +94,7 @@ describe("Gateway device join route", () => {
       );
     });
 
-    const expiredResponse = await fetch(expired.joinUrl);
+    const expiredResponse = await fetchJoinUrl(expired.joinUrl);
     expect(expiredResponse.status).toBe(404);
     const opaqueNotFound = await readJson(expiredResponse);
     expect(opaqueNotFound).toEqual({ error: "not_found" });
@@ -93,22 +103,22 @@ describe("Gateway device join route", () => {
     const shortcode = shortcodeFromUrl(live.joinUrl);
     expect(Buffer.from(shortcode, "base64url").byteLength).toBeGreaterThanOrEqual(16);
 
-    const first = await fetch(live.joinUrl);
+    const first = await fetchJoinUrl(live.joinUrl);
     expect(first.status).toBe(200);
     expect(first.headers.get("content-type")).toContain("application/json");
     expect(first.headers.get("cache-control")).toBe("no-store");
     expect(await readJson(first)).toEqual(decodePairingSetupCode(live.setupCode));
 
-    const used = await fetch(live.joinUrl);
+    const used = await fetchJoinUrl(live.joinUrl);
     expect(used.status).toBe(404);
     expect(await readJson(used)).toEqual(opaqueNotFound);
 
     const unknownUrl = `http://127.0.0.1:${harness.port}/j/${"z".repeat(22)}`;
-    const unknown = await fetch(unknownUrl);
+    const unknown = await fetchJoinUrl(unknownUrl);
     expect(unknown.status).toBe(404);
     expect(await readJson(unknown)).toEqual(opaqueNotFound);
 
-    const limited = await fetch(unknownUrl);
+    const limited = await fetchJoinUrl(unknownUrl);
     expect(limited.status).toBe(429);
     expect(await readJson(limited)).toEqual({ error: "rate_limited" });
   });

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -11,6 +11,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/attempt-steering.test.ts",
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
+      "extensions/codex/src/app-server/run-attempt-state.test.ts",
     ],
     {
       dir: "extensions",

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -11,7 +11,6 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/attempt-steering.test.ts",
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
-      "extensions/codex/src/app-server/run-attempt-state.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
## What Problem This Solves

Resolves two recurring exact-main CI failures caused by process-global time and network state:

- the real Gateway device-join route inherited Undici dispatchers replaced by other suites and intermittently received plain `Not Found` instead of the Gateway JSON response;
- the task-audit command measured a 45-minute fixture against elapsed runner setup time and could cross its one-second allowance.

## Why This Change Was Made

The Gateway route proof now uses and closes a dedicated Undici `Agent`, preserving its real HTTP exchange while isolating unrelated network mocks. The task-audit test freezes only `Date`, retaining real async timers and asserting the exact intended age. The separate Codex shard-ownership failure is already fixed on main by #123363 and is intentionally absent from this diff.

## User Impact

No product behavior changes. CI keeps the real device-join lifecycle and task-audit contracts while removing unrelated dispatcher and runner-speed variance.

## Evidence

- [Main run 31753023126](https://github.com/openclaw/openclaw/actions/runs/31753023126): device-join route received plain `Not Found`; the same failure previously appeared in run 31727405654.
- [Main run 31736554642](https://github.com/openclaw/openclaw/actions/runs/31736554642): task-audit age exceeded its wall-clock allowance by 602ms.
- Gateway device-join focused test — passed, including five consecutive stress runs before consolidation.
- Full task command test file — 25 passed.
- Changed-file formatting, oxlint, and `git diff --check` passed.
- Final combined branch autoreview reported no actionable findings.
- Undici contract checked in `types/fetch.d.ts`, `types/agent.d.ts`, and `lib/dispatcher/agent.js`.

Production LOC: +0/-0 | Tests: +19/-8
