### PR TITLE
feat(onboard): named first agent

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -40,6 +40,7 @@ openclaw onboard --tui
 openclaw onboard --classic
 openclaw onboard --modern
 openclaw onboard --flow quickstart
+openclaw onboard --agent-name robby
 openclaw onboard --flow manual
 openclaw onboard --flow import
 openclaw onboard --import-from hermes --import-source ~/.hermes
@@ -77,6 +78,9 @@ not overwrite the existing skill.
 
 - `--classic`: opens the full step-by-step wizard. It cannot be combined with
   `--non-interactive`; omit `--classic` for automated setup.
+- `--agent-name <name>`: names the first agent when no roster exists. Interactive
+  onboarding asks **What should we call your first agent?** and suggests `main`;
+  non-interactive onboarding keeps `main` unless this flag is provided.
 - `--flow quickstart`: opens the classic wizard with minimal prompts, uses
   token auth by default, and generates a token when no stored or explicit
   credential applies. Explicit local Gateway flags such as
@@ -90,14 +94,15 @@ not overwrite the existing skill.
 - `--tailscale-reset-on-exit` and `--no-tailscale-reset-on-exit`: explicitly control whether Tailscale Serve or Funnel configuration is reset when the Gateway exits. Omitting both preserves the current setting during non-interactive reruns.
 - `--modern` is a compatibility alias for the OpenClaw conversational setup
   assistant. It uses the same live-inference gate as `openclaw setup` and
-  accepts only `--workspace`, `--accept-risk`,
+  accepts only `--workspace`, `--agent-name`, `--accept-risk`,
   `--non-interactive`, and `--json`. Other setup flags are rejected instead of
   being silently ignored.
 
 ## Guided flow
 
 Plain `openclaw onboard` starts the guided flow. It shows the security notice,
