### PR TITLE
fix(doctor): ownership upgrades fail with legacy ownerless cron jobs

### DIFF
--- a/src/commands/doctor-config-preflight.cron.ts
+++ b/src/commands/doctor-config-preflight.cron.ts
@@ -1,0 +1,37 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+/** Restores retired cron migration inputs that canonical config migration intentionally strips. */
+export function withLegacyConfig(
+  config: OpenClawConfig,
+  legacyConfig: OpenClawConfig | undefined,
+): OpenClawConfig {
+  const legacyCron = legacyConfig?.cron as Record<string, unknown> | undefined;
+  if (
+    !legacyCron ||
+    (!Object.hasOwn(legacyCron, "store") && !Object.hasOwn(legacyCron, "webhook"))
+  ) {
+    return config;
+  }
+  return {
+    ...config,
+    cron: {
+      ...config.cron,
+      ...(Object.hasOwn(legacyCron, "store") ? { store: legacyCron.store } : {}),
+      ...(Object.hasOwn(legacyCron, "webhook") ? { webhook: legacyCron.webhook } : {}),
+    },
+  } as OpenClawConfig;
+}
+
+/** Isolates the trusted partition selector from a partially valid legacy config. */
+export function retainStoreConfig(config: OpenClawConfig | undefined): OpenClawConfig | undefined {
+  const cron = config?.cron as { store?: unknown; webhook?: unknown } | undefined;
+  if (typeof cron?.store !== "string" || !cron.store.trim()) {
+    return undefined;
+  }
+  return {
+    cron: {
+      store: cron.store,
+      ...(Object.hasOwn(cron, "webhook") ? { webhook: cron.webhook } : {}),
+    },
+  } as OpenClawConfig;
+}

--- a/src/commands/doctor-config-preflight.state-migration-input.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration-input.test.ts
@@ -45,6 +45,9 @@ const autoMigrateLegacyTaskStateSidecars = vi.hoisted(() =>
 const migrateLegacyMediaPersistence = vi.hoisted(() =>
   vi.fn(() => ({ changes: [], warnings: [] })),
 );
+const migrateLegacyConfigMachineState = vi.hoisted(() =>
+  vi.fn(() => ({ changes: ["cron-store-selection-imported"], warnings: [] })),
+);
 const repairLegacyCronStoreWithoutPrompt = vi.hoisted(() =>
   vi.fn(async () => ({ changes: ["cron-imported"], warnings: [] })),
 );
@@ -84,6 +87,7 @@ vi.mock("./doctor-state-migrations.js", () => ({
   autoMigrateLegacyStateDir,
   autoMigrateLegacyPluginDoctorState,
   autoMigrateLegacyTaskStateSidecars,
+  migrateLegacyConfigMachineState,
   migrateLegacyMediaPersistence,
 }));
 
@@ -140,6 +144,52 @@ describe("runDoctorConfigPreflight state migration input", () => {
     expect(autoMigrateLegacyState).toHaveBeenCalledWith(
       expect.objectContaining({ doctorOnlyStateMigrations: true }),
     );
+  });
+
+  it("does not skip a retired custom cron partition on a pristine state root", async () => {
+    const sourceConfig = {
+      gateway: { mode: "local", port: 19091 },
+      agents: {
+        entries: { ops: {}, research: {} },
+        defaults: {
+          heartbeat: { agentId: "ops" },
+          systemAgent: { agentId: "ops" },
+          authInheritance: { agentId: "ops" },
+        },
+      },
+      cron: { store: "/tmp/custom-cron/jobs.json" },
+      talk: { agentId: "ops" },
+    };
+    readConfigFileSnapshot.mockResolvedValueOnce({
+      exists: true,
+      valid: false,
+      config: sourceConfig,
+      sourceConfig,
+      parsed: {
+        agents: { list: [{ id: "ops", default: true }, { id: "research" }] },
+        cron: { store: "/tmp/custom-cron/jobs.json" },
+      },
+      legacyIssues: [{ path: "cron.store", message: "cron.store is retired" }],
+      warnings: [],
+      issues: [{ path: "agents.ownership", message: "explicit ownership is required" }],
+    });
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      skipPristineCoreStateMigrations: true,
+    });
+
+    expect(repairLegacyCronStoreWithoutPrompt).toHaveBeenCalledWith({
+      cfg: { cron: { store: "/tmp/custom-cron/jobs.json" } },
+      migrateCodexModelRefs: false,
+    });
+    expect(migrateLegacyConfigMachineState).toHaveBeenCalledWith({
+      config: sourceConfig,
+      env: process.env,
+    });
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyPluginDoctorState).toHaveBeenCalled();
   });
 
   it("runs plugin state migrations with resolved legacy config before config repair removes retired paths", async () => {
@@ -304,7 +354,7 @@ describe("runDoctorConfigPreflight state migration input", () => {
     });
     expect(migrationParams?.env).toBe(process.env);
     expect(repairLegacyCronStoreWithoutPrompt).toHaveBeenCalledWith({
-      cfg: migrationParams?.cfg,
+      cfg: expect.objectContaining({ cron: { store: "/tmp/legacy-cron.json" } }),
       migrateCodexModelRefs: false,
     });
     expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -55,6 +55,9 @@ const autoMigrateLegacyTaskStateSidecars = vi.hoisted(() =>
     }),
   ),
 );
