### PR TITLE
fix(ci): keep exact-main test shards isolated

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -162,6 +162,8 @@ describe("tasks commands", () => {
   it("keeps audit JSON stable and sorts combined findings before limiting", async () => {
     await withTaskCommandStateDir(async () => {
       const now = Date.now();
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(now);
       createTaskRecord({
         runtime: "cli",
         ownerKey: "agent:main:main",
@@ -224,8 +226,7 @@ describe("tasks commands", () => {
         token: runningFlow.flowId,
         flow: jsonRoundTrip(runningFlow),
       });
-      expect(limitedFinding?.ageMs).toBeGreaterThanOrEqual(45 * 60_000);
-      expect(limitedFinding?.ageMs).toBeLessThan(45 * 60_000 + 1_000);
+      expect(limitedFinding?.ageMs).toBe(45 * 60_000);
     });
   });
 

--- a/src/gateway/server-http.device-pairing-join.test.ts
+++ b/src/gateway/server-http.device-pairing-join.test.ts
@@ -1,4 +1,5 @@
 // Real Gateway lifecycle proof for admin mint -> public single-use join exchange.
+import { Agent, fetch } from "undici";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { WebSocket } from "ws";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -22,6 +23,7 @@ type JoinSetupResult = {
 
 let harness: Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 let adminSocket: WebSocket;
+let httpDispatcher: Agent;
 
 beforeAll(async () => {
   testState.gatewayAuth = {
@@ -34,6 +36,7 @@ beforeAll(async () => {
     },
   };
   harness = await createGatewaySuiteHarness();
+  httpDispatcher = new Agent({ connections: 1 });
   adminSocket = await harness.openWs();
   const connected = await connectReq(adminSocket, {
     token: "secret",
@@ -46,6 +49,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   adminSocket?.close();
+  await httpDispatcher?.close();
   await harness?.close();
 });
 
@@ -66,8 +70,14 @@ function shortcodeFromUrl(joinUrl: string): string {
   return new URL(joinUrl).pathname.split("/").at(-1) ?? "";
 }
 
-async function readJson(response: Response): Promise<unknown> {
+async function readJson(response: Awaited<ReturnType<typeof fetch>>): Promise<unknown> {
   return JSON.parse(await response.text()) as unknown;
+}
+
+async function fetchJoinUrl(url: string) {
+  // Other Gateway suites replace the process-wide Undici dispatcher. Keep this
+  // real loopback route bound to its own client so cross-suite mocks cannot claim it.
+  return await fetch(url, { dispatcher: httpDispatcher });
 }
 
 describe("Gateway device join route", () => {
@@ -84,7 +94,7 @@ describe("Gateway device join route", () => {
       );
     });
 
-    const expiredResponse = await fetch(expired.joinUrl);
+    const expiredResponse = await fetchJoinUrl(expired.joinUrl);
     expect(expiredResponse.status).toBe(404);
     const opaqueNotFound = await readJson(expiredResponse);
     expect(opaqueNotFound).toEqual({ error: "not_found" });
@@ -93,22 +103,22 @@ describe("Gateway device join route", () => {
     const shortcode = shortcodeFromUrl(live.joinUrl);
     expect(Buffer.from(shortcode, "base64url").byteLength).toBeGreaterThanOrEqual(16);
 
-    const first = await fetch(live.joinUrl);
+    const first = await fetchJoinUrl(live.joinUrl);
     expect(first.status).toBe(200);
     expect(first.headers.get("content-type")).toContain("application/json");
     expect(first.headers.get("cache-control")).toBe("no-store");
     expect(await readJson(first)).toEqual(decodePairingSetupCode(live.setupCode));
 
-    const used = await fetch(live.joinUrl);
+    const used = await fetchJoinUrl(live.joinUrl);
     expect(used.status).toBe(404);
     expect(await readJson(used)).toEqual(opaqueNotFound);
 
     const unknownUrl = `http://127.0.0.1:${harness.port}/j/${"z".repeat(22)}`;
-    const unknown = await fetch(unknownUrl);
+    const unknown = await fetchJoinUrl(unknownUrl);
     expect(unknown.status).toBe(404);
     expect(await readJson(unknown)).toEqual(opaqueNotFound);
 
-    const limited = await fetch(unknownUrl);
+    const limited = await fetchJoinUrl(unknownUrl);
     expect(limited.status).toBe(429);
     expect(await readJson(limited)).toEqual({ error: "rate_limited" });
   });

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -14,6 +14,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts",
+      "extensions/codex/src/app-server/run-attempt-state.test.ts",
       "extensions/codex/src/app-server/run-attempt.steering.test.ts",
       "extensions/codex/src/app-server/run-attempt.turn-watches.test.ts",
       "extensions/codex/src/app-server/run-attempt.usage-limits.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact-main and pull-request CI could fail nondeterministically when shared test-worker state contaminated a real Gateway HTTP request, elapsed wall time crossed a narrow audit-age assertion window, or concurrent shard edits left the Codex attempt-state test without a full-suite owner.

## Why This Change Was Made

The Gateway test now owns and closes a dedicated Undici dispatcher, the task audit test freezes only `Date`, and the Codex state test is registered in the canonical attempt-extra shard. These changes isolate the failing boundaries without changing production behavior, weakening assertions, or adding retries.

## User Impact

No user-visible behavior changes. Maintainers get deterministic exact-head CI coverage for these three failure modes.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-http.device-pairing-join.test.ts` — 1 test passed.
- `node scripts/run-vitest.mjs src/commands/tasks.test.ts` — 25 tests passed.
- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` — 21 ownership/config tests passed, including exact-once full-suite ownership.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts --configLoader runner extensions/codex/src/app-server/run-attempt-state.test.ts` — 2 tests passed.
- Changed-file formatting, Oxlint, and `git diff --check` passed.
- Final structured autoreview reported no accepted or actionable findings.

Supersedes #123365 after two unrelated main-branch merges removed the state test from both competing shard configs.
