### PR TITLE
fix: Control UI test lane fails at random on unrelated pull requests

### DIFF
--- a/test/jsdom-custom-elements.test.ts
+++ b/test/jsdom-custom-elements.test.ts
@@ -1,0 +1,56 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it } from "vitest";
+import {
+  dropRepoOwnedCustomElements,
+  isRepoOwnedDefineStack,
+  jsdomCustomElementDefinitions,
+  trackCustomElementRegistry,
+} from "./jsdom-custom-elements.ts";
+
+describe("jsdom custom element tracking", () => {
+  it("reaches the live jsdom definition list", () => {
+    // Contract with jsdom internals: losing this silently restores the stale-class
+    // flake, because the shared runner would stop dropping repo-owned tags.
+    const definitions = jsdomCustomElementDefinitions(customElements);
+    expect(Array.isArray(definitions)).toBe(true);
+    customElements.define("openclaw-jsdom-contract-probe", class extends HTMLElement {});
+    expect(definitions?.some((entry) => entry.name === "openclaw-jsdom-contract-probe")).toBe(true);
+  });
+
+  it("drops repo-owned tags and keeps dependency-owned ones", () => {
+    const tracking = trackCustomElementRegistry(customElements);
+    if (!tracking) {
+      throw new Error("expected a jsdom registry");
+    }
+    customElements.define("openclaw-repo-owned-probe", class extends HTMLElement {});
+    // Dependency packages are externalized and register once per worker, so their
+    // definitions must survive a reset that the module graph cannot replay.
+    tracking.definitions.push({ name: "wa-dependency-probe" });
+
+    dropRepoOwnedCustomElements(tracking);
+
+    expect(customElements.get("openclaw-repo-owned-probe")).toBeUndefined();
+    expect(tracking.definitions.some((entry) => entry.name === "wa-dependency-probe")).toBe(true);
+    // A repo module re-evaluated by the next file must be able to register again.
+    expect(() =>
+      customElements.define("openclaw-repo-owned-probe", class extends HTMLElement {}),
+    ).not.toThrow();
+  });
+
+  it("attributes a define call to the module that made it", () => {
+    const stack = (caller: string) =>
+      `Error\n    at define (/repo/test/jsdom-custom-elements.ts:58:9)\n${caller}`;
+
+    expect(isRepoOwnedDefineStack(stack("    at /repo/ui/src/components/tooltip.ts:576:18"))).toBe(
+      true,
+    );
+    expect(
+      isRepoOwnedDefineStack(
+        stack(
+          "    at file:///repo/node_modules/@lit/reactive-element/decorators/custom-element.js:27:24",
+        ),
+      ),
+    ).toBe(false);
+    expect(isRepoOwnedDefineStack(undefined)).toBe(false);
+  });
+});

--- a/test/jsdom-custom-elements.ts
+++ b/test/jsdom-custom-elements.ts
@@ -13,7 +13,7 @@
 // they evaluate once per worker through native ESM and never re-register; dropping
 // their definitions would leave `wa-*` and friends permanently unupgraded.
 
