### PR TITLE
fix(media): omit default audio prompt on autodetect path

### DIFF
--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -477,8 +477,9 @@ describe("runCapability auto audio entries", () => {
     expect(seenPrompt).toBeUndefined();
   });
 
-  it("keeps explicit and English-compatible audio prompts", async () => {
+  it("keeps explicit and English-hint audio prompts, omits default on autodetect", async () => {
     const seenPrompts: Array<string | undefined> = [];
+    let autodetectPrompt: string | undefined;
     const runCase = async (audio: MediaUnderstandingConfig) => {
       await runAutoAudioCase({
         transcribeAudio: async (req) => {
@@ -508,18 +509,33 @@ describe("runCapability auto audio entries", () => {
         models: [{ provider: "openai", model: "whisper-1" }],
       });
     }
-    await runCase({
-      enabled: true,
-      models: [{ provider: "openai", model: "whisper-1" }],
-    });
-
+    // Explicit prompts and explicit English hints keep the prompt. The
+    // autodetect path (no language, no prompt) must omit OpenClaw's English
+    // default so it cannot leak into the transcript (see #123305).
     expect(seenPrompts).toEqual([
       "Transcribe in Russian.",
       "Transcribe the audio.",
       "Transcribe the audio.",
       "Transcribe the audio.",
-      "Transcribe the audio.",
     ]);
+
+    await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        autodetectPrompt = req.prompt;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      cfgExtra: {
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              models: [{ provider: "openai", model: "whisper-1" }],
+            },
+          },
+        },
+      } as Partial<OpenClawConfig>,
+    });
+    expect(autodetectPrompt).toBeUndefined();
   });
 
   it("uses mistral when only mistral key is configured", async () => {

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -453,12 +453,7 @@ function resolveAudioProviderPrompt(params: {
   language?: string;
 }): string | undefined {
   const language = params.language?.trim().toLowerCase();
-  // Autodetect (no language hint) must not be treated as English: without an
-  // explicit prompt, omit OpenClaw's English default so the provider performs
-  // real language autodetection and the internal STT hint cannot be echoed
-  // back into the transcript (where it would be indistinguishable from a user
-  // instruction). See #123305. Explicit English hints still keep the default
-  // prompt (language-matched), and explicit prompts always win.
+  // Autodetect must not inject the English default prompt (#123305).
   const isEnglish =
     Boolean(language) &&
     (language === "en" ||

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -453,19 +453,26 @@ function resolveAudioProviderPrompt(params: {
   language?: string;
 }): string | undefined {
   const language = params.language?.trim().toLowerCase();
+  // Autodetect (no language hint) must not be treated as English: without an
+  // explicit prompt, omit OpenClaw's English default so the provider performs
+  // real language autodetection and the internal STT hint cannot be echoed
+  // back into the transcript (where it would be indistinguishable from a user
+  // instruction). See #123305. Explicit English hints still keep the default
+  // prompt (language-matched), and explicit prompts always win.
   const isEnglish =
-    !language ||
-    language === "en" ||
-    language === "eng" ||
-    language === "english" ||
-    language.startsWith("en-") ||
-    language.startsWith("en_");
+    Boolean(language) &&
+    (language === "en" ||
+      language === "eng" ||
+      language === "english" ||
+      language?.startsWith("en-") ||
+      language?.startsWith("en_"));
   if (params.hasConfiguredPrompt || isEnglish) {
     return params.prompt;
   }
   // OpenAI-compatible transcription prompts guide style/context and should
   // match the audio language; omit OpenClaw's English default for non-English
-  // language hints unless the user supplied an explicit prompt.
+  // language hints and the autodetect path unless the user supplied an
+  // explicit prompt.
   return undefined;
 }
 


### PR DESCRIPTION
## What Problem This Solves

When both `tools.media.audio.language` and `tools.media.audio.prompt` are unset so the provider can autodetect the language, OpenClaw forwards its implicit English default prompt `"Transcribe the audio."` to the transcription provider. Providers such as Groq Whisper can echo that prompt verbatim into the transcript, and OpenClaw then inserts the contaminated transcript into `message.content`, where the downstream agent may interpret the suffix as a literal user instruction (e.g. transcribing a voice note instead of answering the spoken questions). #123305

**Plain-language root cause:** When the user sets neither a language nor a custom prompt (letting the system auto-detect the language), OpenClaw still handed the transcription service a fixed English hint sentence "Transcribe the audio." That sentence is internal STT config text, but the transcription service echoed it back into the transcript, and OpenClaw then treated the whole transcript as user speech — so the agent got misled by that "please transcribe" sentence. Setting an explicit language (e.g. `pt`) made it disappear because that path already omitted the default.

## Why This Change Was Made

`resolveAudioProviderPrompt` (src/media-understanding/runner.entries.ts) treated the no-language path as English (`!language || ...`), so on autodetect it returned `DEFAULT_PROMPT.audio`. The adjacent #99023 only omitted the default for explicit non-English language hints and intentionally retained it on the no-language path, which left autodetection vulnerable to prompt bias and prompt leakage.

The cleanest boundary fix (per the issue's suggested direction) is to prevent the internal prompt from entering the provider request in the first place, rather than stripping a hard-coded suffix from the transcript (which could remove legitimate speech). `buildAudioTranscriptionFormData` already omits `undefined` fields, so returning `undefined` on the autodetect path makes the final multipart request carry no `prompt` field at all.

Scope is intentionally narrow (option A): the autodetect path (no language + no prompt) now omits the default. Explicit prompts and explicit English language hints keep their current behavior (language-matched default prompt retained) to preserve #99023's language-matching intent and avoid changing English-hint users.

## User Impact

Multilingual users relying on language autodetection for voice notes no longer get OpenClaw's internal English prompt echoed into transcripts, so the downstream agent is no longer redirected away from the spoken intent by a leaked internal hint. Explicit-prompt and explicit-language-hint users see no change.

## Evidence

### CI proof: exact-head audio-autodetect request-boundary trace

Secretless fork workflow at exact heads runs the real production audio path
(`runCapability` -> `resolveAudioProviderPrompt` -> `buildAudioTranscriptionFormData`
-> `transcribeOpenAiCompatibleAudio` -> HTTP multipart POST) with the real openai
plugin provider hook against a local mock OpenAI-compatible
`/audio/transcriptions` provider that records the exact fields on the wire and
models the documented provider behavior of echoing the prompt into the
transcript.

- Before (main `2ef92d0bbe9`): provider received fields `[file, model, prompt]` and
  returned `WHATSAPP_QA_AUDIO_TRANSCRIPT_OK Transcribe the audio.` — the internal
  default prompt leaked onto the wire and into the transcript.
- After (PR head `18e628b4951`): provider received fields `[file, model]` (no
  `prompt`) and returned `WHATSAPP_QA_AUDIO_TRANSCRIPT_OK` — clean spoken content.
- Delta: the before expectation (`prompt` present) FAILS at the after head,
  proving the behavior changed between the two SHAs.

| Head | `prompt` on wire | request fields | transcript |
|---|---|---|---|
| before `2ef92d0bbe9` (main) | present | `file, model, prompt` | `WHATSAPP_QA_AUDIO_TRANSCRIPT_OK Transcribe the audio.` |
| after `18e628b4951` (PR head) | absent | `file, model` | `WHATSAPP_QA_AUDIO_TRANSCRIPT_OK` |

Gate: `[proof] GATE PASSED: before=prompt-leaked after=prompt-omitted delta=behavior-changed`

Proof run: https://github.com/SunnyShu0925/openclaw/actions/runs/31784215398

Verdict artifact: https://github.com/SunnyShu0925/openclaw/actions/runs/31784215398/artifacts/9212882126
(before/after/delta `verdict.json` + full run logs)

What was not tested: a live STT provider roundtrip (no live provider credentials
available); the boundary trace above covers the provider-facing request fields
and the resulting transcript through the real production path.


Pre-fix the autodetect path forwarded the default prompt; post-fix it forwards `undefined`, and the final multipart FormData omits the `prompt` field.

| Path | language | prompt configured | before `transcribeAudio` receives | after | FormData `prompt` field |
|------|----------|-------------------|-----------------------------------|-------|--------------------------|
| explicit prompt + ru | `ru` | `"Transcribe in Russian."` | `"Transcribe in Russian."` | `"Transcribe in Russian."` | present |
| explicit English hint | `en-US`/`eng`/`english` | none | `"Transcribe the audio."` | `"Transcribe the audio."` | present |
| explicit non-English hint | `pt`/`ru` (no prompt) | none | `undefined` | `undefined` | absent |
| **autodetect (the bug)** | none | none | `"Transcribe the audio."` | `undefined` | **absent (fixed)** |

Regression guard (updated `runner.auto-audio.test.ts`):

```
$ npx vitest run src/media-understanding/runner.auto-audio.test.ts -t "omits default on autodetect"
# pre-fix (source reverted to origin/main):
FAIL  AssertionError: expected 'Transcribe the audio.' to be undefined
  - Expected: undefined
  + Received: "Transcribe the audio."
    expect(autodetectPrompt).toBeUndefined();
# post-fix:
Test Files  1 passed (1)
     Tests  1 passed | 11 skipped
```

Full file:

```
$ npx vitest run src/media-understanding/runner.auto-audio.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Real-behavior proof that the final multipart request omits the `prompt` field when the autodetect path yields `undefined` (tsx direct run of `buildAudioTranscriptionFormData`):

```
autodetect FormData fields: [ 'file', 'model' ]
autodetect has prompt field? false
pre-fix FormData fields: [ 'file', 'model', 'prompt' ]
pre-fix has prompt field? true
pre-fix prompt value: Transcribe the audio.
```

### After-fix provider transcription (mock-gateway harness)

To demonstrate that removing the implicit prompt resolves the **leaked transcript content** (not just the request shape), a local HTTP server stands in for an OpenAI-compatible `/audio/transcriptions` provider. Per the OpenAI Whisper API contract, the `prompt` field guides transcription and can be echoed into the result; the server models that contract by appending any received `prompt` to the transcript. This is a mock-gateway harness (allowed by `proof-rules.md`): the bug under test is OpenClaw injecting the prompt on autodetect — the server only plays a provider whose output is influenced by the `prompt` field, which is documented provider contract behavior, not a fabricated bug. The production code `buildAudioTranscriptionFormData` builds the real multipart body; native fetch delivers it. No real provider credentials or user audio are used — the spoken text is synthetic Portuguese and the API key is a fake placeholder, so there is no provider/user data to redact.

```
=== BEFORE fix — autodetect (no language, no prompt) => prompt='Transcribe the audio.' ===
  resolveAudioProviderPrompt() => "Transcribe the audio."
  [provider] received multipart fields: ["file","model","prompt"]
  [provider] received prompt field: "Transcribe the audio."
  [provider] returning transcript: "Bom dia, tudo bem com voce hoje? Transcribe the audio."

=== AFTER fix — autodetect (no language, no prompt) => prompt=undefined ===
  resolveAudioProviderPrompt() => undefined
  [provider] received multipart fields: ["file","model"]
  [provider] received prompt field: null
  [provider] returning transcript: "Bom dia, tudo bem com voce hoje?"

=== SUMMARY ===
BEFORE transcript: "Bom dia, tudo bem com voce hoje? Transcribe the audio."
AFTER  transcript: "Bom dia, tudo bem com voce hoje?"
BEFORE leaked internal prompt into transcript? true
AFTER  leaked internal prompt into transcript? false
AFTER  transcript is clean spoken content?      true
```

The `prompt` field is present on the wire before the fix (and echoed into the transcript) and absent after the fix (so the provider returns only the spoken content). This matches the issue's live A/B: setting an explicit language made the suffix disappear; this fix makes the autodetect path behave the same way without requiring the user to configure a language.

### Caller / sibling-path verification

`resolveAudioProviderPrompt` has a single caller (the audio branch of `runCapabilityForEntry` in `runner.entries.ts:873`), invoked only inside the `if (capability === "audio")` block (:858). Image/PDF/video capabilities never reach it (they use `resolvePrompt` directly and do not forward a provider `prompt` field over HTTP in the same way). All OpenAI-compatible audio providers (groq, openai, deepinfra, mistral, senseaudio) route through `transcribeOpenAiCompatibleAudio` → `buildAudioTranscriptionFormData`, which already omits `undefined` fields, so the fix applies uniformly across sibling audio providers. Explicit prompts (`hasConfiguredPrompt`) and explicit English language hints retain the prior behavior; only the autodetect path changes.

`tsgo:core` reports no type errors in the changed files (`oxfmt --check` clean).

## AI Assistance

This PR is AI-assisted. Prompt: "Analyze openclaw/openclaw#123305 and prepare a fix following the open-source-pr skill." Session log summary: traced the full call chain from `resolveAudioProviderPrompt` through `buildRequest.prompt` → `transcribeOpenAiCompatibleAudio` → `buildAudioTranscriptionFormData` to confirm `undefined` prompts are omitted from the multipart request; verified the existing `runner.auto-audio.test.ts` locked the buggy autodetect behavior as expected; updated the test to assert `undefined` on autodetect and confirmed pre-fix-fail / post-fix-pass. The author understands the changed code: the fix narrows the `isEnglish` predicate so the no-language (autodetect) path is no longer treated as English, causing `resolveAudioProviderPrompt` to fall through to `return undefined` when no explicit prompt is configured.

Fixes #123305

