### PR TITLE
chore(release): sign 2026.8.1-beta.2 source candidate

### DIFF
--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/acpx",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw ACP runtime backend with plugin-owned session and transport management.",
   "repository": {
     "type": "git",
@@ -43,10 +43,10 @@
       ]
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "staticAssets": [
         {
           "source": "./src/runtime-internals/mcp-proxy.mjs",

--- a/extensions/admin-http-rpc/package.json
+++ b/extensions/admin-http-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/admin-http-rpc",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw admin HTTP RPC endpoint",
   "type": "module",

--- a/extensions/alibaba/package.json
+++ b/extensions/alibaba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/alibaba-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Alibaba Model Studio video provider plugin",
   "type": "module",

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Amazon Bedrock Mantle provider plugin for OpenAI-compatible model routing.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/amazon-bedrock/package.json
+++ b/extensions/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "repository": {
     "type": "git",
@@ -28,10 +28,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
   "repository": {
     "type": "git",
@@ -25,10 +25,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic/package.json
+++ b/extensions/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Anthropic provider, Claude CLI, and native session catalog plugin",
   "type": "module",

--- a/extensions/arcee/package.json
+++ b/extensions/arcee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/arcee-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Arcee provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/azure-speech/package.json
+++ b/extensions/azure-speech/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/azure-speech",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Azure Speech plugin",
   "type": "module",

--- a/extensions/baseten/package.json
+++ b/extensions/baseten/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/baseten-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Baseten provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/beam/package.json
+++ b/extensions/beam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/beam",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "Read-only coding-session Beam receiver",
   "type": "module",

--- a/extensions/bonjour/package.json
+++ b/extensions/bonjour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/bonjour",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Bonjour/mDNS gateway discovery",
   "type": "module",
   "dependencies": {

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/brave-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Brave Search provider plugin for web search.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/browser-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw browser tool plugin",
   "type": "module",

--- a/extensions/buzz/package.json
+++ b/extensions/buzz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/buzz",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "Connect OpenClaw agents to Buzz rooms",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -71,7 +71,9 @@
               "flags": "--use-env",
               "description": "Use BUZZ_PRIVATE_KEY with the supplied relay URL"
             },
-            "envVars": ["BUZZ_PRIVATE_KEY"]
+            "envVars": [
+              "BUZZ_PRIVATE_KEY"
+            ]
           }
         ]
       }
@@ -83,10 +85,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/byteplus/package.json
+++ b/extensions/byteplus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/byteplus-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw BytePlus provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/canvas/package.json
+++ b/extensions/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/canvas-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Canvas plugin",
   "type": "module",

--- a/extensions/cerebras/package.json
+++ b/extensions/cerebras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cerebras-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Cerebras provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/chutes/package.json
+++ b/extensions/chutes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/chutes-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Chutes.ai provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/clawrouter/package.json
+++ b/extensions/clawrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clawrouter",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw ClawRouter plugin",
   "type": "module",

--- a/extensions/clickclack/package.json
+++ b/extensions/clickclack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clickclack",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw ClickClack channel plugin",
   "type": "module",
   "exports": {
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -128,7 +128,9 @@
               "flags": "--use-env",
               "description": "Use CLICKCLACK_BOT_TOKEN"
             },
-            "envVars": ["CLICKCLACK_BOT_TOKEN"]
+            "envVars": [
+              "CLICKCLACK_BOT_TOKEN"
+            ]
           }
         ]
       }
@@ -141,10 +143,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/cloudflare-ai-gateway/package.json
+++ b/extensions/cloudflare-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cloudflare-ai-gateway-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Cloudflare AI Gateway provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Codex app-server harness and native session supervision plugin.",
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
       ]
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/cohere/package.json
+++ b/extensions/cohere/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cohere-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Cohere provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/comfy/package.json
+++ b/extensions/comfy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/comfy-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw ComfyUI provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot-proxy",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw GitHub Copilot agent runtime plugin (registers a `github-copilot` AgentHarness backed by @github/copilot-sdk over JSON-RPC to the GitHub Copilot CLI)",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/crabbox/package.json
+++ b/extensions/crabbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw cloud worker provider backed by the Crabbox CLI",
   "type": "module",

--- a/extensions/cua-computer/package.json
+++ b/extensions/cua-computer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cua-computer",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "Experimental CUA Driver SDK computer control for Windows and Linux node hosts",
   "type": "module",
   "dependencies": {

--- a/extensions/deepgram/package.json
+++ b/extensions/deepgram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepgram-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Deepgram media-understanding provider",
   "type": "module",

--- a/extensions/deepinfra/package.json
+++ b/extensions/deepinfra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepinfra-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw DeepInfra provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/deepseek/package.json
+++ b/extensions/deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepseek-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw DeepSeek provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics, traces, and logs.",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diagnostics-prometheus/package.json
+++ b/extensions/diagnostics-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-prometheus",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diffs-language-pack/package.json
+++ b/extensions/diffs-language-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw diffs viewer syntax highlighting language pack",
   "repository": {
     "type": "git",
@@ -22,13 +22,13 @@
       "minHostVersion": ">=2026.5.27"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "assetScripts": {
       "build": "node --import tsx ../../scripts/build-diffs-viewer-runtime.mts full"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
   "repository": {
     "type": "git",
@@ -28,13 +28,13 @@
       "minHostVersion": ">=2026.4.30"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "assetScripts": {
       "build": "node --import tsx ../../scripts/build-diffs-viewer-runtime.mts curated"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -75,7 +75,9 @@
               "flags": "--use-env",
               "description": "Use DISCORD_BOT_TOKEN"
             },
-            "envVars": ["DISCORD_BOT_TOKEN"]
+            "envVars": [
+              "DISCORD_BOT_TOKEN"
+            ]
           }
         ]
       },
@@ -97,10 +99,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "staticAssets": [
         {
           "source": "./assets/embedded-app-sdk.mjs",

--- a/extensions/document-extract/package.json
+++ b/extensions/document-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/document-extract-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw local document extraction plugin",
   "type": "module",

--- a/extensions/duckduckgo/package.json
+++ b/extensions/duckduckgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/duckduckgo-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw DuckDuckGo plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/elevenlabs/package.json
+++ b/extensions/elevenlabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/elevenlabs-speech",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw ElevenLabs speech plugin",
   "type": "module",

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/exa-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Exa plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/fal/package.json
+++ b/extensions/fal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fal-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw fal provider plugin",
   "type": "module",

--- a/extensions/featherless/package.json
+++ b/extensions/featherless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/featherless-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Featherless AI provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.11"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -64,10 +64,10 @@
       "minHostVersion": ">=2026.5.29"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/file-transfer/package.json
+++ b/extensions/file-transfer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/file-transfer",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw file transfer plugin (file_fetch, dir_list, dir_fetch, file_write)",
   "type": "module",
   "dependencies": {

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/firecrawl-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Firecrawl plugin.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/fireworks/package.json
+++ b/extensions/fireworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fireworks-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Fireworks provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/fish-audio-speech/package.json
+++ b/extensions/fish-audio-speech/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fish-audio-speech",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Fish Audio speech plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/github-copilot/package.json
+++ b/extensions/github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/github-copilot-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw GitHub Copilot provider plugin",
   "type": "module",

--- a/extensions/gmi/package.json
+++ b/extensions/gmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gmi-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw GMI Cloud provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-meet",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Google Meet participant plugin for joining calls through Chrome or Twilio transports.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -34,10 +34,10 @@
       "minHostVersion": ">=2026.4.20"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/google/package.json
+++ b/extensions/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Google plugin",
   "type": "module",

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -123,7 +123,10 @@
               "flags": "--use-env",
               "description": "Use Google Chat environment credentials"
             },
-            "envVars": ["GOOGLE_CHAT_SERVICE_ACCOUNT", "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"],
+            "envVars": [
+              "GOOGLE_CHAT_SERVICE_ACCOUNT",
+              "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"
+            ],
             "envVarMode": "any"
           }
         ]
@@ -135,10 +138,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/gradium/package.json
+++ b/extensions/gradium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gradium-speech",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Gradium speech plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/groq-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Groq media-understanding provider.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/huggingface/package.json
+++ b/extensions/huggingface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/huggingface-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Hugging Face provider plugin",
   "type": "module",

--- a/extensions/image-generation-core/package.json
+++ b/extensions/image-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/image-generation-core",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw image generation runtime package",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/imessage",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -96,10 +96,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/inworld/package.json
+++ b/extensions/inworld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/inworld-speech",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Inworld speech plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/irc",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw IRC channel plugin",
   "type": "module",
   "devDependencies": {
@@ -115,16 +115,19 @@
               "flags": "--use-env",
               "description": "Use IRC environment configuration"
             },
-            "envVars": ["IRC_HOST", "IRC_NICK"]
+            "envVars": [
+              "IRC_HOST",
+              "IRC_NICK"
+            ]
           }
         ]
       }
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/kilocode/package.json
+++ b/extensions/kilocode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kilocode-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Kilo Gateway provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/kimi-coding/package.json
+++ b/extensions/kimi-coding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kimi-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Kimi provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -101,7 +101,10 @@
               "flags": "--use-env",
               "description": "Use LINE environment credentials"
             },
-            "envVars": ["LINE_CHANNEL_ACCESS_TOKEN", "LINE_CHANNEL_SECRET"]
+            "envVars": [
+              "LINE_CHANNEL_ACCESS_TOKEN",
+              "LINE_CHANNEL_SECRET"
+            ]
           }
         ]
       }
