### PR TITLE
fix: restore default-profile backup archives

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -45,7 +45,7 @@ Archive `create`, `verify`, and `restore`, plus SQLite `create`, `list`, `verify
 - The archive embeds a `manifest.json` with the resolved source paths and archive layout.
 - Default output is a timestamped `.tar.gz` archive in the current working directory. Timestamped filenames use your machine's local timezone and include the UTC offset. If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten. Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
-- `openclaw backup verify <archive>` checks that the archive contains exactly one root manifest, rejects traversal-style archive paths and SQLite sidecars, confirms every manifest-declared payload exists, validates every SQLite snapshot's file shape, and runs full integrity and role checks on canonical OpenClaw databases. Dedicated plugin schemas remain opaque because they may require owner-defined SQLite capabilities. `openclaw backup create --verify` runs that validation immediately after writing the archive.
+- `openclaw backup verify <archive>` checks that the archive contains exactly one root manifest, rejects traversal-style archive paths, absolute or archive-escaping symbolic links, and SQLite sidecars, confirms every manifest-declared payload exists, validates every SQLite snapshot's file shape, and runs full integrity and role checks on canonical OpenClaw databases. Dedicated plugin schemas remain opaque because they may require owner-defined SQLite capabilities. `openclaw backup create --verify` runs that validation immediately after writing the archive.
 - `openclaw backup create --only-config` backs up just the active JSON config file.
 
 ## Restore a full archive
@@ -70,7 +70,9 @@ archive.
   relinking. Approvals and delivery/dedupe state also roll back, so review
   pending approvals before resuming the Gateway. Plugin `node_modules` trees
   are not archived; after activation, run `openclaw plugins update <id>` or
-  reinstall with `openclaw plugins install <spec> --force`.
+  reinstall with `openclaw plugins install <spec> --force`. The generated
+  `plugin-skills/` symlink index is also omitted; run `openclaw skills list` or
+  start an agent session after activation to rebuild it from plugin metadata.
 </Warning>
 
 Activation is a separate offline operator step. Stop the Gateway, move the
@@ -260,6 +262,8 @@ These rules do not filter workspace files outside the state directory. They also
 SQLite databases under the state directory are captured with SQLite's online backup API and compacted offline with `VACUUM` so deleted-page remnants do not enter the archive, and live WAL/SHM files are not copied. A plugin-owned database that requires unavailable owner-defined SQLite capabilities fails closed rather than falling back to a direct file copy. SQLite files included through workspace backups are copied as workspace files and are not covered by the compaction guarantee.
 
 Installed plugin source and manifest files under the state directory's `extensions/` tree are included, but their nested `node_modules/` dependency trees are skipped as rebuildable install artifacts. After restoring an archive, use `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force` if a restored plugin reports missing dependencies.
+
+The state directory's `plugin-skills/` root is a generated, OpenClaw-owned symlink index, not authoritative state. Backup creation reports and omits that root because its absolute targets are specific to the source installation. After activating restored state, run `openclaw skills list` or start an agent session to rebuild the links from current plugin metadata. Other relative symbolic links are retained when their targets stay inside the archive root; verification rejects absolute or archive-escaping targets.
 
 Installer-managed and rebuildable runtime roots under the state directory are also skipped: `dev/`, `git/`, `npm/`, legacy `npm-runtime/`, `tmp/`, and `tools/`. These contain managed checkouts, package trees, compiler caches, temporary files, and downloaded runtimes rather than authoritative user state; reinstall or update the corresponding runtime or plugin after restore. An explicitly configured config file, credentials directory, or workspace inside one of these roots remains included.
 

--- a/docs/install/backups.md
+++ b/docs/install/backups.md
@@ -247,7 +247,7 @@ openclaw backup restore "$ARCHIVE" --target ./restored-openclaw
 ```
 
 The target must not exist or must be empty. OpenClaw verifies archive structure,
-the manifest, hardlinks, and SQLite databases before it writes the target. A
+the manifest, hardlinks, symbolic-link containment, and SQLite databases before it writes the target. A
 non-empty target is refused, and a failed extraction cleans its incomplete
 output. The command never touches the live state directory and has no force or
 in-place mode. Treat the restored directory as sensitive: it can contain
