### PR TITLE
fix(gateway): submit known image models without discovery delay

### DIFF
--- a/src/gateway/server-methods/models-list-result.openai-routes.test-support.ts
+++ b/src/gateway/server-methods/models-list-result.openai-routes.test-support.ts
@@ -52,6 +52,7 @@ export async function listModels(params: {
     ({
       agentId: "main",
       agentDir: "/tmp/models-list-openai-agent",
+      catalogComplete: false,
       workspaceDir: "/tmp/models-list-openai-workspace",
       config,
       authModes: {},

--- a/src/gateway/server-methods/models-list-result.openai-routes.test.ts
+++ b/src/gateway/server-methods/models-list-result.openai-routes.test.ts
@@ -240,6 +240,7 @@ describe("models.list OpenAI routes", () => {
       .mockResolvedValueOnce({
         agentId: "main",
         agentDir: "/tmp/models-list-main-agent",
+        catalogComplete: false,
         workspaceDir: "/tmp/models-list-main-workspace",
         config: replacementConfig,
         ...preparedOwnerFacts(replacementConfig),
@@ -249,6 +250,7 @@ describe("models.list OpenAI routes", () => {
       .mockResolvedValueOnce({
         agentId: "main",
         agentDir: "/tmp/models-list-main-agent",
+        catalogComplete: true,
         workspaceDir: "/tmp/models-list-main-workspace",
         config: replacementConfig,
         ...preparedOwnerFacts(replacementConfig),
@@ -286,6 +288,7 @@ describe("models.list OpenAI routes", () => {
       .mockResolvedValueOnce({
         agentId: "main",
         agentDir: "/tmp/models-list-main-agent",
+        catalogComplete: false,
         workspaceDir: "/tmp/models-list-main-workspace",
         config: replacementConfig,
         ...preparedOwnerFacts(replacementConfig),
@@ -295,6 +298,7 @@ describe("models.list OpenAI routes", () => {
       .mockResolvedValueOnce({
         agentId: "worker",
         agentDir: "/tmp/models-list-worker-agent",
+        catalogComplete: true,
         workspaceDir: "/tmp/models-list-worker-workspace",
         config: replacementConfig,
         ...preparedOwnerFacts(replacementConfig),

--- a/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
+++ b/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
@@ -23,6 +23,7 @@ describe("models.list provider catalog outcomes", () => {
     const snapshot = {
       agentId: "main",
       agentDir: "/tmp/models-list-provider-outcomes-agent",
+      catalogComplete: true,
       workspaceDir: "/tmp/models-list-provider-outcomes-workspace",
       config,
       authModes: {},

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -255,6 +255,7 @@ function requestModelsList(params: {
     return {
       ...owner,
       ...(loadParams?.agentId ? { agentId: loadParams.agentId } : {}),
+      catalogComplete: loadParams?.readOnly === false,
       entries,
       routeVariants: entries,
       authMaterializations: [],
@@ -278,6 +279,7 @@ function requestModelsList(params: {
     readPrepared: async () =>
       ({
         ...resolveOwnerFacts(),
+        catalogComplete: false,
         entries: [],
         routeVariants: [],
         authMaterializations: [],

--- a/src/gateway/server-model-catalog.test.ts
+++ b/src/gateway/server-model-catalog.test.ts
@@ -3,6 +3,7 @@ import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
 import type { PublishedModelCatalogOwnerCandidate } from "../agents/prepared-model-catalog.types.js";
 import { setPreparedModelRuntimeAuthLoader } from "../agents/prepared-model-runtime-auth.js";
 import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
+import { markPreparedModelCatalogFull } from "../agents/prepared-model-runtime.facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   loadDeferredCatalog,
@@ -100,6 +101,22 @@ describe("gateway prepared model catalog", () => {
       readOnly: true,
       workspaceDir: "/tmp/gateway-workspace",
     });
+  });
+
+  it("projects whether the published owner already contains a full catalog", async () => {
+    const config = ownerConfig();
+    const fullCatalog = markPreparedModelCatalogFull({
+      entries: [{ provider: "openai", id: "text-only", name: "Text only", input: ["text"] }],
+      routeVariants: [],
+    });
+
+    await expect(
+      loadGatewayModelCatalogSnapshot({
+        getConfig: () => config,
+        loadPublishedPreparedModelCatalogOwnerSnapshot: async () =>
+          ownerSnapshot(config, fullCatalog),
+      }),
+    ).resolves.toMatchObject({ catalogComplete: true });
   });
 
   it("refreshes auth only for the explicit deferred projection", async () => {

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -9,6 +9,7 @@ import {
   type PreparedModelRuntimeAuthScope,
 } from "../agents/prepared-model-runtime-auth.js";
 import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
+import { isPreparedModelCatalogFull } from "../agents/prepared-model-runtime.facts.js";
 // Gateway catalog reads use the atomic prepared runtime generation.
 import { getRuntimeConfig } from "../config/io.js";
 import type { PreparedGatewayModelCatalogSnapshot } from "./server-model-catalog-auth.js";
@@ -99,6 +100,7 @@ function projectGatewayModelCatalogSnapshot(
     ...owner.modelCatalog,
     agentId: owner.agentId,
     agentDir: owner.agentDir,
+    catalogComplete: isPreparedModelCatalogFull(owner.modelCatalog),
     workspaceDir: owner.workspaceDir,
     config: owner.config,
   };

--- a/src/gateway/server-model-catalog.types.ts
+++ b/src/gateway/server-model-catalog.types.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 export type GatewayModelCatalogSnapshot = ModelCatalogSnapshot & {
   agentId: string;
   agentDir: string;
+  catalogComplete: boolean;
   workspaceDir: string;
   config: OpenClawConfig;
 };

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -50,6 +50,7 @@ function makeContextParams(
     loadGatewayModelCatalogSnapshot: vi.fn(async () => ({
       agentId: "main",
       agentDir: "/tmp/model-catalog-agent",
+      catalogComplete: false,
       workspaceDir: "/tmp/model-catalog-workspace",
       config,
       entries: [],

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -124,6 +124,7 @@ function createChatVisionModelCatalogSnapshot(): Awaited<
   return {
     agentId: "main",
     agentDir: "/tmp/chat-attachment-vision-agent",
+    catalogComplete: false,
     workspaceDir: "/tmp/chat-attachment-vision-workspace",
     config: {},
     entries: [
@@ -941,6 +942,7 @@ describe("gateway server chat", () => {
           .mockResolvedValue({
             agentId: "main",
             agentDir: "/tmp/chat-history-agent",
+            catalogComplete: false,
             workspaceDir: "/tmp/chat-history-workspace",
             config,
             entries: catalog,
@@ -1156,6 +1158,7 @@ describe("gateway server chat", () => {
       loadGatewayModelCatalogSnapshot: vi.fn(async () => ({
         agentId: "main",
         agentDir: "/tmp/chat-main-agent",
+        catalogComplete: false,
         workspaceDir: "/tmp/chat-main-workspace",
         config,
         entries: [{ id: "main-only", name: "Main only", provider: "test" }],
@@ -1507,6 +1510,7 @@ describe("gateway server chat", () => {
               .mockResolvedValue({
                 agentId: "work",
                 agentDir: "/tmp/chat-work-agent",
+                catalogComplete: false,
                 workspaceDir: "/tmp/chat-work-workspace",
                 config: persistedConfig,
                 ...catalogSnapshot,
@@ -1759,6 +1763,7 @@ describe("gateway server chat", () => {
             return {
               agentId: "work",
               agentDir: "/tmp/chat-work-agent",
+              catalogComplete: false,
               workspaceDir: "/tmp/chat-work-workspace",
               config,
               entries,

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -499,7 +499,7 @@ describe("gateway server models + voicewake", () => {
       const models = res1.payload?.models ?? [];
       expect(models).toEqual(expectedSortedCatalog());
 
-      expect(agentDiscoveryMock.discoverCalls).toBe(1);
+      expect(agentDiscoveryMock.discoverCalls).toBe(0);
     });
   });
 

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -373,6 +373,24 @@ function normalizeGatewayModelCapabilityBaseUrl(value: string | undefined): stri
   }
 }
 
+function isGatewayModelExplicitlyConfiguredTextOnly(params: {
+  snapshot: GatewayModelCatalogSnapshot;
+  provider?: string;
+  model: string;
+}): boolean {
+  if (!params.provider) {
+    return false;
+  }
+  const configuredModel = findNormalizedProviderValue(
+    params.snapshot.config.models?.providers,
+    params.provider,
+  )?.models?.find(
+    (model) =>
+      normalizeLowercaseStringOrEmpty(model.id) === normalizeLowercaseStringOrEmpty(params.model),
+  );
+  return configuredModel?.input !== undefined && !configuredModel.input.includes("image");
+}
+
 function resolveGatewayProviderStaticModel(params: {
   snapshot: GatewayModelCatalogSnapshot;
   agentId?: string;
@@ -403,6 +421,9 @@ function resolveGatewayProviderStaticModel(params: {
     return undefined;
   }
 
+  if (isGatewayModelExplicitlyConfiguredTextOnly(params)) {
+    return undefined;
+  }
   const configuredProvider = findNormalizedProviderValue(
     params.snapshot.config.models?.providers,
     params.provider,
@@ -411,9 +432,6 @@ function resolveGatewayProviderStaticModel(params: {
   const configuredModel = configuredProvider?.models?.find(
     (model) => normalizeLowercaseStringOrEmpty(model.id) === normalizedModelId,
   );
-  if (configuredModel?.input && !configuredModel.input.includes("image")) {
-    return undefined;
-  }
   const configuredApi = configuredModel?.api ?? configuredProvider?.api;
   if (configuredApi && configuredApi !== staticEntry.api) {
     return undefined;
@@ -445,56 +463,87 @@ export async function resolveGatewayModelSupportsImages(params: {
   }
 
   try {
-    const loadParams = {
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      readOnly: false,
-    };
-    const snapshot = params.loadGatewayModelCatalogSnapshot
-      ? await params.loadGatewayModelCatalogSnapshot(loadParams)
-      : undefined;
-    const catalog = snapshot ? snapshot.entries : await params.loadGatewayModelCatalog(loadParams);
-    const catalogEntry = findModelCatalogEntry(catalog, {
-      provider: params.provider,
-      modelId: params.model,
-    });
-    // Same-generation provider facts repair stale discovered capabilities without
-    // crossing agent ownership, physical routes, or authored input policy.
-    const staticEntry =
-      snapshot && (!catalogEntry || !modelSupportsInput(catalogEntry, "image"))
-        ? resolveGatewayProviderStaticModel({
-            snapshot,
-            agentId: params.agentId,
-            provider: params.provider,
-            model: params.model,
-            catalogEntry,
-          })
+    // Attachment admission first consumes lifecycle-prepared capabilities. Runtime-only models
+    // retain the evidence-based live fallback without making known models wait for discovery.
+    for (const readOnly of [true, false]) {
+      const loadParams = {
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+        readOnly,
+      };
+      const snapshot = params.loadGatewayModelCatalogSnapshot
+        ? await params.loadGatewayModelCatalogSnapshot(loadParams)
         : undefined;
-    const modelEntry = staticEntry ?? catalogEntry;
-    const normalizedProvider = normalizeOptionalLowercaseString(
-      params.provider ?? modelEntry?.provider,
-    );
-    const normalizedCandidates = [
-      normalizeLowercaseStringOrEmpty(params.model),
-      normalizeLowercaseStringOrEmpty(modelEntry?.name),
-    ].filter(Boolean);
-    if (modelEntry) {
-      if (modelSupportsInput(modelEntry, "image")) {
-        return true;
-      }
-      // Legacy safety shim for stale persisted Foundry rows that predate
-      // provider-owned capability normalization.
-      if (
-        normalizedProvider === "microsoft-foundry" &&
-        normalizedCandidates.some(
-          (candidate) =>
-            candidate.startsWith("gpt-") ||
-            candidate.startsWith("o1") ||
-            candidate.startsWith("o3") ||
-            candidate.startsWith("o4") ||
-            candidate === "computer-use-preview",
-        )
-      ) {
-        return true;
+      const catalog = snapshot
+        ? snapshot.entries
+        : await params.loadGatewayModelCatalog(loadParams);
+      const catalogEntry = findModelCatalogEntry(catalog, {
+        provider: params.provider,
+        modelId: params.model,
+      });
+      // Same-generation provider facts repair stale discovered capabilities without
+      // crossing agent ownership, physical routes, or authored input policy.
+      const staticEntry =
+        snapshot && (!catalogEntry || !modelSupportsInput(catalogEntry, "image"))
+          ? resolveGatewayProviderStaticModel({
+              snapshot,
+              agentId: params.agentId,
+              provider: params.provider,
+              model: params.model,
+              catalogEntry,
+            })
+          : undefined;
+      const modelEntry = staticEntry ?? catalogEntry;
+      const normalizedProvider = normalizeOptionalLowercaseString(
+        params.provider ?? modelEntry?.provider,
+      );
+      const normalizedCandidates = [
+        normalizeLowercaseStringOrEmpty(params.model),
+        normalizeLowercaseStringOrEmpty(modelEntry?.name),
+      ].filter(Boolean);
+      if (modelEntry) {
+        if (modelSupportsInput(modelEntry, "image")) {
+          return true;
+        }
+        // Legacy safety shim for stale persisted Foundry rows that predate
+        // provider-owned capability normalization.
+        if (
+          normalizedProvider === "microsoft-foundry" &&
+          normalizedCandidates.some(
+            (candidate) =>
+              candidate.startsWith("gpt-") ||
+              candidate.startsWith("o1") ||
+              candidate.startsWith("o3") ||
+              candidate.startsWith("o4") ||
+              candidate === "computer-use-preview",
+          )
+        ) {
+          return true;
+        }
+        if (
+          normalizedProvider === "claude-cli" &&
+          normalizedCandidates.some(
+            (candidate) =>
+              candidate === "opus" ||
+              candidate === "sonnet" ||
+              candidate === "haiku" ||
+              candidate.startsWith("claude-"),
+          )
+        ) {
+          return true;
+        }
+        if (
+          readOnly &&
+          !snapshot?.catalogComplete &&
+          (!snapshot ||
+            !isGatewayModelExplicitlyConfiguredTextOnly({
+              snapshot,
+              provider: params.provider,
+              model: params.model,
+            }))
+        ) {
+          continue;
+        }
+        return false;
       }
       if (
         normalizedProvider === "claude-cli" &&
@@ -508,19 +557,9 @@ export async function resolveGatewayModelSupportsImages(params: {
       ) {
         return true;
       }
-      return false;
-    }
-    if (
-      normalizedProvider === "claude-cli" &&
-      normalizedCandidates.some(
-        (candidate) =>
-          candidate === "opus" ||
-          candidate === "sonnet" ||
-          candidate === "haiku" ||
-          candidate.startsWith("claude-"),
-      )
-    ) {
-      return true;
+      if (readOnly && snapshot?.catalogComplete) {
+        return false;
+      }
     }
     return false;
   } catch {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -3615,6 +3615,7 @@ describe("deriveSessionTitle", () => {
 describe("resolveGatewayModelSupportsImages", () => {
   const createModelCatalogSnapshot = (params: {
     agentId?: string;
+    catalogComplete?: boolean;
     config?: OpenClawConfig;
     entries?: GatewayModelCatalogSnapshot["entries"];
     staticEntries?: GatewayModelCatalogSnapshot["staticEntries"];
@@ -3622,23 +3623,95 @@ describe("resolveGatewayModelSupportsImages", () => {
     agentId: params.agentId ?? "main",
     agentDir: "/tmp/gateway-model-capability-agent",
     workspaceDir: "/tmp/gateway-model-capability-workspace",
+    catalogComplete: params.catalogComplete ?? false,
     config: params.config ?? {},
     entries: params.entries ?? [],
     routeVariants: [],
     ...(params.staticEntries ? { staticEntries: params.staticEntries } : {}),
   });
 
-  test("uses same-agent provider-static image capabilities missing from the visible catalog", async () => {
+  test("uses prepared Sol capabilities without starting full catalog discovery", async () => {
     const loadGatewayModelCatalog = vi.fn(async () => []);
-    const loadGatewayModelCatalogSnapshot = vi.fn(async () =>
+    const preparedSnapshot = createModelCatalogSnapshot({
+      agentId: "qa",
+      staticEntries: [
+        {
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
+          provider: "openai",
+          input: ["text", "image"],
+        },
+      ],
+    });
+    const loadGatewayModelCatalogSnapshot = vi.fn(async (params?: { readOnly?: boolean }) => {
+      if (params?.readOnly !== true) {
+        throw new Error("full catalog discovery must not start during attachment admission");
+      }
+      return preparedSnapshot;
+    });
+
+    await expect(
+      resolveGatewayModelSupportsImages({
+        agentId: "qa",
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        loadGatewayModelCatalog,
+        loadGatewayModelCatalogSnapshot,
+      }),
+    ).resolves.toBe(true);
+    expect(loadGatewayModelCatalogSnapshot).toHaveBeenCalledWith({
+      agentId: "qa",
+      readOnly: true,
+    });
+    expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
+  });
+
+  test("falls back to live discovery for models absent from the prepared catalog", async () => {
+    const loadGatewayModelCatalogSnapshot = vi.fn(async (params?: { readOnly?: boolean }) =>
       createModelCatalogSnapshot({
         agentId: "qa",
-        staticEntries: [
+        entries: params?.readOnly
+          ? []
+          : [
+              {
+                id: "vendor/runtime-vision-model",
+                name: "Runtime Vision Model",
+                provider: "openrouter",
+                input: ["text", "image"],
+              },
+            ],
+      }),
+    );
+
+    await expect(
+      resolveGatewayModelSupportsImages({
+        agentId: "qa",
+        model: "vendor/runtime-vision-model",
+        provider: "openrouter",
+        loadGatewayModelCatalog: async () => [],
+        loadGatewayModelCatalogSnapshot,
+      }),
+    ).resolves.toBe(true);
+    expect(loadGatewayModelCatalogSnapshot).toHaveBeenNthCalledWith(1, {
+      agentId: "qa",
+      readOnly: true,
+    });
+    expect(loadGatewayModelCatalogSnapshot).toHaveBeenNthCalledWith(2, {
+      agentId: "qa",
+      readOnly: false,
+    });
+  });
+
+  test("falls back to live discovery for provisional prepared text-only metadata", async () => {
+    const loadGatewayModelCatalogSnapshot = vi.fn(async (params?: { readOnly?: boolean }) =>
+      createModelCatalogSnapshot({
+        agentId: "qa",
+        entries: [
           {
-            id: "gpt-5.4",
-            name: "GPT-5.4",
-            provider: "openai",
-            input: ["text", "image"],
+            id: "vendor/runtime-vision-model",
+            name: "Runtime Vision Model",
+            provider: "openrouter",
+            input: params?.readOnly ? ["text"] : ["text", "image"],
           },
         ],
       }),
@@ -3647,17 +3720,75 @@ describe("resolveGatewayModelSupportsImages", () => {
     await expect(
       resolveGatewayModelSupportsImages({
         agentId: "qa",
-        model: "gpt-5.4",
-        provider: "openai",
-        loadGatewayModelCatalog,
+        model: "vendor/runtime-vision-model",
+        provider: "openrouter",
+        loadGatewayModelCatalog: async () => [],
         loadGatewayModelCatalogSnapshot,
       }),
     ).resolves.toBe(true);
-    expect(loadGatewayModelCatalogSnapshot).toHaveBeenCalledWith({
+    expect(loadGatewayModelCatalogSnapshot).toHaveBeenNthCalledWith(1, {
+      agentId: "qa",
+      readOnly: true,
+    });
+    expect(loadGatewayModelCatalogSnapshot).toHaveBeenNthCalledWith(2, {
       agentId: "qa",
       readOnly: false,
     });
-    expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
+  });
+
+  test("does not restart discovery for authoritative text-only metadata from a full owner", async () => {
+    const catalogReadModes: Array<boolean | undefined> = [];
+    await expect(
+      resolveGatewayModelSupportsImages({
+        agentId: "qa",
+        model: "vendor/runtime-text-model",
+        provider: "openrouter",
+        loadGatewayModelCatalog: async () => [],
+        loadGatewayModelCatalogSnapshot: async (params) => {
+          catalogReadModes.push(params?.readOnly);
+          if (params?.readOnly !== true) {
+            throw new Error("full catalog discovery must not restart for a complete owner");
+          }
+          return createModelCatalogSnapshot({
+            agentId: "qa",
+            catalogComplete: true,
+            entries: [
+              {
+                id: "vendor/runtime-text-model",
+                name: "Runtime Text Model",
+                provider: "openrouter",
+                input: ["text"],
+              },
+            ],
+          });
+        },
+      }),
+    ).resolves.toBe(false);
+    expect(catalogReadModes).toEqual([true]);
+  });
+
+  test("does not restart discovery when a full owner authoritatively omits the model", async () => {
+    const catalogReadModes: Array<boolean | undefined> = [];
+    await expect(
+      resolveGatewayModelSupportsImages({
+        agentId: "qa",
+        model: "vendor/missing-model",
+        provider: "openrouter",
+        loadGatewayModelCatalog: async () => [],
+        loadGatewayModelCatalogSnapshot: async (params) => {
+          catalogReadModes.push(params?.readOnly);
+          if (params?.readOnly !== true) {
+            throw new Error("full catalog discovery must not restart for a complete owner");
+          }
+          return createModelCatalogSnapshot({
+            agentId: "qa",
+            catalogComplete: true,
+            entries: [],
+          });
+        },
+      }),
+    ).resolves.toBe(false);
+    expect(catalogReadModes).toEqual([true]);
   });
 
   test("repairs a stale visible text-only row with same-agent provider-static vision", async () => {
@@ -3732,14 +3863,16 @@ describe("resolveGatewayModelSupportsImages", () => {
   });
 
   test("does not override an explicitly configured text-only model with provider-static vision", async () => {
+    const catalogReadModes: Array<boolean | undefined> = [];
     await expect(
       resolveGatewayModelSupportsImages({
         agentId: "qa",
         model: "gpt-5.4",
         provider: "openai",
         loadGatewayModelCatalog: async () => [],
-        loadGatewayModelCatalogSnapshot: async () =>
-          createModelCatalogSnapshot({
+        loadGatewayModelCatalogSnapshot: async (params) => {
+          catalogReadModes.push(params?.readOnly);
+          return createModelCatalogSnapshot({
             agentId: "qa",
             config: {
               models: {
@@ -3779,9 +3912,11 @@ describe("resolveGatewayModelSupportsImages", () => {
                 input: ["text", "image"],
               },
             ],
-          }),
+          });
+        },
       }),
     ).resolves.toBe(false);
+    expect(catalogReadModes).toEqual([true]);
   });
 
   test("does not borrow provider-static image capabilities across configured routes", async () => {


### PR DESCRIPTION
Related: #122350

## What Problem This Solves

Submitting an image from a new Control UI session could block before `chat.send` was acknowledged while OpenClaw discovered every provider's live model catalog. The reported Sol request spent **186.45 seconds** in attachment preparation even though the prepared catalog already proved that `openai/gpt-5.6-sol` accepts images.

## What Changes

Image admission now checks the lifecycle-prepared model catalog first and carries the catalog's completeness as explicit provenance. Live discovery runs only when the prepared snapshot is incomplete and does not contain authoritative capability evidence.

| Model evidence | Before | After |
| --- | --- | --- |
| Prepared image-capable model, including Sol | Wait for full live discovery | Admit from the prepared snapshot |
| Runtime-only model missing from an incomplete snapshot | Run live discovery | Run live discovery |
| Explicitly configured text-only model | Reject image input | Reject image input without discovery |
| Text-only model in an already-complete owner | Could redundantly restart discovery | Treat the complete snapshot as authoritative |

This fixes the pre-acknowledgement model-capability bottleneck. A separate global-lane wait observed after acknowledgement is outside this PR.

## Performance Proof

An identical three-project A/B probe injects 500 ms only into mutable/full catalog discovery and submits a Sol image request:

- benchmark baseline `main@0bd50cc0a5b`: **503.3 / 502.9 / 501.6 ms**
- this PR (`fad37578e2a`): **0.8 / 1.4 / 1.1 ms**
- median: **502.9 ms → 1.1 ms**, removing **99.8%** of the blocking discovery delay

The benchmark uses the same capability resolver in both trees. The only synthetic element is the fixed 500 ms discovery delay, which makes whether discovery was entered directly observable.

## Correctness Proof

- `resolveGatewayModelSupportsImages`: **26/26 passed**, covering prepared image support, explicit text-only policy, provisional text-only fallback, complete-catalog text-only and absent-model negatives, route/agent provenance, and runtime-only discovery.
- Full `session-utils.test.ts`: **161/161 passed**.
- Catalog projection: **12/12 passed**.
- Affected Gateway fixture suites: **172/172 passed**.
- Gateway models/voicewake integration: **18/18 passed**; its prepared-only assertion now proves zero live-discovery calls.
- Production TypeScript and all source-test TypeScript shards passed.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Two clean native Codex review passes followed by a fresh clean cold review. Three earlier actionable findings were fixed before the clean pass: provisional text-only fallback, explicit catalog-completeness provenance, and typed snapshot fixtures.

## Repository-Owned Capability Evidence

The runtime decision is owned entirely by OpenClaw's prepared catalog. Its bundled OpenAI manifest declares `gpt-5.6-sol` with `input: ["text", "image"]` in [`extensions/openai/openclaw.plugin.json`](https://github.com/openclaw/openclaw/blob/fad37578e2a/extensions/openai/openclaw.plugin.json#L44-L48), and the regression test consumes that same prepared/static capability shape. No external checkout, network lookup, or live Codex contract is required for admission.

This is a backend-only timing and capability change. A screenshot would not demonstrate the changed boundary; the direct A/B timing and decision-matrix tests are the reviewer-checkable proof.
