### PR TITLE
fix(gateway): infer headerless URL input files

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -29,6 +29,21 @@ import {
   testState,
 } from "./test-helpers.js";
 
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/net/fetch-guard.js")>(
+    "../infra/net/fetch-guard.js",
+  );
+  fetchWithSsrFGuardMock.mockImplementation(actual.fetchWithSsrFGuard);
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+  };
+});
+
 installGatewayTestHooks({ scope: "suite" });
 
 let enabledServer: Awaited<ReturnType<typeof startServer>>;
@@ -71,6 +86,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   openResponsesTesting.resetResponseSessionState();
+  fetchWithSsrFGuardMock.mockClear();
 });
 
 async function startServer(port: number, opts?: { openResponsesEnabled?: boolean }) {
@@ -1261,6 +1277,33 @@ describe("OpenResponses HTTP API (e2e)", () => {
       testState.agentsConfig = undefined;
       resetConfigRuntimeState();
     }
+  });
+
+  it("dispatches printable URL input_file text when Content-Type is absent", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(Buffer.from("headerless URL file text"), { status: 200 }),
+      release,
+      finalUrl: "https://example.com/notes",
+    });
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "ok" }] } as never);
+
+    const res = await postResponses(enabledPort, {
+      model: "openclaw",
+      input: buildUrlInputMessage({
+        kind: "input_file",
+        url: "https://example.com/notes",
+      }),
+    });
+    const body = await res.text();
+
+    expect(res.status, body).toBe(200);
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    const prompt = (firstAgentOpts() as { extraSystemPrompt?: string }).extraSystemPrompt ?? "";
+    expect(prompt).toContain("headerless URL file text");
+    expect(prompt).toContain('<<<EXTERNAL_UNTRUSTED_CONTENT id="');
   });
 
   it("streams OpenResponses SSE events", async () => {

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -18,6 +18,7 @@ vi.mock("@openclaw/media-core/mime", async () => {
   const actual = await vi.importActual<typeof import("@openclaw/media-core/mime")>(
     "@openclaw/media-core/mime",
   );
+  detectMimeMock.mockImplementation(actual.detectMime);
   return { ...actual, detectMime: (...args: unknown[]) => detectMimeMock(...args) };
 });
 
@@ -78,6 +79,10 @@ function mockUrlFetchResponse(params: {
 
   const release = vi.fn(async () => {});
   const responseBody = Uint8Array.from(params.fetchedBody ?? Buffer.from("url-source"));
+  const headers = new Headers();
+  if (params.fetchedContentType !== undefined) {
+    headers.set("content-type", params.fetchedContentType);
+  }
   fetchWithSsrFGuardMock.mockResolvedValueOnce({
     response: new Response(
       responseBody.buffer.slice(
@@ -86,7 +91,7 @@ function mockUrlFetchResponse(params: {
       ),
       {
         status: 200,
-        headers: { "content-type": params.fetchedContentType ?? "application/octet-stream" },
+        headers,
       },
     ),
     release,
@@ -247,6 +252,7 @@ describe("HEIC input image normalization", () => {
       limits: createImageSourceLimits(["image/png", "image/webp"], true),
       detectedMime: "image/webp",
       fetchedUrl: "https://example.com/photo",
+      fetchedContentType: "application/octet-stream",
       fetchedBody: Buffer.from("webp-bytes"),
       expectedImage: {
         type: "image",
@@ -439,6 +445,37 @@ describe("guarded input file URL fetches", () => {
 });
 
 describe("input file MIME sniffing", () => {
+  it("infers printable URL file bytes as text when Content-Type is absent", async () => {
+    const body = "headerless printable text";
+    mockUrlFetchResponse({
+      source: { type: "url", url: "https://example.com/notes" },
+      fetchedBody: Buffer.from(body),
+    });
+
+    await expect(
+      extractFileContentFromSource({
+        source: { type: "url", url: "https://example.com/notes" },
+        limits: createFileSourceLimits(["text/plain"], true),
+      }),
+    ).resolves.toEqual({ filename: "file", text: body });
+  });
+
+  it("keeps an explicit octet-stream response binary for the same printable URL bytes", async () => {
+    const body = Buffer.from("headerless printable text");
+    mockUrlFetchResponse({
+      source: { type: "url", url: "https://example.com/notes" },
+      fetchedContentType: "application/octet-stream",
+      fetchedBody: body,
+    });
+
+    await expect(
+      extractFileContentFromSource({
+        source: { type: "url", url: "https://example.com/notes" },
+        limits: createFileSourceLimits(["text/plain"], true),
+      }),
+    ).rejects.toThrow("Unsupported file MIME type: application/octet-stream");
+  });
+
   it("rejects base64 files whose bytes sniff as an unsupported image despite a text media type", async () => {
     detectMimeMock.mockResolvedValueOnce("image/png");
 

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -105,7 +105,6 @@ type InputFileSource =
 /** Guarded URL fetch result before final MIME allowlist validation. */
 type InputFetchResult = {
   buffer: Buffer;
-  mimeType: string;
   contentType?: string;
 };
 
@@ -238,10 +237,8 @@ async function fetchWithGuard(params: {
 
     const buffer = await readResponseWithLimit(response, params.maxBytes);
 
-    const contentType = response.headers.get("content-type") || undefined;
-    const parsed = parseContentType(contentType);
-    const mimeType = parsed.mimeType ?? "application/octet-stream";
-    return { buffer, mimeType, contentType };
+    const contentType = response.headers.get("content-type") ?? undefined;
+    return { buffer, contentType };
   } finally {
     await release();
   }
@@ -374,7 +371,7 @@ export async function extractImageContentFromSource(
     });
     return await normalizeInputImage({
       buffer: result.buffer,
-      mimeType: result.mimeType,
+      mimeType: parseContentType(result.contentType).mimeType,
       limits,
     });
   }
@@ -422,7 +419,7 @@ export async function extractFileContentFromSource(params: {
       auditContext: "openresponses.input_file",
     });
     const parsed = parseContentType(result.contentType);
-    mimeType = parsed.mimeType ?? normalizeMimeType(result.mimeType);
+    mimeType = parsed.mimeType;
     charset = parsed.charset;
     buffer = result.buffer;
   }


### PR DESCRIPTION
Closes #123428

## What Problem This Solves

Fixes an issue where URL-backed Open Responses `input_file` text was rejected before agent dispatch when the remote server omitted `Content-Type`. The fetch layer fabricated an octet-stream declaration, preventing safe printable-text inference.

## Why This Change Was Made

The guarded fetch result now preserves the actual optional response header instead of inventing a MIME type. Existing image and file byte classifiers remain authoritative: headerless printable files infer `text/plain`, while explicitly declared `application/octet-stream` remains binary and rejected by the default text allowlist. SSRF, redirect, timeout, and size controls are unchanged.

## User Impact

Open Responses clients can use text-file URLs from servers that omit `Content-Type`. Accepted content is still bounded and wrapped as untrusted external input before agent dispatch.

## Evidence

- Exact reviewed head: `bb72a1ae581b1d0f3e3b9b876038af99abd6637f`.
- Rebased and locally proven against fetched `origin/main` `ac2f8a8dcef621ab5692b5509c51588707b32ea7`.
- Exact-head CI: [run 31764294356](https://github.com/openclaw/openclaw/actions/runs/31764294356) passed on `bb72a1ae581b1d0f3e3b9b876038af99abd6637f`.
- Tests-first media regression failed before the repair with `Unsupported file MIME type: application/octet-stream`.
- Tests-first HTTP regression returned 400 and made zero agent-dispatch calls before the repair.
- Post-fix media/input tests: 22/22 passed.
- Full Open Responses HTTP tests: 68/68 passed.
- Extraction owner test: 1/1 passed.
- HTTP boundary proof: status 200, agent dispatched once, headerless text present inside the external-untrusted-content wrapper.
- Explicit octet-stream control remains rejected for the same printable bytes.
- Core and core-test TypeScript checks, targeted lint/format, and `git diff --check` passed.
- Final integrated Codex autoreview: clean, no findings; TruffleHog clean.

Production delta: +4/-7, net -3. Tests: +81/-1, net +80.

AI-assisted: yes. The repair was reviewed against guarded fetch ownership, MIME classification, Open Responses dispatch, and all existing input security limits.
