### PR TITLE
fix(gateway): suppress false chat metadata warnings during restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway chat metadata reloads:** defer auth and skill snapshot refreshes until the prepared model owner publishes, preventing expected restart and hot-reload replacement windows from emitting false owner-unavailable warnings or failing the pending metadata replacement.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway chat metadata reloads:** defer auth and skill snapshot refreshes until the prepared model owner publishes, preventing expected restart and hot-reload replacement windows from emitting false owner-unavailable warnings or failing the pending metadata replacement.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -122,6 +122,19 @@ describe("gateway chat metadata lifecycle", () => {
     );
   });
 
+  it("retries subordinate changes after a published owner's catch-up build fails", async () => {
+    mocks.refresh.mockRejectedValueOnce(new Error("projection failed"));
+    const { lifecycle: pendingLifecycle } = createLifecycle(false);
+    const lifecycle = await pendingLifecycle;
+
+    await lifecycle.attachContext(context, []);
+    const authListener = mocks.registerAuthListener.mock.calls[0]?.[0];
+
+    authListener();
+
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(2));
+  });
+
   it("defers subordinate changes until an invalidated model owner publishes", async () => {
     mocks.refresh.mockRejectedValueOnce(new ChatMetadataSnapshotUnavailableError());
     const { lifecycle: pendingLifecycle, warn } = createLifecycle(false);

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -121,4 +121,62 @@ describe("gateway chat metadata lifecycle", () => {
       "chat metadata catch-up refresh failed: Error: metadata unavailable",
     );
   });
+
+  it("defers subordinate changes until an invalidated model owner publishes", async () => {
+    mocks.refresh.mockRejectedValueOnce(new ChatMetadataSnapshotUnavailableError());
+    const { lifecycle: pendingLifecycle, warn } = createLifecycle(false);
+    const lifecycle = await pendingLifecycle;
+
+    await lifecycle.attachContext(context, []);
+    expect(mocks.refresh).toHaveBeenCalledOnce();
+
+    const modelListener = mocks.registerModelListener.mock.calls[0]?.[0];
+    const authListener = mocks.registerAuthListener.mock.calls[0]?.[0];
+    const skillsListener = mocks.registerSkillsListener.mock.calls[0]?.[0];
+    expect(modelListener).toEqual(expect.any(Function));
+    expect(authListener).toEqual(expect.any(Function));
+    expect(skillsListener).toEqual(expect.any(Function));
+
+    modelListener({ phase: "invalidated" });
+    authListener();
+    skillsListener();
+
+    expect(mocks.invalidate).toHaveBeenCalledTimes(3);
+    expect(mocks.refresh).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+
+    modelListener({ phase: "published" });
+
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(2));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("refreshes subordinate changes immediately while the model owner is published", async () => {
+    const { lifecycle: pendingLifecycle } = createLifecycle(false);
+    const lifecycle = await pendingLifecycle;
+
+    await lifecycle.attachContext(context, []);
+    const authListener = mocks.registerAuthListener.mock.calls[0]?.[0];
+    const skillsListener = mocks.registerSkillsListener.mock.calls[0]?.[0];
+
+    authListener();
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(2));
+    skillsListener();
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(3));
+  });
+
+  it("propagates a failed model publication without starting a refresh", async () => {
+    const { lifecycle: pendingLifecycle } = createLifecycle(false);
+    const lifecycle = await pendingLifecycle;
+
+    await lifecycle.attachContext(context, []);
+    const modelListener = mocks.registerModelListener.mock.calls[0]?.[0];
+    const publicationError = new Error("replacement failed");
+
+    modelListener({ phase: "invalidated" });
+    modelListener({ phase: "failed", error: publicationError });
+
+    expect(mocks.fail).toHaveBeenCalledWith(publicationError);
+    expect(mocks.refresh).toHaveBeenCalledOnce();
+  });
 });

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -120,6 +120,11 @@ export async function createGatewayChatMetadataLifecycle(params: {
           },
           (error: unknown) => {
             if (!(error instanceof ChatMetadataSnapshotUnavailableError)) {
+              // Capture reached a published owner before this later metadata build failed. Keep
+              // stable auth/skill changes able to retry unless a newer owner event says otherwise.
+              if (preparedModelRuntimeEventVersion === eventVersion) {
+                preparedModelRuntimeAvailable = true;
+              }
               params.log.warn(`chat metadata catch-up refresh failed: ${String(error)}`);
             }
           },

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -11,6 +11,8 @@ export async function createGatewayChatMetadataLifecycle(params: {
   log: GatewayLogger;
 }) {
   let context: GatewayRequestContext | undefined;
+  let preparedModelRuntimeAvailable = false;
+  let preparedModelRuntimeEventVersion = 0;
   const { ChatMetadataSnapshotUnavailableError, createGatewayChatMetadataRuntime } =
     await import("./server-methods/chat-metadata-runtime.js");
   const runtime = createGatewayChatMetadataRuntime({
@@ -42,6 +44,14 @@ export async function createGatewayChatMetadataLifecycle(params: {
       params.log.warn(`chat metadata refresh failed: ${String(error)}`);
     });
   };
+  const invalidateForSubordinateChange = () => {
+    runtime.invalidate();
+    // Auth and skill facts are subordinate to the prepared model owner. During replacement the
+    // publication event owns the one catch-up refresh after every related fact is committed.
+    if (preparedModelRuntimeAvailable) {
+      refreshLogged();
+    }
+  };
   const registerRefreshListeners = async (): Promise<GatewayPostReadySidecarHandle | undefined> => {
     if (params.minimalTestGateway) {
       return undefined;
@@ -57,24 +67,26 @@ export async function createGatewayChatMetadataLifecycle(params: {
     ]);
     const unregisterPreparedModelRuntimePublication =
       registerPreparedModelRuntimePublicationListener((event) => {
+        preparedModelRuntimeEventVersion += 1;
         if (event.phase === "invalidated") {
+          preparedModelRuntimeAvailable = false;
           runtime.invalidate();
           return;
         }
         if (event.phase === "failed") {
+          preparedModelRuntimeAvailable = false;
           runtime.fail(event.error);
           return;
         }
+        preparedModelRuntimeAvailable = true;
         refreshLogged();
       });
     const unregisterSkillsChange = registerSkillsChangeListener(() => {
-      runtime.invalidate();
-      refreshLogged();
+      invalidateForSubordinateChange();
     });
     const unregisterRuntimeAuthProfileStoreMutation =
       registerRuntimeAuthProfileStoreMutationListener(() => {
-        runtime.invalidate();
-        refreshLogged();
+        invalidateForSubordinateChange();
       });
     return {
       stop: async () => {
@@ -97,11 +109,21 @@ export async function createGatewayChatMetadataLifecycle(params: {
         // Publications that complete before listener registration would otherwise be missed.
         // During ordinary startup the owner is published after attachment, so an unavailable
         // snapshot here is expected and the publication listener performs the first refresh.
-        await runtime.refresh().catch((error: unknown) => {
-          if (!(error instanceof ChatMetadataSnapshotUnavailableError)) {
-            params.log.warn(`chat metadata catch-up refresh failed: ${String(error)}`);
-          }
-        });
+        const eventVersion = preparedModelRuntimeEventVersion;
+        await runtime.refresh().then(
+          () => {
+            // A successful catch-up proves availability when publication completed before the
+            // listener was registered. Do not overwrite a newer invalidation or failure event.
+            if (preparedModelRuntimeEventVersion === eventVersion) {
+              preparedModelRuntimeAvailable = true;
+            }
+          },
+          (error: unknown) => {
+            if (!(error instanceof ChatMetadataSnapshotUnavailableError)) {
+              params.log.warn(`chat metadata catch-up refresh failed: ${String(error)}`);
+            }
+          },
+        );
       }
     },
     read: runtime.read,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway restarts could log expected `prepared chat metadata owner is unavailable` warnings when auth-profile or skill snapshot changes arrived while the prepared model owner was being replaced. The later model publication already converged successfully, so these warnings were false operational noise.

## Why This Change Was Made

Chat metadata now tracks the prepared model publication boundary that owns its auth and skill facts. Auth and skill changes still invalidate metadata immediately, but they defer rebuilding while that owner is unpublished; the `published` event performs one catch-up refresh. Stable post-publication changes still refresh immediately, and failed publications still propagate through the existing failure path.

Production LOC: +31/-9 (net +22) for the explicit publication-availability ownership boundary. Tests: +58/-0.

## User Impact

Operators no longer see false chat-metadata refresh warnings during otherwise healthy Gateway restart or replacement windows. Real publication failures and post-publication metadata updates remain visible and functional.

## Evidence

- `corepack pnpm test src/gateway/server-chat-metadata-lifecycle.test.ts` — 6/6 passed on Blacksmith Testbox `tbx_01kzz08gtwh8jmc1cpw88jdm7g`: https://github.com/openclaw/openclaw/actions/runs/31762652088
- `corepack pnpm test src/gateway/server-chat-metadata-lifecycle.integration.test.ts` — 6/6 passed on Blacksmith Testbox `tbx_01kzz0e5fpppdmfcjjt2ed6shn`: https://github.com/openclaw/openclaw/actions/runs/31762814680
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01kzz0gwdp7qjhj642egwabanz`: https://github.com/openclaw/openclaw/actions/runs/31762888438
- `git diff --check` — passed.
- Autoreview — clean, with no accepted/actionable findings.
