### PR TITLE
fix(ci): preserve scoped extension test plans

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -969,11 +969,16 @@ function createBroadToolingScriptPlans(params: VitestRunPlan & { cwd: string }) 
     : null;
 }
 
-function createBoundedExtensionPlans(plan: VitestRunPlan) {
+function createBoundedExtensionPlans(plan: VitestRunPlan, env?: NodeJS.ProcessEnv) {
   const { config, forwardedArgs, watchMode } = plan;
   const roots = EXTENSION_TEST_PROCESS_ROOTS.get(config);
   if (watchMode || !roots) {
     return [plan];
+  }
+  // A CI include file already owns the test scope. Expanding its config here
+  // or emitting local patterns would replace that shard in the run spec.
+  if (env?.[INCLUDE_FILE_ENV_KEY]?.trim()) {
+    return [{ ...plan, includePatterns: null }];
   }
   const chunks = createExtensionTestProcessTargetChunks(config, roots, forwardedArgs);
   if (chunks.length <= 1) {
@@ -3609,12 +3614,15 @@ export function buildVitestRunPlans(
       );
     }
     return explicitConfigTargets.flatMap((config) =>
-      createBoundedExtensionPlans({
-        config,
-        forwardedArgs: nonTargetArgs,
-        includePatterns: null,
-        watchMode,
-      }),
+      createBoundedExtensionPlans(
+        {
+          config,
+          forwardedArgs: nonTargetArgs,
+          includePatterns: null,
+          watchMode,
+        },
+        options.env,
+      ),
     );
   }
 
@@ -3726,7 +3734,7 @@ export function buildVitestRunPlans(
           includePatterns: null,
           watchMode,
         };
-        plans.push(...createBoundedExtensionPlans(plan));
+        plans.push(...createBoundedExtensionPlans(plan, options.env));
       }
       continue;
     }
@@ -3778,12 +3786,15 @@ export function buildVitestRunPlans(
     });
     const boundedExtensionPlans =
       boundedExtensionRoots.length > 0 && boundedRootsCoverGroupedTargets
-        ? createBoundedExtensionPlans({
-            config,
-            forwardedArgs: forwardedPlanArgs,
-            includePatterns,
-            watchMode,
-          })
+        ? createBoundedExtensionPlans(
+            {
+              config,
+              forwardedArgs: forwardedPlanArgs,
+              includePatterns,
+              watchMode,
+            },
+            options.env,
+          )
         : null;
     if (boundedExtensionPlans) {
       plans.push(...boundedExtensionPlans);

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2146,6 +2146,59 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
+  it.each([
+    {
+      channel: "Telegram",
+      config: "test/vitest/vitest.extension-telegram.config.ts",
+    },
+    { channel: "Matrix", config: "test/vitest/vitest.extension-matrix.config.ts" },
+  ])("preserves an externally scoped $channel config target", ({ config }) => {
+    expect(
+      buildVitestRunPlans([config], process.cwd(), () => [], {
+        env: { OPENCLAW_VITEST_INCLUDE_FILE: "ci-shard.json" },
+      }),
+    ).toEqual([
+      {
+        config,
+        forwardedArgs: [],
+        includePatterns: null,
+        watchMode: false,
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      channel: "Telegram",
+      config: "test/vitest/vitest.extension-telegram.config.ts",
+      directory: "extensions/telegram",
+    },
+    {
+      channel: "Matrix",
+      config: "test/vitest/vitest.extension-matrix.config.ts",
+      directory: "extensions/matrix",
+    },
+  ])("preserves an externally scoped $channel directory run spec", ({ config, directory }) => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-external-test-scope-"));
+    try {
+      const includeFile = path.join(tempDir, "ci-shard.json");
+      fs.writeFileSync(includeFile, JSON.stringify([`${directory}/src/example.test.ts`]));
+      const [spec] = createVitestRunSpecs([directory], {
+        baseEnv: { OPENCLAW_VITEST_INCLUDE_FILE: includeFile },
+        tempDir,
+      });
+
+      expect(spec).toMatchObject({
+        config,
+        env: { OPENCLAW_VITEST_INCLUDE_FILE: includeFile },
+        includeFilePath: null,
+        includePatterns: null,
+      });
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it("bounds an explicit Matrix directory target across process lifetimes", () => {
     const plans = buildVitestRunPlans(["extensions/matrix"], process.cwd());
 


### PR DESCRIPTION
## Problem

#123514 bounded full Telegram Vitest processes, but its planner expansion also replaced each already-scoped CI shard with the entire Telegram suite. Run 31776262200 proved the result: jobs 5/6/7/8/9/12/16 each repeated the same 14 chunks, then stalled twice after `bot-native-command-login.test.ts` and exited 143.

## Root cause

`createBoundedExtensionPlans` treated an explicit config as broad even when `OPENCLAW_VITEST_INCLUDE_FILE` already owned the five-file CI scope. Directory targets could also generate a replacement include file downstream.

## Fix

Preserve the authoritative external include scope across config, full-extension, and directory planner routes. Continue chunking genuinely broad Telegram and Matrix runs. No provider runtime behavior changes.

Production delta: +11 net script-support lines. Test delta: +53 lines. The production growth carries the existing injected environment contract through all three shared bounded-extension routes and clears generated directory patterns before run-spec creation.

## Proof

- Owner-boundary regression before fix: expected one scoped plan; received 42 full Telegram plans.
- Focused suite after fix: 269/269 passed, including Telegram and Matrix config plus directory run-spec coverage.
- Planner probe: scoped Telegram `1` plan; broad Telegram `42` plans.
- Oxfmt, type-aware Oxlint, `git diff --check`, `pnpm tsgo:scripts`, and `pnpm tsgo:test:root`: passed.
- Distill: no findings.
- Greybeard: no findings; restores 42 processes/210 files instead of 1,764 processes/8,820 repeated files.
- First exact-head ClawSweeper finding addressed: preserve the external include file for directory targets and cover the run-spec boundary.
- Exact-head CI run 31778619351: passed, including `checks-fast-ci-routing` and `ci-gate`.
