### PR TITLE
test: remove latest duplicate coverage

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -182,24 +182,6 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointAllowsPrivateLanCleartextWsUrls() {
-    assertParsedEndpoint(
-      input = "ws://192.168.1.20:18789",
-      host = "192.168.1.20",
-      displayUrl = "http://192.168.1.20:18789",
-    )
-  }
-
-  @Test
-  fun parseGatewayEndpointAllowsMdnsCleartextWsUrls() {
-    assertParsedEndpoint(
-      input = "ws://gateway.local:18789",
-      host = "gateway.local",
-      displayUrl = "http://gateway.local:18789",
-    )
-  }
-
-  @Test
   fun parseGatewayEndpointAllowsNormalizedMdnsCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://GATEWAY.LOCAL.:18789")
 

--- a/apps/ios/Sources/RootTabsNavigation.swift
+++ b/apps/ios/Sources/RootTabsNavigation.swift
@@ -145,10 +145,6 @@ extension RootTabs {
         return max(0, min(sidebarWidth, dragOffset))
     }
 
-    static func shouldShowSidebarRevealControl(isSidebarVisible: Bool) -> Bool {
-        !isSidebarVisible
-    }
-
     static func visibleSettingsRoute(
         navigationPath: [SettingsRoute],
         baseRoute: SettingsRoute?) -> SettingsRoute?
@@ -164,7 +160,7 @@ extension RootTabs {
         case .split:
             true
         case .drawer:
-            self.shouldShowSidebarRevealControl(isSidebarVisible: isSidebarVisible)
+            !isSidebarVisible
         }
     }
 

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -539,25 +539,6 @@ struct RootTabsPresentationTests {
         #expect(width <= RootTabs.sidebarSplitMaximumWidth)
     }
 
