### PR TITLE
fix(ui): unkeyed preamble segments duplicate assistant text via the accumulated-prefix tracker

### DIFF
--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -125,6 +125,21 @@ export function streamSegmentUsesAccumulatedText(segment: { itemId?: unknown }):
   return !streamSegmentHasItemId(segment);
 }
 
+/** Advance the accumulated-text tracker only when the segment genuinely
+    extends it. A standalone (itemId-less) preamble whose text is not part of
+    the cumulative run text must not become the prefix baseline: the next
+    cumulative snapshot would fail the startsWith check and re-render every
+    earlier segment's text. */
+export function advanceAccumulatedStreamText(
+  previousText: string | null,
+  text: string,
+): string | null {
+  if (!text.trim()) {
+    return previousText;
+  }
+  return previousText === null || text.startsWith(previousText) ? text : previousText;
+}
+
 export function trimAccumulatedStreamPrefix(text: string, previousText: string | null): string {
   if (!previousText || !text.startsWith(previousText)) {
     return text;

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -9,6 +9,7 @@ import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatItem, ChatQueueItem, MessageGroup } from "../../lib/chat/chat-types.ts";
 import {
+  advanceAccumulatedStreamText,
   streamSegmentHasItemId,
   streamSegmentUsesAccumulatedText,
   trimAccumulatedStreamPrefix,
@@ -478,8 +479,11 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       const visibleText = usesAccumulatedText
         ? trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText)
         : text;
-      if (usesAccumulatedText && text.length > 0) {
-        previousAccumulatedStreamText = text;
+      if (usesAccumulatedText) {
+        previousAccumulatedStreamText = advanceAccumulatedStreamText(
+          previousAccumulatedStreamText,
+          text,
+        );
       }
       if (visibleText.length > 0) {
         const streamKey = `stream-seg:${props.sessionKey}:${i}`;

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2586,6 +2586,31 @@ describe("buildCachedChatItems", () => {
     ]);
   });
 
+  it("keeps an unkeyed preamble from corrupting the accumulated prefix tracker", () => {
+    // A standalone (itemId-less) preamble whose text is not part of the
+    // cumulative run text must not become the prefix baseline — pre-fix the
+    // next cumulative snapshot re-rendered every earlier segment's text.
+    const items = buildCachedChatItems(
+      createProps({
+        streamSegments: [
+          { text: "First thought.", ts: 1, toolCallId: "call-1" },
+          { text: "Standalone preamble", ts: 2 },
+          { text: "First thought. After tool.", ts: 3, toolCallId: "call-2" },
+        ],
+        toolMessages: [
+          chatMessage("toolResult", "Tool one", 2),
+          chatMessage("toolResult", "Tool two", 4),
+        ],
+      }),
+    );
+
+    expect(items.filter((item) => item.kind === "stream")).toMatchObject([
+      { text: "First thought." },
+      { text: "Standalone preamble" },
+      { text: "After tool." },
+    ]);
+  });
+
   it("deduplicates accumulated stream snapshots around tool cards", () => {
     const items = buildCachedChatItems(
       createProps({

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import {
+  advanceAccumulatedStreamText,
   streamSegmentHasItemId,
   streamSegmentUsesAccumulatedText,
   trimAccumulatedStreamPrefix,
@@ -304,8 +305,8 @@ function visibleAssistantStreamParts(
         toolCallId: explicitToolCallId ?? indexedToolRef?.id,
       });
     }
-    if (usesAccumulatedText && segment.text.trim()) {
-      previousText = segment.text;
+    if (usesAccumulatedText) {
+      previousText = advanceAccumulatedStreamText(previousText, segment.text);
     }
   }
   if (opts.includeCurrent !== false && typeof state.chatStream === "string") {
@@ -338,12 +339,8 @@ export function visibleCurrentAssistantStreamTail(
     : [];
   let previousText: string | null = null;
   for (const segment of segments) {
-    if (
-      streamSegmentUsesAccumulatedText(segment) &&
-      typeof segment.text === "string" &&
-      segment.text.trim()
-    ) {
-      previousText = segment.text;
+    if (streamSegmentUsesAccumulatedText(segment) && typeof segment.text === "string") {
+      previousText = advanceAccumulatedStreamText(previousText, segment.text);
     }
   }
   return visibleAssistantStreamText(
@@ -651,8 +648,8 @@ export function prunePersistedToolStreamMessages(
       : indexedToolRef?.identity;
     const text = typeof segment.text === "string" ? segment.text : "";
     if (toolIdentity && persistedToolIds.has(toolIdentity)) {
-      if (streamSegmentUsesAccumulatedText(segment) && text.trim()) {
-        lastPrunedAccumulatedText = text;
+      if (streamSegmentUsesAccumulatedText(segment)) {
+        lastPrunedAccumulatedText = advanceAccumulatedStreamText(lastPrunedAccumulatedText, text);
       }
       return [];
     }


### PR DESCRIPTION
## What Problem This Solves

Assistant transcript text duplicates mid-run: after an itemId-less preamble segment (producers exist — `agent-runner-event-handler.ts` emits `itemId: commentaryItemId || undefined`), the next cumulative stream snapshot re-renders every earlier segment's text a second time. The duplication persists into the materialized transcript at run terminal.

## Why This Change Was Made

The accumulated-prefix tracker treated any itemId-less segment as cumulative run text (`streamSegmentUsesAccumulatedText` = "no itemId"). A standalone preamble's text became the prefix baseline; the next genuine cumulative snapshot (gateway deltas carry the full run text) no longer `startsWith` the baseline, so `trimAccumulatedStreamPrefix` returned the whole run text untrimmed. Four sites advanced the tracker inline with the same broken rule (`chat-thread-build.ts`, two in `stream-reconciliation.ts` visible-parts/tail paths, and the recovery prune path). One `advanceAccumulatedStreamText` owner now enforces the continuity invariant everywhere: text becomes the new baseline only when it extends the current one. This shape is robust to any segment producer — no reliance on which marker fields a producer stamps.

## User Impact

Streaming replies with preamble/commentary segments no longer show duplicated paragraphs, live or in the persisted transcript.

## Evidence

- Regression in `chat-thread.test.ts`: tool-flush → standalone preamble → next cumulative snapshot renders "After tool.", not "First thought. After tool." — fails pre-fix. Suite 170 passed.
- Full chat + lib suites: 3139 passed (includes the recovery/pagination fixtures that pin cumulative trimming). `pnpm tsgo:ui` clean.
- Fresh autoreview (codex/gpt-5.6-sol, high): clean, "patch is correct (0.99)".
- Production LOC: +28/−12; the growth is the documented helper replacing four divergent inline advances.

Found via the chat message pipeline lane of the round-2 web-UI QA campaign (finding L19-1).