@@ -112,10 +115,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/linux-canvas/package.json
+++ b/extensions/linux-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/linux-canvas",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Linux desktop canvas bridge",
   "type": "module",
   "dependencies": {

--- a/extensions/linux-node/package.json
+++ b/extensions/linux-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/linux-node",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Linux node device capabilities",
   "type": "module",
   "dependencies": {

--- a/extensions/litellm/package.json
+++ b/extensions/litellm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/litellm-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw LiteLLM provider plugin",
   "type": "module",

--- a/extensions/llama-cpp/package.json
+++ b/extensions/llama-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llama-cpp-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw managed llama.cpp server provider plugin",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.6.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llm-task",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",

--- a/extensions/lmstudio/package.json
+++ b/extensions/lmstudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lmstudio-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw LM Studio provider plugin",
   "type": "module",

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/logbook/package.json
+++ b/extensions/logbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/logbook",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw automatic work journal plugin",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/longcat/package.json
+++ b/extensions/longcat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/longcat-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw LongCat provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -171,10 +171,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mattermost",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Mattermost channel plugin",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -79,7 +79,10 @@
               "flags": "--use-env",
               "description": "Use Mattermost environment credentials"
             },
-            "envVars": ["MATTERMOST_BOT_TOKEN", "MATTERMOST_URL"]
+            "envVars": [
+              "MATTERMOST_BOT_TOKEN",
+              "MATTERMOST_URL"
+            ]
           }
         ]
       }
@@ -92,10 +95,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/media-understanding-core/package.json
+++ b/extensions/media-understanding-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/media-understanding-core",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw media understanding runtime package",
   "type": "module",

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-core",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",
@@ -18,7 +18,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.5.31"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-wiki",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw persistent wiki plugin",
   "type": "module",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/meta/package.json
+++ b/extensions/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/meta-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Meta provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.11"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/microsoft-foundry/package.json
+++ b/extensions/microsoft-foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-foundry",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Microsoft Foundry provider plugin",
   "type": "module",

--- a/extensions/microsoft/package.json
+++ b/extensions/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-speech",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Microsoft speech plugin",
   "type": "module",

--- a/extensions/migrate-claude/package.json
+++ b/extensions/migrate-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-claude",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "Claude to OpenClaw migration provider",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/migrate-hermes/package.json
+++ b/extensions/migrate-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-hermes",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "Hermes to OpenClaw migration provider",
   "type": "module",
@@ -13,7 +13,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/minimax/package.json
+++ b/extensions/minimax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/minimax-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw MiniMax provider and OAuth plugin",
   "type": "module",

--- a/extensions/mistral/package.json
+++ b/extensions/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mistral-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Mistral provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/moonshot/package.json
+++ b/extensions/moonshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/moonshot-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Moonshot provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -70,10 +70,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "runtimeFormat": "cjs"
     },
     "release": {

--- a/extensions/mxc/package.json
+++ b/extensions/mxc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mxc-sandbox",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw MXC sandbox execution plugin for MXC-capable hosts",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.6.11"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false,
       "staticAssets": [
         {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -118,7 +118,9 @@
               "flags": "--use-env",
               "description": "Use Nextcloud Talk environment credentials"
             },
-            "envVars": ["NEXTCLOUD_TALK_BOT_SECRET"]
+            "envVars": [
+              "NEXTCLOUD_TALK_BOT_SECRET"
+            ]
           }
         ]
       }
@@ -129,10 +131,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -70,7 +70,9 @@
               "flags": "--use-env",
               "description": "Use NOSTR_PRIVATE_KEY"
             },
-            "envVars": ["NOSTR_PRIVATE_KEY"]
+            "envVars": [
+              "NOSTR_PRIVATE_KEY"
+            ]
           }
         ]
       }
@@ -81,10 +83,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/novita/package.json
+++ b/extensions/novita/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/novita-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw NovitaAI provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/nvidia/package.json
+++ b/extensions/nvidia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nvidia-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw NVIDIA provider plugin",
   "type": "module",

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/oc-path",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
@@ -14,7 +14,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/ollama/package.json
+++ b/extensions/ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/ollama-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Ollama provider plugin",
   "type": "module",

--- a/extensions/onepassword/package.json
+++ b/extensions/onepassword/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/onepassword",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "1Password SecretRef resolver and audited agent secrets broker for OpenClaw",
   "type": "module",

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/open-prose",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",

--- a/extensions/openai/package.json
+++ b/extensions/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openai-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw OpenAI provider plugins",
   "type": "module",

--- a/extensions/opencode-go/package.json
+++ b/extensions/opencode-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-go-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw OpenCode Go provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": true
     },
     "release": {

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw OpenCode Zen provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/openrouter/package.json
+++ b/extensions/openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openrouter-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw OpenRouter provider plugin",
   "type": "module",

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openshell-sandbox",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/parallel/package.json
+++ b/extensions/parallel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/parallel-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Parallel web search plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/perplexity/package.json
+++ b/extensions/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/perplexity-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Perplexity plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/pixverse/package.json
+++ b/extensions/pixverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/pixverse-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw PixVerse video generation provider plugin.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.5.26"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/policy/package.json
+++ b/extensions/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/policy",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw policy doctor checks for workspace conformance",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-channel",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw QA synthetic channel plugin",
   "type": "module",
@@ -19,7 +19,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-lab",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner",
   "type": "module",
@@ -27,7 +27,7 @@
     "vite": "8.1.5"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -39,7 +39,7 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     }
   }
 }

--- a/extensions/qianfan/package.json
+++ b/extensions/qianfan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qianfan-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Qianfan provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/qwen/package.json
+++ b/extensions/qwen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qwen-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Qwen Cloud provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/raft/package.json
+++ b/extensions/raft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/raft",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Raft channel plugin for Raft CLI wake bridges.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "channel": {
       "id": "raft",

--- a/extensions/reef/package.json
+++ b/extensions/reef/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/reef",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Reef channel plugin — guarded end-to-end encrypted claw-to-claw messaging",
   "type": "module",
   "dependencies": {

--- a/extensions/runway/package.json
+++ b/extensions/runway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/runway-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Runway video provider plugin",
   "type": "module",

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/searxng-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw SearXNG plugin",
   "type": "module",
   "devDependencies": {
@@ -18,10 +18,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/senseaudio/package.json
+++ b/extensions/senseaudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/senseaudio-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw SenseAudio media-understanding provider",
   "type": "module",

--- a/extensions/sglang/package.json
+++ b/extensions/sglang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sglang-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw SGLang provider plugin",
   "type": "module",

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/signal",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Signal channel plugin",
   "type": "module",
   "dependencies": {
@@ -96,10 +96,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -140,7 +140,9 @@
               "flags": "--use-env",
               "description": "Use Slack environment credentials"
             },
-            "envVars": ["SLACK_BOT_TOKEN"]
+            "envVars": [
+              "SLACK_BOT_TOKEN"
+            ]
           }
         ]
       }
@@ -152,10 +154,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/sms/package.json
+++ b/extensions/sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sms",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw SMS/MMS channel plugin for Twilio messages.",
   "repository": {
     "type": "git",
@@ -127,10 +127,10 @@
       }
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "install": {

--- a/extensions/stepfun/package.json
+++ b/extensions/stepfun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/stepfun-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw StepFun provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
   "repository": {
     "type": "git",
@@ -69,7 +69,9 @@
               "flags": "--use-env",
               "description": "Use Synology Chat environment credentials"
             },
-            "envVars": ["SYNOLOGY_CHAT_TOKEN"]
+            "envVars": [
+              "SYNOLOGY_CHAT_TOKEN"
+            ]
           }
         ]
       }
