### PR TITLE
fix(agents): hydrate override thinking catalogs through scoped live discovery

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1134,6 +1134,31 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     );
   });
 
+  it("hydrates a runtime-only switched model's thinking entry via the provider-scoped catalog", async () => {
+    // Regression for #122872: the override rehydration used the unscoped
+    // read-only snapshot, so models that exist only through scoped live
+    // discovery (provider OAuth "auto" aliases) never resolved thinking params.
+    setupModelSwitchRetry({ provider: "openai", model: "gpt-5.4" });
+    state.loadPreparedModelCatalogSnapshotMock.mockResolvedValue({
+      entries: [
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          provider: "openai",
+          reasoning: true,
+        },
+      ],
+      routeVariants: [],
+    });
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+
+    await runBasicAgentCommand();
+
+    expect(state.loadProviderScopedThinkingCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", model: "gpt-5.4" }),
+    );
+  });
+
   it("keeps collection off by default without blocking local execution", async () => {
     setupAdmittedSuccessfulAttempt();
 

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -54,9 +54,9 @@ import {
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../openai-routing.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { resolveSessionRuntimeOverrideForProvider } from "../session-runtime-compat.js";
+import { hydrateProviderScopedThinkingCatalog } from "../thinking-catalog-hydration.js";
 import {
   hasResolvedThinkingCatalogEntry,
-  normalizeThinkingCatalogProviders,
   resolveEffectiveAgentRuntime,
 } from "../thinking-runtime.js";
 import { persistAgentSession } from "./attempt-execution.shared.js";
@@ -512,35 +512,19 @@ export async function resolveEmbeddedModelSelection(params: {
     primaryConfiguredThinkLevel !== "off" &&
     !hasResolvedThinkingCatalogEntry({ catalog: catalogForThinking, provider, model })
   ) {
-    // Thinking capability is a per-model fact; never materialize the full live catalog here.
-    const { loadProviderScopedThinkingCatalog } = await import("../model-catalog.runtime.js");
-    const runtimeCatalog = normalizeThinkingCatalogProviders(
-      await loadProviderScopedThinkingCatalog({
-        config: params.cfg,
-        provider,
-        model,
-        ...(params.sessionAgentId ? { agentId: params.sessionAgentId } : {}),
-        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-      }),
-    );
-    const allowedRuntimeCatalog = createModelVisibilityPolicy({
+    const hydratedCatalog = await hydrateProviderScopedThinkingCatalog({
       cfg: params.cfg,
-      catalog: runtimeCatalog,
+      provider,
+      model,
+      agentId: params.sessionAgentId,
+      workspaceDir: params.workspaceDir,
       defaultProvider,
       defaultModel,
-      agentId: params.sessionAgentId,
-      allowManifestNormalization: true,
       allowPluginNormalization: params.pluginsEnabled,
-      ...params.modelManifestContext,
-    }).allowedCatalog;
-    if (
-      hasResolvedThinkingCatalogEntry({
-        catalog: allowedRuntimeCatalog,
-        provider,
-        model,
-      })
-    ) {
-      catalogForThinking = allowedRuntimeCatalog;
+      modelManifestContext: params.modelManifestContext,
+    });
+    if (hydratedCatalog) {
+      catalogForThinking = hydratedCatalog;
     }
   }
   const thinkingCatalog = catalogForThinking.length > 0 ? catalogForThinking : undefined;

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -32,7 +32,6 @@ import { prepareInternalSessionEffectsSession } from "../internal-session-effect
 import { LiveSessionModelSwitchError } from "../live-model-switch.js";
 import { modelKey, resolveThinkingDefault } from "../model-selection.js";
 import { resolveConfiguredThinkingDefault } from "../model-thinking-default.js";
-import { createModelVisibilityPolicy } from "../model-visibility-policy.js";
 import type { AgentRunSessionTarget } from "../run-session-target.js";
 import {
   isAgentRunDirectAbortReason,
@@ -41,9 +40,9 @@ import {
 } from "../run-termination.js";
 import { resolveSessionRuntimeOverrideForProvider } from "../session-runtime-compat.js";
 import { measureAgentStartup } from "../startup-timing.js";
+import { hydrateProviderScopedThinkingCatalog } from "../thinking-catalog-hydration.js";
 import {
   hasResolvedThinkingCatalogEntry,
-  normalizeThinkingCatalogProviders,
   resolveCandidateThinkingLevel,
   resolveEffectiveAgentRuntime,
 } from "../thinking-runtime.js";
@@ -121,7 +120,9 @@ export async function runEmbeddedAgentAttempt(params: {
     effectiveTurnThinkLevel,
   } = params.modelSelection;
   let thinkingCatalog = params.modelSelection.thinkingCatalog;
-  let attemptedThinkingCatalogHydration = false;
+  // Keyed per override target: one hydration attempt per provider/model, so a
+  // failed discovery neither retries forever nor blocks a later different override.
+  const attemptedThinkingCatalogHydrations = new Set<string>();
   let sessionEntry = params.sessionEntry;
   let lifecycleGeneration = params.lifecycleGeneration;
 
@@ -388,40 +389,34 @@ export async function runEmbeddedAgentAttempt(params: {
               provider: providerOverride,
               model: modelOverride,
             });
+          const thinkingHydrationKey = `${providerOverride}/${modelOverride}`;
           if (
             pluginsEnabled &&
             candidateConfiguredThinkLevel !== "off" &&
-            !attemptedThinkingCatalogHydration &&
+            !attemptedThinkingCatalogHydrations.has(thinkingHydrationKey) &&
             !hasResolvedThinkingCatalogEntry({
               catalog: thinkingCatalog,
               provider: providerOverride,
               model: modelOverride,
             })
           ) {
-            attemptedThinkingCatalogHydration = true;
-            const { loadPreparedModelCatalogSnapshot } =
-              await import("../model-catalog.runtime.js");
-            const runtimeCatalog = normalizeThinkingCatalogProviders(
-              (
-                await loadPreparedModelCatalogSnapshot({
-                  config: cfg,
-                  agentId: sessionAgentId,
-                  workspaceDir,
-                })
-              ).entries,
-            );
-            const allowedRuntimeCatalog = createModelVisibilityPolicy({
+            attemptedThinkingCatalogHydrations.add(thinkingHydrationKey);
+            // Runtime-only models (for example provider OAuth "auto" aliases)
+            // resolve thinking params only through scoped live discovery; the
+            // unscoped read-only snapshot never reaches them (#122872).
+            const hydratedCatalog = await hydrateProviderScopedThinkingCatalog({
               cfg,
-              catalog: runtimeCatalog,
+              provider: providerOverride,
+              model: modelOverride,
+              agentId: sessionAgentId,
+              workspaceDir,
               defaultProvider,
               defaultModel,
-              agentId: sessionAgentId,
-              allowManifestNormalization: true,
               allowPluginNormalization: true,
-              ...modelManifestContext,
-            }).allowedCatalog;
-            if (allowedRuntimeCatalog.length > 0) {
-              thinkingCatalog = allowedRuntimeCatalog;
+              modelManifestContext,
+            });
+            if (hydratedCatalog) {
+              thinkingCatalog = hydratedCatalog;
             }
           }
           const candidateRequestedThinkLevel =

--- a/src/agents/thinking-catalog-hydration.ts
+++ b/src/agents/thinking-catalog-hydration.ts
@@ -1,0 +1,55 @@
+/** Scoped thinking-catalog hydration shared by initial model selection and mid-run overrides. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import type { ModelManifestNormalizationContext } from "./model-ref-shared.js";
+import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
+import {
+  hasResolvedThinkingCatalogEntry,
+  normalizeThinkingCatalogProviders,
+} from "./thinking-runtime.js";
+
+/**
+ * Resolves a provider/model thinking entry through the manifest -> scoped-static ->
+ * scoped-live ladder. Thinking capability is a per-model fact; the full live catalog
+ * is never materialized here. Returns the visibility-filtered catalog only when the
+ * target entry actually resolved, so callers keep their previous catalog otherwise.
+ */
+export async function hydrateProviderScopedThinkingCatalog(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  model: string;
+  agentId?: string;
+  workspaceDir?: string;
+  defaultProvider: string;
+  defaultModel?: string;
+  allowPluginNormalization: boolean;
+  modelManifestContext: ModelManifestNormalizationContext;
+}): Promise<ModelCatalogEntry[] | undefined> {
+  const { loadProviderScopedThinkingCatalog } = await import("./model-catalog.runtime.js");
+  const runtimeCatalog = normalizeThinkingCatalogProviders(
+    await loadProviderScopedThinkingCatalog({
+      config: params.cfg,
+      provider: params.provider,
+      model: params.model,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    }),
+  );
+  const allowedCatalog = createModelVisibilityPolicy({
+    cfg: params.cfg,
+    catalog: runtimeCatalog,
+    defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
+    agentId: params.agentId,
+    allowManifestNormalization: true,
+    allowPluginNormalization: params.allowPluginNormalization,
+    ...params.modelManifestContext,
+  }).allowedCatalog;
+  return hasResolvedThinkingCatalogEntry({
+    catalog: allowedCatalog,
+    provider: params.provider,
+    model: params.model,
+  })
+    ? allowedCatalog
+    : undefined;
+}


### PR DESCRIPTION
## What Problem This Solves

#122872 (follow-up scoped out of merged #122762): `--model xai/auto` with an explicit thinking level fails to resolve the model's thinking params on the mid-run model-override path. xAI's OAuth `auto` alias exists only through scoped live discovery (`catalog.run` mints the row with `canonicalModelId`), but the override rehydration in `run-embedded-attempt.ts` called the bare unscoped `loadPreparedModelCatalogSnapshot` — no `providerDiscoveryProviderIds`, no live discovery — so the `auto` row never materialized and the thinking profile fell to off-only. It also latched `attemptedThinkingCatalogHydration` unconditionally, so a failed hydration blocked any later attempt.

## Why This Change Was Made

The correct ladder (manifest → scoped-static → scoped-live) already existed in `model-selection.ts`'s initial-selection path via `loadProviderScopedThinkingCatalog`; the override path simply diverged from it. Per the one-canonical-flow rule, this PR extracts the shared hydration into `src/agents/thinking-catalog-hydration.ts` and migrates **both** call sites to it, deleting the duplicated ~40-line blocks:

- Override path now hydrates provider-scoped (reaching scoped live discovery for runtime-only models) and adopts the result only when the target entry actually resolved.
- The hydration latch is now keyed per `provider/model` (a `Set`) instead of a global boolean: one attempt per target inside the retry loop (no runaway rediscovery), while a later switch to a *different* model still hydrates.
- Fail-closed is preserved with no new core branch: when scoped discovery yields nothing, the previous catalog stays, the provider policy sees no `params`, and xAI's own `resolveXaiOAuthAutoModelId` keeps the off-only profile. No `"auto"` strings, canonical-id lookups, or Grok tables were added to core — that logic stays in `extensions/xai/` per the owner boundary.

## User Impact

`--model xai/auto --thinking xhigh` (and any provider whose models exist only at runtime) resolves thinking capability on model-switch retries the same way it does at initial selection. Missing catalog/OAuth still degrades to off-only rather than inventing a target.

## Evidence

- New test in `src/agents/agent-command.live-model-switch.test.ts`: after a `LiveSessionModelSwitchError` retry, the override path calls `loadProviderScopedThinkingCatalog` with the switched `provider`/`model` (fails on current main — the scoped loader is never invoked there; verified red-first). All 118 pre-existing tests in the file green.
- Guard suite green: `model-selection.plugin-runtime.test.ts`.
- `pnpm build` clean — 2848 modules, no `[INEFFECTIVE_DYNAMIC_IMPORT]` (the lazy `model-catalog.runtime` boundary moved into the shared helper).
- `pnpm format` + `scripts/run-oxlint.mjs` clean (the extraction also brings `run-embedded-attempt.ts` back under the 700-line lint cap).
- Not covered here: a live OAuth run of `openclaw agent --local --model xai/auto --thinking xhigh` — the pure-policy matrix (4.6 xhigh / 4.5 capped / no-canonical off-only) is owned by `extensions/xai/provider-policy-api.test.ts` from #122762, and `src/agents/xai.live.test.ts` carries the live xhigh case.

### Live-proof status (stated plainly)

The reviewer asks for an after-fix live OAuth run of `openclaw agent --local --model xai/auto --thinking xhigh`. I do not have xAI OAuth credentials on this machine, so I cannot produce that trace myself; the strongest available evidence here is:

- red-first regression: on current main the override path never calls `loadProviderScopedThinkingCatalog` (new test fails); with this branch it is called with the switched `provider`/`model` and the resolved entry is adopted;
- the hydration ladder invoked is byte-for-byte the one the initial-selection path already uses in production (`loadProviderScopedThinkingCatalog` — the same function that materializes the live `xai/auto` row during initial selection today), now shared via one helper rather than duplicated;
- `pnpm build` clean (2848 modules, no `[INEFFECTIVE_DYNAMIC_IMPORT]`), full `agent-command.live-model-switch.test.ts` suite green (119 tests).

If a maintainer or the issue reporter has xAI OAuth handy, `openclaw agent --local --model xai/auto --thinking xhigh -m "ping"` on this branch (and once with OAuth unavailable to confirm the clean off-only degrade) would close the gap — happy to coordinate or run it on a credentialed environment if one can be provided.

Fixes #122872. Related: #122762 (provider-side work that scoped this issue out).

