### PR TITLE
fix(secrets): scope egress sentinels to Gateway and survive client tunnel resets

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -325,6 +325,21 @@ openclaw config set secrets.egressProxy.enabled true --strict-json
 openclaw gateway restart
 ```
 
+For example, bind an OpenAI key to its API host and enable the proxy:
+
+```bash
+openclaw secrets store set OPENAI_API_KEY --allow-host api.openai.com
+openclaw config set secrets.egressProxy.enabled true --strict-json
+```
+
+After restarting the Gateway, a Gateway-hosted agent can run:
+
+```bash
+curl -sS https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY"
+```
+
+In the agent environment, `$OPENAI_API_KEY` is an `oc-sent-v2...end` sentinel. The proxy replaces it with the stored value only for `api.openai.com`. A request to an unbound host is refused with `Secret "OPENAI_API_KEY" is not allowed for host "<host>". Run: openclaw secrets store set OPENAI_API_KEY --allow-host <host>`.
+
 Equivalent config:
 
 ```json5
@@ -338,7 +353,7 @@ Equivalent config:
 }
 ```
 
-When enabled, OpenClaw adds these values to Gateway and sandbox exec environments:
+When enabled, OpenClaw adds these values to Gateway-hosted exec environments:
 
 - `HTTPS_PROXY` and `HTTP_PROXY`, with per-run credentials embedded in the loopback proxy URL
 - `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, and `REQUESTS_CA_BUNDLE`, pointing at the ephemeral CA certificate
@@ -364,8 +379,7 @@ Current limits:
 - Identity-scoped secrets are not supported; only the team store participates.
 - Allowed-host policy is exact-hostname authorization only. It does not validate the resolved IP or prevent an allowed origin from reflecting credentials.
 - Plain HTTP is refused; it is not upgraded or substituted.
