### PR TITLE
fix(cron): prevent cold turns from blocking the gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cron startup responsiveness:** keep scheduled agent model selection on the Gateway's published catalog so a cold cron run cannot trigger broad provider discovery, block the event loop, or spike Gateway memory before the runner starts.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron startup responsiveness:** keep scheduled agent model selection on the Gateway's published catalog so a cold cron run cannot trigger broad provider discovery, block the event loop, or spike Gateway memory before the runner starts.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import type { AgentConfig } from "../config/types.agents.js";
 
 const {
+  loadFullModelCatalogMock,
   loadModelCatalogMock,
   getModelRefStatusMock,
   normalizeModelSelectionMock,
@@ -11,6 +12,7 @@ const {
   resolveConfiguredModelRefMock,
   resolveHooksGmailModelMock,
 } = vi.hoisted(() => ({
+  loadFullModelCatalogMock: vi.fn(),
   loadModelCatalogMock: vi.fn(),
   getModelRefStatusMock: vi.fn(),
   normalizeModelSelectionMock: vi.fn((value: unknown) => {
@@ -175,14 +177,23 @@ describe("cron model formatting and precedence edge cases", () => {
         config: Record<string, unknown>;
         agentId?: string;
         agentDir: string;
+        readOnly?: boolean;
         workspaceDir: string;
-      }) => ({
-        agentId: params.agentId ?? "main",
-        agentDir: params.agentDir,
-        workspaceDir: params.workspaceDir,
-        config: params.config,
-        modelCatalog: { entries: [], routeVariants: [] },
-      }),
+      }) => {
+        if (params.readOnly !== true) {
+          await loadFullModelCatalogMock();
+        }
+        return {
+          agentId: params.agentId ?? "main",
+          agentDir: params.agentDir,
+          workspaceDir: params.workspaceDir,
+          config: params.config,
+          modelCatalog: { entries: [], routeVariants: [] },
+        };
+      },
+    );
+    loadFullModelCatalogMock.mockRejectedValue(
+      new Error("cron model selection must not materialize the full model catalog"),
     );
     getModelRefStatusMock.mockReturnValue({ allowed: false });
     resolveHooksGmailModelMock.mockReturnValue(null);
@@ -196,6 +207,17 @@ describe("cron model formatting and precedence edge cases", () => {
   });
 
   describe("parseModelRef formatting", () => {
+    it("keeps cron owner selection on the published read-only catalog", async () => {
+      await expectDefaultSelectedModel();
+
+      expect(loadModelCatalogMock).toHaveBeenCalledWith({
+        config: {},
+        readOnly: true,
+        allowGatewaySubagentBinding: true,
+      });
+      expect(loadFullModelCatalogMock).not.toHaveBeenCalled();
+    });
+
     it("splits standard provider/model", async () => {
       await expectSelectedModel(
         {
@@ -382,6 +404,7 @@ describe("cron model formatting and precedence edge cases", () => {
       expect(loadModelCatalogMock).toHaveBeenCalledOnce();
       expect(loadModelCatalogMock).toHaveBeenCalledWith({
         config: callerConfig,
+        readOnly: true,
         allowGatewaySubagentBinding: true,
       });
       expect(resolveConfiguredModelRefMock).toHaveBeenCalledWith(

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -97,6 +97,7 @@ export async function resolveCronModelSelectionOwner(params: {
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    readOnly: true,
     allowGatewaySubagentBinding: true,
   });
   if (

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -184,6 +184,7 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
     expect(result.status).toBe("ok");
     expect(loadModelCatalogOwnerMock).toHaveBeenCalledWith({
       config: callerConfig,
+      readOnly: true,
       allowGatewaySubagentBinding: true,
     });
     expect(ensureAgentWorkspaceMock).toHaveBeenCalledWith(

--- a/src/cron/isolated-agent/run.runtime-plugins.test.ts
+++ b/src/cron/isolated-agent/run.runtime-plugins.test.ts
@@ -27,6 +27,7 @@ describe("runCronIsolatedAgentTurn runtime plugin owner", () => {
     await expect(runCronIsolatedAgentTurn(params)).resolves.toMatchObject({ status: "ok" });
     expect(loadModelCatalogOwnerMock).toHaveBeenCalledWith({
       config: params.cfg,
+      readOnly: true,
       allowGatewaySubagentBinding: true,
     });
     expect(loadAgentRuntimePluginRegistryHandleMock).toHaveBeenCalledWith({


### PR DESCRIPTION
Related: #120834

## What Problem This Solves

Fixes an issue where the first isolated scheduled agent turn after Gateway startup could materialize the full live model catalog during model selection. On a source checkout, that broad discovery path can transform thousands of plugin modules, block the event loop for tens of seconds, and add hundreds of megabytes of heap before the runner starts.

Observed evidence on an affected Gateway included consecutive 56.1s and 53.6s liveness delays, a 39.9s health RPC, and a scheduled turn timing out after 60s before runner start.

## Why This Change Was Made

`resolveCronModelSelectionOwner` lost its prior `readOnly: true` contract in #117587 when Gateway subagent binding was added. Without the flag, `loadResolvedPublishedModelCatalogOwner` is allowed to call the prepared snapshot's `loadFullModelCatalog` hook.

This restores `readOnly: true` while retaining `allowGatewaySubagentBinding: true`. Cron model selection now consumes the already-published configured catalog; the provider-scoped runtime-only thinking fallback added in #120834 remains unchanged.

Production LOC: +1/-0 (net +1) | Tests: +33/-7

## User Impact

Cold scheduled agent turns no longer trigger broad provider discovery during owner selection, so they cannot starve Gateway HTTP/RPC responsiveness or spike memory through that path.

## Evidence

- Focused Vitest: 3 files, 65 tests passed.
- Regression makes the owner-loader double fail if cron omits `readOnly: true`, and verifies `loadFullModelCatalog` is never invoked.
- `git diff --check`, formatting, conflict-marker, dependency-pin, boundary, deprecated-API, wrapper-shadowing, dead-export, and related changed guards passed.
- Local changed-gate core typecheck could not provide authoritative proof because the only available borrowed dependency tree predates current `main` (`@openclaw/session-url-contract/parse` missing, plus an unrelated terminal-core signature mismatch). Exact-head CI remains the typecheck authority.
- Autoreview: clean, no accepted/actionable findings.

Provenance: clearly introduced by #117587 (code author/PR author/merger @steipete, 2026-08-01); #120834 repaired the sibling thinking-capability lookup but did not restore the owner lookup's read-only flag.
