### PR TITLE
fix(doctor): return after reporting an unparseable config

### DIFF
--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -118,6 +118,63 @@ function seedPluginStateConflict(stateDir: string): void {
   }
 }
 
+describe("doctor invalid config process exit", () => {
+  it("exits after a complete best-effort report for an unparseable config", () => {
+    const root = fs.realpathSync(tempDirs.make("openclaw-doctor-invalid-config-exit-"));
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_NO_RESPAWN: "1",
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+      NO_COLOR: "1",
+    };
+    delete env.NODE_ENV;
+    delete env.NODE_OPTIONS;
+    delete env.OPENCLAW_GATEWAY_PASSWORD;
+    delete env.OPENCLAW_GATEWAY_TOKEN;
+    delete env.OPENCLAW_GATEWAY_URL;
+    delete env.OPENCLAW_HOME;
+    delete env.VITEST;
+    delete env.VITEST_POOL_ID;
+    delete env.VITEST_WORKER_ID;
+
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, '{"agents": {broken json');
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        path.resolve("src/entry.ts"),
+        "doctor",
+        "--non-interactive",
+        "--no-workspace-suggestions",
+      ],
+      {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+        env,
+        timeout: 60_000,
+      },
+    );
+    const output = `${result.stderr}\n${result.stdout}`;
+
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+    expect(result.signal, output).toBeNull();
+    expect(output).toContain("Config invalid; doctor will run with best-effort config.");
+    expect(output).toContain("Doctor complete.");
+  }, 75_000);
+});
+
 describe.concurrent("gateway startup-migration refusal", () => {
   it("exits cleanly after reporting the refusal once and releasing its lease", async () => {
     const temporaryRoot = await fs.promises.mkdtemp(

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -181,6 +181,9 @@ describe("active tool schema doctor warnings", () => {
       expect.objectContaining({
         agentId: "main",
         workspaceDir: expect.any(String),
+        skipAgentDiscovery: true,
+        allowBundledStaticCatalogFallback: true,
+        preferBundledStaticCatalogTransport: true,
       }),
     );
     expect(toolState.createTools).toHaveBeenCalledWith(

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -38,8 +38,7 @@ async function resolveRuntimeModelContext(params: {
   provider: string;
   modelId: string;
 }): Promise<RuntimeModelContext> {
-  // Doctor runs before agent lifecycle publication; async resolution prepares discovery instead
-  // of reporting an unpublished synchronous runtime as a broken provider.
+  // Doctor diagnostics resolve static transport facts without publishing a live agent generation.
   const resolution = await resolveModelAsync(
     params.provider,
     params.modelId,
@@ -48,6 +47,9 @@ async function resolveRuntimeModelContext(params: {
     {
       agentId: params.agentId,
       workspaceDir: params.workspaceDir,
+      skipAgentDiscovery: true,
+      allowBundledStaticCatalogFallback: true,
+      preferBundledStaticCatalogTransport: true,
     },
   );
   const model = resolution.model as ProviderRuntimeModel | undefined;

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -383,11 +383,19 @@ describe("doctor runtime tool schema checks", () => {
     expect(mocks.loadModelCatalog).toHaveBeenCalledTimes(2);
     expect(mocks.loadModelCatalog).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ agentId: "main" }),
+      expect.objectContaining({
+        agentId: "main",
+        readOnly: true,
+        providerDiscoveryProviderIds: [],
+      }),
     );
     expect(mocks.loadModelCatalog).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ agentId: "worker" }),
+      expect.objectContaining({
+        agentId: "worker",
+        readOnly: true,
+        providerDiscoveryProviderIds: [],
+      }),
     );
     expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -1101,6 +1101,8 @@ export async function collectRuntimeToolSchemaFindings(
           config: cfg,
           agentId,
           agentDir: resolveAgentDir(cfg, agentId),
+          readOnly: true,
+          providerDiscoveryProviderIds: [],
         });
         const modelRef = resolveDefaultModelForAgent({
           cfg,

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -674,7 +674,9 @@ describe("CORE_HEALTH_CHECKS", () => {
         },
       },
     };
-    expect(hooksModelCatalogCase.calls).toContainEqual([{ config: cfg, readOnly: true }]);
+    expect(hooksModelCatalogCase.calls).toContainEqual([
+      { config: cfg, readOnly: true, providerDiscoveryProviderIds: [] },
+    ]);
   });
 
   it("skips gateway auth warning when SecretRef-managed token resolves in lint checks", async () => {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -484,7 +484,11 @@ const hooksModelCheck: HealthCheck = {
       defaultProvider: DEFAULT_PROVIDER,
       defaultModel: DEFAULT_MODEL,
     });
-    const catalog = await loadPreparedModelCatalog({ config: ctx.cfg, readOnly: true });
+    const catalog = await loadPreparedModelCatalog({
+      config: ctx.cfg,
+      readOnly: true,
+      providerDiscoveryProviderIds: [],
+    });
     const status = getModelRefStatus({
       cfg: ctx.cfg,
       catalog,

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -53,7 +53,11 @@ export async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const catalog = await loadPreparedModelCatalog({ config: ctx.cfg, readOnly: true });
+  const catalog = await loadPreparedModelCatalog({
+    config: ctx.cfg,
+    readOnly: true,
+    providerDiscoveryProviderIds: [],
+  });
   const status = getModelRefStatus({
     cfg: ctx.cfg,
     catalog,

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1648,7 +1648,11 @@ describe("doctor health contributions", () => {
 
     await contribution.run(ctx);
 
-    expect(mocks.loadModelCatalog).toHaveBeenCalledWith({ config: cfg, readOnly: true });
+    expect(mocks.loadModelCatalog).toHaveBeenCalledWith({
+      config: cfg,
+      readOnly: true,
+      providerDiscoveryProviderIds: [],
+    });
   });
 
   it("materializes heartbeat cadence before scratch migration and final config writes", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw doctor` with an unparseable config would receive the best-effort report but the command would never return. This leaves interactive terminals stuck and causes scripts or CI to time out on exactly the config state where doctor is the prescribed recovery command.

## Why This Change Was Made

Doctor diagnostics now resolve model transport and catalog facts through scoped, static, read-only paths. They no longer publish a standalone live model generation or start full provider discovery while inspecting tool schemas. The fix closes the resource at its owner boundary; it does not add a forced process exit.

The regression became visible after `639e7718f39` changed the prepared model catalog worker from terminate-per-request to a persistent per-generation worker. With invalid config falling back to an implicit embedded `main` agent, doctor entered full catalog discovery and retained a referenced worker `MessagePort` while awaiting the catalog request.

Production LOC: +16/-4 (net +12) | Tests: +78/-4. The production growth explicitly marks all doctor catalog/model reads as static and non-publishing; no new abstraction or fallback path was added.

AI-assisted change; the implementation and proof were reviewed locally with the repository autoreview workflow.

## User Impact

`openclaw doctor` now finishes and exits after its complete best-effort report for broken JSON, with or without a running Gateway. `openclaw doctor --fix` also returns normally after restoring a recoverable config.

## Evidence

Before the fix, an isolated broken-config `dh1` run reached the doctor report and was killed by `timeout 90` (`exit 124`). A focused handle probe showed the exact retained parent handle as a referenced `MessagePort` owned by the prepared model catalog worker.

After the fix, using isolated state, port `21973`, and `OPENCLAW_SKIP_CHANNELS=1`:

- broken config, no Gateway: exit 0 in 16s; full report ended with `Doctor complete.`
- broken config, owned scratch Gateway running: exit 0 in 13s; full report ended with `Doctor complete.`
- `doctor --fix`: exit 0 in 18s; restored last-known-good config, wrote valid JSON, and ended with `Doctor complete.`
- repaired valid config: exit 0 in 14s

Focused regression proof:

```text
node scripts/run-vitest.mjs src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-health-contributions.test.ts
171 unit tests + 8 command tests passed

node scripts/run-vitest.mjs src/commands/doctor-config-preflight.process.test.ts -- -t "exits after a complete best-effort report for an unparseable config"
1 process regression passed (3 skipped)
```

Exact-head changed gate passed in Blacksmith Testbox `tbx_01kzz1m88hmaj2q5qap70q5qjq`: https://github.com/openclaw/openclaw/actions/runs/31763872404

Autoreview result: clean, no accepted/actionable findings.
