### PR TITLE
fix(agents): keep compacted sessions recoverable across retries

### DIFF
--- a/src/agents/agent-compaction-constants.ts
+++ b/src/agents/agent-compaction-constants.ts
@@ -10,3 +10,5 @@ export const MIN_PROMPT_BUDGET_TOKENS = 8_000;
  * content after reserve tokens are subtracted.
  */
 export const MIN_PROMPT_BUDGET_RATIO = 0.5;
+
+export const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;

--- a/src/agents/compaction-replay.ts
+++ b/src/agents/compaction-replay.ts
@@ -1,0 +1,10 @@
+import { stripStaleAssistantUsageBeforeLatestCompaction } from "./compaction-usage.js";
+import type { AgentMessage } from "./runtime/index.js";
+import { stripStaleThinkingSignaturesForCompactionReplay } from "./thinking-signatures.js";
+
+/** Keep every transcript rebuild safe for the next provider request. */
+export function sanitizeCompactionReplayMessages(messages: AgentMessage[]): AgentMessage[] {
+  return stripStaleThinkingSignaturesForCompactionReplay(
+    stripStaleAssistantUsageBeforeLatestCompaction(messages),
+  );
+}

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -45,6 +45,7 @@ import {
 } from "../session-transcript-repair.js";
 import type { SessionManager } from "../sessions/index.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../stream-message-shared.js";
