### PR TITLE
fix(ai): stabilize prompt caching across discovery order

### DIFF
--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -82,6 +82,17 @@ function makeUnreadableParameterTool() {
   return tool;
 }
 
+function makeUnreadableNameTool() {
+  const tool = makeHealthyTool();
+  Object.defineProperty(tool, "name", {
+    enumerable: true,
+    get() {
+      throw new Error("fuzzplugin name getter exploded");
+    },
+  });
+  return tool;
+}
+
 function makeHealthyTool(parameters: Record<string, unknown> = { type: "object", properties: {} }) {
   return {
     name: "healthy_tool",
@@ -272,11 +283,15 @@ describe("Mistral provider", () => {
     expect(payload).not.toHaveProperty("promptMode");
   });
 
-  it("skips unreadable tool schemas while preserving healthy Mistral tools", async () => {
+  it("skips unreadable tool fields while preserving healthy Mistral tools", async () => {
     const healthyParameters = { type: "object", properties: { query: { type: "string" } } };
     const result = await runMistralFixture({
       ...context,
-      tools: [makeUnreadableParameterTool(), makeHealthyTool(healthyParameters)] as never,
+      tools: [
+        makeUnreadableNameTool(),
+        makeUnreadableParameterTool(),
+        makeHealthyTool(healthyParameters),
+      ] as never,
     });
 
     expect(result.stopReason).toBe("error");
@@ -291,6 +306,25 @@ describe("Mistral provider", () => {
         },
       },
     ]);
+  });
+
+  it("keeps request bytes stable across equivalent tool input order", async () => {
+    const tools = [
+      { ...makeHealthyTool(), name: "zeta_tool", description: "Zeta tool" },
+      { ...makeHealthyTool(), name: "alpha_tool", description: "Alpha tool" },
+    ];
+
+    await runMistralFixture({ ...context, tools } as never);
+    await runMistralFixture({ ...context, tools: tools.toReversed() } as never);
+
+    expect(JSON.stringify(mistralMockState.payloads[0])).toBe(
+      JSON.stringify(mistralMockState.payloads[1]),
+    );
+    expect(
+      (mistralMockState.payloads[0] as { tools: Array<{ function: { name: string } }> }).tools.map(
+        (tool) => tool.function.name,
+      ),
+    ).toEqual(["alpha_tool", "zeta_tool"]);
   });
 
   it("omits tools and automatic tool choice when every schema is unreadable", async () => {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -31,6 +31,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
 import { projectProviderError } from "../utils/provider-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
@@ -784,21 +785,25 @@ async function consumeChatStream(
 }
 
 function toFunctionTools(tools: Tool[]): Array<FunctionTool & { type: "function" }> {
-  return tools.flatMap((tool) => {
+  const converted = tools.flatMap((tool) => {
     try {
-      return {
+      const name = tool.name;
+      const description = tool.description;
+      const value = {
         type: "function",
         function: {
-          name: tool.name,
-          description: tool.description,
+          name,
+          description,
           parameters: stripSymbolKeys(tool.parameters) as Record<string, unknown>,
           strict: false,
         },
-      };
+      } satisfies FunctionTool & { type: "function" };
+      return { name, description, value };
     } catch {
       return [];
     }
   });
+  return sortPromptCacheToolsByName(converted).map(({ value }) => value);
 }
 
 function stripSymbolKeys(value: unknown): unknown {

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -544,6 +544,46 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
+  it("keeps request bytes stable across equivalent tool input order", async () => {
+    const tools = [
+      {
+        name: "zeta_tool",
+        description: "Zeta tool",
+        parameters: { type: "object", properties: {} },
+      },
+      {
+        name: "alpha_tool",
+        description: "Alpha tool",
+        parameters: { type: "object", properties: {} },
+      },
+    ];
+    const payloads: string[] = [];
+
+    for (const orderedTools of [tools, tools.toReversed()]) {
+      const stream = streamOpenAICompletions(
+        model,
+        { ...context, tools: orderedTools },
+        {
+          apiKey: "sk-test",
+          onPayload(payload) {
+            payloads.push(JSON.stringify(payload));
+            throw new Error("stop before network");
+          },
+        },
+      );
+      await stream.result();
+    }
+
+    expect(payloads[0]).toBe(payloads[1]);
+    expect(
+      (
+        JSON.parse(payloads[0] ?? "{}") as {
+          tools: Array<{ function: { name: string } }>;
+        }
+      ).tools.map((tool) => tool.function.name),
+    ).toEqual(["alpha_tool", "zeta_tool"]);
+  });
+
   it("fails locally when a pinned official OpenAI tool is unreadable", async () => {
     const stream = streamOpenAICompletions(
       model,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -49,6 +49,7 @@ import {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
+import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
 import { projectProviderError } from "../utils/provider-error.js";
 import { createReasoningTagTextPartitioner } from "../utils/reasoning-tag-text-partitioner.js";
 import {
@@ -1059,7 +1060,7 @@ function convertTools(
   const projection = projectOpenAITools(tools);
   return {
     projection,
-    tools: projection.tools.map((tool) => ({
+    tools: sortPromptCacheToolsByName(projection.tools).map((tool) => ({
       type: "function",
       function: {
         name: tool.name,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -3,6 +3,13 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 // user-visible sections for owners, tools, safety, skills, and subagents.
 import { describe, expect, it } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { typedCases } from "../test-utils/typed-cases.js";
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { resolveOwnerPromptNumbers } from "./owner-display.js";
@@ -1265,6 +1272,31 @@ describe("buildAgentSystemPrompt", () => {
       `No source default: proactive send needs \`channel\`; ids: ${channelOptions}.`,
     );
     expect(prompt).toContain(`final ONLY ${SILENT_REPLY_TOKEN}`);
+  });
+
+  it("keeps model-visible channel ids stable across external registration order", () => {
+    const activeRegistry = captureActivePluginRegistrySnapshot();
+    const registrations = ["zeta-channel", "alpha-channel"].map((id) => ({
+      pluginId: id,
+      source: "test" as const,
+      plugin: { id },
+    }));
+    const buildPrompt = () =>
+      buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw", toolNames: ["message"] });
+
+    try {
+      setActivePluginRegistry(createTestRegistry(registrations));
+      const firstPrompt = buildPrompt();
+      setActivePluginRegistry(createTestRegistry(registrations.toReversed()));
+      const secondPrompt = buildPrompt();
+
+      expect(firstPrompt).toBe(secondPrompt);
+      expect(firstPrompt).toContain(
+        `ids: ${[...CHANNEL_IDS, "alpha-channel", "zeta-channel"].join("|")}.`,
+      );
+    } finally {
+      restoreActivePluginRegistrySnapshot(activeRegistry);
+    }
   });
 
   it("keeps channel choice guidance lean when message sends have a source channel", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -22,6 +22,7 @@ import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.ty
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { normalizeChatType, type ChatType } from "../channels/chat-type.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
 import {
   hasNativeApprovalPromptRuntimeCapability,
   isKnownNativeApprovalPromptChannel,
@@ -686,7 +687,10 @@ function buildCollapsibleDetailsSection(params: {
 }
 
 function buildMessageChannelOptions(runtimeChannel?: string): string | undefined {
-  const deliverableChannels: readonly string[] = listDeliverableMessageChannels();
+  const externalChannels = normalizePromptCapabilityIds(listDeliverableMessageChannels()).filter(
+    (channelId) => !CHANNEL_IDS.includes(channelId),
+  );
+  const deliverableChannels: readonly string[] = [...CHANNEL_IDS, ...externalChannels];
   if (deliverableChannels.length <= 1) {
     return undefined;
   }


### PR DESCRIPTION
Closes #123542

## What Problem This Solves

Fixes an issue where operators using external channel plugins or dynamically assembled tool inventories could get different model-visible prompt and request bytes when equivalent registrations were discovered in a different order. That instability causes avoidable prompt-cache misses and makes provider request diagnostics vary between otherwise identical runs.

## Why This Change Was Made

Model-visible producers now canonicalize only the unordered portions they own. The system prompt preserves the explicit built-in channel product order and sorts the normalized external suffix; Mistral and direct OpenAI Completions reuse the shared non-mutating tool-order policy before emitting payloads. Mutable plugin registries, first-wins collision behavior, message order, and content order remain unchanged. Mistral also retains its existing behavior of quarantining one malformed tool instead of failing the whole request.

## User Impact

Equivalent channel and tool capability sets now produce byte-identical prompts and provider requests regardless of plugin discovery or tool assembly order. Operators get more reliable prompt-cache reuse, steadier latency/cost behavior, and reproducible request bytes without any configuration or API change.

## Evidence

- Tests-first regressions reproduced all three mismatches on `0b0fe6ecc0fd01bbe7ddb571c192693abcaac091`:
  - external channel suffix `zeta-channel|alpha-channel` versus `alpha-channel|zeta-channel`;
  - Mistral tool order `zeta_tool,alpha_tool` versus `alpha_tool,zeta_tool`;
  - direct OpenAI Completions tool order `zeta_tool,alpha_tool` versus `alpha_tool,zeta_tool`.
- Corrected owner tests: 217/217 passed across Mistral (24), direct OpenAI Completions (60), system prompt (120), and the already-canonical split OpenAI transport (13).
- The Mistral malformed-tool regression proves unreadable name/parameter getters are still skipped while healthy tools reach the payload.
- Blacksmith Testbox changed-gate proof passed for core + coreTests, including core/core-test typechecks, changed lint, dead exports, import cycles, format, schema/storage guards, and architecture checks: https://github.com/openclaw/openclaw/actions/runs/31778122877 (`tbx_01kzzgzf3x332g8ac56trjcm81`).
- Final Codex autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Exact reviewed head: `f4bed3fbac5386e9aaaaf98ee9fd57a91ed032bd`.

Production delta: +17/-7, net +10. Tests: +108/-2, net +106.

AI-assisted: yes. The implementation and tests were reviewed against the system-prompt cache boundary, plugin registry ownership, Mistral conversion/quarantine behavior, direct and split OpenAI Completions transports, and sibling provider ordering policy.
