### PR TITLE
fix(plugins): make setup registration atomic

### DIFF
--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -23,6 +23,11 @@ vi.mock("./native-module-require.js", () => ({
 const tempDirs: string[] = [];
 const mocks = getRegistryJitiMocks();
 
+type SetupRegistryApi = Pick<
+  import("./types.js").OpenClawPluginApi,
+  "registerProvider" | "registerCliBackend" | "registerConfigMigration" | "registerAutoEnableProbe"
+>;
+
 let clearPluginSetupRegistryCache: typeof import("./setup-registry.test-fixtures.js").clearPluginSetupRegistryCache;
 let resolvePluginSetupRegistry: typeof import("./setup-registry.js").resolvePluginSetupRegistry;
 let resolvePluginSetupProviderCore: typeof import("./setup-registry.js").resolvePluginSetupProviderCore;
@@ -828,6 +833,120 @@ describe("setup-registry module loader", () => {
     await expectNoUnhandledRejection(() => {
       expect(resolvePluginSetupRegistry({ env: {} }).configMigrations).toHaveLength(1);
     });
+  });
+
+  it("publishes each plugin setup registration atomically on synchronous success", () => {
+    const throwingRoot = makeTempDir();
+    const healthyRoot = makeTempDir();
+    writeSetupApiStub(throwingRoot);
+    writeSetupApiStub(healthyRoot);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "shared-plugin",
+          rootDir: throwingRoot,
+          setup: {
+            providers: [{ id: "shared-provider" }],
+            cliBackends: ["shared-cli"],
+          },
+        },
+        {
+          id: "shared-plugin",
+          rootDir: healthyRoot,
+          setup: {
+            providers: [{ id: "shared-provider" }],
+            cliBackends: ["shared-cli"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+    const throwingRegister = vi.fn((api: SetupRegistryApi) => {
+      api.registerProvider({ id: "shared-provider", label: "Throwing", auth: [] });
+      api.registerProvider({ id: "SHARED-PROVIDER", label: "Throwing duplicate", auth: [] });
+      api.registerCliBackend({ id: "shared-cli", config: { command: "throwing" } });
+      api.registerCliBackend({ id: "SHARED-CLI", config: { command: "throwing-duplicate" } });
+      api.registerConfigMigration((config) => ({ config, changes: ["throwing"] }));
+      api.registerAutoEnableProbe(() => "throwing");
+      throw new Error("setup registration failed");
+    });
+    const healthyRegister = vi.fn((api: SetupRegistryApi) => {
+      api.registerProvider({ id: "shared-provider", label: "Healthy", auth: [] });
+      api.registerProvider({ id: "SHARED-PROVIDER", label: "Healthy duplicate", auth: [] });
+      api.registerCliBackend({ id: "shared-cli", config: { command: "healthy" } });
+      api.registerCliBackend({ id: "SHARED-CLI", config: { command: "healthy-duplicate" } });
+      api.registerConfigMigration((config) => ({ config, changes: ["healthy"] }));
+      api.registerAutoEnableProbe(() => "healthy");
+    });
+    mocks.createJiti.mockImplementation((modulePath: string) => {
+      const register = modulePath.includes(throwingRoot) ? throwingRegister : healthyRegister;
+      return () => ({ default: { register } });
+    });
+
+    const first = resolvePluginSetupRegistry();
+    const second = resolvePluginSetupRegistry();
+
+    for (const registry of [first, second]) {
+      expect(
+        registry.providers.map(({ pluginId, provider }) => ({
+          pluginId,
+          id: provider.id,
+          label: provider.label,
+        })),
+      ).toEqual([{ pluginId: "shared-plugin", id: "shared-provider", label: "Healthy" }]);
+      expect(
+        registry.cliBackends.map(({ pluginId, backend }) => ({
+          pluginId,
+          id: backend.id,
+          command: backend.config.command,
+        })),
+      ).toEqual([{ pluginId: "shared-plugin", id: "shared-cli", command: "healthy" }]);
+      expect(registry.configMigrations).toHaveLength(1);
+      expect(registry.configMigrations[0]?.migrate({} as never)?.changes).toEqual(["healthy"]);
+      expect(registry.autoEnableProbes).toHaveLength(1);
+      expect(registry.autoEnableProbes[0]?.probe({ config: {}, env: {} } as never)).toBe("healthy");
+      expect(registry.diagnostics).toStrictEqual([]);
+    }
+    expect(second).not.toBe(first);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(1);
+    expect(throwingRegister).toHaveBeenCalledTimes(1);
+    expect(healthyRegister).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores setup contributions registered after the synchronous callback returns", async () => {
+    const pluginRoot = makeTempDir();
+    writeSetupApiStub(pluginRoot);
+    mockSinglePlugin({ id: "async-plugin", rootDir: pluginRoot });
+    mocks.createJiti.mockImplementation(() => {
+      return () => ({
+        default: {
+          register(api: SetupRegistryApi) {
+            api.registerProvider({ id: "sync-provider", label: "Sync", auth: [] });
+            api.registerCliBackend({ id: "sync-cli", config: { command: "sync" } });
+            api.registerConfigMigration((config) => ({ config, changes: ["sync"] }));
+            api.registerAutoEnableProbe(() => "sync");
+            return Promise.resolve().then(() => {
+              api.registerProvider({ id: "async-provider", label: "Async", auth: [] });
+              api.registerCliBackend({ id: "async-cli", config: { command: "async" } });
+              api.registerConfigMigration((config) => ({ config, changes: ["async"] }));
+              api.registerAutoEnableProbe(() => "async");
+            });
+          },
+        },
+      });
+    });
+
+    const first = resolvePluginSetupRegistry();
+    await Promise.resolve();
+    await Promise.resolve();
+    const second = resolvePluginSetupRegistry();
+
+    for (const registry of [first, second]) {
+      expect(registry.providers.map((entry) => entry.provider.id)).toEqual(["sync-provider"]);
+      expect(registry.cliBackends.map((entry) => entry.backend.id)).toEqual(["sync-cli"]);
+      expect(registry.configMigrations).toHaveLength(1);
+      expect(registry.autoEnableProbes).toHaveLength(1);
+    }
   });
 
   it("fails closed when multiple plugins claim the same setup provider id", () => {

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -333,6 +333,18 @@ function ignoreAsyncSetupRegisterResult(result: void | Promise<void>): void {
   void Promise.resolve(result).catch(() => undefined);
 }
 
+function runSetupRegistration(
+  register: (api: ReturnType<typeof buildPluginApi>) => void | Promise<void>,
+  api: ReturnType<typeof buildPluginApi>,
+): boolean {
+  try {
+    ignoreAsyncSetupRegisterResult(register(api));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function matchesProvider(provider: ProviderPlugin, providerId: string): boolean {
   const normalized = normalizeProviderId(providerId);
   if (normalizeProviderId(provider.id) === normalized) {
@@ -609,8 +621,8 @@ export function resolvePluginSetupRegistry(params?: {
   const configMigrations: SetupConfigMigrationEntry[] = [];
   const autoEnableProbes: SetupAutoEnableProbeEntry[] = [];
   const diagnostics: PluginSetupRegistryDiagnostic[] = [];
-  const providerKeys = new Set<string>();
-  const cliBackendKeys = new Set<string>();
+  let providerKeys = new Set<string>();
+  let cliBackendKeys = new Set<string>();
 
   const manifestRegistry =
     params?.manifestRegistry ??
@@ -637,44 +649,53 @@ export function resolvePluginSetupRegistry(params?: {
       continue;
     }
 
-    const recordProviders: ProviderPlugin[] = [];
-    const recordCliBackends: CliBackendPlugin[] = [];
+    const recordProviders: SetupProviderEntry[] = [];
+    const recordCliBackends: SetupCliBackendEntry[] = [];
+    const recordConfigMigrations: SetupConfigMigrationEntry[] = [];
+    const recordAutoEnableProbes: SetupAutoEnableProbeEntry[] = [];
+    const recordProviderKeys = new Set(providerKeys);
+    const recordCliBackendKeys = new Set(cliBackendKeys);
+    let acceptingRegistrations = true;
     const api = buildSetupPluginApi({
       record,
       setupSource: setupRegistration.setupSource,
       handlers: {
         registerProvider(provider) {
           const key = `${record.id}:${normalizeProviderId(provider.id)}`;
-          if (providerKeys.has(key)) {
+          if (!acceptingRegistrations || recordProviderKeys.has(key)) {
             return;
           }
-          providerKeys.add(key);
-          providers.push({
+          recordProviderKeys.add(key);
+          recordProviders.push({
             pluginId: record.id,
             provider,
           });
-          recordProviders.push(provider);
         },
         registerCliBackend(backend) {
           const key = `${record.id}:${normalizeProviderId(backend.id)}`;
-          if (cliBackendKeys.has(key)) {
+          if (!acceptingRegistrations || recordCliBackendKeys.has(key)) {
             return;
           }
-          cliBackendKeys.add(key);
-          cliBackends.push({
+          recordCliBackendKeys.add(key);
+          recordCliBackends.push({
             pluginId: record.id,
             backend,
           });
-          recordCliBackends.push(backend);
         },
         registerConfigMigration(migrate) {
-          configMigrations.push({
+          if (!acceptingRegistrations) {
+            return;
+          }
+          recordConfigMigrations.push({
             pluginId: record.id,
             migrate,
           });
         },
         registerAutoEnableProbe(probe) {
-          autoEnableProbes.push({
+          if (!acceptingRegistrations) {
+            return;
+          }
+          recordAutoEnableProbes.push({
             pluginId: record.id,
             probe,
           });
@@ -682,19 +703,21 @@ export function resolvePluginSetupRegistry(params?: {
       },
     });
 
-    try {
-      const result = setupRegistration.register(api);
-      if (result && typeof result.then === "function") {
-        // Keep setup registration sync-only.
-        ignoreAsyncSetupRegisterResult(result);
-      }
-    } catch {
+    const registered = runSetupRegistration(setupRegistration.register, api);
+    acceptingRegistrations = false;
+    if (!registered) {
       continue;
     }
+    providers.push(...recordProviders);
+    cliBackends.push(...recordCliBackends);
+    configMigrations.push(...recordConfigMigrations);
+    autoEnableProbes.push(...recordAutoEnableProbes);
+    providerKeys = recordProviderKeys;
+    cliBackendKeys = recordCliBackendKeys;
     pushSetupDescriptorDriftDiagnostics({
       record,
-      providers: recordProviders,
-      cliBackends: recordCliBackends,
+      providers: recordProviders.map((entry) => entry.provider),
+      cliBackends: recordCliBackends.map((entry) => entry.backend),
       diagnostics,
     });
   }
@@ -763,13 +786,7 @@ export function resolvePluginSetupProviderCore(params: {
     },
   });
 
-  try {
-    const result = setupRegistration.register(api);
-    if (result && typeof result.then === "function") {
-      // Keep setup registration sync-only.
-      ignoreAsyncSetupRegisterResult(result);
-    }
-  } catch {
+  if (!runSetupRegistration(setupRegistration.register, api)) {
     return undefined;
   }
 
@@ -829,13 +846,7 @@ export function resolvePluginSetupCliBackend(params: {
     },
   });
 
-  try {
-    const result = setupRegistration.register(api);
-    if (result && typeof result.then === "function") {
-      // Keep setup registration sync-only.
-      ignoreAsyncSetupRegisterResult(result);
-    }
-  } catch {
+  if (!runSetupRegistration(setupRegistration.register, api)) {
     return undefined;
   }
 


### PR DESCRIPTION
Closes #123497

## What Problem This Solves

Fixes an issue where a setup plugin could register providers, CLI backends, config migrations, or auto-enable probes and then throw synchronously, leaving those partial contributions published and cached despite failed initialization.

## Why This Change Was Made

The full setup registry now stages each plugin's four contribution families and deduplication keys locally. It commits them only after synchronous registration succeeds, discards them on throw, and closes registration after the callback returns so late asynchronous callbacks cannot mutate an already-published registry. Existing rejected-Promise compatibility remains unchanged.

## User Impact

Failed setup plugins no longer appear partially available or affect doctor migrations, automatic enablement, provider/auth selection, or setup-aware CLI/model pickers. Healthy sibling plugins continue registering normally.

## Evidence

- Tests-first regression failed because a synchronously throwing plugin leaked contributions and dedupe keys into the full registry and cache.
- Tests-first late-callback regression failed because asynchronous callbacks mutated the published registry after `register` returned.
- Post-fix setup/registry sibling proof: 45/45 passed.
- Existing rejected-Promise compatibility remains green.
- Core and core-test TypeScript checks, targeted lint/format, and `git diff --check` passed.
- Exact reviewed head: `55728259808d8edb10651285749f1e1e7f732a55`.
- Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/31773470406
- Final integrated Codex autoreview: clean, no findings; TruffleHog clean.

Production delta: +48/-37, net +11. Tests: +119.

AI-assisted: yes. The repair was reviewed against full and targeted setup registries, cache lifecycle, deduplication, runtime-registry rollback, doctor migration, auto-enable, and provider/backend consumers.