+import { stripStaleThinkingSignaturesForCompactionReplay } from "../thinking-signatures.js";
 import {
   extractToolCallsFromAssistant,
   extractToolResultId,
@@ -69,7 +70,6 @@ import {
   dropThinkingBlocks,
   shouldPreserveLatestAssistantThinking,
   stripInvalidThinkingSignatures,
-  stripStaleThinkingSignaturesForCompactionReplay,
 } from "./thinking.js";
 
 const MODEL_SNAPSHOT_CUSTOM_TYPE = "model-snapshot";

--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
@@ -3,6 +3,7 @@
  */
 import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import type { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { log } from "../logger.js";
 import { flushSessionManagerTranscript } from "./attempt-transcript-helpers.js";
@@ -71,8 +72,9 @@ export async function runEmbeddedAttemptBeforeAgentRun(input: {
         );
         flushSessionManagerTranscript(input.sessionManager);
       });
-      input.activeSession.agent.state.messages =
-        input.sessionManager.buildSessionContext().messages;
+      input.activeSession.agent.state.messages = sanitizeCompactionReplayMessages(
+        input.sessionManager.buildSessionContext().messages,
+      );
       return true;
     } catch (err) {
       log.warn(

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
@@ -3,6 +3,7 @@
  */
 import type { AssembleResult } from "../../../context-engine/types.js";
 import type { AgentRunAttemptFailureSource } from "../../agent-run-terminal-outcome.js";
+import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { SessionManager } from "../../sessions/index.js";
@@ -101,7 +102,9 @@ export function handleEmbeddedAttemptMidTurnPrecheck(input: {
         handled: true as const,
         truncatedCount: truncationResult.truncatedCount,
       };
-      input.replaceSessionMessages(input.sessionManager.buildSessionContext().messages);
+      input.replaceSessionMessages(
+        sanitizeCompactionReplayMessages(input.sessionManager.buildSessionContext().messages),
+      );
       logMidTurnPrecheck(
         request.route,
         `handled=true truncatedCount=${truncationResult.truncatedCount}`,

--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -18,6 +18,7 @@ import {
   resolveEffectiveCompactionMode,
 } from "../../agent-settings.js";
 import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
+import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import { bootstrapHarnessContextEngine } from "../../harness/context-engine-lifecycle.js";
 import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
@@ -317,7 +318,9 @@ export function prepareEmbeddedAttemptSessionBoundary(input: {
     // discard the merged replacement prompt.
     sessionManager.clearNextUserMessagePersistenceSuppression?.();
     attempt.onUserMessagePersistenceInvalidated?.();
-    activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+    activeSession.agent.state.messages = sanitizeCompactionReplayMessages(
+      sessionManager.buildSessionContext().messages,
+    );
   }
 
   // This is the single timestamping source for user messages sent to the LLM.

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -9,6 +9,7 @@ import {
   setAgentRunAttemptTerminalFailure,
   type AgentRunAttemptFailureSource,
 } from "../../agent-run-terminal-outcome.js";
+import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { settleRequesterAfterSessionSpawns } from "../../subagents/registry/subagent-registry.js";
 import type { NormalizedUsage } from "../../usage.js";
@@ -373,7 +374,9 @@ export async function runEmbeddedAttemptSettledPhase(
     let settledStream: Awaited<ReturnType<typeof settleEmbeddedAttemptStream>>;
     try {
       if (input.getRepairedRejectedThinkingReplay() && !rewoundBeforeAgentFinalizeRevision) {
-        activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+        activeSession.agent.state.messages = sanitizeCompactionReplayMessages(
+          sessionManager.buildSessionContext().messages,
+        );
       }
       const settleTerminal = readTerminal();
       const streamSettleState = {
@@ -432,7 +435,9 @@ export async function runEmbeddedAttemptSettledPhase(
         await input.sessionLock.withOwnedTranscriptWrite(() => {
           // Settlement classifies the completed attempt from its original
           // in-memory messages. Later work always sees the rewound branch.
-          activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+          activeSession.agent.state.messages = sanitizeCompactionReplayMessages(
+            sessionManager.buildSessionContext().messages,
+          );
         });
       }
     }

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
@@ -10,6 +10,7 @@ import { resolveQuotaSuspensionEntryMaintenance } from "../../../config/sessions
 import type { SessionEntry as ConfigSessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
+import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
@@ -91,7 +92,7 @@ export function normalizeCompactionRecoveryTranscriptTail(params: {
   );
   params.activeSession.agent.state.messages =
     removedEntries > 0
-      ? params.sessionManager.buildSessionContext().messages
+      ? sanitizeCompactionReplayMessages(params.sessionManager.buildSessionContext().messages)
       : continuableMessages.length === messages.length
         ? messages
         : continuableMessages;

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -3,6 +3,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { ContextEngine } from "../../../context-engine/types.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import type { AssistantMessage } from "../../../llm/types.js";
+import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../../agent-compaction-constants.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import {
   extractObservedOverflowTokenCount,
@@ -30,8 +31,6 @@ import {
   isNoRealConversationCompactionNoop,
   resetNoRealConversationTokenSnapshot,
 } from "./session-bootstrap.js";
-
-const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
 
 type CompactResult = Awaited<ReturnType<ContextEngine["compact"]>>;
 

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -4,12 +4,12 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { castAgentMessage, castAgentMessages } from "../test-helpers/agent-message-fixtures.js";
+import { stripStaleThinkingSignaturesForCompactionReplay } from "../thinking-signatures.js";
 import {
   assessLastAssistantMessage,
   dropReasoningFromHistory,
   dropThinkingBlocks,
   stripInvalidThinkingSignatures,
-  stripStaleThinkingSignaturesForCompactionReplay,
   wrapAnthropicStreamWithRecovery,
 } from "./thinking.js";
 
@@ -1078,7 +1078,7 @@ describe("stripStaleThinkingSignaturesForCompactionReplay", () => {
     expect(stripStaleThinkingSignaturesForCompactionReplay(messages)).toBe(messages);
   });
 
-  it("strips thinking signatures from assistant messages at or before the compaction timestamp", () => {
+  it("strips thinking signatures from assistant messages before the compaction timestamp", () => {
     const compactionSummary = castAgentMessage({
       role: "compactionSummary",
       summary: "summary",

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -5,6 +5,7 @@ import { collectErrorGraphCandidates, formatErrorMessage } from "../../infra/err
 import type { AssistantMessageEvent } from "../../llm/types.js";
 import { createAssistantMessageEventStream } from "../../llm/utils/event-stream.js";
 import type { AgentMessage, StreamFn } from "../runtime/index.js";
+import { isAssistantMessageWithContent, isThinkingBlock } from "../thinking-signatures.js";
 import { log } from "./logger.js";
 
 type AssistantContentBlock = Extract<AgentMessage, { role: "assistant" }>["content"][number];
@@ -23,24 +24,6 @@ type RecoverySessionMeta = {
 const THINKING_BLOCK_ERROR_PATTERN =
   /(?:thinking|redacted_thinking).*?(?:cannot be modified|signature|invalid|missing|empty|blank)|(?:signature|invalid|missing|empty|blank).*?(?:thinking|redacted_thinking)/i;
 const OMITTED_ASSISTANT_REASONING_TEXT = "[assistant reasoning omitted]";
-
-function isAssistantMessageWithContent(message: AgentMessage): message is AssistantMessage {
-  return (
-    Boolean(message) &&
-    typeof message === "object" &&
-    message.role === "assistant" &&
-    Array.isArray(message.content)
-  );
-}
-
-function isThinkingBlock(block: AssistantContentBlock): boolean {
-  return (
-    Boolean(block) &&
-    typeof block === "object" &&
-    ((block as { type?: unknown }).type === "thinking" ||
-      (block as { type?: unknown }).type === "redacted_thinking")
-  );
-}
 
 function isToolCallBlock(block: AssistantContentBlock): boolean {
   if (!block || typeof block !== "object") {
@@ -92,124 +75,6 @@ function hasMeaningfulText(block: AssistantContentBlock): boolean {
 function buildOmittedAssistantReasoningContent(): AssistantContentBlock[] {
   // Provider converters drop blank text blocks; keep this neutral text non-empty so the assistant turn survives replay.
   return [{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT } as AssistantContentBlock];
-}
-
-function parseTimestampMs(value: unknown): number | null {
-  return parseDateFirstTimestampMs(value) ?? null;
-}
-
-function stripSignatureFieldsFromThinkingBlock(
-  block: AssistantContentBlock,
-): AssistantContentBlock {
-  const record = block as unknown as Record<string, unknown>;
-  const stripped: Record<string, unknown> = {};
-  for (const key of Object.keys(record)) {
-    if (key === "thinkingSignature" || key === "signature" || key === "thought_signature") {
-      continue;
-    }
-    // data is the signature payload for redacted_thinking blocks
-    if (key === "data" && record.type === "redacted_thinking") {
-      continue;
-    }
-    stripped[key] = record[key];
-  }
-  return stripped as unknown as AssistantContentBlock;
-}
-
-/**
- * Strip all thinking signature fields from a single assistant message.
- *
- * Removes thinkingSignature / signature / thought_signature from thinking blocks and
- * data from redacted_thinking blocks. Thinking text is preserved. If the message
- * becomes thinking-only with no signatures, the downstream stripInvalidThinkingSignatures
- * will convert those unsigned blocks to placeholder text.
- *
- * Returns the original reference when nothing was stripped.
- */
-function stripThinkingSignaturesFromMessage(message: AgentMessage): AgentMessage {
-  if (!isAssistantMessageWithContent(message)) {
-    return message;
-  }
-  let changed = false;
-  const newContent: AssistantContentBlock[] = [];
-  for (const block of message.content) {
-    if (!isThinkingBlock(block)) {
-      newContent.push(block);
-      continue;
-    }
-    const record = block as unknown as Record<string, unknown>;
-    const hasSignature =
-      record.thinkingSignature != null ||
-      record.signature != null ||
-      record.thought_signature != null ||
-      (record.type === "redacted_thinking" && record.data != null);
-    if (!hasSignature) {
-      newContent.push(block);
-      continue;
-    }
-    newContent.push(stripSignatureFieldsFromThinkingBlock(block));
-    changed = true;
-  }
-  if (!changed) {
-    return message;
-  }
-  return { ...message, content: newContent };
-}
-
-/**
- * Strip thinking signatures from assistant messages that predate the latest compaction.
- *
- * Pre-compaction thinking signatures are cryptographically bound to the original context
- * prefix. After compaction the prefix changes (summarized content is replaced by the
- * compaction summary) so those signatures are stale and Anthropic rejects them with
- * "Invalid signature in thinking block". The existing stripInvalidThinkingSignatures only
- * catches absent/blank signatures; this function catches contextually stale ones identified
- * by timestamp comparison with the latest compaction summary.
- *
- * Only strips from assistant messages whose timestamp is strictly before the latest
- * compaction summary timestamp. Messages at or after that timestamp may have been generated
- * in the new context and retain their signatures. Messages with no parseable timestamp are
- * left unchanged.
- *
- * Returns the original array reference when nothing was changed.
- */
-export function stripStaleThinkingSignaturesForCompactionReplay(
-  messages: AgentMessage[],
-): AgentMessage[] {
-  let latestCompactionTimestamp: number | null = null;
-  for (const message of messages) {
-    if ((message as { role?: unknown }).role !== "compactionSummary") {
-      continue;
-    }
-    const ts = parseTimestampMs((message as { timestamp?: unknown }).timestamp);
-    if (ts !== null) {
-      latestCompactionTimestamp =
-        latestCompactionTimestamp === null ? ts : Math.max(latestCompactionTimestamp, ts);
-    }
-  }
-  if (latestCompactionTimestamp === null) {
-    return messages;
-  }
-
-  let touched = false;
-  const out: AgentMessage[] = [];
-  for (const message of messages) {
-    if (!isAssistantMessageWithContent(message)) {
-      out.push(message);
-      continue;
-    }
-    const ts = parseTimestampMs((message as { timestamp?: unknown }).timestamp);
-    if (ts === null || ts >= latestCompactionTimestamp) {
-      out.push(message);
-      continue;
-    }
-    const stripped = stripThinkingSignaturesFromMessage(message);
-    if (stripped !== message) {
-      touched = true;
-    }
-    out.push(stripped);
-  }
-  return touched ? out : messages;
 }
 
 function hasReplayableThinkingSignature(block: AssistantContentBlock): boolean {
@@ -756,4 +621,3 @@ export function wrapAnthropicStreamWithRecovery(
     return createRecoveryStream(stream, requestMeta, retry, notify);
   };
 }
-import { parseDateFirstTimestampMs } from "@openclaw/normalization-core/number-coercion";

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -83,7 +83,7 @@ export abstract class AgentSessionBase {
   // Compaction state
   protected compactionAbortController: AbortController | undefined = undefined;
   protected autoCompactionAbortController: AbortController | undefined = undefined;
-  protected overflowRecoveryAttempted = false;
+  protected overflowRecoveryAttempts = 0;
   protected contextOverflowRecoveryOwner: "session" | "caller";
 
   // Branch summarization state
@@ -367,7 +367,7 @@ export abstract class AgentSessionBase {
 
     // Retire the exact queued display entry before publishing message_start.
     if (event.type === "message_start" && event.message.role === "user") {
-      this.overflowRecoveryAttempted = false;
+      this.overflowRecoveryAttempts = 0;
       retireQueuedUserMessage(event.message);
     }
 
@@ -436,7 +436,7 @@ export abstract class AgentSessionBase {
         // A length response may still need overflow recovery in checkCompaction();
         // retryCount is independent and resets for every non-error response below.
         if (assistantMsg.stopReason !== "error" && assistantMsg.stopReason !== "length") {
-          this.overflowRecoveryAttempted = false;
+          this.overflowRecoveryAttempts = 0;
         }
 
         // Reset retry counter immediately on successful assistant response

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -1,4 +1,4 @@
-import type { Context, Model } from "openclaw/plugin-sdk/llm";
+import type { AssistantMessage, Context, Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
 import {
@@ -17,8 +17,19 @@ import {
 } from "./agent-session-loop-resource-loader.test-support.js";
 import type { AgentSessionEvent } from "./agent-session-types.js";
 import { SessionManager } from "./session-manager.js";
+import { SettingsManager } from "./settings-manager.js";
 
 registerAgentSessionLoopTestLifecycle();
+
+function createStaleThinkingContent(): AssistantMessage["content"] {
+  return [
+    { type: "thinking", thinking: "old think", thinkingSignature: "stale-thinking" },
+    { type: "thinking", thinking: "old think", signature: "stale-signature" },
+    { type: "thinking", thinking: "old think", thought_signature: "stale-thought" },
+    { type: "redacted_thinking", data: "stale-redacted" },
+    { type: "text", text: "retained answer" },
+  ] as unknown as AssistantMessage["content"];
+}
 
 describe("AgentSession compaction", () => {
   it.each(Array.from({ length: MAX_OVERFLOW_COMPACTION_ATTEMPTS }, (_, index) => index + 1))(
@@ -93,13 +104,7 @@ describe("AgentSession compaction", () => {
       timestamp: Date.now() - 3,
     });
     const retainedAssistantId = sessionManager.appendMessage({
-      ...createAssistant(testModel, [
-        { type: "thinking", thinking: "old think", thinkingSignature: "stale-thinking" },
-        { type: "thinking", thinking: "old think", signature: "stale-signature" },
-        { type: "thinking", thinking: "old think", thought_signature: "stale-thought" },
-        { type: "redacted_thinking", data: "stale-redacted" },
-        { type: "text", text: "retained answer" },
-      ]),
+      ...createAssistant(testModel, createStaleThinkingContent()),
       timestamp: Date.now() - 2,
     });
     const handlers = createCompactionHandlers();
@@ -147,5 +152,80 @@ describe("AgentSession compaction", () => {
       ],
     });
     expect(JSON.stringify(requests[1]?.messages)).not.toContain("stale-");
+  });
+
+  it("sanitizes restored compaction history before pre-prompt maintenance", async () => {
+    const model = { ...testModel, contextWindow: 1_000 };
+    const sessionManager = SessionManager.inMemory();
+    const now = Date.now();
+    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: now - 2 });
+    const retainedAssistantId = sessionManager.appendMessage({
+      ...createAssistant(model, createStaleThinkingContent(), "stop", 950),
+      timestamp: now - 1,
+    });
+    sessionManager.appendCompaction("condensed history", retainedAssistantId, 950);
+    sessionManager.appendMessage({
+      role: "user",
+      content: "post-compaction prompt",
+      timestamp: now + 1_000,
+    });
+    sessionManager.appendMessage({
+      ...createAssistant(model, [], "error"),
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        contextUsage: { state: "unavailable" },
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      errorMessage: "temporary provider error",
+      timestamp: now + 1_001,
+    });
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 100, keepRecentTokens: 20 },
+      retry: { enabled: false },
+    });
+    const compactionEvents: AgentSessionEvent[] = [];
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "complete answer" }], "stop", 20),
+      ),
+    );
+    const { session } = await createTestSession({
+      model,
+      sessionManager,
+      settingsManager,
+      resourceLoader: createResourceLoader(createCompactionHandlers()),
+    });
+    session.subscribe((event) => {
+      if (event.type === "compaction_start" || event.type === "compaction_end") {
+        compactionEvents.push(event);
+      }
+    });
+
+    const retained = session.messages.find(
+      (message) =>
+        message.role === "assistant" &&
+        message.content.some((block) => block.type === "text" && block.text === "retained answer"),
+    );
+    expect(retained).toMatchObject({
+      role: "assistant",
+      usage: { input: 0, output: 0, totalTokens: 0 },
+      content: [
+        { type: "thinking", thinking: "old think" },
+        { type: "thinking", thinking: "old think" },
+        { type: "thinking", thinking: "old think" },
+        { type: "redacted_thinking" },
+        { type: "text", text: "retained answer" },
+      ],
+    });
+
+    await session.prompt("continue restored session");
+
+    expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
+    expect(compactionEvents).toEqual([]);
+    expect(session.getLastAssistantText()).toBe("complete answer");
   });
 });

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -1,0 +1,151 @@
+import type { Context, Model } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  createAutoCompactionSettings,
+  createOverflowAssistant,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  streamMocks,
+  testModel,
+} from "./agent-session-loop-correctness.test-support.js";
+import {
+  createCompactionHandlers,
+  createResourceLoader,
+} from "./agent-session-loop-resource-loader.test-support.js";
+import type { AgentSessionEvent } from "./agent-session-types.js";
+import { SessionManager } from "./session-manager.js";
+
+registerAgentSessionLoopTestLifecycle();
+
+describe("AgentSession compaction", () => {
+  it.each(Array.from({ length: MAX_OVERFLOW_COMPACTION_ATTEMPTS }, (_, index) => index + 1))(
+    "recovers when the provider accepts overflow compaction attempt %i",
+    async (overflowCount) => {
+      let agentRequests = 0;
+      streamMocks.streamSimple.mockImplementation((activeModel: Model) => {
+        agentRequests += 1;
+        const response =
+          agentRequests <= overflowCount
+            ? createOverflowAssistant(activeModel)
+            : createAssistant(activeModel, [{ type: "text", text: "complete retry" }]);
+        return createAssistantResultStream({ ...response, timestamp: Date.now() + agentRequests });
+      });
+      const { session } = await createTestSession({
+        settingsManager: createAutoCompactionSettings(),
+        resourceLoader: createResourceLoader(createCompactionHandlers()),
+      });
+      const compactionEvents: AgentSessionEvent[] = [];
+      session.subscribe((event) => {
+        if (event.type === "compaction_end") {
+          compactionEvents.push(event);
+        }
+      });
+
+      await session.prompt("long request");
+
+      expect(agentRequests).toBe(overflowCount + 1);
+      expect(
+        compactionEvents.filter((event) => event.type === "compaction_end" && event.willRetry),
+      ).toHaveLength(overflowCount);
+      expect(session.getLastAssistantText()).toBe("complete retry");
+    },
+  );
+
+  it("surfaces the shared overflow recovery limit after exhausting it", async () => {
+    let agentRequests = 0;
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) => {
+      agentRequests += 1;
+      return createAssistantResultStream({
+        ...createOverflowAssistant(activeModel),
+        timestamp: Date.now() + agentRequests,
+      });
+    });
+    const { session } = await createTestSession({
+      settingsManager: createAutoCompactionSettings(),
+      resourceLoader: createResourceLoader(createCompactionHandlers()),
+    });
+    const compactionEvents: AgentSessionEvent[] = [];
+    session.subscribe((event) => {
+      if (event.type === "compaction_end") {
+        compactionEvents.push(event);
+      }
+    });
+
+    await session.prompt("long request");
+
+    expect(streamMocks.streamSimple).toHaveBeenCalledTimes(MAX_OVERFLOW_COMPACTION_ATTEMPTS + 1);
+    expect(compactionEvents.at(-1)).toMatchObject({
+      type: "compaction_end",
+      reason: "overflow",
+      willRetry: false,
+      errorMessage: `Context overflow recovery failed after ${MAX_OVERFLOW_COMPACTION_ATTEMPTS} compact-and-retry attempts. Try reducing context or switching to a larger-context model.`,
+    });
+  });
+
+  it("strips stale thinking signatures before continuing after auto-compaction", async () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({
+      role: "user",
+      content: "old prompt",
+      timestamp: Date.now() - 3,
+    });
+    const retainedAssistantId = sessionManager.appendMessage({
+      ...createAssistant(testModel, [
+        { type: "thinking", thinking: "old think", thinkingSignature: "stale-thinking" },
+        { type: "thinking", thinking: "old think", signature: "stale-signature" },
+        { type: "thinking", thinking: "old think", thought_signature: "stale-thought" },
+        { type: "redacted_thinking", data: "stale-redacted" },
+        { type: "text", text: "retained answer" },
+      ]),
+      timestamp: Date.now() - 2,
+    });
+    const handlers = createCompactionHandlers();
+    handlers.set("session_before_compact", [
+      async (event: unknown) => ({
+        compaction: {
+          summary: "condensed history",
+          firstKeptEntryId: retainedAssistantId,
+          tokensBefore: (event as { preparation: { tokensBefore: number } }).preparation
+            .tokensBefore,
+        },
+      }),
+    ]);
+    const requests: Context[] = [];
+    streamMocks.streamSimple.mockImplementation((activeModel: Model, context: Context) => {
+      requests.push(context);
+      return createAssistantResultStream(
+        requests.length === 1
+          ? createOverflowAssistant(activeModel)
+          : createAssistant(activeModel, [{ type: "text", text: "complete retry" }]),
+      );
+    });
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager: createAutoCompactionSettings(),
+      resourceLoader: createResourceLoader(handlers),
+    });
+
+    await session.prompt("long request");
+
+    expect(requests).toHaveLength(2);
+    const retained = session.messages.find(
+      (message) =>
+        message.role === "assistant" &&
+        message.content.some((block) => block.type === "text" && block.text === "retained answer"),
+    );
+    expect(retained).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "old think" },
+        { type: "thinking", thinking: "old think" },
+        { type: "thinking", thinking: "old think" },
+        { type: "redacted_thinking" },
+        { type: "text", text: "retained answer" },
+      ],
+    });
+    expect(JSON.stringify(requests[1]?.messages)).not.toContain("stale-");
+  });
+});

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -1,6 +1,8 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
 import { InvalidSummaryOutputError } from "../../../packages/agent-core/src/harness/types.js";
 import type { AssistantMessage, Model } from "../../llm/types.js";
+import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
+import { stripStaleAssistantUsageBeforeLatestCompaction } from "../compaction-usage.js";
 import {
   calculateContextTokens,
   compact,
@@ -10,6 +12,7 @@ import {
   type CompactionPreparation,
   type CompactionResult,
 } from "../runtime/index.js";
+import { stripStaleThinkingSignaturesForCompactionReplay } from "../thinking-signatures.js";
 import { AgentSessionInspection } from "./agent-session-inspection.js";
 import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
@@ -247,7 +250,11 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     );
     const newEntries = this.sessionManager.getEntries();
     const sessionContext = this.sessionManager.buildSessionContext();
-    this.agent.state.messages = sessionContext.messages;
+    // Compaction replaces the request prefix, invalidating retained usage and thinking signatures.
+    // Sanitize at assignment so every continuation driver receives replay-safe history.
+    this.agent.state.messages = stripStaleThinkingSignaturesForCompactionReplay(
+      stripStaleAssistantUsageBeforeLatestCompaction(sessionContext.messages),
+    );
 
     const savedCompactionEntry = newEntries.find(
       (e) => e.type === "compaction" && e.summary === compactionResult.summary,
@@ -321,20 +328,19 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       if (this.contextOverflowRecoveryOwner === "caller") {
         return false;
       }
-      if (this.overflowRecoveryAttempted) {
+      if (this.overflowRecoveryAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS) {
         this.emit({
           type: "compaction_end",
           reason: "overflow",
           result: undefined,
           aborted: false,
           willRetry: false,
-          errorMessage:
-            "Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
+          errorMessage: `Context overflow recovery failed after ${MAX_OVERFLOW_COMPACTION_ATTEMPTS} compact-and-retry attempts. Try reducing context or switching to a larger-context model.`,
         });
         return false;
       }
 
-      this.overflowRecoveryAttempted = true;
+      this.overflowRecoveryAttempts += 1;
       // Keep the failed response in history, but exclude it from the retry context.
       const messages = this.agent.state.messages;
       if (messages.at(-1)?.role === "assistant") {
@@ -353,17 +359,6 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       if (estimate.lastUsageIndex === null) {
         return false;
       } // No usage data at all
-      // Verify the usage source is post-compaction. Kept pre-compaction messages
-      // have stale usage reflecting the old (larger) context and would falsely
-      // trigger compaction right after one just finished.
-      const usageMsg = messages.at(estimate.lastUsageIndex);
-      if (
-        compactionEntry &&
-        usageMsg?.role === "assistant" &&
-        usageMsg.timestamp <= new Date(compactionEntry.timestamp).getTime()
-      ) {
-        return false;
-      }
       contextTokens = estimate.tokens;
     } else if (assistantMessage.usage.contextUsage?.state === "unavailable") {
       const estimatedContextTokens = this.getContextUsage()?.tokens;

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -2,7 +2,7 @@ import { isContextOverflow } from "@openclaw/ai/internal/runtime";
 import { InvalidSummaryOutputError } from "../../../packages/agent-core/src/harness/types.js";
 import type { AssistantMessage, Model } from "../../llm/types.js";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
-import { stripStaleAssistantUsageBeforeLatestCompaction } from "../compaction-usage.js";
+import { sanitizeCompactionReplayMessages } from "../compaction-replay.js";
 import {
   calculateContextTokens,
   compact,
@@ -12,7 +12,6 @@ import {
   type CompactionPreparation,
   type CompactionResult,
 } from "../runtime/index.js";
-import { stripStaleThinkingSignaturesForCompactionReplay } from "../thinking-signatures.js";
 import { AgentSessionInspection } from "./agent-session-inspection.js";
 import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
@@ -252,9 +251,7 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     const sessionContext = this.sessionManager.buildSessionContext();
     // Compaction replaces the request prefix, invalidating retained usage and thinking signatures.
     // Sanitize at assignment so every continuation driver receives replay-safe history.
-    this.agent.state.messages = stripStaleThinkingSignaturesForCompactionReplay(
-      stripStaleAssistantUsageBeforeLatestCompaction(sessionContext.messages),
-    );
+    this.agent.state.messages = sanitizeCompactionReplayMessages(sessionContext.messages);
 
     const savedCompactionEntry = newEntries.find(
       (e) => e.type === "compaction" && e.summary === compactionResult.summary,

--- a/src/agents/sessions/agent-session-tree.ts
+++ b/src/agents/sessions/agent-session-tree.ts
@@ -1,3 +1,4 @@
+import { sanitizeCompactionReplayMessages } from "../compaction-replay.js";
 import {
   collectEntriesForBranchSummaryFromBranches,
   generateBranchSummary,
@@ -202,7 +203,7 @@ export abstract class AgentSessionTree extends AgentSessionExecution {
 
       // Update agent state
       const sessionContext = this.sessionManager.buildSessionContext();
-      this.agent.state.messages = sessionContext.messages;
+      this.agent.state.messages = sanitizeCompactionReplayMessages(sessionContext.messages);
 
       // Emit session_tree event
       await this.currentExtensionRunner.emit({

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -13,6 +13,7 @@ import {
 import { createSessionEntryWithTranscript } from "../../config/sessions/session-accessor.js";
 import { bindStreamLlmRuntime } from "../../llm/model-runtime-binding.js";
 import type { Message, Model } from "../../llm/types.js";
+import { sanitizeCompactionReplayMessages } from "../compaction-replay.js";
 import { getAgentDir } from "../config.js";
 import {
   Agent,
@@ -545,7 +546,7 @@ async function createAgentSessionImpl(
 
   // Restore messages if session has existing data
   if (hasExistingSession) {
-    agent.state.messages = existingSession.messages;
+    agent.state.messages = sanitizeCompactionReplayMessages(existingSession.messages);
     if (!hasThinkingEntry) {
       sessionManager.appendThinkingLevelChange(thinkingLevel);
     }

--- a/src/agents/thinking-signatures.ts
+++ b/src/agents/thinking-signatures.ts
@@ -1,0 +1,108 @@
+import { parseDateFirstTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import type { AgentMessage } from "./runtime/index.js";
+
+type AssistantContentBlock = Extract<AgentMessage, { role: "assistant" }>["content"][number];
+type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
+
+export function isAssistantMessageWithContent(message: AgentMessage): message is AssistantMessage {
+  return (
+    Boolean(message) &&
+    typeof message === "object" &&
+    message.role === "assistant" &&
+    Array.isArray(message.content)
+  );
+}
+
+export function isThinkingBlock(block: AssistantContentBlock): boolean {
+  return (
+    Boolean(block) &&
+    typeof block === "object" &&
+    ((block as { type?: unknown }).type === "thinking" ||
+      (block as { type?: unknown }).type === "redacted_thinking")
+  );
+}
+
+function stripSignatureFieldsFromThinkingBlock(
+  block: AssistantContentBlock,
+): AssistantContentBlock {
+  const record = block as unknown as Record<string, unknown>;
+  const stripped: Record<string, unknown> = {};
+  for (const key of Object.keys(record)) {
+    if (key === "thinkingSignature" || key === "signature" || key === "thought_signature") {
+      continue;
+    }
+    // data is the signature payload for redacted_thinking blocks
+    if (key === "data" && record.type === "redacted_thinking") {
+      continue;
+    }
+    stripped[key] = record[key];
+  }
+  return stripped as unknown as AssistantContentBlock;
+}
+
+function stripThinkingSignaturesFromMessage(message: AgentMessage): AgentMessage {
+  if (!isAssistantMessageWithContent(message)) {
+    return message;
+  }
+  let changed = false;
+  const newContent: AssistantContentBlock[] = [];
+  for (const block of message.content) {
+    if (!isThinkingBlock(block)) {
+      newContent.push(block);
+      continue;
+    }
+    const record = block as unknown as Record<string, unknown>;
+    const hasSignature =
+      record.thinkingSignature != null ||
+      record.signature != null ||
+      record.thought_signature != null ||
+      (record.type === "redacted_thinking" && record.data != null);
+    if (!hasSignature) {
+      newContent.push(block);
+      continue;
+    }
+    newContent.push(stripSignatureFieldsFromThinkingBlock(block));
+    changed = true;
+  }
+  return changed ? { ...message, content: newContent } : message;
+}
+
+/**
+ * Strip signatures from assistant messages generated before the latest compaction.
+ * Their signatures are bound to the replaced prompt prefix and cannot be replayed.
+ */
+export function stripStaleThinkingSignaturesForCompactionReplay(
+  messages: AgentMessage[],
+): AgentMessage[] {
+  let latestCompactionTimestamp: number | null = null;
+  for (const message of messages) {
+    if (message.role !== "compactionSummary") {
+      continue;
+    }
+    const timestamp = parseDateFirstTimestampMs(message.timestamp);
+    if (timestamp !== undefined) {
+      latestCompactionTimestamp =
+        latestCompactionTimestamp === null
+          ? timestamp
+          : Math.max(latestCompactionTimestamp, timestamp);
+    }
+  }
+  if (latestCompactionTimestamp === null) {
+    return messages;
+  }
+
+  let touched = false;
+  const out = messages.map((message) => {
+    if (!isAssistantMessageWithContent(message)) {
+      return message;
+    }
+    const timestamp = parseDateFirstTimestampMs(message.timestamp);
+    if (timestamp === undefined || timestamp >= latestCompactionTimestamp) {
+      return message;
+    }
+    const stripped = stripThinkingSignaturesFromMessage(message);
+    touched ||= stripped !== message;
+    return stripped;
+  });
+  return touched ? out : messages;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native session-owned compaction stopped after one context-overflow recovery even though the embedded runner allows three attempts. It also prevents retained pre-compaction Anthropic thinking signatures and usage snapshots from reaching later provider requests after compaction, including sessions restored from persisted history.

## Why This Change Was Made

Both recovery paths now use one shared three-attempt limit, and session recovery tracks a bounded counter instead of a boolean. A single neutral replay sanitizer clears stale usage and thinking signatures whenever persisted context is assigned to live agent state, covering compaction, restore, tree navigation, and embedded transcript rebuilds without site-specific policy drift.

## User Impact

Native default-mode sessions can recover from repeated context overflows through the same bounded limit as embedded runs. Compaction continuations and restored sessions no longer replay invalid thinking signatures or immediately trigger false threshold compaction from retained pre-boundary usage, and the terminal recovery message reports the actual shared limit.

## Evidence

- Original pre-fix: `node scripts/run-vitest.mjs src/agents/sessions/agent-session-compaction.test.ts` failed 4/5 tests for the intended reasons: attempts 2 and 3 stopped after two provider calls, exhaustion stopped after one recovery, and the continued request retained all stale signature shapes.
- Coordinator restore regression on the prior PR head: 1/6 tests failed because restored retained usage remained `input: 950` instead of zero.
- Rebased exact-head focused run: 6 Vitest shards, 169 tests passed across session compaction/usage, restore, thinking/replay sanitation, and every touched embedded transcript-rebuild owner.
- `pnpm tsgo` passed.
- `pnpm check:import-cycles` passed with 0 runtime value cycles.
- `git diff --check` and targeted formatting passed.
- Structured autoreview reported no accepted/actionable findings.
- Production LOC: +159/-168 (net -9). Tests: +233/-2.
