### PR TITLE
improve(test): speed channel artifact parity suites

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -584,6 +584,27 @@ const CHANNEL_CONTRACT_REGISTRY_BACKED_TARGETS = [
         `src/channels/plugins/contracts/${suite}.registry-backed-shard-${shard}.contract.test.ts`,
     ),
 );
+const CHANNEL_PLUGIN_SHAPE_PARITY_TEST_TARGET =
+  "src/channels/plugins/contracts/plugin-shape.contract.test.ts";
+const CHANNEL_PLUGIN_SHAPE_PARITY_WIRING_PATHS = new Set([
+  "extensions/imessage/message-tool-api.ts",
+  "extensions/imessage/src/actions.ts",
+  "extensions/imessage/src/channel.ts",
+  "extensions/slack/message-tool-api.ts",
+  "extensions/slack/src/channel-actions.ts",
+  "extensions/slack/src/channel.ts",
+  "extensions/mattermost/gateway-auth-api.ts",
+  "extensions/mattermost/src/channel.ts",
+  "extensions/feishu/session-key-api.ts",
+  "extensions/feishu/src/channel.ts",
+  "extensions/telegram/session-key-api.ts",
+  "extensions/telegram/src/channel.ts",
+  "extensions/discord/session-key-api.ts",
+  "extensions/discord/thread-binding-api.ts",
+  "extensions/discord/src/channel.ts",
+  "extensions/matrix/thread-binding-api.ts",
+  "extensions/matrix/src/channel.ts",
+]);
 const TEST_HELPER_NORMALIZE_TEXT_TARGETS = [
   "src/auto-reply/reply/commands-status.test.ts",
   "src/auto-reply/status.test.ts",
@@ -3084,12 +3105,16 @@ export function resolveChangedTestTargetPlan(
   const targets = [];
   const skippedBroadFallbackPaths = [];
   for (const changedPath of executableChangedPaths) {
+    const needsPluginShapeParity = CHANNEL_PLUGIN_SHAPE_PARITY_WIRING_PATHS.has(changedPath);
     const preciseTargets = resolvePreciseChangedTestTargets(changedPath, {
       ...options,
       skipImportGraph,
     });
     if (preciseTargets) {
       targets.push(...preciseTargets);
+      if (needsPluginShapeParity) {
+        targets.push(CHANNEL_PLUGIN_SHAPE_PARITY_TEST_TARGET);
+      }
       continue;
     }
     const needsBroadFallback = shouldKeepBroadChangedRun([changedPath]) || changedLanes.lanes.all;
@@ -3102,6 +3127,9 @@ export function resolveChangedTestTargetPlan(
     }
     if (isRoutableChangedTarget(changedPath)) {
       targets.push(changedPath);
+    }
+    if (needsPluginShapeParity) {
+      targets.push(CHANNEL_PLUGIN_SHAPE_PARITY_TEST_TARGET);
     }
   }
   if (

--- a/src/channels/plugins/contracts/gateway-auth-artifact.contract.test.ts
+++ b/src/channels/plugins/contracts/gateway-auth-artifact.contract.test.ts
@@ -1,14 +1,13 @@
-// Gateway-auth artifact parity contract for bundled channel plugins.
+// Gateway-auth lightweight artifact contract for bundled channel plugins.
 //
 // Core resolves unauthenticated Gateway callback paths from lightweight
 // `gateway-auth-api` artifacts (src/channels/plugins/gateway-auth-bypass.ts),
-// which invoke the export with a `{ cfg }` params object. This suite pins each
-// artifact export to the exact function the loaded plugin's gateway surface
-// uses and pins the params-object call shape core relies on.
+// which invoke the export with a `{ cfg }` params object. This shard owns
+// inventory, export shape, and that invocation contract; loaded-plugin parity
+// lives in plugin-shape.contract.test.ts.
 import { beforeAll, describe, expect, it } from "vitest";
 import {
   getBundledChannelGatewayAuthArtifactAsync,
-  getBundledChannelPluginAsync,
   listBundledChannelPluginIds,
 } from "./test-helpers/bundled-channel-plugin-loader.js";
 
@@ -29,18 +28,10 @@ describe("bundled channel gateway-auth artifact parity", () => {
 
   it("keeps the artifact table in sync with bundled channels that ship one", () => {
     expect([...artifactResolvers.keys()].toSorted()).toEqual([...GATEWAY_AUTH_ARTIFACT_PLUGIN_IDS]);
+    for (const id of GATEWAY_AUTH_ARTIFACT_PLUGIN_IDS) {
+      expect(typeof artifactResolvers.get(id)).toBe("function");
+    }
   });
-
-  it.each(GATEWAY_AUTH_ARTIFACT_PLUGIN_IDS)(
-    "keeps the %s artifact resolver identical to the plugin gateway surface",
-    async (id) => {
-      const resolveGatewayAuthBypassPaths = artifactResolvers.get(id);
-      expect(typeof resolveGatewayAuthBypassPaths).toBe("function");
-
-      const plugin = await getBundledChannelPluginAsync(id);
-      expect(plugin?.gateway?.resolveGatewayAuthBypassPaths).toBe(resolveGatewayAuthBypassPaths);
-    },
-  );
 
   it("resolves mattermost bypass paths through core's { cfg } call shape", () => {
     // Regression pin: the artifact once took `cfg` positionally, so core's

--- a/src/channels/plugins/contracts/message-tool-artifact.contract.test.ts
+++ b/src/channels/plugins/contracts/message-tool-artifact.contract.test.ts
@@ -1,14 +1,12 @@
-// Message-tool artifact parity contract for bundled channel plugins.
+// Message-tool lightweight artifact contract for bundled channel plugins.
 //
 // Core discovers message-tool schemas from lightweight `message-tool-api`
 // artifacts without loading full channel plugins
-// (src/channels/plugins/message-tool-api.ts). This suite pins each artifact
-// export to the exact function the loaded plugin's action surface uses so
-// discovery cannot drift from runtime behavior.
+// (src/channels/plugins/message-tool-api.ts). This shard owns artifact inventory
+// and export shape; loaded-plugin parity lives in plugin-shape.contract.test.ts.
 import { beforeAll, describe, expect, it } from "vitest";
 import {
   getBundledChannelMessageToolArtifactAsync,
-  getBundledChannelPluginAsync,
   listBundledChannelPluginIds,
 } from "./test-helpers/bundled-channel-plugin-loader.js";
 
@@ -31,16 +29,8 @@ describe("bundled channel message-tool artifact parity", () => {
     expect([...artifactDescribers.keys()].toSorted()).toEqual([
       ...MESSAGE_TOOL_ARTIFACT_PLUGIN_IDS,
     ]);
+    for (const id of MESSAGE_TOOL_ARTIFACT_PLUGIN_IDS) {
+      expect(typeof artifactDescribers.get(id)).toBe("function");
+    }
   });
-
-  it.each(MESSAGE_TOOL_ARTIFACT_PLUGIN_IDS)(
-    "keeps the %s artifact describer identical to the plugin action surface",
-    async (id) => {
-      const describeMessageTool = artifactDescribers.get(id);
-      expect(typeof describeMessageTool).toBe("function");
-
-      const plugin = await getBundledChannelPluginAsync(id);
-      expect(plugin?.actions?.describeMessageTool).toBe(describeMessageTool);
-    },
-  );
 });

--- a/src/channels/plugins/contracts/plugin-shape.contract.test.ts
+++ b/src/channels/plugins/contracts/plugin-shape.contract.test.ts
@@ -4,8 +4,9 @@ import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking"
 // Catalog routing keys off plugin ids, docs surfaces render `meta.docsPath`,
 // and capability flags gate feature discovery, so every bundled channel must
 // keep identity metadata aligned with its catalog id and capability flags
-// coherent with the adapters that implement them. Per-surface behavior checks
-// live in the registry-backed shard suites; this suite pins the static shape.
+// coherent with the adapters that implement them. This suite already loads
+// every bundled plugin, so it also owns loaded-plugin parity for lightweight
+// artifacts while the artifact shards pin inventory, exports, and invocation.
 //
 // Capability rules verified against every bundled channel before pinning.
 // Dropped for legitimate exceptions rather than special-casing:
@@ -18,7 +19,11 @@ import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking"
 import { beforeAll, describe, expect, it } from "vitest";
 import { listBundledPackageChannelMetadata } from "../../../plugins/bundled-package-channel-metadata.js";
 import {
+  getBundledChannelGatewayAuthArtifactAsync,
+  getBundledChannelMessageToolArtifactAsync,
   getBundledChannelPluginAsync,
+  getBundledChannelSessionKeyArtifactAsync,
+  getBundledChannelThreadBindingArtifactAsync,
   listBundledChannelPluginIds,
 } from "./test-helpers/bundled-channel-plugin-loader.js";
 
@@ -37,13 +42,45 @@ const SHARED_SANITIZER_CHANNEL_IDS = [
   "matrix",
   "slack",
 ] as const;
+const MESSAGE_TOOL_ARTIFACT_PLUGIN_IDS = ["imessage", "slack"] as const;
+const SESSION_CONVERSATION_ARTIFACT_PLUGIN_IDS = ["feishu", "telegram"] as const;
+const THREAD_BINDING_ARTIFACT_PLUGIN_IDS = ["discord", "matrix"] as const;
+
+type ExplicitSessionKeyNormalizer = (
+  sessionKey: string,
+  ctx: { ChatType?: string; From?: string; SenderId?: string },
+) => string;
 
 describe("bundled channel plugin shape coherence", () => {
   const plugins = new Map<string, Awaited<ReturnType<typeof getBundledChannelPluginAsync>>>();
+  const messageToolArtifacts = new Map<
+    string,
+    Awaited<ReturnType<typeof getBundledChannelMessageToolArtifactAsync>>
+  >();
+  const sessionKeyArtifacts = new Map<
+    string,
+    Awaited<ReturnType<typeof getBundledChannelSessionKeyArtifactAsync>>
+  >();
+  const threadBindingArtifacts = new Map<
+    string,
+    Awaited<ReturnType<typeof getBundledChannelThreadBindingArtifactAsync>>
+  >();
+  let gatewayAuthArtifact: Awaited<ReturnType<typeof getBundledChannelGatewayAuthArtifactAsync>> =
+    null;
 
   beforeAll(async () => {
     for (const id of bundledChannelPluginIds) {
       plugins.set(id, await getBundledChannelPluginAsync(id));
+    }
+    for (const id of MESSAGE_TOOL_ARTIFACT_PLUGIN_IDS) {
+      messageToolArtifacts.set(id, await getBundledChannelMessageToolArtifactAsync(id));
+    }
+    gatewayAuthArtifact = await getBundledChannelGatewayAuthArtifactAsync("mattermost");
+    for (const id of ["discord", ...SESSION_CONVERSATION_ARTIFACT_PLUGIN_IDS] as const) {
+      sessionKeyArtifacts.set(id, await getBundledChannelSessionKeyArtifactAsync(id));
+    }
+    for (const id of THREAD_BINDING_ARTIFACT_PLUGIN_IDS) {
+      threadBindingArtifacts.set(id, await getBundledChannelThreadBindingArtifactAsync(id));
     }
   });
 
@@ -71,6 +108,80 @@ describe("bundled channel plugin shape coherence", () => {
 
       expect(expected).toBe(visible);
       expect(sanitizeText({ text, payload: { text } })).toBe(expected);
+    },
+  );
+
+  it.each(MESSAGE_TOOL_ARTIFACT_PLUGIN_IDS)(
+    "keeps the %s message-tool artifact identical to the loaded plugin action surface",
+    (id) => {
+      const artifactDescribeMessageTool = messageToolArtifacts.get(id)?.describeMessageTool;
+      const pluginDescribeMessageTool = plugins.get(id)?.actions?.describeMessageTool;
+
+      expect(typeof artifactDescribeMessageTool).toBe("function");
+      expect(typeof pluginDescribeMessageTool).toBe("function");
+      expect(artifactDescribeMessageTool).toBe(pluginDescribeMessageTool);
+    },
+  );
+
+  it("keeps the mattermost gateway-auth artifact identical to the loaded plugin gateway surface", () => {
+    const artifactResolveGatewayAuthBypassPaths =
+      gatewayAuthArtifact?.resolveGatewayAuthBypassPaths;
+    const pluginResolveGatewayAuthBypassPaths =
+      plugins.get("mattermost")?.gateway?.resolveGatewayAuthBypassPaths;
+
+    expect(typeof artifactResolveGatewayAuthBypassPaths).toBe("function");
+    expect(typeof pluginResolveGatewayAuthBypassPaths).toBe("function");
+    expect(artifactResolveGatewayAuthBypassPaths).toBe(pluginResolveGatewayAuthBypassPaths);
+  });
+
+  it.each(SESSION_CONVERSATION_ARTIFACT_PLUGIN_IDS)(
+    "keeps the %s session-conversation artifact identical to the loaded plugin messaging hook",
+    (id) => {
+      const artifactResolveSessionConversation =
+        sessionKeyArtifacts.get(id)?.resolveSessionConversation;
+      const pluginResolveSessionConversation =
+        plugins.get(id)?.messaging?.resolveSessionConversation;
+
+      expect(typeof artifactResolveSessionConversation).toBe("function");
+      expect(typeof pluginResolveSessionConversation).toBe("function");
+      expect(artifactResolveSessionConversation).toBe(pluginResolveSessionConversation);
+    },
+  );
+
+  it("keeps the discord session-key artifact behavior aligned with the loaded plugin adapter", () => {
+    const normalize = sessionKeyArtifacts.get("discord")?.normalizeExplicitDiscordSessionKey as
+      | ExplicitSessionKeyNormalizer
+      | undefined;
+    const pluginNormalize = plugins.get("discord")?.messaging?.normalizeExplicitSessionKey;
+
+    expect(typeof normalize).toBe("function");
+    expect(typeof pluginNormalize).toBe("function");
+    if (typeof normalize !== "function" || typeof pluginNormalize !== "function") {
+      throw new Error("Missing discord session-key normalizer parity surface");
+    }
+
+    // The plugin hook adapts core's params-object shape onto the artifact's
+    // positional export, so pin behavioral parity over representative keys.
+    const cases = [
+      { sessionKey: "discord:channel:123", ctx: { ChatType: "direct", SenderId: "123" } },
+      { sessionKey: "discord:dm:42", ctx: { ChatType: "dm", From: "discord:42" } },
+      { sessionKey: "agent:m:discord:channel:9", ctx: { ChatType: "direct", From: "discord:9" } },
+      { sessionKey: "Discord:Channel:77", ctx: { ChatType: "group", SenderId: "77" } },
+    ] as const;
+    for (const { sessionKey, ctx } of cases) {
+      expect(pluginNormalize({ sessionKey, ctx })).toBe(normalize(sessionKey, ctx));
+    }
+  });
+
+  it.each(THREAD_BINDING_ARTIFACT_PLUGIN_IDS)(
+    "keeps the %s thread-binding artifact equal to the loaded plugin default",
+    (id) => {
+      const artifactPlacement = threadBindingArtifacts.get(id)?.defaultTopLevelPlacement;
+      const pluginPlacement = plugins.get(id)?.conversationBindings?.defaultTopLevelPlacement;
+
+      expect(["current", "child"]).toContain(artifactPlacement);
+      expect(["current", "child"]).toContain(pluginPlacement);
+      expect(artifactPlacement).toBe(pluginPlacement);
     },
   );
 

--- a/src/channels/plugins/contracts/session-key-artifact.contract.test.ts
+++ b/src/channels/plugins/contracts/session-key-artifact.contract.test.ts
@@ -1,9 +1,9 @@
-// Session-key artifact parity contract for bundled channel plugins.
+// Session-key lightweight artifact contract for bundled channel plugins.
 //
 // Core resolves threaded session conversations from lightweight `session-key-api`
 // artifacts before full plugin loading (src/channels/plugins/session-conversation.ts).
-// This suite pins each artifact export to the exact function the loaded plugin's
-// messaging surface uses so the fast path cannot drift from plugin behavior.
+// This shard owns artifact inventory and export shape; loaded-plugin identity and
+// adapter behavior parity live in plugin-shape.contract.test.ts.
 //
 // Artifact exports are intentionally non-uniform: telegram/feishu ship the
 // `resolveSessionConversation` hook core probes, while discord ships only its
@@ -11,7 +11,6 @@
 // forcing one shape.
 import { beforeAll, describe, expect, it } from "vitest";
 import {
-  getBundledChannelPluginAsync,
   getBundledChannelSessionKeyArtifactAsync,
   listBundledChannelPluginIds,
 } from "./test-helpers/bundled-channel-plugin-loader.js";
@@ -19,11 +18,6 @@ import {
 // Bundled channels expected to ship a top-level session-key artifact.
 const SESSION_KEY_ARTIFACT_PLUGIN_IDS = ["discord", "feishu", "telegram"] as const;
 const SESSION_CONVERSATION_ARTIFACT_PLUGIN_IDS = ["feishu", "telegram"] as const;
-
-type ExplicitSessionKeyNormalizer = (
-  sessionKey: string,
-  ctx: { ChatType?: string; From?: string; SenderId?: string },
-) => string;
 
 describe("bundled channel session-key artifact parity", () => {
   const artifacts = new Map<string, Record<string, unknown>>();
@@ -39,39 +33,9 @@ describe("bundled channel session-key artifact parity", () => {
 
   it("keeps the artifact table in sync with bundled channels that ship one", () => {
     expect([...artifacts.keys()].toSorted()).toEqual([...SESSION_KEY_ARTIFACT_PLUGIN_IDS]);
-  });
-
-  it.each(SESSION_CONVERSATION_ARTIFACT_PLUGIN_IDS)(
-    "keeps the %s artifact resolver identical to the plugin messaging hook",
-    async (id) => {
-      const resolveSessionConversation = artifacts.get(id)?.resolveSessionConversation;
-      expect(typeof resolveSessionConversation).toBe("function");
-
-      const plugin = await getBundledChannelPluginAsync(id);
-      expect(plugin?.messaging?.resolveSessionConversation).toBe(resolveSessionConversation);
-    },
-  );
-
-  it("keeps the discord artifact normalizer behind the plugin messaging hook", async () => {
-    const normalize = artifacts.get("discord")?.normalizeExplicitDiscordSessionKey as
-      | ExplicitSessionKeyNormalizer
-      | undefined;
-    expect(typeof normalize).toBe("function");
-
-    const plugin = await getBundledChannelPluginAsync("discord");
-    const pluginNormalize = plugin?.messaging?.normalizeExplicitSessionKey;
-    expect(typeof pluginNormalize).toBe("function");
-
-    // The plugin hook adapts core's params-object shape onto the artifact's
-    // positional export, so pin behavioral parity over representative keys.
-    const cases = [
-      { sessionKey: "discord:channel:123", ctx: { ChatType: "direct", SenderId: "123" } },
-      { sessionKey: "discord:dm:42", ctx: { ChatType: "dm", From: "discord:42" } },
-      { sessionKey: "agent:m:discord:channel:9", ctx: { ChatType: "direct", From: "discord:9" } },
-      { sessionKey: "Discord:Channel:77", ctx: { ChatType: "group", SenderId: "77" } },
-    ] as const;
-    for (const { sessionKey, ctx } of cases) {
-      expect(pluginNormalize?.({ sessionKey, ctx })).toBe(normalize?.(sessionKey, ctx));
+    for (const id of SESSION_CONVERSATION_ARTIFACT_PLUGIN_IDS) {
+      expect(typeof artifacts.get(id)?.resolveSessionConversation).toBe("function");
     }
+    expect(typeof artifacts.get("discord")?.normalizeExplicitDiscordSessionKey).toBe("function");
   });
 });

--- a/src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts
+++ b/src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts
@@ -1,12 +1,11 @@
-// Thread-binding artifact parity contract for bundled channel plugins.
+// Thread-binding lightweight artifact contract for bundled channel plugins.
 //
 // Core resolves default thread placement from lightweight `thread-binding-api`
 // artifacts before full plugin loading (src/channels/plugins/thread-binding-api.ts).
-// This suite pins artifact exports to the runtime plugin's conversationBindings
-// so the fast path cannot drift from loaded-plugin behavior.
+// This shard owns artifact inventory and placement shape; loaded-plugin parity
+// lives in plugin-shape.contract.test.ts.
 import { beforeAll, describe, expect, it } from "vitest";
 import {
-  getBundledChannelPluginAsync,
   getBundledChannelThreadBindingArtifactAsync,
   listBundledChannelPluginIds,
 } from "./test-helpers/bundled-channel-plugin-loader.js";
@@ -30,16 +29,8 @@ describe("bundled channel thread-binding artifact parity", () => {
     expect([...artifactPlacements.keys()].toSorted()).toEqual([
       ...THREAD_BINDING_ARTIFACT_PLUGIN_IDS,
     ]);
+    for (const id of THREAD_BINDING_ARTIFACT_PLUGIN_IDS) {
+      expect(["current", "child"]).toContain(artifactPlacements.get(id));
+    }
   });
-
-  it.each(THREAD_BINDING_ARTIFACT_PLUGIN_IDS)(
-    "keeps the %s artifact placement equal to the runtime plugin default",
-    async (id) => {
-      const artifactPlacement = artifactPlacements.get(id);
-      expect(["current", "child"]).toContain(artifactPlacement);
-
-      const plugin = await getBundledChannelPluginAsync(id);
-      expect(plugin?.conversationBindings?.defaultTopLevelPlacement).toBe(artifactPlacement);
-    },
-  );
 });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1924,6 +1924,40 @@ describe("scripts/test-projects changed-target routing", () => {
     expect(plan.targets).not.toContain("extensions/discord/src/channel-actions.contract.test.ts");
   });
 
+  it.each([
+    ["extensions/imessage/message-tool-api.ts", "extensions/imessage/src/message-tool-api.test.ts"],
+    ["extensions/imessage/src/actions.ts", "extensions/imessage/src/actions.test.ts"],
+    ["extensions/imessage/src/channel.ts", "extensions/imessage/src/test-plugin.test.ts"],
+    ["extensions/slack/message-tool-api.ts", "extensions/slack/message-tool-api.ts"],
+    [
+      "extensions/slack/src/channel-actions.ts",
+      "extensions/slack/src/channel-actions-setup-status.contract.test.ts",
+    ],
+    ["extensions/slack/src/channel.ts", "extensions/slack/src/channel.test.ts"],
+    ["extensions/mattermost/gateway-auth-api.ts", "extensions/mattermost/gateway-auth-api.ts"],
+    ["extensions/mattermost/src/channel.ts", "extensions/mattermost/src/channel.test.ts"],
+    ["extensions/feishu/session-key-api.ts", "extensions/feishu/session-key-api.ts"],
+    ["extensions/feishu/src/channel.ts", "extensions/feishu/src/channel.test.ts"],
+    ["extensions/telegram/session-key-api.ts", "extensions/telegram/session-key-api.ts"],
+    ["extensions/telegram/src/channel.ts", "test/telegram-question-gateway.test.ts"],
+    ["extensions/discord/session-key-api.ts", "extensions/discord/session-key-api.ts"],
+    ["extensions/discord/thread-binding-api.ts", "extensions/discord/thread-binding-api.ts"],
+    ["extensions/discord/src/channel.ts", "extensions/discord/src/channel.test.ts"],
+    ["extensions/matrix/thread-binding-api.ts", "extensions/matrix/thread-binding-api.ts"],
+    ["extensions/matrix/src/channel.ts", "extensions/matrix/src/channel.threading.test.ts"],
+  ] as const)(
+    "routes %s through its owner and the plugin-shape parity contract",
+    (changedPath, ownerTarget) => {
+      const plan = resolveChangedTestTargetPlan([changedPath]);
+
+      expect(plan.mode).toBe("targets");
+      expect(plan.targets).toContain(ownerTarget);
+      expect(plan.targets).toContain(
+        "src/channels/plugins/contracts/plugin-shape.contract.test.ts",
+      );
+    },
+  );
+
   it("routes precise plugin contract helpers without broad-running every shard", () => {
     expect(
       resolveChangedTargetArgs(["--changed", "origin/main"], process.cwd(), () => [


### PR DESCRIPTION
## What Problem This Solves

Four lightweight channel artifact contract shards repeatedly loaded the full bundled plugin set for eight parity assertions, making contract feedback unnecessarily slow and memory-heavy.

## Why This Change Was Made

This moves loaded-plugin parity into the existing plugin-shape registry suite, which already materializes every bundled plugin. The lightweight shards retain artifact inventory, export, and invocation contracts, while precise supplemental changed-test routing keeps every artifact export and loaded-plugin wiring path covered.

## User Impact

There is no runtime behavior change. Maintainers and CI get faster, lower-memory contract feedback while preserving parity coverage and all tests.

## Evidence

| Linux benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `contracts-channel-surface` | 28.7983s / 2895.5MB RSS | 15.9734s / 2841.4MB RSS | -12.8249s |
| `contracts-channel-config` | 25.1678s / 2910.3MB RSS | 14.7910s / 2696.7MB RSS | -10.3768s |
| `contracts-channel-registry` | 24.8364s / 2812.5MB RSS | 17.4596s / 2517.5MB RSS | -7.3768s |
| `contracts-channel-session` | 25.0800s / 3198.2MB RSS | 15.5725s / 2738.3MB RSS | -9.5075s |
| **Total** | **103.8825s** | **63.7965s** | **-40.086s (38.6% faster)** |

- Before: Testbox `tbx_01kzz6s7m09h5w0r5qb7hek719`, [run 31768452382](https://github.com/openclaw/openclaw/actions/runs/31768452382). The longer full-suite SSH session ended with exit 255 after 36m54s, but only after all four relevant configs above had completed successfully.
- After: Testbox `tbx_01kzz9ep4hkm4kex8fas8xn6kv`, [run 31770880739](https://github.com/openclaw/openclaw/actions/runs/31770880739). All 50 files and 475 tests passed.
- Rebased focused proof: `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts src/channels/plugins/contracts/gateway-auth-artifact.contract.test.ts src/channels/plugins/contracts/message-tool-artifact.contract.test.ts src/channels/plugins/contracts/plugin-shape.contract.test.ts src/channels/plugins/contracts/session-key-artifact.contract.test.ts src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts --reporter=dot` passed 264 routing tests and 152 contract tests (416 total).
- Rebased changed gate: Testbox `tbx_01kzz9p9tg9k624t5zjn7w6tqw`, [run 31771092545](https://github.com/openclaw/openclaw/actions/runs/31771092545), `check:changed` exit 0 across types, lint, guards, cycles, and boundaries.
- Final exact-head Codex autoreview was clean with no accepted or actionable findings.
- LOC: runtime production +0/-0; tooling +28/-0; tests +172/-91 (net +81). The tooling growth is the precise supplemental changed-test routing required so artifact/export wiring changes still select the moved parity suite.

AI-assisted. I understand the change and verified the affected routing and contract behavior. Agent transcripts are intentionally omitted.
