### PR TITLE
fix(diagnostics): suppress startup-only heartbeat delay warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway liveness diagnostics:** suppress delayed-heartbeat warnings during startup grace and report timer overdue time separately from the normal heartbeat interval, while preserving delayed-tick recovery deferral.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway liveness diagnostics:** suppress delayed-heartbeat warnings during startup grace and report timer overdue time separately from the normal heartbeat interval, while preserving delayed-tick recovery deferral.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -520,6 +520,12 @@ describe("stuck session diagnostics threshold", () => {
     vi.advanceTimersByTime(30_000);
 
     expectLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+    const delayedHeartbeat = loggerMessages(warnSpy).find((message) =>
+      message.includes("liveness heartbeat delayed"),
+    );
+    expect(delayedHeartbeat).toMatch(/overdue=\d+ms elapsed=\d+ms/u);
+    const timing = delayedHeartbeat?.match(/overdue=(\d+)ms elapsed=(\d+)ms/u);
+    expect(Number(timing?.[2]) - Number(timing?.[1])).toBe(30_000);
     expect(recoverStuckSession).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(30_000);
@@ -2394,6 +2400,7 @@ describe("stuck session diagnostics threshold", () => {
   it("suppresses liveness warnings during startupGraceMs while still sampling", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
     const events: string[] = [];
+    const recoverStuckSession = vi.fn();
     const sampleLiveness = vi.fn(() => ({
       reasons: ["event_loop_delay" as const],
       intervalMs: 30_000,
@@ -2403,6 +2410,7 @@ describe("stuck session diagnostics threshold", () => {
     const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
 
     try {
+      vi.setSystemTime(0);
       startDiagnosticHeartbeat(
         {
           diagnostics: {
@@ -2411,23 +2419,35 @@ describe("stuck session diagnostics threshold", () => {
         },
         {
           emitMemorySample: createEmitMemorySampleMock(),
+          recoverStuckSession,
           sampleLiveness,
           startupGraceMs: 60_000,
+          testTimings: { stuckSessionWarnMs: 1_000, stuckSessionAbortMs: 1_000 },
         },
       );
 
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      vi.setSystemTime(1_001);
       vi.advanceTimersByTime(30_000);
 
       expect(sampleLiveness).toHaveBeenCalledTimes(1);
+      expectNoLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
       expectNoLoggerMessageContaining(warnSpy, "liveness warning:");
       expect(events).not.toContain("diagnostic.liveness.warning");
+      expect(recoverStuckSession).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(30_000);
 
       expect(sampleLiveness).toHaveBeenCalledTimes(2);
       expectLoggerMessageContaining(warnSpy, "liveness warning:");
       expect(events).toContain("diagnostic.liveness.warning");
+      expectRecoveryCall(
+        recoverStuckSession,
+        { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+        ["ageMs", "stateGeneration"],
+      );
     } finally {
       unsubscribe();
     }

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1176,19 +1176,19 @@ export function startDiagnosticHeartbeat(
       lastDiagnosticHeartbeatTickAt === undefined ? 0 : now - lastDiagnosticHeartbeatTickAt;
     lastDiagnosticHeartbeatTickAt = now;
     const heartbeatOverdueMs = Math.max(0, heartbeatElapsedMs - DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
+    const inStartupGrace = livenessGraceUntil > 0 && now < livenessGraceUntil;
     // Observe ordinary timer jitter at the scheduled tick so it cannot consume
     // a run's remaining recovery budget. Material lateness can also hide queued
     // progress events, so the next healthy heartbeat owns recovery instead.
     const recoveryObservationNow = now - heartbeatOverdueMs;
     const shouldDeferRecovery = heartbeatOverdueMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
-    if (shouldDeferRecovery) {
+    if (shouldDeferRecovery && !inStartupGrace) {
       diag.warn(
-        `liveness heartbeat delayed ${Math.round(heartbeatElapsedMs)}ms; deferring recovery decisions`,
+        `liveness heartbeat delayed: overdue=${Math.round(heartbeatOverdueMs)}ms elapsed=${Math.round(heartbeatElapsedMs)}ms; deferring recovery decisions`,
       );
     }
     pruneDiagnosticSessionStates(now, true);
     const work = getDiagnosticWorkSnapshot(now);
-    const inStartupGrace = livenessGraceUntil > 0 && now < livenessGraceUntil;
     const rawLivenessSample = (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
     // Keep sampling during grace so event-loop delay baselines reset, but suppress startup-only reports.
     const livenessSample = inStartupGrace ? null : rawLivenessSample;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary timer jitter on the first diagnostic heartbeat could be reported as a long Gateway liveness stall during startup grace. The warning printed the whole heartbeat interval as the delay, so an observed `31378ms` line described a 30-second interval plus 1.378 seconds of lateness as though the Gateway had stalled for 31.378 seconds.

## Why This Change Was Made

The delayed-tick warning ran before the existing startup-grace check. This moves the lifecycle fact ahead of the warning and suppresses only that startup-only log. Delayed ticks still set `shouldDeferRecovery`, so a late startup heartbeat cannot consume a session's recovery budget or trigger a false stuck-session recovery.

Outside startup grace the warning now reports both facts explicitly:

```text
liveness heartbeat delayed: overdue=<timer lateness>ms elapsed=<interval plus lateness>ms; deferring recovery decisions
```

Production LOC: +3/-3 (net 0) | Tests: +20/-0

## User Impact

Operators no longer see normal startup heartbeat jitter mislabeled as a process-wide stall, while genuine delayed ticks after startup remain visible and retain the same conservative recovery behavior.

## Evidence

- Live evidence that motivated the repair: `elapsed=31378ms` on a 30,000ms heartbeat interval, making the actual overdue time 1,378ms; post-startup control-plane calls completed normally.
- `src/logging/diagnostic.test.ts`: 82/82 focused tests passed.
- Regression proves a materially delayed first tick emits no warning and performs no recovery during startup grace, then recovers on the next on-time tick.
- Existing delayed-tick coverage now proves `elapsed - overdue === 30000ms`.
- Changed gate passed conflict-marker, env-ratchet, max-lines, attribution, dependency-pin, formatting, deprecated-API, plugin-boundary, wrapper-shadowing, patch, dead-export, and temp-file checks. Local core typecheck was not authoritative because the only available borrowed dependency tree predates current `main` (`@openclaw/session-url-contract/parse` missing plus an unrelated terminal-core signature mismatch); exact-head CI remains the typecheck authority.
- Autoreview: clean, no accepted/actionable findings.

Provenance: the delayed-tick recovery guard and warning were introduced in #108455 (PR/code author @harjothkhara, merged by @steipete on 2026-07-16); the older startup-grace suppression remained below the new warning.
