### PR TITLE
fix: manual compaction clears stale CLI history

### DIFF
--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -10,7 +10,11 @@ import type { CliSessionBinding, SessionEntry } from "../config/sessions.js";
 import { normalizeCliSessionReseedReceipt } from "../config/sessions/cli-session-binding.js";
 import { readErrorName } from "../infra/errors.js";
 import { isFailoverError } from "./failover-error.js";
-export { getCliSessionBinding, getCliSessionId } from "../config/sessions/cli-session-binding.js";
+export {
+  clearAllCliSessions,
+  getCliSessionBinding,
+  getCliSessionId,
+} from "../config/sessions/cli-session-binding.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
 
@@ -106,18 +110,6 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = undefined;
   }
-}
-
-type MutableCliSessionFields = Pick<
-  SessionEntry,
-  "cliSessionBindings" | "cliSessionIds" | "claudeCliSessionId"
->;
-
-/** Remove every CLI session binding from a session entry. */
-export function clearAllCliSessions(entry: Partial<MutableCliSessionFields>): void {
-  entry.cliSessionBindings = undefined;
-  entry.cliSessionIds = undefined;
-  entry.claudeCliSessionId = undefined;
 }
 
 /** Decide whether a failed CLI turn invalidates the binding it tried to resume. */

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -674,7 +674,6 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(recordCliCompactionInStore).toHaveBeenCalledWith(
       expect.objectContaining({
         compactionKind: "native-harness",
-        provider: "openai",
         sessionKey,
         tokensAfter: 100,
       }),
@@ -891,7 +890,6 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
     expect(recordCliCompactionInStore).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "codex",
         sessionKey,
         tokensAfter: 42,
         newSessionId: "session-codex-owned-engine-rotated",
@@ -927,7 +925,6 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(recordCliCompactionInStore).toHaveBeenCalledWith(
       expect.objectContaining({
         compactionKind: "context-engine",
-        provider: "external-harness",
         sessionKey,
         tokensAfter: 100,
       }),
@@ -971,7 +968,6 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(maintenance).toHaveBeenCalledTimes(1);
     expect(recordCliCompactionInStore).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "codex",
         sessionKey,
         tokensAfter: 100,
       }),
@@ -1048,7 +1044,6 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(maintenance).toHaveBeenCalledTimes(1);
     expect(recordCliCompactionInStore).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "codex",
         sessionKey,
         tokensAfter: 100,
       }),