@@ -259,7 +259,9 @@ credentials, auth profiles, sessions, and workspace data.
   relinking. Approvals and delivery/dedupe state also roll back, so review
   pending approvals before resuming the Gateway. Plugin `node_modules` trees
   are not archived; after activation, run `openclaw plugins update <id>` or
-  reinstall with `openclaw plugins install <spec> --force`.
+  reinstall with `openclaw plugins install <spec> --force`. Run `openclaw
+  skills list` or start an agent session to regenerate the omitted
+  `plugin-skills/` symlink index from current plugin metadata.
 </Warning>
 
 The manifest records `archiveRoot`, the original paths under `paths`, and an

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -305,7 +305,9 @@ describe("backupRestoreCommand", () => {
             backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
           ).rejects.toThrow(error);
           await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
-          await new Promise<void>((resolve) => setImmediate(resolve));
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
           await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
         },
       );
@@ -343,7 +345,9 @@ describe("backupRestoreCommand", () => {
           backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
         ).rejects.toThrow(/incomplete target was cleaned/iu);
         await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
         await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
       },
     );
@@ -387,6 +391,10 @@ describe("backupRestoreCommand", () => {
         expect((restoreError as Error).message).toMatch(/cleanup denied/iu);
         expect((restoreError as Error).cause).toBeInstanceOf(Error);
         expect((restoreError as Error).cause).not.toBe(cleanupError);
+        expect((restoreError as AggregateError).errors).toEqual([
+          (restoreError as Error).cause,
+          cleanupError,
+        ]);
       },
     );
   });

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -53,7 +53,7 @@ async function listFilesystemLeafEntries(root: string, relative = ""): Promise<s
 function encodeTarEntry(params: {
   path: string;
   contents?: string;
-  type?: "File" | "Directory" | "Link";
+  type?: "File" | "Directory" | "Link" | "SymbolicLink";
   linkpath?: string;
 }): Buffer {
   const body = Buffer.from(params.contents ?? "", "utf8");
@@ -126,6 +126,18 @@ describe("backupRestoreCommand", () => {
         const targetPath = state.path("restored");
         await fs.mkdir(outputDir, { recursive: true });
         await state.writeText("operator-note.txt", "restore me\n");
+        const pluginSkillTarget = state.statePath("plugin-source", "canvas");
+        if (process.platform !== "win32") {
+          await fs.mkdir(pluginSkillTarget, { recursive: true });
+          await fs.writeFile(path.join(pluginSkillTarget, "SKILL.md"), "# Canvas\n", "utf8");
+          const pluginSkillsDir = state.statePath("plugin-skills");
+          await fs.mkdir(pluginSkillsDir, { recursive: true });
+          await fs.symlink(
+            await fs.realpath(pluginSkillTarget),
+            path.join(pluginSkillsDir, "canvas"),
+            "dir",
+          );
+        }
         openOpenClawStateDatabase({ env: state.env });
 
         try {
@@ -152,8 +164,20 @@ describe("backupRestoreCommand", () => {
           expect(restored.warnings.join("\n")).toMatch(/WhatsApp/iu);
           expect(restored.warnings.join("\n")).toMatch(/pending approvals/iu);
           expect(restored.warnings.join("\n")).toMatch(/plugins install <spec> --force/iu);
+          expect(restored.warnings.join("\n")).toMatch(/openclaw skills list/iu);
           expect(runtime.log).toHaveBeenCalledOnce();
           expect(JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0]))).toEqual(restored);
+          if (process.platform !== "win32") {
+            expect(backup.skipped).toContainEqual(
+              expect.objectContaining({
+                sourcePath: state.statePath("plugin-skills"),
+                reason: "regenerable",
+              }),
+            );
+            expect(await listArchiveLeafEntries(backup.archivePath)).not.toContainEqual(
+              expect.stringContaining("/plugin-skills/"),
+            );
+          }
 
           expect(await listFilesystemLeafEntries(targetPath)).toEqual(
             await listArchiveLeafEntries(backup.archivePath),
@@ -239,6 +263,55 @@ describe("backupRestoreCommand", () => {
     );
   });
 
+  it.each([
+    {
+      label: "absolute",
+      linkpath: "/private/tmp/outside-restore",
+      error: /symbolic link target must be relative/iu,
+    },
+    {
+      label: "archive-escaping",
+      linkpath: "../../outside-restore",
+      error: /symbolic link target is outside the declared archive root/iu,
+    },
+  ])(
+    "rejects $label symlink targets before touching the restore target",
+    async ({ linkpath, error }) => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-restore-absolute-symlink-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const archivePath = state.path("absolute-symlink.tar.gz");
+          const targetPath = state.path("restore-target");
+          const archiveRoot = "2026-08-12T00-00-00.000Z-openclaw-backup";
+          const payloadPath = buildBackupArchivePath(archiveRoot, "/tmp/openclaw.json");
+          await writeArchive({
+            archivePath,
+            archiveRoot,
+            payloadPath,
+            extraEntries: [
+              encodeTarEntry({
+                path: `${archiveRoot}/payload/absolute-link`,
+                type: "SymbolicLink",
+                linkpath,
+              }),
+            ],
+          });
+
+          await expect(
+            backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+          ).rejects.toThrow(error);
+          await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+        },
+      );
+    },
+  );
+
   it("cleans an incomplete fresh target when extraction fails", async () => {
     await withOpenClawTestState(
       {
@@ -270,6 +343,50 @@ describe("backupRestoreCommand", () => {
           backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
         ).rejects.toThrow(/incomplete target was cleaned/iu);
         await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    );
+  });
+
+  it("preserves the extraction error when cleanup also fails", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-restore-double-failure-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const archivePath = state.path("unextractable.tar.gz");
+        const targetPath = state.path("restore-target");
+        const archiveRoot = "2026-08-12T00-00-00.000Z-openclaw-backup";
+        const assetPath = buildBackupArchivePath(archiveRoot, "/tmp/openclaw.json");
+        const directoryPath = `${archiveRoot}/payload/invalid-hardlink-target`;
+        await writeArchive({
+          archivePath,
+          archiveRoot,
+          payloadPath: assetPath,
+          extraEntries: [
+            encodeTarEntry({ path: directoryPath, type: "Directory" }),
+            encodeTarEntry({
+              path: `${archiveRoot}/payload/directory-hardlink`,
+              type: "Link",
+              linkpath: directoryPath,
+            }),
+          ],
+        });
+        const cleanupError = new Error("cleanup denied");
+        vi.spyOn(fs, "rm").mockRejectedValueOnce(cleanupError);
+
+        const restoreError = await backupRestoreCommand(createRuntime(), {
+          archive: archivePath,
+          target: targetPath,
+        }).catch((error: unknown) => error);
+
+        expect(restoreError).toBeInstanceOf(Error);
+        expect((restoreError as Error).message).toMatch(/cleanup denied/iu);
+        expect((restoreError as Error).cause).toBeInstanceOf(Error);
+        expect((restoreError as Error).cause).not.toBe(cleanupError);
       },
     );
   });

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -138,7 +138,9 @@ export async function backupRestoreCommand(
     try {
       await cleanupFailedRestore(targetPath, target.created);
     } catch (cleanupError) {
-      throw new Error(
+      // oxlint-disable-next-line preserve-caught-error -- cleanup is the second AggregateError entry; extraction stays the primary cause.
+      throw new AggregateError(
+        [error, cleanupError],
         `Backup restore failed and the incomplete target could not be cleaned: ${targetPath}. Cleanup error: ${formatErrorMessage(cleanupError)}`,
         { cause: error },
       );

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -132,25 +132,33 @@ export async function backupRestoreCommand(
   const verified = await verifyBackupArchive(options.archive);
   const target = await prepareRestoreTarget(targetPath);
 
+  let extractionError: unknown;
+  let extractionFailed = false;
   try {
     await extractBackupArchive(verified.archivePath, targetPath);
-  } catch (error) {
+  } catch (caughtExtractionError) {
+    extractionError = caughtExtractionError;
+    extractionFailed = true;
+  }
+  if (extractionFailed) {
     let cleanupError: unknown;
+    let cleanupFailed = false;
     try {
       await cleanupFailedRestore(targetPath, target.created);
     } catch (caughtCleanupError) {
       cleanupError = caughtCleanupError;
+      cleanupFailed = true;
     }
-    if (cleanupError !== undefined) {
+    if (cleanupFailed) {
       // Extraction stays the primary cause; cleanup rides along as the second AggregateError entry.
       throw new AggregateError(
-        [error, cleanupError],
+        [extractionError, cleanupError],
         `Backup restore failed and the incomplete target could not be cleaned: ${targetPath}. Cleanup error: ${formatErrorMessage(cleanupError)}`,
-        { cause: error },
+        { cause: extractionError },
       );
     }
     throw new Error(`Backup restore failed; the incomplete target was cleaned: ${targetPath}`, {
-      cause: error,
+      cause: extractionError,
     });
   }
 

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as tar from "tar";
 import { resolveStateDir } from "../config/config.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
 import { BACKUP_MAX_DECOMPRESSION_RATIO, canonicalizePathForContainment } from "./backup-shared.js";
@@ -14,6 +15,7 @@ const BACKUP_RESTORE_WARNINGS = [
   "Messaging-channel credentials with ratchet state, especially WhatsApp, may desynchronize after rollback and require relinking.",
   "Approvals and delivery/dedupe state also roll back; review pending approvals before resuming the Gateway.",
   "Plugin node_modules are not archived; after activation, run `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force`.",
+  "Generated plugin-skills links are not archived; after activation, run `openclaw skills list` or start an agent session to rebuild them.",
 ] as const;
 
 type BackupRestoreOptions = {
@@ -31,6 +33,7 @@ type BackupRestoreResult = {
   runtimeVersion: string;
   assetCount: number;
   entryCount: number;
+  symlinkCount: number;
   warnings: string[];
 };
 
@@ -84,6 +87,27 @@ async function cleanupFailedRestore(targetPath: string, created: boolean): Promi
   }
 }
 
+async function extractBackupArchive(archivePath: string, targetPath: string): Promise<void> {
+  let extractionError: Error | undefined;
+  await tar.x({
+    file: archivePath,
+    gzip: true,
+    maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
+    cwd: targetPath,
+    // node-tar strict mode rejects on the first warning before queued writes drain.
+    // Verification catches fatal archive errors; rethrow recoverable warnings after close.
+    strict: false,
+    preserveOwner: false,
+    onwarn: (code, message, data) => {
+      extractionError ??=
+        data instanceof Error ? data : Object.assign(new Error(`${code}: ${message}`), data);
+    },
+  });
+  if (extractionError) {
+    throw extractionError;
+  }
+}
+
 function formatRestoreResult(result: BackupRestoreResult): string {
   return [
     `Backup archive restored to staging: ${shortenHomePath(result.targetPath)}`,
@@ -109,21 +133,14 @@ export async function backupRestoreCommand(
   const target = await prepareRestoreTarget(targetPath);
 
   try {
-    await tar.x({
-      file: verified.archivePath,
-      gzip: true,
-      maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
-      cwd: targetPath,
-      strict: true,
-      preserveOwner: false,
-    });
+    await extractBackupArchive(verified.archivePath, targetPath);
   } catch (error) {
     try {
       await cleanupFailedRestore(targetPath, target.created);
     } catch (cleanupError) {
       throw new Error(
-        `Backup restore failed and the incomplete target could not be cleaned: ${targetPath}`,
-        { cause: cleanupError },
+        `Backup restore failed and the incomplete target could not be cleaned: ${targetPath}. Cleanup error: ${formatErrorMessage(cleanupError)}`,
+        { cause: error },
       );
     }
     throw new Error(`Backup restore failed; the incomplete target was cleaned: ${targetPath}`, {

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -135,10 +135,14 @@ export async function backupRestoreCommand(
   try {
     await extractBackupArchive(verified.archivePath, targetPath);
   } catch (error) {
+    let cleanupError: unknown;
     try {
       await cleanupFailedRestore(targetPath, target.created);
-    } catch (cleanupError) {
-      // oxlint-disable-next-line preserve-caught-error -- cleanup is the second AggregateError entry; extraction stays the primary cause.
+    } catch (caughtCleanupError) {
+      cleanupError = caughtCleanupError;
+    }
+    if (cleanupError !== undefined) {
+      // Extraction stays the primary cause; cleanup rides along as the second AggregateError entry.
       throw new AggregateError(
         [error, cleanupError],
         `Backup restore failed and the incomplete target could not be cleaned: ${targetPath}. Cleanup error: ${formatErrorMessage(cleanupError)}`,

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -65,6 +65,7 @@ type BackupVerifyResult = {
   runtimeVersion: string;
   assetCount: number;
   entryCount: number;
+  symlinkCount: number;
 };
 
 type ArchiveEntry = {
@@ -311,6 +312,34 @@ function verifyHardlinkTargetsAgainstArchiveRoot(
   }
 }
 
+function verifySymbolicLinkTargetsAgainstArchiveRoot(
+  symbolicLinks: Array<{ entryPath: string; linkpath: string }>,
+  archiveRoot: string,
+): void {
+  const normalizedRoot = normalizeArchiveRoot(archiveRoot);
+  for (const link of symbolicLinks) {
+    if (link.linkpath.startsWith("/") || WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE.test(link.linkpath)) {
+      throw new Error(
+        `Archive symbolic link target must be relative: ${link.entryPath} -> ${link.linkpath}`,
+      );
+    }
+    if (link.linkpath.includes("\\")) {
+      throw new Error(
+        `Archive symbolic link target must use forward slashes: ${link.entryPath} -> ${link.linkpath}`,
+      );
+    }
+    const entryPath = normalizeArchivePath(link.entryPath, "Archive symbolic link path");
+    const targetPath = path.posix.normalize(
+      path.posix.join(path.posix.dirname(entryPath), link.linkpath),
+    );
+    if (!isArchivePathWithin(targetPath, normalizedRoot)) {
+      throw new Error(
+        `Archive symbolic link target is outside the declared archive root: ${link.entryPath} -> ${link.linkpath}`,
+      );
+    }
+  }
+}
+
 function formatResult(result: BackupVerifyResult): string {
   return [
     `Backup archive OK: ${result.archivePath}`,
@@ -319,6 +348,7 @@ function formatResult(result: BackupVerifyResult): string {
     `Runtime version: ${result.runtimeVersion}`,
     `Assets verified: ${result.assetCount}`,
     `Archive entries scanned: ${result.entryCount}`,
+    `Symbolic links checked: ${result.symlinkCount}`,
   ].join("\n");
 }
 
@@ -732,6 +762,14 @@ export async function verifyBackupArchive(archive: string): Promise<BackupVerify
         `Archive hardlink target for ${entry.path}`,
       ),
     }));
+  const symbolicLinks = rawEntries
+    .filter((entry) => entry.type === "SymbolicLink")
+    .map((entry) => {
+      if (!entry.linkpath) {
+        throw new Error(`Archive symbolic link is missing its target: ${entry.path}`);
+      }
+      return { entryPath: entry.path, linkpath: entry.linkpath };
+    });
   const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
 
   const manifestMatches = entries.filter((entry) => isRootManifestEntry(entry.normalized));
@@ -761,6 +799,7 @@ export async function verifyBackupArchive(archive: string): Promise<BackupVerify
     manifest.archiveRoot,
     normalizedEntrySet,
   );
+  verifySymbolicLinkTargetsAgainstArchiveRoot(symbolicLinks, manifest.archiveRoot);
   await verifySqliteSnapshots({ archivePath, entries, manifest });
 
   const result: BackupVerifyResult = {
@@ -771,6 +810,7 @@ export async function verifyBackupArchive(archive: string): Promise<BackupVerify
     runtimeVersion: manifest.runtimeVersion,
     assetCount: manifest.assets.length,
     entryCount: rawEntries.length,
+    symlinkCount: symbolicLinks.length,
   };
 
   return result;

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -2212,12 +2212,13 @@ describe("createBackupArchive", () => {
       },
       async (state) => {
         const outputDir = state.path("backups");
-        const externalDbPath = state.path("external-malformed.sqlite");
+        const backingPath = state.statePath("plugins", "backing", "malformed.bin");
         const linkedDbPath = state.statePath("plugins", "dedicated", "linked.sqlite");
+        await fs.mkdir(path.dirname(backingPath), { recursive: true });
         await fs.mkdir(path.dirname(linkedDbPath), { recursive: true });
         await fs.mkdir(outputDir, { recursive: true });
-        await fs.writeFile(externalDbPath, "not a sqlite database", "utf8");
-        await fs.symlink(externalDbPath, linkedDbPath);
+        await fs.writeFile(backingPath, "not a sqlite database", "utf8");
+        await fs.symlink(path.relative(path.dirname(linkedDbPath), backingPath), linkedDbPath);
 
         const result = await createBackupArchive({
           output: outputDir,
@@ -2231,7 +2232,7 @@ describe("createBackupArchive", () => {
         const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
         await expect(
           backupVerifyCommand(runtime, { archive: result.archivePath }),
-        ).resolves.toMatchObject({ ok: true });
+        ).resolves.toEqual(expect.objectContaining({ ok: true, symlinkCount: 1 }));
       },
     );
   });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -23,7 +23,7 @@ import {
   sanitizeOpenClawGlobalStateSnapshot,
   sanitizeOpenClawStateLeaseRows,
 } from "../state/openclaw-state-snapshot-sanitizer.js";
-import { resolveHomeDir, resolveUserPath } from "../utils.js";
+import { resolveHomeDir, resolveUserPath, shortenHomePath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import {
   cleanupBackupArchivePublication,
@@ -748,6 +748,10 @@ export async function createBackupArchive(
   }
 
   const createdAt = new Date(nowMs).toISOString();
+  const stateAsset = plan.included.find((asset) => asset.kind === "state");
+  const pluginSkillsPath = stateAsset
+    ? path.join(stateAsset.sourcePath, "plugin-skills")
+    : undefined;
   const result: BackupCreateResult = {
     createdAt,
     archiveRoot,
@@ -778,7 +782,6 @@ export async function createBackupArchive(
     throw error;
   }
   const tempArchivePath = publication.tempArchivePath;
-  const stateAsset = result.assets.find((asset) => asset.kind === "state");
   const preservedStatePaths = [
     plan.configPath,
     plan.oauthDir,
@@ -851,6 +854,7 @@ export async function createBackupArchive(
     const gatewayLockDir = resolveGatewayLockDir(plan.stateDir);
     const volatilePlan = { stateDirs: [stateAsset?.sourcePath ?? plan.stateDir] };
     let skippedVolatileCount = 0;
+    let skippedPluginSkills = false;
     // node-tar invokes filters from async stat callbacks, so throwing inside
     // the filter is uncaught. Omit unexpected SQLite and reject after tar settles.
     const unexpectedSqliteSourcePaths: string[] = [];
@@ -863,6 +867,12 @@ export async function createBackupArchive(
       const resolvedEntryPath = path.resolve(entryPath);
       if (resolvedEntryPath === manifestPath) {
         return true;
+      }
+      // This OpenClaw-owned symlink index is rebuilt from plugin metadata.
+      // Archiving it would preserve host-specific absolute targets.
+      if (pluginSkillsPath && isPathWithin(resolvedEntryPath, pluginSkillsPath)) {
+        skippedPluginSkills = true;
+        return false;
       }
       if (stateFilter && !stateFilter(entryPath)) {
         return false;
@@ -909,6 +919,7 @@ export async function createBackupArchive(
         // attempt, so reset the closure counter here or retries would report
         // cumulative skip counts across attempts instead of the final one.
         skippedVolatileCount = 0;
+        skippedPluginSkills = false;
         unexpectedSqliteSourcePaths.length = 0;
         const prepared = await writeArchiveStreamToFile({
           archivePath: attemptTempArchivePath,
@@ -964,6 +975,14 @@ export async function createBackupArchive(
       },
     });
     result.skippedVolatileCount = skippedVolatileCount;
+    if (pluginSkillsPath && skippedPluginSkills) {
+      result.skipped.push({
+        kind: "plugin skills",
+        sourcePath: pluginSkillsPath,
+        displayPath: shortenHomePath(pluginSkillsPath),
+        reason: "regenerable",
+      });
+    }
     if (skippedVolatileCount > 0) {
       opts.log?.(
         `Backup skipped ${skippedVolatileCount} volatile file${


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw backup restore` failed for default profiles after `backup create` and `backup verify` had succeeded. Fresh profiles publish absolute generated links under `plugin-skills/`; node-tar rejected those during strict extraction, and cleanup then raced still-pending writes, leaving operators with only an `ENOTEMPTY` cleanup error instead of the restore cause.

## Why This Change Was Made

Backup creation now reports and omits the OpenClaw-owned, regenerable `plugin-skills/` symlink index. Verification retains legitimate relative symbolic links whose resolved targets stay inside the archive root, rejects absolute and archive-escaping targets before extraction, and reports the checked symlink count.

Restore keeps node-tar's warning-as-error behavior without its early-rejection race: it captures every recoverable extraction warning, waits for extraction to close, then rethrows the first warning. If cleanup also fails, an `AggregateError` preserves the extraction error as the primary cause and retains the cleanup error as the second error.

The node-tar 7.5.22 contract behind the failure is `dist/esm/unpack.js`'s `STRIPABSOLUTEPATH` guard (lines 213-257), which emits `TAR_ENTRY_INFO: stripping / from absolute linkpath`; `dist/esm/warn-method.js` lines 13-25 turns that warning into an `error` in strict mode; and `dist/esm/extract.js` lines 24-26 rejects on `error` before the later `close` event.

AI-assisted: yes (Codex). No agent transcript is included.

## User Impact

Operators can create, verify, and restore normal default-profile archives successfully. Unsafe absolute or escaping symlinks fail during verification with the offending entry and target named, incomplete extraction is actually removed before failure returns, and restore output explains how to regenerate plugin-skill links with `openclaw skills list` or a normal agent session.

Production LOC: +91/-13 (net +78) | Tests: +131/-5 (net +126) | Docs: +10/-4. The production growth implements the create/verify/restore ownership and security contracts; it does not add compatibility or retry paths.

## Evidence

- Before: isolated macOS profile `br1` created and verified a 47-entry archive, then restore failed with `Backup restore failed and the incomplete target could not be cleaned ... ENOTEMPTY` while the original `TAR_ENTRY_INFO` rejection was swallowed.
- After: the same isolated state produced a 44-entry archive with `plugin-skills` reported as `regenerable`; verify returned `symlinkCount: 0`; restore completed; `openclaw skills list` recreated both generated links from current plugin metadata.
- Unsafe-archive probe: restoring the pre-fix absolute-link archive exited 1 with `Archive symbolic link target must be relative ...` and did not create the target directory.
- `node scripts/run-vitest.mjs src/commands/backup-restore.test.ts src/commands/backup-verify.test.ts` — 35 passed, 1 platform skip.
- `node scripts/run-vitest.mjs src/infra/backup-create.test.ts --testNamePattern 'preserves noncanonical symlinked SQLite paths without dereferencing them'` — targeted symlink contract passed.
- `pnpm docs:check-mdx && pnpm docs:check-links` — passed; 6,493 internal links checked, 0 broken.
- `node scripts/check-changed.mjs` — passed in Blacksmith Testbox; https://github.com/openclaw/openclaw/actions/runs/31773078705
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean after the final error-contract adjustment; no accepted/actionable findings.