-export type JsdomCustomElementDefinition = { name: string };
+type JsdomCustomElementDefinition = { name: string };
 
 export type CustomElementTracking = {
   registry: CustomElementRegistry;

--- a/test/jsdom-custom-elements.ts
+++ b/test/jsdom-custom-elements.ts
@@ -1,0 +1,80 @@
+// Jsdom custom elements keeps shared-worker element registrations in step with the module graph.
+//
+// Shared (isolate: false) jsdom lanes re-evaluate the module graph for every test
+// file, so each file gets freshly evaluated component classes. jsdom keeps custom
+// element definitions on the window instead, outside that graph. Every Control UI
+// component registers with `if (!customElements.get(tag))`, so a definition that
+// survives the reset pins the tag to the previous file's class: the next file's
+// `document.createElement(tag)` then builds elements closed over the earlier file's
+// module instances, and its own singletons, module mocks, and spies are never the
+// ones production reaches. Registry lifetime has to match graph lifetime.
+//
+// Only repo-owned tags may be dropped. Dependency packages are externalized, so
+// they evaluate once per worker through native ESM and never re-register; dropping
+// their definitions would leave `wa-*` and friends permanently unupgraded.
+
+export type JsdomCustomElementDefinition = { name: string };
+
+export type CustomElementTracking = {
+  registry: CustomElementRegistry;
+  definitions: JsdomCustomElementDefinition[];
+  repoOwnedTags: Set<string>;
+};
+
+export function jsdomCustomElementDefinitions(
+  registry: object,
+): JsdomCustomElementDefinition[] | undefined {
+  const implKey = Object.getOwnPropertySymbols(registry).find(
+    (symbol) => symbol.description === "impl",
+  );
+  if (!implKey) {
+    return undefined;
+  }
+  const impl = (
+    registry as Record<
+      symbol,
+      { _customElementDefinitions?: JsdomCustomElementDefinition[] } | undefined
+    >
+  )[implKey];
+  return impl?._customElementDefinitions;
+}
+
+// Conservative on an unreadable stack: keeping a repo tag costs a stale class in
+// one lane, dropping a dependency tag would leave it unupgraded for the whole run.
+export function isRepoOwnedDefineStack(stack: string | undefined): boolean {
+  // [0] "Error", [1] the patched define in this module, [2] the module calling it.
+  const callerFrame = (stack ?? "").split("\n")[2] ?? "";
+  return callerFrame.trim() !== "" && !/[\\/]node_modules[\\/]/u.test(callerFrame);
+}
+
+// Returns undefined for anything that is not a jsdom registry: mixed lanes run
+// `@vitest-environment node` files whose leftover global has no definitions to track.
+export function trackCustomElementRegistry(
+  registry: CustomElementRegistry,
+): CustomElementTracking | undefined {
+  const definitions = jsdomCustomElementDefinitions(registry);
+  if (!definitions) {
+    return undefined;
+  }
+  const tracking: CustomElementTracking = { registry, definitions, repoOwnedTags: new Set() };
+  const define = registry.define.bind(registry);
+  registry.define = (name, constructor, options) => {
+    if (isRepoOwnedDefineStack(new Error().stack)) {
+      tracking.repoOwnedTags.add(name);
+    }
+    define(name, constructor, options);
+  };
+  return tracking;
+}
+
+export function dropRepoOwnedCustomElements(tracking: CustomElementTracking): void {
+  if (tracking.repoOwnedTags.size === 0) {
+    return;
+  }
+  const survivors = tracking.definitions.filter(
+    (definition) => !tracking.repoOwnedTags.has(definition.name),
+  );
+  tracking.definitions.length = 0;
+  tracking.definitions.push(...survivors);
+  tracking.repoOwnedTags.clear();
+}

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
 import { resetAgentEventsForTest } from "../src/infra/agent-events.js";
 import { clearNamedPluginRuntimeStoresForTest } from "../src/plugin-sdk/runtime-store-registry.js";
+import {
+  type CustomElementTracking,
+  dropRepoOwnedCustomElements,
+  trackCustomElementRegistry,
+} from "./jsdom-custom-elements.ts";
 
 type EvaluatedModuleNode = {
   promise?: unknown;
@@ -33,6 +38,8 @@ const DIAGNOSTIC_EVENT_LISTENER_PRESENCE = Symbol.for(
   "openclaw.diagnosticEventListenerPresence.v1",
 );
 const SESSION_SUSPENSION_TEST_API = Symbol.for("openclaw.sessionSuspensionTestApi");
+// Shared-worker scoped: the registry lives on the worker global, not in the module graph.
+const CUSTOM_ELEMENT_TRACKING = Symbol.for("openclaw.nonIsolatedCustomElementTracking");
 const nativeTimerGlobals = {
   setTimeout: globalThis.setTimeout,
   clearTimeout: globalThis.clearTimeout,
@@ -85,6 +92,48 @@ function restoreSharedTestHomeAfterEnvUnstub(testHomeRaw: string | undefined): v
   process.env.XDG_DATA_HOME = path.join(testHome, ".local", "share");
   process.env.XDG_STATE_HOME = path.join(testHome, ".local", "state");
   process.env.XDG_CACHE_HOME = path.join(testHome, ".cache");
+}
+
+function customElementTrackingStore(): Record<PropertyKey, unknown> & {
+  customElements?: CustomElementRegistry;
+  [CUSTOM_ELEMENT_TRACKING]?: CustomElementTracking;
+} {
+  return globalThis;
+}
+
+function installCustomElementTracking(): void {
+  const globalStore = customElementTrackingStore();
+  const registry = globalStore.customElements;
+  // Re-track when the lane switches back to a fresh jsdom window: the previous
+  // tracking would hold a dead definitions array and stop dropping stale classes.
+  if (!registry || globalStore[CUSTOM_ELEMENT_TRACKING]?.registry === registry) {
+    return;
+  }
+  globalStore[CUSTOM_ELEMENT_TRACKING] = trackCustomElementRegistry(registry);
+}
+
+function dropTrackedRepoOwnedCustomElements(): void {
+  const tracking = customElementTrackingStore()[CUSTOM_ELEMENT_TRACKING];
+  if (tracking) {
+    dropRepoOwnedCustomElements(tracking);
+  }
+}
+
+// The shared jsdom window keeps whatever the previous file mounted. Test helpers
+// that look up `document.body.querySelector(...)` then answer the earlier file's
+// leaked dialog instead of the one under test, and focus assertions read its stale
+// activeElement. File-scoped DOM has to die with the file, like the module graph.
+// `document.head` is left alone: externalized dependency styles register once per
+// worker and cannot be replayed.
+function resetSharedDocumentBody(): void {
+  const body = (globalThis as { document?: Document }).document?.body;
+  if (!body) {
+    return;
+  }
+  body.replaceChildren();
+  for (const attribute of body.getAttributeNames()) {
+    body.removeAttribute(attribute);
+  }
 }
 
 function restoreRealTimers(): void {
@@ -319,6 +368,9 @@ export function serializeMockerResolveMocks(
 export default class OpenClawNonIsolatedRunner extends TestRunner {
   override onCollectStart(file: RunnerTestFile) {
     super.onCollectStart(file);
+    if (!this.config.isolate) {
+      installCustomElementTracking();
+    }
     const internals = this as unknown as TestRunnerInternals;
     if (internals.moduleRunner?.mocker) {
       serializeMockerResolveMocks(internals.moduleRunner.mocker);
@@ -369,6 +421,8 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     // Named plugin runtimes intentionally survive duplicate module evaluation in production.
     // Clear their shared slots here so one test file cannot lend a partial runtime to the next.
     clearNamedPluginRuntimeStoresForTest();
+    dropTrackedRepoOwnedCustomElements();
+    resetSharedDocumentBody();
     vi.resetModules();
     const internals = this as unknown as TestRunnerInternals;
     internals.moduleRunner?.mocker?.reset?.();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Control UI unit suite failed at random on pull requests that never touched the failing file. Different runs blamed different files — `ui/src/app/app-host.test.ts`, `ui/src/pages/sessions/sessions-page.test.ts`, `ui/src/components/session-organizer-batch-mutations.test.ts`, `ui/src/components/sessions-hub-tabs.test.ts` — usually as `expected "…" to be called once, but got 0 times`, with no code change between a green and a red run.

Because vitest orders files by size, adding or resizing any UI file reshuffles which files share a worker, so the failures moved around and read as infrastructure noise. Contributors re-ran CI instead of trusting it, and the shared UI lane also exited non-zero on unhandled `NotSupportedError` rejections in roughly one run in four.

## Why This Change Was Made

`test/non-isolated-runner.ts` already resets the module graph after every file in the `isolate: false` lanes, so each test file evaluates its own component classes. The jsdom window it shares across the whole worker was never reset alongside it, and two pieces of window state outlived the graph that owned them.

**Custom element registrations.** Every Control UI component registers with `if (!customElements.get(tag))` — correct in production, where the module evaluates once. In the shared lane the first file to import a component owned that tag for the rest of the worker: later files evaluated a fresh class the registry never adopted, so `document.createElement(tag)` kept building elements closed over the *first* file's module instances. Those elements called the first file's `i18n` singleton and the first file's real `showConfirmDialog`, while the test asserted on its own module mocks and spies — hence "called 0 times" with no error. The runner now drops repo-owned tags with the graph they came from. Dependency packages are externalized and register once per worker through native ESM, so their definitions are attributed by define call site and kept; dropping them left `wa-*` permanently unupgraded (1851 errors in a discarded first attempt).

**Mounted DOM.** The same window carried the previous file's mounted elements forward, so `waitForConfirmDialogActions` answered a leaked dialog instead of the one under test and focus assertions read a stale `activeElement`. The body is now cleared with the graph. `document.head` deliberately stays: dependency styles register once per worker and cannot be replayed either.

This lands at the runner because that is where per-file shared-worker cleanup already lives — the alternative, moving each affected file into `uiIsolatedTestFiles`, is the reactive workaround this repo has been applying one flake at a time.

Production LOC delta: **0**. The whole diff is test infrastructure plus its regression test.

## User Impact

No runtime behavior change. CI stops failing on unrelated PRs, and a mock that does not reach production now fails deterministically in the file that owns it instead of at random in a sibling.

## Evidence

**Root cause proven deterministically** (before the fix), by adding one oversized probe file that imports the module under test so the size sequencer places it first:

- probe importing `ui/src/pages/sessions/sessions-page.ts` → `sessions-page.test.ts` fails 7 tests, including `retargets the Gateway after deleting the current session` and `archive-gates a confirmed archived row-menu deletion`, with `expected "vi.fn()" to be called once, but got 0 times`.
- probe importing `ui/src/app/app-host.ts` → `app-host.test.ts` fails exactly `retries a pending locale once when the Gateway becomes connected` with `expected "retryPendingLocale" to be called once, but got 0 times`.
- probe leaving one `openclaw-modal-dialog` mounted → `session-organizer-batch-mutations.test.ts` fails 12 tests with `Expected an open confirm dialog`.

Instrumentation confirmed the mechanism directly: with the warm probe in place the test file's `i18n` was a different instance from the one the shell element used (`sameI18n=false`), while the registry still held the warm class (`registryClassIsWarm=true`, `elementIsWarmClass=true`). A separate two-file probe proved the jsdom `document` and `customElements` registry are shared across files in a worker (`registryShared=true sameDocument=true`).

All three repros pass with the fix.

**Baseline flake rate**, unchanged `main`, full `ui` lane: 2 of 4 runs red (one real failure, one unhandled-error exit).

**After the fix**: 6 parallel runs + 1 single-worker run (worst case — all 622 files share one worker) + a post-rebase parallel and serial run, all `612 passed | 10 skipped`, zero failures, zero unhandled errors. `ui-isolated` lane green (27 files). New `test/jsdom-custom-elements.test.ts` green.

`node scripts/check-changed.mjs` green on Blacksmith Testbox (lanes: coreTests, ui, testRoot, tooling).

Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings.

**Follow-up now unblocked (not in this PR):** `test/vitest/vitest.ui-isolated-paths.mjs` lists 27 files hand-moved out of the shared lane, and its stated reason — "custom-element registration matching the current registry" — is exactly what the runner now handles. Several of those files can likely return to the shared lane, which would cut ~48s from that lane. That needs its own per-file ordering proof.
