### PR TITLE
fix: message send works after multi-agent ownership migration

### DIFF
--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -452,6 +452,22 @@ describe("messageCommand", () => {
     expect(readOnlyMessageActionCall().agentId).toBe("ops");
   });
 
+  it("uses the configured system owner for an explicit multi-agent config", async () => {
+    const effectiveConfig = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { ops: {}, research: {} },
+      },
+    };
+    mockResolvedCommandConfig({ rawConfig: {}, resolvedConfig: effectiveConfig, diagnostics: [] });
+
+    await runMessageCommand();
+
+    expect(readOnlyMessageActionCall().cfg).toBe(effectiveConfig);
+    expect(readOnlyMessageActionCall().agentId).toBe("ops");
+  });
+
   it("keeps local-fallback resolved cfg and logs diagnostics", async () => {
     const rawConfig = {
       channels: {

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { CliDeps } from "../cli/deps.js";
+import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv } from "../test-utils/env.js";
 
@@ -416,6 +417,29 @@ describe("messageCommand", () => {
         (id) => !id.startsWith("channels.telegram."),
       ),
     ).toStrictEqual([]);
+  });
+
+  it("keeps the retained legacy owner after config load strips the default marker", async () => {
+    const migrated = migratePersistedImplicitMainRoster({
+      agents: {
+        entries: {
+          ops: { default: true },
+          research: {},
+        },
+      },
+      channels: { telegram: {} },
+    }).config as Record<string, unknown>;
+    testConfig = migrated;
+    const effectiveConfig = structuredClone(migrated);
+    applyPluginAutoEnable.mockReturnValueOnce({ config: effectiveConfig, changes: [] });
+
+    await runMessageCommand();
+
+    expect(
+      (migrated.agents as { entries?: { ops?: { default?: boolean } } }).entries?.ops?.default,
+    ).toBeUndefined();
+    expect(readOnlyMessageActionCall().cfg).toBe(effectiveConfig);
+    expect(readOnlyMessageActionCall().agentId).toBe("ops");
   });
 
   it("keeps local-fallback resolved cfg and logs diagnostics", async () => {

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -442,6 +442,16 @@ describe("messageCommand", () => {
     expect(readOnlyMessageActionCall().agentId).toBe("ops");
   });
 
+  it("resolves the ordinary owner from the effective command config", async () => {
+    const effectiveConfig = { agents: { entries: { ops: {} } } };
+    mockResolvedCommandConfig({ rawConfig: {}, resolvedConfig: effectiveConfig, diagnostics: [] });
+
+    await runMessageCommand();
+
+    expect(readOnlyMessageActionCall().cfg).toBe(effectiveConfig);
+    expect(readOnlyMessageActionCall().agentId).toBe("ops");
+  });
+
   it("keeps local-fallback resolved cfg and logs diagnostics", async () => {
     const rawConfig = {
       channels: {

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -8,7 +8,10 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveDefaultAgentId,
+  tryResolveLegacyCompatibilityAgentId,
+} from "../agents/agent-scope.js";
 import { CHANNEL_MESSAGE_ACTION_NAMES } from "../channels/plugins/message-action-names.js";
 import type { ChannelMessageActionName } from "../channels/plugins/types.public.js";
 import { resolveCommandConfigWithSecrets } from "../cli/command-config-resolution.js";
@@ -64,6 +67,8 @@ export async function messageCommand(
   runtime: RuntimeEnv,
 ) {
   const loadedRaw = getRuntimeConfig();
+  const agentId =
+    tryResolveLegacyCompatibilityAgentId(loadedRaw) ?? resolveDefaultAgentId(loadedRaw);
   const rawAction = normalizeOptionalString(opts.action) ?? "";
   const actionInput = rawAction || "send";
   const normalizedActionInput = normalizeLowercaseStringOrEmpty(actionInput);
@@ -128,7 +133,7 @@ export async function messageCommand(
       action,
       params: opts,
       deps: outboundDeps,
-      agentId: resolveDefaultAgentId(cfg),
+      agentId,
       senderIsOwner: opts.senderIsOwner !== false,
       conversationReadOrigin: "direct-operator",
       broadcastAccountPlan,

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -8,10 +8,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
-import {
-  resolveDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
-} from "../agents/agent-scope.js";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { CHANNEL_MESSAGE_ACTION_NAMES } from "../channels/plugins/message-action-names.js";
 import type { ChannelMessageActionName } from "../channels/plugins/types.public.js";
 import { resolveCommandConfigWithSecrets } from "../cli/command-config-resolution.js";
@@ -21,6 +18,7 @@ import { resolveMessageSecretScope } from "../cli/message-secret-scope.js";
 import { createOutboundSendDeps, type CliDeps } from "../cli/outbound-send-deps.js";
 import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
+import { tryGetLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
 import {
   resolveMessageBroadcastAccountPlan,
@@ -67,8 +65,7 @@ export async function messageCommand(
   runtime: RuntimeEnv,
 ) {
   const loadedRaw = getRuntimeConfig();
-  const agentId =
-    tryResolveLegacyCompatibilityAgentId(loadedRaw) ?? resolveDefaultAgentId(loadedRaw);
+  const compatibilityAgentId = tryGetLegacyDefaultAgentId(loadedRaw);
   const rawAction = normalizeOptionalString(opts.action) ?? "";
   const actionInput = rawAction || "send";
   const normalizedActionInput = normalizeLowercaseStringOrEmpty(actionInput);
@@ -111,6 +108,7 @@ export async function messageCommand(
     runtime,
     autoEnable: true,
   });
+  const agentId = compatibilityAgentId ?? resolveDefaultAgentId(cfg);
   const actionMatch = (CHANNEL_MESSAGE_ACTION_NAMES as readonly string[]).find(
     (name) => normalizeLowercaseStringOrEmpty(name) === normalizedActionInput,
   );

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -8,7 +8,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import { CHANNEL_MESSAGE_ACTION_NAMES } from "../channels/plugins/message-action-names.js";
 import type { ChannelMessageActionName } from "../channels/plugins/types.public.js";
 import { resolveCommandConfigWithSecrets } from "../cli/command-config-resolution.js";
@@ -108,7 +108,7 @@ export async function messageCommand(
     runtime,
     autoEnable: true,
   });
-  const agentId = compatibilityAgentId ?? resolveDefaultAgentId(cfg);
+  const agentId = compatibilityAgentId ?? resolveSystemAgentTargetAgentId(cfg);
   const actionMatch = (CHANNEL_MESSAGE_ACTION_NAMES as readonly string[]).find(
     (name) => normalizeLowercaseStringOrEmpty(name) === normalizedActionInput,
   );

--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -2,6 +2,7 @@
 // send-capable active registry short-circuiting.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
+import { migratePersistedImplicitMainRoster } from "../../config/legacy.roster.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
@@ -115,6 +116,48 @@ describe("bootstrapOutboundChannelPlugin", () => {
 
     expect(loaderMocks.resolveDiscoverableScopedChannelPluginIds).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceDir: "/tmp/openclaw-ops" }),
+    );
+  });
+
+  it("bootstraps outbound sends with the retained legacy owner after config load", async () => {
+    installDiscordSetupShell();
+    const migrated = migratePersistedImplicitMainRoster({
+      agents: {
+        defaults: { workspace: "/tmp/openclaw-legacy" },
+        entries: {
+          ops: { default: true },
+          research: {},
+        },
+      },
+      channels: { discord: {} },
+    }).config as OpenClawConfig;
+    const handle = createEmptyPluginRegistry();
+    handle.channels = [
+      {
+        pluginId: "discord",
+        plugin: {
+          id: "discord",
+          meta: {},
+          outbound: {
+            extractMarkdownImages: true,
+            sendText: async () => ({ messageId: "1" }),
+          },
+        },
+        source: "runtime",
+      },
+    ] as never;
+    loaderMocks.loadPluginRegistryHandle.mockReturnValue(handle);
+
+    await expect(
+      resolveChannelOutboundDirectiveOptions({
+        channel: "discord",
+        cfg: migrated,
+      }),
+    ).resolves.toEqual({ extractMarkdownImages: true });
+
+    expect(migrated.agents?.entries?.ops?.default).toBeUndefined();
+    expect(loaderMocks.resolveDiscoverableScopedChannelPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/openclaw-legacy" }),
     );
   });
 

--- a/src/infra/outbound/channel-bootstrap.runtime.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.ts
@@ -1,10 +1,7 @@
 // Outbound channel bootstrap lazily loads runtime plugins for selected channels
 // when only setup-shell metadata is active.
-import {
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
-} from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { tryResolveLegacyCompatibilityAgentId } from "../../config/legacy.default-agent-owner.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";

--- a/src/infra/outbound/channel-bootstrap.runtime.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.ts
@@ -1,6 +1,10 @@
 // Outbound channel bootstrap lazily loads runtime plugins for selected channels
 // when only setup-shell metadata is active.
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import {
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+  tryResolveLegacyCompatibilityAgentId,
+} from "../../agents/agent-scope.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -101,7 +105,7 @@ export function bootstrapOutboundChannelPlugin(params: {
   // explicit fleets do not fall back to forbidden ambient-agent selection.
   const agentId = params.agentId?.trim()
     ? normalizeAgentId(params.agentId)
-    : resolveDefaultAgentId(cfg);
+    : (tryResolveLegacyCompatibilityAgentId(cfg) ?? resolveDefaultAgentId(cfg));
   const outcomeKey = `${agentId}\0${params.channel}`;
   const registries = resolveBootstrapRegistries(cfg);
   const cachedRegistry = registries.get(outcomeKey);
@@ -111,7 +115,7 @@ export function bootstrapOutboundChannelPlugin(params: {
   }
 
   const autoEnabled = applyPluginAutoEnable({ config: cfg });
-  const workspaceDir = resolveAgentWorkspaceDir(autoEnabled.config, agentId);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const pluginIds = resolveDiscoverableScopedChannelPluginIds({
     config: autoEnabled.config,
     activationSourceConfig: cfg,

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -347,6 +347,19 @@ describe("resolveMessageChannelSelection", () => {
     });
   });
 
+  it("carries the admitted agent into channel bootstrap", async () => {
+    const cfg = {} as never;
+
+    await expectResolvedSelection({ cfg, channel: "alpha", agentId: "ops" });
+
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledWith({
+      channel: "alpha",
+      cfg,
+      agentId: "ops",
+      allowBootstrap: true,
+    });
+  });
+
   it.each([
     {
       params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "not-a-channel" },

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -28,6 +28,7 @@ type MessageChannelSelectionSource = "explicit" | "tool-context-fallback" | "sin
 function resolveAvailableKnownChannel(params: {
   cfg: OpenClawConfig;
   value?: string | null;
+  agentId?: string;
 }): { channel: string; plugin: ChannelPlugin } | undefined {
   const normalized = normalizeDeliverableOutboundChannel(params.value);
   if (!normalized) {
@@ -45,6 +46,7 @@ function resolveAvailableKnownChannel(params: {
   const plugin = resolveOutboundChannelPlugin({
     channel: normalized,
     cfg: params.cfg,
+    agentId: params.agentId,
     allowBootstrap: true,
   });
   return plugin ? { channel: normalized, plugin } : undefined;
@@ -200,6 +202,7 @@ export async function resolveMessageChannelSelection(params: {
   cfg: OpenClawConfig;
   channel?: string | null;
   fallbackChannel?: string | null;
+  agentId?: string;
 }): Promise<{
   channel: string;
   plugin: ChannelPlugin;
@@ -211,11 +214,13 @@ export async function resolveMessageChannelSelection(params: {
     const availableExplicit = resolveAvailableKnownChannel({
       cfg: params.cfg,
       value: params.channel,
+      agentId: params.agentId,
     });
     if (!availableExplicit) {
       const fallback = resolveAvailableKnownChannel({
         cfg: params.cfg,
         value: params.fallbackChannel,
+        agentId: params.agentId,
       });
       if (fallback) {
         return {
@@ -250,6 +255,7 @@ export async function resolveMessageChannelSelection(params: {
   const fallback = resolveAvailableKnownChannel({
     cfg: params.cfg,
     value: params.fallbackChannel,
+    agentId: params.agentId,
   });
   if (fallback) {
     return {

--- a/src/infra/outbound/message-action-routing.ts
+++ b/src/infra/outbound/message-action-routing.ts
@@ -37,6 +37,7 @@ async function resolveChannel(
   params: Record<string, unknown>,
   toolContext?: { currentChannelProvider?: string },
   action?: ChannelMessageActionName,
+  agentId?: string,
 ) {
   const channel = readToolStringParam(params, "channel");
   // Explicit reads must never switch to the source conversation when their
@@ -47,6 +48,7 @@ async function resolveChannel(
     cfg,
     channel,
     fallbackChannel,
+    agentId,
   });
   if (selection.source === "tool-context-fallback") {
     params.channel = selection.channel;
@@ -349,7 +351,7 @@ export async function prepareMessageRoute(params: {
     throw new Error(`Action ${action} requires a target.`);
   }
 
-  const selection = await resolveChannel(cfg, actionParams, input.toolContext, action);
+  const selection = await resolveChannel(cfg, actionParams, input.toolContext, action, agentId);
   const { channel, plugin: channelPlugin } = selection;
   actionParams.channel = channel;
   const explicitAccountId = validateExplicitMessageAccountSelection({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -117,6 +117,7 @@ async function handleBroadcastAction(
               cfg: input.cfg,
               channel: channelHint,
               fallbackChannel: input.toolContext?.currentChannelProvider,
+              agentId: input.agentId,
             })
           ).channel,
         ]
@@ -324,7 +325,7 @@ export async function runMessageAction(input: MessageActionInput): Promise<Messa
     action,
   });
   if (action === "broadcast") {
-    return handleBroadcastAction(input, params);
+    return handleBroadcastAction({ ...input, agentId: resolvedAgentId }, params);
   }
   if (action === "send" && hasPollCreationParams(params)) {
     throw new Error('Poll fields require action "poll"; use action "poll" instead of "send".');


### PR DESCRIPTION
Closes #123322

## What Problem This Solves

Fixes an issue where operators running `openclaw message send` on an explicit multi-agent configuration would receive `AgentSelectionRequiredError` before channel delivery. The failure affected both upgraded configs whose legacy `default: true` marker was stripped during load and canonical explicit configs that selected an owner with `agents.defaults.systemAgent.agentId`.

## Why This Change Was Made

The command captures the retained migration owner from the original loaded config before command secret/plugin resolution clones it. After resolving the effective config, CLI sends use the ownership chain `retained migration owner → configured systemAgent owner → sole-agent fallback`, then carry that prepared agent ID through message routing, channel selection, broadcast handling, and lazy plugin bootstrap.

Generic outbound bootstrap remains strict: it accepts a prepared owner, falls back only to retained legacy compatibility ownership, and still rejects genuinely ownerless explicit fleets. This avoids making `systemAgent` an ambient authority outside the CLI command that explicitly owns this product decision, and does not add a new `--agent` surface.

The regression was made visible by the explicit-ownership migration in #114388, combined with the older CLI transcript-owner path from #54187 and the strict lazy-bootstrap fallback left by #123283.

Production LOC: +19/-6 (net +13) | Tests: +106/-0

## User Impact

CLI-originated message sends and dry runs now work for both migrated multi-agent installs and explicit multi-agent installs with `agents.defaults.systemAgent.agentId` configured. The selected owner is preserved through external channel bootstrap, so workspace discovery, outbound routing, and transcript attribution remain agent-scoped instead of failing before delivery.

Explicit multi-agent configurations with neither a retained migration owner nor a configured system owner still fail closed rather than silently choosing an agent.

## Evidence

- Pre-fix bootstrap regression: `node scripts/run-vitest.mjs src/infra/outbound/channel-bootstrap.runtime.test.ts -t "bootstraps outbound sends with the retained legacy owner after config load"` failed with `AgentSelectionRequiredError` from channel bootstrap.
- Pre-fix CLI regression: `node scripts/run-vitest.mjs src/commands/message.test.ts -t "keeps the retained legacy owner after config load strips the default marker"` failed with the same ambiguity.
- Focused post-fix proof: 159 tests passed across command, agent-scope, routing, channel bootstrap/selection, message routing, broadcast context, and plugin dispatch.
- Source-blind CLI proof with isolated configs and a Telegram numeric dry-run target:
  - migrated two-agent legacy owner: exit 0 with `"dryRun": true`;
  - explicit two-agent `agents.defaults.systemAgent.agentId: "ops"`: exit 0 with `"dryRun": true`;
  - explicit ownerless two-agent config: exits with `AgentSelectionRequiredError`.
- Final changed gate: `node scripts/check-changed.mjs -- <8 changed paths>` passes the core/coreTests typecheck, lint, formatting, dead-code, architecture, and boundary guards after rebasing onto current `main`. Blacksmith Testbox was unavailable because this host lacks the `blacksmith` executable, so repository policy routed trusted-source proof through the local classifier wrapper.
- `git diff --check` and targeted `oxfmt --check` passed.
- Codex autoreview (`--max-priority P1`) reported no accepted/actionable findings for both the owner-propagation repair and the final system-owner contract adjustment.
- No live Reef delivery was attempted; the deterministic CLI dry runs exercise the changed owner and outbound bootstrap path without channel credentials.

AI-assisted; the implementation, tests, runtime proof, and final diff were reviewed by the maintainer before publication.
