### PR TITLE
fix: install externalized configured plugins during upgrades

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -68,7 +68,7 @@ export async function resolveConfiguredPluginInstallContext(params: {
     installRecords: {},
   }).plugins.filter((plugin) => plugin.origin === "bundled");
   const knownIds = new Set([
-    ...snapshot.plugins.map((plugin) => plugin.id),
+    ...snapshot.plugins.filter((plugin) => plugin.origin !== "bundled").map((plugin) => plugin.id),
     ...currentBundledPlugins.map((plugin) => plugin.pluginId),
   ]);
   const configuredChannelOwnerPluginIds = collectEffectiveConfiguredChannelOwnerPluginIds({
@@ -77,14 +77,11 @@ export async function resolveConfiguredPluginInstallContext(params: {
     snapshot,
     configuredChannelIds: params.configuredChannelIds,
   });
-  const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>([
-    ...snapshot.plugins
-      .filter((plugin) => plugin.origin === "bundled")
-      .map((plugin) => [plugin.id, plugin] as const),
-    ...currentBundledPlugins.map(
+  const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>(
+    currentBundledPlugins.map(
       (plugin) => [plugin.pluginId, { packageName: plugin.packageName }] as const,
     ),
-  ]);
+  );
   const configuredPluginIdsWithStaleDescriptors =
     collectConfiguredPluginIdsWithMissingChannelConfigDescriptors({
       snapshot,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -132,6 +132,14 @@ const mocks = vi.hoisted(() => ({
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function mockCurrentBundledPlugin(pluginId: string, packageName: string): void {
+  mocks.loadInstalledPluginIndex.mockReturnValue({
+    plugins: [{ pluginId, origin: "bundled", packageName }],
+    diagnostics: [],
+    installRecords: {},
+  });
+}
+
 function writeLegacyNpmDeclarationStub(params: {
   pluginDir: string;
   pluginId: string;
@@ -1197,6 +1205,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       ],
       diagnostics: [],
     });
+    mockCurrentBundledPlugin("matrix", "@openclaw/matrix");
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -1257,6 +1266,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       ],
     });
+    mockCurrentBundledPlugin("matrix", "@openclaw/matrix");
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -1312,17 +1322,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       ],
       diagnostics: [],
     });
-    mocks.loadInstalledPluginIndex.mockReturnValue({
-      plugins: [
-        {
-          pluginId: "google-meet",
-          origin: "bundled",
-          packageName: "@openclaw/google-meet",
-        },
-      ],
-      diagnostics: [],
-      installRecords: {},
-    });
+    mockCurrentBundledPlugin("google-meet", "@openclaw/google-meet");
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       {
         id: "google-meet",
@@ -1364,6 +1364,56 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
   });
 
+  it("installs an official external plugin when only a stale bundled descriptor remains", async () => {
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "bundled",
+          packageName: "@openclaw/discord",
+          channels: ["discord"],
+        },
+      ],
+      diagnostics: [],
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        label: "Discord",
+        install: { npmSpec: "@openclaw/discord", defaultChoice: "npm" },
+      },
+    ]);
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
+      successfulInstall({
+        pluginId: "discord",
+        npmSpec: "@openclaw/discord",
+        version: "2026.8.1",
+      }),
+    );
+
+    const result = await repairConfiguredPlugins({
+      plugins: {
+        entries: {
+          discord: { enabled: true },
+        },
+      },
+    });
+
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: expectedNpmInstallSpec("@openclaw/discord"),
+      expectedPluginId: "discord",
+      trustedSourceLinkedOfficialInstall: true,
+    });
+    expectRecordFields(result.records.discord, {
+      source: "npm",
+      spec: "@openclaw/discord",
+      installPath: "/tmp/openclaw-plugins/discord",
+    });
+    expect(result.changes).toEqual([
+      `Installed missing configured plugin "discord" from ${expectedNpmInstallSpec("@openclaw/discord")}.`,
+    ]);
+  });
+
   it("removes stale bundled install records even when the plugin is not configured", async () => {
     const records = {
       "google-meet": {
@@ -1378,17 +1428,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       plugins: [],
       diagnostics: [],
     });
-    mocks.loadInstalledPluginIndex.mockReturnValue({
-      plugins: [
-        {
-          pluginId: "google-meet",
-          origin: "bundled",
-          packageName: "@openclaw/google-meet",
-        },
-      ],
-      diagnostics: [],
-      installRecords: {},
-    });
+    mockCurrentBundledPlugin("google-meet", "@openclaw/google-meet");
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -1465,6 +1505,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         ],
       });
+      mockCurrentBundledPlugin("matrix", "@openclaw/matrix");
 
       const { repairMissingConfiguredPluginInstalls } =
         await import("./missing-configured-plugin-install.js");

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -14,6 +14,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts",
+      "extensions/codex/src/app-server/run-attempt-state.test.ts",
       "extensions/codex/src/app-server/run-attempt.steering.test.ts",
       "extensions/codex/src/app-server/run-attempt.turn-watches.test.ts",
       "extensions/codex/src/app-server/run-attempt.usage-limits.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading a packaged OpenClaw install could keep a configured channel's pre-externalization bundled descriptor but receive no official companion plugin install. In release proof run https://github.com/openclaw/openclaw/actions/runs/31755675261, both `published-upgrade-survivor` and `root-managed-vps-upgrade` failed after update at `channels.discord.dm`: the external plugin schema rejected the legacy nested fields `policy` and `allowFrom`, while plugin update reported no sync/npm outcome and a fresh doctor pass could not run Discord's migration without the plugin payload.

## Why This Change Was Made

Configured-plugin repair now treats current bundled discovery as the sole authority for the current package's bundled set. Persisted snapshot records still establish that load-path, workspace, global, and other non-bundled plugins are present, but an unconfirmed `origin: "bundled"` snapshot record can no longer mark a removed payload known or bundled and suppress its trusted official catalog install.

This keeps the existing canonical missing-install flow and contains no plugin-specific production policy.

## User Impact

After an upgrade externalizes a previously bundled configured plugin, post-core convergence or a later `openclaw doctor --fix` installs the trusted official companion package. The plugin can then run its own compatibility migration before config validation instead of leaving the upgraded installation with an invalid legacy channel shape.

No changelog entry is included; this release-critical compatibility repair will be represented in release notes.

AI-assisted: yes.

## Evidence

- Regression first failed on the untouched implementation because the official install call never occurred (`Expected mock call 0`), then passed after the repair:
  - `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts -t 'installs an official external plugin when only a stale bundled descriptor remains'`
- Owner and configured load-path coverage:
  - `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts` — 87 passed
  - `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts` — 2 passed
- Post-core convergence and retirement:
  - `node scripts/run-vitest.mjs src/cli/update-cli/post-core-plugin-convergence.test.ts src/cli/update-cli/post-core-plugin-convergence.retirement.test.ts` — 34 passed
- Discord migration and doctor sequencing:
  - `node scripts/run-vitest.mjs extensions/discord/src/doctor.test.ts src/commands/doctor/repair-sequencing.test.ts` — 41 passed
- Release/update callers:
  - `node scripts/run-vitest.mjs src/commands/doctor/shared/release-configured-plugin-installs.test.ts src/infra/update-post-core-finalize.test.ts` — 42 passed
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 node scripts/check-changed.mjs -- src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts` — passed locally after the remote Testbox remained queued without allocation
- `git diff --check` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings

Production LOC: +4/-7 (net -3) | Tests: +63/-22 (net +41)
