### PR TITLE
fix(cron): removing or disabling a job aborts its active run

### DIFF
--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -71,6 +71,10 @@ describe("active cron schedule ownership", () => {
 
     expect(marker?.scheduleMutated).toBe(true);
     expect(marker?.jobRemoved).toBe(true);
+    expect(marker?.cancellation).toEqual({
+      kind: "requested",
+      reason: "Cron job removed by operator.",
+    });
     expect(hasActiveCronJobs()).toBe(true);
   });
 

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -14,6 +14,9 @@ export type CronActiveJobMarker = {
   jobId: string;
   generation: number;
   token: number;
+  cancellation?:
+    | { kind: "bound"; cancel: (reason: string) => void }
+    | { kind: "requested"; reason: string };
   scheduleMutated?: true;
   triggerMutated?: true;
   jobRemoved?: true;
@@ -50,6 +53,15 @@ function getActiveCronJobCountForGeneration(state: CronActiveJobState) {
 
 function isMarkerActiveInGeneration(marker: CronActiveJobMarker, generation: number) {
   return marker.generation === generation || marker.preserveAcrossGenerationAdvance === true;
+}
+
+function getCurrentCronActiveJobMarker(jobId: string): CronActiveJobMarker | undefined {
+  if (!jobId) {
+    return undefined;
+  }
+  const state = getCronActiveJobState();
+  const marker = state.activeJobs.get(jobId);
+  return marker && isMarkerActiveInGeneration(marker, state.generation) ? marker : undefined;
 }
 
 function notifyActiveCronJobWaitersIfEmpty(state: CronActiveJobState) {
@@ -117,12 +129,8 @@ export function clearCronJobActive(jobId: string, marker?: CronActiveJobMarker) 
 
 /** Records a durable schedule edit against the exact run that was active for it. */
 export function noteActiveCronJobScheduleMutation(jobId: string): void {
-  if (!jobId) {
-    return;
-  }
-  const state = getCronActiveJobState();
-  const marker = state.activeJobs.get(jobId);
-  if (marker && isMarkerActiveInGeneration(marker, state.generation)) {
+  const marker = getCurrentCronActiveJobMarker(jobId);
+  if (marker) {
     // Keep mutation history on the admitted run: A→B→A has the original
     // schedule value but still belongs to the operator's newer edit.
     marker.scheduleMutated = true;
@@ -131,12 +139,8 @@ export function noteActiveCronJobScheduleMutation(jobId: string): void {
 
 /** Records a durable trigger edit against the exact run that evaluated it. */
 export function noteActiveCronJobTriggerMutation(jobId: string): void {
-  if (!jobId) {
-    return;
-  }
-  const state = getCronActiveJobState();
-  const marker = state.activeJobs.get(jobId);
-  if (marker && isMarkerActiveInGeneration(marker, state.generation)) {
+  const marker = getCurrentCronActiveJobMarker(jobId);
+  if (marker) {
     // A→B→A restores the script but cannot return ownership of the new
     // trigger state to an evaluation admitted before either durable edit.
     marker.triggerMutated = true;
@@ -145,19 +149,33 @@ export function noteActiveCronJobTriggerMutation(jobId: string): void {
 
 /** Retires the admitted job identity after its deletion becomes durable. */
 export function noteActiveCronJobRemoval(jobId: string): CronActiveJobMarker | undefined {
-  if (!jobId) {
+  const marker = getCurrentCronActiveJobMarker(jobId);
+  if (!marker) {
     return undefined;
   }
-  const state = getCronActiveJobState();
-  const marker = state.activeJobs.get(jobId);
-  if (marker && isMarkerActiveInGeneration(marker, state.generation)) {
-    // A reused ID names a new job, not a reschedule of the old invocation.
-    // Keep its marker until completion so duplicate-run guards remain intact.
-    marker.scheduleMutated = true;
-    marker.jobRemoved = true;
-    return marker;
+  // A reused ID names a new job, not a reschedule of the old invocation.
+  // Keep its marker until completion so duplicate-run guards remain intact.
+  marker.scheduleMutated = true;
+  marker.jobRemoved = true;
+  requestCronActiveJobMarkerCancellation(marker, "Cron job removed by operator.");
+  return marker;
+}
+
+function requestCronActiveJobMarkerCancellation(marker: CronActiveJobMarker, reason: string): void {
+  const cancellation = marker.cancellation;
+  if (cancellation?.kind === "requested") {
+    return;
   }
-  return undefined;
+  marker.cancellation = { kind: "requested", reason };
+  cancellation?.cancel(reason);
+}
+
+/** Requests cancellation now or when the exact active run binds its controller. */
+export function requestActiveCronJobCancellation(jobId: string, reason: string): void {
+  const marker = getCurrentCronActiveJobMarker(jobId);
+  if (marker) {
+    requestCronActiveJobMarkerCancellation(marker, reason);
+  }
 }
 
 /** Returns whether the given cron job id is currently executing in this process. */

--- a/src/cron/service.one-shot-schedule-ownership.test.ts
+++ b/src/cron/service.one-shot-schedule-ownership.test.ts
@@ -168,12 +168,14 @@ describe("cron one-shot schedule ownership", () => {
         }
 
         if (mode === "queued") {
+          // Removal aborts the in-flight run: the original run must end as the
+          // operator's explicit stop, never finalize "ok" into the replacement.
           expect(
             events.filter((event) => event.action === "finished" && event.jobId === original.id),
           ).toEqual([
             expect.objectContaining({
-              status: "ok",
-              summary: "original run finished",
+              status: "error",
+              error: "Cron job removed by operator.",
               job: expect.objectContaining({ name: "removed original one-shot" }),
             }),
           ]);

--- a/src/cron/service/active-run-cancellation.test.ts
+++ b/src/cron/service/active-run-cancellation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { clearCronJobActive, markCronJobActive, noteActiveCronJobRemoval } from "../active-jobs.js";
 import {
   abortActiveCronTaskRuns,
   cancelActiveCronTaskRun,
@@ -13,6 +14,23 @@ import { resetActiveCronTaskRunsForTests } from "./active-run-cancellation.test-
 const CRON_TASK_RUN_SETTLEMENT_TRACKING_MAX_MS = 60_000;
 
 describe("cron task cancellation tracking", () => {
+  it("consumes a removal request made before the run controller binds", () => {
+    const marker = markCronJobActive("removed-before-controller");
+    const controller = new AbortController();
+    noteActiveCronJobRemoval("removed-before-controller");
+
+    const release = registerActiveCronTaskRun({
+      runId: "removed-before-controller-run",
+      controller,
+      activeJobMarker: marker,
+    });
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason).toBe("Cron job removed by operator.");
+    release?.();
+    clearCronJobActive("removed-before-controller", marker);
+  });
+
   it("retires restart tracking while keeping an unsettled core suspension-visible", async () => {
     resetActiveCronTaskRunsForTests();
     let settle = () => {};

--- a/src/cron/service/active-run-cancellation.ts
+++ b/src/cron/service/active-run-cancellation.ts
@@ -1,5 +1,7 @@
 // Process-local cancellation handles for live cron task runs.
 
+import type { CronActiveJobMarker } from "../active-jobs.js";
+
 const activeCronTaskRunsByRunId = new Map<
   string,
   { controller: AbortController; onCancel?: (reason: string) => void }
@@ -25,17 +27,35 @@ function startActiveCronTaskRunSettlementGrace(promise: Promise<unknown>): void 
 export function registerActiveCronTaskRun(params: {
   runId: string | undefined;
   controller: AbortController;
+  activeJobMarker?: CronActiveJobMarker;
   onCancel?: (reason: string) => void;
 }): (() => void) | undefined {
   const runId = params.runId?.trim();
   if (!runId) {
     return undefined;
   }
-  activeCronTaskRunsByRunId.set(runId, {
+  const handle = {
     controller: params.controller,
     onCancel: params.onCancel,
-  });
+  };
+  activeCronTaskRunsByRunId.set(runId, handle);
+  // A durable remove/disable can land after marker admission but before this
+  // controller exists; consume that exact marker's request before provider work.
+  const cancelJobRun = (reason: string) => {
+    cancelActiveCronTaskRun({ runId, reason });
+  };
+  if (params.activeJobMarker?.cancellation?.kind === "requested") {
+    cancelJobRun(params.activeJobMarker.cancellation.reason);
+  } else if (params.activeJobMarker) {
+    params.activeJobMarker.cancellation = { kind: "bound", cancel: cancelJobRun };
+  }
   return () => {
+    if (
+      params.activeJobMarker?.cancellation?.kind === "bound" &&
+      params.activeJobMarker.cancellation.cancel === cancelJobRun
+    ) {
+      delete params.activeJobMarker.cancellation;
+    }
     if (activeCronTaskRunsByRunId.get(runId)?.controller === params.controller) {
       activeCronTaskRunsByRunId.delete(runId);
     }

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -12,6 +12,7 @@ import {
   noteActiveCronJobScheduleMutation,
   noteActiveCronJobTriggerMutation,
   onCronJobInactive,
+  requestActiveCronJobCancellation,
 } from "../active-jobs.js";
 import { cloneCronRuntimeAuthority, type CronRuntimeAuthority } from "../runtime-authority.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
@@ -202,6 +203,9 @@ async function persistUpdatedJob(params: {
     // Mark only committed edits; a failed SQLite write cannot retire the run's
     // schedule ownership, and idempotent re-saves must not create a new claim.
     noteActiveCronJobScheduleMutation(nextJob.id);
+  }
+  if (isJobEnabled(previousJob) && !isJobEnabled(nextJob)) {
+    requestActiveCronJobCancellation(nextJob.id, "Cron job disabled by operator.");
   }
   if (
     !isDeepStrictEqual(previousJob.trigger, nextJob.trigger) ||

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -30,6 +30,7 @@ import {
 } from "./run-admission.js";
 import {
   cronRunReceiptPersistHooks,
+  resolveCronRunReceiptTerminalStatus,
   type CronRunReceiptSettlementDisposition,
 } from "./run-receipts.js";
 import { recomputeUnownedCronSchedules } from "./run-recovery.js";
@@ -224,6 +225,20 @@ async function finishPreparedManualRun(
         },
       );
     };
+    if (prepared.activeJobMarker?.jobRemoved === true) {
+      finishCronRunReceipt({
+        handle: prepared.runReceipt,
+        status: resolveCronRunReceiptTerminalStatus(
+          triggerSkipped ? "skipped" : coreResult.status,
+          coreResult.triggerEval?.fired,
+        ),
+        finishedAtMs: endedAt,
+        error: coreResult.error,
+      });
+      finalized = true;
+      emitMissingQueuedTerminal();
+      return;
+    }
     if (!isCronActiveJobMarkerCurrent(prepared.activeJobMarker)) {
       emitMissingQueuedTerminal();
       return;

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -23,8 +23,11 @@ import {
   tryBeginGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { isCronJobActive } from "../active-jobs.js";
 import { loadCronStore, saveCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
+import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import { start } from "./ops-lifecycle.js";
 import { remove, update } from "./ops-mutations.js";
 import { enqueueRun, run } from "./ops-run.js";
@@ -67,6 +70,14 @@ function expectIsolatedRunJobId(
     { job?: { id?: string } }?,
   ];
   expect(params?.job?.id).toBe(jobId);
+}
+
+function latestRunReceipt(storePath: string, jobId: string) {
+  return openOpenClawStateDatabase()
+    .db.prepare(
+      "SELECT status, error_text AS error FROM cron_run_receipts WHERE store_key = ? AND job_id = ? ORDER BY started_at_ms DESC, receipt_id DESC LIMIT 1",
+    )
+    .get(cronStoreKey(storePath), jobId) as { status: string; error: string | null };
 }
 
 describe("cron service ops regressions", () => {
@@ -829,7 +840,24 @@ describe("cron service ops regressions", () => {
     clearCommandLane(CommandLane.Cron);
   });
 
-  it("emits one terminal event when a queued job is removed during execution", async () => {
+  it.each([
+    {
+      mutation: "removed",
+      reason: "Cron job removed by operator.",
+      mutate: async (state: ReturnType<typeof createCronServiceState>, jobId: string) => {
+        await expect(remove(state, jobId)).resolves.toEqual({ ok: true, removed: true });
+      },
+      expectRemoved: true,
+    },
+    {
+      mutation: "disabled",
+      reason: "Cron job disabled by operator.",
+      mutate: async (state: ReturnType<typeof createCronServiceState>, jobId: string) => {
+        await update(state, jobId, { enabled: false });
+      },
+      expectRemoved: false,
+    },
+  ])("aborts and records a queued isolated job when it is $mutation", async (testCase) => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
@@ -837,19 +865,15 @@ describe("cron service ops regressions", () => {
     const store = opsRegressionFixtures.makeStorePath();
     const dueAt = Date.parse("2026-02-06T10:05:04.000Z");
     const job = createDueIsolatedJob({
-      id: "queued-removed-manual",
+      id: `queued-${testCase.mutation}-manual`,
       nowMs: dueAt,
       nextRunAtMs: dueAt,
     });
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
-    const started = createDeferred();
-    const execution = createDeferred<{
-      status: "ok";
-      summary: string;
-      delivered: false;
-      deliveryError: string;
-    }>();
+    const started = createDeferred<AbortSignal>();
+    const releaseProvider = createDeferred();
+    const providerExited = createDeferred();
     const events: CronEvent[] = [];
     const state = createCronServiceState({
       cronEnabled: true,
@@ -858,41 +882,88 @@ describe("cron service ops regressions", () => {
       nowMs: () => dueAt,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async () => {
-        started.resolve();
-        return await execution.promise;
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
+        if (!abortSignal) {
+          throw new Error("expected isolated cron abort signal");
+        }
+        onExecutionStarted?.();
+        started.resolve(abortSignal);
+        await Promise.race([
+          releaseProvider.promise,
+          new Promise<void>((resolve) => {
+            if (abortSignal.aborted) {
+              resolve();
+              return;
+            }
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          }),
+        ]);
+        providerExited.resolve();
+        return { status: "ok" as const, summary: "late provider result" };
       }),
       onEvent: (evt) => events.push(evt),
     });
 
     const ack = await enqueueRun(state, job.id, "force");
     const runId = expectQueuedRunAck(ack);
-    await started.promise;
+    const abortSignal = await started.promise;
 
-    await expect(remove(state, job.id)).resolves.toEqual({ ok: true, removed: true });
-    execution.resolve({
-      status: "ok",
-      summary: "completed after removal",
-      delivered: false,
-      deliveryError: "Message delivery failed",
-    });
-    await waitForActiveTasks(5_000);
+    try {
+      await testCase.mutate(state, job.id);
 
-    const terminalEvents = events.filter((evt) => evt.action === "finished" && evt.runId === runId);
-    expect(terminalEvents).toEqual([
-      expect.objectContaining({
-        jobId: job.id,
-        status: "ok",
-        summary: "completed after removal",
-        deliveryError: "Message delivery failed",
-      }),
-    ]);
-    expect(state.store?.jobs.some((entry) => entry.id === job.id)).toBe(false);
+      expect(abortSignal.aborted).toBe(true);
+      expect(abortSignal.reason).toBe(testCase.reason);
+      await providerExited.promise;
+      await waitForActiveTasks(5_000);
 
-    clearCommandLane(CommandLane.Cron);
+      const terminalEvents = events.filter(
+        (evt) => evt.action === "finished" && evt.runId === runId,
+      );
+      expect(terminalEvents).toEqual([
+        expect.objectContaining({
+          jobId: job.id,
+          status: "error",
+          error: testCase.reason,
+        }),
+      ]);
+      expect(
+        readCronTaskRunHistoryPage({
+          storeKey: cronStoreKey(store.storePath),
+          jobId: job.id,
+          runId,
+        }).entries,
+      ).toEqual([
+        expect.objectContaining({
+          jobId: job.id,
+          status: "error",
+          error: testCase.reason,
+        }),
+      ]);
+      expect(latestRunReceipt(store.storePath, job.id)).toEqual({
+        status: "error",
+        error: testCase.reason,
+      });
+      const storedJob = state.store?.jobs.find((entry) => entry.id === job.id);
+      if (testCase.expectRemoved) {
+        expect(storedJob).toBeUndefined();
+      } else {
+        expect(storedJob).toMatchObject({
+          enabled: false,
+          state: {
+            lastStatus: "error",
+            lastError: testCase.reason,
+            runningAtMs: undefined,
+          },
+        });
+      }
+    } finally {
+      releaseProvider.resolve();
+      await waitForActiveTasks(5_000);
+      clearCommandLane(CommandLane.Cron);
+    }
   });
 
-  it("#102238 keeps a timer tick from duplicating a re-enabled active run", async () => {
+  it("#102238 waits for a disabled run to abort before a re-enabled timer tick", async () => {
     const store = opsRegressionFixtures.makeStorePath();
     const now = Date.parse("2026-07-09T12:00:00.000Z");
     const job = createDueIsolatedJob({
@@ -902,7 +973,7 @@ describe("cron service ops regressions", () => {
     });
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
-    const firstRunGate = createDeferred();
+    const firstRunStarted = createDeferred<AbortSignal>();
     let dispatchCount = 0;
     let inFlight = 0;
     let peakInFlight = 0;
@@ -913,12 +984,22 @@ describe("cron service ops regressions", () => {
       nowMs: () => now,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async () => {
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal }) => {
         dispatchCount += 1;
         inFlight += 1;
         peakInFlight = Math.max(peakInFlight, inFlight);
         if (dispatchCount === 1) {
-          await firstRunGate.promise;
+          if (!abortSignal) {
+            throw new Error("expected isolated cron abort signal");
+          }
+          firstRunStarted.resolve(abortSignal);
+          await new Promise<void>((resolve) => {
+            if (abortSignal.aborted) {
+              resolve();
+              return;
+            }
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
         }
         inFlight -= 1;
         return { status: "ok" as const, summary: "done" };
@@ -926,74 +1007,18 @@ describe("cron service ops regressions", () => {
     });
 
     const firstRun = run(state, job.id, "force");
-    try {
-      await vi.waitFor(() => {
-        expect(dispatchCount).toBe(1);
-        expect(isCronJobActive(job.id)).toBe(true);
-      });
-      await update(state, job.id, { enabled: false });
-      await update(state, job.id, { enabled: true });
+    const firstAbortSignal = await firstRunStarted.promise;
+    expect(isCronJobActive(job.id)).toBe(true);
 
-      await onTimer(state);
+    await update(state, job.id, { enabled: false });
+    expect(firstAbortSignal.aborted).toBe(true);
+    await firstRun;
+    await update(state, job.id, { enabled: true });
 
-      expect(dispatchCount).toBe(1);
-      expect(peakInFlight).toBe(1);
-    } finally {
-      firstRunGate.resolve();
-      await firstRun;
-    }
+    await onTimer(state);
 
-    await expect(run(state, job.id, "force")).resolves.toEqual({ ok: true, ran: true });
     expect(dispatchCount).toBe(2);
-  });
-
-  it("#102238 rejects a second manual run after disabling and re-enabling", async () => {
-    const store = opsRegressionFixtures.makeStorePath();
-    const now = Date.parse("2026-07-09T12:00:00.000Z");
-    const job = createDueIsolatedJob({
-      id: "disable-enable-manual",
-      nowMs: now,
-      nextRunAtMs: now - 60_000,
-    });
-    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
-
-    const firstRunGate = createDeferred();
-    let dispatchCount = 0;
-    const state = createCronServiceState({
-      cronEnabled: true,
-      storePath: store.storePath,
-      log: noopLogger,
-      nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async () => {
-        dispatchCount += 1;
-        if (dispatchCount === 1) {
-          await firstRunGate.promise;
-        }
-        return { status: "ok" as const, summary: "done" };
-      }),
-    });
-
-    const firstRun = run(state, job.id, "force");
-    try {
-      await vi.waitFor(() => expect(dispatchCount).toBe(1));
-      await update(state, job.id, { enabled: false });
-      await update(state, job.id, { enabled: true });
-
-      await expect(run(state, job.id, "force")).resolves.toEqual({
-        ok: true,
-        ran: false,
-        reason: "already-running",
-      });
-      expect(dispatchCount).toBe(1);
-    } finally {
-      firstRunGate.resolve();
-      await firstRun;
-    }
-
-    await expect(run(state, job.id, "force")).resolves.toEqual({ ok: true, ran: true });
-    expect(dispatchCount).toBe(2);
+    expect(peakInFlight).toBe(1);
   });
 
   it.each([

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -231,6 +231,7 @@ export async function executeJobCoreWithTimeout(
     ? registerActiveCronTaskRun({
         runId: opts?.runId ?? `cron-active:${job.id}`,
         controller: runAbortController,
+        activeJobMarker: opts?.activeJobMarker,
         onCancel: () => resolveOperatorCancellation?.(operatorCancellationMarker),
       })
     : undefined;


### PR DESCRIPTION
Related: #123436

## What Problem This Solves

Fixes an issue where removing or disabling an automation while its isolated agent run was active left that run executing after the job row disappeared. Operators lost the normal status/stop surface while model and tool work could continue until the generic agent timeout.

The reported live run continued growing from 75 to 119+ transcript events for roughly 12 minutes after `cron rm`; the configured fallback ceiling was 48 hours.

## Why This Change Was Made

The exact active-job marker now carries a cancellation handoff to the existing run-scoped `AbortController`. Remove and enabled→disabled commits request cancellation only after their durable mutation succeeds; a sticky reason covers the narrow admission race where the marker exists before its controller binds. The normal isolated-agent terminal owner still decides abort precedence, and cron finalization persists the resulting error receipt/history even after the job row is gone.

Payload, schedule, and ordinary `cron edit` changes remain future-run-only and do not abort the admitted run. Main-session automation behavior, timeout defaults, and loop heuristics are unchanged. The 48-hour unattended default is tracked in #123436; identical-tool-call/no-progress detection remains #120415.

Production LOC: +82/-24 (net +58) | Tests: +147/-100 (net +47). The production growth is the exact marker→controller cancellation handshake plus missing-job receipt terminalization; it adds no config, protocol, persistence schema, polling, retry, or fallback path.

## User Impact

`cron rm` and true→false disable now act as explicit stop operations for in-flight isolated agent, command, and script runs. Removed jobs leave terminal run/task/receipt evidence with `Cron job removed by operator.`; disabled jobs remain listed as disabled with the terminal error recorded. Re-enabling after cancellation preserves the existing single-flight invariant.

## Evidence

- Pre-fix regression: both remove and disable left the active run's `AbortSignal` un-aborted; the historical test explicitly expected success after removal.
- Focused Vitest: `node scripts/run-vitest.mjs src/cron/active-jobs.test.ts src/cron/service/active-run-cancellation.test.ts src/cron/service/ops.regression.test.ts src/cron/service/timer-outcome-finalization.receipts.test.ts` — 49 passed after the final rebase.
- Changed gate: exact eight-path `node scripts/check-changed.mjs -- ...` — green on Blacksmith run https://github.com/openclaw/openclaw/actions/runs/31764239153. The first broad remote pass caught a two-line max-lines overage in the expanded regression; the test helper was compacted and the exact-path rerun passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
- Live local Ollama proof, isolated scratch Gateway on port 55523: job showed `running`, task acquired an isolated child session, and `llama3.2:latest` was active. `cron rm` removed the row; history/task/receipt all finalized as `error: Cron job removed by operator.` The transcript moved once from 5→6 for cancellation finalization, then stayed 6 across two 10-second samples.
- Independent source-blind validation on a second scratch Gateway: 7/7 clauses passed; an actively blocked Ollama run terminalized 996 ms after removal, its receipt left the `running` state, and transcript count stayed 8 across 11.64 seconds. The validator rejected an initial backgrounded-sleep attempt rather than accepting a false running proof.
- Both scratch Gateways were stopped cleanly; their state/logs were moved recoverably to Trash. Port 18789, `~/.openclaw`, and Ollama model lifecycle were untouched.

AI-assisted: yes. The change was source-read, live-reproduced, regression-tested, independently behavior-validated, and autoreviewed.
