### PR TITLE
fix(sessions): branches.list stalls the event loop for ~12s on long-lived sessions

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -8,6 +8,7 @@ import {
   withOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
+import { listSessionBranches } from "./session-accessor.js";
 import { loadExactSessionEntry } from "./session-accessor.sqlite-entry.js";
 import {
   importSqliteSessionRows,
@@ -197,10 +198,16 @@ it("hands off exact SQLite bytes, duplicate IDs, timestamps and owner without ap
   await withOpenClawTestState({ label: "import-exact" }, async (state) => {
     const params = target(state, "exact");
     const owner = { actor: { type: "human" as const, id: "owner" }, assignedAt: 40 };
+    const firstMessage = { ...message, timestamp: "2026-08-30T00:00:01.000Z" };
+    const canonicalMessage = {
+      ...message,
+      timestamp: "2026-08-30T00:00:02.000Z",
+      message: { role: "user", content: "canonical duplicate" },
+    };
     const rows = [
       { createdAt: 41, eventJson: '{ "type": "session", "id": "exact", "version": 3 }' },
-      { createdAt: 43, eventJson: JSON.stringify(message, null, 2) },
-      { createdAt: 45, eventJson: JSON.stringify(message) },
+      { createdAt: 43, eventJson: JSON.stringify(firstMessage, null, 2) },
+      { createdAt: 45, eventJson: JSON.stringify(canonicalMessage) },
     ];
     await importSqliteSessionRows({
       ...params,
@@ -231,6 +238,16 @@ it("hands off exact SQLite bytes, duplicate IDs, timestamps and owner without ap
       }),
     ).toMatchObject({ skippedExisting: true, transcriptEvents: 0 });
     expect(loadTranscriptEventsSync({ ...params, sessionId: "exact" })).toHaveLength(3);
+    await expect(listSessionBranches(params)).resolves.toEqual({
+      status: "ok",
+      branches: Array.from({ length: 2 }, () => ({
+        leafEntryId: "one",
+        headline: "canonical duplicate",
+        messageCount: 1,
+        updatedAt: canonicalMessage.timestamp,
+        active: true,
+      })),
+    });
   });
 });
 

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -21,6 +21,7 @@ import {
   recordSessionParticipant,
   readSessionTranscriptMessageEventPage,
   readSessionTranscriptMessageEvents,
+  replaceTranscriptEvents,
   rewindSessionToMessage,
   switchSessionBranch,
   updateSessionEntry,
@@ -417,6 +418,80 @@ describe("SQLite session message cuts", () => {
       ],
     });
   });
