### PR TITLE
fix: let plugins correlate skill evaluations

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -248,6 +248,13 @@ api.on(
 );
 ```
 
+When evaluation input includes `correlationId`, OpenClaw forwards it to the
+evaluator event for both manual and apply-triggered evaluations. This value is
+caller-supplied correlation metadata, not authenticated identity or proof of
+authorization. An authorization plugin must mint or replace the value through
+a trusted entry point, bind it to the intended operation, and validate and
+consume it itself.
+
 Stored outcomes identify the evaluator, plugin id, plugin package version,
 status, and returned result. Timeouts and thrown errors are recorded as
 attributed error outcomes; they do not fail the whole evaluation. Applying a

--- a/src/plugins/hook-skill.types.ts
+++ b/src/plugins/hook-skill.types.ts
@@ -15,6 +15,8 @@ export type PluginHookSkillBundleSnapshot = {
 };
 
 export type PluginHookSkillProposalEvaluateEvent = {
+  /** Caller-supplied correlation metadata; not authenticated identity or authorization proof. */
+  correlationId?: string;
   proposal: {
     id: string;
     kind: PluginHookSkillProposalKind;

--- a/src/skills/workshop/service-evaluation.test.ts
+++ b/src/skills/workshop/service-evaluation.test.ts
@@ -123,6 +123,7 @@ describe("Skill Workshop proposal evaluation", () => {
     });
     const hookEvent = hookMocks.evaluate.mock.calls[0]?.[0] as PluginHookSkillProposalEvaluateEvent;
     expect(hookEvent).toMatchObject({
+      correlationId: "optimization-run-1",
       proposal: {
         id: proposal.record.id,
         revision: "v1",

--- a/src/skills/workshop/service-evaluation.ts
+++ b/src/skills/workshop/service-evaluation.ts
@@ -96,6 +96,7 @@ export async function evaluateSkillProposal(
   const rawOutcomes = bundles
     ? await runSkillProposalEvaluators(
         {
+          ...(correlationId ? { correlationId } : {}),
           proposal: {
             id: read.record.id,
             kind: read.record.kind,


### PR DESCRIPTION
Fixes #122880

## What Problem This Solves

Fixes an issue where Skill Workshop authorization plugins could not correlate an evaluator call with the exact evaluation request when an agent applied a proposal. OpenClaw accepted and stored `correlationId`, but omitted it from the plugin evaluator event, so concurrent callers of the same proposal revision could not be isolated safely.

## Why This Change Was Made

OpenClaw now forwards the normalized optional `correlationId` to `skill_proposal_evaluate` hooks and documents its trust boundary. The value remains caller-supplied metadata: an authorization plugin must mint or replace it through a trusted entry point, bind it to the intended operation, and validate and consume it itself.

## User Impact

Plugin developers can correlate manual and apply-triggered Skill Workshop evaluations with the request that initiated them. This enables invocation-bound authorization for agent tool calls without treating `agentId`, `workspaceDir`, or an arbitrary correlation string as authenticated identity.

Direct CLI, Control UI, and Gateway calls do not automatically gain authenticated authorization. They need their own trusted token-minting path or should fail closed in plugins that require invocation-bound approval.

## Evidence

- `node scripts/run-vitest.mjs src/skills/workshop/service-evaluation.test.ts` — 21 tests passed.
- `node scripts/run-vitest.mjs src/plugins/hooks.skill-lifecycle.test.ts` — 6 tests passed.
- `pnpm format:check -- docs/plugins/hooks.md src/plugins/hook-skill.types.ts src/skills/workshop/service-evaluation.ts src/skills/workshop/service-evaluation.test.ts` — passed.
- `pnpm format:docs:check -- docs/plugins/hooks.md` and `pnpm lint:docs -- docs/plugins/hooks.md` — passed.
- `node scripts/check-changed.mjs -- docs/plugins/hooks.md src/plugins/hook-skill.types.ts src/skills/workshop/service-evaluation.ts src/skills/workshop/service-evaluation.test.ts` — passed on Blacksmith Testbox `tbx_01kzz0j7jqbbx00tcgyv3ft2xg` ([run](https://github.com/openclaw/openclaw/actions/runs/31762927591)); one-shot box stopped after success.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted or actionable findings, patch assessed correct at 0.99.
- `git diff --check` — passed.

## AI Assistance

AI-assisted. I reviewed the implementation, trust boundary, tests, and proof results.
