### PR TITLE
fix(ai): recover OpenAI WebSocket turns after compaction rejection

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -45,6 +45,8 @@ import {
 import { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
 import {
   createResponsesStreamWithEncryptedContentRetry,
+  isInvalidEncryptedContentError,
+  resolveNextResponsesEncryptedContentAttempt,
   resolveAzureOpenAIApiVersion,
 } from "./openai-responses-replay-internal.js";
 import { processResponsesStream } from "./openai-responses-stream-internal.js";
@@ -339,7 +341,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         let continuationBaseline: ResponsesContinuationRequest | undefined;
         const createSseStream = async (
           initialRequest = (continuationClaim?.request ?? params) as typeof params,
-          initialAttemptKind: "initial" | "continuation-rejected" = "initial",
+          initialAttemptKind: NonNullable<ResponsesStreamParams["initialAttemptKind"]> = "initial",
         ): Promise<AsyncIterable<unknown>> => {
           const {
             stream: rawResponseStream,
@@ -389,6 +391,12 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             `[responses] websocket_fallback provider=${model.provider} api=${model.api} ` +
               `model=${model.id} reason=${reason}`,
           );
+        const closeWebSocketForFallback = (reason: string) => {
+          finishWebSocket?.({ keep: false });
+          finishWebSocket = undefined;
+          transport = "sse";
+          logWebSocketFallback(reason);
+        };
         if (websocketMode) {
           try {
             const websocket = createOpenAIResponsesWebSocketStream({
@@ -424,15 +432,29 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
                   }
                 } catch (error) {
                   if (error instanceof OpenAIResponsesWebSocketSafeRetryError) {
-                    finishWebSocket?.({ keep: false });
-                    finishWebSocket = undefined;
-                    transport = "sse";
-                    logWebSocketFallback(
+                    // Explicit server rejection proves no output was accepted. Resume at the next
+                    // semantic attempt instead of treating this like an ambiguous disconnect.
+                    const encryptedContentRejected = isInvalidEncryptedContentError(error);
+                    const recovery = encryptedContentRejected
+                      ? await resolveNextResponsesEncryptedContentAttempt(
+                          {
+                            kind: "initial",
+                            // WebSocket sanitization removes `stream`; SSE must restore it.
+                            request: { ...websocket.request, stream: true } as typeof params,
+                          },
+                          error,
+                          { buildFullHistoryRequest: () => buildRequest("full-history") },
+                        )
+                      : undefined;
+                    if (encryptedContentRejected && !recovery) {
+                      throw error;
+                    }
+                    closeWebSocketForFallback(
                       `safe_server_error code=${error.code} status=${safeDebugValue(error.status)} param=${safeDebugValue(error.param)}`,
                     );
                     yield* await createSseStream(
-                      await buildRequest("full-history"),
-                      "continuation-rejected",
+                      recovery?.request ?? (await buildRequest("full-history")),
+                      recovery?.kind ?? "continuation-rejected",
                     );
                     return;
                   }
@@ -449,9 +471,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               },
             };
           } catch {
-            finishWebSocket?.({ keep: false });
-            finishWebSocket = undefined;
-            logWebSocketFallback("setup_failure");
+            closeWebSocketForFallback("setup_failure");
             responseStream = await createSseStream();
           }
         } else {

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -106,7 +106,9 @@ export function parseOpenAIResponsesWebSocketServerError(cause: unknown) {
   }
   const ErrorClass =
     details.code === "previous_response_not_found" ||
-    details.code === "websocket_connection_limit_reached"
+    details.code === "websocket_connection_limit_reached" ||
+    details.code === "invalid_encrypted_content" ||
+    details.code === "thinking_signature_invalid"
       ? OpenAIResponsesWebSocketSafeRetryError
       : OpenAIResponsesWebSocketServerError;
   return new ErrorClass(details.code, details.status, details.param, details.message, cause);

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -281,7 +281,7 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
   requestOptions: unknown;
   model: Model;
   observePrompt?: NonNullable<ReturnType<typeof createResponsesPromptEgressObserver>>;
-  initialAttemptKind?: "initial" | "continuation-rejected";
+  initialAttemptKind?: ResponsesEncryptedContentAttemptKind;
   onCompactionRejected?: () => void;
   buildFullHistoryRequest?: () =>
     | OpenAIResponsesRequestParams

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -584,26 +584,123 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     expect(transportState.websocketCloseCount).toBe(1);
   });
 
-  it("does not replay over SSE after an ambiguous post-dispatch disconnect", async () => {
-    transportState.responseBatches.push([
+  it("recovers a rejected WebSocket compaction replay over full-history SSE", async () => {
+    transportState.responseBatches.push(
+      [
+        message(
+          completedEvent("resp_checkpoint", [
+            {
+              type: "compaction",
+              id: "cmp_rejected",
+              encrypted_content: "opaque-rejected-compaction",
+            },
+          ]),
+        ),
+      ],
+      [
+        {
+          type: "error",
+          error: wrappedSdkServerError({
+            code: "invalid_encrypted_content",
+            message: "compaction checkpoint could not be decrypted",
+            param: "input[0].encrypted_content",
+            status: 400,
+          }),
+        },
+      ],
+      [message(completedEvent("resp_next"))],
+    );
+    transportState.sdkOutcomes.push(sdkCompletion("resp_recovered"));
+    const firstUser = userMessage("full history before compaction", 1);
+    const checkpoint = await run({ messages: [firstUser], tools: [] }, { transport: "websocket" });
+    expect(checkpoint.providerReplay).toMatchObject({ type: "openai-responses-compaction" });
+    transportState.websocketRequests.length = 0;
+    const observations: ResponsesPromptObservation[] = [];
+    const context = {
+      messages: [firstUser, checkpoint, userMessage("continue after compaction", 2)],
+      tools: [],
+    } satisfies Context;
+
+    const result = await run(context, { observations, transport: "websocket" });
+    const next = await run(
       {
-        type: "error",
-        error: wrappedSdkServerError({
-          code: "invalid_websocket_request",
-          message: "request may have been dispatched",
-          param: "input",
-          status: 400,
-        }),
+        ...context,
+        messages: [...context.messages, result, userMessage("continue again", 3)],
       },
+      { observations, transport: "websocket" },
+    );
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      providerReplay: {
+        type: "openai-responses-compaction-suppression",
+        data: "rejected",
+      },
+    });
+    expect(next.stopReason).toBe("stop");
+    expect(transportState.websocketRequests).toHaveLength(2);
+    expect(JSON.stringify(transportState.websocketRequests[0]?.input)).toContain(
+      '"type":"compaction"',
+    );
+    expect(JSON.stringify(transportState.websocketRequests[0]?.input)).not.toContain(
+      "full history before compaction",
+    );
+    expect(transportState.sdkRequests).toHaveLength(1);
+    expect(JSON.stringify(transportState.sdkRequests[0]?.input)).not.toContain(
+      '"type":"compaction"',
+    );
+    expect(JSON.stringify(transportState.sdkRequests[0]?.input)).toContain(
+      "full history before compaction",
+    );
+    expect(JSON.stringify(transportState.websocketRequests[1]?.input)).not.toContain(
+      '"type":"compaction"',
+    );
+    expect(observations.map(({ egress, payloadVariant }) => ({ egress, payloadVariant }))).toEqual([
+      { egress: "responses-websocket", payloadVariant: "initial" },
+      { egress: "responses-sdk", payloadVariant: "compaction-stripped" },
+      { egress: "responses-websocket", payloadVariant: "initial" },
     ]);
-
-    const result = await run({ messages: [userMessage("hello", 1)], tools: [] });
-
-    expect(result.stopReason).toBe("error");
-    expect(result.errorCode).toBe(PROVIDER_POST_DISPATCH_AMBIGUITY_ERROR_CODE);
-    expect(transportState.websocketRequests).toHaveLength(1);
-    expect(transportState.sdkRequests).toEqual([]);
   });
+
+  it.each([
+    [
+      "invalid_websocket_request",
+      "request may have been dispatched",
+      PROVIDER_POST_DISPATCH_AMBIGUITY_ERROR_CODE,
+    ],
+    [
+      "invalid_encrypted_content",
+      "encrypted reasoning was rejected without compaction",
+      "invalid_encrypted_content",
+    ],
+    [
+      "thinking_signature_invalid",
+      "thinking signature was rejected without replayable reasoning",
+      "thinking_signature_invalid",
+    ],
+  ])(
+    "does not replay over SSE after a post-dispatch %s without compaction",
+    async (code, text, expectedCode) => {
+      transportState.responseBatches.push([
+        {
+          type: "error",
+          error: wrappedSdkServerError({
+            code,
+            message: text,
+            param: "input",
+            status: 400,
+          }),
+        },
+      ]);
+
+      const result = await run({ messages: [userMessage("hello", 1)], tools: [] });
+
+      expect(result.stopReason).toBe("error");
+      expect(result.errorCode).toBe(expectedCode);
+      expect(transportState.websocketRequests).toHaveLength(1);
+      expect(transportState.sdkRequests).toEqual([]);
+    },
+  );
 
   it("applies the request timeout after dispatch without falling back", async () => {
     transportState.responseBatches.push([{ type: "delay", ms: 25 }]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native OpenAI users could have a turn fail repeatedly after the API rejected a replayed encrypted compaction checkpoint. The default WebSocket transport treated that explicit rejection as an ambiguous post-dispatch failure, so it neither rebuilt full history nor recorded that the checkpoint must not be replayed again.

## Why This Change Was Made

Classifies OpenAI's explicit encrypted-content rejection codes as retry-safe WebSocket server errors, then resumes the existing Responses encrypted-content recovery state machine over SSE. That shared owner strips encrypted reasoning first when needed, rebuilds full history without a rejected compaction checkpoint, and records the route-scoped suppression tombstone only after the stripped request succeeds. Unrelated post-dispatch failures and encrypted-content errors without recoverable replay state remain non-retryable.

AI-assisted implementation and review; the maintainer reviewed the full code path, dependency contract, tests, and live behavior.

## User Impact

A native OpenAI turn now recovers automatically when a replayed compaction checkpoint is rejected. The successful result records suppression state, so later turns return to WebSocket without retrying the same invalid checkpoint.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-websocket-client.test.ts -t "recovers a rejected WebSocket compaction replay over full-history SSE"` failed because the result stopped with `error` instead of completing with a suppression tombstone.
- Exact post-fix regression: 1 test passed.
- Owner and sibling proof: `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-websocket-client.test.ts packages/ai/src/transports/openai-responses-websocket.test.ts packages/ai/src/transports/openai-responses-prompt-observer.test.ts packages/ai/src/transports/openai-responses-compaction-replay.test.ts` — 87 tests passed.
- Core changed gate: conflict, ratchet, format, dependency, dead-export, production/test typecheck, lint, database-first, sidecar, and import-cycle checks passed.
- Authenticated direct OpenAI proof on AWS Crabbox: an intentionally invalid compaction checkpoint was sent over the real Responses WebSocket endpoint; the observed sequence was WebSocket initial request → compaction-stripped full-history SSE recovery → next-turn WebSocket with no compaction. Both turns completed successfully, the first result carried the suppression tombstone, and the next request did not replay the checkpoint. Run `run_e9d6f07827fb`, lease `cbx_df8d63ec80ef`; the lease was released after proof.
- Direct dependency audit: installed `openai@6.49.0` surfaces structured Responses WebSocket API errors through `WebSocketError`; its compaction input type treats `encrypted_content` as opaque replay state.
- Mandatory Codex autoreview: TruffleHog clean, no accepted/actionable findings, patch correctness 0.98.
- Production LOC: +34/-12 (net +22) for the missing recovery capability and shared fallback teardown. Tests: +112/-15 (net +97).
