### PR TITLE
feat: cookie sync from Mac to a remote Gateway browser profile

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -20641,6 +20641,17 @@
       ]
     },
     {
+      "id": "native.apple.9a896fd0c77fc03f",
+      "source": "Add domain",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-call",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.6889235e143951e7",
       "source": "Add events with least privilege.",
       "surface": "apple",
@@ -25488,6 +25499,17 @@
       ]
     },
     {
+      "id": "native.apple.84777b74e92431dd",
+      "source": "Continuously copy this Mac's logged-in cookies for the domains below into the remote OpenClaw browser profile. Off by default.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument-multiline",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.f91fc44547d416b3",
       "source": "Control Terminal for automation actions; other apps request access separately",
       "surface": "apple",
@@ -25550,6 +25572,39 @@
         {
           "kind": "ui-modifier",
           "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.fa11eff750444eb3",
+      "source": "Cookie sync",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-call",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.1715918edf44328e",
+      "source": "Cookie sync applies when OpenClaw runs on another computer (remote mode).",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.f11213588b9d720e",
+      "source": "Cookies are only synced for these domains; an empty list means nothing is synced.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         }
       ]
     },
@@ -27881,6 +27936,17 @@
       ]
     },
     {
+      "id": "native.apple.ec2ffeff69e197a3",
+      "source": "Domains",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.5a76cb708e01de50",
       "source": "Don't show again",
       "surface": "apple",
@@ -28538,6 +28604,10 @@
         {
           "kind": "ui-call",
           "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift"
+        },
+        {
+          "kind": "conditional-branch",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         },
         {
           "kind": "conditional-branch",
@@ -33168,6 +33238,17 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.947dd547c2e098b9",
+      "source": "Managed profile on the remote computer that receives the cookies.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         }
       ]
     },
@@ -40186,6 +40267,17 @@
       ]
     },
     {
+      "id": "native.apple.f68bfc762a6ffe24",
+      "source": "Remote mode required",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.a1dc871b601e526d",
       "source": "Remote test",
       "surface": "apple",
@@ -40208,6 +40300,10 @@
         {
           "kind": "ui-call",
           "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift"
+        },
+        {
+          "kind": "ui-call",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         }
       ]
     },
@@ -41660,6 +41756,10 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift"
+        },
+        {
+          "kind": "conditional-branch",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         },
         {
           "kind": "ui-localized-call",
@@ -44550,6 +44650,10 @@
           "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift"
         },
         {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        },
+        {
           "kind": "ui-call",
           "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift"
         }
@@ -44707,6 +44811,10 @@
         {
           "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift"
+        },
+        {
+          "kind": "conditional-branch",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         },
         {
           "kind": "ui-localized-call",
@@ -44906,6 +45014,17 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/SettingsProTabActions.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.6f73cd1a65b8039b",
+      "source": "Sync cookies to the remote computer",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         }
       ]
     },
@@ -45344,6 +45463,17 @@
         {
           "kind": "ui-call",
           "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.fbca275c07692781",
+      "source": "Target profile",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         }
       ]
     },
@@ -50404,6 +50534,17 @@
       ]
     },
     {
+      "id": "native.apple.30aead244d2145b5",
+      "source": "example.com",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-call",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.f31e72922dfb4059",
       "source": "expired",
       "surface": "apple",
@@ -50551,6 +50692,17 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/SettingsProTabActions.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.00124ba1399ecec0",
+      "source": "imported",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-call",
+          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         }
       ]
     },

--- a/apps/macos/Sources/OpenClaw/AppState+Preview.swift
+++ b/apps/macos/Sources/OpenClaw/AppState+Preview.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+extension AppState {
+    static var preview: AppState {
+        let state = AppState(preview: true)
+        state.isPaused = false
+        state.launchAtLogin = true
+        state.onboardingSeen = true
+        state.debugPaneEnabled = true
+        state.nativeSettingsPanesEnabled = true
+        state.swabbleEnabled = true
+        state.swabbleTriggerWords = ["Claude", "Computer", "Jarvis"]
+        state.voiceWakeTriggerChime = .system(name: "Glass")
+        state.voiceWakeSendChime = .system(name: "Ping")
+        state.iconAnimationsEnabled = true
+        state.showDockIcon = true
+        state.voiceWakeMicID = "BuiltInMic"
+        state.voiceWakeMicName = "Built-in Microphone"
+        state.voiceWakeLocaleID = Locale.current.identifier
+        state.voiceWakeAdditionalLocaleIDs = ["en-US", "de-DE"]
+        state.voicePushToTalkEnabled = false
+        state.talkEnabled = false
+        state.talkPhaseSoundsEnabled = true
+        state.talkShiftToStopEnabled = true
+        state.iconOverride = .system
+        state.heartbeatsEnabled = true
+        state.connectionMode = .local
+        state.remoteTransport = .ssh
+        state.canvasEnabled = true
+        state.quickChatEnabled = true
+        state.cookieSyncEnabled = false
+        state.cookieSyncIntoProfile = "imported"
+        state.cookieSyncDomains = []
+        state.remoteTarget = "user@example.com"
+        state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "example-token"
+        state.remoteIdentity = "~/.ssh/id_ed25519"
+        state.remoteProjectRoot = "~/Projects/openclaw"
+        state.remoteCliPath = ""
+        return state
+    }
+}

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -328,6 +328,26 @@ final class AppState {
         didSet { self.ifNotPreview { AppDefaults.standard.set(self.quickChatEnabled, forKey: quickChatEnabledKey) } }
     }
 
+    var cookieSyncEnabled: Bool {
+        didSet {
+            self.ifNotPreview { AppDefaults.standard.set(self.cookieSyncEnabled, forKey: cookieSyncEnabledKey) }
+        }
+    }
+
+    var cookieSyncIntoProfile: String {
+        didSet {
+            self.ifNotPreview {
+                AppDefaults.standard.set(self.cookieSyncIntoProfile, forKey: cookieSyncIntoProfileKey)
+            }
+        }
+    }
+
+    var cookieSyncDomains: [String] {
+        didSet {
+            self.ifNotPreview { AppDefaults.standard.set(self.cookieSyncDomains, forKey: cookieSyncDomainsKey) }
+        }
+    }
+
     var activeComputerPresenceEnabled: Bool {
         didSet { self.scheduleActiveComputerPresenceUpdate() }
     }
