### PR TITLE
feat(google): add Gemini 3.7 Flash with LOW thinking floor

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -295,17 +295,17 @@ plugin's catalog; core only reads the generic compat field.
 
 Bundled provider catalogs currently flag these models as `"preferred"`:
 
-| Provider  | Models                                                                                                                                       |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                               |
-| deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                       |
-| google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash` |
-| kimi      | `k3`, `k3-256k`                                                                                                                              |
-| minimax   | `MiniMax-M3`                                                                                                                                 |
-| moonshot  | `kimi-k3`                                                                                                                                    |
-| openai    | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-pro`                                                          |
-| xiaomi    | `mimo-v2.5`                                                                                                                                  |
-| zai       | `glm-5.2`, `glm-5.1`                                                                                                                         |
+| Provider  | Models                                                                                                                                                           |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                                                   |
+| deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                                           |
+| google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash`, `gemini-3.7-flash` |
+| kimi      | `k3`, `k3-256k`                                                                                                                                                  |
+| minimax   | `MiniMax-M3`                                                                                                                                                     |
+| moonshot  | `kimi-k3`                                                                                                                                                        |
+| openai    | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-pro`                                                                              |
+| xiaomi    | `mimo-v2.5`                                                                                                                                                      |
+| zai       | `glm-5.2`, `glm-5.1`                                                                                                                                             |
 
 Everything else, including all Ollama-served local models, stays unflagged and
 keeps normal tool exposure under `"auto"`.

