### PR TITLE
fix: terminals and model setup fail in explicit-agent fleets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI explicit-agent setup and terminals:** preserve the selected agent across terminal reconnects and every structured model-setup step so explicit multi-agent fleets no longer fail with missing-owner errors.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI explicit-agent setup and terminals:** preserve the selected agent across terminal reconnects and every structured model-setup step so explicit multi-agent fleets no longer fail with missing-owner errors.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -11155,7 +11155,19 @@ public struct SystemChangesListResult: Codable, Sendable {
     }
 }
 
-public struct SystemAgentSetupDetectParams: Codable, Sendable {}
+public struct SystemAgentSetupDetectParams: Codable, Sendable {
+    public let agentid: String?
+
+    public init(
+        agentid: String? = nil)
+    {
+        self.agentid = agentid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
 
 public struct SystemAgentSetupDetectResult: Codable, Sendable {
     public let candidates: [[String: AnyCodable]]
@@ -11207,9 +11219,22 @@ public struct SystemAgentSetupDetectResult: Codable, Sendable {
     }
 }
 
-public struct SystemAgentSetupVerifyParams: Codable, Sendable {}
+public struct SystemAgentSetupVerifyParams: Codable, Sendable {
+    public let agentid: String?
+
+    public init(
+        agentid: String? = nil)
+    {
+        self.agentid = agentid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
 
 public struct SystemAgentSetupActivateParams: Codable, Sendable {
+    public let agentid: String?
     public let kind: AnyCodable
     public let modelref: String?
     public let authchoice: String?
@@ -11217,12 +11242,14 @@ public struct SystemAgentSetupActivateParams: Codable, Sendable {
     public let workspace: String?
 
     public init(
+        agentid: String? = nil,
         kind: AnyCodable,
         modelref: String? = nil,
         authchoice: String? = nil,
         apikey: String? = nil,
         workspace: String? = nil)
     {
+        self.agentid = agentid
         self.kind = kind
         self.modelref = modelref
         self.authchoice = authchoice
@@ -11231,6 +11258,7 @@ public struct SystemAgentSetupActivateParams: Codable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
         case kind
         case modelref = "modelRef"
         case authchoice = "authChoice"
@@ -11275,21 +11303,25 @@ public struct SystemAgentSetupActivateResult: Codable, Sendable {
 
 public struct SystemAgentSetupAuthStartParams: Codable, Sendable {
     public let sessionid: String
+    public let agentid: String?
     public let authchoice: String
     public let workspace: String?
 
     public init(
         sessionid: String,
+        agentid: String? = nil,
         authchoice: String,
         workspace: String? = nil)
     {
         self.sessionid = sessionid
+        self.agentid = agentid
         self.authchoice = authchoice
         self.workspace = workspace
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionid = "sessionId"
+        case agentid = "agentId"
         case authchoice = "authChoice"
         case workspace
     }

--- a/packages/gateway-protocol/src/schema/openclaw.test.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   validateSystemAgentChatParams,
   validateSystemAgentChatHistoryParams,
+  validateSystemAgentSetupActivateParams,
+  validateSystemAgentSetupAuthStartParams,
+  validateSystemAgentSetupDetectParams,
   validateSystemAgentSetupVerifyParams,
 } from "../index.js";
 import {
@@ -115,6 +118,27 @@ describe("OpenClaw chat history protocol", () => {
 });
 
 describe("OpenClaw setup detection protocol", () => {
+  it("accepts an explicit owner across the structured setup family", () => {
+    expect(validateSystemAgentSetupDetectParams({ agentId: "research" })).toBe(true);
+    expect(validateSystemAgentSetupVerifyParams({ agentId: "research" })).toBe(true);
+    expect(
+      validateSystemAgentSetupActivateParams({
+        agentId: "research",
+        kind: "existing-model",
+      }),
+    ).toBe(true);
+    expect(
+      validateSystemAgentSetupAuthStartParams({
+        sessionId: "setup-1",
+        agentId: "research",
+        authChoice: "openai-api-key",
+      }),
+    ).toBe(true);
+    expect(validateSystemAgentSetupDetectParams({ agentId: "research", unknown: true })).toBe(
+      false,
+    );
+  });
+
   it("accepts additive presentation metadata and older results without installs", () => {
     const result = {
       candidates: [

--- a/packages/gateway-protocol/src/schema/openclaw.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.ts
@@ -165,7 +165,10 @@ export const SystemChangesListResultSchema = closedObject({
  * client can walk the ladder candidate-by-candidate without ever leaving a
  * broken default model behind.
  */
-export const SystemAgentSetupDetectParamsSchema = closedObject({});
+export const SystemAgentSetupDetectParamsSchema = closedObject({
+  /** Agent whose model, credentials, and workspace are being inspected. */
+  agentId: Type.Optional(NonEmptyString),
+});
 
 const ProviderAutoSetupInferenceKind = Type.TemplateLiteral("provider-auto:${string}", {
   pattern: "^provider-auto:.+$",
@@ -307,7 +310,10 @@ export const SystemAgentSetupDetectResultSchema = closedObject({
 });
 
 /** Live verification of the Gateway's current default-agent inference route. */
-export const SystemAgentSetupVerifyParamsSchema = closedObject({});
+export const SystemAgentSetupVerifyParamsSchema = closedObject({
+  /** Agent whose configured inference route is being verified. */
+  agentId: Type.Optional(NonEmptyString),
+});
 
 export const SystemAgentSetupVerifyResultSchema = Type.Union([
   closedObject({
@@ -323,6 +329,8 @@ export const SystemAgentSetupVerifyResultSchema = Type.Union([
 ]);
 
 export const SystemAgentSetupActivateParamsSchema = closedObject({
+  /** Agent that owns the verified and persisted inference route. */
+  agentId: Type.Optional(NonEmptyString),
   kind: Type.Union([
     Type.Literal("existing-model"),
     Type.Literal("openai-api-key"),
@@ -358,6 +366,8 @@ export const SystemAgentSetupActivateResultSchema = closedObject({
 export const SystemAgentSetupAuthStartParamsSchema = closedObject({
   /** Client-generated so cancellation remains possible if the start reply is lost. */
   sessionId: NonEmptyString,
+  /** Agent that owns credentials and model selection created by this setup flow. */
+  agentId: Type.Optional(NonEmptyString),
   authChoice: NonEmptyString,
   workspace: Type.Optional(Type.String()),
 });

--- a/src/agents/tools/terminal-tool.test.ts
+++ b/src/agents/tools/terminal-tool.test.ts
@@ -326,6 +326,26 @@ describe("terminal tool", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it("preserves an explicit-owner launch failure", async () => {
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: vi.fn() });
+    const tool = createTerminalTool({
+      agentId: "main",
+      agentSessionKey: "agent:main:main",
+      getGatewayContext: () => ({
+        terminalSessions: manager,
+        isTerminalEnabled: () => true,
+        resolveTerminalLaunchPolicy: () => ({
+          ok: false,
+          block: { kind: "owner-required", message: "select an agent explicitly" },
+        }),
+      }),
+    });
+
+    await expect(tool.execute("open", { action: "open" })).rejects.toThrow(
+      "select an agent explicitly",
+    );
+  });
+
   it("does not open while the terminal surface is disabled", async () => {
     const spawn = vi.fn(async () => makeBackend());
     const manager = new TerminalSessionManager({ emit: vi.fn(), spawn });

--- a/src/agents/tools/terminal-tool.ts
+++ b/src/agents/tools/terminal-tool.ts
@@ -158,6 +158,9 @@ function launchBlockMessage(
   if (block.kind === "unknown-agent") {
     return `unknown agent: ${block.agentId}`;
   }
+  if (block.kind === "owner-required") {
+    return block.message;
+  }
   return `terminal unavailable: agent sandboxed (${block.mode})`;
 }
 

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -388,7 +388,7 @@ describe("openclaw.setup", () => {
     const { calls, respond } = makeRespond();
 
     await systemAgentHandler("openclaw.setup.auth.start")({
-      params: { sessionId: "auth-session-1", authChoice: "github-copilot" },
+      params: { sessionId: "auth-session-1", agentId: "research", authChoice: "github-copilot" },
       respond,
       context,
     } as never);
@@ -400,7 +400,11 @@ describe("openclaw.setup", () => {
     const session = wizardSessions.get("auth-session-1");
     const first = await session.next();
     expect(setupInferenceMocks.activateSetupInference).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "provider-auth", authChoice: "github-copilot" }),
+      expect.objectContaining({
+        kind: "provider-auth",
+        agentId: "research",
+        authChoice: "github-copilot",
+      }),
     );
     expect(setupInferenceMocks.activateSetupInference.mock.calls[0]?.[0].signal).toBe(
       session.signal,
@@ -432,6 +436,7 @@ describe("openclaw.setup", () => {
     await systemAgentHandler("openclaw.setup.prepare.start")({
       params: {
         sessionId: "prepare-session-1",
+        agentId: "research",
         authChoice: "ollama",
         workspace: "/tmp/models-workspace",
       },
@@ -552,7 +557,7 @@ describe("openclaw.chat", () => {
     const activeAtResponse: number[] = [];
 
     const pending = systemAgentHandler("openclaw.setup.detect")({
-      params: {},
+      params: { agentId: "research" },
       respond: () => {
         activeAtResponse.push(systemAgentLane().activeCount);
       },
@@ -564,6 +569,9 @@ describe("openclaw.chat", () => {
     await pending;
 
     expect(activeAtResponse).toEqual([0]);
+    expect(setupInferenceDetectionMocks.detectSetupInferenceIsolated).toHaveBeenCalledWith({
+      agentId: "research",
+    });
     expect(systemAgentLane().activeCount).toBe(0);
   });
 
@@ -584,9 +592,13 @@ describe("openclaw.chat", () => {
     setupInferenceMocks.verifySetupInference.mockResolvedValueOnce(result);
     const { calls, respond } = makeRespond();
 
-    await systemAgentHandler("openclaw.setup.verify")({ params: {}, respond } as never);
+    await systemAgentHandler("openclaw.setup.verify")({
+      params: { agentId: "research" },
+      respond,
+    } as never);
 
     expect(setupInferenceMocks.verifySetupInference).toHaveBeenCalledWith({
+      agentId: "research",
       runtime: defaultRuntime,
     });
     expect(calls).toEqual([{ ok: true, payload: result, error: undefined }]);
@@ -624,6 +636,7 @@ describe("openclaw.chat", () => {
     const pending = systemAgentHandler("openclaw.setup.activate")({
       params: {
         kind: "api-key",
+        agentId: "research",
         modelRef: "openai/gpt-5.5",
         authChoice: "openai-api-key",
         apiKey: "test-key",
@@ -642,6 +655,7 @@ describe("openclaw.chat", () => {
 
     expect(setupInferenceMocks.activateSetupInference).toHaveBeenCalledWith({
       kind: "api-key",
+      agentId: "research",
       modelRef: "openai/gpt-5.5",
       authChoice: "openai-api-key",
       apiKey: "test-key",

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -400,12 +400,9 @@ describe("openclaw.setup", () => {
     const session = wizardSessions.get("auth-session-1");
     const first = await session.next();
     expect(setupInferenceMocks.activateSetupInference).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: "provider-auth",
-        agentId: "research",
-        authChoice: "github-copilot",
-      }),
+      expect.objectContaining({ kind: "provider-auth", authChoice: "github-copilot" }),
     );
+    expect(setupInferenceMocks.activateSetupInference.mock.calls[0]?.[0].agentId).toBe("research");
     expect(setupInferenceMocks.activateSetupInference.mock.calls[0]?.[0].signal).toBe(
       session.signal,
     );
@@ -457,6 +454,7 @@ describe("openclaw.setup", () => {
     expect(providerAuthChoiceMocks.applyAuthChoiceLoadedPluginProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         authChoice: "ollama",
+        agentId: "research",
         config: verifiedConfig,
         workspaceDir: "/tmp/models-workspace",
         setDefaultModel: false,
@@ -543,16 +541,7 @@ describe("openclaw.chat", () => {
     setupInferenceDetectionMocks.detectSetupInferenceIsolated.mockImplementation(async () => {
       started.resolve();
       await release.promise;
-      return {
-        candidates: [],
-        unavailableCandidates: [],
-        manualProviders: [],
-        authOptions: [],
-        prepareOptions: [],
-        recommendedInstalls: [],
-        workspace: "/tmp/work",
-        setupComplete: false,
-      };
+      return { setupComplete: false } as never;
     });
     const activeAtResponse: number[] = [];
 
@@ -569,10 +558,9 @@ describe("openclaw.chat", () => {
     await pending;
 
     expect(activeAtResponse).toEqual([0]);
-    expect(setupInferenceDetectionMocks.detectSetupInferenceIsolated).toHaveBeenCalledWith({
-      agentId: "research",
-    });
-    expect(systemAgentLane().activeCount).toBe(0);
+    const [detectOptions] =
+      setupInferenceDetectionMocks.detectSetupInferenceIsolated.mock.calls[0]!;
+    expect(detectOptions?.agentId).toBe("research");
   });
 
   it.each([
@@ -592,10 +580,8 @@ describe("openclaw.chat", () => {
     setupInferenceMocks.verifySetupInference.mockResolvedValueOnce(result);
     const { calls, respond } = makeRespond();
 
-    await systemAgentHandler("openclaw.setup.verify")({
-      params: { agentId: "research" },
-      respond,
-    } as never);
+    const verify = systemAgentHandler("openclaw.setup.verify");
+    await verify({ params: { agentId: "research" }, respond } as never);
 
     expect(setupInferenceMocks.verifySetupInference).toHaveBeenCalledWith({
       agentId: "research",

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -296,7 +296,13 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     // the mutation lane and off the Gateway event loop so health stays live.
     const { detectSetupInferenceIsolated } =
       await import("../../system-agent/setup-inference-detection.js");
-    respond(true, await detectSetupInferenceIsolated(), undefined);
+    respond(
+      true,
+      await detectSetupInferenceIsolated({
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+      }),
+      undefined,
+    );
   },
   /** Re-run the exact current default-agent inference route without mutating setup. */
   "openclaw.setup.verify": async ({ params, respond }) => {
@@ -312,7 +318,14 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     }
     await runSystemAgentGatewayTask(async () => {
       const { verifySetupInference } = await import("../../system-agent/setup-inference.js");
-      respond(true, await verifySetupInference({ runtime: defaultRuntime }), undefined);
+      respond(
+        true,
+        await verifySetupInference({
+          runtime: defaultRuntime,
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+        }),
+        undefined,
+      );
     });
   },
   /** Start one provider-owned OAuth/device-code login over the shared wizard transport. */
@@ -337,6 +350,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
                 await import("../../system-agent/setup-inference.js");
               return await activateSetupInference({
                 kind: "provider-auth",
+                ...(params.agentId ? { agentId: params.agentId } : {}),
                 authChoice: params.authChoice,
                 ...(params.workspace !== undefined ? { workspace: params.workspace } : {}),
                 surface: "gateway",
@@ -403,6 +417,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
                 : undefined;
               const applied = await applyAuthChoiceLoadedPluginProvider({
                 authChoice: params.authChoice,
+                ...(params.agentId ? { agentId: params.agentId } : {}),
                 config: baseConfig,
                 prompter,
                 runtime: {
@@ -480,6 +495,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           };
           const result = await activateSetupInference({
             kind: params.kind,
+            ...(params.agentId ? { agentId: params.agentId } : {}),
             ...(params.modelRef !== undefined ? { modelRef: params.modelRef } : {}),
             ...(params.authChoice !== undefined ? { authChoice: params.authChoice } : {}),
             ...(params.apiKey !== undefined ? { apiKey: params.apiKey } : {}),

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -296,13 +296,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     // the mutation lane and off the Gateway event loop so health stays live.
     const { detectSetupInferenceIsolated } =
       await import("../../system-agent/setup-inference-detection.js");
-    respond(
-      true,
-      await detectSetupInferenceIsolated({
-        ...(params.agentId ? { agentId: params.agentId } : {}),
-      }),
-      undefined,
-    );
+    respond(true, await detectSetupInferenceIsolated(params), undefined);
   },
   /** Re-run the exact current default-agent inference route without mutating setup. */
   "openclaw.setup.verify": async ({ params, respond }) => {
@@ -318,14 +312,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     }
     await runSystemAgentGatewayTask(async () => {
       const { verifySetupInference } = await import("../../system-agent/setup-inference.js");
-      respond(
-        true,
-        await verifySetupInference({
-          runtime: defaultRuntime,
-          ...(params.agentId ? { agentId: params.agentId } : {}),
-        }),
-        undefined,
-      );
+      respond(true, await verifySetupInference({ runtime: defaultRuntime, ...params }), undefined);
     });
   },
   /** Start one provider-owned OAuth/device-code login over the shared wizard transport. */

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -197,6 +197,29 @@ describe("terminal gateway policy", () => {
     expect(respond).toHaveBeenCalledWith(false, undefined, expect.any(Object));
   });
 
+  it("reports a missing explicit owner as invalid request", async () => {
+    const { opts, sessions, respond, resolveTerminalLaunchPolicy } = makeOpts(
+      { cols: 80, rows: 24 },
+      { enabled: true },
+    );
+    resolveTerminalLaunchPolicy.mockReturnValue({
+      ok: false,
+      block: { kind: "owner-required", message: "terminal requires an explicit owner" },
+    });
+
+    await expectDefined(terminalHandlers["terminal.open"], "terminal.open")(opts);
+
+    expect(sessions.open).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message: "terminal requires an explicit owner",
+      }),
+    );
+  });
+
   it("opens a provider-built local resume plan and returns its title", async () => {
     const openTerminal = vi.fn(async () => ({
       kind: "local" as const,

--- a/src/gateway/server-methods/terminal.ts
+++ b/src/gateway/server-methods/terminal.ts
@@ -136,6 +136,14 @@ function respondLaunchBlocked(
     );
     return;
   }
+  if (block.kind === "owner-required") {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, terminalFailureMessage(block.message, hint)),
+    );
+    return;
+  }
   // Fail closed: a sandboxed agent must never receive a host shell.
   respond(
     false,

--- a/src/gateway/terminal/launch.test.ts
+++ b/src/gateway/terminal/launch.test.ts
@@ -38,6 +38,27 @@ describe("createTerminalLaunchPolicy", () => {
     });
   });
 
+  it("requires an explicit terminal owner in explicit multi-agent fleets", () => {
+    const policy = createTerminalLaunchPolicy({
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, research: {} },
+      },
+    });
+
+    expect(policy.resolve()).toMatchObject({
+      ok: false,
+      block: {
+        kind: "owner-required",
+        message: expect.stringContaining("no explicit owner"),
+      },
+    });
+    expect(policy.resolve("research")).toMatchObject({
+      ok: true,
+      plan: { agentId: "research" },
+    });
+  });
+
   it("applies restart-bound revocations without granting access early", () => {
     const enabled = {
       gateway: { terminal: { enabled: true } },

--- a/src/gateway/terminal/launch.ts
+++ b/src/gateway/terminal/launch.ts
@@ -4,6 +4,7 @@ import { existsSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  AgentSelectionRequiredError,
   listAgentIds,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -16,6 +17,7 @@ import { isTerminalConfigEnabled } from "./enabled.js";
 /** Why a terminal cannot open, or `null` when it can. */
 type TerminalLaunchBlock =
   | { kind: "disabled" }
+  | { kind: "owner-required"; message: string }
   | { kind: "unknown-agent"; agentId: string }
   | { kind: "sandboxed"; agentId: string; mode: "all" };
 
@@ -90,7 +92,15 @@ function resolveTerminalLaunch(params: {
   }
   const env = params.env ?? process.env;
   const requested = params.agentId?.trim();
-  const agentId = requested ? normalizeAgentId(requested) : resolveDefaultAgentId(params.config);
+  let agentId: string;
+  try {
+    agentId = requested ? normalizeAgentId(requested) : resolveDefaultAgentId(params.config);
+  } catch (error) {
+    if (!(error instanceof AgentSelectionRequiredError)) {
+      throw error;
+    }
+    return { ok: false, block: { kind: "owner-required", message: error.message } };
+  }
   // Fail closed on unknown ids: they would resolve against the *global*
   // sandbox defaults and an invented workspace, sidestepping a per-agent
   // `sandbox.mode: "all"` refusal below.

--- a/src/system-agent/setup-inference-activate-persist.ts
+++ b/src/system-agent/setup-inference-activate-persist.ts
@@ -7,7 +7,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { normalizePluginTargetConfig } from "../plugins/config-state.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import {
-  projectDefaultInferenceRoute,
+  projectInferenceRoute,
   resolveSystemAgentConfiguredRouteFromConfig,
   sameDefaultInferenceRoute,
 } from "./inference-route.js";
@@ -42,7 +42,7 @@ import {
 } from "./setup-inference-plan-helpers.js";
 import type { SystemAgentOwnerPluginArtifactSnapshot } from "./verified-inference.js";
 
-type ProjectedInferenceRoute = Awaited<ReturnType<typeof projectDefaultInferenceRoute>>;
+type ProjectedInferenceRoute = Awaited<ReturnType<typeof projectInferenceRoute>>;
 
 export type SetupInferenceActivationPersistenceState = {
   committedConfig: OpenClawConfig | undefined;
@@ -101,15 +101,18 @@ export async function persistActivatedSetupInference(input: {
   } = input;
   let committedConfig: OpenClawConfig | undefined;
   let { codexInstallOwnership } = state;
-  const projectRoute = (config: OpenClawConfig) => projectDefaultInferenceRoute(config, routeDeps);
+  const requestedAgentId = params.agentId ? testPlan.routeAgentId : undefined;
+  const projectRoute = (config: OpenClawConfig) =>
+    projectInferenceRoute(config, requestedAgentId, routeDeps);
   const resolveRoute = (config: OpenClawConfig) =>
-    resolveSystemAgentConfiguredRouteFromConfig(config, undefined, routeDeps);
+    resolveSystemAgentConfiguredRouteFromConfig(config, requestedAgentId, routeDeps);
 
   const { stripPendingPluginInstallRecords } = await import("../plugins/install-record-commit.js");
   const agentRuntimeId = resolveSetupAgentRuntimeId(params.kind);
   const selectModel = plan.persistModelRef
     ? await createSystemAgentModelSelectionUpdater({
         model: plan.persistModelRef,
+        ...(params.agentId ? { targetAgentId: testPlan.routeAgentId } : {}),
         ...(agentRuntimeId ? { agentRuntimeId } : {}),
         ...(plan.manualAuth && plan.authProfileId ? { authProfileId: plan.authProfileId } : {}),
       })
@@ -241,7 +244,11 @@ export async function persistActivatedSetupInference(input: {
         }
         if (
           !isDeepStrictEqual(
-            projectSetupTargetModelMetadata(latestRuntime, stagedRoute.modelLabel),
+            projectSetupTargetModelMetadata(
+              latestRuntime,
+              stagedRoute.modelLabel,
+              requestedAgentId,
+            ),
             baselineTargetModelMetadata,
           )
         ) {
@@ -267,7 +274,7 @@ export async function persistActivatedSetupInference(input: {
         }
         if (
           !isDeepStrictEqual(
-            projectSetupTargetModelMetadata(current, stagedRoute.modelLabel),
+            projectSetupTargetModelMetadata(current, stagedRoute.modelLabel, requestedAgentId),
             sourceTargetModelMetadata,
           )
         ) {

--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import {
   type CodexCliApiKeyCredential,
   readCodexCliActiveApiKey,
@@ -21,7 +21,7 @@ import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-reque
 import { resolveUserPath } from "../utils.js";
 import { appendSystemAgentAuditEntry } from "./audit.js";
 import {
-  projectDefaultInferenceRoute,
+  projectInferenceRoute,
   resolveSystemAgentConfiguredRouteFromConfig,
   sameDefaultInferenceRoute,
 } from "./inference-route.js";
@@ -124,6 +124,7 @@ async function activateSetupInferenceUnredacted(
   // The source snapshot includes raw compatibility migrations for comparison,
   // while the writer still projects changes back onto the untouched authored bytes.
   const sourceCfg: OpenClawConfig = snapshot.sourceConfig ?? snapshot.config;
+  const routeAgentId = resolveSystemAgentTargetAgentId(cfg, params.agentId);
   const workspace = params.workspace?.trim()
     ? resolveUserPath(params.workspace)
     : (
@@ -162,6 +163,7 @@ async function activateSetupInferenceUnredacted(
         : {}),
       ...(codexCliApiKey ? { codexCliApiKey } : {}),
       deps,
+      routeAgentId,
     });
     if ("error" in plan) {
       return {
@@ -178,13 +180,14 @@ async function activateSetupInferenceUnredacted(
       const stagedConfig = await applySystemAgentModelSelection({
         config: plan.config,
         model: plan.persistModelRef,
+        ...(params.agentId ? { targetAgentId: testPlan.routeAgentId } : {}),
         ...(agentRuntimeId ? { agentRuntimeId } : {}),
         ...(plan.manualAuth && plan.authProfileId ? { authProfileId: plan.authProfileId } : {}),
       });
       testPlan = {
         ...plan,
         config: stagedConfig,
-        routeAgentId: resolveDefaultAgentId(stagedConfig),
+        routeAgentId: resolveSystemAgentTargetAgentId(stagedConfig, params.agentId),
       };
     }
 
@@ -324,12 +327,13 @@ async function activateSetupInferenceUnredacted(
       ...(codexRegistryNeedsReload ? { allowCurrent: false } : {}),
     });
     const routeDeps = { pluginMetadataPlugins: routeMetadataSnapshot.plugins };
-    const baselineRoute = await projectDefaultInferenceRoute(cfg, routeDeps);
-    const verifiedRoute = await projectDefaultInferenceRoute(testPlan.config, routeDeps);
+    const requestedAgentId = params.agentId ? testPlan.routeAgentId : undefined;
+    const baselineRoute = await projectInferenceRoute(cfg, requestedAgentId, routeDeps);
+    const verifiedRoute = await projectInferenceRoute(testPlan.config, requestedAgentId, routeDeps);
     const stagedRoute = verifiedRoute.route;
     const stagedExecutionRoute = await resolveSystemAgentConfiguredRouteFromConfig(
       testPlan.config,
-      undefined,
+      requestedAgentId,
       routeDeps,
     );
     if (
@@ -351,10 +355,12 @@ async function activateSetupInferenceUnredacted(
     const baselineTargetModelMetadata = projectSetupTargetModelMetadata(
       cfg,
       stagedRoute.modelLabel,
+      requestedAgentId,
     );
     const sourceTargetModelMetadata = projectSetupTargetModelMetadata(
       sourceCfg,
       stagedRoute.modelLabel,
+      requestedAgentId,
     );
     // OpenClaw executes through the reserved agent id but reuses the default
     // route's agent directory. Only a submitted key stays in the isolated store.
@@ -519,7 +525,7 @@ async function activateSetupInferenceUnredacted(
           ? (latestSnapshot.runtimeConfig ?? latestSnapshot.config)
           : undefined;
       const latestRoute = latestRuntime
-        ? await projectDefaultInferenceRoute(latestRuntime, routeDeps)
+        ? await projectInferenceRoute(latestRuntime, requestedAgentId, routeDeps)
         : undefined;
       if (!latestRoute || !sameDefaultInferenceRoute(latestRoute, verifiedRoute)) {
         return {
@@ -530,7 +536,11 @@ async function activateSetupInferenceUnredacted(
         };
       }
       const latestResolvedRoute = latestRuntime
-        ? await resolveSystemAgentConfiguredRouteFromConfig(latestRuntime, undefined, routeDeps)
+        ? await resolveSystemAgentConfiguredRouteFromConfig(
+            latestRuntime,
+            requestedAgentId,
+            routeDeps,
+          )
         : null;
       if (!latestResolvedRoute) {
         return {

--- a/src/system-agent/setup-inference-core.ts
+++ b/src/system-agent/setup-inference-core.ts
@@ -174,6 +174,8 @@ export type BoundVerifySetupInferenceResult =
 
 export type ActivateSetupInferenceParams = {
   kind: SetupInferenceKind | "api-key" | "provider-auth";
+  /** Configured agent that owns the route being tested and persisted. */
+  agentId?: string;
   /** Exact explicit model to probe and persist instead of the route's starter model. */
   modelRef?: string;
   /** Manual step only: provider-auth choice returned by detection. */

--- a/src/system-agent/setup-inference-detect.ts
+++ b/src/system-agent/setup-inference-detect.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalAgentRuntimeId } from "../agents/agent-runtime-id.js";
-import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
+import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { resolveModelRuntimePolicy } from "../agents/model-runtime-policy.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
@@ -35,6 +36,7 @@ import { parseRef } from "./setup-inference-plan-helpers.js";
 function resolveConfiguredCandidateKind(
   config: Parameters<typeof resolveModelRuntimePolicy>[0]["config"],
   modelRef: string | undefined,
+  agentId?: string,
 ): SetupInferenceCandidate["kind"] | undefined {
   if (!modelRef) {
     return undefined;
@@ -45,7 +47,7 @@ function resolveConfiguredCandidateKind(
       config,
       provider: ref.provider,
       modelId: ref.model,
-      agentId: resolveDefaultAgentId(config ?? {}),
+      agentId: resolveSystemAgentTargetAgentId(config ?? {}, agentId),
     }).policy?.id,
   );
   if (runtime === "codex") {
@@ -64,6 +66,7 @@ function resolveConfiguredCandidateKind(
  */
 export async function listManualSetupInferenceOptions(
   deps: DetectSetupInferenceDeps = {},
+  agentId?: string,
 ): Promise<
   Pick<
     SetupInferenceDetection,
@@ -76,6 +79,7 @@ export async function listManualSetupInferenceOptions(
     throw new Error(invalidSetupConfigError(snapshot));
   }
   const cfg = snapshot.runtimeConfig ?? snapshot.config;
+  const targetAgentId = resolveSystemAgentTargetAgentId(cfg, agentId);
   const { workspace } = await resolveSetupInferenceWorkspace({
     configExists: snapshot.exists,
     configValid: snapshot.valid,
@@ -97,12 +101,13 @@ export async function listManualSetupInferenceOptions(
     workspace,
     // Derived from config only (no probing): a pre-existing default model must
     // keep classifying the install as configured even when scanning declined.
-    setupComplete: Boolean(resolveAgentEffectiveModelPrimary(cfg, resolveDefaultAgentId(cfg))),
+    setupComplete: Boolean(resolveAgentEffectiveModelPrimary(cfg, targetAgentId)),
   };
 }
 
 export async function detectSetupInference(
   deps: DetectSetupInferenceDeps = {},
+  agentId?: string,
 ): Promise<SetupInferenceDetection> {
   const { readConfigFileSnapshot } = await import("../config/config.js");
   const snapshot = await readConfigFileSnapshot();
@@ -110,7 +115,11 @@ export async function detectSetupInference(
     throw new Error(invalidSetupConfigError(snapshot));
   }
   const cfg = snapshot.runtimeConfig ?? snapshot.config;
-  const detected = await (deps.detectInferenceBackends ?? detectInferenceBackends)({ config: cfg });
+  const targetAgentId = resolveSystemAgentTargetAgentId(cfg, agentId);
+  const detected = await (deps.detectInferenceBackends ?? detectInferenceBackends)({
+    config: cfg,
+    agentId: targetAgentId,
+  });
   const unavailableCandidates: SetupInferenceUnavailableCandidate[] = [];
   const deferredUnavailableCandidates: SetupInferenceUnavailableCandidate[] = [];
   const probe = deps.probeLocalCommand ?? probeLocalCommand;
@@ -136,7 +145,11 @@ export async function detectSetupInference(
   const configuredModel = detected.find(
     (candidate) => candidate.kind === "existing-model",
   )?.modelRef;
-  const configuredCandidateKind = resolveConfiguredCandidateKind(cfg, configuredModel);
+  const configuredCandidateKind = resolveConfiguredCandidateKind(
+    cfg,
+    configuredModel,
+    targetAgentId,
+  );
   const raw = detected.filter(
     (candidate) =>
       candidate.kind !== "gemini-cli" &&

--- a/src/system-agent/setup-inference-detection.test.ts
+++ b/src/system-agent/setup-inference-detection.test.ts
@@ -309,4 +309,43 @@ describe("isolated setup inference detection", () => {
     expect(second).toEqual(detected);
     expect(Atomics.load(new Int32Array(started), 0)).toBe(1);
   });
+
+  it("serializes different owners and reruns detection for the second owner", async () => {
+    const { detectSetupInferenceIsolated } = await loadDetectionModule();
+    const started = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+    const firstDetection = detectedCodex();
+    const secondDetection = {
+      ...emptyDetection(),
+      workspace: "/tmp/research",
+    };
+
+    const first = detectSetupInferenceIsolated({
+      agentId: "main",
+      workerUrl: blockingWorkerUrl,
+      workerData: {
+        blockMs: 100,
+        detection: firstDetection,
+        partialDetection: emptyDetection(),
+        started,
+      },
+      timeoutMs: 5_000,
+      fallbackEnv: {},
+    });
+    const second = detectSetupInferenceIsolated({
+      agentId: "research",
+      workerUrl: blockingWorkerUrl,
+      workerData: {
+        blockMs: 0,
+        detection: secondDetection,
+        partialDetection: emptyDetection(),
+        started,
+      },
+      timeoutMs: 5_000,
+      fallbackEnv: {},
+    });
+
+    await expect(first).resolves.toEqual(firstDetection);
+    await expect(second).resolves.toEqual(secondDetection);
+    expect(Atomics.load(new Int32Array(started), 0)).toBe(2);
+  });
 });

--- a/src/system-agent/setup-inference-detection.ts
+++ b/src/system-agent/setup-inference-detection.ts
@@ -29,13 +29,16 @@ type DetectionWorkerMessage =
   | { ok: false; error: string };
 
 type DetectionWorkerOptions = {
+  agentId?: string;
   timeoutMs?: number;
   workerUrl?: URL;
   workerData?: WorkerOptions["workerData"];
   fallbackEnv?: NodeJS.ProcessEnv;
 };
 
-let inFlightDetection: Promise<SetupInferenceDetection> | undefined;
+let inFlightDetection:
+  | { agentId: string | undefined; promise: Promise<SetupInferenceDetection> }
+  | undefined;
 let workerShutdown: Promise<void> | undefined;
 
 function trackWorkerShutdown(worker: Worker): void {
@@ -126,7 +129,11 @@ async function runDetectionWorker(
   const execArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
   const worker = new Worker(workerUrl, {
     execArgv,
-    ...(options.workerData === undefined ? {} : { workerData: options.workerData }),
+    ...(options.workerData === undefined
+      ? options.agentId
+        ? { workerData: { agentId: options.agentId } }
+        : {}
+      : { workerData: options.workerData }),
   });
   const timeoutMs = options.timeoutMs ?? SETUP_INFERENCE_DETECTION_TIMEOUT_MS;
 
@@ -202,8 +209,15 @@ async function runDetectionWorker(
 export async function detectSetupInferenceIsolated(
   options: DetectionWorkerOptions = {},
 ): Promise<SetupInferenceDetection> {
+  const agentId = options.agentId?.trim() || undefined;
   if (inFlightDetection) {
-    return await inFlightDetection;
+    if (inFlightDetection.agentId === agentId) {
+      return await inFlightDetection.promise;
+    }
+    // Native provider discovery is process-global. Serialize different owners,
+    // then rerun against the requested owner instead of sharing stale results.
+    await inFlightDetection.promise.catch(() => undefined);
+    return await detectSetupInferenceIsolated(options);
   }
   // A native provider probe can delay Worker termination. Wait for exit before
   // retrying so repeat UI requests neither stack threads nor reuse stale results.
@@ -212,11 +226,11 @@ export async function detectSetupInferenceIsolated(
     return await detectSetupInferenceIsolated(options);
   }
   const current = runDetectionWorker(options);
-  inFlightDetection = current;
+  inFlightDetection = { agentId, promise: current };
   try {
     return await current;
   } finally {
-    if (inFlightDetection === current) {
+    if (inFlightDetection?.promise === current) {
       inFlightDetection = undefined;
     }
   }

--- a/src/system-agent/setup-inference-detection.worker.ts
+++ b/src/system-agent/setup-inference-detection.worker.ts
@@ -1,4 +1,4 @@
-import { parentPort } from "node:worker_threads";
+import { parentPort, workerData } from "node:worker_threads";
 import { listRecommendedToolInstalls } from "../plugins/recommended-tool-installs.js";
 import {
   detectSetupInference,
@@ -13,7 +13,11 @@ if (!parentPort) {
 const port = parentPort;
 
 try {
-  const manual = await listManualSetupInferenceOptions();
+  const agentId =
+    workerData && typeof workerData === "object" && typeof workerData.agentId === "string"
+      ? workerData.agentId
+      : undefined;
+  const manual = await listManualSetupInferenceOptions({}, agentId);
   const partial: SetupInferenceDetection = {
     candidates: [],
     unavailableCandidates: [],
@@ -24,7 +28,7 @@ try {
     type: "partial",
     detection: partial,
   });
-  const detection = await detectSetupInference();
+  const detection = await detectSetupInference({}, agentId);
   port.postMessage({ type: "result", detection });
 } catch (error) {
   port.postMessage({

--- a/src/system-agent/setup-inference-plan-helpers.ts
+++ b/src/system-agent/setup-inference-plan-helpers.ts
@@ -189,7 +189,11 @@ export function parseRef(modelRef: string): { provider: string; model: string } 
     : { provider: modelRef.slice(0, slash), model: modelRef.slice(slash + 1) };
 }
 
-export function projectSetupTargetModelMetadata(config: OpenClawConfig, modelRef: string): unknown {
+export function projectSetupTargetModelMetadata(
+  config: OpenClawConfig,
+  modelRef: string,
+  agentId?: string,
+): unknown {
   const target = parseRef(modelRef);
   const canonicalKey = modelKey(target.provider, target.model);
   const keys = new Set(
@@ -208,7 +212,7 @@ export function projectSetupTargetModelMetadata(config: OpenClawConfig, modelRef
           : { exists: false },
       ]),
     );
-  const defaultAgentId = resolveDefaultAgentId(config);
+  const defaultAgentId = agentId ? normalizeAgentId(agentId) : resolveDefaultAgentId(config);
   const agent = listAgentEntries(config).find(
     (entry) => normalizeAgentId(entry.id) === defaultAgentId,
   );
@@ -272,6 +276,7 @@ export function prepareManualAuthForActivation(params: {
   modelRef: string;
   providerId: string;
   pluginId?: string;
+  agentId?: string;
 }): {
   config: OpenClawConfig;
   profiles: ProviderAuthResult["profiles"];
@@ -302,6 +307,7 @@ function copySelectedModelMetadata(params: {
   target: OpenClawConfig;
   prepared: OpenClawConfig;
   modelRef: string;
+  agentId?: string;
 }): void {
   const preparedDefaultModels = params.prepared.agents?.defaults?.models;
   if (preparedDefaultModels && Object.hasOwn(preparedDefaultModels, params.modelRef)) {
@@ -322,7 +328,9 @@ function copySelectedModelMetadata(params: {
     };
   }
 
-  const defaultAgentId = resolveDefaultAgentId(params.target);
+  const defaultAgentId = params.agentId
+    ? normalizeAgentId(params.agentId)
+    : resolveDefaultAgentId(params.target);
   const preparedAgent = listAgentEntries(params.prepared).find(
     (agent) => normalizeAgentId(agent.id) === defaultAgentId,
   );
@@ -376,6 +384,7 @@ export function projectManualInferenceConfig(params: {
   modelRef: string;
   providerId: string;
   pluginId?: string;
+  agentId?: string;
 }): OpenClawConfig {
   const config = structuredClone(params.baseConfig);
   if (params.selectedProfile && params.selectedProfileId) {
@@ -423,6 +432,7 @@ export function projectManualInferenceConfig(params: {
     target: config,
     prepared: params.preparedConfig,
     modelRef: params.modelRef,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
   });
   return config;
 }

--- a/src/system-agent/setup-inference-plan.ts
+++ b/src/system-agent/setup-inference-plan.ts
@@ -1,4 +1,4 @@
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import type { CodexCliApiKeyCredential } from "../agents/cli-credentials.js";
 import { CliExecutionAuthProfileError } from "../agents/cli-execution-auth.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
@@ -67,6 +67,7 @@ export async function buildTestPlan(params: {
   deps: ActivateSetupInferenceDeps;
 }): Promise<SetupInferenceTestPlan | { error: string; status?: SetupInferenceFailureStatus }> {
   const { kind, cfg, workspaceDir } = params;
+  const routeAgentId = resolveSystemAgentTargetAgentId(cfg, params.routeAgentId);
   const resolveRouteModelRef = (defaultModelRef: string): string | { error: string } => {
     const modelRef = params.modelRef?.trim() || defaultModelRef;
     const selected = parseRef(modelRef);
@@ -172,6 +173,7 @@ export async function buildTestPlan(params: {
             modelRef,
             providerId: ref.provider,
             pluginId: choice.pluginId,
+            agentId: routeAgentId,
           })
         : {
             config: projectManualInferenceConfig({
@@ -180,6 +182,7 @@ export async function buildTestPlan(params: {
               modelRef,
               providerId: ref.provider,
               pluginId: choice.pluginId,
+              agentId: routeAgentId,
             }),
             profiles: [] as ProviderAuthResult["profiles"],
             selectedProfileId: undefined,
@@ -191,7 +194,7 @@ export async function buildTestPlan(params: {
         agentDir: params.agentDir,
         config: prepared.config,
         agentId: "openclaw",
-        routeAgentId: resolveDefaultAgentId(prepared.config),
+        routeAgentId,
         ...(prepared.selectedProfileId ? { authProfileId: prepared.selectedProfileId } : {}),
         persistModelRef: modelRef,
         manualAuth: {
@@ -265,7 +268,7 @@ export async function buildTestPlan(params: {
         modelRef,
         config: cfg,
         agentId: "openclaw",
-        routeAgentId: resolveDefaultAgentId(cfg),
+        routeAgentId,
         persistModelRef: modelRef,
       };
     }
@@ -281,7 +284,7 @@ export async function buildTestPlan(params: {
         modelRef,
         config: cfg,
         agentId: "openclaw",
-        routeAgentId: resolveDefaultAgentId(cfg),
+        routeAgentId,
         persistModelRef: modelRef,
       };
     }
@@ -304,6 +307,7 @@ export async function buildTestPlan(params: {
           selectedProfileId: "openai:codex-cli-api-key",
           modelRef,
           providerId: ref.provider,
+          agentId: routeAgentId,
         });
         return {
           runner: "embedded",
@@ -312,7 +316,7 @@ export async function buildTestPlan(params: {
           agentHarnessRuntimeOverride: "codex",
           config: preparedAuth.config,
           agentId: "openclaw",
-          routeAgentId: resolveDefaultAgentId(preparedAuth.config),
+          routeAgentId,
           agentDir: params.agentDir,
           cleanupBundleMcpOnRunEnd: true,
           authProfileId: preparedAuth.selectedProfileId,
@@ -332,7 +336,7 @@ export async function buildTestPlan(params: {
         agentHarnessRuntimeOverride: "codex",
         config: cfg,
         agentId: "openclaw",
-        routeAgentId: resolveDefaultAgentId(cfg),
+        routeAgentId,
         agentDir: params.agentDir,
         cleanupBundleMcpOnRunEnd: true,
         persistModelRef: modelRef,
@@ -350,7 +354,7 @@ export async function buildTestPlan(params: {
         modelRef,
         config: cfg,
         agentId: "openclaw",
-        routeAgentId: resolveDefaultAgentId(cfg),
+        routeAgentId,
         persistModelRef: modelRef,
       };
     }
@@ -366,7 +370,7 @@ export async function buildTestPlan(params: {
         modelRef,
         config: cfg,
         agentId: "openclaw",
-        routeAgentId: resolveDefaultAgentId(cfg),
+        routeAgentId,
         persistModelRef: modelRef,
       };
     }
@@ -588,6 +592,7 @@ export async function buildTestPlan(params: {
             modelRef,
             providerId: ref.provider,
             ...(resolved.provider.pluginId ? { pluginId: resolved.provider.pluginId } : {}),
+            agentId: routeAgentId,
           })
         : {
             config: projectManualInferenceConfig({
@@ -596,6 +601,7 @@ export async function buildTestPlan(params: {
               modelRef,
               providerId: ref.provider,
               ...(resolved.provider.pluginId ? { pluginId: resolved.provider.pluginId } : {}),
+              agentId: routeAgentId,
             }),
             profiles: [] as ProviderAuthResult["profiles"],
             selectedProfileId: undefined,
@@ -607,7 +613,7 @@ export async function buildTestPlan(params: {
         agentDir: params.agentDir,
         config: preparedAuth.config,
         agentId: "openclaw",
-        routeAgentId: resolveDefaultAgentId(preparedAuth.config),
+        routeAgentId,
         ...(preparedAuth.selectedProfileId
           ? { authProfileId: preparedAuth.selectedProfileId }
           : {}),

--- a/src/system-agent/setup-inference-verify.ts
+++ b/src/system-agent/setup-inference-verify.ts
@@ -2,13 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
-import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
+import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store.js";
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   projectInferenceRoute,
@@ -235,7 +235,7 @@ export async function verifySetupInferenceConfig(params: {
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   };
   const cfg = params.config;
-  const routeAgentId = normalizeAgentId(params.agentId ?? resolveDefaultAgentId(cfg));
+  const routeAgentId = resolveSystemAgentTargetAgentId(cfg, params.agentId);
   if (!resolveAgentEffectiveModelPrimary(cfg, routeAgentId)) {
     return {
       ok: false,
@@ -464,6 +464,7 @@ export async function verifySetupInferenceConfig(params: {
 /** Run one tool-free completion through the configured setup inference route. */
 export async function completeSetupInference(params: {
   prompt: string;
+  agentId?: string;
   runtime: RuntimeEnv;
   timeoutMs?: number;
   deps?: ActivateSetupInferenceDeps;
@@ -481,6 +482,7 @@ export async function completeSetupInference(params: {
   return await completeSetupInferenceConfig({
     config: snapshot.runtimeConfig ?? snapshot.config,
     prompt: params.prompt,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     runtime: params.runtime,
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
     ...(params.deps ? { deps: params.deps } : {}),
@@ -491,6 +493,7 @@ export async function completeSetupInference(params: {
 export async function completeSetupInferenceConfig(params: {
   config: OpenClawConfig;
   prompt: string;
+  agentId?: string;
   runtime: RuntimeEnv;
   timeoutMs?: number;
   deps?: ActivateSetupInferenceDeps;
@@ -499,7 +502,7 @@ export async function completeSetupInferenceConfig(params: {
     ...params.deps,
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   };
-  const routeAgentId = normalizeAgentId(resolveDefaultAgentId(params.config));
+  const routeAgentId = resolveSystemAgentTargetAgentId(params.config, params.agentId);
   if (!resolveAgentEffectiveModelPrimary(params.config, routeAgentId)) {
     return { ok: false, status: "unavailable", error: "No agent model is configured." };
   }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1055,6 +1055,51 @@ describe("detectSetupInference", () => {
     });
   });
 
+  it("detects the explicitly selected owner in a multi-agent fleet", async () => {
+    const { readConfigFileSnapshot } = await import("../config/config.js");
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { model: "openai/gpt-5.5" },
+          research: { model: "anthropic/claude-opus-5" },
+        },
+      },
+    };
+    vi.mocked(readConfigFileSnapshot).mockResolvedValueOnce({
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      issues: [],
+      config,
+      sourceConfig: config,
+      runtimeConfig: config,
+    } as never);
+    vi.mocked(detectInferenceBackends).mockResolvedValueOnce([
+      {
+        kind: "existing-model",
+        modelRef: "anthropic/claude-opus-5",
+        label: "Current model",
+        detail: "anthropic/claude-opus-5 — already configured",
+        credentials: true,
+      },
+    ]);
+
+    const detection = await detectSetupInference(
+      {
+        resolveManifestProviderAuthChoices: () => [],
+        probeLocalCommand: vi.fn(async (command) => ({ command, found: false })),
+      },
+      "research",
+    );
+
+    expect(detectInferenceBackends).toHaveBeenCalledWith({ config, agentId: "research" });
+    expect(detection).toMatchObject({
+      configuredModel: "anthropic/claude-opus-5",
+      setupComplete: true,
+    });
+  });
+
   it("does not re-offer the configured Codex route as a setup candidate", async () => {
     const { readConfigFileSnapshot } = await import("../config/config.js");
     const config: OpenClawConfig = {
@@ -1532,6 +1577,50 @@ describe("activateSetupInference", () => {
     expect(configHarness.current().agents?.defaults?.systemAgent).toEqual({ agentId: "ops" });
     expect(configHarness.transform).toHaveBeenCalledOnce();
     expect(resolveRouteMetadata).toHaveBeenCalledOnce();
+  });
+
+  it("persists inference onto an explicit selected owner without changing the system owner", async () => {
+    const initialConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: {
+          ops: { agentDir: "/tmp/openclaw-ops-agent", model: "openai/gpt-5.5" },
+          research: {
+            agentDir: "/tmp/openclaw-research-agent",
+            model: "openai/broken",
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const configHarness = createConfigTransformHarness(initialConfig);
+    const runCliAgent = vi.fn(successfulRunner("claude-cli", "claude-opus-5"));
+
+    const result = await activateSetupInference({
+      kind: "claude-cli",
+      agentId: "research",
+      deps: {
+        readConfigFileSnapshot: mockConfigSnapshot(initialConfig),
+        runCliAgent: runCliAgent as never,
+        transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(runCliAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "research",
+        agentDir: "/tmp/openclaw-research-agent",
+      }),
+    );
+    expect(configHarness.current().agents).toMatchObject({
+      ownership: "explicit",
+      defaults: { systemAgent: { agentId: "ops" } },
+      entries: {
+        ops: { model: "openai/gpt-5.5" },
+        research: { model: "claude-cli/claude-opus-5" },
+      },
+    });
   });
 
   it("rejects an unattested successful candidate before persisting its model", async () => {

--- a/ui/src/app/app-host.dock-suppression.test.ts
+++ b/ui/src/app/app-host.dock-suppression.test.ts
@@ -52,7 +52,7 @@ describe("OpenClaw shell dock suppression", () => {
         connect: vi.fn(),
       },
       agents: { state: { agentsList: null } },
-      agentSelection: { state: { selectedId: "main" } },
+      agentSelection: { state: { selectedId: "research" } },
       config: {
         current: { terminalEnabled: true, serverVersion: null, devGitBranch: null },
       },
@@ -118,6 +118,13 @@ describe("OpenClaw shell dock suppression", () => {
 
     shell.routeState = { routeId: "appearance" };
     renderLit(shell.render(), container);
+    expect(
+      (
+        container.querySelector("openclaw-terminal-panel") as HTMLElement & {
+          agentId: string | null;
+        }
+      ).agentId,
+    ).toBe("research");
     expect(
       (
         container.querySelector("openclaw-terminal-panel") as HTMLElement & {

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -9,6 +9,7 @@ import "../components/login-gate.ts";
 import "../components/openclaw-mascot.ts";
 import "../components/tooltip.ts";
 import { t } from "../i18n/index.ts";
+import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
@@ -103,6 +104,10 @@ export class OpenClawApp extends OpenClawLightDomElement {
       .watch(
         () => (this.terminalOnly ? this.context?.config : undefined),
         (config, notify) => config.subscribe(notify),
+      )
+      .watch(
+        () => (this.terminalOnly ? this.context?.agentSelection : undefined),
+        (selection, notify) => selection.subscribe(notify),
       );
   }
 
@@ -214,11 +219,15 @@ export class OpenClawApp extends OpenClawLightDomElement {
         gatewaySnapshot,
         context.config.current.terminalEnabled ?? false,
       );
+      const terminalOwner =
+        context.agentSelection.state.selectedId ?? gatewaySnapshot.assistantAgentId;
+      const terminalAgentId = terminalOwner ? normalizeAgentId(terminalOwner) : null;
       // Embedded clients query this host immediately; keep it stable while the chunk loads.
       return html`
         <openclaw-terminal-panel
           .client=${gatewayConnected ? gatewaySnapshot.client : null}
           .available=${terminalAvailable}
+          .agentId=${terminalAgentId}
           .themeMode=${resolveTerminalThemeMode()}
           fullscreen
         ></openclaw-terminal-panel>

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -551,6 +551,7 @@ export function renderApplicationShell(host: ShellViewHost) {
       <openclaw-terminal-panel
         .client=${gatewayConnected ? gatewaySnapshot.client : null}
         .available=${terminalAvailable}
+        .agentId=${selectedAgentId}
         .suppressed=${settingsTakeover}
         .themeMode=${resolveTerminalThemeMode()}
         .basePath=${context.basePath}

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -408,6 +408,10 @@ describe("normalizeInitialApplicationLocation", () => {
     };
     const context = {
       gateway,
+      agentSelection: {
+        state: { selectedId: "main" },
+        subscribe: () => () => undefined,
+      },
       replace: replaceRoute,
     } as unknown as ApplicationContext<RouteId>;
 

--- a/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
+++ b/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
@@ -190,6 +190,7 @@ suite.define(() => {
         const activate = await gateway.waitForRequest("openclaw.setup.activate");
         expect(activate.params).toEqual({
           kind: "provider-auto:llama-cpp",
+          agentId: "main",
           modelRef,
         });
 

--- a/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
+++ b/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
@@ -185,6 +185,7 @@ suite.define(() => {
         const activate = await gateway.waitForRequest("openclaw.setup.activate");
         expect(activate.params).toEqual({
           kind: "provider-auto:lmstudio",
+          agentId: "main",
           modelRef,
         });
 

--- a/ui/src/e2e/model-setup-recovery.e2e.test.ts
+++ b/ui/src/e2e/model-setup-recovery.e2e.test.ts
@@ -112,7 +112,7 @@ suite.define(() => {
         }
 
         const verify = await gateway.waitForRequest("openclaw.setup.verify");
-        expect(verify.params).toEqual({});
+        expect(verify.params).toEqual({ agentId: "main" });
       },
     );
   });

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -108,9 +108,13 @@ suite.define(() => {
         await candidate.getByRole("button", { name: "Test & use" }).click();
 
         const detect = await gateway.waitForRequest("openclaw.setup.detect");
-        expect(detect.params).toEqual({});
+        expect(detect.params).toEqual({ agentId: "main" });
         const activate = await gateway.waitForRequest("openclaw.setup.activate");
-        expect(activate.params).toEqual({ kind: "codex-cli", modelRef: "openai/gpt-5" });
+        expect(activate.params).toEqual({
+          kind: "codex-cli",
+          agentId: "main",
+          modelRef: "openai/gpt-5",
+        });
 
         await page.getByRole("heading", { name: "Connection verified" }).waitFor();
         await expect
@@ -512,6 +516,7 @@ suite.define(() => {
         const activate = await gateway.waitForRequest("openclaw.setup.activate");
         expect(activate.params).toEqual({
           kind: "provider-auto:ollama",
+          agentId: "main",
           modelRef: "ollama/qwen3:0.6b",
         });
 
@@ -802,6 +807,7 @@ suite.define(() => {
         const activate = await gateway.waitForRequest("openclaw.setup.activate");
         expect(activate.params).toEqual({
           kind: "api-key",
+          agentId: "main",
           authChoice: "qwen-cn",
           apiKey: "qwen-test-secret",
         });
@@ -939,7 +945,7 @@ suite.define(() => {
         }
         await page.getByRole("button", { name: "Check model" }).click();
         const verify = await gateway.waitForRequest("openclaw.setup.verify");
-        expect(verify.params).toEqual({});
+        expect(verify.params).toEqual({ agentId: "main" });
         await page.getByText("Ready · 1234 ms").waitFor();
         const detectCountBeforeRefresh = (await gateway.getRequests("openclaw.setup.detect"))
           .length;

--- a/ui/src/pages/model-setup/detect-cache.ts
+++ b/ui/src/pages/model-setup/detect-cache.ts
@@ -1,7 +1,9 @@
 import type { SystemAgentSetupDetectResult } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 
-export type ModelSetupDetectionConnection = Pick<ApplicationGatewaySnapshot, "client" | "hello">;
+export type ModelSetupDetectionConnection = Pick<ApplicationGatewaySnapshot, "client" | "hello"> & {
+  agentId: string | null;
+};
 
 let cached:
   | { connection: ModelSetupDetectionConnection; result: SystemAgentSetupDetectResult }
@@ -22,7 +24,8 @@ export function consumeCachedModelSetupDetection(
   }
   if (
     cached.connection.client !== connection.client ||
-    cached.connection.hello !== connection.hello
+    cached.connection.hello !== connection.hello ||
+    cached.connection.agentId !== connection.agentId
   ) {
     cached = undefined;
     return null;

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -90,6 +90,10 @@ describe("model setup first-run redirect", () => {
         },
         subscribe,
       },
+      agentSelection: {
+        state: { selectedId: "main" },
+        subscribe: () => () => undefined,
+      },
       replace: replaceRoute,
     } as unknown as ApplicationContext<RouteId>;
 
@@ -135,6 +139,10 @@ describe("model setup first-run redirect", () => {
           return () => undefined;
         },
       },
+      agentSelection: {
+        state: { selectedId: "main" },
+        subscribe: () => () => undefined,
+      },
       replace,
     } as unknown as ApplicationContext<RouteId>;
 
@@ -147,11 +155,13 @@ describe("model setup first-run redirect", () => {
     expect(request).toHaveBeenCalledOnce();
     expect(request).toHaveBeenCalledWith(
       "openclaw.setup.detect",
-      {},
+      { agentId: "main" },
       expect.objectContaining({ timeoutMs: 20_000 }),
     );
     expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
-    expect(consumeCachedModelSetupDetection({ client, hello: snapshot.hello })).toEqual(result);
+    expect(
+      consumeCachedModelSetupDetection({ client, hello: snapshot.hello, agentId: "main" }),
+    ).toEqual(result);
   });
 
   it("does not redirect after the operator leaves the default landing", async () => {
@@ -184,6 +194,10 @@ describe("model setup first-run redirect", () => {
           return () => undefined;
         },
       },
+      agentSelection: {
+        state: { selectedId: "main" },
+        subscribe: () => () => undefined,
+      },
       replace,
     } as unknown as ApplicationContext<RouteId>;
 
@@ -192,7 +206,9 @@ describe("model setup first-run redirect", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
 
     expect(replace).not.toHaveBeenCalled();
-    expect(consumeCachedModelSetupDetection({ client, hello: snapshot.hello })).toEqual(result);
+    expect(
+      consumeCachedModelSetupDetection({ client, hello: snapshot.hello, agentId: "main" }),
+    ).toEqual(result);
   });
 
   it("rejects stale detection and retries first-run guidance after a same-client reconnect", async () => {
@@ -233,7 +249,14 @@ describe("model setup first-run redirect", () => {
       },
     };
     const replace = vi.fn();
-    const context = { gateway, replace } as unknown as ApplicationContext<RouteId>;
+    const context = {
+      gateway,
+      agentSelection: {
+        state: { selectedId: "main" },
+        subscribe: () => () => undefined,
+      },
+      replace,
+    } as unknown as ApplicationContext<RouteId>;
     await startRedirect(context);
     expect(request).toHaveBeenCalledOnce();
 
@@ -247,8 +270,12 @@ describe("model setup first-run redirect", () => {
     await Promise.resolve();
 
     expect(request).toHaveBeenCalledTimes(2);
-    expect(consumeCachedModelSetupDetection({ client, hello: nextHello })).toEqual(current);
-    expect(consumeCachedModelSetupDetection({ client, hello: firstHello })).toBeNull();
+    expect(consumeCachedModelSetupDetection({ client, hello: nextHello, agentId: "main" })).toEqual(
+      current,
+    );
+    expect(
+      consumeCachedModelSetupDetection({ client, hello: firstHello, agentId: "main" }),
+    ).toBeNull();
     expect(replace).toHaveBeenCalledOnce();
   });
 
@@ -264,6 +291,10 @@ describe("model setup first-run redirect", () => {
           listener = next;
           return () => undefined;
         },
+      },
+      agentSelection: {
+        state: { selectedId: "main" },
+        subscribe: () => () => undefined,
       },
       replace: vi.fn(),
     } as unknown as ApplicationContext<RouteId>;

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -78,21 +78,24 @@ function startModelSetupFirstRunRedirect(params: {
     ) {
       return;
     }
-    const connection = { client: snapshot.client, hello: snapshot.hello };
+    const agentId = params.context.agentSelection.state.selectedId;
+    const connection = { client: snapshot.client, hello: snapshot.hello, agentId };
     if (
       connection.client === attemptedConnection?.client &&
-      connection.hello === attemptedConnection?.hello
+      connection.hello === attemptedConnection?.hello &&
+      connection.agentId === attemptedConnection?.agentId
     ) {
       return;
     }
     attemptedConnection = connection;
-    void detectModelSetup(snapshot.client)
+    void detectModelSetup(snapshot.client, agentId ?? undefined)
       .then((result) => {
         const current = params.context.gateway.snapshot;
         if (
           current.phase !== "connected" ||
           current.client !== connection.client ||
-          current.hello !== connection.hello
+          current.hello !== connection.hello ||
+          params.context.agentSelection.state.selectedId !== connection.agentId
         ) {
           return;
         }
@@ -107,6 +110,12 @@ function startModelSetupFirstRunRedirect(params: {
       });
   };
   const unsubscribe = params.context.gateway.subscribe(handleSnapshot);
+  const unsubscribeSelection = params.context.agentSelection.subscribe(() =>
+    handleSnapshot(params.context.gateway.snapshot),
+  );
   handleSnapshot(params.context.gateway.snapshot);
-  return unsubscribe;
+  return () => {
+    unsubscribe();
+    unsubscribeSelection();
+  };
 }

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -110,6 +110,10 @@ function createContext() {
     snapshot,
     context: {
       gateway,
+      agentSelection: {
+        state: { selectedId: "main", scopeId: "main" },
+        subscribe: () => () => undefined,
+      },
       basePath: "/openclaw",
       navigate: vi.fn(),
       runtimeConfig,
@@ -124,7 +128,14 @@ async function mountPage(
   const provider = createApplicationContextProvider(context);
   const page = document.createElement("openclaw-model-setup-page") as TestModelSetupPage;
   const { client, ...data } = routeData;
-  page.routeData = { ...data, connection: { client, hello: context.gateway.snapshot.hello } };
+  page.routeData = {
+    ...data,
+    connection: {
+      client,
+      hello: context.gateway.snapshot.hello,
+      agentId: context.agentSelection.state.selectedId,
+    },
+  };
   provider.append(page);
   document.body.append(provider);
   await page.updateComplete;
@@ -292,7 +303,7 @@ describe("ModelSetupPage catalog icons", () => {
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledWith(
         "openclaw.setup.prepare.start",
-        { sessionId: expect.any(String), authChoice: "llama-cpp" },
+        { sessionId: expect.any(String), agentId: "main", authChoice: "llama-cpp" },
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
       expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
@@ -379,6 +390,7 @@ describe("ModelSetupPage catalog icons", () => {
       expect(request).toHaveBeenCalledWith(
         "openclaw.setup.activate",
         {
+          agentId: "main",
           kind: "provider-auto:vendor%2Flocal%3Av1%25beta%3Fx%23y",
           modelRef: "llama-cpp/gemma-4-e4b-it-q4_k_m",
         },

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -107,13 +107,20 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     (iconUrl) => this.currentIconUrls().has(iconUrl),
     (urls) => (this.iconUrls = urls),
   );
-  private readonly subscriptions = new SubscriptionsController(this).watch(
-    () => this.context?.gateway,
-    (gateway, notify) => gateway.subscribe(notify),
-    (gateway) => this.synchronizeGateway(gateway.snapshot),
-  );
+  private readonly subscriptions = new SubscriptionsController(this)
+    .watch(
+      () => this.context?.gateway,
+      (gateway, notify) => gateway.subscribe(notify),
+      (gateway) => this.synchronizeGateway(gateway.snapshot),
+    )
+    .watch(
+      () => this.context?.agentSelection,
+      (selection, notify) => selection.subscribe(notify),
+      () => this.synchronizeGateway(this.context.gateway.snapshot),
+    );
   private readonly wizard = new ModelSetupWizardRunner({
     getClient: () => this.context?.gateway.snapshot.client ?? null,
+    getAgentId: () => this.context?.agentSelection.state.selectedId ?? null,
     onChange: (next) => {
       const previousStep = this.wizardState.phase === "step" ? this.wizardState.step.id : null;
       this.wizardState =
@@ -128,20 +135,33 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   });
 
   private readonly detectTask = new Task<
-    readonly [GatewayBrowserClient | null, object | null],
-    BoundModelResult<SystemAgentSetupDetectResult> & { token: object }
+    readonly [GatewayBrowserClient | null, string | null, object | null],
+    BoundModelResult<SystemAgentSetupDetectResult> & { agentId: string | null; token: object }
   >(this, {
     autoRun: false,
     args: () => {
       const client = this.context?.gateway.snapshot.client ?? null;
-      return [this.canUseSetup(client) ? client : null, null] as const;
+      return [
+        this.canUseSetup(client) ? client : null,
+        this.context?.agentSelection.state.selectedId ?? null,
+        null,
+      ] as const;
     },
-    task: async ([client, token], { signal }) =>
+    task: async ([client, agentId, token], { signal }) =>
       client && token
-        ? { ...(await captureModelResult(client, () => detectModelSetup(client, signal))), token }
+        ? {
+            ...(await captureModelResult(client, () =>
+              detectModelSetup(client, agentId ?? undefined, signal),
+            )),
+            agentId,
+            token,
+          }
         : initialState,
     onComplete: (outcome) => {
-      if (this.context.gateway.snapshot.client !== outcome.client) {
+      if (
+        this.context.gateway.snapshot.client !== outcome.client ||
+        this.context.agentSelection.state.selectedId !== outcome.agentId
+      ) {
         return;
       }
       if ("error" in outcome) {
@@ -216,15 +236,25 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   });
 
   private readonly verifyTask = new Task<
-    readonly [GatewayBrowserClient | null],
-    BoundModelResult<Awaited<ReturnType<typeof verifyModelSetup>>>
+    readonly [GatewayBrowserClient | null, string | null],
+    BoundModelResult<Awaited<ReturnType<typeof verifyModelSetup>>> & { agentId: string | null }
   >(this, {
     autoRun: false,
-    args: () => [null],
-    task: ([client], { signal }) =>
-      client ? captureModelResult(client, () => verifyModelSetup(client, signal)) : initialState,
+    args: () => [null, null],
+    task: async ([client, agentId], { signal }) =>
+      client
+        ? {
+            ...(await captureModelResult(client, () =>
+              verifyModelSetup(client, agentId ?? undefined, signal),
+            )),
+            agentId,
+          }
+        : initialState,
     onComplete: (outcome) => {
-      if (this.context.gateway.snapshot.client !== outcome.client) {
+      if (
+        this.context.gateway.snapshot.client !== outcome.client ||
+        this.context.agentSelection.state.selectedId !== outcome.agentId
+      ) {
         return;
       }
       this.verifyState =
@@ -237,9 +267,9 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   override disconnectedCallback() {
     this.wizardMutationGeneration += 1;
     this.wizardMutationActive = false;
-    void this.detectTask.run([null, null]);
+    void this.detectTask.run([null, null, null]);
     void this.activationTask.run([null, null]);
-    void this.verifyTask.run([null]);
+    void this.verifyTask.run([null, null]);
     this.iconLoader.reset();
     void this.wizard.cancel();
     this.subscriptions.clear();
@@ -253,7 +283,8 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       const current =
         snapshot.phase === "connected" &&
         snapshot.client === connection.client &&
-        snapshot.hello === connection.hello;
+        snapshot.hello === connection.hello &&
+        this.context.agentSelection.state.selectedId === connection.agentId;
       if (current) {
         this.pageState = this.routeData.state;
         this.observedConnection = { ...connection, connected: true };
@@ -271,6 +302,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     const connection = {
       client: snapshot.client,
       hello: snapshot.hello,
+      agentId: this.context.agentSelection.state.selectedId,
       connected: snapshot.phase === "connected",
     };
     if (!this.observedConnection) {
@@ -279,7 +311,8 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         connection.connected &&
         this.routeData &&
         (this.routeData.connection.client !== connection.client ||
-          this.routeData.connection.hello !== connection.hello)
+          this.routeData.connection.hello !== connection.hello ||
+          this.routeData.connection.agentId !== connection.agentId)
       ) {
         void this.detect();
       }
@@ -288,6 +321,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     if (
       connection.client === this.observedConnection.client &&
       connection.hello === this.observedConnection.hello &&
+      connection.agentId === this.observedConnection.agentId &&
       connection.connected === this.observedConnection.connected
     ) {
       return;
@@ -295,11 +329,11 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     this.observedConnection = connection;
     this.wizardMutationGeneration += 1;
     this.wizardMutationActive = false;
-    void this.detectTask.run([null, null]);
+    void this.detectTask.run([null, null, null]);
     this.activationState = { phase: "idle" };
     void this.activationTask.run([null, null]);
     this.verifyState = { phase: "idle" };
-    void this.verifyTask.run([null]);
+    void this.verifyTask.run([null, null]);
     this.iconLoader.reset();
     this.pendingPrepareOption = null;
     void this.wizard.cancel();
@@ -359,7 +393,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     this.resetVerify();
     this.pageState = { phase: "loading" };
     const token = {};
-    await this.detectTask.run([client, token]);
+    await this.detectTask.run([client, this.context.agentSelection.state.selectedId, token]);
     const outcome = this.detectTask.value;
     return outcome?.token === token && "value" in outcome ? outcome.value : null;
   }
@@ -374,7 +408,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
 
   private resetVerify(): void {
     this.verifyState = { phase: "idle" };
-    void this.verifyTask.run([null]);
+    void this.verifyTask.run([null, null]);
   }
 
   private async verifyConnection(): Promise<void> {
@@ -383,7 +417,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       return;
     }
     this.verifyState = { phase: "checking" };
-    await this.verifyTask.run([client]);
+    await this.verifyTask.run([client, this.context.agentSelection.state.selectedId]);
   }
 
   private async activate(
@@ -397,7 +431,8 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     }
     this.manualError = null;
     this.activationState = { phase: "testing", targetId, modelRef };
-    await this.activationTask.run([client, params]);
+    const agentId = this.context.agentSelection.state.selectedId;
+    await this.activationTask.run([client, { ...params, ...(agentId ? { agentId } : {}) }]);
   }
 
   private activateCandidate(candidate: Candidate): void {

--- a/ui/src/pages/model-setup/model-setup-reconnect.test.ts
+++ b/ui/src/pages/model-setup/model-setup-reconnect.test.ts
@@ -69,6 +69,10 @@ function createFixture() {
   const runtimeConfig = createRuntimeConfigCapability(gateway);
   const context = {
     gateway,
+    agentSelection: {
+      state: { selectedId: "main", scopeId: "main" },
+      subscribe: () => () => undefined,
+    },
     basePath: "",
     navigate: vi.fn(),
     runtimeConfig,
@@ -95,7 +99,7 @@ async function mountPage(
   const page = document.createElement("openclaw-model-setup-page") as TestModelSetupPage;
   page.routeData = {
     state: { phase: "ready", result: detection },
-    connection: { client, hello },
+    connection: { client, hello, agentId: context.agentSelection.state.selectedId },
     firstRun: false,
   };
   provider.append(page);

--- a/ui/src/pages/model-setup/route.test.ts
+++ b/ui/src/pages/model-setup/route.test.ts
@@ -24,7 +24,9 @@ function loaderOptions(): RouteLoaderOptions {
 
 describe("model setup route", () => {
   it("keys loader data by the first-run query", () => {
-    const context = {} as ApplicationContext;
+    const context = {
+      agentSelection: { state: { selectedId: "main" } },
+    } as ApplicationContext;
 
     expect(page.loaderDeps?.(context, location)).toBe("");
     expect(page.loaderDeps?.(context, { ...location, search: "?firstRun=1" })).toBe("?firstRun=1");
@@ -65,7 +67,10 @@ describe("model setup route", () => {
         hello: firstHello,
       } as ApplicationGatewaySnapshot,
     };
-    const context = { gateway } as unknown as ApplicationContext;
+    const context = {
+      gateway,
+      agentSelection: { state: { selectedId: "research" } },
+    } as unknown as ApplicationContext;
     const pending = page.loader?.(context, loaderOptions());
 
     expect(request).toHaveBeenCalledOnce();
@@ -76,7 +81,7 @@ describe("model setup route", () => {
 
     await expect(pending).resolves.toEqual({
       state: { phase: "ready", result: current },
-      connection: { client, hello: currentHello },
+      connection: { client, hello: currentHello, agentId: "research" },
       firstRun: false,
     });
     expect(request).toHaveBeenCalledTimes(2);

--- a/ui/src/pages/model-setup/route.ts
+++ b/ui/src/pages/model-setup/route.ts
@@ -18,7 +18,8 @@ async function loadModelSetupRouteData(
   const firstRun = new URLSearchParams(location.search).get("firstRun") === "1";
   const snapshot = context.gateway.snapshot;
   const client = snapshot.phase === "connected" ? snapshot.client : null;
-  const connection = { client, hello: snapshot.hello };
+  const agentId = context.agentSelection.state.selectedId;
+  const connection = { client, hello: snapshot.hello, agentId };
   if (
     !client ||
     !hasOperatorAdminAccess(snapshot.hello?.auth ?? null) ||
@@ -32,7 +33,10 @@ async function loadModelSetupRouteData(
   }
   let state: ModelSetupRouteData["state"];
   try {
-    state = { phase: "ready", result: await detectModelSetup(client) };
+    state = {
+      phase: "ready",
+      result: await detectModelSetup(client, agentId ?? undefined),
+    };
   } catch (error) {
     const message =
       error instanceof Error && error.message.trim()
@@ -45,7 +49,8 @@ async function loadModelSetupRouteData(
   if (
     current.phase === "connected" &&
     current.client === connection.client &&
-    current.hello === connection.hello
+    current.hello === connection.hello &&
+    context.agentSelection.state.selectedId === connection.agentId
   ) {
     return { state, connection, firstRun };
   }

--- a/ui/src/pages/model-setup/rpc.ts
+++ b/ui/src/pages/model-setup/rpc.ts
@@ -7,22 +7,24 @@ import { MODEL_SETUP_DETECT_TIMEOUT_MS, MODEL_SETUP_VERIFY_TIMEOUT_MS } from "./
 
 export function detectModelSetup(
   client: GatewayBrowserClient,
+  agentId?: string,
   signal?: AbortSignal,
 ): Promise<SystemAgentSetupDetectResult> {
   return client.request<SystemAgentSetupDetectResult>(
     "openclaw.setup.detect",
-    {},
+    { ...(agentId ? { agentId } : {}) },
     { timeoutMs: MODEL_SETUP_DETECT_TIMEOUT_MS, ...(signal ? { signal } : {}) },
   );
 }
 
 export function verifyModelSetup(
   client: GatewayBrowserClient,
+  agentId?: string,
   signal?: AbortSignal,
 ): Promise<SystemAgentSetupVerifyResult> {
   return client.request<SystemAgentSetupVerifyResult>(
     "openclaw.setup.verify",
-    {},
+    { ...(agentId ? { agentId } : {}) },
     { timeoutMs: MODEL_SETUP_VERIFY_TIMEOUT_MS, ...(signal ? { signal } : {}) },
   );
 }

--- a/ui/src/pages/model-setup/rpc.ts
+++ b/ui/src/pages/model-setup/rpc.ts
@@ -12,7 +12,7 @@ export function detectModelSetup(
 ): Promise<SystemAgentSetupDetectResult> {
   return client.request<SystemAgentSetupDetectResult>(
     "openclaw.setup.detect",
-    { ...(agentId ? { agentId } : {}) },
+    agentId ? { agentId } : {},
     { timeoutMs: MODEL_SETUP_DETECT_TIMEOUT_MS, ...(signal ? { signal } : {}) },
   );
 }
@@ -24,7 +24,7 @@ export function verifyModelSetup(
 ): Promise<SystemAgentSetupVerifyResult> {
   return client.request<SystemAgentSetupVerifyResult>(
     "openclaw.setup.verify",
-    { ...(agentId ? { agentId } : {}) },
+    agentId ? { agentId } : {},
     { timeoutMs: MODEL_SETUP_VERIFY_TIMEOUT_MS, ...(signal ? { signal } : {}) },
   );
 }

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -71,6 +71,7 @@ describe("ModelSetupWizardRunner", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
+      getAgentId: () => null,
       onChange: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
@@ -102,6 +103,7 @@ describe("ModelSetupWizardRunner", () => {
     });
     const runner = new ModelSetupWizardRunner({
       getClient: () => ({ request }) as unknown as GatewayBrowserClient,
+      getAgentId: () => null,
       onChange: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
@@ -154,6 +156,7 @@ describe("ModelSetupWizardRunner", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
+      getAgentId: () => null,
       onChange: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
@@ -208,6 +211,7 @@ describe("ModelSetupWizardRunner", () => {
     const seen: string[] = [];
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
+      getAgentId: () => null,
       onChange: (state) => {
         if (state.phase === "step" && state.step.type === "progress") {
           seen.push(state.step.message ?? "");

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -27,6 +27,7 @@ describe("ModelSetupWizardRunner", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const runner = new ModelSetupWizardRunner({
       getClient: () => client,
+      getAgentId: () => "research",
       onChange: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
@@ -34,6 +35,12 @@ describe("ModelSetupWizardRunner", () => {
     });
 
     await runner.start("openai-oauth");
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "openclaw.setup.auth.start",
+      { sessionId: expect.any(String), agentId: "research", authChoice: "openai-oauth" },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(runner.state).toMatchObject({ phase: "step" });
     const answer = runner.answer(undefined, false);
     void runner.answer(undefined, false);

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -19,6 +19,7 @@ export type ModelSetupWizardCompletion = {
 
 type WizardRunnerOptions = {
   getClient: () => GatewayBrowserClient | null;
+  getAgentId?: () => string | null;
   onChange: (state: ModelSetupWizardState) => void;
   requestFailedMessage: () => string;
   cancelledMessage: () => string;
@@ -54,9 +55,14 @@ export class ModelSetupWizardRunner {
     this.startMethod = startMethod;
     this.setState({ phase: "starting", authChoice });
     try {
+      const agentId = this.options.getAgentId?.() ?? null;
       const started = await client.request<SystemAgentSetupAuthStartResult>(
         startMethod,
-        { sessionId, authChoice },
+        {
+          sessionId,
+          authChoice,
+          ...(agentId ? { agentId } : {}),
+        },
         { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS, signal: abortController.signal },
       );
       if (generation !== this.generation) {

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -19,7 +19,7 @@ export type ModelSetupWizardCompletion = {
 
 type WizardRunnerOptions = {
   getClient: () => GatewayBrowserClient | null;
-  getAgentId?: () => string | null;
+  getAgentId: () => string | null;
   onChange: (state: ModelSetupWizardState) => void;
   requestFailedMessage: () => string;
   cancelledMessage: () => string;
@@ -55,7 +55,7 @@ export class ModelSetupWizardRunner {
     this.startMethod = startMethod;
     this.setState({ phase: "starting", authChoice });
     try {
-      const agentId = this.options.getAgentId?.() ?? null;
+      const agentId = this.options.getAgentId();
       const started = await client.request<SystemAgentSetupAuthStartResult>(
         startMethod,
         {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI terminals and model setup failed with `AgentSelectionRequiredError` in explicit multi-agent fleets, especially while the UI reconnected after a Gateway restart.

Live evidence from source head `e43015146eb47886bdac161151c4ca8e71703843` showed repeated `terminal.open` and `openclaw.setup.detect` failures during the August 13 restart windows. Current main at investigation start (`6d716d93187c6faa41d9fde8bcb311040b487b6d`) still contained both owner drops.

## Why This Change Was Made

The Control UI already knew the selected agent but did not bind it to the terminal panel, while structured setup used ownerless protocol parameters, a global detection cache, and an ownerless worker. This change carries one explicit agent through terminal launch and the complete detect/verify/auth/prepare/activate setup flow, keys UI results to that owner, and serializes native detection when different owners request it.

Legacy clients remain compatible because the new protocol fields are optional. Ownerless system setup keeps its existing system-agent routing, while an ownerless terminal request in an explicit fleet now receives an actionable `INVALID_REQUEST` instead of surfacing as a generic unavailable handler failure.

Best-fix verdict: this is the owning-boundary fix. Defaulting terminals to the system agent was rejected because terminal workspace and sandbox policy belong to the operator-selected agent. Catching only `setup.detect` was rejected because verify and mutation siblings would still rediscover or write the wrong owner.

## User Impact

Operators can keep a terminal open across Gateway reconnects and use every Control UI model-setup step against the selected agent in an explicit multi-agent fleet. Results from one agent are not reused for another agent.

Named follow-up: audit `models.list` reconnect ownership separately. No `models.list` failure was attributable to this incident, so this PR does not broaden model-catalog behavior.

Production delta: +261/-88 lines (net +173), justified by the additive protocol contract, explicit ownership boundary, and owner-generation fencing. Tests: +329/-31 lines. Generated Swift protocol: +34/-2 lines.

## Evidence

- Exact reviewed head: `04882dbbc69a61b5b1a8fb3efdfc5d578a3a7a5a`.
- Testbox run [31765368004](https://github.com/openclaw/openclaw/actions/runs/31765368004): 274/274 focused tests passed across seven routed Vitest shards, including 129 setup-inference tests, 70 Gateway tests, 12 protocol tests, 12 terminal-tool tests, 65 Control UI unit/bootstrap tests, and 8 real-Chromium mocked-Gateway E2E tests.
- Testbox run [31765534234](https://github.com/openclaw/openclaw/actions/runs/31765534234): targeted oxlint passed with zero warnings or errors.
- Testbox run [31765274520](https://github.com/openclaw/openclaw/actions/runs/31765274520): targeted oxfmt passed and protocol registry/JSON/Swift/Kotlin generation matched; the standalone protocol-since step lacked its merge-base ref, which exact-head PR CI supplies.
- `git diff --check`: passed.
- Autoreview: repair diff clean at confidence 0.97; full branch bundle clean at confidence 0.95 with no accepted/actionable findings.
- Exact-head PR CI remains the final prepare/merge gate.
