### PR TITLE
fix(sessions): hide unowned host catalogs on multi-user gateways

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -371,12 +371,24 @@ byte-offset cursors and bounded backward file reads, so selecting a large
 session or loading an older page does not read the whole JSONL history into one
 Gateway response.
 
-The list and read commands are read-only. They expose catalog metadata and transcript
-content only through the generic `sessions.catalog.list` and
-`sessions.catalog.read` methods to an authenticated operator connection with
-`operator.write`. A Gateway-local Claude CLI row can be adopted from the normal
-Chat composer: OpenClaw imports bounded visible history, resumes with
-`--fork-session` on the first turn, and leaves the source transcript untouched.
+Catalog RPCs keep their normal method scopes: `sessions.catalog.list` and
+`sessions.catalog.read` require `operator.read`; `sessions.catalog.continue` and
+`sessions.catalog.archive` require `operator.write`.
+
+Catalog visibility also follows the authenticated caller. An `operator.admin`
+connection sees every discovered row. When the Gateway has durable profiles for
+fewer than two people, catalog visibility is unchanged and rows remain unfiltered.
+On a multi-user Gateway, a non-admin connection sees and can read, continue, or
+archive only rows whose recorded `createdActor.id` matches the caller's Gateway
+profile. Unattributed host CLI or desktop sessions are hidden from those callers.
+This is a privacy and coordination boundary inside one trusted Gateway domain,
+not hostile-user isolation; use separate agents or Gateway/host trust boundaries
+when people must not share access to files, credentials, or tools. See
+[Multi-user mode](/concepts/multi-user).
+
+A Gateway-local Claude CLI row can be adopted from the normal Chat composer:
+OpenClaw imports bounded visible history, resumes with `--fork-session` on the
+first turn, and leaves the source transcript untouched.
 
 A headless node host can opt into the same continuation flow:
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -241,6 +241,13 @@ more history; appended rows stay visible and are re-fetched to the same depth
 across refreshes. Catalog clients use `sessions.catalog.list`; opening a row uses
 `sessions.catalog.read`.
 
+Catalog visibility follows the authenticated Gateway profile. Admin connections
+see every discovered Claude row, and solo or shared-secret Gateways remain
+unfiltered. On a multi-user Gateway, a non-admin sees only rows already adopted
+by their durable profile; unattributed host-discovered Claude CLI and Desktop
+rows stay hidden. This is a privacy control within one trusted Gateway domain;
+see [Multi-user mode](/concepts/multi-user).
+
 Terminal takeover resolves `claude` from the owning host user's login-shell
 PATH before the service/daemon PATH. This keeps app-launched sessions aligned
 with the Claude CLI the operator gets in a normal terminal.
@@ -286,9 +293,9 @@ macOS app nodes also remain view-only until the app advertises the run command.
 <Note>
 Paired-node Claude sessions remain read-only unless the headless node explicitly
 advertises `agent.cli.claude.run.v1`. OpenClaw never modifies Claude Desktop
