### PR TITLE
fix(ci): restore Codex state test shard owner after merge drift

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -14,6 +14,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts",
+      "extensions/codex/src/app-server/run-attempt-state.test.ts",
       "extensions/codex/src/app-server/run-attempt.steering.test.ts",
       "extensions/codex/src/app-server/run-attempt.turn-watches.test.ts",
       "extensions/codex/src/app-server/run-attempt.usage-limits.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the normal full-suite ownership audit fails on current `main` because `run-attempt-state.test.ts` has no Vitest shard owner.

PR #123392 removed the stale `attempt-light` duplicate as intended, but concurrent PR #123349 had already removed the authoritative `attempt-extra` entry. Their combined landed state turned the duplicate into a missing owner.

## Why This Change Was Made

Restore only the `attempt-extra` registration selected by Peter's explicit reconciliation commit `865b07f40ca5fd3f84051c73e64134ee7ae42ee6`. The light entry remains absent, so the test has exactly one owner.

## User Impact

No product behavior changes. Main and open PRs can again pass the normal full-suite ownership audit.

## Evidence

- Terminal verification after #123392 reproduced the missing owner on merge `746359d55e8f43e9fe5b5779ea328067bd03cead` combined with #123349 merge `d2dad76ecde4bb3e811b9d03ed9932dc61044b8a`.
- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` — 21 passed; no missing or duplicate owners.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts extensions/codex/src/app-server/run-attempt-state.test.ts` — 2 passed.
- Static ownership probe finds the path only in `attempt-extra`.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.

Production LOC: +0/-0 | Tests/config routing: +1/-0
