### PR TITLE
fix(sessions): hide host catalogs from unprofiled multi-user callers

### DIFF
--- a/src/gateway/server-methods/session-catalog-visibility.test.ts
+++ b/src/gateway/server-methods/session-catalog-visibility.test.ts
@@ -10,7 +10,7 @@ type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
 type TestClient = {
   connect: { scopes: string[] };
   connId?: string;
-  authenticatedUserProfile: { profileId: string };
+  authenticatedUserProfile?: { profileId: string };
 };
 
 const hoisted = vi.hoisted(() => ({
@@ -40,6 +40,10 @@ const { sessionCatalogHandlers } = await import("./session-catalog.js");
 
 function client(profileId: string, scopes = ["operator.read", "operator.write"]): TestClient {
   return { connect: { scopes }, authenticatedUserProfile: { profileId } };
+}
+
+function unprofiledClient(scopes = ["operator.read", "operator.write"]): TestClient {
+  return { connect: { scopes } };
 }
 
 function session(threadId: string, sessionKey?: string) {
@@ -197,6 +201,57 @@ describe("session catalog caller visibility", () => {
     expect(archive).not.toHaveBeenCalled();
   });
 
+  it("hides every row from an unprofiled multi-identity caller", async () => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(true);
+    const listedHost = host([session("unadopted-thread")]);
+    hoisted.activeRegistry.sessionCatalogs = [
+      { provider: provider({ list: vi.fn(async () => [listedHost]) }) },
+    ];
+
+    const listed = await call("sessions.catalog.list", {}, unprofiledClient());
+
+    expect(listed).toHaveBeenCalledWith(true, {
+      catalogs: [
+        expect.objectContaining({
+          hosts: [expect.objectContaining({ sessions: [] })],
+        }),
+      ],
+    });
+  });
+
+  it("rejects reads for an unprofiled multi-identity caller", async () => {
+    hoisted.hasMultipleSessionSharingIdentities.mockReturnValue(true);
+    const read = vi.fn(async () => ({
+      hostId: "gateway:local",
+      threadId: "unadopted-thread",
+      items: [{ type: "userMessage" as const, text: "private host history" }],
+    }));
+    hoisted.activeRegistry.sessionCatalogs = [
+      {
+        provider: provider({
+          list: vi.fn(async () => [host([session("unadopted-thread")])]),
+          read,
+        }),
+      },
+    ];
+
+    const transcript = await call(
+      "sessions.catalog.read",
+      { catalogId: "codex", hostId: "gateway:local", threadId: "unadopted-thread" },
+      unprofiledClient(),
+    );
+
+    expect(transcript).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.FORBIDDEN,
+        message: "session catalog thread is not visible to this caller",
+      }),
+    );
+    expect(read).not.toHaveBeenCalled();
+  });
+
   it.each([
     { label: "admin", multiple: true, scopes: ["operator.admin"] },
     { label: "solo Gateway", multiple: false, scopes: ["operator.read"] },
@@ -314,12 +369,14 @@ describe("session catalog caller visibility", () => {
       host([
         session("alpha-thread", "agent:main:alpha"),
         session("beta-thread", "agent:main:beta"),
+        session("unadopted-thread"),
       ]),
     ]);
     hoisted.activeRegistry.sessionCatalogs = [{ provider: provider({ list }) }];
     const config = {};
 
     const alpha = await call("sessions.catalog.list", {}, client("profile-alpha"), config);
+    const unprofiled = await call("sessions.catalog.list", {}, unprofiledClient(), config);
     const beta = await call("sessions.catalog.list", {}, client("profile-beta"), config);
     const rows = (respond: ReturnType<typeof vi.fn>) =>
       respond.mock.calls[0]?.[1]?.catalogs[0]?.hosts[0]?.sessions.map(
@@ -327,7 +384,8 @@ describe("session catalog caller visibility", () => {
       );
 
     expect(rows(alpha)).toEqual(["alpha-thread"]);
+    expect(rows(unprofiled)).toEqual([]);
     expect(rows(beta)).toEqual(["beta-thread"]);
-    expect(list).toHaveBeenCalledTimes(2);
+    expect(list).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/gateway/server-methods/session-catalog-visibility.ts
+++ b/src/gateway/server-methods/session-catalog-visibility.ts
@@ -9,11 +9,10 @@ import { ADMIN_SCOPE, authorizeOperatorScopesForRequiredScope } from "../method-
 import { createSessionCatalogRequestEntrySnapshot } from "./session-catalog-entry-snapshot.js";
 import type { GatewayClient } from "./types.js";
 
-type SessionCatalogVisibility = {
-  cacheKey: string;
-  profileId?: string;
-  restricted: boolean;
-};
+type SessionCatalogVisibility =
+  | { cacheKey: string; kind: "unrestricted" }
+  | { cacheKey: string; kind: "restricted-unprofiled" }
+  | { cacheKey: string; kind: "restricted-owner"; ownerProfileId: string };
 
 export function resolveSessionCatalogVisibility(
   client: GatewayClient | null,
@@ -22,26 +21,31 @@ export function resolveSessionCatalogVisibility(
   const admin = authorizeOperatorScopesForRequiredScope(ADMIN_SCOPE, scopes).allowed;
   const multipleIdentities = hasMultipleSessionSharingIdentities();
   const profileId = client?.authenticatedUserProfile?.profileId;
-  return {
-    cacheKey: JSON.stringify({ admin, multipleIdentities, profileId: profileId ?? null }),
-    ...(profileId ? { profileId } : {}),
-    restricted: multipleIdentities && !admin,
-  };
+  const cacheKey = JSON.stringify({ admin, multipleIdentities, profileId: profileId ?? null });
+  if (!multipleIdentities || admin) {
+    return { cacheKey, kind: "unrestricted" };
+  }
+  return profileId
+    ? { cacheKey, kind: "restricted-owner", ownerProfileId: profileId }
+    : { cacheKey, kind: "restricted-unprofiled" };
 }
 
 export function filterSessionCatalogHost(
   host: SessionCatalogHost,
   visibility: SessionCatalogVisibility,
 ): SessionCatalogHost {
-  if (!visibility.restricted) {
+  if (visibility.kind === "unrestricted") {
     return host;
+  }
+  if (visibility.kind === "restricted-unprofiled") {
+    return { ...host, sessions: [] };
   }
   return {
     ...host,
     sessions: host.sessions.filter((session) => {
       // No sessionKey means the provider cannot link this host-owned CLI row to an adopted
       // OpenClaw session. Keep it private from non-admin callers on multi-identity Gateways.
-      return session.createdActor?.id === visibility.profileId;
+      return session.createdActor?.id === visibility.ownerProfileId;
     }),
   };
 }
@@ -56,8 +60,11 @@ export async function isSessionCatalogThreadVisible(params: {
   threadId: string;
   visibility: SessionCatalogVisibility;
 }): Promise<boolean> {
-  if (!params.visibility.restricted) {
+  if (params.visibility.kind === "unrestricted") {
     return true;
+  }
+  if (params.visibility.kind === "restricted-unprofiled") {
+    return false;
   }
   const requestEntries = createSessionCatalogRequestEntrySnapshot({
     cfg: params.config,
@@ -80,7 +87,7 @@ export async function isSessionCatalogThreadVisible(params: {
     const projected = requestEntries.projectHostCreatedActors(host);
     const session = projected.sessions.find((candidate) => candidate.threadId === params.threadId);
     if (session) {
-      return session.createdActor?.id === params.visibility.profileId;
+      return session.createdActor?.id === params.visibility.ownerProfileId;
     }
     const nextCursor = host.nextCursor;
     if (!nextCursor || seenCursors.has(nextCursor)) {


### PR DESCRIPTION
Follow-up to #123421.

## What Problem This Solves

Fixes an issue where #123421 shipped session-catalog visibility fail-open for a non-admin caller without an authenticated user profile on a multi-identity Gateway. Token- and password-authenticated connections do not receive a durable profile. For an unadopted host CLI row, both the caller profile ID and the row's `createdActor.id` were absent, so the optional-value comparison treated the row as owned and exposed its metadata and transcript.

This affects token/password-auth connections on Gateways that already have multiple durable sharing identities. Admin access remains intentional, profiled callers remain owner-scoped, and Gateways with fewer than two durable identities remain unfiltered.

Credit to the [ClawSweeper review on #123421](https://github.com/openclaw/openclaw/pull/123421#issuecomment-5288607745) for raising the unprofiled-caller case before merge. The original maintainer specification and subsequent rejection of that finding were wrong; this PR closes the resulting fail-open path.

## Why This Change Was Made

Catalog visibility is now a closed discriminated union with three representable modes: unrestricted, restricted to a concrete owner profile, or restricted with no caller profile. The unprofiled restricted mode structurally returns zero list rows and rejects direct thread access before provider dispatch. No comparison between two optional identity values remains.

The existing cache key already distinguishes `profileId: null` from concrete profile IDs, so its shape is unchanged. New coverage verifies that an unprofiled caller and profiled callers receive distinct settled list operations and results.

AI-assisted; the maintainer supplied the corrected product contract and reviewed the behavior.

Production LOC: +21/-14 (net +7). Tests: +60/-2 (net +58). The production growth is the closed authorization mode required to make restricted-without-owner structurally distinct from owner-scoped visibility.

## User Impact

On a multi-identity Gateway, an unprofiled non-admin token/password caller now sees zero catalog sessions and receives the typed `FORBIDDEN` error when attempting to read an unadopted host thread. Private host CLI history no longer becomes visible through the absent-identity equality case.

Existing behavior remains unchanged for admins, solo/shared-secret Gateways without multiple durable identities, and profiled owners reading their own adopted rows.

## Evidence

Pre-fix proof on current `main`:

- `node scripts/run-vitest.mjs src/gateway/server-methods/session-catalog-visibility.test.ts` failed three regressions for the intended reason: the unprofiled caller listed `unadopted-thread`, read its `private host history`, and received that leaked row from its identity-specific cache entry.

Passing proof:

- `node scripts/run-vitest.mjs src/gateway/server-methods/session-catalog-visibility.test.ts src/gateway/server-methods/session-catalog.test.ts` — 35 tests passed after the fix and again after rebasing onto current `main`.
- `node scripts/check-changed.mjs` — all selected core production/test gates passed. The first delegated Daytona run was infrastructure-blocked by missing hydrated workspace modules; the documented trusted-source local fallback passed formatting, typecheck, lint, dead-code, architecture, storage, and boundary guards.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings; overall patch correctness 0.98.

The focused matrix re-asserts admin unfiltered access, solo unfiltered access, profiled owner access, other-profile rejection, pagination, progress frames, and cache isolation between unprofiled and profiled callers.

Source-blind behavior validation returned `blocked_fixture_required`: the public Gateway APIs cannot create synthetic durable profiles or seed catalog rows, so an isolated live probe could not exercise this case without reading real host session history. The isolated Gateway was stopped cleanly and no real state was touched; the failing/passing owner-boundary regressions and exact-head CI provide the safe deterministic proof.