-    @Test func `i pad collapsed split sidebar uses header reveal without reserved rail`() {
-        #expect(
-            RootTabs.shouldShowSidebarRevealInDestinationHeader(
-                isSidebarVisible: false,
-                layoutMode: .split))
-        #expect(
-            RootTabs.shouldShowSidebarRevealInDestinationHeader(
-                isSidebarVisible: true,
-                layoutMode: .split))
-        #expect(
-            RootTabs.shouldShowSidebarRevealInDestinationHeader(
-                isSidebarVisible: false,
-                layoutMode: .drawer))
-        #expect(
-            !RootTabs.shouldShowSidebarRevealInDestinationHeader(
-                isSidebarVisible: true,
-                layoutMode: .drawer))
-    }
-
     @Test func `initial sidebar visibility parses launch argument`() {
         #expect(
             RootTabs.requestedInitialSidebarVisibility(arguments: [
@@ -969,19 +950,6 @@ struct RootTabsPresentationTests {
 
         #expect(mode == .drawer)
         #expect(!RootTabs.preferredSidebarVisibility(layoutMode: mode))
-    }
-
-    @Test func `drawer selection collapses sidebar but split selection does not`() {
-        #expect(RootTabs.shouldCollapseSidebarAfterSelection(layoutMode: .drawer))
-        #expect(!RootTabs.shouldCollapseSidebarAfterSelection(layoutMode: .split))
-    }
-
-    @Test func `hidden sidebar shows reveal control`() {
-        #expect(RootTabs.shouldShowSidebarRevealControl(isSidebarVisible: false))
-    }
-
-    @Test func `sidebar reveal controls hide when sidebar is visible`() {
-        #expect(!RootTabs.shouldShowSidebarRevealControl(isSidebarVisible: true))
     }
 
     @Test func `i pad split prefers integrated visible sidebar`() {

--- a/apps/macos/Tests/OpenClawIPCTests/AudioInputDeviceObserverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AudioInputDeviceObserverTests.swift
@@ -65,13 +65,6 @@ struct AudioInputDeviceObserverTests {
         #expect(selected.shouldRestart(availableUIDs: ["built-in"], defaultUID: "built-in"))
     }
 
-    @Test func `has usable default input device returns bool`() {
-        // Smoke test: verifies the composition logic runs without crashing.
-        // Actual result depends on whether the host has an audio input device.
-        let result = AudioInputDeviceObserver.hasUsableDefaultInputDevice()
-        _ = result // suppress unused-variable warning; the assertion is "no crash"
-    }
-
     @Test func `has usable default input device consistent with components`() {
         // When no default UID exists, the method must return false.
         // When a default UID exists, the result must match alive-set membership.

--- a/packages/normalization-core/src/utf16-slice.test.ts
+++ b/packages/normalization-core/src/utf16-slice.test.ts
@@ -94,13 +94,6 @@ describe("truncateUtf16Safe", () => {
     expect(truncateUtf16Safe("hello world", 5.7)).toBe("hello");
   });
 
-  it("preserves emoji with surrogate pairs", () => {
-    const emoji = "👨‍👩‍👧‍👦";
-    const result = truncateUtf16Safe(emoji, 10);
-    // Should not return dangling surrogate
-    expect(result.length).toBeLessThanOrEqual(emoji.length);
-  });
-
   it("returns empty string when truncating at surrogate pair boundary", () => {
     const input = "👨👩";
     expect(truncateUtf16Safe(input, 1)).toBe("");

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -6,7 +6,6 @@ import type {
   GatewayRequestOptions,
   OpenClawEvent,
   OpenClawTransport,
-  TaskSummary,
 } from "./types.js";
 
 type RequestCall = {
@@ -601,10 +600,6 @@ describe("OpenClaw SDK", () => {
         diffStat: { files: 2, added: 12, removed: 3 },
       },
     ]);
-    const listedTask: TaskSummary | undefined = taskList.tasks[0];
-    expect(listedTask).toBeDefined();
-    expect(listedTask?.lastActivity).toBe("Editing the registry");
-    expect(listedTask?.diffStat).toEqual({ files: 2, added: 12, removed: 3 });
     const taskGet = await oc.tasks.get("task_123");
     expect(taskGet.task).toEqual({
       id: "task_123",

--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -86,10 +86,6 @@ describe("agent-tools.policy", () => {
   it("keeps apply_patch when write is allowlisted", () => {
     expect(isToolAllowedByPolicyName("apply_patch", { allow: ["write"] })).toBe(true);
   });
-
-  it("keeps apply_patch when write is denylisted", () => {
-    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write"] })).toBe(true);
-  });
 });
 
 describe("resolveGroupToolPolicy group context validation", () => {

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -574,13 +574,6 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
-  it("sanitizes transport-classified malformed streaming fragments (#59076)", () => {
-    const msg = makeAssistantError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
-    expect(formatAssistantErrorText(msg)).toBe(
-      "LLM streaming response contained a malformed fragment. Please try again.",
-    );
-  });
-
   it("does not broadly rewrite non-streaming 'Unexpected token' JSON parse errors", () => {
     const msg = makeAssistantError("Unexpected token < in JSON at position 0");
     expect(formatAssistantErrorText(msg)).toBe("Unexpected token < in JSON at position 0");

--- a/src/agents/embedded-agent-helpers/provider-runtime-failure.test.ts
+++ b/src/agents/embedded-agent-helpers/provider-runtime-failure.test.ts
@@ -6,16 +6,6 @@ import {
 } from "../failover/classify.js";
 import { classifyProviderRuntimeFailureKind } from "./provider-runtime-failure.js";
 
-const PLAIN_INTERNAL_SERVER_ERROR_STATUS_SAMPLE = "Proxy notice: Status: Internal Server Error";
-const INTERNAL_SERVER_ERROR_STATUS_WITH_500_SAMPLE =
-  PLAIN_INTERNAL_SERVER_ERROR_STATUS_SAMPLE + "; code:500";
-
-function expectNotFailoverSample(sample: string) {
-  expect(isTimeoutErrorMessage(sample)).toBe(false);
-  expect(classifyFailoverReason(sample)).toBeNull();
-  expect(isFailoverErrorMessage(sample)).toBe(false);
-}
-
 describe("classifyProviderRuntimeFailureKind", () => {
   it("classifies complete HTML after an HTTP reason phrase as upstream_html", () => {
     const raw = "HTTP 502 Bad Gateway\n\n<!doctype html><html><body>down</body></html>";
@@ -258,13 +248,5 @@ describe("classifyProviderRuntimeFailureKind", () => {
     expect(isTimeoutErrorMessage(sample)).toBe(false);
     expect(classifyFailoverReason(sample)).toBeNull();
     expect(isFailoverErrorMessage(sample)).toBe(false);
-  });
-
-  it("does not classify plain status text with internal server error wording as timeout", () => {
-    expectNotFailoverSample(PLAIN_INTERNAL_SERVER_ERROR_STATUS_SAMPLE);
-  });
-
-  it("classifies internal server error status prose with code 500 as timeout", () => {
-    expect(classifyFailoverReason(INTERNAL_SERVER_ERROR_STATUS_WITH_500_SAMPLE)).toBe("timeout");
   });
 });

--- a/src/agents/failover/classify.message-predicates.test.ts
+++ b/src/agents/failover/classify.message-predicates.test.ts
@@ -280,13 +280,4 @@ describe("HTTP 429 overload wording (#98101)", () => {
       "⚠️ API rate limit reached. Please try again later.",
     );
   });
-
-  it("preserves actionable retry details when a rate limit also mentions overload", () => {
-    expect(
-      renderRateLimitOrOverloadedCopy({
-        reason: "rate_limit",
-        raw: "429 rate limit: service overloaded, try again in 30 seconds",
-      }),
-    ).toBe("⚠️ rate limit: service overloaded, try again in 30 seconds");
-  });
 });

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -81,18 +81,6 @@ describe("gateway tool", () => {
     });
   });
 
-  it("exposes only config read actions", () => {
-    const tool = createGatewayTool();
-    const parameters = tool.parameters as {
-      properties?: { action?: { enum?: string[] } };
-    };
-
-    expect(parameters.properties?.action?.enum).toEqual(["config.get", "config.schema.lookup"]);
-    expect(tool.description).toBe(
-      "Read gateway config + schema. Writes/restart: use openclaw tool.",
-    );
-  });
-
   it("scopes config.get output to the requested path and keeps metadata compact", async () => {
     const result = await createGatewayTool().execute("call-config-get", {
       action: "config.get",

--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -176,15 +176,6 @@ describe("cli progress", () => {
     ).toBe(false);
   });
 
-  it("uses the progress stream instead of stdout to decide spinner interactivity", () => {
-    expect(
-      shouldUseInteractiveProgressSpinner({
-        streamIsTty: true,
-        stdinIsRaw: false,
-      }),
-    ).toBe(true);
-  });
-
   it("keeps the normal interactive spinner for regular tty commands", () => {
     expect(
       shouldUseInteractiveProgressSpinner({

--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -46,10 +46,6 @@ describe("resolveMarkdownTableMode default modes", () => {
   it("whatsapp mode is bullets", () => {
     expect(resolveMarkdownTableMode({ channel: "whatsapp" })).toBe("bullets");
   });
-
-  it("slack has no special default in this seam-only slice", () => {
-    expect(resolveMarkdownTableMode({ channel: "slack" })).toBe("code");
-  });
 });
 
 describe("resolveMarkdownTableMode", () => {

--- a/src/cron/isolated-agent/run.session-key.test.ts
+++ b/src/cron/isolated-agent/run.session-key.test.ts
@@ -57,10 +57,4 @@ describe("resolveCronAgentSessionKey", () => {
       }),
     ).toBe("agent:ops:hook:webhook:42");
   });
-
-  it("behaves unchanged when cfg is omitted (backward compat)", () => {
-    expect(resolveCronAgentSessionKey({ sessionKey: "main", agentId: "main" })).toBe(
-      "agent:main:main",
-    );
-  });
 });


### PR DESCRIPTION
## What Problem This Solves

A latest-main audit found 17 tests that no longer owned unique behavior: one vacuous surrogate assertion, exact duplicates of stronger owner tests, strict subsets of complete policy/presentation/parser matrices, and one assertion-free native smoke probe duplicated by an adjacent exact relationship test.

## Why This Change Was Made

The older or weaker copies are removed while their stronger owner-boundary tests remain. The cleanup covers normalization, SDK task shape, provider failover classification and copy, tool policy, CLI progress, markdown defaults, cron session keys, gateway tool schema, assistant error formatting, macOS audio input detection, iOS sidebar presentation, and Android gateway parsing.

Removing the direct iOS predicate-only tests leaves `shouldShowSidebarRevealControl` with one production caller, so its `!isSidebarVisible` expression is inlined into the destination-header owner and the extra helper is deleted.

## User Impact

No user-visible behavior change. The only production edit is a semantics-preserving one-use predicate inline. Existing platform, policy, parser, SDK, and error-copy contracts remain covered by stronger tests.

## Evidence

- Retained TypeScript owners: 16 files across 8 Vitest shards, 384 tests passed.
- macOS `AudioInputDeviceObserverTests`: 5/5 passed.
- iOS `RootTabsPresentationTests`: passed on an iPhone simulator through the repository-generated Xcode project.
- Full classified lightweight guards, formatting, dead-export scans, native schema guard, `tsgo:core:test`, `lint:core`, `lint:apps`, and `test:macos:ci` passed through the documented local fallback because Crabbox failed binary sanity checks.
- Android focused local proof was unavailable because this host has no Java runtime; exact-head hosted CI remains the required Android proof.
- Fresh structured autoreview reported no actionable findings.
- Production: +1/-5. Tests: -139. Total: +1/-143, net -142.

AI-assisted: yes. Each deletion was checked against its exact retained owner, callers, CI routing, and history.
