### PR TITLE
fix(ci): trust dependency approvers before graph compare

### DIFF
--- a/scripts/github/dependency-guard.mjs
+++ b/scripts/github/dependency-guard.mjs
@@ -792,27 +792,6 @@ async function main() {
     return;
   }
 
-  const dependencyGraphChanges = await api.paginate(
-    `/repos/${owner}/${repo}/dependency-graph/compare/${pullRequest.base?.sha}...${pullRequest.head?.sha}`,
-  );
-  if (isRemovalOnlyDependencyGraphChange(dependencyGraphChanges)) {
-    if (mode === "detect") {
-      await setOutput("autoscrub", "false");
-    }
-    await upsertComment(
-      existingGuardComment,
-      renderRemovalOnlyDependencyComment({
-        dependencyGraphChanges,
-        headSha: pullRequest.head?.sha,
-      }),
-    );
-    await writeSummary(
-      "## Dependency Guard\n\nDependency removals are informational and do not require security approval.",
-    );
-    console.log("Dependency removals detected; guard is informational.");
-    return;
-  }
-
   const { isSecurityMember, isRepositoryAdmin } = createGuardApproverChecks({
     api,
     owner,
@@ -864,6 +843,27 @@ async function main() {
       ].join("\n"),
     );
     console.log("Dependency graph change noted for trusted actor; guard is informational.");
+    return;
+  }
+
+  const dependencyGraphChanges = await api.paginate(
+    `/repos/${owner}/${repo}/dependency-graph/compare/${pullRequest.base?.sha}...${pullRequest.head?.sha}`,
+  );
+  if (isRemovalOnlyDependencyGraphChange(dependencyGraphChanges)) {
+    if (mode === "detect") {
+      await setOutput("autoscrub", "false");
+    }
+    await upsertComment(
+      existingGuardComment,
+      renderRemovalOnlyDependencyComment({
+        dependencyGraphChanges,
+        headSha: pullRequest.head?.sha,
+      }),
+    );
+    await writeSummary(
+      "## Dependency Guard\n\nDependency removals are informational and do not require security approval.",
+    );
+    console.log("Dependency removals detected; guard is informational.");
     return;
   }
 

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -252,13 +252,15 @@ describe("dependency guard workflow", () => {
     expect(autoscrubCommentIndex).toBeGreaterThan(deleteCommentIndex);
   });
 
-  it("checks trusted actors before autoscrub can mutate dependency changes", () => {
+  it("checks trusted actors before dependency graph comparison and autoscrub", () => {
     const script = readFileSync("scripts/github/dependency-guard.mjs", "utf8");
     const trustedActorIndex = script.indexOf("const trustedActor =");
+    const dependencyGraphCompareIndex = script.indexOf("const dependencyGraphChanges =");
     const autoscrubCandidateIndex = script.indexOf("const autoscrubCandidate =");
     const autoscrubOutputIndex = script.indexOf('await setOutput("autoscrub", "true")');
 
     expect(trustedActorIndex).toBeGreaterThan(0);
+    expect(dependencyGraphCompareIndex).toBeGreaterThan(trustedActorIndex);
     expect(autoscrubCandidateIndex).toBeGreaterThan(trustedActorIndex);
     expect(autoscrubOutputIndex).toBeGreaterThan(trustedActorIndex);
   });


### PR DESCRIPTION
## What Problem This Solves

Dependency-heavy PRs from trusted maintainers can fail before the guard reaches its existing trusted-actor decision. The detector currently calls GitHub's dependency-graph compare endpoint first; large release version updates repeatedly exceeded the bounded 30-second API request timeout.

This blocked the immutable `2026.8.1-beta.2` source-signing candidate twice on the same 152 expected package/version files.

## Why This Change Was Made

The existing exact-head trusted-state and trusted PR-author checks already make dependency graph changes informational for repository admins and configured security approvers. This change moves the unchanged dependency-graph comparison block after those trusted returns.

Untrusted PRs still perform the graph comparison. Their removal-only path, autoscrub behavior, exact-SHA manual authorization, and blocking behavior remain unchanged.

## User Impact

Trusted maintainer release/version PRs no longer depend on a large dependency-graph compare request that cannot affect their authorization outcome. Contributor and untrusted dependency changes retain the same security checks and approval requirements.

## Evidence

- Release signing PR detector run `31767562911`, attempts 1 and 2: both detected 152 dependency-related files, then timed out on the dependency-graph compare endpoint after 30 seconds.
- Production diff is a pure block move: `+21/-21`.
- Extended existing ordering contract: trusted actor recognition must precede dependency graph comparison and autoscrub.
- `node scripts/run-vitest.mjs test/scripts/dependency-guard-workflow.test.ts test/scripts/dependency-guard-script.test.ts`: 45 tests passed.
- `node --check scripts/github/dependency-guard.mjs`: passed.
- `git diff --check`: passed.
- Mandatory autoreview: clean.