-- Sandbox/container reachability is not implemented. Local container sandboxes default to `network: "none"`, and their loopback address is not the Gateway host. The variables are present, but the proxy is normally unreachable.
-- Remote `node` exec and provider-native harness subprocesses do not use this proxy.
+- Secret egress applies only to Gateway-hosted exec. Sandbox and remote `node` exec receive neither proxy variables nor sentinels, so shared-store `secret` entries are unavailable there. Provider-native harness subprocesses also do not use this proxy.
 - Background subprocesses lose proxy authorization when their owning agent run ends, even if the process itself is still alive.
 
 ## File-backed API keys

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -404,9 +404,11 @@ export function createExecTool(
 
         const resolvedExecEnvState = requestPreparation.getResolvedExecEnvPreparedState(params);
         const storeEnv = await resolveStoreEnv();
-        const canReachGatewayProxy = host === "gateway" || host === "sandbox";
+        // The proxy is loopback-owned by the Gateway. Sandbox and node hosts
+        // cannot use its sentinels, so both sides of the contract stay absent.
+        const useSecretEgress = secretEgressEnabled && host === "gateway";
         let secretEgressEnv: Record<string, string> | undefined;
-        if (secretEgressEnabled && canReachGatewayProxy) {
+        if (useSecretEgress) {
           if (!defaults?.operationalRunInstance) {
             throw new Error("Secret egress proxy requires an admitted agent run instance");
           }
@@ -424,7 +426,7 @@ export function createExecTool(
           defaultPathPrepend,
           pluginEnv: resolvedExecEnvState?.pluginEnv,
           storeEnv: storeEnv.env,
-          storeSecretEnv: secretEgressEnv ? storeEnv.secretSentinels : undefined,
+          storeSecretEnv: useSecretEgress ? storeEnv.secretSentinels : undefined,
           secretEgressEnv,
           warnings,
         });

--- a/src/agents/bash-tools.exec.store-env.test.ts
+++ b/src/agents/bash-tools.exec.store-env.test.ts
@@ -5,12 +5,17 @@ import { looksLikeSecretSentinel, resolveSecretSentinel } from "../secrets/senti
 import { writeSecretStoreEntry } from "../secrets/store/secret-store.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv } from "../test-utils/env.js";
+import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 const mocks = vi.hoisted(() => ({
   egressActive: false,
   proxyUrl: ["http://openclaw:", "fixture-password", "@127.0.0.1:19090"].join(""),
   gatewayParams: [] as Array<{
+    env: Record<string, string>;
+    requestedEnv?: Record<string, string>;
+  }>,
+  nodeHostParams: [] as Array<{
     env: Record<string, string>;
     requestedEnv?: Record<string, string>;
   }>,
@@ -58,6 +63,26 @@ vi.mock("./bash-tools.exec-host-gateway.js", () => ({
   ),
 }));
 
+vi.mock("./bash-tools.exec-host-node.js", () => ({
+  executeNodeHostCommand: vi.fn(
+    async (params: Pick<ExecuteNodeHostCommandParams, "env" | "requestedEnv">) => {
+      mocks.nodeHostParams.push({
+        env: { ...params.env },
+        requestedEnv: params.requestedEnv ? { ...params.requestedEnv } : undefined,
+      });
+      return {
+        content: [{ type: "text", text: "node ok" }],
+        details: {
+          status: "completed",
+          exitCode: 0,
+          durationMs: 0,
+          aggregated: "node ok",
+        },
+      };
+    },
+  ),
+}));
+
 vi.mock("../process/supervisor/index.js", () => ({
   getProcessSupervisor: () => ({
     spawn: async (input: { env?: Record<string, string>; onStdout?: (chunk: string) => void }) => {
@@ -96,6 +121,17 @@ type StoreEntry = {
   allowedHosts?: string[];
 };
 
+type StoreEnvHost = "gateway" | "sandbox" | "node";
+
+const EGRESS_ENV = {
+  HTTPS_PROXY: mocks.proxyUrl,
+  HTTP_PROXY: mocks.proxyUrl,
+  NODE_EXTRA_CA_CERTS: "/state/secret-egress/root-ca.pem",
+  SSL_CERT_FILE: "/state/secret-egress/root-ca.pem",
+  CURL_CA_BUNDLE: "/state/secret-egress/root-ca.pem",
+  REQUESTS_CA_BUNDLE: "/state/secret-egress/root-ca.pem",
+} as const;
+
 async function withTeamStoreEntries(
   entries: StoreEntry[],
   run: () => Promise<void>,
@@ -116,6 +152,47 @@ async function withTeamStoreEntries(
   }
 }
 
+async function captureStoreExecEnvironment(params: {
+  host: StoreEnvHost;
+  callId: string;
+  config?: { secrets: { egressProxy: { enabled: boolean } } };
+}): Promise<Record<string, string>> {
+  let sandboxEnv: Record<string, string> | undefined;
+  const sandbox: BashSandboxConfig | undefined =
+    params.host === "sandbox"
+      ? {
+          containerName: "store-env-sandbox",
+          workspaceDir: process.cwd(),
+          containerWorkdir: "/workspace",
+          buildExecSpec: async (input) => {
+            sandboxEnv = { ...input.env };
+            return {
+              argv: ["remote-shell", input.command],
+              env: {},
+              stdinMode: "pipe-open" as const,
+            };
+          },
+        }
+      : undefined;
+  const tool = createExecTool({
+    host: params.host,
+    security: "full",
+    ask: "off",
+    cwd: process.cwd(),
+    sandbox,
+    operationalRunInstance: { instanceId: "instance-1", runId: "run-1" },
+    config: params.config,
+  });
+  await tool.execute(params.callId, { command: "echo ok", yieldMs: 120_000 });
+  if (params.host === "gateway") {
+    return mocks.gatewayParams.at(-1)?.env ?? {};
+  }
+  if (params.host === "node") {
+    return mocks.nodeHostParams.at(-1)?.env ?? {};
+  }
+  return sandboxEnv ?? {};
+}
+
 describe("exec store environment", () => {
   beforeAll(async () => {
     ({ createExecTool } = await import("./bash-tools.exec-run.js"));
@@ -125,6 +202,7 @@ describe("exec store environment", () => {
   beforeEach(() => {
     mocks.egressActive = false;
     mocks.gatewayParams.length = 0;
+    mocks.nodeHostParams.length = 0;
     mocks.spawnInputs.length = 0;
     mocks.proxyBindings.length = 0;
   });
@@ -295,95 +373,82 @@ describe("exec store environment", () => {
     });
   });
 
-  it("keeps disabled secret egress byte-identical with a secret-kind store entry", async () => {
-    await withTeamStoreEntries(
-      [
-        {
-          name: "SERVICE_API_KEY",
-          value: "disabled-secret",
-          kind: "secret",
-          allowedHosts: ["api.example.com"],
+  it.each(["gateway", "sandbox", "node"] as const)(
+    "keeps disabled secret egress byte-identical for %s exec",
+    async (host) => {
+      await withTeamStoreEntries(
+        [
+          { name: "AWS_REGION", value: "us-west-2", kind: "env" },
+          {
+            name: "SERVICE_API_KEY",
+            value: "disabled-secret",
+            kind: "secret",
+            allowedHosts: ["api.example.com"],
+          },
+        ],
+        async () => {
+          const baseline = await captureStoreExecEnvironment({
+            host,
+            callId: `call-egress-absent-${host}`,
+          });
+          const explicitFalse = await captureStoreExecEnvironment({
+            host,
+            callId: `call-egress-disabled-${host}`,
+            config: { secrets: { egressProxy: { enabled: false } } },
+          });
+
+          expect(JSON.stringify(explicitFalse)).toBe(JSON.stringify(baseline));
         },
-      ],
-      async () => {
-        const absentConfig = createExecTool({ host: "gateway", security: "full", ask: "off" });
-        await absentConfig.execute("call-egress-absent", {
-          command: "echo ok",
-          yieldMs: 120_000,
-        });
-        const baseline = JSON.stringify({
-          gateway: mocks.gatewayParams[0],
-          spawn: mocks.spawnInputs[0],
-        });
-        mocks.gatewayParams.length = 0;
-        mocks.spawnInputs.length = 0;
+      );
+    },
+  );
 
-        const explicitFalse = createExecTool({
-          host: "gateway",
-          security: "full",
-          ask: "off",
-          config: { secrets: { egressProxy: { enabled: false } } },
-        });
-        await explicitFalse.execute("call-egress-disabled", {
-          command: "echo ok",
-          yieldMs: 120_000,
-        });
+  it.each(["gateway", "sandbox", "node"] as const)(
+    "applies enabled secret egress correctly for %s exec",
+    async (host) => {
+      await withTeamStoreEntries(
+        [
+          { name: "AWS_REGION", value: "us-west-2", kind: "env" },
+          {
+            name: "SERVICE_API_KEY",
+            value: "enabled-secret",
+            kind: "secret",
+            allowedHosts: ["API.EXAMPLE.COM"],
+          },
+        ],
+        async () => {
+          mocks.egressActive = true;
+          const env = await captureStoreExecEnvironment({
+            host,
+            callId: `call-egress-enabled-${host}`,
+            config: { secrets: { egressProxy: { enabled: true } } },
+          });
+          expect(env.AWS_REGION).toBe("us-west-2");
+          if (host === "gateway") {
+            expect(looksLikeSecretSentinel(env.SERVICE_API_KEY ?? "")).toBe(true);
+            expect(resolveSecretSentinel(env.SERVICE_API_KEY ?? "")).toBe("enabled-secret");
+            expect(env).toMatchObject(EGRESS_ENV);
+            expect(JSON.stringify(env)).not.toContain("enabled-secret");
+            expect(mocks.proxyBindings).toEqual([
+              [
+                expect.objectContaining({
+                  name: "SERVICE_API_KEY",
+                  allowedHosts: ["api.example.com"],
+                  sentinel: env.SERVICE_API_KEY,
+                }),
+              ],
+            ]);
+            return;
+          }
 
-        expect(
-          JSON.stringify({ gateway: mocks.gatewayParams[0], spawn: mocks.spawnInputs[0] }),
-        ).toBe(baseline);
-      },
-    );
-  });
-
-  it("injects proxy trust and secret-kind sentinels without changing env-kind entries", async () => {
-    await withTeamStoreEntries(
-      [
-        { name: "AWS_REGION", value: "us-west-2", kind: "env" },
-        {
-          name: "SERVICE_API_KEY",
-          value: "enabled-secret",
-          kind: "secret",
-          allowedHosts: ["API.EXAMPLE.COM"],
+          expect(env).not.toHaveProperty("SERVICE_API_KEY");
+          expect(JSON.stringify(env)).not.toContain("oc-sent-v2.");
+          for (const [key, value] of Object.entries(EGRESS_ENV)) {
+            expect(env[key]).not.toBe(value);
+          }
+          expect(mocks.proxyBindings).toEqual([]);
         },
-      ],
-      async () => {
-        mocks.egressActive = true;
-        const tool = createExecTool({
-          host: "gateway",
-          security: "full",
-          ask: "off",
-          operationalRunInstance: { instanceId: "instance-1", runId: "run-1" },
-          config: { secrets: { egressProxy: { enabled: true } } },
-        });
-        await tool.execute("call-egress-enabled", {
-          command: "echo ok",
-          yieldMs: 120_000,
-        });
-
-        const env = mocks.gatewayParams[0]?.env ?? {};
-        expect(env.AWS_REGION).toBe("us-west-2");
-        expect(looksLikeSecretSentinel(env.SERVICE_API_KEY ?? "")).toBe(true);
-        expect(resolveSecretSentinel(env.SERVICE_API_KEY ?? "")).toBe("enabled-secret");
-        expect(env).toMatchObject({
-          HTTPS_PROXY: mocks.proxyUrl,
-          HTTP_PROXY: mocks.proxyUrl,
-          NODE_EXTRA_CA_CERTS: "/state/secret-egress/root-ca.pem",
-          SSL_CERT_FILE: "/state/secret-egress/root-ca.pem",
-          CURL_CA_BUNDLE: "/state/secret-egress/root-ca.pem",
-          REQUESTS_CA_BUNDLE: "/state/secret-egress/root-ca.pem",
-        });
-        expect(JSON.stringify(env)).not.toContain("enabled-secret");
-        expect(mocks.proxyBindings).toEqual([
-          [
-            expect.objectContaining({
-              name: "SERVICE_API_KEY",
-              allowedHosts: ["api.example.com"],
-              sentinel: env.SERVICE_API_KEY,
-            }),
-          ],
-        ]);
-      },
-    );
-  });
+      );
+    },
+  );
 });

--- a/src/secrets/egress-proxy/proxy-server.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.test.ts
@@ -256,6 +256,36 @@ afterEach(async () => {
 });
 
 describe("secret egress proxy", () => {
+  it("survives a client that resets a refused tunnel instead of crashing the Gateway", async () => {
+    // The proxy runs inside the Gateway process, so an unhandled socket 'error' would take
+    // the whole Gateway down. curl resets the connection after a 407, which is exactly this.
+    const proxyPort = Number(new URL(proxyEnv.HTTPS_PROXY as string).port);
+    const uncaught: Error[] = [];
+    const onUncaught = (error: Error) => uncaught.push(error);
+    process.on("uncaughtException", onUncaught);
+    try {
+      await new Promise<void>((resolve) => {
+        const socket = net.connect(proxyPort, "127.0.0.1", () => {
+          // No Proxy-Authorization: the proxy answers 407, then the peer resets abruptly.
+          socket.write("CONNECT example.test:443 HTTP/1.1\r\nHost: example.test:443\r\n\r\n");
+          setTimeout(() => {
+            socket.resetAndDestroy();
+            setTimeout(resolve, 150);
+          }, 50);
+        });
+        socket.on("error", () => {});
+      });
+    } finally {
+      process.off("uncaughtException", onUncaught);
+    }
+
+    expect(uncaught).toEqual([]);
+    // The listener must still serve traffic after the reset.
+    const stillAlive = await rawConnect({ auth: basicProxyAuth(registeredPassword(proxyEnv)) });
+    expect(stillAlive.response).toContain("200 Connection Established");
+    stillAlive.socket.destroy();
+  });
+
   it.each([
     { label: "missing", auth: undefined, expectedReason: "missing-proxy-auth" },
     {

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -488,6 +488,12 @@ export async function startSecretEgressProxyServer(params: {
   proxy.on("connection", (socket) => {
     sockets.add(socket);
     socket.once("close", () => sockets.delete(socket));
+    // The proxy runs inside the Gateway process, so an unhandled socket 'error' would
+    // take the Gateway down. Clients legitimately reset refused tunnels (curl does this
+    // after a 407), so peer resets are expected and must stay local to the socket.
+    socket.on("error", () => {
+      socket.destroy();
+    });
   });
   proxy.on("connect", (request, clientSocket, head) => {
     void (async () => {


### PR DESCRIPTION
## What Problem This Solves

Two defects in the secret egress proxy shipped last week, both found by a live stress run against the real OpenAI API.

**1. A client resetting a refused tunnel crashed the Gateway.** The proxy runs inside the Gateway process. Sockets accepted by the CONNECT listener had no `'error'` handler, so an ordinary `ECONNRESET` — exactly what `curl` emits after it receives a `407` and abandons the tunnel — surfaced as an unhandled `'error'` event and terminated the process. Any *unauthenticated* caller could take the Gateway down with a single CONNECT followed by a hangup; the auth check gives no protection, because the reset lands below it.

**2. Sandbox and node executions received sentinels without a proxy.** `bash-tools.exec-run.ts` injected `store`-kind sentinel values for every execution host, but only Gateway-hosted executions can reach the loopback proxy that substitutes them. A sandboxed or node-hosted command therefore saw an `oc-sent-v2...end` placeholder with nothing to replace it, and the request failed with an opaque vendor `401` instead of a real secret or a clear refusal.

## Why This Change Was Made

For (1) the socket error stays local to the socket that produced it. Peer resets on a refused tunnel are expected client behavior, not a Gateway fault, so they must never escalate into a process-availability failure. The inline comment records that reasoning, because the reason is not local to the callsite.

For (2) the two previously independent conditions collapse into one per-execution predicate:

```ts
useSecretEgress = secretEgressEnabled && host === "gateway"
```

It gates proxy registration/environment and sentinel injection together, so the two can no longer disagree — the disagreement was the bug. `env`-kind entries are untouched and still resolve everywhere.

## User Impact

- The Gateway survives clients that reset refused tunnels. Before this change a single unauthenticated CONNECT plus a reset was a remote crash.
- Sandbox and node executions no longer receive unusable sentinel placeholders; they behave as if the proxy is off, which is the truthful state.
- Docs gain a worked `curl` example showing the bound-host success path and the exact refusal text for an unbound host.

## Evidence

**The crash regression is genuine** — the new test fails on pre-fix code for the right reason, and passes after:

```
=== production fix REVERTED:
AssertionError: expected [ Error: read ECONNRESET { …(3) } ] to deeply equal []
+     "message": "read ECONNRESET",
+     "code": "ECONNRESET",
 Tests  1 failed | 11 passed (12)
```

```
=== fix restored
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Agent boundary suite: `Tests 12 passed (12)`.

**Live egress stress against the real OpenAI API: 15 passed, 0 failed.** Bound host returns 200 with only a sentinel in the environment; an unbound host is refused with remediation text and no plaintext in the refusal; unauthenticated callers get 407; a wrong token is refused; a 300 KiB body is substituted across the streaming carry window; ten parallel requests all return 200; non-sentinel traffic passes through; revocation immediately kills authorization; the audit trail contains neither plaintext nor sentinel; 60 register/revoke cycles followed by live reuse still substitutes; and 25 abrupt tunnel resets are survived with traffic still served afterward.

The crash was originally hit at step 4 of that run, reproduced deterministically before the fix (`CRASH: read ECONNRESET`) and after (`SURVIVED: proxy host process still alive`).

**LOC:** production +14/−3; tests +271/−94; docs +20/−3.

Autoreview (codex/gpt-5.6-sol, high): `autoreview clean: no accepted/actionable findings reported`.
