### PR TITLE
fix(macos): adopt Peekaboo 4.1 bridge contracts

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b9da0800ad69c2e9ac7aef5828a9c6037cc84e36bfe110280567a3484a98773b",
+  "originHash" : "d435a807d9fca378cce9f1a0b27df5a61650f24f4376f4ea9e570ce6b8c6e117",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -53,15 +53,6 @@
       "state" : {
         "revision" : "33bb0e4b1e407feac791e047dcaaf9c69b25fd26",
         "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "peekaboo",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/steipete/Peekaboo.git",
-      "state" : {
-        "revision" : "416247a4e08088dfa227d07658a08e427bc04353",
-        "version" : "3.9.8"
       }
     },
     {

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d435a807d9fca378cce9f1a0b27df5a61650f24f4376f4ea9e570ce6b8c6e117",
+  "originHash" : "000000bde5955caf22291bddf4458c7a1f7ff8d1e501538e0ea1413cc68a251e",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -53,6 +53,14 @@
       "state" : {
         "revision" : "33bb0e4b1e407feac791e047dcaaf9c69b25fd26",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "peekaboo",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openclaw/Peekaboo.git",
+      "state" : {
+        "revision" : "a2fb16764a7d1c53bf696127c287ba32703f614f"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -20,7 +20,9 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
-        .package(name: "Peekaboo", path: "/private/tmp/peekaboo-embedded-bridge-runtime"),
+        .package(
+            url: "https://github.com/openclaw/Peekaboo.git",
+            revision: "a2fb16764a7d1c53bf696127c287ba32703f614f"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
-        .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.9.8"),
+        .package(name: "Peekaboo", path: "/private/tmp/peekaboo-embedded-bridge-runtime"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -406,6 +406,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         await MacNodeModeCoordinator.shared.stopAndWait()
     }
 
+    var peekabooBridgeTerminationCleanup: @MainActor () async -> Void = {
+        await PeekabooBridgeHostCoordinator.shared.shutdown()
+    }
+
     var waitForTerminationCleanupDeadline: @MainActor () async -> Void = {
         try? await Task.sleep(for: .seconds(AppTerminationTiming.cleanupDeadlineSeconds))
     }
@@ -656,7 +660,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         WebChatManager.shared.resetTunnels()
         Task { await RemoteTunnelManager.shared.stopAll() }
         Task { await GatewayConnection.shared.shutdown() }
-        Task { await PeekabooBridgeHostCoordinator.shared.stop() }
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -666,9 +669,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard self.terminationCleanupTask == nil else {
             return .terminateLater
         }
-        let cleanup = self.nodeTerminationCleanup
+        let nodeCleanup = self.nodeTerminationCleanup
+        let bridgeCleanup = self.peekabooBridgeTerminationCleanup
         self.terminationCleanupTask = Task { @MainActor [weak self] in
-            await cleanup()
+            async let nodeCleanupResult: Void = nodeCleanup()
+            async let bridgeCleanupResult: Void = bridgeCleanup()
+            _ = await (nodeCleanupResult, bridgeCleanupResult)
             self?.finishTerminationCleanup(for: sender)
         }
         let waitForDeadline = self.waitForTerminationCleanupDeadline

--- a/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
@@ -90,7 +90,12 @@ final class PeekabooBridgeHostCoordinator {
                     socketPath: socketPath,
                     allowlistedTeams: Self.allowedClientTeamIDs,
                     allowlistedBundles: Self.allowedClientBundleIDs,
-                    hostKind: .gui))
+                    hostKind: .gui),
+                snapshotOptions: .init(
+                    snapshotValidityWindow: 600,
+                    maxSnapshots: 50,
+                    deleteArtifactsOnCleanup: false,
+                    copyArtifactsOnStore: true))
         }
         self.aliasManager = LegacyPeekabooSocketAliasManager(
             targetSocketPath: socketPath,

--- a/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
@@ -1,20 +1,122 @@
+import Darwin
 import Foundation
 import os
-import PeekabooAutomationKit
 import PeekabooBridge
-import PeekabooFoundation
-import Security
+
+protocol PeekabooBridgeRuntimeControlling: Sendable {
+    func startChecked() async throws -> PeekabooEmbeddedBridgeRuntimeSnapshot
+    func stopChecked() async
+    func snapshot() async -> PeekabooEmbeddedBridgeRuntimeSnapshot
+}
+
+extension PeekabooEmbeddedBridgeRuntime: PeekabooBridgeRuntimeControlling {}
+
+struct LegacyPeekabooSocketAliasManager {
+    let targetSocketPath: String
+    let aliasSocketPaths: [String]
+
+    func ensureAliases(logger: Logger) {
+        for aliasPath in self.aliasSocketPaths {
+            self.ensureAlias(at: aliasPath, logger: logger)
+        }
+    }
+
+    private func ensureAlias(at aliasPath: String, logger: Logger) {
+        let fileManager = FileManager.default
+        let aliasURL = URL(fileURLWithPath: aliasPath)
+        do {
+            try fileManager.createDirectory(
+                at: aliasURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+
+            var pathInfo = Darwin.stat()
+            if lstat(aliasPath, &pathInfo) == 0 {
+                guard pathInfo.st_mode & S_IFMT == S_IFLNK else {
+                    logger.debug(
+                        "Preserving non-symlink legacy PeekabooBridge path at \(aliasPath, privacy: .public)")
+                    return
+                }
+                let destination = try fileManager.destinationOfSymbolicLink(atPath: aliasPath)
+                let destinationURL = URL(
+                    fileURLWithPath: destination,
+                    relativeTo: aliasURL.deletingLastPathComponent()).standardizedFileURL
+                let targetURL = URL(fileURLWithPath: self.targetSocketPath).standardizedFileURL
+                guard destinationURL.path == targetURL.path else {
+                    logger.debug(
+                        "Preserving unowned legacy PeekabooBridge symlink at \(aliasPath, privacy: .public)")
+                    return
+                }
+                return
+            }
+            guard errno == ENOENT else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            try fileManager.createSymbolicLink(
+                atPath: aliasPath,
+                withDestinationPath: self.targetSocketPath)
+        } catch {
+            let message = "Failed to create legacy PeekabooBridge socket symlink: \(error.localizedDescription)"
+            logger.debug("\(message, privacy: .public)")
+        }
+    }
+}
 
 @MainActor
 final class PeekabooBridgeHostCoordinator {
+    typealias RuntimeFactory = @MainActor () -> any PeekabooBridgeRuntimeControlling
+
     static let shared = PeekabooBridgeHostCoordinator()
 
-    private let logger = Logger(subsystem: "ai.openclaw", category: "PeekabooBridge")
-
-    private var host: PeekabooBridgeHost?
-    private var services: OpenClawPeekabooBridgeServices?
+    static let allowedClientTeamIDs: Set<String> = ["FWJYW4S8P8"]
+    static let allowedClientBundleIDs: Set<String> = ["boo.peekaboo.peekaboo"]
 
     private static let legacySocketDirectoryNames = ["clawdbot", "clawdis", "moltbot"]
+
+    private let logger: Logger
+    private let runtimeFactory: RuntimeFactory
+    private let aliasManager: LegacyPeekabooSocketAliasManager
+
+    private var desiredEnabled = false
+    private var retainedRuntime: (any PeekabooBridgeRuntimeControlling)?
+    private var reconciliationTail: Task<Void, Never>?
+
+    init() {
+        let socketPath = Self.openclawSocketPath
+        self.logger = Logger(subsystem: "ai.openclaw", category: "PeekabooBridge")
+        self.runtimeFactory = {
+            PeekabooEmbeddedBridgeRuntime.make(
+                configuration: .init(
+                    socketPath: socketPath,
+                    allowlistedTeams: Self.allowedClientTeamIDs,
+                    allowlistedBundles: Self.allowedClientBundleIDs,
+                    hostKind: .gui))
+        }
+        self.aliasManager = LegacyPeekabooSocketAliasManager(
+            targetSocketPath: socketPath,
+            aliasSocketPaths: Self.legacySocketPaths)
+    }
+
+    init(runtimeFactory: @escaping RuntimeFactory, aliasManager: LegacyPeekabooSocketAliasManager) {
+        self.logger = Logger(subsystem: "ai.openclaw", category: "PeekabooBridge")
+        self.runtimeFactory = runtimeFactory
+        self.aliasManager = aliasManager
+    }
+
+    func setEnabled(_ enabled: Bool) async {
+        self.desiredEnabled = enabled
+        let predecessor = self.reconciliationTail
+        let operation = Task { @MainActor [weak self] in
+            await predecessor?.value
+            await self?.reconcileDesiredState()
+        }
+        self.reconciliationTail = operation
+        await operation.value
+    }
+
+    func shutdown() async {
+        await self.setEnabled(false)
+    }
 
     private static var openclawSocketPath: String {
         let fileManager = FileManager.default
@@ -37,169 +139,76 @@ final class PeekabooBridgeHostCoordinator {
         return Self.legacySocketDirectoryNames.map { Self.makeSocketPath(for: $0, in: base) }
     }
 
-    func setEnabled(_ enabled: Bool) async {
-        if enabled {
-            await self.startIfNeeded()
+    private func reconcileDesiredState() async {
+        if self.desiredEnabled {
+            await self.ensureStarted()
         } else {
-            await self.stop()
+            await self.ensureStopped()
         }
     }
 
-    func stop() async {
-        guard let host else { return }
-        await host.stop()
-        self.host = nil
-        self.services = nil
+    private func ensureStarted() async {
+        if let retainedRuntime {
+            let snapshot = await retainedRuntime.snapshot()
+            guard snapshot.state != .ready else { return }
+            do {
+                let started = try await retainedRuntime.startChecked()
+                guard started.state == .ready else {
+                    self.logger.error("PeekabooBridge retained runtime did not become ready")
+                    return
+                }
+                self.aliasManager.ensureAliases(logger: self.logger)
+            } catch {
+                let message = "Failed to restart retained PeekabooBridge runtime: \(error.localizedDescription)"
+                self.logger.error("\(message, privacy: .public)")
+            }
+            return
+        }
+
+        let candidate = self.runtimeFactory()
+        do {
+            let started = try await candidate.startChecked()
+            guard started.state == .ready else {
+                await self.stopCandidate(candidate)
+                self.logger.error("PeekabooBridge runtime returned before becoming ready")
+                return
+            }
+            guard self.desiredEnabled else {
+                await self.stopCandidate(candidate)
+                return
+            }
+
+            self.retainedRuntime = candidate
+            self.aliasManager.ensureAliases(logger: self.logger)
+            self.logger.info("PeekabooBridge host ready at \(started.socketPath, privacy: .public)")
+        } catch {
+            self.logger.error("Failed to start PeekabooBridge host: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func ensureStopped() async {
+        guard let retainedRuntime else { return }
+        await retainedRuntime.stopChecked()
+        let snapshot = await retainedRuntime.snapshot()
+        guard snapshot.state == .stopped else {
+            // A runtime that still owns the socket must stay retained so the next reconciliation can finish teardown.
+            let state = snapshot.state.rawValue
+            self.logger.error("PeekabooBridge host retained after incomplete stop in state \(state, privacy: .public)")
+            return
+        }
+        self.retainedRuntime = nil
         self.logger.info("PeekabooBridge host stopped")
     }
 
-    private func startIfNeeded() async {
-        guard self.host == nil else { return }
-
-        // Peekaboo owns release-signer migrations; hosts must accept its current compatibility set.
-        var allowlistedTeamIDs = PeekabooBridgeConstants.trustedReleaseTeamIDs
-        if let teamID = Self.currentTeamID() {
-            allowlistedTeamIDs.insert(teamID)
+    private func stopCandidate(_ candidate: any PeekabooBridgeRuntimeControlling) async {
+        await candidate.stopChecked()
+        let snapshot = await candidate.snapshot()
+        guard snapshot.state == .stopped else {
+            self.retainedRuntime = candidate
+            let state = snapshot.state.rawValue
+            let message = "PeekabooBridge candidate retained after incomplete stop in state \(state)"
+            self.logger.error("\(message, privacy: .public)")
+            return
         }
-        let allowlistedBundles: Set<String> = []
-
-        self.ensureLegacySocketSymlinks()
-
-        let services = OpenClawPeekabooBridgeServices()
-        let server = PeekabooBridgeServer(
-            services: services,
-            hostKind: .gui,
-            allowlistedTeams: allowlistedTeamIDs,
-            allowlistedBundles: allowlistedBundles)
-
-        let host = PeekabooBridgeHost(
-            socketPath: Self.openclawSocketPath,
-            server: server,
-            allowedTeamIDs: allowlistedTeamIDs,
-            requestTimeoutSec: 10)
-
-        self.services = services
-        self.host = host
-
-        await host.start()
-        self.logger
-            .info("PeekabooBridge host started at \(Self.openclawSocketPath, privacy: .public)")
-    }
-
-    private func ensureLegacySocketSymlinks() {
-        for legacyPath in Self.legacySocketPaths {
-            self.ensureLegacySocketSymlink(at: legacyPath)
-        }
-    }
-
-    private func ensureLegacySocketSymlink(at legacyPath: String) {
-        let fileManager = FileManager.default
-        let legacyDirectory = (legacyPath as NSString).deletingLastPathComponent
-        do {
-            let directoryAttributes: [FileAttributeKey: Any] = [
-                .posixPermissions: 0o700,
-            ]
-            try fileManager.createDirectory(
-                atPath: legacyDirectory,
-                withIntermediateDirectories: true,
-                attributes: directoryAttributes)
-            let linkURL = URL(fileURLWithPath: legacyPath)
-            let linkValues = try? linkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
-            if linkValues?.isSymbolicLink == true {
-                let destination = try FileManager.default.destinationOfSymbolicLink(atPath: legacyPath)
-                let destinationURL = URL(fileURLWithPath: destination, relativeTo: linkURL.deletingLastPathComponent())
-                    .standardizedFileURL
-                if destinationURL.path == URL(fileURLWithPath: Self.openclawSocketPath).standardizedFileURL.path {
-                    return
-                }
-                try fileManager.removeItem(atPath: legacyPath)
-            } else if fileManager.fileExists(atPath: legacyPath) {
-                try fileManager.removeItem(atPath: legacyPath)
-            }
-            try fileManager.createSymbolicLink(atPath: legacyPath, withDestinationPath: Self.openclawSocketPath)
-        } catch {
-            let message = "Failed to create legacy PeekabooBridge socket symlink: \(error.localizedDescription)"
-            self.logger
-                .debug("\(message, privacy: .public)")
-        }
-    }
-
-    private static func currentTeamID() -> String? {
-        var code: SecCode?
-        guard SecCodeCopySelf(SecCSFlags(), &code) == errSecSuccess,
-              let code
-        else {
-            return nil
-        }
-
-        var staticCode: SecStaticCode?
-        guard SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode) == errSecSuccess,
-              let staticCode
-        else {
-            return nil
-        }
-
-        var infoCF: CFDictionary?
-        guard SecCodeCopySigningInformation(
-            staticCode,
-            SecCSFlags(rawValue: kSecCSSigningInformation),
-            &infoCF) == errSecSuccess,
-            let info = infoCF as? [String: Any]
-        else {
-            return nil
-        }
-
-        return info[kSecCodeInfoTeamIdentifier as String] as? String
-    }
-}
-
-@MainActor
-private final class OpenClawPeekabooBridgeServices: PeekabooBridgeServiceProviding {
-    let permissions: PermissionsService
-    let screenCapture: any ScreenCaptureServiceProtocol
-    let automation: any UIAutomationServiceProtocol
-    let windows: any WindowManagementServiceProtocol
-    let applications: any ApplicationServiceProtocol
-    let menu: any MenuServiceProtocol
-    let dock: any DockServiceProtocol
-    let dialogs: any DialogServiceProtocol
-    let snapshots: any SnapshotManagerProtocol
-    let desktopObservation: any DesktopObservationServiceProtocol
-
-    init() {
-        let logging = LoggingService(subsystem: "ai.openclaw.peekaboo")
-        let feedbackClient: any AutomationFeedbackClient = NoopAutomationFeedbackClient()
-
-        let snapshots = InMemorySnapshotManager(options: .init(
-            snapshotValidityWindow: 600,
-            maxSnapshots: 50,
-            deleteArtifactsOnCleanup: false))
-        let applications = ApplicationService(feedbackClient: feedbackClient)
-
-        let screenCapture = ScreenCaptureService(loggingService: logging)
-        let automation = UIAutomationService(
-            snapshotManager: snapshots,
-            loggingService: logging,
-            searchPolicy: .balanced,
-            feedbackClient: feedbackClient)
-        let menu = MenuService(applicationService: applications, feedbackClient: feedbackClient)
-        let screens = ScreenService()
-
-        self.permissions = PermissionsService()
-        self.snapshots = snapshots
-        self.applications = applications
-        self.screenCapture = screenCapture
-        self.automation = automation
-        self.windows = WindowManagementService(applicationService: applications, feedbackClient: feedbackClient)
-        self.menu = menu
-        self.dock = DockService(feedbackClient: feedbackClient)
-        self.dialogs = DialogService(feedbackClient: feedbackClient)
-        self.desktopObservation = DesktopObservationService(
-            screenCapture: screenCapture,
-            automation: automation,
-            applications: applications,
-            menu: menu,
-            screens: screens,
-            snapshotManager: snapshots)
     }
 }

--- a/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
@@ -68,7 +68,7 @@ final class PeekabooBridgeHostCoordinator {
 
     static let shared = PeekabooBridgeHostCoordinator()
 
-    static let allowedClientTeamIDs: Set<String> = ["FWJYW4S8P8"]
+    static let allowedClientTeamIDs = PeekabooBridgeConstants.trustedReleaseTeamIDs
     static let allowedClientBundleIDs: Set<String> = ["boo.peekaboo.peekaboo"]
 
     private static let legacySocketDirectoryNames = ["clawdbot", "clawdis", "moltbot"]

--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -40,6 +40,8 @@
     <string></string>
     <key>OpenClawGitCommit</key>
     <string></string>
+    <key>PeekabooSourceCommit</key>
+    <string></string>
     <key>OpenClawPortGuardianStorageVersion</key>
     <integer>2</integer>
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -162,44 +162,48 @@ struct GatewayLaunchAgentManagerTests {
     }
 
     @Test func `attach only runtime override blocks gateway launch agent writes`() async throws {
-        let dir = FileManager().temporaryDirectory
-            .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)
-        let marker = dir.appendingPathComponent("disable-launchagent")
-        try FileManager().createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { try? FileManager().removeItem(at: dir) }
-        defer {
-            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
-            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+        try await TestIsolation.withIsolatedState {
+            let dir = FileManager().temporaryDirectory
+                .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)
+            let marker = dir.appendingPathComponent("disable-launchagent")
+            try FileManager().createDirectory(at: dir, withIntermediateDirectories: true)
+            defer { try? FileManager().removeItem(at: dir) }
+            defer {
+                GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            }
+
+            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
             GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+
+            let error = GatewayLaunchAgentManager.applyAttachOnlyRuntimeOverride()
+            let kickstartError = await GatewayLaunchAgentManager.kickstart()
+
+            #expect(error == nil)
+            #expect(kickstartError == nil)
+            #expect(FileManager().fileExists(atPath: marker.path))
+            #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
         }
-
-        GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
-        GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
-        GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
-
-        let error = GatewayLaunchAgentManager.applyAttachOnlyRuntimeOverride()
-        let kickstartError = await GatewayLaunchAgentManager.kickstart()
-
-        #expect(error == nil)
-        #expect(kickstartError == nil)
-        #expect(FileManager().fileExists(atPath: marker.path))
-        #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
     }
 
     @Test func `unintercepted daemon commands fail closed during tests`() async {
-        let marker = FileManager.default.temporaryDirectory
-            .appendingPathComponent("openclaw-no-disable-marker-\(UUID().uuidString)")
-        defer {
-            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+        await TestIsolation.withIsolatedState {
+            let marker = FileManager.default.temporaryDirectory
+                .appendingPathComponent("openclaw-no-disable-marker-\(UUID().uuidString)")
+            defer {
+                GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+            }
+
+            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
             GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+
+            let error = await GatewayLaunchAgentManager.kickstart()
+
+            #expect(error == "Gateway daemon commands require explicit interception during tests")
         }
-
-        GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
-        GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
-
-        let error = await GatewayLaunchAgentManager.kickstart()
-
-        #expect(error == "Gateway daemon commands require explicit interception during tests")
     }
 
     @Test func `launch agent plist snapshot parses args and env`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -34,6 +34,7 @@ struct GatewayLaunchAgentManagerTests {
         let command = await CommandResolver.openclawCommand(
             subcommand: "gateway",
             extraArgs: ["status", "--json"],
+            configRoot: ["gateway": ["mode": "local"]],
             projectRoot: root,
             profile: AppProfile(environment: ["OPENCLAW_PROFILE": "work"]))
 

--- a/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
@@ -86,6 +86,42 @@ struct MenuContentSmokeTests {
         #expect(delegate.applicationShouldTerminate(NSApplication.shared) == .terminateNow)
     }
 
+    @Test func `application termination waits for Peekaboo Bridge shutdown`() async {
+        let delegate = AppDelegate()
+        let cleanupStarted = AsyncStream<Void>.makeStream()
+        let cleanupRelease = AsyncStream<Void>.makeStream()
+        let deadlineRelease = AsyncStream<Void>.makeStream()
+        var startedIterator = cleanupStarted.stream.makeAsyncIterator()
+        var replies: [Bool] = []
+        delegate.nodeTerminationCleanup = {}
+        delegate.peekabooBridgeTerminationCleanup = {
+            cleanupStarted.continuation.yield()
+            for await _ in cleanupRelease.stream {
+                return
+            }
+        }
+        delegate.waitForTerminationCleanupDeadline = {
+            for await _ in deadlineRelease.stream {
+                return
+            }
+        }
+        delegate.applicationTerminationReply = { _, allow in
+            replies.append(allow)
+        }
+
+        #expect(delegate.applicationShouldTerminate(NSApplication.shared) == .terminateLater)
+        _ = await startedIterator.next()
+        #expect(replies.isEmpty)
+
+        cleanupRelease.continuation.yield()
+        cleanupRelease.continuation.finish()
+        while replies.isEmpty {
+            await Task.yield()
+        }
+        #expect(replies == [true])
+        #expect(delegate.applicationShouldTerminate(NSApplication.shared) == .terminateNow)
+    }
+
     @Test func `application termination deadline does not await stalled cleanup`() async {
         let delegate = AppDelegate()
         let cleanup = CancellationIgnoringTerminationCleanup()

--- a/apps/macos/Tests/OpenClawIPCTests/PeekabooBridgeHostCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PeekabooBridgeHostCoordinatorTests.swift
@@ -7,8 +7,11 @@ import Testing
 @MainActor
 struct PeekabooBridgeHostCoordinatorTests {
     @Test
-    func `production authorization is limited to the Foundation Peekaboo CLI`() {
-        #expect(PeekabooBridgeHostCoordinator.allowedClientTeamIDs == ["FWJYW4S8P8"])
+    func `production authorization uses the canonical Peekaboo CLI release signers`() {
+        #expect(
+            PeekabooBridgeHostCoordinator.allowedClientTeamIDs ==
+                PeekabooBridgeConstants.trustedReleaseTeamIDs)
+        #expect(PeekabooBridgeHostCoordinator.allowedClientTeamIDs == ["Y5PE65HELJ", "FWJYW4S8P8"])
         #expect(PeekabooBridgeHostCoordinator.allowedClientBundleIDs == ["boo.peekaboo.peekaboo"])
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/PeekabooBridgeHostCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PeekabooBridgeHostCoordinatorTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import PeekabooBridge
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct PeekabooBridgeHostCoordinatorTests {
+    @Test
+    func `production authorization is limited to the Foundation Peekaboo CLI`() {
+        #expect(PeekabooBridgeHostCoordinator.allowedClientTeamIDs == ["FWJYW4S8P8"])
+        #expect(PeekabooBridgeHostCoordinator.allowedClientBundleIDs == ["boo.peekaboo.peekaboo"])
+    }
+
+    @Test
+    func `later disable stops an earlier suspended startup before it is retained`() async {
+        let startEntered = AsyncTestGate()
+        let releaseStart = AsyncTestGate()
+        let runtime = ScriptedBridgeRuntime(
+            startAction: {
+                startEntered.open()
+                await releaseStart.wait()
+            })
+        let factory = ScriptedRuntimeFactory([runtime])
+        let coordinator = Self.coordinator(factory: factory)
+
+        let enableTask = Task { await coordinator.setEnabled(true) }
+        await startEntered.wait()
+        let disableTask = Task { await coordinator.setEnabled(false) }
+        await Task.yield()
+        await Task.yield()
+        releaseStart.open()
+
+        await enableTask.value
+        await disableTask.value
+        #expect(await runtime.startCount == 1)
+        #expect(await runtime.stopCount == 1)
+        #expect(await runtime.snapshot().state == .stopped)
+    }
+
+    @Test
+    func `a later enable retries after startup failure`() async {
+        let failedRuntime = ScriptedBridgeRuntime(startResults: [.failure(.startup)])
+        let readyRuntime = ScriptedBridgeRuntime()
+        let factory = ScriptedRuntimeFactory([failedRuntime, readyRuntime])
+        let coordinator = Self.coordinator(factory: factory)
+
+        await coordinator.setEnabled(true)
+        await coordinator.setEnabled(true)
+
+        #expect(factory.makeCount == 2)
+        #expect(await failedRuntime.startCount == 1)
+        #expect(await readyRuntime.startCount == 1)
+        await coordinator.setEnabled(false)
+        #expect(await readyRuntime.stopCount == 1)
+    }
+
+    @Test
+    func `incomplete stop retains the runtime for a later teardown retry`() async {
+        let runtime = ScriptedBridgeRuntime(stopStates: [.stopping, .stopped])
+        let factory = ScriptedRuntimeFactory([runtime])
+        let coordinator = Self.coordinator(factory: factory)
+
+        await coordinator.setEnabled(true)
+        await coordinator.setEnabled(false)
+        await coordinator.setEnabled(false)
+
+        #expect(factory.makeCount == 1)
+        #expect(await runtime.stopCount == 2)
+        #expect(await runtime.snapshot().state == .stopped)
+    }
+
+    @Test
+    func `legacy aliases never replace regular files or unrelated symlinks`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-peekaboo-alias-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let target = root.appendingPathComponent("target.sock").path
+        let regularAlias = root.appendingPathComponent("regular/bridge.sock")
+        let foreignAlias = root.appendingPathComponent("foreign/bridge.sock")
+        let newAlias = root.appendingPathComponent("new/bridge.sock")
+        try FileManager.default.createDirectory(
+            at: regularAlias.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: foreignAlias.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data("owned by another process".utf8).write(to: regularAlias)
+        try FileManager.default.createSymbolicLink(
+            atPath: foreignAlias.path,
+            withDestinationPath: root.appendingPathComponent("other.sock").path)
+
+        LegacyPeekabooSocketAliasManager(
+            targetSocketPath: target,
+            aliasSocketPaths: [regularAlias.path, foreignAlias.path, newAlias.path])
+            .ensureAliases(logger: .init(subsystem: "ai.openclaw.tests", category: "PeekabooBridge"))
+
+        #expect(try String(contentsOf: regularAlias, encoding: .utf8) == "owned by another process")
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: foreignAlias.path) ==
+            root.appendingPathComponent("other.sock").path)
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: newAlias.path) == target)
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["OPENCLAW_PEEKABOO_HANDSHAKE_CLI"] != nil))
+    func `embedded runtime serves an exact socket handshake`() async throws {
+        let cliPath = try #require(ProcessInfo.processInfo.environment["OPENCLAW_PEEKABOO_HANDSHAKE_CLI"])
+        let socketPath = "/tmp/oc-pb-\(UUID().uuidString).sock"
+        defer {
+            try? FileManager.default.removeItem(atPath: socketPath)
+            try? FileManager.default.removeItem(atPath: "\(socketPath).lock")
+        }
+
+        let coordinator = PeekabooBridgeHostCoordinator(
+            runtimeFactory: {
+                PeekabooEmbeddedBridgeRuntime.make(
+                    configuration: .init(
+                        socketPath: socketPath,
+                        allowlistedTeams: PeekabooBridgeHostCoordinator.allowedClientTeamIDs,
+                        allowlistedBundles: PeekabooBridgeHostCoordinator.allowedClientBundleIDs,
+                        hostKind: .gui))
+            },
+            aliasManager: .init(targetSocketPath: socketPath, aliasSocketPaths: []))
+        await coordinator.setEnabled(true)
+
+        let result = try await Task.detached {
+            let process = Process()
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.executableURL = URL(fileURLWithPath: cliPath)
+            process.arguments = ["bridge", "status", "--bridge-socket", socketPath, "--json"]
+            process.standardOutput = stdout
+            process.standardError = stderr
+            try process.run()
+            process.waitUntilExit()
+            return ProcessResult(
+                status: process.terminationStatus,
+                stdout: String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+                stderr: String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self))
+        }.value
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stdout.replacingOccurrences(of: "\\/", with: "/").contains(socketPath))
+        #expect(result.stdout.contains("backgroundBridgeHost"))
+
+        await coordinator.shutdown()
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    private static func coordinator(factory: ScriptedRuntimeFactory) -> PeekabooBridgeHostCoordinator {
+        PeekabooBridgeHostCoordinator(
+            runtimeFactory: { factory.make() },
+            aliasManager: .init(targetSocketPath: "/tmp/openclaw-test.sock", aliasSocketPaths: []))
+    }
+}
+
+private struct ProcessResult: Sendable {
+    let status: Int32
+    let stdout: String
+    let stderr: String
+}
+
+private enum ScriptedRuntimeError: Error {
+    case startup
+}
+
+private actor ScriptedBridgeRuntime: PeekabooBridgeRuntimeControlling {
+    private let socketPath = "/tmp/openclaw-scripted-peekaboo.sock"
+    private let startAction: @Sendable () async -> Void
+    private var startResults: [Result<PeekabooEmbeddedBridgeRuntimeState, ScriptedRuntimeError>]
+    private var stopStates: [PeekabooEmbeddedBridgeRuntimeState]
+    private var state: PeekabooEmbeddedBridgeRuntimeState = .stopped
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    init(
+        startResults: [Result<PeekabooEmbeddedBridgeRuntimeState, ScriptedRuntimeError>] = [.success(.ready)],
+        stopStates: [PeekabooEmbeddedBridgeRuntimeState] = [.stopped],
+        startAction: @escaping @Sendable () async -> Void = {})
+    {
+        self.startResults = startResults
+        self.stopStates = stopStates
+        self.startAction = startAction
+    }
+
+    func startChecked() async throws -> PeekabooEmbeddedBridgeRuntimeSnapshot {
+        self.startCount += 1
+        await self.startAction()
+        let result = self.startResults.isEmpty ? .success(.ready) : self.startResults.removeFirst()
+        self.state = try result.get()
+        return self.snapshot()
+    }
+
+    func stopChecked() async {
+        self.stopCount += 1
+        self.state = self.stopStates.isEmpty ? .stopped : self.stopStates.removeFirst()
+    }
+
+    func snapshot() -> PeekabooEmbeddedBridgeRuntimeSnapshot {
+        .init(state: self.state, socketPath: self.socketPath, hostCapabilities: [])
+    }
+}
+
+@MainActor
+private final class ScriptedRuntimeFactory {
+    private var runtimes: [ScriptedBridgeRuntime]
+    private(set) var makeCount = 0
+
+    init(_ runtimes: [ScriptedBridgeRuntime]) {
+        self.runtimes = runtimes
+    }
+
+    func make() -> any PeekabooBridgeRuntimeControlling {
+        self.makeCount += 1
+        return self.runtimes.removeFirst()
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
@@ -8,16 +8,18 @@ import Testing
 @MainActor
 struct UpdateOrchestrationTests {
     @MainActor
-    @Test func `post update performs no service work under active profile`() {
-        let profile = AppProfile(environment: ["OPENCLAW_PROFILE": "work"])
-        NodeServiceManager._testResetPersistentServiceCalls()
-        GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+    @Test func `post update performs no service work under active profile`() async {
+        await TestIsolation.withIsolatedState {
+            let profile = AppProfile(environment: ["OPENCLAW_PROFILE": "work"])
+            NodeServiceManager._testResetPersistentServiceCalls()
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
 
-        #expect(!PostUpdateController.shared.startIfNeeded(profile: profile))
-        let snapshot = NodeServiceManager._testPersistentServiceCallSnapshot()
-        #expect(snapshot.commands.isEmpty)
-        #expect(snapshot.ownershipReads == 0)
-        #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
+            #expect(!PostUpdateController.shared.startIfNeeded(profile: profile))
+            let snapshot = NodeServiceManager._testPersistentServiceCallSnapshot()
+            #expect(snapshot.commands.isEmpty)
+            #expect(snapshot.ownershipReads == 0)
+            #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
+        }
     }
 
     @Test func `Sparkle receipt appears only after the target app launches`() throws {

--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -49,7 +49,9 @@ export PEEKABOO_BRIDGE_SOCKET=/path/to/bridge.sock
 
 ## Security and permissions
 
-- The bridge validates **caller code signatures**; an allowlist of TeamIDs is enforced (Peekaboo host TeamID plus the running app's own TeamID).
+- The bridge validates **caller code signatures**. The production OpenClaw host accepts only the Foundation-signed
+  Peekaboo client (`FWJYW4S8P8`, bundle identifier `boo.peekaboo.peekaboo`); sharing the app's UID or using another
+  client signed by the app's development team is not sufficient.
 - Prefer the signed bridge/app identity over a generic `node` runtime for Accessibility. Granting Accessibility to `node` lets any package launched by that Node executable inherit GUI automation access; see [macOS permissions](/platforms/mac/permissions#accessibility-grants-for-node-and-cli-runtimes).
 - Requests time out after 10 seconds (`requestTimeoutSec: 10`).
 - If required permissions are missing, the bridge returns a clear error message rather than launching System Settings.

--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -49,9 +49,10 @@ export PEEKABOO_BRIDGE_SOCKET=/path/to/bridge.sock
 
 ## Security and permissions
 
-- The bridge validates **caller code signatures**. The production OpenClaw host accepts only the Foundation-signed
-  Peekaboo client (`FWJYW4S8P8`, bundle identifier `boo.peekaboo.peekaboo`); sharing the app's UID or using another
-  client signed by the app's development team is not sufficient.
+- The bridge validates **caller code signatures**. The production OpenClaw host accepts only the exact Peekaboo CLI
+  bundle (`boo.peekaboo.peekaboo`) signed by Peekaboo's canonical current/legacy release signer set (`FWJYW4S8P8`
+  and `Y5PE65HELJ`); sharing the app's UID or using another client signed by the app's development team is not
+  sufficient.
 - Prefer the signed bridge/app identity over a generic `node` runtime for Accessibility. Granting Accessibility to `node` lets any package launched by that Node executable inherit GUI automation access; see [macOS permissions](/platforms/mac/permissions#accessibility-grants-for-node-and-cli-runtimes).
 - Requests time out after 10 seconds (`requestTimeoutSec: 10`).
 - If required permissions are missing, the bridge returns a clear error message rather than launching System Settings.

--- a/docs/platforms/mac/xpc.md
+++ b/docs/platforms/mac/xpc.md
@@ -44,13 +44,14 @@ Agent -> Gateway -> Node Service (WS)
 - The built-in agent `computer` tool does **not** use this socket. A paired macOS node fulfills `computer.act` in the app process with embedded Peekaboo services.
 - UI automation uses a separate UNIX socket (`~/Library/Application Support/OpenClaw/<socket>`) and the PeekabooBridge JSON protocol.
 - Host preference order (client-side): Peekaboo.app -> Claude.app -> OpenClaw.app -> local execution.
-- Security: bridge hosts require the Foundation Team ID and the signed Peekaboo client bundle identifier; a DEBUG-only
-  same-UID escape hatch is guarded by `PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1` (Peekaboo convention).
+- Security: bridge hosts require the exact signed Peekaboo client bundle identifier and Peekaboo's canonical
+  current/legacy release signer set; a DEBUG-only same-UID escape hatch is guarded by
+  `PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1` (Peekaboo convention).
 - See: [PeekabooBridge usage](/platforms/mac/peekaboo) for details.
 
 ## Operational flows
 
-- Restart/rebuild: `scripts/restart-mac.sh` kills existing instances, rebuilds via Swift, repackages, and relaunches. It auto-detects an available signing identity and falls back to `--no-sign` if none is found; pass `--sign` to require signing (fails if no key is available) or `--no-sign` to force the unsigned path. `SIGN_IDENTITY` set in the environment is unset on the signed path, so `scripts/codesign-mac-app.sh`'s own identity auto-detection picks the cert.
+- Restart/rebuild: `scripts/restart-mac.sh` kills existing instances, rebuilds via Swift, repackages, and relaunches. It auto-detects an available signing identity and falls back to `--no-sign` if none is found; pass `--sign` to require signing (fails if no key is available) or `--no-sign` to force the unsigned path. An explicit `SIGN_IDENTITY` is preserved through packaging; otherwise `scripts/codesign-mac-app.sh` auto-detects the certificate.
 - Single instance: the app checks `NSWorkspace.runningApplications` for a duplicate bundle ID and exits if more than one instance is found (`isDuplicateInstance()` in `MenuBar.swift`).
 
 ## Hardening notes

--- a/docs/platforms/mac/xpc.md
+++ b/docs/platforms/mac/xpc.md
@@ -44,7 +44,8 @@ Agent -> Gateway -> Node Service (WS)
 - The built-in agent `computer` tool does **not** use this socket. A paired macOS node fulfills `computer.act` in the app process with embedded Peekaboo services.
 - UI automation uses a separate UNIX socket (`~/Library/Application Support/OpenClaw/<socket>`) and the PeekabooBridge JSON protocol.
 - Host preference order (client-side): Peekaboo.app -> Claude.app -> OpenClaw.app -> local execution.
-- Security: bridge hosts require an allowlisted TeamID (the bundled `PeekabooBridgeHostCoordinator` allowlists a fixed team plus the app's own signing team); a DEBUG-only same-UID escape hatch is guarded by `PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1` (Peekaboo convention).
+- Security: bridge hosts require the Foundation Team ID and the signed Peekaboo client bundle identifier; a DEBUG-only
+  same-UID escape hatch is guarded by `PEEKABOO_ALLOW_UNSIGNED_SOCKET_CLIENTS=1` (Peekaboo convention).
 - See: [PeekabooBridge usage](/platforms/mac/peekaboo) for details.
 
 ## Operational flows

--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 APP_BUNDLE="dist/OpenClaw.app"
 IDENTITY="${SIGN_IDENTITY:-}"
 TIMESTAMP_MODE="${CODESIGN_TIMESTAMP:-auto}"
+CODESIGN_TIMESTAMP_RETRY_ATTEMPTS="${CODESIGN_TIMESTAMP_RETRY_ATTEMPTS:-8}"
+CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS="${CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS:-5}"
 DISABLE_LIBRARY_VALIDATION="${DISABLE_LIBRARY_VALIDATION:-0}"
 SKIP_TEAM_ID_CHECK="${SKIP_TEAM_ID_CHECK:-0}"
 ENT_TMP_DIR=""
@@ -22,6 +24,8 @@ Env:
   SIGN_IDENTITY="Apple Development: Your Name (TEAMID)"
   ALLOW_ADHOC_SIGNING=1
   CODESIGN_TIMESTAMP=auto|on|off
+  CODESIGN_TIMESTAMP_RETRY_ATTEMPTS=8
+  CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS=5
   DISABLE_LIBRARY_VALIDATION=1      # dev-only Sparkle Team ID workaround
   SKIP_TEAM_ID_CHECK=1              # bypass Team ID audit
 HELP
@@ -147,9 +151,19 @@ if [[ "$IDENTITY" == "-" ]]; then
   timestamp_arg="--timestamp=none"
 fi
 
+if [[ ! "$CODESIGN_TIMESTAMP_RETRY_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: CODESIGN_TIMESTAMP_RETRY_ATTEMPTS must be a positive integer" >&2
+  exit 1
+fi
+if [[ ! "$CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS must be a nonnegative integer" >&2
+  exit 1
+fi
+
 ENT_TMP_DIR=$(mktemp -d -t openclaw-entitlements.XXXXXX)
 trap cleanup EXIT
 ENT_TMP_APP="$ENT_TMP_DIR/app.plist"
+CODESIGN_OUTPUT="$ENT_TMP_DIR/codesign-output"
 
 options_args=()
 if [[ "$IDENTITY" != "-" ]]; then
@@ -185,15 +199,46 @@ APP_ENTITLEMENTS="$ENT_TMP_APP"
 # clear extended attributes to avoid stale signatures
 xattr -cr "$APP_BUNDLE" 2>/dev/null || true
 
+codesign_with_timestamp_retry() {
+  local attempt=1
+  local command_rc
+  local delay
+
+  while true; do
+    : >"$CODESIGN_OUTPUT"
+    command_rc=0
+    codesign "$@" >"$CODESIGN_OUTPUT" 2>&1 || command_rc=$?
+    cat "$CODESIGN_OUTPUT" >&2
+    if [[ "$command_rc" -eq 0 ]]; then
+      return 0
+    fi
+    if [[ "$timestamp_arg" != "--timestamp" ]] ||
+      ! grep -Eiq 'A timestamp was expected but was not found|timestamp service is not available' "$CODESIGN_OUTPUT"
+    then
+      return "$command_rc"
+    fi
+    if [[ "$attempt" -ge "$CODESIGN_TIMESTAMP_RETRY_ATTEMPTS" ]]; then
+      echo "codesign timestamp retry limit reached after $attempt attempts" >&2
+      return "$command_rc"
+    fi
+
+    delay=$((CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS * attempt))
+    ((delay <= 30)) || delay=30
+    echo "Transient Apple timestamp failure; retrying codesign in ${delay}s (attempt $((attempt + 1))/$CODESIGN_TIMESTAMP_RETRY_ATTEMPTS)" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+}
+
 sign_item() {
   local target="$1"
   local entitlements="$2"
-  codesign --force ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --entitlements "$entitlements" --sign "$IDENTITY" "$target"
+  codesign_with_timestamp_retry --force ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --entitlements "$entitlements" --sign "$IDENTITY" "$target"
 }
 
 sign_plain_item() {
   local target="$1"
-  codesign --force ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --sign "$IDENTITY" "$target"
+  codesign_with_timestamp_retry --force ${options_args+"${options_args[@]}"} "${timestamp_args[@]}" --sign "$IDENTITY" "$target"
 }
 
 team_id_for() {

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -425,10 +425,12 @@ plist_set_string_required "$APP_ROOT/Contents/Info.plist" CFBundleShortVersionSt
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" CFBundleVersion "$APP_BUILD"
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" OpenClawBuildTimestamp "$BUILD_TS"
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" OpenClawGitCommit "$BUILD_GIT_COMMIT"
+plist_set_string_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit "$BUILD_GIT_COMMIT"
 if [[ "$BUILD_CONFIG" == "release" ]]; then
   EMBEDDED_GIT_COMMIT="$(plist_print_required "$APP_ROOT/Contents/Info.plist" OpenClawGitCommit)"
-  if [[ "$EMBEDDED_GIT_COMMIT" != "$BUILD_GIT_COMMIT" ]]; then
-    echo "ERROR: Release app embedded Git commit '$EMBEDDED_GIT_COMMIT', expected '$BUILD_GIT_COMMIT'." >&2
+  BRIDGE_SOURCE_COMMIT="$(plist_print_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit)"
+  if [[ "$EMBEDDED_GIT_COMMIT" != "$BUILD_GIT_COMMIT" || "$BRIDGE_SOURCE_COMMIT" != "$BUILD_GIT_COMMIT" ]]; then
+    echo "ERROR: Release app source mismatch: OpenClawGitCommit='$EMBEDDED_GIT_COMMIT', PeekabooSourceCommit='$BRIDGE_SOURCE_COMMIT', expected='$BUILD_GIT_COMMIT'." >&2
     exit 1
   fi
 fi

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -612,7 +612,11 @@ stop_packaged_app_if_running() {
 
 stop_packaged_app_if_running
 
-echo "🔏 Signing bundle (auto-selects signing identity if SIGN_IDENTITY is unset)"
+if [[ -n "${SIGN_IDENTITY:-}" ]]; then
+  echo "🔏 Signing bundle with explicit SIGN_IDENTITY"
+else
+  echo "🔏 Signing bundle (auto-selecting signing identity)"
+fi
 "$ROOT_DIR/scripts/codesign-mac-app.sh" "$APP_ROOT"
 
 echo "✅ Bundle ready at $APP_ROOT"

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -65,6 +65,39 @@ if [[ "$BUNDLE_ID" == *.debug ]]; then
   AUTO_CHECKS=false
 fi
 
+resolve_peekaboo_source_commit() {
+  local resolved_file="$ROOT_DIR/apps/macos/Package.resolved"
+  /usr/bin/python3 - "$resolved_file" <<'PY'
+import json
+from pathlib import Path
+import re
+import sys
+
+resolved_file = Path(sys.argv[1])
+try:
+    resolved = json.loads(resolved_file.read_text())
+except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"ERROR: Could not parse Peekaboo source revision from {resolved_file}: {error}")
+
+pins = resolved.get("pins") if isinstance(resolved, dict) else None
+if not isinstance(pins, list):
+    raise SystemExit(f"ERROR: Expected a pins array in {resolved_file}")
+
+peekaboo_pins = [pin for pin in pins if isinstance(pin, dict) and pin.get("identity") == "peekaboo"]
+if len(peekaboo_pins) != 1:
+    raise SystemExit(f"ERROR: Expected exactly one 'peekaboo' pin in {resolved_file}; found {len(peekaboo_pins)}")
+
+state = peekaboo_pins[0].get("state")
+revision = state.get("revision") if isinstance(state, dict) else None
+if not isinstance(revision, str) or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+    raise SystemExit(
+        f"ERROR: Peekaboo pin in {resolved_file} must have an exact 40-character lowercase hexadecimal revision"
+    )
+
+print(revision, end="")
+PY
+}
+
 sparkle_canonical_build_from_version() {
   (cd "$ROOT_DIR" && node --import tsx "$ROOT_DIR/scripts/sparkle-build.ts" canonical-build "$1")
 }
@@ -344,6 +377,8 @@ merge_framework_machos() {
   done < <(find "$primary" -type f -print0)
 }
 
+PEEKABOO_SOURCE_COMMIT="$(resolve_peekaboo_source_commit)"
+
 require_swift_toolchain
 
 if [[ "${SKIP_PNPM_INSTALL:-0}" != "1" ]]; then
@@ -425,12 +460,16 @@ plist_set_string_required "$APP_ROOT/Contents/Info.plist" CFBundleShortVersionSt
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" CFBundleVersion "$APP_BUILD"
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" OpenClawBuildTimestamp "$BUILD_TS"
 plist_set_string_required "$APP_ROOT/Contents/Info.plist" OpenClawGitCommit "$BUILD_GIT_COMMIT"
-plist_set_string_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit "$BUILD_GIT_COMMIT"
+plist_set_string_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit "$PEEKABOO_SOURCE_COMMIT"
 if [[ "$BUILD_CONFIG" == "release" ]]; then
   EMBEDDED_GIT_COMMIT="$(plist_print_required "$APP_ROOT/Contents/Info.plist" OpenClawGitCommit)"
   BRIDGE_SOURCE_COMMIT="$(plist_print_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit)"
-  if [[ "$EMBEDDED_GIT_COMMIT" != "$BUILD_GIT_COMMIT" || "$BRIDGE_SOURCE_COMMIT" != "$BUILD_GIT_COMMIT" ]]; then
-    echo "ERROR: Release app source mismatch: OpenClawGitCommit='$EMBEDDED_GIT_COMMIT', PeekabooSourceCommit='$BRIDGE_SOURCE_COMMIT', expected='$BUILD_GIT_COMMIT'." >&2
+  if [[ "$EMBEDDED_GIT_COMMIT" != "$BUILD_GIT_COMMIT" ]]; then
+    echo "ERROR: Release app OpenClaw source mismatch: OpenClawGitCommit='$EMBEDDED_GIT_COMMIT', expected='$BUILD_GIT_COMMIT'." >&2
+    exit 1
+  fi
+  if [[ "$BRIDGE_SOURCE_COMMIT" != "$PEEKABOO_SOURCE_COMMIT" ]]; then
+    echo "ERROR: Release app Peekaboo source mismatch: PeekabooSourceCommit='$BRIDGE_SOURCE_COMMIT', expected='$PEEKABOO_SOURCE_COMMIT'." >&2
     exit 1
   fi
 fi

--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -405,7 +405,6 @@ elif [ "$SIGN" -eq 1 ]; then
     fail "No signing identity found. Use --no-sign or install a signing key."
   fi
   unset ALLOW_ADHOC_SIGNING
-  unset SIGN_IDENTITY
 fi
 
 # 3) Package and sign outside the live bundle. A failed package/sign operation

--- a/test/scripts/codesign-mac-app.test.ts
+++ b/test/scripts/codesign-mac-app.test.ts
@@ -75,6 +75,32 @@ fi
   chmodSync(fakeCodesign, 0o755);
 }
 
+function installTransientFakeCodesign(binDir: string) {
+  const fakeCodesign = path.join(binDir, "codesign");
+  writeFileSync(
+    fakeCodesign,
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+count=0
+if [ -f "$CODESIGN_COUNT_FILE" ]; then
+  count="$(cat "$CODESIGN_COUNT_FILE")"
+fi
+count=$((count + 1))
+printf '%s' "$count" >"$CODESIGN_COUNT_FILE"
+if [ "\${CODESIGN_PERMANENT_FAILURE:-0}" = "1" ]; then
+  echo "signing identity is not available" >&2
+  exit 7
+fi
+if [ "$count" -le "$CODESIGN_TRANSIENT_FAILURES" ]; then
+  echo "A timestamp was expected but was not found" >&2
+  exit 1
+fi
+`,
+  );
+  chmodSync(fakeCodesign, 0o755);
+}
+
 describe("codesign-mac-app temp file hygiene", () => {
   it("does not generate unused entitlement plist files", () => {
     const script = readFileSync(scriptPath, "utf8");
@@ -194,6 +220,72 @@ describe("codesign-mac-app temp file hygiene", () => {
       expect(copiedEntitlements).toContain("com.apple.security.automation.apple-events");
       expect(copiedEntitlements).toContain("com.apple.security.device.camera");
     }
+    expect(entitlementTemps(tempRoot)).toEqual([]);
+  });
+
+  it("retries only transient Apple timestamp failures", () => {
+    const tempRoot = tempDirs.make("openclaw-codesign-retry-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    const countFile = path.join(tempRoot, "codesign-count");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
+    writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+    installTransientFakeCodesign(binDir);
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODESIGN_COUNT_FILE: countFile,
+        CODESIGN_TIMESTAMP_RETRY_ATTEMPTS: "3",
+        CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS: "0",
+        CODESIGN_TRANSIENT_FAILURES: "2",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SIGN_IDENTITY: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",
+        SKIP_TEAM_ID_CHECK: "1",
+        TMPDIR: tempRoot,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("Transient Apple timestamp failure");
+    expect(readFileSync(countFile, "utf8")).toBe("5");
+    expect(entitlementTemps(tempRoot)).toEqual([]);
+  });
+
+  it("does not retry non-timestamp signing failures", () => {
+    const tempRoot = tempDirs.make("openclaw-codesign-permanent-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    const countFile = path.join(tempRoot, "codesign-count");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+    installTransientFakeCodesign(binDir);
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODESIGN_COUNT_FILE: countFile,
+        CODESIGN_PERMANENT_FAILURE: "1",
+        CODESIGN_TIMESTAMP_RETRY_ATTEMPTS: "3",
+        CODESIGN_TIMESTAMP_RETRY_DELAY_SECONDS: "0",
+        CODESIGN_TRANSIENT_FAILURES: "0",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SIGN_IDENTITY: "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",
+        SKIP_TEAM_ID_CHECK: "1",
+        TMPDIR: tempRoot,
+      },
+    });
+
+    expect(result.status).toBe(7);
+    expect(result.stderr).not.toContain("Transient Apple timestamp failure");
+    expect(readFileSync(countFile, "utf8")).toBe("1");
     expect(entitlementTemps(tempRoot)).toEqual([]);
   });
 });

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -150,6 +150,85 @@ function getSparkleBuildHelperBlock(): string {
   return script.slice(start, end);
 }
 
+function getPeekabooSourceCommitHelperBlock(): string {
+  const script = readFileSync(scriptPath, "utf8");
+  const start = script.indexOf("resolve_peekaboo_source_commit() {");
+  const end = script.indexOf("sparkle_canonical_build_from_version()");
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return script.slice(start, end);
+}
+
+function runPeekabooSourceCommitHarness(packageResolved: string) {
+  const root = tempDirs.make("openclaw-package-peekaboo-source-");
+  const resolvedFile = path.join(root, "apps", "macos", "Package.resolved");
+  mkdirSync(path.dirname(resolvedFile), { recursive: true });
+  writeFileSync(resolvedFile, packageResolved, "utf8");
+
+  return runHelper(`
+    set -euo pipefail
+    ROOT_DIR=${JSON.stringify(root)}
+    ${getPeekabooSourceCommitHelperBlock()}
+    resolve_peekaboo_source_commit
+  `);
+}
+
+function getSourceProvenanceStampBlock(): string {
+  const script = readFileSync(scriptPath, "utf8");
+  const start = script.indexOf(
+    'plist_set_string_required "$APP_ROOT/Contents/Info.plist" OpenClawBuildTimestamp',
+  );
+  const end = script.indexOf(
+    'plist_set_or_add_string "$APP_ROOT/Contents/Info.plist" SUFeedURL',
+    start,
+  );
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return script.slice(start, end);
+}
+
+function runSourceProvenanceStampHarness(corruptKey?: string) {
+  const openClawCommit = "a".repeat(40);
+  const peekabooCommit = "b".repeat(40);
+  const corruptCommit = "c".repeat(40);
+  const result = runHelper(`
+    set -euo pipefail
+    stamped_openclaw=
+    stamped_peekaboo=
+    plist_set_string_required() {
+      case "$2" in
+        OpenClawGitCommit) stamped_openclaw="$3" ;;
+        PeekabooSourceCommit) stamped_peekaboo="$3" ;;
+      esac
+    }
+    plist_print_required() {
+      local value
+      case "$2" in
+        OpenClawGitCommit) value="$stamped_openclaw" ;;
+        PeekabooSourceCommit) value="$stamped_peekaboo" ;;
+        *) return 1 ;;
+      esac
+      if [[ "$2" == ${JSON.stringify(corruptKey ?? "")} ]]; then
+        value=${JSON.stringify(corruptCommit)}
+      fi
+      printf '%s' "$value"
+    }
+    APP_ROOT=/tmp/OpenClaw.app
+    BUILD_TS=2026-08-13T00:00:00.000Z
+    BUILD_GIT_COMMIT=${JSON.stringify(openClawCommit)}
+    PEEKABOO_SOURCE_COMMIT=${JSON.stringify(peekabooCommit)}
+    BUILD_CONFIG=release
+    ${getSourceProvenanceStampBlock()}
+    printf '%s\n%s\n' "$stamped_openclaw" "$stamped_peekaboo"
+  `);
+
+  return { result, openClawCommit, peekabooCommit };
+}
+
 function getMLXTTSHelperBuildBlock(): string {
   const script = readFileSync(scriptPath, "utf8");
   const start = script.indexOf("build_mlx_tts_helper() {");
@@ -576,9 +655,63 @@ describe("package-mac-app plist stamping", () => {
     expect(bridgeSourceRead).toBeGreaterThan(sourceCheck);
     expect(bridgeSourceRead).toBeLessThan(signing);
     expect(script).toContain(
+      'plist_set_string_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit "$PEEKABOO_SOURCE_COMMIT"',
+    );
+    expect(script).not.toContain(
       'plist_set_string_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit "$BUILD_GIT_COMMIT"',
     );
-    expect(script).toContain("Release app source mismatch");
+  });
+
+  it("stamps and validates independent OpenClaw and Peekaboo source revisions", () => {
+    const { result, openClawCommit, peekabooCommit } = runSourceProvenanceStampHarness();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`${openClawCommit}\n${peekabooCommit}\n`);
+    expect(result.stderr).toBe("");
+  });
+
+  it.each([
+    { key: "OpenClawGitCommit", diagnostic: "Release app OpenClaw source mismatch" },
+    { key: "PeekabooSourceCommit", diagnostic: "Release app Peekaboo source mismatch" },
+  ])("fails release validation independently for a wrong $key", ({ key, diagnostic }) => {
+    const { result } = runSourceProvenanceStampHarness(key);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(diagnostic);
+  });
+
+  it("resolves the exact pinned Peekaboo source revision from Package.resolved", () => {
+    const expectedRevision = "a2fb16764a7d1c53bf696127c287ba32703f614f";
+    const packageResolved = readFileSync("apps/macos/Package.resolved", "utf8");
+    const result = runPeekabooSourceCommitHarness(packageResolved);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(expectedRevision);
+    expect(result.stderr).toBe("");
+  });
+
+  it.each([
+    {
+      title: "is missing",
+      packageResolved: '{"pins":[]}',
+      diagnostic: "exactly one 'peekaboo' pin",
+    },
+    {
+      title: "has a malformed revision",
+      packageResolved:
+        '{"pins":[{"identity":"peekaboo","state":{"revision":"A2FB16764A7D1C53BF696127C287BA32703F614F"}}]}',
+      diagnostic: "40-character lowercase hexadecimal revision",
+    },
+    {
+      title: "is invalid JSON",
+      packageResolved: "not-json",
+      diagnostic: "Could not parse Peekaboo source revision",
+    },
+  ])("fails closed when the Peekaboo package pin $title", ({ packageResolved, diagnostic }) => {
+    const result = runPeekabooSourceCommitHarness(packageResolved);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(diagnostic);
   });
 
   it("keeps dependency installation lockfile-safe", () => {

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -556,6 +556,9 @@ describe("package-mac-app plist stamping", () => {
     const embeddedRead = script.indexOf(
       'plist_print_required "$APP_ROOT/Contents/Info.plist" OpenClawGitCommit',
     );
+    const bridgeSourceRead = script.indexOf(
+      'plist_print_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit',
+    );
     const signing = script.indexOf('"$ROOT_DIR/scripts/codesign-mac-app.sh"');
     const releaseBranch = script.lastIndexOf(
       'if [[ "$BUILD_CONFIG" == "release" ]]; then',
@@ -570,7 +573,12 @@ describe("package-mac-app plist stamping", () => {
     expect(script).toContain('--expected-commit "$BUILD_GIT_COMMIT"');
     expect(embeddedRead).toBeGreaterThan(sourceCheck);
     expect(embeddedRead).toBeLessThan(signing);
-    expect(script).toContain("Release app embedded Git commit");
+    expect(bridgeSourceRead).toBeGreaterThan(sourceCheck);
+    expect(bridgeSourceRead).toBeLessThan(signing);
+    expect(script).toContain(
+      'plist_set_string_required "$APP_ROOT/Contents/Info.plist" PeekabooSourceCommit "$BUILD_GIT_COMMIT"',
+    );
+    expect(script).toContain("Release app source mismatch");
   });
 
   it("keeps dependency installation lockfile-safe", () => {

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -954,6 +954,36 @@ describe("package-mac-app plist stamping", () => {
     );
   });
 
+  it("passes an explicit signing identity unchanged to the signer", () => {
+    const script = readFileSync(scriptPath, "utf8");
+    const start = script.indexOf('if [[ -n "${SIGN_IDENTITY:-}" ]]');
+    const signingBlock = script.slice(start, script.indexOf('echo "✅ Bundle ready', start));
+    const tempRoot = tempDirs.make("openclaw-package-signing-identity-");
+    const scriptsDir = path.join(tempRoot, "scripts");
+    const signerPath = path.join(scriptsDir, "codesign-mac-app.sh");
+    const identity = "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)";
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(
+      signerPath,
+      '#!/usr/bin/env bash\nprintf "identity=%s\\n" "${SIGN_IDENTITY-<unset>}"\n',
+    );
+    chmodSync(signerPath, 0o755);
+
+    const result = runHelper(`
+      set -euo pipefail
+      ROOT_DIR=${JSON.stringify(tempRoot)}
+      APP_ROOT=${JSON.stringify(path.join(tempRoot, "OpenClaw.app"))}
+      SIGN_IDENTITY=${JSON.stringify(identity)}
+      export SIGN_IDENTITY
+      ${signingBlock}
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Signing bundle with explicit SIGN_IDENTITY");
+    expect(result.stdout).toContain(`identity=${identity}`);
+    expect(result.stderr).toBe("");
+  });
+
   it("fails when the packaged app survives forced shutdown", () => {
     const result = runStopPackagedAppHarness(0);
 

--- a/test/scripts/restart-mac.test.ts
+++ b/test/scripts/restart-mac.test.ts
@@ -217,6 +217,33 @@ function runRestartArgParser(...args: string[]) {
   return spawnSync("bash", [harnessPath, ...args], { encoding: "utf8" });
 }
 
+function runSigningEnvironmentBlock(signIdentity: string) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-restart-mac-signing-test-"));
+  tempRoots.push(root);
+  const script = readFileSync(restartScriptPath, "utf8");
+  const start = script.indexOf('if [ "$NO_SIGN" -eq 1 ]; then');
+  const signingBlock = script.slice(start, script.indexOf("# 3) Package and sign", start));
+  const harnessPath = join(root, "signing-environment-harness.sh");
+  writeFileSync(
+    harnessPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "NO_SIGN=0",
+      "SIGN=1",
+      "check_signing_keys() { return 0; }",
+      'fail() { printf "ERROR: %s\\n" "$*" >&2; exit 1; }',
+      signingBlock,
+      'printf "%s\\n" "${SIGN_IDENTITY-<unset>}"',
+    ].join("\n"),
+  );
+  chmodSync(harnessPath, 0o755);
+  return spawnSync("bash", [harnessPath], {
+    encoding: "utf8",
+    env: { ...process.env, SIGN_IDENTITY: signIdentity },
+  });
+}
+
 function runProfileGuard(profile: string) {
   const root = mkdtempSync(join(tmpdir(), "openclaw-restart-mac-profile-test-"));
   tempRoots.push(root);
@@ -355,6 +382,15 @@ afterEach(() => {
 });
 
 describe("scripts/restart-mac.sh", () => {
+  it("preserves an explicit signing identity through signed packaging", () => {
+    const identity = "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)";
+    const result = runSigningEnvironmentBlock(identity);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(identity);
+    expect(result.stderr).toBe("");
+  });
+
   it("rejects unknown restart options before side effects", () => {
     const result = runRestartArgParser("--wat");
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's macOS app embedded an older Peekaboo bridge and duplicated its service assembly, native desktop-lane table, snapshot state, and lifecycle ownership. That duplication drifted from Peekaboo's background-first contracts and made the elevation host difficult to verify or upgrade safely.

## What Changed

- pin Peekaboo to exact landed revision `a2fb16764a7d1c53bf696127c287ba32703f614f` from [Peekaboo #457](https://github.com/openclaw/Peekaboo/pull/457)
- host the checked `PeekabooEmbeddedBridgeRuntime` instead of maintaining an OpenClaw-specific service container and operation-lane table
- preserve OpenClaw's 10-minute / 50-snapshot contract, legacy socket aliases, and Computer Control gating while serializing start, stop, restart, and drain-aware shutdown
- require the exact Peekaboo CLI bundle and Peekaboo's canonical current/legacy release signer set
- publish independent source identity receipts: the OpenClaw app commit and the pinned Peekaboo dependency commit
- package release builds as stable `ai.openclaw.mac` with the OpenClaw Foundation identity, bounded Apple timestamp retries, universal main/helper binaries, and exact source checks
- isolate shared launch-agent hooks and command routing in macOS tests so parallel suites cannot contaminate one another

## User Impact

The macOS app can act as a background-only, fail-closed Peekaboo elevation host without linking PeekabooCore, agent, provider, browser, or daemon-control state. Ordinary user launches retain their current presentation behavior; unattended launches use the existing `--background-only` policy explicitly.

## Real Behavior Proof

Exact reviewed head: `bce26b58f8b4e6b36cfcb2ae834ad4e682772a87`.

A proof-only arm64 Release bundle was assembled from the exact current `OpenClaw` Release binary and canonical bundle layout, then the complete app, MLX helper, Sparkle framework, and compatibility library were signed by `Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)`. Strict deep signature verification passed. The app identified as stable `ai.openclaw.mac`, Team `FWJYW4S8P8`, CDHash `3ae9c5289469ac9d2abbfe1fe71192aedfafa63f`. This was not a release candidate: local Xcode 27 beta repeatedly failed Metal compilation for the unrelated universal MLX helper, so canonical universal packaging remains a supported-toolchain/CI gate.

The signed bundle was launched at a stable task-owned path in an isolated `HOME`, state directory, and profile with `--attach-only --background-only`. The Foundation-signed Peekaboo 4.1.0 CLI (`boo.peekaboo.peekaboo`, Team `FWJYW4S8P8`, CDHash `88f595eebf3d9a97964bfe646a0e64030458d65c`) selected the exact isolated socket as `remote gui`, negotiated Bridge 1.24, and received:

- host PID `22123` with a process-generation receipt
- host CDHash matching the signed proof app
- `sourceCommit: a2fb16764a7d1c53bf696127c287ba32703f614f`, matching the pinned Peekaboo dependency
- `backgroundBridgeHost`, `screenCaptureKitProcessOwnership`, host-generation, source/signature, OCR, and capture-engine capabilities

The same explicit socket completed remote application inventory with `success=true` and 19 applications. After SIGTERM, the task-owned app exited and removed its socket/lease; the installed OpenClaw process remained running. No AppleScript or JXA was used.

[Peekaboo #457 proof](https://github.com/openclaw/Peekaboo/pull/457#issuecomment-5288683594) separately verifies the signed caller boundary: the allowlisted Foundation CLI succeeds while a same-Team, non-allowlisted bundle receives typed `unauthorizedClient` and cannot fall back locally. The pinned dependency retains Peekaboo's canonical current/legacy release signer migration set (`FWJYW4S8P8`, `Y5PE65HELJ`) while still requiring the exact CLI bundle identifier.

## Verification

- `OPENCLAW_PEEKABOO_HANDSHAKE_CLI=/opt/homebrew/bin/peekaboo swift test --package-path apps/macos --skip-build --filter 'OpenClawIPCTests.PeekabooBridgeHostCoordinatorTests'` — 6 passed, including exact signed-CLI socket handshake
- `swift build --package-path apps/macos --product OpenClaw --configuration release` — passed
- `swift build --package-path apps/macos --target OpenClawIPCTests` — passed
- gateway process + launch-agent paired suites — 57 passed repeatedly after cross-suite hook isolation
- gateway process + update orchestration sibling suites — 66 passed
- focused packaging/signing/restart Vitest suites — 89 passed
- docs MDX and formatting — passed
- full branch and incremental Codex autoreviews — clean; secret scans clean

The first exact-head macOS CI run exposed the shared gateway test-hook race and failed in `GatewayProcessManagerTests`; that suite is green after the isolation repair. The following macOS run exposed an independent local-mode assumption in `GatewayLaunchAgentManagerTests`; the command test now pins its existing `configRoot` injection boundary. Remaining load-sensitive macOS Swift flakes from that run are tracked as a separate follow-up rather than broadening this bridge PR.

Release-note context: macOS Computer Control now hosts Peekaboo through its checked background-first embedded runtime with exact dependency/signature receipts and drain-aware shutdown.
