### PR TITLE
fix(agents): preserve Swarm collector errors

### DIFF
--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -389,7 +389,10 @@ while (pending.size > 0) {
   for (const item of batch.completed) {
     pending.delete(item.runId);
     if (item.status !== "done") {
-      throw new Error(item.schemaError ?? item.result ?? `${item.runId}: ${item.status}`);
+      const detail = [item.error, item.schemaError, item.result].find(
+        (value) => typeof value === "string" && value.trim(),
+      );
+      throw new Error(detail ?? `${item.runId}: ${item.status}`);
     }
     completed.push(item); // Process each result as soon as it finishes.
   }
@@ -412,6 +415,7 @@ type AgentsWaitResult = {
     status: "done" | "failed" | "killed" | "timeout";
     result: string;
     structured?: unknown;
+    error?: string;
     schemaError?: string;
     sessionKey: string;
     label?: string;
@@ -424,6 +428,16 @@ type AgentsWaitResult = {
   }>;
 };
 ```
+
+A completed item can contain partial `structured` data and still have
+`status: "failed"` when the provider or runtime fails afterward. In that case,
+`error` is the authoritative terminal failure. Recovery code should prefer a
+nonblank `error`, then `schemaError`, then a nonblank `result`, and finally a
+run/status fallback.
+
+Individual failed items do not make a mixed `agents_wait` poll a top-level tool
+error. The poll remains a successful JSON result so callers can process its
+`completed`, `pending`, and `errors` arrays independently.
 
 The call returns immediately when any requested child is already complete,
 when at least one pending child completes, when no valid pending ids remain,

--- a/src/agents/code-mode-swarm-controller-source.ts
+++ b/src/agents/code-mode-swarm-controller-source.ts
@@ -32,7 +32,9 @@ export const CODE_MODE_SWARM_CONTROLLER_SOURCE = String.raw`
     if (!completion || completion.status !== "done") {
       const runId = completion?.runId ?? spawned.runId ?? "unknown";
       const status = completion?.status ?? "failed";
-      const detail = completion?.schemaError || completion?.result || "collector returned no result";
+      const detail = [completion?.error, completion?.schemaError, completion?.result].find(
+        (value) => typeof value === "string" && value.trim()
+      ) || "collector returned no result";
       throw new SwarmAgentError(runId, status, detail);
     }
     return options.schema !== undefined ? completion.structured : completion.result;

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -285,6 +285,41 @@ describe("Code Mode swarm guest", () => {
     }
   });
 
