### PR TITLE
fix: speed up local node launches and isolate scratch state

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -21,9 +21,9 @@ When sandboxing is enabled and `workspaceAccess` is not `"rw"`, tools operate in
 ## Default location
 
 - Default: `~/.openclaw/workspace`
-- If `OPENCLAW_PROFILE` is set and not `"default"`, the default becomes `~/.openclaw/workspace-<profile>`.
+- If `OPENCLAW_PROFILE` is set and not `"default"`, the default becomes `~/.openclaw-<profile>/workspace`.
 - `OPENCLAW_WORKSPACE_DIR` overrides both of the above when set.
-- `openclaw onboard --non-interactive` uses `<state-dir>/workspace` when `OPENCLAW_STATE_DIR` is non-default, including for the initial `main` agent entry.
+- A non-default `OPENCLAW_STATE_DIR` keeps the default workspace at `<state-dir>/workspace`, including scheduled maintenance and the initial `main` agent entry.
 - Non-default agents (`agents.entries.*`) without an explicit workspace resolve to `<state-dir>/workspace-<agentId>`, not the shared default workspace.
 
 Override in `~/.openclaw/openclaw.json`:

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -51,7 +51,7 @@ when personas must not share compiled wiki knowledge.
 | -------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | Config                           | `~/.openclaw/openclaw.json`                                                            | `OPENCLAW_CONFIG_PATH`                                                                      |
 | State dir                        | `~/.openclaw`                                                                          | `OPENCLAW_STATE_DIR`                                                                        |
-| Default agent's workspace        | `~/.openclaw/workspace` (or `workspace-<profile>` when `OPENCLAW_PROFILE` is set)      | `agents.entries.*.workspace`, then `agents.defaults.workspace`, or `OPENCLAW_WORKSPACE_DIR` |
+| Default agent's workspace        | `<stateDir>/workspace` (`~/.openclaw-<profile>/workspace` for a named profile)         | `agents.entries.*.workspace`, then `agents.defaults.workspace`, or `OPENCLAW_WORKSPACE_DIR` |
 | Other agents' workspace          | `<stateDir>/workspace-<agentId>` (or `<agents.defaults.workspace>/<agentId>` when set) | `agents.entries.*.workspace`                                                                |
 | Agent dir                        | `~/.openclaw/agents/<agentId>/agent`                                                   | `agents.entries.*.agentDir`                                                                 |
 | Sessions and transcripts         | `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`                             | —                                                                                           |
@@ -63,7 +63,7 @@ If you configure nothing, OpenClaw runs one agent:
 
 - `agentId` defaults to `main`.
 - Sessions key as `agent:main:<mainKey>` (default `mainKey` is `main`).
-- Workspace defaults to `~/.openclaw/workspace` (or `workspace-<profile>` when `OPENCLAW_PROFILE` is set to something other than `default`).
+- Workspace defaults to `<stateDir>/workspace` (`~/.openclaw/workspace` for the default install and `~/.openclaw-<profile>/workspace` for a named profile).
 - State defaults to `~/.openclaw/agents/main/agent`.
 
 ## Agent helper

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -17,7 +17,7 @@ OpenClaw stamps `agents.ownership: "explicit"` when creating a multi-agent fleet
 
 ### `agents.defaults.workspace`
 
