### PR TITLE
fix(ui): stop Models page agent roster retry storms

### DIFF
--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -21,9 +21,15 @@ export async function readPreparedServerMethodModelCatalog(
   context: GatewayRequestContext,
   options?: { agentId?: string },
 ): Promise<ModelCatalogEntry[] | undefined> {
-  return context.readPreparedGatewayModelCatalog
-    ? await context.readPreparedGatewayModelCatalog(options)
-    : undefined;
+  try {
+    return context.readPreparedGatewayModelCatalog
+      ? await context.readPreparedGatewayModelCatalog(options)
+      : undefined;
+  } catch {
+    // Catalog metadata decorates these responses; owner selection or lifecycle
+    // races must not make the primary roster/session RPC unavailable.
+    return undefined;
+  }
 }
 
 type LoadOptionalServerMethodModelCatalogOptions<T> = {

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -100,6 +100,20 @@ test("agents.list reads published model facts without starting provider discover
   expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
 });
 
+test("agents.list returns the roster when optional prepared model facts are unavailable", async () => {
+  await setAgentsConfig({ ownership: "explicit", entries: { ops: {}, research: {} } });
+  const readPreparedGatewayModelCatalog = vi.fn(async () => {
+    throw new Error("prepared model catalog requires an explicit owner");
+  });
+
+  await expect(listAgentIdsViaRpc(false, { readPreparedGatewayModelCatalog })).resolves.toEqual([
+    "ops",
+    "research",
+  ]);
+
+  expect(readPreparedGatewayModelCatalog).toHaveBeenCalledOnce();
+});
+
 beforeEach(async () => {
   testState.agentConfig = undefined;
   testState.sessionStorePath = undefined;

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -148,8 +148,10 @@ function createHarness(initialScopeId: string) {
           ],
         },
         agentsLoading: false,
+        agentsError: null as string | null,
       },
       ensureList: vi.fn(),
+      refreshList: vi.fn(),
       subscribe,
     },
     agentSelection,
@@ -571,6 +573,25 @@ describe("ModelProvidersPage agent scope", () => {
         ([method]) => method === "models.authStatus" || method === "models.list",
       ),
     ).toEqual([]);
+  });
+
+  it("shows a roster failure without automatically retrying it", async () => {
+    const { agentSelection, context } = createHarness("main");
+    agentSelection.state.selectedId = null;
+    agentSelection.state.scopeId = null;
+    context.agents.state.agentsList = null;
+    context.agents.state.agentsError = "Agent roster unavailable";
+
+    const page = appendPage(context);
+    await page.updateComplete;
+
+    expect(context.agents.ensureList).not.toHaveBeenCalled();
+    expect(page.textContent).toContain("Agent roster unavailable");
+
+    [...page.querySelectorAll<HTMLButtonElement>("button")]
+      .find((button) => button.textContent?.trim() === "Refresh")
+      ?.click();
+    expect(context.agents.refreshList).toHaveBeenCalledOnce();
   });
 
   it("recovers when the agent changes while a refresh is in flight", async () => {

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -197,7 +197,11 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     if (snapshot.client !== this.observedClient) {
       this.resetClientState(snapshot.client);
     }
-    if (!this.context.agents.state.agentsList && !this.context.agents.state.agentsLoading) {
+    if (
+      !this.context.agents.state.agentsList &&
+      !this.context.agents.state.agentsLoading &&
+      !this.context.agents.state.agentsError
+    ) {
       void this.context.agents.ensureList();
     }
     if (
@@ -587,7 +591,9 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
 
   override render() {
     const gatewaySnapshot = this.context.gateway.snapshot;
-    const agents = this.context.agents.state.agentsList?.agents ?? [];
+    const agentsState = this.context.agents.state;
+    const agents = agentsState.agentsList?.agents ?? [];
+    const rosterError = agentsState.agentsList ? null : agentsState.agentsError;
     const selected = agents.find((agent) => normalizeAgentId(agent.id) === this.selectedAgentId);
     const selectedAgentLabel = selected ? normalizeAgentLabel(selected) : this.selectedAgentId;
     const data = this.data ?? EMPTY_MODEL_PROVIDERS_DATA;
@@ -620,9 +626,9 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     const configuredModels = buildSelectableDefaultModels(data.models, defaults);
     const body = renderModelProviders({
       connected: gatewaySnapshot.phase === "connected",
-      loading: gatewaySnapshot.phase === "connected" && this.data === null,
+      loading: gatewaySnapshot.phase === "connected" && this.data === null && !rosterError,
       refreshing: this.refreshTask.status === TaskStatus.PENDING,
-      error: data.error ?? data.catalogError,
+      error: rosterError ?? data.error ?? data.catalogError,
       updatedAt: data.updatedAt,
       costDays: MODEL_PROVIDERS_COST_DAYS,
       credentialAgentLabel: selectedAgentLabel,
@@ -649,7 +655,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       addProviderOpen: this.addProviderOpen,
       addProviderId: this.addProviderId,
       addProviderKey: this.addProviderKey,
-      onRefresh: () => void this.refresh({ force: true }),
+      onRefresh: () =>
+        void (rosterError ? this.context.agents.refreshList() : this.refresh({ force: true })),
       onOpenKeyEditor: (provider) => this.openKeyEditor(provider),
       onCloseKeyEditor: () => this.closeKeyEditor(),
       onKeyDraftChange: (value) => (this.keyDraft = value),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Models page with an explicit multi-agent roster could trigger a tight `agents.list` retry loop when optional prepared model-catalog enrichment required an agent selection. On Mainframe this produced 1,319 failed calls in about 30 seconds and briefly drove the Gateway process above one CPU core.

## Why This Change Was Made

`agents.list` remains a roster-level operation: optional model-catalog metadata now fails open instead of making the roster RPC unavailable. If the roster itself still fails, the Models page shows the error and waits for the existing explicit Refresh action instead of retrying after every failed publication.

The shared optional catalog helper also keeps `sessions.list` available during the same owner-selection or catalog-lifecycle failure. No protocol, config, storage, or migration surface changes.

## User Impact

The Models page can recover its agent roster without entering a request/CPU storm. Operators get one visible failure and a clear Refresh action if the roster request genuinely fails.

## Evidence

- Live Mainframe reproduction before the fix: a fresh `/settings/model-providers` route issued 1,319 failing `agents.list` calls from `23:50:14.479` through `23:50:44.837`. The calls stopped immediately when the tab closed; CPU dropped from repeated 24–76% samples (one 109.6% sample) to 0.2–0.4%.
- Red regression proof before production edits:
  - Gateway roster test rejected with the optional prepared-catalog owner-selection error.
  - Models-page test observed an automatic `ensureList()` retry instead of a terminal error state.
- Post-fix focused proof on Node 24.15.0: 15 Gateway tests and 21 UI tests passed.
- Testbox `tbx_01kzzabjstkd6swjzw7178ge23`:
  - `pnpm check:changed`: passed (core/UI types, lint, formatting, i18n, dependency/boundary, cycle, and storage guards).
  - `ui/src/e2e/model-providers.e2e.test.ts`: 4/4 passed.
- Mandatory local autoreview: clean, correctness 0.98, no actionable findings.
- Production delta: +21/-8 across the Gateway optional-enrichment boundary and Models-page terminal error/retry behavior. Tests: +35.

The broader `model-agent-scoping.e2e.test.ts` currently times out waiting for Debug to emit `models.authStatus`; current Debug behavior emits `models.list` only. This branch does not touch that surface, so the stale expectation is not broadened into this repair.
