### PR TITLE
fix(agents): scope embedded prompt media roots to the owning agent

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -5,7 +5,9 @@
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ImageContent } from "../../../llm/types.js";
+import { getAgentScopedMediaLocalRoots } from "../../../media/local-roots.js";
 import { readPersistedMediaFacts } from "../../../media/media-facts.js";
+import { parseAgentSessionKey } from "../../../routing/session-key.js";
 import type { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import type { AgentMessage } from "../../runtime/index.js";
@@ -290,6 +292,7 @@ export async function handleEmbeddedAttemptPromptError(input: {
 /** Prepares prompt-lock ownership and prompt-local images for submission. */
 type PromptExecutionAttempt = Pick<
   EmbeddedRunAttemptParams,
+  | "agentId"
   | "config"
   | "imageOrder"
   | "images"
@@ -337,6 +340,14 @@ export async function prepareEmbeddedAttemptPromptExecution(input: {
     (await attempt.userTurnTranscriptRecorder?.resolveMessage());
   const persistedMedia = persistedMessage ? (readPersistedMediaFacts(persistedMessage) ?? []) : [];
 
+  // Mirror the CLI runner (cli-runner/execute.ts): scope media roots to the
+  // owning agent so named-agent `workspace-<id>` staging hydrates when
+  // workspaceOnly is off, while sibling agent workspaces stay rejected.
+  // workspaceOnly keeps its stricter workspace-dir-only fallback in images.ts.
+  const mediaOwnerAgentId = parseAgentSessionKey(attempt.sessionKey)?.agentId || attempt.agentId;
+  const agentScopedLocalRoots = input.effectiveFsWorkspaceOnly
+    ? undefined
+    : getAgentScopedMediaLocalRoots(attempt.config ?? {}, mediaOwnerAgentId);
   const result = await detectAndLoadPromptImages({
     prompt: input.prompt,
     workspaceDir: input.effectiveWorkspace,
@@ -350,6 +361,7 @@ export async function prepareEmbeddedAttemptPromptExecution(input: {
     maxBytes: MAX_IMAGE_BYTES,
     maxDimensionPx: resolveImageSanitizationLimits(attempt.config).maxDimensionPx,
     workspaceOnly: input.effectiveFsWorkspaceOnly,
+    localRoots: agentScopedLocalRoots,
     sandbox:
       input.sandbox?.enabled && input.sandbox.fsBridge
         ? { root: input.sandbox.workspaceDir, bridge: input.sandbox.fsBridge }

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
@@ -220,6 +220,73 @@ describe("plugin harness prompt media", () => {
     }
   });
 
+  it("hydrates a named agent's workspace staging without widening sibling access", async () => {
+    // Regression for the embedded sibling of #122684 (#123273): without
+    // agent-scoped roots, workspaceOnly=false fell back to default roots and
+    // rejected named-agent workspace-<id> staging paths.
+    const stateDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-harness-agent-media-")),
+    );
+    const workspaceDir = path.join(stateDir, "workspace-arthur");
+    const siblingWorkspaceDir = path.join(stateDir, "workspace-merlin");
+    const imagePath = path.join(workspaceDir, "media", "inbound", "photo.png");
+    const siblingImagePath = path.join(siblingWorkspaceDir, "media", "inbound", "photo.png");
+    const image = Buffer.from(TINY_PNG_BASE64, "base64");
+    await fs.mkdir(path.dirname(imagePath), { recursive: true });
+    await fs.mkdir(path.dirname(siblingImagePath), { recursive: true });
+    await fs.writeFile(imagePath, image);
+    await fs.writeFile(siblingImagePath, image);
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const config = {
+      agents: {
+        defaults: { sandbox: { mode: "off" } },
+        entries: {
+          arthur: { default: true, workspace: workspaceDir },
+          merlin: { workspace: siblingWorkspaceDir },
+        },
+      },
+    };
+
+    try {
+      const result = await preparePluginHarnessPromptImages({
+        runParams: {
+          agentId: "arthur",
+          config,
+          media: [{ path: imagePath, contentType: "image/png" }],
+          sessionId: "session-agent-media",
+        },
+        runtime: {
+          model: { input: ["text", "image"] },
+          sessionId: "session-agent-media",
+          workspaceDir,
+        },
+        pluginHarnessOwnsTransport: true,
+      } as unknown as Parameters<typeof preparePluginHarnessPromptImages>[0]);
+      expect(result.images ?? []).toHaveLength(1);
+
+      await expect(
+        preparePluginHarnessPromptImages({
+          runParams: {
+            agentId: "arthur",
+            config,
+            media: [{ path: siblingImagePath, contentType: "image/png" }],
+            sessionId: "session-agent-media",
+          },
+          runtime: {
+            model: { input: ["text", "image"] },
+            sessionId: "session-agent-media",
+            workspaceDir,
+          },
+          pluginHarnessOwnsTransport: true,
+        } as unknown as Parameters<typeof preparePluginHarnessPromptImages>[0]),
+      ).rejects.toThrow("failed to hydrate 1 structured image attachment");
+    } finally {
+      envSnapshot.restore();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("delivers readable images when an unresolved attachment is hydration-suppressed", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-harness-mixed-media-"));
     const imagePath = path.join(workspaceDir, "present.png");


### PR DESCRIPTION
## What Problem This Solves

#122684 fixed named-agent image hydration for the CLI runner by passing agent-scoped media roots, but the embedded/plugin-harness sibling path (`prepareEmbeddedAttemptPromptExecution`) never got the same treatment. There, `detectAndLoadPromptImages` falls back to `workspaceOnly ? [workspaceDir] : undefined` — so with `tools.fs.workspaceOnly: false`, a named agent's `workspace-<id>` staging path is validated against the default roots (which only allow the literal `workspace` dir) and hydration throws `failed to hydrate N structured image attachment(s)`. This is the residual path behind #123273's "workspaceOnly=false does NOT help" observation: on the embedded path, disabling workspaceOnly is the only thing that *could* break it.

## Why This Change Was Made

One-sided fix completion: the CLI runner (`src/agents/cli-runner/execute.ts:178`) and the embedded runner share the hydration invariant, but only one got the agent-scoped roots. This mirrors the exact same owner resolution (session-key owner first, then explicit `agentId`) and keeps the boundary tight — `getAgentScopedMediaLocalRoots` adds only the *active* agent's workspace; sibling `workspace-*` dirs stay rejected by `local-media-access.ts`. The strict `workspaceOnly: true` fallback (`[workspaceDir]` only) is deliberately left untouched so this change never widens that mode.

## User Impact

Named (non-default) agents on the embedded/plugin-harness path can now receive image attachments when `workspaceOnly` is off, instead of dying with a hydration error before the reply. No access widening: the sibling-workspace rejection is asserted in the new test.

## Evidence

- New regression test in `src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts`: named agent `arthur` staging under `workspace-arthur` hydrates (fails with exactly the reported error before this patch — verified red-first), and sibling `workspace-merlin` still throws.
- Guard suites green: `run-attempt-dispatch.media.test.ts`, `cli-runner.helpers.test.ts` (the #122684 canonical pair), `local-media-access.test.ts` — `node scripts/run-vitest.mjs`, 3 shards passed.
- `pnpm format` + `scripts/run-oxlint.mjs` clean on touched files. `check:changed` Crabbox delegation unavailable locally; typecheck lanes covered by PR CI.

- **Real behavior proof** (from the #123273 reporter, [comment](https://github.com/openclaw/openclaw/pull/123413#issuecomment-5293833933)): deterministic live failure on `2026.7.2-beta.7` (named-agent Telegram images fail 6/6 over a week with the exact hydration error; debug log shows the named agent's staged path rejected by default roots), standalone repro against unpatched dist returns `failed: 1`, and an equivalent patch has been running in production on two independent hosts (Ubuntu/Node 22 + macOS) since 2026-08-13: repro flips to `loaded: 1`, live named-agent images work with zero failures, default-agent behavior unchanged, and sibling-workspace denial preserved.

Related: #123273, #122616, #122684.

