### PR TITLE
fix: isolate device-join HTTP route tests

### DIFF
--- a/src/gateway/server-http.device-pairing-join.test.ts
+++ b/src/gateway/server-http.device-pairing-join.test.ts
@@ -1,4 +1,5 @@
 // Real Gateway lifecycle proof for admin mint -> public single-use join exchange.
+import { Agent, fetch } from "undici";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { WebSocket } from "ws";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -22,6 +23,7 @@ type JoinSetupResult = {
 
 let harness: Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 let adminSocket: WebSocket;
+let httpDispatcher: Agent;
 
 beforeAll(async () => {
   testState.gatewayAuth = {
@@ -34,6 +36,7 @@ beforeAll(async () => {
     },
   };
   harness = await createGatewaySuiteHarness();
+  httpDispatcher = new Agent({ connections: 1 });
   adminSocket = await harness.openWs();
   const connected = await connectReq(adminSocket, {
     token: "secret",
@@ -46,6 +49,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   adminSocket?.close();
+  await httpDispatcher?.close();
   await harness?.close();
 });
 
@@ -66,8 +70,14 @@ function shortcodeFromUrl(joinUrl: string): string {
   return new URL(joinUrl).pathname.split("/").at(-1) ?? "";
 }
 
-async function readJson(response: Response): Promise<unknown> {
+async function readJson(response: Awaited<ReturnType<typeof fetch>>): Promise<unknown> {
   return JSON.parse(await response.text()) as unknown;
+}
+
+async function fetchJoinUrl(url: string) {
+  // Other Gateway suites replace the process-wide Undici dispatcher. Keep this
+  // real loopback route bound to its own client so cross-suite mocks cannot claim it.
+  return await fetch(url, { dispatcher: httpDispatcher });
 }
 
 describe("Gateway device join route", () => {
@@ -84,7 +94,7 @@ describe("Gateway device join route", () => {
       );
     });
 
-    const expiredResponse = await fetch(expired.joinUrl);
+    const expiredResponse = await fetchJoinUrl(expired.joinUrl);
     expect(expiredResponse.status).toBe(404);
     const opaqueNotFound = await readJson(expiredResponse);
     expect(opaqueNotFound).toEqual({ error: "not_found" });
@@ -93,22 +103,22 @@ describe("Gateway device join route", () => {
     const shortcode = shortcodeFromUrl(live.joinUrl);
     expect(Buffer.from(shortcode, "base64url").byteLength).toBeGreaterThanOrEqual(16);
 
-    const first = await fetch(live.joinUrl);
+    const first = await fetchJoinUrl(live.joinUrl);
     expect(first.status).toBe(200);
     expect(first.headers.get("content-type")).toContain("application/json");
     expect(first.headers.get("cache-control")).toBe("no-store");
     expect(await readJson(first)).toEqual(decodePairingSetupCode(live.setupCode));
 
-    const used = await fetch(live.joinUrl);
+    const used = await fetchJoinUrl(live.joinUrl);
     expect(used.status).toBe(404);
     expect(await readJson(used)).toEqual(opaqueNotFound);
 
     const unknownUrl = `http://127.0.0.1:${harness.port}/j/${"z".repeat(22)}`;
-    const unknown = await fetch(unknownUrl);
+    const unknown = await fetchJoinUrl(unknownUrl);
     expect(unknown.status).toBe(404);
     expect(await readJson(unknown)).toEqual(opaqueNotFound);
 
-    const limited = await fetch(unknownUrl);
+    const limited = await fetchJoinUrl(unknownUrl);
     expect(limited.status).toBe(429);
     expect(await readJson(limited)).toEqual({ error: "rate_limited" });
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent Gateway CI failure where the real device-join route received a plain `Not Found` response from another process-wide HTTP dispatcher instead of the Gateway's JSON `{ "error": "not_found" }` response.

## Why This Change Was Made

The test now gives its real loopback requests a dedicated Undici `Agent` and closes it with the suite. This keeps the route proof independent from other Gateway suites that intentionally replace the process-wide Undici dispatcher, while preserving the actual server, HTTP exchange, single-use redemption, expiry, and rate-limit behavior.

## User Impact

No product behavior changes. CI now exercises the device-join route through an isolated real HTTP client instead of inheriting unrelated suite-level network mocks.

## Evidence

- Before: [exact-main CI run 31753023126](https://github.com/openclaw/openclaw/actions/runs/31753023126) parsed plain `Not Found` at the first expired-code response; the same failure previously appeared in run 31727405654.
- Focused regression: `node scripts/run-vitest.mjs src/gateway/server-http.device-pairing-join.test.ts` — passed.
- Stress proof: the same focused test passed five consecutive isolated runs.
- Changed-file formatting, oxlint, and `git diff --check` passed.
- Autoreview reported no actionable findings.
- Dependency contract checked in `undici/types/fetch.d.ts`, `undici/types/agent.d.ts`, and `undici/lib/dispatcher/agent.js`: `fetch` accepts a per-request dispatcher and `Agent` owns closeable origin-scoped pools.

Production LOC: +0/-0 | Tests: +16/-6