-then asks one question up front: **full access** (recommended — setup looks for
+asks for the first agent's name when no roster exists, then asks one discovery
+question up front: **full access** (recommended — setup looks for
 AI apps, keys, and local runtimes automatically) or **ask first** (setup asks
 once before looking around, or lets you configure manually). The
 choice persists as `wizard.accessMode`. With discovery allowed, onboarding
@@ -221,6 +226,7 @@ OPENCLAW_LOCALE=en openclaw onboard # Explicit English override
 
 ```bash
 openclaw onboard --non-interactive --accept-risk --skip-health \
+  --agent-name robby \
   --auth-choice custom-api-key \
   --custom-base-url "https://llm.example.com/v1" \
   --custom-model-id "foo-large" \

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -13,6 +13,13 @@ top-level keys, see [Configuration reference](/gateway/configuration-reference).
 
 OpenClaw stamps `agents.ownership: "explicit"` when creating a multi-agent fleet. Such fleets have no default: channels and ambient services need bindings or surface-specific `agentId` targets. Doctor materializes legacy owners during upgrade; sole-agent configs need no marker.
 
+On a fresh install, interactive onboarding asks for the first agent's name and
+uses `main` as the suggested value. Automated onboarding keeps the historical
+`main` default unless you pass `openclaw onboard --non-interactive --agent-name
+<name> ...`. A sole named agent uses the same default workspace and shared auth
+store as `main`; onboarding also migrates legacy `agent:main:*` session history
+to that sole owner before it finishes.
+
 ## Agent defaults
 
 ### `agents.defaults.workspace`

--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -166,6 +166,26 @@ describe("createAgent", () => {
     expect((mocks.persisted.agents as { list?: unknown }).list).toBeUndefined();
   });
 
+  it("replaces only the load-time compatibility roster when creating a named first agent", async () => {
+    await createAgent({
+      entry: { id: "robby", name: "robby", workspace: "/tmp/robby" },
+      bootstrapFirstAgent: true,
+    });
+
+    expect(mocks.transformConfigFileWithRetry).toHaveBeenCalledOnce();
+    expect(mocks.transformConfigFileWithRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        writeOptions: { allowedAgentRosterRemovals: ["main"] },
+      }),
+    );
+    expect(mocks.persisted).toMatchObject({
+      agents: { entries: { robby: expect.objectContaining({ workspace: "/tmp/robby" }) } },
+    });
+    expect(
+      (mocks.persisted.agents as { entries?: Record<string, unknown> }).entries,
+    ).not.toHaveProperty("main");
+  });
+
   it("keeps the first staged roster entry marker-free", async () => {
     mocks.config = { agents: { list: [] } };
 

--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -97,6 +97,7 @@ describe("createAgent", () => {
       }) => {
         const transformed = (await transform(structuredClone(mocks.config), {
           snapshot: { exists: false },
+          previousHash: null,
         })) as {
           nextConfig: Record<string, unknown>;
           result: unknown;
@@ -184,6 +185,25 @@ describe("createAgent", () => {
     expect(
       (mocks.persisted.agents as { entries?: Record<string, unknown> }).entries,
     ).not.toHaveProperty("main");
+  });
+
+  it("rejects first-agent creation when the approved config hash changed under the lock", async () => {
+    mocks.transformConfigFileWithRetry.mockImplementationOnce(async ({ transform }) =>
+      transform(structuredClone(mocks.config), {
+        snapshot: { exists: true },
+        previousHash: "concurrent",
+      }),
+    );
+
+    await expect(
+      createAgent({
+        entry: { id: "robby", name: "robby", workspace: "/tmp/robby" },
+        bootstrapFirstAgent: true,
+        expectedConfigHash: "approved",
+      }),
+    ).rejects.toThrow("config changed before first-agent creation");
+
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
   });
 
   it("keeps the first staged roster entry marker-free", async () => {

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -6,6 +6,7 @@ import {
   findAgentEntryIndex,
   listAgentEntries,
 } from "../commands/agents.config.js";
+import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { transformConfigFileWithRetry, withConfigMutationExclusive } from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
@@ -60,6 +61,8 @@ type CreateAgentParams = {
   entry?: CreateAgentEntry;
   /** Internal authorization for onboarding to materialize the reserved sole `main` agent. */
   bootstrapMain?: boolean;
+  /** Replace the load-time compatibility roster when onboarding creates the first real agent. */
+  bootstrapFirstAgent?: boolean;
   workspace?: string;
   model?: string;
   emoji?: unknown;
@@ -85,6 +88,30 @@ function createError(
 /** True when raw user input contains a character that can survive agent-id normalization. */
 function hasValidRawAgentIdCharacters(value: string): boolean {
   return /[a-z0-9]/iu.test(value);
+}
+
+export function validateAgentIdInput(
+  rawId: string,
+  options: { allowBootstrapMain?: boolean; displayName?: string } = {},
+):
+  | { ok: true; agentId: string }
+  | { ok: false; reason: "invalid-name" | "reserved-id"; message: string; agentId?: string } {
+  const displayName = options.displayName ?? rawId;
+  if (!hasValidRawAgentIdCharacters(rawId)) {
+    return {
+      ok: false,
+      reason: "invalid-name",
+      message: `agent name "${displayName}" has no valid id characters`,
+    };
+  }
+  const agentId = normalizeAgentId(rawId);
+  if (
+    (agentId === RESERVED_BOOTSTRAP_AGENT_ID && options.allowBootstrapMain !== true) ||
+    isReservedSystemAgentId(agentId)
+  ) {
+    return { ok: false, reason: "reserved-id", message: `"${agentId}" is reserved`, agentId };
+  }
+  return { ok: true, agentId };
 }
 
 function isInjectedBootstrapMainEntry(entry: CreateAgentEntry | undefined): boolean {
@@ -120,17 +147,15 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
     return createError("invalid-name", "agent name is required");
   }
   const rawId = params.entry?.id ?? rawName;
-  if (!hasValidRawAgentIdCharacters(rawId)) {
-    return createError("invalid-name", `agent name "${rawName}" has no valid id characters`);
+  const validation = validateAgentIdInput(rawId, {
+    allowBootstrapMain: params.bootstrapMain,
+    displayName: rawName,
+  });
+  if (!validation.ok) {
+    return createError(validation.reason, validation.message, validation.agentId);
   }
-  const agentId = normalizeAgentId(rawId);
+  const agentId = validation.agentId;
   const isBootstrapMain = agentId === RESERVED_BOOTSTRAP_AGENT_ID && params.bootstrapMain === true;
-  if (
-    (!isBootstrapMain && agentId === RESERVED_BOOTSTRAP_AGENT_ID) ||
-    isReservedSystemAgentId(agentId)
-  ) {
-    return createError("reserved-id", `"${agentId}" is reserved`, agentId);
-  }
 
   const safeName = sanitizeAgentIdentityLine(rawName);
   const model = normalizeOptionalString(params.model);
@@ -173,8 +198,18 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
       const committed = await transformConfig<CreateAgentResult>({
         afterWrite: { mode: "auto" },
         maxAttempts: 1,
+        ...(params.bootstrapFirstAgent
+          ? { writeOptions: { allowedAgentRosterRemovals: [RESERVED_BOOTSTRAP_AGENT_ID] } }
+          : {}),
         transform: async (currentConfig, context) => {
-          const currentEntries = listAgentEntries(currentConfig);
+          const hasAuthoredRoster =
+            params.bootstrapFirstAgent === true &&
+            hasResolvedRosterBeforeMigrations(context.snapshot);
+          if (params.bootstrapFirstAgent && hasAuthoredRoster) {
+            throw new DuplicateAgentError();
+          }
+          const bootstrappingFirstAgent = params.bootstrapFirstAgent === true;
+          const currentEntries = bootstrappingFirstAgent ? [] : listAgentEntries(currentConfig);
           const existingIndex = findAgentEntryIndex(currentEntries, agentId);
           const existingEntry = currentEntries[existingIndex];
           if (
@@ -219,9 +254,19 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
             isBootstrapMain &&
             isInjectedBootstrapMainEntry(existingEntry) &&
             !context.snapshot.exists;
+          const creationBase = bootstrappingFirstAgent
+            ? {
+                ...currentConfig,
+                agents: {
+                  ...currentConfig.agents,
+                  entries: {},
+                  list: undefined,
+                },
+              }
+            : currentConfig;
           let nextConfig =
             existingIndex < 0 || materializeInjectedMain
-              ? applyAgentConfig(currentConfig, {
+              ? applyAgentConfig(creationBase, {
                   agentId,
                   name: safeName,
                   workspace: workspaceDir,
@@ -229,7 +274,7 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
                   model,
                   identity,
                 })
-              : currentConfig;
+              : creationBase;
           if (params.entry) {
             const { default: _retiredDefault, ...stagedEntry } = params.entry;
             const list = listAgentEntries(nextConfig);

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -7,7 +7,11 @@ import {
   listAgentEntries,
 } from "../commands/agents.config.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
-import { transformConfigFileWithRetry, withConfigMutationExclusive } from "../config/config.js";
+import {
+  ConfigMutationConflictError,
+  transformConfigFileWithRetry,
+  withConfigMutationExclusive,
+} from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -37,6 +41,7 @@ type CreateAgentResult =
       agentDir: string;
       model?: string;
       bootstrapPending: boolean;
+      configHash?: string;
       bindingResult?: ReturnType<typeof applyAgentBindings>;
     }
   | {
@@ -63,6 +68,8 @@ type CreateAgentParams = {
   bootstrapMain?: boolean;
   /** Replace the load-time compatibility roster when onboarding creates the first real agent. */
   bootstrapFirstAgent?: boolean;
+  /** Config revision that must still own first-agent creation under the write lock. */
+  expectedConfigHash?: string | null;
   workspace?: string;
   model?: string;
   emoji?: unknown;
@@ -202,6 +209,15 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
           ? { writeOptions: { allowedAgentRosterRemovals: [RESERVED_BOOTSTRAP_AGENT_ID] } }
           : {}),
         transform: async (currentConfig, context) => {
+          if (
+            Object.hasOwn(params, "expectedConfigHash") &&
+            context.previousHash !== params.expectedConfigHash
+          ) {
+            throw new ConfigMutationConflictError("config changed before first-agent creation", {
+              currentHash: context.previousHash,
+              retryable: false,
+            });
+          }
           const hasAuthoredRoster =
             params.bootstrapFirstAgent === true &&
             hasResolvedRosterBeforeMigrations(context.snapshot);
@@ -369,7 +385,10 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
       ) {
         throw new Error(`agent "${agentId}" deletion tombstone changed during creation`);
       }
-      return committed.result!;
+      const result = committed.result!;
+      return typeof committed.persistedHash === "string"
+        ? { ...result, configHash: committed.persistedHash }
+        : result;
     });
   } catch (error) {
     if (error instanceof DuplicateAgentError) {

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -177,6 +177,11 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardOptions().skipBootstrap).toBe(true);
   });
 
+  it("forwards --agent-name to onboarding", async () => {
+    await runCli(["onboard", "--agent-name", "robby"]);
+    expect(setupWizardOptions().agentName).toBe("robby");
+  });
+
   it("forwards explicit --tailscale-reset-on-exit", async () => {
     await runCli(["onboard", "--tailscale-reset-on-exit"]);
     expect(setupWizardOptions().tailscaleResetOnExit).toBe(true);

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -43,6 +43,7 @@ export function resolveTailscaleResetOnExitFlag(command: Command): boolean | und
 const MODERN_ONBOARD_OPTION_KEYS = new Set([
   "modern",
   "workspace",
+  "agentName",
   "acceptRisk",
   "nonInteractive",
   "json",
@@ -205,6 +206,7 @@ export function registerOnboardCommand(program: Command): void {
       "--workspace <dir>",
       "Workspace proposal for guided setup; persisted by classic/non-interactive setup",
     )
+    .option("--agent-name <name>", "Name for the first agent (default: main)")
     .option(
       "--reset",
       "Reset config + credentials + sessions before running onboard (workspace only with --reset-scope full)",
@@ -335,10 +337,12 @@ export function registerOnboardCommand(program: Command): void {
             interactive: !opts.nonInteractive,
             welcomeVariant: "onboarding",
             ...(opts.workspace ? { setupWorkspace: opts.workspace as string } : {}),
+            ...(opts.agentName ? { setupAgentName: opts.agentName as string } : {}),
           },
           defaultRuntime,
           {
             ...(opts.workspace ? { workspace: opts.workspace as string } : {}),
+            ...(opts.agentName ? { agentName: opts.agentName as string } : {}),
             ...(opts.acceptRisk ? { acceptRisk: true } : {}),
           },
         );
@@ -354,6 +358,7 @@ export function registerOnboardCommand(program: Command): void {
       await setupWizardCommand(
         {
           workspace: opts.workspace as string | undefined,
+          agentName: opts.agentName as string | undefined,
           nonInteractive: Boolean(opts.nonInteractive),
           acceptRisk: Boolean(opts.acceptRisk),
           classic: Boolean(opts.classic),

--- a/src/commands/onboard-agent.persistence.test.ts
+++ b/src/commands/onboard-agent.persistence.test.ts
@@ -7,18 +7,29 @@ import {
   replaceConfigFile,
   resetConfigRuntimeState,
 } from "../config/config.js";
-import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { readExactSessionEntryRowForCanonicalRepair } from "../config/sessions/session-accessor.sqlite-canonical-repair.js";
+import { writeSessionEntry } from "../config/sessions/session-accessor.sqlite-entry-store.js";
+import { appendTranscriptEventInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  runOpenClawAgentWriteTransaction,
+} from "../state/openclaw-agent-db.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { ensureOnboardingAgent } from "./onboard-agent.js";
 
 describe("onboarding authored config persistence", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   beforeEach(() => {
-    envSnapshot = captureEnv(["OPENCLAW_TOKEN"]);
+    envSnapshot = captureEnv(["OPENCLAW_AGENT_DIR", "OPENCLAW_STATE_DIR", "OPENCLAW_TOKEN"]);
   });
 
   afterEach(() => {
     envSnapshot.restore();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     resetConfigRuntimeState();
   });
 
@@ -57,6 +68,102 @@ describe("onboarding authored config persistence", () => {
       expect(persistedRaw).not.toContain("plaintext-secret");
       expect(persistedRaw).toContain("./channels.json");
       expect(await fs.readFile(includePath, "utf8")).toBe(includeRaw);
+    });
+  });
+
+  it("leaves an existing roster config byte-identical", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      const configPath = path.join(configDir, "openclaw.json");
+      const raw = `{
+  agents: { entries: { existing: { name: "Existing" } } },
+}\n`;
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(configPath, raw);
+      resetConfigRuntimeState();
+      const snapshot = await readConfigFileSnapshot();
+
+      await ensureOnboardingAgent({
+        config: snapshot.config,
+        workspace: path.join(home, "workspace"),
+        firstAgent: { name: "ignored" },
+      });
+
+      expect(await fs.readFile(configPath, "utf8")).toBe(raw);
+    });
+  });
+
+  it("renames a legacy install and converges its main session before returning", async () => {
+    await withTempHome(async (rawHome) => {
+      const home = await fs.realpath(rawHome);
+      const stateDir = path.join(home, ".openclaw");
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      deleteTestEnvValue("OPENCLAW_AGENT_DIR");
+      resetConfigRuntimeState();
+      await replaceConfigFile({ nextConfig: {}, afterWrite: { mode: "auto" } });
+
+      const legacyKey = "agent:main:main";
+      const canonicalKey = "agent:robby:main";
+      const legacyDatabasePath = path.join(
+        stateDir,
+        "agents",
+        "main",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const entry = { sessionId: "legacy-main-session", updatedAt: 100 };
+      runOpenClawAgentWriteTransaction(
+        (database) => {
+          writeSessionEntry(database, legacyKey, entry, {
+            allowStoredAliases: true,
+            previousEntry: null,
+          });
+          appendTranscriptEventInTransaction(
+            database,
+            {
+              agentId: "main",
+              path: legacyDatabasePath,
+              sessionId: entry.sessionId,
+              sessionKey: legacyKey,
+            },
+            { type: "message", text: "legacy history" },
+            { allowStoredAlias: true },
+          );
+        },
+        { agentId: "main", path: legacyDatabasePath },
+      );
+
+      const result = await ensureOnboardingAgent({
+        config: {},
+        workspace: path.join(stateDir, "workspace"),
+        firstAgent: { name: "robby" },
+      });
+      const ownerDatabasePath = path.join(
+        stateDir,
+        "agents",
+        "robby",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const readEntry = (databasePath: string, agentId: string, key: string) =>
+        runOpenClawAgentWriteTransaction(
+          (database) => readExactSessionEntryRowForCanonicalRepair(database, key)?.entry,
+          { agentId, path: databasePath },
+        );
+
+      expect(result.agentId).toBe("robby");
+      expect(readEntry(ownerDatabasePath, "robby", canonicalKey)).toMatchObject(entry);
+      expect(readEntry(legacyDatabasePath, "main", legacyKey)).toBeUndefined();
+      expect(
+        withExistingOpenClawStateDatabaseReadOnly(
+          ({ db }) =>
+            db
+              .prepare(
+                "SELECT status FROM migration_sources WHERE source_key = 'legacy-main-session-keys'",
+              )
+              .get() as { status: string },
+        ),
+      ).toEqual({ status: "completed" });
     });
   });
 });

--- a/src/commands/onboard-agent.persistence.test.ts
+++ b/src/commands/onboard-agent.persistence.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   readConfigFileSnapshot,
   replaceConfigFile,
@@ -10,8 +10,11 @@ import {
 import { readExactSessionEntryRowForCanonicalRepair } from "../config/sessions/session-accessor.sqlite-canonical-repair.js";
 import { writeSessionEntry } from "../config/sessions/session-accessor.sqlite-entry-store.js";
 import { appendTranscriptEventInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
+import { runSessionStartupMigration } from "../config/sessions/startup-migration.js";
+import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
@@ -164,6 +167,108 @@ describe("onboarding authored config persistence", () => {
               .get() as { status: string },
         ),
       ).toEqual({ status: "completed" });
+    });
+  });
+
+  it("surfaces a locked migration and converges it on the next startup", async () => {
+    await withTempHome(async (rawHome) => {
+      const home = await fs.realpath(rawHome);
+      const stateDir = path.join(home, ".openclaw");
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      deleteTestEnvValue("OPENCLAW_AGENT_DIR");
+      resetConfigRuntimeState();
+      await replaceConfigFile({ nextConfig: {}, afterWrite: { mode: "auto" } });
+
+      const legacyKey = "agent:main:main";
+      const canonicalKey = "agent:robby:main";
+      const legacyDatabasePath = path.join(
+        stateDir,
+        "agents",
+        "main",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const entry = { sessionId: "locked-legacy-session", updatedAt: 100 };
+      runOpenClawAgentWriteTransaction(
+        (database) => {
+          writeSessionEntry(database, legacyKey, entry, {
+            allowStoredAliases: true,
+            previousEntry: null,
+          });
+          appendTranscriptEventInTransaction(
+            database,
+            {
+              agentId: "main",
+              path: legacyDatabasePath,
+              sessionId: entry.sessionId,
+              sessionKey: legacyKey,
+            },
+            { type: "message", text: "locked history" },
+            { allowStoredAlias: true },
+          );
+        },
+        { agentId: "main", path: legacyDatabasePath },
+      );
+      const sourceDatabase = openOpenClawAgentDatabase({
+        agentId: "main",
+        path: legacyDatabasePath,
+      });
+      sourceDatabase.db.exec("BEGIN IMMEDIATE");
+      let result: Awaited<ReturnType<typeof ensureOnboardingAgent>>;
+      try {
+        result = await ensureOnboardingAgent({
+          config: {},
+          workspace: path.join(stateDir, "workspace"),
+          firstAgent: { name: "robby" },
+        });
+      } finally {
+        sourceDatabase.db.exec("ROLLBACK");
+      }
+
+      expect(result.sessionMigrationWarnings).toEqual([
+        expect.stringMatching(/incomplete.*openclaw doctor --fix/),
+      ]);
+      const readLedgerStatus = () =>
+        withExistingOpenClawStateDatabaseReadOnly(
+          ({ db }) =>
+            db
+              .prepare(
+                "SELECT status FROM migration_sources WHERE source_key = 'legacy-main-session-keys'",
+              )
+              .get() as { status: string } | undefined,
+        );
+      expect(readLedgerStatus()).toBeUndefined();
+      const log = { info: vi.fn(), warn: vi.fn() };
+      await runSessionStartupMigration({
+        cfg: result.config,
+        env: process.env,
+        log,
+        deps: {
+          migrateOrphanedSessionKeys: vi.fn(async () => ({ changes: [], warnings: [] })),
+          prepareLegacySessionSurfaces: () => EMPTY_LEGACY_SESSION_SURFACES,
+          resolveAllAgentSessionStoreTargetsSync: () => [],
+          sweepOrphanSessionStoreTemps: vi.fn(async () => 0),
+        },
+      });
+      const ownerDatabasePath = path.join(
+        stateDir,
+        "agents",
+        "robby",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const readEntry = (databasePath: string, agentId: string, key: string) =>
+        runOpenClawAgentWriteTransaction(
+          (database) => readExactSessionEntryRowForCanonicalRepair(database, key)?.entry,
+          { agentId, path: databasePath },
+        );
+
+      expect(readEntry(ownerDatabasePath, "robby", canonicalKey)).toMatchObject(entry);
+      expect(readEntry(legacyDatabasePath, "main", legacyKey)).toBeUndefined();
+      expect(log.info).toHaveBeenCalledWith(
+        expect.stringContaining("migrated retired main-agent session keys"),
+      );
+      expect(readLedgerStatus()).toEqual({ status: "completed" });
     });
   });
 });

--- a/src/commands/onboard-agent.test.ts
+++ b/src/commands/onboard-agent.test.ts
@@ -2,11 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   createAgent: vi.fn(),
+  migrateLegacyMainSessionKeys: vi.fn(),
   readConfigFileSnapshot: vi.fn(),
 }));
 
-vi.mock("../agents/agent-create.js", () => ({ createAgent: mocks.createAgent }));
+vi.mock("../agents/agent-create.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/agent-create.js")>()),
+  createAgent: mocks.createAgent,
+}));
 vi.mock("../config/config.js", () => ({ readConfigFileSnapshot: mocks.readConfigFileSnapshot }));
+vi.mock("../config/sessions/legacy-main-session-migration.js", () => ({
+  migrateLegacyMainSessionKeys: mocks.migrateLegacyMainSessionKeys,
+}));
 
 const { ensureOnboardingAgent } = await import("./onboard-agent.js");
 
@@ -21,6 +28,7 @@ describe("onboarding main-agent creation", () => {
       agentDir: "/tmp/agent",
       bootstrapPending: true,
     });
+    mocks.migrateLegacyMainSessionKeys.mockResolvedValue({});
     mocks.readConfigFileSnapshot
       .mockResolvedValueOnce({
         exists: false,
@@ -68,6 +76,31 @@ describe("onboarding main-agent creation", () => {
         },
         gateway: { mode: "local", controlUi: { enabled: true } },
       },
+    });
+  });
+
+  it("stages a normalized named first agent and runs legacy-session convergence", async () => {
+    mocks.createAgent.mockResolvedValueOnce({
+      status: "created",
+      agentId: "robby",
+      name: "Robby!",
+      workspace: "/tmp/work",
+      agentDir: "/tmp/agent",
+      bootstrapPending: true,
+    });
+
+    await ensureOnboardingAgent({
+      config: {},
+      workspace: "/tmp/work",
+      firstAgent: { name: "Robby!" },
+    });
+
+    expect(mocks.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: { id: "robby", name: "Robby!", workspace: "/tmp/work" } }),
+    );
+    expect(mocks.migrateLegacyMainSessionKeys).toHaveBeenCalledWith({
+      cfg: expect.objectContaining({ agents: expect.any(Object) }),
+      mode: "automatic",
     });
   });
 

--- a/src/commands/onboard-agent.test.ts
+++ b/src/commands/onboard-agent.test.ts
@@ -10,7 +10,10 @@ vi.mock("../agents/agent-create.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../agents/agent-create.js")>()),
   createAgent: mocks.createAgent,
 }));
-vi.mock("../config/config.js", () => ({ readConfigFileSnapshot: mocks.readConfigFileSnapshot }));
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+}));
 vi.mock("../config/sessions/legacy-main-session-migration.js", () => ({
   migrateLegacyMainSessionKeys: mocks.migrateLegacyMainSessionKeys,
 }));
@@ -21,12 +24,13 @@ describe("onboarding main-agent creation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.createAgent.mockResolvedValue({
-      status: "existing",
+      status: "created",
       agentId: "main",
       name: "main",
       workspace: "/tmp/work",
       agentDir: "/tmp/agent",
       bootstrapPending: true,
+      configHash: "hash-after-create",
     });
     mocks.migrateLegacyMainSessionKeys.mockResolvedValue({});
     mocks.readConfigFileSnapshot
@@ -87,6 +91,7 @@ describe("onboarding main-agent creation", () => {
       workspace: "/tmp/work",
       agentDir: "/tmp/agent",
       bootstrapPending: true,
+      configHash: "hash-after-create",
     });
 
     await ensureOnboardingAgent({
@@ -113,7 +118,12 @@ describe("onboarding main-agent creation", () => {
         workspace: "/tmp/work",
         preserveCandidateRoster: true,
       }),
-    ).resolves.toEqual({ config, agentId: "main", bootstrapPending: false });
+    ).resolves.toEqual({
+      config,
+      agentId: "main",
+      bootstrapPending: false,
+      createdAgent: false,
+    });
     expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
     expect(mocks.createAgent).not.toHaveBeenCalled();
   });
@@ -139,6 +149,58 @@ describe("onboarding main-agent creation", () => {
     });
 
     expect(result.configHash).toBeUndefined();
+    expect(mocks.createAgent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a whitespace-only explicit first-agent name instead of defaulting to main", async () => {
+    await expect(
+      ensureOnboardingAgent({
+        config: {},
+        workspace: "/tmp/work",
+        firstAgent: { name: "   " },
+      }),
+    ).rejects.toThrow("Agent name is required");
+
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.createAgent).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an incomplete legacy-session migration with a doctor recovery hint", async () => {
+    mocks.migrateLegacyMainSessionKeys.mockResolvedValueOnce({
+      armed: true,
+      complete: false,
+      warnings: ["database is locked"],
+    });
+
+    const result = await ensureOnboardingAgent({
+      config: {},
+      workspace: "/tmp/work",
+      firstAgent: { name: "robby" },
+    });
+
+    expect(result.sessionMigrationWarnings).toEqual([
+      expect.stringMatching(/database is locked.*openclaw doctor --fix/),
+    ]);
+  });
+
+  it("rejects a roster written after the approved config revision", async () => {
+    mocks.readConfigFileSnapshot.mockReset().mockResolvedValueOnce({
+      exists: true,
+      valid: true,
+      hash: "concurrent",
+      sourceConfigBeforeMigrations: { agents: { entries: { ops: {} } } },
+      config: { agents: { entries: { ops: {} } } },
+    });
+
+    await expect(
+      ensureOnboardingAgent({
+        config: {},
+        workspace: "/tmp/work",
+        firstAgent: { name: "robby" },
+        expectedConfigHash: "approved",
+      }),
+    ).rejects.toThrow("config changed before first-agent creation");
+
     expect(mocks.createAgent).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/onboard-agent.ts
+++ b/src/commands/onboard-agent.ts
@@ -7,7 +7,7 @@ import {
   tryResolveLegacyCompatibilityAgentId,
 } from "../agents/agent-scope-config.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
-import { readConfigFileSnapshot } from "../config/config.js";
+import { readConfigFileSnapshot, resolveConfigSnapshotHash } from "../config/config.js";
 import { createMergePatch } from "../config/merge-patch.js";
 import { applyMergePatch } from "../config/merge-patch.js";
 import { migrateLegacyMainSessionKeys } from "../config/sessions/legacy-main-session-migration.js";
@@ -61,10 +61,13 @@ export async function ensureOnboardingAgent(params: {
   firstAgent?: FirstOnboardingAgent;
   preserveCandidateRoster?: boolean;
   baseConfig?: OpenClawConfig;
+  expectedConfigHash?: string | null;
 }): Promise<{
   config: OpenClawConfig;
   agentId: string;
   bootstrapPending: boolean;
+  createdAgent: boolean;
+  sessionMigrationWarnings?: string[];
   /**
    * Config hash observed after this helper created the first roster agent.
    * Callers that captured a hash before calling must adopt it for their own
@@ -73,6 +76,20 @@ export async function ensureOnboardingAgent(params: {
    */
   configHash?: string;
 }> {
+  if (params.firstAgent) {
+    const validationError = validateFirstOnboardingAgentName(params.firstAgent.name);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+  }
+  const hasExpectedConfigHash = Object.hasOwn(params, "expectedConfigHash");
+  let before = hasExpectedConfigHash ? await readConfigFileSnapshot() : undefined;
+  if (before?.exists && !before.valid) {
+    throw new Error("Cannot create the first agent from an invalid OpenClaw config.");
+  }
+  if (before && (resolveConfigSnapshotHash(before) ?? null) !== params.expectedConfigHash) {
+    throw new Error("OpenClaw config changed before first-agent creation. Retry setup.");
+  }
   const candidateRoster = listAgentEntries(params.config);
   if (
     candidateRoster.length > 0 &&
@@ -83,9 +100,10 @@ export async function ensureOnboardingAgent(params: {
       agentId:
         tryResolveLegacyCompatibilityAgentId(params.config) ?? resolveDefaultAgentId(params.config),
       bootstrapPending: false,
+      createdAgent: false,
     };
   }
-  const before = await readConfigFileSnapshot();
+  before ??= await readConfigFileSnapshot();
   if (before.exists && !before.valid) {
     throw new Error("Cannot create the first agent from an invalid OpenClaw config.");
   }
@@ -100,9 +118,10 @@ export async function ensureOnboardingAgent(params: {
       }),
       agentId: tryResolveLegacyCompatibilityAgentId(effective) ?? resolveDefaultAgentId(effective),
       bootstrapPending: false,
+      createdAgent: false,
     };
   }
-  const firstAgentName = params.firstAgent?.name.trim() || "main";
+  const firstAgentName = params.firstAgent ? params.firstAgent.name.trim() : "main";
   const created = await createAgent({
     entry: {
       id: normalizeAgentId(firstAgentName),
@@ -111,6 +130,7 @@ export async function ensureOnboardingAgent(params: {
     },
     bootstrapMain: normalizeAgentId(firstAgentName) === "main",
     bootstrapFirstAgent: true,
+    ...(hasExpectedConfigHash ? { expectedConfigHash: params.expectedConfigHash } : {}),
     skipBootstrap: params.config.agents?.defaults?.skipBootstrap,
     skipOptionalBootstrapFiles: params.config.agents?.defaults?.skipOptionalBootstrapFiles,
   });
@@ -121,16 +141,30 @@ export async function ensureOnboardingAgent(params: {
   if (!after.valid) {
     throw new Error("Agent creation wrote an invalid OpenClaw config.");
   }
+  if (created.configHash && after.hash !== created.configHash) {
+    throw new Error("OpenClaw config changed after first-agent creation. Retry setup.");
+  }
   const config = mergeOnboardingCandidate({
     base: candidateBase,
     candidate: params.config,
     currentRuntime: after.config,
   });
-  await migrateLegacyMainSessionKeys({ cfg: after.config, mode: "automatic" });
+  const sessionMigration = await migrateLegacyMainSessionKeys({
+    cfg: after.config,
+    mode: "automatic",
+  });
+  const sessionMigrationWarnings =
+    sessionMigration.armed && !sessionMigration.complete
+      ? [
+          `Legacy main-agent session history migration is incomplete${sessionMigration.warnings.length > 0 ? `: ${sessionMigration.warnings.join("; ")}` : ""}. Run \`openclaw doctor --fix\`; OpenClaw will also retry at next startup.`,
+        ]
+      : [];
   return {
     config,
     agentId: created.agentId,
     bootstrapPending: created.bootstrapPending,
-    ...(after.hash !== undefined ? { configHash: after.hash } : {}),
+    createdAgent: created.status === "created",
+    ...(created.configHash ? { configHash: created.configHash } : {}),
+    ...(sessionMigrationWarnings.length > 0 ? { sessionMigrationWarnings } : {}),
   };
 }