+
+  it("summarizes a large shared branch graph without repeated path walks", async () => {
+    const stateDir = tempDirs.make("openclaw-large-branches-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sessionId = "large-branches-source";
+    const scope = { agentId, env, sessionId, sessionKey };
+    await upsertSessionEntryCore(scope, { sessionId, updatedAt: Date.now() });
+    const events: Parameters<typeof replaceTranscriptEvents>[1] = [
+      {
+        type: "session",
+        id: sessionId,
+        version: 3,
+        timestamp: "2026-08-30T00:00:00.000Z",
+      },
+      {
+        type: "message",
+        id: "orphan-user",
+        parentId: "missing-ancestor",
+        timestamp: "2026-08-30T00:00:01.000Z",
+        message: { role: "user", content: "orphan prompt" },
+      },
+      {
+        type: "message",
+        id: "orphan-assistant",
+        parentId: "orphan-user",
+        timestamp: "2026-08-30T00:00:02.000Z",
+        message: { role: "assistant", content: "orphan answer" },
+      },
+    ];
+    for (let index = 1; index <= 12_554; index += 1) {
+      events.push({
+        type: "message",
+        id: `main-${index}`,
+        parentId: index === 1 ? null : `main-${index - 1}`,
+        timestamp: new Date(Date.UTC(2026, 7, 30, 0, 0, index)).toISOString(),
+        message: { role: index % 2 === 0 ? "assistant" : "user", content: `main ${index}` },
+      });
+    }
+    for (let index = 1; index <= 1_360; index += 1) {
+      events.push({
+        type: "message",
+        id: `side-${index}`,
+        parentId: "main-5376",
+        appendMode: "side",
+        timestamp: new Date(Date.UTC(2026, 7, 30, 1, 0, index)).toISOString(),
+        message: { role: "assistant", content: `side ${index}` },
+      });
+    }
+    events.push({
+      type: "leaf",
+      id: "active-leaf",
+      parentId: "main-12554",
+      targetId: "main-12554",
+      timestamp: "2026-08-30T02:00:02.000Z",
+    });
+    await replaceTranscriptEvents(scope, events);
+
+    const startedAt = performance.now();
+    const result = await listSessionBranches({ agentId, env, sessionKey });
+    const elapsedMs = performance.now() - startedAt;
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") {
+      throw new Error("expected branch list result");
+    }
+    expect(elapsedMs).toBeLessThan(1_000);
+    expect(result.branches).toHaveLength(1_362);
+    expect(result.branches.find((branch) => branch.leafEntryId === "orphan-assistant")).toEqual({
+      leafEntryId: "orphan-assistant",
+      headline: "orphan answer",
+      messageCount: 2,
+      updatedAt: "2026-08-30T00:00:02.000Z",
+      active: false,
+    });
+  }, 15_000);
 
   it("switches to another tip and rebuilds the active-path projection", async () => {
     const { env } = await createSession();

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -81,6 +81,7 @@ type SessionBranchCacheEntry = {
   generation: string | null;
   maxSeq: number | null;
 };
+type SessionBranchPathSummary = Pick<SessionBranchSummary, "headline" | "messageCount">;
 
 // Branch listing must not scale with transcript size on every request. Appends advance max(seq),
 // while every in-place or replacement path rotates generation; cap the validated LRU at 32 sessions.
@@ -415,13 +416,14 @@ function validateBranchTip(
 
 function summarizeSessionBranches(events: readonly TranscriptEvent[]): SessionBranchSummary[] {
   const tree = scanSessionTranscriptTree(events);
+  const pathSummaries = new Map<string, SessionBranchPathSummary>();
   return sessionBranchTipNodes(tree)
     .toSorted(
       (left, right) =>
         Number(right.id === tree.leafId) - Number(left.id === tree.leafId) ||
         right.index - left.index,
     )
-    .map((node) => summarizeSessionBranch(tree, node.id));
+    .map((node) => summarizeSessionBranch(tree, node, pathSummaries));
 }
 
 function sessionBranchTipNodes(tree: SessionTranscriptTree<TranscriptEvent>) {
@@ -439,24 +441,46 @@ function sessionBranchTipNodes(tree: SessionTranscriptTree<TranscriptEvent>) {
 
 function summarizeSessionBranch(
   tree: SessionTranscriptTree<TranscriptEvent>,
-  leafEntryId: string,
+  leaf: SessionTranscriptTree<TranscriptEvent>["nodes"][number],
+  summaries: Map<string, SessionBranchPathSummary>,
 ): SessionBranchSummary {
-  const path = selectSessionTranscriptTreePathNodes(tree, leafEntryId);
-  const messages = path.flatMap((node) => {
+  const uncachedPath: typeof tree.nodes = [];
+  const seen = new Set<string>();
+  let current = leaf;
+  // Stop at the first cached ancestor so every shared prefix is summarized once.
+  // A cycle still produces the empty summary returned by the path selector.
+  while (!summaries.has(current.id)) {
+    if (seen.has(current.id)) {
+      uncachedPath.length = 0;
+      break;
+    }
+    seen.add(current.id);
+    uncachedPath.push(current);
+    const parent = current.parentId === null ? undefined : tree.byId.get(current.parentId);
+    if (!parent) {
+      break;
+    }
+    current = parent;
+  }
+
+  let summary = summaries.get(current.id);
+  for (const node of uncachedPath.toReversed()) {
     const record = asRecord(node.entry);
-    return record?.type === "message" ? [record] : [];
-  });
-  const headline = messages
-    .toReversed()
-    .map((record) => extractHeadlineText(record.message))
-    .find((value): value is string => value !== undefined);
-  const timestamp = asRecord(tree.byId.get(leafEntryId)?.entry)?.timestamp;
+    const headline = record?.type === "message" ? extractHeadlineText(record.message) : undefined;
+    summary = {
+      headline: headline ?? summary?.headline ?? "",
+      messageCount: (summary?.messageCount ?? 0) + (record?.type === "message" ? 1 : 0),
+    };
+    summaries.set(node.id, summary);
+  }
+
+  const timestamp = asRecord(leaf.entry)?.timestamp;
   return {
-    leafEntryId,
-    headline: truncateBranchHeadline(headline ?? ""),
-    messageCount: messages.length,
+    leafEntryId: leaf.id,
+    headline: truncateBranchHeadline(summary?.headline ?? ""),
+    messageCount: summary?.messageCount ?? 0,
     ...(typeof timestamp === "string" && timestamp.trim() ? { updatedAt: timestamp } : {}),
-    active: tree.leafId === leafEntryId,
+    active: tree.leafId === leaf.id,
   };
 }
 

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -417,13 +417,16 @@ function validateBranchTip(
 function summarizeSessionBranches(events: readonly TranscriptEvent[]): SessionBranchSummary[] {
   const tree = scanSessionTranscriptTree(events);
   const pathSummaries = new Map<string, SessionBranchPathSummary>();
-  return sessionBranchTipNodes(tree)
-    .toSorted(
-      (left, right) =>
-        Number(right.id === tree.leafId) - Number(left.id === tree.leafId) ||
-        right.index - left.index,
-    )
-    .map((node) => summarizeSessionBranch(tree, node, pathSummaries));
+  return (
+    sessionBranchTipNodes(tree)
+      .toSorted(
+        (left, right) =>
+          Number(right.id === tree.leafId) - Number(left.id === tree.leafId) ||
+          right.index - left.index,
+      )
+      // SAFETY: scanSessionTranscriptTree inserts every returned node into byId.
+      .map((node) => summarizeSessionBranch(tree, tree.byId.get(node.id)!, pathSummaries))
+  );
 }
 
 function sessionBranchTipNodes(tree: SessionTranscriptTree<TranscriptEvent>) {


### PR DESCRIPTION
Closes #123540

## What Problem This Solves

Long-lived sessions can contain thousands of transcript events and more than one thousand branch tips. A cold `sessions.branches.list` request walked the shared transcript prefix once for every tip. This blocked the Gateway event loop for seconds and delayed unrelated work.

## Why This Change Was Made

The SQLite session accessor owns branch-summary projection. It now memoizes the count and latest headline for each visited ancestor. Each shared prefix is summarized once, while the existing branch selector, active-first ordering, timestamps, missing-parent suffixes, and cycle behavior stay unchanged.

This repair was ported onto current main rather than rebasing the stale patch. It keeps newer session lifecycle, model-lock, incognito, commit-guard, and deferred-index behavior added since the original branch base.

## User Impact

- Branch listing no longer freezes the Gateway on a large shared session graph.
- Branch order, headlines, message counts, timestamps, and active flags do not change.
- No config, schema, storage, protocol, or migration surface changes.

## Evidence

The same production `sessions.branches.list` handler read a disposable SQLite session with 13,917 events and 1,362 tips on current main `0a6c013be5f50981b12d021b387b4fd1ea7e491e` and rebased repaired head `25776eec814d88160251eff06658c2a444624281`.

| Result | Current main | Repaired head |
| --- | ---: | ---: |
| Cold RPC | 4,824 ms | 48 ms |
| Zero-delay timer drift | 4,824 ms | 49 ms |
| Branch count | 1,362 | 1,362 |
| Ordered result SHA-256 | `32c1950f…66aded` | `32c1950f…66aded` |

The 100x reduction removes the event-loop stall. The identical complete-result hash proves output equivalence. A warm-cache control remained 1 ms on both revisions.

## Testing

- Regression negative control on main: failed at 1,322 ms against the 1,000 ms bound.
- Repaired focused suites: 30 tests passed; the rebased large-graph case completed in 476 ms.
- Exact SQLite import negative control: without canonical tip resolution, duplicate IDs returned the first physical row's timestamp; the repaired head returns the canonical final row for both preserved tips.
- `pnpm check:changed`: passed, including core and test type checks, type-aware lint, formatting, import cycles, schema guards, and repository ratchets.

## Change Shape

- Owner: SQLite session branch-summary projection.
- Removed path: repeated full root-path summary work for every branch tip.
- Production delta: +48/-21, net +27 lines. The cache is local to one cold summary build and is the minimum state needed to share ancestor results while preserving missing-parent, cycle, and exact-import semantics.
- Tests: net +92 lines for the realistic 13,917-event regression, retained-suffix contract, and exact-import duplicate-ID compatibility.
