### PR TITLE
fix(doctor): surface the resume failure cause for interrupted auth-profile archives

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -44,8 +44,20 @@ import {
   maybeMigrateAuthProfileJsonStoresToSqlite,
   maybeRepairOpenAICodexAuthConfig,
 } from "./doctor-auth-flat-profiles.js";
+import {
+  createAuthProfileMigrationSourceReceipt,
+  type AuthProfileMigrationSourceReceipt,
+} from "./doctor-auth-migration-receipts.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import { maybeRepairCodexSessionRoutes } from "./doctor/shared/codex-route-session-repair.js";
+
+type MigrationReceiptTestApi = {
+  recordAuthProfileMigrationImported: (receipt: AuthProfileMigrationSourceReceipt) => void;
+};
+
+const { recordAuthProfileMigrationImported } = (globalThis as Record<PropertyKey, unknown>)[
+  Symbol.for("openclaw.authProfileMigrationReceiptsTestApi")
+] as MigrationReceiptTestApi;
 
 const states: OpenClawTestState[] = [];
 
@@ -504,6 +516,38 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     expect(fs.existsSync(oauthPath)).toBe(true);
     expectNoMigratedArchive(oauthPath);
     expect(readPersistedAuthProfileStoreRaw(state.agentDir())).toEqual(unreadableStore);
