### PR TITLE
fix(codex): fail closed native execution until containment

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -154,7 +154,6 @@ function startThreadWithHarness(
     finalConfigPatch: undefined,
     bundleMcpThreadConfig,
     nativeToolSurfaceEnabled: true,
-    nativeContainmentConfirmed: true,
     nativeProviderWebSearchSupport: "supported",
     sandboxExecServerEnabled: false,
     sandbox: null,

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -154,6 +154,7 @@ function startThreadWithHarness(
     finalConfigPatch: undefined,
     bundleMcpThreadConfig,
     nativeToolSurfaceEnabled: true,
+    nativeContainmentConfirmed: true,
     nativeProviderWebSearchSupport: "supported",
     sandboxExecServerEnabled: false,
     sandbox: null,

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -159,6 +159,8 @@ export async function startCodexAttemptThread(params: {
   /** OpenClaw owns configured MCP dynamically for this scheduled turn. */
   configuredMcpOwnershipVersion?: 1;
   nativeToolSurfaceEnabled: boolean;
+  /** Must be true only after the managed Codex runtime passes containment gates. */
+  nativeContainmentConfirmed?: boolean;
   nativeProviderWebSearchSupport: CodexNativeWebSearchSupport;
   sandboxExecServerEnabled: boolean;
   sandbox: CodexSandboxContext;
@@ -168,6 +170,11 @@ export async function startCodexAttemptThread(params: {
   onStartupTimeout: () => void | Promise<void>;
   spawnedBy: EmbeddedRunAttemptParams["spawnedBy"];
 }): Promise<StartCodexAttemptThreadResult> {
+  // Keep native Code Mode disabled until the managed runtime proves finite,
+  // descendant-safe command execution. This is the local fail-closed fence;
+  // the capability is intentionally absent until the upstream patch lands.
+  const nativeToolSurfaceEnabled =
+    params.nativeToolSurfaceEnabled && params.nativeContainmentConfirmed === true;
   let pluginAppServer = params.appServer;
   const startupRuntimeAuthProfileId =
     params.startupPreparedAuth?.kind === "profile"
@@ -204,7 +211,7 @@ export async function startCodexAttemptThread(params: {
         );
         const pluginStartupPolicy = resolveCodexPluginThreadConfigStartupPolicy({
           pluginConfig: params.pluginConfig,
-          nativeToolSurfaceEnabled: params.nativeToolSurfaceEnabled,
+          nativeToolSurfaceEnabled,
           scheduledRuntimeAuthority: params.buildAttemptParams().scheduledRuntimeAuthority,
         });
         const {
@@ -392,7 +399,7 @@ export async function startCodexAttemptThread(params: {
             try {
               startupSandboxEnvironment = shouldRequireCodexSandboxExecServerEnvironment({
                 sandbox: params.sandbox,
-                nativeToolSurfaceEnabled: params.nativeToolSurfaceEnabled,
+                nativeToolSurfaceEnabled,
                 sandboxExecServerEnabled: params.sandboxExecServerEnabled,
               })
                 ? await ensureCodexSandboxExecServerEnvironment({
@@ -410,7 +417,7 @@ export async function startCodexAttemptThread(params: {
               }
               if (
                 params.sandbox?.enabled &&
-                params.nativeToolSurfaceEnabled &&
+                nativeToolSurfaceEnabled &&
                 params.sandboxExecServerEnabled &&
                 !startupSandboxEnvironment
               ) {
@@ -424,13 +431,13 @@ export async function startCodexAttemptThread(params: {
             }
             const startupEnvironmentSelection = resolveCodexSandboxEnvironmentSelection(
               startupSandboxEnvironment,
-              params.nativeToolSurfaceEnabled,
+              nativeToolSurfaceEnabled,
             );
             const startupExecutionCwd = resolveCodexAppServerExecutionCwd({
               effectiveCwd: params.effectiveCwd,
               localWorkspaceRoot: params.effectiveWorkspace,
               environment: startupSandboxEnvironment,
-              nativeToolSurfaceEnabled: params.nativeToolSurfaceEnabled,
+              nativeToolSurfaceEnabled,
               remoteWorkspaceRoot: params.appServer.remoteWorkspaceRoot,
             });
             const startupSandboxPolicy = startupSandboxEnvironment
@@ -480,13 +487,13 @@ export async function startCodexAttemptThread(params: {
                 finalConfigPatch: params.finalConfigPatch,
                 buildFinalConfigPatch: params.buildFinalConfigPatch,
                 nativeHookRelayGeneration: params.nativeHookRelayGeneration,
-                nativeCodeModeEnabled: params.nativeToolSurfaceEnabled,
+                nativeCodeModeEnabled: nativeToolSurfaceEnabled,
                 nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
                 userMcpServersEnabled:
                   params.configuredMcpOwnershipVersion === 1
                     ? false
-                    : params.nativeToolSurfaceEnabled,
+                    : nativeToolSurfaceEnabled,
                 mcpServersFingerprint:
                   params.configuredMcpOwnershipVersion === 1
                     ? undefined

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -62,10 +62,7 @@ import type {
   CodexTurnEnvironmentParams,
   JsonObject,
 } from "./protocol.js";
-import {
-  isCodexNativeContainmentCapability,
-  type CodexNativeContainmentCapability,
-} from "./runtime-artifact.js";
+import { isCodexNativeContainmentCapability } from "./runtime-artifact.js";
 import {
   ensureCodexSandboxExecServerEnvironment,
   releaseCodexSandboxExecServerEnvironment,
@@ -164,7 +161,7 @@ export async function startCodexAttemptThread(params: {
   configuredMcpOwnershipVersion?: 1;
   nativeToolSurfaceEnabled: boolean;
   /** Must be minted by runtime-artifact validation; never accept a caller boolean. */
-  nativeContainmentCapability?: CodexNativeContainmentCapability;
+  nativeContainmentCapability?: Parameters<typeof isCodexNativeContainmentCapability>[0];
   nativeProviderWebSearchSupport: CodexNativeWebSearchSupport;
   sandboxExecServerEnabled: boolean;
   sandbox: CodexSandboxContext;
@@ -177,7 +174,7 @@ export async function startCodexAttemptThread(params: {
   // Keep native Code Mode disabled unless a non-forgeable runtime-artifact
   // capability was minted after digest validation. No current caller has one.
   const nativeToolSurfaceEnabled =
-    params.nativeToolSurfaceEnabled === true &&
+    params.nativeToolSurfaceEnabled &&
     isCodexNativeContainmentCapability(params.nativeContainmentCapability);
   let pluginAppServer = params.appServer;
   const startupRuntimeAuthProfileId =
@@ -495,9 +492,7 @@ export async function startCodexAttemptThread(params: {
                 nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
                 userMcpServersEnabled:
-                  params.configuredMcpOwnershipVersion === 1
-                    ? false
-                    : nativeToolSurfaceEnabled,
+                  params.configuredMcpOwnershipVersion === 1 ? false : nativeToolSurfaceEnabled,
                 mcpServersFingerprint:
                   params.configuredMcpOwnershipVersion === 1
                     ? undefined
@@ -701,7 +696,7 @@ export async function startCodexAttemptThread(params: {
       releaseSharedClientLease,
     };
   } catch (error) {
-    if (params.signal.aborted || shouldClearSharedClientAfterStartupAbandon(error)) {
+    if (params.signal.aborted || shouldClearStartupAbandon(error)) {
       releaseSharedClientLease?.();
       releaseSharedClientLease = undefined;
       await closeCodexStartupClientBestEffort(startupClientForAbandonedRequestCleanup);
@@ -725,14 +720,12 @@ export async function startCodexAttemptThread(params: {
   }
 }
 
-function shouldClearSharedClientAfterStartupAbandon(error: unknown): boolean {
+function shouldClearStartupAbandon(error: unknown): boolean {
   return isCodexAppServerStartupError(error);
 }
 
 function shouldClearSharedClientAfterStartupRace(error: unknown): boolean {
-  return (
-    shouldClearSharedClientAfterStartupAbandon(error) || isCodexAppServerRequestTimeoutError(error)
-  );
+  return shouldClearStartupAbandon(error) || isCodexAppServerRequestTimeoutError(error);
 }
 
 function shouldClearSharedClientAfterStartupFailure(params: {

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -63,6 +63,10 @@ import type {
   JsonObject,
 } from "./protocol.js";
 import {
+  isCodexNativeContainmentCapability,
+  type CodexNativeContainmentCapability,
+} from "./runtime-artifact.js";
+import {
   ensureCodexSandboxExecServerEnvironment,
   releaseCodexSandboxExecServerEnvironment,
   type CodexSandboxExecEnvironment,
@@ -159,8 +163,8 @@ export async function startCodexAttemptThread(params: {
   /** OpenClaw owns configured MCP dynamically for this scheduled turn. */
   configuredMcpOwnershipVersion?: 1;
   nativeToolSurfaceEnabled: boolean;
-  /** Must be true only after the managed Codex runtime passes containment gates. */
-  nativeContainmentConfirmed?: boolean;
+  /** Must be minted by runtime-artifact validation; never accept a caller boolean. */
+  nativeContainmentCapability?: CodexNativeContainmentCapability;
   nativeProviderWebSearchSupport: CodexNativeWebSearchSupport;
   sandboxExecServerEnabled: boolean;
   sandbox: CodexSandboxContext;
@@ -170,11 +174,11 @@ export async function startCodexAttemptThread(params: {
   onStartupTimeout: () => void | Promise<void>;
   spawnedBy: EmbeddedRunAttemptParams["spawnedBy"];
 }): Promise<StartCodexAttemptThreadResult> {
-  // Keep native Code Mode disabled until the managed runtime proves finite,
-  // descendant-safe command execution. This is the local fail-closed fence;
-  // the capability is intentionally absent until the upstream patch lands.
+  // Keep native Code Mode disabled unless a non-forgeable runtime-artifact
+  // capability was minted after digest validation. No current caller has one.
   const nativeToolSurfaceEnabled =
-    params.nativeToolSurfaceEnabled && params.nativeContainmentConfirmed === true;
+    params.nativeToolSurfaceEnabled === true &&
+    isCodexNativeContainmentCapability(params.nativeContainmentCapability);
   let pluginAppServer = params.appServer;
   const startupRuntimeAuthProfileId =
     params.startupPreparedAuth?.kind === "profile"

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -162,6 +162,7 @@ async function buildDynamicToolsForTest(
     sandboxSessionKey,
     sandbox: { enabled: false, backendId: "docker" } as never,
     nativeToolSurfaceEnabled: true,
+    nativeContainmentConfirmed: true,
     runAbortController: new AbortController(),
     sessionAgentId: "main",
     pluginConfig: {},

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -162,7 +162,6 @@ async function buildDynamicToolsForTest(
     sandboxSessionKey,
     sandbox: { enabled: false, backendId: "docker" } as never,
     nativeToolSurfaceEnabled: true,
-    nativeContainmentConfirmed: true,
     runAbortController: new AbortController(),
     sessionAgentId: "main",
     pluginConfig: {},
@@ -1293,7 +1292,7 @@ describe("Codex app-server dynamic tool build", () => {
     const gatewayTools = await buildDynamicToolsForTest(gatewayParams, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
-    expect(gatewayTools.map((tool) => tool.name)).toEqual(["message"]);
+    expect(gatewayTools.map((tool) => tool.name)).toEqual(["exec", "process", "message"]);
 
     const allowlistedParams = {
       ...gatewayParams,

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -35,6 +35,10 @@ import {
   resolveCodexNativeExecutionPolicy,
   type CodexNativeExecutionPolicy,
 } from "./native-execution-policy.js";
+import {
+  isCodexNativeContainmentCapability,
+  type CodexNativeContainmentCapability,
+} from "./runtime-artifact.js";
 import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
 import { mapCodexAppServerRemoteWorkspacePath } from "./remote-workspace-path.js";
 import type { CodexSandboxExecEnvironment } from "./sandbox-exec-server.js";
@@ -90,8 +94,8 @@ type DynamicToolBuildParams = {
   sandboxSessionKey: string;
   sandbox: OpenClawSandboxContext;
   nativeToolSurfaceEnabled?: boolean;
-  /** Must be set only after the managed Codex binary passes containment gates. */
-  nativeContainmentConfirmed?: boolean;
+  /** Must be minted by runtime-artifact validation; never accept a caller boolean. */
+  nativeContainmentCapability?: CodexNativeContainmentCapability;
   nativeProviderWebSearchSupport?: CodexNativeWebSearchSupport;
   runAbortController: AbortController;
   sessionAgentId: string;
@@ -157,6 +161,15 @@ type CodexDynamicToolBuildStageSummary = {
   totalMs: number;
   stages: CodexDynamicToolBuildStageTiming[];
 };
+function resolveEffectiveNativeToolSurfaceEnabled(input: {
+  nativeToolSurfaceEnabled?: boolean;
+  nativeContainmentCapability?: CodexNativeContainmentCapability;
+}): boolean {
+  return (
+    input.nativeToolSurfaceEnabled === true &&
+    isCodexNativeContainmentCapability(input.nativeContainmentCapability)
+  );
+}
 const CODEX_DYNAMIC_TOOL_BUILD_WARN_TOTAL_MS = 1_000;
 const CODEX_DYNAMIC_TOOL_BUILD_WARN_STAGE_MS = 500;
 /** Creates cheap optional timing instrumentation for the dynamic-tool hot path. */
@@ -216,6 +229,10 @@ export function formatCodexDynamicToolBuildStageSummary(
 /** Builds, filters, and normalizes Codex-compatible runtime tools for a single turn. */
 export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const { params } = input;
+  // One effective value controls native exposure, sandbox selection, and all
+  // fallback branches. The current runtime has no minted capability, so this
+  // remains false even if an upstream caller requests native Code Mode.
+  const nativeToolSurfaceEnabled = resolveEffectiveNativeToolSurfaceEnabled(input);
   const messagePolicyParams = input.ignoreDisableMessageTool
     ? { ...params, disableMessageTool: false }
     : params;
@@ -371,12 +388,12 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const webSearchPlan = resolveCodexWebSearchPlan({
     config: params.config,
     disableTools: params.disableTools,
-    nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled,
+    nativeToolSurfaceEnabled,
     nativeProviderWebSearchSupport: input.nativeProviderWebSearchSupport,
   });
   const readableAllTools = [...readableAllToolProjection.tools];
   const normallyProfiledTools =
-    input.nativeToolSurfaceEnabled === false
+    nativeToolSurfaceEnabled === false
       ? filterCodexDynamicToolsForDisabledNativeSurface(readableAllTools, input.pluginConfig, {
           preserveShell: shouldKeepOpenClawShellDynamicTools(input, nativeExecutionPolicy),
         })
@@ -506,7 +523,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         normalizedToolCount: exposedTools.length,
         forceHeartbeatTool: input.forceHeartbeatTool === true,
         ignoreRuntimePlan: input.ignoreRuntimePlan === true,
-        nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled === true,
+        nativeToolSurfaceEnabled,
       },
     );
   }
@@ -571,7 +588,7 @@ function isCodexNativeExecutionBlockedByNodeExecHost(
     agentId?: string;
     runtimeSessionKey?: string;
     sandbox?: OpenClawSandboxContext;
-    nativeContainmentConfirmed?: boolean;
+    nativeContainmentCapability?: CodexNativeContainmentCapability;
   } = {},
 ): boolean {
   return !resolveCodexNativeExecutionPolicy({
@@ -581,7 +598,7 @@ function isCodexNativeExecutionBlockedByNodeExecHost(
     agentId: options.agentId,
     execOverrides: params.execOverrides,
     sandboxAvailable: options.sandbox?.enabled,
-    nativeContainmentConfirmed: options.nativeContainmentConfirmed,
+    nativeContainmentCapability: options.nativeContainmentCapability,
     readRuntimeSessionEntry: true,
   }).nativeToolSurfaceAllowed;
 }
@@ -763,13 +780,13 @@ function shouldExposeSandboxExecDynamicTool(input: DynamicToolBuildParams): bool
       agentId: input.sessionAgentId,
       runtimeSessionKey: input.sandboxSessionKey,
       sandbox: input.sandbox,
-      nativeContainmentConfirmed: input.nativeContainmentConfirmed,
+      nativeContainmentCapability: input.nativeContainmentCapability,
     })
   ) {
     return false;
   }
   const backendId = input.sandbox?.enabled ? input.sandbox.backendId.trim().toLowerCase() : "";
-  return Boolean(backendId && input.nativeToolSurfaceEnabled === false);
+  return Boolean(backendId && !resolveEffectiveNativeToolSurfaceEnabled(input));
 }
 function isSandboxShellDynamicToolExcluded(config: CodexPluginConfig): boolean {
   return isCodexDynamicToolExcluded(config, ["exec", "sandbox_exec", "process", "sandbox_process"]);
@@ -826,7 +843,7 @@ function shouldKeepOpenClawShellDynamicTools(
     !isCodexMemoryFlushRun(input.params) &&
     // Disabled native Code Mode sends `environments: []`, so Codex cannot
     // advertise a shell. Preserve OpenClaw's policy-filtered direct shell.
-    input.nativeToolSurfaceEnabled === false &&
+    !resolveEffectiveNativeToolSurfaceEnabled(input) &&
     input.sandbox?.enabled !== true &&
     nodePolicy.effectiveExecHost !== "node"
   );
@@ -841,7 +858,7 @@ function resolveCodexNativeExecutionPolicyForDynamicTools(
     agentId: input.sessionAgentId,
     execOverrides: input.params.execOverrides,
     sandboxAvailable: input.sandbox?.enabled,
-    nativeContainmentConfirmed: input.nativeContainmentConfirmed,
+    nativeContainmentCapability: input.nativeContainmentCapability,
     readRuntimeSessionEntry: true,
   });
 }

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -90,6 +90,8 @@ type DynamicToolBuildParams = {
   sandboxSessionKey: string;
   sandbox: OpenClawSandboxContext;
   nativeToolSurfaceEnabled?: boolean;
+  /** Must be set only after the managed Codex binary passes containment gates. */
+  nativeContainmentConfirmed?: boolean;
   nativeProviderWebSearchSupport?: CodexNativeWebSearchSupport;
   runAbortController: AbortController;
   sessionAgentId: string;
@@ -569,6 +571,7 @@ function isCodexNativeExecutionBlockedByNodeExecHost(
     agentId?: string;
     runtimeSessionKey?: string;
     sandbox?: OpenClawSandboxContext;
+    nativeContainmentConfirmed?: boolean;
   } = {},
 ): boolean {
   return !resolveCodexNativeExecutionPolicy({
@@ -578,6 +581,7 @@ function isCodexNativeExecutionBlockedByNodeExecHost(
     agentId: options.agentId,
     execOverrides: params.execOverrides,
     sandboxAvailable: options.sandbox?.enabled,
+    nativeContainmentConfirmed: options.nativeContainmentConfirmed,
     readRuntimeSessionEntry: true,
   }).nativeToolSurfaceAllowed;
 }
@@ -759,6 +763,7 @@ function shouldExposeSandboxExecDynamicTool(input: DynamicToolBuildParams): bool
       agentId: input.sessionAgentId,
       runtimeSessionKey: input.sandboxSessionKey,
       sandbox: input.sandbox,
+      nativeContainmentConfirmed: input.nativeContainmentConfirmed,
     })
   ) {
     return false;
@@ -836,6 +841,7 @@ function resolveCodexNativeExecutionPolicyForDynamicTools(
     agentId: input.sessionAgentId,
     execOverrides: input.params.execOverrides,
     sandboxAvailable: input.sandbox?.enabled,
+    nativeContainmentConfirmed: input.nativeContainmentConfirmed,
     readRuntimeSessionEntry: true,
   });
 }

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -35,12 +35,12 @@ import {
   resolveCodexNativeExecutionPolicy,
   type CodexNativeExecutionPolicy,
 } from "./native-execution-policy.js";
+import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
+import { mapCodexAppServerRemoteWorkspacePath } from "./remote-workspace-path.js";
 import {
   isCodexNativeContainmentCapability,
   type CodexNativeContainmentCapability,
 } from "./runtime-artifact.js";
-import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
-import { mapCodexAppServerRemoteWorkspacePath } from "./remote-workspace-path.js";
 import type { CodexSandboxExecEnvironment } from "./sandbox-exec-server.js";
 import {
   CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
@@ -392,12 +392,11 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     nativeProviderWebSearchSupport: input.nativeProviderWebSearchSupport,
   });
   const readableAllTools = [...readableAllToolProjection.tools];
-  const normallyProfiledTools =
-    nativeToolSurfaceEnabled === false
-      ? filterCodexDynamicToolsForDisabledNativeSurface(readableAllTools, input.pluginConfig, {
-          preserveShell: shouldKeepOpenClawShellDynamicTools(input, nativeExecutionPolicy),
-        })
-      : filterCodexDynamicTools(readableAllTools, input.pluginConfig);
+  const normallyProfiledTools = !nativeToolSurfaceEnabled
+    ? filterCodexDynamicToolsForDisabledNativeSurface(readableAllTools, input.pluginConfig, {
+        preserveShell: shouldKeepOpenClawShellDynamicTools(input, nativeExecutionPolicy),
+      })
+    : filterCodexDynamicTools(readableAllTools, input.pluginConfig);
   const hostSystemAgentActive =
     input.isHostScopedToolActive?.("openclaw") ?? isHostScopedAgentToolActive("openclaw");
   const profileFilteredTools =

--- a/extensions/codex/src/app-server/native-execution-policy.test.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.test.ts
@@ -1,7 +1,10 @@
 // Codex tests cover native execution policy plugin behavior.
 import type { getSessionEntry as getSessionEntryType } from "openclaw/plugin-sdk/session-store-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveCodexNativeExecutionPolicy } from "./native-execution-policy.js";
+import {
+  formatCodexNativeExecutionBlock,
+  resolveCodexNativeExecutionPolicy,
+} from "./native-execution-policy.js";
 
 const sessionStoreMocks = vi.hoisted(() => ({
   getSessionEntry: vi.fn<typeof getSessionEntryType>(),
@@ -32,45 +35,61 @@ describe("resolveCodexNativeExecutionPolicy", () => {
     });
   });
 
-  it("allows Codex native execution for gateway exec hosts", () => {
+  it("formats the actual block reason instead of assuming node ownership", () => {
+    expect(
+      formatCodexNativeExecutionBlock({
+        surface: "command/exec",
+        reason: "Codex app-server native execution is fail-closed pending cgroup v2 containment.",
+      }),
+    ).toContain("pending cgroup v2 containment");
+    expect(
+      formatCodexNativeExecutionBlock({
+        surface: "command/exec",
+        reason: "OpenClaw exec host=node is active for this session.",
+      }),
+    ).toContain("host=node is active");
+  });
+
+  it("rejects a caller-shaped artifact object for gateway exec hosts", () => {
     expect(
       resolveCodexNativeExecutionPolicy({
         config: { tools: { exec: { host: "gateway" } } },
         sessionKey: "session-1",
-        nativeContainmentConfirmed: true,
+        nativeContainmentCapability: {
+          artifactId: "codex-app-server:v1:caller-input",
+          artifactFingerprint: "0".repeat(64),
+        },
       }),
     ).toMatchObject({
-      nativeToolSurfaceAllowed: true,
+      nativeToolSurfaceAllowed: false,
       requestedExecHost: "gateway",
       effectiveExecHost: "gateway",
     });
   });
 
-  it("resolves auto to gateway when no sandbox is active", () => {
+  it("keeps auto-to-gateway fail closed without a minted capability", () => {
     expect(
       resolveCodexNativeExecutionPolicy({
         config: { tools: { exec: { host: "auto" } } },
         sessionKey: "session-1",
         sandboxAvailable: false,
-        nativeContainmentConfirmed: true,
       }),
     ).toMatchObject({
-      nativeToolSurfaceAllowed: true,
+      nativeToolSurfaceAllowed: false,
       requestedExecHost: "auto",
       effectiveExecHost: "gateway",
     });
   });
 
-  it("resolves auto to sandbox when a sandbox is active", () => {
+  it("keeps auto-to-sandbox fail closed without a minted capability", () => {
     expect(
       resolveCodexNativeExecutionPolicy({
         config: { tools: { exec: { host: "auto" } } },
         sessionKey: "session-1",
         sandboxAvailable: true,
-        nativeContainmentConfirmed: true,
       }),
     ).toMatchObject({
-      nativeToolSurfaceAllowed: true,
+      nativeToolSurfaceAllowed: false,
       requestedExecHost: "auto",
       effectiveExecHost: "sandbox",
     });

--- a/extensions/codex/src/app-server/native-execution-policy.test.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.test.ts
@@ -20,11 +20,24 @@ describe("resolveCodexNativeExecutionPolicy", () => {
     sessionStoreMocks.getSessionEntry.mockReset();
   });
 
+  it("fails closed until the Codex runtime proves native containment", () => {
+    expect(
+      resolveCodexNativeExecutionPolicy({
+        config: { tools: { exec: { host: "gateway" } } },
+        sessionKey: "session-unsafe",
+      }),
+    ).toMatchObject({
+      nativeToolSurfaceAllowed: false,
+      effectiveExecHost: "gateway",
+    });
+  });
+
   it("allows Codex native execution for gateway exec hosts", () => {
     expect(
       resolveCodexNativeExecutionPolicy({
         config: { tools: { exec: { host: "gateway" } } },
         sessionKey: "session-1",
+        nativeContainmentConfirmed: true,
       }),
     ).toMatchObject({
       nativeToolSurfaceAllowed: true,
@@ -39,6 +52,7 @@ describe("resolveCodexNativeExecutionPolicy", () => {
         config: { tools: { exec: { host: "auto" } } },
         sessionKey: "session-1",
         sandboxAvailable: false,
+        nativeContainmentConfirmed: true,
       }),
     ).toMatchObject({
       nativeToolSurfaceAllowed: true,
@@ -53,6 +67,7 @@ describe("resolveCodexNativeExecutionPolicy", () => {
         config: { tools: { exec: { host: "auto" } } },
         sessionKey: "session-1",
         sandboxAvailable: true,
+        nativeContainmentConfirmed: true,
       }),
     ).toMatchObject({
       nativeToolSurfaceAllowed: true,

--- a/extensions/codex/src/app-server/native-execution-policy.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.ts
@@ -6,6 +6,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { resolveSandboxRuntimeStatus } from "openclaw/plugin-sdk/sandbox";
 import { getSessionEntry, type SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  isCodexNativeContainmentCapability,
+  type CodexNativeContainmentCapability,
+} from "./runtime-artifact.js";
 
 type ExecHost = "sandbox" | "gateway" | "node";
 type ExecTarget = "auto" | ExecHost;
@@ -46,8 +50,8 @@ export function resolveCodexNativeExecutionPolicy(params: {
   agentId?: string;
   execOverrides?: ExecHostOverride;
   sandboxAvailable?: boolean;
-  /** Explicit capability from a command-containment-verified Codex runtime. */
-  nativeContainmentConfirmed?: boolean;
+  /** Non-forgeable capability minted by runtime-artifact validation. */
+  nativeContainmentCapability?: CodexNativeContainmentCapability;
   readRuntimeSessionEntry?: boolean;
 }): CodexNativeExecutionPolicy {
   const config = params.config ?? {};
@@ -83,7 +87,10 @@ export function resolveCodexNativeExecutionPolicy(params: {
   });
   const node =
     params.execOverrides?.node ?? sessionEntry?.execNode ?? agentExec?.node ?? globalExec?.node;
-  if (effectiveExecHost !== "node" && params.nativeContainmentConfirmed === true) {
+  if (
+    effectiveExecHost !== "node" &&
+    isCodexNativeContainmentCapability(params.nativeContainmentCapability)
+  ) {
     return {
       nativeToolSurfaceAllowed: true,
       requestedExecHost,
@@ -99,22 +106,24 @@ export function resolveCodexNativeExecutionPolicy(params: {
     blockReason:
       effectiveExecHost === "node"
         ? "OpenClaw exec host=node is active for this session. Codex app-server native execution cannot route shell, filesystem, MCP, or app-backed work through the selected OpenClaw node."
-        : "Codex app-server native execution is fail-closed until the runtime proves per-invocation process-group containment, finite deadlines, bounded output, and descendant cleanup.",
+        : "Codex app-server native execution is fail-closed until the runtime artifact proves per-invocation cgroup v2 or transient-unit containment, finite deadlines, bounded output, and descendant cleanup.",
   };
 }
 
-/** Formats the user-facing explanation shown when native tools are blocked by exec host=node. */
-export function formatCodexNativeNodeExecBlock(params: {
+/** Formats a native-execution denial using the policy's actual block reason. */
+export function formatCodexNativeExecutionBlock(params: {
   surface: string;
   reason?: string;
 }): string {
   return [
-    `Codex-native ${params.surface} is unavailable because OpenClaw exec host=node is active for this session.`,
     params.reason ??
-      "Codex app-server native execution cannot route execution through the selected OpenClaw node.",
-    "Use a normal Codex harness turn so OpenClaw exec/process tools run on the node, or switch exec host to gateway for native Codex app-server execution.",
+      "Codex app-server native execution is unavailable because its containment capability is not validated.",
+    `Codex-native ${params.surface} remains disabled; use the configured OpenClaw fallback execution surface.`,
   ].join(" ");
 }
+
+/** Backwards-compatible name for callers that render node-exec denials. */
+export const formatCodexNativeNodeExecBlock = formatCodexNativeExecutionBlock;
 
 function resolvePolicyAgentId(params: {
   config: OpenClawConfig;

--- a/extensions/codex/src/app-server/native-execution-policy.ts
+++ b/extensions/codex/src/app-server/native-execution-policy.ts
@@ -46,6 +46,8 @@ export function resolveCodexNativeExecutionPolicy(params: {
   agentId?: string;
   execOverrides?: ExecHostOverride;
   sandboxAvailable?: boolean;
+  /** Explicit capability from a command-containment-verified Codex runtime. */
+  nativeContainmentConfirmed?: boolean;
   readRuntimeSessionEntry?: boolean;
 }): CodexNativeExecutionPolicy {
   const config = params.config ?? {};
@@ -81,7 +83,7 @@ export function resolveCodexNativeExecutionPolicy(params: {
   });
   const node =
     params.execOverrides?.node ?? sessionEntry?.execNode ?? agentExec?.node ?? globalExec?.node;
-  if (effectiveExecHost !== "node") {
+  if (effectiveExecHost !== "node" && params.nativeContainmentConfirmed === true) {
     return {
       nativeToolSurfaceAllowed: true,
       requestedExecHost,
@@ -95,7 +97,9 @@ export function resolveCodexNativeExecutionPolicy(params: {
     effectiveExecHost,
     node,
     blockReason:
-      "OpenClaw exec host=node is active for this session. Codex app-server native execution cannot route shell, filesystem, MCP, or app-backed work through the selected OpenClaw node.",
+      effectiveExecHost === "node"
+        ? "OpenClaw exec host=node is active for this session. Codex app-server native execution cannot route shell, filesystem, MCP, or app-backed work through the selected OpenClaw node."
+        : "Codex app-server native execution is fail-closed until the runtime proves per-invocation process-group containment, finite deadlines, bounded output, and descendant cleanup.",
   };
 }
 

--- a/extensions/codex/src/app-server/runtime-artifact.test.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.test.ts
@@ -9,7 +9,9 @@ import {
   bindCodexAppServerRuntimeArtifact,
   captureCodexAppServerRuntimeArtifactBeforeStart,
   finalizeCodexAppServerRuntimeArtifact,
+  isCodexNativeContainmentCapability,
   readCodexAppServerClientRuntimeArtifact,
+  validateAndMintCodexNativeContainmentCapability,
   validateCodexAppServerRuntimeArtifact,
 } from "./runtime-artifact.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
@@ -70,6 +72,17 @@ describe("Codex app-server runtime artifact", () => {
 
       expect(readCodexAppServerClientRuntimeArtifact(client)).toEqual(binding);
       await expect(validateCodexAppServerRuntimeArtifact(binding)).resolves.toBe(true);
+      const capability = await validateAndMintCodexNativeContainmentCapability({
+        actual: binding,
+        expected: binding,
+      });
+      expect(isCodexNativeContainmentCapability(capability)).toBe(true);
+      expect(
+        isCodexNativeContainmentCapability({
+          artifactId: binding.id,
+          artifactFingerprint: binding.fingerprint,
+        }),
+      ).toBe(false);
       await fs.writeFile(codeModeHost, "host-v2");
       await expect(validateCodexAppServerRuntimeArtifact(binding)).resolves.toBe(false);
     });

--- a/extensions/codex/src/app-server/runtime-artifact.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.ts
@@ -46,6 +46,23 @@ const SAFE_NODE_OPTIONS_NUMERIC_FLAGS = new Set([
 ]);
 const SAFE_NODE_OPTIONS_DNS_RESULT_ORDERS = new Set(["ipv4first", "ipv6first", "verbatim"]);
 const ARTIFACT_BINDINGS_SYMBOL = Symbol.for("openclaw.codexAppServerRuntimeArtifactBindings");
+const CONTAINMENT_CAPABILITIES_SYMBOL = Symbol.for(
+  "openclaw.codexAppServerNativeContainmentCapabilities",
+);
+
+/** A non-forgeable capability minted only after an expected artifact is revalidated. */
+export type CodexNativeContainmentCapability = Readonly<{
+  artifactId: string;
+  artifactFingerprint: string;
+}>;
+
+function getContainmentCapabilities(): WeakSet<object> {
+  const globalState = globalThis as typeof globalThis & {
+    [CONTAINMENT_CAPABILITIES_SYMBOL]?: WeakSet<object>;
+  };
+  globalState[CONTAINMENT_CAPABILITIES_SYMBOL] ??= new WeakSet();
+  return globalState[CONTAINMENT_CAPABILITIES_SYMBOL];
+}
 
 type CodexRuntimeArtifactSpawnIdentity = Readonly<{
   command: string;
@@ -883,5 +900,39 @@ export async function validateCodexAppServerRuntimeArtifact(
   } catch {
     return false;
   }
+}
+
+/**
+ * Mints the native-execution capability only from a matching expected binding
+ * whose selected files have just been re-hashed. The WeakSet brand prevents a
+ * caller from manufacturing an object with the same two public fields.
+ */
+export async function validateAndMintCodexNativeContainmentCapability(params: {
+  actual: AgentHarnessRuntimeArtifactBinding | undefined;
+  expected: AgentHarnessRuntimeArtifactBinding | undefined;
+  signal?: AbortSignal;
+}): Promise<CodexNativeContainmentCapability | undefined> {
+  if (
+    !params.actual ||
+    !params.expected ||
+    params.actual.id !== params.expected.id ||
+    params.actual.fingerprint !== params.expected.fingerprint ||
+    !(await validateCodexAppServerRuntimeArtifact(params.actual, params.signal))
+  ) {
+    return undefined;
+  }
+  const capability = Object.freeze({
+    artifactId: params.actual.id,
+    artifactFingerprint: params.actual.fingerprint,
+  });
+  getContainmentCapabilities().add(capability);
+  return capability;
+}
+
+/** Returns true only for a capability minted by the artifact validator above. */
+export function isCodexNativeContainmentCapability(
+  capability: CodexNativeContainmentCapability | undefined,
+): boolean {
+  return Boolean(capability && getContainmentCapabilities().has(capability));
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The Codex app-server native command executor is upstream-owned. Until its per-invocation deadline, descendant termination, and output-boundary contract is proven, OpenClaw must not advertise native Code Mode as if gateway ownership were safe. A recursive native command escaped the intended request boundary in the RCA; this patch makes the OpenClaw boundary fail closed.

## Changes

- native Code Mode is disabled at app-server startup unless `nativeContainmentConfirmed` is explicitly true
- the policy and dynamic-tool paths carry the capability without inferring it from exec host
- tests cover default denial and explicit verified-runtime allowance
- current gateway/node-owned OpenClaw fallback surfaces remain available

The matching upstream Codex patch is in `the-real-bojangles/codex` branch `fix/issue6-native-command-containment`; this PR intentionally does not enable the capability until that upstream route is accepted and its CI proves the process-group/cgroup contract.

## Evidence

- Branch is clean and contains only 6 OpenClaw files in commit `117ad93d`.
- `git diff --check` passed locally.
- The focused Vitest/Rust commands could not run in this checkout host: `node_modules` and the Rust toolchain/`just` are absent.
- No live installed path, host/service/config, credentials, provider/data/trading action, or recovered incident payload was touched.
- The upstream Codex draft/head is `the-real-bojangles/codex@268e69fa28`; GitHub rejected external PR creation against `openai/codex` with `CreatePullRequest` permission denied, so that upstream route remains an explicit maintainer handoff.