@@ -557,6 +577,9 @@ final class AppState {
         self.remoteCliPath = AppDefaults.standard.string(forKey: remoteCliPathKey)?.nonEmpty ?? ""
         self.canvasEnabled = AppDefaults.standard.object(forKey: canvasEnabledKey) as? Bool ?? true
         self.quickChatEnabled = AppDefaults.standard.object(forKey: quickChatEnabledKey) as? Bool ?? true
+        self.cookieSyncEnabled = AppDefaults.standard.object(forKey: cookieSyncEnabledKey) as? Bool ?? false
+        self.cookieSyncIntoProfile = AppDefaults.standard.string(forKey: cookieSyncIntoProfileKey) ?? "imported"
+        self.cookieSyncDomains = AppDefaults.standard.stringArray(forKey: cookieSyncDomainsKey) ?? []
         self.activeComputerPresenceEnabled = Self.resolveActiveComputerPresenceEnabled()
         self.execApprovalMode = .deny
         self.execApprovalPolicyLoadState = .loading
@@ -1548,6 +1571,9 @@ extension AppState {
         state.remoteTransport = .ssh
         state.canvasEnabled = true
         state.quickChatEnabled = true
+        state.cookieSyncEnabled = false
+        state.cookieSyncIntoProfile = "imported"
+        state.cookieSyncDomains = []
         state.remoteTarget = "user@example.com"
         state.remoteUrl = "wss://gateway.example.ts.net"
         state.remoteToken = "example-token"

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -577,9 +577,7 @@ final class AppState {
         self.remoteCliPath = AppDefaults.standard.string(forKey: remoteCliPathKey)?.nonEmpty ?? ""
         self.canvasEnabled = AppDefaults.standard.object(forKey: canvasEnabledKey) as? Bool ?? true
         self.quickChatEnabled = AppDefaults.standard.object(forKey: quickChatEnabledKey) as? Bool ?? true
-        self.cookieSyncEnabled = AppDefaults.standard.object(forKey: cookieSyncEnabledKey) as? Bool ?? false
-        self.cookieSyncIntoProfile = AppDefaults.standard.string(forKey: cookieSyncIntoProfileKey) ?? "imported"
-        self.cookieSyncDomains = AppDefaults.standard.stringArray(forKey: cookieSyncDomainsKey) ?? []
+        (self.cookieSyncEnabled, self.cookieSyncIntoProfile, self.cookieSyncDomains) = Self.loadCookieSyncDefaults()
         self.activeComputerPresenceEnabled = Self.resolveActiveComputerPresenceEnabled()
         self.execApprovalMode = .deny
         self.execApprovalPolicyLoadState = .loading
@@ -1544,47 +1542,14 @@ extension AppState {
 }
 
 extension AppState {
-    static var preview: AppState {
-        let state = AppState(preview: true)
-        state.isPaused = false
-        state.launchAtLogin = true
-        state.onboardingSeen = true
-        state.debugPaneEnabled = true
-        state.nativeSettingsPanesEnabled = true
-        state.swabbleEnabled = true
-        state.swabbleTriggerWords = ["Claude", "Computer", "Jarvis"]
-        state.voiceWakeTriggerChime = .system(name: "Glass")
-        state.voiceWakeSendChime = .system(name: "Ping")
-        state.iconAnimationsEnabled = true
-        state.showDockIcon = true
-        state.voiceWakeMicID = "BuiltInMic"
-        state.voiceWakeMicName = "Built-in Microphone"
-        state.voiceWakeLocaleID = Locale.current.identifier
-        state.voiceWakeAdditionalLocaleIDs = ["en-US", "de-DE"]
-        state.voicePushToTalkEnabled = false
-        state.talkEnabled = false
-        state.talkPhaseSoundsEnabled = true
-        state.talkShiftToStopEnabled = true
-        state.iconOverride = .system
-        state.heartbeatsEnabled = true
-        state.connectionMode = .local
-        state.remoteTransport = .ssh
-        state.canvasEnabled = true
-        state.quickChatEnabled = true
-        state.cookieSyncEnabled = false
-        state.cookieSyncIntoProfile = "imported"
-        state.cookieSyncDomains = []
-        state.remoteTarget = "user@example.com"
-        state.remoteUrl = "wss://gateway.example.ts.net"
-        state.remoteToken = "example-token"
-        state.remoteIdentity = "~/.ssh/id_ed25519"
-        state.remoteProjectRoot = "~/Projects/openclaw"
-        state.remoteCliPath = ""
-        return state
+    private static func loadCookieSyncDefaults() -> (Bool, String, [String]) {
+        let defaults = AppDefaults.standard
+        return (
+            defaults.object(forKey: cookieSyncEnabledKey) as? Bool ?? false,
+            defaults.string(forKey: cookieSyncIntoProfileKey) ?? "imported",
+            defaults.stringArray(forKey: cookieSyncDomainsKey) ?? [])
     }
-}
 
-extension AppState {
     static func resolveActiveComputerPresenceEnabled(defaults: UserDefaults = AppDefaults.standard) -> Bool {
         defaults.bool(forKey: activeComputerPresenceEnabledKey)
     }

--- a/apps/macos/Sources/OpenClaw/Constants.swift
+++ b/apps/macos/Sources/OpenClaw/Constants.swift
@@ -43,6 +43,9 @@ let canvasEnabledKey = "openclaw.canvasEnabled"
 let quickChatEnabledKey = "openclaw.quickChatEnabled"
 let cameraEnabledKey = "openclaw.cameraEnabled"
 let computerControlEnabledKey = "openclaw.computerControlEnabled"
+let cookieSyncEnabledKey = "openclaw.cookieSyncEnabled"
+let cookieSyncIntoProfileKey = "openclaw.cookieSyncIntoProfile"
+let cookieSyncDomainsKey = "openclaw.cookieSyncDomains"
 
 func isComputerControlEnabled(defaults: UserDefaults = AppDefaults.standard) -> Bool {
     // object(forKey:) preserves an explicit false; bool(forKey:) would conflate it with an unset default.

--- a/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
+++ b/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
@@ -1,0 +1,406 @@
+import Darwin
+import Foundation
+import Observation
+import OSLog
+
+@MainActor
+@Observable
+final class CookieSyncManager: NSObject {
+    enum State: Equatable {
+        case stopped
+        case running
+        case error(String)
+    }
+
+    private struct Endpoint: Equatable {
+        let url: URL
+        let token: String?
+        let password: String?
+    }
+
+    private struct SyncIntent: Equatable {
+        let domains: [String]
+        let profile: String
+        let endpoint: Endpoint
+    }
+
+    static let shared = CookieSyncManager()
+
+    private(set) var state: State = .stopped
+    private(set) var lastSummary: String?
+
+    @ObservationIgnored private let logger = Logger(subsystem: "ai.openclaw", category: "cookie-sync")
+    @ObservationIgnored private let queue = DispatchQueue(label: "ai.openclaw.cookie-sync")
+    @ObservationIgnored private weak var appState: AppState?
+    @ObservationIgnored private var endpointState: GatewayEndpointState?
+    @ObservationIgnored private var endpointTask: Task<Void, Never>?
+    @ObservationIgnored private var reconcileTask: Task<Void, Never>?
+    @ObservationIgnored private var retryTask: Task<Void, Never>?
+    @ObservationIgnored private var process: Process?
+    @ObservationIgnored private var stdoutPipe: Pipe?
+    @ObservationIgnored private var stderrPipe: Pipe?
+    @ObservationIgnored private var stdoutSource: DispatchSourceRead?
+    @ObservationIgnored private var stderrSource: DispatchSourceRead?
+    @ObservationIgnored private var startupWatchdog: DispatchSourceTimer?
+    @ObservationIgnored private var stdoutBuffer = Data()
+    @ObservationIgnored private var processGeneration: UUID?
+    @ObservationIgnored private var runningIntent: SyncIntent?
+    @ObservationIgnored private var reconcileGeneration: UInt64 = 0
+    @ObservationIgnored private var retryAttempt = 0
+    @ObservationIgnored private var isStarted = false
+
+    func start(state: AppState) {
+        self.appState = state
+        guard !self.isStarted else {
+            self.scheduleReconcile(resetRetry: true)
+            return
+        }
+        self.isStarted = true
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(self.settingsDidChange),
+            name: UserDefaults.didChangeNotification,
+            object: AppDefaults.standard)
+        center.addObserver(
+            self,
+            selector: #selector(self.settingsDidChange),
+            name: .openclawConfigDidChange,
+            object: nil)
+        center.addObserver(
+            self,
+            selector: #selector(self.cliDidChange),
+            name: .openclawCLIInstalled,
+            object: nil)
+
+        self.endpointTask = Task { [weak self] in
+            let states = await GatewayEndpointStore.shared.subscribe()
+            for await state in states {
+                guard !Task.isCancelled, let self else { return }
+                self.endpointState = state
+                self.scheduleReconcile(resetRetry: true)
+            }
+        }
+        self.scheduleReconcile(resetRetry: true)
+    }
+
+    func stop() {
+        NotificationCenter.default.removeObserver(self)
+        self.endpointTask?.cancel()
+        self.endpointTask = nil
+        self.reconcileTask?.cancel()
+        self.reconcileTask = nil
+        self.retryTask?.cancel()
+        self.retryTask = nil
+        self.isStarted = false
+        self.stopChild(nextState: .stopped)
+    }
+
+    static func normalizedDomains(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values
+            .flatMap { $0.split(separator: ",", omittingEmptySubsequences: false).map(String.init) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
+    }
+
+    @objc private nonisolated func settingsDidChange(_: Notification) {
+        Task { @MainActor [weak self] in
+            self?.scheduleReconcile(resetRetry: true)
+        }
+    }
+
+    @objc private nonisolated func cliDidChange(_: Notification) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.stopChild(nextState: .stopped)
+            self.scheduleReconcile(resetRetry: true)
+        }
+    }
+
+    private func scheduleReconcile(resetRetry: Bool, delay: Duration = .milliseconds(350)) {
+        if resetRetry {
+            self.retryAttempt = 0
+            self.retryTask?.cancel()
+            self.retryTask = nil
+        }
+        self.reconcileGeneration &+= 1
+        let generation = self.reconcileGeneration
+        self.reconcileTask?.cancel()
+        self.reconcileTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self, generation == self.reconcileGeneration else { return }
+            await self.reconcile(generation: generation)
+        }
+    }
+
+    private func reconcile(generation: UInt64) async {
+        guard let appState = self.appState,
+              appState.cookieSyncEnabled,
+              appState.connectionMode == .remote
+        else {
+            self.stopChild(nextState: .stopped)
+            return
+        }
+
+        let domains = Self.normalizedDomains(appState.cookieSyncDomains)
+        guard !domains.isEmpty else {
+            self.stopChild(nextState: .stopped)
+            return
+        }
+
+        let profile = appState.cookieSyncIntoProfile
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nonEmpty ?? "imported"
+        guard let endpoint = self.remoteEndpoint else {
+            self.stopChild(nextState: .error("no remote gateway credentials available"))
+            return
+        }
+        let intent = SyncIntent(domains: domains, profile: profile, endpoint: endpoint)
+        if self.process?.isRunning == true, self.runningIntent == intent {
+            return
+        }
+        self.stopChild(nextState: .stopped)
+
+        guard let executable = await self.resolveLocalOpenClawExecutable(),
+              !Task.isCancelled,
+              generation == self.reconcileGeneration
+        else {
+            if !Task.isCancelled, generation == self.reconcileGeneration {
+                self.state = .error("OpenClaw CLI not found locally; cookie sync needs the CLI on this Mac")
+            }
+            return
+        }
+        self.launch(executable: executable, intent: intent)
+    }
+
+    private var remoteEndpoint: Endpoint? {
+        guard case let .ready(mode, url, rawToken, rawPassword, _) = self.endpointState,
+              mode == .remote
+        else { return nil }
+        let token = rawToken?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+        let password = rawPassword?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+        guard token != nil || password != nil else { return nil }
+        return Endpoint(url: url, token: token, password: token == nil ? password : nil)
+    }
+
+    private func resolveLocalOpenClawExecutable() async -> String? {
+        #if DEBUG
+        if let executable = CommandResolver.projectOpenClawExecutable() {
+            return executable
+        }
+        #endif
+        if case let .ready(location, _) = await CLIInstaller.status() {
+            return location
+        }
+        return CommandResolver.findExecutable(
+            named: "openclaw",
+            searchPaths: CommandResolver.preferredPaths())
+    }
+
+    private func launch(executable: String, intent: SyncIntent) {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let generation = UUID()
+        let arguments = [
+            "browser",
+            "cookie-sync",
+            "--watch",
+            "--domains",
+            intent.domains.joined(separator: ","),
+            "--into",
+            intent.profile,
+        ]
+
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = CommandResolver.preferredPaths().joined(separator: ":")
+        environment["OPENCLAW_GATEWAY_URL"] = intent.endpoint.url.absoluteString
+        environment.removeValue(forKey: "OPENCLAW_GATEWAY_TOKEN")
+        environment.removeValue(forKey: "OPENCLAW_GATEWAY_PASSWORD")
+        if let token = intent.endpoint.token {
+            environment["OPENCLAW_GATEWAY_TOKEN"] = token
+        } else if let password = intent.endpoint.password {
+            environment["OPENCLAW_GATEWAY_PASSWORD"] = password
+        }
+        process.environment = environment
+        process.terminationHandler = { [weak self] process in
+            let terminationStatus = process.terminationStatus
+            Task { @MainActor [weak self] in
+                self?.childTerminated(generation: generation, status: terminationStatus)
+            }
+        }
+
+        self.process = process
+        self.stdoutPipe = stdoutPipe
+        self.stderrPipe = stderrPipe
+        self.processGeneration = generation
+        self.runningIntent = intent
+        self.stdoutBuffer.removeAll(keepingCapacity: true)
+
+        do {
+            try process.run()
+            try? stdoutPipe.fileHandleForWriting.close()
+            try? stderrPipe.fileHandleForWriting.close()
+            self.installReadSources(stdoutPipe: stdoutPipe, stderrPipe: stderrPipe, generation: generation)
+            self.installStartupWatchdog(generation: generation)
+            self.state = .running
+            self.logger.info("cookie sync started for \(intent.domains.count, privacy: .public) domain(s)")
+        } catch {
+            self.logger.error("cookie sync launch failed: \(error.localizedDescription, privacy: .public)")
+            self.stopChild(nextState: .error("Cookie sync could not start: \(error.localizedDescription)"))
+            self.scheduleRetry()
+        }
+    }
+
+    private func installReadSources(stdoutPipe: Pipe, stderrPipe: Pipe, generation: UUID) {
+        let stdoutDescriptor = stdoutPipe.fileHandleForReading.fileDescriptor
+        let stdoutSource = DispatchSource.makeReadSource(fileDescriptor: stdoutDescriptor, queue: self.queue)
+        stdoutSource.setEventHandler { [weak self] in
+            let data = Self.readAvailable(fileDescriptor: stdoutDescriptor, byteCount: stdoutSource.data)
+            Task { @MainActor [weak self] in
+                self?.consumeStdout(data, generation: generation)
+            }
+        }
+        self.stdoutSource = stdoutSource
+        stdoutSource.resume()
+
+        let stderrDescriptor = stderrPipe.fileHandleForReading.fileDescriptor
+        let stderrSource = DispatchSource.makeReadSource(fileDescriptor: stderrDescriptor, queue: self.queue)
+        stderrSource.setEventHandler { [weak self] in
+            let data = Self.readAvailable(fileDescriptor: stderrDescriptor, byteCount: stderrSource.data)
+            Task { @MainActor [weak self] in
+                self?.consumeStderr(data, generation: generation)
+            }
+        }
+        self.stderrSource = stderrSource
+        stderrSource.resume()
+    }
+
+    private func installStartupWatchdog(generation: UUID) {
+        let timer = DispatchSource.makeTimerSource(queue: self.queue)
+        timer.schedule(deadline: .now() + 5)
+        timer.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.processGeneration == generation else { return }
+                self.startupWatchdog?.cancel()
+                self.startupWatchdog = nil
+                if self.process?.isRunning == true {
+                    self.retryAttempt = 0
+                    self.logger.debug("cookie sync startup watchdog passed")
+                }
+            }
+        }
+        self.startupWatchdog = timer
+        timer.resume()
+    }
+
+    private func consumeStdout(_ data: Data, generation: UUID) {
+        guard self.processGeneration == generation else { return }
+        guard !data.isEmpty else {
+            self.stdoutSource?.cancel()
+            self.stdoutSource = nil
+            return
+        }
+        self.stdoutBuffer.append(data)
+        if self.stdoutBuffer.count > 64 * 1024 {
+            self.stdoutBuffer.removeFirst(self.stdoutBuffer.count - 64 * 1024)
+        }
+        while let newline = self.stdoutBuffer.firstIndex(of: 0x0A) {
+            let lineData = self.stdoutBuffer.prefix(upTo: newline)
+            self.stdoutBuffer.removeSubrange(...newline)
+            let line = String(decoding: lineData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            self.lastSummary = line
+            self.logger.info("cookie sync: \(line, privacy: .public)")
+        }
+    }
+
+    private func consumeStderr(_ data: Data, generation: UUID) {
+        guard self.processGeneration == generation else { return }
+        guard !data.isEmpty else {
+            self.stderrSource?.cancel()
+            self.stderrSource = nil
+            return
+        }
+        let message = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !message.isEmpty {
+            self.logger.error("cookie sync stderr: \(message, privacy: .private)")
+        }
+    }
+
+    private func childTerminated(generation: UUID, status: Int32) {
+        guard self.processGeneration == generation else { return }
+        self.stopChild(nextState: .error("Cookie sync exited with status \(status)"))
+        self.scheduleRetry()
+    }
+
+    private func scheduleRetry() {
+        guard self.shouldBeActive else { return }
+        self.retryAttempt += 1
+        let delaySeconds = min(30, 1 << min(self.retryAttempt - 1, 5))
+        self.retryTask?.cancel()
+        self.retryTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(delaySeconds))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.scheduleReconcile(resetRetry: false, delay: .zero)
+        }
+    }
+
+    private var shouldBeActive: Bool {
+        guard let appState = self.appState else { return false }
+        return appState.cookieSyncEnabled &&
+            appState.connectionMode == .remote &&
+            !Self.normalizedDomains(appState.cookieSyncDomains).isEmpty
+    }
+
+    private func stopChild(nextState: State) {
+        self.startupWatchdog?.cancel()
+        self.startupWatchdog = nil
+        self.stdoutSource?.cancel()
+        self.stdoutSource = nil
+        self.stderrSource?.cancel()
+        self.stderrSource = nil
+        let process = self.process
+        self.process = nil
+        self.processGeneration = nil
+        self.runningIntent = nil
+        try? self.stdoutPipe?.fileHandleForReading.close()
+        try? self.stdoutPipe?.fileHandleForWriting.close()
+        try? self.stderrPipe?.fileHandleForReading.close()
+        try? self.stderrPipe?.fileHandleForWriting.close()
+        self.stdoutPipe = nil
+        self.stderrPipe = nil
+        self.stdoutBuffer.removeAll(keepingCapacity: false)
+        if process?.isRunning == true {
+            process?.terminate()
+        }
+        self.state = nextState
+    }
+
+    private nonisolated static func readAvailable(fileDescriptor: Int32, byteCount: UInt) -> Data {
+        let count = max(1, min(Int(byteCount), 64 * 1024))
+        var data = Data(count: count)
+        let bytesRead = data.withUnsafeMutableBytes { buffer in
+            Darwin.read(fileDescriptor, buffer.baseAddress, count)
+        }
+        guard bytesRead > 0 else { return Data() }
+        data.removeSubrange(bytesRead..<data.count)
+        return data
+    }
+}