+  });
+
+  it("surfaces the resume failure cause instead of a generic warning", async () => {
+    const state = await makeTestState();
+    const sourcePath = await state.writeText(
+      "credentials/oauth.json",
+      `${JSON.stringify({ openai: { access: "fake", refresh: "fake", expires: 42 } })}\n`,
+    );
+    const receipt = createAuthProfileMigrationSourceReceipt({
+      sourcePath,
+      sourceBytes: fs.readFileSync(sourcePath),
+      sourceRecordCount: 1,
+      targetDatabasePath: path.join(state.agentDir(), "openclaw-agent.sqlite"),
+      // An out-of-union target table makes resumePendingAuthProfileMigrationArchives throw
+      // "invalid pending auth profile migration receipt" — the cheapest way to reproduce one of
+      // its 5 distinct throw causes without corrupting on-disk state.
+      targetTable: "bogus_table" as AuthProfileMigrationSourceReceipt["targetTable"],
+      env: state.env,
+    });
+    recordAuthProfileMigrationImported(receipt);
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+    });
+
+    expect(result.warnings).toContainEqual(
+      expect.stringMatching(
+        /^Could not finalize an interrupted auth profile archive; legacy sources were left for recovery: .*invalid pending auth profile migration receipt.*/,
+      ),
+    );
   });
 
   it.each(["legacy-main", "state-db"] as const)(

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -963,9 +963,8 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   let resumeWarning: string | undefined;
   try {
     resumedChanges = resumePendingAuthProfileMigrationArchives(env);
-  } catch {
-    resumeWarning =
-      "Could not finalize an interrupted auth profile archive; legacy sources were left for recovery.";
+  } catch (err) {
+    resumeWarning = `Could not finalize an interrupted auth profile archive; legacy sources were left for recovery: ${String(err)}`;
   }
   const candidates = listAuthProfileSqliteMigrationCandidates(params.cfg, env);
   const configStore = coerceLegacyConfigAuthProfileStore(params.cfg);


### PR DESCRIPTION
Related: #123164

## What Problem This Solves

Resolves a problem where `openclaw doctor` / `openclaw doctor --fix` users whose interrupted
auth-profile archive fails again on a later resume attempt cannot tell why it failed — the warning is
always the same generic sentence no matter which underlying cause fired.

## Why This Change Was Made

`maybeMigrateAuthProfileJsonStoresToSqlite` (`src/commands/doctor-auth-flat-profiles.ts`) has three
sibling `catch` blocks around auth-profile migration steps. #123164 fixed the identical defect in the
sibling catch block that migrates shared legacy OAuth credentials, changing it from a bare `catch {}`
that dropped the error to `catch (err)` with `` `: ${String(err)}` `` appended. **This PR fixes the
one remaining sibling** — the catch block wrapping `resumePendingAuthProfileMigrationArchives`, which
can throw for several distinct reasons (invalid receipt shape, target verification failure, lock
contention, SQLite failure, corrupt receipt JSON) — the same way. Migration behavior is unchanged;
only the diagnostic text changes.

## Real behavior proof

Behavior addressed: `maybeMigrateAuthProfileJsonStoresToSqlite`'s resume-pending-archive `catch`
block discards the caught error instead of surfacing its cause in the user-visible warning.
Real environment tested: real Node process, real SQLite state DB (via `createOpenClawTestState`,
`layout: "state-only"`), real function under test (`maybeMigrateAuthProfileJsonStoresToSqlite`)
driven with no mocking of the code path being proved. **Not a full end-to-end reproduction**: the
pending-migration-receipt row is seeded directly via the existing test-only helper
(`recordAuthProfileMigrationImported`, exposed by `src/commands/doctor-auth-migration-receipts.ts`
under `globalThis[Symbol.for("openclaw.authProfileMigrationReceiptsTestApi")]` when `NODE_ENV=test` —
the same seeding pattern `src/commands/doctor-auth-migration-receipts.test.ts` uses for this
function's other resume paths) rather than produced by killing a real `doctor` process
mid-migration.
Exact steps or command run after this patch: a standalone script sets `NODE_ENV=test`, seeds one
pending migration receipt with `targetTable` set to a value outside its 3-member union (so
`resumePendingAuthProfileMigrationArchives`'s row-shape check throws
`"invalid pending auth profile migration receipt"`), calls the real
`maybeMigrateAuthProfileJsonStoresToSqlite`, and prints `result.warnings` — run once against the base
commit and once against this PR's head to produce the before/after captures below.

Before evidence (base `c66d5d84db4d473bbbfb51cc6f14e82d61623ee6`, production code exactly as it was before this PR's diff):

```
$ node --import tsx probe-resume-warning.mts
result.warnings = ["Could not finalize an interrupted auth profile archive; legacy sources were left for recovery."]
```

Evidence after fix (head `aa58e5d08463f19ad95f642383b5992945a26231`):

```
$ node --import tsx probe-resume-warning.mts
result.warnings = ["Could not finalize an interrupted auth profile archive; legacy sources were left for recovery: Error: invalid pending auth profile migration receipt"]
```

Observed result after fix: the warning string now ends with `: Error: invalid pending auth profile
migration receipt` instead of a bare period.
What was not tested: the other 4 real throw causes inside `resumePendingAuthProfileMigrationArchives`
were not individually reproduced — the fix (`${String(err)}` on whatever was caught) is cause-agnostic,
so this one cause is representative, not exhaustive.
Proof limitations or environment constraints: temporary SQLite state dir under the OS temp directory,
not a real user state directory.

## Evidence

Changed files: `src/commands/doctor-auth-flat-profiles.ts` (production, +2/-3, no new imports, no
logic change) and `src/commands/doctor-auth-flat-profiles.test.ts` (+44, one new regression test using
the same receipt-seeding approach as the proof above, inside `vitest`). Confirmed the test fails on
pre-fix code (matches the raw "before" capture above) and passes after the fix.

- `node scripts/run-vitest.mjs src/commands/doctor-auth-flat-profiles.test.ts` — 52/52 pass (full file).
- `./node_modules/.bin/oxfmt --check src/commands/doctor-auth-flat-profiles.ts
  src/commands/doctor-auth-flat-profiles.test.ts` — `All matched files use the correct format.`
- `node scripts/run-oxlint.mjs src/commands/doctor-auth-flat-profiles.ts
  src/commands/doctor-auth-flat-profiles.test.ts` — exit 0, no output.
- `pnpm tsgo:core` — exit 0.
- Codex autoreview (`--mode local`) — `autoreview clean: no accepted/actionable findings reported`.

## Non-Scope

- `resumePendingAuthProfileMigrationArchives` itself — not touched, only the caller's `catch`.
- The already-correct third sibling catch block (`Failed to migrate auth profile JSON for ...`) —
  no change needed.
- #123164's own fixed sibling (shared-OAuth catch) — already landed, not touched.
