### PR TITLE
fix(ui): show Claude Code logo in mock Control UI sidebar

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1578,6 +1578,8 @@ async function createChatPickerScenario(
       "sessions.groups.list": { groups: [{ name: "Research", position: 0 }] },
       // Coding session catalogs so the sidebar's catalog sections (header
       // right-click menu, hide/restore preference) are exercised in the mock.
+      // Ids must match registered plugin catalogs (`claude`, `codex`) or the
+      // sidebar cannot resolve bundled brand marks.
       "sessions.catalog.list": {
         catalogs: [
           {
@@ -1616,7 +1618,7 @@ async function createChatPickerScenario(
             ],
           },
           {
-            id: "claude-code",
+            id: "claude",
             label: "Claude Code",
             capabilities: { continueSession: true, archive: false },
             hosts: [
@@ -1679,7 +1681,7 @@ async function createChatPickerScenario(
           },
           {
             match: {
-              catalogId: "claude-code",
+              catalogId: "claude",
               hostId: "gateway",
               threadId: "claude-thread-1",
             },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running `pnpm dev:ui:mock` would see a Codex brand mark on the Control UI sidebar catalog header, but no Claude mark on the Claude Code header.

## Why This Change Was Made

The mock catalog used id `claude-code`. The sidebar only resolves bundled brand marks for registered plugin catalog ids, and Anthropic registers `claude`. The mock list and matching `sessions.catalog.read` case now use `claude`.

No production Gateway or live catalog behavior changes.

## User Impact

`pnpm dev:ui:mock` now shows the Claude brand mark next to Claude Code, same as Codex. Operators on a live Gateway were already on the correct id.

## Evidence

- Before: mock sidebar rendered Codex with `[data-provider-icon="codex"]` and Claude Code with only the collapse chevron, because `hasProviderBrandIcon("claude-code")` is false.
- After: mock catalog id is `claude`, which the existing sidebar table already treats as branded (`ui/src/test-helpers/app-sidebar-cases/catalog-live.ts`).
- Autoreview `--mode local`: clean, no accepted findings.
- Format: `oxfmt --check scripts/control-ui-mock-dev.ts` passed.
