### PR TITLE
fix: make device onboarding and dispatch outcomes honest

### DIFF
--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -12,6 +12,7 @@ import { isTimeoutError } from "../../agents/failover-error.js";
 import type { MainSessionRecoveryPendingTarget } from "../../agents/main-session-recovery/main-session-recovery-store.js";
 import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
 import { normalizeAgentRunTimeoutPhase } from "../../agents/run-timeout-attribution.js";
+import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import { agentCommandFromGatewayIngress } from "../../commands/agent.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { clearAgentRunContext } from "../../infra/agent-run-registry.js";
@@ -194,6 +195,7 @@ export function dispatchAgentRunFromGateway(params: {
     : runAgent();
   void agentRun
     .then(async (result) => {
+      const recordedOutcome = readAgentRunTerminalOutcome(result);
       const signalStopReason = resolveResolvedAgentTimeoutStopReason(
         result?.meta,
         params.abortController.signal,
@@ -209,7 +211,9 @@ export function dispatchAgentRunFromGateway(params: {
         status:
           aborted || result?.meta?.stopReason === "timeout" || timeoutPhase
             ? "timeout"
-            : result?.meta?.error || result?.meta?.stopReason === "error"
+            : recordedOutcome === "failed" ||
+                result?.meta?.error ||
+                result?.meta?.stopReason === "error"
               ? "error"
               : "ok",
         error: result?.meta?.error,

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -504,6 +504,36 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.token).toBe("test-token");
   });
 
+  it("reconnects with admin only after sessions.create cwd returns structured escalation", async () => {
+    const scopeAttempts: Array<readonly string[] | undefined> = [];
+    gatewayClientRequest = async () => {
+      scopeAttempts.push(lastClientOptions?.scopes);
+      if (scopeAttempts.length === 1) {
+        throw Object.assign(new Error("missing scope: operator.admin"), {
+          name: "GatewayClientRequestError",
+          gatewayCode: "FORBIDDEN",
+          details: {
+            code: "MISSING_SCOPE",
+            missingScope: "operator.admin",
+            requiredScopes: ["operator.admin"],
+          },
+          retryable: false,
+        });
+      }
+      return { key: "agent:main:dashboard:created" };
+    };
+    setLocalLoopbackGatewayConfig();
+
+    await expect(
+      callGatewayCli({
+        method: "sessions.create",
+        params: { cwd: "/outside/configured/workspaces" },
+      }),
+    ).resolves.toEqual({ key: "agent:main:dashboard:created" });
+
+    expect(scopeAttempts).toEqual([["operator.write"], ["operator.admin"]]);
+  });
+
   it("keeps direct-local backend shared-token auth independent of paired device state", async () => {
     setLocalLoopbackGatewayConfig();
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from "node:crypto";
 import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   GATEWAY_CLIENT_MODES,
@@ -14,6 +15,7 @@ import {
   ConnectErrorDetailCodes,
   readConnectErrorDetailCode,
 } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import { readMissingScopeErrorDetails } from "../../packages/gateway-protocol/src/gateway-error-details.js";
 import {
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
@@ -67,6 +69,8 @@ import { canSkipGatewayConfigLoad } from "./explicit-connection-policy.js";
 import { resolvePreauthHandshakeTimeoutMs } from "./handshake-timeouts.js";
 import {
   CLI_DEFAULT_OPERATOR_SCOPES,
+  ADMIN_SCOPE,
+  WRITE_SCOPE,
   isGatewayMethodClassified,
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
@@ -1184,22 +1188,60 @@ export async function buildGatewayProbeConnectionDetails(
   };
 }
 
+function shouldEscalateSessionCreateCwdScope(params: {
+  opts: CallGatewayBaseOptions;
+  scopes: readonly OperatorScope[];
+  error: unknown;
+}): boolean {
+  if (
+    params.opts.method !== "sessions.create" ||
+    !isRecord(params.opts.params) ||
+    !normalizeOptionalString(params.opts.params.cwd) ||
+    params.scopes.length !== 1 ||
+    params.scopes[0] !== WRITE_SCOPE
+  ) {
+    return false;
+  }
+  const errorRecord = isRecord(params.error) ? params.error : undefined;
+  const missingScope = readMissingScopeErrorDetails(errorRecord?.details);
+  return (
+    missingScope?.missingScope === ADMIN_SCOPE && missingScope.requiredScopes.includes(ADMIN_SCOPE)
+  );
+}
+
+async function callGatewayWithScopeEscalation<T>(
+  opts: CallGatewayBaseOptions,
+  scopes: OperatorScope[],
+): Promise<T> {
+  try {
+    return await callGatewayWithScopes<T>(opts, scopes);
+  } catch (error) {
+    // sessions.create checks filesystem-backed cwd containment before mutation.
+    // Retry only that structured, pre-mutation escalation on an admin connection.
+    if (!shouldEscalateSessionCreateCwdScope({ opts, scopes, error })) {
+      throw error;
+    }
+    return await callGatewayWithScopes<T>(opts, [ADMIN_SCOPE]);
+  }
+}
+
 export async function callGatewayCli<T = Record<string, unknown>>(
   opts: CallGatewayCliOptions,
 ): Promise<T> {
-  const scopes = Array.isArray(opts.scopes)
-    ? opts.scopes
-    : isGatewayMethodClassified(opts.method)
-      ? resolveLeastPrivilegeOperatorScopesForMethod(opts.method, opts.params)
-      : CLI_DEFAULT_OPERATOR_SCOPES;
-  return await callGatewayWithScopes(opts, scopes);
+  if (Array.isArray(opts.scopes)) {
+    return await callGatewayWithScopes(opts, opts.scopes);
+  }
+  const scopes = isGatewayMethodClassified(opts.method)
+    ? resolveLeastPrivilegeOperatorScopesForMethod(opts.method, opts.params)
+    : CLI_DEFAULT_OPERATOR_SCOPES;
+  return await callGatewayWithScopeEscalation(opts, scopes);
 }
 
 export async function callGatewayLeastPrivilege<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
 ): Promise<T> {
   const scopes = resolveLeastPrivilegeOperatorScopesForMethod(opts.method, opts.params);
-  return await callGatewayWithScopes(opts, scopes);
+  return await callGatewayWithScopeEscalation(opts, scopes);
 }
 
 export async function callGateway<T = Record<string, unknown>>(

--- a/src/gateway/server-http.device-pairing-join.test.ts
+++ b/src/gateway/server-http.device-pairing-join.test.ts
@@ -1,10 +1,13 @@
 // Real Gateway lifecycle proof for admin mint -> public single-use join exchange.
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { WebSocket } from "ws";
+import { getPairedDevice } from "../infra/device-pairing.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { decodePairingSetupCode } from "../pairing/setup-code.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { loadDeviceIdentity } from "./device-authz.test-helpers.js";
 import {
   connectReq,
   createGatewaySuiteHarness,
@@ -99,6 +102,58 @@ describe("Gateway device join route", () => {
 
     expect(response.status).toBe(200);
     expect(await readJson(response)).toEqual(decodePairingSetupCode(setup.setupCode));
+  });
+
+  it("approves the joined node's initial surface but gates a later manifest escalation", async () => {
+    const setup = await mintJoinUrl();
+    const joined = await fetch(setup.joinUrl);
+    expect(joined.status).toBe(200);
+    const payload = (await readJson(joined)) as ReturnType<typeof decodePairingSetupCode>;
+    const loaded = loadDeviceIdentity("join-code-node-surface");
+    const client = {
+      id: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      version: "1.0.0",
+      platform: "macos",
+      deviceFamily: "Mac",
+      mode: GATEWAY_CLIENT_MODES.NODE,
+    };
+
+    const firstNode = await harness.openWs();
+    const first = await connectReq(firstNode, {
+      skipDefaultAuth: true,
+      bootstrapToken: payload.bootstrapToken,
+      role: "node",
+      scopes: [],
+      client,
+      deviceIdentityPath: loaded.identityPath,
+      commands: ["system.run"],
+    });
+    expect(first.ok).toBe(true);
+    firstNode.close();
+
+    const paired = await getPairedDevice(loaded.identity.deviceId);
+    expect(paired).toMatchObject({
+      approvedVia: "bootstrap",
+      nodeSurface: { commands: ["system.run"] },
+    });
+    expect(paired?.pendingNodeSurface).toBeUndefined();
+
+    const secondNode = await harness.openWs();
+    const second = await connectReq(secondNode, {
+      skipDefaultAuth: true,
+      deviceToken: paired?.tokens?.node?.token,
+      role: "node",
+      scopes: [],
+      client,
+      deviceIdentityPath: loaded.identityPath,
+      commands: ["system.run", "system.which"],
+    });
+    expect(second.ok).toBe(true);
+    secondNode.close();
+
+    const escalated = await getPairedDevice(loaded.identity.deviceId);
+    expect(escalated?.nodeSurface?.commands).toEqual(["system.run"]);
+    expect(escalated?.pendingNodeSurface?.commands).toEqual(["system.run", "system.which"]);
   });
 
   it("burns once, expires opaquely, and rate-limits misses on the real HTTP server", async () => {

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -10,6 +10,7 @@ import {
   listSubagentRunsForRequester,
   resetSubagentRegistryForTests,
 } from "../../agents/subagents/registry/subagent-registry.test-helpers.js";
+import { recordAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import { getDetachedTaskLifecycleRuntime } from "../../tasks/detached-task-runtime.js";
 import {
   findTaskByRunId,
@@ -18,6 +19,7 @@ import {
 } from "../../tasks/task-registry.js";
 import { setDetachedTaskLifecycleRuntime } from "../../tasks/task-runtime.test-helpers.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { waitForAgentJob } from "../agent-turn/agent-job.js";
 import { dispatchAgentRunFromGateway } from "../agent-turn/agent-run-dispatch.js";
 import { createAgentTurnIo } from "../agent-turn/io.js";
 import { registerPluginSubagentRunFromGateway } from "./agent-task-tracking.js";
@@ -906,6 +908,55 @@ describe("gateway agent handler", () => {
         undefined,
         { runId: "agent-run-resolved-error" },
       );
+    });
+  });
+
+  it("projects a recorded failed dispatch outcome through agent.wait", async () => {
+    mocks.agentCommand.mockResolvedValueOnce(
+      recordAgentRunTerminalOutcome(
+        {
+          payloads: [{ text: "Device worker unavailable.", isError: true }],
+          meta: {},
+        },
+        "failed",
+      ),
+    );
+    const context = makeContext();
+    const respond = vi.fn();
+    const onSettled = vi.fn(() => true);
+    const runId = "agent-run-recorded-dispatch-failure";
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "run on the unavailable device",
+        sessionKey: "agent:main:main",
+        timeout: "600",
+        allowModelOverride: false,
+      },
+      runId,
+      dedupeKeys: [`agent:${runId}`],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      io: createAgentTurnIo(respond),
+      context,
+      taskTrackingMode: "none",
+      onSettled,
+    });
+
+    await waitForAssertion(() => {
+      expect(onSettled).toHaveBeenCalledWith({
+        terminalOutcome: expect.objectContaining({ status: "error", reason: "failed" }),
+        onRecovered: expect.any(Function),
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ runId, status: "error", summary: "failed" }),
+        undefined,
+        { runId },
+      );
+    });
+    await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toMatchObject({
+      status: "error",
     });
   });
 

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -10,10 +10,7 @@ import { managedWorktrees } from "../../agents/worktrees/service.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
 import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
-import {
-  DEVICE_WORKER_PROVIDER_ID,
-  isDeviceWorkerAvailable,
-} from "../worker-environments/device-provider.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "../worker-environments/device-provider.js";
 import { projectWorkerSessionPlacement } from "../worker-environments/placement-projector.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-record.js";
 import {
@@ -83,21 +80,6 @@ async function resolveWorkerSessionTarget(params: {
   if (profileId) {
     dispatchTarget = { profileId };
   } else if (deviceId) {
-    const available = await isDeviceWorkerAvailable(
-      params.context.workerEnvironmentService,
-      deviceId,
-    );
-    if (!available) {
-      params.respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.UNAVAILABLE,
-          `device worker requires a connected current node host; reconnect or reprovision: ${deviceId}`,
-        ),
-      );
-      return undefined;
-    }
     dispatchTarget = {
       profileId: `device:${deviceId}`,
       deviceId,

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -298,7 +298,7 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       });
       return;
     }
-    if (existingPlacement?.state !== "active") {
+    if (existingPlacement?.state !== "active" && existingPlacement?.state !== "failed") {
       respondInvalidWorkerSession(
         respond,
         `session cannot stop cloud worker from placement ${existingPlacement?.state ?? "local"}`,

--- a/src/gateway/server-methods/sessions.dispatch.device.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.device.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
-import { bindDeviceWorkerAvailability } from "../worker-environments/device-provider.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-store.js";
-import type { WorkerEnvironmentServiceContract } from "../worker-environments/service-contract.js";
 import {
   dispatchTestSessionId,
   dispatchTestSessionKey,
@@ -53,11 +51,8 @@ describe("sessions.dispatch device targets", () => {
       updatedAtMs: 2,
       stateChangedAtMs: 2,
     } satisfies WorkerSessionPlacementRecord);
-    const workerEnvironmentService = {} as WorkerEnvironmentServiceContract;
-    bindDeviceWorkerAvailability(workerEnvironmentService, async () => true);
     const respond = await invokeSessionDispatch(
       makeDispatchTestContext({
-        workerEnvironmentService,
         workerPlacementDispatchService: { dispatch },
         workerSessionPlacementService: { getMany: () => new Map() },
       }),
@@ -86,19 +81,33 @@ describe("sessions.dispatch device targets", () => {
   });
 
   it("rejects a device target without a connected session-capable pairing", async () => {
-    const dispatch = vi.fn();
-    const workerEnvironmentService = {} as WorkerEnvironmentServiceContract;
-    bindDeviceWorkerAvailability(workerEnvironmentService, async () => false);
+    dispatchTestMocks.resolveTarget.mockReturnValue(
+      makeSessionTarget({
+        sessionId: dispatchTestSessionId,
+        worktree: { id: "worktree-1", branch: "openclaw/device-test", repoRoot: "/repo" },
+      }),
+    );
+    dispatchTestMocks.findLiveByOwner.mockReturnValue({
+      id: "worktree-1",
+      ownerKind: "session",
+      ownerId: dispatchTestSessionKey,
+    });
+    const dispatch = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "device worker requires a connected current node host; reconnect or reprovision: device-1",
+        ),
+      );
     const respond = await invokeSessionDispatch(
       makeDispatchTestContext({
-        workerEnvironmentService,
         workerPlacementDispatchService: { dispatch },
         workerSessionPlacementService: { getMany: () => new Map() },
       }),
       { deviceId: "device-1" },
     );
 
-    expect(dispatch).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledOnce();
     expect(respond).toHaveBeenCalledWith(
       false,
       undefined,

--- a/src/gateway/server-methods/sessions.reclaim.test.ts
+++ b/src/gateway/server-methods/sessions.reclaim.test.ts
@@ -88,6 +88,47 @@ describe("sessions.reclaim", () => {
     );
   });
 
+  it("delegates a failed placement to the reclaim owner", async () => {
+    const failed = {
+      ...makeReclaimedPlacement(),
+      state: "failed",
+      environmentId: null,
+      activeOwnerEpoch: null,
+      workspaceBaseManifestRef: null,
+      remoteWorkspaceDir: null,
+      workerBundleHash: null,
+      recoveryError: "device worker is offline",
+      terminalReason: "device worker is offline",
+    } as WorkerSessionPlacementRecord;
+    const local = {
+      ...failed,
+      state: "local",
+      generation: failed.generation + 1,
+      recoveryError: null,
+      terminalReason: null,
+      terminalAtMs: null,
+    } as WorkerSessionPlacementRecord;
+    const reclaim = vi.fn().mockResolvedValue(local);
+    const respond = await invokeSessionReclaim(
+      makeDispatchTestContext({
+        workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+        workerSessionPlacementService: {
+          getMany: () => new Map([[dispatchTestSessionId, failed]]),
+        },
+      }),
+    );
+
+    expect(reclaim).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        placement: expect.objectContaining({ state: "local" }),
+      }),
+      undefined,
+    );
+  });
+
   it("rejects a missing placement", async () => {
     const reclaim = vi.fn();
     const respond = await invokeSessionReclaim(

--- a/src/gateway/server/ws-connection/connect-device-metadata.ts
+++ b/src/gateway/server/ws-connection/connect-device-metadata.ts
@@ -9,6 +9,7 @@ import {
   CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
   deviceBootstrapProfilesEqual,
   isMobilePairingSetupBootstrapProfile,
+  isNodePairingSetupBootstrapProfile,
   isVoiceNodePairingSetupBootstrapProfile,
   resolveBootstrapProfileScopesForRole,
   type DeviceBootstrapProfile,
@@ -66,6 +67,8 @@ export function isSetupCodeHandoffBootstrapClient(params: {
   return (
     (isMobilePairingSetupBootstrapProfile(params.profile) &&
       isSetupCodeMobileBootstrapClient(params.client)) ||
+    (isNodePairingSetupBootstrapProfile(params.profile) &&
+      params.client.id === GATEWAY_CLIENT_IDS.NODE_HOST) ||
     (isVoiceNodePairingSetupBootstrapProfile(params.profile) &&
       isSetupCodeVoiceNodeBootstrapClient(params.client))
   );

--- a/src/gateway/server/ws-connection/connect-node-session.ts
+++ b/src/gateway/server/ws-connection/connect-node-session.ts
@@ -137,18 +137,21 @@ export async function prepareGatewayNodeConnect(
     }
     throw error;
   }
-  // The ssh-verify key match already proved this node runs under the
-  // operator's account on a machine they own, which is the same claim
-  // a manual capability approval asserts; approve the first declared
-  // surface directly. Surface upgrades still prompt.
-  if (deviceApprovedVia === "ssh-verified" && !pairedNode && reconciliation.pendingPairing) {
+  // SSH verification proves machine ownership, while an admin-minted setup code
+  // records that admin's consent to this machine's initial declared surface.
+  // Approve either initial surface directly; later manifest upgrades still prompt.
+  if (
+    (deviceApprovedVia === "ssh-verified" || deviceApprovedVia === "bootstrap") &&
+    !pairedNode &&
+    reconciliation.pendingPairing
+  ) {
     const surfaceRequestId = reconciliation.pendingPairing.request.requestId;
     const approvedSurface = await approveNodePairing(surfaceRequestId, {
       callerScopes: [ADMIN_SCOPE, PAIRING_SCOPE, WRITE_SCOPE],
     });
     if (approvedSurface && "node" in approvedSurface) {
       logGateway.info(
-        `security audit: node capability surface ssh-verified auto-approve node=${reconciliation.nodeId} commands=${reconciliation.declaredCommands.join(",") || "<none>"}`,
+        `security audit: node capability surface ${deviceApprovedVia} auto-approve node=${reconciliation.nodeId} commands=${reconciliation.declaredCommands.join(",") || "<none>"}`,
       );
       buildRequestContext().broadcast(
         "node.pair.resolved",

--- a/src/gateway/worker-environments/device-provider.ts
+++ b/src/gateway/worker-environments/device-provider.ts
@@ -11,7 +11,6 @@ import type {
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
 import { createNodeWorkerLaunchAdapter } from "./node-launch-adapter.js";
-import type { WorkerEnvironmentServiceContract } from "./service-contract.js";
 
 export const DEVICE_WORKER_PROVIDER_ID = "device";
 
@@ -23,14 +22,14 @@ type DeviceWorkerAvailability = (deviceId: string) => Promise<boolean>;
 const DEVICE_WORKER_AVAILABILITY = new WeakMap<object, DeviceWorkerAvailability>();
 
 export function bindDeviceWorkerAvailability(
-  service: WorkerEnvironmentServiceContract,
+  service: object,
   isAvailable: DeviceWorkerAvailability,
 ): void {
   DEVICE_WORKER_AVAILABILITY.set(service, isAvailable);
 }
 
 export async function isDeviceWorkerAvailable(
-  service: WorkerEnvironmentServiceContract | undefined,
+  service: object | undefined,
   deviceId: string,
 ): Promise<boolean> {
   const isAvailable = service ? DEVICE_WORKER_AVAILABILITY.get(service) : undefined;

--- a/src/gateway/worker-environments/placement-dispatch-device.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-device.test.ts
@@ -6,6 +6,7 @@ import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { bindDeviceWorkerAvailability } from "./device-provider.js";
 import { REQUEST, type PlacementStore } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
@@ -29,6 +30,7 @@ describe("device worker placement dispatch", () => {
 
   it("provisions, syncs, and activates a local-install device environment", async () => {
     const harness = createHarness(placementStore);
+    bindDeviceWorkerAvailability(harness.environments, async () => true);
     vi.mocked(harness.environments.createFromProfileSnapshot).mockResolvedValue({
       ...harness.ready,
       providerId: "device",
@@ -76,5 +78,37 @@ describe("device worker placement dispatch", () => {
     });
     expect(harness.environments.destroy).not.toHaveBeenCalled();
     expect(harness.placements.current()).toMatchObject({ state: "active" });
+  });
+
+  it("records an unavailable device dispatch as a durable failed placement", async () => {
+    const harness = createHarness(placementStore);
+    bindDeviceWorkerAvailability(harness.environments, async () => false);
+    const states: string[] = [];
+    const request = {
+      ...REQUEST,
+      profileId: "device:offline-device",
+      deviceId: "offline-device",
+      inheritedProfile: {
+        providerId: "device",
+        profileSnapshot: {
+          install: "bundle" as const,
+          settings: { device: "offline-device" },
+        },
+      },
+    };
+
+    await expect(
+      harness.service.dispatch(request, (placement) => states.push(placement.state)),
+    ).rejects.toThrow("device worker requires a connected current node host");
+
+    expect(states).toEqual(["requested", "failed"]);
+    expect(harness.environments.createFromProfileSnapshot).not.toHaveBeenCalled();
+    expect(createWorkerSessionPlacementStore({ database }).get(REQUEST.sessionId)).toMatchObject({
+      state: "failed",
+      environmentId: null,
+      recoveryError: expect.stringContaining("connected current node host"),
+      terminalReason: expect.stringContaining("connected current node host"),
+      terminalAtMs: 1_000,
+    });
   });
 });

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -104,6 +104,34 @@ describe("worker placement dispatch reclaim", () => {
     ]);
   });
 
+  it("reclaims an environment-free failed placement back to clean local state", async () => {
+    const harness = createHarness(placementStore);
+    const requested = placementStore.startDispatch(REQUEST);
+    const failed = placementStore.fail({
+      sessionId: REQUEST.sessionId,
+      expectedGeneration: requested.generation,
+      recoveryError: "device worker is offline",
+    });
+
+    await expect(
+      harness.service.reclaim({
+        sessionId: REQUEST.sessionId,
+        sessionKey: REQUEST.sessionKey,
+        agentId: REQUEST.agentId,
+      }),
+    ).resolves.toMatchObject({
+      state: "local",
+      generation: failed.generation + 1,
+      environmentId: null,
+      recoveryError: null,
+      terminalReason: null,
+      terminalAtMs: null,
+    });
+
+    expect(harness.environments.startTunnel).not.toHaveBeenCalled();
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+  });
+
   it("retains and reports cloud versions that conflict during an idle reclaim", async () => {
     const harness = createHarness(placementStore, {
       reconcileConflictPaths: ["src/local.ts"],

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -18,6 +18,7 @@ import type {
 } from "./service-contract.js";
 import { deriveEnvironmentIntent } from "./service-contract.js";
 import type { WorkerEnvironmentService } from "./service.js";
+import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-lifecycle.js";
 import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
 import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import {
@@ -44,6 +45,7 @@ type WorkerLocalDispatchBarrier = (params: {
 }) => Promise<WorkerDispatchPlacement>;
 
 type WorkerReclaimedPlacement = Extract<WorkerDispatchPlacement, { state: "reclaimed" }>;
+type WorkerReclaimPlacement = Extract<WorkerDispatchPlacement, { state: "local" | "reclaimed" }>;
 type WorkerPlacementReclaimBarrier = (
   params: WorkerPlacementReclaimRequest & {
     reclaim: (localPath: string) => Promise<WorkerReclaimedPlacement>;
@@ -510,10 +512,10 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
       },
     });
 
-  const reclaimInFlight = new Map<string, Promise<WorkerReclaimedPlacement>>();
+  const reclaimInFlight = new Map<string, Promise<WorkerReclaimPlacement>>();
   const reclaim = async (
     request: WorkerPlacementReclaimRequest,
-  ): Promise<WorkerReclaimedPlacement> => {
+  ): Promise<WorkerReclaimPlacement> => {
     const current = placements.get(request.sessionId);
     if (current?.state === "reclaimed") {
       return current;
@@ -522,7 +524,30 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
     if (inFlight) {
       return await inFlight;
     }
-    const operation = reclaimOnce(request).catch((error: unknown) => {
+    const operation = (async () => {
+      const owned = placements.get(request.sessionId);
+      if (owned?.state === "failed") {
+        if (
+          !isFailedWorkerPlacementEnvironmentGone({
+            environmentService: environments,
+            placement: owned,
+          })
+        ) {
+          throw new Error("Failed cloud worker environment must be stopped before reclaim");
+        }
+        const local = placements.transition({
+          sessionId: request.sessionId,
+          from: "failed",
+          to: "local",
+          expectedGeneration: owned.generation,
+        });
+        if (local.state !== "local") {
+          throw new Error("Failed cloud worker reclaim did not produce a local placement");
+        }
+        return local;
+      }
+      return await reclaimOnce(request);
+    })().catch((error: unknown) => {
       // Another teardown path can win after this call has crossed its durable completion fence.
       // Report the committed terminal state instead of leaking a stale tunnel error to callers.
       const completed = placements.get(request.sessionId);

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { supportsWorkerExecutionContextLaunch } from "./admission.js";
-import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider.js";
+import { DEVICE_WORKER_PROVIDER_ID, isDeviceWorkerAvailable } from "./device-provider.js";
 import {
   createPlacementFailureActions,
   isUnavailableEnvironment,
@@ -178,6 +178,11 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           return placement;
         },
       });
+      if (request.deviceId && !(await isDeviceWorkerAvailable(environments, request.deviceId))) {
+        throw new Error(
+          `device worker requires a connected current node host; reconnect or reprovision: ${request.deviceId}`,
+        );
+      }
       const localPath = await options.resolveWorkspacePath(request);
       const idempotencyKey = `session-dispatch:${request.sessionId}:${placement.generation}`;
       const expectedEnvironmentId = deriveEnvironmentIntent(idempotencyKey).environmentId;

--- a/src/gateway/worker-environments/placement-state.ts
+++ b/src/gateway/worker-environments/placement-state.ts
@@ -27,7 +27,7 @@ const WORKER_SESSION_PLACEMENT_TRANSITIONS = {
   draining: ["reconciling"],
   reconciling: ["local", "reclaimed", "failed"],
   reclaimed: ["requested"],
-  failed: ["requested"],
+  failed: ["local", "requested"],
 } as const satisfies WorkerSessionPlacementTransition;
 
 export function parseWorkerSessionPlacementState(value: string): WorkerSessionPlacementState {

--- a/src/gateway/worker-environments/service-contract.ts
+++ b/src/gateway/worker-environments/service-contract.ts
@@ -94,7 +94,7 @@ export type WorkerPlacementDispatchContract = {
   ): Promise<Extract<WorkerSessionPlacementRecord, { state: "active" }>>;
   reclaim?(
     request: WorkerPlacementReclaimRequest,
-  ): Promise<Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>>;
+  ): Promise<Extract<WorkerSessionPlacementRecord, { state: "local" | "reclaimed" }>>;
   forceDestroyEnvironment?(
     environmentId: string,
     onCleanupError?: (error: unknown) => void,


### PR DESCRIPTION
## What Problem This Solves

Fixes five verification-driven honesty failures found by the live node-hosting E2E on merged main `92eed63f584`:

- a one-paste join-code onboarding could approve the device but leave its initial node command surface pending manual approval;
- dispatching to an offline device returned a visible error without recording that the dispatch was attempted;
- a failed placement could not be reclaimed back to local execution;
- `gateway call sessions.create` negotiated only write scope for an arbitrary `cwd`, so an admin-backed call was rejected by the handler's state-aware admin gate;
- an immediately rejected turn could be recorded as failed while `agent.wait` briefly reported `ok`.

## Why This Change Was Made

The repairs record and consume facts at their owning boundaries. Admin-minted node bootstrap consent now approves only the initial declared surface, offline dispatch crosses the durable placement barrier before failing, failed reclaim is a guarded state-machine transition, CLI scope negotiation retries only the structured pre-mutation `sessions.create` escalation, and Gateway dispatch consumes the channel owner's recorded terminal marker through the canonical terminal-outcome builder.

Later node manifest expansion still requires approval. Failed placements retaining a live environment remain fenced, and write-only callers keep workspace-contained `cwd` access without gaining arbitrary host-path access.

## User Impact

Admins can paste one join command and receive a usable session-hosting device without a hidden second approval. Offline dispatch attempts remain fast and visible while becoming auditable and recoverable. Admin-backed arbitrary-cwd session creation works as documented, write-only scope remains contained, and `agent.wait` agrees with the durable session failure state.

AI-assisted maintainer repair; the implementation and proof were reviewed with the repository's autoreview workflow.

## Evidence

- Live source evidence: node-hosting E2E findings reproduced on merged main `92eed63f584`; this PR is the verification-driven repair wave.
- Regression-first proof: every added behavior test failed on the pre-fix owner path before passing with the repair.
- Focused changed tests, three consecutive runs: 7 files, 444 tests per run, all green.
- `node scripts/check-changed.mjs -- <16 changed paths>`: green. Blacksmith/Testbox and owned-cloud provider doctors failed before lease creation, so the repository wrapper used its documented local trusted-source fallback.
- `pnpm build`: green.
- `pnpm plugin-sdk:surface:check`: green.
- `pnpm db:kysely:check`: green.
- `pnpm lint:kysely`: green.
- Whole-branch autoreview against current `origin/main`: clean, no accepted/actionable findings.
- Exact-head CI: [run 31773521322](https://github.com/openclaw/openclaw/actions/runs/31773521322), green on `da480eddb12927053503c8fa252f0d057a383edc`.

Production LOC: +106/-43 (net +63) | Tests and test support: +258/-10.