@@ -1082,7 +1077,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(compactCalls).toHaveLength(1);
     expect(maintenance).toHaveBeenCalledTimes(1);
     expect(recordCliCompactionInStore).toHaveBeenCalledWith(
-      expect.objectContaining({ provider: "codex", sessionKey }),
+      expect.objectContaining({ sessionKey }),
     );
     expect(updatedEntry?.compactionCount).toBe(1);
   });

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -646,7 +646,7 @@ export async function runCliTurnCompactionLifecycle(params: {
     return params.sessionEntry;
   }
 
-  let compactionKind: "context-engine" | "native-harness" | undefined;
+  let compactionKind: EmbeddedAgentCompactResult["compactionKind"];
   let contextCompactionOutcome: CliTranscriptCompactionOutcome | undefined;
   let nativeCompactionResult: EmbeddedAgentCompactResult | undefined;
   let useContextEngineCompaction = true;
@@ -774,7 +774,6 @@ export async function runCliTurnCompactionLifecycle(params: {
   return (
     (await cliCompactionDeps.recordCliCompactionInStore({
       compactionKind,
-      provider: params.provider,
       sessionKey: params.sessionKey,
       sessionStore: params.sessionStore,
       storePath: params.storePath,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -2776,7 +2776,6 @@ describe("recordCliCompactionInStore", () => {
 
       await recordCliCompactionInStore({
         compactionKind: "native-harness",
-        provider: "codex",
         sessionKey,
         sessionStore,
         storePath,
@@ -2845,7 +2844,6 @@ describe("recordCliCompactionInStore", () => {
 
       await recordCliCompactionInStore({
         compactionKind: "native-harness",
-        provider: "codex",
         sessionKey,
         sessionStore,
         storePath,
@@ -2881,7 +2879,6 @@ describe("recordCliCompactionInStore", () => {
 
       await recordCliCompactionInStore({
         compactionKind: "native-harness",
-        provider: "codex",
         sessionKey,
         sessionStore,
         storePath,
@@ -2919,16 +2916,20 @@ describe("recordCliCompactionInStore", () => {
             codex: {
               sessionId: "stale-cli-session",
             },
+            "claude-cli": {
+              sessionId: "stale-claude-session",
+            },
           },
           cliSessionIds: {
             codex: "stale-cli-session",
+            "claude-cli": "stale-claude-session",
           },
+          claudeCliSessionId: "stale-claude-session",
         },
       };
 
       await recordCliCompactionInStore({
         compactionKind: "context-engine",
-        provider: "codex",
         sessionKey,
         sessionStore,
         storePath,
@@ -2942,6 +2943,9 @@ describe("recordCliCompactionInStore", () => {
       expect(sessionStore[sessionKey]?.compactionCount).toBe(1);
       expect(sessionStore[sessionKey]?.totalTokens).toBe(42);
       expect(sessionStore[sessionKey]?.cliSessionBindings?.codex).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionBindings).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionIds).toBeUndefined();
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
       expect(persisted?.sessionId).toBe(sessionId);
       expect(persisted?.modelProvider).toBe("openai");
       expect(persisted?.model).toBe("gpt-5.5");
@@ -2968,7 +2972,6 @@ describe("recordCliCompactionInStore", () => {
 
       const result = await recordCliCompactionInStore({
         compactionKind: "context-engine",
-        provider: "codex",
         sessionKey,
         sessionStore,
         storePath,

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -14,12 +14,14 @@ import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-m
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
+  clearAllCliSessions,
   clearCliSession,
   getCliSessionBinding,
   setCliSessionBinding,
   setCliSessionId,
 } from "../cli-session.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
+import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
 import { clearMainSessionRecoveryAfterAgentRun } from "../main-session-recovery/main-session-recovery-clear.js";
 import { isCliProvider } from "../model-selection.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
@@ -494,8 +496,7 @@ export async function persistCliSessionForkSuccessorInStore(params: {
 
 /** Records CLI compaction metadata on the persisted session entry. */
 export async function recordCliCompactionInStore(params: {
-  compactionKind: "context-engine" | "native-harness";
-  provider: string;
+  compactionKind: NonNullable<EmbeddedAgentCompactResult["compactionKind"]>;
   sessionKey: string;
   sessionStore: Record<string, SessionEntry>;
   storePath: string;
@@ -503,18 +504,16 @@ export async function recordCliCompactionInStore(params: {
   newSessionId?: string;
   expectedSessionId?: string;
 }): Promise<SessionEntry | undefined> {
-  const { compactionKind, provider, sessionKey, sessionStore, storePath, expectedSessionId } =
-    params;
+  const { compactionKind, sessionKey, sessionStore, storePath, expectedSessionId } = params;
   const entry = sessionStore[sessionKey];
   if (!entry) {
     return undefined;
   }
 
   const next = { ...entry };
-  // Context-engine compaction rewrites history outside the CLI process, invalidating its native
-  // session id. Native harness compaction updates that same session in place, so preserve it.
+  // A shared-history rewrite invalidates every binding; native compaction preserves its session.
   if (compactionKind === "context-engine") {
-    clearCliSession(next, provider);
+    clearAllCliSessions(next);
   }
   next.compactionCount = (entry.compactionCount ?? 0) + 1;
   next.updatedAt = Date.now();

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -2578,6 +2578,25 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(enqueueCommandInLaneMock).not.toHaveBeenCalled();
   });
 
+  it("reports native harness compaction ownership", async () => {
+    resolveContextEngineMock.mockResolvedValue({
+      info: { ownsCompaction: false },
+      compact: contextEngineCompactMock,
+    });
+    maybeCompactAgentHarnessSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: { summary: "harness", firstKeptEntryId: "entry-1", tokensBefore: 100 },
+    });
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({ provider: "openai", model: "gpt-5.5", agentHarnessId: "codex" }),
+    );
+
+    expect(result.compactionKind).toBe("native-harness");
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
+  });
+
   it("binds context-engine compaction runtime LLM to the session agent", async () => {
     resolveSessionAgentIdsMock.mockReturnValueOnce({
       defaultAgentId: "main",
@@ -2636,6 +2655,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
+    expect(result.compactionKind).toBe("context-engine");
 
     expect(mockCallArg(hookRunner.runBeforeCompaction)).toEqual({
       messageCount: -1,

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -570,11 +570,13 @@ async function compactResolvedContextEngine(
         })
       : undefined;
   if (lockedNativeHarness) {
-    return harnessResult ?? lockedCompactionRuntimeFailure(selectedHarnessRuntime);
+    return harnessResult
+      ? { ...harnessResult, compactionKind: "native-harness" }
+      : lockedCompactionRuntimeFailure(selectedHarnessRuntime);
   }
   if (harnessResult) {
     if (!shouldFallbackAfterHarnessCompaction(harnessResult)) {
-      return harnessResult;
+      return { ...harnessResult, compactionKind: "native-harness" };
     }
     log.warn(
       `native harness compaction could not use its session binding; falling back to context engine: ${harnessResult.reason ?? "unknown"}`,
@@ -837,6 +839,7 @@ async function compactResolvedContextEngine(
         return {
           ok: result.ok,
           compacted: result.compacted,
+          compactionKind: "context-engine",
           reason: result.reason,
           result: result.result
             ? {

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -261,6 +261,7 @@ export type EmbeddedAgentRunResult = {
 export type EmbeddedAgentCompactResult = {
   ok: boolean;
   compacted: boolean;
+  compactionKind?: "context-engine" | "native-harness";
   reason?: string;
   /** Structured failure metadata used by model fallback classification. */
   failure?: {

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -646,6 +646,7 @@ describe("handleCompactCommand", () => {
     vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
       ok: true,
       compacted: true,
+      compactionKind: "context-engine",
       result: {
         summary: "compacted",
         firstKeptEntryId: "first-kept",
@@ -680,6 +681,7 @@ describe("handleCompactCommand", () => {
       throw new Error("incrementCompactionCount sessionEntry missing");
     }
     expect(call.sessionEntry.sessionId).toBe("target-session");
+    expect(call.compactionKind).toBe("context-engine");
     expect(call.tokensAfter).toBe(321);
   });
 
@@ -712,6 +714,7 @@ describe("handleCompactCommand", () => {
   it.each([
     {
       owner: "Codex",
+      compactionKind: "native-harness" as const,
       details: {
         backend: "codex-app-server",
         threadId: "thread-1",
@@ -722,14 +725,21 @@ describe("handleCompactCommand", () => {
     },
     {
       owner: "Copilot",
+      compactionKind: "native-harness" as const,
       details: { success: true, tokensRemoved: 45, messagesRemoved: 2 },
     },
-    { owner: "context engine", details: undefined, successor: "successor-session" },
+    {
+      owner: "context engine",
+      compactionKind: "context-engine" as const,
+      details: undefined,
+      successor: "successor-session",
+    },
   ])("counts confirmed $owner compaction without a post-compaction count", async (testCase) => {
     const { details } = testCase;
     vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
       ok: true,
       compacted: true,
+      compactionKind: testCase.compactionKind,
       result: {
         summary: "",
         firstKeptEntryId: "",
@@ -756,6 +766,7 @@ describe("handleCompactCommand", () => {
     );
 
     expect(vi.mocked(incrementCompactionCount)).toHaveBeenCalledOnce();
+    expect(requireIncrementCompactionCountCall().compactionKind).toBe(testCase.compactionKind);
     expect(requireIncrementCompactionCountCall().tokensAfter).toBeUndefined();
     if ("successor" in testCase) {
       expect(requireIncrementCompactionCountCall().newSessionId).toBe("successor-session");

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -335,12 +335,11 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       sessionStore: params.sessionStore,
       sessionKey: params.sessionKey,
       storePath: compactionStorePath,
-      // Update token counts after compaction
       tokensAfter: result.result?.tokensAfter,
       newSessionId: result.result?.sessionId,
+      compactionKind: result.compactionKind,
     });
   }
-  // Use the post-compaction token count for context summary if available
   const totalTokens = didCompact
     ? tokensAfterCompaction
     : runtime.resolveFreshSessionTotalTokens(targetSessionEntry);

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -515,6 +515,53 @@ describe("incrementCompactionCount", () => {
     expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(3);
   });
 
+  it.each([
+    {
+      action: "clears",
+      compactionKind: "context-engine" as const,
+      expectedIds: undefined,
+    },
+    {
+      action: "preserves",
+      compactionKind: "native-harness" as const,
+      expectedIds: { "claude-cli": "claude-session", "codex-cli": "codex-session" },
+    },
+  ])("$action CLI bindings after $compactionKind compaction", async (testCase) => {
+    const entry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      cliSessionIds: { "claude-cli": "claude-session", "codex-cli": "codex-session" },
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+        "codex-cli": { sessionId: "codex-session" },
+      },
+      claudeCliSessionId: "claude-session",
+    } as SessionEntry;
+    const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
+
+    await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      compactionKind: testCase.compactionKind,
+    });
+
+    const stored = await loadStoredEntry(storePath, sessionKey);
+    expect(stored.cliSessionIds).toEqual(testCase.expectedIds);
+    expect(stored.cliSessionBindings).toEqual(
+      testCase.expectedIds
+        ? {
+            "claude-cli": { sessionId: "claude-session" },
+            "codex-cli": { sessionId: "codex-session" },
+          }
+        : undefined,
+    );
+    expect(stored.claudeCliSessionId).toBe(
+      testCase.compactionKind === "native-harness" ? "claude-session" : undefined,
+    );
+  });
+
   it("persists incognito compaction metadata only in the scoped store", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-incognito-compact-"));
     tempDirs.push(tmp);

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,6 +1,8 @@
 /** Session update helpers for skill snapshots, compaction, and lifecycle hooks. */
 import crypto from "node:crypto";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { clearAllCliSessions } from "../../agents/cli-session.js";
+import type { EmbeddedAgentCompactResult } from "../../agents/embedded-agent-runner/types.js";
 import {
   type ExecPolicyOverrides,
   resolveNodeExecEligibility,
@@ -325,6 +327,7 @@ export async function incrementCompactionCount(params: {
   tokensAfter?: number;
   /** Session id after compaction when a context engine changed identity. */
   newSessionId?: string;
+  compactionKind?: EmbeddedAgentCompactResult["compactionKind"];
 }): Promise<number | undefined> {
   const {
     agentId,
@@ -337,6 +340,7 @@ export async function incrementCompactionCount(params: {
     amount = 1,
     tokensAfter,
     newSessionId,
+    compactionKind,
   } = params;
   if (!sessionStore || !sessionKey) {
     return undefined;
@@ -347,11 +351,13 @@ export async function incrementCompactionCount(params: {
   }
   const incrementBy = Math.max(0, amount);
   const nextCount = (entry.compactionCount ?? 0) + incrementBy;
-  // Build update payload with compaction count and optionally updated token counts
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,
     updatedAt: now,
   };
+  if (compactionKind === "context-engine") {
+    clearAllCliSessions(updates);
+  }
   const sessionIdChanged = Boolean(newSessionId && newSessionId !== entry.sessionId);
   if (sessionIdChanged && newSessionId) {
     updates.sessionId = newSessionId;
@@ -360,13 +366,11 @@ export async function incrementCompactionCount(params: {
       new Set([...(entry.usageFamilySessionIds ?? []), entry.sessionId, newSessionId]),
     );
   }
-  // If tokensAfter is provided, update the cached token counts to reflect post-compaction state
   const tokensAfterCompaction = resolveNonNegativeTokenCount(tokensAfter);
   if (tokensAfterCompaction !== undefined) {
     updates.totalTokens = tokensAfterCompaction;
     updates.totalTokensFresh = true;
     updates.totalTokensVersion = SESSION_TOTAL_TOKENS_VERSION;
-    // Clear input/output breakdown since we only have the total estimate after compaction
     updates.inputTokens = undefined;
     updates.outputTokens = undefined;
     updates.cacheRead = undefined;

--- a/src/config/sessions/cli-session-binding.ts
+++ b/src/config/sessions/cli-session-binding.ts
@@ -112,3 +112,11 @@ export function getCliSessionId(
 ): string | undefined {
   return getCliSessionBinding(entry, provider)?.sessionId;
 }
+
+export function clearAllCliSessions(
+  entry: Partial<Pick<SessionEntry, "cliSessionBindings" | "cliSessionIds" | "claudeCliSessionId">>,
+): void {
+  entry.cliSessionBindings = undefined;
+  entry.cliSessionIds = undefined;
+  entry.claudeCliSessionId = undefined;
+}

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -5,6 +5,7 @@ import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import { clearAllCliSessions } from "./cli-session-binding.js";
 import { writeTranscriptArchive } from "./session-accessor.sqlite-archive.js";
 import type {
   SessionTranscriptAccessScope,
@@ -242,8 +243,9 @@ export async function trimTranscriptForManualCompact(
       delete nextEntry.totalTokens;
       delete nextEntry.totalTokensFresh;
       delete nextEntry.totalTokensVersion;
+      clearAllCliSessions(nextEntry);
       nextEntry.updatedAt = options.nowMs ?? Date.now();
-      // The transcript rewrite and token invalidation describe one generation.
+      // The transcript rewrite, binding clear, and token invalidation describe one generation.
       // Keep them in this transaction so either both become visible or neither does.
       writeSessionEntry(writeDatabase, resolved.sessionKey, nextEntry, {
         previousEntry: freshEntry,

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -5,6 +5,7 @@ import {
   errorShape,
   validateSessionsCompactParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { clearAllCliSessions } from "../../agents/cli-session.js";
 import { resolveEmbeddedSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
 import { hasPendingFollowupQueueWork } from "../../auto-reply/reply/queue/state.js";
 import {
@@ -403,8 +404,7 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
           if (result.ok && result.compacted) {
             let persisted: boolean;
             try {
-              // Guarded terminal persist: skip when session ownership rotated
-              // while compaction ran (sessionId/lifecycleRevision/work-start).
+              // Skip terminal persistence when session ownership rotated during compaction.
               const persistProjection = await applySessionPatchProjection({
                 agentId: target.agentId,
                 sessionKeys: [compactTarget.primaryKey],
@@ -423,6 +423,9 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
                   entryToUpdate.updatedAt = Date.now();
                   entryToUpdate.compactionCount =
                     Math.max(0, entryToUpdate.compactionCount ?? 0) + 1;
+                  if (result.compactionKind === "context-engine") {
+                    clearAllCliSessions(entryToUpdate);
+                  }
                   if (
                     result.result?.sessionId &&
                     result.result.sessionId !== entryToUpdate.sessionId

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -567,6 +567,12 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
       spawnedCwd: "/tmp/task-repo",
       thinkingLevel: "medium",
       reasoningLevel: "stream",
+      cliSessionIds: { "claude-cli": "claude-session", "codex-cli": "codex-session" },
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+        "codex-cli": { sessionId: "codex-session" },
+      },
+      claudeCliSessionId: "claude-session",
       contextBudgetStatus: {
         schemaVersion: 1,
         source: "pre-prompt-estimate",
@@ -657,6 +663,7 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
     return {
       ok: true,
       compacted: true,
+      compactionKind: "context-engine",
       result: {
         summary: "summary",
         firstKeptEntryId: "entry-1",
@@ -781,6 +788,9 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
     | {
         compactionCheckpoints?: unknown[];
         compactionCount?: number;
+        cliSessionBindings?: unknown;
+        cliSessionIds?: unknown;
+        claudeCliSessionId?: string;
         contextBudgetStatus?: unknown;
         totalTokens?: number;
         totalTokensFresh?: boolean;
@@ -788,6 +798,9 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
     | undefined;
   expect(storedEntry?.compactionCount).toBe(1);
   expect(storedEntry?.compactionCheckpoints).toHaveLength(1);
+  expect(storedEntry?.cliSessionBindings).toBeUndefined();
+  expect(storedEntry?.cliSessionIds).toBeUndefined();
+  expect(storedEntry?.claudeCliSessionId).toBeUndefined();
   expect(storedEntry?.contextBudgetStatus).toBeUndefined();
   expect(storedEntry?.totalTokens).toBe(80);
   expect(storedEntry?.totalTokensFresh).toBe(true);
@@ -803,6 +816,8 @@ test("sessions.compact records terminal Codex native compaction", async () => {
       compactionCount: 2,
       totalTokens: 54_321,
       totalTokensFresh: true,
+      cliSessionIds: { "codex-cli": "thread-1" },
+      cliSessionBindings: { "codex-cli": { sessionId: "thread-1" } },
     }),
     sessionKey: "agent:main:main",
     storePath,
@@ -816,6 +831,7 @@ test("sessions.compact records terminal Codex native compaction", async () => {
   embeddedRunMock.compactEmbeddedAgentSession.mockResolvedValueOnce({
     ok: true,
     compacted: true,
+    compactionKind: "native-harness",
     result: {
       summary: "",
       firstKeptEntryId: "",
@@ -863,6 +879,10 @@ test("sessions.compact records terminal Codex native compaction", async () => {
   // advances and stale token accounting is cleared for recomputation.
   const codexEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
   expect(codexEntry?.compactionCount).toBe(3);
+  expect(codexEntry?.cliSessionIds).toEqual({ "codex-cli": "thread-1" });
+  expect(codexEntry?.cliSessionBindings).toEqual({
+    "codex-cli": { sessionId: "thread-1" },
+  });
   expect(codexEntry?.totalTokens).toBeUndefined();
   expect(codexEntry?.totalTokensFresh).toBeUndefined();
 
@@ -1633,7 +1653,14 @@ test("sessions.patch waits for terminal compaction before archiving the session"
 test("sessions.compact maxLines trims SQLite transcript rows and archives the full pre-compaction transcript", async () => {
   const { dir, storePath } = await createSessionStoreDir();
   await seedSessionEntry({
-    entry: sessionStoreEntry("sess-main"),
+    entry: sessionStoreEntry("sess-main", {
+      cliSessionIds: { "claude-cli": "claude-session", "codex-cli": "codex-session" },
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+        "codex-cli": { sessionId: "codex-session" },
+      },
+      claudeCliSessionId: "claude-session",
+    }),
     sessionKey: "agent:main:main",
     storePath,
   });
@@ -1687,6 +1714,10 @@ test("sessions.compact maxLines trims SQLite transcript rows and archives the fu
     .map((line) => JSON.parse(line) as Record<string, unknown>);
   expect(archivedEvents).toEqual(original);
   await expect(fs.readdir(dir)).resolves.not.toContain("sess-main.jsonl");
+  const trimmedEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
+  expect(trimmedEntry?.cliSessionIds).toBeUndefined();
+  expect(trimmedEntry?.cliSessionBindings).toBeUndefined();
+  expect(trimmedEntry?.claudeCliSessionId).toBeUndefined();
 
   // No active run present, so the interrupt guard short-circuits without aborting.
   expect(embeddedRunMock.abortCalls).toEqual([]);


### PR DESCRIPTION
Related: #121041
Related: #122705
Related: #123466

## What Problem This Solves

Fixes an issue where successful manual `/compact`, `sessions.compact`, and `sessions.compact --max-lines` operations could leave CLI-backed sessions bound to backend history from before OpenClaw rewrote the shared transcript. The next turn could resume that stale native history, making the reported compaction silently ineffective.

## Why This Change Was Made

@IlyaKuprov identified the missing manual and Gateway clears in #121041. This rewrite supersedes that conflicted patch on current `main`, preserves Ilya's contribution through `Co-authored-by`, and carries #123466's existing `context-engine` versus `native-harness` discriminator through the embedded compaction result instead of adding another boolean policy seam.

Context-engine compaction and max-lines trimming now clear every backend binding because they rewrite the shared transcript. Native-harness compaction preserves bindings because the native session is compacted in place. Max-lines clears the bindings in the same SQLite transaction as the transcript rewrite and token invalidation.

## User Impact

Manual compaction now takes effect on the next CLI-backed turn: OpenClaw starts from the compacted transcript instead of resuming stale pre-compaction backend history. Native harness compaction keeps its existing same-session continuity.

## Evidence

- Pre-fix regression: `reply-state.test.ts` failed because both `claude-cli` and `codex-cli` bindings remained after a context-engine compaction.
- Post-rebase focused proof: 332 tests passed across unit-fast, Gateway, auto-reply, embedded-agent, and agent-support shards.
- `pnpm tsgo` passed.
- `pnpm tsgo:core:test` passed before the clean rebase; the post-rebase focused runtime proof and production typecheck passed again.
- `git diff --check` and touched-path formatting passed.
- Final Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +42/-32 (net +10). Tests: +120/-13.
