### PR TITLE
fix(agents): stop duplicate and invisible subagent announce give-ups

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -4,6 +4,7 @@
 import { sanitizePendingFinalDeliveryText } from "../../../auto-reply/reply/pending-final-delivery.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { sourceDeliveryTargetsMatch } from "../../../infra/outbound/source-delivery-plan.js";
+import { defaultRuntime } from "../../../runtime.js";
 import { deriveSessionChatTypeFromKey } from "../../../sessions/session-chat-type-shared.js";
 import { isNonTerminalAgentRunStatus } from "../../../shared/agent-run-status.js";
 import { sanitizeAgentRunTerminalReplyText } from "../../agent-run-terminal-reply.js";
@@ -15,6 +16,7 @@ import {
 } from "../../embedded-agent-runner/delivery-evidence.js";
 import type { AgentInternalEvent } from "../../internal-events.js";
 import {
+  hasAnnounceSendEvidence,
   sourceOwnerChangedResult,
   summarizeDeliveryError,
 } from "./subagent-announce-delivery-retry.js";
@@ -105,6 +107,11 @@ export async function deliverCompletionDirect(params: {
     !params.deliveryTarget.to ||
     !isDirectMessageDeliveryTarget(params.deliveryTarget, params.requesterSessionKey)
   ) {
+    // Returning silently is why an announce give-up looked like it had no
+    // salvageable text: the decline itself left no trace.
+    defaultRuntime.log(
+      `[warn] Subagent completion text-direct salvage skipped: contentChars=${content?.length ?? 0} deliver=${params.deliveryTarget.deliver} channel=${params.deliveryTarget.channel ?? "-"} to=${params.deliveryTarget.to ?? "-"} requester=${params.requesterSessionKey}`,
+    );
     return undefined;
   }
   const agentId = tryResolveSubagentRequesterAgentId(
@@ -170,10 +177,13 @@ export async function deliverCompletionDirect(params: {
       // retryable failure and send the same completion twice.
       return committedDelivery;
     }
+    // A send-then-throw already put the text on the platform. Reporting it as
+    // undelivered would retry and post the same completion again.
     return {
       delivered: false,
       path: "direct",
       error: `text completion direct delivery failed: ${summarizeDeliveryError(err)}`,
+      ...(hasAnnounceSendEvidence(err) ? { terminal: true } : {}),
     };
   }
 }

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -177,13 +177,18 @@ export async function deliverCompletionDirect(params: {
       // retryable failure and send the same completion twice.
       return committedDelivery;
     }
-    // A send-then-throw already put the text on the platform. Reporting it as
-    // undelivered would retry and post the same completion again.
+    // A send-then-throw already put the text on the platform. Reporting a plain
+    // failure would fall back to steering and then retry the announce, posting
+    // the same completion again. `ambiguous` is the existing disposition for
+    // "may already be visible": it stops fallback steering in the dispatcher and
+    // stops the registry retry, which `terminal` alone does not do.
     return {
       delivered: false,
       path: "direct",
       error: `text completion direct delivery failed: ${summarizeDeliveryError(err)}`,
-      ...(hasAnnounceSendEvidence(err) ? { terminal: true } : {}),
+      ...(hasAnnounceSendEvidence(err)
+        ? { terminal: true, disposition: "ambiguous" as const }
+        : {}),
     };
   }
 }

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../infra/outbound/session-binding-service.js";
 import { normalizeLegacySessionEntryDelivery } from "../../../infra/state-migrations.legacy-session-store.js";
 import { setActivePluginRegistry } from "../../../plugins/runtime.js";
