### PR TITLE
fix(test): stabilize Vitest ownership audit

### DIFF
--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -81,11 +81,36 @@ describe("projects vitest config", () => {
     expect(agentConfigs.size).toBe(agentVitestProjectConfigs.length);
   });
 
-  it("covers each normal full-suite test file exactly once", async () => {
-    const { missing, duplicated } = await auditFullSuiteTestFileOwnership();
+  it("covers each normal full-suite test file exactly once after configs cached filtered includes", async () => {
+    const contractTestConfigs = [
+      contractChannelSurfaceConfig,
+      contractChannelConfigConfig,
+      contractChannelRegistryConfig,
+      contractChannelSessionConfig,
+      contractPluginConfig,
+    ].map(requireTestConfig);
+    const previousIncludes = contractTestConfigs.map((config) => config.include);
 
-    expect(missing).toStrictEqual([]);
-    expect(duplicated).toStrictEqual([]);
+    try {
+      // A CLI path outside the contract patterns caches these defaults with empty includes.
+      for (const config of contractTestConfigs) {
+        config.include = [];
+      }
+
+      const { missing, duplicated } = await auditFullSuiteTestFileOwnership();
+
+      expect(missing).toStrictEqual([]);
+      expect(duplicated).toStrictEqual([]);
+    } finally {
+      contractTestConfigs.forEach((config, index) => {
+        const previousInclude = previousIncludes[index];
+        if (previousInclude === undefined) {
+          delete config.include;
+        } else {
+          config.include = previousInclude;
+        }
+      });
+    }
   });
 
   it("keeps all embedded harnesses under their canonical embedded owner", () => {

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -14,6 +14,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts",
+      "extensions/codex/src/app-server/run-attempt-state.test.ts",
       "extensions/codex/src/app-server/run-attempt.steering.test.ts",
       "extensions/codex/src/app-server/run-attempt.turn-watches.test.ts",
       "extensions/codex/src/app-server/run-attempt.usage-limits.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Running `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` used to report a false 95-file missing list because contract project defaults had already been cached under the CLI path filter before the ownership audit cleared `process.argv`. The owner fix landed in #123168 while this work was in flight, but there was no regression that exercised the cached narrowed-config state.

A later merge race also left `run-attempt-state.test.ts` with no Vitest owner: #123349 removed attempt-extra to resolve a temporary duplicate, then #123392 removed attempt-light while explicitly selecting attempt-extra as authoritative. The merge order produced the opposite result from that decision and made the exactly-once guard red again.

## Why This Change Was Made

The regression temporarily gives the five already-imported contract config defaults the exact empty include lists produced by an unrelated CLI path, runs the normal ownership audit, and restores every include in `finally`. This proves the audit result is independent of cached CLI narrowing without changing normal targeted-run behavior or adding a test-only production seam.

The Codex state helper test is restored to attempt-extra, matching the explicit owner decision in #123392 and the original registration in #123363. No runtime or protocol behavior changes.

## User Impact

Test infrastructure only. Focused debugging no longer emits the misleading 95-file list, and the full-suite ownership guard again enforces exactly one project owner per normal test file.

## Evidence

- Pre-fix reproduction: the focused test reported the exact 95-file missing list.
- Regression proof: temporarily removing the fresh audit import makes the new test fail with the same 95 files.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` — 21 passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast-isolated.config.ts` — 99 files passed; 1,354 passed, 24 skipped.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts extensions/codex/src/app-server/run-attempt-state.test.ts` — 2 passed.
- Changed gate — passed locally after the remote backend was unavailable.
- Fresh full-branch autoreview — clean, no actionable findings; overall 0.99.
- Upstream contract checked in `openai/codex@c2bcb9a26b5b`: `TurnStartParams.input`, `UserInput::Text`, and text-to-`InputText` conversion.
