### PR TITLE
fix(comfy): forward req.timeoutMs in music generation

### DIFF
--- a/extensions/comfy/music-generation-provider.test.ts
+++ b/extensions/comfy/music-generation-provider.test.ts
@@ -166,4 +166,52 @@ describe("comfy music-generation provider", () => {
       }),
     ).rejects.toThrow("Comfy music output download exceeds 1 bytes");
   });
+
+  it("honors req.timeoutMs for the music workflow poll deadline", async () => {
+    // Submit succeeds, but the workflow never produces outputs: every history
+    // poll returns an empty object. The request-level timeoutMs must bound the
+    // wait — before the fix, music ignored req.timeoutMs and always waited the
+    // 5-minute default.
+    fetchWithSsrFGuardMock.mockImplementation(async (params: { url?: string }) => {
+      const url = params.url ?? "";
+      const body = url.includes("/prompt")
+        ? JSON.stringify({ prompt_id: "music-job-slow" })
+        : JSON.stringify({});
+      return {
+        response: new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+        release: vi.fn(async () => {}),
+      };
+    });
+
+    const provider = buildComfyMusicGenerationProvider();
+    await expect(
+      provider.generateMusic({
+        provider: "comfy",
+        model: "workflow",
+        prompt: "gentle ambient synth loop",
+        timeoutMs: 1000,
+        cfg: {
+          plugins: {
+            entries: {
+              comfy: {
+                config: {
+                  music: {
+                    workflow: {
+                      "6": { inputs: { text: "" } },
+                      "9": { inputs: {} },
+                    },
+                    promptNodeId: "6",
+                    outputNodeId: "9",
+                  },
+                },
+              },
+            },
+          },
+        } as never,
+      }),
+    ).rejects.toThrow("Comfy workflow did not finish within 1s");
+  });
 });

--- a/extensions/comfy/music-generation-provider.ts
+++ b/extensions/comfy/music-generation-provider.ts
@@ -70,6 +70,7 @@ export function buildComfyMusicGenerationProvider(): MusicGenerationProvider {
         authStore: req.authStore,
         prompt: req.prompt,
         model: req.model,
+        timeoutMs: req.timeoutMs,
         capability: "music",
         outputKinds: ["audio"],
         inputImage: resolveInputImage(req.inputImages?.[0]),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Comfy music workflows ignored the request-level timeout passed by the music-generation runtime. Image and video generation already forwarded that value, but music omitted it and fell back to the shared runner's default.

## Why This Change Was Made

The Comfy music provider now forwards `req.timeoutMs` to the existing shared workflow runner, matching the image and video providers. The request timeout bounds the workflow operations and polling phase it is passed to; this change does not claim one global end-to-end deadline across every workflow stage.

## User Impact

Operators can configure a request-level timeout for Comfy music generation and have the workflow polling path honor it instead of silently using the default.

## Evidence

- Sanitized AWS loopback proof used the real Comfy music provider against a real local HTTP server whose submitted workflow never completed.
- Before: current-main SHA `4fd208fc6064563815e10a53648728a7c98bd684` remained active for the outer 3-second cap with `timeoutMs=1000`, `pollIntervalMs=100`, and 27 history polls. Run: https://crabbox.openclaw.ai/portal/runs/run_17cd4846f7d4
- After: patch head `8ebd524ccceff2867314bbca9272e1932595bea5` rejected after 1,279 ms with `Comfy workflow did not finish within 1s` and 10 history polls. Run: https://crabbox.openclaw.ai/portal/runs/run_832963fc7b31
- Focused provider test: 4/4 passed.
- Full Comfy extension suite: 46/46 passed.
- Changed gates passed formatting, conflict markers, ratchets, dependency guards, plugin boundaries, dead-code checks, extension typechecks, and extension-test typechecks. The run then found one unnecessary `String()` conversion in the new test; exact head `e46749f6ca59c52ff362704d9d1705823732587c` removes it without changing behavior or LOC.
- Exact-head `oxfmt --check` and `git diff --check` pass. Fresh exact-head CI and ClawSweeper review remain the merge gates.

Punchcard-Session: coral-harbor-river-yv
