### PR TITLE
fix(ollama): pick the smallest capable local model during CLI onboarding

### DIFF
--- a/extensions/ollama/src/setup-model-selection.test.ts
+++ b/extensions/ollama/src/setup-model-selection.test.ts
@@ -6,7 +6,7 @@ import {
   findAvailableOllamaModelName,
   mergeUniqueModelNames,
   normalizeOllamaModelName,
-  selectAppGuidedOllamaModelId,
+  selectAppGuidedOllamaModelFromDiscovery,
 } from "./setup-model-selection.js";
 
 afterEach(() => {
@@ -73,36 +73,33 @@ describe("Ollama onboarding model selection", () => {
 
   it("selects a deterministic tools-capable model with enough context", () => {
     expect(
-      selectAppGuidedOllamaModelId([
-        { id: "llama3:8b", contextWindow: 32_768, supportsTools: true },
-        { id: "qwen3:0.6b", contextWindow: 40_960, supportsTools: true },
-        { id: "gemma4:e4b", contextWindow: 8_192, supportsTools: true },
+      selectAppGuidedOllamaModelFromDiscovery([
+        { name: "llama3:8b", contextWindow: 32_768, capabilities: ["tools"] },
+        { name: "qwen3:0.6b", contextWindow: 40_960, capabilities: ["tools"] },
+        { name: "gemma4:e4b", contextWindow: 8_192, capabilities: ["tools"] },
       ]),
     ).toBe("qwen3:0.6b");
   });
 
   it("prefers the smallest non-reasoning setup model", () => {
     expect(
-      selectAppGuidedOllamaModelId([
+      selectAppGuidedOllamaModelFromDiscovery([
         {
-          id: "deepseek-r1:8b",
+          name: "deepseek-r1:8b",
           contextWindow: 131_072,
-          supportsTools: true,
-          reasoning: true,
+          capabilities: ["tools", "thinking"],
           size: 1_000,
         },
         {
-          id: "orieg/gemma3-tools:12b-ft",
+          name: "orieg/gemma3-tools:12b-ft",
           contextWindow: 131_072,
-          supportsTools: true,
-          reasoning: false,
+          capabilities: ["tools"],
           size: 8_000,
         },
         {
-          id: "llama3.2:latest",
+          name: "llama3.2:latest",
           contextWindow: 131_072,
-          supportsTools: true,
-          reasoning: false,
+          capabilities: ["tools"],
           size: 2_000,
         },
       ]),

--- a/extensions/ollama/src/setup-model-selection.ts
+++ b/extensions/ollama/src/setup-model-selection.ts
@@ -6,6 +6,7 @@ import {
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
+  isReasoningModelHeuristic,
   readOllamaModelShowInfo,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
@@ -77,7 +78,7 @@ export function orderPreferredOllamaModelIds(modelIds: Iterable<string>): string
   return ordered;
 }
 
-export function selectAppGuidedOllamaModelId(
+function selectAppGuidedOllamaModelId(
   models: Iterable<{
     id: string;
     contextWindow?: number;
@@ -101,6 +102,21 @@ export function selectAppGuidedOllamaModelId(
   const fastest =
     smallestSize === undefined ? pool : pool.filter((model) => model.size === smallestSize);
   return orderPreferredOllamaModelIds(fastest.map((model) => model.id))[0];
+}
+
+export function selectAppGuidedOllamaModelFromDiscovery(
+  models: Iterable<OllamaModelWithContext>,
+): string | undefined {
+  return selectAppGuidedOllamaModelId(
+    [...models].map((model) => ({
+      id: model.name,
+      contextWindow: model.contextWindow,
+      supportsTools: model.capabilities?.includes("tools") === true,
+      reasoning:
+        model.capabilities?.includes("thinking") === true || isReasoningModelHeuristic(model.name),
+      size: model.size,
+    })),
+  );
 }
 
 export function buildOllamaModelsConfig(

--- a/extensions/ollama/src/setup.non-interactive-auth.test.ts
+++ b/extensions/ollama/src/setup.non-interactive-auth.test.ts
@@ -34,6 +34,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
 
 function createOllamaFetchMock(params: {
   tags: string[];
+  tagModels?: Array<{ name: string; size?: number }>;
   show?: Record<string, number | undefined>;
   capabilities?: Record<string, string[] | undefined>;
   pullResponse?: Response;
@@ -41,7 +42,9 @@ function createOllamaFetchMock(params: {
   return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = requestUrl(input);
     if (url.endsWith("/api/tags")) {
-      return jsonResponse({ models: params.tags.map((name) => ({ name })) });
+      return jsonResponse({
+        models: params.tagModels ?? params.tags.map((name) => ({ name })),
+      });
     }
     if (url.endsWith("/api/show")) {
       const body = JSON.parse(requestBodyText(init?.body)) as { model?: string };
@@ -165,6 +168,41 @@ describe("Ollama non-interactive onboarding", () => {
     );
     expect(result.models?.providers?.ollama?.apiKey).toBe("ollama-local");
     expect(upsertAuthProfileWithLock).not.toHaveBeenCalled();
+  });
+
+  it("uses the smallest capable discovered model as the non-interactive default", async () => {
+    const fetchMock = createOllamaFetchMock({
+      tags: [],
+      tagModels: [
+        { name: "qwen3:4b-instruct", size: 2_497_293_803 },
+        { name: "gemma4:latest", size: 9_608_350_718 },
+        { name: "llama3.2:latest", size: 2_019_393_189 },
+      ],
+      show: {
+        "qwen3:4b-instruct": 262_144,
+        "gemma4:latest": 131_072,
+        "llama3.2:latest": 131_072,
+      },
+      capabilities: {
+        "qwen3:4b-instruct": ["completion", "tools", "thinking"],
+        "gemma4:latest": ["completion", "tools", "thinking"],
+        "llama3.2:latest": ["completion", "tools"],
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = createRuntime();
+
+    const result = await configureOllamaNonInteractive({
+      nextConfig: {},
+      opts: { customBaseUrl: "http://127.0.0.1:11434" },
+      runtime,
+    });
+
+    expect(fetchMock.mock.calls.map((call) => requestUrl(call[0]))).not.toContain(
+      "http://127.0.0.1:11434/api/pull",
+    );
+    expect(result.agents?.defaults?.model).toEqual({ primary: "ollama/llama3.2:latest" });
+    expect(runtime.log).toHaveBeenCalledWith("Default Ollama model: llama3.2:latest");
   });
 
   it("preserves the capabilities of an explicitly selected model beyond the discovery limit", async () => {

--- a/extensions/ollama/src/setup.runtime.ts
+++ b/extensions/ollama/src/setup.runtime.ts
@@ -31,7 +31,6 @@ import {
   buildOllamaProvider,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
-  isReasoningModelHeuristic,
   isOllamaCloudModel,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
@@ -43,7 +42,7 @@ import {
   inspectOllamaModelsForSetup,
   mergeUniqueModelNames,
   normalizeOllamaModelName,
-  selectAppGuidedOllamaModelId,
+  selectAppGuidedOllamaModelFromDiscovery,
 } from "./setup-model-selection.js";
 import { pullOllamaModel, pullOllamaModelNonInteractive } from "./setup-pull.js";
 
@@ -366,18 +365,9 @@ async function promptAndConfigureHostBackedOllama(params: {
     baseUrl,
     prompter: params.prompter,
   });
-  const localDefaultModelId = selectAppGuidedOllamaModelId(
-    [...discoveredModelsByName.values()].map((model) => ({
-      id: model.name,
-      contextWindow: model.contextWindow,
-      supportsTools: model.capabilities?.includes("tools") === true,
-      reasoning:
-        model.capabilities?.includes("thinking") === true || isReasoningModelHeuristic(model.name),
-      size: model.size,
-    })),
-  );
   const cloudDefaultModelId = suggestedModelNames.find(isOllamaCloudModel);
-  const defaultModelId = localDefaultModelId ?? cloudDefaultModelId;
+  const defaultModelId =
+    selectAppGuidedOllamaModelFromDiscovery(discoveredModelsByName.values()) ?? cloudDefaultModelId;
 
   return {
     ...(defaultModelId ? { defaultModel: `ollama/${defaultModelId}` } : {}),
@@ -485,6 +475,7 @@ export async function configureOllamaNonInteractive(params: {
 
   const requestedDefaultModelId =
     explicitModel ??
+    selectAppGuidedOllamaModelFromDiscovery(discoveredModelsByName.values()) ??
     expectDefined(OLLAMA_SUGGESTED_MODELS_LOCAL[0], "default suggested Ollama model");
   const availableModelNames = new Set(modelNames);
   const availableDefaultModelId = findAvailableOllamaModelName(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running non-interactive CLI onboarding with a local Ollama host could get a 9.6 GB default model even when a smaller, tools-capable, non-reasoning model was already installed.

On a real Ollama 0.32.5 host with 28 models, onboarding selected `gemma4:latest` (9,608,350,718 bytes) instead of `llama3.2:latest` (2,019,393,189 bytes). `qwen3:4b-instruct` was also present at 2,497,293,803 bytes but advertises thinking capability.

## Why This Change Was Made

Host discovery already preserved `/api/tags` size and `/api/show` capability/context facts. The non-interactive setup owner bypassed the guided selection policy and began from the static Gemma family suggestion, while interactive setup adapted the complete discovery rows into that policy.

This change makes that discovery-to-policy adapter the single production seam and calls it from both host-backed setup paths. Explicit CLI model choices remain authoritative, and the existing Gemma family preference remains the fallback when no measured eligible candidate exists. Cloud setup policy is unchanged.

## User Impact

`openclaw onboard --non-interactive --auth-choice ollama` now defaults to the smallest installed non-reasoning model that advertises tools and at least 16k context. This avoids an unnecessary large-model default while preserving explicit selections and size-less registry fallback behavior.

## Evidence

Live host catalog:

| Model | Size | Parameters | Relevant capabilities |
| --- | ---: | ---: | --- |
| `gemma4:latest` | 9,608,350,718 bytes | 8.0B | tools, thinking |
| `qwen3:4b-instruct` | 2,497,293,803 bytes | 4.0B | tools, thinking |
| `llama3.2:latest` | 2,019,393,189 bytes | 3.2B | tools, non-reasoning |

Before, exact CLI repro:

```text
Default Ollama model: gemma4:latest
agents.defaults.model.primary = ollama/gemma4:latest
```

After, exact-head CLI repro against the same host:

```text
Default Ollama model: llama3.2:latest
agents.defaults.model.primary = ollama/llama3.2:latest
```

The isolated onboarding run then reached the expected gateway-not-listening health check; config persistence happens before that check. No operator gateway or default OpenClaw state was touched.

Validation:

- Regression test failed before the fix with received primary `ollama/gemma4:latest`, then passed after the owner repair.
- `node scripts/run-vitest.mjs extensions/ollama/src/setup.test.ts extensions/ollama/src/setup-model-selection.test.ts extensions/ollama/src/setup.non-interactive-auth.test.ts` — 54 tests passed.
- `node scripts/check-changed.mjs` — all selected extension production/test typecheck, lint, dead-export, boundary, and architecture guards passed. Blacksmith was capacity-queued, so the documented trusted-source local fallback was used.
- `pnpm build` — exact-head build passed.
- Autoreview — clean, no accepted/actionable findings.

Sibling check: Ollama Cloud keeps its curated cloud ordering and does not make a local-size choice. LM Studio carries tool/reasoning/context facts but its API does not expose model file size; interactive and CLI setup consistently use the existing family preference. llama.cpp currently manages one explicit approximately 5 GB preset rather than selecting among discovered model sizes.
