### PR TITLE
fix: preserve steering after tool-authority checks

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-queue-message.ts
@@ -346,7 +346,13 @@ export async function steerActiveSessionWithOptionalDeliveryWait(
       log.warn(`failed to cancel ask_user before image steering: ${String(error)}`);
     }
   }
-  if (await claimEmbeddedPendingUserInputAnswer(text, options, sessionKey)) {
+  // Non-user steering must install its transcript listener synchronously; an
+  // unnecessary await here lets callers emit before subscribe() runs.
+  if (
+    isInboundUserMessage &&
+    isPlainTextAnswer &&
+    (await claimEmbeddedPendingUserInputAnswer(text, options, sessionKey))
+  ) {
     options?.onQueueAccepted?.(true);
     return;
   }

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -193,13 +193,13 @@ describe("executeAgentTurn: CLI session routing", () => {
     expect(state.runCliAgentMock).toHaveBeenCalledOnce();
     expectMockCallArgFields(state.runCliAgentMock, 0, "CLI runtime", {
       sessionKey: "main",
-      agentId: "agent",
+      agentId: "main",
       sessionId: "session",
       suppressNextUserMessagePersistence: false,
       persistAssistantTranscript: true,
       storePath: "/tmp/sessions.json",
       sessionTarget: {
-        agentId: "agent",
+        agentId: "main",
         sessionId: "session",
         sessionKey: "main",
         storePath: "/tmp/sessions.json",

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -236,14 +236,19 @@ vi.mock("../../utils/message-channel.js", async () => ({
   isInternalMessageChannel: (value: unknown) => state.isInternalMessageChannelMock(value),
 }));
 
-vi.mock("../heartbeat.js", () => ({
-  DEFAULT_HEARTBEAT_EVERY: "30m",
-  stripHeartbeatToken: (text: string) => ({
-    text,
-    didStrip: false,
-    shouldSkip: false,
-  }),
-}));
+vi.mock("../heartbeat.js", async () => {
+  const actual = await vi.importActual<typeof import("../heartbeat.js")>("../heartbeat.js");
+  return {
+    DEFAULT_HEARTBEAT_EVERY: actual.DEFAULT_HEARTBEAT_EVERY,
+    HEARTBEAT_CRON_TASK_GUIDANCE: actual.HEARTBEAT_CRON_TASK_GUIDANCE,
+    resolveHeartbeatPromptCore: actual.resolveHeartbeatPromptCore,
+    stripHeartbeatToken: (text: string) => ({
+      text,
+      didStrip: false,
+      shouldSkip: false,
+    }),
+  };
+});
 
 vi.mock("./current-turn-images.js", () => ({
   resolveCurrentTurnImages: (params: unknown) => state.resolveCurrentTurnImagesMock(params),

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -237,6 +237,7 @@ vi.mock("../../utils/message-channel.js", async () => ({
 }));
 
 vi.mock("../heartbeat.js", () => ({
+  DEFAULT_HEARTBEAT_EVERY: "30m",
   stripHeartbeatToken: (text: string) => ({
     text,
     didStrip: false,
@@ -451,7 +452,7 @@ export function createFollowupRun(): FollowupRun {
     summaryLine: "hello",
     enqueuedAt: Date.now(),
     run: {
-      agentId: "agent",
+      agentId: "main",
       agentDir: "/tmp/agent",
       sessionId: "session",
       sessionKey: "main",

--- a/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
@@ -116,6 +116,7 @@ function createReplyOperation(): ReplyOperation {
     lastActivityAtMs: Date.now(),
     recordActivity: vi.fn(),
     setPhase: vi.fn(),
+    bindToolAuthorityFingerprint: vi.fn(),
     freezeAbort: vi.fn(),
     fail: vi.fn(),
     complete: vi.fn(),

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -51,6 +51,11 @@ const resolveOutboundAttachmentFromUrlMock = vi.fn();
 const createReplyMediaContextRuntimeMock = vi.fn();
 const EXPECTED_STEER_QUEUE_IDENTITY =
   "channel-user:v1:6f3f31084a7a2a6ff17176c0c16682e64d9f21301f64ff7e5bf1173b54fadc33";
+const TEST_TOOL_AUTHORITY_FINGERPRINT = "test-tool-authority";
+
+vi.mock("./reply-tool-authority.js", () => ({
+  resolveFollowupRunToolAuthorityFingerprint: () => "test-tool-authority",
+}));
 
 vi.mock("../../agents/model-fallback-runner.js", () => ({
   runWithModelFallback: (params: {
@@ -292,10 +297,14 @@ const { runReplyAgent } = await import("./agent-runner.js");
 function createReplyOperation(): ReplyOperation {
   return {
     result: undefined,
+    toolAuthorityFingerprint: TEST_TOOL_AUTHORITY_FINGERPRINT,
+    abortSignal: new AbortController().signal,
     startedAtMs: Date.now(),
     lastActivityAtMs: Date.now(),
     recordActivity: vi.fn(),
     setPhase: vi.fn(),
+    bindToolAuthorityFingerprint: vi.fn(),
+    bindToolAuthorityRoute: vi.fn(),
     freezeAbort: vi.fn(),
     fail: vi.fn(),
     complete: vi.fn(),
@@ -486,6 +495,7 @@ describe("runReplyAgent media path normalization", () => {
         queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
         onQueueAccepted: parkedSteerAcceptedMock,
         taskSuggestionDeliveryMode: "gateway",
+        toolAuthorityFingerprint: TEST_TOOL_AUTHORITY_FINGERPRINT,
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
@@ -534,6 +544,7 @@ describe("runReplyAgent media path normalization", () => {
         images,
         media: followupRun.media,
         taskSuggestionDeliveryMode: undefined,
+        toolAuthorityFingerprint: TEST_TOOL_AUTHORITY_FINGERPRINT,
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
@@ -580,6 +591,7 @@ describe("runReplyAgent media path normalization", () => {
       resetTriggered: false,
     });
     operation.setPhase("running");
+    operation.bindToolAuthorityFingerprint(TEST_TOOL_AUTHORITY_FINGERPRINT);
     expect(operation.acceptedSteeredInboundAudio).toBe(false);
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: true,
@@ -615,6 +627,7 @@ describe("runReplyAgent media path normalization", () => {
         queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
         onQueueAccepted: parkedSteerAcceptedMock,
         taskSuggestionDeliveryMode: undefined,
+        toolAuthorityFingerprint: TEST_TOOL_AUTHORITY_FINGERPRINT,
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/reply-run-registry.contracts.ts
+++ b/src/auto-reply/reply/reply-run-registry.contracts.ts
@@ -96,6 +96,8 @@ export type ReplyMessageInjectionTarget = {
   readonly identity: "leaf" | "run";
   readonly runId?: string;
   readonly originatingLeafEntryId: string | null | undefined;
+  /** Tool authority captured with the exact active operation. */
+  readonly toolAuthorityFingerprint?: string;
 };
 
 type ReplyMessageInjectionRejectionReason =

--- a/src/auto-reply/reply/reply-run-registry.registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.registry.ts
@@ -123,6 +123,9 @@ export const replyRunRegistry: ReplyRunRegistry = {
       identity: normalizeOptionalString(expectedRunId) ? "run" : "leaf",
       ...(resolved.backend.runId ? { runId: resolved.backend.runId } : {}),
       originatingLeafEntryId,
+      ...(operation?.toolAuthorityFingerprint
+        ? { toolAuthorityFingerprint: operation.toolAuthorityFingerprint }
+        : {}),
     };
     return target;
   },

--- a/src/gateway/server-methods/chat-send-message-injection.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.ts
@@ -29,13 +29,16 @@ import type { GatewayRequestContext } from "./types.js";
 /** Captures the prepared request data used by both pre-ACK and detached injection attempts. */
 export function createChatSendMessageInjectionStarter(params: {
   target: ReplyMessageInjectionTarget | undefined;
-  request: Pick<NormalizedChatSendRequest, "p" | "rawMessage" | "supportsTaskSuggestions">;
+  request: Pick<
+    NormalizedChatSendRequest,
+    "p" | "rawMessage" | "supportsTaskSuggestions" | "toolBindings"
+  >;
   session: Pick<PreparedChatSendSession, "cfg" | "entry">;
   turn: ReturnType<typeof prepareChatSendUserTurn>;
   imageOrder: ReplyBackendQueueMessageOptions["imageOrder"];
   userTurnTranscriptRecorder: ReplyBackendQueueMessageOptions["userTurnTranscriptRecorder"];
 }) {
-  const { p, rawMessage, supportsTaskSuggestions } = params.request;
+  const { p, rawMessage, supportsTaskSuggestions, toolBindings } = params.request;
   const { cfg, entry } = params.session;
   const { ctx, isInternalTextSlashCommandTurn, replyOptionImages, replyOptionMedia } = params.turn;
   return (): ReplyMessageInjectionAttempt | undefined => {
@@ -57,6 +60,11 @@ export function createChatSendMessageInjectionStarter(params: {
       {
         steeringMode: "all",
         isInboundUserMessage: true,
+        // chat.send cannot alter per-turn tool policy. Preserve the captured
+        // active authority only when no request-scoped tool bindings are present.
+        ...(toolBindings === undefined && params.target.toolAuthorityFingerprint
+          ? { toolAuthorityFingerprint: params.target.toolAuthorityFingerprint }
+          : {}),
         ...(replyOptionImages?.length ? { images: replyOptionImages } : {}),
         ...(params.imageOrder?.length ? { imageOrder: params.imageOrder } : {}),
         ...(replyOptionMedia?.length ? { media: replyOptionMedia } : {}),

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -26,7 +26,7 @@ import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import { getTotalPendingReplies } from "../../auto-reply/reply/dispatcher-registry.js";
 import { markInboundContextLabel } from "../../auto-reply/reply/inbound-context-marker.js";
 import {
-  replyRunRegistry,
+  replyRunRegistry as baseReplyRunRegistry,
   type ReplyBackendQueueMessageOptions,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
@@ -61,6 +61,16 @@ import type { GatewayRequestContext } from "./types.js";
 type ProjectedDispatchParams = Parameters<
   typeof import("../../auto-reply/dispatch.js").dispatchInboundMessageWithProjectedDispatcher
 >[0];
+
+const TEST_TOOL_AUTHORITY_FINGERPRINT = "test-tool-authority";
+const replyRunRegistry = {
+  ...baseReplyRunRegistry,
+  begin(...args: Parameters<typeof baseReplyRunRegistry.begin>) {
+    const operation = baseReplyRunRegistry.begin(...args);
+    operation.bindToolAuthorityFingerprint(TEST_TOOL_AUTHORITY_FINGERPRINT);
+    return operation;
+  },
+};
 
 const mockState = vi.hoisted(() => ({
   config: {} as Record<string, unknown>,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where main CI failed across four Node shards after authority-aware steering changes. The same regressions could make Gateway chat steering fall back to a new turn and could let a non-user embedded steer emit before its transcript listener was installed.

## Why This Change Was Made

The captured reply-operation authority now crosses the Gateway message-injection target when the request has no turn-scoped tool bindings, preserving the exact active authority without widening tool-bound requests. Non-user steering skips the asynchronous pending-question claim path so transcript observation is installed synchronously. Test fixtures now use canonical session ownership, complete reply-operation authority contracts, and narrow heartbeat exports.

The repair keeps the new tool-authority safety boundary intact; it does not add retries, weaken assertions, or bypass mismatches.

## User Impact

Gateway chat messages can continue steering an eligible active turn instead of unnecessarily starting another turn. Embedded queued steering reliably observes transcript completion and cancellation again.

## Evidence

- Reproduced the original four execution failures on current main and bisected them to the authority-lifecycle commit range.
- `node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts` — 192 tests passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts` — 15 tests passed.
- Execution-focused routed suites passed; the sole post-rebase heartbeat-mock failure also passed after the fixture repair.
- Focused media-runner tests — 14 tests passed.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31780502502
- Changed-file formatting, Oxlint, typechecks, guards, and final structured autoreview passed.

Production LOC: +22/-3 (net +19), required to preserve the active authority binding and synchronous transcript-listener lifecycle. Tests and test support: +41/-11.

Relevant failing main runs: https://github.com/openclaw/openclaw/actions/runs/31776439546, https://github.com/openclaw/openclaw/actions/runs/31776648638, and https://github.com/openclaw/openclaw/actions/runs/31776785997.
