### PR TITLE
fix(skills): keep shared skill roots safe during collection review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Skill Workshop collection safety:** keep skills that resolve outside their workspace out of autonomous collection review, and pin collection drop/rollback moves to the workspace root so symlink swaps cannot redirect mutations.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Skill Workshop collection safety:** keep skills that resolve outside their workspace out of autonomous collection review, and pin collection drop/rollback moves to the workspace root so symlink swaps cannot redirect mutations.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/skills/workshop/collection-reconcile.test.ts
+++ b/src/skills/workshop/collection-reconcile.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
@@ -16,6 +17,7 @@ import {
   reconcileSkillCollection,
   restoreLatestSkillCollectionBackup,
 } from "./collection-reconcile.js";
+import { stageSkillCollectionDrop } from "./collection-rollback.js";
 import { getArchivedSkillFiles } from "./curator.js";
 import { readSkillProposalTargetTreeSha256 } from "./proposal-bundle.js";
 import { inspectSkillProposal, listSkillProposals, proposeCreateSkill } from "./service.js";
@@ -69,12 +71,118 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  __setFsSafeTestHooksForTest(undefined);
   closeOpenClawStateDatabaseForTest();
   await testState.cleanup();
   await tempDirs.cleanup();
 });
 
 describe("skill collection reconciliation", () => {
+  it.runIf(process.platform !== "win32")(
+    "keeps trusted external symlink targets outside the autonomous collection",
+    async () => {
+      const targetSkillsDir = await tempDirs.make("openclaw-skill-collection-readonly-target-");
+      const targetSkillDir = path.join(targetSkillsDir, "shared-skill");
+      await writeSkill({
+        dir: targetSkillDir,
+        name: "shared-skill",
+        description: "Shared read-only procedure",
+        body: "# Shared\n\nDo not rewrite this target.\n",
+      });
+      await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+      await fs.symlink(targetSkillDir, path.join(workspaceDir, "skills", "shared-skill"), "dir");
+      const config = {
+        skills: {
+          load: { allowSymlinkTargets: [targetSkillsDir] },
+          workshop: { allowSymlinkTargetWrites: true },
+        },
+      };
+
+      expect(listWritableSkillCollection(workspaceDir, { config })).toEqual([]);
+      await expect(
+        stageSkillCollectionDrop({
+          workspaceDir,
+          name: "shared-skill",
+          baseDir: path.join(workspaceDir, "skills", "shared-skill"),
+        }),
+      ).rejects.toMatchObject({ code: "path-alias" });
+      await expect(fs.readFile(path.join(targetSkillDir, "SKILL.md"), "utf8")).resolves.toContain(
+        "Do not rewrite this target.",
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a collection drop before traversing a trusted external skills root",
+    async () => {
+      const targetSkillsDir = await tempDirs.make("openclaw-skill-collection-external-root-");
+      const targetSkillDir = path.join(targetSkillsDir, "shared-skill");
+      await writeSkill({
+        dir: targetSkillDir,
+        name: "shared-skill",
+        description: "Shared external procedure",
+        body: "# Shared\n\nCanonical procedure.\n",
+      });
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      const config = {
+        skills: {
+          load: { allowSymlinkTargets: [targetSkillsDir] },
+          workshop: { allowSymlinkTargetWrites: true },
+        },
+      };
+
+      await expect(
+        reconcileSkillCollection({
+          workspaceDir,
+          config,
+          env: testState.env,
+          ...(await readCollectionReceipt(config)),
+          plan: [{ action: "drop", name: "shared-skill", reason: "must stay external" }],
+        }),
+      ).rejects.toThrow("Cannot drop a skill that does not exist");
+      await expect(fs.readFile(path.join(targetSkillDir, "SKILL.md"), "utf8")).resolves.toContain(
+        "Canonical procedure.",
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a skills-root swap at the drop mutation boundary",
+    async () => {
+      await writeWorkspaceSkills(workspaceDir, [
+        { name: "procedure", description: "Workspace procedure" },
+      ]);
+      const outsideWorkspace = await tempDirs.make("openclaw-skill-collection-swap-target-");
+      await writeWorkspaceSkills(outsideWorkspace, [
+        { name: "procedure", description: "External procedure" },
+      ]);
+      const skillsDir = path.join(workspaceDir, "skills");
+      const displacedSkillsDir = path.join(workspaceDir, "skills-before-swap");
+      let swapped = false;
+      __setFsSafeTestHooksForTest({
+        beforeRootFallbackMutation: async (operation) => {
+          if (operation !== "move" || swapped) {
+            return;
+          }
+          swapped = true;
+          await fs.rename(skillsDir, displacedSkillsDir);
+          await fs.symlink(path.join(outsideWorkspace, "skills"), skillsDir, "dir");
+        },
+      });
+
+      await expect(
+        stageSkillCollectionDrop({
+          workspaceDir,
+          name: "procedure",
+          baseDir: path.join(skillsDir, "procedure"),
+        }),
+      ).rejects.toBeTruthy();
+      await expect(
+        fs.readFile(path.join(outsideWorkspace, "skills", "procedure", "SKILL.md"), "utf8"),
+      ).resolves.toContain("External procedure");
+    },
+  );
+
   it("consolidates a collection atomically and preserves one recoverable backup", async () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "deploy-one", description: "First deploy notes", body: "# Deploy one\n" },
@@ -818,8 +926,10 @@ describe("skill collection reconciliation", () => {
   });
 });
 
-async function readCollectionReceipt() {
-  const skills = listWritableSkillCollection(workspaceDir);
+async function readCollectionReceipt(
+  config?: Parameters<typeof listWritableSkillCollection>[1]["config"],
+) {
+  const skills = listWritableSkillCollection(workspaceDir, { config });
   return {
     readSkillHashes: new Map(
       await Promise.all(

--- a/src/skills/workshop/collection-reconcile.test.ts
+++ b/src/skills/workshop/collection-reconcile.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
@@ -926,9 +927,7 @@ describe("skill collection reconciliation", () => {
   });
 });
 
-async function readCollectionReceipt(
-  config?: Parameters<typeof listWritableSkillCollection>[1]["config"],
-) {
+async function readCollectionReceipt(config?: OpenClawConfig) {
   const skills = listWritableSkillCollection(workspaceDir, { config });
   return {
     readSkillHashes: new Map(

--- a/src/skills/workshop/collection-reconcile.ts
+++ b/src/skills/workshop/collection-reconcile.ts
@@ -50,7 +50,7 @@ import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
 import { readSkillProposalTargetTreeSha256 } from "./proposal-bundle.js";
 import { prepareSkillProposalDraft } from "./proposal-draft.js";
 import { withSkillCollectionLock } from "./target-lock.js";
-import { assertWritableSkillTarget } from "./workspace-skill-read.js";
+import { assertWritableSkillTarget, isWorkspaceOwnedSkillTarget } from "./workspace-skill-read.js";
 
 const BACKUP_SCHEMA = "openclaw.skill-collection-backup.v1";
 
@@ -82,6 +82,11 @@ export function listWritableSkillCollection(
       try {
         assertWritableSkillTarget(workspaceDir, skill);
       } catch {
+        continue;
+      }
+      // Autonomous reconciliation may drop whole skill directories, so its
+      // inventory is narrower than manual proposal apply's explicit symlink opt-in.
+      if (!isWorkspaceOwnedSkillTarget(workspaceDir, skill)) {
         continue;
       }
       const filePath = path.resolve(skill.filePath);
@@ -218,12 +223,13 @@ export async function reconcileSkillCollection(params: {
             continue;
           }
           const skill = currentByName.get(entry.name)!;
-          droppedSkills.push(await stageSkillCollectionDrop(skill));
+          droppedSkills.push(await stageSkillCollectionDrop({ ...skill, workspaceDir }));
         }
         await commitCollectionBackup(workspaceDir, backup);
       } catch (error) {
         try {
           await rollbackSkillCollectionMutation({
+            workspaceDir,
             appliedWrites,
             droppedSkills,
           });

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -245,6 +245,41 @@ describe("skill collection review", () => {
     ]);
   });
 
+  it.runIf(process.platform !== "win32")(
+    "does not dispatch a review for read-only trusted symlink targets",
+    async () => {
+      const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-readonly-");
+      const targetSkillsDir = await makeWorkspaceDir("openclaw-collection-review-target-");
+      const targetSkillDir = path.join(targetSkillsDir, "skills", "shared-skill");
+      await writeWorkspaceSkills(targetSkillsDir, [
+        { name: "shared-skill", description: "Shared read-only procedure" },
+      ]);
+      await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+      await fs.symlink(
+        path.join(targetSkillsDir, "skills", "shared-skill"),
+        path.join(workspaceDir, "skills", "shared-skill"),
+        "dir",
+      );
+      const onError = vi.fn();
+
+      await runScheduledSkillCollectionReviews({
+        config: {
+          agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+          skills: {
+            load: { allowSymlinkTargets: [path.join(targetSkillsDir, "skills")] },
+            workshop: { autonomous: { mode: "auto" } },
+          },
+        },
+        env: testState.env,
+        onError,
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(runEmbeddedAgent).not.toHaveBeenCalled();
+      await expect(fs.access(path.join(targetSkillDir, "SKILL.md"))).resolves.toBeUndefined();
+    },
+  );
+
   it("does not dispatch a second review when the runner fails after reconciliation", async () => {
     const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-restart-");
     await writeWorkspaceSkills(workspaceDir, [

--- a/src/skills/workshop/collection-rollback.ts
+++ b/src/skills/workshop/collection-rollback.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { removePathWithinRoot } from "../../infra/fs-safe-remove.js";
-import { pathExists } from "../../infra/fs-safe.js";
+import { pathExists, root } from "../../infra/fs-safe.js";
 import { logWarn } from "../../logger.js";
 import {
   restoreWorkspaceSkillMutation,
@@ -11,6 +11,7 @@ import {
 } from "../lifecycle/workspace-skill-write.js";
 
 export async function rollbackSkillCollectionMutation(params: {
+  workspaceDir: string;
   appliedWrites: readonly PreparedWorkspaceSkillMutation[];
   droppedSkills: readonly { name: string; baseDir: string; stagedDir: string }[];
 }): Promise<void> {
@@ -30,12 +31,18 @@ export async function rollbackSkillCollectionMutation(params: {
       errors.push(error);
     }
   }
+  const workspaceRoot = await root(params.workspaceDir);
   for (const skill of params.droppedSkills.toReversed()) {
     try {
-      if (await pathExists(skill.baseDir)) {
+      const baseRelativePath = relativeSkillCollectionPath(params.workspaceDir, skill.baseDir);
+      if (await workspaceRoot.exists(baseRelativePath)) {
         throw new Error(`Dropped skill changed before restoration: ${skill.name}`);
       }
-      await fs.rename(skill.stagedDir, skill.baseDir);
+      await workspaceRoot.move(
+        relativeSkillCollectionPath(params.workspaceDir, skill.stagedDir),
+        baseRelativePath,
+        { overwrite: true },
+      );
     } catch (error) {
       errors.push(error);
     }
@@ -46,6 +53,7 @@ export async function rollbackSkillCollectionMutation(params: {
 }
 
 export async function stageSkillCollectionDrop(params: {
+  workspaceDir: string;
   name: string;
   baseDir: string;
 }): Promise<{ name: string; baseDir: string; stagedDir: string }> {
@@ -53,7 +61,12 @@ export async function stageSkillCollectionDrop(params: {
     path.dirname(params.baseDir),
     `.openclaw-drop-${path.basename(params.baseDir)}-${randomUUID()}`,
   );
-  await fs.rename(params.baseDir, stagedDir);
+  const workspaceRoot = await root(params.workspaceDir);
+  await workspaceRoot.move(
+    relativeSkillCollectionPath(params.workspaceDir, params.baseDir),
+    relativeSkillCollectionPath(params.workspaceDir, stagedDir),
+    { overwrite: true },
+  );
   return { name: params.name, baseDir: params.baseDir, stagedDir };
 }
 
@@ -157,14 +170,24 @@ async function removeSkillCollectionDirectory(
   workspaceDir: string,
   skillDir: string,
 ): Promise<void> {
-  const relativePath = path.relative(workspaceDir, skillDir);
-  if (!relativePath || path.isAbsolute(relativePath) || relativePath.startsWith(`..${path.sep}`)) {
-    throw new Error(`Skill directory must be inside the workspace: ${skillDir}`);
-  }
+  const relativePath = relativeSkillCollectionPath(workspaceDir, skillDir);
   await removePathWithinRoot({
     rootDir: workspaceDir,
     relativePath,
     recursive: true,
     force: false,
   });
+}
+
+function relativeSkillCollectionPath(workspaceDir: string, skillDir: string): string {
+  const relativePath = path.relative(workspaceDir, skillDir);
+  if (
+    !relativePath ||
+    relativePath === ".." ||
+    path.isAbsolute(relativePath) ||
+    relativePath.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(`Skill directory must be inside the workspace: ${skillDir}`);
+  }
+  return relativePath;
 }

--- a/src/skills/workshop/workspace-skill-read.ts
+++ b/src/skills/workshop/workspace-skill-read.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isPathInside } from "../../infra/path-guards.js";
 import {
   buildWorkspaceSkillStatus,
   resolveSkillStatusEntry,
@@ -10,6 +11,7 @@ import {
   assertInsideWorkspace,
   readWorkspaceSkillFile,
 } from "../lifecycle/workspace-skill-write.js";
+import { tryRealpath } from "../loading/symlink-targets.js";
 
 const WRITABLE_WORKSPACE_SOURCES = new Set(["openclaw-workspace", "agents-skills-project"]);
 
@@ -22,6 +24,17 @@ export function assertWritableSkillTarget(workspaceDir: string, skill: SkillStat
   if (path.basename(skill.filePath) !== "SKILL.md") {
     throw new Error("Skill Workshop can only update SKILL.md targets.");
   }
+}
+
+export function isWorkspaceOwnedSkillTarget(
+  workspaceDir: string,
+  skill: Pick<SkillStatusEntry, "baseDir">,
+): boolean {
+  const workspaceRealPath = tryRealpath(path.resolve(workspaceDir));
+  const skillRealPath = tryRealpath(path.resolve(skill.baseDir));
+  return Boolean(
+    workspaceRealPath && skillRealPath && isPathInside(workspaceRealPath, skillRealPath),
+  );
 }
 
 type WritableWorkspaceSkillSummary = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scheduled Skill Workshop collection review could admit a workspace skill that resolves into an external shared skill root. Rewrites then failed on the intentional symlink-write guard, while a drop could traverse a symlinked `skills/` root and rename the canonical external directory.

## Why This Change Was Made

Autonomous collection review now includes only skill directories whose real path remains inside the workspace, regardless of loading trust or the separate manual proposal-apply opt-in. Collection drop and rollback also use the root-pinned fs-safe move primitive instead of raw path-based renames, closing the mutation-time parent-swap window. Manual Skill Workshop proposal apply keeps its existing explicit symlink-target write policy.

The collection feature introduced in #121653 correctly refused symlink rewrites but did not apply that ownership boundary when building the writable inventory or staging drops.

Production LOC: +52/-10 (net +42, justified by the workspace ownership and mutation-time security boundary) | Tests: +146/-2 | Changelog: +1/-0

## User Impact

Daily collection review skips externally owned shared skills instead of failing or risking mutation of their canonical directory. Ordinary workspace-owned skills continue to be reviewed, rewritten, dropped, backed up, and restored as before.

## Evidence

- Reproduced from a scheduled collection-review failure on `e04dfd26e237cfc73afb20a5d58d707b0574cdb2`: a configured external skill symlink was admitted, then rejected as an untrusted write target.
- `node scripts/run-vitest.mjs src/skills/workshop/collection-reconcile.test.ts src/skills/workshop/collection-review.test.ts` — 33 passed.
- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts` — 46 passed, including the unchanged manual symlink-write opt-in.
- `node scripts/run-oxlint.mjs <five changed TypeScript files>` — passed.
- `oxfmt --check <five changed TypeScript files>` and `git diff --check` — passed.
- Autoreview: clean, no accepted/actionable findings; patch judged correct at 0.96 confidence.

Regression coverage includes per-skill external symlinks, a whole external `skills/` root, scheduled-review admission, and a parent-directory swap at the drop mutation boundary.
