### PR TITLE
fix(agent): prevent silent replies with durable sessions

### DIFF
--- a/src/agents/tools/gateway.runtime-identity.test.ts
+++ b/src/agents/tools/gateway.runtime-identity.test.ts
@@ -232,7 +232,7 @@ describe("gateway tool runtime identity", () => {
     ).rejects.toThrow("terminal source reply requires trusted agent runtime identity");
   });
 
-  it("mints message action identity for split policy and durable run sessions", async () => {
+  it("mints split-session message action identity and rejects policy-session substitution", async () => {
     const policySessionKey = "agent:ops:telegram:default:direct:alice";
     const runSessionKey = "agent:ops:main";
     const operationalRunInstance = createOperationalRunInstanceRef("run-split-session");
@@ -258,6 +258,19 @@ describe("gateway tool runtime identity", () => {
         operationalRunInstance,
       },
       async () => {
+        await expect(
+          resolveMessageActionAgentRuntimeIdentityToken({
+            opts: {},
+            target: "local",
+            turnCapability,
+            turnCapabilitySessionKey: "agent:ops:telegram:default:direct:mallory",
+            runId: operationalRunInstance.runId,
+            sessionId: "session-split-session",
+            sourceReplyFinal: true,
+            sourceReplyToolCallId: "message-call-substituted-session",
+          }),
+        ).rejects.toThrow("terminal source reply requires an active turn capability");
+
         const token = await resolveMessageActionAgentRuntimeIdentityToken({
           opts: {},
           target: "local",

--- a/src/agents/tools/gateway.runtime-identity.test.ts
+++ b/src/agents/tools/gateway.runtime-identity.test.ts
@@ -232,6 +232,56 @@ describe("gateway tool runtime identity", () => {
     ).rejects.toThrow("terminal source reply requires trusted agent runtime identity");
   });
 
+  it("mints message action identity for split policy and durable run sessions", async () => {
+    const policySessionKey = "agent:ops:telegram:default:direct:alice";
+    const runSessionKey = "agent:ops:main";
+    const operationalRunInstance = createOperationalRunInstanceRef("run-split-session");
+    const turnCapability = mintMessageActionTurnCapability({
+      agentId: "ops",
+      runId: operationalRunInstance.runId,
+      sessionKey: policySessionKey,
+      sourceReplySessionKey: runSessionKey,
+      sessionId: "session-split-session",
+      toolContext: {
+        currentChannelProvider: "telegram",
+        currentChannelId: "alice",
+        currentChatType: "direct",
+        currentSourceTurnId: "source-turn-split-session",
+      },
+    });
+    mintedTurnCapabilities.push(turnCapability);
+
+    await withActiveGatewayToolCallerIdentity(
+      {
+        agentId: "ops",
+        sessionKey: runSessionKey,
+        operationalRunInstance,
+      },
+      async () => {
+        const token = await resolveMessageActionAgentRuntimeIdentityToken({
+          opts: {},
+          target: "local",
+          turnCapability,
+          turnCapabilitySessionKey: policySessionKey,
+          runId: operationalRunInstance.runId,
+          sessionId: "session-split-session",
+          sourceReplyFinal: true,
+          sourceReplyToolCallId: "message-call-split-session",
+        });
+
+        await expect(verifyAgentRuntimeIdentityToken(token)).resolves.toMatchObject({
+          sessionKey: policySessionKey,
+          operationalRunInstance,
+          messageActionContext: {
+            sourceReplySessionKey: runSessionKey,
+            sourceReplyFinal: true,
+            sourceReplyToolCallId: "message-call-split-session",
+          },
+        });
+      },
+    );
+  });
+
   it.each([
     ["exec.approval.request", undefined, false],
     ["plugin.approval.request", "codex", false],

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -401,6 +401,7 @@ export async function resolveMessageActionAgentRuntimeIdentityToken(params: {
   opts: GatewayCallOptions;
   target: "local" | "remote";
   turnCapability?: string;
+  turnCapabilitySessionKey?: string;
   runId?: string;
   sessionId?: string;
   sourceReplyFinal?: boolean;
@@ -426,11 +427,13 @@ export async function resolveMessageActionAgentRuntimeIdentityToken(params: {
   if (usesUntrustedGatewayContext && !terminalSourceReply) {
     return undefined;
   }
+  const turnCapabilitySessionKey =
+    normalizeOptionalString(params.turnCapabilitySessionKey) ?? identity.sessionKey;
   const messageActionContext = resolveMessageActionTurnCapability({
     token: params.turnCapability,
     agentId: identity.agentId,
     runId: params.runId,
-    sessionKey: identity.sessionKey,
+    sessionKey: turnCapabilitySessionKey,
     sessionId: params.sessionId,
   });
   if (!messageActionContext) {
@@ -472,6 +475,7 @@ export async function resolveMessageActionAgentRuntimeIdentityToken(params: {
       };
   return await mintAgentRuntimeIdentityToken({
     ...identity,
+    sessionKey: turnCapabilitySessionKey,
     operationalRunInstance: identity.operationalRunInstance,
     messageActionContext: resolvedMessageActionContext,
   });

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -544,6 +544,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
                   opts: gatewayOpts,
                   target: gatewayResolved.target,
                   turnCapability: options?.messageActionTurnCapability,
+                  turnCapabilitySessionKey: options?.agentSessionKey,
                   runId: options?.runId,
                   sessionId: options?.sessionId,
                   sourceReplyFinal: context?.sourceReplyFinal,


### PR DESCRIPTION
Related: #87744

## What Problem This Solves

Fixes source-channel turns that use a durable run session and can finish silently because a valid terminal `message` action is rejected before delivery.

## Root Cause and Fix

The turn capability is authorized against the source policy session, while the active operational run uses the durable run session. Message-action identity minting incorrectly used the durable session for both roles.

The fix carries the existing prepared policy session into capability validation and the signed Gateway identity. It preserves the durable operational run and receipt owner. The capability resolver still requires exact agent, run, policy-session, and session identity; a new negative owner-boundary assertion proves that substituting the policy session fails closed.

This is shared across runtimes and channels. It adds no provider-specific path, compatibility behavior, or fallback. Open PR #105765 covers a different downstream fallback after a genuinely empty message-tool-only completion.

Maintainer decision: approved in the originating task after the split-session authority defect was explained.

## User Impact

Valid terminal message-tool replies reach the source channel when policy and durable run session keys differ, instead of ending after typing with no visible reply.

Intentional silence is unchanged. Exact `NO_REPLY` still remains silent; this patch only allows an explicitly requested terminal message send to pass its existing authorization check.

## Evidence

- Live RED on current `main`: native Codex + Telegram DM attempted the terminal `message` action twice; both failed with `terminal source reply requires an active turn capability`. Telegram recorded typing and cancellation, but no message. The provider mock received zero requests.
- Regression RED before the fix: the shared Gateway identity test failed with the same capability error; 11 existing tests passed.
- Owner-boundary GREEN: the split policy/durable session mints successfully, and a substituted policy session is rejected before signing.
- Focused suites: 3 files, 300 tests passed.
- `pnpm tsgo`, `pnpm check:test-types`, focused Oxfmt, type-aware Oxlint, and `git diff --check`: passed.
- Distill: no findings; one canonical policy-session value serves validation and signing.
- Greybeard: no findings; no new I/O, discovery, cache, lifecycle state, or hot-loop work.
- Direct dependency check: `@openai/codex` tag `rust-v0.147.0` (`3ed6f04f6bf8b7c46299d1cb1ff99c74ce21a51d`) forwards dynamic tool calls and emits terminal turn completion independently; no upstream change is required.
- Exact-head CI for `39fe551bff22809d8572faa28827e9215b6dc4ab`: 156 completed checks, zero failures or pending checks.
- Final exact-head local ClawSweeper review: PASS; patch correct, zero findings, security concerns, maintainer decisions, or Rank-up moves.

### Redacted Telegram proof

Exact head: `39fe551bff22809d8572faa28827e9215b6dc4ab`

```text
user -> SUT: Reply with CODEX_SPLIT_SESSION_FIXED_39FE551B only.
Codex -> message tool: send(final=true, text=CODEX_SPLIT_SESSION_FIXED_39FE551B)
message tool -> Codex: ok=true, sourceReplyRoute=current-source
Gateway: message.action succeeded; Telegram outbound send succeeded
Telegram timeline: 1 SUT message; typing start/cancel; 0 edits; 0 deletes; 0 retries; 0 duplicates
Provider mock requests: 0
Prior active-turn-capability errors: 0
Prior empty-queue warnings: 0
```

The recorded Telegram text exactly matched `CODEX_SPLIT_SESSION_FIXED_39FE551B`.

AI-assisted: yes. I reproduced the failure, inspected the shared authority boundary and exact pinned Codex source, reviewed the final diff, and ran the listed proof.