@@ -80,10 +82,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/synology-chat/src/core.test.ts
+++ b/extensions/synology-chat/src/core.test.ts
@@ -7,7 +7,7 @@ import {
   runSetupWizardConfigure,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAccountIds, resolveAccount } from "./accounts.js";
 import { SynologyChatChannelConfigSchema } from "./config-schema.js";
 import {
@@ -32,7 +32,24 @@ const synologyChatSetupPlugin = {
 };
 
 const synologyChatConfigure = createPluginSetupWizardConfigure(synologyChatSetupPlugin);
-const originalEnv = { ...process.env };
+const synologyTestEnvKeys = [
+  "SYNOLOGY_CHAT_TOKEN",
+  "SYNOLOGY_CHAT_INCOMING_URL",
+  "SYNOLOGY_NAS_HOST",
+  "SYNOLOGY_ALLOWED_USER_IDS",
+  "SYNOLOGY_RATE_LIMIT",
+  "OPENCLAW_BOT_NAME",
+] as const;
+
+function clearSynologyTestEnv(): void {
+  vi.unstubAllEnvs();
+  for (const key of synologyTestEnvKeys) {
+    delete process.env[key];
+  }
+}
+
+beforeEach(clearSynologyTestEnv);
+afterEach(clearSynologyTestEnv);
 
 function createSynologySetupPrompter(params: { allowedUserIds?: string } = {}) {
   return createTestWizardPrompter({
@@ -75,22 +92,6 @@ async function expectDmAuthorization(params: {
 }
 
 describe("synology-chat core", () => {
-  afterAll(() => {
-    vi.unstubAllEnvs();
-    process.env = { ...originalEnv };
-  });
-
-  beforeEach(() => {
-    vi.unstubAllEnvs();
-    process.env = { ...originalEnv };
-    delete process.env.SYNOLOGY_CHAT_TOKEN;
-    delete process.env.SYNOLOGY_CHAT_INCOMING_URL;
-    delete process.env.SYNOLOGY_NAS_HOST;
-    delete process.env.SYNOLOGY_ALLOWED_USER_IDS;
-    delete process.env.SYNOLOGY_RATE_LIMIT;
-    delete process.env.OPENCLAW_BOT_NAME;
-  });
-
   it("exports dangerouslyAllowNameMatching in the JSON schema", () => {
     const properties = (SynologyChatChannelConfigSchema.schema.properties ?? {}) as Record<
       string,

--- a/extensions/synthetic/package.json
+++ b/extensions/synthetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synthetic-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Synthetic provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tavily-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Tavily plugin",
   "type": "module",
   "dependencies": {
@@ -21,10 +21,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/teams-meetings/package.json
+++ b/extensions/teams-meetings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/teams-meetings",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Microsoft Teams browser meeting participant plugin.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/telegram",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",
@@ -75,7 +75,9 @@
               "flags": "--use-env",
               "description": "Use TELEGRAM_BOT_TOKEN"
             },
-            "envVars": ["TELEGRAM_BOT_TOKEN"]
+            "envVars": [
+              "TELEGRAM_BOT_TOKEN"
+            ]
           }
         ]
       },

--- a/extensions/telegram/src/bot-native-command-plugins.test.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.test.ts
@@ -1,14 +1,10 @@
-import {
-  createEmptyPluginRegistry,
-  resetPluginRuntimeStateForTest,
-  setActivePluginRegistry,
-} from "openclaw/plugin-sdk/channel-test-helpers";
 // Telegram tests cover bot native commands plugin behavior.
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { clearPluginCommands, registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTelegramTopicCommandContext } from "./bot-native-commands.fixture-test-support.js";
+import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 import {
   createCommandBot,
   createNativeCommandTestParams,
@@ -25,16 +21,41 @@ const pluginSessionMocks = vi.hoisted(() => ({
   resolveStorePath: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/session-store-runtime")>(
-    "openclaw/plugin-sdk/session-store-runtime",
-  );
-  return {
-    ...actual,
-    getSessionEntry: pluginSessionMocks.getSessionEntry,
-    resolveStorePath: pluginSessionMocks.resolveStorePath,
-  };
-});
+vi.mock("./bot-native-commands.runtime.js", () => ({
+  ensureConfiguredBindingRouteReady: vi.fn(async () => ({ ok: true })),
+  finalizeInboundContext: vi.fn((ctx: unknown) => ctx),
+  getAgentScopedMediaLocalRoots: vi.fn((_cfg: OpenClawConfig, agentId: string) => [
+    `/tmp/.openclaw/workspace-${agentId}`,
+  ]),
+  getSessionEntry: pluginSessionMocks.getSessionEntry,
+  resolveChunkMode: vi.fn(() => "length"),
+  resolveThreadSessionKeys: vi.fn(
+    ({
+      baseSessionKey,
+      parentSessionKey,
+    }: {
+      baseSessionKey: string;
+      parentSessionKey?: string;
+    }) => ({
+      sessionKey: baseSessionKey,
+      parentSessionKey,
+    }),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/session-store-runtime", () => ({
+  formatSqliteSessionFileMarker: ({
+    agentId,
+    sessionId,
+    storePath,
+  }: {
+    agentId: string;
+    sessionId: string;
+    storePath: string;
+  }) => `sqlite:${agentId}:${sessionId}:${storePath}`,
+  getSessionEntry: pluginSessionMocks.getSessionEntry,
+  resolveStorePath: pluginSessionMocks.resolveStorePath,
+}));
 type CommandBotHarness = ReturnType<typeof createCommandBot>;
 type PlugCommandHarnessParams = {
   botHarness?: CommandBotHarness;
@@ -136,17 +157,12 @@ function replyAt(params: Record<string, unknown>, index = 0) {
   return reply;
 }
 
-resetPluginRuntimeStateForTest();
-setActivePluginRegistry(createEmptyPluginRegistry());
-const { registerTelegramNativeCommands } = await import("./bot-native-commands.js");
-registerTelegramNativeCommands(createNativeCommandTestParams({}));
+afterAll(() => clearPluginCommands());
 
 describe("registerTelegramNativeCommands", () => {
   beforeEach(() => {
     resetTelegramForumFlagCacheForTest();
     resetNativeCommandMenuMocks();
-    resetPluginRuntimeStateForTest();
-    setActivePluginRegistry(createEmptyPluginRegistry());
     clearPluginCommands();
     pluginCommandHandler.mockReset().mockResolvedValue({ text: "ok" });
     pluginSessionMocks.getSessionEntry.mockReset().mockReturnValue(undefined);

--- a/extensions/tencent/package.json
+++ b/extensions/tencent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tencent-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Tencent Cloud provider plugin (TokenHub + Token Plan)",
   "type": "module",
   "devDependencies": {
@@ -18,10 +18,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -120,10 +120,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/together/package.json
+++ b/extensions/together/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/together-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw Together provider plugin",
   "type": "module",

--- a/extensions/tokenjuice/package.json
+++ b/extensions/tokenjuice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tokenjuice",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw tokenjuice exec output compaction plugin",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "tokenjuice": "0.8.1"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tts-local-cli/package.json
+++ b/extensions/tts-local-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tts-local-cli",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw local CLI TTS plugin",
   "type": "module",

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "channel": {
       "id": "twitch",

--- a/extensions/vault/package.json
+++ b/extensions/vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vault",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "HashiCorp Vault SecretRef provider integration for OpenClaw",
   "type": "module",

--- a/extensions/venice/package.json
+++ b/extensions/venice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/venice-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Venice provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/vercel-ai-gateway/package.json
+++ b/extensions/vercel-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vercel-ai-gateway-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Vercel AI Gateway provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/vllm/package.json
+++ b/extensions/vllm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vllm-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw vLLM provider plugin",
   "type": "module",

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -34,10 +34,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/volcengine/package.json
+++ b/extensions/volcengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/volcengine-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Volcengine provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/voyage/package.json
+++ b/extensions/voyage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voyage-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Voyage embedding provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/vydra/package.json
+++ b/extensions/vydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vydra-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Vydra media provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/web-readability/package.json
+++ b/extensions/web-readability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/web-readability-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw local Readability web extraction plugin",
   "type": "module",

--- a/extensions/webhooks/package.json
+++ b/extensions/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/webhooks",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw webhook bridge plugin",
   "type": "module",

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -69,10 +69,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
+++ b/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
@@ -18,6 +18,12 @@ import { createTestWebInboundMessage } from "./inbound/test-message.test-helper.
 
 installWebAutoReplyTestHomeHooks();
 
+const whatsappAccountOwner = (accountId = "default") =>
+  ({
+    agentId: "alfred",
+    match: { channel: "whatsapp", accountId },
+  }) satisfies NonNullable<OpenClawConfig["bindings"]>[number];
+
 describe("broadcast groups", () => {
   installWebAutoReplyUnitTestHooks();
 
@@ -47,6 +53,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner()],
       broadcast: {
         strategy: "sequential",
         "+1000": ["alfred", "baerbel"],
@@ -68,6 +75,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner()],
       broadcast: {
         strategy: "sequential",
         "123@g.us": ["alfred", "baerbel"],
@@ -157,6 +165,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner("work")],
       broadcast: {
         strategy: "sequential",
         "123@g.us": ["alfred", "baerbel"],
@@ -199,6 +208,7 @@ describe("broadcast groups", () => {
         defaults: { maxConcurrent: 10 },
         list: [{ id: "alfred" }, { id: "baerbel" }],
       },
+      bindings: [whatsappAccountOwner()],
       broadcast: {
         strategy: "parallel",
         "+1000": ["alfred", "baerbel"],

--- a/extensions/whatsapp/src/monitor-inbox.policy.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.policy.test.ts
@@ -122,14 +122,13 @@ describe("web monitor inbox", () => {
         }),
       ),
     );
-    await vi.waitFor(() => expectPairingPromptSent(sock, "999@s.whatsapp.net", "+999"));
+    await listener.close();
 
+    expectPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
     // Should NOT call onMessage for unauthorized senders
     expect(onMessage).not.toHaveBeenCalled();
     // Should NOT send read receipts for blocked senders (privacy + avoids Baileys Bad MAC churn).
     expect(sock.readMessages).not.toHaveBeenCalled();
-
-    await listener.close();
   });
 
   it("delivery coordinator applies hot-reloaded dmPolicy to the active listener", async () => {

--- a/extensions/workboard/package.json
+++ b/extensions/workboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/workboard",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw dashboard workboard plugin",
   "type": "module",
@@ -13,7 +13,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xai-plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "private": true,
   "description": "OpenClaw xAI plugin",
   "type": "module",

--- a/extensions/xiaomi/package.json
+++ b/extensions/xiaomi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xiaomi-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Xiaomi provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/zai/package.json
+++ b/extensions/zai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zai-provider",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Z.AI provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -74,7 +74,9 @@
               "flags": "--use-env",
               "description": "Use ZALO_BOT_TOKEN"
             },
-            "envVars": ["ZALO_BOT_TOKEN"]
+            "envVars": [
+              "ZALO_BOT_TOKEN"
+            ]
           }
         ]
       }
@@ -85,10 +87,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -65,10 +65,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1-beta.2"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/zoom-meetings/package.json
+++ b/extensions/zoom-meetings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zoom-meetings",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "OpenClaw Zoom browser meeting participant plugin.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.8.1"
+    "openclaw": ">=2026.8.1-beta.2"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.8.1"
+      "pluginApi": ">=2026.8.1-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
+      "openclawVersion": "2026.8.1-beta.2",
       "bundledDist": false
     },
     "release": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "openclaw": {
     "schemaVersions": {
       "state": 7,
@@ -1852,7 +1852,7 @@
     "test:docker:update-migration": "env OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@2026.4.23} OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-plugin-deps-cleanup} bash scripts/e2e/upgrade-survivor-docker.sh",
     "test:docker:update-restart-auth": "env OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE=auto-auth OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT=${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s} bash scripts/e2e/upgrade-survivor-docker.sh",
     "test:docker:update-run-package-self-upgrade": "bash scripts/e2e/update-run-package-self-upgrade-docker.sh",
-    "test:docker:upgrade-survivor": "bash scripts/e2e/upgrade-survivor-docker.sh",
+    "test:docker:upgrade-survivor": "node --import tsx scripts/run-with-env.mts OPENCLAW_DOCKER_ALL_LANES=upgrade-survivor -- node scripts/test-docker-all.mjs",
     "test:env-mutations:report": "node --import tsx scripts/test-env-mutation-report.ts",
     "test:skip-inventory:report": "node --import tsx scripts/test-skip-inventory.ts",
     "test:type-suppression-inventory:report": "node --import tsx scripts/type-suppression-inventory.ts",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/ai",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "Reusable model provider adapters and streaming runtime from OpenClaw",
   "keywords": [
     "ai",

--- a/packages/gateway-client/package.json
+++ b/packages/gateway-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gateway-client",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "Reference WebSocket client for the OpenClaw Gateway protocol",
   "keywords": [
     "client",

--- a/packages/gateway-protocol/package.json
+++ b/packages/gateway-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gateway-protocol",
-  "version": "2026.8.1",
+  "version": "2026.8.1-beta.2",
   "description": "Typed schemas and runtime validators for the OpenClaw Gateway WebSocket protocol",
   "keywords": [
     "gateway",

--- a/scripts/github/dependency-guard.mjs
+++ b/scripts/github/dependency-guard.mjs
@@ -792,6 +792,27 @@ async function main() {
     return;
   }
 
+  const dependencyGraphChanges = await api.paginate(
+    `/repos/${owner}/${repo}/dependency-graph/compare/${pullRequest.base?.sha}...${pullRequest.head?.sha}`,
+  );
+  if (isRemovalOnlyDependencyGraphChange(dependencyGraphChanges)) {
+    if (mode === "detect") {
+      await setOutput("autoscrub", "false");
+    }
+    await upsertComment(
+      existingGuardComment,
+      renderRemovalOnlyDependencyComment({
+        dependencyGraphChanges,
+        headSha: pullRequest.head?.sha,
+      }),
+    );
+    await writeSummary(
+      "## Dependency Guard\n\nDependency removals are informational and do not require security approval.",
+    );
+    console.log("Dependency removals detected; guard is informational.");
+    return;
+  }
+
   const { isSecurityMember, isRepositoryAdmin } = createGuardApproverChecks({
     api,
     owner,
@@ -843,27 +864,6 @@ async function main() {
       ].join("\n"),
     );
     console.log("Dependency graph change noted for trusted actor; guard is informational.");
-    return;
-  }
-
-  const dependencyGraphChanges = await api.paginate(
-    `/repos/${owner}/${repo}/dependency-graph/compare/${pullRequest.base?.sha}...${pullRequest.head?.sha}`,
-  );
-  if (isRemovalOnlyDependencyGraphChange(dependencyGraphChanges)) {
-    if (mode === "detect") {
-      await setOutput("autoscrub", "false");
-    }
-    await upsertComment(
-      existingGuardComment,
-      renderRemovalOnlyDependencyComment({
-        dependencyGraphChanges,
-        headSha: pullRequest.head?.sha,
-      }),
-    );
-    await writeSummary(
-      "## Dependency Guard\n\nDependency removals are informational and do not require security approval.",
-    );
-    console.log("Dependency removals detected; guard is informational.");
     return;
   }
 

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -2,7 +2,7 @@
   "entries": [
     {
       "name": "@openclaw/buzz",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "Connect OpenClaw agents to Buzz rooms",
       "source": "official",
       "kind": "channel",
@@ -316,7 +316,7 @@
     },
     {
       "name": "@openclaw/clickclack",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw ClickClack channel plugin",
       "source": "official",
       "kind": "channel",
@@ -646,7 +646,7 @@
     },
     {
       "name": "@openclaw/discord",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
       "source": "official",
       "kind": "channel",
@@ -726,7 +726,7 @@
     },
     {
       "name": "@openclaw/feishu",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
       "source": "official",
       "kind": "channel",
@@ -784,7 +784,7 @@
     },
     {
       "name": "@openclaw/googlechat",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
       "source": "official",
       "kind": "channel",
@@ -902,7 +902,7 @@
     },
     {
       "name": "@openclaw/imessage",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac",
       "source": "official",
       "kind": "channel",
@@ -975,7 +975,7 @@
     },
     {
       "name": "@openclaw/irc",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw IRC channel plugin",
       "source": "official",
       "kind": "channel",
@@ -1093,7 +1093,7 @@
     },
     {
       "name": "@openclaw/line",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
       "source": "official",
       "kind": "channel",
@@ -1188,7 +1188,7 @@
     },
     {
       "name": "@openclaw/matrix",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
       "source": "official",
       "kind": "channel",
@@ -1330,7 +1330,7 @@
     },
     {
       "name": "@openclaw/mattermost",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Mattermost channel plugin",
       "source": "official",
       "kind": "channel",
@@ -1405,7 +1405,7 @@
     },
     {
       "name": "@openclaw/msteams",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
       "source": "official",
       "kind": "channel",
@@ -1449,7 +1449,7 @@
     },
     {
       "name": "@openclaw/nextcloud-talk",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
       "source": "official",
       "kind": "channel",
@@ -1561,7 +1561,7 @@
     },
     {
       "name": "@openclaw/nostr",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
       "source": "official",
       "kind": "channel",
@@ -1864,7 +1864,7 @@
     },
     {
       "name": "@openclaw/raft",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Raft channel plugin for Raft CLI wake bridges.",
       "source": "official",
       "kind": "channel",
@@ -1950,7 +1950,7 @@
     },
     {
       "name": "@openclaw/signal",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Signal channel plugin",
       "source": "official",
       "kind": "channel",
@@ -2036,7 +2036,7 @@
     },
     {
       "name": "@openclaw/slack",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
       "source": "official",
       "kind": "channel",
@@ -2169,7 +2169,7 @@
     },
     {
       "name": "@openclaw/sms",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw SMS/MMS channel plugin for Twilio messages.",
       "source": "official",
       "kind": "channel",
@@ -2294,7 +2294,7 @@
     },
     {
       "name": "@openclaw/synology-chat",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
       "source": "official",
       "kind": "channel",
@@ -2369,7 +2369,7 @@
     },
     {
       "name": "@openclaw/tlon",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
       "source": "official",
       "kind": "channel",
@@ -2463,7 +2463,7 @@
     },
     {
       "name": "@openclaw/twitch",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
       "source": "official",
       "kind": "channel",
@@ -2544,7 +2544,7 @@
     },
     {
       "name": "@openclaw/whatsapp",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
       "source": "official",
       "kind": "channel",
@@ -2643,7 +2643,7 @@
     },
     {
       "name": "@openclaw/zalo",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
       "source": "official",
       "kind": "channel",
@@ -2711,7 +2711,7 @@
     },
     {
       "name": "@openclaw/zalouser",
-      "version": "2026.8.1",
+      "version": "2026.8.1-beta.2",
       "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
       "source": "official",
       "kind": "channel",

--- a/scripts/lib/openclaw-test-state.mts
+++ b/scripts/lib/openclaw-test-state.mts
@@ -127,16 +127,20 @@ function scenarioConfig(scenario: string, options: TestStateOptions = {}) {
         },
       },
       agents: {
+        ownership: "explicit",
         defaults: {
           model: {
             primary: "openai/gpt-5.6-luna",
           },
           contextTokens: 64000,
           skills: ["memory"],
+          authInheritance: { agentId: "main" },
+          heartbeat: { agentId: "main" },
+          sessionStore: { agentId: "main" },
+          systemAgent: { agentId: "main" },
         },
         entries: {
           main: {
-            default: true,
             name: "Main",
             workspace: "~/workspace",
             model: {
@@ -156,6 +160,11 @@ function scenarioConfig(scenario: string, options: TestStateOptions = {}) {
           },
         },
       },
+      bindings: [
+        { agentId: "main", match: { channel: "discord", accountId: "*" } },
+        { agentId: "main", match: { channel: "telegram", accountId: "*" } },
+        { agentId: "main", match: { channel: "whatsapp", accountId: "*" } },
+      ],
       skills: {
         allowBundled: ["memory", "openclaw-testing"],
         limits: {
@@ -176,10 +185,8 @@ function scenarioConfig(scenario: string, options: TestStateOptions = {}) {
         discord: {
           enabled: true,
           token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
-          dm: {
-            policy: "allowlist",
-            allowFrom: ["111111111111111111"],
-          },
+          dmPolicy: "allowlist",
+          allowFrom: ["111111111111111111"],
           groupPolicy: "allowlist",
           guilds: {
             "222222222222222222": {
@@ -472,6 +479,7 @@ OPENCLAW_TEST_STATE_JSON
     }
   },
   "agents": {
+    "ownership": "explicit",
     "defaults": {
       "model": {
         "primary": "openai/gpt-5.6-luna"
@@ -479,12 +487,22 @@ OPENCLAW_TEST_STATE_JSON
       "contextTokens": 64000,
       "skills": [
         "memory"
-      ]
+      ],
+      "authInheritance": {
+        "agentId": "main"
+      },
+      "heartbeat": {
+        "agentId": "main"
+      },
+      "sessionStore": {
+        "agentId": "main"
+      },
+      "systemAgent": {
+        "agentId": "main"
+      }
     },
-    "list": [
-      {
-        "id": "main",
-        "default": true,
+    "entries": {
+      "main": {
         "name": "Main",
         "workspace": "~/workspace",
         "model": {
@@ -496,8 +514,7 @@ OPENCLAW_TEST_STATE_JSON
         ],
         "contextTokens": 64000
       },
-      {
-        "id": "ops",
+      "ops": {
         "name": "Ops",
         "workspace": "~/workspace/ops",
         "model": {
@@ -505,8 +522,31 @@ OPENCLAW_TEST_STATE_JSON
         },
         "fastModeDefault": true
       }
-    ]
+    }
   },
+  "bindings": [
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "discord",
+        "accountId": "*"
+      }
+    },
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "telegram",
+        "accountId": "*"
+      }
+    },
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "whatsapp",
+        "accountId": "*"
+      }
+    }
+  ],
   "skills": {
     "allowBundled": [
       "memory",
@@ -545,12 +585,10 @@ OPENCLAW_TEST_STATE_JSON
         "provider": "default",
         "id": "DISCORD_BOT_TOKEN"
       },
-      "dm": {
-        "policy": "allowlist",
-        "allowFrom": [
-          "111111111111111111"
-        ]
-      },
+      "dmPolicy": "allowlist",
+      "allowFrom": [
+        "111111111111111111"
+      ],
       "groupPolicy": "allowlist",
       "guilds": {
         "222222222222222222": {

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -1186,7 +1186,7 @@ async function prepareOpenClawPackage(baseEnv: NodeJS.ProcessEnv, logDir: string
     baseEnv.OPENCLAW_BUNDLED_CHANNEL_HOST_BUILD = "0";
     baseEnv.OPENCLAW_NPM_ONBOARD_HOST_BUILD = "0";
     console.log(`==> OpenClaw package: ${packageTgz}`);
-    return;
+    return false;
   }
 
   const packDir = path.join(logDir, "openclaw-package");
@@ -1205,6 +1205,67 @@ async function prepareOpenClawPackage(baseEnv: NodeJS.ProcessEnv, logDir: string
   baseEnv.OPENCLAW_BUNDLED_CHANNEL_HOST_BUILD = "0";
   baseEnv.OPENCLAW_NPM_ONBOARD_HOST_BUILD = "0";
   console.log(`==> OpenClaw package: ${baseEnv.OPENCLAW_CURRENT_PACKAGE_TGZ}`);
+  return true;
+}
+
+type PreparedPrepublishPluginRegistry = {
+  candidateVersion: string;
+  dir: string;
+  manifestSha256: string;
+};
+
+function preparePrepublishPluginRegistry(params: {
+  allowCreate: boolean;
+  baseEnv: NodeJS.ProcessEnv;
+  candidateVersion: string;
+  logDir: string;
+  plan: DockerCandidatePlan;
+  sourceSha: string;
+}): PreparedPrepublishPluginRegistry | null {
+  if (!params.plan.needs.prepublishPluginRegistry) {
+    return null;
+  }
+  const supplied = readCompleteTuple(
+    params.baseEnv,
+    REGISTRY_ENV_KEYS,
+    "Docker candidate registry",
+  );
+  if (supplied) {
+    params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR = path.resolve(
+      supplied.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+    );
+    validateRegistryEnvironment(params.baseEnv, params.plan);
+    return {
+      candidateVersion: supplied.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION,
+      dir: params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+      manifestSha256: supplied.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256,
+    };
+  }
+  if (!params.allowCreate) {
+    throw new Error(
+      "Docker plan requires a prepublish plugin registry tuple for the supplied package",
+    );
+  }
+
+  const registryDir = path.join(params.logDir, "prepublish-plugin-registry");
+  fs.rmSync(registryDir, { force: true, recursive: true });
+  const artifact = createPrepublishPluginRegistryArtifact({
+    repoRoot: ROOT_DIR,
+    outputDir: registryDir,
+    sourceSha: params.sourceSha,
+    candidateVersion: params.candidateVersion,
+    requiredPackages: params.plan.requiredPrepublishPluginPackages,
+  });
+  params.baseEnv.OPENCLAW_DOCKER_E2E_SELECTED_SHA = params.sourceSha;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR = registryDir;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION = params.candidateVersion;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256 = artifact.manifestSha256;
+  validateRegistryEnvironment(params.baseEnv, params.plan);
+  return {
+    candidateVersion: params.candidateVersion,
+    dir: registryDir,
+    manifestSha256: artifact.manifestSha256,
+  };
 }
 
 async function prepareDockerCandidate(
@@ -1222,29 +1283,21 @@ async function prepareDockerCandidate(
     for (const key of [...CANDIDATE_ENV_KEYS, ...REGISTRY_ENV_KEYS]) {
       delete candidateEnv[key];
     }
+    candidateEnv.OPENCLAW_DOCKER_E2E_SELECTED_SHA = sourceSha;
+    const version = rootPackageVersion(ROOT_DIR);
+    const registry = preparePrepublishPluginRegistry({
+      allowCreate: true,
+      baseEnv: candidateEnv,
+      candidateVersion: version,
+      logDir,
+      plan,
+      sourceSha,
+    });
     await prepareOpenClawPackage(candidateEnv, logDir);
     const packagePath = candidateEnv.OPENCLAW_CURRENT_PACKAGE_TGZ!;
     const packed = inspectNpmPackageTarball(packagePath);
-    const version = rootPackageVersion(ROOT_DIR);
     if (packed.packageJson.name !== "openclaw" || packed.packageJson.version !== version) {
       throw new Error("packed Docker candidate name or version differs from the root package");
-    }
-    let registry = null;
-    if (plan.needs.prepublishPluginRegistry) {
-      const registryDir = path.join(logDir, "prepublish-plugin-registry");
-      fs.rmSync(registryDir, { force: true, recursive: true });
-      const artifact = createPrepublishPluginRegistryArtifact({
-        repoRoot: ROOT_DIR,
-        outputDir: registryDir,
-        sourceSha,
-        candidateVersion: version,
-        requiredPackages: plan.requiredPrepublishPluginPackages,
-      });
-      registry = {
-        dir: registryDir,
-        candidateVersion: version,
-        manifestSha256: artifact.manifestSha256,
-      };
     }
     candidate = {
       package: { path: packagePath, name: packed.packageJson.name, version, sha256: packed.sha256 },
@@ -1908,6 +1961,18 @@ async function main() {
       `resolved zero runnable Docker lanes; frozen target does not support: ${omittedUnsupportedLaneNames.join(", ")}`,
     );
   }
+
+  const needsCurrentTreePackage =
+    lanesNeedOpenClawPackage(scheduledLanes) && !baseEnv.OPENCLAW_CURRENT_PACKAGE_TGZ;
+  preparePrepublishPluginRegistry({
+    allowCreate: needsCurrentTreePackage,
+    baseEnv,
+    candidateVersion: rootPackageVersion(ROOT_DIR),
+    logDir,
+    plan,
+    sourceSha: gitOutput(ROOT_DIR, ["rev-parse", "HEAD"]),
+  });
+  validateDockerCandidateEnvironment(baseEnv, plan);
 
   await runPhase(
     phases,

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -38,6 +38,8 @@ type WritePersistedInstalledPluginIndexInstallRecordsFn =
   (typeof import("../plugins/installed-plugin-index-records.js"))["writePersistedInstalledPluginIndexInstallRecords"];
 type WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn =
   (typeof import("../plugins/installed-plugin-index-records.js"))["writePersistedInstalledPluginIndexInstallRecordsWithLease"];
+type ReadPersistedInstalledPluginIndexInstallRecordsFn =
+  (typeof import("../plugins/installed-plugin-index-records.js"))["readPersistedInstalledPluginIndexInstallRecords"];
 type PluginInstallRecordMap = Record<string, PluginInstallRecord>;
 
 function createEmptyUninstallActions() {
@@ -55,6 +57,7 @@ function createEmptyUninstallActions() {
 }
 
 let mockInstalledPluginIndexInstallRecords: PluginInstallRecordMap = {};
+let mockPersistedPluginInstallRecords: PluginInstallRecordMap = {};
 let mockHookInstallRecords: Record<string, HookInstallRecord> = {};
 let mockInstalledPluginIndexRevision = 0;
 
@@ -112,9 +115,14 @@ export const recordPluginInstallMock: UnknownMock = vi.fn();
 const loadInstalledPluginIndexInstallRecords: AsyncUnknownMock = vi.fn(async () =>
   clonePluginInstallRecords(mockInstalledPluginIndexInstallRecords),
 );
+const readPersistedInstalledPluginIndexInstallRecords: Mock<ReadPersistedInstalledPluginIndexInstallRecordsFn> =
+  vi.fn<ReadPersistedInstalledPluginIndexInstallRecordsFn>(async () =>
+    clonePluginInstallRecords(mockPersistedPluginInstallRecords),
+  );
 const writePersistedInstalledPluginIndexInstallRecords: Mock<WritePersistedInstalledPluginIndexInstallRecordsFn> =
   vi.fn<WritePersistedInstalledPluginIndexInstallRecordsFn>(async (records) => {
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
     return "/tmp/openclaw-state/openclaw.sqlite";
   });
 export const readPersistedInstalledPluginIndexMock: Mock<ReadPersistedInstalledPluginIndexFn> =
@@ -123,6 +131,7 @@ export const writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock: Mock
   vi.fn<WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn>(async (records) => {
     const previous = await readPersistedInstalledPluginIndexMock();
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
     mockInstalledPluginIndexRevision += 1;
     return { previous, revision: mockInstalledPluginIndexRevision };
   });
@@ -132,6 +141,9 @@ export const restorePersistedInstalledPluginIndexIfCurrentMock: Mock<RestorePers
       return false;
     }
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(
+      (index?.installRecords ?? {}) as PluginInstallRecordMap,
+    );
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(
       (index?.installRecords ?? {}) as PluginInstallRecordMap,
     );
     mockInstalledPluginIndexRevision += 1;
@@ -214,6 +226,12 @@ export { runtimeErrors, pluginsCliRuntimeLogs };
 
 export function setInstalledPluginIndexInstallRecords(records: PluginInstallRecordMap): void {
   mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+  mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
+}
+
+export function setRecoveredPluginInstallRecords(records: PluginInstallRecordMap): void {
+  mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+  mockPersistedPluginInstallRecords = {};
 }
 
 function restoreRuntimeCaptureMocks() {
@@ -373,6 +391,10 @@ vi.mock("../plugins/installed-plugin-index-records.js", async (importOriginal) =
     ...actual,
     loadInstalledPluginIndexInstallRecords: ((...args: unknown[]) =>
       invokeMock<unknown[], unknown>(loadInstalledPluginIndexInstallRecords, ...args)) as (
+      ...args: unknown[]
+    ) => unknown,
+    readPersistedInstalledPluginIndexInstallRecords: ((...args: unknown[]) =>
+      invokeMock<unknown[], unknown>(readPersistedInstalledPluginIndexInstallRecords, ...args)) as (
       ...args: unknown[]
     ) => unknown,
     writePersistedInstalledPluginIndexInstallRecords: ((...args: unknown[]) =>
@@ -842,8 +864,10 @@ export function resetPluginsCliTestState() {
   enablePluginInConfigMock.mockReset();
   recordPluginInstallMock.mockReset();
   mockInstalledPluginIndexInstallRecords = {};
+  mockPersistedPluginInstallRecords = {};
   mockInstalledPluginIndexRevision = 0;
   loadInstalledPluginIndexInstallRecords.mockReset();
+  readPersistedInstalledPluginIndexInstallRecords.mockReset();
   writePersistedInstalledPluginIndexInstallRecords.mockReset();
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mockReset();
   readPersistedInstalledPluginIndexMock.mockReset();
@@ -932,8 +956,12 @@ export function resetPluginsCliTestState() {
   loadInstalledPluginIndexInstallRecords.mockImplementation(async () =>
     clonePluginInstallRecords(mockInstalledPluginIndexInstallRecords),
   );
+  readPersistedInstalledPluginIndexInstallRecords.mockImplementation(async () =>
+    clonePluginInstallRecords(mockPersistedPluginInstallRecords),
+  );
   writePersistedInstalledPluginIndexInstallRecords.mockImplementation(async (records) => {
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
     return "/tmp/openclaw-state/openclaw.sqlite";
   });
   readPersistedInstalledPluginIndexMock.mockResolvedValue(null);
@@ -941,6 +969,7 @@ export function resetPluginsCliTestState() {
     async (records) => {
       const previous = await readPersistedInstalledPluginIndexMock();
       mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+      mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
       mockInstalledPluginIndexRevision += 1;
       return { previous, revision: mockInstalledPluginIndexRevision };
     },
@@ -951,6 +980,9 @@ export function resetPluginsCliTestState() {
         return false;
       }
       mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(
+        (index?.installRecords ?? {}) as PluginInstallRecordMap,
+      );
+      mockPersistedPluginInstallRecords = clonePluginInstallRecords(
         (index?.installRecords ?? {}) as PluginInstallRecordMap,
       );
       mockInstalledPluginIndexRevision += 1;

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -930,7 +930,7 @@ describe("update-cli", () => {
     readPackageVersion.mockResolvedValue("2.0.0");
 
     mockPackageInstallStatus(tempDir);
-    primeNpmChannelTag("latest", "0.0.1");
+    primeNpmChannelTag(isBetaTag(VERSION) ? "beta" : "latest", "0.0.1");
     vi.mocked(runGatewayUpdate).mockResolvedValue({
       status: "ok",
       mode: "npm",
@@ -5418,7 +5418,9 @@ describe("update-cli", () => {
     expect(postCoreSpawn?.[1]).toEqual([entryPath, "update", "--no-restart", "--yes"]);
     expect(postCoreSpawn?.[2].stdio).toBe("inherit");
     expect(postCoreSpawn?.[2].env?.OPENCLAW_UPDATE_POST_CORE).toBe("1");
-    expect(postCoreSpawn?.[2].env?.OPENCLAW_UPDATE_POST_CORE_CHANNEL).toBe("stable");
+    expect(postCoreSpawn?.[2].env?.OPENCLAW_UPDATE_POST_CORE_CHANNEL).toBe(
+      isBetaTag(VERSION) ? "beta" : "stable",
+    );
     expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
     expect(getLogOutput()).not.toContain("already-current");
   });

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -542,6 +542,9 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note,
   });
   const cfg = finalized.cfg;
+  if (legacyDefaultAgentId) {
+    retainLegacyDefaultAgentId(cfg, legacyDefaultAgentId);
+  }
   const shouldWriteConfig = finalized.shouldWriteConfig && !legacyMigrationBlocksWrite;
   const singleTopLevelIncludeWrite =
     shouldWriteConfig &&

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -15,6 +15,7 @@ import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.
 import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
 import { printClawBanner } from "../cli/claw-banner.js";
+import { inheritLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
@@ -190,7 +191,7 @@ export function applyWizardMetadata(
 ): OpenClawConfig {
   const commit =
     normalizeOptionalString(process.env.GIT_COMMIT) ?? normalizeOptionalString(process.env.GIT_SHA);
-  return {
+  return inheritLegacyDefaultAgentId(cfg, {
     ...cfg,
     wizard: {
       ...cfg.wizard,
@@ -200,7 +201,7 @@ export function applyWizardMetadata(
       lastRunCommand: params.command,
       lastRunMode: params.mode,
     },
-  };
+  });
 }
 
 /** Formats the no-GUI SSH tunnel hint for opening the Control UI remotely. */

--- a/src/commands/onboard-helpers.wizard-metadata.test.ts
+++ b/src/commands/onboard-helpers.wizard-metadata.test.ts
@@ -1,0 +1,22 @@
+// Wizard metadata tests cover config provenance without losing migration ownership.
+import { describe, expect, it } from "vitest";
+import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
+import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applyWizardMetadata } from "./onboard-helpers.js";
+
+describe("applyWizardMetadata", () => {
+  it("preserves the migrated legacy owner across the config replacement", () => {
+    const cfg = migratePersistedImplicitMainRoster({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    }).config as OpenClawConfig;
+    expect(tryResolveLegacyCompatibilityAgentId(cfg)).toBe("main");
+
+    const result = applyWizardMetadata(cfg, { command: "doctor", mode: "local" });
+
+    expect(result).not.toBe(cfg);
+    expect(tryResolveLegacyCompatibilityAgentId(result)).toBe("main");
+  });
+});

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -282,9 +282,10 @@ function tryResolveDoctorStateMigrationAgentId(cfg: OpenClawConfig): string | un
 }
 
 function tryResolveDoctorSessionMigrationAgentId(cfg: OpenClawConfig): string | undefined {
+  const hasExplicitSessionStoreOwner = Boolean(cfg.agents?.defaults?.sessionStore?.agentId?.trim());
   return (
     tryResolveDoctorStateMigrationAgentId(cfg) ??
-    (!isPerAgentSessionStoreConfig(cfg.session?.store)
+    (hasExplicitSessionStoreOwner || !isPerAgentSessionStoreConfig(cfg.session?.store)
       ? resolveSessionStoreCompatibilityAgentId(cfg)
       : undefined)
   );

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1253,6 +1253,42 @@ describe("state migrations", () => {
     await expectMissingPath(path.join(stateDir, "credentials", "chatapp-allowFrom.json"));
   });
 
+  it("migrates the legacy session store for an explicit fixed-store owner", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(legacyStorePath), { recursive: true });
+    await fs.writeFile(
+      legacyStorePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "legacy-main", updatedAt: 20 },
+      }),
+      "utf8",
+    );
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        defaults: { sessionStore: { agentId: "main" } },
+        entries: { main: {}, ops: {} },
+      },
+    } satisfies OpenClawConfig;
+
+    const detected = await detectLegacyStateMigrations({ cfg, env, homedir: () => root });
+    expect(detected.targetAgentId).toBe("main");
+    expect(detected.sessions.hasLegacy).toBe(true);
+
+    await runLegacyStateMigrations({ detected, config: cfg, now: () => 1234 });
+
+    const targetStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const store = JSON.parse(await fs.readFile(targetStorePath, "utf8")) as Record<
+      string,
+      { sessionId: string }
+    >;
+    expect(store["agent:main:main"]?.sessionId).toBe("legacy-main");
+    await expectMissingPath(legacyStorePath);
+  });
+
   it("canonicalizes parsed owners before removing the legacy store", async () => {
     const root = await createTempDir();
     const stateDir = path.join(root, ".openclaw");

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -1,4 +1,3 @@
-// Plugin install persistence tests cover saving installed plugin records after install.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -16,6 +15,7 @@ import {
   resetPluginsCliTestState,
   pluginsCliRuntimeLogs,
   setInstalledPluginIndexInstallRecords,
+  setRecoveredPluginInstallRecords,
   configWriteMock,
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
   applyPluginUninstallDirectoryRemovalMock,
@@ -106,12 +106,18 @@ describe("persistPluginInstall", () => {
         },
       },
     } as OpenClawConfig;
+    const install = {
+      source: "npm" as const,
+      spec: "alpha@1.0.0",
+      installPath: "/tmp/alpha",
+    };
     enablePluginInConfigMock.mockImplementation((...args: unknown[]) => {
       const [cfg, pluginId] = args as [OpenClawConfig, string];
       expect(pluginId).toBe("alpha");
       expect(cfg.plugins?.allow).toEqual(["memory-core", "alpha"]);
       return { config: enabledConfig, enabled: true };
     });
+    setRecoveredPluginInstallRecords({ alpha: install });
 
     const next = await persistPluginInstall({
       snapshot: {
@@ -126,11 +132,7 @@ describe("persistPluginInstall", () => {
         },
       },
       pluginId: "alpha",
-      install: {
-        source: "npm",
-        spec: "alpha@1.0.0",
-        installPath: "/tmp/alpha",
-      },
+      install,
     });
 
     expect(next).toEqual(enabledConfig);

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -26,6 +26,7 @@ import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js
 import type { PluginInstallLogger } from "./install-types.js";
 import {
   loadInstalledPluginIndexInstallRecords,
+  readPersistedInstalledPluginIndexInstallRecords,
   recordPluginInstallInRecords,
   withoutPluginInstallRecords,
 } from "./installed-plugin-index-records.js";
@@ -494,12 +495,20 @@ export async function persistPluginInstall(params: {
     }
     runtime.log(theme.warn(message));
   };
-  const installRecords = await tracePluginLifecyclePhaseAsync(
+  const { installRecords, persistedInstallRecords } = await tracePluginLifecyclePhaseAsync(
     "install records load",
-    () => loadInstalledPluginIndexInstallRecords(),
+    async () => {
+      const [records, persisted] = await Promise.all([
+        loadInstalledPluginIndexInstallRecords(),
+        readPersistedInstalledPluginIndexInstallRecords(),
+      ]);
+      return { installRecords: records, persistedInstallRecords: persisted };
+    },
     { command: "install" },
   );
-  const previousInstall = installRecords[params.pluginId];
+  // Managed npm recovery sees the just-installed package before its first ledger commit.
+  // Only durable prior ownership preserves an operator's existing allow/deny policy.
+  const previousInstall = persistedInstallRecords?.[params.pluginId];
   const replacedInstallRemoval = resolveReplacedManagedInstallRemoval({
     pluginId: params.pluginId,
     previousInstall,

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -158,6 +158,12 @@ describe("package scripts", () => {
     );
   });
 
+  it("prepares unpublished plugin companions for the upgrade survivor", () => {
+    expect(readPackageJson().scripts["test:docker:upgrade-survivor"]).toBe(
+      "node --import tsx scripts/run-with-env.mts OPENCLAW_DOCKER_ALL_LANES=upgrade-survivor -- node scripts/test-docker-all.mjs",
+    );
+  });
+
   it("runs browser extension bootstrap E2E against real Chromium", () => {
     expect(readPackageJson().scripts["test:e2e:browser-extension"]).toBe(
       "node --import tsx scripts/run-with-env.mts PLAYWRIGHT_BROWSERS_PATH=.artifacts/playwright-browsers -- node --import tsx scripts/ensure-playwright-chromium.mts --require-playwright-chromium && node --import tsx scripts/run-with-env.mts PLAYWRIGHT_BROWSERS_PATH=.artifacts/playwright-browsers OPENCLAW_BROWSER_EXTENSION_E2E=1 OPENCLAW_E2E_WORKERS=1 -- node scripts/run-vitest.mjs extensions/browser/chrome-extension/bootstrap.chromium.test.ts",

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -252,15 +252,13 @@ describe("dependency guard workflow", () => {
     expect(autoscrubCommentIndex).toBeGreaterThan(deleteCommentIndex);
   });
 
-  it("checks trusted actors before dependency graph comparison and autoscrub", () => {
+  it("checks trusted actors before autoscrub can mutate dependency changes", () => {
     const script = readFileSync("scripts/github/dependency-guard.mjs", "utf8");
     const trustedActorIndex = script.indexOf("const trustedActor =");
-    const dependencyGraphCompareIndex = script.indexOf("const dependencyGraphChanges =");
     const autoscrubCandidateIndex = script.indexOf("const autoscrubCandidate =");
     const autoscrubOutputIndex = script.indexOf('await setOutput("autoscrub", "true")');
 
     expect(trustedActorIndex).toBeGreaterThan(0);
-    expect(dependencyGraphCompareIndex).toBeGreaterThan(trustedActorIndex);
     expect(autoscrubCandidateIndex).toBeGreaterThan(trustedActorIndex);
     expect(autoscrubOutputIndex).toBeGreaterThan(trustedActorIndex);
   });

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -15,6 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { DEFAULT_RESOURCE_LIMITS } from "../../scripts/lib/docker-e2e-plan.mts";
@@ -221,6 +222,79 @@ function runCandidatePrep(fixture: ReturnType<typeof candidateFixture>) {
   return { manifestPath, result };
 }
 
+function addPrepublishPluginSchedulerFixture(fixture: ReturnType<typeof candidateFixture>) {
+  const packageNames = ["@openclaw/codex", "@openclaw/discord", "@openclaw/whatsapp"];
+  for (const packageName of packageNames) {
+    const packageDir = path.join(fixture.root, "extensions", packageName.split("/")[1]!);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: packageName,
+        version: fixture.version,
+        openclaw: { release: { publishToNpm: true } },
+      }),
+    );
+  }
+
+  const scriptsLibDir = path.join(fixture.root, "scripts", "lib");
+  mkdirSync(scriptsLibDir, { recursive: true });
+  writeFileSync(path.join(scriptsLibDir, "plugin-npm-runtime-build.mjs"), "process.exit(0);\n");
+  writeFileSync(
+    path.join(scriptsLibDir, "plugin-npm-package-manifest.mjs"),
+    `import { spawnSync } from "node:child_process";
+import path from "node:path";
+const runIndex = process.argv.indexOf("--run");
+const separator = process.argv.indexOf("--");
+const packageDir = process.argv[runIndex + 1];
+const command = process.argv[separator + 1];
+const args = process.argv.slice(separator + 2);
+const result = spawnSync(command, args, {
+  cwd: path.resolve(process.cwd(), packageDir),
+  stdio: "inherit",
+});
+process.exit(result.status ?? 1);
+`,
+  );
+
+  const survivorScript = path.join(fixture.root, "scripts", "e2e", "upgrade-survivor-docker.sh");
+  mkdirSync(path.dirname(survivorScript), { recursive: true });
+  writeFileSync(
+    survivorScript,
+    `#!/usr/bin/env bash
+set -euo pipefail
+node - <<'NODE'
+const fs = require("node:fs");
+const keys = [
+  "OPENCLAW_DOCKER_E2E_SELECTED_SHA",
+  "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR",
+  "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION",
+  "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
+];
+fs.writeFileSync(
+  process.env.OPENCLAW_TEST_ENV_CAPTURE,
+  JSON.stringify(Object.fromEntries(keys.map((key) => [key, process.env[key]]))),
+);
+NODE
+`,
+  );
+  chmodSync(survivorScript, 0o755);
+
+  execFileSync("git", ["add", "."], { cwd: fixture.root });
+  execFileSync(
+    "git",
+    ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "companions"],
+    { cwd: fixture.root },
+  );
+  return {
+    ...fixture,
+    sourceSha: execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: fixture.root,
+      encoding: "utf8",
+    }).trim(),
+  };
+}
+
 function addRegistry(
   fixture: ReturnType<typeof candidateFixture>,
   packageNames = ["@openclaw/discord", "@openclaw/feishu"],
@@ -403,6 +477,92 @@ describe("scripts/test-docker-all scheduler", () => {
     const result = runCandidatePrep(fixture).result;
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("working-tree changes");
+  });
+
+  posixIt("prepares required plugin companions for normal current-tree execution", () => {
+    const fixture = addPrepublishPluginSchedulerFixture(candidateFixture());
+    const capturePath = path.join(fixture.root, "lane-env.json");
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of [
+      "OPENCLAW_DOCKER_E2E_SELECTED_SHA",
+      "OPENCLAW_CURRENT_PACKAGE_TGZ",
+      "OPENCLAW_CURRENT_PACKAGE_VERSION",
+      "OPENCLAW_CURRENT_PACKAGE_SHA256",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
+    ]) {
+      delete env[key];
+    }
+    Object.assign(env, {
+      OPENCLAW_DOCKER_ALL_BUILD: "0",
+      OPENCLAW_DOCKER_ALL_LANES: "upgrade-survivor",
+      OPENCLAW_DOCKER_ALL_LOG_DIR: path.join(fixture.root, "logs"),
+      OPENCLAW_DOCKER_ALL_PREFLIGHT: "0",
+      OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+      OPENCLAW_DOCKER_E2E_REPO_ROOT: fixture.root,
+      OPENCLAW_TEST_ENV_CAPTURE: capturePath,
+    });
+
+    const result = spawnSync(process.execPath, ["scripts/test-docker-all.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const captured = JSON.parse(readFileSync(capturePath, "utf8")) as Record<string, string>;
+    expect(captured.OPENCLAW_DOCKER_E2E_SELECTED_SHA).toBe(fixture.sourceSha);
+    expect(captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION).toBe(fixture.version);
+    expect(captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256).toMatch(/^[0-9a-f]{64}$/u);
+    const registryDir = expectDefined(
+      captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+      "captured prepublish plugin registry directory",
+    );
+    expect(path.isAbsolute(registryDir)).toBe(true);
+    const manifest = JSON.parse(
+      readFileSync(path.join(registryDir, "prepublish-plugin-registry.json"), "utf8"),
+    ) as { packages: Array<{ name: string }> };
+    expect(manifest.packages.map((entry) => entry.name)).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+      "@openclaw/whatsapp",
+    ]);
+  });
+
+  posixIt("rejects a supplied package without its required plugin registry", () => {
+    const fixture = candidateFixture();
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of [
+      "OPENCLAW_DOCKER_E2E_SELECTED_SHA",
+      "OPENCLAW_CURRENT_PACKAGE_VERSION",
+      "OPENCLAW_CURRENT_PACKAGE_SHA256",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
+    ]) {
+      delete env[key];
+    }
+    Object.assign(env, {
+      OPENCLAW_CURRENT_PACKAGE_TGZ: fixture.packagePath,
+      OPENCLAW_DOCKER_ALL_BUILD: "0",
+      OPENCLAW_DOCKER_ALL_LANES: "upgrade-survivor",
+      OPENCLAW_DOCKER_ALL_LOG_DIR: path.join(fixture.root, "logs"),
+      OPENCLAW_DOCKER_ALL_PREFLIGHT: "0",
+      OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+      OPENCLAW_DOCKER_E2E_REPO_ROOT: fixture.root,
+    });
+
+    const result = spawnSync(process.execPath, ["scripts/test-docker-all.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "requires a prepublish plugin registry tuple for the supplied package",
+    );
   });
 
   it.each([

--- a/test/scripts/openclaw-test-state.test.ts
+++ b/test/scripts/openclaw-test-state.test.ts
@@ -233,11 +233,28 @@ describe("scripts/lib/openclaw-test-state", () => {
           source: "env",
         },
       });
-      expect(payload.config.channels.discord.enabled).toBe(true);
-      expect(payload.config.channels.discord.dm).toStrictEqual({
-        allowFrom: ["111111111111111111"],
-        policy: "allowlist",
+      expect(payload.config.agents.ownership).toBe("explicit");
+      expect(payload.config.agents.defaults).toMatchObject({
+        authInheritance: { agentId: "main" },
+        heartbeat: { agentId: "main" },
+        sessionStore: { agentId: "main" },
+        systemAgent: { agentId: "main" },
       });
+      expect(payload.config.bindings).toEqual([
+        { agentId: "main", match: { channel: "discord", accountId: "*" } },
+        { agentId: "main", match: { channel: "telegram", accountId: "*" } },
+        { agentId: "main", match: { channel: "whatsapp", accountId: "*" } },
+      ]);
+      expect(Object.keys(payload.config.agents.entries)).toEqual(["main", "ops"]);
+      expect(payload.config.agents).not.toHaveProperty("list");
+      for (const agent of Object.values(payload.config.agents.entries)) {
+        expect(agent).not.toHaveProperty("default");
+      }
+      expect(payload.config.channels.discord.enabled).toBe(true);
+      expect(payload.config.channels.discord.dmPolicy).toBe("allowlist");
+      expect(payload.config.channels.discord.allowFrom).toEqual(["111111111111111111"]);
+      expect(payload.config.channels.discord.dm?.policy).toBeUndefined();
+      expect(payload.config.channels.discord.dm?.allowFrom).toBeUndefined();
       expect(payload.config.channels.telegram.enabled).toBe(true);
       expect(payload.config.channels.whatsapp.enabled).toBe(true);
     } finally {
@@ -272,6 +289,33 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(payload.workspace).toBe(`${payload.home}/workspace`);
       expect(payload.secretKey).toMatch(secretKeyPattern);
       expect(payload.config).toStrictEqual({});
+
+      const upgradeProbe = await execFileAsync("bash", [
+        "-lc",
+        `${cleanupTestStateHomeTrap()}; export OPENCLAW_TEST_STATE_TMPDIR=${shellQuote(path.join(tempRoot, "upgrade-function-tmp"))}; source ${shellQuote(snippetFile)}; openclaw_test_state_create "upgrade case" upgrade-survivor; node -e 'const fs=require("node:fs"); process.stdout.write(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8"));'`,
+      ]);
+      const upgradeConfig = JSON.parse(upgradeProbe.stdout);
+      expect(upgradeConfig.agents.ownership).toBe("explicit");
+      expect(upgradeConfig.agents.defaults).toMatchObject({
+        authInheritance: { agentId: "main" },
+        heartbeat: { agentId: "main" },
+        sessionStore: { agentId: "main" },
+        systemAgent: { agentId: "main" },
+      });
+      expect(upgradeConfig.bindings).toEqual([
+        { agentId: "main", match: { channel: "discord", accountId: "*" } },
+        { agentId: "main", match: { channel: "telegram", accountId: "*" } },
+        { agentId: "main", match: { channel: "whatsapp", accountId: "*" } },
+      ]);
+      expect(Object.keys(upgradeConfig.agents.entries)).toEqual(["main", "ops"]);
+      expect(upgradeConfig.agents).not.toHaveProperty("list");
+      for (const agent of Object.values(upgradeConfig.agents.entries)) {
+        expect(agent).not.toHaveProperty("default");
+      }
+      expect(upgradeConfig.channels.discord.dmPolicy).toBe("allowlist");
+      expect(upgradeConfig.channels.discord.allowFrom).toEqual(["111111111111111111"]);
+      expect(upgradeConfig.channels.discord.dm?.policy).toBeUndefined();
+      expect(upgradeConfig.channels.discord.dm?.allowFrom).toBeUndefined();
 
       const trailingTmpDir = path.join(tempRoot, "function-trailing-tmp");
       const trailingProbe = await execFileAsync("bash", [


### PR DESCRIPTION
## What Problem This Solves

The reconstructed `2026.8.1-beta.2` source candidate needs an immutable, GitHub-verified commit after rebasing the release work onto the frozen current-main repair base.

The candidate carries the beta.2 upgrade ownership repairs that keep explicit multi-agent configuration valid across Doctor normalization, config persistence, plugin installation, and fresh-process restart boundaries.

## Why This Change Was Made

This integration PR signs the source/package portion of the Code SHA without changing canonical `release/2026.8.1` or generating release notes early. Its complete delta from the isolated base contains:

- beta.2 release validation and explicit ownership repairs;
- canonical Doctor metadata ownership preservation;
- current package and official-plugin version metadata for `2026.8.1-beta.2`.

Generated Control UI translation memory is intentionally excluded from this PR because CI requires generated locale artifacts to be isolated from source changes. A locale-only signing PR will follow on top of this verified source commit, preserving the already-reviewed final candidate tree.

`CHANGELOG.md` remains byte-identical to the frozen base. Release notes will be generated only after Full Release Validation passes for the final signed Code SHA.

## User Impact

The beta.2 source and official plugin roster can be signed without weakening generated-artifact ownership. Existing explicit multi-agent installations retain their configured owners through update and Doctor repair, and externalized configured plugins can be installed before plugin-owned migrations run.

## Evidence

- Trusted integration base: `ec4a97ea5216ac0d77f29d3459f38a2ebe2ed00a`, containing only landed workflow repair #123456 on top of the frozen base.
- Unsigned source candidate: `a5a712093464ac5a6ec407b7c000923f54a5a3b8`; tree `85c58dbb49edaf44062b96f64311c4df28e715e5`.
- Source/release repair autoreviews completed clean before generated locale refresh.
- Matrix rebase cleanup autoreview: clean; focused boundary lint passed; 9 Matrix route tests passed.
- Synology test-environment ownership autoreview: clean; focused lint passed; the exact two-worker extension-messaging project passed all 131 files and 1,411 tests after reproducing 4 order-dependent Nostr failures before the fix.
- Beta-aware update fixture autoreview: clean; the full update CLI suite plus sibling channel contracts passed all 339 tests after reproducing the two beta-only failures before the fix.
- WhatsApp ownership/drain fixture autoreview: clean; focused contracts passed 15 tests and the original 16-worker full WhatsApp project passed all 98 files and 1,333 tests after reproducing five failures before the fix. Explicit account-owner correction credited to Vincent Koc (#123170).
- Telegram plugin-command fixture autoreview: clean; the formerly hanging file passes all 25 tests in 20 seconds, and the exact adjacent `accounts.test.ts` boundary passes all 63 tests in 23 seconds under a 90-second watchdog. The pre-fix full project passed functionally but spent 889 seconds importing and repeatedly exceeded CI's 300-second no-output watchdog at this file.
- Release version alignment: root core, 148 current-roster plugins, three workspace packages, and official channel catalog aligned to `2026.8.1-beta.2`.
- 94 npm package locks validated.
- `git diff --check`: passed.
- `CHANGELOG.md`: unchanged from the isolated base.

This PR is the source signing boundary. A generated-locale-only PR will produce the final signed Code SHA, after which product, package, install/update, and performance validation will run before changelog generation or publication.
