### PR TITLE
fix(plugins): preserve bundled provider compat across allowlists

### DIFF
--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -19,6 +19,7 @@ import type {
   StartupMigrationLease,
 } from "../infra/startup-migration-checkpoint.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -605,6 +606,19 @@ export async function runDoctorConfigPreflight(
       ) {
         throwStartupMigrationGuardRejected();
       }
+      refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
+    }
+    if (
+      migrationCheckpoint &&
+      shouldPersistRefreshedPluginIndex &&
+      configSnapshotRead.pluginMetadataSnapshot?.policyHash !==
+        resolveInstalledPluginIndexPolicyHash(baseConfig, startupMigrationEnv)
+    ) {
+      // State migration can change activation policy after the initial index was derived.
+      // Persist only a generation that describes the post-migration policy.
+      configSnapshotRead = await readConfigSnapshotForPreflight(false);
+      snapshot = configSnapshotRead.snapshot;
+      baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
       refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
     }
     if (

--- a/src/infra/state-migrations.config-machine-state.ts
+++ b/src/infra/state-migrations.config-machine-state.ts
@@ -2,6 +2,7 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { compareOpenClawVersions } from "../config/version.js";
+import { clearBundledDiscoveryModeMemo } from "../plugins/bundled-discovery-state.js";
 import {
   importConfigMachineState,
   readConfigMachineState,
@@ -64,6 +65,11 @@ export function migrateLegacyConfigMachineState(params: {
     return { changes: [], warnings: [] };
   }
   const result = importConfigMachineState(entries, { env: params.env });
+  if (entries.some(([key]) => key === "plugins.bundledDiscovery")) {
+    // Same-process readers must not keep the pre-migration absent mode cached,
+    // or doctor rebuilds plugin indexes against stale strict-gate decisions.
+    clearBundledDiscoveryModeMemo();
+  }
   const changes = result.imported.map((key) => `Migrated ${key} → shared SQLite state`);
   changes.push(...result.kept.map((key) => `Kept existing shared SQLite ${key} state`));
   if (installs && hasInstalls) {

--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -29,7 +29,6 @@ vi.mock("./bundled-compat.js", () => ({
 
 import {
   resolveBundledCompatActivationInputs,
-  resolvePluginActivationInputs,
   withActivatedPluginIds,
 } from "./activation-context.js";
 
@@ -82,10 +81,11 @@ describe("plugin activation inputs", () => {
       },
     );
 
-    resolvePluginActivationInputs({
+    resolveBundledCompatActivationInputs({
       rawConfig: { plugins: { allow: ["openai"] } },
       workspaceDir,
       applyAutoEnable: true,
+      resolveBundledPluginIds: () => [],
     });
 
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith({
@@ -109,11 +109,12 @@ describe("plugin activation inputs", () => {
       [firstManifestRegistry, firstDiscovery],
       [secondManifestRegistry, secondDiscovery],
     ] as const) {
-      resolvePluginActivationInputs({
+      resolveBundledCompatActivationInputs({
         rawConfig: { plugins: { allow: [manifestRegistry.plugins[0]!.id] } },
         manifestRegistry,
         discovery,
         applyAutoEnable: true,
+        resolveBundledPluginIds: () => [],
       });
     }
 
@@ -169,6 +170,7 @@ describe("plugin activation inputs", () => {
     expect(withBundledPluginEnablementCompatMock).toHaveBeenCalledWith({
       config: autoEnabledConfig,
       pluginIds: ["anthropic"],
+      env: process.env,
     });
     expect(activation.config).toBe(compatConfig);
     expect(activation.normalized.entries.anthropic?.enabled).toBe(true);

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -33,12 +33,14 @@ type PluginActivationParams = {
 };
 
 type BundledCompatActivationParams = PluginActivationParams & {
+  activation?: "defaults" | "selected";
   onlyPluginIds?: readonly string[];
   resolveBundledPluginIds: (params: {
     config?: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
     onlyPluginIds?: readonly string[];
+    manifestRegistry?: PluginManifestRegistry;
   }) => string[];
 };
 
@@ -123,9 +125,7 @@ function applyPluginAutoEnableForActivation(params: {
   });
 }
 
-export function resolvePluginActivationInputs(
-  params: PluginActivationParams,
-): PluginActivationInputs {
+function resolvePluginActivationInputs(params: PluginActivationParams): PluginActivationInputs {
   const env = params.env ?? process.env;
   const rawConfig = params.rawConfig ?? params.resolvedConfig;
   let resolvedConfig = params.resolvedConfig ?? params.rawConfig;
@@ -174,10 +174,13 @@ export function resolveBundledCompatActivationInputs(
     workspaceDir: params.workspaceDir,
     env,
     onlyPluginIds: params.onlyPluginIds,
+    ...(params.manifestRegistry ? { manifestRegistry: params.manifestRegistry } : {}),
   });
   const config = withBundledPluginEnablementCompat({
     config: snapshot.config,
     pluginIds: bundledPluginIds,
+    env,
+    ...(params.activation ? { activation: params.activation } : {}),
   });
 
   return {

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -52,6 +52,7 @@ export function loadBundledCapabilityRuntimeRegistry(
       : (withBundledPluginEnablementCompat({
           config: params.config,
           pluginIds: params.pluginIds,
+          env,
         }) ?? {});
   const snapshot =
     !params.discovery && !params.installRecords ? getGatewayPluginMetadataSnapshot() : undefined;

--- a/src/plugins/bundled-compat.test.ts
+++ b/src/plugins/bundled-compat.test.ts
@@ -3,25 +3,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 
-const readBundledDiscoveryMode = vi.hoisted(() => vi.fn<() => "compat" | "allowlist">());
+const readBundledDiscoveryModeMemoized = vi.hoisted(() => vi.fn<() => "compat" | "allowlist">());
 
-vi.mock("./bundled-discovery-state.js", () => ({ readBundledDiscoveryMode }));
+vi.mock("./bundled-discovery-state.js", () => ({ readBundledDiscoveryModeMemoized }));
 
 describe("withBundledPluginEnablementCompat", () => {
   beforeEach(() => {
-    readBundledDiscoveryMode.mockClear();
-    readBundledDiscoveryMode.mockReturnValue("allowlist");
+    readBundledDiscoveryModeMemoized.mockClear();
+    readBundledDiscoveryModeMemoized.mockReturnValue("allowlist");
   });
 
   it("returns unchanged config for an empty plugin list without reading upgrade state", () => {
     const config = { plugins: { allow: ["openai"] } } satisfies OpenClawConfig;
 
     expect(withBundledPluginEnablementCompat({ config, pluginIds: [] })).toBe(config);
-    expect(readBundledDiscoveryMode).not.toHaveBeenCalled();
+    expect(readBundledDiscoveryModeMemoized).not.toHaveBeenCalled();
   });
 
   it("honors bundledDiscovery compat before plugin allowlists", () => {
-    readBundledDiscoveryMode.mockReturnValue("compat");
+    readBundledDiscoveryModeMemoized.mockReturnValue("compat");
     const config = {
       plugins: {
         allow: ["discord"],
@@ -58,7 +58,7 @@ describe("withBundledPluginEnablementCompat", () => {
   });
 
   it("adds compat allow entries for plugins that already have entries", () => {
-    readBundledDiscoveryMode.mockReturnValue("compat");
+    readBundledDiscoveryModeMemoized.mockReturnValue("compat");
     const config = {
       plugins: {
         allow: ["openai"],

--- a/src/plugins/bundled-compat.ts
+++ b/src/plugins/bundled-compat.ts
@@ -1,21 +1,24 @@
 /** Compatibility helper that auto-enables bundled plugins for legacy flows. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginEntryConfig } from "../config/types.plugins.js";
-import { readBundledDiscoveryMode } from "./bundled-discovery-state.js";
+import { readBundledDiscoveryModeMemoized } from "./bundled-discovery-state.js";
 import { normalizePluginId } from "./config-state.js";
 
 /** Returns config with selected bundled plugins explicitly enabled when compat rules require it. */
 export function withBundledPluginEnablementCompat(params: {
   config: OpenClawConfig | undefined;
   pluginIds: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  activation?: "defaults" | "selected";
 }): OpenClawConfig | undefined {
   if (params.pluginIds.length === 0) {
     return params.config;
   }
   const existingEntries = params.config?.plugins?.entries ?? {};
-  const forcePluginsEnabled = params.config?.plugins?.enabled === false;
+  const selectPlugins = params.activation !== "defaults";
+  const forcePluginsEnabled = selectPlugins && params.config?.plugins?.enabled === false;
   const allow = params.config?.plugins?.allow;
-  const bypassAllowlist = readBundledDiscoveryMode() === "compat";
+  const bypassAllowlist = readBundledDiscoveryModeMemoized(params.env) === "compat";
   const allowSet =
     !bypassAllowlist && Array.isArray(allow) && allow.length > 0
       ? new Set(allow.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean))
@@ -35,7 +38,7 @@ export function withBundledPluginEnablementCompat(params: {
     if (nextAllow && nextAllow.size !== beforeAllowSize) {
       changed = true;
     }
-    if (existingEntries[pluginId] !== undefined) {
+    if (!selectPlugins || existingEntries[pluginId] !== undefined) {
       continue;
     }
     nextEntries[pluginId] = { enabled: true };
@@ -54,7 +57,7 @@ export function withBundledPluginEnablementCompat(params: {
       ...params.config?.plugins,
       ...(forcePluginsEnabled ? { enabled: true } : {}),
       ...(nextAllow ? { allow: [...nextAllow] } : {}),
-      entries: nextEntries,
+      ...(selectPlugins ? { entries: nextEntries } : {}),
     },
   };
 }

--- a/src/plugins/bundled-discovery-state.test.ts
+++ b/src/plugins/bundled-discovery-state.test.ts
@@ -1,60 +1,100 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolvePluginInstallRoots, withPluginInstallRoots } from "./install-root-context.js";
+// Covers memoized bundled-discovery mode reads across machine-state writes.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  clearBundledDiscoveryModeMemo,
+  readBundledDiscoveryModeMemoized,
+} from "./bundled-discovery-state.js";
+import { removeBundledDiscoveryStateRoot } from "./bundled-discovery.test-support.js";
 
-const mocks = vi.hoisted(() => ({
-  readConfigMachineState: vi.fn(),
-}));
-
-vi.mock("../state/config-machine-state.js", () => ({
-  readConfigMachineState: mocks.readConfigMachineState,
-}));
-
-const { readBundledDiscoveryMode } = await import("./bundled-discovery-state.js");
-
-describe("bundled discovery state", () => {
-  beforeEach(() => {
-    mocks.readConfigMachineState.mockReset();
+describe("readBundledDiscoveryModeMemoized", () => {
+  afterEach(() => {
+    clearBundledDiscoveryModeMemo();
   });
 
-  it("reads machine state from the active plugin registry state directory", async () => {
-    const sourceEnv = { OPENCLAW_STATE_DIR: "/operator/openclaw" };
-    const isolatedRoots = {
-      ...resolvePluginInstallRoots(sourceEnv),
-      stateDir: "/tmp/private-plugin-state",
-    };
-    mocks.readConfigMachineState.mockReturnValue("allowlist");
-
-    await withPluginInstallRoots(isolatedRoots, async () => {
-      expect(readBundledDiscoveryMode({ env: sourceEnv })).toBe("allowlist");
-    });
-
-    expect(mocks.readConfigMachineState).toHaveBeenCalledWith("plugins.bundledDiscovery", {
-      env: {
-        OPENCLAW_STATE_DIR: "/tmp/private-plugin-state",
-      },
-    });
+  it("observes a machine-state write after the memo is cleared", async () => {
+    const stateDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-discovery-")),
+    );
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    try {
+      clearBundledDiscoveryModeMemo();
+      // Pre-migration read caches the absent mode.
+      expect(readBundledDiscoveryModeMemoized()).toBeUndefined();
+      writeConfigMachineState("plugins.bundledDiscovery", "compat");
+      // Regression for the doctor same-process staleness: the memo must not
+      // outlive the write, or index rebuilds keep strict-gate decisions.
+      expect(readBundledDiscoveryModeMemoized()).toBeUndefined();
+      clearBundledDiscoveryModeMemo();
+      expect(readBundledDiscoveryModeMemoized()).toBe("compat");
+    } finally {
+      envSnapshot.restore();
+      await removeBundledDiscoveryStateRoot(stateDir);
+    }
   });
 
-  it("preserves explicit database path ownership", async () => {
-    const sourceEnv = { OPENCLAW_STATE_DIR: "/operator/openclaw" };
-    const isolatedRoots = {
-      ...resolvePluginInstallRoots(sourceEnv),
-      stateDir: "/tmp/private-plugin-state",
-    };
-    mocks.readConfigMachineState.mockReturnValue("compat");
+  it("does not leak one state root's cached mode into an interleaved scope", async () => {
+    // The memo is keyed by the resolved state-database path: isolated scopes
+    // (agent execution, doctor lint) alternating in one process must each see
+    // their own root's mode without explicit clears.
+    const compatRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bd-compat-")),
+    );
+    const plainRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bd-plain-")),
+    );
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    try {
+      setTestEnvValue("OPENCLAW_STATE_DIR", compatRoot);
+      writeConfigMachineState("plugins.bundledDiscovery", "compat");
+      clearBundledDiscoveryModeMemo();
+      expect(readBundledDiscoveryModeMemoized()).toBe("compat");
 
-    await withPluginInstallRoots(isolatedRoots, async () => {
-      expect(
-        readBundledDiscoveryMode({
-          env: sourceEnv,
-          path: "/explicit/openclaw.sqlite",
-        }),
-      ).toBe("compat");
-    });
+      setTestEnvValue("OPENCLAW_STATE_DIR", plainRoot);
+      expect(readBundledDiscoveryModeMemoized()).toBeUndefined();
 
-    expect(mocks.readConfigMachineState).toHaveBeenCalledWith("plugins.bundledDiscovery", {
-      env: sourceEnv,
-      path: "/explicit/openclaw.sqlite",
-    });
+      setTestEnvValue("OPENCLAW_STATE_DIR", compatRoot);
+      expect(readBundledDiscoveryModeMemoized()).toBe("compat");
+    } finally {
+      envSnapshot.restore();
+      await removeBundledDiscoveryStateRoot(compatRoot);
+      await removeBundledDiscoveryStateRoot(plainRoot);
+    }
+  });
+
+  it("honors a caller-supplied env's state root over the process root", async () => {
+    // Two-root regression (#123416 review): provider and manifest-contract
+    // registry loads pass an explicit env; compat recorded in that env's root
+    // must be readable even when the process root has no mode, and the
+    // process-root read must stay strict.
+    const compatRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bd-caller-")),
+    );
+    const plainRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bd-process-")),
+    );
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    try {
+      setTestEnvValue("OPENCLAW_STATE_DIR", compatRoot);
+      writeConfigMachineState("plugins.bundledDiscovery", "compat");
+      // Process root has no recorded mode.
+      setTestEnvValue("OPENCLAW_STATE_DIR", plainRoot);
+      clearBundledDiscoveryModeMemo();
+
+      const callerEnv = { ...process.env, OPENCLAW_STATE_DIR: compatRoot };
+      expect(readBundledDiscoveryModeMemoized(callerEnv)).toBe("compat");
+      expect(readBundledDiscoveryModeMemoized()).toBeUndefined();
+      // Alternating scopes stay correct: the memo re-keys per resolved root.
+      expect(readBundledDiscoveryModeMemoized(callerEnv)).toBe("compat");
+    } finally {
+      envSnapshot.restore();
+      await removeBundledDiscoveryStateRoot(compatRoot);
+      await removeBundledDiscoveryStateRoot(plainRoot);
+    }
   });
 });

--- a/src/plugins/bundled-discovery-state.ts
+++ b/src/plugins/bundled-discovery-state.ts
@@ -1,10 +1,12 @@
 // Bundled-discovery compatibility is machine-owned upgrade state.
 import { readConfigMachineState } from "../state/config-machine-state.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
   hasActivePluginInstallRoots,
   resolveActivePluginInstallRoots,
 } from "./install-root-context.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 
 export function readBundledDiscoveryMode(
   options: OpenClawStateDatabaseOptions = {},
@@ -21,4 +23,51 @@ export function readBundledDiscoveryMode(
         };
   const value = readConfigMachineState<unknown>("plugins.bundledDiscovery", resolvedOptions);
   return value === "compat" || value === "allowlist" ? value : undefined;
+}
+
+// Single-slot process memo keyed by the resolved state-database path: the mode
+// is machine-owned upgrade state that only changes through doctor/restart, and
+// per-plugin activation must not open SQLite once per decision. The key keeps
+// interleaved isolated scopes (agent execution, doctor lint) from inheriting
+// another root's cached mode; the reads honor the active install-root context.
+let memoizedBundledDiscoveryMode:
+  | { key: string; value: "compat" | "allowlist" | undefined }
+  | undefined;
+
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  memoizedBundledDiscoveryMode = undefined;
+});
+
+function resolveBundledDiscoveryMemoKey(env: NodeJS.ProcessEnv): string {
+  const scopedEnv = hasActivePluginInstallRoots()
+    ? { ...env, OPENCLAW_STATE_DIR: resolveActivePluginInstallRoots(env).stateDir }
+    : env;
+  return resolveOpenClawStateSqlitePath(scopedEnv);
+}
+
+/**
+ * Callers loading a registry with an explicit env pass it so the mode comes
+ * from that env's state root; omitting it reads the process root. Pinned
+ * install roots win over both, matching readBundledDiscoveryMode.
+ */
+export function readBundledDiscoveryModeMemoized(
+  env: NodeJS.ProcessEnv = process.env,
+): "compat" | "allowlist" | undefined {
+  const key = resolveBundledDiscoveryMemoKey(env);
+  if (memoizedBundledDiscoveryMode?.key !== key) {
+    memoizedBundledDiscoveryMode = {
+      key,
+      value: readBundledDiscoveryMode(env === process.env ? {} : { env }),
+    };
+  }
+  return memoizedBundledDiscoveryMode.value;
+}
+
+/**
+ * Clears the memo after a machine-state write so same-process readers observe
+ * the new mode. Without this, doctor's migration could cache the pre-migration
+ * absent mode and rebuild plugin indexes against stale strict-gate decisions.
+ */
+export function clearBundledDiscoveryModeMemo(): void {
+  memoizedBundledDiscoveryMode = undefined;
 }

--- a/src/plugins/bundled-discovery.test-support.ts
+++ b/src/plugins/bundled-discovery.test-support.ts
@@ -1,0 +1,16 @@
+// Shared cleanup for bundled-discovery real-state test roots.
+import fs from "node:fs/promises";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db-cache.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+
+/**
+ * Removes a temporary OPENCLAW_STATE_DIR root after closing its cached SQLite
+ * handle. The plugins Vitest project runs isolate:false, so an open handle
+ * would leak into later files, and Windows cannot delete open database files.
+ */
+export async function removeBundledDiscoveryStateRoot(stateDir: string): Promise<void> {
+  closeOpenClawStateDatabaseByPath(
+    resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv),
+  );
+  await fs.rm(stateDir, { recursive: true, force: true });
+}

--- a/src/plugins/bundled-provider-compat.ts
+++ b/src/plugins/bundled-provider-compat.ts
@@ -1,0 +1,42 @@
+import type { PluginManifestContractListKey } from "./manifest-registry.js";
+
+const BUNDLED_PROVIDER_COMPAT_CONTRACT_KEYS = [
+  "speechProviders",
+  "externalAuthProviders",
+  "embeddingProviders",
+  "mediaUnderstandingProviders",
+  "transcriptSourceProviders",
+  "realtimeVoiceProviders",
+  "realtimeTranscriptionProviders",
+  "imageGenerationProviders",
+  "videoGenerationProviders",
+  "musicGenerationProviders",
+  "webFetchProviders",
+  "webSearchProviders",
+  "workerProviders",
+  "usageProviders",
+  "migrationProviders",
+] as const satisfies readonly PluginManifestContractListKey[];
+const BUNDLED_PROVIDER_COMPAT_CONTRACTS: ReadonlySet<PluginManifestContractListKey> = new Set(
+  BUNDLED_PROVIDER_COMPAT_CONTRACT_KEYS,
+);
+
+type BundledProviderCompatPlugin = {
+  origin: string;
+  providers?: readonly unknown[];
+  contracts?: Partial<Record<PluginManifestContractListKey, readonly unknown[]>>;
+};
+
+export function isBundledProviderCompatContract(contract: PluginManifestContractListKey): boolean {
+  return BUNDLED_PROVIDER_COMPAT_CONTRACTS.has(contract);
+}
+
+export function isBundledProviderCompatPlugin(plugin: BundledProviderCompatPlugin): boolean {
+  return (
+    plugin.origin === "bundled" &&
+    ((plugin.providers?.length ?? 0) > 0 ||
+      BUNDLED_PROVIDER_COMPAT_CONTRACT_KEYS.some(
+        (contract) => (plugin.contracts?.[contract]?.length ?? 0) > 0,
+      ))
+  );
+}

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -1,8 +1,43 @@
 /** Exercises runtime capability-provider loading from manifest-backed plugin contracts. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { createEmptyPluginRegistry } from "./registry.js";
+
+// Real machine state instead of a module mock: the plugins project runs every
+// file in one shared worker (isolate=false), so a mocked bundled-discovery
+// module here and the real module in sibling suites would shadow each other
+// depending on file order.
+let discoveryCompatRoot: string | undefined;
+let discoveryEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
+function setBundledDiscoveryCompat(): void {
+  if (!discoveryCompatRoot) {
+    discoveryCompatRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-capability-compat-")),
+    );
+    const seedSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", discoveryCompatRoot);
+    try {
+      writeConfigMachineState("plugins.bundledDiscovery", "compat");
+    } finally {
+      seedSnapshot.restore();
+    }
+  }
+  discoveryEnvSnapshot ??= captureEnv(["OPENCLAW_STATE_DIR"]);
+  setTestEnvValue("OPENCLAW_STATE_DIR", discoveryCompatRoot);
+  clearBundledDiscoveryModeMemo();
+}
+function restoreBundledDiscoveryState(): void {
+  discoveryEnvSnapshot?.restore();
+  discoveryEnvSnapshot = undefined;
+  clearBundledDiscoveryModeMemo();
+}
 
 type MockManifestRegistry = {
   plugins: Array<Record<string, unknown>>;
@@ -41,11 +76,6 @@ const mocks = vi.hoisted(() => ({
     plugins: [],
   })),
   withBundledPluginEnablementCompat: vi.fn(({ config }) => config),
-  readBundledDiscoveryMode: vi.fn<() => "compat" | "allowlist" | undefined>(() => "allowlist"),
-}));
-
-vi.mock("./bundled-discovery-state.js", () => ({
-  readBundledDiscoveryMode: mocks.readBundledDiscoveryMode,
 }));
 
 vi.mock("./loader.js", () => ({
@@ -293,7 +323,7 @@ function expectBundledCompatLoadPath(params: {
 }
 
 function createCompatChainConfig() {
-  mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+  setBundledDiscoveryCompat();
   const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
   const enablementCompat = {
     plugins: {
@@ -382,12 +412,14 @@ describe("resolvePluginCapabilityProviders", () => {
     mocks.loadBundledCapabilityRuntimeRegistry.mockImplementation(() => mocks.createMockRegistry());
     mocks.withBundledPluginEnablementCompat.mockReset();
     mocks.withBundledPluginEnablementCompat.mockImplementation(({ config }) => config);
-    mocks.readBundledDiscoveryMode.mockReset();
-    mocks.readBundledDiscoveryMode.mockReturnValue("allowlist");
+    restoreBundledDiscoveryState();
   });
 
   afterEach(() => {
     clearPluginMetadataLifecycleCaches();
+    // isolate:false shared worker: the compat state root must not outlive
+    // this file's last test into sibling suites.
+    restoreBundledDiscoveryState();
   });
 
   it("resolves bundled capability plugins from the current metadata snapshot", () => {
@@ -576,7 +608,7 @@ describe("resolvePluginCapabilityProviders", () => {
   });
 
   it("preserves restrictive-allowlist compatibility only for known bundled active owners", () => {
-    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+    setBundledDiscoveryCompat();
     const active = createEmptyPluginRegistry();
     active.plugins.push({ id: "bundled-owner", origin: "bundled" } as never);
     addSpeechProvider(active, "bundled-provider", { pluginId: "bundled-owner" });
@@ -603,7 +635,6 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(resolvePluginCapabilityProviders({ key: "speechProviders", cfg })).toEqual([
       expect.objectContaining({ id: "bundled-provider" }),
     ]);
-    expect(mocks.readBundledDiscoveryMode).toHaveBeenCalledTimes(1);
   });
 
   it.each([{ entries: { blocked: { enabled: false } } }, { deny: ["blocked"] }])(
@@ -1707,7 +1738,7 @@ describe("resolvePluginCapabilityProviders", () => {
   });
 
   it("loads fallback snapshots without startup dependency repair", () => {
-    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+    setBundledDiscoveryCompat();
     const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
     const enablementCompat = {
       plugins: {
@@ -1872,7 +1903,7 @@ describe("resolvePluginCapabilityProviders", () => {
   });
 
   it("loads only the bundled owner plugin for a targeted provider lookup", () => {
-    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+    setBundledDiscoveryCompat();
     const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
     const enablementCompat = {
       plugins: {

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -2,11 +2,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
+import { removeBundledDiscoveryStateRoot } from "./bundled-discovery.test-support.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 
@@ -420,6 +421,15 @@ describe("resolvePluginCapabilityProviders", () => {
     // isolate:false shared worker: the compat state root must not outlive
     // this file's last test into sibling suites.
     restoreBundledDiscoveryState();
+  });
+
+  afterAll(async () => {
+    restoreBundledDiscoveryState();
+    if (discoveryCompatRoot) {
+      const stateRoot = discoveryCompatRoot;
+      discoveryCompatRoot = undefined;
+      await removeBundledDiscoveryStateRoot(stateRoot);
+    }
   });
 
   it("resolves bundled capability plugins from the current metadata snapshot", () => {

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "./active-runtime-registry.js";
 import { loadBundledCapabilityRuntimeRegistry } from "./bundled-capability-runtime.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
+import { isBundledProviderCompatContract } from "./bundled-provider-compat.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveRuntimePluginRegistry, type PluginLoadOptions } from "./loader.js";
 import {
@@ -97,6 +98,7 @@ function resolveCapabilityPluginIds(params: {
         // Legacy TTS remains available when the operator disables plugins globally.
         allowRestrictiveAllowlistBypass:
           params.key === "speechProviders" && params.cfg?.plugins?.enabled === false,
+        allowBundledProviderCompat: isBundledProviderCompatContract(params.key),
       }),
   );
   return {
@@ -118,6 +120,7 @@ function createCapabilityProviderLoadOptions(params: {
   const config = withBundledPluginEnablementCompat({
     config: params.cfg,
     pluginIds,
+    ...(params.loadContext?.env ? { env: params.loadContext.env } : {}),
   });
   const overrides: PluginLoadOptions = {
     ...(config === undefined ? {} : { config }),
@@ -419,6 +422,7 @@ function filterPolicyAllowedCapabilityProviders<K extends CapabilityProviderRegi
       config: params.cfg,
       allowRestrictiveAllowlistBypass:
         params.key === "speechProviders" && params.cfg?.plugins?.enabled === false,
+      allowBundledProviderCompat: isBundledProviderCompatContract(params.key),
     });
   }) as PluginRegistry[K];
 }

--- a/src/plugins/cli-root-descriptors.ts
+++ b/src/plugins/cli-root-descriptors.ts
@@ -42,7 +42,7 @@ export async function getPluginCliCommandDescriptors(
         continue;
       }
       seenPluginIds.add(plugin.id);
-      if (!isInstalledPluginEnabled(snapshot.index, plugin.id, context.config)) {
+      if (!isInstalledPluginEnabled(snapshot.index, plugin.id, context.config, context.env)) {
         continue;
       }
       const pluginConfig = normalizedConfig.entries[normalizePluginPolicyId(plugin.id)]?.config;

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -115,7 +115,9 @@ function publishCurrentPluginMetadataSnapshot(
   }
   currentPluginMetadataConfigIdentityCache.clear();
   const compatiblePolicyHashes = snapshot
-    ? options.compatibleConfigs?.map((config) => resolveInstalledPluginIndexPolicyHash(config))
+    ? options.compatibleConfigs?.map((config) =>
+        resolveInstalledPluginIndexPolicyHash(config, options.env),
+      )
     : undefined;
   const compatibleConfigFingerprints = snapshot
     ? options.compatibleConfigs?.map((config, index) =>
@@ -164,7 +166,7 @@ function publishCurrentPluginMetadataSnapshot(
     return revision;
   }
   if (options.config) {
-    const policyHash = resolveInstalledPluginIndexPolicyHash(options.config);
+    const policyHash = resolveInstalledPluginIndexPolicyHash(options.config, options.env);
     if (
       policyHash === snapshot.policyHash ||
       Boolean(compatiblePolicyHashes?.includes(policyHash))
@@ -309,7 +311,7 @@ export function withPluginMetadataSnapshotScope<T>(
 ): T {
   const workspaceDir = options.workspaceDir ?? snapshot.workspaceDir;
   const compatiblePolicyHashes = options.compatibleConfigs?.map((config) =>
-    resolveInstalledPluginIndexPolicyHash(config),
+    resolveInstalledPluginIndexPolicyHash(config, options.env),
   );
   const compatibleConfigFingerprints = options.compatibleConfigs?.map((config, index) =>
     resolvePluginMetadataControlPlaneFingerprint(config, {
@@ -329,7 +331,7 @@ export function withPluginMetadataSnapshotScope<T>(
     : snapshot.configFingerprint;
   const configIdentities = new WeakSet<OpenClawConfig>();
   if (options.config) {
-    const policyHash = resolveInstalledPluginIndexPolicyHash(options.config);
+    const policyHash = resolveInstalledPluginIndexPolicyHash(options.config, options.env);
     if (
       options.trustConfigIdentity === true ||
       policyHash === snapshot.policyHash ||
@@ -411,7 +413,7 @@ function resolveCompatiblePluginMetadataSnapshot(
   }
   const requestedPolicyHash =
     params.config && !canReuseCachedConfig
-      ? resolveInstalledPluginIndexPolicyHash(params.config)
+      ? resolveInstalledPluginIndexPolicyHash(params.config, params.env)
       : undefined;
   if (requestedPolicyHash && snapshot.policyHash !== requestedPolicyHash) {
     if (!candidate.compatiblePolicyHashes?.includes(requestedPolicyHash)) {

--- a/src/plugins/gateway-startup-plugin-activation.ts
+++ b/src/plugins/gateway-startup-plugin-activation.ts
@@ -1,8 +1,10 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { collectConfiguredAgentHarnessRuntimes } from "../agents/harness-runtimes.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
+import { isBundledProviderCompatPlugin } from "./bundled-provider-compat.js";
 import { hasExplicitChannelConfig } from "./channel-presence-policy.js";
-import { resolveEffectivePluginActivationState } from "./config-state.js";
+import { normalizePluginsConfig, resolveEffectivePluginActivationState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import {
   blocksPluginStartup,
@@ -31,6 +33,7 @@ type PluginStartupActivationParams = {
   pluginsConfig: NormalizedPluginsConfig;
   activationSource: { plugins: NormalizedPluginsConfig; rootConfig?: OpenClawConfig };
   platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
 };
 
 type GatewayStartupActivationParams = PluginStartupActivationParams & {
@@ -95,16 +98,36 @@ export function addRequiredAgentHarnessPluginIds(
 function resolveStartupActivationState(
   params: PluginStartupActivationParams,
   autoEnabledReason?: string,
+  applyBundledProviderCompat = false,
 ) {
+  const config = applyBundledProviderCompat
+    ? (withBundledPluginEnablementCompat({
+        config: params.config,
+        pluginIds: [params.plugin.pluginId],
+        env: params.env,
+        activation: "defaults",
+      }) ?? params.config)
+    : params.config;
   return resolveEffectivePluginActivationState({
     id: params.plugin.pluginId,
     origin: params.plugin.origin,
-    config: params.pluginsConfig,
-    rootConfig: params.config,
+    config: applyBundledProviderCompat
+      ? normalizePluginsConfig(config.plugins)
+      : params.pluginsConfig,
+    rootConfig: config,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin, params.platform),
     activationSource: params.activationSource,
     ...(autoEnabledReason ? { autoEnabledReason } : {}),
   });
+}
+
+function isProviderCompatStartupPolicy(policy: StartupActivationPolicy): boolean {
+  return (
+    policy === "provider" ||
+    policy === "worker" ||
+    policy === "speech" ||
+    policy === "implicit-external"
+  );
 }
 
 function hasExplicitHookPolicyConfig(
@@ -158,6 +181,12 @@ function passesPluginStartupPolicy(
   const activationState = resolveStartupActivationState(
     params,
     policy === "worker" ? "cloud worker provider required" : undefined,
+    isProviderCompatStartupPolicy(policy) &&
+      isBundledProviderCompatPlugin({
+        origin: plugin.origin,
+        providers: plugin.contributions?.providers,
+        contracts: plugin.contributions?.contracts,
+      }),
   );
   if (!activationState.enabled) {
     return false;

--- a/src/plugins/gateway-startup-plugin-plan.bundled-discovery.test.ts
+++ b/src/plugins/gateway-startup-plugin-plan.bundled-discovery.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
+import { removeBundledDiscoveryStateRoot } from "./bundled-discovery.test-support.js";
 import { resolveGatewayStartupPluginPlanFromRegistry } from "./channel-plugin-ids.js";
 import type { InstalledPluginIndexRecord } from "./installed-plugin-index.js";
 import type { PluginManifestRegistry } from "./manifest-registry.js";
@@ -130,8 +131,8 @@ describe("gateway startup plan under bundledDiscovery compat", () => {
     } finally {
       envSnapshot.restore();
       clearBundledDiscoveryModeMemo();
-      await fs.rm(compatRoot, { recursive: true, force: true });
-      await fs.rm(plainRoot, { recursive: true, force: true });
+      await removeBundledDiscoveryStateRoot(compatRoot);
+      await removeBundledDiscoveryStateRoot(plainRoot);
     }
   });
 });

--- a/src/plugins/gateway-startup-plugin-plan.bundled-discovery.test.ts
+++ b/src/plugins/gateway-startup-plugin-plan.bundled-discovery.test.ts
@@ -1,0 +1,137 @@
+// Covers gateway-startup plan activation under bundledDiscovery machine state.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
+import { resolveGatewayStartupPluginPlanFromRegistry } from "./channel-plugin-ids.js";
+import type { InstalledPluginIndexRecord } from "./installed-plugin-index.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginRegistrySnapshot } from "./plugin-registry-snapshot.js";
+
+function buildStartupFixture() {
+  const records: InstalledPluginIndexRecord[] = ["openai", "browser"].map((pluginId) => {
+    const rootDir = `/tmp/plugins/${pluginId}`;
+    return {
+      pluginId,
+      manifestPath: `${rootDir}/openclaw.plugin.json`,
+      manifestHash: `${pluginId}-manifest`,
+      rootDir,
+      origin: "bundled",
+      enabled: true,
+      enabledByDefault: true,
+      startup: {
+        sidecar: true,
+        memory: false,
+        agentHarnesses: [],
+        configPaths: [],
+      },
+      contributions: {
+        channels: [],
+        channelConfigs: [],
+        providers: pluginId === "openai" ? ["openai"] : [],
+        modelCatalogProviders: [],
+        modelSupportPrefixes: [],
+        modelSupportPatterns: [],
+        autoEnableProviderIds: [],
+        commandAliases: [],
+        contracts: {},
+      },
+      compat: [],
+    };
+  });
+  const index: PluginRegistrySnapshot = {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "test",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins: records,
+    diagnostics: [],
+  };
+  const manifestRegistry: PluginManifestRegistry = {
+    plugins: ["openai", "browser"].map((id) => ({
+      id,
+      origin: "bundled",
+      enabledByDefault: true,
+      activation: { onStartup: true },
+      providers: id === "openai" ? ["openai"] : [],
+      channels: [],
+      cliBackends: [],
+      rootDir: `/tmp/plugins/${id}`,
+      source: `/tmp/plugins/${id}/index.ts`,
+      manifestPath: `/tmp/plugins/${id}/openclaw.plugin.json`,
+      skills: [],
+      hooks: [],
+    })),
+    diagnostics: [],
+  };
+  return { index, manifestRegistry };
+}
+
+describe("gateway startup plan under bundledDiscovery compat", () => {
+  afterEach(() => {
+    clearBundledDiscoveryModeMemo();
+  });
+
+  it("keeps provider owners while omitted non-providers remain strict", async () => {
+    // Two-root regression (#123416): the plan's default-startup fallback must
+    // read compat from the plan env, not the process root.
+    const compatRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plan-compat-")),
+    );
+    const plainRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plan-plain-")),
+    );
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    try {
+      setTestEnvValue("OPENCLAW_STATE_DIR", compatRoot);
+      writeConfigMachineState("plugins.bundledDiscovery", "compat");
+      setTestEnvValue("OPENCLAW_STATE_DIR", plainRoot);
+      clearBundledDiscoveryModeMemo();
+
+      const { index, manifestRegistry } = buildStartupFixture();
+      // Sanity: without an allowlist both default-enabled plugins can start.
+      expect(
+        resolveGatewayStartupPluginPlanFromRegistry({
+          config: {},
+          env: { ...process.env },
+          index,
+          manifestRegistry,
+        }).pluginIds,
+      ).toEqual(["openai", "browser"]);
+      const config = {
+        agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
+        plugins: { allow: ["some-other-plugin"] },
+      };
+      const planEnv = { ...process.env, OPENCLAW_STATE_DIR: compatRoot };
+
+      const compatPlan = resolveGatewayStartupPluginPlanFromRegistry({
+        config,
+        env: planEnv,
+        index,
+        manifestRegistry,
+      }).pluginIds;
+      expect(compatPlan).toContain("openai");
+      expect(compatPlan).not.toContain("browser");
+      // Process root has no recorded mode: strict allowlist gate stands.
+      const strictPlan = resolveGatewayStartupPluginPlanFromRegistry({
+        config,
+        env: { ...process.env },
+        index,
+        manifestRegistry,
+      }).pluginIds;
+      expect(strictPlan).not.toContain("openai");
+      expect(strictPlan).not.toContain("browser");
+    } finally {
+      envSnapshot.restore();
+      clearBundledDiscoveryModeMemo();
+      await fs.rm(compatRoot, { recursive: true, force: true });
+      await fs.rm(plainRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/plugins/gateway-startup-plugin-plan.ts
+++ b/src/plugins/gateway-startup-plugin-plan.ts
@@ -169,6 +169,7 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
         activationSource,
         manifestLookup,
         platform: params.platform,
+        env: params.env,
       });
       if (canStartConfiguredChannel) {
         pluginIds.push(plugin.pluginId);
@@ -182,6 +183,7 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
         config: params.config,
         pluginsConfig,
         activationSource,
+        env: params.env,
         requiredAgentHarnessRuntimes,
         configuredWorkerProviderIds,
         configuredSpeechProviderIds,

--- a/src/plugins/installed-plugin-index-policy.test.ts
+++ b/src/plugins/installed-plugin-index-policy.test.ts
@@ -1,0 +1,98 @@
+// Covers policy-hash invalidation inputs for the persisted installed-plugin index.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
+import { removeBundledDiscoveryStateRoot } from "./bundled-discovery.test-support.js";
+import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+
+describe("resolveInstalledPluginIndexPolicyHash", () => {
+  afterEach(() => {
+    clearBundledDiscoveryModeMemo();
+  });
+
+  // Real machine state in isolated roots: module mocks would evict this file
+  // from the unit-fast lane and leak across isolate=false workers.
+  const makeStateRoot = async (mode?: "compat" | "allowlist"): Promise<string> => {
+    const stateDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-index-policy-")),
+    );
+    if (mode) {
+      const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      try {
+        writeConfigMachineState("plugins.bundledDiscovery", mode);
+      } finally {
+        envSnapshot.restore();
+      }
+    }
+    return stateDir;
+  };
+
+  const envForRoot = (stateDir: string): NodeJS.ProcessEnv => ({
+    ...process.env,
+    OPENCLAW_STATE_DIR: stateDir,
+  });
+
+  it("changes when the machine-state bundled discovery mode changes", async () => {
+    // Regression for #123297's upgrade path: doctor migrates the mode into
+    // machine state without touching openclaw.json, so the mode must be a
+    // policy-hash input or persisted enabled values stay stale after --fix.
+    const config = { plugins: { allow: ["rollover"] } };
+    const unsetRoot = await makeStateRoot();
+    const compatRoot = await makeStateRoot("compat");
+    const allowlistRoot = await makeStateRoot("allowlist");
+    try {
+      const unset = resolveInstalledPluginIndexPolicyHash(config, envForRoot(unsetRoot));
+      const compat = resolveInstalledPluginIndexPolicyHash(config, envForRoot(compatRoot));
+      const allowlist = resolveInstalledPluginIndexPolicyHash(config, envForRoot(allowlistRoot));
+
+      expect(compat).not.toBe(unset);
+      expect(allowlist).not.toBe(unset);
+      expect(allowlist).not.toBe(compat);
+    } finally {
+      for (const dir of [unsetRoot, compatRoot, allowlistRoot]) {
+        await removeBundledDiscoveryStateRoot(dir);
+      }
+    }
+  });
+
+  it("hashes the caller-scoped env's mode, not the process root's", async () => {
+    // Two-root regression (#123416): explicit-env snapshot checks must hash
+    // that env's mode or persisted indexes leak decisions across roots.
+    const compatRoot = await makeStateRoot("compat");
+    const plainRoot = await makeStateRoot();
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", plainRoot);
+    try {
+      clearBundledDiscoveryModeMemo();
+      const config = { plugins: { allow: ["rollover"] } };
+      expect(resolveInstalledPluginIndexPolicyHash(config, envForRoot(compatRoot))).not.toBe(
+        resolveInstalledPluginIndexPolicyHash(config),
+      );
+      // Same root through either spelling hashes identically.
+      expect(resolveInstalledPluginIndexPolicyHash(config, envForRoot(plainRoot))).toBe(
+        resolveInstalledPluginIndexPolicyHash(config),
+      );
+    } finally {
+      envSnapshot.restore();
+      await removeBundledDiscoveryStateRoot(compatRoot);
+      await removeBundledDiscoveryStateRoot(plainRoot);
+    }
+  });
+
+  it("stays stable for an unchanged mode and config", async () => {
+    const compatRoot = await makeStateRoot("compat");
+    try {
+      const config = { plugins: { allow: ["rollover"] } };
+      expect(resolveInstalledPluginIndexPolicyHash(config, envForRoot(compatRoot))).toBe(
+        resolveInstalledPluginIndexPolicyHash(config, envForRoot(compatRoot)),
+      );
+    } finally {
+      await removeBundledDiscoveryStateRoot(compatRoot);
+    }
+  });
+});

--- a/src/plugins/installed-plugin-index-policy.ts
+++ b/src/plugins/installed-plugin-index-policy.ts
@@ -1,5 +1,6 @@
 // Applies policy checks to installed plugin index records.
 import type { OpenClawConfig } from "../config/types.js";
+import { readBundledDiscoveryModeMemoized } from "./bundled-discovery-state.js";
 import { listPluginCompatRecords } from "./compat/registry.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
@@ -20,7 +21,12 @@ export function resolveCompatRegistryVersion(): string {
 }
 
 /** Hashes config policy inputs that can change installed plugin activation. */
-export function resolveInstalledPluginIndexPolicyHash(config: OpenClawConfig | undefined): string {
+export function resolveInstalledPluginIndexPolicyHash(
+  config: OpenClawConfig | undefined,
+  // Callers scoped to an explicit env hash that env's state-root mode so
+  // persisted indexes cannot leak activation decisions across roots.
+  env?: NodeJS.ProcessEnv,
+): string {
   const normalized = normalizePluginsConfig(config?.plugins);
   const channelPolicy: Record<string, boolean> = {};
   const channels = config?.channels;
@@ -39,6 +45,10 @@ export function resolveInstalledPluginIndexPolicyHash(config: OpenClawConfig | u
       enabled: normalized.enabled,
       allow: normalized.allow,
       deny: normalized.deny,
+      // Machine-state discovery mode changes activation for bundled plugins;
+      // omitting it left persisted indexes stale across doctor's compat
+      // migration (allow-listed installs stayed mass-disabled after --fix).
+      bundledDiscovery: readBundledDiscoveryModeMemoized(env) ?? null,
       slots: normalized.slots,
       entries: Object.fromEntries(
         Object.entries(normalized.entries)

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -235,9 +235,10 @@ export function buildInstalledPluginIndexRecords(params: {
   candidates: readonly PluginCandidate[];
   registry: PluginManifestRegistry;
   config?: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
   diagnostics: PluginDiagnostic[];
   installRecords: Record<string, InstalledPluginInstallRecordInfo>;
+  /** Index builds scoped to an explicit env stamp that env's compat decisions. */
+  env?: NodeJS.ProcessEnv;
 }): InstalledPluginIndexRecord[] {
   const candidateBySource = buildCandidateLookup(params.candidates);
   const normalizedConfig = normalizePluginsConfig(params.config?.plugins);

--- a/src/plugins/installed-plugin-index-store-write.ts
+++ b/src/plugins/installed-plugin-index-store-write.ts
@@ -12,6 +12,8 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resolveUserPath } from "../infra/home-dir.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
+import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
+import { isBundledProviderCompatPlugin } from "./bundled-provider-compat.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { isGatewayPluginMetadataSnapshotActive } from "./current-plugin-metadata-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
@@ -303,10 +305,24 @@ function refreshPersistedPolicyState(
   persisted: InstalledPluginIndex,
   params: RefreshInstalledPluginIndexParams,
 ): InstalledPluginIndex {
-  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  const activationConfig = withBundledPluginEnablementCompat({
+    config: params.config,
+    env: params.env,
+    pluginIds: persisted.plugins
+      .filter((plugin) =>
+        isBundledProviderCompatPlugin({
+          origin: plugin.origin,
+          providers: plugin.contributions?.providers,
+          contracts: plugin.contributions?.contracts,
+        }),
+      )
+      .map((plugin) => plugin.pluginId),
+    activation: "defaults",
+  });
+  const normalizedConfig = normalizePluginsConfig(activationConfig?.plugins);
   return {
     ...persisted,
-    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+    policyHash: resolveInstalledPluginIndexPolicyHash(params.config, params.env),
     generatedAtMs: (params.now?.() ?? new Date()).getTime(),
     refreshReason: params.reason,
     plugins: persisted.plugins.map((plugin) => ({
@@ -315,7 +331,7 @@ function refreshPersistedPolicyState(
         id: plugin.pluginId,
         origin: plugin.origin,
         config: normalizedConfig,
-        rootConfig: params.config,
+        rootConfig: activationConfig,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
       }).enabled,
     })),

--- a/src/plugins/installed-plugin-index.compat.test.ts
+++ b/src/plugins/installed-plugin-index.compat.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
+import type { PluginCandidate } from "./discovery.js";
+import { refreshPersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
+import { isInstalledPluginEnabled, loadInstalledPluginIndex } from "./installed-plugin-index.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const PLUGIN_ID = "contract-provider";
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function createFixture() {
+  const stateDir = makeTrackedTempDir("openclaw-provider-compat-index", tempDirs);
+  const pluginDir = path.join(stateDir, PLUGIN_ID);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "index.ts"),
+    "throw new Error('runtime entry should not load while resolving plugin policy');\n",
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: PLUGIN_ID,
+      enabledByDefault: true,
+      configSchema: { type: "object" },
+      contracts: { speechProviders: [PLUGIN_ID] },
+    }),
+    "utf8",
+  );
+  const candidate: PluginCandidate = {
+    idHint: PLUGIN_ID,
+    source: path.join(pluginDir, "index.ts"),
+    rootDir: pluginDir,
+    origin: "bundled",
+  };
+  const env = {
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_VERSION: "2026.4.25",
+    VITEST: "true",
+  };
+  return { candidate, env, stateDir };
+}
+
+function setMode(env: NodeJS.ProcessEnv, mode: "compat" | "allowlist") {
+  writeConfigMachineState("plugins.bundledDiscovery", mode, { env });
+  clearBundledDiscoveryModeMemo();
+}
+
+describe("bundled provider compatibility in installed plugin indexes", () => {
+  it("applies fresh and dynamic policy to a contract-only provider", () => {
+    const { candidate, env } = createFixture();
+    const config = { plugins: { allow: ["listed"] } };
+    setMode(env, "compat");
+    const index = loadInstalledPluginIndex({ candidates: [candidate], config, env });
+
+    expect(index.plugins[0]?.enabled).toBe(true);
+    expect(isInstalledPluginEnabled(index, PLUGIN_ID, config, env)).toBe(true);
+
+    setMode(env, "allowlist");
+    expect(isInstalledPluginEnabled(index, PLUGIN_ID, config, env)).toBe(false);
+
+    setMode(env, "compat");
+    expect(
+      isInstalledPluginEnabled(
+        index,
+        PLUGIN_ID,
+        { plugins: { ...config.plugins, deny: [PLUGIN_ID] } },
+        env,
+      ),
+    ).toBe(false);
+  });
+
+  it("refreshes persisted contract-only provider policy without rebuilding source records", async () => {
+    const { candidate, env, stateDir } = createFixture();
+    const config = { plugins: { allow: ["listed"] } };
+    setMode(env, "compat");
+    const initial = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [candidate],
+      config,
+      env,
+    });
+    expect(initial.plugins[0]?.enabled).toBe(true);
+
+    setMode(env, "allowlist");
+    const strict = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      config,
+      env,
+      policyPluginIds: [PLUGIN_ID],
+    });
+    expect(strict.plugins[0]?.enabled).toBe(false);
+
+    setMode(env, "compat");
+    const compatible = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      config,
+      env,
+      policyPluginIds: [PLUGIN_ID],
+    });
+    expect(compatible.plugins[0]?.enabled).toBe(true);
+  });
+});

--- a/src/plugins/installed-plugin-index.compat.test.ts
+++ b/src/plugins/installed-plugin-index.compat.test.ts
@@ -58,6 +58,28 @@ function setMode(env: NodeJS.ProcessEnv, mode: "compat" | "allowlist") {
 }
 
 describe("bundled provider compatibility in installed plugin indexes", () => {
+  it("passes the caller environment through manifest validation", () => {
+    const { candidate, env } = createFixture();
+    const index = loadInstalledPluginIndex({
+      candidates: [
+        {
+          ...candidate,
+          origin: "global",
+          packageDir: candidate.rootDir,
+          packageManifest: {
+            install: {
+              npmSpec: "@openclaw/contract-provider",
+              minHostVersion: ">=2099.1.1",
+            },
+          },
+        },
+      ],
+      env: { ...env, OPENCLAW_VERSION: "2099.1.1" },
+    });
+
+    expect(index.plugins.map((plugin) => plugin.pluginId)).toEqual([PLUGIN_ID]);
+  });
+
   it("applies fresh and dynamic policy to a contract-only provider", () => {
     const { candidate, env } = createFixture();
     const config = { plugins: { allow: ["listed"] } };

--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -81,6 +81,7 @@ function buildInstalledPluginIndex(
   const registry = loadPluginManifestRegistryCore({
     config: params.config,
     workspaceDir: params.workspaceDir,
+    env,
     candidates: discovery.candidates,
     diagnostics: discovery.diagnostics,
     installRecords,

--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -1,6 +1,8 @@
 /** Public installed-plugin-index API for load, refresh, policy hash, and invalidation checks. */
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
+import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
+import { isBundledProviderCompatPlugin } from "./bundled-provider-compat.js";
 import { normalizePluginsConfig, resolveEffectivePluginActivationState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
@@ -79,17 +81,22 @@ function buildInstalledPluginIndex(
   const registry = loadPluginManifestRegistryCore({
     config: params.config,
     workspaceDir: params.workspaceDir,
-    env,
     candidates: discovery.candidates,
     diagnostics: discovery.diagnostics,
     installRecords,
   });
   const diagnostics = [...(registry.diagnostics ?? [])];
   const generatedAtMs = (params.now?.() ?? new Date()).getTime();
+  const activationConfig = withBundledPluginEnablementCompat({
+    config: params.config,
+    env,
+    pluginIds: registry.plugins.filter(isBundledProviderCompatPlugin).map((plugin) => plugin.id),
+    activation: "defaults",
+  });
   const plugins = buildInstalledPluginIndexRecords({
     candidates: discovery.candidates,
     registry,
-    config: params.config,
+    config: activationConfig,
     env,
     diagnostics,
     installRecords,
@@ -102,7 +109,7 @@ function buildInstalledPluginIndex(
       hostContractVersion: resolveCompatibilityHostVersion(env),
       compatRegistryVersion: resolveCompatRegistryVersion(),
       migrationVersion: INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION,
-      policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+      policyHash: resolveInstalledPluginIndexPolicyHash(params.config, env),
       generatedAtMs,
       ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
       ...(params.refreshReason ? { refreshReason: params.refreshReason } : {}),
@@ -162,6 +169,7 @@ export function isInstalledPluginEnabled(
   index: InstalledPluginIndex,
   pluginId: string,
   config?: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
 ): boolean {
   const record = getInstalledPluginRecord(index, pluginId);
   if (!record) {
@@ -170,12 +178,24 @@ export function isInstalledPluginEnabled(
   if (!config) {
     return record.enabled;
   }
-  const normalizedConfig = normalizePluginsConfig(config?.plugins);
+  const activationConfig = withBundledPluginEnablementCompat({
+    config,
+    env,
+    pluginIds: isBundledProviderCompatPlugin({
+      origin: record.origin,
+      providers: record.contributions?.providers,
+      contracts: record.contributions?.contracts,
+    })
+      ? [record.pluginId]
+      : [],
+    activation: "defaults",
+  });
+  const normalizedConfig = normalizePluginsConfig(activationConfig?.plugins);
   const state = resolveEffectivePluginActivationState({
     id: record.pluginId,
     origin: record.origin,
     config: normalizedConfig,
-    rootConfig: config,
+    rootConfig: activationConfig,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(record),
   });
   // The index records startup policy; current activation is evaluated against

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -916,7 +916,7 @@ export const listManagedPlugins = withManagedPluginCache(
     const bundledOfficialEntries = listOfficialExternalPluginCatalogEntries();
     const capabilityConsentDiagnostics: PluginDiagnostic[] = [];
     const plugins = metadata.index.plugins.map((record): ManagedPluginCatalogEntry => {
-      const enabled = isInstalledPluginEnabled(metadata.index, record.pluginId, params.config);
+      const enabled = isInstalledPluginEnabled(metadata.index, record.pluginId, params.config, env);
       const manifest = metadata.byPluginId.get(record.pluginId);
       const localCatalog = normalizeCatalogMetadata(manifest?.catalog);
       const ownership = resolveInstalledPluginPackageOwnership(metadata.index, record.pluginId);

--- a/src/plugins/manifest-contract-eligibility.test.ts
+++ b/src/plugins/manifest-contract-eligibility.test.ts
@@ -7,9 +7,26 @@ const mocks = vi.hoisted(() => ({
   readBundledDiscoveryMode: vi.fn<() => "compat" | "allowlist" | undefined>(() => "allowlist"),
 }));
 
-vi.mock("./bundled-discovery-state.js", () => ({
-  readBundledDiscoveryMode: mocks.readBundledDiscoveryMode,
-}));
+vi.mock("./bundled-discovery-state.js", async () => {
+  const { registerPluginMetadataProcessMemoLifecycleClear } =
+    await import("./plugin-metadata-lifecycle.js");
+  // Mirror the real single-slot memo over the mocked raw reader so the
+  // read-once-per-lifecycle assertions keep exercising the memoized seam.
+  let memo: { value: "compat" | "allowlist" | undefined } | undefined;
+  registerPluginMetadataProcessMemoLifecycleClear(() => {
+    memo = undefined;
+  });
+  return {
+    readBundledDiscoveryMode: mocks.readBundledDiscoveryMode,
+    readBundledDiscoveryModeMemoized: () => {
+      memo ??= { value: mocks.readBundledDiscoveryMode() };
+      return memo.value;
+    },
+    clearBundledDiscoveryModeMemo: () => {
+      memo = undefined;
+    },
+  };
+});
 
 vi.mock("./plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: mocks.loadPluginMetadataSnapshot,
@@ -39,8 +56,9 @@ describe("bundled manifest contract availability", () => {
     origin: "bundled" as const,
     contracts: { imageGenerationProviders: ["google"] },
   };
+  const index = { plugins: [{ pluginId: "google", origin: "bundled", enabled: false }] };
   const snapshot = {
-    index: { plugins: [{ pluginId: "google", origin: "bundled", enabled: false }] },
+    index,
     plugins: [plugin],
   } as never;
 
@@ -64,7 +82,14 @@ describe("bundled manifest contract availability", () => {
       config: { plugins: { allow: ["another-plugin"] } },
     },
   ])("does not expose $name", ({ config }) => {
-    expect(isManifestPluginAvailableForControlPlane({ snapshot, plugin, config })).toBe(false);
+    expect(
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config,
+        allowBundledProviderCompat: true,
+      }),
+    ).toBe(false);
     expect(
       listAvailableManifestContractValues({
         snapshot,
@@ -176,7 +201,14 @@ describe("bundled manifest contract availability", () => {
     expect(mocks.readBundledDiscoveryMode).toHaveBeenCalledTimes(1);
 
     clearPluginMetadataLifecycleCaches();
-    expect(isManifestPluginAvailableForControlPlane({ snapshot, plugin, config })).toBe(false);
+    expect(
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config,
+        allowBundledProviderCompat: true,
+      }),
+    ).toBe(false);
     expect(mocks.readBundledDiscoveryMode).toHaveBeenCalledTimes(2);
   });
 
@@ -190,7 +222,7 @@ describe("bundled manifest contract availability", () => {
     ).toBe(true);
   });
 
-  it("preserves the shipped restrictive-allowlist bundled compatibility mode", () => {
+  it("preserves the shipped provider-contract compatibility mode", () => {
     mocks.readBundledDiscoveryMode.mockReturnValue("compat");
 
     expect(
@@ -198,6 +230,7 @@ describe("bundled manifest contract availability", () => {
         snapshot,
         plugin,
         config: { plugins: { allow: ["another-plugin"] } },
+        allowBundledProviderCompat: true,
       }),
     ).toBe(true);
   });
@@ -208,10 +241,30 @@ describe("bundled manifest contract availability", () => {
       mocks.readBundledDiscoveryMode.mockReturnValue("compat");
 
       expect(
-        isManifestPluginAvailableForControlPlane({ snapshot, plugin, config: { plugins } }),
+        isManifestPluginAvailableForControlPlane({
+          snapshot,
+          plugin,
+          config: { plugins },
+          allowBundledProviderCompat: true,
+        }),
       ).toBe(false);
     },
   );
+
+  it("keeps non-provider manifest contracts behind the allowlist", () => {
+    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+    const nonProviderPlugin = {
+      ...plugin,
+      contracts: { documentExtractors: ["document"] },
+    };
+    expect(
+      listAvailableManifestContractValues({
+        snapshot: { index, plugins: [nonProviderPlugin] } as never,
+        contract: "documentExtractors",
+        config: { plugins: { allow: ["another-plugin"] } },
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("loadManifestContractSnapshot", () => {

--- a/src/plugins/manifest-contract-eligibility.ts
+++ b/src/plugins/manifest-contract-eligibility.ts
@@ -5,12 +5,12 @@ import {
   resolveChannelConfigRecord,
 } from "../config/channel-configured-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { readBundledDiscoveryMode } from "./bundled-discovery-state.js";
+import { readBundledDiscoveryModeMemoized } from "./bundled-discovery-state.js";
+import { isBundledProviderCompatContract } from "./bundled-provider-compat.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
 import { resolveManifestOwnerBasePolicyBlock } from "./manifest-owner-policy.js";
 import type { PluginManifestContractListKey, PluginManifestRecord } from "./manifest-registry.js";
-import { getPluginCache } from "./plugin-cache.js";
 import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type {
   PluginMetadataManifestView,
@@ -25,6 +25,9 @@ export function isManifestPluginOwnerAllowedByControlPlanePolicy(params: {
   };
   config?: OpenClawConfig;
   allowRestrictiveAllowlistBypass?: boolean;
+  allowBundledProviderCompat?: boolean;
+  /** Callers scoped to an explicit env read compat from that env's state root. */
+  env?: NodeJS.ProcessEnv;
 }): boolean {
   if (!params.config?.plugins) {
     return true;
@@ -54,9 +57,10 @@ export function isManifestPluginOwnerAllowedByControlPlanePolicy(params: {
   ) {
     return true;
   }
-  const metadata = getPluginCache().metadata;
-  metadata.bundledDiscoveryMode ??= { value: readBundledDiscoveryMode() };
-  return metadata.bundledDiscoveryMode.value === "compat";
+  return (
+    params.allowBundledProviderCompat === true &&
+    readBundledDiscoveryModeMemoized(params.env) === "compat"
+  );
 }
 
 export function isManifestPluginAvailableForControlPlane(params: {
@@ -67,6 +71,8 @@ export function isManifestPluginAvailableForControlPlane(params: {
   > & { channels?: readonly string[] };
   config?: OpenClawConfig;
   allowRestrictiveAllowlistBypass?: boolean;
+  allowBundledProviderCompat?: boolean;
+  env?: NodeJS.ProcessEnv;
 }): boolean {
   if (!isManifestPluginOwnerAllowedByControlPlanePolicy(params)) {
     return false;
@@ -74,7 +80,12 @@ export function isManifestPluginAvailableForControlPlane(params: {
   if (params.plugin.origin === "bundled") {
     return true;
   }
-  return isInstalledPluginEnabled(params.snapshot.index, params.plugin.id, params.config);
+  return isInstalledPluginEnabled(
+    params.snapshot.index,
+    params.plugin.id,
+    params.config,
+    params.env,
+  );
 }
 
 export function hasManifestContractValue(params: {
@@ -91,6 +102,7 @@ export function listAvailableManifestContractPlugins(params: {
   contract: PluginManifestContractListKey;
   value?: string;
   config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
 }): PluginManifestRecord[] {
   return params.snapshot.plugins.filter(
     (plugin) =>
@@ -103,6 +115,8 @@ export function listAvailableManifestContractPlugins(params: {
         snapshot: params.snapshot,
         plugin,
         config: params.config,
+        env: params.env,
+        allowBundledProviderCompat: isBundledProviderCompatContract(params.contract),
       }),
   );
 }
@@ -111,6 +125,7 @@ export function listAvailableManifestContractValues(params: {
   snapshot: Pick<PluginMetadataSnapshot, "index" | "plugins">;
   contract: PluginManifestContractListKey;
   config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
 }): string[] {
   const values = new Set<string>();
   for (const plugin of listAvailableManifestContractPlugins(params)) {

--- a/src/plugins/plugin-control-plane-context.ts
+++ b/src/plugins/plugin-control-plane-context.ts
@@ -64,7 +64,8 @@ function resolvePluginControlPlaneContext(
     (params.index ? resolveInstalledManifestRegistryIndexFingerprint(params.index) : undefined);
   return {
     discovery: resolvePluginDiscoveryContext(params),
-    policyFingerprint: params.policyHash ?? resolveInstalledPluginIndexPolicyHash(params.config),
+    policyFingerprint:
+      params.policyHash ?? resolveInstalledPluginIndexPolicyHash(params.config, params.env),
     ...(inventoryFingerprint ? { inventoryFingerprint } : {}),
     ...(params.activationFingerprint
       ? { activationFingerprint: params.activationFingerprint }

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -174,7 +174,7 @@ export function isPluginMetadataSnapshotCompatible(params: {
       serializePluginIdScope(snapshotPluginIds) === serializePluginIdScope(requestedPluginIds));
   return (
     scopeMatches &&
-    params.snapshot.policyHash === resolveInstalledPluginIndexPolicyHash(params.config) &&
+    params.snapshot.policyHash === resolveInstalledPluginIndexPolicyHash(params.config, env) &&
     (!params.snapshot.configFingerprint ||
       params.snapshot.configFingerprint ===
         resolvePluginControlPlaneFingerprint({

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -176,12 +176,15 @@ function resolveContributionPluginIds(params: {
   index: PluginRegistrySnapshot;
   includeDisabled?: boolean;
   config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
 }): readonly string[] {
   if (params.includeDisabled) {
     return params.index.plugins.map((plugin) => plugin.pluginId);
   }
   return params.index.plugins
-    .filter((plugin) => isInstalledPluginEnabled(params.index, plugin.pluginId, params.config))
+    .filter((plugin) =>
+      isInstalledPluginEnabled(params.index, plugin.pluginId, params.config, params.env),
+    )
     .map((plugin) => plugin.pluginId);
 }
 
@@ -200,6 +203,7 @@ function loadContributionManifestRegistry(
       index: params.index,
       includeDisabled: params.includeDisabled,
       config: params.config,
+      env: params.env,
     }),
     includeDisabled: true,
   });
@@ -217,6 +221,7 @@ function listContributionManifestPlugins(
         index: params.index,
         includeDisabled: params.includeDisabled,
         config: params.config,
+        env: params.env,
       }),
     );
     return plugins.filter((plugin) => enabledPluginIds.has(plugin.id));
@@ -280,6 +285,7 @@ export function resolvePluginContributionOwners(
         index,
         includeDisabled: params.includeDisabled,
         config: params.config,
+        env: params.env,
       }),
     );
     return normalizeSortedUniqueStringEntries(

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -538,7 +538,7 @@ export function loadPluginRegistrySnapshotWithMetadata(
     });
   } else if (
     params.config &&
-    persistedIndex.policyHash !== resolveInstalledPluginIndexPolicyHash(params.config)
+    persistedIndex.policyHash !== resolveInstalledPluginIndexPolicyHash(params.config, params.env)
   ) {
     diagnostics.push({
       level: "warn",

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -1,6 +1,9 @@
 // Runtime boundary for resolving provider plugins from metadata and config.
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { resolvePluginActivationInputs, withActivatedPluginIds } from "./activation-context.js";
+import {
+  resolveBundledCompatActivationInputs,
+  withActivatedPluginIds,
+} from "./activation-context.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
@@ -16,6 +19,7 @@ import { hasExplicitPluginIdScope } from "./plugin-scope.js";
 import { resolveProviderConfigApiOwnerHint } from "./provider-config-owner.js";
 import {
   resolveActivatableProviderOwnerPluginIds,
+  resolveBundledProviderCompatPluginIds,
   resolveDiscoverableProviderOwnerPluginIds,
   resolveDiscoveredProviderPluginIds,
   resolveEnabledProviderPluginIds,
@@ -245,13 +249,16 @@ function resolveRuntimeProviderPluginLoadState(
     config: base.rawConfig,
     pluginIds: explicitOwnerPluginIds,
   });
-  const activation = resolvePluginActivationInputs({
+  const activation = resolveBundledCompatActivationInputs({
     rawConfig: requestConfig,
     env: base.env,
     workspaceDir: base.workspaceDir,
     applyAutoEnable: params.applyAutoEnable ?? true,
     discovery: snapshot.discovery,
     manifestRegistry: snapshot.manifestRegistry,
+    onlyPluginIds: runtimeRequestedPluginIds,
+    resolveBundledPluginIds: resolveBundledProviderCompatPluginIds,
+    activation: "defaults",
   });
   const providerPluginIds = mergeExplicitOwnerPluginIds(
     resolveEnabledProviderPluginIds({

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -254,6 +254,7 @@ function expectBundledCompatChainApplied(params: {
   expect(withBundledPluginEnablementCompatMock).toHaveBeenCalledWith({
     config: params.config,
     pluginIds: params.pluginIds,
+    activation: "defaults",
   });
   if (params.loadModules) {
     expectPluginLoaderCall({ config: params.enabledConfig, loadModules: true });
@@ -266,10 +267,7 @@ function createAutoEnabledStatusConfig(
   entries: Record<string, unknown>,
   rawConfigOverrides?: Record<string, unknown>,
 ) {
-  const rawConfig = {
-    plugins: {},
-    ...rawConfigOverrides,
-  };
+  const rawConfig = { plugins: {}, ...rawConfigOverrides };
   const autoEnabledConfig = {
     ...rawConfig,
     plugins: {
@@ -1098,7 +1096,6 @@ describe("plugin status reports", () => {
 
   it("formats and summarizes compatibility notices", () => {
     const notice = createCompatibilityNotice({ pluginId: "legacy-plugin", code: "hook-only" });
-
     expect(formatPluginCompatibilityNotice(notice)).toBe(`legacy-plugin ${HOOK_ONLY_MESSAGE}`);
     expect(summarizePluginCompatibility([notice])).toEqual({
       noticeCount: 1,

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -246,6 +246,8 @@ function buildPluginReport(
   const runtimeCompatConfig = withBundledPluginEnablementCompat({
     config,
     pluginIds: bundledProviderIds,
+    ...(params?.env ? { env: params.env } : {}),
+    activation: "defaults",
   });
   const onlyPluginIds =
     params?.effectiveOnly === true


### PR DESCRIPTION
## What Problem This Solves

Migrated configs can keep `plugins.allow` with machine-owned `bundledDiscovery=compat`. The shipped contract preserves bundled provider defaults while keeping omitted channel and tool plugins strict.

Current main lost that policy in two places. Runtime provider activation evaluated the raw allowlist, and installed-plugin index projections did not include the compatibility mode in their policy hash. This disabled default bundled providers and could retain stale disabled projections after Doctor migrated the mode.

Fixes #123297.

## Why This Change Was Made

The repair reuses one compatibility transform before the shared activation decision. Its explicit activation mode either preserves provider defaults or selects a requested capability provider. It does not bypass global disable, `plugins.deny`, per-entry disable, or the strict `allowlist` mode.

The installed-index policy hash now includes the state-root-scoped discovery mode. A lifecycle memo prevents one SQLite read per plugin and is cleared after Doctor writes the migrated mode. Doctor refreshes a pending derived index when state migration changes that policy, so it persists the post-migration generation.

Every provider-compatibility consumer forwards its environment. The stable contract is provider-only. Omitted bundled channels and tools remain governed by `plugins.allow`.

## User Impact

Existing migrated allowlists keep default bundled providers such as OpenAI and Anthropic. New or strict allowlists keep their current behavior. Explicit provider denies still win.

## Evidence

Real product path with isolated state directories: non-interactive Doctor migration, source Gateway startup, then Gateway `plugins.list`.

| Revision and policy | Enabled | OpenAI | Anthropic | TTS local CLI | Browser | Telegram |
| --- | ---: | --- | --- | --- | --- | --- |
| Main `85ec67d66fa`, compat | 1/165 | disabled | disabled | disabled | disabled | disabled |
| Head `7f926d25cd8`, compat | 72/165 | enabled | enabled | enabled | disabled | disabled |
| Head, strict allowlist | 1/165 | disabled | disabled | disabled | disabled | disabled |
| Head, compat plus `deny: ["openai"]` | 71/165 | disabled | enabled | enabled | disabled | disabled |

- Doctor wrote `plugins.bundledDiscovery="compat"` to the shared SQLite state before both Gateway starts.
- Current main loaded only `memory-core`; exact head loaded OpenAI and Anthropic.
- Strict mode and explicit OpenAI deny remained authoritative.
- Omitted channel and tool plugins, including Browser and Telegram, remain disabled in compatibility mode.
- A local OpenAI agent turn with an isolated empty auth store reached provider authentication in compatibility mode. The same turn stopped at model availability when OpenAI was denied.

Production delta: +273/-39, net +234. The growth adds the shipped state migration, lifecycle-owned state memo, policy hash, and provider-only compatibility owner; generic activation remains strict. Tests and test support: +609/-85, net +524.