+import { defaultRuntime } from "../../../runtime.js";
 import {
   createChannelTestPluginBase,
   createTestRegistry,
@@ -28,6 +29,7 @@ import {
 import {
   createTaskCompletionEvent,
   expectDeliveryPath,
+  expectRecord,
   expectRecordFields,
   imageCompletionEvents,
   mockCallArg,
@@ -1640,6 +1642,62 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
     expect(onDeliveryResult).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a sent-then-failed direct text completion terminal", async () => {
+    const callGateway = createPayloadGatewayMock();
+    const sendMessage = vi.fn(async () => {
+      throw Object.assign(
+        new Error("session file changed while embedded prompt lock was released"),
+        { sentBeforeError: true },
+      );
+    }) as unknown as typeof runtimeSendMessage;
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+    });
+
+    expectRecordFields(result, { delivered: false, path: "direct", terminal: true });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a never-sent direct text completion retryable", async () => {
+    const callGateway = createPayloadGatewayMock();
+    const sendMessage = vi.fn(async () => {
+      throw new Error("transient transport failure");
+    }) as unknown as typeof runtimeSendMessage;
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+    });
+
+    expect(expectRecord(result, "never-sent direct text completion").terminal).toBeUndefined();
+  });
+
+  it("logs why a direct text completion salvage declined", async () => {
+    const callGateway = createPayloadGatewayMock();
+    const sendMessage = createSendMessageMock();
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+
+    await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        status: "error",
+        statusLabel: "failed",
+      }),
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Subagent completion text-direct salvage skipped: contentChars=0"),
+    );
+    logSpy.mockRestore();
   });
 
   it("uses the caller owner for direct completion delivery to a bare requester key", async () => {

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1644,7 +1644,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("marks a sent-then-failed direct text completion terminal", async () => {
+  it("marks a sent-then-failed direct text completion ambiguous and terminal", async () => {
     const callGateway = createPayloadGatewayMock();
     const sendMessage = vi.fn(async () => {
       throw Object.assign(
@@ -1659,7 +1659,14 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
     });
 
-    expectRecordFields(result, { delivered: false, path: "direct", terminal: true });
+    // `ambiguous` is what actually stops the steer fallback and the registry
+    // retry; `terminal` alone is not consulted on the completion-handoff path.
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      terminal: true,
+      disposition: "ambiguous",
+    });
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
@@ -1675,7 +1682,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
     });
 
-    expect(expectRecord(result, "never-sent direct text completion").terminal).toBeUndefined();
+    const record = expectRecord(result, "never-sent direct text completion");
+    expect(record.terminal).toBeUndefined();
+    expect(record.disposition).toBeUndefined();
   });
 
   it("logs why a direct text completion salvage declined", async () => {

--- a/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
@@ -170,6 +170,41 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
+  it("does not fallback-steer after a send-evidence completion direct failure", async () => {
+    const steer = vi.fn(async () => ({ status: "steered" }) as const);
+    const direct = vi.fn(async () => ({
+      delivered: false,
+      path: "direct" as const,
+      error: "text completion direct delivery failed: post-send bookkeeping failed",
+      terminal: true,
+      disposition: "ambiguous" as const,
+    }));
+
+    // This is the shape `deliverCompletionDirect` returns for a send-then-throw:
+    // the text is already on the platform, so steering the requester would post
+    // the same completion a second time.
+    const result = await runSubagentAnnounceDispatch({
+      expectsCompletionMessage: true,
+      steer,
+      direct,
+    });
+
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(steer).not.toHaveBeenCalled();
+    expect(result.delivered).toBe(false);
+    expect(result.path).toBe("direct");
+    expect(result.terminal).toBe(true);
+    expect(result.disposition).toBe("ambiguous");
+    expect(result.phases).toEqual([
+      {
+        phase: "direct-primary",
+        delivered: false,
+        path: "direct",
+        error: "text completion direct delivery failed: post-send bookkeeping failed",
+      },
+    ]);
+  });
+
   it("returns direct failure when completion fallback steering cannot deliver", async () => {
     const steer = vi.fn(async () => ({ status: "none" }) as const);
     const direct = vi.fn(async () => ({

--- a/src/agents/subagents/registry/subagent-registry-helpers.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-helpers.test.ts
@@ -297,8 +297,23 @@ describe("logAnnounceGiveUp", () => {
     logAnnounceGiveUp(entry, "expiry");
 
     expect(logSpy).toHaveBeenCalledWith(
-      '[warn] Subagent announce give up (expiry) run=run-1 child=agent:main:subagent:child requester=agent:main:main retries=3 endedAgo=5s deliveryError="direct-primary: routed-dispatch-did-not-queue-final"',
+      '[warn] Subagent announce give up (expiry) run=run-1 child=agent:main:subagent:child requester=agent:main:main retries=3 endedAgo=5s discardedResultChars=0 deliveryError="direct-primary: routed-dispatch-did-not-queue-final"',
     );
+    logSpy.mockRestore();
+  });
+
+  it("reports discarded completion text at error level", () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const entry = createRunEntry({
+      completion: { required: true, resultText: "child result text" },
+      delivery: { status: "failed", attemptCount: 3, lastError: "message_tool_delivery_missing" },
+    });
+
+    logAnnounceGiveUp(entry, "permanent_failure");
+
+    const line = String(logSpy.mock.calls[0]?.[0]);
+    expect(line).toContain("[error] Subagent announce give up (permanent_failure)");
+    expect(line).toContain("discardedResultChars=17");
     logSpy.mockRestore();
   });
 

--- a/src/agents/subagents/registry/subagent-registry-helpers.ts
+++ b/src/agents/subagents/registry/subagent-registry-helpers.ts
@@ -91,8 +91,11 @@ export function logAnnounceGiveUp(
   const deliveryError = lastDeliveryError
     ? ` deliveryError=${formatAnnounceGiveUpLogField(lastDeliveryError)}`
     : "";
+  // Losing completion text with nothing user-visible is an error, not a warning.
+  // A give-up with no text to lose (a run briefed to stay silent) stays a warning.
+  const discardedResultChars = (entry.completion?.resultText ?? "").length;
   defaultRuntime.log(
-    `[warn] Subagent announce give up (${reason}) run=${entry.runId} child=${entry.childSessionKey} requester=${entry.requesterSessionKey} retries=${retryCount} endedAgo=${endedAgoLabel}${deliveryError}`,
+    `[${discardedResultChars > 0 ? "error" : "warn"}] Subagent announce give up (${reason}) run=${entry.runId} child=${entry.childSessionKey} requester=${entry.requesterSessionKey} retries=${retryCount} endedAgo=${endedAgoLabel} discardedResultChars=${discardedResultChars}${deliveryError}`,
   );
 }
 


### PR DESCRIPTION
Related: #103004
Related: #90178
Related: #44925
Related: #67777
Related: #118625
Related: #123548

## What Problem This Solves

Two operational problems on the subagent announce completion-delivery path.

1. **A completion can be posted more than once.** When the direct text-completion
   delivery sends successfully but then fails during post-send bookkeeping, the
   result is reported as undelivered. The announce retry loop treats that as
   retryable and the outbound send is not idempotency-deduped, so the same
   subagent result can land in the conversation up to three times.

2. **When a completion is discarded, nothing says how much was lost.** After
   retries are exhausted the give-up line is a single `[warn]` with no indication
   of whether real result text was thrown away. A run that was deliberately
   silent (a scheduled job briefed not to reply) and a run whose finished work
   was destroyed produce identical log lines, so operators cannot tell data loss
   from routine noise. The direct-delivery salvage compounded this: whenever it
   declined it returned silently, leaving no trace that salvageable text existed
   at all.

## Why This Change Was Made

`deliverCompletionDirect()`'s catch already protected against double-sending for
one case — an `onDeliveryResult` callback that fired before the throw — but it
never consulted `hasAnnounceSendEvidence(err)`, which is how the rest of this
module recognizes a send-then-throw (`sentBeforeError` / `visibleReplySent`, and
`OutboundDeliveryError` chains). The outer announce catch at
`subagent-announce-direct-delivery.ts` already does exactly this consult; this
brings the inner one into line.

The send-evidence result returns `disposition: "ambiguous"` (alongside
`terminal: true`), because `ambiguous` is what the two owners downstream
actually consult. `runSubagentAnnounceDispatch()` short-circuits the completion
handoff on `delivered` or on a `session_queued` / `intentional_non_delivery` /
`ambiguous` / `permanent_failure` disposition
(`subagent-announce-dispatch.ts:151-158`) — `terminal` is only consulted on the
steer phases, so a `terminal`-only result would still have fallen through to
fallback steering. The announce flow then maps a dispositionless undelivered
result to `retryable` (`subagent-announce.ts:594`), and
`subagent-announce.requester-settle-wake.ts:501` settles rather than replays an
`ambiguous` batch. `ambiguous` is already this module's marker for "may already
be visible" — `deliverCompletionDirect()` uses it for the
`adapter_returned_no_identity` suppression a few lines above, and
`subagent-announce-dispatch.test.ts` already pins that an ambiguous completion
direct failure must not fallback-steer, precisely to avoid duplicates.

The failure mode of the change is bounded and in the safe direction: a wrong
send-evidence verdict costs one missed retry on a genuinely unsent message,
which the new give-up line now reports explicitly.

`logAnnounceGiveUp()` now reports `discardedResultChars` and escalates to
`[error]` only when the frozen completion actually held text. A give-up with
nothing to lose stays a `[warn]`, so deliberately silent runs do not start
paging anyone.

The decline path in `deliverCompletionDirect()` logs why it declined
(content length, whether the route was deliverable, channel, target, requester).
That line is the diagnostic hook that makes the whole class of failure visible.
Note that the same line also fires on the by-policy declines — a non-direct
target, or a child that finished with no result text — so it is chattier than a
pure anomaly signal. Warning level matches the surrounding announce logging and
keeps it visible next to the give-up line it explains; say the word if you would
rather have it gated on `contentChars > 0` or dropped to debug.

Files changed:

- `src/agents/subagents/announce/subagent-announce-completion-delivery.ts`
- `src/agents/subagents/registry/subagent-registry-helpers.ts`

Non-goal, called out deliberately: this PR does **not** change which requesters
are eligible for the raw text salvage. Group, channel, and thread requesters
still get no direct fallback when the completion agent skips the message tool in
`message_tool_only` mode, and their result is still discarded. That is part (1)
of #103004 (closed as a duplicate of #90178 and #92076, both of which are now
closed too), and widening the salvage to non-direct targets contradicts several
explicit invariants in
`subagent-announce-delivery.test.ts` ("does not raw-send channel completions
just because the requester key is direct", "does not raw-send grouped child
results when requester-agent output is empty", and four related cases). It needs
a design decision about whether raw child text may ever enter a group, not a
drive-by fix. This PR makes that loss loud instead of silent; the policy question
is filed separately as #123548, with candidate directions and the conflicting
invariants enumerated.

Relationship to existing work: #88182 introduced the direct-message scope for
this salvage. #90041 proposed a blunter widening and was closed unmerged as
inactive, with the review noting that its direct bypass "conflicts with current
main's explicit message-tool delivery contract" — which is exactly why this PR
does not reopen that question. #90178 was addressed by #99396, which covers
parent wake, not this path.

## User Impact

Operators no longer see the same subagent result posted two or three times after
a transient post-send failure. When an announce is abandoned, the log now says
whether completed work was destroyed and how large it was, at `[error]` when it
was — which makes the loss alertable instead of invisible. Deliberately silent
runs are unchanged and stay at warning level.

## Evidence

Reproduction (generic):

- **Duplicate send:** make the outbound send succeed and then fail post-send
  (any error carrying `sentBeforeError: true`, e.g. a session-store writer
  rebound during transcript mirroring — an error class already listed in
  `PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS`). Before this change the announce
  retried and re-posted; after it, the result is terminal.
- **Invisible loss:** run a subagent whose requester resolves to
  `message_tool_only` reply mode and whose completion agent does not call the
  `message` tool. Before this change: `[warn] Subagent announce give up ...` and
  nothing else. After: `[error] Subagent announce give up ...
  discardedResultChars=<n>`. Observed on a live deployment 20 times over five
  weeks before it was noticed at all, which is the point.

Focused tests:

```
npx vitest run --maxWorkers=2 src/agents/subagents/announce src/agents/subagents/registry
# Test Files 98 passed (98) — Tests 3163 passed (3163)
```

New coverage:

- `subagent-announce-dispatch.test.ts` — a send-evidence direct failure
  (`{ delivered: false, path: "direct", terminal: true, disposition: "ambiguous" }`,
  the exact shape `deliverCompletionDirect()` now returns) does not
  fallback-steer: `steer` is never called and the result stays on the `direct`
  phase. This is the seam where a `terminal`-only result would still have
  produced the duplicate.
- `subagent-announce-delivery.test.ts` — a send-then-failed direct text
  completion resolves `{ delivered: false, path: "direct", terminal: true,
  disposition: "ambiguous" }`.
- `subagent-announce-delivery.test.ts` — a never-sent failure stays retryable
  (both `terminal` and `disposition` undefined), so this does not swallow real
  failures.
- `subagent-announce-delivery.test.ts` — a declined salvage logs
  `Subagent completion text-direct salvage skipped: contentChars=0`.
- `subagent-registry-helpers.test.ts` — the give-up line reports
  `discardedResultChars` and uses `[error]` when text was lost; the existing
  expiry case pins `discardedResultChars=0` at `[warn]`.

Also run: `oxlint` clean on all changed files, and `git diff --check` clean. The
type-aware lint and full `tsgo` passes ran clean on the first revision of this
branch; on the machine I have they now exhaust memory, so for this revision I am
relying on CI's `check-prod-types` / `check-test-types` / `check-lint` lanes. The
disposition field added here is the same `SubagentAnnounceDeliveryDisposition`
union member already returned a few lines above in the same function, so the
declared `Promise<SubagentAnnounceDeliveryResult | undefined>` return type is
unchanged.

On real-transport proof: I can't attach the originating logs — they are from a
private deployment and carry conversation identifiers — and provoking a genuine
send-then-throw needs a live channel account plus a post-send storage fault, so
I have no sanitized end-to-end trace to offer. What I can point at is that the
duplicate is produced by a decision made entirely inside this repo's code: the
dispatcher's short-circuit list and the outcome mapper are the two owners, and
both are now covered at their own boundaries by the tests above. If a maintainer
wants a specific harness or fixture instead, tell me which one and I will add
it.

_AI-assisted: written with Claude, from a production incident report. The full
diff and reasoning have been reviewed by hand._

