### PR TITLE
fix(codex): keep token usage fresh after native compaction

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -1006,6 +1006,22 @@ describe("maybeCompactCodexAppServerSession", () => {
       },
     });
     fake.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: { last: { totalTokens: 999 } },
+      },
+    });
+    fake.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: { last: { totalTokens: 321 } },
+      },
+    });
+    fake.emit({
       method: "item/completed",
       params: {
         threadId: "thread-1",
@@ -1026,8 +1042,7 @@ describe("maybeCompactCodexAppServerSession", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
-    expect(result.result?.tokensAfter).toBeUndefined();
-    expect(compactDetails(result).tokenUsageSource).toBeUndefined();
+    expect(result.result?.tokensAfter).toBe(321);
     expect(compactDetails(result).signal).toBe("thread/compact/start");
   });
 

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -29,6 +29,7 @@ import {
   type CodexAppServerLiveThreadOwnership,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
+import { readCodexThreadContextSnapshot } from "./event-projector-usage.js";
 import {
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
@@ -64,7 +65,9 @@ type CodexAppServerCompactOptions = {
   nativeInterruptGraceMs?: number;
 };
 
-type CodexNativeCompactionCompletion = { completed: true } | { completed: false; reason: string };
+type CodexNativeCompactionCompletion =
+  | { completed: true; tokensAfter?: number }
+  | { completed: false; reason: string };
 
 function watchCodexNativeCompactionCompletion(params: {
   client: CodexAppServerClient;
@@ -73,13 +76,7 @@ function watchCodexNativeCompactionCompletion(params: {
   timeoutMs: number;
   interruptGraceMs: number;
   retireUnconfirmed: () => Promise<void>;
-}): {
-  completion: Promise<CodexNativeCompactionCompletion>;
-  beginRequest: () => void;
-  confirmRequestRejected: () => void;
-  retireUnconfirmedRequest: (reason: string) => Promise<CodexNativeCompactionCompletion>;
-  cancel: () => void;
-} {
+}) {
   const runOutsideBindingLease = AsyncLocalStorage.snapshot();
   let settled = false;
   let requestStarted = false;
@@ -89,6 +86,7 @@ function watchCodexNativeCompactionCompletion(params: {
   let compactionTurnId: string | undefined;
   let compactionItemId: string | undefined;
   let compactionItemCompleted = false;
+  let tokensAfter: number | undefined;
   let resolveCompletion = (_result: CodexNativeCompactionCompletion) => {};
   const completion = new Promise<CodexNativeCompactionCompletion>((resolve) => {
     resolveCompletion = resolve;
@@ -110,6 +108,8 @@ function watchCodexNativeCompactionCompletion(params: {
     clearTimeout(interruptGraceTimeout);
     resolveCompletion(result);
   };
+  const complete = () =>
+    finish({ completed: true, ...(tokensAfter !== undefined ? { tokensAfter } : {}) });
   const retireUnconfirmed = (reason: string) => {
     if (settled || retirementStarted) {
       return;
@@ -146,15 +146,15 @@ function watchCodexNativeCompactionCompletion(params: {
       .catch((error: unknown) => {
         // This exact InvalidRequest proves the target turn was already terminal.
         if (isCodexAlreadyTerminalInterruptError(error)) {
-          finish(
-            compactionItemCompleted
-              ? { completed: true }
-              : {
-                  completed: false,
-                  reason:
-                    "codex app-server compaction reached terminal state without a completed compaction item",
-                },
-          );
+          if (compactionItemCompleted) {
+            complete();
+            return;
+          }
+          finish({
+            completed: false,
+            reason:
+              "codex app-server compaction reached terminal state without a completed compaction item",
+          });
           return;
         }
         embeddedAgentLog.warn("codex app-server compaction interrupt request failed", {
@@ -223,6 +223,11 @@ function watchCodexNativeCompactionCompletion(params: {
     if (compactionTurnId && notificationTurnId !== compactionTurnId) {
       return;
     }
+    if (notification.method === "thread/tokenUsage/updated") {
+      tokensAfter =
+        readCodexThreadContextSnapshot(notification.params).activeContextTokens ?? tokensAfter;
+      return;
+    }
     const item = readCodexNotificationItem(notification.params);
     if (item?.type === "contextCompaction") {
       if (notification.method === "item/started") {
@@ -252,21 +257,16 @@ function watchCodexNativeCompactionCompletion(params: {
       });
       return;
     }
-    if (!compactionItemId) {
-      finish({
-        completed: false,
-        reason: "codex app-server compaction turn completed without a compaction item",
-      });
+    const incompleteReason = !compactionItemId
+      ? "codex app-server compaction turn completed without a compaction item"
+      : !compactionItemCompleted
+        ? "codex app-server compaction turn completed before its compaction item"
+        : undefined;
+    if (incompleteReason) {
+      finish({ completed: false, reason: incompleteReason });
       return;
     }
-    if (!compactionItemCompleted) {
-      finish({
-        completed: false,
-        reason: "codex app-server compaction turn completed before its compaction item",
-      });
-      return;
-    }
-    finish({ completed: true });
+    complete();
   });
   removeCloseHandler = params.client.addCloseHandler(() => {
     retireUnconfirmed("codex app-server closed before native compaction completed");
@@ -293,7 +293,7 @@ function watchCodexNativeCompactionCompletion(params: {
     },
     confirmRequestRejected: () =>
       finish({ completed: false, reason: "codex app-server rejected the compaction request" }),
-    retireUnconfirmedRequest: async (reason) => {
+    retireUnconfirmedRequest: async (reason: string) => {
       retireUnconfirmed(reason);
       return await completion;
     },
@@ -558,6 +558,7 @@ async function compactCodexNativeThread(
         let retainedThreadOwnership: CodexAppServerLiveThreadOwnership | undefined;
         let compactionSucceeded = false;
         let compactionRequestDefinitelyRejected = false;
+        let tokensAfter: number | undefined;
         const releaseCompactionThread = async (threadId: string) => {
           if (
             await unsubscribeCodexThreadBestEffort(client, {
@@ -636,26 +637,6 @@ async function compactCodexNativeThread(
             releaseThreadSubscription = async () => releaseCompactionThread(binding.threadId);
           }
         };
-        const beginNativeCompactionRequest = async (timeoutMs?: number) => {
-          completionWatch.beginRequest();
-          const requestParams = { threadId: binding.threadId };
-          if (timeoutMs === undefined) {
-            await client.request("thread/compact/start", requestParams);
-          } else {
-            await client.request("thread/compact/start", requestParams, { timeoutMs });
-          }
-        };
-        const settleNativeCompactionRequestError = async (error: unknown) => {
-          if (error instanceof CodexAppServerRpcError) {
-            completionWatch.confirmRequestRejected();
-          } else {
-            // Transport errors after the write leave the server-side start
-            // ambiguous. Retire or detach the thread before releasing its fence.
-            await completionWatch.retireUnconfirmedRequest(
-              `codex app-server compaction start was unconfirmed: ${coerceErrorMessage(error)}`,
-            );
-          }
-        };
         try {
           const guardedResult = await options.bindingStore.withLease(bindingIdentity, async () => {
             const currentBinding = await options.bindingStore.read(bindingIdentity);
@@ -714,7 +695,16 @@ async function compactCodexNativeThread(
               binding,
             });
             try {
-              await beginNativeCompactionRequest(guardedRequestTimeoutMs);
+              completionWatch.beginRequest();
+              if (guardedRequestTimeoutMs === undefined) {
+                await client.request("thread/compact/start", { threadId: binding.threadId });
+              } else {
+                await client.request(
+                  "thread/compact/start",
+                  { threadId: binding.threadId },
+                  { timeoutMs: guardedRequestTimeoutMs },
+                );
+              }
               return { started: true as const, accepted: true as const };
             } catch (error) {
               if (error instanceof CodexAppServerRpcError) {
@@ -734,7 +724,15 @@ async function compactCodexNativeThread(
             return guardedResult.result;
           }
           if (!guardedResult.accepted) {
-            await settleNativeCompactionRequestError(guardedResult.error);
+            if (guardedResult.error instanceof CodexAppServerRpcError) {
+              completionWatch.confirmRequestRejected();
+            } else {
+              // Transport errors after the write leave the server-side start
+              // ambiguous. Retire or detach the thread before releasing its fence.
+              await completionWatch.retireUnconfirmedRequest(
+                `codex app-server compaction start was unconfirmed: ${coerceErrorMessage(guardedResult.error)}`,
+              );
+            }
             throw guardedResult.error;
           }
           embeddedAgentLog.info("started codex app-server compaction", {
@@ -745,6 +743,7 @@ async function compactCodexNativeThread(
           if (!completion.completed) {
             throw new Error(completion.reason);
           }
+          tokensAfter = completion.tokensAfter;
           embeddedAgentLog.info("completed codex app-server compaction", {
             sessionId: params.sessionId,
             threadId: binding.threadId,
@@ -807,7 +806,7 @@ async function compactCodexNativeThread(
             }
           }
         }
-        const resultDetails: JsonObject = {
+        const details: JsonObject = {
           backend: "codex-app-server",
           threadId: binding.threadId,
           signal: "thread/compact/start",
@@ -820,7 +819,7 @@ async function compactCodexNativeThread(
               }
             : {}),
         };
-        return codexNativeCompactionResult(params, { compacted: true, details: resultDetails });
+        return codexNativeCompactionResult(params, { compacted: true, tokensAfter, details });
       },
     );
   } catch (error) {
@@ -845,7 +844,7 @@ async function compactCodexNativeThread(
 
 function codexNativeCompactionResult(
   params: CompactEmbeddedAgentSessionParams,
-  outcome: { compacted: boolean; reason?: string; details: JsonObject },
+  outcome: { compacted: boolean; reason?: string; tokensAfter?: number; details: JsonObject },
 ): EmbeddedAgentCompactResult {
   return {
     ok: true,
@@ -855,6 +854,7 @@ function codexNativeCompactionResult(
       summary: "",
       firstKeptEntryId: "",
       tokensBefore: params.currentTokenCount ?? 0,
+      ...(outcome.tokensAfter !== undefined ? { tokensAfter: outcome.tokensAfter } : {}),
       details: outcome.details,
     },
   };

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -16,7 +16,7 @@ function readCodexThreadTokenUsage(params: JsonObject): ReturnType<typeof normal
   return last ? normalizeCodexThreadTokenUsage(last) : undefined;
 }
 
-function readCodexThreadContextSnapshot(params: JsonObject): {
+export function readCodexThreadContextSnapshot(params: JsonObject): {
   activeContextTokens?: number;
   cachedInputTokens?: number;
   cacheWriteInputTokens?: number;

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -5,7 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
+import {
+  resolveFreshSessionTotalTokens,
+  type InternalSessionEntry as SessionEntry,
+} from "../../config/sessions.js";
 import {
   listSessionEntriesCore,
   loadSessionEntry,
@@ -2780,13 +2783,14 @@ describe("recordCliCompactionInStore", () => {
         sessionKey,
         sessionStore,
         storePath,
-        tokensAfter: 0,
+        tokensAfter: 3_210,
       });
 
       const persisted = loadPersistedSessionStore(storePath);
       expect(sessionStore[sessionKey]?.compactionCount).toBe(1);
-      expect(sessionStore[sessionKey]?.totalTokens).toBe(0);
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(3_210);
       expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
+      expect(resolveFreshSessionTotalTokens(sessionStore[sessionKey])).toBe(3_210);
       expect(sessionStore[sessionKey]?.inputTokens).toBeUndefined();
       expect(sessionStore[sessionKey]?.outputTokens).toBeUndefined();
       expect(sessionStore[sessionKey]?.cacheRead).toBeUndefined();
@@ -2796,8 +2800,9 @@ describe("recordCliCompactionInStore", () => {
         sessionId: "stale-cli-session",
       });
       expect(sessionStore[sessionKey]?.cliSessionIds?.codex).toBe("stale-cli-session");
-      expect(persisted[sessionKey]?.totalTokens).toBe(0);
+      expect(persisted[sessionKey]?.totalTokens).toBe(3_210);
       expect(persisted[sessionKey]?.totalTokensFresh).toBe(true);
+      expect(resolveFreshSessionTotalTokens(persisted[sessionKey])).toBe(3_210);
       expect(persisted[sessionKey]?.contextBudgetStatus).toBeUndefined();
       expect(persisted[sessionKey]?.cliSessionBindings?.codex).toEqual({
         sessionId: "stale-cli-session",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users compacting a Codex-backed session would see OpenClaw's context meter become permanently stale even though Codex had recomputed the reduced active-context total. That stale snapshot also prevented freshness-dependent behavior such as memory-flush gating from using the post-compaction total.

## Why This Change Was Made

Codex emits the authoritative reduced snapshot on the existing `thread/tokenUsage/updated` notification before the native compaction item completes. The native completion watcher now captures the latest thread- and turn-correlated snapshot and returns it as `tokensAfter`, reusing the same parser as normal Codex turn projection and the same single notification subscription.

Only the total is propagated. Codex's post-compaction recomputation deliberately zeroes the input/output/cache breakdown while setting the estimated active-context total, and OpenClaw's compaction result/store contract only accepts `tokensAfter`; persisting those zero buckets would imply false per-call accounting.

The nearby watcher cleanup removes its redundant explicit inferred return shape and two one-use request/error wrappers, and consolidates incomplete-completion handling. Production LOC remains net zero.

AI-assisted; the resulting code and behavior were reviewed and verified.

## User Impact

After native Codex compaction, session token meters immediately show the reduced value as fresh instead of switching to an approximate/stale state. Freshness-dependent context decisions can use the new total on the next step.

## Evidence

### Upstream Codex contract

Directly inspected sibling Codex source at `c2bcb9a26b5bdbdc66c48cf3bc3bb382568e800c`:

- Local compaction installs replacement history, calls `recompute_token_usage`, then completes the item: [compact.rs:368-382](https://github.com/openai/codex/blob/c2bcb9a26b5bdbdc66c48cf3bc3bb382568e800c/codex-rs/core/src/compact.rs#L368-L382).
- Remote-v2 uses the same ordering: [compact_remote_v2.rs:312-326](https://github.com/openai/codex/blob/c2bcb9a26b5bdbdc66c48cf3bc3bb382568e800c/codex-rs/core/src/compact_remote_v2.rs#L312-L326).
- Recompute stores the reduced total and emits `TokenCountEvent`: [session/mod.rs:3877-3915](https://github.com/openai/codex/blob/c2bcb9a26b5bdbdc66c48cf3bc3bb382568e800c/codex-rs/core/src/session/mod.rs#L3877-L3915).
- App-server projects that event as `thread/tokenUsage/updated`: [bespoke_event_handling.rs:1577-1593](https://github.com/openai/codex/blob/c2bcb9a26b5bdbdc66c48cf3bc3bb382568e800c/codex-rs/app-server/src/bespoke_event_handling.rs#L1577-L1593).

OpenClaw's existing normal-turn projector already consumes the same notification in `extensions/codex/src/app-server/event-projector.ts:264` and surfaces the usage in its result at `extensions/codex/src/app-server/event-projector.ts:331`.

### Regression proof

With only the test change applied to pre-fix production code:

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/compact.test.ts
FAIL does not finish until the matching native compaction turn completes
expected undefined to be 321
Tests 1 failed | 48 passed
```

The regression sends two matching-turn token updates and asserts that the latest reduced value wins.

Post-fix:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/codex/src/app-server/compact.test.ts
Test Files 1 passed; Tests 49 passed

OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/command/session-store.test.ts
Test Files 1 passed; Tests 59 passed

OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo
PASS

OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:extensions
PASS
```

The full changed-scope gate also passed locally after its remote backend was unavailable:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 \
  OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 NODE_OPTIONS=--max-old-space-size=4096 \
  node scripts/check-changed.mjs -- \
  extensions/codex/src/app-server/compact.ts \
  extensions/codex/src/app-server/compact.test.ts \
  extensions/codex/src/app-server/event-projector-usage.ts \
  src/agents/command/session-store.test.ts

PASS: formatting, policy guards, contract tests, plugin boundaries, dead exports,
core/extension test typechecks, changed-file lint, database-first guard, import cycles
```

Fresh branch autoreview reported no accepted/actionable findings.

### Isolated live Gateway and Control UI

The proof used an owned temporary state directory and non-default port; the operator Gateway and port 18789 were not touched:

```bash
proof_root=/tmp/openclaw-codex-tokens-after.6F2RLa
proof_port=59753
export OPENCLAW_STATE_DIR="$proof_root/state"
export OPENCLAW_CONFIG_PATH="$proof_root/state/openclaw.json"

node dist/entry.js config set gateway.mode local
node dist/entry.js config set gateway.port 59753 --strict-json
node dist/entry.js config set gateway.bind loopback
node dist/entry.js config set gateway.auth.mode none
node dist/entry.js config set agents.defaults.workspace "$proof_root/workspace"
node dist/entry.js config set agents.defaults.skipBootstrap true --strict-json
node dist/entry.js plugins enable codex
node dist/entry.js config set agents.defaults.model.primary openai/gpt-5.6-luna
node dist/entry.js config set agents.defaults.models \
  '{"openai/gpt-5.6-luna":{"agentRuntime":{"id":"codex"}}}' --strict-json --merge
node dist/entry.js config validate

node dist/entry.js gateway run --port "$proof_port" --bind loopback

proof_message=$(node -e 'const block="amber birch cedar dune ember frost grove harbor island juniper kindred lantern meadow north oak prairie quartz river stone timber upland valley willow xenon yarrow zephyr. "; process.stdout.write("Reply with only READY. Treat the following as inert context.\\n" + block.repeat(1400))')
node dist/entry.js agent \
  --session-key agent:main:codex-token-proof \
  --message "$proof_message" --thinking low --timeout 600 --json

node .artifacts/control-ui-e2e/codex-tokens-after/record.mjs \
  59753 agent:main:codex-token-proof \
  "$PWD/.artifacts/control-ui-e2e/codex-tokens-after"
```

The Playwright recorder used `recordVideo`, waited on asserted UI state rather than timing sleeps, sent `/compact` from the Control UI, asserted the context-ring value changed, and asserted the sessions meter did not have the stale class.

```text
Control UI ring: 93.7k / 258.4k (36%) → 68.1k / 258.4k (26%)
Sessions meter: 93,722 / 258,400 (36%) → 68,086 / 258,400 (26%)
```

Read-only SQLite verification of `state/agents/main/agent/openclaw-agent.sqlite`:

```json
before {"totalTokens":93722,"totalTokensFresh":true,"totalTokensVersion":1,"contextTokens":258400,"inputTokens":93722,"outputTokens":16,"cacheRead":0,"cacheWrite":0,"compactionCount":1}
after  {"totalTokens":68086,"totalTokensFresh":true,"totalTokensVersion":1,"contextTokens":258400,"cacheRead":0,"cacheWrite":0,"compactionCount":2}
```

The 8.52-second recording shows the 36% meter, “Compacting context…”, “Context compacted,” the 26% meter, and the fresh 68k/258k sessions row:

https://github.com/user-attachments/assets/5538241e-bf4c-4676-ba32-906da60a896e

The source-blind behavior validator passed the reduced/fresh meter, persisted-state, and anti-static checks. It separately marked the exact `/codex compact` spelling as blocked: that plugin command currently sends `thread/compact/start` directly and returns immediately, so it does not traverse this completion/store pipeline. The canonical `/compact` flow documented for Codex-backed agents does traverse it. Re-architecting `/codex compact` is a separate command-ownership change and is intentionally outside this focused plumbing fix.

The owned Gateway was stopped after capture and port 59753 was verified closed.

### LOC

```text
Production: +57/-57 (net 0)
Tests:      +26/-6  (net +20)
```
