### PR TITLE
experiment(ci): Node 26 timing A/B (not for merge)

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -6,7 +6,7 @@ inputs:
   node-version:
     description: Node.js version to install.
     required: false
-    default: "24.x"
+    default: "26.x"
   install-bun:
     description: Whether to install Bun alongside Node.
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  NODE_VERSION: "24.x"
+  NODE_VERSION: "26.x"
 
 jobs:
   # Preflight: establish routing truth and job matrices once, then let real
@@ -1125,7 +1125,7 @@ jobs:
 
       - name: Setup Node.js
         env:
-          REQUESTED_NODE_VERSION: "24.x"
+          REQUESTED_NODE_VERSION: "26.x"
         run: |
           set -euo pipefail
           source .github/actions/setup-pnpm-store-cache/ensure-node.sh
@@ -1579,7 +1579,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
-          node-version: "24.x"
+          node-version: "26.x"
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
           # preflight; hosted paths use the pnpm store cache instead.
@@ -1645,7 +1645,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
-          node-version: "24.x"
+          node-version: "26.x"
           install-bun: "false"
           # Hosted paths use the pnpm store cache; first-attempt same-repo
           # Blacksmith runs restore the preflight-published dependency tree.
@@ -1686,7 +1686,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
-          node-version: "24.x"
+          node-version: "26.x"
           install-bun: "false"
           # Hosted paths use the pnpm store cache; first-attempt same-repo
           # Blacksmith runs restore the preflight-published dependency tree.
@@ -1724,7 +1724,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
-          node-version: "24.x"
+          node-version: "26.x"
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
           # preflight; hosted paths use the pnpm store cache instead.


### PR DESCRIPTION
## What Problem This Solves
Timing experiment: measures whether Node 26.x improves CI wall/lane times enough to justify adoption before the runner image ships it in the toolcache (research says +5-15s/lane setup tax until then).

## Why This Change Was Made
Maintainer-requested A/B (Peter, 2026-08-14). All Node pins in ci.yml + setup-node-env flip 24.x -> 26.x. A same-hour Node 24 baseline dispatch on main provides the comparison run under identical cache/runner conditions.

## User Impact
None — experiment PR, **not for merge**. Will be closed after data collection.

## Evidence
Comparison table will be posted in comments after both dispatches complete. Known caveats: all version-keyed caches (compile, vitest-fs, dependency) cold-start on 26; prompt snapshots are generated under Node 24 and may fail — failures are data, not blockers, for this experiment.