-metadata or archives Claude sessions. The page requires an operator connection
-with write scope because it uses authenticated `node.invoke`; list and read
-remain read-only even on a continuation-enabled node.
+metadata or archives Claude sessions. Catalog list and read use `operator.read`,
+while continuation uses `operator.write`. Paired-node command advertisement and
+Gateway node policy remain additional requirements for node-backed rows.
 </Note>
 
 See [Nodes: Claude sessions and transcripts](/nodes#claude-sessions-and-transcripts)

--- a/extensions/acpx/src/pi-session-catalog-continuation.test.ts
+++ b/extensions/acpx/src/pi-session-catalog-continuation.test.ts
@@ -90,6 +90,33 @@ afterEach(async () => {
 });
 
 describe("Pi session catalog continuation", () => {
+  it("projects only adopted Pi rows with their OpenClaw session key", async () => {
+    await createPiStoreFixture(
+      temporaryDirectories,
+      "hi",
+      "Pi catalog session",
+      { command: "pwd" },
+      true,
+    );
+    await installFakePiFixture(temporaryDirectories, originalPath);
+    const { entries, provider } = capturePiContinuationCatalog();
+    const sessionEntries = { entriesForAgent: () => entries } as never;
+
+    const before = await provider.list({ hostIds: ["gateway"], sessionEntries });
+    expect(before[0]?.sessions[0]).not.toHaveProperty("sessionKey");
+
+    const adopted = await provider.continueSession!({
+      hostId: "gateway",
+      threadId: "pi-session",
+    });
+    const after = await provider.list({ hostIds: ["gateway"], sessionEntries });
+
+    expect(after[0]?.sessions[0]).toMatchObject({
+      threadId: "pi-session",
+      sessionKey: adopted.sessionKey,
+    });
+  });
+
   it("adopts once with the native ACP binding and an exact file baseline", async () => {
     const sessionDirectory = await createPiStoreFixture(
       temporaryDirectories,

--- a/extensions/acpx/src/pi-session-catalog-runtime.ts
+++ b/extensions/acpx/src/pi-session-catalog-runtime.ts
@@ -12,6 +12,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type {
   SessionCatalogHost,
+  SessionCatalogEntrySnapshot,
   SessionCatalogProvider,
   SessionCatalogSession,
   SessionCatalogTerminalPlan,
@@ -147,6 +148,21 @@ function setCatalogCapabilities(
   return page;
 }
 
+function projectPiAdoptedSessions(
+  page: PiSessionPage,
+  adopted: ReadonlyMap<string, string>,
+): PiSessionPage {
+  return {
+    ...page,
+    sessions: page.sessions.map((session) => {
+      const sessionKey = adopted.get(
+        sessionCatalogAdoptedSourceKey(LOCAL_HOST_ID, session.threadId),
+      );
+      return sessionKey ? { ...session, sessionKey } : session;
+    }),
+  };
+}
+
 async function listPiNodeHost(
   runtime: PluginRuntime,
   query: Parameters<SessionCatalogProvider["list"]>[0],
@@ -246,6 +262,9 @@ async function listPiHosts(
 ): Promise<SessionCatalogHost[]> {
   const runtime = api.runtime;
   const canContinue = resolvePiContinuationAvailability(api).available;
+  const adopted = query.sessionEntries
+    ? listAdoptedPiSessions(api, query.sessionEntries)
+    : new Map<string, string>();
   const requested = query.hostIds ? new Set(query.hostIds) : undefined;
   const hosts: SessionCatalogHost[] = [];
   const wantsLocal = !requested || requested.has(LOCAL_HOST_ID);
@@ -266,15 +285,18 @@ async function listPiHosts(
           ...(query.search ? { searchTerm: query.search } : {}),
           cursor: query.cursors?.[LOCAL_HOST_ID],
         }).then((page) =>
-          setCatalogCapabilities(page, {
-            canContinue,
-            canOpenTerminal:
-              resolveNodeHostExecutable("pi", {
-                env: process.env,
-                pathEnv: process.env.PATH ?? "",
-                strategy: "fallback",
-              }) !== undefined,
-          }),
+          projectPiAdoptedSessions(
+            setCatalogCapabilities(page, {
+              canContinue,
+              canOpenTerminal:
+                resolveNodeHostExecutable("pi", {
+                  env: process.env,
+                  pathEnv: process.env.PATH ?? "",
+                  strategy: "fallback",
+                }) !== undefined,
+            }),
+            adopted,
+          ),
         )),
       });
     } catch {
@@ -338,11 +360,15 @@ function resolvePiContinuationAvailability(
   return executable ? { available: true } : { available: false, message: "Pi CLI is unavailable" };
 }
 
-function listAdoptedPiSessions(api: OpenClawPluginApi): Map<string, string> {
+function listAdoptedPiSessions(
+  api: OpenClawPluginApi,
+  sessionEntries?: SessionCatalogEntrySnapshot,
+): Map<string, string> {
   return listAdoptedSessionCatalogSessions({
     config: currentPiCatalogConfig(api),
     pluginId: api.id,
     runtime: api.runtime,
+    sessionEntries,
     sourceFromEntry: (entry) => {
       const acpx = isRecord(entry.pluginExtensions?.acpx) ? entry.pluginExtensions.acpx : undefined;
       const marker = acpx && isRecord(acpx.piSessionCatalog) ? acpx.piSessionCatalog : undefined;

--- a/extensions/llama-cpp/doctor-contract-api.ts
+++ b/extensions/llama-cpp/doctor-contract-api.ts
@@ -7,7 +7,7 @@ import {
 import {
   resolveManagedLlamaServerPaths,
   selectLlamaServerAsset,
-} from "./src/llama-server-install.js";
+} from "./src/llama-server-assets.js";
 
 const LEGACY_BASE_URL = "local://llama-cpp";
 const PROVIDER_PATH = "models.providers.llama-cpp";

--- a/extensions/llama-cpp/src/llama-server-assets.ts
+++ b/extensions/llama-cpp/src/llama-server-assets.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { resolveLlamaCppDataDir } from "./defaults.js";
+
+export const LLAMA_SERVER_RELEASE = "b10357";
+export const LLAMA_SERVER_BUILD = 10_357;
+export const LLAMA_SERVER_COMMIT = "689e227db485c6b33d061555e74034c93a867649";
+
+export type LlamaServerAsset = {
+  platform: NodeJS.Platform;
+  arch: string;
+  backend: "metal" | "cpu";
+  archive: "tar.gz" | "zip";
+  name: string;
+  sha256: string;
+  executable: string;
+};
+
+const LLAMA_SERVER_ASSETS: LlamaServerAsset[] = [
+  {
+    platform: "darwin",
+    arch: "arm64",
+    backend: "metal",
+    archive: "tar.gz",
+    name: `llama-${LLAMA_SERVER_RELEASE}-bin-macos-arm64.tar.gz`,
+    sha256: "7f464a2d473d53ebb9c1d7d16db1258ec98c371569816491850686e6a4334c52",
+    executable: "llama-server",
+  },
+  {
+    platform: "darwin",
+    arch: "x64",
+    backend: "cpu",
+    archive: "tar.gz",
+    name: `llama-${LLAMA_SERVER_RELEASE}-bin-macos-x64.tar.gz`,
+    sha256: "8282cf6b30bfab87080044e98b7b78f2896bfc60414926fae6039a89c0fb6ec2",
+    executable: "llama-server",
+  },
+  {
+    platform: "linux",
+    arch: "arm64",
+    backend: "cpu",
+    archive: "tar.gz",
+    name: `llama-${LLAMA_SERVER_RELEASE}-bin-ubuntu-arm64.tar.gz`,
+    sha256: "0653b6aa14de35920824045bca7e48f98f629f41943d0fefab1e317bbe8e22a8",
+    executable: "llama-server",
+  },
+  {
+    platform: "linux",
+    arch: "x64",
+    backend: "cpu",
+    archive: "tar.gz",
+    name: `llama-${LLAMA_SERVER_RELEASE}-bin-ubuntu-x64.tar.gz`,
+    sha256: "6b0ba012036e6d727521100158bfcaa73b460fbb31acab2931c9485f347bd16b",
+    executable: "llama-server",
+  },
+  {
+    platform: "win32",
+    arch: "arm64",
+    backend: "cpu",
+    archive: "zip",
+    name: `llama-${LLAMA_SERVER_RELEASE}-bin-win-cpu-arm64.zip`,
+    sha256: "a0d73be8d3151d9401fa193f1b83c6d7401191b41786e75f0a60184058333e86",
+    executable: "llama-server.exe",
+  },
+  {
+    platform: "win32",
+    arch: "x64",
+    backend: "cpu",
+    archive: "zip",
+    name: `llama-${LLAMA_SERVER_RELEASE}-bin-win-cpu-x64.zip`,
+    sha256: "6c64cc7db679980fcb34bbbe96b2b1df6127e90ccdad2bd6fbe39532fee2fc4e",
+    executable: "llama-server.exe",
+  },
+];
+
+export function selectLlamaServerAsset(
+  platform: NodeJS.Platform = process.platform,
+  arch = process.arch,
+): LlamaServerAsset {
+  const asset = LLAMA_SERVER_ASSETS.find(
+    (candidate) => candidate.platform === platform && candidate.arch === arch,
+  );
+  if (!asset) {
+    throw new Error(
+      `No verified llama-server ${LLAMA_SERVER_RELEASE} build is available for ${platform}/${arch}. Install a compatible llama-server manually, then rerun llama.cpp setup with its absolute path.`,
+    );
+  }
+  return asset;
+}
+
+export function resolveManagedLlamaServerPaths(asset = selectLlamaServerAsset()): {
+  installDir: string;
+  command: string;
+  presetPath: string;
+} {
+  const installDir = path.join(
+    resolveLlamaCppDataDir(),
+    LLAMA_SERVER_RELEASE,
+    `${asset.platform}-${asset.arch}`,
+  );
+  return {
+    installDir,
+    command: path.join(installDir, asset.executable),
+    presetPath: path.join(resolveLlamaCppDataDir(), "models.ini"),
+  };
+}

--- a/extensions/llama-cpp/src/llama-server-install.ts
+++ b/extensions/llama-cpp/src/llama-server-install.ts
@@ -11,79 +11,23 @@ import {
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import * as tar from "tar";
 import { resolveLlamaCppDataDir } from "./defaults.js";
+import {
+  LLAMA_SERVER_BUILD,
+  LLAMA_SERVER_COMMIT,
+  LLAMA_SERVER_RELEASE,
+  resolveManagedLlamaServerPaths,
+  selectLlamaServerAsset,
+  type LlamaServerAsset,
+} from "./llama-server-assets.js";
 
-const LLAMA_SERVER_RELEASE = "b10357";
-const LLAMA_SERVER_BUILD = 10_357;
-const LLAMA_SERVER_COMMIT = "689e227db485c6b33d061555e74034c93a867649";
+export {
+  resolveManagedLlamaServerPaths,
+  selectLlamaServerAsset,
+  type LlamaServerAsset,
+} from "./llama-server-assets.js";
+
 const DOWNLOAD_TIMEOUT_MS = 30 * 60_000;
 const VERSION_TIMEOUT_MS = 15_000;
-
-export type LlamaServerAsset = {
-  platform: NodeJS.Platform;
-  arch: string;
-  backend: "metal" | "cpu";
-  archive: "tar.gz" | "zip";
-  name: string;
-  sha256: string;
-  executable: string;
-};
-
-const LLAMA_SERVER_ASSETS: LlamaServerAsset[] = [
-  {
-    platform: "darwin",
-    arch: "arm64",
-    backend: "metal",
-    archive: "tar.gz",
-    name: `llama-${LLAMA_SERVER_RELEASE}-bin-macos-arm64.tar.gz`,
-    sha256: "7f464a2d473d53ebb9c1d7d16db1258ec98c371569816491850686e6a4334c52",
-    executable: "llama-server",
-  },
-  {
-    platform: "darwin",
-    arch: "x64",
-    backend: "cpu",
-    archive: "tar.gz",
-    name: `llama-${LLAMA_SERVER_RELEASE}-bin-macos-x64.tar.gz`,
-    sha256: "8282cf6b30bfab87080044e98b7b78f2896bfc60414926fae6039a89c0fb6ec2",
-    executable: "llama-server",
-  },
-  {
-    platform: "linux",
-    arch: "arm64",
-    backend: "cpu",
-    archive: "tar.gz",
-    name: `llama-${LLAMA_SERVER_RELEASE}-bin-ubuntu-arm64.tar.gz`,
-    sha256: "0653b6aa14de35920824045bca7e48f98f629f41943d0fefab1e317bbe8e22a8",
-    executable: "llama-server",
-  },
-  {
-    platform: "linux",
-    arch: "x64",
-    backend: "cpu",
-    archive: "tar.gz",
-    name: `llama-${LLAMA_SERVER_RELEASE}-bin-ubuntu-x64.tar.gz`,
-    sha256: "6b0ba012036e6d727521100158bfcaa73b460fbb31acab2931c9485f347bd16b",
-    executable: "llama-server",
-  },
-  {
-    platform: "win32",
-    arch: "arm64",
-    backend: "cpu",
-    archive: "zip",
-    name: `llama-${LLAMA_SERVER_RELEASE}-bin-win-cpu-arm64.zip`,
-    sha256: "a0d73be8d3151d9401fa193f1b83c6d7401191b41786e75f0a60184058333e86",
-    executable: "llama-server.exe",
-  },
-  {
-    platform: "win32",
-    arch: "x64",
-    backend: "cpu",
-    archive: "zip",
-    name: `llama-${LLAMA_SERVER_RELEASE}-bin-win-cpu-x64.zip`,
-    sha256: "6c64cc7db679980fcb34bbbe96b2b1df6127e90ccdad2bd6fbe39532fee2fc4e",
-    executable: "llama-server.exe",
-  },
-];
 
 export type LlamaDownloadProgress = (status: {
   downloadedSize: number;
@@ -92,21 +36,6 @@ export type LlamaDownloadProgress = (status: {
 }) => void;
 
 const installationPromises = new Map<string, Promise<string>>();
-
-export function selectLlamaServerAsset(
-  platform: NodeJS.Platform = process.platform,
-  arch = process.arch,
-): LlamaServerAsset {
-  const asset = LLAMA_SERVER_ASSETS.find(
-    (candidate) => candidate.platform === platform && candidate.arch === arch,
-  );
-  if (!asset) {
-    throw new Error(
-      `No verified llama-server ${LLAMA_SERVER_RELEASE} build is available for ${platform}/${arch}. Install a compatible llama-server manually, then rerun llama.cpp setup with its absolute path.`,
-    );
-  }
-  return asset;
-}
 
 function compareVersion(left: string, right: string): number {
   const leftParts = left.split(".").map(Number);
@@ -141,23 +70,6 @@ function assertSupportedLinuxRuntime(asset: LlamaServerAsset): void {
 
 function assetUrl(asset: LlamaServerAsset): string {
   return `https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_SERVER_RELEASE}/${asset.name}`;
-}
-
-export function resolveManagedLlamaServerPaths(asset = selectLlamaServerAsset()): {
-  installDir: string;
-  command: string;
-  presetPath: string;
-} {
-  const installDir = path.join(
-    resolveLlamaCppDataDir(),
-    LLAMA_SERVER_RELEASE,
-    `${asset.platform}-${asset.arch}`,
-  );
-  return {
-    installDir,
-    command: path.join(installDir, asset.executable),
-    presetPath: path.join(resolveLlamaCppDataDir(), "models.ini"),
-  };
 }
 
 export async function sha256File(filePath: string): Promise<string> {

--- a/extensions/opencode/session-catalog-plugin.ts
+++ b/extensions/opencode/session-catalog-plugin.ts
@@ -13,6 +13,7 @@ import type {
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type {
   SessionCatalogHost,
+  SessionCatalogEntrySnapshot,
   SessionCatalogProvider,
   SessionCatalogSession,
   SessionCatalogTranscriptItem,
@@ -255,6 +256,21 @@ function setCatalogCapabilities(
   return page;
 }
 
+function projectOpenCodeAdoptedSessions(
+  page: OpenCodeSessionPage,
+  adopted: ReadonlyMap<string, string>,
+): OpenCodeSessionPage {
+  return {
+    ...page,
+    sessions: page.sessions.map((session) => {
+      const sessionKey = adopted.get(
+        sessionCatalogAdoptedSourceKey(LOCAL_HOST_ID, session.threadId),
+      );
+      return sessionKey ? { ...session, sessionKey } : session;
+    }),
+  };
+}
+
 async function listOpenCodeNodeHost(
   runtime: PluginRuntime,
   query: Parameters<SessionCatalogProvider["list"]>[0],
@@ -362,6 +378,9 @@ async function listOpenCodeHosts(
     backendId: ACPX_BACKEND_ID,
     agentId: OPENCODE_ACP_AGENT_ID,
   }).available;
+  const adopted = query.sessionEntries
+    ? listAdoptedOpenCodeSessions(api, query.sessionEntries)
+    : new Map<string, string>();
   const requested = query.hostIds ? new Set(query.hostIds) : undefined;
   const hosts: SessionCatalogHost[] = [];
   if (
@@ -386,7 +405,12 @@ async function listOpenCodeHosts(
             cursor: query.cursors?.[LOCAL_HOST_ID],
           },
           { configIdentity: config },
-        ).then((page) => setCatalogCapabilities(page, { canContinue, canOpenTerminal: true }))),
+        ).then((page) =>
+          projectOpenCodeAdoptedSessions(
+            setCatalogCapabilities(page, { canContinue, canOpenTerminal: true }),
+            adopted,
+          ),
+        )),
       });
     } catch {
       hosts.push({
@@ -470,11 +494,15 @@ function currentOpenCodeCatalogConfig(api: OpenClawPluginApi): OpenClawConfig {
   return (api.runtime.config?.current?.() ?? api.config ?? {}) as OpenClawConfig;
 }
 
-function listAdoptedOpenCodeSessions(api: OpenClawPluginApi): Map<string, string> {
+function listAdoptedOpenCodeSessions(
+  api: OpenClawPluginApi,
+  sessionEntries?: SessionCatalogEntrySnapshot,
+): Map<string, string> {
   return listAdoptedSessionCatalogSessions({
     config: currentOpenCodeCatalogConfig(api),
     pluginId: api.id,
     runtime: api.runtime,
+    sessionEntries,
     sourceFromEntry: (entry) => {
       const opencode = isRecord(entry.pluginExtensions?.opencode)
         ? entry.pluginExtensions.opencode

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -256,7 +256,7 @@ function captureOpenCodeContinuationCatalog() {
     {},
     { id: "opencode", config: {}, runtime },
   );
-  return { createSessionEntry, provider: provider! };
+  return { createSessionEntry, entries, provider: provider! };
 }
 
 async function installFakeOpenCode(
@@ -608,6 +608,26 @@ describe("OpenCode session catalog", () => {
     ]);
     expect(transcriptMocks.messages[0]?.["__openclaw"]).toEqual({
       mirrorOrigin: "opencode-catalog-import",
+    });
+  });
+
+  itWithCli("projects only adopted OpenCode rows with their OpenClaw session key", async () => {
+    await installFakeOpenCode();
+    const { entries, provider } = captureOpenCodeContinuationCatalog();
+    const sessionEntries = { entriesForAgent: () => entries } as never;
+
+    const before = await provider.list({ hostIds: ["gateway"], sessionEntries });
+    expect(before[0]?.sessions[0]).not.toHaveProperty("sessionKey");
+
+    const adopted = await provider.continueSession!({
+      hostId: "gateway",
+      threadId: "ses_test",
+    });
+    const after = await provider.list({ hostIds: ["gateway"], sessionEntries });
+
+    expect(after[0]?.sessions[0]).toMatchObject({
+      threadId: "ses_test",
+      sessionKey: adopted.sessionKey,
     });
   });
 

--- a/src/gateway/server-methods/session-catalog-visibility.test.ts
+++ b/src/gateway/server-methods/session-catalog-visibility.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
+import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+
+type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
+  sessionCatalogs: Array<{ provider: SessionCatalogProvider }>;
+};
+type TestClient = {
+  connect: { scopes: string[] };
+  connId?: string;
+  authenticatedUserProfile: { profileId: string };
+};
+
+const hoisted = vi.hoisted(() => ({
+  activeRegistry: {} as TestPluginRegistry,
+  hasMultipleSessionSharingIdentities: vi.fn(() => false),
+  listSessionEntriesReadOnly: vi.fn(
+    (): Array<{
+      sessionKey: string;
+      entry: { createdActor?: { type: "human"; id: string }; updatedAt?: number };
+    }> => [],
+  ),
+}));
+
+vi.mock("../../plugins/runtime.js", () => ({
+  getActivePluginRegistry: () => hoisted.activeRegistry,
+  requireActivePluginRegistry: () => hoisted.activeRegistry,
+}));
+vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions/session-accessor.js")>()),
+  listSessionEntriesReadOnly: hoisted.listSessionEntriesReadOnly,
+}));
+vi.mock("../../state/user-profiles.js", () => ({
+  hasMultipleSessionSharingIdentities: hoisted.hasMultipleSessionSharingIdentities,
+}));
+
+const { sessionCatalogHandlers } = await import("./session-catalog.js");
+
+function client(profileId: string, scopes = ["operator.read", "operator.write"]): TestClient {
+  return { connect: { scopes }, authenticatedUserProfile: { profileId } };
+}
+
+function session(threadId: string, sessionKey?: string) {
+  return {
+    threadId,
+    status: "stored",
+    archived: false,
+    ...(sessionKey ? { sessionKey } : {}),
+    canContinue: true,
+    canArchive: true,
+  };
+}
+
+function host(sessions: ReturnType<typeof session>[], nextCursor?: string) {
+  return {
+    hostId: "gateway:local",
+    label: "Local",
+    kind: "gateway" as const,
+    connected: true,
+    sessions,
+    ...(nextCursor ? { nextCursor } : {}),
+  };
+}
+
+function provider(overrides: Partial<SessionCatalogProvider> = {}): SessionCatalogProvider {
+  return {
+    id: "codex",
+    label: "Codex",
+    list: vi.fn(async () => []),
+    read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
+    ...overrides,
+  };
+}
+
+async function call(
+  method: keyof typeof sessionCatalogHandlers,
+  params: Record<string, unknown>,
+  requestClient: TestClient,
+  config: Record<string, unknown> = {},
+  contextOverrides: Record<string, unknown> = {},
+) {
+  const respond = vi.fn();
+  await sessionCatalogHandlers[method]?.({
+    params,
+    respond,
+    client: requestClient,
+    context: { getRuntimeConfig: () => config, ...contextOverrides },
+  } as never);
+  return respond;
+}
+
+function setActors(entries: Array<[sessionKey: string, profileId: string]>) {
+  hoisted.listSessionEntriesReadOnly.mockReturnValue(
+    entries.map(([sessionKey, profileId], index) => ({
+      sessionKey,
+      entry: { createdActor: { type: "human", id: profileId }, updatedAt: entries.length - index },
+    })),
+  );
+}
+
+describe("session catalog caller visibility", () => {
+  beforeEach(() => {
+    hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+    hoisted.hasMultipleSessionSharingIdentities.mockReset().mockReturnValue(false);
+    hoisted.listSessionEntriesReadOnly.mockReset().mockReturnValue([]);
+  });
+
+  it("filters streamed and final rows to the caller's adopted sessions", async () => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(true);
+    setActors([
+      ["agent:main:owned", "profile-owner"],
+      ["agent:main:other", "profile-other"],
+    ]);
+    const listedHost = host([
+      session("owned-thread", "agent:main:owned"),
+      session("other-thread", "agent:main:other"),
+      session("unadopted-thread"),
+    ]);
+    const broadcastToConnIds = vi.fn();
+    hoisted.activeRegistry.sessionCatalogs = [
+      {
+        provider: provider({
+          list: vi.fn(async ({ onHost }) => {
+            onHost?.(listedHost);
+            return [listedHost];
+          }),
+        }),
+      },
+    ];
+
+    const respond = await call(
+      "sessions.catalog.list",
+      { progressId: "profile-progress" },
+      { ...client("profile-owner"), connId: "owner-conn" },
+      {},
+      { broadcastToConnIds },
+    );
+    const visible = [expect.objectContaining({ threadId: "owned-thread" })];
+
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.catalog.host",
+      expect.objectContaining({
+        catalog: expect.objectContaining({
+          hosts: [expect.objectContaining({ sessions: visible })],
+        }),
+      }),
+      new Set(["owner-conn"]),
+      { dropIfSlow: true },
+    );
+    expect(respond).toHaveBeenCalledWith(true, {
+      catalogs: [
+        expect.objectContaining({
+          hosts: [expect.objectContaining({ sessions: visible })],
+        }),
+      ],
+    });
+  });
+
+  it("rejects hidden targets before read, continue, or archive dispatch", async () => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(true);
+    setActors([["agent:main:other", "profile-other"]]);
+    const list = vi.fn(async () => [host([session("other-thread", "agent:main:other")])]);
+    const read = vi.fn(async () => ({
+      hostId: "gateway:local",
+      threadId: "other-thread",
+      items: [],
+    }));
+    const continueSession = vi.fn(async () => ({ sessionKey: "agent:main:other" }));
+    const archive = vi.fn(async () => ({ ok: true as const }));
+    hoisted.activeRegistry.sessionCatalogs = [
+      { provider: provider({ list, read, continueSession, archive }) },
+    ];
+
+    for (const [method, params] of [
+      ["sessions.catalog.read", {}],
+      ["sessions.catalog.continue", {}],
+      ["sessions.catalog.archive", { confirmNoOtherRunner: true }],
+    ] as const) {
+      const respond = await call(
+        method,
+        { catalogId: "codex", hostId: "gateway:local", threadId: "other-thread", ...params },
+        client("profile-owner"),
+      );
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: ErrorCodes.FORBIDDEN,
+          message: "session catalog thread is not visible to this caller",
+        }),
+      );
+    }
+    expect(read).not.toHaveBeenCalled();
+    expect(continueSession).not.toHaveBeenCalled();
+    expect(archive).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "admin", multiple: true, scopes: ["operator.admin"] },
+    { label: "solo Gateway", multiple: false, scopes: ["operator.read"] },
+  ])("keeps $label list and read responses unfiltered", async ({ multiple, scopes }) => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(multiple);
+    const listedHost = host([session("unadopted-thread")]);
+    const readResult = {
+      hostId: "gateway:local",
+      threadId: "unadopted-thread",
+      items: [{ type: "userMessage" as const, text: "host history" }],
+    };
+    hoisted.activeRegistry.sessionCatalogs = [
+      {
+        provider: provider({
+          list: vi.fn(async () => [listedHost]),
+          read: vi.fn(async () => readResult),
+        }),
+      },
+    ];
+    const requestClient = client("profile-owner", scopes);
+
+    const listed = await call("sessions.catalog.list", {}, requestClient);
+    const transcript = await call(
+      "sessions.catalog.read",
+      { catalogId: "codex", hostId: "gateway:local", threadId: "unadopted-thread" },
+      requestClient,
+    );
+
+    expect(listed).toHaveBeenCalledWith(true, {
+      catalogs: [expect.objectContaining({ hosts: [listedHost] })],
+    });
+    expect(transcript).toHaveBeenCalledWith(true, readResult);
+  });
+
+  it("lets an identified owner list and read their adopted row", async () => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(true);
+    setActors([["agent:main:owned", "profile-owner"]]);
+    const listedHost = host([session("owned-thread", "agent:main:owned")]);
+    const readResult = { hostId: "gateway:local", threadId: "owned-thread", items: [] };
+    hoisted.activeRegistry.sessionCatalogs = [
+      {
+        provider: provider({
+          list: vi.fn(async () => [listedHost]),
+          read: vi.fn(async () => readResult),
+        }),
+      },
+    ];
+    const owner = client("profile-owner");
+
+    const listed = await call("sessions.catalog.list", {}, owner);
+    const transcript = await call(
+      "sessions.catalog.read",
+      { catalogId: "codex", hostId: "gateway:local", threadId: "owned-thread" },
+      owner,
+    );
+
+    expect(listed).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        catalogs: [
+          expect.objectContaining({
+            hosts: [
+              expect.objectContaining({
+                sessions: [
+                  expect.objectContaining({
+                    threadId: "owned-thread",
+                    createdActor: { type: "human", id: "profile-owner" },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(transcript).toHaveBeenCalledWith(true, readResult);
+  });
+
+  it("pages before authorizing an older owner thread", async () => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(true);
+    setActors([
+      ["agent:main:other", "profile-other"],
+      ["agent:main:owned", "profile-owner"],
+    ]);
+    const list = vi.fn(async ({ cursors }: { cursors?: Record<string, string> }) => [
+      cursors
+        ? host([session("owned-thread", "agent:main:owned")])
+        : host([session("other-thread", "agent:main:other")], "page-2"),
+    ]);
+    const readResult = { hostId: "gateway:local", threadId: "owned-thread", items: [] };
+    hoisted.activeRegistry.sessionCatalogs = [
+      { provider: provider({ list: list as never, read: vi.fn(async () => readResult) }) },
+    ];
+
+    const transcript = await call(
+      "sessions.catalog.read",
+      { catalogId: "codex", hostId: "gateway:local", threadId: "owned-thread" },
+      client("profile-owner"),
+    );
+
+    expect(transcript).toHaveBeenCalledWith(true, readResult);
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cursors: { "gateway:local": "page-2" } }),
+    );
+  });
+
+  it("isolates settled list cache entries between identities", async () => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(true);
+    setActors([
+      ["agent:main:alpha", "profile-alpha"],
+      ["agent:main:beta", "profile-beta"],
+    ]);
+    const list = vi.fn(async () => [
+      host([
+        session("alpha-thread", "agent:main:alpha"),
+        session("beta-thread", "agent:main:beta"),
+      ]),
+    ]);
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider({ list }) }];
+    const config = {};
+
+    const alpha = await call("sessions.catalog.list", {}, client("profile-alpha"), config);
+    const beta = await call("sessions.catalog.list", {}, client("profile-beta"), config);
+    const rows = (respond: ReturnType<typeof vi.fn>) =>
+      respond.mock.calls[0]?.[1]?.catalogs[0]?.hosts[0]?.sessions.map(
+        (item: { threadId: string }) => item.threadId,
+      );
+
+    expect(rows(alpha)).toEqual(["alpha-thread"]);
+    expect(rows(beta)).toEqual(["beta-thread"]);
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/server-methods/session-catalog-visibility.ts
+++ b/src/gateway/server-methods/session-catalog-visibility.ts
@@ -1,0 +1,92 @@
+import type { SessionCatalogHost } from "../../../packages/gateway-protocol/src/index.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type {
+  SessionCatalogListProviderParams,
+  SessionCatalogProvider,
+} from "../../plugins/session-catalog.js";
+import { hasMultipleSessionSharingIdentities } from "../../state/user-profiles.js";
+import { ADMIN_SCOPE, authorizeOperatorScopesForRequiredScope } from "../method-scopes.js";
+import { createSessionCatalogRequestEntrySnapshot } from "./session-catalog-entry-snapshot.js";
+import type { GatewayClient } from "./types.js";
+
+type SessionCatalogVisibility = {
+  cacheKey: string;
+  profileId?: string;
+  restricted: boolean;
+};
+
+export function resolveSessionCatalogVisibility(
+  client: GatewayClient | null,
+): SessionCatalogVisibility {
+  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  const admin = authorizeOperatorScopesForRequiredScope(ADMIN_SCOPE, scopes).allowed;
+  const multipleIdentities = hasMultipleSessionSharingIdentities();
+  const profileId = client?.authenticatedUserProfile?.profileId;
+  return {
+    cacheKey: JSON.stringify({ admin, multipleIdentities, profileId: profileId ?? null }),
+    ...(profileId ? { profileId } : {}),
+    restricted: multipleIdentities && !admin,
+  };
+}
+
+export function filterSessionCatalogHost(
+  host: SessionCatalogHost,
+  visibility: SessionCatalogVisibility,
+): SessionCatalogHost {
+  if (!visibility.restricted) {
+    return host;
+  }
+  return {
+    ...host,
+    sessions: host.sessions.filter((session) => {
+      // No sessionKey means the provider cannot link this host-owned CLI row to an adopted
+      // OpenClaw session. Keep it private from non-admin callers on multi-identity Gateways.
+      return session.createdActor?.id === visibility.profileId;
+    }),
+  };
+}
+
+export async function isSessionCatalogThreadVisible(params: {
+  allowProcessHomeFallback: boolean;
+  config: OpenClawConfig;
+  fallbackAgentId: string;
+  hostId: string;
+  list: SessionCatalogProvider["list"];
+  listNodes: NonNullable<SessionCatalogListProviderParams["listNodes"]>;
+  threadId: string;
+  visibility: SessionCatalogVisibility;
+}): Promise<boolean> {
+  if (!params.visibility.restricted) {
+    return true;
+  }
+  const requestEntries = createSessionCatalogRequestEntrySnapshot({
+    cfg: params.config,
+    fallbackAgentId: params.fallbackAgentId,
+  });
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  while (true) {
+    const hosts = await params.list({
+      allowProcessHomeFallback: params.allowProcessHomeFallback,
+      hostIds: [params.hostId],
+      ...(cursor ? { cursors: { [params.hostId]: cursor } } : {}),
+      sessionEntries: requestEntries.sessionEntries,
+      listNodes: params.listNodes,
+    });
+    const host = hosts.find((candidate) => candidate.hostId === params.hostId);
+    if (!host) {
+      return false;
+    }
+    const projected = requestEntries.projectHostCreatedActors(host);
+    const session = projected.sessions.find((candidate) => candidate.threadId === params.threadId);
+    if (session) {
+      return session.createdActor?.id === params.visibility.profileId;
+    }
+    const nextCursor = host.nextCursor;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      return false;
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+}

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -18,6 +18,7 @@ type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
 
 const hoisted = vi.hoisted(() => ({
   activeRegistry: {} as TestPluginRegistry,
+  hasMultipleSessionSharingIdentities: vi.fn(() => false),
   listSessionEntriesReadOnly: vi.fn<
     (scope?: { agentId?: string; clone?: boolean; projection?: "full" | "list" }) => Array<{
       sessionKey: string;
@@ -57,7 +58,9 @@ vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
   return { ...actual, listSessionEntriesReadOnly: hoisted.listSessionEntriesReadOnly };
 });
-
+vi.mock("../../state/user-profiles.js", () => ({
+  hasMultipleSessionSharingIdentities: hoisted.hasMultipleSessionSharingIdentities,
+}));
 const { resolveRegisteredCatalogCreateTarget, sessionCatalogHandlers } =
   await import("./session-catalog.js");
 
@@ -108,6 +111,7 @@ function startCall(
 describe("session catalog Gateway methods", () => {
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+    hoisted.hasMultipleSessionSharingIdentities.mockReset().mockReturnValue(false);
     hoisted.listSessionEntriesReadOnly.mockReset();
     hoisted.listSessionEntriesReadOnly.mockReturnValue([]);
     hoisted.recordSessionStateEvent.mockClear();

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -4,6 +4,7 @@ import {
   ErrorCodes,
   errorShape,
   type SessionCatalog,
+  type SessionCatalogLocator,
   type SessionsCatalogArchiveParams,
   type SessionsCatalogContinueParams,
   type SessionsCatalogListParams,
@@ -13,6 +14,7 @@ import {
   validateSessionsCatalogListParams,
   validateSessionsCatalogReadParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { allowsProcessHomeSessionScan } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
@@ -34,7 +36,17 @@ import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
 import { createSessionCatalogRequestEntrySnapshot } from "./session-catalog-entry-snapshot.js";
 import { SessionCatalogListAdmission } from "./session-catalog-list-admission.js";
 import { catalogStartHandler } from "./session-catalog-terminal-start.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import {
+  filterSessionCatalogHost,
+  isSessionCatalogThreadVisible,
+  resolveSessionCatalogVisibility,
+} from "./session-catalog-visibility.js";
+import type {
+  GatewayClient,
+  GatewayRequestContext,
+  GatewayRequestHandlers,
+  RespondFn,
+} from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 const SESSION_CATALOG_SEARCH_MAX_UTF16_UNITS = 500;
@@ -64,6 +76,13 @@ const sessionCatalogListAdmission = new SessionCatalogListAdmission(
   MAX_CONCURRENT_SESSION_CATALOG_LISTS,
   MAX_QUEUED_SESSION_CATALOG_LISTS,
 );
+
+function listSessionCatalogProvider(
+  provider: SessionCatalogProvider,
+  params: SessionCatalogListProviderParams,
+) {
+  return sessionCatalogListAdmission.run(() => provider.list(params));
+}
 
 function createSessionCatalogRequestNodeSnapshot(): NonNullable<
   SessionCatalogListProviderParams["listNodes"]
@@ -256,6 +275,7 @@ function sessionCatalogListKey(params: {
   request: SessionsCatalogListParams;
   search?: string;
   allowProcessHomeFallback: boolean;
+  visibilityKey: string;
 }): string {
   const cursors = params.request.cursors
     ? Object.entries(params.request.cursors).toSorted(([left], [right]) =>
@@ -270,6 +290,7 @@ function sessionCatalogListKey(params: {
     params.request.hostIds ?? null,
     cursors,
     params.allowProcessHomeFallback,
+    params.visibilityKey,
   ]);
 }
 
@@ -335,6 +356,37 @@ function catalogResult(
   return result;
 }
 
+async function authorizeSessionCatalogThread(params: {
+  client: GatewayClient | null;
+  context: GatewayRequestContext;
+  provider: SessionCatalogProvider;
+  request: SessionCatalogLocator;
+  respond: RespondFn;
+}): Promise<{ allowProcessHomeFallback: boolean } | null> {
+  const config = params.context.getRuntimeConfig();
+  const allowHomeFallback = allowProcessHomeFallback(params.context.logGateway);
+  const visibility = resolveSessionCatalogVisibility(params.client);
+  const visible = await isSessionCatalogThreadVisible({
+    allowProcessHomeFallback: allowHomeFallback,
+    config,
+    fallbackAgentId: resolveDefaultAgentId(config),
+    hostId: params.request.hostId,
+    list: (request) => listSessionCatalogProvider(params.provider, request),
+    listNodes: createSessionCatalogRequestNodeSnapshot(),
+    threadId: params.request.threadId,
+    visibility,
+  });
+  if (visible) {
+    return { allowProcessHomeFallback: allowHomeFallback };
+  }
+  params.respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.FORBIDDEN, "session catalog thread is not visible to this caller"),
+  );
+  return null;
+}
+
 export const sessionCatalogHandlers: GatewayRequestHandlers = {
   "sessions.catalog.list": async ({ params, respond, context, client }) => {
     if (
@@ -386,6 +438,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
     const search = normalizeSessionCatalogSearch(request.search);
     const allowHomeFallback = allowProcessHomeFallback(context.logGateway);
+    const visibility = resolveSessionCatalogVisibility(client);
     const progressId = request.progressId;
     const progressConnId = progressId && client?.connId ? client.connId : undefined;
     const listKey = sessionCatalogListKey({
@@ -393,6 +446,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       request,
       search,
       allowProcessHomeFallback: allowHomeFallback,
+      visibilityKey: visibility.cacheKey,
     });
     const cache = catalogListCache(config, catalogRegistrations);
     const cached = cache.get(listKey);
@@ -438,12 +492,11 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
               }
             : undefined;
           const onHost = (host: SessionCatalog["hosts"][number]) => {
-            const catalog = catalogResult(
-              provider,
-              [requestEntries.projectHostCreatedActors(host)],
-              undefined,
-              createSession,
+            const visibleHost = filterSessionCatalogHost(
+              requestEntries.projectHostCreatedActors(host),
+              visibility,
             );
+            const catalog = catalogResult(provider, [visibleHost], undefined, createSession);
             // Progressive frames are an optimization. The final RPC response remains
             // authoritative when a slow client drops an intermediate host update.
             for (const subscriber of progressSubscribers.values()) {
@@ -460,21 +513,21 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
             }
           };
           try {
-            const hosts = await sessionCatalogListAdmission.run(() =>
-              provider.list({
-                allowProcessHomeFallback: allowHomeFallback,
-                search,
-                limitPerHost: request.limitPerHost,
-                hostIds: request.hostIds,
-                ...(request.cursors !== undefined ? { cursors: request.cursors } : {}),
-                sessionEntries: requestEntries.sessionEntries,
-                listNodes,
-                onHost,
-              }),
-            );
+            const hosts = await listSessionCatalogProvider(provider, {
+              allowProcessHomeFallback: allowHomeFallback,
+              search,
+              limitPerHost: request.limitPerHost,
+              hostIds: request.hostIds,
+              ...(request.cursors !== undefined ? { cursors: request.cursors } : {}),
+              sessionEntries: requestEntries.sessionEntries,
+              listNodes,
+              onHost,
+            });
             return catalogResult(
               provider,
-              hosts.map(requestEntries.projectHostCreatedActors),
+              hosts.map((host) =>
+                filterSessionCatalogHost(requestEntries.projectHostCreatedActors(host), visibility),
+              ),
               undefined,
               createSession,
             );
@@ -507,7 +560,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
   },
 
-  "sessions.catalog.read": async ({ params, respond, context }) => {
+  "sessions.catalog.read": async ({ params, respond, context, client }) => {
     if (
       !assertValidParams(
         params,
@@ -524,12 +577,22 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      const authorization = await authorizeSessionCatalogThread({
+        client,
+        context,
+        provider,
+        request,
+        respond,
+      });
+      if (!authorization) {
+        return;
+      }
       const { catalogId: _catalogId, ...providerRequest } = request;
       respond(
         true,
         await provider.read({
           ...providerRequest,
-          allowProcessHomeFallback: allowProcessHomeFallback(context.logGateway),
+          allowProcessHomeFallback: authorization.allowProcessHomeFallback,
         }),
       );
     } catch (error) {
@@ -564,13 +627,23 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      const authorization = await authorizeSessionCatalogThread({
+        client,
+        context,
+        provider,
+        request,
+        respond,
+      });
+      if (!authorization) {
+        return;
+      }
       const { catalogId: _catalogId, ...providerRequest } = request;
       // Fail closed for unscoped callers: providers gate high-authority
       // continues (e.g. node-executing bindings) on these scopes.
       const clientScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
       const result = await provider.continueSession({
         ...providerRequest,
-        allowProcessHomeFallback: allowProcessHomeFallback(context.logGateway),
+        allowProcessHomeFallback: authorization.allowProcessHomeFallback,
         clientScopes,
       });
       if (result.conversationBinding) {
@@ -630,7 +703,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     resolveRegisteredCatalogCreateTarget,
   ),
 
-  "sessions.catalog.archive": async ({ params, respond, context }) => {
+  "sessions.catalog.archive": async ({ params, respond, context, client }) => {
     if (
       !assertValidParams(
         params,
@@ -651,12 +724,22 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      const authorization = await authorizeSessionCatalogThread({
+        client,
+        context,
+        provider,
+        request,
+        respond,
+      });
+      if (!authorization) {
+        return;
+      }
       const { catalogId: _catalogId, ...providerRequest } = request;
       respond(
         true,
         await provider.archive({
           ...providerRequest,
-          allowProcessHomeFallback: allowProcessHomeFallback(context.logGateway),
+          allowProcessHomeFallback: authorization.allowProcessHomeFallback,
         }),
       );
     } catch (error) {

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -13,7 +13,7 @@ import {
   finalizeNodePairingCleanupClaim,
   recordPairedNodeConnection,
 } from "../../../infra/device-pairing-node.js";
-import { listProfiles } from "../../../state/user-profiles.js";
+import { hasMultipleSessionSharingIdentities } from "../../../state/user-profiles.js";
 import { resolveRuntimeServiceVersion } from "../../../version.js";
 import { resolveChatAttachmentPolicy } from "../../chat-attachment-policy.js";
 import {
@@ -153,8 +153,7 @@ export async function sendGatewayHello(
       tickIntervalMs: TICK_INTERVAL_MS,
       attachments: resolveChatAttachmentPolicy(context.configSnapshot),
       allowedSessionVisibilities: allowedSessionVisibilities(context.configSnapshot),
-      hasMultipleSessionSharingIdentities:
-        listProfiles().filter((profile) => !profile.mergedInto).length >= 2,
+      hasMultipleSessionSharingIdentities: hasMultipleSessionSharingIdentities(),
     },
   };
   advanceHandshakePhase("hello_payload_prepared");

--- a/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
@@ -59,7 +59,7 @@ vi.mock("../health-state.js", () => ({
 }));
 
 vi.mock("../../../state/user-profiles.js", () => ({
-  listProfiles: vi.fn(() => []),
+  hasMultipleSessionSharingIdentities: vi.fn(() => false),
 }));
 
 vi.mock("../../control-ui-plugin-tabs.js", () => ({

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -722,3 +722,10 @@ export function listProfiles(options: OpenClawStateDatabaseOptions = {}): UserPr
     { databaseLabel: database.path, operationLabel: "user-profiles.list" },
   );
 }
+
+/** True when session-sharing policy can distinguish at least two durable people. */
+export function hasMultipleSessionSharingIdentities(
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  return listProfiles(options).filter((profile) => !profile.mergedInto).length >= 2;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a non-admin operator on a multi-identity Gateway could list the host user's locally discovered Claude Code, Codex, Pi, OpenCode, and Beam session rows without caller ownership filtering. Catalog list metadata could include absolute working directories or a first prompt as the row name, while transcript reads could return normalized text and provider raw payloads.

Within OpenClaw's documented one-trusted-operator-domain model, this is a hardening and correctness fix, not a vulnerability. Its practical blast radius grew when multi-identity Gateways became a real product mode. Intentional `operator.admin` visibility is unchanged, and solo or shared-secret deployments remain unfiltered.

## Why This Change Was Made

The Gateway now owns one catalog visibility policy: admins see all rows; Gateways with fewer than two durable identities preserve existing behavior; otherwise a non-admin sees and can read, continue, or archive only rows whose authoritative enriched `createdActor.id` matches the caller's authenticated profile. A row without `sessionKey` cannot be linked to an adopted OpenClaw session, so it is treated as private host CLI history and hidden from non-admin callers on multi-identity Gateways.

On a Gateway that already has multiple durable identities, an unprofiled non-admin caller has no owner identity and therefore sees no catalog rows by design. The solo/shared-secret exception is based on the Gateway having fewer than two durable sharing identities; it is not an unprofiled-connection bypass on an otherwise multi-identity Gateway.

The same policy filters progressive and final list results, partitions the three-second list cache by identity/admin/cardinality, and guards direct read, continue, and archive calls before provider dispatch. Direct checks follow provider pagination so older adopted sessions remain usable. Pi and OpenCode now project their existing adoption link as `sessionKey`; they contain no visibility decision or filtering policy.

The branch also fixes a pre-existing red `main` doctor-closure gate by moving static llama-server asset metadata into a dependency-light module. This keeps llama.cpp doctor enumeration from cold-loading the SSRF/download runtime without changing installation behavior.

AI-assisted; the maintainer supplied the exact product rule and reviewed the resulting behavior.

Production LOC: +394/-142 raw (net +252), tests: +387/-3, docs: +28/-9. The llama-server extraction moves 105 static metadata lines and contributes net +17 production lines. The remaining net +235 production lines implement the new core authorization boundary, paginated direct-target proof, canonical multi-identity signal, and the two bounded adoption projections; there was no existing core policy path to reuse without leaving list progress, direct methods, or cache sharing exposed.

## User Impact

On a multi-user Gateway, non-admin operators no longer see or operate on another profile's adopted catalog sessions or unattributed host CLI/Desktop history. Their own adopted rows remain visible and usable. Hidden direct reads and mutations return an explicit `FORBIDDEN` result rather than an empty transcript.

Admins deliberately retain complete catalog access. Gateways without multiple durable sharing identities receive byte-for-byte equivalent unfiltered catalog responses. Method scopes do not change: list/read remain `operator.read`; continue/archive remain `operator.write`.

The Control UI hidden-catalog preference, provider discovery roots, and provider-specific cwd/first-prompt projection are unchanged.

## Evidence

Pre-fix regression proof:

- Core Gateway suite failed because streamed/final rows were unfiltered, hidden reads reached the provider, and two profiles shared the settled cache result (`run_359c73f36407`).
- Pi and OpenCode projection tests each failed after successful adoption because the listed row omitted `sessionKey`.

Passing proof:

- `node scripts/run-vitest.mjs src/gateway/server-methods/session-catalog.test.ts src/gateway/server-methods/session-catalog-visibility.test.ts extensions/acpx/src/pi-session-catalog-continuation.test.ts extensions/opencode/session-catalog.test.ts src/gateway/server/ws-connection/connect-hello.update-scope.test.ts src/gateway/server.auth.default-token.test.ts src/plugins/doctor-contract-closure-guard.test.ts extensions/llama-cpp/doctor-contract-api.test.ts extensions/llama-cpp/src/setup.test.ts extensions/llama-cpp/src/managed-server.test.ts` — 107 tests passed across five routed shards.
- `node scripts/check-changed.mjs` — all changed gates passed (local trusted-source fallback after the remote coordinator returned HTTP 500 during provisioning).
- `pnpm docs:check-mdx` — passed.
- `pnpm docs:check-links` — 6,488 internal links checked, zero broken.
- `pnpm format:docs:check` and `pnpm docs:check-i18n-glossary` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.
- Source-blind real-Gateway validation was attempted with isolated state and no credentials. It was fixture-blocked because the public CLI/API cannot safely provision synthetic catalog rows plus two profile-bound non-admin callers and an admin without using real host history; the isolated Gateway was stopped and real state was untouched.

The focused matrix covers multi-identity owner/other/unattributed rows, typed read/continue/archive rejection before provider dispatch, admin bypass, solo compatibility, owner access through a later provider page, progress frames, and cross-profile cache isolation.
