### PR TITLE
feat(tasks): follow background task progress from the CLI

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -53,7 +53,11 @@ Not every agent run creates a task. Heartbeat turns and normal interactive chat 
     ```bash
     # Show details for a specific task (by task ID, run ID, or session key)
     openclaw tasks show <lookup>
+
+    # Follow live progress until execution and delivery finish
+    openclaw tasks follow <lookup>
     ```
+
   </Tab>
   <Tab title="Cancel and notify">
     ```bash
@@ -219,6 +223,18 @@ openclaw tasks notify <lookup> state_changes
     ```
 
     The lookup token accepts a task ID, run ID, or session key. Shows the full record including timing, delivery state, error, and terminal summary.
+
+  </Accordion>
+  <Accordion title="tasks follow">
+    ```bash
+    openclaw tasks follow <lookup> [--json]
+    ```
+
+    Follows one task by task ID, run ID, or session key. The command prints a bounded current snapshot, recent visible messages from a child session when one exists, live task and tool activity, the execution outcome, and the separate completion-delivery state. JSON mode is JSON Lines and gives every item a deterministic identifier for reconnect deduplication.
+
+    The viewer reconnects and replays durable state after a transient disconnect or Gateway restart. Pressing Ctrl-C closes only the viewer. It does not cancel the task or change notifications or delivery.
+
+    Use `tasks show` for one point-in-time record, `tasks follow` for one terminal-friendly live stream, the Control UI Tasks page for visual inspection and actions, and `openclaw logs --follow` for gateway-wide diagnostics rather than a task-scoped view.
 
   </Accordion>
   <Accordion title="tasks cancel">

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -20,6 +20,8 @@ openclaw tasks list
 openclaw tasks list --runtime acp
 openclaw tasks list --status running
 openclaw tasks show <lookup>
+openclaw tasks follow <lookup>
+openclaw tasks follow <lookup> --json
 openclaw tasks notify <lookup> state_changes
 openclaw tasks cancel <lookup>
 openclaw tasks retry <lookup> [lookup...]
