### PR TITLE
fix(telegram): retry abandoned messages instead of dropping them

### DIFF
--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -657,7 +657,7 @@ describe("telegram bot message processor", () => {
     await expect(replay.deferredWork?.task).resolves.toEqual({ kind: "completed" });
   });
 
-  it("settles an abandoned deferred turn as skipped", async () => {
+  it("settles an abandoned deferred turn as retryable", async () => {
     buildTelegramMessageContext.mockResolvedValue(createMessageContext());
     const finalizeSpooledReplayResult = vi.fn(
       async (result: TelegramMessageProcessingResult): Promise<TelegramMessageProcessingResult> =>
@@ -675,10 +675,15 @@ describe("telegram bot message processor", () => {
       processSampleMessage(processMessage, { finalizeSpooledReplayResult }, { update }),
     );
 
-    expect(replay.value).toEqual({ kind: "skipped" });
-    await expect(replay.deferredWork?.task).resolves.toEqual({ kind: "skipped" });
+    expect(replay.value).toMatchObject({ kind: "failed-retryable" });
+    await expect(replay.deferredWork?.task).resolves.toMatchObject({
+      kind: "failed-retryable",
+    });
     expect(finalizeSpooledReplayResult).toHaveBeenCalledTimes(1);
-    expect(finalizeSpooledReplayResult).toHaveBeenCalledWith({ kind: "skipped" }, "terminal");
+    expect(finalizeSpooledReplayResult).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "failed-retryable" }),
+      "terminal",
+    );
   });
 
   it("keeps isolated retry settlement separate from the outer spool participant", async () => {
@@ -750,7 +755,10 @@ describe("telegram bot message processor", () => {
     await deferred;
     outerAbortController.abort(new Error("outer spool timeout"));
 
-    await expect(processing).resolves.toEqual({ kind: "skipped" });
+    await expect(processing).resolves.toEqual({
+      kind: "failed-retryable",
+      error: "turn-abandoned",
+    });
     expect(queuedAbortSignal?.aborted).toBe(true);
   });
 

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -426,7 +426,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
             },
             onAbandoned: () => {
               if (!adopted) {
-                void settle({ kind: "skipped" }, "terminal");
+                void settle({ kind: "failed-retryable", error: "turn-abandoned" }, "terminal");
               }
               // Generic reply abandonment is synchronous; Telegram has no
               // owner-local resource teardown gated on core claim release.

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -3427,6 +3427,62 @@ describe("createTelegramBot", () => {
     expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([701]);
   });
 
+  it("retries a deferred spooled update after its queued turn is abandoned", async () => {
+    configureOpenDm();
+    let queuedLifecycle: GetReplyOptions["turnAdoptionLifecycle"];
+    replySpy
+      .mockImplementationOnce(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+        queuedLifecycle = opts?.turnAdoptionLifecycle;
+        queuedLifecycle?.onDeferred?.();
+        return undefined;
+      })
+      .mockImplementationOnce(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+        await opts?.turnAdoptionLifecycle?.onAdopted?.();
+        return { text: "recovered" };
+      });
+    const { onUpdateId } = setupUpdateOffsetTracker({
+      lastUpdateId: 701,
+    });
+    const messageHandler = getMessageHandler();
+
+    const firstReplayPromise = dispatchSpooledPrivateText(messageHandler, {
+      updateId: 702,
+      messageId: 702,
+      text: "retry after queued turn abandonment",
+    });
+    await vi.waitFor(() => {
+      expect(queuedLifecycle?.onAbandoned).toEqual(expect.any(Function));
+    });
+    queuedLifecycle?.onAbandoned?.();
+    const firstReplay = await firstReplayPromise;
+    const firstDeferredWork = requireValue(firstReplay.deferredWork, "first deferred spooled work");
+    await expect(firstDeferredWork.task).resolves.toMatchObject({ kind: "failed-retryable" });
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId).not.toHaveBeenCalled();
+
+    const secondReplay = await dispatchSpooledPrivateText(messageHandler, {
+      updateId: 702,
+      messageId: 702,
+      text: "retry after queued turn abandonment",
+    });
+    const secondDeferredWork = requireValue(
+      secondReplay.deferredWork,
+      "second deferred spooled work",
+    );
+    await expect(secondDeferredWork.task).resolves.toEqual({ kind: "completed" });
+    await flushTelegramTestMicrotasks();
+    expect(replySpy).toHaveBeenCalledTimes(2);
+    expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([702]);
+
+    const duplicateReplay = await dispatchSpooledPrivateText(messageHandler, {
+      updateId: 702,
+      messageId: 702,
+      text: "retry after queued turn abandonment",
+    });
+    expect(duplicateReplay.deferredWork).toBeUndefined();
+    expect(replySpy).toHaveBeenCalledTimes(2);
+  });
+
   it("skips replayed update ids even when the semantic update key differs", async () => {
     const { onUpdateId, run: runMiddlewareChain } = setupUpdateOffsetTracker({
       lastUpdateId: 300,


### PR DESCRIPTION
Closes #123519

## What Problem This Solves

Fixes an issue where Telegram messages queued behind an active same-session run could disappear when the queued turn was abandoned. Durable ingress retried the update, but Telegram's in-process update tracker suppressed that retry and falsely completed the ingress row.

Reported by @hannesrudolph.

## Why This Change Was Made

Queue abandonment now uses the existing retryable processing outcome at the producer. This keeps durable-ingress release, Telegram update tracking, and message-dispatch dedupe aligned without changing intentional terminal skips or adding a compatibility path. Production code delta: 1 line added, 1 removed.

## User Impact

Telegram messages abandoned before turn adoption remain eligible for same-process durable retry. Once a retry is adopted, later Telegram redelivery remains deduplicated.

## Evidence

- Real-user Telegram repro on pre-fix `14882ac44dcd82bfa6fc145c5bcac73ceff036c4`: queued marker `OPENCLAW_E2E_ABANDONED_123519` received no reply; provider received zero requests containing that marker; Gateway logged both `visible channel turn dispatched with no queued reply payloads` and `completed without a recorded processing outcome`.
- Regression red on pre-fix code: abandonment settled as `skipped`, failing the expected retryable owner outcome.
- Regression green: `defer -> abandon -> same-process retry -> adopt -> duplicate redelivery suppressed`.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts` — 170 passed.
- Targeted Oxfmt, Oxlint, `pnpm tsgo:extensions`, `pnpm check:test-types`, and `git diff --check` — passed.
- Final real-user Telegram proof on `0fc06d7a8206fac7443c0e952fb47d9ae1d40ae0`: queued message `48661` received the SUT acknowledgement reaction, then `/stop` (`48663`) produced `⚙️ Agent was aborted.` (`48664`). Gateway dispatched message `48661` twice (initial attempt plus same-process retry) and emitted zero `completed without a recorded processing outcome` diagnostics. The forced stop intentionally prevented model admission; the transport retry is the changed path under test.

