### PR TITLE
fix(cli): emit Directory errors as JSON

### DIFF
--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -277,6 +277,58 @@ describe("registerDirectoryCli", () => {
   });
 
   it.each([
+    [
+      "self",
+      ["directory", "self", "--channel", "demo-directory", "--json"],
+      "Error: Channel demo-directory does not support directory self",
+    ],
+    [
+      "peers",
+      ["directory", "peers", "list", "--channel", "demo-directory", "--json"],
+      "Error: Channel demo-directory does not support directory peers",
+    ],
+    [
+      "groups",
+      ["directory", "groups", "list", "--channel", "demo-directory", "--json"],
+      "Error: Channel demo-directory does not support directory groups",
+    ],
+    [
+      "group members",
+      [
+        "directory",
+        "groups",
+        "members",
+        "--channel",
+        "demo-directory",
+        "--group-id",
+        "group-1",
+        "--json",
+      ],
+      "Error: Channel demo-directory does not support group members listing",
+    ],
+  ])("writes JSON errors for unsupported directory %s", async (_label, args, expectedError) => {
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: { "demo-directory": {} } },
+      channelId: "demo-directory",
+      plugin: {
+        id: "demo-directory",
+        directory: {},
+      },
+      configChanged: false,
+    });
+
+    const program = new Command().name("openclaw");
+    registerDirectoryCli(program);
+
+    await expect(program.parseAsync(args, { from: "user" })).rejects.toThrow("exit:1");
+
+    expect(runtimeState.defaultRuntime.writeJson).toHaveBeenCalledOnce();
+    expect(runtimeState.defaultRuntime.writeJson).toHaveBeenCalledWith({ error: expectedError });
+    expect(runtimeState.defaultRuntime.error).not.toHaveBeenCalled();
+    expect(runtimeState.defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each([
     ["peers list", ["directory", "peers", "list", "--channel", "slack", "--limit", "5x"]],
     ["groups list", ["directory", "groups", "list", "--channel", "slack", "--limit", "5x"]],
     [

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -185,9 +185,22 @@ export function registerDirectoryCli(program: Command) {
     printDirectoryList({ title: params.title, emptyMessage: params.emptyMessage, entries: result });
   };
 
+  const runDirectoryAction = async (opts: { json?: unknown }, action: () => Promise<void>) => {
+    try {
+      await action();
+    } catch (err) {
+      if (opts.json) {
+        defaultRuntime.writeJson({ error: String(err) });
+      } else {
+        defaultRuntime.error(danger(String(err)));
+      }
+      defaultRuntime.exit(1);
+    }
+  };
+
   withChannel(directory.command("self").description("Show the current account user")).action(
-    async (opts) => {
-      try {
+    (opts) =>
+      runDirectoryAction(opts, async () => {
         const { cfg, channelId, accountId, plugin } = await resolve({
           channel: opts.channel as string | undefined,
           account: opts.account as string | undefined,
@@ -217,19 +230,15 @@ export function registerDirectoryCli(program: Command) {
             rows: buildRows([result]),
           }).trimEnd(),
         );
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
-    },
+      }),
   );
 
   const peers = directory.command("peers").description("Peer directory (contacts/users)");
   withChannel(peers.command("list").description("List peers"))
     .option("--query <text>", "Optional search query")
     .option("--limit <n>", "Limit results")
-    .action(async (opts) => {
-      try {
+    .action((opts) =>
+      runDirectoryAction(opts, async () => {
         await runDirectoryList({
           opts,
           action: "listPeers",
@@ -237,18 +246,15 @@ export function registerDirectoryCli(program: Command) {
           title: "Peers",
           emptyMessage: "No peers found.",
         });
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
-    });
+      }),
+    );
 
   const groups = directory.command("groups").description("Group directory");
   withChannel(groups.command("list").description("List groups"))
     .option("--query <text>", "Optional search query")
     .option("--limit <n>", "Limit results")
-    .action(async (opts) => {
-      try {
+    .action((opts) =>
+      runDirectoryAction(opts, async () => {
         await runDirectoryList({
           opts,
           action: "listGroups",
@@ -256,11 +262,8 @@ export function registerDirectoryCli(program: Command) {
           title: "Groups",
           emptyMessage: "No groups found.",
         });
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
-    });
+      }),
+    );
 
   withChannel(
     groups
@@ -269,8 +272,8 @@ export function registerDirectoryCli(program: Command) {
       .requiredOption("--group-id <id>", "Group id"),
   )
     .option("--limit <n>", "Limit results")
-    .action(async (opts) => {
-      try {
+    .action((opts) =>
+      runDirectoryAction(opts, async () => {
         const limit = parseLimit(opts.limit);
         const { cfg, channelId, accountId, plugin } = await resolve({
           channel: opts.channel as string | undefined,
@@ -300,9 +303,6 @@ export function registerDirectoryCli(program: Command) {
           emptyMessage: "No group members found.",
           entries: result,
         });
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
-    });
+      }),
+    );
 }


### PR DESCRIPTION
Closes #123384

## What Problem This Solves

Fixes an issue where `openclaw directory ... --json` commands would emit empty stdout on failure and write only a styled human error to stderr. Automation explicitly requesting JSON had no parseable failure result.

## Why This Change Was Made

All four Directory action families now share one local action runner. It writes `{ error: String(err) }` through the existing JSON output owner when `--json` is active, while preserving current human stderr and exit-code behavior otherwise. The refactor removes four duplicated catch policies without changing global CLI semantics.

## User Impact

Directory self, peer, group, and group-member commands now produce structured JSON errors on stdout and exit 1 when they fail in JSON mode. Human-mode errors remain unchanged.

## Evidence

- Tests-first table regression failed in all four JSON action families because `writeJson` was never called.
- Post-fix Directory CLI suite: 12/12 passed.
- Source-blind CLI process proof confirmed structured JSON stdout in JSON mode and human stderr in normal mode.
- Core and core-test TypeScript checks passed.
- Targeted formatting, lint, and `git diff --check` passed.
- Final integrated Codex autoreview: clean, no findings; TruffleHog clean.

Production delta: +28/-28, net 0. Tests: +52.

AI-assisted: yes. The repair was reviewed against the complete Directory dispatch, output routing, channel setup, and sibling JSON error contracts.
