### PR TITLE
fix(slack): keep cached monitor identity and allowlists live

### DIFF
--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -19,6 +19,7 @@ const onFlushCallbacks: Array<
 > = [];
 const prepareSlackMessageMock = vi.fn(
   async (_params?: {
+    ctx: Parameters<typeof createSlackMessageHandler>[0]["ctx"];
     opts: { onVisibleDrop?: () => void };
   }): Promise<{ ctxPayload: Record<string, unknown> } | null> => ({ ctxPayload: {} }),
 );

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -174,6 +174,59 @@ describe("createSlackMessageHandler", () => {
     expect(context.cfg).toBe(startupConfig);
   });
 
+  it("keeps cached runtime contexts synchronized with mutable monitor state", async () => {
+    const startupConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "max" } } };
+    const runtimeConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "ultra" } } };
+    const initialChannels = { C_OLD: { enabled: true } };
+    const resolvedChannels = { C_RESOLVED: { enabled: true } };
+    const context = createContext({ cfg: startupConfig });
+    context.botUserId = "U_STALE";
+    context.channelsConfig = initialChannels;
+    const handler = createSlackMessageHandler({
+      ctx: context,
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+    setRuntimeConfigSnapshot(runtimeConfig, runtimeConfig);
+
+    const handleMessage = async (ts: string) => {
+      await handler(
+        {
+          type: "message",
+          channel: "D1",
+          user: "U1",
+          ts,
+          text: "hello",
+        } as never,
+        { source: "message" },
+      );
+      const entry = enqueueMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      await runOnFlush([entry]);
+    };
+
+    await handleMessage("1709000000.009007");
+    const initialRuntimeContext = prepareSlackMessageMock.mock.calls[0]?.[0]?.ctx;
+    expect(initialRuntimeContext).toMatchObject({
+      cfg: runtimeConfig,
+      botUserId: "U_STALE",
+      channelsConfig: initialChannels,
+    });
+
+    context.botUserId = "U_RECOVERED";
+    context.channelsConfig = resolvedChannels;
+    await handleMessage("1709000000.009008");
+
+    const reusedRuntimeContext = prepareSlackMessageMock.mock.calls[1]?.[0]?.ctx;
+    expect(reusedRuntimeContext).toBe(initialRuntimeContext);
+    expect(reusedRuntimeContext).toMatchObject({
+      cfg: runtimeConfig,
+      botUserId: "U_RECOVERED",
+      channelsConfig: resolvedChannels,
+    });
+    expect(context.cfg).toBe(startupConfig);
+  });
+
   it.each([
     {
       label: "without a source snapshot",

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -132,7 +132,9 @@ export function createSlackMessageHandler(params: {
     if (cached) {
       return cached;
     }
-    const runtimeContext = { ...ctx, cfg: runtimeConfig };
+    // Keep identity, allowlists, and other mutable monitor state live while pinning this config.
+    const runtimeContext = Object.create(ctx) as SlackMonitorContext;
+    runtimeContext.cfg = runtimeConfig;
     runtimeContexts.set(runtimeConfig, runtimeContext);
     return runtimeContext;
   };


### PR DESCRIPTION
## What Problem This Solves

Follow up on #123373: a cached Slack runtime-config context currently shallow-copies the entire monitor. If Slack later resolves a channel allowlist or recovers its bot identity without publishing another config object, subsequent messages keep seeing the stale copied monitor fields.

## Why This Change Was Made

Keep the existing WeakMap cache and per-turn config snapshot, but derive each cached context from the live monitor through its prototype. Only `cfg` becomes an own pinned value; bot identity, resolved allowlists, and other mutable monitor fields continue to reflect their owner.

This preserves the existing low-cost lookup: no per-message context reconstruction, disk read, Slack reconnection, SDK change, or configuration-surface change.

## Monitor Ownership And Compatibility

- `extensions/slack/src/monitor/provider.ts` replaces `ctx.botUserId`, `ctx.identityHealth`, `ctx.installationIdentity`, `ctx.allowFrom`, and `ctx.channelsConfig` after monitor startup; these fields must remain owned by the original live monitor.
- `extensions/slack/src/monitor/message-handler/prepare.ts` consumes those monitor fields through direct property reads, and the downstream Slack monitor/message-handler paths do not spread or enumerate the entire context.
- The cached object therefore keeps only the per-turn `cfg` snapshot as its own property and inherits all other fields from the authoritative monitor; it remains cached by config identity.
- A moving `main` alone is not a reason to rebase this conflict-free PR. Current-main compatibility must instead be confirmed by the exact-head CI and repository merge checks before landing.

## Evidence

- Added a regression that reuses one runtime-config snapshot across two Slack messages while the monitor bot identity and resolved channel allowlist change between them.
- Confirmed the regression fails against current `main` with stale `U_STALE` / `C_OLD` state, then passes with the fix.
- Focused Slack message-handler, tool-result, and slash-command suites: **120 tests passed**.
- Changed-file formatting/lint, Git whitespace validation, and independent autoreview passed.

AI-assisted: yes (Codex).