--- a/extensions/google/google.live.test.ts
+++ b/extensions/google/google.live.test.ts
@@ -140,7 +140,7 @@ function registerGoogleRealtimeVoiceProvider() {
 }
 
 describeLive("google plugin live", () => {
-  it.each(["gemini-3.6-flash", "gemini-3.5-flash-lite"])(
+  it.each(["gemini-3.7-flash", "gemini-3.5-flash-lite"])(
     "discovers and completes through %s",
     async (modelId) => {
       const provider = await buildGoogleLiveCatalogProvider({

--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -34,7 +34,11 @@ describe("google provider catalog", () => {
       maxTokens: 65_536,
       reasoning: true,
       input: ["text", "image"],
+      thinkingLevelMap: { minimal: null },
     });
+    expect(provider.models.find((model) => model.id === "gemini-3.6-flash")).not.toHaveProperty(
+      "thinkingLevelMap",
+    );
   });
 
   it("keeps Google AI Studio and Vertex model ids aligned", () => {
@@ -78,6 +82,14 @@ describe("google provider catalog", () => {
                     inputTokenLimit: 1_048_576,
                     outputTokenLimit: 65_536,
                     supportedGenerationMethods: ["generateContent", "countTokens"],
+                    thinking: true,
+                  },
+                  {
+                    name: "models/gemini-3.7-flash",
+                    displayName: "Gemini 3.7 Flash",
+                    inputTokenLimit: 1_048_576,
+                    outputTokenLimit: 65_536,
+                    supportedGenerationMethods: ["generateContent"],
                     thinking: true,
                   },
                   {
@@ -135,6 +147,16 @@ describe("google provider catalog", () => {
         maxTokens: 65_536,
         input: ["text", "image", "video"],
         compat: { codeMode: "preferred" },
+      }),
+      expect.objectContaining({
+        id: "gemini-3.7-flash",
+        name: "Gemini 3.7 Flash",
+        reasoning: true,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+        input: ["text", "image", "video"],
+        compat: { codeMode: "preferred" },
+        thinkingLevelMap: { minimal: null },
       }),
       expect.objectContaining({
         id: "gemma-3-1b-it",

--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -26,9 +26,10 @@ describe("google provider catalog", () => {
         "gemini-3.1-pro-preview",
         "gemini-3.5-flash-lite",
         "gemini-3.6-flash",
+        "gemini-3.7-flash",
       ]),
     );
-    expect(provider.models.find((model) => model.id === "gemini-3.6-flash")).toMatchObject({
+    expect(provider.models.find((model) => model.id === "gemini-3.7-flash")).toMatchObject({
       contextWindow: 1_048_576,
       maxTokens: 65_536,
       reasoning: true,

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -26,6 +26,7 @@ const GOOGLE_GEMINI_TEXT_MODEL_ROWS: ReadonlyArray<
   ["gemini-2.5-flash-lite", "Gemini 2.5 Flash-Lite", false],
   ["gemini-3.5-flash", "Gemini 3.5 Flash", true],
   ["gemini-3.6-flash", "Gemini 3.6 Flash", true],
+  ["gemini-3.7-flash", "Gemini 3.7 Flash", true],
   ["gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", true],
   ["gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", true],
   ["gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", true],

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -19,21 +19,26 @@ const GOOGLE_VERTEX_BASE_URL = "https://{location}-aiplatform.googleapis.com";
 const GOOGLE_GEMINI_MODELS_CACHE_TTL_MS = 60_000;
 const GOOGLE_GEMINI_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
 const GOOGLE_GEMINI_TEXT_MODEL_ROWS: ReadonlyArray<
-  readonly [id: string, name: string, prefersCodeMode: boolean]
+  readonly [
+    id: string,
+    name: string,
+    prefersCodeMode: boolean,
+    thinkingLevelMap?: ModelDefinitionConfig["thinkingLevelMap"],
+  ]
 > = [
   ["gemini-2.5-pro", "Gemini 2.5 Pro", false],
   ["gemini-2.5-flash", "Gemini 2.5 Flash", false],
   ["gemini-2.5-flash-lite", "Gemini 2.5 Flash-Lite", false],
   ["gemini-3.5-flash", "Gemini 3.5 Flash", true],
   ["gemini-3.6-flash", "Gemini 3.6 Flash", true],
-  ["gemini-3.7-flash", "Gemini 3.7 Flash", true],
+  ["gemini-3.7-flash", "Gemini 3.7 Flash", true, { minimal: null }],
   ["gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", true],
   ["gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", true],
   ["gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", true],
   ["gemini-3-flash-preview", "Gemini 3 Flash Preview", true],
 ];
 const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = GOOGLE_GEMINI_TEXT_MODEL_ROWS.map(
-  ([id, name, prefersCodeMode]): ModelDefinitionConfig => {
+  ([id, name, prefersCodeMode, thinkingLevelMap]): ModelDefinitionConfig => {
     const model: ModelDefinitionConfig = {
       id,
       name,
@@ -42,6 +47,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = GOOGLE_GEMINI_TEXT_MO
       cost: GOOGLE_GEMINI_COST,
       contextWindow: 1_048_576,
       maxTokens: 65_536,
+      ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
     };
     if (prefersCodeMode) {
       model.compat = { codeMode: "preferred" };
@@ -122,6 +128,9 @@ function buildGoogleLiveModel(row: unknown): ModelDefinitionConfig | undefined {
     contextWindow,
     maxTokens,
     ...(staticModel?.compat ? { compat: { ...staticModel.compat } } : {}),
+    ...(staticModel?.thinkingLevelMap
+      ? { thinkingLevelMap: { ...staticModel.thinkingLevelMap } }
+      : {}),
   };
 }
 

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -47,8 +47,10 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = GOOGLE_GEMINI_TEXT_MO
       cost: GOOGLE_GEMINI_COST,
       contextWindow: 1_048_576,
       maxTokens: 65_536,
-      ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
     };
+    if (thinkingLevelMap) {
+      model.thinkingLevelMap = thinkingLevelMap;
+    }
     if (prefersCodeMode) {
       model.compat = { codeMode: "preferred" };
     }

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -536,7 +536,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
   });
 
   it.each([
-    ["gemini-3.6-flash", "gemini-3-flash-preview"],
+    ["gemini-3.7-flash", "gemini-3-flash-preview"],
     ["gemini-3.5-flash-lite", "gemini-3.1-flash-lite"],
   ])("resolves future Gemini 3 text family %s from %s metadata", (modelId, templateId) => {
     const model = resolveGoogleGeminiForwardCompatModel({

--- a/extensions/google/thinking.test.ts
+++ b/extensions/google/thinking.test.ts
@@ -37,32 +37,41 @@ describe("google thinking policy", () => {
   });
 
   it.each([
-    ["off", "MINIMAL"],
-    ["minimal", "MINIMAL"],
-    ["low", "LOW"],
-    ["medium", "MEDIUM"],
-    ["adaptive", undefined],
-    ["high", "HIGH"],
-    ["xhigh", "HIGH"],
-  ] as const)("maps Gemini 3 Flash thinking level %s to %s", (thinkingLevel, expected) => {
+    ["gemini-flash-latest", "off", "MINIMAL"],
+    ["gemini-flash-latest", "minimal", "MINIMAL"],
+    ["gemini-flash-latest", "low", "LOW"],
+    ["gemini-flash-latest", "medium", "MEDIUM"],
+    ["gemini-flash-latest", "adaptive", undefined],
+    ["gemini-flash-latest", "high", "HIGH"],
+    ["gemini-flash-latest", "xhigh", "HIGH"],
+    ["gemini-3.6-flash", "off", "MINIMAL"],
+    ["gemini-3.6-flash", "minimal", "MINIMAL"],
+    ["gemini-3.7-flash", "off", "LOW"],
+    ["gemini-3.7-flash", "minimal", "LOW"],
+    ["gemini-3.7-flash", "low", "LOW"],
+    ["gemini-3.7-flash", "medium", "MEDIUM"],
+    ["gemini-3.7-flash", "high", "HIGH"],
+  ] as const)("maps %s thinking level %s to %s", (modelId, thinkingLevel, expected) => {
     expect(
       resolveGoogleGemini3ThinkingLevel({
-        modelId: "gemini-flash-latest",
+        modelId,
         thinkingLevel,
       }),
     ).toBe(expected);
   });
 
   it.each([
-    [-1, undefined],
-    [0, "MINIMAL"],
-    [2048, "LOW"],
-    [8192, "MEDIUM"],
-    [8193, "HIGH"],
-  ] as const)("maps Gemini 3 Flash budget %s to %s", (thinkingBudget, expected) => {
+    ["gemini-3.1-flash-lite", -1, undefined],
+    ["gemini-3.1-flash-lite", 0, "MINIMAL"],
+    ["gemini-3.1-flash-lite", 2048, "LOW"],
+    ["gemini-3.1-flash-lite", 8192, "MEDIUM"],
+    ["gemini-3.1-flash-lite", 8193, "HIGH"],
+    ["gemini-3.6-flash", 0, "MINIMAL"],
+    ["gemini-3.7-flash", 0, "LOW"],
+  ] as const)("maps %s budget %s to %s", (modelId, thinkingBudget, expected) => {
     expect(
       resolveGoogleGemini3ThinkingLevel({
-        modelId: "gemini-3.1-flash-lite",
+        modelId,
         thinkingBudget,
       }),
     ).toBe(expected);

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -42,6 +42,26 @@ const createOutput = () => createGoogleAssistantOutput(model);
 
 describe("buildGoogleSimpleThinking", () => {
   it.each([
+    { id: "gemini-flash-latest", expectedLevel: "MINIMAL" },
+    { id: "gemini-3.6-flash", expectedLevel: "MINIMAL" },
+    { id: "gemini-3.7-flash", expectedLevel: "LOW" },
+  ])("uses the supported thinking floor for $id", ({ id, expectedLevel }) => {
+    const flashModel = { ...model, id };
+
+    expect(buildGoogleSimpleThinking(flashModel, { reasoning: "minimal" })).toEqual({
+      enabled: true,
+      level: expectedLevel,
+    });
+    expect(
+      buildGoogleGenerateContentParams(
+        flashModel,
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+        { thinking: { enabled: false } },
+      ).config?.thinkingConfig,
+    ).toEqual({ thinkingLevel: expectedLevel });
+  });
+
+  it.each([
     { id: "gemini-pro-latest", expectedLevel: "LOW" },
     { id: "gemini-flash-latest", expectedLevel: "LOW" },
   ])("recognizes the supported $id Gemini 3 alias", ({ id, expectedLevel }) => {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -15,6 +15,7 @@ import {
 } from "@google/genai";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import { transformProviderMessages as transformMessages } from "../provider-transcript-transform.js";
+import { googleFlashSupportsMinimalThinking } from "../transports/google-thinking-level.js";
 import {
   assignTransportErrorDetails,
   coerceTransportToolCallArguments,
@@ -589,7 +590,11 @@ function getDisabledGoogleThinkingConfig<T extends GoogleApiType>(model: Model<T
     return { thinkingLevel: ThinkingLevel.LOW };
   }
   if (isGemini3FlashModel(model)) {
-    return { thinkingLevel: ThinkingLevel.MINIMAL };
+    return {
+      thinkingLevel: googleFlashSupportsMinimalThinking(model.id)
+        ? ThinkingLevel.MINIMAL
+        : ThinkingLevel.LOW,
+    };
   }
   if (isGemma4Model(model) || model.id.toLowerCase().includes("gemini-2.5-pro")) {
     return {};
@@ -639,7 +644,9 @@ function getGoogleThinkingLevel<T extends GoogleApiType>(
   }
   switch (effort) {
     case "minimal":
-      return ThinkingLevel.MINIMAL;
+      return isGemini3FlashModel(model) && !googleFlashSupportsMinimalThinking(model.id)
+        ? ThinkingLevel.LOW
+        : ThinkingLevel.MINIMAL;
     case "low":
       return ThinkingLevel.LOW;
     case "medium":

--- a/packages/ai/src/transports.ts
+++ b/packages/ai/src/transports.ts
@@ -2,6 +2,7 @@
 export * from "./transports/anthropic-payload-policy.js";
 export * from "./transports/anthropic-transport-stream.js";
 export * from "./transports/deepseek-text-filter.js";
+export * from "./transports/google-thinking-level.js";
 export * from "./transports/json-unsafe-integers.js";
 export * from "./transports/model-max-tokens-params.js";
 export * from "./transports/model-transport-debug.js";

--- a/packages/ai/src/transports/google-thinking-level.ts
+++ b/packages/ai/src/transports/google-thinking-level.ts
@@ -1,0 +1,10 @@
+/** Returns whether a Gemini Flash model accepts the MINIMAL thinking level. */
+export function googleFlashSupportsMinimalThinking(modelId: string): boolean {
+  const match = modelId.toLowerCase().match(/(?:^|\/)gemini-3\.(\d+)-flash(?:-|$)/);
+  if (!match) {
+    return true;
+  }
+  // Live Gemini API contract on 2026-08-13: gemini-3.7-flash rejects thinkingLevel
+  // MINIMAL with HTTP 400 INVALID_ARGUMENT; 3.6 and earlier flash models accept it.
+  return Number.parseInt(match[1] ?? "0", 10) < 7;
+}

--- a/src/llm/providers/stream-wrappers/google-thinking-payload.ts
+++ b/src/llm/providers/stream-wrappers/google-thinking-payload.ts
@@ -1,3 +1,4 @@
+import { googleFlashSupportsMinimalThinking } from "@openclaw/ai/transports";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 /** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */
@@ -81,10 +82,11 @@ export function resolveGoogleGemini3ThinkingLevel(params: {
   if (!isGoogleGemini3FlashModel(params.modelId)) {
     return undefined;
   }
+  const minimalLevel = googleFlashSupportsMinimalThinking(params.modelId) ? "MINIMAL" : "LOW";
   switch (params.thinkingLevel) {
     case "off":
     case "minimal":
-      return "MINIMAL";
+      return minimalLevel;
     case "low":
       return "LOW";
     case "medium":
@@ -105,7 +107,7 @@ export function resolveGoogleGemini3ThinkingLevel(params: {
     return undefined;
   }
   if (params.thinkingBudget <= 0) {
-    return "MINIMAL";
+    return minimalLevel;
   }
   if (params.thinkingBudget <= 2048) {
     return "LOW";


### PR DESCRIPTION
## What Problem This Solves

Google now serves `gemini-3.7-flash` (verified live on `models.list`, 2026-08-13: 1,048,576-token context, 65,536 max output, thinking-capable), but OpenClaw's Google static catalog did not list it, so it only appeared through live discovery without the curated `codeMode: preferred` compat.

Live testing the new model surfaced a real regression class: `gemini-3.7-flash` is the first Flash model to reject `thinkingConfig.thinkingLevel: "MINIMAL"` (HTTP 400 `INVALID_ARGUMENT` — "Thinking level MINIMAL is not supported for this model"; LOW/MEDIUM/HIGH succeed, and `gemini-3.6-flash` still accepts MINIMAL). OpenClaw hardcoded MINIMAL as the "thinking off" floor for all Gemini 3 Flash models in two sibling surfaces, so every reasoning-off request to 3.7-flash failed with a silent `stopReason: "error"` — the worst bug class per repo doctrine.

## Why This Change Was Made

- `extensions/google/provider-catalog.ts`: add the `gemini-3.7-flash` static row (codeMode preferred, same 1M/65k shape as 3.6) and declare the capability fact `thinkingLevelMap: { minimal: null }` on that row; the live-discovery path now copies `thinkingLevelMap` from the static catalog alongside `compat`.
- New canonical predicate `googleFlashSupportsMinimalThinking` in `packages/ai/src/transports/google-thinking-level.ts` (exported via `@openclaw/ai/transports`) owns the "which Flash models still accept MINIMAL" contract in one place: Gemini 3.x Flash with minor ≥ 7 does not.
- `packages/ai/src/providers/google-shared.ts` (direct google-generative-ai transport): the disabled-thinking config and the effort→level mapping floor at LOW instead of MINIMAL when the predicate says MINIMAL is unsupported.
- `src/llm/providers/stream-wrappers/google-thinking-payload.ts` (gemini-cli/antigravity payload wrapper): `resolveGoogleGemini3ThinkingLevel` maps `off`/`minimal`/budget≤0 to LOW for those models, importing the same predicate instead of duplicating the version rule.
- Docs: `docs/tools/code-mode.md` google row includes `gemini-3.7-flash`.

Scope notes: the `opencode` and `github-copilot` plugin manifests also list Gemini models, but those are separate upstream gateways with no proof they serve 3.7 yet — intentionally untouched. The forward-compat regexes already matched `gemini-3.7-flash` dynamically, so no resolution-logic changes were needed.

## User Impact

`google/gemini-3.7-flash` is selectable out of the box with code-mode preferred, and requests with reasoning off (or explicit `minimal`) complete instead of erroring. `gemini-3.6-flash` and earlier keep MINIMAL behavior unchanged.

## Evidence

- Live `models.list` probe: `gemini-3.7-flash` present (displayName "Gemini 3.7 Flash", 1,048,576 in / 65,536 out, thinking true).
- Live `generateContent` contract probe: `thinkingLevel: MINIMAL` → 400 INVALID_ARGUMENT on 3.7-flash; LOW/MEDIUM/HIGH → 200 STOP; 3.6-flash MINIMAL → 200 STOP.
- Live suite: `pnpm test:live extensions/google/google.live.test.ts -- -t "discovers and completes"` → 2 passed (`gemini-3.7-flash`, `gemini-3.5-flash-lite`); before the thinking fix the 3.7 case failed with `stopReason: "error"`.
- Focused tests: `node scripts/run-vitest.mjs extensions/google/thinking.test.ts extensions/google/provider-catalog.test.ts extensions/google/provider-models.test.ts packages/ai/src/providers/google-shared.test.ts` → all passed (regression tables keep 3.6/flash-latest MINIMAL assertions and add 3.7 LOW-floor cases).
- `node scripts/check-changed.mjs` green locally (remote backend lease failed for the delegated run; trusted-source local fallback per AGENTS).
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- Production LOC delta: catalog row +1, thinking-floor fix ~+20 (new 10-line predicate module + two floor branches + live-catalog map copy); tests ~+70. Growth carries the new model capability plus the MINIMAL-retirement contract; no simpler net-neutral shape absorbs it without duplicating the version rule across the two transport surfaces.