+  it.each([
+    { name: "blank result", schemaError: undefined },
+    { name: "schema error", schemaError: "structured output was invalid" },
+  ])("prefers an authoritative execution error over $name", async ({ schemaError }) => {
+    const first = await workerExec('return await agents.run("Fail after output");', true);
+    expectWaiting(first);
+    const second = await workerResume(first, [
+      { id: first.pendingRequests[0]!.id, ok: true, value: { runId: "collector-4" } },
+    ]);
+    expectWaiting(second);
+
+    const failed = await workerResume(second, [
+      {
+        id: second.pendingRequests[0]!.id,
+        ok: true,
+        value: {
+          runId: "collector-4",
+          status: "failed",
+          result: "",
+          structured: { partial: true },
+          error: "provider failed after tool output",
+          ...(schemaError ? { schemaError } : {}),
+        },
+      },
+    ]);
+
+    expect(failed).toMatchObject({ status: "failed", code: "internal_error" });
+    if (failed.status === "failed") {
+      expect(failed.error).toContain(
+        "SwarmAgentError: Swarm agent collector-4 failed: provider failed after tool output",
+      );
+      expect(failed.error).not.toContain("structured output was invalid");
+    }
+  });
+
   it("sends phase and log as fire-and-forget swarm notes", async () => {
     const first = await workerExec('phase("Plan"); log("Working"); return "ok";', true);
     expectWaiting(first);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -3041,7 +3041,7 @@ describe("subagent registry lifecycle hardening", () => {
     expect(entry.endedReason).toBe(SUBAGENT_ENDED_REASON_COMPLETE);
   });
 
-  it("preserves a real failure after structured output was accepted", async () => {
+  it("preserves the authoritative execution failure after structured output was accepted", async () => {
     const structured = { answer: "yes" };
     const entry = createRunEntry({
       expectsCompletionMessage: false,
@@ -3060,6 +3060,10 @@ describe("subagent registry lifecycle hardening", () => {
     );
 
     await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    expect(entry.execution.outcome).toMatchObject({
+      status: "error",
+      error: "provider failed after tool output",
+    });
     expect(entry.collectorCompletion).toEqual({ status: "failed", structured });
   });
 

--- a/src/agents/tools/agents-wait-tool.test.ts
+++ b/src/agents/tools/agents-wait-tool.test.ts
@@ -154,6 +154,45 @@ describe("agents_wait", () => {
     });
   });
 
+  it("projects an authorized collector failure without failing a mixed batch", async () => {
+    const failed = collectorRun("failed", "agent:main:main", {
+      status: "failed",
+      structured: { partial: true },
+    });
+    failed.execution = {
+      status: "terminal",
+      outcome: { status: "error", error: "provider failed after tool output" },
+    };
+    failed.completion = { required: false, resultText: null, capturedAt: 10 };
+    records.set(failed.runId, failed);
+    records.set("pending", collectorRun("pending", "agent:main:main"));
+    const tool = createAgentsWaitTool({
+      agentSessionKey: "agent:main:main",
+      agentId: "main",
+      config: { tools: { swarm: true } },
+    });
+
+    const result = await tool.execute("call", {
+      ids: [failed.runId, "pending"],
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toEqual({
+      completed: [
+        {
+          runId: failed.runId,
+          status: "failed",
+          result: "",
+          structured: { partial: true },
+          error: "provider failed after tool output",
+          sessionKey: failed.childSessionKey,
+        },
+      ],
+      pending: ["pending"],
+    });
+    expect(isToolResultError(result)).toBe(false);
+  });
+
   it("orders completions by their durable capture time instead of input order", async () => {
     const later = collectorRun("later", "agent:main:main", { status: "done" });
     later.completion = { required: false, resultText: "later", capturedAt: 10 };

--- a/src/agents/tools/agents-wait-tool.ts
+++ b/src/agents/tools/agents-wait-tool.ts
@@ -70,6 +70,9 @@ function completionResult(entry: SubagentRunRecord) {
     status: completion.status,
     result: resolveSubagentCompletionResultText(entry) ?? "",
     ...(completion.structured !== undefined ? { structured: completion.structured } : {}),
+    ...(entry.execution.outcome?.status === "error"
+      ? { error: entry.execution.outcome.error }
+      : {}),
     ...(completion.schemaError ? { schemaError: completion.schemaError } : {}),
     sessionKey: entry.childSessionKey,
     ...(entry.label ? { label: entry.label } : {}),


### PR DESCRIPTION
Closes #123463

## What Problem This Solves

Fixes an issue where a structured Swarm collector could fail after producing partial data but expose only `status: "failed"` with a blank result. The authoritative provider/runtime error was lost before `agents_wait` and Code Mode consumed the completion.

## Why This Change Was Made

`agents_wait` now adds an optional per-item `error` directly from the already-durable execution outcome. Collector persistence and mixed-batch polling semantics remain unchanged. Code Mode and the documented recovery pattern prefer a nonblank authoritative error, then schema error, then nonblank result, then a run/status fallback.

## User Impact

Swarm callers receive the actual provider/runtime failure while retaining partial structured output. Mixed batches still return normally so completed, failed, and pending runs can be processed together.

## Evidence

- Exact head: `899e787c32b109fbb8282ab9df499c57b3a7dc6e`, rebased onto `e7528c6d91a5cacfb99707e6d860966f79254565`.
- Tests-first `agents_wait` regression failed because the completed item omitted `error`.
- Tests-first Code Mode regressions returned generic/schema errors instead of the provider failure.
- Post-fix `agents_wait`: 18/18 passed.
- Post-fix Code Mode Swarm: 15/15 passed.
- Subagent lifecycle suite: 148/148 passed.
- Source-blind contract probes passed for mixed-batch success, partial structured retention, authoritative error projection, and blank/schema/result fallback precedence.
- Core and core-test TypeScript checks, targeted lint/format, docs listing, full docs checks, and `git diff --check` passed. Testbox proof: https://github.com/openclaw/openclaw/actions/runs/31770260430
- Final integrated Codex autoreview: clean, no findings; TruffleHog clean.

Production delta: +6/-1, net +5. Tests: +79/-1, net +78. Docs: +15/-1, net +14.

AI-assisted: yes. The repair was reviewed across collector lifecycle, registry execution outcomes, `agents_wait`, QuickJS `agents.run`, mixed-batch error classification, and public Swarm documentation.
