### PR TITLE
fix(ui): keep notifications at the top of the viewport

### DIFF
--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -476,6 +476,15 @@ suite.define(() => {
       }
       const handedOffToast = page.locator(".shell > openclaw-toast-host .app-toast");
       await expect.poll(() => handedOffToast.textContent()).toContain("Codex hidden");
+      const [toastBounds, composerBounds] = await Promise.all([
+        handedOffToast.boundingBox(),
+        page.locator(".agent-chat__composer-shell").boundingBox(),
+      ]);
+      if (!toastBounds || !composerBounds) {
+        throw new Error("expected the handed-off toast and chat composer to have layout boxes");
+      }
+      expect(Math.round(toastBounds.y)).toBe(20);
+      expect(toastBounds.y + toastBounds.height).toBeLessThan(composerBounds.y);
       await handedOffToast.getByRole("button", { name: "Dismiss" }).click();
       await expect.poll(() => handedOffToast.isVisible()).toBe(false);
     },

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -615,15 +615,13 @@ openclaw-session-owner-chip {
   line-height: 1;
 }
 
-/* Passive notification, so it sits in the trailing bottom corner rather than
- * centered over the content column, where it landed on top of the chat composer's
- * controls. Overlapping the composer region from the corner is accepted. The host
- * shows one toast at a time (`show()` replaces the active one), so there is no
- * stack to offset against. */
+/* Passive notifications stay in the trailing top corner, away from the chat
+ * composer and other bottom-docked controls. The host shows one toast at a time
+ * (`show()` replaces the active one), so there is no stack to offset against. */
 .app-toast {
   position: fixed;
   right: calc(20px + var(--safe-area-right));
-  bottom: calc(20px + var(--safe-area-bottom));
+  top: calc(20px + var(--safe-area-top));
   z-index: var(--z-toast);
   display: flex;
   align-items: center;
@@ -638,7 +636,7 @@ openclaw-session-owner-chip {
 }
 
 /* A corner toast degenerates at phone widths, where it would span nearly the
- * whole viewport anyway. Use the full-width bottom idiom instead. */
+ * whole viewport anyway. Use the full-width top idiom instead. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .app-toast {
     left: max(12px, var(--safe-area-left));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI notifications appeared at the bottom of the viewport near the WebChat composer, obscuring the primary chat controls on narrow screens.

## Why This Change Was Made

The shared app toast now uses the viewport's top safe-area inset at every supported width. Modal toast routing, horizontal safe-area handling, wrapping, and dismissal behavior remain unchanged; a focused browser regression verifies that a toast handed back from the mobile navigation drawer stays above the composer.

AI-assisted change; the implementation and proof were reviewed before submission.

## User Impact

Notifications remain visible without covering the WebChat composer or other bottom-docked controls.

## Evidence

**Before — bottom notification near the composer**

![Before: notification fixed near the bottom composer](https://github.com/user-attachments/assets/05d46a7a-6c8b-4d10-b834-879dd8cb9401)

**After — notification fixed to the viewport top**

![After: notification fixed to the top safe area](https://github.com/user-attachments/assets/9b1d3dba-2730-4f69-8bc1-e1abfd1a786d)

- RED: the unmodified parent placed the handed-off toast at mobile y=759 and desktop y=815 instead of the 20 px top inset.
- GREEN: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` — 12 passed in real Chromium.
- GREEN: `pnpm --dir ui test src/lib/toast.test.ts` — 7 passed.
- GREEN: UI TypeScript and i18n verification passed before commit.
- Autoreview reported no actionable findings.
- The repository remote changed-file gate exceeded its 10-minute Testbox queue timeout without reporting a test failure; exact-head PR CI remains the remote proof.
