### PR TITLE
fix(ui): zone writes during startup erase persisted Workboard pins

### DIFF
--- a/ui/src/lib/sidebar-zone.test.ts
+++ b/ui/src/lib/sidebar-zone.test.ts
@@ -64,7 +64,7 @@ describe("reconcileSidebarZone", () => {
     ).toEqual(["route:usage"]);
   });
 
-  it("keeps active Workboard boards and drops stale or plugin-off pins", () => {
+  it("keeps active Workboard boards, drops stale ids, and preserves plugin-off pins", () => {
     const boards = [
       { id: "default", total: 0, active: 0, archived: 0, byStatus: {} },
       { id: "ops", total: 0, active: 0, archived: 0, byStatus: {} },
@@ -80,6 +80,8 @@ describe("reconcileSidebarZone", () => {
         true,
       ).sidebarEntries,
     ).toEqual(["workboard:ops", "route:usage"]);
+    // Disabled is indistinguishable from an unloaded config snapshot at
+    // startup; a zone write then must not erase persisted pins.
     expect(
       reconcileSidebarZone(
         ["workboard:ops", "route:usage"],
@@ -89,8 +91,11 @@ describe("reconcileSidebarZone", () => {
         boards,
         false,
         true,
-      ).sidebarEntries,
-    ).toEqual(["route:usage"]);
+      ),
+    ).toEqual({
+      entries: [{ type: "route", route: "usage" }],
+      sidebarEntries: ["workboard:ops", "route:usage"],
+    });
   });
 
   it("preserves Workboard pins until the active plugin's board catalog is authoritative", () => {

--- a/ui/src/lib/sidebar-zone.ts
+++ b/ui/src/lib/sidebar-zone.ts
@@ -51,14 +51,13 @@ export function reconcileSidebarZone(
       continue;
     }
     if (entry.type === "workboard") {
-      if (!workboardEnabled) {
-        continue;
-      }
       seen.add(canonicalKey);
       canonical.push(canonicalKey);
-      // An unloaded catalog cannot distinguish deletion from startup. Preserve
-      // the slot but render nothing until the active plugin returns its ids.
-      if (!workboardBoardsReady) {
+      // Disabled reads exactly like startup: the runtime config snapshot is
+      // unloaded until the gateway answers, so a zone write in that window
+      // would erase every persisted pin. Preserve the slot, render nothing;
+      // only a loaded catalog that positively lacks the id deletes below.
+      if (!workboardEnabled || !workboardBoardsReady) {
         continue;
       }
       if (!validBoardIds.has(entry.boardId)) {


### PR DESCRIPTION
## What Problem This Solves

Pinned Workboard boards silently vanish from the sidebar — permanently, across devices — if the user pins/unpins/drags any sidebar item during the startup window before the runtime config snapshot loads, or while the workboard plugin is toggled off. The persisted zone prefs are rewritten without the `workboard:<id>` entries, so the pins are gone even after the plugin loads/re-enables.

## Why This Change Was Made

`reconcileSidebarZone` (ui/src/lib/sidebar-zone.ts) treated `!workboardEnabled` as authorization to drop workboard entries from the **canonical** persisted list, while the `!workboardBoardsReady` branch right below deliberately preserves slots because "an unloaded catalog cannot distinguish deletion from startup." Enablement has the identical ambiguity: `isWorkboardEnabledInConfigSnapshot` reads an unloaded snapshot as disabled (plugin-activation.ts:57 — "an unloaded snapshot therefore reads as disabled"), and zone mutations persist `reconciledSidebarZone().sidebarEntries` (session-organizer-controller.ts). The reconciler violated its own header contract (unknown state must not be pruned). Disabled now folds into the slot-preserving branch: keep canonical, render nothing; only a loaded, enabled catalog that positively lacks a board id deletes it.

## User Impact

Sidebar customization survives startup races and plugin toggles. A disabled workboard renders no pins (unchanged) but no longer destroys them.

## Evidence

- `ui/src/lib/sidebar-zone.test.ts`: plugin-off case now asserts canonical preservation with empty render; fails pre-fix (entries erased). Suite 6 passed.
- Consumer suites at head: app-sidebar + app 8798 passed / 41 passed.
- Fresh autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC: net −1 (+5/−6).

Provenance: the drop shipped with the original workboard pinning feature (#112302, commit 440539b5380) — no separate product decision; the not-ready branch's contract came later and the enabled branch was never aligned. Found via the sidebar/navigation lane of the round-2 web-UI QA campaign.
