### PR TITLE
fix(cron): explicit-agent schedules run without a default agent

### DIFF
--- a/src/cron/service.session-reaper-in-finally.test.ts
+++ b/src/cron/service.session-reaper-in-finally.test.ts
@@ -52,12 +52,23 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
     vi.clearAllMocks();
   });
 
-  it("re-arms the scheduler when resolving the default reaper agent fails", async () => {
+  it("runs explicit-agent jobs when no default reaper agent exists", async () => {
     const store = await makeStorePath();
     const now = Date.parse("2026-02-10T10:00:00.000Z");
-    const job = createDueIsolatedJob({ id: "recover-default-agent", nowMs: now });
+    const job = {
+      ...createDueIsolatedJob({ id: "explicit-agent", nowMs: now }),
+      agentId: "worker",
+    };
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
-    let defaultAgentAvailable = false;
+    const sessionStorePath = path.join(path.dirname(store.storePath), "sessions", "sessions.json");
+    await replaceSessionEntry(
+      {
+        agentId: "worker",
+        storePath: sessionStorePath,
+        sessionKey: "agent:worker:cron:explicit-agent:run:expired",
+      },
+      { sessionId: "worker-expired", updatedAt: now - 25 * 3_600_000 },
+    );
     const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "done" });
     const state = createCronServiceState({
       storePath: store.storePath,
@@ -67,25 +78,20 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
-      resolveDefaultAgentId: () => {
-        if (!defaultAgentAvailable) {
-          throw new Error("default agent temporarily unavailable");
-        }
-        return "main";
-      },
-      sessionStorePath: path.join(path.dirname(store.storePath), "sessions", "sessions.json"),
+      resolveDefaultAgentId: () => undefined,
+      resolveSessionStoreAgentIds: () => ["worker"],
+      sessionStorePath,
     });
     state.store = { version: 1, jobs: [job] };
 
     await withCronServiceStateForTest(state, async () => {
-      await expect(onTimer(state)).rejects.toThrow("default agent temporarily unavailable");
-      expect(state.running).toBe(false);
-      expect(state.timer).not.toBeNull();
-
-      defaultAgentAvailable = true;
       await expect(onTimer(state)).resolves.toBeUndefined();
       expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+      expect(
+        listSessionEntriesCore({ agentId: "worker", storePath: sessionStorePath }),
+      ).toStrictEqual([]);
       expect(state.running).toBe(false);
+      expect(state.timer).not.toBeNull();
     });
   });
 

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -173,21 +173,11 @@ async function onAdmittedTimer(state: CronServiceState) {
     armRunningRecheckTimer(state);
     return;
   }
