### PR TITLE
fix(agents): prevent duplicate final replies in CLI sessions

### DIFF
--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { SessionEntry } from "../config/sessions.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
   listSessionEntriesCore,
   loadTranscriptEvents,
   replaceSessionEntry,
@@ -261,7 +263,7 @@ function makeResult(params: {
       durationMs: 1,
       stopReason: "end_turn",
       executionTrace: {
-        runner: params.runner ?? "embedded",
+        runner: params.runner ?? "cli",
         fallbackUsed: false,
         winnerProvider: "openai",
         winnerModel: "gpt-5.5",
@@ -460,57 +462,121 @@ describe("agentCommand compaction transcript rotation", () => {
     ).resolves.toContainEqual(expect.objectContaining({ role: "assistant" }));
   });
 
-  it.each(["cli", "embedded"] as const)(
-    "persists the pending final before %s compaction failure and still delivers",
-    async (runner) => {
-      const sessionId = `${runner}-compaction-failure`;
-      const sessionKey = `agent:main:explicit:${sessionId}`;
-      const text = `${runner} reply generated before compaction`;
-      let compactionSessionEntry: SessionEntry | undefined;
-      let storedEntryBeforeCompaction: SessionEntry | undefined;
-      state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text, runner }));
-      state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
-        compactionSessionEntry = params.sessionEntry;
-        storedEntryBeforeCompaction = findStoredSessionEntry(sessionKey);
-        throw new Error(COMPACTION_ERROR);
-      });
-
-      const result = await agentCommand({
-        message: "room message",
-        sessionId,
-        sessionKey,
-        cwd: state.workspaceDir,
-        channel: "discord",
-        to: "discord:dm:123",
-        accountId: "main",
-        deliver: true,
-      });
-
-      expect(compactionSessionEntry).toMatchObject({
-        pendingFinalDelivery: {
-          kind: "replayable",
-          text,
-          context: {
-            channel: "discord",
-            to: "discord:dm:123",
-            accountId: "main",
+  it("keeps embedded assistant transcript ownership when visible text is projected", async () => {
+    const storePath = requireStorePath();
+    const sessionId = "embedded-projected-final";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    state.runAgentAttemptMock.mockImplementationOnce(async (attempt) => {
+      if (!attempt.userTurnTranscriptRecorder) {
+        throw new Error("missing embedded user-turn transcript recorder");
+      }
+      await attempt.userTurnTranscriptRecorder.persistApproved();
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId, sessionKey, storePath },
+        {
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "[Thu 2026-08-13 16:39 PDT] OVERRIDE-OK" }],
+            api: "ollama",
+            provider: "ollama",
+            model: "llama3.2:latest",
+            timestamp: Date.now(),
           },
+          cwd: state.workspaceDir,
         },
-      });
-      expect(storedEntryBeforeCompaction).toMatchObject({
-        pendingFinalDelivery: { kind: "replayable", text },
-      });
-      expect(result).toMatchObject({ deliverySucceeded: true });
-      expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
-      expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
-        expect.objectContaining({ payloads: [{ text }] }),
       );
-      expect(readLifecyclePhases()).toContain("end");
-      expect(readLifecyclePhases()).not.toContain("error");
-      const storedEntryAfterDelivery = findStoredSessionEntry(sessionKey);
-      expect(storedEntryAfterDelivery?.pendingFinalDelivery).toBeUndefined();
-    },
-  );
+      await appendTranscriptEvent(
+        { agentId: "main", sessionId, sessionKey, storePath },
+        {
+          type: "custom",
+          customType: "openclaw:bootstrap-context:full",
+          data: { runId: "embedded-run" },
+        },
+      );
+      return makeResult({
+        sessionId,
+        text: "OVERRIDE-OK",
+        runner: "embedded",
+      });
+    });
+
+    await agentCommand({
+      message: "Reply with exactly: OVERRIDE-OK",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+    });
+
+    const events = (await loadTranscriptEvents({
+      agentId: "main",
+      sessionId,
+      storePath,
+    })) as Array<{
+      type?: unknown;
+      customType?: unknown;
+      message?: { role?: unknown; api?: unknown };
+    }>;
+    const assistantEvents = events.filter(
+      (event) => event.type === "message" && event.message?.role === "assistant",
+    );
+    expect(assistantEvents).toHaveLength(1);
+    expect(assistantEvents.filter((event) => event.message?.api === "cli")).toHaveLength(0);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "custom" && event.customType === "openclaw:bootstrap-context:full",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("persists the pending final before CLI compaction failure and still delivers", async () => {
+    const sessionId = "cli-compaction-failure";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const text = "cli reply generated before compaction";
+    let compactionSessionEntry: SessionEntry | undefined;
+    let storedEntryBeforeCompaction: SessionEntry | undefined;
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text, runner: "cli" }));
+    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+      compactionSessionEntry = params.sessionEntry;
+      storedEntryBeforeCompaction = findStoredSessionEntry(sessionKey);
+      throw new Error(COMPACTION_ERROR);
+    });
+
+    const result = await agentCommand({
+      message: "room message",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(compactionSessionEntry).toMatchObject({
+      pendingFinalDelivery: {
+        kind: "replayable",
+        text,
+        context: {
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+        },
+      },
+    });
+    expect(storedEntryBeforeCompaction).toMatchObject({
+      pendingFinalDelivery: { kind: "replayable", text },
+    });
+    expect(result).toMatchObject({ deliverySucceeded: true });
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ payloads: [{ text }] }),
+    );
+    expect(readLifecyclePhases()).toContain("end");
+    expect(readLifecyclePhases()).not.toContain("error");
+    const storedEntryAfterDelivery = findStoredSessionEntry(sessionKey);
+    expect(storedEntryAfterDelivery?.pendingFinalDelivery).toBeUndefined();
+  });
 
   it("excludes hidden reasoning from the pending final persisted before compaction", async () => {
     const sessionId = "reasoning-filter-compaction-failure";

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -5,7 +5,10 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import type { SessionEntry } from "../config/sessions.js";
-import { createUserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
+import {
+  createUserTurnTranscriptRecorder,
+  type UserTurnTranscriptRecorder,
+} from "../sessions/user-turn-transcript.js";
 import {
   deliveryContextFromSession,
   normalizeSessionDeliveryState,
@@ -2056,7 +2059,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       meta: Record<string, unknown> & { agentMeta: Record<string, unknown> };
     };
     result.meta.executionTrace = {
-      runner: "embedded",
+      runner: "cli",
       fallbackUsed: false,
       winnerProvider: "openai",
       winnerModel: "gpt-5.4",
@@ -2231,22 +2234,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("session-1");
   });
 
-  it.each([
-    {
-      name: "persists only the CLI assistant reply after the runner persists the current user turn",
-      runner: "cli",
-      canonicalUserRecorder: true,
-      embeddedAssistantGapFill: false,
-    },
-    {
-      name: "persists the full embedded turn when no canonical user recorder exists",
-      runner: "embedded",
-      canonicalUserRecorder: false,
-      embeddedAssistantGapFill: true,
-    },
-  ])("$name", async ({ runner, canonicalUserRecorder, embeddedAssistantGapFill }) => {
+  it("persists only the CLI assistant reply after the runner persists the current user turn", async () => {
     type AttemptCall = {
       onUserMessagePersisted?: () => void;
+      userTurnTranscriptRecorder: UserTurnTranscriptRecorder;
     };
     setupSingleAttemptFallback();
     setupStoredSession();
@@ -2256,12 +2247,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
     };
     result.meta.executionTrace = {
-      runner,
+      runner: "cli",
       fallbackUsed: false,
       winnerProvider: "openai",
       winnerModel: "gpt-5.4",
     };
     state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
+      attemptParams.userTurnTranscriptRecorder.markRuntimePersisted();
       attemptParams.onUserMessagePersisted?.();
       return result;
     });
@@ -2274,21 +2266,17 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       target: () => undefined,
     });
 
-    await (canonicalUserRecorder
-      ? agentCommand({
-          message: "hello",
-          to: "+1234567890",
-          userTurnTranscriptRecorder,
-        })
-      : runBasicAgentCommand());
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      userTurnTranscriptRecorder,
+    });
 
