### PR TITLE
fix(gateway): make the node worker deadline the sole expiry authority

### DIFF
--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -488,11 +488,19 @@ describe("node worker launch adapter", () => {
       request.onDispatchReady?.("invoke-1");
       return wire(receipt(input, "running"));
     });
+    // Scheduling lag lands the clock read that sizes the RPC budget ahead of the timer wheel,
+    // so the per-RPC timer expires just before the cancellation deadline it was derived from.
+    // That must stay a terminal deadline, not a retryable RPC timeout that funds a second
+    // cancel dispatch out of the residue.
+    let cancelling = false;
+    let cancelClockReads = 0;
     const adapter = createNodeWorkerLaunchAdapter({
       getTransport: () => transportWith(invoke),
       cancellationTimeoutMs: 25,
+      now: () => Date.now() + (cancelling && ++cancelClockReads === 3 ? 5 : 0),
       sleep: async () => {
         controller.abort();
+        cancelling = true;
       },
     });
 

--- a/src/gateway/worker-environments/node-launch-adapter.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.ts
@@ -267,14 +267,19 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
         "device worker node transport is unavailable",
       );
     }
-    const rpcController = new AbortController();
-    const rpcBudgetMs = Math.max(1, Math.min(rpcTimeoutMs, remainingMs));
-    const rpcTimer = setTimeout(
-      () => rpcController.abort(new Error("node worker RPC timed out")),
-      rpcBudgetMs,
-    );
-    rpcTimer.unref?.();
-    const signal = AbortSignal.any([params.deadline.signal, rpcController.signal]);
+    // The deadline is the sole expiry authority unless the per-RPC budget binds first.
+    // A second timer armed at the same expiry makes "retryable RPC timeout" versus
+    // "terminal deadline" a scheduling race, and the retryable branch then funds another
+    // attempt out of a residual budget too small to complete it.
+    const rpcBudgetMs = Math.min(rpcTimeoutMs, remainingMs);
+    const rpcController = rpcBudgetMs < remainingMs ? new AbortController() : undefined;
+    const rpcTimer = rpcController
+      ? setTimeout(() => rpcController.abort(new Error("node worker RPC timed out")), rpcBudgetMs)
+      : undefined;
+    rpcTimer?.unref?.();
+    const signal = rpcController
+      ? AbortSignal.any([params.deadline.signal, rpcController.signal])
+      : params.deadline.signal;
     try {
       const node = await findNode({
         transport,
@@ -309,7 +314,7 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
       }
       return parseInvokeReceipt(result.payloadJSON);
     } catch (error) {
-      if (rpcController.signal.aborted && !params.deadline.signal.aborted) {
+      if (rpcController?.signal.aborted && !params.deadline.signal.aborted) {
         throw new NodeWorkerLaunchTransportError("TIMEOUT", "node worker RPC timed out");
       }
       throw error;


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/worker-environments/node-launch-adapter.test.ts > "reports unknown cancellation outcome after a hard cancellation deadline"` flakes on CI (for example [run 31765534464](https://github.com/openclaw/openclaw/actions/runs/31765534464), job `checks-node-compact-large-11`, shard `agentic-gateway-core-1`) with `expected [...] to have a length of 1 but got 2`, while passing locally.

The flake is a real product defect in the adapter, not a test-seam artifact. `invoke` armed a per-RPC abort timer for every invocation, sized `Math.max(1, Math.min(rpcTimeoutMs, remainingMs))`. When the deadline is the shorter bound — which is always true on the cancellation path, since `cancellationTimeoutMs` and `rpcTimeoutMs` are both 30s by default in `device-provider.ts` — that timer expires at the same instant as the deadline timer. Which one fires first is a scheduling race:

- deadline first → terminal expiry → `cancelUntilTerminal` breaks and reports the unknown outcome (one cancel dispatch);
- per-RPC timer first → `NodeWorkerLaunchTransportError("TIMEOUT")`, which is retryable → the loop passes `remainingMs() > 0` with a sub-millisecond residue and dispatches a second cancel RPC that cannot possibly complete before the deadline.

So a hard cancellation deadline could send an extra, guaranteed-doomed cancel RPC to the device after the operator-visible deadline was effectively exhausted, and the terminal-versus-retryable classification of the same expiry was nondeterministic.

## Why This Change Was Made

Fixed at the owner boundary: the deadline is the single expiry authority for an attempt whose budget it already bounds. The per-RPC timer is armed only when its budget genuinely binds first (`rpcBudgetMs < remainingMs`); otherwise the RPC rides the deadline signal alone. That deletes the duplicate expiry authority rather than adding a guard downstream, so the retryable/terminal distinction is decided by which bound is actually shorter, not by timer insertion order. The `Math.max(1, ...)` floor is gone too — it manufactured budget the deadline did not have.

RPC-timeout retries are unchanged where the RPC budget really is the shorter bound (`retries a timed-out launch RPC within the overall deadline`, `retries a timed-out cancellation RPC within one cleanup deadline`).

Production LOC delta: +5/-9 code lines in the adapter, of which 4 added lines are the invariant comment; net production code is roughly neutral with one added branch that removes a race.

## User Impact

A worker cancellation that hangs past its cleanup deadline now reports the unknown outcome deterministically and stops dispatching, instead of sometimes issuing an extra cancel RPC to the device host. No config, protocol, or API surface changes.

## Evidence

The existing flaky test is now deterministic: it injects a clock read that lands one scheduling slice ahead of the timer wheel while sizing the RPC budget, which is what CI lag does to the same-millisecond race.

- Pre-fix (fix stashed, new test in place): `expected [ [ ... ], …(1) ] to have a length of 1 but got 2` — the exact CI failure, reproduced on demand.
- Post-fix: `node scripts/run-vitest.mjs src/gateway/worker-environments/node-launch-adapter.test.ts` — 15/15 passing.
- Bounded loop: 12 consecutive focused runs under 6 saturating CPU load generators — 12 pass, 0 fail.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `node scripts/run-tsgo-core-test-shards.mjs` clean; `oxfmt --check` and `scripts/run-oxlint.mjs` clean on both files.
- Codex autoreview (`gpt-5.6-sol`, xhigh): `autoreview clean: no accepted/actionable findings reported`.

Note: `scripts/check-changed.mjs` fails in this worktree on the `max-lines` ratchet for `src/gateway/server-http.ts`, which this PR does not touch; the worktree cannot reach an `origin/main` ancestor, so the ratchet's base comparison degenerates. Unrelated to this change.
