### PR TITLE
fix: retain file changes across conversation compaction

### DIFF
--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -1,6 +1,133 @@
 import type { Message } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
-import { serializeConversation } from "./utils.js";
+import type { AgentMessage } from "../../types.js";
+import {
+  computeFileLists,
+  createFileOps,
+  extractFileOpsFromMessage,
+  mergeSummaryFileOperations,
+  serializeConversation,
+} from "./utils.js";
+
+describe("file operation provenance", () => {
+  it.each([
+    {
+      name: "path aliases",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              name: "read",
+              arguments: { path: 42, file_path: "src/read.ts" },
+            },
+            {
+              type: "toolCall",
+              name: "write",
+              arguments: { path: null, file_path: false, filePath: "src/write.ts" },
+            },
+            {
+              type: "toolCall",
+              name: "edit",
+              arguments: { path: "src/edit.ts", file_path: "ignored.ts" },
+            },
+          ],
+        },
+      ],
+      expected: {
+        readFiles: ["src/read.ts"],
+        modifiedFiles: ["src/edit.ts", "src/write.ts"],
+      },
+    },
+    {
+      name: "namespaced tool names",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", name: "mcp__files__READ", arguments: { path: "src/read.ts" } },
+            { type: "toolCall", name: "files__edit", arguments: { path: "src/edit.ts" } },
+          ],
+        },
+      ],
+      expected: { readFiles: ["src/read.ts"], modifiedFiles: ["src/edit.ts"] },
+    },
+    {
+      name: "apply_patch result summary",
+      messages: [
+        {
+          role: "toolResult",
+          toolName: "apply_patch",
+          details: {
+            summary: {
+              added: ["src/added.ts"],
+              modified: ["src/modified.ts"],
+              deleted: ["src/deleted.ts"],
+            },
+          },
+        },
+        {
+          role: "toolResult",
+          toolName: "apply_patch",
+          content: [
+            {
+              type: "toolResult",
+              details: {
+                summary: { added: [], modified: ["src/nested.ts"], deleted: [] },
+              },
+            },
+          ],
+        },
+      ],
+      expected: {
+        readFiles: [],
+        modifiedFiles: ["src/added.ts", "src/modified.ts", "src/nested.ts"],
+      },
+    },
+    {
+      name: "unknown tools",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", name: "plugin__inspect", arguments: { path: "ignored.ts" } },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolName: "unknown_patch",
+          details: { summary: { added: ["also-ignored.ts"], modified: [], deleted: [] } },
+        },
+      ],
+      expected: { readFiles: [], modifiedFiles: [] },
+    },
+  ])("extracts $name", ({ messages, expected }) => {
+    const fileOps = createFileOps();
+    for (const message of messages as unknown as AgentMessage[]) {
+      extractFileOpsFromMessage(message, fileOps);
+    }
+    expect(computeFileLists(fileOps)).toEqual(expected);
+  });
+
+  it("merges file identity forward across two compactions", () => {
+    const first = createFileOps();
+    first.read.add("src/first-read.ts");
+    first.written.add("src/first-write.ts");
+
+    const second = createFileOps();
+    mergeSummaryFileOperations(second, computeFileLists(first));
+    second.edited.add("src/second-edit.ts");
+
+    const third = createFileOps();
+    mergeSummaryFileOperations(third, computeFileLists(second));
+
+    expect(computeFileLists(third)).toEqual({
+      readFiles: ["src/first-read.ts"],
+      modifiedFiles: ["src/first-write.ts", "src/second-edit.ts"],
+    });
+  });
+});
 
 describe("serializeConversation", () => {
   it.each([

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -1,18 +1,28 @@
 import type { AssistantMessage, Message } from "@openclaw/llm-core";
-// Agent Core helper module supports utils behavior.
+import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { AgentMessage } from "../../types.js";
 import type { FileOperations } from "../types.js";
 
 export type { FileOperations } from "../types.js";
 
+function normalizeFileToolName(value: unknown): string {
+  const name = typeof value === "string" ? value.toLowerCase() : "";
+  const separator = name.indexOf("__", name.startsWith("mcp__") ? 5 : 0);
+  return separator < 0 ? name : name.slice(separator + 2);
+}
+
+function addFilePaths(target: Set<string>, value: unknown): void {
+  for (const path of Array.isArray(value) ? value : []) {
+    if (typeof path === "string") {
+      target.add(path);
+    }
+  }
+}
+
 /** Create an empty file-operation accumulator. */
 export function createFileOps(): FileOperations {
-  return {
-    read: new Set(),
-    written: new Set(),
-    edited: new Set(),
-  };
+  return { read: new Set(), written: new Set(), edited: new Set() };
 }
 
 /** Restore file metadata recorded by an earlier compaction or branch summary. */
@@ -20,45 +30,42 @@ export function mergeSummaryFileOperations(
   fileOps: FileOperations,
   details: { readFiles: string[]; modifiedFiles: string[] },
 ): void {
-  for (const path of Array.isArray(details.readFiles) ? details.readFiles : []) {
-    fileOps.read.add(path);
-  }
-  for (const path of Array.isArray(details.modifiedFiles) ? details.modifiedFiles : []) {
-    fileOps.edited.add(path);
-  }
+  addFilePaths(fileOps.read, details.readFiles);
+  addFilePaths(fileOps.edited, details.modifiedFiles);
 }
 
-/** Add file operations from assistant tool calls to an accumulator. */
+/** Add file operations from tool calls and results to an accumulator. */
 export function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOperations): void {
-  if (message.role !== "assistant") {
-    return;
-  }
-  if (!("content" in message) || !Array.isArray(message.content)) {
+  if (message.role === "toolResult") {
+    if (normalizeFileToolName(message.toolName) !== "apply_patch") {
+      return;
+    }
+    for (const result of [message, ...(Array.isArray(message.content) ? message.content : [])]) {
+      const details = asRecord(asRecord(result)?.details);
+      const summary = asRecord(details?.summary);
+      addFilePaths(fileOps.written, summary?.added);
+      addFilePaths(fileOps.edited, summary?.modified);
+    }
+    // Deleted paths no longer exist for a continuation to inspect, so omit them.
     return;
   }
 
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    return;
+  }
   for (const block of message.content) {
-    if (typeof block !== "object" || block === null) {
+    const toolCall = asRecord(block);
+    if (toolCall?.type !== "toolCall") {
       continue;
     }
-    if (!("type" in block) || block.type !== "toolCall") {
-      continue;
-    }
-    if (!("arguments" in block) || !("name" in block)) {
-      continue;
-    }
-
-    const args = block.arguments as Record<string, unknown> | undefined;
-    if (!args) {
-      continue;
-    }
-
-    const path = typeof args.path === "string" ? args.path : undefined;
+    const args = asRecord(toolCall.arguments);
+    const path = [args?.path, args?.file_path, args?.filePath].find(
+      (value): value is string => typeof value === "string",
+    );
     if (!path) {
       continue;
     }
-
-    switch (block.name) {
+    switch (normalizeFileToolName(toolCall.name)) {
       case "read":
         fileOps.read.add(path);
         break;
@@ -85,17 +92,11 @@ export function computeFileLists(fileOps: FileOperations): {
 
 /** Format file lists as summary metadata tags. */
 export function formatFileOperations(readFiles: string[], modifiedFiles: string[]): string {
-  const sections: string[] = [];
-  if (readFiles.length > 0) {
-    sections.push(`<read-files>\n${readFiles.join("\n")}\n</read-files>`);
-  }
-  if (modifiedFiles.length > 0) {
-    sections.push(`<modified-files>\n${modifiedFiles.join("\n")}\n</modified-files>`);
-  }
-  if (sections.length === 0) {
-    return "";
-  }
-  return `\n\n${sections.join("\n\n")}`;
+  const sections = [
+    readFiles.length ? `<read-files>\n${readFiles.join("\n")}\n</read-files>` : "",
+    modifiedFiles.length ? `<modified-files>\n${modifiedFiles.join("\n")}\n</modified-files>` : "",
+  ].filter(Boolean);
+  return sections.length ? `\n\n${sections.join("\n\n")}` : "";
 }
 
 /** Extract visible summary text without normalizing valid model output. */
@@ -125,14 +126,13 @@ function truncateForSummary(text: string, maxChars: number): string {
   }
   const tailChars = Math.min(Math.floor(maxChars * 0.3), 600);
   const diagnosticSearch = sliceUtf16Safe(text, -maxChars);
-  const diagnosticMatches = Array.from(
-    diagnosticSearch.matchAll(new RegExp(IMPORTANT_TOOL_RESULT_TAIL.source, "gi")),
-  );
+  const diagnosticMatches = [
+    ...diagnosticSearch.matchAll(new RegExp(IMPORTANT_TOOL_RESULT_TAIL.source, "gi")),
+  ];
   const diagnosticMatch =
-    diagnosticMatches
-      .toReversed()
-      .find((match) => /^(error|exception|fatal|panic|errno)$/i.test(match[0])) ??
-    diagnosticMatches.at(-1);
+    diagnosticMatches.findLast((match) =>
+      /^(error|exception|fatal|panic|errno)$/i.test(match[0]),
+    ) ?? diagnosticMatches.at(-1);
   if (diagnosticMatch) {
     const head = truncateUtf16Safe(text, maxChars - tailChars);
     const displacedHead = sliceUtf16Safe(text, Math.max(0, head.length - 32), maxChars);
@@ -164,16 +164,16 @@ export function getCompactionContentBlockText(block: {
   content?: unknown;
   text?: string;
 }): string {
-  if (block.type === "text" && block.text) {
+  if (
+    (block.type === "text" || block.type === "toolResult" || block.type === "tool_result") &&
+    block.text
+  ) {
     return block.text;
   }
-  if (block.type !== "toolResult" && block.type !== "tool_result") {
-    return "";
-  }
-  if (block.text) {
-    return block.text;
-  }
-  return typeof block.content === "string" ? block.content : "";
+  return (block.type === "toolResult" || block.type === "tool_result") &&
+    typeof block.content === "string"
+    ? block.content
+    : "";
 }
 
 /** Serialize LLM messages to plain text for summarization prompts. */
@@ -185,10 +185,7 @@ export function serializeConversation(messages: Message[]): string {
       const content =
         typeof msg.content === "string"
           ? msg.content
-          : msg.content
-              .filter((c): c is { type: "text"; text: string } => c.type === "text")
-              .map((c) => c.text)
-              .join("");
+          : msg.content.map(getCompactionContentBlockText).join("");
       if (content) {
         parts.push(`[User]: ${content}`);
       }
@@ -203,8 +200,7 @@ export function serializeConversation(messages: Message[]): string {
         } else if (block.type === "thinking") {
           thinkingParts.push(block.thinking);
         } else if (block.type === "toolCall") {
-          const args = block.arguments;
-          const argsStr = Object.entries(args)
+          const argsStr = Object.entries(block.arguments)
             .map(([k, v]) => `${k}=${stringifyCompactionValue(v)}`)
             .join(", ");
           toolCalls.push(`${block.name}(${argsStr})`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where file identities could disappear from compacted conversation history when coding tools used accepted path aliases, namespaced tool names, or `apply_patch`. After compaction, the surviving `<read-files>` and `<modified-files>` blocks could therefore omit files the agent had actually read or changed.

## Why This Change Was Made

File-operation extraction now normalizes the open-ended namespace prefix, selects the first string path from `path`, `file_path`, or `filePath`, and consumes the structured `apply_patch` result summary instead of parsing patch text. Added files are recorded as writes, modified files as edits, and deleted files are intentionally omitted because they no longer exist for a continuation to inspect. Nearby accumulator and summary formatting logic was consolidated so production code shrinks by four lines.

## User Impact

Agents retain accurate read and modified file context across ordinary compaction, branch summaries, and repeated compactions, including MCP-projected tools and multi-file patches. Unknown tools remain ignored.

## Evidence

- Pre-fix: `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/utils.test.ts` failed exactly the path-alias, namespaced-name, and `apply_patch` provenance cases (3 failed, 14 passed).
- Post-fix: `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/utils.test.ts` (17 passed).
- `pnpm tsgo` passed.
- `pnpm tsgo:core:test` passed.
- Structured autoreview reported no accepted/actionable findings.
- Production numstat: +60/-64 (net -4); tests: +128/-1.
