### PR TITLE
fix(ui): avoid session catalog refresh storms

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-live.test.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.test.ts
@@ -93,4 +93,20 @@ describe("SessionCatalogLiveState", () => {
     expect(result?.materialChange).toBe(false);
     expect(live.sawChange).toBe(false);
   });
+
+  it.each([
+    ["mode-less client", { deviceId: "legacy-client" }, false],
+    ["browser with a node role", { deviceId: "browser", mode: "webchat", roles: ["node"] }, false],
+    [
+      "operator with a node role",
+      { deviceId: "operator", mode: "operator", roles: ["node"] },
+      false,
+    ],
+    ["node with an operator role", { deviceId: "node", mode: "node", roles: ["operator"] }, true],
+    ["legacy node role", { deviceId: "legacy-node", roles: ["node"] }, true],
+  ] as const)("classifies %s presence for catalog refreshes", (_name, entry, expected) => {
+    const live = new SessionCatalogLiveState();
+
+    expect(live.observePresence({ presence: [entry] })).toBe(expected);
+  });
 });

--- a/ui/src/components/app-sidebar-session-catalog-live.test.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
+
+describe("SessionCatalogLiveState presence refreshes", () => {
+  it("ignores mode-less and non-node presence churn", () => {
+    const live = new SessionCatalogLiveState();
+
+    expect(live.observePresence({ presence: [{ deviceId: "legacy-client" }] })).toBe(false);
+    expect(
+      live.observePresence({ presence: [{ deviceId: "operator-client", mode: "operator" }] }),
+    ).toBe(false);
+    expect(
+      live.observePresence({ presence: [{ deviceId: "browser-client", mode: "webchat" }] }),
+    ).toBe(false);
+    expect(
+      live.observePresence({
+        presence: [{ deviceId: "operator-client", mode: "node", roles: ["operator"] }],
+      }),
+    ).toBe(false);
+    expect(
+      live.observePresence({
+        presence: [{ deviceId: "malformed-client", mode: "node", roles: [7, null] }],
+      }),
+    ).toBe(false);
+  });
+
+  it("invalidates when explicit node presence changes", () => {
+    const live = new SessionCatalogLiveState();
+
+    expect(live.observePresence({ presence: [{ deviceId: "devbox", mode: "node" }] })).toBe(true);
+    expect(live.observePresence({ presence: [{ deviceId: "devbox", mode: "node" }] })).toBe(false);
+    expect(
+      live.observePresence({
+        presence: [{ deviceId: "devbox", mode: "node", reason: "disconnect" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a mode-less presence entry with an authenticated node role", () => {
+    const live = new SessionCatalogLiveState();
+
+    expect(live.observePresence({ presence: [{ deviceId: "legacy-node", roles: ["node"] }] })).toBe(
+      true,
+    );
+  });
+});

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -106,6 +106,7 @@ export class SessionCatalogLiveState {
   progressive = true;
 
   private activationTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private activationQueueIfActive = false;
   private connectionEpoch = 0;
   private refetchOwner: symbol | null = null;
   private presenceSignature: string | null = null;
@@ -309,7 +310,15 @@ export class SessionCatalogLiveState {
       const rawId = typeof record.deviceId === "string" ? record.deviceId : record.instanceId;
       const id = typeof rawId === "string" ? rawId.trim().toLowerCase() : "";
       const mode = typeof record.mode === "string" ? record.mode.trim().toLowerCase() : "";
-      if (!id || mode === "gateway") {
+      // Catalog hosts are native nodes. Browser/operator churn cannot change that inventory;
+      // older nodes may omit mode, so only then does the authenticated role decide.
+      const isNodePresence = mode
+        ? mode === "node"
+        : Array.isArray(record.roles) &&
+          record.roles.some(
+            (role) => typeof role === "string" && role.trim().toLowerCase() === "node",
+          );
+      if (!id || !isNodePresence) {
         continue;
       }
       const reason = typeof record.reason === "string" ? record.reason.trim().toLowerCase() : "";
@@ -409,14 +418,20 @@ export class SessionCatalogLiveState {
     visible: boolean;
     connected: boolean;
     generation: number;
+    queueIfActive: boolean;
     refresh: () => void;
   }) {
     if (!params.visible || !params.connected) {
       return;
     }
+    // Focus can fire without a hidden interval. Preserve the existing freshness poll and
+    // do not queue behind an active request unless a real visibility/presence change occurred.
+    if (!params.queueIfActive && this.timer !== null) {
+      return;
+    }
     this.cancelTimer();
     if (this.requestGeneration === params.generation) {
-      this.refreshPending = true;
+      this.refreshPending ||= params.queueIfActive;
       return;
     }
     params.refresh();
@@ -424,6 +439,7 @@ export class SessionCatalogLiveState {
 
   cancelActivation() {
     this.cancelTimer("activationTimer");
+    this.activationQueueIfActive = false;
   }
 
   cancelScheduledRefreshes() {
@@ -431,7 +447,8 @@ export class SessionCatalogLiveState {
     this.cancelActivation();
   }
 
-  scheduleActivation(refresh: () => void) {
+  scheduleActivation(queueIfActive: boolean, refresh: (queueIfActive: boolean) => void) {
+    this.activationQueueIfActive ||= queueIfActive;
     if (this.activationTimer !== null) {
       return;
     }
@@ -439,7 +456,9 @@ export class SessionCatalogLiveState {
     // One short window keeps the burst to a single fleet scan.
     this.activationTimer = globalThis.setTimeout(() => {
       this.activationTimer = null;
-      refresh();
+      const shouldQueue = this.activationQueueIfActive;
+      this.activationQueueIfActive = false;
+      refresh(shouldQueue);
     }, 50);
   }
 }

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -106,6 +106,7 @@ export class SessionCatalogLiveState {
   progressive = true;
 
   private activationTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private activationQueueIfActive = false;
   private connectionEpoch = 0;
   private refetchOwner: symbol | null = null;
   private presenceSignature: string | null = null;
@@ -309,7 +310,17 @@ export class SessionCatalogLiveState {
       const rawId = typeof record.deviceId === "string" ? record.deviceId : record.instanceId;
       const id = typeof rawId === "string" ? rawId.trim().toLowerCase() : "";
       const mode = typeof record.mode === "string" ? record.mode.trim().toLowerCase() : "";
-      if (!id || mode === "gateway") {
+      const authenticatedRoles = Array.isArray(record.roles)
+        ? record.roles.filter((role: unknown): role is string => typeof role === "string")
+        : null;
+      const hasAuthenticatedRoles = authenticatedRoles !== null;
+      const hasNodeRole =
+        authenticatedRoles?.some((role) => role.trim().toLowerCase() === "node") === true;
+      // Catalog hosts are native node connections. Browser/operator presence changes on
+      // every tab connect, disconnect, and watched-session update, but cannot change the
+      // native host inventory and must not trigger another full catalog scan. Older nodes
+      // can omit mode, but their authenticated node role remains authoritative.
+      if (!id || (hasAuthenticatedRoles ? !hasNodeRole : mode !== "node")) {
         continue;
       }
       const reason = typeof record.reason === "string" ? record.reason.trim().toLowerCase() : "";
@@ -397,14 +408,21 @@ export class SessionCatalogLiveState {
     visible: boolean;
     connected: boolean;
     generation: number;
+    queueIfActive: boolean;
     refresh: () => void;
   }) {
     if (!params.visible || !params.connected) {
       return;
     }
+    // A visible tab already has a freshness poll scheduled after its last request.
+    // Window focus can fire during startup and browser activation without the page
+    // ever becoming hidden, so it must not replace that poll with an immediate scan.
+    if (!params.queueIfActive && this.timer !== null) {
+      return;
+    }
     this.cancelTimer();
     if (this.requestGeneration === params.generation) {
-      this.refreshPending = true;
+      this.refreshPending ||= params.queueIfActive;
       return;
     }
     params.refresh();
@@ -412,6 +430,7 @@ export class SessionCatalogLiveState {
 
   cancelActivation() {
     this.cancelTimer("activationTimer");
+    this.activationQueueIfActive = false;
   }
 
   cancelScheduledRefreshes() {
@@ -419,7 +438,8 @@ export class SessionCatalogLiveState {
     this.cancelActivation();
   }
 
-  scheduleActivation(refresh: () => void) {
+  scheduleActivation(queueIfActive: boolean, refresh: (queueIfActive: boolean) => void) {
+    this.activationQueueIfActive ||= queueIfActive;
     if (this.activationTimer !== null) {
       return;
     }
@@ -427,7 +447,9 @@ export class SessionCatalogLiveState {
     // One short window keeps the burst to a single fleet scan.
     this.activationTimer = globalThis.setTimeout(() => {
       this.activationTimer = null;
-      refresh();
+      const shouldQueue = this.activationQueueIfActive;
+      this.activationQueueIfActive = false;
+      refresh(shouldQueue);
     }, 50);
   }
 }

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -112,25 +112,27 @@ export function resolveSessionCatalogAgentId(
   return selected && selected !== helloDefault ? null : helloDefault;
 }
 
-function requestSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
-  const snapshot = owner.context?.gateway.snapshot;
-  owner.sessionCatalogLive.requestRefresh({
-    visible: document.visibilityState !== "hidden",
-    connected:
-      owner.isSessionDataHostConnected &&
-      owner.sessionCatalogAgentId !== null &&
-      Boolean(sessionCatalogListClient(snapshot, owner.sessionDataHostConnected)),
-    generation: owner.sessionScopeGeneration,
-    refresh: () => void owner.refreshSessionCatalogs(),
-  });
-}
-
-export function scheduleSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
+export function scheduleSessionCatalogRefresh(
+  owner: SessionCatalogDataOwner,
+  queueIfActive = false,
+): void {
   if (document.visibilityState === "hidden") {
     owner.sessionCatalogLive.cancelScheduledRefreshes();
     return;
   }
-  owner.sessionCatalogLive.scheduleActivation(() => requestSessionCatalogRefresh(owner));
+  owner.sessionCatalogLive.scheduleActivation(queueIfActive, (shouldQueue) => {
+    const snapshot = owner.context?.gateway.snapshot;
+    owner.sessionCatalogLive.requestRefresh({
+      visible: document.visibilityState !== "hidden",
+      connected:
+        owner.isSessionDataHostConnected &&
+        owner.sessionCatalogAgentId !== null &&
+        Boolean(sessionCatalogListClient(snapshot, owner.sessionDataHostConnected)),
+      generation: owner.sessionScopeGeneration,
+      queueIfActive: shouldQueue,
+      refresh: () => void owner.refreshSessionCatalogs(),
+    });
+  });
 }
 
 export function updateSessionCatalogData(owner: SessionCatalogDataOwner, defer = false): void {
@@ -156,7 +158,7 @@ export function applySessionCatalogPresence(
   payload: unknown,
 ): void {
   if (owner.sessionCatalogLive.observePresence(payload)) {
-    scheduleSessionCatalogRefresh(owner);
+    scheduleSessionCatalogRefresh(owner, true);
   }
 }
 

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -112,7 +112,10 @@ export function resolveSessionCatalogAgentId(
   return selected && selected !== helloDefault ? null : helloDefault;
 }
 
-function requestSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
+function requestSessionCatalogRefresh(
+  owner: SessionCatalogDataOwner,
+  queueIfActive: boolean,
+): void {
   const snapshot = owner.context?.gateway.snapshot;
   owner.sessionCatalogLive.requestRefresh({
     visible: document.visibilityState !== "hidden",
@@ -121,16 +124,22 @@ function requestSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
       owner.sessionCatalogAgentId !== null &&
       Boolean(sessionCatalogListClient(snapshot, owner.sessionDataHostConnected)),
     generation: owner.sessionScopeGeneration,
+    queueIfActive,
     refresh: () => void owner.refreshSessionCatalogs(),
   });
 }
 
-export function scheduleSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
+export function scheduleSessionCatalogRefresh(
+  owner: SessionCatalogDataOwner,
+  queueIfActive = false,
+): void {
   if (document.visibilityState === "hidden") {
     owner.sessionCatalogLive.cancelScheduledRefreshes();
     return;
   }
-  owner.sessionCatalogLive.scheduleActivation(() => requestSessionCatalogRefresh(owner));
+  owner.sessionCatalogLive.scheduleActivation(queueIfActive, (shouldQueue) =>
+    requestSessionCatalogRefresh(owner, shouldQueue),
+  );
 }
 
 export function updateSessionCatalogData(owner: SessionCatalogDataOwner, defer = false): void {
@@ -156,7 +165,7 @@ export function applySessionCatalogPresence(
   payload: unknown,
 ): void {
   if (owner.sessionCatalogLive.observePresence(payload)) {
-    scheduleSessionCatalogRefresh(owner);
+    scheduleSessionCatalogRefresh(owner, true);
   }
 }
 

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -348,8 +348,8 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     );
   };
 
-  private readonly handleSessionCatalogPageActivation = () => {
-    scheduleSessionCatalogRefresh(this);
+  private readonly handleSessionCatalogPageActivation = (event: Event) => {
+    scheduleSessionCatalogRefresh(this, event.type === "visibilitychange");
   };
 
   refreshSessionCatalogs(): Promise<void> {

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -456,6 +456,7 @@ suite.define(() => {
 
   it("auto-loads older chat without moving the viewport and disables paired-node continuation", async () => {
     const page = await suite.browser.newPage();
+    await page.clock.install();
     const catalogResponse = (threadId: string, name: string, nextCursor?: string) => ({
       catalogs: [
         {
@@ -549,17 +550,14 @@ suite.define(() => {
       cursors: { "node:devbox": "catalog-page-2" },
     });
     const catalogRequestCount = (await gateway.getRequests("sessions.catalog.list")).length;
-    await page.clock.install();
     await page.evaluate(() => window.dispatchEvent(new Event("focus")));
     await page.clock.runFor(50);
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
-      .toBeGreaterThanOrEqual(catalogRequestCount + 1);
+    expect((await gateway.getRequests("sessions.catalog.list")).length).toBe(catalogRequestCount);
     await page.clock.fastForward(30_000);
     await page.clock.runFor(100);
     await expect
       .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
-      .toBeGreaterThanOrEqual(catalogRequestCount + 2);
+      .toBeGreaterThanOrEqual(catalogRequestCount + 1);
     await page.getByText("Older remote review", { exact: true }).waitFor();
     await page.getByText("Remote architecture review", { exact: true }).click();
     await expect.poll(() => page.getByText("newer answer", { exact: true }).count()).toBe(1);

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -456,6 +456,7 @@ suite.define(() => {
 
   it("auto-loads older chat without moving the viewport and disables paired-node continuation", async () => {
     const page = await suite.browser.newPage();
+    await page.clock.install();
     const catalogResponse = (threadId: string, name: string, nextCursor?: string) => ({
       catalogs: [
         {
@@ -550,17 +551,14 @@ suite.define(() => {
       cursors: { "node:devbox": "catalog-page-2" },
     });
     const catalogRequestCount = (await gateway.getRequests("sessions.catalog.list")).length;
-    await page.clock.install();
     await page.evaluate(() => window.dispatchEvent(new Event("focus")));
     await page.clock.runFor(50);
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
-      .toBeGreaterThanOrEqual(catalogRequestCount + 1);
+    expect((await gateway.getRequests("sessions.catalog.list")).length).toBe(catalogRequestCount);
     await page.clock.fastForward(30_000);
     await page.clock.runFor(100);
     await expect
       .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
-      .toBeGreaterThanOrEqual(catalogRequestCount + 2);
+      .toBeGreaterThanOrEqual(catalogRequestCount + 1);
     await catalog.getByRole("link", { name: "Older remote review", exact: true }).waitFor();
     const remote = catalog.getByRole("link", { name: /^Remote architecture review$/ });
     await remote.hover();

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
@@ -12,6 +12,112 @@ import {
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar session catalog pagination", () => {
+  it("does not queue another scan when focus returns during the startup scan", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = deferred<SessionsCatalogListResult>();
+      const request = vi.fn().mockReturnValue(pending.promise);
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledOnce();
+
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(50);
+      pending.resolve(catalogPage([]));
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(request).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the scheduled freshness poll when a visible page receives focus", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn().mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledOnce();
+
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(request).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(29_950);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("queues a fresh scan when a hidden tab returns during an active scan", async () => {
+    vi.useFakeTimers();
+    let visibility: DocumentVisibilityState = "visible";
+    const visibilitySpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockImplementation(() => visibility);
+    try {
+      const pending = deferred<SessionsCatalogListResult>();
+      const request = vi
+        .fn()
+        .mockReturnValueOnce(pending.promise)
+        .mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledOnce();
+
+      visibility = "hidden";
+      document.dispatchEvent(new Event("visibilitychange"));
+      visibility = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(request).toHaveBeenCalledOnce();
+
+      pending.resolve(catalogPage([]));
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      visibilitySpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("coalesces the visibility and focus events from one tab activation", async () => {
     vi.useFakeTimers();
     let visibility: DocumentVisibilityState = "visible";

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-events.ts
@@ -12,6 +12,148 @@ import {
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar session catalog pagination", () => {
+  it("does not queue a duplicate startup scan when focus returns during the first scan", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = deferred<SessionsCatalogListResult>();
+      const request = vi.fn().mockReturnValue(pending.promise);
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledOnce();
+
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(50);
+      pending.resolve(catalogPage([]));
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(request).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("queues a fresh scan when a hidden tab returns during an active scan", async () => {
+    vi.useFakeTimers();
+    let visibility: DocumentVisibilityState = "visible";
+    const visibilitySpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockImplementation(() => visibility);
+    try {
+      const pending = deferred<SessionsCatalogListResult>();
+      const request = vi
+        .fn()
+        .mockReturnValueOnce(pending.promise)
+        .mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledOnce();
+
+      visibility = "hidden";
+      document.dispatchEvent(new Event("visibilitychange"));
+      visibility = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(request).toHaveBeenCalledOnce();
+
+      pending.resolve(catalogPage([]));
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      visibilitySpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the scheduled freshness poll when a visible page receives focus", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn().mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledOnce();
+
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(request).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(29_950);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores browser presence churn when deciding whether native catalogs changed", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn().mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledOnce();
+
+      gateway.publishEvent("presence", {
+        presence: [{ deviceId: "browser-1", mode: "webchat", reason: "connect" }],
+      });
+      gateway.publishEvent("presence", {
+        presence: [
+          { deviceId: "browser-1", mode: "webchat", reason: "connect" },
+          { deviceId: "browser-2", mode: "webchat", reason: "connect" },
+        ],
+      });
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(request).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("coalesces the visibility and focus events from one tab activation", async () => {
     vi.useFakeTimers();
     let visibility: DocumentVisibilityState = "visible";
@@ -178,6 +320,66 @@ describe("AppSidebar session catalog pagination", () => {
       await vi.advanceTimersByTimeAsync(30_000);
 
       expect(request).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves a native presence refresh when focus starts the activation burst", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn().mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+
+      globalThis.dispatchEvent(new Event("focus"));
+      gateway.publishEvent("presence", {
+        presence: [{ deviceId: "node-1", mode: "node", reason: "connect" }],
+      });
+      await vi.advanceTimersByTimeAsync(49);
+      expect(request).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refreshes catalogs for compatible native presence without a mode", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn().mockResolvedValue(catalogPage([]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+
+      gateway.publishEvent("presence", {
+        presence: [{ deviceId: "node-1", roles: ["node"], reason: "connect" }],
+      });
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(request).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## What Problem This Solves

The sidebar session catalog can launch redundant full refreshes when a visible browser window receives focus, when browser/operator presence changes, or when focus arrives during an active startup request. Those events cannot all change the native catalog inventory, but they currently replace the scheduled freshness poll or queue another scan.

## Why This Change Was Made

The catalog lifecycle now distinguishes passive focus from real visibility/native-presence changes. Explicit presence `mode` is authoritative; the authenticated `node` role is used only for older mode-less node records. Activation bursts still coalesce, while a real hidden-to-visible transition can queue one required follow-up behind an active request.

This PR is now standalone on `main`; it no longer depends on #123482.

## User Impact

Opening or focusing the Control UI no longer causes catalog refresh storms, while native node changes and a returning hidden tab still refresh promptly.

## Evidence

- Five focused regressions failed on current `main`: three presence-classification cases and two duplicate-focus scans.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar-session-catalog-live.test.ts ui/src/components/app-sidebar.test.ts` — 311/311 passing.
- `node scripts/run-vitest.mjs ui/src/e2e/claude-sessions.e2e.test.ts` — 8/8 passing; proves focus preserves the scheduled poll.
- Scoped UI/core-test typechecks, lint, formatting, dead-export, dependency, patch, max-lines, and assertion-safety checks passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Production LOC: +43/-22 (net +21), required to preserve queued real changes while suppressing passive focus/browser churn. Tests/test support: +125/-5.
- Current head: `746d759ed720662f261ffcfa574c8df7a2ba789e`.
