### PR TITLE
fix(agents): prevent scoped model checks from stalling the gateway

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -102,7 +102,12 @@ const state = vi.hoisted(() => ({
   resolveSupportedThinkingLevelMock: vi.fn(({ level }: { level?: string }) => level),
   resolveThinkingDefaultMock: vi.fn((_args: unknown) => "low"),
   loadManifestModelCatalogMock: vi.fn(() => []),
-  loadProviderScopedThinkingCatalogMock: vi.fn((_params: unknown) => undefined),
+  loadProviderScopedThinkingCatalogMock: vi.fn(
+    async (_params: unknown): Promise<ModelCatalogSnapshot["entries"] | undefined> => undefined,
+  ),
+  loadFullModelCatalogMock: vi.fn(async () => {
+    throw new Error("full model catalog should not materialize");
+  }),
   loadPreparedModelCatalogSnapshotMock: vi.fn(
     async (): Promise<ModelCatalogSnapshot> => ({
       entries: [],
@@ -577,7 +582,10 @@ vi.mock("./model-catalog.js", () => ({
 vi.mock("./model-catalog.runtime.js", () => ({
   // The scoped thinking catalog hydrates from the same runtime snapshot the test controls.
   loadProviderScopedThinkingCatalog: async (params: unknown) => {
-    state.loadProviderScopedThinkingCatalogMock(params);
+    const scoped = await state.loadProviderScopedThinkingCatalogMock(params);
+    if (scoped !== undefined) {
+      return scoped;
+    }
     return (await state.loadPreparedModelCatalogSnapshotMock()).entries;
   },
   loadPreparedModelCatalogSnapshot: state.loadPreparedModelCatalogSnapshotMock,
@@ -916,6 +924,8 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.resolveThinkingDefaultMock.mockReturnValue("low");
     state.resolveAgentSkillsFilterMock.mockReturnValue(undefined);
     state.loadManifestModelCatalogMock.mockReturnValue([]);
+    state.loadProviderScopedThinkingCatalogMock.mockReset().mockResolvedValue(undefined);
+    state.loadFullModelCatalogMock.mockClear();
     state.loadPreparedModelCatalogSnapshotMock.mockResolvedValue({
       entries: [],
       routeVariants: [],
@@ -2471,16 +2481,17 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       }
       return "low";
     });
-    state.loadPreparedModelCatalogSnapshotMock.mockResolvedValue({
-      entries: [
-        {
-          provider: "OpenAI",
-          id: "gpt-5.6-terra",
-          name: "GPT 5.6 Terra",
-          reasoning: true,
-        },
-      ],
-      routeVariants: [],
+    state.loadProviderScopedThinkingCatalogMock.mockResolvedValue([
+      {
+        provider: "OpenAI",
+        id: "gpt-5.6-terra",
+        name: "GPT 5.6 Terra",
+        reasoning: true,
+      },
+    ]);
+    state.loadPreparedModelCatalogSnapshotMock.mockImplementation(async () => {
+      await state.loadFullModelCatalogMock();
+      return { entries: [], routeVariants: [] };
     });
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
       await params.run(params.provider, params.model);
@@ -2507,7 +2518,17 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       modelOverride: "gpt-5.6-terra",
       resolvedThinkLevel: "medium",
     });
-    expect(state.loadPreparedModelCatalogSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(state.loadProviderScopedThinkingCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: state.runtimeConfigMock,
+        provider: "openai",
+        model: "gpt-5.6-terra",
+        agentId: "default",
+        workspaceDir: "/tmp/workspace",
+      }),
+    );
+    expect(state.loadPreparedModelCatalogSnapshotMock).not.toHaveBeenCalled();
+    expect(state.loadFullModelCatalogMock).not.toHaveBeenCalled();
   });
 
   it("persists and clears current run delivery context for restart recovery", async () => {

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -399,16 +399,16 @@ export async function runEmbeddedAgentAttempt(params: {
             })
           ) {
             attemptedThinkingCatalogHydration = true;
-            const { loadPreparedModelCatalogSnapshot } =
+            const { loadProviderScopedThinkingCatalog } =
               await import("../model-catalog.runtime.js");
             const runtimeCatalog = normalizeThinkingCatalogProviders(
-              (
-                await loadPreparedModelCatalogSnapshot({
-                  config: cfg,
-                  agentId: sessionAgentId,
-                  workspaceDir,
-                })
-              ).entries,
+              await loadProviderScopedThinkingCatalog({
+                config: cfg,
+                provider: providerOverride,
+                model: modelOverride,
+                agentId: sessionAgentId,
+                workspaceDir,
+              }),
             );
             const allowedRuntimeCatalog = createModelVisibilityPolicy({
               cfg,

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -70,6 +70,9 @@ async function resolveCollectorOutputModelError(params: {
       config: params.cfg,
       agentDir: params.targetAgentDir,
       workspaceDir: params.workspaceDir,
+      readOnly: true,
+      providerDiscoveryProviderIds: [provider],
+      scopedLiveProviderDiscovery: true,
     });
   } catch (error) {
     return `sessions_spawn could not verify outputSchema model capabilities: ${summarizeSpawnError(error)}`;

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -17,6 +17,9 @@ import {
 const hoisted = vi.hoisted(() => ({
   callGatewayMock: vi.fn(),
   loadSessionStoreMock: vi.fn(),
+  loadFullModelCatalogMock: vi.fn(async () => {
+    throw new Error("full model catalog should not materialize");
+  }),
   loadPreparedModelCatalogMock: vi.fn(),
   updateSessionStoreMock: vi.fn(),
   registerSubagentRunMock: vi.fn(),
@@ -182,6 +185,7 @@ describe("spawnSubagentDirect seam flow", () => {
     resetSubagentRegistryForTests();
     hoisted.callGatewayMock.mockReset();
     hoisted.loadSessionStoreMock.mockReset();
+    hoisted.loadFullModelCatalogMock.mockClear();
     hoisted.loadPreparedModelCatalogMock.mockReset().mockResolvedValue([]);
     hoisted.updateSessionStoreMock.mockReset();
     hoisted.registerSubagentRunMock.mockReset();
@@ -1021,14 +1025,29 @@ describe("spawnSubagentDirect seam flow", () => {
 
   it("rejects schema collection for a model that cannot call tools", async () => {
     hoisted.configOverride = createConfigOverride({ tools: { swarm: true } });
-    hoisted.loadPreparedModelCatalogMock.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "no-tools",
-        name: "No tools",
-        compat: { supportsTools: false },
-      },
-    ]);
+    hoisted.loadPreparedModelCatalogMock.mockImplementation(async (options: unknown) => {
+      const scoped = options as {
+        readOnly?: boolean;
+        providerDiscoveryProviderIds?: string[];
+        scopedLiveProviderDiscovery?: boolean;
+      };
+      if (
+        scoped.readOnly !== true ||
+        scoped.scopedLiveProviderDiscovery !== true ||
+        scoped.providerDiscoveryProviderIds?.[0] !== "openai" ||
+        scoped.providerDiscoveryProviderIds.length !== 1
+      ) {
+        return await hoisted.loadFullModelCatalogMock();
+      }
+      return [
+        {
+          provider: "openai",
+          id: "no-tools",
+          name: "No tools",
+          compat: { supportsTools: false },
+        },
+      ];
+    });
 
     const rejected = await spawnSubagentDirect(
       {
@@ -1042,10 +1061,14 @@ describe("spawnSubagentDirect seam flow", () => {
 
     expect(rejected.status).toBe("error");
     expect(rejected.error).toContain("requires a tool-capable target model");
+    expect(hoisted.loadFullModelCatalogMock).not.toHaveBeenCalled();
     expect(hoisted.loadPreparedModelCatalogMock).toHaveBeenCalledWith({
       config: hoisted.configOverride,
       agentDir: expect.any(String),
       workspaceDir: "/tmp/workspace-main",
+      readOnly: true,
+      providerDiscoveryProviderIds: ["openai"],
+      scopedLiveProviderDiscovery: true,
     });
     expect(hoisted.updateSessionStoreMock).not.toHaveBeenCalled();
     expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -55,8 +55,13 @@ const hoisted = vi.hoisted(() => {
     provider: "openai",
     model: "gpt-5.4",
   }));
-  const resolveHooksGmailModel = vi.fn<() => string | null>(() => null);
-  const loadModelCatalog = vi.fn(async () => ({}));
+  const resolveHooksGmailModel = vi.fn<() => { provider: string; model: string } | null>(
+    () => null,
+  );
+  const loadFullModelCatalog = vi.fn(async () => {
+    throw new Error("full model catalog should not materialize");
+  });
+  const loadModelCatalog = vi.fn(async (_options?: unknown): Promise<unknown> => ({}));
   const getModelRefStatus = vi.fn(() => ({
     key: "openai/gpt-5.4",
     allowed: true,
@@ -101,6 +106,7 @@ const hoisted = vi.hoisted(() => {
     isCliProvider,
     resolveConfiguredModelRef,
     resolveHooksGmailModel,
+    loadFullModelCatalog,
     loadModelCatalog,
     getModelRefStatus,
     prepareModelRuntimeSnapshot,
@@ -484,6 +490,7 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.resolveConfiguredModelRef.mockClear();
     hoisted.resolveHooksGmailModel.mockReset();
     hoisted.resolveHooksGmailModel.mockReturnValue(null);
+    hoisted.loadFullModelCatalog.mockClear();
     hoisted.loadModelCatalog.mockReset();
     hoisted.loadModelCatalog.mockResolvedValue({});
     hoisted.getModelRefStatus.mockReset();
@@ -2545,7 +2552,26 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("runs Gmail model validation after sidecars are ready", async () => {
-    hoisted.resolveHooksGmailModel.mockReturnValueOnce("openai/gpt-5.4");
+    hoisted.resolveHooksGmailModel.mockReturnValueOnce({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    hoisted.loadModelCatalog.mockImplementationOnce(async (options: unknown) => {
+      const scoped = options as {
+        readOnly?: boolean;
+        providerDiscoveryProviderIds?: string[];
+        scopedLiveProviderDiscovery?: boolean;
+      };
+      if (
+        scoped.readOnly !== true ||
+        scoped.scopedLiveProviderDiscovery !== true ||
+        scoped.providerDiscoveryProviderIds?.[0] !== "openai" ||
+        scoped.providerDiscoveryProviderIds.length !== 1
+      ) {
+        return await hoisted.loadFullModelCatalog();
+      }
+      return [];
+    });
 
     const result = await startGatewaySidecars({
       cfg: {
@@ -2573,8 +2599,15 @@ describe("startGatewayPostAttachRuntime", () => {
     await waitForGatewayTestState(() => {
       expect(hoisted.loadModelCatalog).toHaveBeenCalledTimes(1);
     });
+    expect(hoisted.loadFullModelCatalog).not.toHaveBeenCalled();
+    expect(hoisted.loadModelCatalog).toHaveBeenCalledWith({
+      config: expect.any(Object),
+      readOnly: true,
+      providerDiscoveryProviderIds: ["openai"],
+      scopedLiveProviderDiscovery: true,
+    });
     expect(hoisted.getModelRefStatus).toHaveBeenCalledWith(
-      expect.objectContaining({ ref: "openai/gpt-5.4" }),
+      expect.objectContaining({ ref: { provider: "openai", model: "gpt-5.4" } }),
     );
   });
 

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -857,7 +857,12 @@ export async function startGatewaySidecars(params: {
                 defaultProvider: DEFAULT_PROVIDER,
                 defaultModel: DEFAULT_MODEL,
               });
-            const catalog = await loadPreparedModelCatalog({ config: params.cfg });
+            const catalog = await loadPreparedModelCatalog({
+              config: params.cfg,
+              readOnly: true,
+              providerDiscoveryProviderIds: [hooksModelRef.provider],
+              scopedLiveProviderDiscovery: true,
+            });
             const status = getModelRefStatus({
               cfg: params.cfg,
               catalog,


### PR DESCRIPTION
Related: #120834
Related: #123368

## What Problem This Solves

Fixes an issue where configured Gmail model validation, fallback-attempt thinking hydration, and `sessions_spawn` structured-output capability checks could materialize the full live model catalog. On source deployments, any of those narrow reads could fan out across provider plugins, block Gateway responsiveness, and add a large transient heap load.

## Why This Change Was Made

The fallback attempt now reuses the provider-scoped thinking helper introduced by #120834. Gmail validation and structured-output capability checks keep live runtime-model discovery, but constrain it to the selected provider and mark the prepared-catalog read as read-only, so none of the three paths can invoke the full-catalog loader.

Production LOC: +17/-9 (net +8) | Tests: +102/-25

## User Impact

Cold Gateway startup, model fallback attempts, and structured-output subagent spawns no longer risk broad provider discovery stalls from these dormant paths. Runtime-only provider models remain discoverable within the provider being checked.

## Evidence

- Before the fix, focused regressions failed independently at all three sites: Gmail called the full-catalog counter, fallback thinking threw from the full loader at `run-embedded-attempt.ts:406`, and structured-output spawn returned the full-loader error instead of the tool-capability verdict.
- After the fix, the three focused remote Vitest shards passed: 242/242 tests, with every full-catalog counter remaining at zero.
- Path-scoped changed guards passed, including formatting, dependency pins, boundaries, dead-export scan, and production typecheck.
- `pnpm check:test-types` passed across core, extension, and root test typecheck shards.
- `pnpm build` passed, including CLI bootstrap imports, runtime postbuild, Plugin SDK export verification, and Control UI build.
- Codex autoreview: clean, no accepted/actionable findings.

Provenance: the fallback-attempt read came from #116584 and was missed when #120834 repaired its primary and cron siblings. The Gmail prepared-catalog call came from #111173. The structured-output capability read originated in #110932 and was carried through #114030 and #114301.