-    if (canonicalUserRecorder) {
-      expect(mockCallArg(state.runAgentAttemptMock)).toMatchObject({
-        userTurnTranscriptRecorder,
-      });
-    }
-    expectRecordFields(mockCallArg(state.persistCliTurnTranscriptMock), {
-      embeddedAssistantGapFill,
+    expect(mockCallArg(state.runAgentAttemptMock)).toMatchObject({
+      userTurnTranscriptRecorder,
+    });
+    expect(mockCallArg(state.persistCliTurnTranscriptMock)).toMatchObject({
+      skipUserTurn: true,
     });
   });
 
@@ -3443,13 +3431,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         sessionFile: "sqlite:default:internal-session:/tmp/openclaw-session-store.json",
       }),
     );
-    expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: "rotated-model-run-session",
-        sessionKey: "agent:default:internal-session-effects:run",
-        storePath: "/tmp/openclaw-session-store.json",
-      }),
-    );
+    expect(state.persistCliTurnTranscriptMock).not.toHaveBeenCalled();
     expect(state.removeInternalSessionEffectsSessionMock).toHaveBeenCalledWith({
       agentId: "default",
       sessionId: "rotated-model-run-session",

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -10,7 +10,6 @@ import {
   parseSqliteSessionFileMarker,
 } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
-  appendTranscriptEvent,
   appendTranscriptMessage,
   listSessionEntriesCore,
   loadTranscriptEvents,
@@ -1931,7 +1930,6 @@ describe("CLI attempt execution", () => {
           sessionCwd: tmpDir,
           storePath,
           config: {},
-          embeddedAssistantGapFill: true,
         });
       } else {
         await persistAcpTurnTranscript({
@@ -2156,7 +2154,7 @@ describe("CLI attempt execution", () => {
     );
   });
 
-  it("does not gap-fill an assistant already owned by the runtime", async () => {
+  it("does not append a CLI assistant already owned by the runtime", async () => {
     const sessionKey = "agent:main:direct:runtime-owned-assistant";
     const sessionEntry = makeSessionEntry("session-runtime-owned-assistant");
     await appendTranscriptMessage(
@@ -2181,7 +2179,7 @@ describe("CLI attempt execution", () => {
       sessionAgentId: "main",
       sessionCwd: tmpDir,
       config: {},
-      embeddedAssistantGapFill: true,
+      skipUserTurn: true,
       skipAssistantTurn: true,
     });
 
@@ -2276,201 +2274,6 @@ describe("CLI attempt execution", () => {
     await expect(fs.stat(staleSessionFile)).rejects.toMatchObject({ code: "ENOENT" });
     const persisted = readSessionStore();
     expect(persisted[sessionKey]).toBeUndefined();
-  });
-
-  it("embedded assistant gap-fill skips user mirror and dedupes identical assistant tails", async () => {
-    const sessionKey = "agent:main:subagent:embedded-gap-fill";
-    const sessionEntry = makeSessionEntry("session-embedded-gap-fill");
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await writeSessionStoreSeed(sessionStore);
-
-    const result = makeCliResult("already mirrored");
-    result.meta.executionTrace = {
-      winnerProvider: "anthropic",
-      winnerModel: "claude-opus-4-6",
-      fallbackUsed: false,
-      runner: "embedded",
-    };
-
-    const updatedFirst = await persistCliTranscriptEntry({
-      body: "ignored for gap fill",
-      transcriptBody: "also ignored",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-
-    const target = {
-      agentId: "main",
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      storePath,
-    };
-    let messages = await readSessionMessages(target);
-    expect(messages).toHaveLength(1);
-    expectRecordFields(requireRecord(messages[0], "assistant message"), {
-      role: "assistant",
-      content: [{ type: "text", text: "already mirrored" }],
-    });
-
-    await persistCliTurnTranscript({
-      body: "still ignored",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry: updatedFirst,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-
-    messages = await readSessionMessages(target);
-    expect(messages).toHaveLength(1);
-  });
-
-  it("embedded assistant gap-fill skips trailing openclaw.cache-ttl custom entries (regression for #83427)", async () => {
-    const sessionKey = "agent:main:subagent:embedded-gap-fill-cache-ttl";
-    const sessionEntry = makeSessionEntry("session-embedded-gap-fill-cache-ttl");
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await writeSessionStoreSeed(sessionStore);
-
-    const result = makeCliResult("canonical answer");
-    result.meta.executionTrace = {
-      winnerProvider: "anthropic",
-      winnerModel: "claude-haiku-4-5-20251001",
-      fallbackUsed: false,
-      runner: "embedded",
-    };
-
-    const updatedFirst = await persistCliTranscriptEntry({
-      body: "ignored for gap fill",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-    await appendTranscriptEvent(
-      { agentId: "main", sessionId: sessionEntry.sessionId, sessionKey, storePath },
-      {
-        type: "custom",
-        customType: "openclaw.cache-ttl",
-        timestamp: new Date().toISOString(),
-        data: {
-          provider: "anthropic",
-          modelId: "claude-haiku-4-5-20251001",
-        },
-      } as never,
-    );
-
-    await persistCliTurnTranscript({
-      body: "still ignored",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry: updatedFirst,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-
-    const messages = await readSessionMessages({
-      agentId: "main",
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      storePath,
-    });
-    expect(messages).toHaveLength(1);
-    expectRecordFields(requireRecord(messages[0], "assistant message"), {
-      role: "assistant",
-      content: [{ type: "text", text: "canonical answer" }],
-    });
-  });
-
-  it("embedded assistant gap-fill appends repeated replies after a user tail", async () => {
-    const sessionKey = "agent:main:subagent:embedded-repeated-reply";
-    const sessionEntry = makeSessionEntry("session-embedded-repeated-reply");
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await writeSessionStoreSeed(sessionStore);
-
-    const result = makeCliResult("same answer");
-    result.meta.executionTrace = {
-      winnerProvider: "anthropic",
-      winnerModel: "claude-opus-4-6",
-      fallbackUsed: false,
-      runner: "embedded",
-    };
-
-    const updatedFirst = await persistCliTranscriptEntry({
-      body: "ignored for gap fill",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-    expect(updatedFirst).not.toHaveProperty("sessionFile");
-
-    await appendTranscriptMessage(
-      { agentId: "main", sessionId: sessionEntry.sessionId, sessionKey, storePath },
-      {
-        message: {
-          role: "user",
-          content: "next prompt",
-          timestamp: Date.now(),
-        },
-        cwd: tmpDir,
-      },
-    );
-
-    await persistCliTurnTranscript({
-      body: "still ignored",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry: updatedFirst,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-
-    const messages = await readSessionMessages({
-      agentId: "main",
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      storePath,
-    });
-    expect(messages.map((message) => message.role)).toEqual(["assistant", "user", "assistant"]);
-    expect(messages).toHaveLength(3);
-    expectRecordFields(requireRecord(messages[2], "deduped assistant message"), {
-      content: [{ type: "text", text: "same answer" }],
-    });
   });
 
   it("persists the transcript body instead of runtime-only CLI prompt context", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -25,7 +25,6 @@ import {
   persistSessionTranscriptTurn,
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
-import { readTailAssistantTextFromSessionTranscript } from "../../config/sessions/transcript.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -138,10 +137,6 @@ function rebaseExecApprovalContinuationPromptRange(params: {
   };
 }
 
-function normalizeTranscriptMirrorText(value: string): string {
-  return value.trim().replace(/\s+/gu, " ");
-}
-
 const ACP_TRANSCRIPT_USAGE = {
   input: 0,
   output: 0,
@@ -213,7 +208,6 @@ type PersistTextTurnTranscriptParams = {
   threadId?: string | number;
   sessionCwd: string;
   config: OpenClawConfig;
-  embeddedAssistantGapFill?: boolean;
   skipAssistantTurn?: boolean;
   assistant: {
     api: string;
@@ -374,19 +368,6 @@ async function persistTextTurnTranscript(
         stopReason: "stop",
         timestamp: Date.now(),
       },
-      shouldAppend: async (
-        context: import("../../config/sessions/session-accessor.js").SessionTranscriptTurnWriteContext,
-      ) => {
-        if (!params.embeddedAssistantGapFill) {
-          return true;
-        }
-        const latest = await readTailAssistantTextFromSessionTranscript(context, {
-          excludeTranscriptOnlyOpenClawAssistant: true,
-        });
-        const normalizedReply = normalizeTranscriptMirrorText(replyText);
-        const normalizedLatest = latest?.text ? normalizeTranscriptMirrorText(latest.text) : "";
-        return !normalizedLatest || normalizedLatest !== normalizedReply;
-      },
     });
   }
 
@@ -476,7 +457,6 @@ export async function persistCliTurnTranscript(params: {
   threadId?: string | number;
   sessionCwd: string;
   config: OpenClawConfig;
-  embeddedAssistantGapFill?: boolean;
   skipUserTurn?: boolean;
   skipAssistantTurn?: boolean;
 }): Promise<PersistTextTurnTranscriptResult> {
@@ -484,8 +464,7 @@ export async function persistCliTurnTranscript(params: {
   const replyText = resolveCliTranscriptReplyText(result);
   const provider = result.meta.agentMeta?.provider?.trim() ?? "cli";
   const model = result.meta.agentMeta?.model?.trim() ?? "default";
-  const gapFill = params.embeddedAssistantGapFill ?? false;
-  const skipUserTurn = gapFill || requestedSkipUserTurn === true;
+  const skipUserTurn = requestedSkipUserTurn === true;
 
   return await persistTextTurnTranscript({
     ...transcript,
@@ -493,7 +472,6 @@ export async function persistCliTurnTranscript(params: {
     transcriptBody: skipUserTurn ? undefined : transcript.transcriptBody,
     userMessage: skipUserTurn ? undefined : transcript.userMessage,
     finalText: replyText,
-    embeddedAssistantGapFill: gapFill,
     assistant: {
       api: "cli",
       provider,

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -180,15 +180,8 @@ export async function finalizeEmbeddedAgentCommand(params: {
     publishSessionOwnership();
 
     const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
-    const embeddedAssistantGapFill =
-      transcriptPersistenceRunner === "embedded" ||
-      (transcriptPersistenceRunner === undefined &&
-        Boolean(result.meta.finalAssistantVisibleText?.trim()));
     let persistedCliTurnTranscript = false;
-    if (
-      !sessionReboundDuringRun &&
-      (transcriptPersistenceRunner === "cli" || embeddedAssistantGapFill)
-    ) {
+    if (!sessionReboundDuringRun && transcriptPersistenceRunner === "cli") {
       try {
         const transcriptResult = await attemptExecutionRuntime.persistCliTurnTranscript({
           body,
@@ -203,7 +196,6 @@ export async function finalizeEmbeddedAgentCommand(params: {
           threadId: params.opts.threadId,
           sessionCwd: effectiveCwd,
           config: cfg,
-          embeddedAssistantGapFill,
           skipAssistantTurn: assistantTranscriptOwned,
           skipUserTurn:
             suppressUserTurnPersistence ||

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -1004,31 +1004,7 @@ describe("agentCommand", () => {
     });
   });
 
-  it("persists embedded-runner turns to the session transcript", async () => {
-    await withTempHome(async (home) => {
-      const store = path.join(home, "sessions.json");
-      mockConfig(home, store);
-      const base = createDefaultAgentResult({ payloads: [{ text: "assistant-visible" }] });
-      vi.mocked(runEmbeddedAgent).mockResolvedValueOnce({
-        ...base,
-        meta: {
-          ...base.meta,
-          executionTrace: { runner: "embedded" },
-        },
-      });
-
-      await agentCommand({ message: "hello from user", agentId: "main" }, runtime);
-
-      expect(vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript)).toHaveBeenCalledTimes(1);
-      const persistArgs = vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript).mock
-        .calls[0]?.[0];
-      expect(persistArgs?.embeddedAssistantGapFill).toBe(true);
-      expect(persistArgs?.body).toBe("hello from user");
-      expect(persistArgs?.result.meta?.executionTrace?.runner).toBe("embedded");
-    });
-  });
-
-  it("gap-fills Telegram-visible embedded replies without a runner trace", async () => {
+  it("delivers embedded replies without re-persisting them", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       mockConfig(home, store);
@@ -1090,11 +1066,7 @@ describe("agentCommand", () => {
         accountId: undefined,
         verbose: false,
       });
-      expect(vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript)).toHaveBeenCalledTimes(1);
-      const persistArgs = vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript).mock
-        .calls[0]?.[0];
-      expect(persistArgs?.embeddedAssistantGapFill).toBe(true);
-      expect(persistArgs?.body).toBe("call a tool then answer");
+      expect(vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -41,7 +41,6 @@ import {
   appendExactAssistantMessageToSessionTranscript,
   readLatestAssistantTextFromSessionTranscript,
   readRecentUserAssistantTextForSession,
-  readTailAssistantTextFromSessionTranscript,
 } from "./transcript.js";
 import type { InternalSessionEntry, SessionEntry } from "./types.js";
 
@@ -1310,72 +1309,6 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(latestAssistantText).toBeUndefined();
   });
 
-  it("keeps transcript-only OpenClaw assistant entries available to the tail reader", async () => {
-    await writeTranscriptStore();
-
-    const mirrorResult = await appendAssistantMessageToSessionTranscript({
-      sessionKey,
-      text: "Tail delivery mirror",
-      storePath: fixture.storePath(),
-    });
-    expect(mirrorResult.ok).toBe(true);
-    if (!mirrorResult.ok) {
-      return;
-    }
-
-    const tailAssistantText = await readTailAssistantTextFromSessionTranscript({
-      agentId: "main",
-      sessionId,
-      sessionKey,
-      storePath: fixture.storePath(),
-    });
-    expect(tailAssistantText?.id).toBe(mirrorResult.messageId);
-    expect(tailAssistantText?.text).toBe("Tail delivery mirror");
-  });
-
-  it("scans past trailing non-assistant entries (e.g. openclaw.cache-ttl) to find the latest assistant text", async () => {
-    // Regression for openclaw/openclaw#83427: the cache-ttl custom entry was
-    // emitted after the canonical assistant turn, and the tail reader returned
-    // undefined on the first non-assistant line, so the gap-fill check in
-    // persistTextTurnTranscript wrote a duplicate `api: "cli"` assistant
-    // message — poisoning the model's own context with verbatim duplicates.
-    await writeTranscriptStore();
-
-    const assistantResult = await appendExactAssistantMessageToSessionTranscript({
-      sessionKey,
-      storePath: fixture.storePath(),
-      message: createExactAssistantMessage({
-        text: "Canonical answer",
-        provider: "anthropic",
-        model: "claude-haiku-4-5-20251001",
-      }),
-    });
-    expect(assistantResult.ok).toBe(true);
-    if (!assistantResult.ok) {
-      return;
-    }
-
-    const cacheTtlEntry = `${JSON.stringify({
-      type: "custom",
-      customType: "openclaw.cache-ttl",
-      timestamp: new Date().toISOString(),
-      data: {
-        provider: "anthropic",
-        modelId: "claude-haiku-4-5-20251001",
-      },
-    })}\n`;
-    await appendTranscriptEvent(createFixtureTranscriptScope(), JSON.parse(cacheTtlEntry));
-
-    const tailAssistantText = await readTailAssistantTextFromSessionTranscript({
-      agentId: "main",
-      sessionId,
-      sessionKey,
-      storePath: fixture.storePath(),
-    });
-    expect(tailAssistantText?.id).toBe(assistantResult.messageId);
-    expect(tailAssistantText?.text).toBe("Canonical answer");
-  });
-
   it("scans past trailing assistant entries without visible text", async () => {
     await writeTranscriptStore();
 
@@ -1420,84 +1353,6 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     });
     expect(latestAssistantText?.id).toBe(assistantResult.messageId);
     expect(latestAssistantText?.text).toBe("Visible answer before tool call");
-  });
-
-  it("does not scan past a real tail assistant with no visible text for dedupe", async () => {
-    await writeTranscriptStore();
-
-    const assistantResult = await appendExactAssistantMessageToSessionTranscript({
-      sessionKey,
-      storePath: fixture.storePath(),
-      message: createExactAssistantMessage({
-        text: "Older visible answer",
-      }),
-    });
-    expect(assistantResult.ok).toBe(true);
-
-    const toolOnlyResult = await appendExactAssistantMessageToSessionTranscript({
-      sessionKey,
-      storePath: fixture.storePath(),
-      message: {
-        ...createExactAssistantMessage({
-          content: [
-            {
-              type: "toolCall",
-              id: "call_tail_no_visible_text",
-              name: "maniple__list_workers",
-              arguments: {},
-            },
-          ],
-        }),
-        stopReason: "toolUse",
-      },
-    });
-    expect(toolOnlyResult.ok).toBe(true);
-    if (!toolOnlyResult.ok) {
-      return;
-    }
-
-    await expect(
-      readTailAssistantTextFromSessionTranscript(toolOnlyResult.target, {
-        excludeTranscriptOnlyOpenClawAssistant: true,
-      }),
-    ).resolves.toBeUndefined();
-  });
-
-  it("scans past excluded delivery mirrors in explicit file-backed tail reads", async () => {
-    const transcriptPath = path.join(fixture.sessionsDir(), "file-backed-delivery-tail.jsonl");
-    fs.writeFileSync(
-      transcriptPath,
-      [
-        {
-          type: "message",
-          id: "real-assistant",
-          message: createExactAssistantMessage({ text: "File-backed canonical answer" }),
-        },
-        {
-          type: "message",
-          id: "delivery-mirror",
-          message: {
-            ...createExactAssistantMessage({
-              provider: "openclaw",
-              model: "delivery-mirror",
-              text: "delivery mirror text",
-            }),
-          },
-        },
-      ]
-        .map((event) => JSON.stringify(event))
-        .join("\n") + "\n",
-      "utf-8",
-    );
-
-    await expect(
-      readTailAssistantTextFromSessionTranscript(transcriptPath, {
-        excludeTranscriptOnlyOpenClawAssistant: true,
-      }),
-    ).resolves.toMatchObject({
-      id: "real-assistant",
-      text: "File-backed canonical answer",
-    });
   });
 
   it("does not reuse an older matching assistant message across turns", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -147,7 +147,6 @@ class SessionTranscriptAgentScopeMismatchError extends Error {
 }
 
 export type LatestAssistantTranscriptText = AssistantTranscriptText;
-type TailAssistantTranscriptText = AssistantTranscriptText;
 
 export { resolveSessionTranscriptFile } from "./transcript-file-resolve.js";
 
@@ -373,112 +372,6 @@ export async function readLatestAssistantTextFromSessionTranscript(
       if (assistantText) {
         return assistantText;
       }
-    } catch {
-      continue;
-    }
-  }
-  return undefined;
-}
-
-export async function readTailAssistantTextFromSessionTranscript(
-  sessionFile:
-    | string
-    | undefined
-    | { agentId?: string; sessionId?: string; sessionKey?: string; storePath?: string },
-  options?: { excludeTranscriptOnlyOpenClawAssistant?: boolean },
-): Promise<TailAssistantTranscriptText | undefined> {
-  if (typeof sessionFile === "object") {
-    if (!sessionFile.sessionId || (!sessionFile.agentId && !sessionFile.sessionKey)) {
-      return undefined;
-    }
-    const events = await loadTranscriptEvents({
-      ...(sessionFile.agentId ? { agentId: sessionFile.agentId } : {}),
-      sessionId: sessionFile.sessionId,
-      ...(sessionFile.sessionKey ? { sessionKey: sessionFile.sessionKey } : {}),
-      ...(sessionFile.storePath ? { storePath: sessionFile.storePath } : {}),
-    });
-    for (const event of events.toReversed()) {
-      const parsed = event as { message?: { model?: unknown; provider?: unknown; role?: unknown } };
-      if (!parsed.message || typeof parsed.message !== "object") {
-        continue;
-      }
-      if (parsed.message.role !== "assistant") {
-        return undefined;
-      }
-      const assistantText = parseAssistantTranscriptText(JSON.stringify(event), {
-        excludeTranscriptOnlyOpenClawAssistant:
-          options?.excludeTranscriptOnlyOpenClawAssistant === true,
-      });
-      if (assistantText) {
-        return assistantText;
-      }
-      if (
-        options?.excludeTranscriptOnlyOpenClawAssistant !== true ||
-        !isTranscriptOnlyOpenClawAssistantMessage(parsed.message)
-      ) {
-        return undefined;
-      }
-    }
-    return undefined;
-  }
-  const sqliteMarker = parseSqliteSessionFileMarker(sessionFile);
-  if (sqliteMarker) {
-    const events = await loadTranscriptEvents({
-      agentId: sqliteMarker.agentId,
-      sessionId: sqliteMarker.sessionId,
-      storePath: sqliteMarker.storePath,
-    });
-    for (const event of events.toReversed()) {
-      const parsed = event as { message?: { model?: unknown; provider?: unknown; role?: unknown } };
-      if (!parsed.message || typeof parsed.message !== "object") {
-        continue;
-      }
-      if (parsed.message.role !== "assistant") {
-        return undefined;
-      }
-      const assistantText = parseAssistantTranscriptText(JSON.stringify(event), {
-        excludeTranscriptOnlyOpenClawAssistant:
-          options?.excludeTranscriptOnlyOpenClawAssistant === true,
-      });
-      if (assistantText) {
-        return assistantText;
-      }
-      if (
-        options?.excludeTranscriptOnlyOpenClawAssistant !== true ||
-        !isTranscriptOnlyOpenClawAssistantMessage(parsed.message)
-      ) {
-        return undefined;
-      }
-    }
-    return undefined;
-  }
-  if (!sessionFile?.trim()) {
-    return undefined;
-  }
-
-  for await (const line of streamSessionTranscriptLinesReverse(sessionFile)) {
-    try {
-      const parsed = JSON.parse(line) as { message?: unknown };
-      // Skip non-message entries (e.g. `openclaw.cache-ttl` custom events) so
-      // a metadata line emitted after the canonical assistant turn doesn't
-      // make the tail reader fall through to "no assistant tail" and cause
-      // persistTextTurnTranscript to append a duplicate. Stop at any real
-      // message entry — a user turn means a new turn has started and a
-      // matching reply is a legitimate repeat, not a gap-fill duplicate.
-      if (!parsed.message || typeof parsed.message !== "object") {
-        continue;
-      }
-      const assistantText = parseAssistantTranscriptText(line, options);
-      if (assistantText) {
-        return assistantText;
-      }
-      if (
-        options?.excludeTranscriptOnlyOpenClawAssistant === true &&
-        isTranscriptOnlyOpenClawAssistantMessage(parsed.message)
-      ) {
-        continue;
-      }
-      return undefined;
     } catch {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw agent` runs could store the final assistant reply twice when the embedded model's raw transcript text differed from the user-visible projection. Webchat and TUI then rendered both stored rows, and later turns received both copies in model context.

## Why This Change Was Made

Embedded runs already own their canonical user, tool, assistant, and bootstrap transcript events. This removes the second post-run projection writer for embedded results and keeps synthetic `api: "cli"` persistence only for actual CLI backends. The now-unused tail-text dedupe reader and its tests are deleted with that path.

Production LOC: +2/-139 (net -137) | Tests: +139/-461

## User Impact

`openclaw agent`, `agent --deliver`, and other callers of the shared agent-command finalizer now preserve one canonical assistant reply per embedded turn. CLI stdout and delivery still use the returned result, while transcript storage remains owned by the embedded runtime.

## Evidence

Live local Ollama proof used an isolated scratch profile, port, workspace, and SQLite store; the operator profile, port 18789, and managed gateway were not touched.

Before (`d9d97024002`), forcing the reported timestamp projection produced:

```text
seq 7  assistant api=ollama text="[Thu 2026-08-13 16:39 PDT] OVERRIDE-OK"
seq 8  custom openclaw:bootstrap-context:full runId=61015c9a-...
seq 9  assistant api=cli text="OVERRIDE-OK"
```

After (`8c3d8c5d39d571bdd8138bb44aba4e71a6d0c8a9`), the exact reported command returned `OVERRIDE-OK` and stored:

```text
seq 4  user      "Reply with exactly: OVERRIDE-OK"
seq 5  assistant api=ollama text="OVERRIDE-OK"
seq 6  custom openclaw:bootstrap-context:full runId=d16f09d5-...
```

A follow-up on the same session added one Ollama assistant and one bootstrap event; totals were two user rows, two assistant rows, two bootstrap rows, and zero `api:"cli"` assistants. A run without `--model` also stored one Ollama assistant and one bootstrap event. The `chat.send` control stored one Ollama assistant, one bootstrap event, and zero CLI assistants.

The projection anti-cheat probe confirmed the actual trigger still passes: raw assistant text was `[Thu 2026-08-13 17:11 PDT]\nPROJECTED-OK`, visible text was `PROJECTED-OK`, and storage contained only the raw Ollama assistant followed by its bootstrap marker.

Validation:

- Regression test demonstrated red before the fix: expected one assistant event, observed two.
- `node scripts/run-vitest.mjs` across the five owner/sibling files: 63 + 36 + 143 + 116 tests passed.
- Exact rebased-head regression: 1 passed.
- `node scripts/check-changed.mjs --timed`: full core/coreTests plan passed locally after Testbox capacity remained queued and AWS fallback was unavailable.
- Autoreview: clean, no accepted/actionable findings.

