### PR TITLE
feat(codex): pass explicit skill selections as structured turn input

### DIFF
--- a/extensions/codex/src/app-server/explicit-skill-input.test.ts
+++ b/extensions/codex/src/app-server/explicit-skill-input.test.ts
@@ -1,0 +1,102 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resolveCodexExplicitSkillInputs } from "./explicit-skill-input.js";
+import type { v2 } from "./protocol.js";
+
+describe("resolveCodexExplicitSkillInputs", () => {
+  const cwd = path.resolve("repo");
+  const skillPath = path.join(cwd, ".agents", "skills", "release", "SKILL.md");
+
+  it("uses the enabled catalog identity for a path-matched selection", async () => {
+    const request = vi.fn(
+      async () =>
+        ({
+          data: [
+            {
+              cwd,
+              skills: [
+                {
+                  name: "release",
+                  description: "Release workflow",
+                  path: skillPath,
+                  scope: "repo",
+                  enabled: true,
+                },
+              ],
+              errors: [],
+            },
+          ],
+        }) satisfies v2.SkillsListResponse,
+    );
+
+    await expect(
+      resolveCodexExplicitSkillInputs({
+        client: { request } as never,
+        cwd,
+        selections: [{ name: "release-command", path: skillPath }],
+      }),
+    ).resolves.toEqual([{ type: "skill", name: "release", path: skillPath }]);
+    expect(request).toHaveBeenCalledWith(
+      "skills/list",
+      { cwds: [cwd], forceReload: false },
+      { signal: undefined },
+    );
+  });
+
+  it("skips disabled and unmatched selections", async () => {
+    const request = vi.fn(
+      async () =>
+        ({
+          data: [
+            {
+              cwd,
+              skills: [
+                {
+                  name: "release",
+                  description: "Release workflow",
+                  path: skillPath,
+                  scope: "repo",
+                  enabled: false,
+                },
+              ],
+              errors: [],
+            },
+          ],
+        }) satisfies v2.SkillsListResponse,
+    );
+
+    await expect(
+      resolveCodexExplicitSkillInputs({
+        client: { request } as never,
+        cwd,
+        selections: [
+          { name: "release", path: skillPath },
+          { name: "missing", path: path.join(cwd, "missing", "SKILL.md") },
+        ],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("fails open when the catalog request fails", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("skills/list unavailable");
+    });
+
+    await expect(
+      resolveCodexExplicitSkillInputs({
+        client: { request } as never,
+        cwd,
+        selections: [{ name: "release", path: skillPath }],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("does not request the catalog without selections", async () => {
+    const request = vi.fn();
+
+    await expect(
+      resolveCodexExplicitSkillInputs({ client: { request } as never, cwd, selections: [] }),
+    ).resolves.toEqual([]);
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/codex/src/app-server/explicit-skill-input.ts
+++ b/extensions/codex/src/app-server/explicit-skill-input.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import {
+  embeddedAgentLog,
+  formatErrorMessage,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { CodexAppServerClient } from "./client.js";
+import type { v2 } from "./protocol.js";
+
+type CodexExplicitSkillInput = { type: "skill"; name: string; path: string };
+
+function comparablePath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+export async function resolveCodexExplicitSkillInputs(params: {
+  client: CodexAppServerClient;
+  cwd: string;
+  selections: EmbeddedRunAttemptParams["explicitSkillSelections"];
+  signal?: AbortSignal;
+}): Promise<CodexExplicitSkillInput[]> {
+  if (!params.selections?.length) {
+    return [];
+  }
+  // The prompt instruction block owns skills unavailable to Codex, so misses and RPC errors
+  // stay fail-open instead of blocking the turn.
+  try {
+    const response = (await params.client.request(
+      "skills/list",
+      { cwds: [params.cwd], forceReload: false } satisfies v2.SkillsListParams,
+      { signal: params.signal },
+    )) as v2.SkillsListResponse;
+    const cwd = comparablePath(params.cwd);
+    const catalog = response.data.find((entry) => comparablePath(entry.cwd) === cwd);
+    return params.selections.flatMap((selection) => {
+      const selectedPath = comparablePath(selection.path);
+      const skill = catalog?.skills.find(
+        (candidate) => candidate.enabled && comparablePath(candidate.path) === selectedPath,
+      );
+      return skill ? [{ type: "skill" as const, name: skill.name, path: skill.path }] : [];
+    });
+  } catch (error) {
+    embeddedAgentLog.debug("codex explicit skill catalog unavailable; using prompt fallback", {
+      error: formatErrorMessage(error),
+    });
+    return [];
+  }
+}

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -129,6 +129,11 @@ export type CodexUserInput =
   | {
       type: "localImage";
       path: string;
+    }
+  | {
+      type: "skill";
+      name: string;
+      path: string;
     };
 
 export type CodexDynamicToolFunctionSpec = JsonObject & {

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -8,6 +8,7 @@ import {
   utf8JsonByteLength,
 } from "./attempt-diagnostics.js";
 import { isCodexAppServerIndeterminateRequestCancellationError } from "./client.js";
+import { resolveCodexExplicitSkillInputs } from "./explicit-skill-input.js";
 import { assertCodexTurnStartResponse } from "./protocol-validators.js";
 import type { CodexTurnStartResponse } from "./protocol.js";
 import { readCodexRateLimitsRevision } from "./rate-limit-cache.js";
@@ -42,6 +43,12 @@ export async function prepareCodexAttemptTurnRequest(
     runAbortController,
   } = connection;
   const { state } = turnRuntime;
+  const explicitSkillInputs = await resolveCodexExplicitSkillInputs({
+    client: resourceState.client,
+    cwd: resourceState.codexExecutionCwd,
+    selections: runtimeParams.explicitSkillSelections,
+    signal: runAbortController.signal,
+  });
   const buildCodexModelInputMessages = () => [
     ...prompt.codexModelInputHistoryMessages,
     buildCodexUserPromptMessage({ ...runtimeParams, prompt: turnState.codexTurnPromptText }),
@@ -105,6 +112,7 @@ export async function prepareCodexAttemptTurnRequest(
       cwd: resourceState.codexExecutionCwd,
       appServer: turnAppServer,
       promptText: turnState.codexTurnPromptText,
+      explicitSkillInputs,
       sandboxPolicy: resourceState.codexSandboxPolicy,
       environmentSelection: resourceState.codexEnvironmentSelection,
       clearInheritedServiceTier: resourceState.thread.clearInheritedServiceTier,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4393,6 +4393,50 @@ describe("runCodexAppServerAttempt", () => {
       { type: "text", text: "hello", text_elements: [] },
       { type: "image", url: `data:image/png;base64,${pngBase64}` },
     ]);
+    expect(
+      requests.filter(
+        (entry) =>
+          entry.method === "skills/list" &&
+          (entry.params as { forceReload?: boolean } | undefined)?.forceReload === false,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("appends path-matched explicit skills to the initial turn input", async () => {
+    const params = createRunParams();
+    const skillPath = path.join(params.workspaceDir, ".agents", "skills", "release", "SKILL.md");
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method !== "skills/list") {
+        return undefined;
+      }
+      return {
+        data: [
+          {
+            cwd: params.workspaceDir,
+            skills: [
+              {
+                name: "release",
+                description: "Release workflow",
+                path: skillPath,
+                scope: "repo",
+                enabled: true,
+              },
+            ],
+            errors: [],
+          },
+        ],
+      } satisfies v2.SkillsListResponse;
+    });
+    params.explicitSkillSelections = [{ name: "release-command", path: skillPath }];
+
+    const run = runCodexAppServerAttempt(params);
+    await completeStartedRun(run, harness.waitForMethod, harness.completeTurn);
+
+    const turnStart = harness.requests.find((entry) => entry.method === "turn/start");
+    expect((turnStart?.params as { input?: unknown[] } | undefined)?.input).toEqual([
+      { type: "text", text: "hello", text_elements: [] },
+      { type: "skill", name: "release", path: skillPath },
+    ]);
   });
 
   it("does not drop turn completion notifications emitted while turn/start is in flight", async () => {

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -10,6 +10,7 @@ import type {
   CodexSandboxPolicy,
   CodexTurnEnvironmentParams,
   CodexTurnStartParams,
+  CodexUserInput,
 } from "./protocol.js";
 import { readCodexSupportedReasoningEfforts } from "./reasoning-effort.js";
 import {
@@ -57,6 +58,7 @@ export function buildTurnStartParams(
     cwd: string;
     appServer: CodexAppServerRuntimeOptions;
     promptText?: string;
+    explicitSkillInputs?: Array<Extract<CodexUserInput, { type: "skill" }>>;
     sandboxPolicy?: CodexSandboxPolicy;
     environmentSelection?: CodexTurnEnvironmentParams[];
     model?: string | null;
@@ -87,7 +89,13 @@ export function buildTurnStartParams(
     : undefined;
   return {
     threadId: options.threadId,
-    input: buildCodexUserInput(options.promptText ?? params.prompt, params.images),
+    // codex-rs/app-server-protocol/src/protocol/v2/turn.rs:292-324 at 91d6f48992ad defines
+    // UserInput::Skill; skills/src/selection.rs:60-92 blocks those names from duplicate text
+    // selection while leaving unmatched Codex-native-only names scannable.
+    input: [
+      ...buildCodexUserInput(options.promptText ?? params.prompt, params.images),
+      ...(options.explicitSkillInputs ?? []),
+    ],
     ...(additionalContext ? { additionalContext } : {}),
     cwd: options.cwd,
     approvalPolicy: options.appServer.approvalPolicy,

--- a/extensions/llama-cpp/src/llama-server-install.ts
+++ b/extensions/llama-cpp/src/llama-server-install.ts
@@ -4,10 +4,6 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import JSZip from "jszip";
-import {
-  fetchWithSsrFGuard,
-  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
-} from "openclaw/plugin-sdk/ssrf-runtime";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import * as tar from "tar";
 import { resolveLlamaCppDataDir } from "./defaults.js";
@@ -105,6 +101,10 @@ export async function downloadVerifiedFile(params: {
 }): Promise<void> {
   const partialPath = `${params.destination}.partial-${randomUUID()}`;
   await fsp.mkdir(path.dirname(params.destination), { recursive: true });
+  // Setup/doctor closure must not cold-load the SSRF barrel (DNS, proxy state,
+  // logging); defer it to actual download time per the closure guard contract.
+  const { fetchWithSsrFGuard, ssrfPolicyFromHttpBaseUrlAllowedOrigin } =
+    await import("openclaw/plugin-sdk/ssrf-runtime");
   try {
     const { response, release } = await fetchWithSsrFGuard({
       url: params.url,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -25,7 +25,7 @@ import type { RuntimePluginToolGrant } from "../../../plugins/runtime/tool-grant
 import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
-import type { SkillSnapshot } from "../../../skills/types.js";
+import type { ExplicitSkillSelection, SkillSnapshot } from "../../../skills/types.js";
 import type {
   SkillProposalOrigin,
   SkillWorkshopProposalMutationBudget,
@@ -226,6 +226,7 @@ export type RunEmbeddedAgentParams = {
   finalizePromptForResolvedTools?: ResolvedToolPromptFinalizer;
   currentInboundEventKind?: InboundEventKind;
   currentInboundContext?: CurrentInboundPromptContext;
+  explicitSkillSelections?: ExplicitSkillSelection[];
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
   /** Ordered facts represented by attachment text in the current prompt. */

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -307,6 +307,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     skipPreparedUserTurnMessage: runtime.skipPreparedUserTurnMessage,
     currentInboundEventKind: params.currentInboundEventKind,
     currentInboundContext: params.currentInboundContext,
+    explicitSkillSelections: params.explicitSkillSelections,
     images: promptMedia.images,
     imageOrder: promptMedia.imageOrder,
     media: promptMedia.media,

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -237,6 +237,7 @@ export async function runEmbeddedFallbackCandidate(params: {
         onContextEngineTurnCandidate: params.onContextEngineTurnCandidate,
         currentInboundEventKind: turn.followupRun.currentInboundEventKind,
         currentInboundContext: turn.followupRun.currentInboundContext,
+        explicitSkillSelections: turn.followupRun.explicitSkillSelections,
         extraSystemPrompt: turn.followupRun.run.extraSystemPrompt,
         sourceReplyDeliveryMode: turn.followupRun.run.sourceReplyDeliveryMode,
         forceMessageTool: turn.followupRun.run.sourceReplyDeliveryMode === "message_tool_only",

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -932,6 +932,9 @@ describe("handleInlineActions", () => {
       ].join("\n"),
     );
     expect(ctx.Body).toBe(result.cleanedBody);
+    expect(result.explicitSkillSelections).toEqual([
+      { name: "office_hours", path: "/tmp/skills/office-hours/SKILL.md" },
+    ]);
   });
 
   it("reloads preloaded skill commands when final exec overrides are present", async () => {

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -19,7 +19,7 @@ import {
   resolveSkillCommandInvocation,
   resolveSkillReferenceInvocations,
 } from "../../skills/discovery/chat-commands.js";
-import type { SkillCommandSpec } from "../../skills/types.js";
+import type { ExplicitSkillSelection, SkillCommandSpec } from "../../skills/types.js";
 import {
   copyReplyPayloadMetadata,
   markCommandReplyForDelivery,
@@ -177,6 +177,7 @@ type InlineActionResult =
       directives: InlineDirectives;
       abortedLastRun: boolean;
       cleanedBody: string;
+      explicitSkillSelections?: ExplicitSkillSelection[];
     };
 
 function extractTextFromToolResult(result: unknown): string | null {
@@ -310,6 +311,7 @@ export async function handleInlineActions(params: {
 
   let directives = initialDirectives;
   let cleanedBody = initialCleanedBody;
+  let explicitSkillSelections: ExplicitSkillSelection[] | undefined;
   const targetSessionEntry = sessionStore?.[sessionKey] ?? sessionEntry;
 
   const isStopLikeInbound = isAbortRequestText(command.rawBodyNormalized);
@@ -550,6 +552,10 @@ export async function handleInlineActions(params: {
       };
     }
     if (referenced.skills.length > 0) {
+      const selections = referenced.skills.flatMap((skill) =>
+        skill.skillFile ? [{ name: skill.name, path: skill.skillFile }] : [],
+      );
+      explicitSkillSelections = selections.length > 0 ? selections : undefined;
       cleanedBody = referenced.body;
       ctx.Body = cleanedBody;
       ctx.agentText = cleanedBody;
@@ -682,6 +688,7 @@ export async function handleInlineActions(params: {
       directives,
       abortedLastRun,
       cleanedBody,
+      ...(explicitSkillSelections ? { explicitSkillSelections } : {}),
     };
   }
   const remainingBodyAfterInlineStatus = (() => {
@@ -722,5 +729,6 @@ export async function handleInlineActions(params: {
     directives,
     abortedLastRun,
     cleanedBody,
+    ...(explicitSkillSelections ? { explicitSkillSelections } : {}),
   };
 }

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -330,6 +330,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     currentInboundEventKind: inboundEventKind,
     currentInboundAudio: hasInboundAudio(sessionCtx),
     currentInboundContext,
+    explicitSkillSelections: params.explicitSkillSelections,
     ...(queuedFollowupAbortSignal ? { abortSignal: queuedFollowupAbortSignal } : {}),
     deliveryCorrelations: opts?.queuedDeliveryCorrelations,
     turnAdoptionLifecycle: opts?.turnAdoptionLifecycle,

--- a/src/auto-reply/reply/get-reply-run.types.ts
+++ b/src/auto-reply/reply/get-reply-run.types.ts
@@ -4,6 +4,7 @@ import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ExtractedFileImage } from "../../media-understanding/extracted-file-images.js";
+import type { ExplicitSkillSelection } from "../../skills/types.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
 import type { buildCommandContext } from "./commands.js";
@@ -100,5 +101,6 @@ export type RunPreparedReplyParams = {
   storePath?: string;
   workspaceDir: string;
   abortedLastRun: boolean;
+  explicitSkillSelections?: ExplicitSkillSelection[];
   autoFallbackPrimaryProbe?: AutoFallbackPrimaryProbe;
 };

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1110,6 +1110,7 @@ export async function getReplyFromConfig(
   await maybeEmitMissingResetHooks();
   directives = inlineActionResult.directives;
   cleanedBody = inlineActionResult.cleanedBody;
+  const explicitSkillSelections = inlineActionResult.explicitSkillSelections;
   abortedLastRun = inlineActionResult.abortedLastRun ?? abortedLastRun;
   const runAutoFallbackPrimaryProbe = directives.hasModelDirective
     ? undefined
@@ -1286,6 +1287,7 @@ export async function getReplyFromConfig(
       storePath,
       workspaceDir,
       abortedLastRun,
+      explicitSkillSelections,
       autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
     }),
   );

--- a/src/auto-reply/reply/queue.media-carrier.test.ts
+++ b/src/auto-reply/reply/queue.media-carrier.test.ts
@@ -1,4 +1,4 @@
-// Prompt media carrier tests cover collect batching, deferral, and retry identity.
+// Prompt metadata carrier tests cover collect batching, deferral, and retry identity.
 import { afterEach, describe, expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
@@ -16,7 +16,7 @@ afterEach(() => {
   queueKeys.clear();
 });
 
-describe("followup prompt media carrier", () => {
+describe("followup prompt metadata carrier", () => {
   it("keeps collected prompt bytes and ordered facts stable across deferred admission", async () => {
     const key = `prompt-media-collect-${Date.now()}`;
     queueKeys.add(key);
@@ -24,12 +24,20 @@ describe("followup prompt media carrier", () => {
     const done = createDeferred();
     const calls: FollowupRun[] = [];
 
-    for (const [prompt, path, contentType] of [
-      ["[media attached: /tmp/a.png (image/png)]\nfirst", "/tmp/a.png", "image/png"],
-      ["[media attached: /tmp/b.pdf (application/pdf)]\nsecond", "/tmp/b.pdf", "application/pdf"],
+    for (const [prompt, path, contentType, skillName] of [
+      ["[media attached: /tmp/a.png (image/png)]\nfirst", "/tmp/a.png", "image/png", "a"],
+      [
+        "[media attached: /tmp/b.pdf (application/pdf)]\nsecond",
+        "/tmp/b.pdf",
+        "application/pdf",
+        "b",
+      ],
     ] as const) {
       const run = createQueueTestRun({ prompt });
       run.media = [{ path, contentType }];
+      run.explicitSkillSelections = [
+        { name: skillName, path: `/tmp/skills/${skillName}/SKILL.md` },
+      ];
       enqueueFollowupRun(key, run, settings);
     }
 
@@ -59,6 +67,14 @@ describe("followup prompt media carrier", () => {
         { path: "/tmp/b.pdf", contentType: "application/pdf" },
       ],
     ]);
+    const expectedSkills = [
+      { name: "a", path: "/tmp/skills/a/SKILL.md" },
+      { name: "b", path: "/tmp/skills/b/SKILL.md" },
+    ];
+    expect(calls.map((run) => run.explicitSkillSelections)).toEqual([
+      expectedSkills,
+      expectedSkills,
+    ]);
   });
 
   it("preserves facts when an overflow source is rebuilt for retry", () => {
@@ -66,10 +82,12 @@ describe("followup prompt media carrier", () => {
       prompt: "[media attached: /tmp/retry.png (image/png)]\nretry me",
     });
     source.media = [{ path: "/tmp/retry.png", contentType: "image/png" }];
+    source.explicitSkillSelections = [{ name: "retry", path: "/tmp/skills/retry/SKILL.md" }];
 
     const retry = createOverflowSummaryRetrySource(source);
 
     expect(retry.prompt).toBe(source.prompt);
     expect(retry.media).toEqual(source.media);
+    expect(retry.explicitSkillSelections).toEqual(source.explicitSkillSelections);
   });
 });

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -318,6 +318,7 @@ type FollowupRuntimeMetadata = Pick<
   | "currentInboundEventKind"
   | "currentInboundAudio"
   | "currentInboundContext"
+  | "explicitSkillSelections"
   | "abortSignal"
   | "queueAbortSignal"
   | "deliveryCorrelations"
@@ -554,10 +555,19 @@ function collectRuntimeMetadata(
       item.onReplyAdmissionWaitChange ? [item.onReplyAdmissionWaitChange] : [],
     ),
   );
+  const explicitSkillSelections = [
+    ...new Map(
+      items
+        .flatMap((item) => item.explicitSkillSelections ?? [])
+        .map((selection) => [selection.path, selection] as const),
+    ).values(),
+  ];
   return {
     currentInboundEventKind: currentTurnSource?.currentInboundEventKind,
     currentInboundAudio: currentTurnSource?.currentInboundAudio,
     currentInboundContext: collectCurrentInboundContext(items),
+    explicitSkillSelections:
+      explicitSkillSelections.length > 0 ? explicitSkillSelections : undefined,
     abortSignal,
     queueAbortSignal: items.find((item) => item.queueAbortSignal)?.queueAbortSignal,
     deliveryCorrelations: deliveryCorrelations.length > 0 ? deliveryCorrelations : undefined,
@@ -914,6 +924,7 @@ export function createOverflowSummaryRetrySource(source: FollowupRun): FollowupR
     prompt: source.prompt,
     queueAbortSignal: source.queueAbortSignal,
     transcriptPrompt: source.transcriptPrompt,
+    explicitSkillSelections: source.explicitSkillSelections,
     media: source.media,
     messageId: source.messageId,
     summaryLine: source.summaryLine,
@@ -979,6 +990,7 @@ async function runSyntheticOverflowSummary(params: {
     errorContext: "followup overflow summary transcript",
   });
   const currentInboundEventKind = resolveOverflowSummaryInboundEventKind(params.sources);
+  const runtimeMetadata = collectRuntimeMetadata(params.sources);
   let admitted = false;
   await params.runFollowup({
     prompt: params.prompt,
@@ -989,7 +1001,8 @@ async function runSyntheticOverflowSummary(params: {
     run: params.source.run,
     enqueuedAt: Date.now(),
     abortSignal: params.abortSignal,
-    onReplyAdmissionWaitChange: collectRuntimeMetadata(params.sources).onReplyAdmissionWaitChange,
+    onReplyAdmissionWaitChange: runtimeMetadata.onReplyAdmissionWaitChange,
+    explicitSkillSelections: runtimeMetadata.explicitSkillSelections,
     ...(params.onAdmitted
       ? {
           turnAdoptionLifecycle: {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -18,7 +18,7 @@ import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js
 import type { PluginHookChannelContext } from "../../../plugins/hook-types.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
-import type { SkillSnapshot } from "../../../skills/types.js";
+import type { ExplicitSkillSelection, SkillSnapshot } from "../../../skills/types.js";
 import type {
   QueuedReplyDeliveryCorrelation,
   SourceReplyDeliveryMode,
@@ -83,6 +83,8 @@ export type FollowupRun = {
   currentInboundAudio?: boolean;
   /** Explicit current-turn context that should be visible for this run but not persisted as user text. */
   currentInboundContext?: CurrentInboundPromptContext;
+  /** Explicit skills resolved from the authenticated inbound message. */
+  explicitSkillSelections?: ExplicitSkillSelection[];
   /** Abort signal for turns that are canceled by their source-channel admission fence. */
   abortSignal?: AbortSignal;
   /** Queue-owned cancellation fence used when lifecycle cleanup invalidates pending work. */

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -60,6 +60,11 @@ export type SkillUsagePath = {
   skillSource: SkillTelemetrySource;
 };
 
+export type ExplicitSkillSelection = {
+  name: string;
+  path: string;
+};
+
 export type SkillCommandSpec = {
   name: string;
   /** Canonical SKILL.md path for file-scoped usage accounting. */


### PR DESCRIPTION
Closes #123367 (Phase 2, final phase)

## What Problem This Solves

Phase 1 (#123387) made explicit `$skill-name` references resolve on every channel via the reply-pipeline instruction block. On the Codex app-server harness, Codex's own byte scanner also selects skills it discovers from the same `$` tokens, so a skill known to both products was handled twice (OpenClaw instruction + Codex native body injection), and OpenClaw had no way to hand Codex a structured, provenance-clean selection.

## Why This Change Was Made

OpenClaw-resolved selections now travel as data (`ExplicitSkillSelection { name, path }`) from the inline-action resolver through the queue/drain and embedded-runner params to the Codex adapter, which matches them against the Codex catalog (`skills/list`, path-matched, enabled-only) and appends structured `UserInput::Skill` items to the turn input. Codex contract (verified in codex-rs at `91d6f48992ad`): `UserInput::Skill` exists in the v2 app-server protocol (`app-server-protocol/src/protocol/v2/turn.rs:292-324`) and structured skill inputs add their names to `blocked_plain_names` (`skills/src/selection.rs:60-92`), so Codex's text scanner cannot double-select the same skill while Codex-native-only names stay scannable. Catalog misses and RPC errors fail open to the instruction path — the turn never fails on skill lookup, and the instruction block keeps owning skills Codex cannot see.

One red-main heal rides this PR per landing policy:
- `fix(plugins)`: llama-cpp's `llama-server-install.ts` statically imported the `ssrf-runtime` barrel inside the doctor/legacy-setup closure (landed with #123105), failing the doctor-contract closure guard whenever a PR selects that lane. Deferred to a dynamic import at download time, the guard's stated remedy.
- (An initial lane-ownership heal for `run-attempt-state.test.ts` was superseded mid-flight by c28e9a478ea on `main`, which settled ownership on the attempt-light lane; the commit was dropped from this PR after verifying the audit is green on the rebased head.)

## User Impact

Codex-harness agents get native skill injection for explicitly referenced skills with no double selection; behavior on other harnesses is unchanged. No config surface added.

## Evidence

- Focused suites green: explicit-skill-input (stub client: match, disabled/unmatched skip, RPC-error fail-open, no-RPC-on-empty), turn-params shape, inline-actions selection capture, queue media-carrier merge — 169 tests across 4 files; ownership audit 21 passed (fails on current `origin/main`, proving the heal); doctor closure guard + llama-cpp suites green post-heal.
- `pnpm plugin-sdk:surface:check` passed (field flows structurally; no regen needed).
- Codex autoreview clean (gpt-5.6-sol, high): "patch is correct (0.98)".
- Production LOC ~+115/−9 (new capability: structured selection threading + codex matcher); tests +172/−5.
