### PR TITLE
Rank skill name matches ahead of descriptions

### DIFF
--- a/ui/src/e2e/chat-skill-references.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-references.e2e.test.ts
@@ -39,6 +39,15 @@ suite.define(() => {
             textAliases: ["/technical_documentation"],
           },
           {
+            acceptsArgs: true,
+            description: "Publish a temporary remote preview.",
+            name: "openclaw_stg_test",
+            scope: "both",
+            source: "skill",
+            skillModelVisible: true,
+            textAliases: ["/openclaw_stg_test"],
+          },
+          {
             acceptsArgs: false,
             description: "Show gateway status.",
             name: "status",
@@ -80,12 +89,24 @@ suite.define(() => {
         await composer.press("Enter");
         await expect.poll(() => composer.inputValue()).toBe("Review this with $autoreview ");
 
+        await composer.fill(`${await composer.inputValue()}and $stg`);
+        await expect.poll(() => picker.getByRole("option").count()).toBe(1);
+        await expect
+          .poll(() => picker.getByRole("option").first().textContent())
+          .toContain("$openclaw_stg_test");
+        await composer.press("Tab");
+        await expect
+          .poll(() => composer.inputValue())
+          .toBe("Review this with $autoreview and $openclaw_stg_test ");
+
         await composer.fill(`${await composer.inputValue()}and $technical`);
         await expect.poll(() => picker.getByRole("option").count()).toBe(1);
         await composer.press("Tab");
         await expect
           .poll(() => composer.inputValue())
-          .toBe("Review this with $autoreview and $technical_documentation ");
+          .toBe(
+            "Review this with $autoreview and $openclaw_stg_test and $technical_documentation ",
+          );
 
         if (artifactDir) {
           await page.screenshot({
@@ -97,7 +118,7 @@ suite.define(() => {
         await page.getByRole("button", { name: "Send message" }).click();
         const request = await gateway.waitForRequest("chat.send");
         expect((request.params as { message?: unknown }).message).toBe(
-          "Review this with $autoreview and $technical_documentation",
+          "Review this with $autoreview and $openclaw_stg_test and $technical_documentation",
         );
 
         await composer.fill("Print $HOME");

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -429,7 +429,7 @@ describe("parseSlashCommand", () => {
   it("keeps equal-rank skill names ordered independently of the browser locale", () => {
     const localeCompare = vi
       .spyOn(String.prototype, "localeCompare")
-      .mockImplementation(function (compareString, locales, options) {
+      .mockImplementation(function (this: string, compareString, locales, options) {
         if (locales === undefined) {
           return new Intl.Collator("da").compare(this, compareString);
         }

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -1,7 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 // @vitest-environment node
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildFallbackSlashCommands,
   buildSlashCommandsFromEntries,
@@ -424,6 +424,46 @@ describe("parseSlashCommand", () => {
       "alpha_description",
       "beta_description",
     ]);
+  });
+
+  it("keeps equal-rank skill names ordered independently of the browser locale", () => {
+    const localeCompare = vi
+      .spyOn(String.prototype, "localeCompare")
+      .mockImplementation(function (compareString, locales, options) {
+        if (locales === undefined) {
+          return new Intl.Collator("da").compare(this, compareString);
+        }
+        return Intl.Collator(locales, options).compare(this, compareString);
+      });
+    try {
+      applyRemoteEntries([
+        {
+          name: "skill_z",
+          textAliases: ["/skill_z"],
+          description: "Search z skills.",
+          source: "skill",
+          skillModelVisible: true,
+          scope: "both",
+          acceptsArgs: true,
+        },
+        {
+          name: "skill_aa",
+          textAliases: ["/skill_aa"],
+          description: "Search aa skills.",
+          source: "skill",
+          skillModelVisible: true,
+          scope: "both",
+          acceptsArgs: true,
+        },
+      ]);
+
+      expect(getSkillCommandCompletions("skill").map((command) => command.name)).toEqual([
+        "skill_aa",
+        "skill_z",
+      ]);
+    } finally {
+      localeCompare.mockRestore();
+    }
   });
 
   it("keeps model-hidden skills in slash commands but out of $ completions", () => {

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -328,7 +328,7 @@ describe("parseSlashCommand", () => {
     expect(getSkillCommandCompletions("pro").map((command) => command.name)).toEqual(["prose"]);
   });
 
-  it("normalizes hyphenated skill reference queries", () => {
+  it("matches skill reference queries across normalized name segments", () => {
     applyRemoteEntries([
       {
         name: "release_notes",
@@ -339,10 +339,90 @@ describe("parseSlashCommand", () => {
         scope: "both",
         acceptsArgs: true,
       },
+      {
+        name: "openclaw_stg_test",
+        textAliases: ["/openclaw_stg_test"],
+        description: "Publish a temporary remote preview.",
+        source: "skill",
+        skillModelVisible: true,
+        scope: "both",
+        acceptsArgs: true,
+      },
     ]);
 
     expect(getSkillCommandCompletions("release-n").map((command) => command.name)).toEqual([
       "release_notes",
+    ]);
+    expect(getSkillCommandCompletions("stg").map((command) => command.name)).toEqual([
+      "openclaw_stg_test",
+    ]);
+  });
+
+  it("ranks skill name matches ahead of description-only matches", () => {
+    applyRemoteEntries([
+      {
+        name: "skill_search",
+        textAliases: ["/skill_search"],
+        description: "Search skills.",
+        source: "skill",
+        skillModelVisible: true,
+        scope: "both",
+        acceptsArgs: true,
+      },
+      {
+        name: "skill_search_alpha",
+        textAliases: ["/skill_search_alpha"],
+        description: "Search alpha skills.",
+        source: "skill",
+        skillModelVisible: true,
+        scope: "both",
+        acceptsArgs: true,
+      },
+      {
+        name: "skill_search_beta",
+        textAliases: ["/skill_search_beta"],
+        description: "Search beta skills.",
+        source: "skill",
+        skillModelVisible: true,
+        scope: "both",
+        acceptsArgs: true,
+      },
+      {
+        name: "workspace_skill_search_helper",
+        textAliases: ["/workspace_skill_search_helper"],
+        description: "Search a workspace.",
+        source: "skill",
+        skillModelVisible: true,
+        scope: "both",
+        acceptsArgs: true,
+      },
+      {
+        name: "alpha_description",
+        textAliases: ["/alpha_description"],
+        description: "Use skill-search for alpha tasks.",
+        source: "skill",
+        skillModelVisible: true,
+        scope: "both",
+        acceptsArgs: true,
+      },
+      {
+        name: "beta_description",
+        textAliases: ["/beta_description"],
+        description: "Use skill-search for beta tasks.",
+        source: "skill",
+        skillModelVisible: true,
+        scope: "both",
+        acceptsArgs: true,
+      },
+    ]);
+
+    expect(getSkillCommandCompletions("skill-search").map((command) => command.name)).toEqual([
+      "skill_search",
+      "skill_search_alpha",
+      "skill_search_beta",
+      "workspace_skill_search_helper",
+      "alpha_description",
+      "beta_description",
     ]);
   });
 

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -1,11 +1,11 @@
 // Control UI chat domain owns pure slash command rules.
 
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { CommandEntry } from "../../../../packages/gateway-protocol/src/index.js";
 import { buildBuiltinChatCommands } from "../../../../src/auto-reply/commands-registry.shared.js";
 import { t } from "../../i18n/index.ts";
-import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 
 export type SlashCommandCategory = "session" | "model" | "agents" | "tools";
 

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -539,7 +539,7 @@ export function getSkillCommandCompletions(filter: string): SlashCommandDef[] {
       const relevance =
         getCommandRelevance(left, lower, normalizeSkillCommandName) -
         getCommandRelevance(right, lower, normalizeSkillCommandName);
-      return relevance || left.name.localeCompare(right.name);
+      return relevance || left.name.localeCompare(right.name, "en");
     });
 }
 

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -461,18 +461,28 @@ const TIER_ORDER: Record<SlashCommandTier, number> = {
 
 const NON_MATCHING_COMMAND_RANK = 4;
 
-function getSlashCommandRelevance(command: SlashCommandDef, filter: string): number {
-  const names = [command.name, ...(command.aliases ?? [])].map(normalizeLowercaseStringOrEmpty);
-  if (names.some((name) => name === filter)) {
+function normalizeSkillCommandName(value: string): string {
+  return normalizeLowercaseStringOrEmpty(value).replace(/-/gu, "_");
+}
+
+function getCommandRelevance(
+  command: SlashCommandDef,
+  filter: string,
+  normalizeName: (value: string) => string = normalizeLowercaseStringOrEmpty,
+): number {
+  const normalizedFilter = normalizeName(filter);
+  const names = [command.name, ...(command.aliases ?? [])].map(normalizeName);
+  if (names.some((name) => name === normalizedFilter)) {
     return 0;
   }
-  if (names.some((name) => name.startsWith(filter))) {
+  if (names.some((name) => name.startsWith(normalizedFilter))) {
     return 1;
   }
-  if (names.some((name) => name.includes(filter))) {
+  if (names.some((name) => name.includes(normalizedFilter))) {
     return 2;
   }
-  return normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(filter)
+  const description = normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command));
+  return description.includes(normalizeLowercaseStringOrEmpty(filter))
     ? 3
     : NON_MATCHING_COMMAND_RANK;
 }
@@ -485,7 +495,7 @@ export function getSlashCommandCompletions(
   const showAll = options?.showAll ?? false;
   let commands = lower
     ? SLASH_COMMANDS.filter(
-        (command) => getSlashCommandRelevance(command, lower) < NON_MATCHING_COMMAND_RANK,
+        (command) => getCommandRelevance(command, lower) < NON_MATCHING_COMMAND_RANK,
       )
     : SLASH_COMMANDS;
 
@@ -496,7 +506,7 @@ export function getSlashCommandCompletions(
 
   return commands.toSorted((a, b) => {
     if (lower) {
-      const relevance = getSlashCommandRelevance(a, lower) - getSlashCommandRelevance(b, lower);
+      const relevance = getCommandRelevance(a, lower) - getCommandRelevance(b, lower);
       if (relevance !== 0) {
         return relevance;
       }
@@ -515,34 +525,20 @@ export function getSlashCommandCompletions(
   });
 }
 
-function getSkillCommandRelevance(command: SlashCommandDef, filter: string): number {
-  const normalizedFilter = filter.replace(/-/gu, "_");
-  const normalizedName = command.name.replace(/-/gu, "_");
-  if (normalizedName === normalizedFilter) {
-    return 0;
-  }
-  if (normalizedName.startsWith(normalizedFilter)) {
-    return 1;
-  }
-  if (normalizedName.includes(normalizedFilter)) {
-    return 2;
-  }
-  return normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(filter)
-    ? 3
-    : NON_MATCHING_COMMAND_RANK;
-}
-
 export function getSkillCommandCompletions(filter: string): SlashCommandDef[] {
   const lower = normalizeLowercaseStringOrEmpty(filter);
   return SLASH_COMMANDS.filter(
     (command) => command.source === "skill" && command.skillModelVisible === true,
   )
     .filter(
-      (command) => !lower || getSkillCommandRelevance(command, lower) < NON_MATCHING_COMMAND_RANK,
+      (command) =>
+        !lower ||
+        getCommandRelevance(command, lower, normalizeSkillCommandName) < NON_MATCHING_COMMAND_RANK,
     )
     .toSorted((left, right) => {
       const relevance =
-        getSkillCommandRelevance(left, lower) - getSkillCommandRelevance(right, lower);
+        getCommandRelevance(left, lower, normalizeSkillCommandName) -
+        getCommandRelevance(right, lower, normalizeSkillCommandName);
       return relevance || left.name.localeCompare(right.name);
     });
 }

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -515,20 +515,36 @@ export function getSlashCommandCompletions(
   });
 }
 
+function getSkillCommandRelevance(command: SlashCommandDef, filter: string): number {
+  const normalizedFilter = filter.replace(/-/gu, "_");
+  const normalizedName = command.name.replace(/-/gu, "_");
+  if (normalizedName === normalizedFilter) {
+    return 0;
+  }
+  if (normalizedName.startsWith(normalizedFilter)) {
+    return 1;
+  }
+  if (normalizedName.includes(normalizedFilter)) {
+    return 2;
+  }
+  return normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(filter)
+    ? 3
+    : NON_MATCHING_COMMAND_RANK;
+}
+
 export function getSkillCommandCompletions(filter: string): SlashCommandDef[] {
   const lower = normalizeLowercaseStringOrEmpty(filter);
-  const normalized = lower.replace(/-/gu, "_");
   return SLASH_COMMANDS.filter(
     (command) => command.source === "skill" && command.skillModelVisible === true,
   )
     .filter(
-      (command) =>
-        !lower ||
-        command.name.startsWith(lower) ||
-        command.name.replace(/-/gu, "_").startsWith(normalized) ||
-        normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(lower),
+      (command) => !lower || getSkillCommandRelevance(command, lower) < NON_MATCHING_COMMAND_RANK,
     )
-    .toSorted((left, right) => left.name.localeCompare(right.name));
+    .toSorted((left, right) => {
+      const relevance =
+        getSkillCommandRelevance(left, lower) - getSkillCommandRelevance(right, lower);
+      return relevance || left.name.localeCompare(right.name);
+    });
 }
 
 type ParsedSlashCommand = {


### PR DESCRIPTION
## New behavior

Skill references now prioritize matches in the skill name before incidental matches in the description. Typing `$openclaw` therefore shows `openclaw_local_test` and `openclaw_stg_test` before skills such as `canvas`, `healthcheck`, and `node_connect` whose descriptions merely mention OpenClaw.

Matching is ordered by exact normalized name, name prefix, normalized name substring, then description. Alphabetical ordering remains deterministic within each tier, and hidden skills remain excluded.

## How to verify

1. Open the Control UI chat composer against a Gateway that exposes the relevant skills.
2. Type `help $` and observe the normal alphabetical skill catalog.
3. Type `help $openclaw`.
4. Confirm `openclaw_local_test` and `openclaw_stg_test` appear before description-only matches.

## Validation

- Focused owner regression: 22 tests passed.
- Control UI production build completed and the Gateway served the rebuilt asset.
- Fresh-browser real-Gateway walkthrough confirmed the expected `$` and `$openclaw` ordering.

Visual proof will be refreshed through the required PR proof-pack workflow after both review phases are clean.