### PR TITLE
fix(macos): prevent app-owned child processes surviving shutdown

### DIFF
--- a/apps/macos/Sources/OpenClaw/ManagedProcess.swift
+++ b/apps/macos/Sources/OpenClaw/ManagedProcess.swift
@@ -1,0 +1,215 @@
+import Darwin
+import Foundation
+import Subprocess
+
+final class ManagedProcess: @unchecked Sendable {
+    private enum WakeReason: Sendable {
+        case exited
+        case terminate(gracefully: Bool)
+    }
+
+    private struct StartFailure: LocalizedError, Sendable {
+        let message: String
+        var errorDescription: String? {
+            self.message
+        }
+    }
+
+    private final class State: @unchecked Sendable {
+        private let lock = NSLock()
+        private var childHandles: [FileHandle]
+        private var finished = false
+        private var status: TerminationStatus?
+
+        init(childHandles: [FileHandle]) {
+            self.childHandles = childHandles
+        }
+
+        var isRunning: Bool {
+            self.lock.withLock { !self.finished }
+        }
+
+        var terminationStatus: TerminationStatus? {
+            self.lock.withLock { self.status }
+        }
+
+        func closeChildHandles() {
+            let handles = self.lock.withLock {
+                defer { self.childHandles.removeAll() }
+                return self.childHandles
+            }
+            handles.forEach { try? $0.close() }
+        }
+
+        func finish(status: TerminationStatus?) {
+            self.lock.withLock { (self.finished, self.status) = (true, status) }
+        }
+
+        static func hasExited(_ processIdentifier: pid_t) -> Bool {
+            var info = siginfo_t()
+            return waitid(P_PID, id_t(processIdentifier), &info, WEXITED | WNOHANG | WNOWAIT) == 0 &&
+                info.si_pid != 0
+        }
+    }
+
+    private let state: State
+    private let startEvents: AsyncStream<Result<pid_t, StartFailure>>
+    private let wakeContinuation: AsyncStream<WakeReason>.Continuation
+    let completionTask: Task<TerminationStatus?, Never>
+
+    var isRunning: Bool {
+        self.state.isRunning
+    }
+
+    var terminationStatus: TerminationStatus? {
+        self.state.terminationStatus
+    }
+
+    private init(
+        state: State,
+        startEvents: AsyncStream<Result<pid_t, StartFailure>>,
+        wakeContinuation: AsyncStream<WakeReason>.Continuation,
+        completionTask: Task<TerminationStatus?, Never>)
+    {
+        self.state = state
+        self.startEvents = startEvents
+        self.wakeContinuation = wakeContinuation
+        self.completionTask = completionTask
+    }
+
+    static func launch(
+        configuration: Subprocess.Configuration,
+        input: some InputProtocol,
+        output: some OutputProtocol,
+        error: some ErrorOutputProtocol,
+        closeAfterSpawn childHandles: [FileHandle] = [],
+        closeStdinForGracefulShutdown stdinHandle: FileHandle? = nil,
+        gracefulShutdownTimeout: Duration = .zero) -> ManagedProcess
+    {
+        var configuration = configuration
+        configuration.platformOptions.createSession = true
+        configuration.platformOptions.teardownSequence = [
+            .send(signal: .terminate, toProcessGroup: true, allowedDurationToNextStep: .milliseconds(250)),
+        ]
+        let state = State(childHandles: childHandles)
+        let (startEvents, startContinuation) = AsyncStream.makeStream(of: Result<pid_t, StartFailure>.self)
+        let (wakeEvents, wakeContinuation) = AsyncStream.makeStream(
+            of: WakeReason.self,
+            bufferingPolicy: .bufferingNewest(1))
+        let task = Task.detached(priority: .userInitiated) { () -> TerminationStatus? in
+            do {
+                let result = try await Subprocess.run(
+                    configuration,
+                    input: input,
+                    output: output,
+                    error: error)
+                { execution in
+                    let pid = pid_t(execution.processIdentifier.value)
+                    state.closeChildHandles()
+                    startContinuation.yield(.success(pid))
+
+                    let exitSource = DispatchSource.makeProcessSource(
+                        identifier: pid,
+                        eventMask: .exit,
+                        queue: .global(qos: .userInitiated))
+                    exitSource.setEventHandler { wakeContinuation.yield(.exited) }
+                    exitSource.resume()
+                    if State.hasExited(pid) { wakeContinuation.yield(.exited) }
+                    var wakeIterator = wakeEvents.makeAsyncIterator()
+                    let wakeReason = await wakeIterator.next() ?? .terminate(gracefully: true)
+                    exitSource.cancel()
+
+                    func killGroup() async {
+                        try? execution.send(signal: .kill, toProcessGroup: true)
+                        try? await Task.sleep(for: .milliseconds(50))
+                    }
+
+                    guard !State.hasExited(pid), case let .terminate(gracefully) = wakeReason else {
+                        // The unreaped leader pins the group identity while descendants are killed.
+                        await killGroup()
+                        return
+                    }
+                    if graceful, let stdinHandle {
+                        try? stdinHandle.close()
+                        if await self.waitForExit(pid, timeout: gracefulShutdownTimeout) {
+                            await killGroup()
+                            return
+                        }
+                    }
+                    try? await Task.sleep(for: .milliseconds(10))
+                    try? execution.send(signal: .terminate, toProcessGroup: true)
+                    _ = await self.waitForExit(pid, timeout: .milliseconds(250))
+                    await killGroup()
+                }
+                state.finish(status: result.terminationStatus)
+                return result.terminationStatus
+            } catch {
+                state.closeChildHandles()
+                let message = (error as? SubprocessError)?.description ?? error.localizedDescription
+                startContinuation.yield(.failure(StartFailure(message: message)))
+                state.finish(status: nil)
+                return nil
+            }
+        }
+        return ManagedProcess(
+            state: state,
+            startEvents: startEvents,
+            wakeContinuation: wakeContinuation,
+            completionTask: task)
+    }
+
+    static func launch(
+        configuration: Subprocess.Configuration,
+        stdin: FileHandle,
+        stdout: FileHandle,
+        stderr: FileHandle,
+        closeStdinForGracefulShutdown stdinWriter: FileHandle? = nil,
+        gracefulShutdownTimeout: Duration = .zero) -> ManagedProcess
+    {
+        self.launch(
+            configuration: configuration,
+            input: .fileDescriptor(.init(rawValue: stdin.fileDescriptor), closeAfterSpawningProcess: false),
+            output: .fileDescriptor(.init(rawValue: stdout.fileDescriptor), closeAfterSpawningProcess: false),
+            error: .fileDescriptor(.init(rawValue: stderr.fileDescriptor), closeAfterSpawningProcess: false),
+            closeAfterSpawn: [stdin, stdout, stderr],
+            closeStdinForGracefulShutdown: stdinWriter,
+            gracefulShutdownTimeout: gracefulShutdownTimeout)
+    }
+
+    static func environment(from values: [String: String]) -> Environment {
+        .custom(values.reduce(into: [:]) { result, element in
+            if let key = Environment.Key(rawValue: element.key) { result[key] = element.value }
+        })
+    }
+
+    func waitUntilStarted() async throws -> pid_t {
+        var iterator = self.startEvents.makeAsyncIterator()
+        return try await iterator.next()!.get()
+    }
+
+    func requestTermination(gracefully: Bool = true) {
+        self.wakeContinuation.yield(.terminate(gracefully: gracefully))
+    }
+
+    func wait() async {
+        _ = await self.completionTask.value
+    }
+
+    func terminate(gracefully: Bool = true) async {
+        self.requestTermination(gracefully: gracefully)
+        await self.wait()
+    }
+
+    deinit {
+        self.requestTermination()
+    }
+
+    private static func waitForExit(_ processIdentifier: pid_t, timeout: Duration) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if State.hasExited(processIdentifier) { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return State.hasExited(processIdentifier)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/ManagedProcess.swift
+++ b/apps/macos/Sources/OpenClaw/ManagedProcess.swift
@@ -124,7 +124,9 @@ final class ManagedProcess: @unchecked Sendable {
                         try? await Task.sleep(for: .milliseconds(50))
                     }
 
-                    guard !State.hasExited(pid), case let .terminate(gracefully) = wakeReason else {
+                    guard !State.hasExited(pid),
+                          case let .terminate(gracefully: graceful) = wakeReason
+                    else {
                         // The unreaped leader pins the group identity while descendants are killed.
                         await killGroup()
                         return

--- a/apps/macos/Sources/OpenClaw/ManagedProcess.swift
+++ b/apps/macos/Sources/OpenClaw/ManagedProcess.swift
@@ -18,6 +18,7 @@ final class ManagedProcess: @unchecked Sendable {
     private final class State: @unchecked Sendable {
         private let lock = NSLock()
         private var childHandles: [FileHandle]
+        private var abortiveTerminationRequested = false
         private var finished = false
         private var status: TerminationStatus?
 
@@ -31,6 +32,14 @@ final class ManagedProcess: @unchecked Sendable {
 
         var terminationStatus: TerminationStatus? {
             self.lock.withLock { self.status }
+        }
+
+        var shouldAbortGracefulTermination: Bool {
+            self.lock.withLock { self.abortiveTerminationRequested }
+        }
+
+        func requestAbortiveTermination() {
+            self.lock.withLock { self.abortiveTerminationRequested = true }
         }
 
         func closeChildHandles() {
@@ -133,7 +142,11 @@ final class ManagedProcess: @unchecked Sendable {
                     }
                     if graceful, let stdinHandle {
                         try? stdinHandle.close()
-                        if await self.waitForExit(pid, timeout: gracefulShutdownTimeout) {
+                        if await self.waitForExit(
+                            pid,
+                            timeout: gracefulShutdownTimeout,
+                            interruptWhenAbortive: state)
+                        {
                             await killGroup()
                             return
                         }
@@ -190,6 +203,9 @@ final class ManagedProcess: @unchecked Sendable {
     }
 
     func requestTermination(gracefully: Bool = true) {
+        if !gracefully {
+            self.state.requestAbortiveTermination()
+        }
         self.wakeContinuation.yield(.terminate(gracefully: gracefully))
     }
 
@@ -206,11 +222,20 @@ final class ManagedProcess: @unchecked Sendable {
         self.requestTermination()
     }
 
-    private static func waitForExit(_ processIdentifier: pid_t, timeout: Duration) async -> Bool {
+    private static func waitForExit(
+        _ processIdentifier: pid_t,
+        timeout: Duration,
+        interruptWhenAbortive state: State? = nil) async -> Bool
+    {
         let deadline = ContinuousClock.now.advanced(by: timeout)
         while ContinuousClock.now < deadline {
             if State.hasExited(processIdentifier) { return true }
-            try? await Task.sleep(for: .milliseconds(10))
+            if state?.shouldAbortGracefulTermination == true { return false }
+            do {
+                try await Task.sleep(for: .milliseconds(10))
+            } catch {
+                return false
+            }
         }
         return State.hasExited(processIdentifier)
     }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalogClient.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalogClient.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import Subprocess
 
 final class MacNodeCodexThreadCatalogClient: @unchecked Sendable {
     private let loadRoot: () -> [String: Any]
@@ -82,23 +83,21 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
     private final class Connection: @unchecked Sendable {
         enum Lifecycle {
             case running
-            case stopping(abortive: Bool)
+            case stopping
         }
 
         let generation = UUID()
         let invocation: MacNodeCodexThreadCatalog.ResolvedInvocation
         let initializeRequestID: Int
-        let process = Process()
         let stdinPipe = Pipe()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
+        var process: ManagedProcess?
+        var cleanupTask: Task<Void, Never>?
         var stdoutBuffer = Data()
         var initialized = false
-        var exited = false
         var stdoutReachedEOF = false
         var lifecycle: Lifecycle = .running
-        var stopWaiters: [CheckedContinuation<Void, Never>] = []
-        var stopDeadline: DispatchSourceTimer?
 
         init(
             invocation: MacNodeCodexThreadCatalog.ResolvedInvocation,
@@ -111,7 +110,6 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
 
     private static let maxQueuedRequests = 64
     private static let maxStdoutDrainBytes = 256 * 1024
-    private static let stopDeadlineSeconds = AppTerminationTiming.cleanupDeadlineSeconds * 0.75
 
     private let queue = DispatchQueue(label: "ai.openclaw.codex-thread-catalog")
     private let idleTimeoutSeconds: Double
@@ -132,9 +130,7 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
 
     deinit {
         self.cancelIdleTimer()
-        // Runtime/coordinator teardown awaits shutdown(). Deinit stays EOF-only
-        // best effort so it cannot create a second untracked process-reaper path.
-        try? self.connection?.stdinPipe.fileHandleForWriting.close()
+        self.connection?.process?.requestTermination()
     }
 
     func request(
@@ -190,7 +186,7 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
     }
 
     func shutdown() async {
-        await withCheckedContinuation { continuation in
+        let cleanup: Task<Void, Never>? = await withCheckedContinuation { continuation in
             self.queue.async {
                 self.cancelIdleTimer()
                 if let active = self.active {
@@ -202,9 +198,10 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
                 for request in pending {
                     self.complete(request, with: .failure(CancellationError()))
                 }
-                self.stopConnection(abortive: false, waiter: continuation)
+                continuation.resume(returning: self.stopConnection(abortive: false))
             }
         }
+        await cleanup?.value
     }
 
     private func takeRequestIDOnQueue() -> Int {
@@ -233,8 +230,7 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
         let request = self.pending[0]
         if let connection = self.connection {
             guard case .running = connection.lifecycle else { return }
-            if connection.exited ||
-                !connection.process.isRunning ||
+            if connection.process?.isRunning != true ||
                 connection.invocation != request.invocation
             {
                 // Invocation replacement is graceful, but the successor remains
@@ -258,20 +254,11 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
             invocation: request.invocation,
             initializeRequestID: self.takeRequestIDOnQueue())
         self.connection = connection
-        let process = connection.process
-        process.executableURL = URL(fileURLWithPath: request.invocation.executable)
-        process.arguments = request.invocation.arguments
-        process.currentDirectoryURL = request.invocation.cwd
         var environment = ProcessInfo.processInfo.environment
         environment["PATH"] = CommandResolver.preferredPaths().joined(separator: ":")
         for key in request.invocation.clearEnv {
             environment.removeValue(forKey: key)
         }
-        process.environment = environment
-        process.standardInput = connection.stdinPipe
-        process.standardOutput = connection.stdoutPipe
-        process.standardError = connection.stderrPipe
-
         // DispatchSource readability callbacks may be followed by future drain
         // loops. Keep both pipes non-blocking so an open App Server cannot stall
         // the catalog handshake after emitting one JSON-RPC frame.
@@ -289,21 +276,48 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
                 handle.readabilityHandler = nil
             }
         }
-        process.terminationHandler = { [weak self] _ in
-            guard let self else { return }
-            self.queue.async {
-                self.handleTermination(generation: generation)
+        let configuration = Subprocess.Configuration(
+            .path(.init(request.invocation.executable)),
+            arguments: Arguments(request.invocation.arguments),
+            environment: ManagedProcess.environment(from: environment),
+            workingDirectory: request.invocation.cwd.map { .init($0.path) })
+        // Codex stdio exits on EOF; its upstream harness allows 200 ms before forced termination.
+        let process = ManagedProcess.launch(
+            configuration: configuration,
+            stdin: connection.stdinPipe.fileHandleForReading,
+            stdout: connection.stdoutPipe.fileHandleForWriting,
+            stderr: connection.stderrPipe.fileHandleForWriting,
+            closeStdinForGracefulShutdown: connection.stdinPipe.fileHandleForWriting,
+            gracefulShutdownTimeout: .milliseconds(200))
+        connection.process = process
+        Task { [weak self] in
+            let started = await (try? process.waitUntilStarted()) != nil
+            self?.queue.async { [weak self] in
+                self?.finishConnectionLaunch(started: started, generation: generation)
             }
         }
+    }
 
-        do {
-            try process.run()
-        } catch {
+    private func finishConnectionLaunch(
+        started: Bool,
+        generation: UUID)
+    {
+        guard let connection = self.connection,
+              connection.generation == generation,
+              connection.cleanupTask == nil
+        else { return }
+        guard started, let process = connection.process else {
             self.discardUnstartedConnection(connection)
             self.finishActive(
                 .failure(MacNodeCodexThreadCatalog.CatalogError.appServerUnavailable),
                 restartConnection: false)
             return
+        }
+        Task { [weak self, completionTask = process.completionTask] in
+            _ = await completionTask.value
+            self?.queue.async { [weak self] in
+                self?.handleTermination(generation: generation)
+            }
         }
         do {
             try self.write(
@@ -373,6 +387,11 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
             }
             if errno == EINTR { continue }
             if errno == EAGAIN || errno == EWOULDBLOCK {
+                if connection.process?.isRunning == false {
+                    self.queue.asyncAfter(deadline: .now() + .milliseconds(1)) { [weak self] in
+                        self?.drainStdout(from: handle, generation: generation)
+                    }
+                }
                 return
             }
             connection.stdoutReachedEOF = true
@@ -457,7 +476,6 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
 
     private func handleTermination(generation: UUID) {
         guard let connection = self.connection, connection.generation == generation else { return }
-        connection.exited = true
         // A short-lived server can exit before its readability callback runs.
         // Drain its final frame before projecting termination onto the request.
         if !connection.stdoutReachedEOF {
@@ -471,8 +489,9 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
     private func finishTerminatedConnectionIfNeeded(generation: UUID) {
         guard let connection = self.connection,
               connection.generation == generation,
-              connection.exited,
-              connection.stdoutReachedEOF
+              connection.process?.isRunning == false,
+              connection.stdoutReachedEOF,
+              connection.cleanupTask == nil
         else { return }
 
         let wasRunning = if case .running = connection.lifecycle {
@@ -562,92 +581,53 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
         self.idleTimer = nil
     }
 
-    private func stopConnection(
-        abortive: Bool,
-        waiter: CheckedContinuation<Void, Never>? = nil)
-    {
-        guard let connection = self.connection else {
-            waiter?.resume()
-            return
+    @discardableResult
+    private func stopConnection(abortive: Bool) -> Task<Void, Never>? {
+        guard let connection = self.connection else { return nil }
+        if let cleanupTask = connection.cleanupTask {
+            if abortive {
+                connection.process?.requestTermination(gracefully: false)
+            }
+            return cleanupTask
         }
-        if let waiter {
-            connection.stopWaiters.append(waiter)
-        }
-        switch connection.lifecycle {
-        case let .stopping(wasAbortive):
-            if abortive, !wasAbortive {
-                connection.lifecycle = .stopping(abortive: true)
-                if connection.process.isRunning {
-                    connection.process.terminate()
+        guard let process = connection.process else { return nil }
+        connection.lifecycle = .stopping
+        let generation = connection.generation
+        let cleanupTask = Task { [weak self] in
+            await process.terminate(gracefully: !abortive)
+            await withCheckedContinuation { continuation in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                self.queue.async {
+                    if let current = self.connection, current.generation == generation {
+                        if !current.stdoutReachedEOF {
+                            self.drainStdout(
+                                from: current.stdoutPipe.fileHandleForReading,
+                                generation: generation)
+                        }
+                        self.retireConnection(current)
+                        self.startNextIfNeeded()
+                    }
+                    continuation.resume()
                 }
             }
-        case .running:
-            connection.lifecycle = .stopping(abortive: abortive)
-            try? connection.stdinPipe.fileHandleForWriting.close()
-            self.scheduleStopDeadline(for: connection)
-            if abortive, connection.process.isRunning {
-                connection.process.terminate()
-            } else if !connection.process.isRunning {
-                connection.exited = true
-                self.drainStdout(
-                    from: connection.stdoutPipe.fileHandleForReading,
-                    generation: connection.generation)
-                self.finishTerminatedConnectionIfNeeded(generation: connection.generation)
-            }
         }
+        connection.cleanupTask = cleanupTask
+        return cleanupTask
     }
 
     private func discardUnstartedConnection(_ connection: Connection) {
         guard self.connection?.generation == connection.generation else { return }
         self.connection = nil
         self.closeLocalPipeHandles(connection)
-        connection.process.terminationHandler = nil
     }
 
     private func retireConnection(_ connection: Connection) {
         guard self.connection?.generation == connection.generation else { return }
         self.connection = nil
-        connection.stopDeadline?.cancel()
-        connection.stopDeadline = nil
         self.closeLocalPipeHandles(connection)
-        connection.process.terminationHandler = nil
-        let waiters = connection.stopWaiters
-        connection.stopWaiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
-        }
-    }
-
-    private func scheduleStopDeadline(for connection: Connection) {
-        let generation = connection.generation
-        let timer = DispatchSource.makeTimerSource(queue: self.queue)
-        timer.schedule(deadline: .now() + Self.stopDeadlineSeconds)
-        timer.setEventHandler { [weak self] in
-            self?.forceStopConnection(generation: generation)
-        }
-        connection.stopDeadline = timer
-        timer.resume()
-    }
-
-    private func forceStopConnection(generation: UUID) {
-        guard let connection = self.connection,
-              connection.generation == generation,
-              case .stopping = connection.lifecycle
-        else { return }
-        connection.stopDeadline?.cancel()
-        connection.stopDeadline = nil
-        if connection.process.isRunning {
-            Darwin.kill(connection.process.processIdentifier, SIGKILL)
-        }
-        // stdout is O_NONBLOCK from launch, so descendants retaining the write
-        // end yield EAGAIN here instead of holding the lifecycle queue.
-        self.drainStdout(
-            from: connection.stdoutPipe.fileHandleForReading,
-            generation: generation)
-        guard self.connection?.generation == generation else { return }
-        self.closeLocalPipeHandles(connection)
-        connection.stdoutReachedEOF = true
-        self.finishTerminatedConnectionIfNeeded(generation: generation)
     }
 
     private func closeLocalPipeHandles(_ connection: Connection) {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalogClient.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalogClient.swift
@@ -110,6 +110,8 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
 
     private static let maxQueuedRequests = 64
     private static let maxStdoutDrainBytes = 256 * 1024
+    private static let gracefulShutdownTimeout: Duration = .seconds(
+        AppTerminationTiming.cleanupDeadlineSeconds * 0.75)
 
     private let queue = DispatchQueue(label: "ai.openclaw.codex-thread-catalog")
     private let idleTimeoutSeconds: Double
@@ -281,14 +283,14 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
             arguments: Arguments(request.invocation.arguments),
             environment: ManagedProcess.environment(from: environment),
             workingDirectory: request.invocation.cwd.map { .init($0.path) })
-        // Codex stdio exits on EOF; its upstream harness allows 200 ms before forced termination.
+        // Leave enough of the app's cleanup budget for group termination and joined reaping.
         let process = ManagedProcess.launch(
             configuration: configuration,
             stdin: connection.stdinPipe.fileHandleForReading,
             stdout: connection.stdoutPipe.fileHandleForWriting,
             stderr: connection.stderrPipe.fileHandleForWriting,
             closeStdinForGracefulShutdown: connection.stdinPipe.fileHandleForWriting,
-            gracefulShutdownTimeout: .milliseconds(200))
+            gracefulShutdownTimeout: Self.gracefulShutdownTimeout)
         connection.process = process
         Task { [weak self] in
             let started = await (try? process.waitUntilStarted()) != nil

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -2,6 +2,7 @@ import Darwin
 import Foundation
 import OpenClawKit
 import OSLog
+import Subprocess
 
 extension Notification.Name {
     static let openclawNodeHostWorkerFailed = Notification.Name("openclaw.node-host-worker.failed")
@@ -66,7 +67,8 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private let session: GatewayNodeSession
     private let startupTimeout: TimeInterval
     private let onUnexpectedExit: @Sendable () -> Void
-    private var process: Process?
+    private var process: ManagedProcess?
+    private var processCleanupTask: Task<Void, Never>?
     private var stdinPipe: Pipe?
     private var stdoutPipe: Pipe?
     private var stderrPipe: Pipe?
@@ -87,7 +89,6 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private var eventDeliveryTask: Task<Void, Never>?
     private var inventoryPublicationTask: Task<Void, Never>?
     private var inventoryPublicationGeneration: UInt64 = 0
-    private var stopping = false
 
     init(
         session: GatewayNodeSession,
@@ -287,12 +288,12 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     }
 
     func stop() async {
-        await withCheckedContinuation { continuation in
+        let cleanup: Task<Void, Never>? = await withCheckedContinuation { continuation in
             self.queue.async {
-                self.stopLocked(reason: "worker stopped")
-                continuation.resume()
+                continuation.resume(returning: self.stopLocked(reason: "worker stopped"))
             }
         }
+        await cleanup?.value
     }
 
     private func startLocked(launch: MacNodeHostWorkerLaunch) {
@@ -301,10 +302,17 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
             self.finishStartLocked(.failure(WorkerError.unavailable("node-host worker command missing")))
             return
         }
-        self.stopLocked(reason: "worker restarted", preserveStart: true)
-        self.stopping = false
-
-        let process = Process()
+        if self.process != nil {
+            let cleanup = self.stopLocked(reason: "worker restarted", preserveStart: true)
+            Task { [weak self] in
+                await cleanup?.value
+                self?.queue.async { [weak self] in
+                    guard let self, self.startContinuation != nil else { return }
+                    self.startLocked(launch: launch)
+                }
+            }
+            return
+        }
         let stdinPipe = Pipe()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
@@ -312,34 +320,16 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
             self.finishStartLocked(.failure(WorkerError.unavailable("could not protect worker input pipe")))
             return
         }
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = Array(command.dropFirst())
-        process.currentDirectoryURL = launch.currentDirectoryURL
         var environment = ProcessInfo.processInfo.environment
         environment["PATH"] = CommandResolver.preferredPaths().joined(separator: ":")
         environment["OPENCLAW_NODE_EXEC_HOST"] = "app"
         environment["OPENCLAW_NODE_EXEC_FALLBACK"] = "0"
-        process.environment = environment
-        process.standardInput = stdinPipe
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-        self.process = process
         self.launchedWorker = launch
         self.stdinPipe = stdinPipe
         self.stdoutPipe = stdoutPipe
         self.stderrPipe = stderrPipe
         let processGeneration = UUID()
         self.processGeneration = processGeneration
-
-        process.terminationHandler = { [weak self] process in
-            guard let self else { return }
-            self.queue.async {
-                guard self.process === process else { return }
-                self.stopLocked(
-                    reason: "worker exited with status \(process.terminationStatus)",
-                    notifyUnexpectedExit: true)
-            }
-        }
 
         let timer = DispatchSource.makeTimerSource(queue: self.queue)
         // Cold config and plugin discovery can exceed the old 20-second bound.
@@ -355,52 +345,87 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         self.startTimer = timer
         timer.resume()
 
-        do {
-            try process.run()
-            let stdoutSource = DispatchSource.makeReadSource(
-                fileDescriptor: stdoutPipe.fileHandleForReading.fileDescriptor,
-                queue: self.queue)
-            stdoutSource.setEventHandler { [weak self] in
-                guard let self, self.processGeneration == processGeneration else { return }
-                let data = Self.readAvailable(
-                    fileDescriptor: stdoutPipe.fileHandleForReading.fileDescriptor,
-                    byteCount: stdoutSource.data)
-                if data.isEmpty {
-                    self.stdoutSource?.cancel()
-                } else {
-                    self.consumeStdoutLocked(data)
-                }
+        let configuration = Subprocess.Configuration(
+            .path(.init(executable)),
+            arguments: Arguments(Array(command.dropFirst())),
+            environment: ManagedProcess.environment(from: environment),
+            workingDirectory: launch.currentDirectoryURL.map { .init($0.path) })
+        let process = ManagedProcess.launch(
+            configuration: configuration,
+            stdin: stdinPipe.fileHandleForReading,
+            stdout: stdoutPipe.fileHandleForWriting,
+            stderr: stderrPipe.fileHandleForWriting)
+        self.process = process
+        Task { [weak self] in
+            let started = await (try? process.waitUntilStarted()) != nil
+            self?.queue.async { [weak self] in
+                self?.finishProcessLaunch(started: started, generation: processGeneration)
             }
-            self.stdoutSource = stdoutSource
-            stdoutSource.resume()
+        }
+    }
 
-            let stderrSource = DispatchSource.makeReadSource(
-                fileDescriptor: stderrPipe.fileHandleForReading.fileDescriptor,
-                queue: self.queue)
-            stderrSource.setEventHandler { [weak self] in
-                guard let self, self.processGeneration == processGeneration else { return }
-                let data = Self.readAvailable(
-                    fileDescriptor: stderrPipe.fileHandleForReading.fileDescriptor,
-                    byteCount: stderrSource.data)
-                guard !data.isEmpty else {
-                    self.stderrSource?.cancel()
-                    return
-                }
-                if let message = String(data: data, encoding: .utf8)?
-                    .trimmingCharacters(in: .whitespacesAndNewlines),
-                    !message.isEmpty
-                {
-                    self.logger.error("node-host worker stderr: \(message, privacy: .private)")
-                }
-            }
-            self.stderrSource = stderrSource
-            stderrSource.resume()
-            try? stdinPipe.fileHandleForReading.close()
-            try? stdoutPipe.fileHandleForWriting.close()
-            try? stderrPipe.fileHandleForWriting.close()
-        } catch {
-            self.finishStartLocked(.failure(WorkerError.unavailable("node-host worker launch failed")))
+    private func finishProcessLaunch(
+        started: Bool,
+        generation: UUID)
+    {
+        guard self.processGeneration == generation, self.processCleanupTask == nil else { return }
+        guard started,
+              let process = self.process,
+              let stdoutPipe = self.stdoutPipe,
+              let stderrPipe = self.stderrPipe
+        else {
             self.stopLocked(reason: "worker launch failed")
+            return
+        }
+        let stdoutSource = DispatchSource.makeReadSource(
+            fileDescriptor: stdoutPipe.fileHandleForReading.fileDescriptor,
+            queue: self.queue)
+        stdoutSource.setEventHandler { [weak self] in
+            guard let self, self.processGeneration == generation else { return }
+            let data = Self.readAvailable(
+                fileDescriptor: stdoutPipe.fileHandleForReading.fileDescriptor,
+                byteCount: stdoutSource.data)
+            if data.isEmpty {
+                self.stdoutSource?.cancel()
+            } else {
+                self.consumeStdoutLocked(data)
+            }
+        }
+        self.stdoutSource = stdoutSource
+        stdoutSource.resume()
+
+        let stderrSource = DispatchSource.makeReadSource(
+            fileDescriptor: stderrPipe.fileHandleForReading.fileDescriptor,
+            queue: self.queue)
+        stderrSource.setEventHandler { [weak self] in
+            guard let self, self.processGeneration == generation else { return }
+            let data = Self.readAvailable(
+                fileDescriptor: stderrPipe.fileHandleForReading.fileDescriptor,
+                byteCount: stderrSource.data)
+            guard !data.isEmpty else {
+                self.stderrSource?.cancel()
+                return
+            }
+            if let message = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !message.isEmpty
+            {
+                self.logger.error("node-host worker stderr: \(message, privacy: .private)")
+            }
+        }
+        self.stderrSource = stderrSource
+        stderrSource.resume()
+        Task { [weak self, completionTask = process.completionTask] in
+            let status = await completionTask.value
+            self?.queue.async { [weak self] in
+                guard let self,
+                      self.processGeneration == generation,
+                      self.processCleanupTask == nil
+                else { return }
+                self.stopLocked(
+                    reason: "worker exited with status \(String(describing: status))",
+                    notifyUnexpectedExit: true)
+            }
         }
     }
 
@@ -634,35 +659,17 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         continuation.resume(with: result)
     }
 
+    @discardableResult
     private func stopLocked(
         reason: String,
         preserveStart: Bool = false,
-        notifyUnexpectedExit: Bool = false)
+        notifyUnexpectedExit: Bool = false) -> Task<Void, Never>?
     {
-        guard !self.stopping else { return }
+        if let processCleanupTask = self.processCleanupTask { return processCleanupTask }
         let wasReady = self.manifest != nil
-        self.stopping = true
         self.startTimer?.cancel()
         self.startTimer = nil
-        self.stdoutSource?.cancel()
-        self.stdoutSource = nil
-        self.stderrSource?.cancel()
-        self.stderrSource = nil
-        try? self.stdinPipe?.fileHandleForWriting.close()
-        try? self.stdinPipe?.fileHandleForReading.close()
-        try? self.stdoutPipe?.fileHandleForReading.close()
-        try? self.stdoutPipe?.fileHandleForWriting.close()
-        try? self.stderrPipe?.fileHandleForReading.close()
-        try? self.stderrPipe?.fileHandleForWriting.close()
-        if self.process?.isRunning == true {
-            self.process?.terminate()
-        }
-        self.process = nil
         self.launchedWorker = nil
-        self.stdinPipe = nil
-        self.stdoutPipe = nil
-        self.stderrPipe = nil
-        self.processGeneration = nil
         self.stdoutBuffer.removeAll(keepingCapacity: false)
         self.manifest = nil
         self.inventoryData = nil
@@ -680,6 +687,36 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         if notifyUnexpectedExit, wasReady {
             self.onUnexpectedExit()
         }
+        guard let process = self.process else {
+            return nil
+        }
+        let cleanupTask = Task { [weak self] in
+            await process.terminate()
+            await withCheckedContinuation { continuation in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                self.queue.async {
+                    self.stdoutSource?.cancel()
+                    self.stdoutSource = nil
+                    self.stderrSource?.cancel()
+                    self.stderrSource = nil
+                    try? self.stdinPipe?.fileHandleForWriting.close()
+                    try? self.stdoutPipe?.fileHandleForReading.close()
+                    try? self.stderrPipe?.fileHandleForReading.close()
+                    self.process = nil
+                    self.processCleanupTask = nil
+                    self.stdinPipe = nil
+                    self.stdoutPipe = nil
+                    self.stderrPipe = nil
+                    self.processGeneration = nil
+                    continuation.resume()
+                }
+            }
+        }
+        self.processCleanupTask = cleanupTask
+        return cleanupTask
     }
 
     private static func decodeInvokeResponse(_ result: [String: Any], id: String) -> BridgeInvokeResponse {

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -25,9 +25,7 @@ final class RemotePortTunnel: @unchecked Sendable {
         self.process.isRunning
     }
 
-    var processIdentifier: pid_t {
-        self.process.processIdentifier
-    }
+    let processIdentifier: pid_t
 
     private let process: ManagedProcess
     private let stderrHandle: FileHandle?
@@ -59,261 +57,15 @@ final class RemotePortTunnel: @unchecked Sendable {
         }
     }
 
-    private enum ProcessWakeReason: Sendable {
-        case exited
-        case terminate
-    }
-
-    private struct ProcessStartFailure: LocalizedError, Sendable {
-        let message: String
-
-        var errorDescription: String? {
-            self.message
-        }
-    }
-
-    private final class ProcessStartSignal: @unchecked Sendable {
-        private let lock = NSLock()
-        private var result: Result<pid_t, ProcessStartFailure>?
-        private var continuation: CheckedContinuation<pid_t, any Error>?
-
-        func wait() async throws -> pid_t {
-            try await withCheckedThrowingContinuation { continuation in
-                self.lock.lock()
-                if let result = self.result {
-                    self.lock.unlock()
-                    continuation.resume(with: result)
-                    return
-                }
-                self.continuation = continuation
-                self.lock.unlock()
-            }
-        }
-
-        func succeed(_ processIdentifier: pid_t) {
-            self.resolve(.success(processIdentifier))
-        }
-
-        func fail(_ error: ProcessStartFailure) {
-            self.resolve(.failure(error))
-        }
-
-        private func resolve(_ result: Result<pid_t, ProcessStartFailure>) {
-            self.lock.lock()
-            guard self.result == nil else {
-                self.lock.unlock()
-                return
-            }
-            self.result = result
-            let continuation = self.continuation
-            self.continuation = nil
-            self.lock.unlock()
-            continuation?.resume(with: result)
-        }
-    }
-
-    private final class ProcessWakeSignal: @unchecked Sendable {
-        private let lock = NSLock()
-        private var reason: ProcessWakeReason?
-        private var continuation: CheckedContinuation<ProcessWakeReason, Never>?
-        private var source: DispatchSourceProcess?
-
-        func wait(processIdentifier: pid_t) async -> ProcessWakeReason {
-            await withCheckedContinuation { continuation in
-                self.lock.lock()
-                if let reason = self.reason {
-                    self.lock.unlock()
-                    continuation.resume(returning: reason)
-                    return
-                }
-                self.continuation = continuation
-                self.lock.unlock()
-
-                if Self.hasExited(processIdentifier) {
-                    self.resolve(.exited)
-                    return
-                }
-
-                let source = DispatchSource.makeProcessSource(
-                    identifier: processIdentifier,
-                    eventMask: .exit,
-                    queue: .global(qos: .userInitiated))
-                source.setEventHandler { [weak self] in
-                    self?.resolve(.exited)
-                }
-
-                self.lock.lock()
-                if self.reason == nil {
-                    self.source = source
-                }
-                let shouldStart = self.reason == nil
-                self.lock.unlock()
-
-                source.resume()
-                if !shouldStart {
-                    source.cancel()
-                    return
-                }
-                // Cover an exit between the preflight waitid and kqueue registration.
-                if Self.hasExited(processIdentifier) {
-                    self.resolve(.exited)
-                }
-            }
-        }
-
-        func requestTermination() {
-            self.resolve(.terminate)
-        }
-
-        private func resolve(_ reason: ProcessWakeReason) {
-            self.lock.lock()
-            guard self.reason == nil else {
-                self.lock.unlock()
-                return
-            }
-            self.reason = reason
-            let continuation = self.continuation
-            self.continuation = nil
-            let source = self.source
-            self.source = nil
-            self.lock.unlock()
-            source?.cancel()
-            continuation?.resume(returning: reason)
-        }
-
-        private static func hasExited(_ processIdentifier: pid_t) -> Bool {
-            var info = siginfo_t()
-            let result = waitid(
-                P_PID,
-                id_t(processIdentifier),
-                &info,
-                WEXITED | WNOHANG | WNOWAIT)
-            return result == 0 && info.si_pid != 0
-        }
-    }
-
-    private final class ProcessCompletionState: @unchecked Sendable {
-        private let lock = NSLock()
-        private var finished = false
-        private var status: TerminationStatus?
-
-        var isRunning: Bool {
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            return !self.finished
-        }
-
-        var terminationStatus: TerminationStatus? {
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            return self.status
-        }
-
-        func finish(status: TerminationStatus?) {
-            self.lock.lock()
-            self.finished = true
-            self.status = status
-            self.lock.unlock()
-        }
-    }
-
-    fileprivate final class ManagedProcess: @unchecked Sendable {
-        let processIdentifier: pid_t
-        private let task: Task<Void, Never>
-        private let wakeSignal: ProcessWakeSignal
-        private let state: ProcessCompletionState
-
-        var isRunning: Bool {
-            self.state.isRunning
-        }
-
-        var terminationStatus: TerminationStatus? {
-            self.state.terminationStatus
-        }
-
-        private init(
-            processIdentifier: pid_t,
-            task: Task<Void, Never>,
-            wakeSignal: ProcessWakeSignal,
-            state: ProcessCompletionState)
-        {
-            self.processIdentifier = processIdentifier
-            self.task = task
-            self.wakeSignal = wakeSignal
-            self.state = state
-        }
-
-        static func start(
-            configuration: Subprocess.Configuration,
-            error: some ErrorOutputProtocol & Sendable) async throws -> ManagedProcess
-        {
-            let startSignal = ProcessStartSignal()
-            let wakeSignal = ProcessWakeSignal()
-            let state = ProcessCompletionState()
-            let task = Task.detached(priority: .userInitiated) {
-                do {
-                    let result = try await Subprocess.run(
-                        configuration,
-                        input: .none,
-                        output: .discarded,
-                        error: error)
-                    { execution in
-                        let processIdentifier = execution.processIdentifier.value
-                        startSignal.succeed(processIdentifier)
-                        let reason = await wakeSignal.wait(processIdentifier: processIdentifier)
-                        switch reason {
-                        case .terminate:
-                            try? execution.send(signal: .terminate, toProcessGroup: true)
-                            try? await Task.sleep(for: .milliseconds(250))
-                            // The leader stays unreaped until this body returns, so its
-                            // process-group identity cannot be reused before escalation.
-                            try? execution.send(signal: .kill, toProcessGroup: true)
-                        case .exited:
-                            // A crashed SSH leader can leave ProxyCommand descendants.
-                            // The zombie leader still pins the group identity here.
-                            try? execution.send(signal: .kill, toProcessGroup: true)
-                        }
-                    }
-                    state.finish(status: result.terminationStatus)
-                } catch {
-                    let message = if let subprocessError = error as? SubprocessError {
-                        subprocessError.description
-                    } else {
-                        error.localizedDescription
-                    }
-                    startSignal.fail(ProcessStartFailure(message: message))
-                    state.finish(status: nil)
-                }
-            }
-            let processIdentifier = try await startSignal.wait()
-            return ManagedProcess(
-                processIdentifier: processIdentifier,
-                task: task,
-                wakeSignal: wakeSignal,
-                state: state)
-        }
-
-        func requestTermination() {
-            self.wakeSignal.requestTermination()
-        }
-
-        func terminate() async {
-            self.requestTermination()
-            await self.task.value
-        }
-
-        deinit {
-            self.requestTermination()
-        }
-    }
-
     private init(
         process: ManagedProcess,
+        processIdentifier: pid_t,
         localPort: UInt16?,
         stderrHandle: FileHandle?,
         guardianReceipt: PortGuardian.Record)
     {
         self.process = process
+        self.processIdentifier = processIdentifier
         self.localPort = localPort
         self.stderrHandle = stderrHandle
         self.guardianReceipt = guardianReceipt
@@ -426,29 +178,24 @@ final class RemotePortTunnel: @unchecked Sendable {
 
         var platformOptions = PlatformOptions()
         platformOptions.qualityOfService = .userInitiated
-        platformOptions.createSession = true
-        platformOptions.teardownSequence = [
-            .send(
-                signal: .terminate,
-                toProcessGroup: true,
-                allowedDurationToNextStep: .milliseconds(250)),
-        ]
         let processConfiguration = Subprocess.Configuration(
             .path(.init("/usr/bin/ssh")),
             arguments: Arguments(args),
-            environment: self.environment(from: CommandResolver.sshEnvironment()),
+            environment: ManagedProcess.environment(from: CommandResolver.sshEnvironment()),
             platformOptions: platformOptions)
-        let process: ManagedProcess
+        let process = ManagedProcess.launch(
+            configuration: processConfiguration,
+            input: .none,
+            output: .discarded,
+            error: .fileDescriptor(
+                .init(rawValue: stderrWriter.fileDescriptor),
+                closeAfterSpawningProcess: false),
+            closeAfterSpawn: [stderrWriter])
+        let processIdentifier: pid_t
         do {
-            process = try await ManagedProcess.start(
-                configuration: processConfiguration,
-                error: .fileDescriptor(
-                    .init(rawValue: stderrWriter.fileDescriptor),
-                    closeAfterSpawningProcess: false))
-            try? stderrWriter.close()
+            processIdentifier = try await process.waitUntilStarted()
         } catch {
             await PortGuardian.shared.cancelTunnelSpawn(spawnPreparation)
-            try? stderrWriter.close()
             Self.cleanupStderr(stderrHandle)
             throw error
         }
@@ -459,7 +206,7 @@ final class RemotePortTunnel: @unchecked Sendable {
             // a crash window where a live SSH process has no durable reap receipt.
             receipt = try await PortGuardian.shared.record(
                 port: Int(localPort),
-                pid: process.processIdentifier,
+                pid: processIdentifier,
                 command: "/usr/bin/ssh",
                 mode: .remote,
                 preparation: spawnPreparation)
@@ -481,6 +228,7 @@ final class RemotePortTunnel: @unchecked Sendable {
         do {
             try await Self.waitForListener(
                 process: process,
+                processIdentifier: processIdentifier,
                 localPort: localPort,
                 stderrHandle: stderrHandle,
                 stderrCapture: stderrCapture)
@@ -493,6 +241,7 @@ final class RemotePortTunnel: @unchecked Sendable {
 
         return RemotePortTunnel(
             process: process,
+            processIdentifier: processIdentifier,
             localPort: localPort,
             stderrHandle: stderrHandle,
             guardianReceipt: receipt)
@@ -500,6 +249,7 @@ final class RemotePortTunnel: @unchecked Sendable {
 
     private static func waitForListener(
         process: ManagedProcess,
+        processIdentifier: pid_t,
         localPort: UInt16,
         stderrHandle: FileHandle,
         stderrCapture: StderrCapture) async throws
@@ -511,7 +261,7 @@ final class RemotePortTunnel: @unchecked Sendable {
                 let msg = stderr.isEmpty ? "ssh tunnel exited before listening" : "ssh tunnel failed: \(stderr)"
                 throw NSError(domain: "RemotePortTunnel", code: 4, userInfo: [NSLocalizedDescriptionKey: msg])
             }
-            if await PortGuardian.shared.isListening(port: Int(localPort), pid: process.processIdentifier) {
+            if await PortGuardian.shared.isListening(port: Int(localPort), pid: processIdentifier) {
                 return
             }
             do {
@@ -524,16 +274,6 @@ final class RemotePortTunnel: @unchecked Sendable {
         let stderr = stderrCapture.snapshot()
         let msg = stderr.isEmpty ? "ssh tunnel did not open local port \(localPort)" : "ssh tunnel failed: \(stderr)"
         throw NSError(domain: "RemotePortTunnel", code: 4, userInfo: [NSLocalizedDescriptionKey: msg])
-    }
-
-    private static func environment(from values: [String: String]) -> Environment {
-        var converted: [Environment.Key: String] = [:]
-        converted.reserveCapacity(values.count)
-        for (key, value) in values {
-            guard let environmentKey = Environment.Key(rawValue: key) else { continue }
-            converted[environmentKey] = value
-        }
-        return .custom(converted)
     }
 
     /// Shared with MacChatTranscriptCache: the offline cache identity must key
@@ -765,47 +505,6 @@ final class RemotePortTunnel: @unchecked Sendable {
 
     static func _testDrainStderr(_ handle: FileHandle) -> String {
         self.drainStderr(handle, captured: "")
-    }
-
-    final class TestProcess: @unchecked Sendable {
-        private let process: ManagedProcess
-
-        fileprivate init(process: ManagedProcess) {
-            self.process = process
-        }
-
-        var isRunning: Bool {
-            self.process.isRunning
-        }
-
-        var terminationStatus: TerminationStatus? {
-            self.process.terminationStatus
-        }
-
-        func requestTermination() {
-            self.process.requestTermination()
-        }
-
-        func terminate() async {
-            await self.process.terminate()
-        }
-    }
-
-    static func _testStartProcess(
-        executable: String,
-        arguments: [String],
-        environment: [String: String] = [:]) async throws -> TestProcess
-    {
-        var platformOptions = PlatformOptions()
-        platformOptions.createSession = true
-        let configuration = Subprocess.Configuration(
-            .path(.init(executable)),
-            arguments: Arguments(arguments),
-            environment: self.environment(from: environment),
-            platformOptions: platformOptions)
-        return try await TestProcess(process: ManagedProcess.start(
-            configuration: configuration,
-            error: .discarded))
     }
 
     #endif

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -1056,8 +1056,8 @@ extension MacNodeCodexThreadCatalogTests {
               printf '{"id":%s,"result":{"data":[]}}\n' "$id"
             done
             touch "${0}.eof"
-            trap '' TERM
-            /bin/sleep 0.2
+            trap 'touch "${0}.term"' TERM
+            /bin/sleep 0.35
             touch "${0}.graceful-exit"
             """#)
         let leaderPIDFile = URL(fileURLWithPath: fake.executable.path + ".leader.pid")

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -1041,6 +1041,43 @@ extension MacNodeCodexThreadCatalogTests {
         await client.shutdown()
     }
 
+    @Test func `explicit shutdown reaps a graceful App Server and its descendants`() async throws {
+        let fake = try makeAppServer(
+            preamble: #"""
+            printf '%s\n' "$$" > "${0}.leader.pid"
+            trap 'touch "${0}.term"; exit 0' TERM
+            """#,
+            body: #"""
+            /bin/sh -c 'trap "" HUP TERM; printf "%s\n" "$$" > "$1"; while :; do /bin/sleep 1; done' \
+              descendant "${0}.descendant.pid" </dev/null >/dev/null 2>&1 &
+            while [ ! -s "${0}.descendant.pid" ]; do /bin/sleep 0.01; done
+            while IFS= read -r request; do
+              id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
+              printf '{"id":%s,"result":{"data":[]}}\n' "$id"
+            done
+            touch "${0}.eof"
+            trap '' TERM
+            /bin/sleep 0.2
+            touch "${0}.graceful-exit"
+            """#)
+        let leaderPIDFile = URL(fileURLWithPath: fake.executable.path + ".leader.pid")
+        let descendantPIDFile = URL(fileURLWithPath: fake.executable.path + ".descendant.pid")
+        defer { TestProcessSupport.killLeakedProcesses(in: [descendantPIDFile, leaderPIDFile]) }
+        let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
+
+        _ = try await self.requestEmptyList(client: client, executable: fake.executable)
+        let leaderPID = try await TestProcessSupport.waitForPID(in: leaderPIDFile)
+        let descendantPID = try await TestProcessSupport.waitForPID(in: descendantPIDFile)
+
+        await client.shutdown()
+
+        #expect(FileManager.default.fileExists(atPath: fake.executable.path + ".eof"))
+        #expect(FileManager.default.fileExists(atPath: fake.executable.path + ".graceful-exit"))
+        #expect(!FileManager.default.fileExists(atPath: fake.executable.path + ".term"))
+        #expect(TestProcessSupport.processIsGone(leaderPID))
+        #expect(TestProcessSupport.processIsGone(descendantPID))
+    }
+
     @Test func `shuts down an idle lifecycle client`() async throws {
         let fake = try makeEmptyListServer(blocksEOFExit: true)
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 0.05)

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -18,8 +18,13 @@ private actor StubMacNodeHostWorker: MacNodeHostWorking {
             pathEnv: "/usr/bin:/bin")
     }
 
-    func start(launch _: MacNodeHostWorkerLaunch) async throws -> MacNodeHostManifest { self.manifest }
-    func supports(_ command: String) async -> Bool { self.manifest.commands.contains(command) }
+    func start(launch _: MacNodeHostWorkerLaunch) async throws -> MacNodeHostManifest {
+        self.manifest
+    }
+
+    func supports(_ command: String) async -> Bool {
+        self.manifest.commands.contains(command)
+    }
 
     func invoke(_ request: BridgeInvokeRequest) async -> BridgeInvokeResponse {
         self.requests.append(request)
@@ -29,10 +34,15 @@ private actor StubMacNodeHostWorker: MacNodeHostWorking {
     func handleInput(invokeId _: String, seq _: Int, payloadJSON _: String) async {}
     func cancel(invokeId _: String) async {}
 
-    func setRoute(_: GatewayNodeSessionRoute?, authorityGeneration _: UInt64) async -> Bool { true }
+    func setRoute(_: GatewayNodeSessionRoute?, authorityGeneration _: UInt64) async -> Bool {
+        true
+    }
+
     func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
     func stop() async {}
-    func invokedCommands() -> [String] { self.requests.map(\.command) }
+    func invokedCommands() -> [String] {
+        self.requests.map(\.command)
+    }
 }
 
 @Suite(.serialized)
@@ -167,24 +177,19 @@ struct MacNodeHostWorkerTests {
     @Test(arguments: [
         (
             MacNodeCodexThreadCatalogContract.listCommand,
-            "UNAVAILABLE: Codex session catalog is disabled"
-        ),
+            "UNAVAILABLE: Codex session catalog is disabled"),
         (
             MacNodeCodexThreadCatalogContract.turnsCommand,
-            "UNAVAILABLE: Codex session catalog is disabled"
-        ),
+            "UNAVAILABLE: Codex session catalog is disabled"),
         (
             MacNodeClaudeSessionCatalogContract.listCommand,
-            "UNAVAILABLE: Claude session catalog is disabled"
-        ),
+            "UNAVAILABLE: Claude session catalog is disabled"),
         (
             MacNodeClaudeSessionCatalogContract.readCommand,
-            "UNAVAILABLE: Claude session catalog is disabled"
-        ),
+            "UNAVAILABLE: Claude session catalog is disabled"),
         (
             OpenClawComputerCommand.act.rawValue,
-            "COMPUTER_DISABLED: enable Computer Control in Settings"
-        ),
+            "COMPUTER_DISABLED: enable Computer Control in Settings"),
     ])
     func `worker cannot bypass native capability consent`(command: String, expectedMessage: String) async {
         let worker = StubMacNodeHostWorker(commands: [command])
@@ -310,6 +315,36 @@ struct MacNodeHostWorkerTests {
         }
     }
 
+    @Test func `worker deinit terminates its owned process`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-worker-deinit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let pidFile = directory.appendingPathComponent("worker.pid")
+        defer {
+            TestProcessSupport.killLeakedProcesses(in: [pidFile])
+            try? FileManager.default.removeItem(at: directory)
+        }
+        var worker: MacNodeHostWorker? = MacNodeHostWorker(session: GatewayNodeSession())
+        let script = """
+        printf '%s\n' "$$" > "$1"
+        printf '%s\n' '{"type":"ready","version":"test","manifest":{"caps":[],"commands":[],"pathEnv":"/bin"}}'
+        while :; do /bin/sleep 1; done
+        """
+
+        _ = try await #require(worker).start(launch: MacNodeHostWorkerLaunch(command: [
+            "/bin/sh",
+            "-c",
+            script,
+            "worker",
+            pidFile.path,
+        ]))
+        let pid = try await TestProcessSupport.waitForPID(in: pidFile)
+
+        worker = nil
+
+        #expect(await TestProcessSupport.waitUntilGone(pid))
+    }
+
     @Test func `changed worker command replaces the running process`() async throws {
         let worker = MacNodeHostWorker(session: GatewayNodeSession())
         let firstScript = """
@@ -329,6 +364,47 @@ struct MacNodeHostWorkerTests {
         #expect(first.version == "first")
         #expect(second.version == "second")
         await worker.stop()
+    }
+
+    @Test func `stop waits for the worker leader and reaps its descendants`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-worker-stop-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let leaderPIDFile = directory.appendingPathComponent("leader.pid")
+        let descendantPIDFile = directory.appendingPathComponent("descendant.pid")
+        let termCompleteFile = directory.appendingPathComponent("term-complete")
+        defer {
+            TestProcessSupport.killLeakedProcesses(in: [descendantPIDFile, leaderPIDFile])
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let worker = MacNodeHostWorker(session: GatewayNodeSession())
+        let script = """
+        printf '%s\n' "$$" > "$1"
+        /bin/sh -c 'trap "" HUP TERM; printf "%s\\n" "$$" > "$1"; while :; do /bin/sleep 1; done' \
+          descendant "$2" </dev/null >/dev/null 2>&1 &
+        while [ ! -s "$2" ]; do /bin/sleep 0.01; done
+        trap 'touch "$3"; /bin/sleep 0.2; exit 0' TERM
+        printf '%s\n' '{"type":"ready","version":"test","manifest":{"caps":[],"commands":[],"pathEnv":"/bin"}}'
+        while :; do /bin/sleep 1; done
+        """
+
+        _ = try await worker.start(launch: MacNodeHostWorkerLaunch(command: [
+            "/bin/sh",
+            "-c",
+            script,
+            "worker",
+            leaderPIDFile.path,
+            descendantPIDFile.path,
+            termCompleteFile.path,
+        ]))
+        let leaderPID = try await TestProcessSupport.waitForPID(in: leaderPIDFile)
+        let descendantPID = try await TestProcessSupport.waitForPID(in: descendantPIDFile)
+
+        await worker.stop()
+
+        #expect(FileManager.default.fileExists(atPath: termCompleteFile.path))
+        #expect(TestProcessSupport.processIsGone(leaderPID))
+        #expect(TestProcessSupport.processIsGone(descendantPID))
     }
 
     @Test func `worker drains stdout while a large stdin frame is backpressured`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -440,9 +440,10 @@ struct MacNodeHostWorkerTests {
             let responses = try await AsyncTimeout.withTimeout(
                 seconds: 5,
                 onTimeout: { WorkerBackpressureTimeout() },
-                operation: { [first, second] in [await first.value, await second.value] })
+                operation: { [first, second] in await [first.value, second.value] })
             await worker.stop()
-            #expect(responses.allSatisfy { $0.ok })
+            let allResponsesSucceeded = responses.allSatisfy(\.ok)
+            #expect(allResponsesSucceeded)
         } catch {
             await worker.stop()
             throw error

--- a/apps/macos/Tests/OpenClawIPCTests/ManagedProcessTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ManagedProcessTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Subprocess
+import Testing
+@testable import OpenClaw
+
+#if canImport(Darwin)
+import Darwin
+
+struct ManagedProcessTests {
+    @Test func `launch failures preserve the executable description`() async {
+        let executable = "/tmp/openclaw-missing-process-\(UUID().uuidString)"
+
+        do {
+            _ = try await self.start(executable: executable)
+            Issue.record("expected the missing executable to fail")
+        } catch {
+            #expect(error.localizedDescription.contains(executable))
+        }
+    }
+
+    @Test func `termination waits for the original child to exit`() async throws {
+        let process = try await self.start(executable: "/bin/sleep", arguments: ["30"])
+
+        await process.terminate()
+
+        #expect(!process.isRunning)
+        #expect(self.terminatedBySignal(process.terminationStatus, SIGTERM))
+    }
+
+    @Test func `instant exits cannot outrun process monitoring`() async throws {
+        for _ in 0..<32 {
+            let process = try await self.start(executable: "/usr/bin/true")
+            defer { process.requestTermination() }
+
+            let deadline = ContinuousClock.now + .seconds(1)
+            while process.isRunning, ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(1))
+            }
+            #expect(!process.isRunning)
+            await process.terminate()
+        }
+    }
+
+    @Test func `termination escalates for a TERM-resistant descendant`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-managed-process-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let childPIDFile = directory.appendingPathComponent("child.pid")
+        let process = try await self.start(
+            executable: "/bin/sh",
+            arguments: [
+                "-c",
+                """
+                /bin/sh -c 'trap "" TERM; echo $$ > "$CHILD_PID_FILE"; while :; do sleep 1; done' &
+                while :; do sleep 1; done
+                """,
+            ],
+            environment: ["CHILD_PID_FILE": childPIDFile.path])
+        defer { process.requestTermination() }
+        let childPID = try await TestProcessSupport.waitForPID(
+            in: childPIDFile,
+            timeout: .seconds(1))
+
+        let startedAt = ContinuousClock.now
+        await process.terminate()
+
+        #expect(ContinuousClock.now - startedAt < .seconds(2))
+        #expect(!process.isRunning)
+        #expect(self.terminatedBySignal(process.terminationStatus, SIGTERM))
+        #expect(TestProcessSupport.processIsGone(childPID))
+    }
+
+    private func start(
+        executable: String,
+        arguments: [String] = [],
+        environment: [String: String] = [:]) async throws -> ManagedProcess
+    {
+        let configuration = Subprocess.Configuration(
+            .path(.init(executable)),
+            arguments: Arguments(arguments),
+            environment: ManagedProcess.environment(from: environment))
+        let process = ManagedProcess.launch(
+            configuration: configuration,
+            input: .none,
+            output: .discarded,
+            error: .discarded)
+        _ = try await process.waitUntilStarted()
+        return process
+    }
+
+    private func terminatedBySignal(_ status: TerminationStatus?, _ signal: Int32) -> Bool {
+        guard case let .signaled(code) = status else { return false }
+        return code == signal
+    }
+}
+#endif

--- a/apps/macos/Tests/OpenClawIPCTests/ManagedProcessTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ManagedProcessTests.swift
@@ -27,6 +27,49 @@ struct ManagedProcessTests {
         #expect(self.terminatedBySignal(process.terminationStatus, SIGTERM))
     }
 
+    @Test func `abortive termination interrupts the stdin grace period`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-managed-process-abort-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let eofFile = directory.appendingPathComponent("eof")
+        let termFile = directory.appendingPathComponent("term")
+        let stdinPipe = Pipe()
+        let configuration = Subprocess.Configuration(
+            .path(.init("/bin/sh")),
+            arguments: Arguments([
+                "-c",
+                #"trap 'touch "$2"; exit 0' TERM; while IFS= read -r _; do :; done; touch "$1"; while :; do sleep 1; done"#,
+                "managed-process",
+                eofFile.path,
+                termFile.path,
+            ]))
+        let process = ManagedProcess.launch(
+            configuration: configuration,
+            input: .fileDescriptor(
+                .init(rawValue: stdinPipe.fileHandleForReading.fileDescriptor),
+                closeAfterSpawningProcess: false),
+            output: .discarded,
+            error: .discarded,
+            closeAfterSpawn: [stdinPipe.fileHandleForReading],
+            closeStdinForGracefulShutdown: stdinPipe.fileHandleForWriting,
+            gracefulShutdownTimeout: .seconds(2))
+        _ = try await process.waitUntilStarted()
+
+        let startedAt = ContinuousClock.now
+        let termination = Task { await process.terminate() }
+        let eofDeadline = ContinuousClock.now + .seconds(1)
+        while !FileManager.default.fileExists(atPath: eofFile.path), ContinuousClock.now < eofDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        process.requestTermination(gracefully: false)
+        await termination.value
+
+        #expect(FileManager.default.fileExists(atPath: eofFile.path))
+        #expect(FileManager.default.fileExists(atPath: termFile.path))
+        #expect(ContinuousClock.now - startedAt < .seconds(1))
+    }
+
     @Test func `instant exits cannot outrun process monitoring`() async throws {
         for _ in 0..<32 {
             let process = try await self.start(executable: "/usr/bin/true")

--- a/apps/macos/Tests/OpenClawIPCTests/RemotePortTunnelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RemotePortTunnelTests.swift
@@ -4,7 +4,6 @@ import Testing
 #if canImport(Darwin)
 import Darwin
 import Foundation
-import Subprocess
 
 struct RemotePortTunnelTests {
     @Test func `tunnel owns its SSH process instead of multiplexing`() {
@@ -36,89 +35,6 @@ struct RemotePortTunnelTests {
 
         let drained = RemotePortTunnel._testDrainStderr(handle)
         #expect(drained.isEmpty)
-    }
-
-    @Test func `process launch failures preserve the executable description`() async {
-        let executable = "/tmp/openclaw-missing-process-\(UUID().uuidString)"
-
-        do {
-            _ = try await RemotePortTunnel._testStartProcess(
-                executable: executable,
-                arguments: [])
-            Issue.record("expected the missing executable to fail")
-        } catch {
-            #expect(error.localizedDescription.contains(executable))
-        }
-    }
-
-    @Test func `termination waits for the original child to exit`() async throws {
-        let process = try await RemotePortTunnel._testStartProcess(
-            executable: "/bin/sleep",
-            arguments: ["30"])
-        defer { process.requestTermination() }
-
-        await process.terminate()
-        #expect(!process.isRunning)
-        #expect(terminatedBySignal(process.terminationStatus, SIGTERM))
-    }
-
-    @Test func `instant exits cannot outrun process monitoring`() async throws {
-        for _ in 0..<32 {
-            let process = try await RemotePortTunnel._testStartProcess(
-                executable: "/usr/bin/true",
-                arguments: [])
-            defer { process.requestTermination() }
-
-            let deadline = ContinuousClock.now + .seconds(1)
-            while process.isRunning, ContinuousClock.now < deadline {
-                try await Task.sleep(for: .milliseconds(1))
-            }
-            #expect(!process.isRunning)
-            await process.terminate()
-        }
-    }
-
-    @Test func `termination escalates for a TERM-resistant child`() async throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("openclaw-tunnel-term-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let readyFile = directory.appendingPathComponent("ready")
-        let childPIDFile = directory.appendingPathComponent("child.pid")
-        let process = try await RemotePortTunnel._testStartProcess(
-            executable: "/bin/sh",
-            arguments: [
-                "-c",
-                """
-                /bin/sh -c 'trap "" TERM; echo $$ > "$CHILD_PID_FILE"; while :; do sleep 1; done' &
-                while [ ! -s "$CHILD_PID_FILE" ]; do sleep 0.01; done
-                echo ready > "$READY_FILE"
-                while :; do sleep 1; done
-                """,
-            ],
-            environment: [
-                "READY_FILE": readyFile.path,
-                "CHILD_PID_FILE": childPIDFile.path,
-            ])
-        defer { process.requestTermination() }
-        let readyDeadline = ContinuousClock.now + .seconds(1)
-        while !FileManager.default.fileExists(atPath: readyFile.path),
-              ContinuousClock.now < readyDeadline
-        {
-            usleep(10000)
-        }
-        #expect(FileManager.default.fileExists(atPath: readyFile.path))
-        let childPID = try #require(pid_t(
-            String(contentsOf: childPIDFile, encoding: .utf8)
-                .trimmingCharacters(in: .whitespacesAndNewlines)))
-
-        let startedAt = ContinuousClock.now
-        await process.terminate()
-
-        #expect(ContinuousClock.now - startedAt < .seconds(2))
-        #expect(!process.isRunning)
-        #expect(terminatedBySignal(process.terminationStatus, SIGTERM))
-        #expect(awaitProcessExit(childPID))
     }
 
     @Test func `port is free detects I pv4 listener`() {
@@ -213,20 +129,4 @@ struct RemotePortTunnelTests {
     }
 }
 
-private func awaitProcessExit(_ pid: pid_t) -> Bool {
-    let deadline = ContinuousClock.now + .seconds(1)
-    while ContinuousClock.now < deadline {
-        errno = 0
-        if kill(pid, 0) == -1, errno == ESRCH {
-            return true
-        }
-        usleep(10000)
-    }
-    return false
-}
-
-private func terminatedBySignal(_ status: TerminationStatus?, _ signal: Int32) -> Bool {
-    guard case let .signaled(code) = status else { return false }
-    return code == signal
-}
 #endif

--- a/apps/macos/Tests/OpenClawIPCTests/TestProcessSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TestProcessSupport.swift
@@ -1,0 +1,47 @@
+import Darwin
+import Foundation
+import Testing
+
+enum TestProcessSupport {
+    static func pollPID(in file: URL) -> pid_t? {
+        guard let value = try? String(contentsOf: file, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+        return pid_t(value)
+    }
+
+    static func waitForPID(in file: URL, timeout: Duration = .seconds(2)) async throws -> pid_t {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if let pid = self.pollPID(in: file) { return pid }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        return try #require(self.pollPID(in: file))
+    }
+
+    static func processIsGone(_ pid: pid_t) -> Bool {
+        errno = 0
+        return kill(pid, 0) == -1 && errno == ESRCH
+    }
+
+    static func waitUntilGone(_ pid: pid_t, timeout: Duration = .seconds(2)) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if self.processIsGone(pid) { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return self.processIsGone(pid)
+    }
+
+    static func killLeakedProcesses(in files: [URL]) {
+        let pids = files.compactMap { self.pollPID(in: $0) }
+        for pid in pids where !self.processIsGone(pid) {
+            _ = kill(pid, SIGKILL)
+        }
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline, pids.contains(where: { !self.processIsGone($0) }) {
+            usleep(10000)
+        }
+    }
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where macOS remote tunnels, Codex App Server clients, and node-host workers could return from terminal shutdown after signaling only the process leader, leaving app-owned descendants alive. Node-host stop could also return before the leader was reaped.

## Why This Change Was Made

One extracted process owner now creates a dedicated session/process group before launch completes, retains Codex's stdin-EOF graceful-exit window, performs bounded group TERM-to-KILL teardown, kills inherited descendants before leader reaping, and joins cleanup. It replaces the three Foundation Process lifecycle paths without adding a second supervisor or fallback.

## User Impact

App-owned SSH, Codex, and node-host helper trees no longer remain after terminal shutdown or restart. There is no configuration, protocol, schema, dependency, documentation, or UI change.

AI-assisted; the implementation and owner-boundary behavior were reviewed before publication.

## Evidence

- Pre-fix owner regressions: Codex shutdown failed 4 assertions (EOF/graceful markers missing; leader and descendant alive); worker stop failed 3 (TERM completion missing; leader and descendant alive).
- Post-fix native proof: 70 tests across ManagedProcessTests, MacNodeCodexThreadCatalogTests, MacNodeHostWorkerTests, RemotePortTunnelTests, and MacNodeHostWorkerPipeTests passed. The named worker stop/reap regression also passed 5 consecutive reruns; Codex descendant/EOF, ordered shutdown, abortive grace interruption, worker deinit ownership, and worker stop/reap regressions passed.
- Changed-scope gate passed after the remote broker was unavailable and the trusted-source wrapper fell back locally: all guards, six Vitest shards, Swift lint, and the native state schema v7 guard passed.
- SwiftFormat lint passed; SwiftLint reported 0 violations; `git diff --check` passed.
- Fresh full-branch autoreview against current main: TruffleHog clean; one review pass; no accepted/actionable findings.
- ClawSweeper findings addressed: the current 1.5-second app-owned Codex EOF budget is preserved, and a later abortive stop interrupts that grace wait before group teardown.
- Direct dependency inspection confirmed that Codex stdio EOF closes the single-client connection and drains background/thread/transport work, while Swift Subprocess creates a new session, targets process groups through negative PIDs, carries group intent into terminal KILL, and reaps after I/O monitoring cleanup.
- Production LOC: +471/-511 (net -40). Tests and test support: +317/-116.
- No screenshots: no UI or user-interaction surface changed.
