### PR TITLE
improve(test): speed runtime-token CLI pairing proof

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -192,6 +192,7 @@ describe("gateway e2e", () => {
   it("pairs the local CLI before a runtime-token loopback gateway becomes ready", async () => {
     const { envSnapshot, tempHome } = await setupGatewayTempHome({
       prefix: "openclaw-gw-runtime-token-cli-pairing-",
+      minimalGateway: true,
     });
     let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
     try {


### PR DESCRIPTION
## What Problem This Solves

The focused runtime-token local CLI pairing regression unnecessarily pays for unrelated full Gateway startup work. Current `main` has already removed most of the obsolete 35.9s audit cost, but this test still spends time and memory on fixture surfaces it does not exercise.

## Why This Change Was Made

Enable the existing test-only minimal Gateway mode for this case. The test still starts the real Gateway and preserves the same config/auth bootstrap, generated runtime token, pre-readiness local CLI pairing, health RPC, SQLite pairing record, `operator.admin` device token, silent approval, config-persistence assertions, and cleanup. Minimal mode skips unrelated agent CLI shim setup, Control UI seeding, and broad test startup work; no assertion or production code changes.

The regression and owner fix originated in 3a4f337802cc / #114380 on 2026-07-27. This PR optimizes only that test's fixture setup.

## User Impact

No runtime behavior change. Gateway end-to-end feedback for this regression is slightly faster and uses less memory.

## Evidence

Measured on the same reusable Blacksmith Testbox (`tbx_01kzzcpm5btztb27rhvksqhaty`) after one private-QA build: https://github.com/openclaw/openclaw/actions/runs/31773868229

| Fixture | Sample | Test body | Wall | Max RSS |
| --- | ---: | ---: | ---: | ---: |
| Full Gateway | 1 | 3.843s | 8.46s | 1,398,976 KiB |
| Full Gateway | 2 | 3.785s | 8.37s | 1,404,224 KiB |
| Minimal Gateway | 1 | 3.617s | 8.18s | 1,328,408 KiB |
| Minimal Gateway | 2 | 3.598s | 8.13s | 1,319,720 KiB |
| Minimal Gateway | 3 | 3.563s | 9.21s | 1,305,368 KiB |

Full-Gateway averages: body 3.814s, max RSS 1,401,600 KiB. Minimal-Gateway averages: body 3.593s, max RSS 1,317,832 KiB; median wall 8.18s.

Measured gain: test body -0.221s (-5.8%), max RSS -83,768 KiB (-6.0%), and median wall about -0.24s (-2.8%). Wall time is noisier than body time and RSS, so the body/RSS deltas are the stronger signal.

Final exact-head proof on a cold Testbox (`tbx_01kzzezwtcax86yaeser440p2z`): https://github.com/openclaw/openclaw/actions/runs/31776075902

- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed.
- The exact focused Gateway e2e test passed; cold-box timings are not used in the A/B claim.
- `check:changed` passed the precise `coreTests` lane: conflict/ratchet/format/boundary/dead-export guards, core test typecheck, and lint.
- Final Codex autoreview was clean with no accepted or actionable findings; it confirmed that the real pairing owner path remains covered and the measured reduction is justified.
- Production runtime LOC: +0/-0. Tests: +1/-0.

AI-assisted. No transcript attached.
