### PR TITLE
fix(ci): restore unique Codex test shard ownership

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -11,7 +11,6 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/attempt-steering.test.ts",
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
-      "extensions/codex/src/app-server/run-attempt-state.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the normal full-suite ownership audit fails on `main` and every open PR because `extensions/codex/src/app-server/run-attempt-state.test.ts` is registered in two Vitest shards.

## Why This Change Was Made

Keep the upstream `attempt-extra` owner established by #123363 and remove the duplicate `attempt-light` entry that arrived when #123235 merged. This is Peter's explicit reconciliation from commit `865b07f40ca5fd3f84051c73e64134ee7ae42ee6`, transplanted onto current `main`; although the light lane is smaller, the maintainer reconciliation is the authoritative owner decision.

PR #123365 already contains that reconciliation in its history, but its merge base and head both omit the light entry, so merging that behind-main branch cannot remove the later addition on current `main`. This focused PR applies the exact deletion where it now matters.

## User Impact

No product behavior changes. CI can again prove that every normal full-suite test file has exactly one shard owner.

## Evidence

- Before: CI run 31755590821, job 94632742545 failed `test/vitest-projects-config.test.ts` with the duplicate `attempt-extra` / `attempt-light` ownership record.
- Static ownership probe: only `test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts` now contains the test path.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Focused ownership audit and changed gate: pending owned-run completion.

Production LOC: +0/-0 | Tests/config routing: +0/-1

The sibling `../codex` source gate is not applicable: this patch changes only OpenClaw's test-shard inventory and makes no Codex protocol or runtime behavior claim.