--- a/src/commands/onboard-agent.ts
+++ b/src/commands/onboard-agent.ts
@@ -1,15 +1,29 @@
 // First-run main-agent creation through the canonical agent service.
-import { createAgent } from "../agents/agent-create.js";
+import { createAgent, validateAgentIdInput } from "../agents/agent-create.js";
 import {
   listAgentEntries,
   resolveDefaultAgentId,
   toAgentEntriesRecord,
   tryResolveLegacyCompatibilityAgentId,
 } from "../agents/agent-scope-config.js";
+import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { createMergePatch } from "../config/merge-patch.js";
 import { applyMergePatch } from "../config/merge-patch.js";
+import { migrateLegacyMainSessionKeys } from "../config/sessions/legacy-main-session-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+
+export type FirstOnboardingAgent = { name: string };
+
+export function validateFirstOnboardingAgentName(value: string | undefined): string | undefined {
+  const name = value?.trim();
+  if (!name) {
+    return "Agent name is required.";
+  }
+  const validation = validateAgentIdInput(name, { allowBootstrapMain: true });
+  return validation.ok ? undefined : `${validation.message}. Choose another name.`;
+}
 
 function isInjectedMainRoster(config: OpenClawConfig): boolean {
   const roster = listAgentEntries(config);
@@ -44,6 +58,7 @@ function mergeOnboardingCandidate(params: {
 export async function ensureOnboardingAgent(params: {
   config: OpenClawConfig;
   workspace: string;
+  firstAgent?: FirstOnboardingAgent;
   preserveCandidateRoster?: boolean;
   baseConfig?: OpenClawConfig;
 }): Promise<{
@@ -76,7 +91,7 @@ export async function ensureOnboardingAgent(params: {
   }
   const effective = before.config;
   const candidateBase = params.baseConfig ?? effective;
-  if (before.exists && listAgentEntries(effective).length > 0) {
+  if (before.exists && hasResolvedRosterBeforeMigrations(before)) {
     return {
       config: mergeOnboardingCandidate({
         base: candidateBase,
@@ -87,13 +102,15 @@ export async function ensureOnboardingAgent(params: {
       bootstrapPending: false,
     };
   }
+  const firstAgentName = params.firstAgent?.name.trim() || "main";
   const created = await createAgent({
     entry: {
-      id: "main",
-      name: "main",
+      id: normalizeAgentId(firstAgentName),
+      name: firstAgentName,
       workspace: params.workspace,
     },
-    bootstrapMain: true,
+    bootstrapMain: normalizeAgentId(firstAgentName) === "main",
+    bootstrapFirstAgent: true,
     skipBootstrap: params.config.agents?.defaults?.skipBootstrap,
     skipOptionalBootstrapFiles: params.config.agents?.defaults?.skipOptionalBootstrapFiles,
   });
@@ -104,23 +121,16 @@ export async function ensureOnboardingAgent(params: {
   if (!after.valid) {
     throw new Error("Agent creation wrote an invalid OpenClaw config.");
   }
+  const config = mergeOnboardingCandidate({
+    base: candidateBase,
+    candidate: params.config,
+    currentRuntime: after.config,
+  });
+  await migrateLegacyMainSessionKeys({ cfg: after.config, mode: "automatic" });
   return {
-    config: mergeOnboardingCandidate({
-      base: candidateBase,
-      candidate: params.config,
-      currentRuntime: after.config,
-    }),
+    config,
     agentId: created.agentId,
     bootstrapPending: created.bootstrapPending,
     ...(after.hash !== undefined ? { configHash: after.hash } : {}),
   };
-}
-
-export function ensureOnboardingConfig(
-  config: OpenClawConfig,
-  workspace: string,
-  preserveCandidateRoster = false,
-  baseConfig?: OpenClawConfig,
-) {
-  return ensureOnboardingAgent({ config, workspace, preserveCandidateRoster, baseConfig });
 }

--- a/src/commands/onboard-first-agent.ts
+++ b/src/commands/onboard-first-agent.ts
@@ -1,0 +1,23 @@
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { type FirstOnboardingAgent, validateFirstOnboardingAgentName } from "./onboard-agent.js";
+
+export async function promptFirstOnboardingAgent(
+  hasAuthoredRoster: boolean,
+  requestedName: string | undefined,
+  prompter: WizardPrompter,
+  nonInteractive = false,
+): Promise<FirstOnboardingAgent | undefined> {
+  if (hasAuthoredRoster) {
+    return undefined;
+  }
+  const name =
+    requestedName ??
+    (nonInteractive
+      ? "main"
+      : await prompter.text({
+          message: "What should we call your first agent?",
+          initialValue: "main",
+          validate: validateFirstOnboardingAgentName,
+        }));
+  return { name };
+}

--- a/src/commands/onboard-first-agent.ts
+++ b/src/commands/onboard-first-agent.ts
@@ -21,3 +21,12 @@ export async function promptFirstOnboardingAgent(
         }));
   return { name };
 }
+
+export async function showSessionMigrationWarnings(
+  prompter: WizardPrompter,
+  warnings: readonly string[] | undefined,
+): Promise<void> {
+  if (warnings?.length) {
+    await prompter.note(warnings.join("\n"), "Session history migration");
+  }
+}

--- a/src/commands/onboard-guided-memory-import.test.ts
+++ b/src/commands/onboard-guided-memory-import.test.ts
@@ -6,7 +6,13 @@ import { resetLogger } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { runGuidedOnboarding, type GuidedOnboardingDeps } from "./onboard-guided.js";
+import {
+  runGuidedOnboarding as runGuidedOnboardingImpl,
+  type GuidedOnboardingDeps,
+} from "./onboard-guided.js";
+
+const runGuidedOnboarding = (...[opts, ...rest]: Parameters<typeof runGuidedOnboardingImpl>) =>
+  runGuidedOnboardingImpl({ agentName: "main", ...opts }, ...rest);
 
 const restoreTerminalState = vi.hoisted(() => vi.fn());
 
@@ -44,6 +50,7 @@ vi.mock("../state/local-onboarding-state.js", () => ({
 }));
 vi.mock("./onboard-agent.js", () => ({
   ensureOnboardingAgent: async ({ config }: { config: OpenClawConfig }) => ({ config }),
+  validateFirstOnboardingAgentName: () => undefined,
 }));
 vi.mock("./onboard-helpers.js", () => ({
   DEFAULT_WORKSPACE: "/tmp/openclaw-workspace",

--- a/src/commands/onboard-guided.custodian.test.ts
+++ b/src/commands/onboard-guided.custodian.test.ts
@@ -7,7 +7,13 @@ import { loggingState } from "../logging/state.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import { WizardCancelledError, type WizardPrompter } from "../wizard/prompts.js";
-import { runGuidedOnboarding, type GuidedOnboardingDeps } from "./onboard-guided.js";
+import {
+  runGuidedOnboarding as runGuidedOnboardingImpl,
+  type GuidedOnboardingDeps,
+} from "./onboard-guided.js";
+
+const runGuidedOnboarding = (...[opts, ...rest]: Parameters<typeof runGuidedOnboardingImpl>) =>
+  runGuidedOnboardingImpl({ agentName: "main", ...opts }, ...rest);
 
 const restoreTerminalState = vi.hoisted(() => vi.fn());
 const promptAuthChoiceGrouped = vi.hoisted(() => vi.fn());
@@ -126,6 +132,7 @@ vi.mock("./onboard-agent.js", () => ({
     agentId: "main",
     bootstrapPending: true,
   }),
+  validateFirstOnboardingAgentName: () => undefined,
 }));
 
 vi.mock("./onboard-helpers.js", () => ({
@@ -1084,7 +1091,7 @@ describe("runGuidedOnboarding custodian flow", () => {
     await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, runtime, deps);
 
     expect(deps.launchHatchTui).not.toHaveBeenCalled();
-    expect(deps.runSystemAgentChat).toHaveBeenCalledWith("/tmp/work", runtime, true);
+    expect(deps.runSystemAgentChat).toHaveBeenCalledWith("/tmp/work", runtime, true, "main");
     const notes = JSON.stringify((prompter.note as ReturnType<typeof vi.fn>).mock.calls);
     expect(notes).toContain("config write raced");
   });

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -9,7 +9,13 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { runGuidedOnboarding, type GuidedOnboardingDeps } from "./onboard-guided.js";
+import {
+  runGuidedOnboarding as runGuidedOnboardingImpl,
+  type GuidedOnboardingDeps,
+} from "./onboard-guided.js";
+
+const runGuidedOnboarding = (...[opts, ...rest]: Parameters<typeof runGuidedOnboardingImpl>) =>
+  runGuidedOnboardingImpl({ agentName: "main", ...opts }, ...rest);
 
 const restoreTerminalState = vi.hoisted(() => vi.fn());
 const promptAuthChoiceGrouped = vi.hoisted(() => vi.fn());
@@ -122,6 +128,7 @@ vi.mock("../state/local-onboarding-state.js", () => ({
 }));
 vi.mock("./onboard-agent.js", () => ({
   ensureOnboardingAgent: async ({ config }: { config: OpenClawConfig }) => ({ config }),
+  validateFirstOnboardingAgentName: () => undefined,
 }));
 
 vi.mock("./onboard-helpers.js", () => ({
@@ -316,6 +323,27 @@ describe("runGuidedOnboarding", () => {
     );
     expect(deps.launchHatchTui).not.toHaveBeenCalled();
     expect(prompter.outro).toHaveBeenCalledWith("Your browser is ready — I'll be in Settings.");
+  });
+
+  it("prompts for and passes the named first agent into system-agent setup", async () => {
+    const prompter = createWizardPrompter({ text: vi.fn(async () => "robby") });
+    const applySetup = vi.fn(async () => setupApplyResult());
+
+    await runGuidedOnboardingImpl(
+      { acceptRisk: true, workspace: "/tmp/work", skipUi: true },
+      makeRuntime(),
+      setupDeps({ prompter, applySetup }),
+    );
+
+    expect(prompter.text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "What should we call your first agent?",
+        initialValue: "main",
+      }),
+    );
+    expect(applySetup).toHaveBeenCalledWith(
+      expect.objectContaining({ firstAgent: { name: "robby" } }),
+    );
   });
 
   it("shows gateway repair failures before recovery and keeps onboarding pending", async () => {

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -17,7 +17,7 @@ import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { requireRiskAcknowledgement } from "../wizard/setup.shared.js";
 import type { runBrowserHatchHandoff } from "./onboard-browser-handoff.js";
-import { promptFirstOnboardingAgent } from "./onboard-first-agent.js";
+import { promptFirstOnboardingAgent, showSessionMigrationWarnings } from "./onboard-first-agent.js";
 import {
   activationLines,
   formatSetupCandidateFailure,
@@ -556,6 +556,7 @@ async function runGuidedOnboardingFlow(
         firstAgent,
       });
       persistedConfig = created.config;
+      await showSessionMigrationWarnings(prompter, created.sessionMigrationWarnings);
     }
   } else {
     // Announced default: apply the same setup plan the conversational "yes"

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { formatCliCommand } from "../cli/command-format.js";
 import { isUnconfiguredConfigSource } from "../cli/fresh-install-config.js";
+import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withConsoleSubsystemsSuppressed } from "../logging/console.js";
@@ -16,6 +17,7 @@ import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { requireRiskAcknowledgement } from "../wizard/setup.shared.js";
 import type { runBrowserHatchHandoff } from "./onboard-browser-handoff.js";
+import { promptFirstOnboardingAgent } from "./onboard-first-agent.js";
 import {
   activationLines,
   formatSetupCandidateFailure,
@@ -41,6 +43,7 @@ export type GuidedOnboardingDeps = {
     workspace: string,
     runtime: RuntimeEnv,
     acceptRisk: boolean,
+    agentName?: string,
   ) => Promise<void>;
   createPrompter?: () => WizardPrompter | Promise<WizardPrompter>;
   persistRiskAcknowledgement?: (config: OpenClawConfig) => Promise<string | void>;
@@ -64,27 +67,38 @@ export type GuidedOnboardingDeps = {
 
 export type GuidedAccessMode = "full" | "guarded";
 
-type GuidedOnboardingHandoff = { workspace: string; next: "browser" | "hatch" | "chat" };
+type GuidedOnboardingHandoff = {
+  workspace: string;
+  next: "browser" | "hatch" | "chat";
+  agentName?: string;
+};
 
 async function openSystemAgentChat(
   deps: GuidedOnboardingDeps,
   workspace: string,
   runtime: RuntimeEnv,
   acceptRisk: boolean,
+  agentName?: string,
 ): Promise<void> {
   const runChat =
     deps.runSystemAgentChat ??
-    (async (setupWorkspace: string, chatRuntime: RuntimeEnv, riskAccepted: boolean) => {
+    (async (
+      setupWorkspace: string,
+      chatRuntime: RuntimeEnv,
+      riskAccepted: boolean,
+      setupAgentName?: string,
+    ) => {
       const { runConversationalOnboarding } = await import("./onboard-interactive.js");
       await runConversationalOnboarding(
         {
           workspace: setupWorkspace,
+          ...(setupAgentName ? { agentName: setupAgentName } : {}),
           ...(riskAccepted ? { acceptRisk: true } : {}),
         },
         chatRuntime,
       );
     });
-  await runChat(workspace, runtime, acceptRisk);
+  await runChat(workspace, runtime, acceptRisk, agentName);
 }
 
 async function persistRiskAcknowledgement(config: OpenClawConfig): Promise<string | undefined> {
@@ -170,6 +184,8 @@ async function runGuidedOnboardingFlow(
   if (!onboardingSecurityAcknowledgedAt) {
     throw new Error("Local onboarding requires its persisted security acknowledgement.");
   }
+  const hasAuthoredRoster = hasResolvedRosterBeforeMigrations(snapshot);
+  const firstAgent = await promptFirstOnboardingAgent(hasAuthoredRoster, opts.agentName, prompter);
 
   // Reset removes config but keeps SQLite. Only the original, pre-acknowledgement
   // snapshot distinguishes a new installation from an interrupted previous run.
@@ -494,7 +510,7 @@ async function runGuidedOnboardingFlow(
         (await import("../wizard/setup.memory-import.js")).runSetupMemoryImportStep;
       await runMemoryImport({ config: persistedConfig, prompter, runtime });
     }
-    return { workspace, next: "chat" };
+    return { workspace, next: "chat", ...(firstAgent ? { agentName: firstAgent.name } : {}) };
   }
 
   // Setup apply installs and restarts the machine-level Gateway service.
@@ -531,6 +547,16 @@ async function runGuidedOnboardingFlow(
         t("wizard.setup.workspaceConflictTitle"),
       );
     }
+    if (firstAgent) {
+      const { ensureOnboardingAgent } = await import("./onboard-agent.js");
+      const created = await ensureOnboardingAgent({
+        config: persistedConfig,
+        workspace: appliedWorkspace,
+        baseConfig: persistedConfig,
+        firstAgent,
+      });
+      persistedConfig = created.config;
+    }
   } else {
     // Announced default: apply the same setup plan the conversational "yes"
     // would, then hand off to the hatch instead of parking in the OpenClaw chat.
@@ -549,19 +575,12 @@ async function runGuidedOnboardingFlow(
         }
         assertLocalSetupOwner(ownerSnapshot.sourceConfig ?? ownerSnapshot.config);
       }
-      const { ensureOnboardingAgent } = await import("./onboard-agent.js");
-      // Only fresh-file creation is a side effect here. Pre-roster authored persistence
-      // remains doctor-owned; the injected main roster is intentionally not flattened.
-      await ensureOnboardingAgent({
-        config: existingConfig,
-        workspace,
-        baseConfig: existingConfig,
-      });
       const applySetup =
         deps.applySetup ?? (await import("../system-agent/setup-apply.js")).applySystemAgentSetup;
       const applied = await withConsoleSubsystemsSuppressed(() =>
         applySetup({
           workspace,
+          ...(firstAgent ? { firstAgent } : {}),
           ...(allowWorkspaceChange ? { allowWorkspaceChange: true } : {}),
           ...(resumingSetup ? { resume: true } : {}),
           ...(localSetup?.status === "pending"
@@ -604,7 +623,7 @@ async function runGuidedOnboardingFlow(
         }),
         t("wizard.guided.aiAccessTitle"),
       );
-      return { workspace, next: "chat" };
+      return { workspace, next: "chat", ...(firstAgent ? { agentName: firstAgent.name } : {}) };
     }
   }
   if (wantsDiscovery) {
@@ -731,5 +750,5 @@ export async function runGuidedOnboarding(
   }
   // Chat handoff: legacy remote-gateway flow, or local recovery after a
   // failed setup apply — the conversational chat can finish interactively.
-  await openSystemAgentChat(deps, handoff.workspace, runtime, true);
+  await openSystemAgentChat(deps, handoff.workspace, runtime, true, handoff.agentName);
 }

--- a/src/commands/onboard-interactive.ts
+++ b/src/commands/onboard-interactive.ts
@@ -54,6 +54,7 @@ export async function runConversationalOnboarding(
     {
       welcomeVariant: "onboarding",
       ...(opts.workspace ? { setupWorkspace: opts.workspace } : {}),
+      ...(opts.agentName ? { setupAgentName: opts.agentName } : {}),
       verifiedInference: inference.binding,
     },
     runtime,

--- a/src/commands/onboard-non-interactive/local.default-agent.test.ts
+++ b/src/commands/onboard-non-interactive/local.default-agent.test.ts
@@ -173,8 +173,32 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
     expect(mocks.applyAuthChoice.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.ensureOnboardingAgent.mock.invocationCallOrder[0]!,
     );
+    expect(mocks.ensureOnboardingAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ firstAgent: { name: "main" } }),
+    );
     expect(mocks.commitConfig.mock.invocationCallOrder[0]).toBeGreaterThan(
       mocks.ensureOnboardingAgent.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("passes an explicit first-agent name into the single creation step", async () => {
+    await runNonInteractiveLocalSetup({
+      opts: {
+        nonInteractive: true,
+        mode: "local",
+        agentName: "robby",
+        authChoice: "skip",
+        skipHooks: true,
+        skipSkills: true,
+        skipHealth: true,
+      },
+      runtime,
+      baseConfig: {},
+    });
+
+    expect(mocks.ensureOnboardingAgent).toHaveBeenCalledOnce();
+    expect(mocks.ensureOnboardingAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ firstAgent: { name: "robby" } }),
     );
   });
 

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -269,6 +269,9 @@ export async function runNonInteractiveLocalSetup(params: {
     baseConfig,
     firstAgent: { name: opts.agentName ?? "main" },
   });
+  for (const warning of created.sessionMigrationWarnings ?? []) {
+    runtime.log(`Warning: ${warning}`);
+  }
   nextConfig = applyLocalSetupWorkspaceConfig(created.config, requestedWorkspaceDir);
   // First-agent creation is the first permitted config mutation. Preserve its
   // resulting hash so the canonical wizard write still rejects foreign edits.

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -267,6 +267,7 @@ export async function runNonInteractiveLocalSetup(params: {
     config: nextConfig,
     workspace: workspaceDir,
     baseConfig,
+    firstAgent: { name: opts.agentName ?? "main" },
   });
   nextConfig = applyLocalSetupWorkspaceConfig(created.config, requestedWorkspaceDir);
   // First-agent creation is the first permitted config mutation. Preserve its

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -58,6 +58,8 @@ export type OnboardOptions = OnboardDynamicProviderOptions & {
   /** Force the terminal hatch instead of the guided browser handoff. */
   tui?: boolean;
   workspace?: string;
+  /** Name for the first persisted agent; defaults to `main` in non-interactive setup. */
+  agentName?: string;
   nonInteractive?: boolean;
   /** Required for non-interactive setup; skips the interactive risk prompt when true. */
   acceptRisk?: boolean;

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -191,6 +191,34 @@ describe("setupWizardCommand", () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({ exists: false, valid: false, config: {} });
   });
 
+  it.each(["main", "robby", "Robby!"])("accepts valid first-agent name %s", async (agentName) => {
+    const runtime = makeRuntime();
+
+    await setupWizardCommand({ nonInteractive: true, acceptRisk: true, agentName }, runtime);
+
+    expect(mocks.runNonInteractiveSetup).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName }),
+      runtime,
+    );
+  });
+
+  it.each(["!!!", "openclaw", "crestodian"])(
+    "rejects invalid or reserved first-agent name %s before setup",
+    async (agentName) => {
+      const runtime = makeRuntime();
+
+      await setupWizardCommand(
+        { nonInteractive: true, acceptRisk: true, reset: true, agentName },
+        runtime,
+      );
+
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Invalid --agent-name"));
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(mocks.handleReset).not.toHaveBeenCalled();
+      expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
+    },
+  );
+
   it("fails fast for invalid secret-input-mode before setup starts", async () => {
     const runtime = makeRuntime();
 

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -482,6 +482,15 @@ export async function setupWizardCommand(
     normalizedAuthChoice === opts.authChoice && flow === opts.flow
       ? opts
       : { ...opts, authChoice: normalizedAuthChoice, flow };
+  if (normalizedOpts.agentName !== undefined) {
+    const { validateFirstOnboardingAgentName } = await import("./onboard-agent.js");
+    const error = validateFirstOnboardingAgentName(normalizedOpts.agentName);
+    if (error) {
+      runtime.error(`Invalid --agent-name: ${error}`);
+      runtime.exit(1);
+      return;
+    }
+  }
   if (!validatePreflightOptions(normalizedOpts, runtime)) {
     return;
   }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -230,7 +230,15 @@ export async function setupCommand(
 
   if (!snapshot.exists) {
     const { ensureOnboardingAgent } = await import("./onboard-agent.js");
-    next = (await ensureOnboardingAgent({ config: next, workspace, baseConfig: cfg })).config;
+    const onboardingAgent = await ensureOnboardingAgent({
+      config: next,
+      workspace,
+      baseConfig: cfg,
+    });
+    next = onboardingAgent.config;
+    for (const warning of onboardingAgent.sessionMigrationWarnings ?? []) {
+      runtime.log(`Warning: ${warning}`);
+    }
   }
 
   const configChanged =

--- a/src/commands/system-agent-with-inference.ts
+++ b/src/commands/system-agent-with-inference.ts
@@ -57,7 +57,7 @@ function failOneShotExecution(
 export async function runSystemAgentWithInference(
   opts: SystemAgentCommandOptions = {},
   runtime: RuntimeEnv = defaultRuntime,
-  onboardingOptions: Pick<OnboardOptions, "workspace" | "acceptRisk"> = {},
+  onboardingOptions: Pick<OnboardOptions, "workspace" | "agentName" | "acceptRisk"> = {},
   deps: SystemAgentWithInferenceDeps = {},
 ): Promise<void> {
   if (opts.yes && !opts.message?.trim()) {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -64,10 +64,12 @@ type ProjectedDispatchParams = Parameters<
 >[0];
 
 const TEST_TOOL_AUTHORITY_FINGERPRINT = "test-tool-authority";
+const TEST_TOOL_AUTHORITY_ROUTE = { provider: "openai", model: "gpt-5.6-sol" } as const;
 const replyRunRegistry = {
   ...baseReplyRunRegistry,
   begin(...args: Parameters<typeof baseReplyRunRegistry.begin>) {
     const operation = baseReplyRunRegistry.begin(...args);
+    operation.bindToolAuthorityRoute(TEST_TOOL_AUTHORITY_ROUTE);
     operation.bindToolAuthorityFingerprint(TEST_TOOL_AUTHORITY_FINGERPRINT);
     return operation;
   },

--- a/src/system-agent/chat-turn-router.approval.test.ts
+++ b/src/system-agent/chat-turn-router.approval.test.ts
@@ -539,6 +539,53 @@ describe("SystemAgentChatEngine approval", () => {
     );
   });
 
+  it("preserves the pending first-agent name when a planner adds the verified model", async () => {
+    useTempStateDir();
+    const applySetup = vi.fn(async () => ({
+      configPath: "/tmp/openclaw.json",
+      configHashBefore: "before",
+      configHashAfter: "after",
+      bootstrapPending: false,
+      workspaceReady: true,
+      gateway: { status: "ready" as const, action: "reused" as const },
+      lines: [],
+    }));
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => ({
+        reply: "I'll keep the verified model.",
+        command: "setup workspace /tmp/new-work model openai/gpt-5.5",
+        modelLabel: "planner",
+      }),
+      classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
+      deps: {
+        applySetup,
+        verifyInferenceConfig: vi.fn(async () => ({
+          ok: true as const,
+          modelRef: "openai/gpt-5.5",
+          latencyMs: 100,
+        })),
+        loadOverview: fakeOverviewLoader({ defaultModel: "openai/gpt-5.5" }),
+      },
+    });
+    engine.propose({
+      kind: "setup",
+      workspace: "/tmp/old-work",
+      agentName: "robby",
+    });
+
+    await engine.handle("keep the model and change the workspace");
+    await engine.handle("yes");
+
+    expect(applySetup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: "/tmp/new-work",
+        firstAgent: { name: "robby" },
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("tells the agent loop when a preserved proposal was resolved", async () => {
     const observedInputs: string[] = [];
     const router = createRouterHarness({

--- a/src/system-agent/chat-turn-router.ts
+++ b/src/system-agent/chat-turn-router.ts
@@ -100,7 +100,11 @@ function preservePendingSetupModel(
   if (requestedModel && requestedModel !== pendingModel) {
     return operation;
   }
-  return { ...operation, ...(requestedModel ? {} : pendingModel ? { model: pendingModel } : {}) };
+  return {
+    ...operation,
+    ...(requestedModel ? {} : pendingModel ? { model: pendingModel } : {}),
+    ...(operation.agentName ? {} : pending.agentName ? { agentName: pending.agentName } : {}),
+  };
 }
 
 export class ChatTurnRouter {

--- a/src/system-agent/chat-turn-router.ts
+++ b/src/system-agent/chat-turn-router.ts
@@ -97,13 +97,16 @@ function preservePendingSetupModel(
   }
   const pendingModel = pending.model?.trim();
   const requestedModel = operation.model?.trim();
+  const withAgentName = {
+    ...operation,
+    ...(operation.agentName ? {} : pending.agentName ? { agentName: pending.agentName } : {}),
+  };
   if (requestedModel && requestedModel !== pendingModel) {
-    return operation;
+    return withAgentName;
   }
   return {
-    ...operation,
+    ...withAgentName,
     ...(requestedModel ? {} : pendingModel ? { model: pendingModel } : {}),
-    ...(operation.agentName ? {} : pending.agentName ? { agentName: pending.agentName } : {}),
   };
 }
 

--- a/src/system-agent/onboarding-welcome.test.ts
+++ b/src/system-agent/onboarding-welcome.test.ts
@@ -72,11 +72,15 @@ describe("buildOnboardingWelcome", () => {
       noteAssistantMessage,
     };
 
-    const { text: welcome, question } = await buildOnboardingWelcome({ engine: engine as never });
+    const { text: welcome, question } = await buildOnboardingWelcome({
+      engine: engine as never,
+      agentName: "robby",
+    });
 
     expect(propose).toHaveBeenCalledWith({
       kind: "setup",
       workspace: "/existing/workspace",
+      agentName: "robby",
     });
     expect(question.id).toBe("onboarding-apply-setup");
     expect(question.options[0]).toMatchObject({

--- a/src/system-agent/onboarding-welcome.ts
+++ b/src/system-agent/onboarding-welcome.ts
@@ -95,6 +95,7 @@ export async function loadAuthoredSetupConfig(params: {
 export async function buildOnboardingWelcome(params: {
   engine: SystemAgentChatEngine;
   workspace?: string;
+  agentName?: string;
   /** Only the local terminal can finish the machine-owned Gateway installation. */
   localRecovery?: true;
 }): Promise<OnboardingWelcome> {
@@ -145,7 +146,11 @@ export async function buildOnboardingWelcome(params: {
     pendingSetup?.workspace || requestedWorkspace || authoredWorkspace || DEFAULT_WORKSPACE,
   );
 
-  params.engine.propose({ kind: "setup", workspace });
+  params.engine.propose({
+    kind: "setup",
+    workspace,
+    ...(params.agentName ? { agentName: params.agentName } : {}),
+  });
   const welcome = [
     "## Hi, I'm OpenClaw — let's hatch your agent.",
     "",

--- a/src/system-agent/operation-types.ts
+++ b/src/system-agent/operation-types.ts
@@ -22,7 +22,7 @@ export type SystemAgentOperation =
       id: string;
       provider?: string;
     }
-  | { kind: "setup"; workspace?: string; model?: string }
+  | { kind: "setup"; workspace?: string; model?: string; agentName?: string }
   | { kind: "model-setup"; workspace?: string }
   | { kind: "channel-list" }
   | { kind: "channel-info"; channel: string }

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -509,6 +509,7 @@ export async function executeSetup(
         applySetup(
           {
             workspace,
+            ...(operation.agentName ? { firstAgent: { name: operation.agentName } } : {}),
             expectedInferenceRoute: verified.route,
             ...recovery?.applyOptions,
             surface,

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -233,7 +233,7 @@ describe("parseSystemAgentOperation", () => {
     expect(applySetup).not.toHaveBeenCalled();
 
     const result = await executeSystemAgentOperation(
-      { kind: "setup", workspace: "/tmp/work" },
+      { kind: "setup", workspace: "/tmp/work", agentName: "robby" },
       runtime,
       {
         approved: true,
@@ -248,6 +248,7 @@ describe("parseSystemAgentOperation", () => {
     expect(applySetup).toHaveBeenCalledWith(
       {
         workspace: "/tmp/work",
+        firstAgent: { name: "robby" },
         expectedInferenceRoute: expect.any(Object),
         surface: "cli",
         runtime,

--- a/src/system-agent/setup-apply.concurrency.test.ts
+++ b/src/system-agent/setup-apply.concurrency.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { withTempHome } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveAgentDir } from "../agents/agent-scope.js";
+import { readConfigFileSnapshot, resetConfigRuntimeState } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { applySystemAgentSetup } from "./setup-apply.js";
+
+const runtime: RuntimeEnv = {
+  log: () => {},
+  error: () => {},
+  exit: ((code: number) => {
+    throw new Error(`exit:${code}`);
+  }) as RuntimeEnv["exit"],
+};
+
+const sourceConfig = {
+  agents: { defaults: { model: "openai/gpt-5.5" } },
+} satisfies OpenClawConfig;
+
+async function writeConcurrentRoster(pathname: string, agentId: string): Promise<void> {
+  await fs.writeFile(
+    pathname,
+    JSON.stringify({
+      agents: {
+        defaults: { model: "openai/gpt-5.5" },
+        entries: { [agentId]: {} },
+      },
+    }),
+  );
+  resetConfigRuntimeState();
+}
+
+async function writeInitialConfig() {
+  const absent = await readConfigFileSnapshot();
+  await fs.mkdir(path.dirname(absent.path), { recursive: true });
+  await fs.writeFile(absent.path, JSON.stringify(sourceConfig));
+  resetConfigRuntimeState();
+  return await readConfigFileSnapshot();
+}
+
+afterEach(() => {
+  resetConfigRuntimeState();
+});
+
+describe("applySystemAgentSetup first-agent concurrency", () => {
+  it("rejects a same-route agent switch after the controlled first-agent handoff", async () => {
+    await withTempHome(async () => {
+      const initial = await writeInitialConfig();
+      const initialRuntime = initial.runtimeConfig ?? initial.config;
+      let commitCount = 0;
+
+      await expect(
+        applySystemAgentSetup(
+          {
+            workspace: "/tmp/openclaw-first-agent-race",
+            firstAgent: { name: "robby" },
+            expectedAgentId: "main",
+            expectedAgentDir: resolveAgentDir(initialRuntime, "main"),
+            expectedModelRef: "openai/gpt-5.5",
+            surface: "gateway",
+            runtime,
+          },
+          {
+            commit: async (effect) => {
+              commitCount += 1;
+              if (commitCount === 2) {
+                await writeConcurrentRoster(initial.path, "other");
+              }
+              return await effect();
+            },
+          },
+        ),
+      ).rejects.toThrow(/config changed|default agent changed/);
+
+      const after = await readConfigFileSnapshot();
+      expect(after.sourceConfig?.agents?.entries).toEqual({ other: {} });
+    });
+  });
+
+  it("rejects a roster written before the conditional first-agent create", async () => {
+    await withTempHome(async () => {
+      const initial = await writeInitialConfig();
+
+      await expect(
+        applySystemAgentSetup(
+          {
+            workspace: "/tmp/openclaw-first-agent-race",
+            firstAgent: { name: "robby" },
+            expectedConfigHash: initial.hash ?? null,
+            surface: "gateway",
+            runtime,
+          },
+          {
+            commit: async (effect) => {
+              await writeConcurrentRoster(initial.path, "concurrent");
+              return await effect();
+            },
+          },
+        ),
+      ).rejects.toThrow("config changed before first-agent creation");
+
+      const after = await readConfigFileSnapshot();
+      expect(after.sourceConfig?.agents?.entries).toEqual({ concurrent: {} });
+    });
+  });
+});

--- a/src/system-agent/setup-apply.model-selection.test.ts
+++ b/src/system-agent/setup-apply.model-selection.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applySystemAgentModelSelection } from "./setup-apply.js";
+
+describe("applySystemAgentModelSelection", () => {
+  it("clears stale harness pins in both model scopes for a native route", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
+        },
+        entries: {
+          work: {
+            default: true,
+            model: "openai/gpt-5.5",
+            models: {
+              "openai/gpt-5.5": {
+                alias: "primary",
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await applySystemAgentModelSelection({ config, model: "openai/gpt-5.5" });
+
+    expect(result.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toBeUndefined();
+    expect(result.agents?.entries?.work?.models?.["openai/gpt-5.5"]).toEqual({ alias: "primary" });
+    expect(result.agents?.entries?.work?.model).toBe("openai/gpt-5.5");
+  });
+
+  it("pins the verified credential without creating a global visibility map", async () => {
+    const result = await applySystemAgentModelSelection({
+      config: {
+        agents: {
+          defaults: { model: "openai/gpt-5.5" },
+          entries: { main: { default: true } },
+        },
+      },
+      model: "openai/gpt-5.5",
+      authProfileId: "openai:verified",
+    });
+
+    expect(result.agents?.defaults?.model).toBe("openai/gpt-5.5@openai:verified");
+    expect(result.agents?.defaults?.models).toBeUndefined();
+  });
+});

--- a/src/system-agent/setup-apply.test.ts
+++ b/src/system-agent/setup-apply.test.ts
@@ -249,6 +249,7 @@ describe("applySystemAgentSetup transaction boundaries", () => {
           config: next,
           agentId: id,
           bootstrapPending: true,
+          createdAgent: true,
           configHash: "agent-create",
         };
       },

--- a/src/system-agent/setup-apply.test.ts
+++ b/src/system-agent/setup-apply.test.ts
@@ -118,7 +118,7 @@ vi.mock("../agents/agent-scope.js", async (importOriginal) => ({
     resolveAgentEntry(config, agentId)?.agentDir ?? `/agents/${agentId}`,
 }));
 
-import { applySystemAgentModelSelection, applySystemAgentSetup } from "./setup-apply.js";
+import { applySystemAgentSetup } from "./setup-apply.js";
 
 const runtime: RuntimeEnv = {
   log: vi.fn(),
@@ -214,57 +214,6 @@ function setSetupCommitState(config: OpenClawConfig, initialSnapshot: ConfigSnap
   mocks.state.commitSnapshot = initialSnapshot;
 }
 
-describe("applySystemAgentModelSelection", () => {
-  it("clears stale harness pins in both model scopes for a native route", async () => {
-    const config = {
-      agents: {
-        defaults: {
-          models: {
-            "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
-          },
-        },
-        entries: {
-          work: {
-            default: true,
-            model: "openai/gpt-5.5",
-            models: {
-              "openai/gpt-5.5": {
-                alias: "primary",
-                agentRuntime: { id: "codex" },
-              },
-            },
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
-
-    const result = await applySystemAgentModelSelection({
-      config,
-      model: "openai/gpt-5.5",
-    });
-
-    expect(result.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toBeUndefined();
-    expect(result.agents?.entries?.work?.models?.["openai/gpt-5.5"]).toEqual({ alias: "primary" });
-    expect(result.agents?.entries?.work?.model).toBe("openai/gpt-5.5");
-  });
-
-  it("pins the verified credential without creating a global visibility map", async () => {
-    const result = await applySystemAgentModelSelection({
-      config: {
-        agents: {
-          defaults: { model: "openai/gpt-5.5" },
-          entries: { main: { default: true } },
-        },
-      },
-      model: "openai/gpt-5.5",
-      authProfileId: "openai:verified",
-    });
-
-    expect(result.agents?.defaults?.model).toBe("openai/gpt-5.5@openai:verified");
-    expect(result.agents?.defaults?.models).toBeUndefined();
-  });
-});
-
 describe("applySystemAgentSetup transaction boundaries", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -278,18 +227,32 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     setSetupCommitState(structuredClone(config), snapshot("probe", config));
     mocks.state.commitPreviousHash = "probe";
     mocks.state.persistedConfig = undefined;
-    mocks.ensureOnboardingAgent.mockImplementation(async ({ config: current, name, workspace }) => {
-      const id = name === "Research Buddy" ? "research-buddy" : name.toLowerCase();
-      const next = {
-        ...current,
-        agents: {
-          ...current.agents,
-          entries: { [id]: { default: true, workspace, agentDir: `/agents/${id}` } },
-        },
-      };
-      mocks.state.persistedConfig = next;
-      return { config: next, agentId: id, bootstrapPending: true };
-    });
+    mocks.ensureOnboardingAgent.mockImplementation(
+      async ({ config: current, firstAgent, workspace }) => {
+        const name = firstAgent?.name ?? "main";
+        const id = name === "Research Buddy" ? "research-buddy" : name.toLowerCase();
+        const next = {
+          ...current,
+          agents: {
+            ...current.agents,
+            entries: { [id]: { default: true, workspace, agentDir: `/agents/${id}` } },
+          },
+        };
+        mocks.state.persistedConfig = next;
+        const createdSnapshot = snapshot("agent-create", next);
+        mocks.state.initialSnapshot = createdSnapshot;
+        mocks.state.commitConfig = next;
+        mocks.state.commitSnapshot = createdSnapshot;
+        mocks.state.commitPreviousHash = "agent-create";
+        mocks.events.push("agent-create");
+        return {
+          config: next,
+          agentId: id,
+          bootstrapPending: true,
+          configHash: "agent-create",
+        };
+      },
+    );
     mocks.readSnapshot.mockImplementation(async () => mocks.state.initialSnapshot);
     mocks.readVerifiedSnapshot.mockImplementation(async () => mocks.state.initialSnapshot);
     mocks.readVerifiedSnapshotWithPluginMetadata.mockImplementation(async () => ({
@@ -304,6 +267,7 @@ describe("applySystemAgentSetup transaction boundaries", () => {
       });
       mocks.events.push("commit");
       mocks.state.persistedConfig = result.nextConfig;
+      mocks.state.initialSnapshot = snapshot("persisted", result.nextConfig);
       return {
         nextConfig: result.nextConfig,
         path: "/tmp/openclaw.json",
@@ -391,7 +355,37 @@ describe("applySystemAgentSetup transaction boundaries", () => {
         entries: { main: { default: true } },
       },
     });
-    expect(mocks.events).toEqual(["commit", "workspace"]);
+    expect(mocks.events).toEqual(["agent-create", "commit", "workspace"]);
+  });
+
+  it("creates a named first agent while preserving the pre-roster verified route", async () => {
+    const source = { agents: { defaults: { model: "openai/gpt-5.5" } } } satisfies OpenClawConfig;
+    const runtimeConfig = {
+      agents: {
+        defaults: { model: "openai/gpt-5.5" },
+        entries: { main: { default: true, agentDir: "/agents/main" } },
+      },
+    } satisfies OpenClawConfig;
+    const absentRoster = snapshot("probe", source, runtimeConfig);
+    setSetupCommitState(runtimeConfig, absentRoster);
+    const expectedInferenceRoute = await projectDefaultInferenceRoute(runtimeConfig);
+    mocks.readVerifiedSnapshot.mockImplementation(async () => mocks.state.initialSnapshot);
+
+    await applySystemAgentSetup(
+      baseParams({
+        expectedConfigHash: "probe",
+        expectedAgentId: "main",
+        expectedAgentDir: "/agents/main",
+        expectedInferenceRoute,
+        firstAgent: { name: "Research Buddy" },
+      }),
+    );
+
+    expect(mocks.ensureOnboardingAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ firstAgent: { name: "Research Buddy" } }),
+    );
+    expect(mocks.state.persistedConfig?.agents?.entries).toHaveProperty("research-buddy");
+    expect(mocks.state.persistedConfig?.agents?.entries).not.toHaveProperty("main");
   });
 
   it("does not mistake a proposal-created roster for an existing fleet", async () => {

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -28,6 +28,7 @@ import {
 } from "./inference-route.js";
 import { requireValidSystemAgentSetupSnapshot } from "./setup-config-snapshot.js";
 import {
+  assertSetupTarget,
   sameSetupConfiguredRoute,
   sameSetupInferenceRoute,
 } from "./setup-inference-route-guard.js";
@@ -312,62 +313,46 @@ export async function applySystemAgentSetup(
   let snapshotConfig = requireValidSystemAgentSetupSnapshot(snapshot);
   const configHashBefore = resolveConfigSnapshotHash(snapshot);
   const startedWithoutAuthoredRoster = !hasResolvedRosterBeforeMigrations(snapshot);
-  let ignoreVerifiedAgentIdentity = false;
+  let verifiedRoute = params.expectedInferenceRoute;
+  let guardedExpectedAgentId = expectedAgentId;
+  let guardedExpectedAgentDir = expectedAgentDir;
+  let sessionMigrationWarnings: string[] = [];
 
   if (hasExpectedConfigHash && resolveConfigSnapshotHash(snapshot) !== expectedConfigHash) {
     throw new Error("OpenClaw config changed while AI access was being tested. Try setup again.");
   }
 
-  const guardModules =
+  let guardModules =
     expectedAgentId || expectedAgentDir || expectedModelRef
       ? await Promise.all([
           import("../agents/agent-scope.js"),
           import("../agents/model-selection.js"),
         ] as const)
       : undefined;
-  const assertExpectedTarget = (
-    config: OpenClawConfig,
-    options: { ignoreAgentIdentity?: boolean } = {},
-  ): void => {
+  const assertExpectedTarget = (config: OpenClawConfig): void => {
     if (!guardModules) {
       return;
     }
-    const [{ resolveAgentDir, resolveDefaultAgentId }, { resolveDefaultModelForAgent }] =
-      guardModules;
-    const currentAgentId = resolveDefaultAgentId(config);
-    if (!options.ignoreAgentIdentity && expectedAgentId && currentAgentId !== expectedAgentId) {
-      throw new Error(
-        "The default agent changed while AI access was being tested. Try setup again.",
-      );
-    }
-    if (
-      !options.ignoreAgentIdentity &&
-      expectedAgentDir &&
-      resolveAgentDir(config, currentAgentId) !== expectedAgentDir
-    ) {
-      throw new Error(
-        "The agent credential location changed while AI access was being tested. Try setup again.",
-      );
-    }
-    if (expectedModelRef) {
-      const current = resolveDefaultModelForAgent({ cfg: config, agentId: currentAgentId });
-      const currentModelRef = `${current.provider}/${current.model}`;
-      if (currentModelRef !== expectedModelRef) {
-        throw new Error(
-          "The default model changed while AI access was being tested. Try setup again.",
-        );
-      }
-    }
+    assertSetupTarget({
+      config,
+      expectedAgentId: guardedExpectedAgentId,
+      expectedAgentDir: guardedExpectedAgentDir,
+      expectedModelRef,
+      resolveAgentDir: guardModules[0].resolveAgentDir,
+      resolveDefaultAgentId: guardModules[0].resolveDefaultAgentId,
+      resolveDefaultModelForAgent: guardModules[1].resolveDefaultModelForAgent,
+    });
   };
   assertExpectedTarget(snapshotConfig.runtimeConfig);
 
   const assertVerifiedRoute = async (
     setupSnapshot: ConfigFileSnapshot,
-    expectedRoute = params.expectedInferenceRoute,
+    expectedRoute = verifiedRoute,
     phase: "before" | "after" = "before",
+    ignoreAgentIdentity = false,
   ) => {
     if (!expectedRoute) {
-      return;
+      return undefined;
     }
     // Setup reads with plugin validation skipped so it can repair broken plugin
     // config. Bind that view to the fully validated path, root hash, includes,
@@ -391,7 +376,7 @@ export async function applySystemAgentSetup(
         : null;
     if (
       !currentRoute ||
-      !sameSetupInferenceRoute(currentRoute, expectedRoute, ignoreVerifiedAgentIdentity)
+      !sameSetupInferenceRoute(currentRoute, expectedRoute, ignoreAgentIdentity)
     ) {
       throw new Error(
         phase === "before"
@@ -399,26 +384,56 @@ export async function applySystemAgentSetup(
           : "The default-agent inference route changed after the config write, so no further setup effects were applied. Retry setup from the current OpenClaw session.",
       );
     }
+    return currentRoute;
   };
   await assertVerifiedRoute(snapshot);
 
   let expectedWriteHash = expectedConfigHash;
   if (startedWithoutAuthoredRoster) {
     const { ensureOnboardingAgent } = await import("../commands/onboard-agent.js");
-    await commit(
+    const onboardingSourceConfig =
+      snapshot.sourceConfigBeforeMigrations ?? snapshotConfig.sourceConfig;
+    const created = await commit(
       async () =>
         await ensureOnboardingAgent({
-          config: snapshotConfig.sourceConfig,
+          config: onboardingSourceConfig,
           workspace,
-          baseConfig: snapshotConfig.sourceConfig,
+          baseConfig: onboardingSourceConfig,
           firstAgent: params.firstAgent ?? { name: "main" },
+          expectedConfigHash: configHashBefore ?? null,
         }),
     );
+    if (!created.createdAgent || !created.configHash) {
+      throw new Error(
+        "OpenClaw did not create the approved first agent because the roster changed. Retry setup.",
+      );
+    }
     snapshot = await readSetupConfigFileSnapshot();
     snapshotConfig = requireValidSystemAgentSetupSnapshot(snapshot);
-    expectedWriteHash = resolveConfigSnapshotHash(snapshot);
-    ignoreVerifiedAgentIdentity = true;
-    await assertVerifiedRoute(snapshot);
+    if ((resolveConfigSnapshotHash(snapshot) ?? null) !== created.configHash) {
+      throw new Error("OpenClaw config changed after first-agent creation. Retry setup.");
+    }
+    const createdRoster = listAgentEntries(snapshotConfig.sourceConfig);
+    if (
+      createdRoster.length !== 1 ||
+      normalizeAgentId(createdRoster[0]?.id ?? "") !== created.agentId
+    ) {
+      throw new Error("OpenClaw first-agent ownership changed during setup. Retry setup.");
+    }
+    const rebasedRoute = await assertVerifiedRoute(snapshot, verifiedRoute, "before", true);
+    verifiedRoute = rebasedRoute ?? verifiedRoute;
+    guardModules ??= await Promise.all([
+      import("../agents/agent-scope.js"),
+      import("../agents/model-selection.js"),
+    ] as const);
+    guardedExpectedAgentId = created.agentId;
+    guardedExpectedAgentDir = guardModules[0].resolveAgentDir(
+      snapshotConfig.runtimeConfig,
+      created.agentId,
+    );
+    assertExpectedTarget(snapshotConfig.runtimeConfig);
+    expectedWriteHash = created.configHash;
+    sessionMigrationWarnings = created.sessionMigrationWarnings ?? [];
   }
 
   const prompter = createQuickstartNotePrompter(runtime);
@@ -511,15 +526,16 @@ export async function applySystemAgentSetup(
         writeOptions: { auditOrigin: "system-agent", allowConfigSizeDrop: false },
         transform: async (currentConfig, context) => {
           const currentSnapshot = requireValidSystemAgentSetupSnapshot(context.snapshot);
-          if (hasExpectedConfigHash && context.previousHash !== expectedWriteHash) {
+          if (
+            (hasExpectedConfigHash || startedWithoutAuthoredRoster) &&
+            context.previousHash !== expectedWriteHash
+          ) {
             throw new Error(
               "OpenClaw config changed while AI access was being tested. Try setup again.",
             );
           }
           await assertVerifiedRoute(context.snapshot);
-          assertExpectedTarget(currentSnapshot.runtimeConfig, {
-            ignoreAgentIdentity: ignoreVerifiedAgentIdentity,
-          });
+          assertExpectedTarget(currentSnapshot.runtimeConfig);
 
           // Rebuild config and Gateway settings from the same locked snapshot.
           // A retry can preserve unrelated concurrent edits without carrying
@@ -533,18 +549,14 @@ export async function applySystemAgentSetup(
           const finalizedConfig = finalizeConfig
             ? finalizeConfig(setupCandidate.nextConfig, currentSnapshot.sourceConfig)
             : setupCandidate.nextConfig;
-          const expectedSourceRoute = params.expectedInferenceRoute
+          const expectedSourceRoute = verifiedRoute
             ? await projectDefaultInferenceRoute(finalizedConfig)
             : undefined;
           if (
-            params.expectedInferenceRoute &&
-            (!params.expectedInferenceRoute.route ||
+            verifiedRoute &&
+            (!verifiedRoute.route ||
               !expectedSourceRoute?.route ||
-              !sameSetupConfiguredRoute(
-                expectedSourceRoute.route,
-                params.expectedInferenceRoute.route,
-                ignoreVerifiedAgentIdentity,
-              ))
+              !sameSetupConfiguredRoute(expectedSourceRoute.route, verifiedRoute.route, false))
           ) {
             throw new Error(
               "The setup candidate no longer preserves the exact verified inference route, so it was not saved. Retry setup from the current OpenClaw session.",
@@ -580,7 +592,7 @@ export async function applySystemAgentSetup(
   }
   const onboardingTarget = resolveOnboardingAgentTarget(nextConfig);
   const effectiveWorkspace = onboardingTarget.workspaceDir;
-  if (params.expectedInferenceRoute) {
+  if (verifiedRoute) {
     const afterRead = await readConfigFileSnapshotWithPluginMetadata();
     const afterSnapshot = afterRead.snapshot;
     requireValidSystemAgentSetupSnapshot(afterSnapshot);
@@ -599,13 +611,7 @@ export async function applySystemAgentSetup(
     await assertVerifiedRoute(afterSnapshot, expectedPersistedRoute, "after");
     // Plugin defaults are part of the access-tested runtime route. Reject a
     // metadata change that would make the committed config run differently.
-    if (
-      !sameSetupConfiguredRoute(
-        expectedPersistedRoute.route,
-        params.expectedInferenceRoute.route,
-        ignoreVerifiedAgentIdentity,
-      )
-    ) {
+    if (!sameSetupConfiguredRoute(expectedPersistedRoute.route, verifiedRoute.route, false)) {
       throw new Error(
         "The materialized inference route no longer matches the exact verified route, so no further setup effects were applied. Retry setup from the current OpenClaw session.",
       );
@@ -613,6 +619,7 @@ export async function applySystemAgentSetup(
   }
 
   const lines: string[] = [
+    ...sessionMigrationWarnings,
     `Workspace: ${shortenHomePath(effectiveWorkspace)}`,
     model ? `Default model: ${model}` : undefined,
   ].filter((line): line is string => line !== undefined);

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -2,6 +2,7 @@
 import { isDeepStrictEqual } from "node:util";
 import { listAgentEntries, toAgentEntriesRecord } from "../agents/agent-scope-config.js";
 import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
+import type { FirstOnboardingAgent } from "../commands/onboard-agent.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import {
   readConfigFileSnapshot,
@@ -23,10 +24,13 @@ import type { WizardPrompter } from "../wizard/prompts.js";
 import type { GatewayServiceSetupOutcome } from "../wizard/setup.finalize.js";
 import {
   projectDefaultInferenceRoute,
-  sameDefaultInferenceRoute,
   type DefaultInferenceRouteProjection,
 } from "./inference-route.js";
 import { requireValidSystemAgentSetupSnapshot } from "./setup-config-snapshot.js";
+import {
+  sameSetupConfiguredRoute,
+  sameSetupInferenceRoute,
+} from "./setup-inference-route-guard.js";
 
 /**
  * The whole first-run setup as one approved operation: the user says "yes" in
@@ -37,6 +41,8 @@ import { requireValidSystemAgentSetupSnapshot } from "./setup-config-snapshot.js
  */
 export type SystemAgentSetupApplyParams = {
   workspace: string;
+  /** Selected first agent when setup starts without a persisted roster. */
+  firstAgent?: FirstOnboardingAgent;
   /** Explicit interactive approval to replace an existing fleet workspace root. */
   allowWorkspaceChange?: boolean;
   model?: string;
@@ -302,8 +308,11 @@ export async function applySystemAgentSetup(
     import("../plugins/install-record-commit.js"),
   ]);
 
-  const snapshot = await readSetupConfigFileSnapshot();
-  const snapshotConfig = requireValidSystemAgentSetupSnapshot(snapshot);
+  let snapshot = await readSetupConfigFileSnapshot();
+  let snapshotConfig = requireValidSystemAgentSetupSnapshot(snapshot);
+  const configHashBefore = resolveConfigSnapshotHash(snapshot);
+  const startedWithoutAuthoredRoster = !hasResolvedRosterBeforeMigrations(snapshot);
+  let ignoreVerifiedAgentIdentity = false;
 
   if (hasExpectedConfigHash && resolveConfigSnapshotHash(snapshot) !== expectedConfigHash) {
     throw new Error("OpenClaw config changed while AI access was being tested. Try setup again.");
@@ -316,19 +325,26 @@ export async function applySystemAgentSetup(
           import("../agents/model-selection.js"),
         ] as const)
       : undefined;
-  const assertExpectedTarget = (config: OpenClawConfig): void => {
+  const assertExpectedTarget = (
+    config: OpenClawConfig,
+    options: { ignoreAgentIdentity?: boolean } = {},
+  ): void => {
     if (!guardModules) {
       return;
     }
     const [{ resolveAgentDir, resolveDefaultAgentId }, { resolveDefaultModelForAgent }] =
       guardModules;
     const currentAgentId = resolveDefaultAgentId(config);
-    if (expectedAgentId && currentAgentId !== expectedAgentId) {
+    if (!options.ignoreAgentIdentity && expectedAgentId && currentAgentId !== expectedAgentId) {
       throw new Error(
         "The default agent changed while AI access was being tested. Try setup again.",
       );
     }
-    if (expectedAgentDir && resolveAgentDir(config, currentAgentId) !== expectedAgentDir) {
+    if (
+      !options.ignoreAgentIdentity &&
+      expectedAgentDir &&
+      resolveAgentDir(config, currentAgentId) !== expectedAgentDir
+    ) {
       throw new Error(
         "The agent credential location changed while AI access was being tested. Try setup again.",
       );
@@ -373,7 +389,10 @@ export async function applySystemAgentSetup(
             verifiedSnapshot.runtimeConfig ?? verifiedSnapshot.config,
           )
         : null;
-    if (!currentRoute || !sameDefaultInferenceRoute(currentRoute, expectedRoute)) {
+    if (
+      !currentRoute ||
+      !sameSetupInferenceRoute(currentRoute, expectedRoute, ignoreVerifiedAgentIdentity)
+    ) {
       throw new Error(
         phase === "before"
           ? "The default-agent inference route changed before setup could start, so no workspace or Gateway settings were changed. Retry setup from the current OpenClaw session."
@@ -382,6 +401,25 @@ export async function applySystemAgentSetup(
     }
   };
   await assertVerifiedRoute(snapshot);
+
+  let expectedWriteHash = expectedConfigHash;
+  if (startedWithoutAuthoredRoster) {
+    const { ensureOnboardingAgent } = await import("../commands/onboard-agent.js");
+    await commit(
+      async () =>
+        await ensureOnboardingAgent({
+          config: snapshotConfig.sourceConfig,
+          workspace,
+          baseConfig: snapshotConfig.sourceConfig,
+          firstAgent: params.firstAgent ?? { name: "main" },
+        }),
+    );
+    snapshot = await readSetupConfigFileSnapshot();
+    snapshotConfig = requireValidSystemAgentSetupSnapshot(snapshot);
+    expectedWriteHash = resolveConfigSnapshotHash(snapshot);
+    ignoreVerifiedAgentIdentity = true;
+    await assertVerifiedRoute(snapshot);
+  }
 
   const prompter = createQuickstartNotePrompter(runtime);
   const { configureGatewayForSetup } = await import("../wizard/setup.gateway-config.js");
@@ -473,20 +511,24 @@ export async function applySystemAgentSetup(
         writeOptions: { auditOrigin: "system-agent", allowConfigSizeDrop: false },
         transform: async (currentConfig, context) => {
           const currentSnapshot = requireValidSystemAgentSetupSnapshot(context.snapshot);
-          if (hasExpectedConfigHash && context.previousHash !== expectedConfigHash) {
+          if (hasExpectedConfigHash && context.previousHash !== expectedWriteHash) {
             throw new Error(
               "OpenClaw config changed while AI access was being tested. Try setup again.",
             );
           }
           await assertVerifiedRoute(context.snapshot);
-          assertExpectedTarget(currentSnapshot.runtimeConfig);
+          assertExpectedTarget(currentSnapshot.runtimeConfig, {
+            ignoreAgentIdentity: ignoreVerifiedAgentIdentity,
+          });
 
           // Rebuild config and Gateway settings from the same locked snapshot.
           // A retry can preserve unrelated concurrent edits without carrying
           // stale settings from the losing attempt into service setup or probes.
           const setupCandidate = await buildSetupCandidate(
             currentConfig,
-            hasResolvedRosterBeforeMigrations(context.snapshot),
+            startedWithoutAuthoredRoster
+              ? false
+              : hasResolvedRosterBeforeMigrations(context.snapshot),
           );
           const finalizedConfig = finalizeConfig
             ? finalizeConfig(setupCandidate.nextConfig, currentSnapshot.sourceConfig)
@@ -498,7 +540,11 @@ export async function applySystemAgentSetup(
             params.expectedInferenceRoute &&
             (!params.expectedInferenceRoute.route ||
               !expectedSourceRoute?.route ||
-              !isDeepStrictEqual(expectedSourceRoute.route, params.expectedInferenceRoute.route))
+              !sameSetupConfiguredRoute(
+                expectedSourceRoute.route,
+                params.expectedInferenceRoute.route,
+                ignoreVerifiedAgentIdentity,
+              ))
           ) {
             throw new Error(
               "The setup candidate no longer preserves the exact verified inference route, so it was not saved. Retry setup from the current OpenClaw session.",
@@ -553,7 +599,13 @@ export async function applySystemAgentSetup(
     await assertVerifiedRoute(afterSnapshot, expectedPersistedRoute, "after");
     // Plugin defaults are part of the access-tested runtime route. Reject a
     // metadata change that would make the committed config run differently.
-    if (!isDeepStrictEqual(expectedPersistedRoute.route, params.expectedInferenceRoute.route)) {
+    if (
+      !sameSetupConfiguredRoute(
+        expectedPersistedRoute.route,
+        params.expectedInferenceRoute.route,
+        ignoreVerifiedAgentIdentity,
+      )
+    ) {
       throw new Error(
         "The materialized inference route no longer matches the exact verified route, so no further setup effects were applied. Retry setup from the current OpenClaw session.",
       );
@@ -713,7 +765,7 @@ export async function applySystemAgentSetup(
 
   return {
     configPath: committed.path,
-    configHashBefore: committed.previousHash,
+    configHashBefore,
     configHashAfter: committed.persistedHash,
     bootstrapPending: workspaceResult?.bootstrapPending === true,
     workspaceReady: workspaceResult !== undefined,

--- a/src/system-agent/setup-inference-route-guard.ts
+++ b/src/system-agent/setup-inference-route-guard.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   sameDefaultInferenceRoute,
   type DefaultInferenceRouteProjection,
@@ -40,4 +41,38 @@ export function sameSetupConfiguredRoute(
   const normalize = (route: DefaultInferenceRouteProjection["route"]) =>
     route ? { ...route, agentId: "<agent>", agentDir: "<agent-dir>" } : null;
   return isDeepStrictEqual(normalize(left), normalize(right));
+}
+
+export function assertSetupTarget(params: {
+  config: OpenClawConfig;
+  expectedAgentId?: string;
+  expectedAgentDir?: string;
+  expectedModelRef?: string;
+  resolveAgentDir: (config: OpenClawConfig, agentId: string) => string;
+  resolveDefaultAgentId: (config: OpenClawConfig) => string;
+  resolveDefaultModelForAgent: (params: { cfg: OpenClawConfig; agentId: string }) => {
+    provider: string;
+    model: string;
+  };
+}): void {
+  const agentId = params.resolveDefaultAgentId(params.config);
+  if (params.expectedAgentId && agentId !== params.expectedAgentId) {
+    throw new Error("The default agent changed while AI access was being tested. Try setup again.");
+  }
+  if (
+    params.expectedAgentDir &&
+    params.resolveAgentDir(params.config, agentId) !== params.expectedAgentDir
+  ) {
+    throw new Error(
+      "The agent credential location changed while AI access was being tested. Try setup again.",
+    );
+  }
+  if (params.expectedModelRef) {
+    const current = params.resolveDefaultModelForAgent({ cfg: params.config, agentId });
+    if (`${current.provider}/${current.model}` !== params.expectedModelRef) {
+      throw new Error(
+        "The default model changed while AI access was being tested. Try setup again.",
+      );
+    }
+  }
 }

--- a/src/system-agent/setup-inference-route-guard.ts
+++ b/src/system-agent/setup-inference-route-guard.ts
@@ -1,0 +1,43 @@
+import { isDeepStrictEqual } from "node:util";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  sameDefaultInferenceRoute,
+  type DefaultInferenceRouteProjection,
+} from "./inference-route.js";
+
+function withoutAgentIdentity(projection: DefaultInferenceRouteProjection): unknown {
+  const agent = isRecord(projection.agent)
+    ? { ...projection.agent, id: "<agent>", agentDir: "<agent-dir>" }
+    : projection.agent;
+  return {
+    ...projection,
+    route: projection.route
+      ? { ...projection.route, agentId: "<agent>", agentDir: "<agent-dir>" }
+      : null,
+    defaultSelection: { explicitIds: [] },
+    ...(agent ? { agent } : {}),
+  };
+}
+
+export function sameSetupInferenceRoute(
+  left: DefaultInferenceRouteProjection,
+  right: DefaultInferenceRouteProjection,
+  ignoreAgentIdentity: boolean,
+): boolean {
+  return ignoreAgentIdentity
+    ? isDeepStrictEqual(withoutAgentIdentity(left), withoutAgentIdentity(right))
+    : sameDefaultInferenceRoute(left, right);
+}
+
+export function sameSetupConfiguredRoute(
+  left: DefaultInferenceRouteProjection["route"],
+  right: DefaultInferenceRouteProjection["route"],
+  ignoreAgentIdentity: boolean,
+): boolean {
+  if (!ignoreAgentIdentity) {
+    return isDeepStrictEqual(left, right);
+  }
+  const normalize = (route: DefaultInferenceRouteProjection["route"]) =>
+    route ? { ...route, agentId: "<agent>", agentDir: "<agent-dir>" } : null;
+  return isDeepStrictEqual(normalize(left), normalize(right));
+}

--- a/src/system-agent/system-agent.ts
+++ b/src/system-agent/system-agent.ts
@@ -43,6 +43,8 @@ export type RunSystemAgentOptions = {
   welcomeVariant?: "onboarding";
   /** Workspace override for the proposed first-run setup (from --workspace). */
   setupWorkspace?: string;
+  /** Selected first-agent name for the onboarding setup proposal. */
+  setupAgentName?: string;
   onReady?: () => void;
   deps?: SystemAgentCommandDeps;
   formatOverview?: (overview: SystemAgentOverview) => string;

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -47,6 +47,8 @@ export type SystemAgentTuiOptions = Pick<
   welcomeVariant?: "onboarding";
   /** Workspace override for the proposed first-run setup (from --workspace). */
   setupWorkspace?: string;
+  /** Selected first-agent name for the proposed onboarding setup. */
+  setupAgentName?: string;
   runChannelsAdd?: (
     opts: ChannelsAddOptions,
     runtime: RuntimeEnv,
@@ -479,6 +481,7 @@ export async function runSystemAgentTui(
           engine,
           localRecovery: true,
           ...(boundOpts.setupWorkspace ? { workspace: boundOpts.setupWorkspace } : {}),
+          ...(boundOpts.setupAgentName ? { agentName: boundOpts.setupAgentName } : {}),
         })
       ).text;
     } else {

--- a/src/wizard/setup.default-agent.test.ts
+++ b/src/wizard/setup.default-agent.test.ts
@@ -156,6 +156,7 @@ describe("runSetupWizard default-agent ownership", () => {
       valid: true,
       config,
       sourceConfig: config,
+      sourceConfigBeforeMigrations: config,
       issues: [],
     });
     mocks.writeConfig.mockImplementation(async (nextConfig: OpenClawConfig) => nextConfig);

--- a/src/wizard/setup.shared.ts
+++ b/src/wizard/setup.shared.ts
@@ -43,6 +43,41 @@ export function hasQuickstartGatewayOverrides(
   );
 }
 
+export function formatQuickstartGatewaySummary(
+  defaults: QuickstartGatewayDefaults,
+  keepExisting: boolean,
+): string {
+  const bind = {
+    auto: t("wizard.gateway.bindAuto"),
+    custom: t("wizard.gateway.bindCustom"),
+    lan: t("wizard.gateway.bindLan"),
+    loopback: t("wizard.gateway.bindLoopback"),
+    tailnet: t("wizard.gateway.bindTailnet"),
+  }[defaults.bind];
+  return [
+    ...(keepExisting ? [t("wizard.setup.quickstartKeepSettings")] : []),
+    t("wizard.setup.quickstartGatewayPort", { port: defaults.port }),
+    t("wizard.setup.quickstartGatewayBind", { bind }),
+    ...(defaults.bind === "custom" && defaults.customBindHost
+      ? [
+          t("wizard.setup.quickstartGatewayCustomIp", {
+            host: defaults.customBindHost,
+          }),
+        ]
+      : []),
+    t("wizard.setup.quickstartGatewayAuth", {
+      auth:
+        defaults.authMode === "token"
+          ? t("wizard.setup.quickstartAuthTokenDefault")
+          : t("common.password"),
+    }),
+    t("wizard.setup.quickstartTailscaleExposure", {
+      exposure: t(`wizard.gatewayTailscale.${defaults.tailscaleMode}`),
+    }),
+    t("wizard.setup.quickstartDirectChannels"),
+  ].join("\n");
+}
+
 /**
  * Config writes go through the pending-plugin-install commit helper so wizard
  * flows never drop install records that a concurrent migration already staged.

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -698,6 +698,13 @@ describe("runSetupWizard", () => {
 
   it("prompts for and stages the named first agent on a fresh install", async () => {
     const prompter = buildWizardPrompter({ text: vi.fn(async () => "robby") });
+    ensureOnboardingConfig.mockImplementationOnce(async ({ config }) => ({
+      config,
+      agentId: "robby",
+      bootstrapPending: true,
+      createdAgent: true,
+      sessionMigrationWarnings: ["Run `openclaw doctor --fix` and retry setup."],
+    }));
 
     await runSetupWizard(
       {
@@ -728,6 +735,10 @@ describe("runSetupWizard", () => {
         preserveCandidateRoster: false,
         firstAgent: { name: "robby" },
       }),
+    );
+    expect(prompter.note).toHaveBeenCalledWith(
+      "Run `openclaw doctor --fix` and retry setup.",
+      "Session history migration",
     );
   });
 

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -177,6 +177,13 @@ function providerPluginStub(
 }
 const healthCommand = vi.hoisted(() => vi.fn(async () => {}));
 const ensureWorkspaceAndSessions = vi.hoisted(() => vi.fn(async () => {}));
+const ensureOnboardingConfig = vi.hoisted(() =>
+  vi.fn(async ({ config }: { config: OpenClawConfig }) => ({
+    config,
+    agentId: "main",
+    bootstrapPending: true,
+  })),
+);
 const replaceConfigFile = vi.hoisted(() =>
   vi.fn(
     async (params: {
@@ -476,13 +483,10 @@ vi.mock("../config/config.js", async (importActual) => {
   };
 });
 vi.mock("../commands/onboard-agent.js", async () => {
-  const { resolveDefaultAgentId } = await import("../agents/agent-scope-config.js");
   return {
-    ensureOnboardingConfig: async (config: OpenClawConfig) => ({
-      config,
-      agentId: resolveDefaultAgentId(config),
-      bootstrapPending: true,
-    }),
+    ensureOnboardingAgent: ensureOnboardingConfig,
+    validateFirstOnboardingAgentName: (value: string | undefined) =>
+      value?.trim() ? undefined : "Agent name is required.",
   };
 });
 vi.mock("../commands/onboard-helpers.js", () => ({
@@ -689,6 +693,42 @@ describe("runSetupWizard", () => {
     });
     runSetupMemoryImportStep.mockReset();
     runSetupMemoryImportStep.mockResolvedValue(undefined);
+    ensureOnboardingConfig.mockClear();
+  });
+
+  it("prompts for and stages the named first agent on a fresh install", async () => {
+    const prompter = buildWizardPrompter({ text: vi.fn(async () => "robby") });
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+        workspace: "/tmp/openclaw-workspace",
+      },
+      createRuntime(),
+      prompter,
+    );
+
+    expect(prompter.text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "What should we call your first agent?",
+        initialValue: "main",
+      }),
+    );
+    expect(ensureOnboardingConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: "/tmp/openclaw-workspace",
+        preserveCandidateRoster: false,
+        firstAgent: { name: "robby" },
+      }),
+    );
   });
 
   it("exits successfully after the auto-launched TUI returns", async () => {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1602,6 +1602,45 @@ describe("runSetupWizard", () => {
     expect(acknowledgePromotion).toHaveBeenCalledOnce();
   });
 
+  it("reports an explicit agent name that conflicts with an imported roster", async () => {
+    const importedConfig: OpenClawConfig = {
+      agents: { entries: { imported: { name: "Imported" } } },
+    };
+    readConfigFileSnapshot.mockResolvedValueOnce(configSnapshot({}, false)).mockResolvedValue({
+      ...configSnapshot(importedConfig),
+      sourceConfigBeforeMigrations: {},
+    });
+    const runtime = createRuntime();
+    const prompter = buildWizardPrompter();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        importFrom: "hermes",
+        agentName: "robby",
+        authChoice: "skip",
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "--agent-name cannot be combined with an import that supplies an agent roster. Remove --agent-name or choose an import without agents.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(prompter.text).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: "What should we call your first agent?" }),
+    );
+    expect(ensureOnboardingConfig).not.toHaveBeenCalled();
+  });
+
   it("consumes a verified imported model without testing it twice", async () => {
     const workspaceDir = await makeCaseDir("verified-import-flow-");
     runSetupMigrationImport.mockResolvedValueOnce({

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -1,9 +1,10 @@
 import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { listAgentEntries } from "../agents/agent-scope-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
 import * as firstAgentOnboarding from "../commands/onboard-first-agent.js";
-import type { GatewayAuthChoice, OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
+import type { OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { ConfigMutationConflictError } from "../config/config.js";
 import { createMergePatch } from "../config/merge-patch.js";
@@ -37,6 +38,7 @@ import { runSetupModelAuthStep, type SetupModelAuthCandidate } from "./setup.mod
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
   hasQuickstartGatewayOverrides,
+  formatQuickstartGatewaySummary,
   readSetupConfigFileSnapshot,
   readValidSetupConfigFile,
   requireRiskAcknowledgement,
@@ -291,6 +293,14 @@ async function runSetupWizardOnce(
     flow = "quickstart";
     break;
   }
+  const importSuppliedRoster = usedImportFlow && listAgentEntries(baseConfig).length > 0;
+  if (importSuppliedRoster && opts.agentName !== undefined) {
+    runtime.error(
+      "--agent-name cannot be combined with an import that supplies an agent roster. Remove --agent-name or choose an import without agents.",
+    );
+    runtime.exit(1);
+    return;
+  }
   const wizardFlow: WizardFlow = flow === "advanced" ? "advanced" : "quickstart";
   const hasExplicitQuickstartGatewayOverrides =
     wizardFlow === "quickstart" && hasQuickstartGatewayOverrides(opts);
@@ -301,52 +311,13 @@ async function runSetupWizardOnce(
   );
 
   if (flow === "quickstart") {
-    const formatBind = (value: "loopback" | "lan" | "auto" | "custom" | "tailnet") => {
-      if (value === "loopback") {
-        return t("wizard.gateway.bindLoopback");
-      }
-      if (value === "lan") {
-        return t("wizard.gateway.bindLan");
-      }
-      if (value === "custom") {
-        return t("wizard.gateway.bindCustom");
-      }
-      if (value === "tailnet") {
-        return t("wizard.gateway.bindTailnet");
-      }
-      return t("wizard.gateway.bindAuto");
-    };
-    const formatAuth = (value: GatewayAuthChoice) => {
-      if (value === "token") {
-        return t("wizard.setup.quickstartAuthTokenDefault");
-      }
-      return t("common.password");
-    };
-    const formatTailscale = (value: "off" | "serve" | "funnel") => {
-      return t(`wizard.gatewayTailscale.${value}`);
-    };
-    const quickstartLines = [
-      ...(quickstartGateway.hasExisting && !hasExplicitQuickstartGatewayOverrides
-        ? [t("wizard.setup.quickstartKeepSettings")]
-        : []),
-      t("wizard.setup.quickstartGatewayPort", { port: quickstartGateway.port }),
-      t("wizard.setup.quickstartGatewayBind", { bind: formatBind(quickstartGateway.bind) }),
-      ...(quickstartGateway.bind === "custom" && quickstartGateway.customBindHost
-        ? [
-            t("wizard.setup.quickstartGatewayCustomIp", {
-              host: quickstartGateway.customBindHost,
-            }),
-          ]
-        : []),
-      t("wizard.setup.quickstartGatewayAuth", {
-        auth: formatAuth(quickstartGateway.authMode),
-      }),
-      t("wizard.setup.quickstartTailscaleExposure", {
-        exposure: formatTailscale(quickstartGateway.tailscaleMode),
-      }),
-      t("wizard.setup.quickstartDirectChannels"),
-    ];
-    await prompter.note(quickstartLines.join("\n"), "QuickStart");
+    await prompter.note(
+      formatQuickstartGatewaySummary(
+        quickstartGateway,
+        quickstartGateway.hasExisting && !hasExplicitQuickstartGatewayOverrides,
+      ),
+      "QuickStart",
+    );
   }
 
   const localPort = quickstartGateway.port;
@@ -515,7 +486,8 @@ async function runSetupWizardOnce(
 
   const { applyLocalSetupWorkspaceConfig, applySkipBootstrapConfig } =
     await loadOnboardConfigModule();
-  const hasAuthoredRoster = hasResolvedRosterBeforeMigrations(currentSetupSnapshot);
+  const hasAuthoredRoster =
+    importSuppliedRoster || hasResolvedRosterBeforeMigrations(currentSetupSnapshot);
   const { workspaceDir, allowWorkspaceChange } = await resolveSetupWorkspaceSelection({
     baseConfig,
     requestedWorkspaceDir,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
+import { promptFirstOnboardingAgent } from "../commands/onboard-first-agent.js";
 import type { GatewayAuthChoice, OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { ConfigMutationConflictError } from "../config/config.js";
@@ -52,18 +53,6 @@ const loadConfigLoggingModule = createLazyRuntimeModule(() => import("../config/
 const loadOnboardConfigModule = createLazyRuntimeModule(
   () => import("../commands/onboard-config.js"),
 );
-
-function hasConfiguredDefaultModel(config: OpenClawConfig): boolean {
-  return resolveAgentModelPrimaryValue(config.agents?.defaults?.model) !== undefined;
-}
-
-function isSetupImportFlowChoice(flow: SetupFlowChoice): boolean {
-  return flow === "import" || flow.startsWith("import:");
-}
-
-function resolveImportProviderFromFlowChoice(flow: SetupFlowChoice): string | undefined {
-  return flow.startsWith("import:") ? flow.slice("import:".length) : undefined;
-}
 
 export async function runSetupWizard(
   opts: OnboardOptions,
@@ -156,7 +145,8 @@ async function runSetupWizardOnce(
     command: formatCliCommand("openclaw configure"),
   });
   const manualHint = t("wizard.setup.flowAdvancedHint");
-  const hasExistingModelConfig = hasConfiguredDefaultModel(baseConfig);
+  const hasExistingModelConfig =
+    resolveAgentModelPrimaryValue(baseConfig.agents?.defaults?.model) !== undefined;
   const migrationDetections = await detectSetupMigrationSources({ config: baseConfig, runtime });
   const migrationOptions = await listSetupMigrationOptions({
     baseConfig,
@@ -240,8 +230,8 @@ async function runSetupWizardOnce(
   let usedImportFlow = false;
   let acknowledgeMigrationPromotion: (() => Promise<void>) | undefined;
   let importedInferenceVerified = false;
-  while (opts.importFrom || isSetupImportFlowChoice(flow)) {
-    const importFrom = opts.importFrom ?? resolveImportProviderFromFlowChoice(flow);
+  while (opts.importFrom || flow === "import" || flow.startsWith("import:")) {
+    const importFrom = opts.importFrom ?? (flow.startsWith("import:") ? flow.slice(7) : undefined);
     prompter.disableBackNavigation?.();
     let migrationOutcome: Awaited<ReturnType<typeof runSetupMigrationImport>>;
     try {
@@ -533,6 +523,12 @@ async function runSetupWizardOnce(
     prompter,
     hasAuthoredRoster,
   });
+  const firstAgent = await promptFirstOnboardingAgent(
+    hasAuthoredRoster,
+    opts.agentName,
+    prompter,
+    opts.nonInteractive,
+  );
   let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(
     baseConfig,
     requestedWorkspaceDir,
@@ -564,8 +560,16 @@ async function runSetupWizardOnce(
     prompter,
     runtime,
   });
-  const onboard = (await import("../commands/onboard-agent.js")).ensureOnboardingConfig;
-  nextConfig = (await onboard(gateway.nextConfig, workspaceDir, usedImportFlow, baseConfig)).config;
+  const { ensureOnboardingAgent } = await import("../commands/onboard-agent.js");
+  nextConfig = (
+    await ensureOnboardingAgent({
+      config: gateway.nextConfig,
+      workspace: workspaceDir,
+      preserveCandidateRoster: usedImportFlow,
+      baseConfig,
+      ...(firstAgent ? { firstAgent } : {}),
+    })
+  ).config;
 
   let liveModelVerified = false;
   let setupConfigPersisted = false;
@@ -574,7 +578,7 @@ async function runSetupWizardOnce(
   if (
     opts.nonInteractive !== true &&
     !importedInferenceVerified &&
-    hasConfiguredDefaultModel(nextConfig) &&
+    resolveAgentModelPrimaryValue(nextConfig.agents?.defaults?.model) !== undefined &&
     ((usedImportFlow && keepExistingModelConfig) || opts.authChoice !== "skip")
   ) {
     const verificationTarget = resolveOnboardingAgentTarget(nextConfig);

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -2,7 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
-import { promptFirstOnboardingAgent } from "../commands/onboard-first-agent.js";
+import * as firstAgentOnboarding from "../commands/onboard-first-agent.js";
 import type { GatewayAuthChoice, OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { ConfigMutationConflictError } from "../config/config.js";
@@ -70,8 +70,7 @@ async function runSetupWizardOnce(
   runtimeInput: RuntimeEnv | undefined,
   prompter: WizardPrompter,
 ) {
-  let runtime = runtimeInput;
-  runtime ??= defaultRuntime;
+  const runtime = runtimeInput ?? defaultRuntime;
   const onboardHelpers = await import("../commands/onboard-helpers.js");
   await onboardHelpers.printWizardHeader(runtime);
   await prompter.intro(t("wizard.setup.intro"));
@@ -523,7 +522,7 @@ async function runSetupWizardOnce(
     prompter,
     hasAuthoredRoster,
   });
-  const firstAgent = await promptFirstOnboardingAgent(
+  const firstAgent = await firstAgentOnboarding.promptFirstOnboardingAgent(
     hasAuthoredRoster,
     opts.agentName,
     prompter,
@@ -561,15 +560,16 @@ async function runSetupWizardOnce(
     runtime,
   });
   const { ensureOnboardingAgent } = await import("../commands/onboard-agent.js");
-  nextConfig = (
-    await ensureOnboardingAgent({
-      config: gateway.nextConfig,
-      workspace: workspaceDir,
-      preserveCandidateRoster: usedImportFlow,
-      baseConfig,
-      ...(firstAgent ? { firstAgent } : {}),
-    })
-  ).config;
+  const onboardingAgent = await ensureOnboardingAgent({
+    config: gateway.nextConfig,
+    workspace: workspaceDir,
+    preserveCandidateRoster: usedImportFlow,
+    baseConfig,
+    ...(firstAgent ? { firstAgent } : {}),
+  });
+  nextConfig = onboardingAgent.config;
+  const migrationWarnings = onboardingAgent.sessionMigrationWarnings;
+  await firstAgentOnboarding.showSessionMigrationWarnings(prompter, migrationWarnings);
 
   let liveModelVerified = false;
   let setupConfigPersisted = false;


### PR DESCRIPTION
## What Problem This Solves

Fresh OpenClaw installs always materialized a literal `main` agent, even when the operator wanted a meaningful name. Legacy installs with config but no persisted roster also had no safe onboarding path to choose a name while retaining their existing `agent:main:*` session history.

## Why This Change Was Made

Interactive onboarding now asks “What should we call your first agent?” only when no persisted roster exists, while non-interactive onboarding preserves the historical `main` default and adds `--agent-name <name>` as an opt-in. First-agent creation replaces only the load-time compatibility roster under the config lock, commits the complete named entry once through `createAgent`, and immediately runs the H2.3 legacy-session migration. System-agent setup preserves the live-verified provider/model/profile route across this pre-roster identity transition without weakening configured-roster guards. Auth credentials and default workspace ownership do not move.

## User Impact

Operators can give the first agent a useful name during guided or classic onboarding, or in automation with `--agent-name`. Existing automation remains byte-compatible by defaulting to `main`. When a legacy no-roster install chooses a new sole-agent name, its existing main session history is available under the new agent before onboarding finishes; a crash after the roster commit remains convergent through the startup migration engine.

## Evidence

- Unfiltered touched and colocated Vitest suites: 22 files across 6 shards, 449 tests passed.
- Real SQLite legacy-install fixture proves `agent:main:main` becomes `agent:robby:main`, the source row is removed only after proof, and the H2.3 ledger is complete.
- Focused coverage proves the wizard and guided/system-agent prompt, non-interactive `main` compatibility, valid/invalid/reserved `--agent-name` handling, single first-agent creation, configured-roster byte preservation, and pre-roster inference-route identity guarding.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, and `pnpm check:test-types` passed.
- `node scripts/check-changed.mjs --staged` passed on Testbox `tbx_01kzze1bjb4zqe6cyna4z89a20` (exit 0).
- Docs formatting, MDX, and link checks passed.
