### PR TITLE
feat(skills): resolve explicit $skill references on every channel

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -155,22 +155,21 @@ reference more than one skill:
 Use $github and $release_notes to summarize this change for the release.
 ```
 
-OpenClaw resolves these references against the current agent's eligible,
-user-invocable, model-visible skills and tells the model to read each referenced `SKILL.md`
-before acting. A single message can reference up to eight distinct skills;
+OpenClaw resolves explicit references from authorized senders on every channel
+against the current agent's eligible, user-invocable skills and tells the model
+to read each referenced `SKILL.md` before acting. A single message can reference up to eight distinct skills;
 OpenClaw returns a visible error instead of ignoring extra references. The `$`
 form is composable prompt text; `/release_notes ...`
 remains the standalone command form and may use direct tool dispatch when the
 skill declares `command-dispatch: tool`. Common uppercase shell variables such
 as `$HOME`, `$PATH`, and `$EDITOR` remain ordinary text; use lowercase
-`$home`, `$path`, or `$editor` to reference skills with those names.
+`$home`, `$path`, or `$editor` to reference skills with those names. Escape a
+reference as `\$name` when it should stay literal.
 
-Skills with `disable-model-invocation: true` stay out of the `$` picker because
-their instructions are intentionally absent from the model's prompt. Invoke
-those explicitly with their standalone slash command instead.
-
-`$` references are interpreted on WebChat/Control UI turns. Other messaging
-channels keep `$name` as ordinary text; use the skill's slash command there.
+Skills with `disable-model-invocation: true` stay out of the `$` picker and the
+model's normal prompt, so the model cannot select them on its own. An authorized
+explicit `$skill-name` reference still invokes them; the flag only hides the
+skill from model-initiated selection.
 
 ## Skill Workshop
 

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -889,7 +889,7 @@ describe("handleInlineActions", () => {
     expect(handleCommandsMock).not.toHaveBeenCalled();
   });
 
-  it("keeps $ skill references literal on message channels", async () => {
+  it("resolves authorized $ skill references on message channels", async () => {
     const typing = createTypingController();
     const original = "Review with $office_hours.";
     const ctx = buildTestCtx({ Body: original, CommandBody: original });
@@ -911,7 +911,8 @@ describe("handleInlineActions", () => {
             name: "office_hours",
             skillName: "office-hours",
             description: "Engineering office hours",
-            modelVisible: true,
+            modelVisible: false,
+            skillFile: "/tmp/skills/office-hours/SKILL.md",
           },
         ],
       },
@@ -919,10 +920,18 @@ describe("handleInlineActions", () => {
 
     expect(result.kind).toBe("continue");
     if (result.kind !== "continue") {
-      throw new Error("expected message-channel text to continue unchanged");
+      throw new Error("expected referenced skill to continue to the model");
     }
-    expect(result.cleanedBody).toBe(original);
-    expect(ctx.Body).toBe(original);
+    expect(result.cleanedBody).toBe(
+      [
+        "Use the following explicitly referenced skills for this request. Read each skill's SKILL.md before acting:",
+        "- office-hours (SKILL.md: /tmp/skills/office-hours/SKILL.md)",
+        "",
+        "User request:",
+        original,
+      ].join("\n"),
+    );
+    expect(ctx.Body).toBe(result.cleanedBody);
   });
 
   it("reloads preloaded skill commands when final exec overrides are present", async () => {

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -20,7 +20,6 @@ import {
   resolveSkillReferenceInvocations,
 } from "../../skills/discovery/chat-commands.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
-import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import {
   copyReplyPayloadMetadata,
   markCommandReplyForDelivery,
@@ -134,7 +133,13 @@ function applyExplicitSkillReferences(
   }
   const instruction = [
     "Use the following explicitly referenced skills for this request. Read each skill's SKILL.md before acting:",
-    ...skills.map((skill) => `- ${skill.skillName}`),
+    // Hidden skills are absent from the available-skills prompt, so explicit invocation
+    // carries the SKILL.md path the model needs to load them.
+    ...skills.map((skill) =>
+      skill.modelVisible === false && skill.skillFile
+        ? `- ${skill.skillName} (SKILL.md: ${skill.skillFile})`
+        : `- ${skill.skillName}`,
+    ),
     "",
     "User request:",
     body,
@@ -352,9 +357,7 @@ export async function handleInlineActions(params: {
 
   const slashCommandName = resolveSlashCommandName(command.commandBodyNormalized);
   const hasSkillReferences =
-    command.isAuthorizedSender &&
-    ctx.Surface === INTERNAL_MESSAGE_CHANNEL &&
-    hasSkillReferenceCandidate(initialCleanedBody);
+    command.isAuthorizedSender && hasSkillReferenceCandidate(initialCleanedBody);
   const shouldLoadSkillCommands =
     allowTextCommands &&
     (hasSkillReferences ||

--- a/src/skills/discovery/chat-command-invocation.ts
+++ b/src/skills/discovery/chat-command-invocation.ts
@@ -111,7 +111,7 @@ export function resolveSkillReferenceInvocations(params: {
       continue;
     }
     const command = findSkillCommand(params.skillCommands, name);
-    if (!command || command.modelVisible === false || seen.has(command.name)) {
+    if (!command || seen.has(command.name)) {
       continue;
     }
     seen.add(command.name);

--- a/src/skills/discovery/chat-commands.test.ts
+++ b/src/skills/discovery/chat-commands.test.ts
@@ -264,7 +264,7 @@ describe("resolveSkillReferenceInvocations", () => {
   it("ignores common shell variables, escaped references, and unknown names", () => {
     expect(
       resolveSkillReferenceInvocations({
-        text: String.raw`Keep $HOME and \$demo_skill literal; $unknown is not installed.`,
+        text: String.raw`Keep $PATH and \$demo_skill literal; $unknown is not installed.`,
         skillCommands,
       }),
     ).toEqual([]);
@@ -288,7 +288,7 @@ describe("resolveSkillReferenceInvocations", () => {
     ).toEqual(["demo_skill"]);
   });
 
-  it("excludes slash-only skills that are hidden from the model prompt", () => {
+  it("resolves explicitly referenced skills hidden from the model prompt", () => {
     expect(
       resolveSkillReferenceInvocations({
         text: "Use $hidden_skill.",
@@ -300,8 +300,8 @@ describe("resolveSkillReferenceInvocations", () => {
             modelVisible: false,
           },
         ],
-      }),
-    ).toEqual([]);
+      }).map((command) => command.name),
+    ).toEqual(["hidden_skill"]);
   });
 });
 

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -11,7 +11,6 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/attempt-steering.test.ts",
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
-      "extensions/codex/src/app-server/run-attempt-state.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
Part of #123367 (Phase 1+3)

## What Problem This Solves

Explicit `$skill-name` references only worked on WebChat/Control UI turns; every other channel kept the token literal, so the same message behaved differently per channel. Manual-only skills (`disable-model-invocation: true`) additionally could not be invoked via `$` references at all — the explicit resolver skipped them.

## Why This Change Was Made

Maintainer product decision on #123367: if the user explicitly names a skill, it is invoked — everywhere. Resolution stays in the reply pipeline (one harness-independent owner before harness dispatch), so behavior is identical across embedded, Claude, and Codex harnesses and across channels. `disable-model-invocation` now governs exactly what its name says: model-initiated selection. Explicitly referenced hidden skills carry their `SKILL.md` path in the injected instruction because the model cannot discover them from the available-skills prompt; model-visible skill lines stay byte-identical for prompt-cache stability.

Existing guards are unchanged: authorized senders only, `\$name` escaping, all-uppercase shell variables (`$PATH`, `$HOME`) stay literal, resolution only against real eligible skill names, 8-reference cap.

Phase 2 (Codex-side dedup: pass OpenClaw-resolved selections as structured `UserInput::Skill` and neutralize consumed tokens, salvaging the #123311 design) follows as its own PR.

## User Impact

`$skill-name` in a Telegram/Discord/Slack/etc. message from an authorized sender now invokes the skill exactly like on WebChat, including manual-only skills. Docs updated (`docs/tools/skills.md`).

## Evidence

- Focused suites green: `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/skills/discovery/chat-commands.test.ts` (24 + 31 passed). The prior contract-pinning test ("keeps $ skill references literal on message channels") is flipped to assert resolution and hidden-skill path rendering.
- `node scripts/check-changed.mjs` green.
- Codex autoreview clean (gpt-5.6-sol, high): "patch is correct (0.98)".
- Production LOC +9/−6 (net +3); docs +10/−11; tests +18/−9.

## Red-main heal (bundled per landing policy)

Current `main` fails the full-suite ownership audit (`test/vitest-projects-config.test.ts`): `extensions/codex/src/app-server/run-attempt-state.test.ts` (added by #123345 without a lane owner) was registered in two vitest lanes by independent repairs — `attempt-light` via #123235 and `attempt-extra` via #123363. The second commit here removes the `attempt-light` entry so `attempt-extra` keeps ownership (matching #123363's rationale); audit passes locally (21 tests green).