+const migrateLegacyConfigMachineState = vi.hoisted(() =>
+  vi.fn(() => ({ changes: [], warnings: [] })),
+);
 const migrateLegacyMediaPersistence = vi.hoisted(() =>
   vi.fn(() => ({ changes: [], warnings: [] })),
 );
@@ -175,6 +178,7 @@ vi.mock("./doctor-state-migrations.js", () => ({
   autoMigrateLegacyStateDir,
   autoMigrateLegacyPluginDoctorState,
   autoMigrateLegacyTaskStateSidecars,
+  migrateLegacyConfigMachineState,
   migrateLegacyMediaPersistence,
 }));
 

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -44,6 +44,7 @@ import {
   refreshStartupPluginQuarantine,
   runStartupUpgradeConvergence,
 } from "./doctor-config-preflight-plugin-verification.js";
+import * as cronMigration from "./doctor-config-preflight.cron.js";
 import type { CronCodexRuntimePolicyTarget } from "./doctor/cron/store-migration.js";
 import { resolveStateMigrationConfigInput } from "./doctor/shared/legacy-config-state-migration-input.js";
 import { createDoctorPluginMetadataSnapshotScope } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
@@ -55,23 +56,6 @@ const loadDoctorStateMigrations = createLazyRuntimeModule(
 const loadLegacyCronRepair = createLazyRuntimeModule(
   () => import("./doctor/cron/legacy-repair.js"),
 );
-
-function withLegacyCronWebhook(
-  config: OpenClawConfig,
-  legacyConfig: OpenClawConfig | undefined,
-): OpenClawConfig {
-  const legacyCron = legacyConfig?.cron as Record<string, unknown> | undefined;
-  if (!legacyCron || !Object.hasOwn(legacyCron, "webhook")) {
-    return config;
-  }
-  return {
-    ...config,
-    cron: {
-      ...config.cron,
-      webhook: legacyCron.webhook,
-    },
-  } as OpenClawConfig;
-}
 
 async function maybeMigrateLegacyConfig(): Promise<string[]> {
   const changes: string[] = [];
@@ -500,11 +484,18 @@ export async function runDoctorConfigPreflight(
         autoMigrateLegacyState,
         autoMigrateLegacyPluginDoctorState,
         autoMigrateLegacyTaskStateSidecars,
+        migrateLegacyConfigMachineState,
       } = stateMigrations;
       if (stateMigrationInput) {
         const pluginDoctorOnlyConfig =
           stateMigrationInput.pluginDoctorConfig ?? stateMigrationInput.cfg;
-        if (skipPristineCoreStateMigrations && pluginDoctorOnlyConfig) {
+        // Retired cron.store selects a persisted SQLite partition. Preserve it in machine state
+        // before config repair removes the only custom-partition evidence.
+        if (
+          skipPristineCoreStateMigrations &&
+          pluginDoctorOnlyConfig &&
+          !cronMigration.retainStoreConfig(pluginDoctorOnlyConfig)
+        ) {
           // Core state is absent, but plugin paths may own external migration state.
           // Keep their doctor owner active without loading channel/session detectors.
           noteStartupStateMigrationResult(
@@ -529,7 +520,7 @@ export async function runDoctorConfigPreflight(
           } = await measurePreflightStep("cron-repair-import", loadLegacyCronRepair);
           const cronResult = await measurePreflightStep("cron-repair", () =>
             repairLegacyCronStoreWithoutPrompt({
-              cfg: withLegacyCronWebhook(migrationConfig, pluginDoctorConfig),
+              cfg: cronMigration.withLegacyConfig(migrationConfig, pluginDoctorConfig),
               migrateCodexModelRefs: false,
             }),
           );
@@ -558,6 +549,26 @@ export async function runDoctorConfigPreflight(
           noteStartupStateMigrationResult(legacyStateResult);
         } else if (stateMigrationInput.pluginDoctorConfig) {
           const pluginDoctorConfig = stateMigrationInput.pluginDoctorConfig;
+          const cronMigrationConfig = cronMigration.retainStoreConfig(pluginDoctorConfig);
+          if (cronMigrationConfig) {
+            // A partially valid config cannot drive general core migrations, but its retired
+            // cron.store is still the sole authority for selecting and preserving that partition.
+            const { repairLegacyCronStoreWithoutPrompt } = await measurePreflightStep(
+              "cron-repair-import",
+              loadLegacyCronRepair,
+            );
+            noteStartupStateMigrationResult(
+              await measurePreflightStep("cron-repair", () =>
+                repairLegacyCronStoreWithoutPrompt({
+                  cfg: cronMigrationConfig,
+                  migrateCodexModelRefs: false,
+                }),
+              ),
+            );
+            noteStartupStateMigrationResult(
+              migrateLegacyConfigMachineState({ config: pluginDoctorConfig, env: process.env }),
+            );
+          }
           noteStartupStateMigrationResult(
             await measurePreflightStep("plugin-doctor-migrations", () =>
               runWithPluginMetadataSnapshot({ config: pluginDoctorConfig }, () =>

--- a/src/commands/doctor-state-migrations.ts
+++ b/src/commands/doctor-state-migrations.ts
@@ -1,5 +1,6 @@
 /** Re-exports legacy state migration helpers used by doctor preflight. */
 export type { LegacyStateDetection } from "../infra/state-migrations.js";
+export { migrateLegacyConfigMachineState } from "../infra/state-migrations.config-machine-state.js";
 export {
   autoMigrateLegacyStateDir,
   autoMigrateLegacyPluginDoctorState,

--- a/src/commands/doctor/shared/default-agent-role-materialization.write.test.ts
+++ b/src/commands/doctor/shared/default-agent-role-materialization.write.test.ts
@@ -5,10 +5,19 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createConfigIO, resetConfigRuntimeState } from "../../../config/io.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../../../config/legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { makeCronJob } from "../../../cron/delivery.test-helpers.js";
+import { cronStoreKey } from "../../../cron/store/key.js";
+import { loadCronRows, replaceCronRows } from "../../../cron/store/row-codec.js";
+import { writeConfigMachineState } from "../../../state/config-machine-state.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../../state/openclaw-state-db.js";
 
 const roots: string[] = [];
 
 afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
   resetConfigRuntimeState();
   await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
 });
@@ -389,6 +398,120 @@ describe("default role materialization authored writes", () => {
     const reread = await io.readConfigFileSnapshot();
     await io.writeConfigFile(reread.config, { baseSnapshot: reread });
     await expect(fs.readFile(configPath, "utf8")).resolves.toBe(firstPersisted);
+  });
+
+  it("assigns only ownerless cron rows before retiring the retained legacy owner", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-cron-owner-write-"));
+    roots.push(root);
+    const configPath = path.join(root, "openclaw.json");
+    const storePath = path.join(root, "custom-cron", "jobs.json");
+    const env = {
+      HOME: root,
+      OPENCLAW_STATE_DIR: root,
+      OPENCLAW_TEST_FAST: "1",
+    } as NodeJS.ProcessEnv;
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          list: [{ id: "ops", default: true }, { id: "research" }],
+        },
+      }),
+    );
+    writeConfigMachineState("cron.store", storePath, { env });
+    const storeKey = cronStoreKey(storePath);
+    const database = openOpenClawStateDatabase({ env }).db;
+    replaceCronRows(database, storeKey, {
+      version: 1,
+      jobs: [makeCronJob({ id: "ownerless" }), makeCronJob({ id: "owned", agentId: "research" })],
+    });
+    const otherStoreKey = cronStoreKey(path.join(root, "other-cron", "jobs.json"));
+    replaceCronRows(database, otherStoreKey, {
+      version: 1,
+      jobs: [makeCronJob({ id: "other-ownerless" })],
+    });
+    const io = createConfigIO({
+      configPath,
+      env,
+      homedir: () => root,
+      observe: false,
+      logger: { warn: () => {}, error: () => {} },
+    });
+    const snapshot = await io.readConfigFileSnapshot();
+    const nextConfig: OpenClawConfig = {
+      ...snapshot.config,
+      agents: { ...snapshot.config.agents, ownership: "explicit" },
+    };
+
+    await io.writeConfigFile(nextConfig, {
+      baseSnapshot: snapshot,
+      explicitSetPaths: [["agents", "ownership"]],
+      explicitSetValueSource: nextConfig,
+    });
+
+    const persisted = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
+    expect(persisted.agents?.ownership).toBe("explicit");
+    expect(persisted.agents?.entries?.ops).not.toHaveProperty("default");
+    expect(loadCronRows(openOpenClawStateDatabase({ env }).db, storeKey)).toMatchObject([
+      { job_id: "ownerless", agent_id: "ops" },
+      { job_id: "owned", agent_id: "research" },
+    ]);
+    expect(loadCronRows(database, otherStoreKey)).toMatchObject([
+      { job_id: "other-ownerless", agent_id: null },
+    ]);
+
+    const firstPersisted = await fs.readFile(configPath, "utf8");
+    const reread = await io.readConfigFileSnapshot();
+    await io.writeConfigFile(reread.config, { baseSnapshot: reread });
+    await expect(fs.readFile(configPath, "utf8")).resolves.toBe(firstPersisted);
+  });
+
+  it("leaves the legacy owner marker intact when a cron row is corrupt", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-corrupt-cron-owner-write-"));
+    roots.push(root);
+    const configPath = path.join(root, "openclaw.json");
+    const env = {
+      HOME: root,
+      OPENCLAW_STATE_DIR: root,
+      OPENCLAW_TEST_FAST: "1",
+    } as NodeJS.ProcessEnv;
+    const storePath = path.join(root, "cron", "jobs.json");
+    const source = JSON.stringify({
+      agents: { list: [{ id: "ops", default: true }, { id: "research" }] },
+    });
+    await fs.writeFile(configPath, source);
+    writeConfigMachineState("cron.store", storePath, { env });
+    const database = openOpenClawStateDatabase({ env }).db;
+    replaceCronRows(database, cronStoreKey(storePath), {
+      version: 1,
+      jobs: [makeCronJob({ id: "corrupt" })],
+    });
+    database
+      .prepare(
+        "UPDATE cron_jobs SET job_json = ?, schedule_kind = ? WHERE store_key = ? AND job_id = ?",
+      )
+      .run("not json", "broken", cronStoreKey(storePath), "corrupt");
+    const io = createConfigIO({
+      configPath,
+      env,
+      homedir: () => root,
+      observe: false,
+      logger: { warn: () => {}, error: () => {} },
+    });
+    const snapshot = await io.readConfigFileSnapshot();
+    const nextConfig: OpenClawConfig = {
+      ...snapshot.config,
+      agents: { ...snapshot.config.agents, ownership: "explicit" },
+    };
+
+    await expect(
+      io.writeConfigFile(nextConfig, {
+        baseSnapshot: snapshot,
+        explicitSetPaths: [["agents", "ownership"]],
+        explicitSetValueSource: nextConfig,
+      }),
+    ).rejects.toThrow("ownership cannot be verified");
+    await expect(fs.readFile(configPath, "utf8")).resolves.toBe(source);
   });
 
   it("preserves migrated legacy ownership during an unrelated write", async () => {

--- a/src/config/io.cron-owner-refusal.test.ts
+++ b/src/config/io.cron-owner-refusal.test.ts
@@ -1,6 +1,9 @@
 import { expect, it, vi } from "vitest";
 import type { LegacyCronRepairState } from "../commands/doctor/cron/legacy-repair.js";
-import { prepareCronOwnerWriteRefusal } from "./io.cron-owner-refusal.js";
+import {
+  isCronOwnerWriteRefusalError,
+  prepareCronOwnerWriteRefusal,
+} from "./io.cron-owner-refusal.js";
 import { assertAutomaticBindingsWriteAllowed } from "./io.ownership-write-guard.js";
 
 const state = (rawJobs: Array<Record<string, unknown>>) =>
@@ -10,6 +13,7 @@ const deps = (activeGateway?: { pid: number; port: number }, jobs?: Record<strin
     activeGateway ? { ...activeGateway, createdAt: new Date(0).toISOString() } : undefined,
   ),
   loadLegacyCronRepairState: vi.fn(async () => (jobs ? state(jobs) : null)),
+  materializeLegacyDefaultCronJobOwners: vi.fn(() => 0),
 });
 
 it("refuses unsafe ownership writes and rechecks at commit", async () => {
@@ -40,4 +44,73 @@ it("refuses unsafe ownership writes and rechecks at commit", async () => {
       ownershipPaths: [["bindings"]],
     }),
   ).toThrow("cannot append to $include-owned bindings");
+});
+
+it("materializes a proven retained owner before the commit recheck", async () => {
+  for (const safe of [deps(), deps(undefined, [{ id: "owned", agentId: "research" }])]) {
+    await prepareCronOwnerWriteRefusal(
+      { storePath: "/tmp/cron.json", provenOwnerAgentId: "ops" },
+      safe,
+    );
+    expect(safe.materializeLegacyDefaultCronJobOwners).not.toHaveBeenCalled();
+  }
+
+  const injected = deps(undefined, [{ id: "ownerless" }, { id: "owned", agentId: "research" }]);
+  injected.materializeLegacyDefaultCronJobOwners.mockImplementationOnce(() => {
+    injected.loadLegacyCronRepairState.mockResolvedValue(
+      state([
+        { id: "ownerless", agentId: "ops" },
+        { id: "owned", agentId: "research" },
+      ]),
+    );
+    return 1;
+  });
+
+  const plan = await prepareCronOwnerWriteRefusal(
+    {
+      storePath: "/tmp/custom-cron.json",
+      provenOwnerAgentId: "ops",
+      env: { OPENCLAW_STATE_DIR: "/tmp/state" },
+    },
+    injected,
+  );
+  await plan.recheck();
+
+  expect(injected.materializeLegacyDefaultCronJobOwners).toHaveBeenCalledOnce();
+  expect(injected.materializeLegacyDefaultCronJobOwners).toHaveBeenCalledWith({
+    storePath: "/tmp/custom-cron.json",
+    legacyDefaultAgentId: "ops",
+    env: { OPENCLAW_STATE_DIR: "/tmp/state" },
+  });
+});
+
+it("keeps ambiguous and failed owner handoffs as typed refusals", async () => {
+  const ambiguous = deps(undefined, [{ id: "ownerless" }]);
+  await expect(
+    prepareCronOwnerWriteRefusal({ storePath: "/tmp/cron.json" }, ambiguous),
+  ).rejects.toSatisfy(isCronOwnerWriteRefusalError);
+  expect(ambiguous.materializeLegacyDefaultCronJobOwners).not.toHaveBeenCalled();
+
+  const failed = deps(undefined, [{ id: "ownerless" }]);
+  failed.materializeLegacyDefaultCronJobOwners.mockImplementationOnce(() => {
+    throw new Error("database is temporarily read-only");
+  });
+  const failure = prepareCronOwnerWriteRefusal(
+    { storePath: "/tmp/cron.json", provenOwnerAgentId: "ops" },
+    failed,
+  );
+  await expect(failure).rejects.toSatisfy(isCronOwnerWriteRefusalError);
+  await expect(failure).rejects.toThrow("database is temporarily read-only");
+
+  const corrupt = deps();
+  corrupt.loadLegacyCronRepairState.mockRejectedValueOnce(
+    new Error("database disk image is malformed"),
+  );
+  const unreadable = prepareCronOwnerWriteRefusal(
+    { storePath: "/tmp/corrupt-cron.json", provenOwnerAgentId: "ops" },
+    corrupt,
+  );
+  await expect(unreadable).rejects.toSatisfy(isCronOwnerWriteRefusalError);
+  await expect(unreadable).rejects.toThrow("database disk image is malformed");
+  expect(corrupt.materializeLegacyDefaultCronJobOwners).not.toHaveBeenCalled();
 });

--- a/src/config/io.cron-owner-refusal.ts
+++ b/src/config/io.cron-owner-refusal.ts
@@ -1,17 +1,28 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { formatErrorMessage } from "../infra/errors.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 
 type CronOwnerRefusalDeps = Pick<
   typeof import("../infra/gateway-lock.js"),
   "readActiveGatewayLockIdentity"
 > &
-  Pick<typeof import("../commands/doctor/cron/legacy-repair.js"), "loadLegacyCronRepairState">;
+  Pick<typeof import("../commands/doctor/cron/legacy-repair.js"), "loadLegacyCronRepairState"> &
+  Pick<
+    typeof import("../cron/legacy-default-agent-owner-migration.js"),
+    "materializeLegacyDefaultCronJobOwners"
+  >;
 const RETRY = ' Run "openclaw doctor --fix", then retry.';
+const CRON_OWNER_REFUSAL = "cron-owner-safety";
 
 function refused(message: string, cause?: unknown): Error {
   return Object.assign(new Error(message, cause === undefined ? undefined : { cause }), {
     code: "CONFIG_WRITE_REJECTED",
+    refusal: CRON_OWNER_REFUSAL,
   });
+}
+
+export function isCronOwnerWriteRefusalError(error: unknown): error is Error {
+  return error instanceof Error && "refusal" in error && error.refusal === CRON_OWNER_REFUSAL;
 }
 
 function hasOwner(record: Record<string, unknown> | undefined): boolean {
@@ -25,20 +36,33 @@ function hasOwner(record: Record<string, unknown> | undefined): boolean {
 }
 
 async function loadDefaultDeps(): Promise<CronOwnerRefusalDeps> {
-  const [{ readActiveGatewayLockIdentity }, { loadLegacyCronRepairState }] = await Promise.all([
+  const [
+    { readActiveGatewayLockIdentity },
+    { loadLegacyCronRepairState },
+    { materializeLegacyDefaultCronJobOwners },
+  ] = await Promise.all([
     import("../infra/gateway-lock.js"),
     import("../commands/doctor/cron/legacy-repair.js"),
+    import("../cron/legacy-default-agent-owner-migration.js"),
   ]);
-  return { readActiveGatewayLockIdentity, loadLegacyCronRepairState };
+  return {
+    readActiveGatewayLockIdentity,
+    loadLegacyCronRepairState,
+    materializeLegacyDefaultCronJobOwners,
+  };
 }
 
 async function assertSafe(
   storePath: string,
   env: NodeJS.ProcessEnv,
   deps: CronOwnerRefusalDeps,
+  provenOwnerAgentId?: string,
 ): Promise<void> {
   const active = await deps.readActiveGatewayLockIdentity({ env }).catch((error: unknown) => {
-    throw refused(`Config write refused: cannot inspect the Gateway lock.${RETRY}`, error);
+    throw refused(
+      `Config write refused: cannot inspect the Gateway lock (${formatErrorMessage(error)}).${RETRY}`,
+      error,
+    );
   });
   if (active && active.pid !== process.pid) {
     throw refused(
@@ -49,7 +73,7 @@ async function assertSafe(
     .loadLegacyCronRepairState({ cfg: {}, storePath, env, readOnly: true })
     .catch((error: unknown) => {
       throw refused(
-        `Config write refused: cannot inspect cron ownership at ${storePath}.${RETRY}`,
+        `Config write refused: cannot inspect cron ownership at ${storePath} (${formatErrorMessage(error)}).${RETRY}`,
         error,
       );
     });
@@ -58,6 +82,27 @@ async function assertSafe(
       const id = normalizeOptionalString(job.id) ?? normalizeOptionalString(job.jobId);
       return !hasOwner(job) && !hasOwner(id ? state.projectedOwnersByJobId.get(id) : undefined);
     }).length ?? 0;
+  const unverifiable = state?.invalidConfigRows?.length ?? 0;
+  if (unverifiable > 0) {
+    throw refused(
+      `Config write refused: cron store ${storePath} contains ${unverifiable} corrupt row(s) whose ownership cannot be verified.${RETRY}`,
+    );
+  }
+  if (ownerless > 0 && provenOwnerAgentId) {
+    try {
+      deps.materializeLegacyDefaultCronJobOwners({
+        storePath,
+        legacyDefaultAgentId: provenOwnerAgentId,
+        env,
+      });
+    } catch (error) {
+      throw refused(
+        `Config write refused: cannot assign ownerless cron jobs at ${storePath} to the retained legacy owner (${formatErrorMessage(error)}).${RETRY}`,
+        error,
+      );
+    }
+    return await assertSafe(storePath, env, deps);
+  }
   if (ownerless > 0) {
     throw refused(
       `Config write refused: cron store ${storePath} contains ${ownerless} ownerless legacy cron job(s).${RETRY}`,
@@ -66,12 +111,12 @@ async function assertSafe(
 }
 
 export async function prepareCronOwnerWriteRefusal(
-  params: { storePath: string; env?: NodeJS.ProcessEnv },
+  params: { storePath: string; provenOwnerAgentId?: string; env?: NodeJS.ProcessEnv },
   injectedDeps?: CronOwnerRefusalDeps,
 ): Promise<{ recheck: () => Promise<void> }> {
   const env = params.env ?? process.env;
   const deps = injectedDeps ?? (await loadDefaultDeps());
-  const recheck = () => assertSafe(params.storePath, env, deps);
+  const recheck = () => assertSafe(params.storePath, env, deps, params.provenOwnerAgentId);
   await recheck();
   return { recheck };
 }

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -123,7 +123,6 @@ export async function writeConfigFileFromContext(
   assertConfigWriteAllowedInCurrentMode({ configPath, env: deps.env });
   const unsetPaths = resolveManagedUnsetPathsForWrite(options.unsetPaths);
   let nextConfig = cfg;
-  let persistCandidate: unknown;
   const snapshotRead = options.baseSnapshot
     ? {
         snapshot: options.baseSnapshot,
@@ -281,11 +280,12 @@ export async function writeConfigFileFromContext(
   const cronOwnerRefusal = persistOwnership
     ? await prepareCronOwnerWriteRefusal({
         storePath: resolveCronJobsStorePathFromConfig(nextConfig, deps.env),
+        ...(retainedFleetOwner ? { provenOwnerAgentId: retainedFleetOwner } : {}),
         env: deps.env,
       })
     : undefined;
 
-  persistCandidate = nextConfig;
+  let persistCandidate: unknown = nextConfig;
   let envRefMap: Map<string, string> | null = null;
   const changedPaths = new Set<string>();
   collectChangedPaths(snapshot.config, nextConfig, "", changedPaths);

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -31,6 +31,9 @@ export async function runWriteConfigHealth(
   ctx: DoctorHealthFlowContext,
   options: { runPostWriteRepairs?: boolean } = {},
 ): Promise<void> {
+  if (ctx.configWriteDeferredByCronOwnership === true) {
+    return;
+  }
   const { applyWizardMetadata } = await import("../commands/onboard-helpers.js");
   const { replaceConfigFile } = await import("../config/config.js");
   const { logConfigUpdated } = await import("../config/logging.js");
@@ -53,23 +56,41 @@ export async function runWriteConfigHealth(
     }
     const legacyParentVersionOverride =
       resolveLegacyParentVersionOverride(ctx).lastTouchedVersionOverride;
-    await replaceConfigFile({
-      nextConfig: ctx.cfg,
-      afterWrite: { mode: "auto" },
-      writeOptions: {
-        auditOrigin: "doctor",
-        allowConfigSizeDrop: ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
-        skipPluginValidation:
-          ctx.configResult.skipPluginValidationOnWrite === true || updateDoctorRun,
-        ...(configResultWritePending && ctx.configResult.explicitSetPaths
-          ? { explicitSetPaths: ctx.configResult.explicitSetPaths }
-          : {}),
-        preservedLegacyRootKeys: ctx.configResult.preservedLegacyRootKeys,
-        ...(legacyParentVersionOverride
-          ? { lastTouchedVersionOverride: legacyParentVersionOverride }
-          : {}),
-      },
-    });
+    try {
+      await replaceConfigFile({
+        nextConfig: ctx.cfg,
+        afterWrite: { mode: "auto" },
+        writeOptions: {
+          auditOrigin: "doctor",
+          allowConfigSizeDrop: ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
+          skipPluginValidation:
+            ctx.configResult.skipPluginValidationOnWrite === true || updateDoctorRun,
+          ...(configResultWritePending && ctx.configResult.explicitSetPaths
+            ? { explicitSetPaths: ctx.configResult.explicitSetPaths }
+            : {}),
+          preservedLegacyRootKeys: ctx.configResult.preservedLegacyRootKeys,
+          ...(legacyParentVersionOverride
+            ? { lastTouchedVersionOverride: legacyParentVersionOverride }
+            : {}),
+        },
+      });
+    } catch (error) {
+      const { isCronOwnerWriteRefusalError } = await import("../config/io.cron-owner-refusal.js");
+      if (!isCronOwnerWriteRefusalError(error)) {
+        throw error;
+      }
+      const { note } = await import("../../packages/terminal-core/src/note.js");
+      note(
+        [
+          error.message,
+          "Doctor left the config unchanged, preserving any retained legacy owner for a later repair.",
+          'Resolve the reported Gateway or cron-store condition, then rerun "openclaw doctor --fix".',
+        ].join("\n"),
+        "Doctor warnings",
+      );
+      ctx.configWriteDeferredByCronOwnership = true;
+      return;
+    }
     // The final writer runs again after health repairs. Advance its baseline only
     // after the atomic write succeeds so later failures cannot mark volatile state durable.
     ctx.cfgForPersistence = structuredClone(ctx.cfg);

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -37,6 +37,8 @@ export type DoctorHealthFlowContext = {
   cfgForPersistence: OpenClawConfig;
   /** The finalized config-flow candidate crossed the atomic writer boundary. */
   configResultWriteCommitted?: boolean;
+  /** Cron ownership could not be made safe, so every config write remains deferred this run. */
+  configWriteDeferredByCronOwnership?: true;
   /** One-shot repairs that require a durable config write have completed. */
   postConfigWriteRepairsCommitted?: boolean;
   sourceConfigValid: boolean;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1093,6 +1093,51 @@ describe("doctor health contributions", () => {
     expect(mocks.collectActiveToolSchemaProjectionWarnings).not.toHaveBeenCalled();
   });
 
+  it("defers every config write after a cron ownership handoff refusal", async () => {
+    const laterRun = vi.fn(async () => undefined);
+    const cfg = {
+      agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+    } as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: { cfg, shouldWriteConfig: true },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+    mocks.replaceConfigFile.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          'Config write refused: cannot inspect cron ownership. Run "openclaw doctor --fix", then retry.',
+        ),
+        { code: "CONFIG_WRITE_REJECTED", refusal: "cron-owner-safety" },
+      ),
+    );
+
+    await runDoctorHealthContributionList(ctx, [
+      requireDoctorContribution("doctor:write-config-migrations"),
+      createDoctorHealthContribution({
+        id: "doctor:test-later",
+        label: "Test later",
+        run: laterRun,
+      }),
+    ]);
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    expect(laterRun).not.toHaveBeenCalled();
+    expect(ctx.configResultWriteCommitted).not.toBe(true);
+    expect(ctx.configWriteDeferredByCronOwnership).toBe(true);
+    expect(ctx.cfgForPersistence).toEqual(cfg);
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("preserving any retained legacy owner"),
+      "Doctor warnings",
+    );
+  });
+
   it("skips read-scope gateway probes when gateway health only proved reachability", async () => {
     mocks.checkGatewayHealth.mockResolvedValue({
       authenticated: false,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -437,12 +437,17 @@ async function runDoctorHealthContributionList(
     try {
       if (!runWithPluginMetadataSnapshot) {
         await contribution.run(ctx);
-        continue;
+      } else {
+        const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
+        await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, () =>
+          contribution.run(ctx),
+        );
       }
-      const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
-      await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, () =>
-        contribution.run(ctx),
-      );
+      if (ctx.configWriteDeferredByCronOwnership === true) {
+        // Later repairs consume the candidate config. Stop before they persist state under an
+        // ownership topology that the config writer deliberately left non-durable.
+        return;
+      }
     } catch (error) {
       await (contribution.required ? Promise.reject(error as Error) : Promise.resolve());
       const { note } = await loadNoteModule();


### PR DESCRIPTION
Closes #123371

## What Problem This Solves

Fixes an issue where operators upgrading a legacy multi-agent roster would have `openclaw doctor --fix` fail when the cron store still contained ownerless legacy jobs.

## Why This Change Was Made

The config writer now uses only the uniquely retained legacy owner that it already proves, repairs ownerless cron rows in the selected store before the atomic config rename removes that evidence, and preserves explicit owners. Doctor defers the config write with a precise warning when ownership cannot be safely verified or persisted, leaving the legacy marker available for a later self-healing retry.

This adds no config key, default, or SQLite schema surface. It does not guess the first agent, overwrite explicit ownership, or cross a custom `cron.store` boundary.

## User Impact

Legacy multi-agent upgrades with ownerless cron jobs now complete safely and idempotently. Missing stores and already migrated stores remain no-ops. Temporarily unreadable or unwritable stores leave the config marker untouched and can self-heal on a later Doctor run. Corrupt or ambiguous ownership still blocks the write rather than risking misattribution.

## Evidence

- Red on unmodified `main`: a retained `ops` legacy default plus one ownerless row exited 1 at the config-write refusal; the config marker and row stayed unchanged.
- Green on this patch: the identical CLI migration exits 0, assigns only the ownerless row to `ops`, preserves a `research`-owned row, and a second run is byte-stable.
- Compatibility controls: missing store, custom store, explicit-owner preservation, no-proven-owner, corrupt/unreadable store, and retry behavior.
- Focused Doctor/config/cron suites: 508 assertions passed.
- Static proof: core production and test typechecks, oxlint, oxfmt, changed-file guards, native-state/schema checks, database-first checks, import-cycle check.
- Autoreview: clean branch review, no accepted/actionable findings.
- Source-blind behavior validator: the same migration contract passed red/green, repeat-run, missing-store, custom-store, negative-owner, and recovery scenarios on the unchanged behavior bundle. A fresh rerun was blocked before execution by a local file-descriptor exhaustion fault; no result from that attempt is claimed.
- Testbox fallback: the reserved hosted lease timed out while queued without running the workload; local checks above are supplemented by this PR's exact-head CI.
- Review metric: production +172/-50 (net +122); tests +297/-2 (net +295). Production growth is the custom-store preflight and typed safe-deferral boundary required to avoid erasing the sole ownership evidence.
- AI-assisted: yes. The change was independently reproduced, reviewed, and behavior-validated; no session transcript is attached.

Release-note context: fixes Doctor upgrades from legacy default ownership to explicit multi-agent ownership.


### Sanitized terminal proof

```text
BASE (unmodified main)
$ openclaw doctor --fix --yes --non-interactive
Config write refused: cron store contains 1 ownerless legacy cron job(s).
exit=1
config legacy default=ops
rows: owned|research, ownerless|NULL

HEAD ec45d574e098
$ openclaw doctor --fix --yes --non-interactive
Doctor complete.
exit=0
config explicit owners=ops,research; legacy default markers=0
rows: owned|research, ownerless|ops

$ openclaw doctor --fix --yes --non-interactive   # repeat
Doctor complete.
exit=0
config bytes unchanged; rows unchanged
```

Maintainer source review traced the complete path from Doctor preflight through the config writer's final pre-rename guard and the cron store transaction. The custom-store selector, explicit-owner preservation, retry/defer branches, startup finalizer, and the four related ownership PRs were checked directly. No replacement field or broader transaction is needed.
