### PR TITLE
feat(ui): thicken chat effort slider into capsule rail

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4911,7 +4911,7 @@ button.chat-reply-preview--message:disabled {
 .chat-controls__effort-scale {
   display: flex;
   justify-content: space-between;
-  margin: 3px 6px -2px;
+  margin: 3px 6px 0;
   color: var(--muted);
   font-size: 10px;
   font-weight: 550;
@@ -4923,7 +4923,7 @@ button.chat-reply-preview--message:disabled {
   position: relative;
   display: flex;
   align-items: center;
-  height: 22px;
+  height: 26px;
   margin: 0 6px;
 }
 
@@ -4933,7 +4933,7 @@ button.chat-reply-preview--message:disabled {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 5px;
+  padding: 0 12px;
   pointer-events: none;
 }
 
@@ -4950,7 +4950,7 @@ button.chat-reply-preview--message:disabled {
   position: relative;
   z-index: 1;
   width: 100%;
-  height: 22px;
+  height: 26px;
   margin: 0;
   padding: 0;
   background: transparent;
@@ -4966,20 +4966,21 @@ button.chat-reply-preview--message:disabled {
 }
 
 .chat-controls__reasoning-range::-webkit-slider-runnable-track {
-  height: 3px;
+  height: 26px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-full);
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--text) 45%, transparent) var(--reasoning-fill, 0%),
-    color-mix(in srgb, var(--text) 14%, transparent) var(--reasoning-fill, 0%)
+    color-mix(in srgb, var(--text) 18%, transparent) var(--reasoning-fill, 0%),
+    color-mix(in srgb, var(--text) 7%, transparent) var(--reasoning-fill, 0%)
   );
 }
 
 .chat-controls__reasoning-range::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 14px;
-  height: 14px;
-  margin-top: -5.5px;
+  width: 28px;
+  height: 20px;
+  margin-top: 3px;
   border: none;
   border-radius: var(--radius-full);
   background: var(--text-strong);
@@ -4999,20 +5000,21 @@ button.chat-reply-preview--message:disabled {
 }
 
 .chat-controls__reasoning-range::-moz-range-track {
-  height: 3px;
+  height: 26px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--text) 14%, transparent);
+  background: color-mix(in srgb, var(--text) 7%, transparent);
 }
 
 .chat-controls__reasoning-range::-moz-range-progress {
-  height: 3px;
+  height: 24px;
   border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--text) 45%, transparent);
+  background: color-mix(in srgb, var(--text) 18%, transparent);
 }
 
 .chat-controls__reasoning-range::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
+  width: 28px;
+  height: 20px;
   border: none;
   border-radius: var(--radius-full);
   background: var(--text-strong);


### PR DESCRIPTION
## What Problem This Solves

The effort slider in the Control UI chat composer was a thin 3px line with floating dots and a small round thumb, making the control hard to see and hit.

## Why This Change Was Made

Redesign the slider per the maintainer-approved spec as a thick 26px capsule rail with a hairline border and soft committed-fill tint, a 28x20 pill thumb, and dots aligned to the true thumb stop centers inside the rail. This is CSS-only: there are no behavior, markup, or i18n changes.

## User Impact

The chat composer effort control is now easier to recognize and target while preserving the same interaction and effort levels in both dark and light themes.

Release-note context: user-visible UI polish in the Control UI chat composer.

## Evidence

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Effort slider before in dark theme](https://github.com/user-attachments/assets/2ad421af-436c-4cf7-9a29-b93369977341) | ![Effort slider after in dark theme](https://github.com/user-attachments/assets/cd1b19a9-b111-42f3-9635-0a3a40278ce2) |
| Light | ![Effort slider before in light theme](https://github.com/user-attachments/assets/749af882-65b2-40d1-8007-602d92b3867e) | ![Effort slider after in light theme](https://github.com/user-attachments/assets/49a948b4-542a-474c-b6a3-f814a365b5eb) |

- Focused e2e: `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 2 files, 15 tests passed.
- Codex autoreview (structured helper): clean, no findings.
- Source-blind visual validation: passed in dark and light themes, including mid-drag stop alignment and label update.
