### PR TITLE
[BACKPORT] fix(slack): apply updated global settings without stale monitor state

### DIFF
--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -1,6 +1,11 @@
 // Slack tests cover message handler plugin behavior.
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type InboundDebounceFlush = { admission: Promise<void>; completion: Promise<void> };
 
@@ -66,13 +71,14 @@ vi.mock("./message-handler/pipeline.runtime.js", () => ({
 }));
 
 function createContext(overrides?: {
+  cfg?: OpenClawConfig;
   rememberSlackChannelType?: (
     channel: string | null | undefined,
     channelType: string | null | undefined,
   ) => void;
 }) {
   return {
-    cfg: {},
+    cfg: overrides?.cfg ?? {},
     accountId: "default",
     app: {
       client: {},
@@ -116,12 +122,257 @@ async function handleDirectMessage(
 
 describe("createSlackMessageHandler", () => {
   beforeEach(() => {
+    clearRuntimeConfigSnapshot();
     enqueueMock.mockClear();
     flushKeyMock.mockClear();
     onFlushCallbacks.length = 0;
     prepareSlackMessageMock.mockClear();
     dispatchPreparedSlackMessageMock.mockClear();
     resolveThreadTsMock.mockClear();
+  });
+
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("uses the latest runtime config for messages without restarting the monitor", async () => {
+    const startupConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "max" } } };
+    const updatedConfig: OpenClawConfig = {
+      agents: { defaults: { thinkingDefault: "ultra", fastModeDefault: true } },
+    };
+    const context = createContext({ cfg: startupConfig });
+    const handler = createSlackMessageHandler({
+      ctx: context,
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    setRuntimeConfigSnapshot(updatedConfig, updatedConfig);
+    await handler(
+      {
+        type: "message",
+        channel: "D1",
+        user: "U1",
+        ts: "1709000000.009001",
+        text: "hello",
+      } as never,
+      { source: "message" },
+    );
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    await runOnFlush([entry]);
+
+    expect(prepareSlackMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({ cfg: updatedConfig }),
+      }),
+    );
+    expect(context.cfg).toBe(startupConfig);
+  });
+
+  it("keeps cached runtime contexts synchronized with mutable monitor state", async () => {
+    const startupConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "max" } } };
+    const runtimeConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "ultra" } } };
+    const initialChannels = { C_OLD: { enabled: true } };
+    const resolvedChannels = { C_RESOLVED: { enabled: true } };
+    const context = createContext({ cfg: startupConfig });
+    context.botUserId = "U_STALE";
+    context.channelsConfig = initialChannels;
+    const handler = createSlackMessageHandler({
+      ctx: context,
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+    setRuntimeConfigSnapshot(runtimeConfig, runtimeConfig);
+
+    const handleMessage = async (ts: string) => {
+      await handler(
+        {
+          type: "message",
+          channel: "D1",
+          user: "U1",
+          ts,
+          text: "hello",
+        } as never,
+        { source: "message" },
+      );
+      const entry = enqueueMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      await runOnFlush([entry]);
+    };
+
+    await handleMessage("1709000000.009007");
+    const initialRuntimeContext = prepareSlackMessageMock.mock.calls[0]?.[0]?.ctx;
+    expect(initialRuntimeContext).toMatchObject({
+      cfg: runtimeConfig,
+      botUserId: "U_STALE",
+      channelsConfig: initialChannels,
+    });
+
+    context.botUserId = "U_RECOVERED";
+    context.channelsConfig = resolvedChannels;
+    await handleMessage("1709000000.009008");
+
+    const reusedRuntimeContext = prepareSlackMessageMock.mock.calls[1]?.[0]?.ctx;
+    expect(reusedRuntimeContext).toBe(initialRuntimeContext);
+    expect(reusedRuntimeContext).toMatchObject({
+      cfg: runtimeConfig,
+      botUserId: "U_RECOVERED",
+      channelsConfig: resolvedChannels,
+    });
+    expect(context.cfg).toBe(startupConfig);
+  });
+
+  it.each([
+    {
+      label: "without a source snapshot",
+      includeSourceSnapshot: false,
+      messageTs: "1709000000.009004",
+    },
+    {
+      label: "with an unrelated source snapshot",
+      includeSourceSnapshot: true,
+      messageTs: "1709000000.009005",
+    },
+  ])("preserves explicit monitor config $label", async ({ includeSourceSnapshot, messageTs }) => {
+    const explicitConfig: OpenClawConfig = {
+      agents: { defaults: { thinkingDefault: "ultra" } },
+      messages: { responsePrefix: "scoped" },
+    };
+    const unrelatedRuntimeConfig: OpenClawConfig = {
+      agents: { defaults: { thinkingDefault: "low" } },
+    };
+    setRuntimeConfigSnapshot(
+      unrelatedRuntimeConfig,
+      includeSourceSnapshot ? unrelatedRuntimeConfig : undefined,
+    );
+    const context = createContext({ cfg: explicitConfig });
+    const handler = createSlackMessageHandler({
+      ctx: context,
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    setRuntimeConfigSnapshot({ agents: { defaults: { thinkingDefault: "high" } } });
+    await handler(
+      {
+        type: "message",
+        channel: "D1",
+        user: "U1",
+        ts: messageTs,
+        text: "hello",
+      } as never,
+      { source: "message" },
+    );
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    await runOnFlush([entry]);
+
+    expect(prepareSlackMessageMock).toHaveBeenCalledWith(expect.objectContaining({ ctx: context }));
+    expect(context.cfg).toBe(explicitConfig);
+  });
+
+  it("follows runtime updates when the monitor config matches the runtime source", async () => {
+    const startupSourceConfig: OpenClawConfig = {
+      agents: { defaults: { thinkingDefault: "max" } },
+    };
+    const startupRuntimeConfig: OpenClawConfig = {
+      agents: { defaults: { thinkingDefault: "max", fastModeDefault: false } },
+    };
+    const updatedRuntimeConfig: OpenClawConfig = {
+      agents: { defaults: { thinkingDefault: "ultra", fastModeDefault: true } },
+    };
+    setRuntimeConfigSnapshot(startupRuntimeConfig, startupSourceConfig);
+    const context = createContext({ cfg: structuredClone(startupSourceConfig) });
+    const handler = createSlackMessageHandler({
+      ctx: context,
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    setRuntimeConfigSnapshot(updatedRuntimeConfig, updatedRuntimeConfig);
+    await handler(
+      {
+        type: "message",
+        channel: "D1",
+        user: "U1",
+        ts: "1709000000.009006",
+        text: "hello",
+      } as never,
+      { source: "message" },
+    );
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    await runOnFlush([entry]);
+
+    expect(prepareSlackMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({ cfg: updatedRuntimeConfig }),
+      }),
+    );
+    expect(context.cfg).toEqual(startupSourceConfig);
+  });
+
+  it("keeps each in-flight message on its captured config snapshot", async () => {
+    const startupConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "max" } } };
+    const firstConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "high" } } };
+    const secondConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "ultra" } } };
+    const context = createContext({ cfg: startupConfig });
+    const handler = createSlackMessageHandler({
+      ctx: context,
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+    let releaseFirstPreparation!: () => void;
+    const firstPreparation = new Promise<void>((resolve) => {
+      releaseFirstPreparation = resolve;
+    });
+    prepareSlackMessageMock.mockImplementationOnce(async () => {
+      await firstPreparation;
+      return { ctxPayload: {} };
+    });
+
+    setRuntimeConfigSnapshot(firstConfig, firstConfig);
+    await handler(
+      {
+        type: "message",
+        channel: "D1",
+        user: "U1",
+        ts: "1709000000.009002",
+        text: "first",
+      } as never,
+      { source: "message" },
+    );
+    const firstEntry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    const firstFlush = runOnFlush([firstEntry]);
+    await vi.waitFor(() => expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1));
+
+    setRuntimeConfigSnapshot(secondConfig, secondConfig);
+    await handler(
+      {
+        type: "message",
+        channel: "D2",
+        user: "U2",
+        ts: "1709000000.009003",
+        text: "second",
+      } as never,
+      { source: "message" },
+    );
+    const secondEntry = enqueueMock.mock.calls[1]?.[0] as Record<string, unknown>;
+    await runOnFlush([secondEntry]);
+    releaseFirstPreparation();
+    await firstFlush;
+
+    expect(prepareSlackMessageMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ ctx: expect.objectContaining({ cfg: firstConfig }) }),
+    );
+    expect(prepareSlackMessageMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ ctx: expect.objectContaining({ cfg: secondConfig }) }),
+    );
+    expect(context.cfg).toBe(startupConfig);
   });
 
   it("does not track invalid non-message events from the message stream", async () => {

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -5,6 +5,11 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackSendIdentity } from "../send.js";
 import type { SlackMessageEvent } from "../types.js";
@@ -101,6 +106,38 @@ export function createSlackMessageHandler(params: {
   dispatchReplayGuard?: SlackMessageDispatchReplayGuard;
 }): SlackMessageHandler {
   const { ctx, account, trackEvent, onPrepared } = params;
+  const startupRuntimeConfig = getRuntimeConfigSnapshot();
+  const startupRuntimeSourceConfig = getRuntimeConfigSourceSnapshot();
+  // Bind snapshot ownership once so unrelated process-global config cannot replace scoped monitors.
+  const followsRuntimeConfig =
+    !startupRuntimeConfig ||
+    startupRuntimeConfig === ctx.cfg ||
+    (startupRuntimeSourceConfig !== null &&
+      selectApplicableRuntimeConfig({
+        inputConfig: ctx.cfg,
+        runtimeConfig: startupRuntimeConfig,
+        runtimeSourceConfig: startupRuntimeSourceConfig,
+      }) === startupRuntimeConfig);
+  const runtimeContexts = new WeakMap<
+    NonNullable<SlackMonitorContext["cfg"]>,
+    SlackMonitorContext
+  >();
+  const resolveRuntimeContext = (): SlackMonitorContext => {
+    // Channel monitors outlive config reloads; pin one live snapshot per turn without reconnecting.
+    const runtimeConfig = getRuntimeConfigSnapshot();
+    if (!followsRuntimeConfig || !runtimeConfig || runtimeConfig === ctx.cfg) {
+      return ctx;
+    }
+    const cached = runtimeContexts.get(runtimeConfig);
+    if (cached) {
+      return cached;
+    }
+    // Keep identity, allowlists, and other mutable monitor state live while pinning this config.
+    const runtimeContext = Object.create(ctx) as SlackMonitorContext;
+    runtimeContext.cfg = runtimeConfig;
+    runtimeContexts.set(runtimeConfig, runtimeContext);
+    return runtimeContext;
+  };
   const dispatchReplayGuard =
     params.dispatchReplayGuard ??
     createSlackMessageDispatchReplayGuard({
@@ -273,8 +310,9 @@ export function createSlackMessageHandler(params: {
               let prepared: Awaited<ReturnType<typeof prepareSlackMessage>>;
               let settlementHandedOff = false;
               try {
+                const runtimeContext = resolveRuntimeContext();
                 prepared = await prepareSlackMessage({
-                  ctx,
+                  ctx: runtimeContext,
                   account,
                   message: syntheticMessage,
                   opts: {


### PR DESCRIPTION
## What Problem This Solves

Backport merged main PR #123373 to `sjf_openclaw_2026-07-31` so existing Slack monitors use updated global settings on their next message without requiring a Gateway or Slack restart.

Also includes the exact follow-up patch from main PR #123403 so cached config views do not freeze Slack bot identity, resolved channel allowlists, or other mutable monitor-owned state. Merge #123403 into `main` before merging this backport to keep both branches behaviorally aligned.

## Why This Change Was Made

- Preserve explicit independent monitor configurations while allowing global-runtime-owned monitors to follow updated in-memory config snapshots.
- Pin each in-flight message to its own configuration snapshot.
- Reuse a WeakMap-cached context per config object without rebuilding the Slack monitor or its transport.
- Derive cached contexts from the live monitor so identity recovery and allowlist resolution remain current.
- Reuse already-shipped SDK helpers; no SDK export, config key, migration, dependency, or release-surface changes.

## Evidence

- Mainline source: #123373 / `358eecf8cb87c912ff7208cf1f40fca8f9a31aa3`.
- Mainline follow-up: #123403 / `cf40bde1a735fcecdb32c8890b7568dc076ac113`.
- The incremental follow-up patch has the same stable Git patch-id on main and this branch: `e93e4e8070688cddd76ee1b314952d84db715a65`.
- Release-branch Slack message-handler, tool-result, and slash-command suites: **108 tests passed**.
- Regression fails before the follow-up when cached contexts retain stale bot identity/channel state, and passes after the identical mainline fix.
- Changed-file formatting/lint, Git whitespace validation, TruffleHog, and independent autoreview passed.

AI-assisted: yes (Codex).