--- a/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
+++ b/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
@@ -85,6 +85,8 @@ final class CookieSyncManager: NSObject {
     }
 
     func stop() {
+        // This singleton's notification lifetime follows its explicit start/stop lifecycle.
+        // swiftlint:disable:next notification_center_detachment
         NotificationCenter.default.removeObserver(self)
         self.endpointTask?.cancel()
         self.endpointTask = nil
@@ -318,6 +320,8 @@ final class CookieSyncManager: NSObject {
         while let newline = self.stdoutBuffer.firstIndex(of: 0x0A) {
             let lineData = self.stdoutBuffer.prefix(upTo: newline)
             self.stdoutBuffer.removeSubrange(...newline)
+            // Preserve lossy decoding so malformed CLI bytes do not hide the rest of a status line.
+            // swiftlint:disable:next optional_data_string_conversion
             let line = String(decoding: lineData, as: UTF8.self)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !line.isEmpty else { continue }
@@ -333,6 +337,8 @@ final class CookieSyncManager: NSObject {
             self.stderrSource = nil
             return
         }
+        // Preserve lossy decoding so malformed CLI bytes do not hide useful diagnostics.
+        // swiftlint:disable:next optional_data_string_conversion
         let message = String(decoding: data, as: UTF8.self)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if !message.isEmpty {

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -27,6 +27,7 @@ struct GeneralSettings: View {
     @State private var remoteStatus: RemoteStatus = .idle
     @State private var showRemoteAdvanced = false
     @State private var computerControlPermissions = ComputerControlPermissionSnapshot.probe()
+    @State private var cookieSyncManager = CookieSyncManager.shared
     private let isPreview = ProcessInfo.processInfo.isPreview
     private var isNixMode: Bool {
         ProcessInfo.processInfo.isNixMode
@@ -192,6 +193,56 @@ struct GeneralSettings: View {
                 }
             }
 
+            SettingsCardGroup("Cookie sync") {
+                SettingsCardToggleRow(
+                    title: "Sync cookies to the remote computer",
+                    subtitle: """
+                    Continuously copy this Mac's logged-in cookies for the domains below into the remote OpenClaw \
+                    browser profile. Off by default.
+                    """,
+                    binding: self.$state.cookieSyncEnabled)
+                    .disabled(self.state.connectionMode != .remote)
+
+                SettingsCardRow(
+                    title: "Domains",
+                    subtitle: "Cookies are only synced for these domains; an empty list means nothing is synced.")
+                {
+                    DomainAllowlistEditor(domains: self.$state.cookieSyncDomains)
+                        .frame(width: 320)
+                }
+                .disabled(self.state.connectionMode != .remote)
+
+                SettingsCardRow(
+                    title: "Target profile",
+                    subtitle: "Managed profile on the remote computer that receives the cookies.")
+                {
+                    TextField("imported", text: self.$state.cookieSyncIntoProfile)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 200)
+                }
+                .disabled(self.state.connectionMode != .remote)
+
+                SettingsCardRow(
+                    title: "Status",
+                    subtitle: .verbatim(self.cookieSyncStatusDetail),
+                    showsDivider: self.state.connectionMode != .remote)
+                {
+                    Label(self.cookieSyncStatusTitle, systemImage: self.cookieSyncStatusIcon)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(self.cookieSyncStatusColor)
+                }
+
+                if self.state.connectionMode != .remote {
+                    SettingsCardRow(
+                        title: "Remote mode required",
+                        subtitle: "Cookie sync applies when OpenClaw runs on another computer (remote mode).",
+                        showsDivider: false)
+                    {
+                        EmptyView()
+                    }
+                }
+            }
+
             SettingsCardGroup("Developer") {
                 SettingsCardToggleRow(
                     title: "Enable debug tools",
@@ -346,6 +397,41 @@ struct GeneralSettings: View {
         switch self.computerControlPermissions.diagnostic {
         case .granted: .green
         case .missing, .accessibilityGrantMayBeStale: .orange
+        }
+    }
+
+    private var cookieSyncStatusTitle: String {
+        switch self.cookieSyncManager.state {
+        case .stopped: "Stopped"
+        case .running: "Running"
+        case .error: "Error"
+        }
+    }
+
+    private var cookieSyncStatusDetail: String {
+        switch self.cookieSyncManager.state {
+        case .stopped:
+            self.cookieSyncManager.lastSummary.map { "Last sync: \($0)" } ?? "Cookie sync is not active."
+        case .running:
+            self.cookieSyncManager.lastSummary ?? "Watching this Mac's browser cookie store for changes."
+        case let .error(message):
+            message
+        }
+    }
+
+    private var cookieSyncStatusIcon: String {
+        switch self.cookieSyncManager.state {
+        case .stopped: "stop.circle"
+        case .running: "checkmark.circle.fill"
+        case .error: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var cookieSyncStatusColor: Color {
+        switch self.cookieSyncManager.state {
+        case .stopped: .secondary
+        case .running: .green
+        case .error: .orange
         }
     }
 
@@ -819,6 +905,52 @@ struct GeneralSettings: View {
         case .checking: return .secondary
         case .missingNode, .missingGateway, .incompatible, .error: return .orange
         }
+    }
+}
+
+private struct DomainAllowlistEditor: View {
+    @Binding var domains: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(self.domains.indices, id: \.self) { index in
+                HStack(spacing: 8) {
+                    TextField("example.com", text: self.binding(for: index))
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { self.normalizeEntries() }
+
+                    Button("Remove") {
+                        self.domains.remove(at: index)
+                        self.normalizeEntries()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+
+            Button("Add domain") {
+                guard !self.domains.contains(where: {
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }) else { return }
+                self.domains.append("")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .onDisappear { self.normalizeEntries() }
+    }
+
+    private func binding(for index: Int) -> Binding<String> {
+        Binding(
+            get: { self.domains.indices.contains(index) ? self.domains[index] : "" },
+            set: { value in
+                guard self.domains.indices.contains(index) else { return }
+                self.domains[index] = value
+            })
+    }
+
+    private func normalizeEntries() {
+        self.domains = CookieSyncManager.normalizedDomains(self.domains)
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -400,41 +400,6 @@ struct GeneralSettings: View {
         }
     }
 
-    private var cookieSyncStatusTitle: String {
-        switch self.cookieSyncManager.state {
-        case .stopped: "Stopped"
-        case .running: "Running"
-        case .error: "Error"
-        }
-    }
-
-    private var cookieSyncStatusDetail: String {
-        switch self.cookieSyncManager.state {
-        case .stopped:
-            self.cookieSyncManager.lastSummary.map { "Last sync: \($0)" } ?? "Cookie sync is not active."
-        case .running:
-            self.cookieSyncManager.lastSummary ?? "Watching this Mac's browser cookie store for changes."
-        case let .error(message):
-            message
-        }
-    }
-
-    private var cookieSyncStatusIcon: String {
-        switch self.cookieSyncManager.state {
-        case .stopped: "stop.circle"
-        case .running: "checkmark.circle.fill"
-        case .error: "exclamationmark.triangle.fill"
-        }
-    }
-
-    private var cookieSyncStatusColor: Color {
-        switch self.cookieSyncManager.state {
-        case .stopped: .secondary
-        case .running: .green
-        case .error: .orange
-        }
-    }
-
     private var connectionStatusPanel: some View {
         HStack(alignment: .center, spacing: 14) {
             ZStack {
@@ -904,6 +869,43 @@ struct GeneralSettings: View {
         case .ok: return .green
         case .checking: return .secondary
         case .missingNode, .missingGateway, .incompatible, .error: return .orange
+        }
+    }
+}
+
+extension GeneralSettings {
+    private var cookieSyncStatusTitle: String {
+        switch self.cookieSyncManager.state {
+        case .stopped: "Stopped"
+        case .running: "Running"
+        case .error: "Error"
+        }
+    }
+
+    private var cookieSyncStatusDetail: String {
+        switch self.cookieSyncManager.state {
+        case .stopped:
+            self.cookieSyncManager.lastSummary.map { "Last sync: \($0)" } ?? "Cookie sync is not active."
+        case .running:
+            self.cookieSyncManager.lastSummary ?? "Watching this Mac's browser cookie store for changes."
+        case let .error(message):
+            message
+        }
+    }
+
+    private var cookieSyncStatusIcon: String {
+        switch self.cookieSyncManager.state {
+        case .stopped: "stop.circle"
+        case .running: "checkmark.circle.fill"
+        case .error: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var cookieSyncStatusColor: Color {
+        switch self.cookieSyncManager.state {
+        case .stopped: .secondary
+        case .running: .green
+        case .error: .orange
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -599,6 +599,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ExecApprovalsPromptServer.shared.start()
         ExecApprovalsGatewayPrompter.shared.start()
         MacNodeModeCoordinator.shared.start()
+        if let state {
+            CookieSyncManager.shared.start(state: state)
+        }
         VoiceWakeGlobalSettingsSync.shared.start()
         QuickChatController.shared.start()
         Task { PresenceReporter.shared.start() }
@@ -649,6 +652,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ExecApprovalsPromptServer.shared.stop()
         ExecApprovalsGatewayPrompter.shared.stop()
         MacNodeModeCoordinator.shared.stop()
+        CookieSyncManager.shared.stop()
         TerminationSignalWatcher.shared.stop()
         VoiceWakeGlobalSettingsSync.shared.stop()
         DashboardManager.shared.close()

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -118,6 +118,21 @@ When the macOS app uses a local Gateway, it can offer this import once and make 
 
 System-profile import is enabled by default. Set `browser.allowSystemProfileImport=false` to disable both CLI and agent-triggered imports. Import is host-local and cannot run through the browser node proxy.
 
+### Cookie sync to a remote Gateway
+
+`import-profile` targets a managed profile on the same host. When your OpenClaw Gateway and agent browser run on a separate computer, use `cookie-sync` to decrypt cookies on this Mac and push them into a managed profile on that remote Gateway over the operator connection:
+
+```bash
+openclaw browser cookie-sync --domains github.com,news.ycombinator.com --into work
+openclaw browser --url wss://gateway.example.com cookie-sync --domains github.com --into work --watch
+```
+
+- `--domains` is required. Cookie sync copies live session cookies, so it never sends an unrestricted cookie jar; a missing or empty allowlist is a hard error.
+- `--into` selects the target managed profile on the Gateway (default `imported`); `--gateway`/`--url` selects a remote Gateway (default is the configured/local one).
+- `--watch` keeps the command running and re-pushes when the source Cookies database changes. The macOS Keychain secret is read once per watch session, so you approve a single consent prompt rather than one per change.
+- Decryption is host-local (macOS only) and reuses the same allowlist and Keychain path as `import-profile`. Cookies are decrypted on this Mac and shipped over the existing TLS-pinned Gateway connection; no cookie values are printed.
+- Some Google sessions use device-bound session credentials (DBSC) that stay tied to this Mac and can still require re-authentication after sync. For those sites, prefer driving the browser on the Mac itself through the [browser node proxy](#remote-browser-control-node-host-proxy).
+
 ## Chrome extension relay
 
 ```bash

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -133,6 +133,8 @@ openclaw browser --url wss://gateway.example.com cookie-sync --domains github.co
 - Decryption is host-local (macOS only) and reuses the same allowlist and Keychain path as `import-profile`. Cookies are decrypted on this Mac and shipped over the existing TLS-pinned Gateway connection; no cookie values are printed.
 - Some Google sessions use device-bound session credentials (DBSC) that stay tied to this Mac and can still require re-authentication after sync. For those sites, prefer driving the browser on the Mac itself through the [browser node proxy](#remote-browser-control-node-host-proxy).
 
+The macOS app exposes the same capability under **Settings → General → Cookie sync**: an off-by-default toggle, an editable domain allowlist, and a target-profile field. When enabled in remote mode it supervises `cookie-sync --watch` for you against the connected Gateway and shows a live status row.
+
 ## Chrome extension relay
 
 ```bash

--- a/extensions/browser/src/browser/routes/agent.storage.device.test.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.device.test.ts
@@ -3,6 +3,7 @@ import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helper
 import type { BrowserRequest } from "./types.js";
 
 const routeState = vi.hoisted(() => ({
+  cookiesSetManyViaPlaywright: vi.fn(async () => ({ added: 2 })),
   setDeviceViaPlaywright: vi.fn(async () => {}),
   withPlaywrightRouteContext: vi.fn(),
 }));
@@ -23,20 +24,24 @@ type PlaywrightRouteParams = {
     cdpUrl: string;
     tab: { targetId: string };
     signal: AbortSignal;
-    pw: { setDeviceViaPlaywright: typeof routeState.setDeviceViaPlaywright };
+    pw: {
+      cookiesSetManyViaPlaywright: typeof routeState.cookiesSetManyViaPlaywright;
+      setDeviceViaPlaywright: typeof routeState.setDeviceViaPlaywright;
+    };
   }) => Promise<unknown>;
 };
 
-function getSetDeviceHandler() {
+function getPostHandler(route: string) {
   const { app, postHandlers } = createBrowserRouteApp();
   registerBrowserAgentStorageRoutes(app, {} as never);
-  const handler = postHandlers.get("/set/device");
+  const handler = postHandlers.get(route);
   expect(handler).toBeTypeOf("function");
   return handler;
 }
 
 describe("browser device route", () => {
   beforeEach(() => {
+    routeState.cookiesSetManyViaPlaywright.mockClear();
     routeState.setDeviceViaPlaywright.mockClear();
     routeState.withPlaywrightRouteContext
       .mockReset()
@@ -45,7 +50,10 @@ describe("browser device route", () => {
           cdpUrl: "http://127.0.0.1:18800",
           tab: { targetId: "tab-1" },
           signal: params.req.signal ?? new AbortController().signal,
-          pw: { setDeviceViaPlaywright: routeState.setDeviceViaPlaywright },
+          pw: {
+            cookiesSetManyViaPlaywright: routeState.cookiesSetManyViaPlaywright,
+            setDeviceViaPlaywright: routeState.setDeviceViaPlaywright,
+          },
         });
       });
   });
@@ -54,7 +62,7 @@ describe("browser device route", () => {
     const controller = new AbortController();
     const response = createBrowserRouteResponse();
 
-    await getSetDeviceHandler()?.(
+    await getPostHandler("/set/device")?.(
       {
         params: {},
         query: {},
@@ -71,5 +79,74 @@ describe("browser device route", () => {
       signal: controller.signal,
     });
     expect(response.body).toEqual({ ok: true, targetId: "tab-1" });
+  });
+});
+
+describe("browser cookie batch route", () => {
+  beforeEach(() => {
+    routeState.cookiesSetManyViaPlaywright.mockClear();
+    routeState.withPlaywrightRouteContext
+      .mockReset()
+      .mockImplementation(async (params: PlaywrightRouteParams) => {
+        await params.run({
+          cdpUrl: "http://127.0.0.1:18800",
+          tab: { targetId: "tab-1" },
+          signal: params.req.signal ?? new AbortController().signal,
+          pw: {
+            cookiesSetManyViaPlaywright: routeState.cookiesSetManyViaPlaywright,
+            setDeviceViaPlaywright: routeState.setDeviceViaPlaywright,
+          },
+        });
+      });
+  });
+
+  it("parses and injects a non-empty cookie batch", async () => {
+    const controller = new AbortController();
+    const response = createBrowserRouteResponse();
+    const cookies = [
+      {
+        name: "session",
+        value: "secret",
+        domain: ".example.com",
+        path: "/",
+        expires: 1_700_000_000,
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+      },
+      { name: "theme", value: "dark", url: "https://example.com" },
+    ];
+
+    await getPostHandler("/cookies/set-many")?.(
+      {
+        params: {},
+        query: {},
+        body: { targetId: "requested-tab", cookies },
+        signal: controller.signal,
+      },
+      response.res,
+    );
+
+    expect(routeState.cookiesSetManyViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18800",
+      targetId: "tab-1",
+      cookies,
+      signal: controller.signal,
+    });
+    expect(response.body).toEqual({ ok: true, targetId: "tab-1", added: 2 });
+  });
+
+  it.each([
+    ["missing", {}],
+    ["empty", { cookies: [] }],
+    ["non-array", { cookies: {} }],
+  ])("rejects a %s cookies payload", async (_label, body) => {
+    const response = createBrowserRouteResponse();
+
+    await getPostHandler("/cookies/set-many")?.({ params: {}, query: {}, body }, response.res);
+
+    expect(response.statusCode).toBe(400);
+    expect(routeState.withPlaywrightRouteContext).not.toHaveBeenCalled();
+    expect(routeState.cookiesSetManyViaPlaywright).not.toHaveBeenCalled();
   });
 });

--- a/extensions/browser/src/browser/routes/agent.storage.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.ts
@@ -233,6 +233,47 @@ export function registerBrowserAgentStorageRoutes(
     });
   });
 
+  app.post("/cookies/set-many", async (req, res) => {
+    const body = readBody(req);
+    const targetId = resolveTargetIdFromBody(body);
+    const rawCookies = body.cookies;
+    if (!Array.isArray(rawCookies) || rawCookies.length === 0) {
+      return jsonError(res, 400, "cookies must be a non-empty array");
+    }
+    const cookieRecords: Record<string, unknown>[] = [];
+    for (const cookie of rawCookies) {
+      if (!cookie || typeof cookie !== "object" || Array.isArray(cookie)) {
+        return jsonError(res, 400, "cookies must contain only cookie objects");
+      }
+      cookieRecords.push(cookie as Record<string, unknown>);
+    }
+    let cookies: CookieSetOptions[];
+    try {
+      cookies = cookieRecords.map((cookie) => parseCookieSetOptions(cookie));
+    } catch (err) {
+      return jsonError(res, 400, formatErrorMessage(err));
+    }
+
+    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature: "cookies set-many",
+      run: async ({ cdpUrl, tab, pw, signal }) => {
+        const result = await pw.cookiesSetManyViaPlaywright({
+          cdpUrl,
+          targetId: tab.targetId,
+          cookies,
+          signal,
+        });
+        signal.throwIfAborted();
+        res.json({ ok: true, targetId: tab.targetId, added: result.added });
+      },
+    });
+  });
+
   app.post("/cookies/clear", async (req, res) => {
     const body = readBody(req);
     const targetId = resolveTargetIdFromBody(body);

--- a/extensions/browser/src/browser/system-chrome-cookies.ts
+++ b/extensions/browser/src/browser/system-chrome-cookies.ts
@@ -5,7 +5,7 @@ import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 
 export type SystemBrowser = "chrome" | "brave" | "edge" | "chromium";
 
-type PlaywrightCookie = {
+export type PlaywrightCookie = {
   name: string;
   value: string;
   domain: string;
@@ -30,7 +30,7 @@ type ChromeCookieRow = {
   samesite: number | bigint;
 };
 
-type CookieImportCounts = {
+export type CookieImportCounts = {
   total: number;
   imported: number;
   failed: number;
@@ -108,6 +108,23 @@ async function readKeychainSecret(entry: KeychainEntry, signal?: AbortSignal): P
     throw new Error(`macOS Keychain returned an empty ${entry.service} secret`);
   }
   return secret;
+}
+
+/** Read and retain one Safe Storage secret for a long-running cookie sync session. */
+export async function cacheKeychainSecret(
+  browser: SystemBrowser,
+  signal?: AbortSignal,
+): Promise<KeychainSecretReader> {
+  const entry = KEYCHAIN_ENTRIES[browser];
+  const secret = await readKeychainSecret(entry, signal);
+  return async (requestedEntry, requestedSignal) => {
+    requestedSignal?.throwIfAborted();
+    if (requestedEntry.service !== entry.service || requestedEntry.account !== entry.account) {
+      throw new Error("cached Keychain secret does not match the selected system browser");
+    }
+    // The decryptor zeroes caller-owned secret buffers, so retain only this private copy.
+    return Buffer.from(secret);
+  };
 }
 
 /** Convert Chromium's Windows-epoch microseconds to Unix seconds. */

--- a/extensions/browser/src/browser/system-profiles.test.ts
+++ b/extensions/browser/src/browser/system-profiles.test.ts
@@ -1,0 +1,178 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test-support.js";
+
+const profileMocks = vi.hoisted(() => ({
+  managedUserDataDir: "",
+  cookiesSetManyViaPlaywright: vi.fn(async (params: { cookies: unknown[] }) => ({
+    added: params.cookies.length,
+  })),
+}));
+
+vi.mock("./chrome.js", () => ({
+  resolveOpenClawUserDataDir: () => profileMocks.managedUserDataDir,
+}));
+
+vi.mock("./pw-ai-module.js", () => ({
+  getPwAiModule: vi.fn(async () => ({
+    cookiesSetManyViaPlaywright: profileMocks.cookiesSetManyViaPlaywright,
+  })),
+}));
+
+vi.mock("./server-context.js", () => ({
+  runProfileContextOperation: async (
+    _profile: unknown,
+    signal: AbortSignal | undefined,
+    run: (signal: AbortSignal, runtime: { running: { userDataDir: string } }) => Promise<unknown>,
+    options?: { commit?: (result: unknown) => Promise<void> },
+  ) => {
+    const result = await run(signal ?? new AbortController().signal, {
+      running: { userDataDir: profileMocks.managedUserDataDir },
+    });
+    await options?.commit?.(result);
+    return result;
+  },
+}));
+
+const { readSystemProfileCookies } = await import("../system-profile-api.js");
+const { importSystemProfileCookies } = await import("./system-profiles.js");
+
+const KEYCHAIN_FIXTURE = "fixture-value";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function encryptV10(value: string, host: string): Buffer {
+  const key = crypto.pbkdf2Sync(KEYCHAIN_FIXTURE, "saltysalt", 1003, 16, "sha1");
+  const cipher = crypto.createCipheriv("aes-128-cbc", key, Buffer.alloc(16, 0x20));
+  const plain = Buffer.concat([
+    crypto.createHash("sha256").update(host).digest(),
+    Buffer.from(value),
+  ]);
+  return Buffer.concat([Buffer.from("v10"), cipher.update(plain), cipher.final()]);
+}
+
+function createSystemProfileFixture(): string {
+  const homeDir = tempDirs.make("openclaw-system-profile-test-");
+  const root = path.join(homeDir, "Library", "Application Support", "Google", "Chrome");
+  const profileDir = path.join(root, "Default", "Network");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "Local State"),
+    JSON.stringify({ profile: { info_cache: { Default: { name: "Personal" } } } }),
+  );
+  const database = new DatabaseSync(path.join(profileDir, "Cookies"));
+  try {
+    database.exec(`
+      PRAGMA journal_mode = WAL;
+      CREATE TABLE cookies (
+        host_key TEXT,
+        top_frame_site_key TEXT,
+        name TEXT,
+        value TEXT,
+        encrypted_value BLOB,
+        path TEXT,
+        expires_utc INTEGER,
+        is_secure INTEGER,
+        is_httponly INTEGER,
+        has_expires INTEGER,
+        samesite INTEGER
+      )
+    `);
+    const insert = database.prepare("INSERT INTO cookies VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    for (const [host, name, value] of [
+      [".example.com", "session", "allowed-value"],
+      [".other.test", "other", "blocked-value"],
+    ] as const) {
+      insert.run(host, "", name, "", encryptV10(value, host), "/", 0, 1, 1, 0, -1);
+    }
+  } finally {
+    database.close();
+  }
+  return homeDir;
+}
+
+function createManagedProfileFixture() {
+  profileMocks.managedUserDataDir = tempDirs.make("openclaw-managed-profile-test-");
+  fs.writeFileSync(
+    path.join(profileMocks.managedUserDataDir, "Local State"),
+    JSON.stringify({
+      profile: { info_cache: { Default: { openclaw_mock_keychain: true } } },
+    }),
+  );
+  const profile = {
+    name: "imported",
+    driver: "openclaw" as const,
+    cdpUrl: "http://127.0.0.1:18800",
+    cdpIsLoopback: true,
+    attachOnly: false,
+  };
+  return {
+    ctx: {
+      state: () => ({ resolved: { profiles: { imported: profile } } }),
+      forProfile: () => ({
+        profile,
+        ensureBrowserAvailable: vi.fn(async () => {}),
+        ensureTabAvailable: vi.fn(async () => ({ targetId: "tab-1" })),
+      }),
+    },
+    createProfile: vi.fn(async () => {}),
+  };
+}
+
+describe("system profile cookie reader", () => {
+  beforeEach(() => {
+    profileMocks.cookiesSetManyViaPlaywright.mockClear();
+  });
+
+  it("snapshots, decrypts, and applies the domain allowlist", async () => {
+    const homeDir = createSystemProfileFixture();
+    const readSecret = vi.fn(async () => Buffer.from(KEYCHAIN_FIXTURE));
+
+    const result = await readSystemProfileCookies(
+      { browser: "chrome", systemProfile: "Default", domains: ["example.com"] },
+      { platform: "darwin", homeDir, readSecret },
+    );
+
+    expect(result).toMatchObject({
+      browser: "chrome",
+      systemProfile: "Default",
+      counts: { total: 2, imported: 1, failed: 0, skipped: 1 },
+      domains: [".example.com"],
+    });
+    expect(result.cookies).toEqual([
+      expect.objectContaining({
+        name: "session",
+        value: "allowed-value",
+        domain: ".example.com",
+      }),
+    ]);
+    expect(readSecret).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the existing import flow on the shared reader", async () => {
+    const homeDir = createSystemProfileFixture();
+    const runtime = createManagedProfileFixture();
+
+    const result = await importSystemProfileCookies(
+      { browser: "chrome", systemProfile: "Default", into: "imported", domains: ["example.com"] },
+      runtime as never,
+      {
+        platform: "darwin",
+        homeDir,
+        cfg: { browser: {} },
+        readSecret: async () => Buffer.from(KEYCHAIN_FIXTURE),
+      },
+    );
+
+    expect(result.cookies).toEqual({ total: 2, imported: 1, failed: 0, skipped: 1 });
+    expect(profileMocks.cookiesSetManyViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: "http://127.0.0.1:18800",
+        targetId: "tab-1",
+        cookies: [expect.objectContaining({ domain: ".example.com", name: "session" })],
+      }),
+    );
+  });
+});

--- a/extensions/browser/src/browser/system-profiles.ts
+++ b/extensions/browser/src/browser/system-profiles.ts
@@ -14,7 +14,9 @@ import { type BrowserRouteContext, runProfileContextOperation } from "./server-c
 import { isProfileRestartRequiredError } from "./server-context.lifecycle.js";
 import {
   readChromeCookiesDatabase,
+  type CookieImportCounts,
   type KeychainSecretReader,
+  type PlaywrightCookie,
   type SystemBrowser,
 } from "./system-chrome-cookies.js";
 
@@ -44,11 +46,14 @@ export type ImportSystemProfileResult = {
 
 type CreateProfile = (params: { name: string; driver?: "openclaw" }) => Promise<unknown>;
 
-type SystemProfileDeps = {
+type SystemCookieReaderDeps = {
   platform?: NodeJS.Platform;
   homeDir?: string;
-  cfg?: OpenClawConfig;
   readSecret?: KeychainSecretReader;
+};
+
+type SystemProfileDeps = SystemCookieReaderDeps & {
+  cfg?: OpenClawConfig;
 };
 
 const SYSTEM_BROWSER_DIRS: Record<SystemBrowser, string[]> = {
@@ -58,6 +63,7 @@ const SYSTEM_BROWSER_DIRS: Record<SystemBrowser, string[]> = {
   chromium: ["Chromium"],
 };
 
+/** Normalize a supported Chrome-family browser identifier. */
 function resolveSystemBrowser(value?: string): SystemBrowser {
   const browser = value?.trim().toLowerCase() || "chrome";
   if (browser === "chrome" || browser === "brave" || browser === "edge" || browser === "chromium") {
@@ -66,6 +72,7 @@ function resolveSystemBrowser(value?: string): SystemBrowser {
   throw new Error(`unsupported system browser "${value}"; use chrome, brave, edge, or chromium`);
 }
 
+/** Resolve the macOS user-data root for one Chrome-family browser. */
 function resolveSystemBrowserRoot(browser: SystemBrowser, homeDir = os.homedir()): string {
   return path.join(homeDir, "Library", "Application Support", ...SYSTEM_BROWSER_DIRS[browser]);
 }
@@ -77,6 +84,31 @@ function resolveSystemCookiesFile(root: string, profileId: string): string | und
     path.join(root, profileId, "Cookies"),
   ];
   return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+/** Enforce the host-local platform contract before touching browser cookie state. */
+export function assertSystemCookiePlatform(
+  platform = process.platform,
+  operation = "cookie access",
+): void {
+  if (platform !== "darwin") {
+    throw new Error(`system profile ${operation} is only supported on macOS in this release`);
+  }
+}
+
+/** Resolve one Chrome-family profile's source cookie database. */
+export function resolveSystemCookieSource(
+  params: { browser?: string; systemProfile?: string },
+  deps: Pick<SystemCookieReaderDeps, "homeDir"> = {},
+): { browser: SystemBrowser; systemProfile: string; cookiesFile: string } {
+  const browser = resolveSystemBrowser(params.browser);
+  const systemProfile = params.systemProfile?.trim() || "Default";
+  const root = resolveSystemBrowserRoot(browser, deps.homeDir);
+  const cookiesFile = resolveSystemCookiesFile(root, systemProfile);
+  if (!cookiesFile) {
+    throw new Error(`cookies database not found for ${browser} profile "${systemProfile}"`);
+  }
+  return { browser, systemProfile, cookiesFile };
 }
 
 function readProfileNames(root: string): Map<string, string> {
@@ -134,10 +166,7 @@ export function listSystemProfiles(
 }
 
 /** Create a transactionally coherent snapshot while Chrome may be writing its WAL. */
-function snapshotCookieDatabase(source: string): {
-  databasePath: string;
-  cleanup: () => void;
-} {
+function snapshotCookieDatabase(source: string): { databasePath: string; cleanup: () => void } {
   const tmpRoot = resolvePreferredOpenClawTmpDir();
   fs.mkdirSync(tmpRoot, { recursive: true });
   const tempDir = fs.mkdtempSync(path.join(tmpRoot, "openclaw-system-cookies-"));
@@ -158,6 +187,39 @@ function snapshotCookieDatabase(source: string): {
   };
 }
 
+/** Snapshot and decrypt cookies from one local macOS Chrome-family profile. */
+export async function readSystemProfileCookies(
+  params: {
+    browser?: string;
+    systemProfile?: string;
+    domains?: readonly string[];
+    signal?: AbortSignal;
+  },
+  deps: SystemCookieReaderDeps = {},
+): Promise<{
+  browser: SystemBrowser;
+  systemProfile: string;
+  cookies: PlaywrightCookie[];
+  counts: CookieImportCounts;
+  domains: string[];
+}> {
+  assertSystemCookiePlatform(deps.platform);
+  const source = resolveSystemCookieSource(params, deps);
+  const snapshot = snapshotCookieDatabase(source.cookiesFile);
+  try {
+    const decrypted = await readChromeCookiesDatabase({
+      browser: source.browser,
+      databasePath: snapshot.databasePath,
+      domains: params.domains,
+      readSecret: deps.readSecret,
+      signal: params.signal,
+    });
+    return { browser: source.browser, systemProfile: source.systemProfile, ...decrypted };
+  } finally {
+    snapshot.cleanup();
+  }
+}
+
 /** Import decrypted system-profile cookies into one managed OpenClaw profile. */
 export async function importSystemProfileCookies(
   params: ImportSystemProfileParams,
@@ -169,9 +231,7 @@ export async function importSystemProfileCookies(
   },
   deps: SystemProfileDeps = {},
 ): Promise<ImportSystemProfileResult> {
-  if ((deps.platform ?? process.platform) !== "darwin") {
-    throw new Error("system profile import is only supported on macOS in this release");
-  }
+  assertSystemCookiePlatform(deps.platform, "import");
   const cfg = deps.cfg ?? getRuntimeConfig();
   if (cfg.browser?.allowSystemProfileImport === false) {
     throw new Error("system profile import is disabled (browser.allowSystemProfileImport=false)");
@@ -227,60 +287,52 @@ export async function importSystemProfileCookies(
             );
           }
 
-          const copied = snapshotCookieDatabase(cookiesFile);
-          try {
-            const decrypted = await readChromeCookiesDatabase({
-              browser,
-              databasePath: copied.databasePath,
-              domains: params.domains,
-              readSecret: deps.readSecret,
+          const decrypted = await readSystemProfileCookies(
+            { browser, systemProfile, domains: params.domains, signal },
+            deps,
+          );
+          signal.throwIfAborted();
+          const pw = await getPwAiModule({ mode: "strict" });
+          if (!pw) {
+            throw new Error("Playwright is required to import system profile cookies");
+          }
+          let injected = 0;
+          if (decrypted.cookies.length > 0) {
+            const tab = await profileCtx.ensureTabAvailable(undefined, {
+              allowPlaywrightFallback: true,
               signal,
             });
-            signal.throwIfAborted();
-            const pw = await getPwAiModule({ mode: "strict" });
-            if (!pw) {
-              throw new Error("Playwright is required to import system profile cookies");
-            }
-            let injected = 0;
-            if (decrypted.cookies.length > 0) {
-              const tab = await profileCtx.ensureTabAvailable(undefined, {
-                allowPlaywrightFallback: true,
+            try {
+              const result = await pw.cookiesSetManyViaPlaywright({
+                cdpUrl: profileCtx.profile.cdpUrl,
+                targetId: tab.targetId,
+                cookies: decrypted.cookies,
                 signal,
               });
-              try {
-                const result = await pw.cookiesSetManyViaPlaywright({
-                  cdpUrl: profileCtx.profile.cdpUrl,
-                  targetId: tab.targetId,
-                  cookies: decrypted.cookies,
-                  signal,
-                });
-                signal.throwIfAborted();
-                injected = result.added;
-              } catch {
-                // Session/CDP errors may include rejected cookie payloads. Keep decrypted values private.
-                throw new Error(`failed to inject imported cookies into managed profile "${into}"`);
-              }
+              signal.throwIfAborted();
+              injected = result.added;
+            } catch {
+              // Session/CDP errors may include rejected cookie payloads. Keep decrypted values private.
+              throw new Error(`failed to inject imported cookies into managed profile "${into}"`);
             }
-            // Cookies rejected by Playwright are counted, not fatal: the import stays
-            // best-effort and imported reflects what actually landed in the profile.
-            const rejected = decrypted.cookies.length - injected;
-            const result: ImportSystemProfileResult = {
-              ok: true,
-              systemProfile,
-              into,
-              browser,
-              cookies: {
-                total: decrypted.counts.total,
-                imported: injected,
-                failed: decrypted.counts.failed + rejected,
-                skipped: decrypted.counts.skipped,
-              },
-              domains: decrypted.domains,
-            };
-            return result;
-          } finally {
-            copied.cleanup();
           }
+          // Cookies rejected by Playwright are counted, not fatal: the import stays
+          // best-effort and imported reflects what actually landed in the profile.
+          const rejected = decrypted.cookies.length - injected;
+          const result: ImportSystemProfileResult = {
+            ok: true,
+            systemProfile,
+            into,
+            browser,
+            cookies: {
+              total: decrypted.counts.total,
+              imported: injected,
+              failed: decrypted.counts.failed + rejected,
+              skipped: decrypted.counts.skipped,
+            },
+            domains: decrypted.domains,
+          };
+          return result;
         },
         {
           commit: async (result) => await runtime.finalize?.(result),

--- a/extensions/browser/src/cli/browser-cli-cookie-sync.test.ts
+++ b/extensions/browser/src/cli/browser-cli-cookie-sync.test.ts
@@ -1,0 +1,140 @@
+import { Command } from "commander";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCliRuntimeCapture } from "../../test-support.js";
+import * as parentCoreApiModule from "../core-api.js";
+import * as cliCoreApiModule from "./core-api.js";
+
+const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGatewayFromCli: vi.fn(async () => ({ ok: true, targetId: "tab-1", added: 1 })),
+}));
+
+const systemProfileMocks = vi.hoisted(() => ({
+  readSystemProfileCookies: vi.fn(async () => ({
+    browser: "chrome" as const,
+    systemProfile: "Default",
+    cookies: [
+      {
+        name: "session",
+        value: "cookie-secret",
+        domain: ".example.com",
+        path: "/",
+        httpOnly: true,
+        secure: true,
+      },
+    ],
+    counts: { total: 2, imported: 1, failed: 0, skipped: 1 },
+    domains: [".example.com"],
+  })),
+}));
+
+vi.mock("../sdk-node-runtime.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../sdk-node-runtime.js")>("../sdk-node-runtime.js");
+  return { ...actual, callGatewayFromCli: gatewayMocks.callGatewayFromCli };
+});
+
+vi.mock("../system-profile-api.js", () => ({
+  assertSystemCookiePlatform: vi.fn(),
+  readSystemProfileCookies: systemProfileMocks.readSystemProfileCookies,
+  resolveSystemCookieSource: vi.fn(),
+}));
+
+vi.spyOn(parentCoreApiModule, "runCommandWithRuntime").mockImplementation(
+  async (_runtime, action, onError) => {
+    try {
+      await action();
+    } catch (error) {
+      onError?.(error);
+    }
+  },
+);
+vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(runtime.log);
+vi.spyOn(cliCoreApiModule.defaultRuntime, "error").mockImplementation(runtime.error);
+vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(runtime.exit);
+
+let registerBrowserCookieSyncCommand: typeof import("./browser-cli-cookie-sync.js").registerBrowserCookieSyncCommand;
+
+function createProgram() {
+  const program = new Command();
+  const browser = program
+    .command("browser")
+    .option("--url <url>", "Gateway URL")
+    .option("--token <token>", "Gateway token")
+    .option("--timeout <ms>", "Timeout", "30000");
+  registerBrowserCookieSyncCommand(browser, (command) => command.optsWithGlobals());
+  return program;
+}
+
+describe("browser cookie-sync CLI", () => {
+  beforeAll(async () => {
+    ({ registerBrowserCookieSyncCommand } = await import("./browser-cli-cookie-sync.js"));
+  });
+
+  beforeEach(() => {
+    resetRuntimeCapture();
+    gatewayMocks.callGatewayFromCli.mockClear();
+    systemProfileMocks.readSystemProfileCookies.mockClear();
+  });
+
+  it("requires a non-empty domain allowlist before any read or gateway call", async () => {
+    await expect(
+      createProgram().parseAsync(["browser", "cookie-sync"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("--domains is required");
+    expect(systemProfileMocks.readSystemProfileCookies).not.toHaveBeenCalled();
+    expect(gatewayMocks.callGatewayFromCli).not.toHaveBeenCalled();
+  });
+
+  it("reads allowlisted cookies locally and posts them through browser.request", async () => {
+    await createProgram().parseAsync(
+      [
+        "browser",
+        "--url",
+        "wss://gateway.example",
+        "--token",
+        "test-token",
+        "cookie-sync",
+        "--domains",
+        "example.com, accounts.example.com",
+        "--into",
+        "work",
+        "--browser",
+        "chrome",
+        "--system",
+        "Profile 1",
+      ],
+      { from: "user" },
+    );
+
+    expect(systemProfileMocks.readSystemProfileCookies).toHaveBeenCalledWith(
+      {
+        browser: "chrome",
+        systemProfile: "Profile 1",
+        domains: ["example.com", "accounts.example.com"],
+        signal: undefined,
+      },
+      { readSecret: undefined },
+    );
+    expect(gatewayMocks.callGatewayFromCli).toHaveBeenCalledWith(
+      "browser.request",
+      expect.objectContaining({ url: "wss://gateway.example", token: "test-token" }),
+      {
+        method: "POST",
+        path: "/cookies/set-many",
+        query: { profile: "work" },
+        body: {
+          cookies: [expect.objectContaining({ name: "session", domain: ".example.com" })],
+        },
+        timeoutMs: 30_000,
+      },
+      { progress: undefined, scopes: ["operator.admin"] },
+    );
+    expect(runtime.log.mock.calls.at(-1)?.[0]).toContain(
+      "chrome/Default -> work via wss://gateway.example",
+    );
+    expect(runtime.log.mock.calls.at(-1)?.[0]).not.toContain("cookie-secret");
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-cookie-sync.ts
+++ b/extensions/browser/src/cli/browser-cli-cookie-sync.ts
@@ -1,0 +1,230 @@
+/** Host-local macOS system-cookie sync into a managed Browser profile. */
+import fs from "node:fs";
+import path from "node:path";
+import type { Command } from "commander";
+import {
+  cacheKeychainSecret,
+  type KeychainSecretReader,
+} from "../browser/system-chrome-cookies.js";
+import { parseSystemProfileDomains } from "../browser/system-profile-domains.js";
+import {
+  assertSystemCookiePlatform,
+  readSystemProfileCookies,
+  resolveSystemCookieSource,
+} from "../system-profile-api.js";
+import {
+  callBrowserRequest,
+  runBrowserCliCommand,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
+import { defaultRuntime } from "./core-api.js";
+
+const COOKIE_SYNC_DEBOUNCE_MS = 1_500;
+
+type CookieSyncOptions = {
+  domains?: string;
+  into: string;
+  browser: string;
+  system: string;
+  watch?: boolean;
+};
+
+type CookieSyncSummary = {
+  browser: string;
+  systemProfile: string;
+  into: string;
+  gateway: string;
+  total: number;
+  pushed: number;
+  skipped: number;
+  failed: number;
+  domains: string[];
+};
+
+function parseCookieSyncDomains(raw: string | undefined): string[] {
+  if (raw === undefined) {
+    throw new Error("--domains is required; cookie sync never sends an unrestricted cookie jar");
+  }
+  const domains = parseSystemProfileDomains(raw.split(","));
+  if (!domains) {
+    throw new Error("--domains must include at least one non-empty domain");
+  }
+  return domains;
+}
+
+function describeGatewayTarget(parent: BrowserParentOpts): string {
+  return parent.url?.trim() || "configured/default";
+}
+
+function formatCookieSyncSummary(summary: CookieSyncSummary): string {
+  const domains = summary.domains.length > 0 ? summary.domains.join(",") : "none";
+  return (
+    `cookie sync ${summary.browser}/${summary.systemProfile} -> ${summary.into} ` +
+    `via ${summary.gateway}: total=${summary.total} pushed=${summary.pushed} ` +
+    `skipped=${summary.skipped} failed=${summary.failed} domains=${domains}`
+  );
+}
+
+async function pushSystemProfileCookies(params: {
+  options: CookieSyncOptions;
+  parent: BrowserParentOpts;
+  domains: readonly string[];
+  signal?: AbortSignal;
+  readSecret?: KeychainSecretReader;
+}): Promise<CookieSyncSummary> {
+  const source = await readSystemProfileCookies(
+    {
+      browser: params.options.browser,
+      systemProfile: params.options.system,
+      domains: params.domains,
+      signal: params.signal,
+    },
+    { readSecret: params.readSecret },
+  );
+  let pushed = 0;
+  if (source.cookies.length > 0) {
+    const result = await callBrowserRequest<{ added: number }>(params.parent, {
+      method: "POST",
+      path: "/cookies/set-many",
+      query: { profile: params.options.into },
+      body: { cookies: source.cookies },
+    });
+    pushed = result.added;
+  }
+  return {
+    browser: source.browser,
+    systemProfile: source.systemProfile,
+    into: params.options.into,
+    gateway: describeGatewayTarget(params.parent),
+    total: source.counts.total,
+    pushed,
+    skipped: source.counts.skipped,
+    failed: source.counts.failed + Math.max(0, source.cookies.length - pushed),
+    domains: source.domains.toSorted(),
+  };
+}
+
+async function watchSystemProfileCookies(params: {
+  options: CookieSyncOptions;
+  parent: BrowserParentOpts;
+  domains: readonly string[];
+}): Promise<void> {
+  assertSystemCookiePlatform();
+  const source = resolveSystemCookieSource({
+    browser: params.options.browser,
+    systemProfile: params.options.system,
+  });
+  const controller = new AbortController();
+  const readSecret = await cacheKeychainSecret(source.browser, controller.signal);
+  let debounce: NodeJS.Timeout | undefined;
+  let inFlight = false;
+  let stopped = false;
+  let stopError: Error | undefined;
+  let resolveStopped: (() => void) | undefined;
+  let rejectStopped: ((error: Error) => void) | undefined;
+  const stoppedPromise = new Promise<void>((resolve, reject) => {
+    resolveStopped = resolve;
+    rejectStopped = reject;
+  });
+
+  const runCycle = async () => {
+    if (stopped || inFlight) {
+      return;
+    }
+    inFlight = true;
+    try {
+      const summary = await pushSystemProfileCookies({
+        ...params,
+        readSecret,
+        signal: controller.signal,
+      });
+      defaultRuntime.error(formatCookieSyncSummary(summary));
+    } catch (error) {
+      if (!stopped) {
+        defaultRuntime.error(`cookie sync failed: ${String(error)}`);
+      }
+    } finally {
+      inFlight = false;
+      if (stopped) {
+        if (stopError) {
+          rejectStopped?.(stopError);
+        } else {
+          resolveStopped?.();
+        }
+      }
+    }
+  };
+
+  const sourceName = path.basename(source.cookiesFile);
+  const watcher = fs.watch(path.dirname(source.cookiesFile), (_event, filename) => {
+    const changedName = filename === null ? null : path.basename(filename);
+    if (
+      changedName !== null &&
+      changedName !== sourceName &&
+      !changedName.startsWith(`${sourceName}-`)
+    ) {
+      return;
+    }
+    clearTimeout(debounce);
+    debounce = setTimeout(() => void runCycle(), COOKIE_SYNC_DEBOUNCE_MS);
+  });
+  const stop = () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    clearTimeout(debounce);
+    watcher.close();
+    controller.abort(new Error("cookie sync stopped"));
+    if (!inFlight) {
+      if (stopError) {
+        rejectStopped?.(stopError);
+      } else {
+        resolveStopped?.();
+      }
+    }
+  };
+  const fail = (error: Error) => {
+    stopError = error;
+    stop();
+  };
+  watcher.on("error", fail);
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  try {
+    await runCycle();
+    await stoppedPromise;
+  } finally {
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
+    watcher.removeListener("error", fail);
+    stop();
+  }
+}
+
+/** Register `browser cookie-sync`. */
+export function registerBrowserCookieSyncCommand(
+  browser: Command,
+  parentOpts: (cmd: Command) => BrowserParentOpts,
+) {
+  browser
+    .command("cookie-sync")
+    .description("Sync allowlisted macOS Chrome-family cookies into a managed profile")
+    .option("--domains <list>", "Required comma-separated domain allowlist")
+    .option("--into <profile>", "Target managed Browser profile", "imported")
+    .option("--browser <browser>", "System browser: chrome, brave, edge, or chromium", "chrome")
+    .option("--system <id>", "System browser profile directory", "Default")
+    .option("--watch", "Watch the source Cookies database and re-sync changes", false)
+    .action((options: CookieSyncOptions, command: Command) =>
+      runBrowserCliCommand(async () => {
+        const domains = parseCookieSyncDomains(options.domains);
+        const parent = parentOpts(command);
+        if (options.watch) {
+          await watchSystemProfileCookies({ options, parent, domains });
+          return;
+        }
+        const summary = await pushSystemProfileCookies({ options, parent, domains });
+        defaultRuntime.log(formatCookieSyncSummary(summary));
+      }),
+    );
+}

--- a/extensions/browser/src/cli/browser-cli.ts
+++ b/extensions/browser/src/cli/browser-cli.ts
@@ -70,6 +70,15 @@ const browserCommandGroupDefinitions: readonly BrowserCommandGroupDefinition[] =
   },
   {
     placeholders: [
+      command("cookie-sync", "Sync allowlisted macOS browser cookies to a managed profile"),
+    ],
+    register: async (args) => {
+      const module = await import("./browser-cli-cookie-sync.js");
+      module.registerBrowserCookieSyncCommand(args.browser, args.parentOpts);
+    },
+  },
+  {
+    placeholders: [
       command("screenshot", "Capture a screenshot (prints the saved path)"),
       command("snapshot", "Capture a snapshot (default: ai; aria is the accessibility tree)"),
     ],

--- a/extensions/browser/src/system-profile-api.ts
+++ b/extensions/browser/src/system-profile-api.ts
@@ -1,0 +1,6 @@
+/** Narrow host-local system-profile surface shared by the Browser runtime and CLI. */
+export {
+  assertSystemCookiePlatform,
+  readSystemProfileCookies,
+  resolveSystemCookieSource,
+} from "./browser/system-profiles.js";


### PR DESCRIPTION
## What Problem This Solves

When OpenClaw runs on its own computer (a dedicated remote box, headless Linux, or a cloud container), the agent's browser starts logged out. You are already authenticated to your sites in Chrome on your Mac, but the remote browser cannot see those sessions, so agent browsing dead-ends on login walls.

This adds **cookie sync**: decrypt selected-domain cookies from this Mac's Chrome-family browser and push them into a managed browser profile on the remote Gateway, continuously, over the connection the app already trusts. It is the useful half of [agentcookie](https://github.com/mvanhorn/agentcookie), rebuilt on OpenClaw's existing primitives — no Tailscale, no bespoke crypto, no separate pairing.

## Why This Change Was Made

Everything needed already existed but was not wired together: macOS Keychain cookie decryption (`system-chrome-cookies.ts`), the fail-closed domain allowlist (`system-profile-domains.ts`), the WAL-safe DB snapshot, the batch Playwright injector (`cookiesSetManyViaPlaywright`), and the CLI's operator transport (`browser.request`). The existing one-shot `import-profile` only targets the *Gateway host's* cookies, so it is macOS/local-only. Cookie sync inverts that: decrypt on the Mac (host-local by contract — the Keychain read must stay here) and ship the decrypted batch to a possibly-remote profile.

Design boundaries kept intact:
- **Decryption stays on the Mac.** The Swift manager resolves a **local** CLI and never the SSH-redirect path, because the Keychain lives here.
- **Off by default.** The macOS toggle defaults false; a fresh install spawns nothing. The domain allowlist is **mandatory** — a missing/empty list is a hard error, never "sync everything".
- **Credentials via environment, never argv.** The app injects `OPENCLAW_GATEWAY_URL` + token/password into the child environment.
- **No cookie values are logged.** Summaries report counts and domains only.

## User Impact

- New CLI: `openclaw browser cookie-sync --domains <csv> --into <profile> [--watch]` (works against local or `--gateway` remote). `--watch` re-syncs on cookie-DB changes with a single Keychain prompt per session.
- New macOS setting: **Settings → General → Cookie sync** — off-by-default toggle, editable domain allowlist, target-profile field, and a live status row. Actionable only in remote-gateway mode.
- New batch route `POST /cookies/set-many` (operator.admin, mirrors `/cookies/set`).
- Net-neutral refactor: `import-profile` and `cookie-sync` now share one `readSystemProfileCookies` reader (single decrypt path).
- **Caveat (documented):** device-bound session credentials (DBSC — notably some Google sessions) stay tied to this Mac and can require re-auth after sync. Those sites should use the browser node proxy instead.

## Evidence

- **Live end-to-end (this Mac → isolated loopback Gateway):**
  - One-shot: decrypted 1,213 real Chrome cookies, allowlist `github.com,google.com,x.com,openai.com` → **pushed 137, skipped 1,076, failed 0**, injected into a managed profile (`pushed` = Playwright `addCookies` success count). Every synced domain was within the allowlist; no cookie values printed.
  - `--watch`: initial sync (github-only → 10 pushed, correct scoping), stayed watching, exited cleanly on SIGTERM (single Keychain prompt per session confirmed).
  - Test rig and injected cookies torn down after.
- **Unit tests:** batch route (happy + 400 paths), reader extraction with injected keychain/homeDir, CLI (missing `--domains` hard-errors with zero reads/gateway calls; posts `/cookies/set-many` with `profile` query; operator.admin scope; summary asserts no cookie value leaks). Focused vitest green.
- **Swift:** `swift build --package-path apps/macos --product OpenClaw --configuration release` — PASS.
- **Autoreview (Codex/Sol) on the full branch:** clean (recorded in the landing notes).

### Owner boundaries
Two owner surfaces in one coherent feature: `extensions/browser/**` (TS: route, reader, CLI) and `apps/macos/**` (Swift: settings + supervisor). No core `src/**`, no gateway protocol, no new node.invoke command, no new config/env surface beyond the CLI flags.

### Screenshots

macOS **Settings → General → Cookie sync**, rendered from the shipped SwiftUI via an isolated `NSHostingView` capture (no live app state touched):

Off by default — the section stays inert until the app runs in remote mode (note the "Remote mode required" hint, disabled controls, and default `imported` target):

![Cookie sync settings, off by default](https://github.com/user-attachments/assets/4c614555-7eb3-47b9-a2fc-73140c2876e4)

In remote mode — turn it on, add the domains to keep in sync, and set the target profile that receives them:

![Cookie sync settings, configured in remote mode](https://github.com/user-attachments/assets/c186cbca-5965-4b95-9a87-68428668757d)