-Default: `OPENCLAW_WORKSPACE_DIR` when set, otherwise `~/.openclaw/workspace` (or `~/.openclaw/workspace-<profile>` when `OPENCLAW_PROFILE` is set to a non-default profile).
+Default: `OPENCLAW_WORKSPACE_DIR` when set, otherwise `<state-dir>/workspace`. This is `~/.openclaw/workspace` for the default install and `~/.openclaw-<profile>/workspace` for a named profile. A custom `OPENCLAW_STATE_DIR` keeps the workspace under that state directory.
 
 ```json5
 {

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -55,8 +55,9 @@ longer package exports: `agent-runtime-test-contracts`,
 `plugin-test-runtime`, `provider-http-test-mocks`, `provider-test-contracts`,
 `reply-payload-testing`, `sqlite-runtime-testing`, `test-env`, `test-fixtures`,
 `test-live`, `test-live-auth`, `test-media-generation`,
-`test-media-understanding`, `test-node-mocks`, and `testing`. The private bundled helper surface
-`ssrf-runtime-internal` is also repo-local only.
+`test-media-understanding`, `test-node-mocks`, and `testing`.
+`ssrf-runtime-internal` is a JavaScript-only host runtime reserved for exact
+trusted local-service plugins; it is not a public plugin authoring API.
 
 ### Bundled plugin helper subpaths
 
@@ -396,6 +397,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | --- | --- |
     | `plugin-sdk/codex-mcp-projection` | Private-local after July 2026; Bundled Codex plugin helper for projecting user MCP server config into Codex app-server thread config (default-only package export) |
     | `plugin-sdk/codex-session-transcript-runtime` | Private-local bundled Codex plugin helper for serializing transcript-mirror writes (default-only package export) |
+    | `plugin-sdk/ssrf-runtime-internal` | Private-local host helper for configured loopback requests owned by bundled Ollama/browser and the exact official `@openclaw/llama-cpp-provider` package (default-only package export) |
 
   </Accordion>
 </AccordionGroup>

--- a/package.json
+++ b/package.json
@@ -209,7 +209,6 @@
     "!dist/plugin-sdk/sqlite-runtime-testing.js",
     "!dist/plugin-sdk/sqlite-runtime-testing.d.ts",
     "!dist/plugin-sdk/ssrf-dispatcher.d.ts",
-    "!dist/plugin-sdk/ssrf-runtime-internal.js",
     "!dist/plugin-sdk/ssrf-runtime-internal.d.ts",
     "!dist/plugin-sdk/string-normalization-runtime.d.ts",
     "!dist/plugin-sdk/system-event-runtime.d.ts",
@@ -666,6 +665,9 @@
     "./plugin-sdk/ssrf-runtime": {
       "types": "./dist/plugin-sdk/ssrf-runtime.d.ts",
       "default": "./dist/plugin-sdk/ssrf-runtime.js"
+    },
+    "./plugin-sdk/ssrf-runtime-internal": {
+      "default": "./dist/plugin-sdk/ssrf-runtime-internal.js"
     },
     "./plugin-sdk/media-runtime": {
       "types": "./dist/plugin-sdk/media-runtime.d.ts",

--- a/packages/memory-host-sdk/src/host/config-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.test.ts
@@ -15,6 +15,25 @@ describe("resolveMemoryHostAgentWorkspaceDir", () => {
       }),
     ).toBe("/home/peter/.openclaw-work/workspace");
   });
+
+  it("keeps the default agent workspace inside an overridden state directory", () => {
+    expect(
+      resolveMemoryHostAgentWorkspaceDir({}, "main", {
+        HOME: "/home/peter",
+        OPENCLAW_STATE_DIR: "/srv/openclaw-scratch",
+      }),
+    ).toBe("/srv/openclaw-scratch/workspace");
+  });
+
+  it("prefers an explicit workspace override to the state directory", () => {
+    expect(
+      resolveMemoryHostAgentWorkspaceDir({}, "main", {
+        HOME: "/home/peter",
+        OPENCLAW_STATE_DIR: "/srv/openclaw-scratch",
+        OPENCLAW_WORKSPACE_DIR: "/srv/openclaw-workspace",
+      }),
+    ).toBe("/srv/openclaw-workspace");
+  });
 });
 
 describe("resolveRememberAcrossConversations", () => {

--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -224,6 +224,13 @@ function resolveStateDir(
 
 /** Resolve the default agent workspace, partitioned by OPENCLAW_PROFILE when set. */
 function resolveDefaultAgentWorkspaceDir(env: NodeJS.ProcessEnv = process.env): string {
+  const workspaceDir = env.OPENCLAW_WORKSPACE_DIR?.trim();
+  if (workspaceDir) {
+    return resolveMemoryHostUserPath(workspaceDir, env);
+  }
+  if (env.OPENCLAW_STATE_DIR?.trim()) {
+    return path.join(resolveStateDir(env), "workspace");
+  }
   const home = resolveRequiredHomeDir(env, os.homedir);
   const profile = env.OPENCLAW_PROFILE?.trim();
   if (profile && normalizeLowercaseStringOrEmpty(profile) !== "default") {

--- a/scripts/lib/plugin-sdk-entries.mts
+++ b/scripts/lib/plugin-sdk-entries.mts
@@ -60,7 +60,6 @@ const nonProductionPluginSdkSubpathSet = new Set([
   "qa-runtime",
   "reply-payload-testing",
   "sqlite-runtime-testing",
-  "ssrf-runtime-internal",
   "test-env",
   "test-fixtures",
   "test-live",

--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -107,6 +107,17 @@ describe("agent roster resolution", () => {
     expect(resolveAgentWorkspaceDir(cfg, "research")).toBe("/srv/ops/research");
   });
 
+  it("keeps the implicit default workspace inside an overridden state directory", () => {
+    const stateDir = "/srv/openclaw-scratch";
+
+    expect(
+      resolveAgentWorkspaceDir({}, "main", {
+        HOME: "/home/operator",
+        OPENCLAW_STATE_DIR: stateDir,
+      }),
+    ).toBe(`${stateDir}/workspace`);
+  });
+
   it("offers a non-throwing diagnostic lookup for malformed rosters", () => {
     expect(tryResolveDefaultAgentId({ agents: { list: [{ id: "alpha" }] } })).toBe("alpha");
     for (const marker of ["false", 1]) {

--- a/src/agents/workspace-default.ts
+++ b/src/agents/workspace-default.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveProfileStateDir } from "../cli/profile-utils.js";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 
 /** Resolve the default agent workspace directory from env/profile/home state. */
@@ -17,6 +18,9 @@ export function resolveDefaultAgentWorkspaceDir(
   const workspaceDir = env.OPENCLAW_WORKSPACE_DIR?.trim();
   if (workspaceDir) {
     return path.resolve(workspaceDir);
+  }
+  if (env.OPENCLAW_STATE_DIR?.trim()) {
+    return path.join(resolveStateDir(env, homedir), "workspace");
   }
   const home = resolveRequiredHomeDir(env, homedir);
   const profile = env.OPENCLAW_PROFILE?.trim();

--- a/src/gateway/worker-environments/bundle-staging.ts
+++ b/src/gateway/worker-environments/bundle-staging.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, type BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { collectPackageDistInventory } from "../../infra/package-dist-inventory.js";
@@ -17,6 +17,58 @@ export type WorkerBundleManifestEntry = {
   size: number;
   sha256: string;
 };
+
+export type WorkerBundleSourceIdentityEntry = {
+  path: string;
+  realPath: string;
+  kind: "directory" | "file";
+  dev: bigint;
+  ino: bigint;
+  mode: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+};
+
+type WorkerBundleSourceIdentityMap = Map<string, WorkerBundleSourceIdentityEntry>;
+
+function recordSourceIdentity(
+  identities: WorkerBundleSourceIdentityMap | undefined,
+  entry: WorkerBundleSourceIdentityEntry,
+): void {
+  identities?.set(`${entry.kind}\0${entry.path}`, entry);
+}
+
+async function recordSourceDirectoryIdentity(
+  identities: WorkerBundleSourceIdentityMap | undefined,
+  directoryPath: string,
+): Promise<void> {
+  if (!identities) {
+    return;
+  }
+  const realPath = await fs.realpath(directoryPath);
+  const stats = await fs.lstat(realPath, { bigint: true });
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`Unsafe worker bundle directory: ${directoryPath}`);
+  }
+  recordSourceIdentity(identities, {
+    path: realPath,
+    realPath,
+    kind: "directory",
+    ...sourceIdentityStats(stats),
+  });
+}
+
+function sourceIdentityStats(stats: BigIntStats) {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    size: stats.size,
+    mtimeNs: stats.mtimeNs,
+    ctimeNs: stats.ctimeNs,
+  };
+}
 
 export function comparePaths(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
@@ -89,6 +141,7 @@ type StagedFileSource = {
 async function stageFileEntry(
   stagingRoot: string,
   source: StagedFileSource,
+  sourceIdentities?: WorkerBundleSourceIdentityMap,
 ): Promise<{ entry: WorkerBundleManifestEntry; contents: Buffer }> {
   const { sourcePath, expectedRealPath, stagedPath } = source;
   const sourceRealPath = await fs.realpath(sourcePath);
@@ -103,8 +156,8 @@ async function stageFileEntry(
   let contents: Buffer;
   let mode: number;
   try {
-    const openedStats = await handle.stat();
-    const currentStats = await fs.lstat(sourcePath);
+    const openedStats = await handle.stat({ bigint: true });
+    const currentStats = await fs.lstat(sourcePath, { bigint: true });
     const currentRealPath = await fs.realpath(sourcePath);
     if (
       !openedStats.isFile() ||
@@ -120,7 +173,13 @@ async function stageFileEntry(
     if (source.transform) {
       contents = source.transform(contents);
     }
-    mode = normalizePortableMode(openedStats.mode, stagedPath);
+    mode = normalizePortableMode(Number(openedStats.mode), stagedPath);
+    recordSourceIdentity(sourceIdentities, {
+      path: expectedRealPath,
+      realPath: currentRealPath,
+      kind: "file",
+      ...sourceIdentityStats(openedStats),
+    });
   } finally {
     await handle.close();
   }
@@ -145,13 +204,18 @@ async function stageManifestEntry(
   stagingRoot: string,
   relativePath: string,
   transform?: (contents: Buffer) => Buffer,
+  sourceIdentities?: WorkerBundleSourceIdentityMap,
 ): Promise<{ entry: WorkerBundleManifestEntry; contents: Buffer }> {
-  return await stageFileEntry(stagingRoot, {
-    sourcePath: path.join(sourceRoot, relativePath),
-    expectedRealPath: path.resolve(sourceRootRealPath, ...relativePath.split("/")),
-    stagedPath: relativePath,
-    transform,
-  });
+  return await stageFileEntry(
+    stagingRoot,
+    {
+      sourcePath: path.join(sourceRoot, relativePath),
+      expectedRealPath: path.resolve(sourceRootRealPath, ...relativePath.split("/")),
+      stagedPath: relativePath,
+      transform,
+    },
+    sourceIdentities,
+  );
 }
 
 // tsdown keeps some @openclaw workspace packages external of dist (never-bundle list),
@@ -204,10 +268,13 @@ async function readWorkspaceDependencyNames(sourceRoot: string): Promise<Set<str
 async function collectVendoredPackageFiles(
   packageName: string,
   vendorRealRoot: string,
+  sourceIdentities?: WorkerBundleSourceIdentityMap,
 ): Promise<string[]> {
   const files = ["package.json"];
   const walk = async (relativeDir: string): Promise<void> => {
-    const dirents = await fs.readdir(path.join(vendorRealRoot, ...relativeDir.split("/")), {
+    const directoryPath = path.join(vendorRealRoot, ...relativeDir.split("/"));
+    await recordSourceDirectoryIdentity(sourceIdentities, directoryPath);
+    const dirents = await fs.readdir(directoryPath, {
       withFileTypes: true,
     });
     for (const dirent of dirents) {
@@ -239,6 +306,7 @@ async function stageVendoredWorkspacePackages(params: {
   sourceRoot: string;
   stagingRoot: string;
   packageNames: readonly string[];
+  sourceIdentities?: WorkerBundleSourceIdentityMap;
 }): Promise<{ entries: WorkerBundleManifestEntry[]; vendoredDirsByName: Map<string, string> }> {
   const entries: WorkerBundleManifestEntry[] = [];
   const vendoredDirsByName = new Map<string, string>();
@@ -256,40 +324,56 @@ async function stageVendoredWorkspacePackages(params: {
       );
     }
     const vendorDir = `vendor/${packageName.replace(/^@/u, "").replaceAll("/", "-")}`;
-    const files = await collectVendoredPackageFiles(packageName, vendorRealRoot);
+    const files = await collectVendoredPackageFiles(
+      packageName,
+      vendorRealRoot,
+      params.sourceIdentities,
+    );
     const referencedPackages = new Set<string>();
     for (const relativePath of files.filter((candidate) => candidate !== "package.json")) {
-      const { entry, contents } = await stageFileEntry(params.stagingRoot, {
-        sourcePath: path.join(vendorRealRoot, ...relativePath.split("/")),
-        expectedRealPath: path.resolve(vendorRealRoot, ...relativePath.split("/")),
-        stagedPath: `${vendorDir}/${relativePath}`,
-      });
+      const { entry, contents } = await stageFileEntry(
+        params.stagingRoot,
+        {
+          sourcePath: path.join(vendorRealRoot, ...relativePath.split("/")),
+          expectedRealPath: path.resolve(vendorRealRoot, ...relativePath.split("/")),
+          stagedPath: `${vendorDir}/${relativePath}`,
+        },
+        params.sourceIdentities,
+      );
       collectOpenclawImportSpecifiers(relativePath, contents, referencedPackages);
       entries.push(entry);
     }
-    const { entry: packageManifestEntry } = await stageFileEntry(params.stagingRoot, {
-      sourcePath: path.join(vendorRealRoot, "package.json"),
-      expectedRealPath: path.resolve(vendorRealRoot, "package.json"),
-      stagedPath: `${vendorDir}/package.json`,
-      transform: (contents) =>
-        pruneVendoredPackageManifest(packageName, referencedPackages, contents),
-    });
+    const { entry: packageManifestEntry } = await stageFileEntry(
+      params.stagingRoot,
+      {
+        sourcePath: path.join(vendorRealRoot, "package.json"),
+        expectedRealPath: path.resolve(vendorRealRoot, "package.json"),
+        stagedPath: `${vendorDir}/package.json`,
+        transform: (contents) =>
+          pruneVendoredPackageManifest(packageName, referencedPackages, contents),
+      },
+      params.sourceIdentities,
+    );
     entries.push(packageManifestEntry);
     vendoredDirsByName.set(packageName, vendorDir);
   }
   return { entries, vendoredDirsByName };
 }
 
-export async function collectWorkerBundleManifest(
+async function collectWorkerBundleManifestInternal(
   sourceRoot: string,
   stagingRoot: string,
+  sourceIdentities?: WorkerBundleSourceIdentityMap,
 ): Promise<WorkerBundleManifestEntry[]> {
   const sourceRootRealPath = await fs.realpath(sourceRoot);
   // Control UI assets are built lazily after the Gateway starts and never execute on workers.
   // Excluding them keeps worker identity stable across that startup race.
-  const distFiles = (await collectPackageDistInventory(sourceRoot)).filter(
-    (relativePath) => !relativePath.startsWith(CONTROL_UI_DIST_PREFIX),
-  );
+  const distFiles = (
+    await collectPackageDistInventory(sourceRoot, {
+      onDirectory: async (directoryPath) =>
+        await recordSourceDirectoryIdentity(sourceIdentities, directoryPath),
+    })
+  ).filter((relativePath) => !relativePath.startsWith(CONTROL_UI_DIST_PREFIX));
   if (distFiles.length === 0) {
     throw new Error(
       `OpenClaw worker bundle has no packaged dist files; build the running package at ${sourceRoot}`,
@@ -303,6 +387,8 @@ export async function collectWorkerBundleManifest(
       sourceRootRealPath,
       stagingRoot,
       relativePath,
+      undefined,
+      sourceIdentities,
     );
     collectOpenclawImportSpecifiers(relativePath, contents, referencedPackages);
     entries.push(entry);
@@ -312,6 +398,7 @@ export async function collectWorkerBundleManifest(
     sourceRoot,
     stagingRoot,
     packageNames: [...workspaceDependencyNames].filter((name) => referencedPackages.has(name)),
+    sourceIdentities,
   });
   entries.push(...vendored.entries);
   // The shipped root manifest is derived after the dist scan so vendored workspace deps
@@ -322,7 +409,32 @@ export async function collectWorkerBundleManifest(
     stagingRoot,
     "package.json",
     (contents) => pruneWorkerPackageManifest(contents, vendored.vendoredDirsByName),
+    sourceIdentities,
   );
   entries.push(manifest.entry);
   return entries.toSorted((left, right) => comparePaths(left.path, right.path));
+}
+
+export async function collectWorkerBundleManifest(
+  sourceRoot: string,
+  stagingRoot: string,
+): Promise<WorkerBundleManifestEntry[]> {
+  return await collectWorkerBundleManifestInternal(sourceRoot, stagingRoot);
+}
+
+export async function collectWorkerBundleManifestWithSourceIdentity(
+  sourceRoot: string,
+  stagingRoot: string,
+): Promise<{
+  manifest: WorkerBundleManifestEntry[];
+  sourceIdentity: WorkerBundleSourceIdentityEntry[];
+}> {
+  const identities: WorkerBundleSourceIdentityMap = new Map();
+  const manifest = await collectWorkerBundleManifestInternal(sourceRoot, stagingRoot, identities);
+  return {
+    manifest,
+    sourceIdentity: [...identities.values()].toSorted((left, right) =>
+      comparePaths(`${left.kind}\0${left.path}`, `${right.kind}\0${right.path}`),
+    ),
+  };
 }

--- a/src/gateway/worker-environments/bundle.test.ts
+++ b/src/gateway/worker-environments/bundle.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as tar from "tar";
 import { describe, expect, it, vi } from "vitest";
-import { resolveNodeWorkerBuild } from "../../node-host/node-worker-build.js";
+import { resolveNodeWorkerInstallation } from "../../node-host/node-worker-build.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
@@ -83,11 +83,13 @@ describe("worker bundle producer", () => {
         cacheDir: path.join(root, "cache-b"),
         openclawVersion: "1.2.3",
       }).prepare();
-      const nodeBuild = await resolveNodeWorkerBuild({
-        packageRoot: packageA,
-        openclawVersion: "1.2.3",
-        protocolFeatures: [],
-      });
+      const nodeBuild = (
+        await resolveNodeWorkerInstallation({
+          packageRoot: packageA,
+          openclawVersion: "1.2.3",
+          protocolFeatures: [],
+        })
+      ).build;
 
       expect(first.bundleHash).toMatch(/^[a-f0-9]{64}$/u);
       expect(second.bundleHash).toBe(first.bundleHash);

--- a/src/infra/package-dist-inventory.ts
+++ b/src/infra/package-dist-inventory.ts
@@ -301,6 +301,7 @@ async function collectRelativeFiles(
   baseDir: string,
   rules: PackageDistInventoryRules,
   fsLimit: LimitFunction,
+  onDirectory?: (directoryPath: string) => Promise<void>,
 ): Promise<string[]> {
   const rootRelativePath = normalizeRelativePath(path.relative(baseDir, rootDir));
   if (rootRelativePath && isOmittedDistSubtree(rootRelativePath, rules)) {
@@ -313,6 +314,7 @@ async function collectRelativeFiles(
         `Unsafe package dist path: ${normalizeRelativePath(path.relative(baseDir, rootDir))}`,
       );
     }
+    await onDirectory?.(rootDir);
     const entries = await fsLimit(() => fs.readdir(rootDir, { withFileTypes: true }));
     const files = await Promise.all(
       entries.map(async (entry) => {
@@ -322,7 +324,7 @@ async function collectRelativeFiles(
           throw new Error(`Unsafe package dist path: ${relativePath}`);
         }
         if (entry.isDirectory()) {
-          return await collectRelativeFiles(entryPath, baseDir, rules, fsLimit);
+          return await collectRelativeFiles(entryPath, baseDir, rules, fsLimit, onDirectory);
         }
         if (entry.isFile()) {
           return isPackagedDistPath(relativePath, rules) ? [relativePath] : [];
@@ -340,10 +342,19 @@ async function collectRelativeFiles(
 }
 
 /** Collects package dist files that should be present after install/update publication. */
-export async function collectPackageDistInventory(packageRoot: string): Promise<string[]> {
+export async function collectPackageDistInventory(
+  packageRoot: string,
+  options: { onDirectory?: (directoryPath: string) => Promise<void> } = {},
+): Promise<string[]> {
   const rules = await collectPackageDistInventoryRulesForRoot(packageRoot);
   const fsLimit = pLimit(PACKAGE_DIST_INVENTORY_SCAN_CONCURRENCY);
-  return await collectRelativeFiles(path.join(packageRoot, "dist"), packageRoot, rules, fsLimit);
+  return await collectRelativeFiles(
+    path.join(packageRoot, "dist"),
+    packageRoot,
+    rules,
+    fsLimit,
+    options.onDirectory,
+  );
 }
 
 async function readPackageDistInventoryOptional(packageRoot: string): Promise<string[] | null> {

--- a/src/node-host/node-worker-build.ts
+++ b/src/node-host/node-worker-build.ts
@@ -1,9 +1,13 @@
+import type { BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { WorkerAdmissionHandshake } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { WORKER_PROTOCOL_FEATURES } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
-import { collectWorkerBundleManifest } from "../gateway/worker-environments/bundle-staging.js";
+import {
+  collectWorkerBundleManifestWithSourceIdentity,
+  type WorkerBundleSourceIdentityEntry,
+} from "../gateway/worker-environments/bundle-staging.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { hashWorkerBundleManifest } from "../shared/worker-bundle-hash.js";
 import { VERSION } from "../version.js";
@@ -17,29 +21,66 @@ type NodeWorkerBuildOptions = {
 export type NodeWorkerInstallation = {
   packageRoot: string;
   build: WorkerAdmissionHandshake;
+  revalidateBuild(): Promise<boolean>;
 };
 
-/** Computes the build identity of the node host's own worker-capable installation. */
-export async function resolveNodeWorkerBuild(
-  options: NodeWorkerBuildOptions = {},
-): Promise<WorkerAdmissionHandshake> {
-  const packageRoot =
-    options.packageRoot ??
-    resolveOpenClawPackageRootSync({
-      moduleUrl: import.meta.url,
-      argv1: process.argv[1],
-      cwd: process.cwd(),
-    });
-  if (!packageRoot) {
-    throw new Error("Unable to locate the running OpenClaw package root for node worker hosting");
+const SOURCE_IDENTITY_STAT_CONCURRENCY = 64;
+
+function sameSourceIdentityStats(
+  expected: WorkerBundleSourceIdentityEntry,
+  current: BigIntStats,
+): boolean {
+  return (
+    current.dev === expected.dev &&
+    current.ino === expected.ino &&
+    current.mode === expected.mode &&
+    current.size === expected.size &&
+    current.mtimeNs === expected.mtimeNs &&
+    current.ctimeNs === expected.ctimeNs &&
+    (expected.kind === "file" ? current.isFile() : current.isDirectory()) &&
+    !current.isSymbolicLink()
+  );
+}
+
+async function matchesWorkerBundleSourceIdentity(
+  entries: readonly WorkerBundleSourceIdentityEntry[],
+): Promise<boolean> {
+  for (let offset = 0; offset < entries.length; offset += SOURCE_IDENTITY_STAT_CONCURRENCY) {
+    const batch = entries.slice(offset, offset + SOURCE_IDENTITY_STAT_CONCURRENCY);
+    const matches = await Promise.all(
+      batch.map(async (expected) => {
+        try {
+          const current = await fs.lstat(expected.path, { bigint: true });
+          return expected.path === expected.realPath && sameSourceIdentityStats(expected, current);
+        } catch {
+          return false;
+        }
+      }),
+    );
+    if (matches.includes(false)) {
+      return false;
+    }
   }
+  return true;
+}
+
+async function computeNodeWorkerBuild(
+  packageRoot: string,
+  options: NodeWorkerBuildOptions,
+): Promise<{
+  build: WorkerAdmissionHandshake;
+  sourceIdentity: WorkerBundleSourceIdentityEntry[];
+}> {
   const stagingRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-node-worker-build-"));
   try {
-    const manifest = await collectWorkerBundleManifest(packageRoot, stagingRoot);
+    const collected = await collectWorkerBundleManifestWithSourceIdentity(packageRoot, stagingRoot);
     return {
-      bundleHash: hashWorkerBundleManifest(manifest),
-      openclawVersion: options.openclawVersion ?? VERSION,
-      protocolFeatures: [...(options.protocolFeatures ?? WORKER_PROTOCOL_FEATURES)].toSorted(),
+      build: {
+        bundleHash: hashWorkerBundleManifest(collected.manifest),
+        openclawVersion: options.openclawVersion ?? VERSION,
+        protocolFeatures: [...(options.protocolFeatures ?? WORKER_PROTOCOL_FEATURES)].toSorted(),
+      },
+      sourceIdentity: collected.sourceIdentity,
     };
   } finally {
     await fs.rm(stagingRoot, { recursive: true, force: true });
@@ -61,8 +102,40 @@ export async function resolveNodeWorkerInstallation(
     throw new Error("Unable to locate the running OpenClaw package root for node worker hosting");
   }
   const canonicalRoot = await fs.realpath(packageRoot);
+  const initial = await computeNodeWorkerBuild(canonicalRoot, options);
+  let sourceIdentity = initial.sourceIdentity;
+  let invalid = false;
+  let pending: Promise<boolean> | undefined;
+  const revalidateBuild = () => {
+    if (invalid) {
+      return Promise.resolve(false);
+    }
+    pending ??= (async () => {
+      if (await matchesWorkerBundleSourceIdentity(sourceIdentity)) {
+        return true;
+      }
+      try {
+        const current = await computeNodeWorkerBuild(canonicalRoot, options);
+        if (current.build.bundleHash !== initial.build.bundleHash) {
+          invalid = true;
+          return false;
+        }
+        sourceIdentity = current.sourceIdentity;
+        return true;
+      } catch {
+        invalid = true;
+        return false;
+      }
+    })().finally(() => {
+      pending = undefined;
+    });
+    return pending;
+  };
   return {
     packageRoot: canonicalRoot,
-    build: await resolveNodeWorkerBuild({ ...options, packageRoot: canonicalRoot }),
+    build: initial.build,
+    // The prepared runtime owns one immutable advertised build. Launches stat this
+    // fixed source set and only rebuild after metadata drift; a mismatch fences it.
+    revalidateBuild,
   };
 }

--- a/src/node-host/node-worker-entry.ts
+++ b/src/node-host/node-worker-entry.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isPathInside } from "../infra/path-guards.js";
 import type { NodeWorkerLaunchInput } from "../worker/node-supervisor-protocol.js";
-import { resolveNodeWorkerBuild, type NodeWorkerInstallation } from "./node-worker-build.js";
+import type { NodeWorkerInstallation } from "./node-worker-build.js";
 
 /** Resolves an explicitly selected worker install without crossing local/bundle trust modes. */
 export async function resolveNodeWorkerEntry(params: {
@@ -17,12 +17,7 @@ export async function resolveNodeWorkerEntry(params: {
     if (!installation || installation.build.bundleHash !== params.expectedBundleHash) {
       throw new Error("node worker local install does not match its advertised build");
     }
-    const current = await resolveNodeWorkerBuild({
-      packageRoot: installation.packageRoot,
-      openclawVersion: installation.build.openclawVersion,
-      protocolFeatures: installation.build.protocolFeatures,
-    });
-    if (current.bundleHash !== installation.build.bundleHash) {
+    if (!(await installation.revalidateBuild())) {
       throw new Error("node worker local install changed after its build was advertised");
     }
     const root = fs.realpathSync.native(installation.packageRoot);

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -1,5 +1,6 @@
 import childProcess from "node:child_process";
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -199,7 +200,7 @@ describe("node worker supervisor", () => {
     await supervisor.close();
   });
 
-  it("runs the advertised local install and refuses it after its worker bytes change", async () => {
+  it("reuses the advertised local install and refuses it after its worker bytes change", async () => {
     const root = tempDirs.make("node-worker-local-install-");
     const packageRoot = path.join(root, "package");
     const workspaceDir = path.join(root, "workspace");
@@ -229,12 +230,14 @@ describe("node worker supervisor", () => {
       input.descriptor.admission.handshake = structuredClone(installation.build);
       return input;
     };
+    const stagingRoot = vi.spyOn(fsp, "mkdtemp");
 
     const first = localInput("local-success");
     expect(await supervisor.launch(first, TEST_WORKER_ENDPOINT)).toMatchObject({
       state: "running",
     });
     expect(await waitForTerminal(supervisor, first.launchId)).toMatchObject({ state: "completed" });
+    expect(stagingRoot).not.toHaveBeenCalled();
 
     fs.writeFileSync(distPath, "export const workerBuild = 2;\n");
     expect(
@@ -243,6 +246,7 @@ describe("node worker supervisor", () => {
       state: "failed",
       errorText: expect.stringContaining("changed after its build was advertised"),
     });
+    expect(stagingRoot).toHaveBeenCalledTimes(1);
     await supervisor.close();
   });
 

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -167,6 +167,7 @@ vi.mock("./mcp.js", () => ({
 vi.mock("./node-worker-build.js", () => ({
   resolveNodeWorkerInstallation: vi.fn(async () => ({
     packageRoot: "/tmp/openclaw-node-worker",
+    revalidateBuild: vi.fn(async () => true),
     build: structuredClone(mocks.nodeWorkerBuild),
   })),
 }));

--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -51,6 +51,7 @@ vi.mock("./node-worker-supervisor.js", () => ({
 vi.mock("./node-worker-build.js", () => ({
   resolveNodeWorkerInstallation: vi.fn(async () => ({
     packageRoot: "/tmp/openclaw-node-worker",
+    revalidateBuild: vi.fn(async () => true),
     build: {
       bundleHash: "a".repeat(64),
       openclawVersion: "2026.8.1",

--- a/src/node-host/runtime.worker-supervisor.test.ts
+++ b/src/node-host/runtime.worker-supervisor.test.ts
@@ -67,6 +67,7 @@ describe("node-host runtime worker supervisor lifetime", () => {
     const input = testWorkerLaunchInput(fixture.workspaceDir, "launch-runtime", "wait");
     resolveNodeWorkerInstallationMock.mockResolvedValue({
       packageRoot: fixture.root,
+      revalidateBuild: vi.fn(async () => true),
       build: input.descriptor.admission.handshake,
     });
     let releaseLaunchResponse!: () => void;

--- a/src/node-host/skills.test.ts
+++ b/src/node-host/skills.test.ts
@@ -68,6 +68,15 @@ describe("scanNodeHostedSkills", () => {
     ]);
   });
 
+  it("treats a missing skills directory as an empty fresh-node inventory", () => {
+    const warn = vi.fn();
+
+    expect(scanNodeHostedSkills({ skillsDir: path.join(createRoot(), "missing"), warn })).toEqual(
+      [],
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("loads descriptors and preserves the full SKILL.md content", () => {
     const root = createRoot();
     const content = writeSkill(root, "release-helper", "Prepare a release", "# Release\nDo it.");

--- a/src/node-host/skills.ts
+++ b/src/node-host/skills.ts
@@ -47,7 +47,9 @@ function listCandidateSkillFiles(skillsDir: string, warn: (message: string) => v
   try {
     entries = fs.readdirSync(skillsDir, { withFileTypes: true });
   } catch (error) {
-    warn(`node host skill scan skipped (${skillsDir}): ${String(error)}`);
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      warn(`node host skill scan skipped (${skillsDir}): ${String(error)}`);
+    }
     return [];
   }
   const candidates: string[] = [];

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1131,6 +1131,11 @@ describe("plugin sdk alias helpers", () => {
         installRoot: path.join(makeTempDir(), ".openclaw", "npm"),
         packageName: "@openclaw/ollama",
       });
+    const { packageRoot: installedLlamaRoot, pluginEntry: installedLlamaEntry } =
+      writeInstalledPluginEntry({
+        installRoot: path.join(makeTempDir(), ".openclaw", "npm"),
+        packageName: "@openclaw/llama-cpp-provider",
+      });
 
     for (const owner of owners.filter(({ resolution }) => resolution === undefined)) {
       const sourceSubpaths = withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined }, () =>
@@ -1172,6 +1177,16 @@ describe("plugin sdk alias helpers", () => {
         ),
       ),
     );
+    const installedLlamaAliases = withCwd(installedLlamaRoot, () =>
+      withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined, NODE_ENV: undefined }, () =>
+        buildPluginLoaderAliasMap(
+          installedLlamaEntry,
+          path.join(fixture.root, "openclaw.mjs"),
+          undefined,
+          "dist",
+        ),
+      ),
+    );
 
     expect(privateQaOtherSubpaths).toEqual(["core"]);
     for (const owner of ownersWithAliases) {
@@ -1182,6 +1197,9 @@ describe("plugin sdk alias helpers", () => {
     expect(otherAliases[ssrfInternalSpecifier]).toBeUndefined();
     expect(privateQaOtherAliases[ssrfInternalSpecifier]).toBeUndefined();
     expect(installedAliases[ssrfInternalSpecifier]).toBeUndefined();
+    expect(fs.realpathSync(installedLlamaAliases[ssrfInternalSpecifier] ?? "")).toBe(
+      fs.realpathSync(distSsrFInternalPath),
+    );
 
     const createJiti = await getCreateJiti();
     const sourceLoaderBaseUrl = pathToFileURL(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -420,7 +420,7 @@ const PLUGIN_SDK_PACKAGE_NAMES = ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"]
 const CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH = "codex-mcp-projection";
 const CODEX_SESSION_TRANSCRIPT_PLUGIN_SDK_SUBPATH = "codex-session-transcript-runtime";
 const NATIVE_HOOK_RELAY_RUNTIME_PLUGIN_SDK_SUBPATH = "native-hook-relay-runtime";
-const OLLAMA_CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH = "ssrf-runtime-internal";
+const CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH = "ssrf-runtime-internal";
 const PRIVATE_QA_ONLY_PLUGIN_SDK_SUBPATHS = new Set([
   "agent-runtime-test-contracts",
   "channel-contract-testing",
@@ -466,12 +466,18 @@ const PRIVATE_PLUGIN_SDK_SUBPATH_OWNERS: readonly PrivatePluginSdkSubpathOwner[]
   {
     bundledPluginId: "ollama",
     allowPrivateQaCli: false,
-    subpaths: [OLLAMA_CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH],
+    subpaths: [CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH],
   },
   {
     bundledPluginId: "browser",
     allowPrivateQaCli: false,
-    subpaths: [OLLAMA_CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH],
+    subpaths: [CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH],
+  },
+  {
+    bundledPluginId: "llama-cpp",
+    officialInstalledPackageName: "@openclaw/llama-cpp-provider",
+    allowPrivateQaCli: false,
+    subpaths: [CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH],
   },
 ];
 const PLUGIN_SDK_SOURCE_CANDIDATE_EXTENSIONS = [
@@ -718,7 +724,7 @@ function readPrivateLocalOnlyPluginSdkSubpaths(packageRoot: string): string[] {
     ...new Set([
       CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH,
       NATIVE_HOOK_RELAY_RUNTIME_PLUGIN_SDK_SUBPATH,
-      OLLAMA_CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH,
+      CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH,
       ...(Array.isArray(parsed)
         ? parsed.filter((subpath): subpath is string => isSafePluginSdkSubpathSegment(subpath))
         : []),

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../../../../src/infra/node-runner-inventory.js";
 import { handleInvoke, type NodeInvokeRequestPayload } from "../../../../src/node-host/invoke.js";
 import {
-  resolveNodeWorkerBuild,
+  resolveNodeWorkerInstallation,
   type NodeWorkerInstallation,
 } from "../../../../src/node-host/node-worker-build.js";
 import { createNodeWorkerSupervisor } from "../../../../src/node-host/node-worker-supervisor.js";
@@ -145,15 +145,11 @@ async function createSourceWorkerInstallation(root: string): Promise<NodeWorkerI
     path.join(packageRoot, "node_modules"),
     process.platform === "win32" ? "junction" : "dir",
   );
-  const canonicalRoot = await fs.realpath(packageRoot);
-  return {
-    packageRoot: canonicalRoot,
-    build: await resolveNodeWorkerBuild({
-      packageRoot: canonicalRoot,
-      openclawVersion: VERSION,
-      protocolFeatures: WORKER_PROTOCOL_FEATURES,
-    }),
-  };
+  return await resolveNodeWorkerInstallation({
+    packageRoot,
+    openclawVersion: VERSION,
+    protocolFeatures: WORKER_PROTOCOL_FEATURES,
+  });
 }
 
 async function connectClient(params: {

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -308,6 +308,17 @@ describe("plugin npm runtime build planning", () => {
     expect(listMissingPluginNpmRuntimeHostExports(plan)).toEqual([]);
   });
 
+  it("keeps published llama.cpp runtime imports resolvable from the host package", async () => {
+    const result = await buildPluginNpmRuntime({
+      repoRoot,
+      packageDir: "extensions/llama-cpp",
+      logLevel: "silent",
+    });
+    const plan = expectPluginNpmRuntimeBuildPlan(result);
+
+    expect(listMissingPluginNpmRuntimeHostExports(plan)).toEqual([]);
+  });
+
   it("detects unresolved side-effect host imports in built plugin runtimes", () => {
     const outDir = tempDirs.make("openclaw-plugin-runtime-host-import-");
     writeFileSync(


### PR DESCRIPTION
## What Problem This Solves

Fixes four regressions found in the live node-hosting E2E on merged `main` at `92eed63f584`:

- every local-install worker launch repeated the complete install walk, staging copy, and content hash, adding 127.5 seconds before spawn;
- a gateway using a scratch `OPENCLAW_STATE_DIR` could run scheduled skill maintenance against the operator's real `~/.openclaw/workspace`;
- a fresh dist node could not load the official llama.cpp plugin because its required private SSRF runtime was absent from the packaged host surface;
- a fresh node warned when its optional skills directory did not exist.

AI-assisted; the resulting ownership boundaries, behavior, tests, and evidence were reviewed and understood.

## Why This Change Was Made

The node host now owns one lifecycle-bounded advertised worker installation. Warm launches validate a fixed metadata snapshot without another directory walk, staging copy, or content hash; metadata drift performs one single-flight canonical recomputation, and a changed bundle hash permanently fences the advertised install until restart.

Implicit default workspaces now follow the resolved state directory in both core and the memory host, while explicit workspace overrides and the ordinary default install path remain unchanged. The llama.cpp fix keeps the managed-proxy loopback helper private: it ships as a JavaScript-only host runtime and is granted to the exact official package rather than widened into the public SDK. Missing node-host skills directories suppress only `ENOENT`; other filesystem errors still warn.

## User Impact

Repeated local worker launches no longer spend minutes re-hashing an unchanged OpenClaw install. Scratch/profile gateways keep default workspace and maintenance work inside their selected state tree. Fresh node hosts can load the official llama.cpp plugin, and an empty optional skills directory starts quietly.

## Evidence

- Live baseline: the wave-2 run measured 127.5 seconds of pre-spawn install hashing on every local launch and 139 seconds for a no-origin turn.
- Built-install timing after this change: initial advertisement hash `10807.8 ms`; warm launch revalidation `29.8 ms`, valid=true. This removes about 127.47 seconds from the reported launch-side delay and stays well below the 1-second target.
- The local-install regression runs advertisement → warm launch → mutate `dist/entry.js` → one canonical recomputation → refused launch. The warm launch creates no staging tree.
- Focused final-code command passed three consecutive times: six Vitest shards per run, 145 tests passed and one unchanged skip per run.
- `pnpm check:changed` passed the full all-lanes changed gate, including all core/plugin/test TypeScript projects, lint, dead-code, package, SDK, architecture, and import-cycle checks.
- `pnpm build` passed in 4m48.8s, including runtime postbuild loading 36 built plugin control-plane modules and all 144 public SDK subpaths.
- `pnpm db:kysely:check`, `pnpm plugin-sdk:check-exports`, and `pnpm plugin-sdk:surface:check` passed; both generators were run and produced no additional diff.
- An npm-packed `@openclaw/llama-cpp-provider@2026.8.1` installed through an isolated managed `npm-pack:` project and appeared as loaded with zero diagnostics in the built CLI.
- Source-blind behavior validation passed scratch workspace containment, two silent fresh-node starts with no skills directory, and a separate llama.cpp runtime inspection with zero diagnostics.
- Final branch autoreview: clean, no accepted/actionable findings.

The configured hosted Testbox executable was unavailable on this host before allocation, so trusted heavy proof used the repository-authorized local fallback. No UI surface changed, so screenshots are not applicable.
