### PR TITLE
fix(agents): sign the resize log byte delta from its value

### DIFF
--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -3,8 +3,9 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 
-const { infoMock, warnMock } = vi.hoisted(() => ({
+const { infoMock, resizeToJpegMock, warnMock } = vi.hoisted(() => ({
   infoMock: vi.fn(),
+  resizeToJpegMock: vi.fn(),
   warnMock: vi.fn(),
 }));
 
@@ -24,6 +25,16 @@ vi.mock("../logging/subsystem.js", () => {
   return { createSubsystemLogger: () => makeLogger() };
 });
 
+vi.mock("../media/media-services.js", () => ({
+  buildImageResizeSideGrid: () => [2000],
+  getImageMetadata: vi.fn(),
+  IMAGE_REDUCE_QUALITY_STEPS: [85],
+  isImageProcessorUnavailableError: () => false,
+  MAX_IMAGE_INPUT_PIXELS: 25_000_000,
+  readImageMetadataFromHeader: () => ({ width: 2001, height: 8 }),
+  resizeToJpeg: resizeToJpegMock,
+}));
+
 import { sanitizeContentBlocksImages } from "./tool-images.js";
 
 async function createLargePng(): Promise<Buffer> {
@@ -39,6 +50,8 @@ describe("tool-images log context", () => {
 
   beforeEach(() => {
     infoMock.mockClear();
+    resizeToJpegMock.mockReset();
+    resizeToJpegMock.mockResolvedValue(Buffer.alloc(100, 2));
     warnMock.mockClear();
   });
 
@@ -49,5 +62,32 @@ describe("tool-images log context", () => {
     await sanitizeContentBlocksImages(blocks, "read:/tmp/images/sample-diagram.png");
     const messages = infoMock.mock.calls.map((call) => String(call[0] ?? ""));
     expect(messages.join("\n")).toContain("sample-diagram.png");
+  });
+
+  it.each([
+    { sourceBytes: 200, outputBytes: 150, pct: 25, label: "-25%" },
+    { sourceBytes: 200, outputBytes: 200, pct: 0, label: "0%" },
+    { sourceBytes: 200, outputBytes: 250, pct: -25, label: "+25%" },
+    { sourceBytes: 3, outputBytes: 2, pct: 33.3, label: "-33.3%" },
+  ])("logs the signed byte delta for $label", async ({ sourceBytes, outputBytes, pct, label }) => {
+    resizeToJpegMock.mockResolvedValue(Buffer.alloc(outputBytes, 2));
+    const blocks = [
+      {
+        type: "image" as const,
+        data: Buffer.alloc(sourceBytes, 1).toString("base64"),
+        mimeType: "image/png",
+      },
+    ];
+    await sanitizeContentBlocksImages(blocks, "read:/tmp/images/sample-diagram.png");
+    const [message, context] = infoMock.mock.calls.at(-1) ?? [];
+    expect(message).toContain(`sample-diagram.png 2001x8px`);
+    expect(message).toContain(`(${label})`);
+    expect(message).not.toContain("(--");
+    expect(context).toMatchObject({
+      fileName: "sample-diagram.png",
+      sourceBytes,
+      outputBytes,
+      byteReductionPct: pct,
+    });
   });
 });

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -249,7 +249,7 @@ async function resizeImageBase64IfNeeded(params: {
             ? Number((((buf.byteLength - out.byteLength) / buf.byteLength) * 100).toFixed(1))
             : 0;
         log.info(
-          `Image resized to fit limits: ${sourceWithFile} ${formatBytesShort(buf.byteLength)} -> ${formatBytesShort(out.byteLength)} (-${byteReductionPct}%)`,
+          `Image resized to fit limits: ${sourceWithFile} ${formatBytesShort(buf.byteLength)} -> ${formatBytesShort(out.byteLength)} (${byteReductionPct < 0 ? "+" : ""}${-byteReductionPct}%)`,
           {
             label: params.label,
             fileName: params.fileName,


### PR DESCRIPTION
Related: #123273

## What Problem This Solves

Fixes an issue where image re-encoding growth was logged with a doubled minus sign, such as `(--62.5%)`, and an unchanged byte count was logged as `(-0%)`. Those diagnostics made the resize result look mathematically inverted while debugging image failures.

## Why This Change Was Made

The resize pipeline already records a signed `byteReductionPct`. The log now derives its display directly from that value in the existing interpolation: reductions remain negative, zero is unsigned, and growth is positive. Structured metadata and image-processing behavior are unchanged.

## User Impact

Operators now see accurate resize diagnostics: shrink `(-82.9%)`, unchanged `(0%)`, and growth `(+483.9%)`. This is a log-only correction and does not change image output.

## Evidence

- Clean current-main red proof: the deterministic production-path table passed shrink and rounding but failed zero (`(-0%)`) and growth (`(--25%)`).
- Rewritten exact-head green proof:
  - `node scripts/run-vitest.mjs src/agents/tool-images.log.test.ts src/agents/tool-images.test.ts`
  - 16 tests passed across the focused sanitizer suites.
- The table covers shrink, zero, growth, decimal rounding, filename context, structured `byteReductionPct`, and the absence of `(--)`, using an explicit media-service mock without `importOriginal`.
- Real production resize pipeline, real PNG/JPEG processing:

```text
Image resized to fit limits: shrink-sample.png 600x600px 1.03MB -> 180.6KB (-82.9%)
Image resized to fit limits: growth-sample.png 2001x8px 149B -> 870B (+483.9%)
```

- `pnpm format` and changed-file oxlint passed.
- `autoreview --mode local`: clean, no accepted/actionable findings.
- `check-changed` passed the touched core production typecheck, formatting, lint, dead-export, boundary, dependency, and repository guard lanes. The aggregate local run stopped on an unrelated current-main UI test type error at `ui/src/pages/chat/route-loader.ts:712`; exact-head hosted CI remains the merge authority.
- Blacksmith Testbox was attempted twice; both fresh leases were shut down by the service before command execution.

Production delta: `+1/-1` (net zero). Test delta: `+41/-1`.

Punchcard-Session: brisk-cedar-valley-dv