@@ -57,6 +59,18 @@ openclaw tasks show <lookup> [--json]
 ```
 
 Shows one task by task ID, run ID, or session key.
+
+### `follow`
+
+```bash
+openclaw tasks follow <lookup> [--json]
+```
+
+Prints a bounded task snapshot and recent visible child-session messages, then follows live task updates until both execution and completion delivery finish. The lookup accepts the same task ID, run ID, or session key as `tasks show`.
+
+The default output is human-readable. `--json` emits one JSON object per line with a deterministic `id` and `cursor`, timestamp, task ID, runtime, event kind, and bounded state. A reconnect or Gateway restart replays durable task state and recent session history; deterministic IDs let consumers discard replayed duplicates.
+
+Press Ctrl-C to stop the local viewer. It does not cancel the task or change its notification or delivery state.
 
 ### `notify`
 
@@ -149,3 +163,4 @@ Inspects or cancels durable Task Flow state under the task ledger.
 
 - [CLI reference](/cli)
 - [Background tasks](/automation/tasks)
+- [Control UI](/web/control-ui)

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   tasksAuditCommand: vi.fn(),
   tasksMaintenanceCommand: vi.fn(),
   tasksShowCommand: vi.fn(),
+  tasksFollowCommand: vi.fn(),
   tasksNotifyCommand: vi.fn(),
   tasksCancelCommand: vi.fn(),
   flowsListCommand: vi.fn(),
@@ -44,6 +45,7 @@ const tasksListCommand = mocks.tasksListCommand;
 const tasksAuditCommand = mocks.tasksAuditCommand;
 const tasksMaintenanceCommand = mocks.tasksMaintenanceCommand;
 const tasksShowCommand = mocks.tasksShowCommand;
+const tasksFollowCommand = mocks.tasksFollowCommand;
 const tasksNotifyCommand = mocks.tasksNotifyCommand;
 const tasksCancelCommand = mocks.tasksCancelCommand;
 const flowsListCommand = mocks.flowsListCommand;
@@ -111,6 +113,7 @@ vi.mock("../../commands/tasks.js", () => ({
   tasksAuditCommand: mocks.tasksAuditCommand,
   tasksMaintenanceCommand: mocks.tasksMaintenanceCommand,
   tasksShowCommand: mocks.tasksShowCommand,
+  tasksFollowCommand: mocks.tasksFollowCommand,
   tasksNotifyCommand: mocks.tasksNotifyCommand,
   tasksCancelCommand: mocks.tasksCancelCommand,
 }));
@@ -600,6 +603,15 @@ describe("registerStatusHealthSessionsCommands", () => {
     await runCli(["tasks", "show", "run-123", "--json"]);
 
     expectCommandOptions(tasksShowCommand, {
+      lookup: "run-123",
+      json: true,
+    });
+  });
+
+  it("runs tasks follow subcommand with lookup and JSON Lines forwarding", async () => {
+    await runCli(["tasks", "follow", "run-123", "--json"]);
+
+    expectCommandOptions(tasksFollowCommand, {
       lookup: "run-123",
       json: true,
     });

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -721,6 +721,25 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     });
 
   tasksCmd
+    .command("follow")
+    .description("Follow one background task until execution and delivery finish")
+    .argument("<lookup>", "Task id, run id, or session key")
+    .option("--json", "Output JSON Lines", false)
+    .action(async (lookup, opts, command) => {
+      const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksFollowCommand } = await loadTasksCommands();
+        await tasksFollowCommand(
+          {
+            lookup,
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  tasksCmd
     .command("notify")
     .description("Set task notify policy")
     .argument("<lookup>", "Task id, run id, or session key")

--- a/src/commands/tasks-follow.test.ts
+++ b/src/commands/tasks-follow.test.ts
@@ -1,0 +1,343 @@
+// Task follow command tests cover replay, JSONL, bounds, reconnect dedupe, and viewer-only abort.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+
+const mocks = vi.hoisted(() => ({
+  clientOptions: undefined as Record<string, unknown> | undefined,
+  historyMessages: [] as unknown[],
+  task: undefined as Record<string, unknown> | undefined,
+  request: vi.fn(),
+  stop: vi.fn(),
+  stopAndWait: vi.fn(async () => {}),
+  reconcileTaskLookupToken: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: () => ({}),
+}));
+
+vi.mock("../gateway/client-bootstrap.js", () => ({
+  resolveGatewayClientBootstrap: vi.fn(async () => ({
+    url: "ws://127.0.0.1:18789",
+    urlSource: "test",
+    connectionDetails: { url: "ws://127.0.0.1:18789" },
+    auth: { token: "test-token" },
+  })),
+}));
+
+vi.mock("../gateway/client.js", () => ({
+  GatewayClient: class {
+    constructor(options: Record<string, unknown>) {
+      mocks.clientOptions = options;
+    }
+
+    request(method: string, params?: unknown) {
+      return mocks.request(method, params);
+    }
+
+    stop() {
+      mocks.stop();
+    }
+
+    stopAndWait() {
+      return mocks.stopAndWait();
+    }
+  },
+}));
+
+vi.mock("../gateway/client-start-readiness.js", () => ({
+  startGatewayClientWhenEventLoopReady: vi.fn(async () => {
+    queueMicrotask(() => {
+      const onHelloOk = mocks.clientOptions?.onHelloOk;
+      if (typeof onHelloOk === "function") {
+        onHelloOk({});
+      }
+    });
+    return { ready: true, aborted: false };
+  }),
+}));
+
+vi.mock("../tasks/task-registry.reconcile.js", () => ({
+  reconcileTaskLookupToken: mocks.reconcileTaskLookupToken,
+}));
+
+import { tasksFollowCommand } from "./tasks-follow.js";
+
+function taskRecord(): TaskRecord {
+  return {
+    taskId: "task-1",
+    runtime: "subagent",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    childSessionKey: "agent:main:subagent:child",
+    task: "Do bounded work",
+    status: "running",
+    deliveryStatus: "pending",
+    notifyPolicy: "done_only",
+    createdAt: 1,
+  };
+}
+
+function taskSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "task-1",
+    taskId: "task-1",
+    runtime: "subagent",
+    kind: "subagent",
+    status: "running",
+    deliveryStatus: "pending",
+    childSessionKey: "agent:main:subagent:child",
+    agentId: "main",
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+function createRuntime() {
+  return {
+    log: vi.fn<RuntimeEnv["log"]>(),
+    error: vi.fn<RuntimeEnv["error"]>(),
+    exit: vi.fn<RuntimeEnv["exit"]>(),
+  };
+}
+
+function emitGatewayEvent(event: Record<string, unknown>) {
+  const onEvent = mocks.clientOptions?.onEvent;
+  if (typeof onEvent !== "function") {
+    throw new Error("missing mocked Gateway event handler");
+  }
+  onEvent(event);
+}
+
+function jsonEvents(runtime: ReturnType<typeof createRuntime>) {
+  return runtime.log.mock.calls.map(
+    ([line]) => JSON.parse(String(line)) as Record<string, unknown>,
+  );
+}
+
+beforeEach(() => {
+  mocks.clientOptions = undefined;
+  mocks.historyMessages = [];
+  mocks.task = taskSummary();
+  mocks.request.mockReset();
+  mocks.stop.mockReset();
+  mocks.stopAndWait.mockClear();
+  mocks.reconcileTaskLookupToken.mockReset();
+  mocks.reconcileTaskLookupToken.mockReturnValue(taskRecord());
+  mocks.request.mockImplementation(async (method: string) => {
+    if (method === "tasks.get") {
+      return { task: mocks.task };
+    }
+    if (method === "chat.history") {
+      return { messages: mocks.historyMessages };
+    }
+    throw new Error(`unexpected method: ${method}`);
+  });
+});
+
+describe("tasksFollowCommand", () => {
+  it("emits bounded JSON Lines replay and stops on final execution and delivery", async () => {
+    const runtime = createRuntime();
+    mocks.task = taskSummary({
+      status: "completed",
+      deliveryStatus: "delivered",
+      terminalOutcome: "succeeded",
+      updatedAt: 5,
+    });
+    mocks.historyMessages = [
+      {
+        role: "user",
+        content: "u".repeat(2_000),
+        __openclaw: { seq: 1, recordTimestampMs: 3 },
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "hidden reasoning" },
+          { type: "text", text: `visible result Authorization: Bearer ${"s".repeat(32)}` },
+        ],
+        __openclaw: { seq: 2, recordTimestampMs: 4 },
+      },
+      { role: "toolResult", content: "unbounded tool result", __openclaw: { seq: 3 } },
+    ];
+
+    await tasksFollowCommand({ lookup: "task-1", json: true }, runtime);
+
+    const events = jsonEvents(runtime);
+    expect(events.map((event) => event.kind)).toEqual([
+      "task.snapshot",
+      "session.message",
+      "session.message",
+    ]);
+    expect(events.every((event) => typeof event.id === "string" && event.id === event.cursor)).toBe(
+      true,
+    );
+    const firstMessage = events.find((event) => event.kind === "session.message");
+    if (!firstMessage) {
+      throw new Error("missing replayed session message");
+    }
+    expect((firstMessage.state as { text: string }).text).toHaveLength(1_000);
+    expect(JSON.stringify(events)).not.toContain("hidden reasoning");
+    expect(JSON.stringify(events)).not.toContain("unbounded tool result");
+    expect(JSON.stringify(events)).not.toContain("s".repeat(32));
+    expect(mocks.clientOptions?.scopes).toEqual(["operator.read"]);
+    expect(mocks.stopAndWait).toHaveBeenCalledOnce();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("keeps live updates ordered and deduplicates replay across reconnect and gaps", async () => {
+    const runtime = createRuntime();
+    const follow = tasksFollowCommand({ lookup: "task-1", json: true }, runtime);
+    await vi.waitFor(() => expect(runtime.log).toHaveBeenCalled());
+
+    const runningUpdate = taskSummary({
+      updatedAt: 10,
+      lastToolName: "exec",
+      lastActivity: "running checks",
+    });
+    emitGatewayEvent({
+      event: "task",
+      seq: 10,
+      payload: { action: "upserted", task: runningUpdate },
+    });
+    emitGatewayEvent({
+      event: "task",
+      seq: 11,
+      payload: { action: "upserted", task: runningUpdate },
+    });
+    await vi.waitFor(() =>
+      expect(jsonEvents(runtime).some((event) => event.gatewaySeq === 10)).toBe(true),
+    );
+
+    mocks.task = runningUpdate;
+    const onGap = mocks.clientOptions?.onGap;
+    if (typeof onGap !== "function") {
+      throw new Error("missing mocked Gateway gap handler");
+    }
+    onGap({ expected: 12, received: 14 });
+
+    const onClose = mocks.clientOptions?.onClose;
+    const onHelloOk = mocks.clientOptions?.onHelloOk;
+    if (typeof onClose !== "function" || typeof onHelloOk !== "function") {
+      throw new Error("missing mocked Gateway reconnect handlers");
+    }
+    onClose(1006, "restart");
+    onClose(1006, "restart");
+    onHelloOk({});
+
+    const finalTask = taskSummary({
+      status: "completed",
+      deliveryStatus: "delivered",
+      terminalOutcome: "succeeded",
+      updatedAt: 20,
+      terminalSummary: "done",
+    });
+    emitGatewayEvent({
+      event: "task",
+      seq: 15,
+      payload: { action: "upserted", task: finalTask },
+    });
+    await follow;
+
+    const events = jsonEvents(runtime);
+    const runningIds = events
+      .filter(
+        (event) => (event.state as { lastActivity?: string }).lastActivity === "running checks",
+      )
+      .map((event) => event.id);
+    expect(new Set(runningIds).size).toBe(1);
+    expect(events.some((event) => event.kind === "connection.gap")).toBe(true);
+    expect(events.filter((event) => event.kind === "connection.disconnected")).toHaveLength(1);
+    expect(events.some((event) => event.kind === "connection.reconnected")).toBe(true);
+    const finalEvent = events.at(-1);
+    if (!finalEvent) {
+      throw new Error("missing terminal task event");
+    }
+    expect(finalEvent.kind).toBe("task.update");
+    expect((finalEvent.state as { deliveryStatus: string }).deliveryStatus).toBe("delivered");
+  });
+
+  it("waits for completion delivery after execution reaches a terminal state", async () => {
+    const runtime = createRuntime();
+    mocks.task = taskSummary({
+      status: "completed",
+      deliveryStatus: "session_queued",
+      terminalOutcome: "succeeded",
+      updatedAt: 30,
+    });
+
+    let settled = false;
+    const follow = tasksFollowCommand({ lookup: "task-1", json: true }, runtime).then(() => {
+      settled = true;
+    });
+    await vi.waitFor(() => expect(runtime.log).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    emitGatewayEvent({
+      event: "task",
+      seq: 31,
+      payload: {
+        action: "upserted",
+        task: taskSummary({
+          status: "completed",
+          deliveryStatus: "delivered",
+          terminalOutcome: "succeeded",
+          updatedAt: 31,
+        }),
+      },
+    });
+    await follow;
+
+    expect(settled).toBe(true);
+    expect(
+      jsonEvents(runtime).map(
+        (event) => (event.state as { deliveryStatus?: string }).deliveryStatus,
+      ),
+    ).toEqual(["session_queued", "delivered"]);
+  });
+
+  it("Ctrl-C stops only the viewer and never sends a task mutation", async () => {
+    const runtime = createRuntime();
+    let sigint: (() => void) | undefined;
+    const once = vi.spyOn(process, "once").mockImplementation((event, listener) => {
+      if (event === "SIGINT") {
+        sigint = listener as () => void;
+      }
+      return process;
+    });
+    const remove = vi.spyOn(process, "removeListener").mockImplementation(() => process);
+
+    const follow = tasksFollowCommand({ lookup: "task-1" }, runtime);
+    await vi.waitFor(() => expect(runtime.log).toHaveBeenCalled());
+    expect(runtime.log.mock.calls[0]?.[0]).toEqual(expect.stringContaining("[task.snapshot]"));
+    if (!sigint) {
+      throw new Error("missing SIGINT listener");
+    }
+    sigint();
+    await follow;
+
+    expect(mocks.request.mock.calls.map(([method]) => method)).toEqual([
+      "tasks.get",
+      "chat.history",
+    ]);
+    expect(runtime.exit).not.toHaveBeenCalled();
+    once.mockRestore();
+    remove.mockRestore();
+  });
+
+  it("rejects an unknown lookup before opening a Gateway client", async () => {
+    const runtime = createRuntime();
+    mocks.reconcileTaskLookupToken.mockReturnValue(undefined);
+
+    await tasksFollowCommand({ lookup: "missing" }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("missing"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.clientOptions).toBeUndefined();
+  });
+});

--- a/src/commands/tasks-follow.ts
+++ b/src/commands/tasks-follow.ts
@@ -1,0 +1,574 @@
+// Task-scoped CLI follow stream over the Gateway's bounded task and chat projections.
+
+import { createHash, randomUUID } from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import type { TaskSummary } from "../../packages/gateway-protocol/src/index.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { formatLookupMiss } from "../cli/error-format.js";
+import { getRuntimeConfig } from "../config/config.js";
+import { resolveGatewayClientBootstrap } from "../gateway/client-bootstrap.js";
+import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-readiness.js";
+import { GatewayClient } from "../gateway/client.js";
+import { redactSensitiveText } from "../logging/redact.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { reconcileTaskLookupToken } from "../tasks/task-registry.reconcile.js";
+import { VERSION } from "../version.js";
+
+const INITIAL_CONNECT_TIMEOUT_MS = 15_000;
+const HISTORY_LIMIT = 20;
+const HISTORY_MAX_CHARS = 20_000;
+const MESSAGE_TEXT_MAX_CHARS = 1_000;
+const MAX_REMEMBERED_EVENT_IDS = 2_048;
+
+type FollowTaskEventKind =
+  | "connection.disconnected"
+  | "connection.gap"
+  | "connection.reconnected"
+  | "session.message"
+  | "task.deleted"
+  | "task.snapshot"
+  | "task.update";
+
+type FollowTaskEvent = {
+  id: string;
+  cursor: string;
+  timestamp: string;
+  taskId: string;
+  runtime: string;
+  kind: FollowTaskEventKind;
+  gatewaySeq?: number;
+  sessionKey?: string;
+  state: Record<string, unknown>;
+};
+
+type TaskEventPayload =
+  | { action: "upserted"; task: TaskSummary }
+  | { action: "deleted"; taskId: string }
+  | { action: "restored" };
+
+type ChatHistoryResult = {
+  messages?: unknown[];
+};
+
+type TasksGetResult = {
+  task?: TaskSummary;
+};
+
+function stableEventId(kind: FollowTaskEventKind, value: unknown): string {
+  const digest = createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 20);
+  return `${kind}:${digest}`;
+}
+
+function timestampToIso(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (typeof value === "string" && !Number.isNaN(Date.parse(value))) {
+    return new Date(value).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function truncateText(value: string): string {
+  const sanitized = redactSensitiveText(sanitizeTerminalText(value), { mode: "tools" }).trim();
+  if (sanitized.length <= MESSAGE_TEXT_MAX_CHARS) {
+    return sanitized;
+  }
+  return truncateWithMarker(sanitized, MESSAGE_TEXT_MAX_CHARS, {
+    marker: "…",
+    reserve: 1,
+    trimEnd: false,
+  });
+}
+
+function normalizeTaskEventPayload(value: unknown): TaskEventPayload | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (value.action === "restored") {
+    return { action: "restored" };
+  }
+  if (value.action === "deleted" && typeof value.taskId === "string") {
+    return { action: "deleted", taskId: value.taskId };
+  }
+  if (value.action !== "upserted" || !isRecord(value.task)) {
+    return null;
+  }
+  const task = value.task as TaskSummary;
+  return typeof task.id === "string" && typeof task.status === "string"
+    ? { action: "upserted", task }
+    : null;
+}
+
+function extractVisibleMessageText(message: Record<string, unknown>): string | undefined {
+  const role = normalizeOptionalString(message.role);
+  if (role !== "user" && role !== "assistant") {
+    return undefined;
+  }
+  const content = message.content;
+  if (typeof content === "string") {
+    return truncateText(content) || undefined;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .flatMap((block) => {
+      if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") {
+        return [];
+      }
+      return [block.text];
+    })
+    .join("\n");
+  return truncateText(text) || undefined;
+}
+
+function readMessageMetadata(message: Record<string, unknown>): {
+  id?: string;
+  seq?: number;
+  timestamp?: unknown;
+} {
+  const openClawMetadata = message["__openclaw"];
+  const metadata = isRecord(openClawMetadata) ? openClawMetadata : undefined;
+  return {
+    ...(typeof metadata?.id === "string" ? { id: metadata.id } : {}),
+    ...(typeof metadata?.seq === "number" ? { seq: metadata.seq } : {}),
+    timestamp: metadata?.recordTimestampMs ?? message.timestamp,
+  };
+}
+
+function projectHistoryEvents(task: TaskSummary, messages: unknown[]): FollowTaskEvent[] {
+  const sessionKey = normalizeOptionalString(task.childSessionKey);
+  if (!sessionKey) {
+    return [];
+  }
+  const events: FollowTaskEvent[] = [];
+  for (const candidate of messages) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+    const text = extractVisibleMessageText(candidate);
+    const role = normalizeOptionalString(candidate.role);
+    if (!text || (role !== "user" && role !== "assistant")) {
+      continue;
+    }
+    const metadata = readMessageMetadata(candidate);
+    const identity = {
+      taskId: task.id,
+      sessionKey,
+      role,
+      seq: metadata.seq,
+      messageId: metadata.id,
+      text,
+    };
+    const id = stableEventId("session.message", identity);
+    events.push({
+      id,
+      cursor: id,
+      timestamp: timestampToIso(metadata.timestamp ?? task.updatedAt),
+      taskId: task.id,
+      runtime: task.runtime ?? task.kind ?? "unknown",
+      kind: "session.message",
+      sessionKey,
+      state: {
+        role,
+        text,
+        ...(metadata.seq !== undefined ? { seq: metadata.seq } : {}),
+        ...(metadata.id ? { messageId: metadata.id } : {}),
+      },
+    });
+  }
+  return events;
+}
+
+function projectTaskEvent(
+  task: TaskSummary,
+  kind: "task.snapshot" | "task.update",
+  gatewaySeq?: number,
+): FollowTaskEvent {
+  const state = {
+    status: task.status,
+    deliveryStatus: task.deliveryStatus ?? null,
+    terminalOutcome: task.terminalOutcome ?? null,
+    title: task.title ?? null,
+    progressSummary: task.progressSummary ?? null,
+    terminalSummary: task.terminalSummary ?? null,
+    error: task.error ?? null,
+    toolUseCount: task.toolUseCount ?? 0,
+    lastToolName: task.lastToolName ?? null,
+    lastActivity: task.lastActivity ?? null,
+  };
+  // Snapshot replay and live updates share an identity so reconnects cannot
+  // make the same durable task version look like a new event.
+  const id = stableEventId("task.update", {
+    taskId: task.id,
+    updatedAt: task.updatedAt,
+    state,
+  });
+  return {
+    id,
+    cursor: id,
+    timestamp: timestampToIso(task.updatedAt ?? task.endedAt ?? task.startedAt ?? task.createdAt),
+    taskId: task.id,
+    runtime: task.runtime ?? task.kind ?? "unknown",
+    kind,
+    ...(gatewaySeq !== undefined ? { gatewaySeq } : {}),
+    ...(task.childSessionKey ? { sessionKey: task.childSessionKey } : {}),
+    state,
+  };
+}
+
+function isFollowTerminal(task: TaskSummary): boolean {
+  const executionTerminal = ["completed", "failed", "cancelled", "timed_out"].includes(task.status);
+  const deliveryTerminal = [
+    "delivered",
+    "dismissed",
+    "failed",
+    "not_applicable",
+    "parent_missing",
+  ].includes(task.deliveryStatus ?? "");
+  return executionTerminal && deliveryTerminal;
+}
+
+function formatHumanEvent(event: FollowTaskEvent): string {
+  const prefix = `${event.timestamp} [${event.kind}]`;
+  if (event.kind === "session.message") {
+    const role = normalizeOptionalString(event.state.role) ?? "message";
+    const text = normalizeOptionalString(event.state.text) ?? "";
+    return `${prefix} ${role}: ${text}`;
+  }
+  if (event.kind.startsWith("connection.")) {
+    const message = normalizeOptionalString(event.state.message) ?? "Gateway connection changed";
+    return `${prefix} ${message}`;
+  }
+  if (event.kind === "task.deleted") {
+    return `${prefix} task record removed`;
+  }
+  const parts = [normalizeOptionalString(event.state.status) ?? "unknown"];
+  const deliveryStatus = normalizeOptionalString(event.state.deliveryStatus);
+  if (deliveryStatus) {
+    parts.push(`delivery ${deliveryStatus}`);
+  }
+  const lastToolName = normalizeOptionalString(event.state.lastToolName);
+  if (lastToolName) {
+    parts.push(`tool ${lastToolName}`);
+  }
+  const detail = [
+    event.state.error,
+    event.state.terminalSummary,
+    event.state.progressSummary,
+    event.state.lastActivity,
+  ]
+    .map((value) => normalizeOptionalString(value))
+    .find(Boolean);
+  if (detail) {
+    parts.push(detail);
+  }
+  return `${prefix} ${parts.join(" · ")}`;
+}
+
+function createFollowEvent(params: {
+  kind: "connection.disconnected" | "connection.gap" | "connection.reconnected" | "task.deleted";
+  taskId: string;
+  runtime: string;
+  generation: number;
+  state: Record<string, unknown>;
+}): FollowTaskEvent {
+  const timestamp = new Date().toISOString();
+  const id = stableEventId(params.kind, {
+    taskId: params.taskId,
+    generation: params.generation,
+    state: params.state,
+  });
+  return {
+    id,
+    cursor: id,
+    timestamp,
+    taskId: params.taskId,
+    runtime: params.runtime,
+    kind: params.kind,
+    state: params.state,
+  };
+}
+
+/** Follows one durable task without mutating its execution or delivery state. */
+export async function tasksFollowCommand(
+  opts: { json?: boolean; lookup: string },
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const localTask = reconcileTaskLookupToken(opts.lookup);
+  if (!localTask) {
+    runtime.error(
+      formatLookupMiss({
+        noun: "Task",
+        value: sanitizeTerminalText(opts.lookup),
+        listCommand: "openclaw tasks list",
+        valueLabel: "task id",
+      }),
+    );
+    runtime.exit(1);
+    return;
+  }
+
+  const taskId = localTask.taskId;
+  const taskRuntime = localTask.runtime;
+  const seenIds = new Set<string>();
+  const seenOrder: string[] = [];
+  let client: GatewayClient | undefined;
+  let connected = false;
+  let connectionGeneration = 0;
+  let disconnectedGeneration: number | undefined;
+  let done = false;
+  let abortedByViewer = false;
+  let processing = Promise.resolve();
+  let resolveCompletion: (() => void) | undefined;
+  let rejectCompletion: ((error: Error) => void) | undefined;
+  const completion = new Promise<void>((resolve, reject) => {
+    resolveCompletion = resolve;
+    rejectCompletion = reject;
+  });
+
+  const emit = (event: FollowTaskEvent) => {
+    if (seenIds.has(event.id)) {
+      return;
+    }
+    seenIds.add(event.id);
+    seenOrder.push(event.id);
+    if (seenOrder.length > MAX_REMEMBERED_EVENT_IDS) {
+      const oldest = seenOrder.shift();
+      if (oldest) {
+        seenIds.delete(oldest);
+      }
+    }
+    if (opts.json) {
+      writeRuntimeJson(runtime, event, 0);
+    } else {
+      runtime.log(formatHumanEvent(event));
+    }
+  };
+
+  const finish = () => {
+    if (done) {
+      return;
+    }
+    done = true;
+    resolveCompletion?.();
+  };
+  const fail = (error: unknown) => {
+    if (done) {
+      return;
+    }
+    done = true;
+    rejectCompletion?.(error instanceof Error ? error : new Error(String(error)));
+  };
+  const enqueue = (operation: () => Promise<void>) => {
+    processing = processing
+      .then(async () => {
+        if (!done) {
+          await operation();
+        }
+      })
+      .catch(fail);
+  };
+
+  const replayHistory = async (task: TaskSummary) => {
+    const sessionKey = normalizeOptionalString(task.childSessionKey);
+    if (!sessionKey || !client) {
+      return;
+    }
+    const result = await client.request<ChatHistoryResult>("chat.history", {
+      sessionKey,
+      ...(task.agentId ? { agentId: task.agentId } : {}),
+      limit: HISTORY_LIMIT,
+      maxChars: HISTORY_MAX_CHARS,
+    });
+    for (const event of projectHistoryEvents(task, result.messages ?? [])) {
+      emit(event);
+    }
+  };
+
+  const replaySnapshot = async (kind: "task.snapshot" | "task.update", seq?: number) => {
+    if (!client) {
+      return;
+    }
+    const result = await client.request<TasksGetResult>("tasks.get", { taskId });
+    if (!result.task) {
+      throw new Error(`Gateway returned no task for ${taskId}`);
+    }
+    emit(projectTaskEvent(result.task, kind, seq));
+    await replayHistory(result.task);
+    if (isFollowTerminal(result.task)) {
+      finish();
+    }
+  };
+
+  const config = getRuntimeConfig();
+  const bootstrap = await resolveGatewayClientBootstrap({ config, env: process.env });
+  if (bootstrap.authFailureReason) {
+    runtime.error(bootstrap.authFailureReason);
+    runtime.exit(1);
+    return;
+  }
+
+  const initialTimer = setTimeout(() => {
+    fail(new Error(`Timed out connecting to the Gateway while following ${taskId}`));
+  }, INITIAL_CONNECT_TIMEOUT_MS);
+  const abortViewer = () => {
+    abortedByViewer = true;
+    finish();
+  };
+  process.once("SIGINT", abortViewer);
+
+  try {
+    client = new GatewayClient({
+      url: bootstrap.url,
+      token: bootstrap.auth.token,
+      password: bootstrap.auth.password,
+      tlsFingerprint: bootstrap.tlsFingerprint,
+      preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
+      ...(bootstrap.deviceAuthScope ? { deviceAuthScope: bootstrap.deviceAuthScope } : {}),
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      clientDisplayName: "openclaw-tasks-follow",
+      clientVersion: VERSION,
+      platform: process.platform,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      scopes: ["operator.read"],
+      instanceId: randomUUID(),
+      onHelloOk: () => {
+        clearTimeout(initialTimer);
+        connectionGeneration += 1;
+        disconnectedGeneration = undefined;
+        const reconnecting = connected;
+        const generation = connectionGeneration;
+        connected = true;
+        enqueue(async () => {
+          if (reconnecting) {
+            emit(
+              createFollowEvent({
+                kind: "connection.reconnected",
+                taskId,
+                runtime: taskRuntime,
+                generation,
+                state: { message: "Gateway reconnected; replaying durable task state" },
+              }),
+            );
+          }
+          await replaySnapshot("task.snapshot");
+        });
+      },
+      onEvent: (event) => {
+        if (event.event !== "task") {
+          return;
+        }
+        const payload = normalizeTaskEventPayload(event.payload);
+        if (!payload) {
+          return;
+        }
+        if (payload.action === "restored") {
+          enqueue(async () => await replaySnapshot("task.snapshot", event.seq));
+          return;
+        }
+        if (payload.action === "deleted") {
+          if (payload.taskId !== taskId) {
+            return;
+          }
+          enqueue(async () => {
+            emit(
+              createFollowEvent({
+                kind: "task.deleted",
+                taskId,
+                runtime: taskRuntime,
+                generation: connectionGeneration,
+                state: { message: "Task record was removed before a final state was observed" },
+              }),
+            );
+            throw new Error(`Task record removed while following ${taskId}`);
+          });
+          return;
+        }
+        if (payload.task.id !== taskId) {
+          return;
+        }
+        enqueue(async () => {
+          emit(projectTaskEvent(payload.task, "task.update", event.seq));
+          await replayHistory(payload.task);
+          if (isFollowTerminal(payload.task)) {
+            finish();
+          }
+        });
+      },
+      onGap: (gap) => {
+        enqueue(async () => {
+          emit(
+            createFollowEvent({
+              kind: "connection.gap",
+              taskId,
+              runtime: taskRuntime,
+              generation: connectionGeneration,
+              state: {
+                message: `Gateway event gap ${gap.expected}-${gap.received}; replaying durable task state`,
+                expected: gap.expected,
+                received: gap.received,
+              },
+            }),
+          );
+          await replaySnapshot("task.snapshot");
+        });
+      },
+      onClose: (_code, reason) => {
+        if (!done && connected && disconnectedGeneration !== connectionGeneration) {
+          disconnectedGeneration = connectionGeneration;
+          enqueue(async () => {
+            emit(
+              createFollowEvent({
+                kind: "connection.disconnected",
+                taskId,
+                runtime: taskRuntime,
+                generation: connectionGeneration,
+                state: {
+                  message: `Gateway disconnected${reason ? `: ${truncateText(reason)}` : ""}; reconnecting`,
+                },
+              }),
+            );
+          });
+        }
+      },
+      onReconnectPaused: (info) => {
+        fail(new Error(`Gateway reconnect paused: ${info.reason}`));
+      },
+    });
+
+    const readiness = await startGatewayClientWhenEventLoopReady(client, { clientOptions: {} });
+    if (!readiness.ready) {
+      throw new Error(
+        readiness.aborted
+          ? "Gateway client start was aborted"
+          : "Gateway event loop was not ready for task follow",
+      );
+    }
+    await completion;
+    if (!abortedByViewer) {
+      await processing;
+    }
+  } catch (error) {
+    if (abortedByViewer) {
+      return;
+    }
+    runtime.error(
+      redactSensitiveText(error instanceof Error ? error.message : String(error), {
+        mode: "tools",
+      }),
+    );
+    runtime.exit(1);
+  } finally {
+    clearTimeout(initialTimer);
+    process.removeListener("SIGINT", abortViewer);
+    await client?.stopAndWait().catch(() => client?.stop());
+  }
+}

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -52,6 +52,8 @@ import {
   type TaskSystemAuditSeverity,
 } from "./tasks-audit-system.js";
 
+export { tasksFollowCommand } from "./tasks-follow.js";
+
 const RUNTIME_PAD = 8;
 const STATUS_PAD = 10;
 const DELIVERY_PAD = 14;

--- a/src/gateway/client-callsites.guard.test.ts
+++ b/src/gateway/client-callsites.guard.test.ts
@@ -12,6 +12,7 @@ const ALLOWED_GATEWAY_CLIENT_CALLSITES = new Set([
   "extensions/google-meet/src/voice-call-gateway.ts",
   "extensions/qa-lab/src/gateway-rpc-client.ts",
   "src/acp/server.ts",
+  "src/commands/tasks-follow.ts",
   "src/gateway/call.ts",
   "src/gateway/gateway-cli-backend.live-helpers.ts",
   "src/gateway/operator-approvals-client.ts",


### PR DESCRIPTION
Closes #123488

## What Problem This Solves

Operators can inspect durable background tasks from the CLI, but they cannot stay attached to one task without repeatedly polling `tasks show`. Gateway logs are too broad for this job, and the Control UI does not cover every remote, headless, or shell-first workflow. As a result, operators can miss progress transitions and may not know whether execution finished while completion delivery is still pending.

## Why This Change Was Made

This adds `openclaw tasks follow <lookup>` with human-readable and JSON Lines output. The viewer reuses the `tasks show` lookup contract, connects with `operator.read`, projects existing bounded task summaries and visible session history, filters the existing task event stream to one task, and replays durable state after event gaps or Gateway reconnects. Stable record identifiers suppress replay duplicates, execution and delivery remain separate, and Ctrl-C closes only the viewer.

The change is read-only. It adds no task or session persistence, protocol schema, cancellation, notification, delivery, or restart-recovery owner.

## User Impact

Operators can follow one subagent, ACP, cron, or CLI task from a terminal until both execution and completion delivery reach a terminal state. `--json` supports line-oriented consumers with bounded, redacted records and duplicate-safe identifiers. Existing `tasks show`, Control UI, task execution, and delivery behavior remain unchanged.

## Evidence

- Exact head: `e5c7ebd3143c014fdb0412043c71b10bf66737f5`, based on `6bd21a11222af41e7c758739c0e0cd2994dee445`.
- Focused CLI, command, and Gateway callsite-guard tests: 44/44 passed, covering human output, JSONL, bounded and redacted visible history, hidden reasoning and tool-result exclusion, `operator.read`, ordered updates, event gaps, duplicate suppression, reconnect, separate execution and delivery terminal behavior, Ctrl-C viewer-only behavior, lookup failure, and the production `GatewayClient` allowlist.
- `pnpm check:changed` passed all selected core, core-test, and docs lanes. Crabbox 0.41.6 matched the current stable release but had no ready remote provider, so the repository used its documented local fallback.
- `pnpm build` passed through the rebased CLI invocation, including CLI bootstrap imports, runtime post-build module loading, bundled plugin assets, and the Control UI build.
- Built CLI help exposes `openclaw tasks follow [options] <lookup>` and `--json` as JSON Lines.
- AutoReview loop 3 reviewed the exact rebased 37,028-byte bundle with `gpt-5.6-luna` at maximum thinking. TruffleHog passed and the review reported no accepted or actionable findings.
- The original `check-lint` failure had no lint finding. Every core shard completed, then the GitHub-hosted runner received a shutdown signal while linting extensions and exited 143. The new head retriggers that infrastructure-cancelled job.

### Live Gateway transcript

This proof used a loopback-only development Gateway and a dedicated temporary state root. It did not read or operate the normal Gateway. The controlled task had finished execution while delivery was still queued, so the viewer stayed attached. I stopped the isolated Gateway, completed delivery in the same SQLite-owned task row while it was down, and restarted it. The existing viewer emitted one disconnect marker, reconnected, replayed the durable terminal state, and exited 0. The task identifier below is redacted; the event order, timestamps, state, and exit status are unchanged.

```console
$ openclaw tasks follow proof-task --json
{"id":"task.update:2b19603b9c063d79222e","cursor":"task.update:2b19603b9c063d79222e","timestamp":"2026-08-14T05:42:17.953Z","taskId":"proof-task","runtime":"cli","kind":"task.snapshot","state":{"status":"failed","deliveryStatus":"session_queued","terminalOutcome":null,"title":"Validate rebased exact bundle","progressSummary":"Waiting for controlled isolated Gateway restart","terminalSummary":null,"error":"backing session missing","toolUseCount":0,"lastToolName":null,"lastActivity":null}}
{"id":"connection.disconnected:ad74b4a060be0e56a1ca","cursor":"connection.disconnected:ad74b4a060be0e56a1ca","timestamp":"2026-08-14T05:43:23.468Z","taskId":"proof-task","runtime":"cli","kind":"connection.disconnected","state":{"message":"Gateway disconnected: service restart; reconnecting"}}
{"id":"connection.reconnected:861f5a0dd801ecd00d09","cursor":"connection.reconnected:861f5a0dd801ecd00d09","timestamp":"2026-08-14T05:44:24.517Z","taskId":"proof-task","runtime":"cli","kind":"connection.reconnected","state":{"message":"Gateway reconnected; replaying durable task state"}}
{"id":"task.update:78abefab30bead105630","cursor":"task.update:78abefab30bead105630","timestamp":"2026-08-14T05:43:45.000Z","taskId":"proof-task","runtime":"cli","kind":"task.snapshot","state":{"status":"completed","deliveryStatus":"delivered","terminalOutcome":"succeeded","title":"Validate rebased exact bundle","progressSummary":"Waiting for controlled isolated Gateway restart","terminalSummary":"Isolated reconnect proof completed","error":null,"toolUseCount":0,"lastToolName":null,"lastActivity":null}}
$ echo $?
0
```

Production: +595 lines. Tests: +356 lines. Docs: +31 lines.

AI-assisted: yes. The change was reviewed against the CLI lookup owner, durable task ledger, Gateway authorization and event boundary, bounded session-history projection, Control UI behavior, and delivery and restart semantics.