-  let sessionReaperDefaultAgentId: string | undefined;
   state.running = true;
   // Keep a watchdog timer armed while a tick is executing. If execution hangs
   // (for example in a provider call), the scheduler still wakes to re-check.
   armRunningRecheckTimer(state);
   try {
-    const hasSessionReaperStore = Boolean(
-      state.deps.resolveSessionStorePath || state.deps.sessionStorePath,
-    );
-    sessionReaperDefaultAgentId = hasSessionReaperStore
-      ? (state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId)?.trim()
-      : undefined;
-    if (hasSessionReaperStore && !sessionReaperDefaultAgentId) {
-      throw new Error("Cron session reaper requires the prepared configured default agent id.");
-    }
     const dueJobs = await locked(state, async () => {
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
       if (state.stopped || state.restartRecoveryPending) {
@@ -441,47 +431,50 @@ async function onAdmittedTimer(state: CronServiceState) {
     try {
       // Reaper discovery is maintenance: failure must never strand the timer
       // or leave the scheduler's execution slot permanently occupied.
-      if (sessionReaperDefaultAgentId) {
-        const defaultAgentId = sessionReaperDefaultAgentId;
-        const storeTargets = new Map<string, { agentId: string; storePath: string }>();
-        const addStoreTarget = (agentId: string, storePath: string) => {
-          storeTargets.set(`${agentId}\0${storePath}`, { agentId, storePath });
+      if (state.deps.resolveSessionStorePath || state.deps.sessionStorePath) {
+        const configuredDefaultAgentId = (
+          state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId
+        )?.trim();
+        const defaultAgentId = configuredDefaultAgentId
+          ? normalizeAgentId(configuredDefaultAgentId)
+          : undefined;
+        const reaperAgentIds = new Set(
+          (state.deps.resolveSessionStoreAgentIds?.() ?? []).map(normalizeAgentId),
+        );
+        const resolveJobAgentId = (job: CronJob): string | undefined => {
+          if (typeof job.agentId === "string" && job.agentId.trim()) {
+            return normalizeAgentId(job.agentId);
+          }
+          try {
+            return resolveAgentIdFromSessionKey(job.sessionKey, defaultAgentId);
+          } catch {
+            // An ownerless legacy job needs a configured default for cleanup.
+            // Other prepared owners remain valid reaper targets without one.
+            return undefined;
+          }
         };
-        const resolveJobAgentId = (job: CronJob) =>
-          typeof job.agentId === "string" && job.agentId.trim()
-            ? normalizeAgentId(job.agentId)
-            : resolveAgentIdFromSessionKey(job.sessionKey, defaultAgentId);
-        const configuredAgentIds = state.deps.resolveSessionStoreAgentIds?.() ?? [];
-        if (state.deps.resolveSessionStorePath) {
-          for (const agentId of configuredAgentIds) {
-            const normalizedAgentId = normalizeAgentId(agentId);
-            addStoreTarget(
-              normalizedAgentId,
-              state.deps.resolveSessionStorePath(normalizedAgentId),
-            );
+        for (const job of state.store?.jobs ?? []) {
+          const agentId = resolveJobAgentId(job);
+          if (agentId) {
+            reaperAgentIds.add(agentId);
           }
-          for (const job of state.store?.jobs ?? []) {
-            const agentId = resolveJobAgentId(job);
-            addStoreTarget(agentId, state.deps.resolveSessionStorePath(agentId));
-          }
-          addStoreTarget(defaultAgentId, state.deps.resolveSessionStorePath(defaultAgentId));
-        } else if (state.deps.sessionStorePath) {
-          for (const agentId of configuredAgentIds) {
-            addStoreTarget(normalizeAgentId(agentId), state.deps.sessionStorePath);
-          }
-          for (const job of state.store?.jobs ?? []) {
-            addStoreTarget(resolveJobAgentId(job), state.deps.sessionStorePath);
-          }
-          addStoreTarget(defaultAgentId, state.deps.sessionStorePath);
+        }
+        if (defaultAgentId) {
+          reaperAgentIds.add(defaultAgentId);
         }
 
-        if (storeTargets.size > 0) {
+        if (reaperAgentIds.size > 0) {
           const nowMs = state.deps.nowMs();
-          for (const { agentId, storePath } of storeTargets.values()) {
+          for (const agentId of reaperAgentIds) {
+            const storePath = state.deps.resolveSessionStorePath
+              ? state.deps.resolveSessionStorePath(agentId)
+              : state.deps.sessionStorePath;
+            if (!storePath) {
+              continue;
+            }
             try {
               await sweepCronRunSessions({
                 agentId,
-                defaultAgentId,
                 cronConfig: state.deps.cronConfig,
                 sessionStorePath: storePath,
                 nowMs,

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -33,9 +33,9 @@ const taskStatusMocks = vi.hoisted(() => ({
 }));
 
 function sweepCronRunSessions(
-  params: Omit<Parameters<typeof sweepCronRunSessionsImpl>[0], "agentId" | "defaultAgentId">,
+  params: Omit<Parameters<typeof sweepCronRunSessionsImpl>[0], "agentId">,
 ) {
-  return sweepCronRunSessionsImpl({ ...params, agentId: "main", defaultAgentId: "main" });
+  return sweepCronRunSessionsImpl({ ...params, agentId: "main" });
 }
 
 vi.mock("../tasks/task-status-access.js", () => ({
@@ -282,7 +282,6 @@ describe("sweepCronRunSessions", () => {
     expect(
       await sweepCronRunSessionsImpl({
         agentId: "main",
-        defaultAgentId: "main",
         sessionStorePath: exactStorePath,
         nowMs: now,
         log,
@@ -290,7 +289,6 @@ describe("sweepCronRunSessions", () => {
     ).toEqual({ swept: true, pruned: 0 });
     const result = await sweepCronRunSessionsImpl({
       agentId: "ops",
-      defaultAgentId: "main",
       sessionStorePath: exactStorePath,
       nowMs: now,
       log,
@@ -636,7 +634,6 @@ describe("sweepCronRunSessions", () => {
     expect(
       await sweepCronRunSessionsImpl({
         agentId: "main",
-        defaultAgentId: "main",
         sessionStorePath: storePath,
         nowMs: now,
         log,
@@ -646,7 +643,6 @@ describe("sweepCronRunSessions", () => {
     expect(
       await sweepCronRunSessionsImpl({
         agentId: "MAIN",
-        defaultAgentId: "main",
         sessionStorePath: `${tmpDir}${path.sep}.${path.sep}sessions.json`,
         nowMs: now + 1_000,
         log,

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -90,7 +90,6 @@ export async function removeCronJobBaseSession(params: {
 export async function sweepCronRunSessions(params: {
   cronConfig?: CronConfig;
   agentId: string;
-  defaultAgentId: string;
   /** Resolved path to sessions.json — required. */
   sessionStorePath: string;
   nowMs?: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cron jobs with explicit agent ownership would stop running when an explicit multi-agent roster intentionally had no ambient default agent.

The timer tried to prepare optional session-reaper maintenance before loading due jobs. Without a default agent, that preparation threw, so no due job could be reserved or executed. Once a job became overdue, the past-due timer retried the same failure every two seconds.

## Why This Change Was Made

Session cleanup is now kept entirely in the timer's maintenance `finally` path. Reaper targets come from configured or persisted agent owners, explicit cron job owners, valid agent-scoped session keys, and a default only when one exists. A genuinely ownerless legacy cleanup target is skipped when no default can resolve it; it no longer blocks scheduling.

The unused `defaultAgentId` input was also removed from `sweepCronRunSessions`, consolidating ownership at the scheduler boundary. No default is invented, and no config, protocol, storage, or migration surface changes.

Production delta: net -8 lines. Tests/test support: net +2 lines.

## User Impact

Operators can use explicit multi-agent rosters without defining a default agent and still have explicitly owned cron jobs run on schedule. Session reaping continues for every resolvable configured, persisted, job, or session-key owner.

## Evidence

- Live Mainframe reproduction on `49275b8f4b464b04d32c7c3851877096b47620e3`: three enabled jobs all had explicit agent IDs and the roster had no ambient default. The previous Gateway process logged 368 `Cron session reaper requires the prepared configured default agent id` failures; after a job became overdue, failures repeated every two seconds. A clean restart reproduced the same failure once per minute before the next job became due.
- Behavior regression failed before the production change with the exact reaper-default error, before the explicit-agent job ran.
- After the fix: `src/cron/service.session-reaper-in-finally.test.ts` and `src/cron/session-reaper.test.ts` pass, 35/35 tests. The regression proves the explicit-agent job executes and its expired cron-run session is reaped without a default.
- Blacksmith Testbox `tbx_01kzzd1m3xwcw9jy8zd7zrb9pt` ([run](https://github.com/openclaw/openclaw/actions/runs/31774194592)) passed core production and core-test typechecks. The remaining broad lint was stopped because the delegated base drift classified unrelated current-main files into the run.
- Exact changed-file oxlint and runtime import-cycle checks pass locally; import cycles: 0.
- Local autoreview: clean, correctness 0.96, no actionable findings.

The unmerged branch was not deployed to Mainframe; post-merge live verification remains the final operator proof.
