### PR TITLE
fix(mobile): embedded Control UI follows the app's dark or light appearance

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
@@ -36,6 +36,10 @@ internal fun ControlUiWebView(
   val context = LocalContext.current
   val darkAppearance = LocalResolvedAppearanceIsDark.current
 
+  // A WebView reads prefers-color-scheme from the Context it was built with, so an appearance
+  // flip has to rebuild it; keying on the resolved boolean keeps that to real dark/light changes.
+  // The reload is safe because both Control UI surfaces reattach to server-side state: the shell
+  // outlives the page, and the desktop session lingers on the Gateway long enough to re-observe.
   key(darkAppearance) {
     AndroidView(
       modifier = modifier,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
@@ -1,15 +1,18 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.R
 import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprintInput
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.Configuration
+import android.view.ContextThemeWrapper
 import android.view.View
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -31,47 +34,55 @@ internal fun ControlUiWebView(
   modifier: Modifier = Modifier,
 ) {
   val context = LocalContext.current
-  val webViewRef = remember { arrayOfNulls<WebView>(1) }
+  val darkAppearance = LocalResolvedAppearanceIsDark.current
 
-  DisposableEffect(Unit) {
-    onDispose {
-      val webView = webViewRef[0] ?: return@onDispose
-      webView.stopLoading()
-      webView.destroy()
-      webViewRef[0] = null
-    }
+  key(darkAppearance) {
+    AndroidView(
+      modifier = modifier,
+      factory = {
+        val webView = WebView(controlUiWebViewContext(context, darkAppearance))
+        val webSettings = webView.settings
+        webSettings.setAllowContentAccess(false)
+        webSettings.setAllowFileAccess(false)
+        webSettings.setAllowFileAccessFromFileURLs(false)
+        webSettings.setAllowUniversalAccessFromFileURLs(false)
+        webSettings.setSafeBrowsingEnabled(true)
+        webSettings.javaScriptEnabled = true
+        webSettings.domStorageEnabled = true
+        webSettings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+        webSettings.builtInZoomControls = false
+        webSettings.displayZoomControls = false
+        webSettings.setSupportZoom(false)
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+          WebSettingsCompat.setAlgorithmicDarkeningAllowed(webSettings, false)
+        }
+        webView.overScrollMode = View.OVER_SCROLL_NEVER
+        // The native gateway connection already established this route's trust.
+        // Reuse only that exact accepted fingerprint; every other SSL error cancels.
+        // The same client protects both terminal and dashboard pages.
+        webView.webViewClient = ControlUiWebViewClient(page)
+        installControlUiAuthScript(webView, page)
+        webView.loadUrl(url)
+        webView
+      },
+      onRelease = { webView ->
+        webView.stopLoading()
+        webView.destroy()
+      },
+    )
   }
+}
 
-  AndroidView(
-    modifier = modifier,
-    factory = {
-      val webView = WebView(context)
-      val webSettings = webView.settings
-      webSettings.setAllowContentAccess(false)
-      webSettings.setAllowFileAccess(false)
-      webSettings.setAllowFileAccessFromFileURLs(false)
-      webSettings.setAllowUniversalAccessFromFileURLs(false)
-      webSettings.setSafeBrowsingEnabled(true)
-      webSettings.javaScriptEnabled = true
-      webSettings.domStorageEnabled = true
-      webSettings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
-      webSettings.builtInZoomControls = false
-      webSettings.displayZoomControls = false
-      webSettings.setSupportZoom(false)
-      if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-        WebSettingsCompat.setAlgorithmicDarkeningAllowed(webSettings, false)
-      }
-      webView.overScrollMode = View.OVER_SCROLL_NEVER
-      // The native gateway connection already established this route's trust.
-      // Reuse only that exact accepted fingerprint; every other SSL error cancels.
-      // The same client protects both terminal and dashboard pages.
-      webView.webViewClient = ControlUiWebViewClient(page)
-      installControlUiAuthScript(webView, page)
-      webView.loadUrl(url)
-      webViewRef[0] = webView
-      webView
-    },
-  )
+private fun controlUiWebViewContext(
+  context: Context,
+  darkAppearance: Boolean,
+): Context {
+  val configuration = Configuration(context.resources.configuration)
+  val nightMode = if (darkAppearance) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
+  configuration.uiMode = (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or nightMode
+  // WebView derives prefers-color-scheme from the host theme's isLightTheme value.
+  // Reapplying the app's DayNight theme to this resolved configuration keeps that value authoritative.
+  return ContextThemeWrapper(context.createConfigurationContext(configuration), R.style.Theme_OpenClawNode)
 }
 
 /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OpenClawTheme.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OpenClawTheme.kt
@@ -9,9 +9,12 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+
+internal val LocalResolvedAppearanceIsDark = staticCompositionLocalOf { false }
 
 /**
  * App theme wrapper that installs dynamic Material colors and legacy mobile color tokens.
@@ -30,6 +33,7 @@ fun OpenClawTheme(
 
   CompositionLocalProvider(
     LocalMobileColors provides mobileColors,
+    LocalResolvedAppearanceIsDark provides isDark,
   ) {
     MaterialTheme(colorScheme = colorScheme, content = content)
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ControlUiWebViewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ControlUiWebViewTest.kt
@@ -1,14 +1,69 @@
 package ai.openclaw.app.ui
 
+import ai.openclaw.app.AppearanceThemeMode
+import ai.openclaw.app.NodeRuntime
+import android.content.res.Configuration
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 import java.security.MessageDigest
 
 @RunWith(RobolectricTestRunner::class)
 class ControlUiWebViewTest {
+  @Test
+  @Config(sdk = [31], qualifiers = "notnight")
+  fun darkAndSystemAppearancesConfigureWebViewForLightSystem() {
+    assertMountedAppearance(AppearanceThemeMode.Dark, dark = true)
+    assertMountedAppearance(AppearanceThemeMode.System, dark = false)
+  }
+
+  @Test
+  @Config(sdk = [31], qualifiers = "night")
+  fun lightAndSystemAppearancesConfigureWebViewForDarkSystem() {
+    assertMountedAppearance(AppearanceThemeMode.Light, dark = false)
+    assertMountedAppearance(AppearanceThemeMode.System, dark = true)
+  }
+
+  @Test
+  @Config(sdk = [31], qualifiers = "notnight")
+  fun appearanceChangeRecreatesWebViewWithUpdatedTheme() {
+    val controller = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    var mode by mutableStateOf(AppearanceThemeMode.Dark)
+    controller.get().setContent {
+      OpenClawTheme(themeMode = mode) {
+        TestControlUiWebView()
+      }
+    }
+    idleMainLooper()
+    val darkWebView = requireNotNull(findWebView(controller.get().window.decorView))
+    assertWebViewAppearance(darkWebView, dark = true)
+
+    mode = AppearanceThemeMode.Light
+    idleMainLooper()
+    val lightWebView = requireNotNull(findWebView(controller.get().window.decorView))
+    assertNotSame(darkWebView, lightWebView)
+    assertWebViewAppearance(lightWebView, dark = false)
+
+    controller.pause().stop().destroy()
+    idleMainLooper()
+  }
+
   @Test
   fun pinnedSslError_proceedsOnlyForExactCertificateAtGatewayOrigin() {
     val certificate = "accepted gateway certificate".toByteArray()
@@ -53,4 +108,80 @@ class ControlUiWebViewTest {
       .getInstance("SHA-256")
       .digest(bytes)
       .joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+
+  private fun mountControlUiWebView(themeMode: AppearanceThemeMode): MountedControlUiWebView {
+    val controller = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    controller.get().setContent {
+      OpenClawTheme(themeMode = themeMode) {
+        TestControlUiWebView()
+      }
+    }
+    idleMainLooper()
+    return MountedControlUiWebView(
+      controller = controller,
+      webView = requireNotNull(findWebView(controller.get().window.decorView)),
+    )
+  }
+
+  private fun assertMountedAppearance(
+    themeMode: AppearanceThemeMode,
+    dark: Boolean,
+  ) {
+    val mounted = mountControlUiWebView(themeMode)
+    try {
+      assertWebViewAppearance(mounted.webView, dark)
+    } finally {
+      mounted.close()
+    }
+  }
+
+  private fun assertWebViewAppearance(
+    webView: WebView,
+    dark: Boolean,
+  ) {
+    val expectedNightMode = if (dark) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
+    assertEquals(expectedNightMode, webView.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)
+
+    val attributes = webView.context.theme.obtainStyledAttributes(intArrayOf(android.R.attr.isLightTheme))
+    try {
+      assertEquals(!dark, attributes.getBoolean(0, true))
+    } finally {
+      attributes.recycle()
+    }
+  }
+
+  private fun findWebView(view: View): WebView? {
+    if (view is WebView) return view
+    if (view !is ViewGroup) return null
+    for (index in 0 until view.childCount) {
+      findWebView(view.getChildAt(index))?.let { return it }
+    }
+    return null
+  }
+
+  private fun idleMainLooper() = shadowOf(Looper.getMainLooper()).idle()
+
+  private data class MountedControlUiWebView(
+    val controller: org.robolectric.android.controller.ActivityController<ComponentActivity>,
+    val webView: WebView,
+  ) {
+    fun close() {
+      controller.pause().stop().destroy()
+      shadowOf(Looper.getMainLooper()).idle()
+    }
+  }
+}
+
+@androidx.compose.runtime.Composable
+private fun TestControlUiWebView() {
+  ControlUiWebView(
+    page =
+      NodeRuntime.GatewayControlPage(
+        baseUrl = "http://127.0.0.1",
+        token = null,
+        password = null,
+        tlsFingerprintSha256 = null,
+      ),
+    url = "about:blank",
+  )
 }

--- a/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
+++ b/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
@@ -206,6 +206,8 @@ final class AuthenticatedControlUIWebViewCoordinator: NSObject, WKNavigationDele
 
 /// Ephemeral, script-hardened WKWebView for a self-contained Control UI page.
 struct AuthenticatedControlUIWebView: UIViewRepresentable {
+    @Environment(\.colorScheme) private var colorScheme
+
     let url: URL
     let authScript: String?
     let tls: GatewayTLSParams?
@@ -227,6 +229,7 @@ struct AuthenticatedControlUIWebView: UIViewRepresentable {
         }
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
+        self.applyAppearance(to: webView)
         webView.navigationDelegate = context.coordinator
         webView.isOpaque = true
         webView.backgroundColor = .black
@@ -245,8 +248,13 @@ struct AuthenticatedControlUIWebView: UIViewRepresentable {
         return webView
     }
 
-    func updateUIView(_: WKWebView, context _: Context) {
+    func updateUIView(_ webView: WKWebView, context _: Context) {
+        self.applyAppearance(to: webView)
         // Connection changes recreate the view via `.id`; unrelated SwiftUI passes must not reload it.
+    }
+
+    private func applyAppearance(to webView: WKWebView) {
+        webView.overrideUserInterfaceStyle = self.colorScheme == .dark ? .dark : .light
     }
 
     static func dismantleUIView(

--- a/apps/ios/Tests/TerminalHubScreenTests.swift
+++ b/apps/ios/Tests/TerminalHubScreenTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import SwiftUI
 import Testing
+import WebKit
 @testable import OpenClaw
 @testable import OpenClawKit
 
@@ -236,4 +238,59 @@ struct TerminalHubScreenTests {
         #expect(
             TerminalHubScreen.terminalAuthUserScript(config: nil, storedOperatorToken: nil) == nil)
     }
+
+    @Test func `authenticated Control UI follows the resolved app appearance`() async throws {
+        let cases: [(AppAppearancePreference, UIUserInterfaceStyle, UIUserInterfaceStyle)] = [
+            (.dark, .light, .dark),
+            (.light, .dark, .light),
+            (.system, .light, .light),
+            (.system, .dark, .dark),
+        ]
+
+        for (preference, systemStyle, expectedStyle) in cases {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+            window.overrideUserInterfaceStyle = systemStyle
+            window.rootViewController = UIHostingController(rootView: Self.controlUIView(preference: preference))
+            window.makeKeyAndVisible()
+            window.rootViewController?.view.setNeedsLayout()
+            window.rootViewController?.view.layoutIfNeeded()
+
+            let webView = try await Self.webView(in: window)
+            #expect(webView.overrideUserInterfaceStyle == expectedStyle)
+            webView.stopLoading()
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+    }
+
+    private static func controlUIView(preference: AppAppearancePreference) -> AnyView {
+        AnyView(
+            AuthenticatedControlUIWebView(
+                url: URL(fileURLWithPath: "/"),
+                authScript: nil,
+                tls: nil)
+                .preferredColorScheme(preference.colorScheme))
+    }
+
+    private static func webView(in window: UIWindow) async throws -> WKWebView {
+        for _ in 0..<50 {
+            if let webView = self.findWebView(in: window) {
+                return webView
+            }
+            try await Task.sleep(for: .milliseconds(10))
+            window.rootViewController?.view.layoutIfNeeded()
+        }
+        throw ControlUIAppearanceTestError.webViewNotMounted
+    }
+
+    private static func findWebView(in view: UIView) -> WKWebView? {
+        if let webView = view as? WKWebView {
+            return webView
+        }
+        return view.subviews.lazy.compactMap { self.findWebView(in: $0) }.first
+    }
+}
+
+private enum ControlUIAppearanceTestError: Error {
+    case webViewNotMounted
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS and Android users running the app in dark mode would see the embedded
Control UI render in light mode. The Terminal and Desktop screens host the Control UI in a
WebView; the Control UI defaults to `themeMode: "system"`, and inside a native WebView "system"
resolves from the WebView's own colour scheme rather than the host app's Appearance setting. The
result was a bright white terminal or a remote desktop letterboxed in white inside an otherwise
dark app.

## Why This Change Was Made

The fix stays native and keeps the Control UI's existing `system` default authoritative — no new
query parameter, no change to the settings model or the document-start auth contract.

On iOS the shared `AuthenticatedControlUIWebView` reads `@Environment(\.colorScheme)`, which the
app root already drives through `.preferredColorScheme(appearanceModel.preference.colorScheme)`,
and sets `overrideUserInterfaceStyle` on the web view in both `makeUIView` and `updateUIView`, so a
mid-session Appearance change propagates without recreating the view.

On Android the app theme resolves dark/light for Compose only — it never drives
`AppCompatDelegate`, so Android Views (including WebView) disagreed with the Compose UI.
`OpenClawTheme` now publishes the already-resolved boolean as `LocalResolvedAppearanceIsDark`, and
`ControlUiWebView` constructs the WebView from a `ContextThemeWrapper` over a configuration whose
`UI_MODE_NIGHT_*` bit matches. A WebView reads `prefers-color-scheme` from its construction
Context, so an appearance flip has to rebuild it; `key(darkAppearance)` scopes that to real
dark/light changes. The reload is safe because both Control UI surfaces reattach to server-side
state.

Fixed once in the shared WebView host, so Terminal, Desktop, and any future Control UI surface
inherit it.

## User Impact

The embedded Control UI now matches the app's Appearance setting on both platforms, including when
the app follows the system and the user changes the system theme with a screen open.

## Evidence

Live on the Android emulator (`Medium_Phone_API_36.0`), via WebView devtools CDP against the
running Control UI document:

- App dark → `{"prefersDark": true}`
- System light, app dark → `{"prefersDark": true}` (follows the app, not the system)

Before/after screenshots of the Terminal screen are attached below.

- Android: `:app:assemblePlayDebug`, `:app:testPlayDebugUnitTest`, `pnpm android:format`,
  `pnpm android:lint` — all pass. New `ControlUiWebViewTest` covers explicit dark, explicit light,
  and system-driven resolution plus the recreation-on-flip behavior.
- iOS: simulator build plus `TerminalHubScreenTests` additions covering the resolved-appearance
  mapping.
- `apps/.i18n/native-source.json` carries only a line-number shift for an existing entry in
  `ControlUiWebView.kt`; no generated i18n artifacts are committed.
- `$autoreview`: clean, no accepted or actionable findings.

Same emulator, same gateway, same navigation (session Dashboard, which hosts the Control UI in a
WebView) — only the APK differs.

Before (`origin/main`), the Control UI renders light inside the dark app:

![before](https://github.com/user-attachments/assets/9239f9ac-d585-496a-8908-af0c6571522f)

After (this branch):

![after](https://github.com/user-attachments/assets/d1a333ee-6508-4b44-8897-20fc19faf5ce)

Read back from the running WebView over CDP: before `data-theme=light`, `--bg: #faf9f7`; after
`{"theme":"dark","bg":"#0e1015","prefersDark":true}`.
