### PR TITLE
fix(ui): stop app-card badges from squeezing titles into mid-word wraps

### DIFF
--- a/ui/src/styles/apps.css
+++ b/ui/src/styles/apps.css
@@ -101,10 +101,13 @@
   padding: 14px;
 }
 
+/* Wrapping keeps the nowrap badge from squeezing the title into a mid-word
+   break on narrow cards: the badge drops to its own line instead. */
 .apps-card__title-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 6px 8px;
   min-width: 0;
 }
 
@@ -113,7 +116,11 @@
   color: var(--text);
 }
 
+/* Growing right-aligns an inline badge (title absorbs the slack) yet leaves
+   a wrapped badge left-aligned under the title. Basis must stay auto: a 0%
+   basis would let the badge share the line and squeeze the title again. */
 .apps-card__title {
+  flex: 1 1 auto;
   margin: 0;
   color: var(--text-strong);
   font-size: var(--control-ui-text-md, 15px);
@@ -121,7 +128,6 @@
 }
 
 .apps-card__badge {
-  margin-inline-start: auto;
   padding: 2px 9px;
   border: 1px solid var(--border);
   border-radius: 999px;


### PR DESCRIPTION
## What Problem This Solves

On the Control UI Apps page (`/apps`), the "On your wrist" cards break their title layout at narrow card widths: the bundled-app badge ("Included with the iOS app" / "Included with the Android app") is `white-space: nowrap`, so the card title is the only shrinkable item in the flex title row and wraps mid-phrase — "Apple Watch" and "Wear OS" render as two stacked lines next to a squeezed badge. The Chrome-extension card's "coming soon" badge hits the same class of break.

## Why This Change Was Made

The title row (`.apps-card__title-row`) was a non-wrapping flex row of icon + title + badge with the badge pushed right via `margin-inline-start: auto`. The fix lets the row wrap and gives the title `flex: 1 1 auto`: when there is room the title absorbs the slack and the badge stays inline at the right edge (unchanged wide layout); when there isn't, the whole badge drops to its own line, left-aligned under an intact single-line title. The `auto` basis is load-bearing — a `flex: 1` (0% basis) title would let the badge share the line and squeeze the title again. CSS-only; production LOC +6 in a stylesheet, no markup or test-surface change.

## User Impact

Watch-section and Chrome-extension cards keep clean single-line titles at every card width, including the two-column ~270px grid minimum where the break was reported. Wide layouts are pixel-equivalent aside from the badge's 1px alignment.

## Evidence

Captured on the mocked Control UI dev server (`pnpm dev:ui:mock`) with Playwright at a 590px viewport (cards near the 260px grid minimum), device scale 2.

Before:

<img src="https://github.com/user-attachments/assets/afe01302-e373-4f58-af3c-cab1152ee67b" width="580" alt="Before: Apple Watch and Wear OS titles wrap mid-phrase next to squeezed badges" />

After (narrow — badge wraps to its own line, title intact):

<img src="https://github.com/user-attachments/assets/a1ad7651-76d0-49d7-b2d2-e3934bd87cc3" width="580" alt="After narrow: single-line titles with the badge on its own line" />

After (wide — badge stays inline, right-aligned, unchanged):

<img src="https://github.com/user-attachments/assets/2005ed29-2403-4b38-b3c5-ad80079babbc" width="580" alt="After wide: badge inline and right-aligned as before" />

Validation:

- `node scripts/run-vitest.mjs ui/src/pages/apps/view.test.ts` — 1 file, 6 tests passed
- `stylelint --config config/stylelint.config.mjs ui/src/styles/apps.css` — clean
- `oxfmt --check ui/src/styles/apps.css` — clean; `git diff --check` clean
- Codex autoreview (gpt-5.6-sol, high): clean, no accepted/actionable findings
- Remote check-changed delegation was unavailable (Daytona lease memory-tier 400, Testbox doctor red), so the lanes above ran locally per the trusted-source fallback rule.
