### PR TITLE
fix(fal): write onboarding default image model to mediaModels.image

### DIFF
--- a/extensions/fal/onboard.test.ts
+++ b/extensions/fal/onboard.test.ts
@@ -1,0 +1,37 @@
+// Fal tests cover onboard plugin behavior.
+import {
+  type OpenClawConfig,
+  resolveAgentModelPrimaryValue,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { describe, expect, it } from "vitest";
+import { applyFalConfig, FAL_DEFAULT_IMAGE_MODEL_REF } from "./onboard.js";
+
+const emptyCfg: OpenClawConfig = {};
+
+describe("applyFalConfig", () => {
+  it("writes the default image model to mediaModels.image (the key the runtime reads)", () => {
+    const result = applyFalConfig(emptyCfg);
+
+    expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.mediaModels?.image)).toBe(
+      FAL_DEFAULT_IMAGE_MODEL_REF,
+    );
+    // The retired key must stay untouched: nothing in the runtime reads it.
+    expect(result.agents?.defaults).not.toHaveProperty("imageGenerationModel");
+  });
+
+  it("does not overwrite an existing mediaModels.image default", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          mediaModels: { image: { primary: "other-provider/custom-model" } },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = applyFalConfig(cfg);
+
+    expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.mediaModels?.image)).toBe(
+      "other-provider/custom-model",
+    );
+  });
+});

--- a/extensions/fal/onboard.ts
+++ b/extensions/fal/onboard.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 export const FAL_DEFAULT_IMAGE_MODEL_REF = "fal/fal-ai/flux/dev";
 
 export function applyFalConfig(cfg: OpenClawConfig): OpenClawConfig {
-  if (cfg.agents?.defaults?.imageGenerationModel) {
+  if (cfg.agents?.defaults?.mediaModels?.image) {
     return cfg;
   }
   return {
@@ -13,8 +13,9 @@ export function applyFalConfig(cfg: OpenClawConfig): OpenClawConfig {
       ...cfg.agents,
       defaults: {
         ...cfg.agents?.defaults,
-        imageGenerationModel: {
-          primary: FAL_DEFAULT_IMAGE_MODEL_REF,
+        mediaModels: {
+          ...cfg.agents?.defaults?.mediaModels,
+          image: { primary: FAL_DEFAULT_IMAGE_MODEL_REF },
         },
       },
     },


### PR DESCRIPTION
## Summary

fix(fal): write the onboarding default image model to `agents.defaults.mediaModels.image` — the key the runtime actually reads — instead of the retired `imageGenerationModel` key

## What Problem This Solves

After completing fal onboarding (auth wizard / `--fal-api-key`), the generated config sets the default image model so `image_generate` works out of the box. But `applyFalConfig` writes it to a **retired key**:

```ts
// extensions/fal/onboard.ts
defaults: { ...cfg.agents?.defaults, imageGenerationModel: { primary: FAL_DEFAULT_IMAGE_MODEL_REF } },
```

The runtime never reads that key — image generation resolves `agents.defaults.mediaModels.image` (`src/image-generation/runtime.ts:71` via `resolveCapabilityModelCandidates`). Three independent confirmations that the written key is dead:

- `src/config/dead-config-keys.test.ts:53` asserts `agents.defaults.imageGenerationModel` is reported as an unrecognized dead key by config validation.
- The only migration from the retired key to `mediaModels.image` runs in doctor (`legacy-config-migrations.runtime.retired.ts`), i.e. the user must run `openclaw doctor --fix` before the onboarding result takes effect.
- The sibling providers do it right: `vydra/onboard.ts` and `pixverse/onboard.ts` both write `mediaModels.image|video`.

**代码证据**: `extensions/fal/onboard.ts:6-22` (writes `imageGenerationModel`); `src/image-generation/runtime.ts:71` (reads `mediaModels.image`).

Trigger condition: any fresh fal onboarding.

User symptom: right after onboarding, `image_generate` still throws `No image-generation model configured.` — the onboarding result is a no-op until the user happens to run `doctor --fix`.

## Root Cause

- The fal onboarding flow was added in commit `bca2501c7f7` (2026-05-27) writing the then-current key; when the config schema moved image models to `mediaModels.image`, this call site was missed (vydra/pixverse onboardings were written later against the new key).
- Violated invariant: onboarding must write configuration the runtime actually consumes; writing to a retired key produces a config that validation itself flags as dead.

## Why This Fix

- Option A (chosen): write `mediaModels.image` directly, mirroring `vydra/onboard.ts` exactly (same guard: don't overwrite an existing `mediaModels.image` default). Minimal, consistent with sibling providers.
- Option B: keep writing the dead key and rely on the doctor migration. Rejected: requires every onboarded user to run `doctor --fix` before the feature works — that is the bug, not a fix.
- Not chosen: writing both keys — the retired key is explicitly flagged by validation; writing it spreads the dead config further.

## User Impact

- Affected scenarios: fresh fal onboarding via the auth wizard or `--fal-api-key`.
- Before: default image model silently configured into a dead key; `image_generate` fails with "No image-generation model configured." until `openclaw doctor --fix`.
- After: the default is resolvable immediately after onboarding; existing `mediaModels.image` settings are preserved.
- Behavior change: onboarding now produces a working config on first use.

## Evidence

### Real Behavior Proof

Real stack, no mocks: the proof runs the **real** `applyFalConfig` and then asks the **real** runtime resolver (`resolveCapabilityModelCandidates` from `src/media-generation/runtime-shared.ts`, the same call `src/image-generation/runtime.ts:69` makes) to resolve the image model from the produced config.

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-fal-onboard-model-key.mjs
[proof] mediaModels.image after onboarding: null
[proof] legacy imageGenerationModel after onboarding: {"primary":"fal/fal-ai/flux/dev"}
[proof] runtime-resolved candidates: []
[proof] RESULT: FAIL - runtime resolves no image model after onboarding (expected fal/fal-ai/flux/dev); image_generate would throw "No image-generation model configured."
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-fal-onboard-model-key.mjs
[proof] mediaModels.image after onboarding: {"primary":"fal/fal-ai/flux/dev"}
[proof] legacy imageGenerationModel after onboarding: null
[proof] runtime-resolved candidates: [{"provider":"fal","model":"fal-ai/flux/dev"}]
[proof] RESULT: PASS - onboarding default fal/fal-ai/flux/dev is resolvable by the runtime
```

**What was not tested:** a live image generation call against fal's API (requires credentials); the proof covers the full config-write → runtime-resolve path that was broken.

## Tests and Validation

- New `extensions/fal/onboard.test.ts` — 2/2 passed: onboarding writes `mediaModels.image` (and never the retired key), and an existing `mediaModels.image` default is preserved.
- `npx oxlint --deny=warn` on both files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
- Maintainer live follow-up identified a separate existing CLI auth-choice scope-filter defect affecting media-only providers; that independent entry-point bug will be fixed separately and does not change this config-writer owner repair.
- Exact-head maintainer verification confirms the runtime reads only `mediaModels.image` and the contributor patch matches the existing Vydra provider ownership pattern.
