### PR TITLE
fix: stabilize steering tests and skill reconciliation

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -127,6 +127,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
       settled = true;
     });
 
+    await vi.waitFor(() => expect(emit).toBeTypeOf("function"));
     emit({
       type: "message_start",
       message: queuedMessage,
@@ -173,6 +174,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     const rejection = expect(failedWait).rejects.toThrow("SQLite transcript append failed");
 
     try {
+      await vi.waitFor(() => expect(listeners).toHaveLength(2));
       reportSteeringMessagePersistenceFailure(
         failedMessage,
         new Error("SQLite transcript append failed"),
@@ -283,10 +285,11 @@ describe("embedded OpenClaw queued steering cancellation", () => {
       "active session ended before queued steering message was committed to the transcript",
     );
 
-    emit({ type: "agent_end", messages: [] });
-    await vi.advanceTimersByTimeAsync(0);
-
     try {
+      await vi.waitFor(() => expect(emit).toBeTypeOf("function"));
+      emit({ type: "agent_end", messages: [] });
+      await vi.advanceTimersByTimeAsync(0);
+
       await rejection;
       expect(queueMessages).toEqual([keepMessage]);
       expect(retireDisplay).toHaveBeenCalledOnce();
@@ -329,11 +332,12 @@ describe("embedded OpenClaw queued steering cancellation", () => {
       "active session ended before queued steering message was committed to the transcript",
     );
 
-    emit({ type: "agent_end", messages: [] });
-    await vi.advanceTimersByTimeAsync(0);
-    releasePreparation();
-
     try {
+      await vi.waitFor(() => expect(emit).toBeTypeOf("function"));
+      emit({ type: "agent_end", messages: [] });
+      await vi.advanceTimersByTimeAsync(0);
+      releasePreparation();
+
       await rejection;
       await vi.advanceTimersByTimeAsync(0);
       expect(enqueued).toBe(false);
@@ -370,6 +374,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
       settled = true;
     });
 
+    await vi.waitFor(() => expect(emit).toBeTypeOf("function"));
     emit({ type: "message_end", message: second });
     await Promise.resolve();
     expect(settled).toBe(false);
@@ -518,6 +523,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
         waitForTranscriptCommit: true,
       });
 
+      await vi.waitFor(() => expect(emit).toBeTypeOf("function"));
       emit({ type: "agent_end", messages: [] });
       emit({ type: "auto_retry_start", attempt: 1, maxAttempts: 3, delayMs: 1_000 });
       await vi.advanceTimersByTimeAsync(0);
@@ -560,6 +566,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
       const wait = steerWithDeliveryWait(activeSession, "completion survives compaction");
 
+      await vi.waitFor(() => expect(emit).toBeTypeOf("function"));
       emit({ type: "agent_end", messages: [] });
       emit({ type: "compaction_start", reason: "threshold" });
       await vi.advanceTimersByTimeAsync(0);

--- a/src/agents/tools/skill-workshop-tool.list.test.ts
+++ b/src/agents/tools/skill-workshop-tool.list.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeWorkspaceSkills } from "../../skills/test-support/e2e-test-helpers.js";
+import { withSkillCollectionLock } from "../../skills/workshop/target-lock.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-list-state-",
+  });
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+describe("skill_workshop list", () => {
+  it.each([0, 1.5, "1.5", "25items", "many"])(
+    "rejects invalid list limit %s before touching proposal state",
+    async (limit) => {
+      const workspaceDir = await tempDirs.make("openclaw-skill-workshop-list-");
+      const tool = createSkillWorkshopTool({
+        workspaceDir,
+        config: {},
+        agentId: "main",
+        env: testState.env,
+      });
+
+      await expect(tool.execute("call-list-limit", { action: "list", limit })).rejects.toThrow(
+        "limit must be a positive integer",
+      );
+      await expect(fs.access(path.join(testState.stateDir, "skill-workshop"))).rejects.toThrow();
+    },
+  );
+
+  it("reconciles a full pending page while preserving list limits through 50", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-list-");
+    const tool = createSkillWorkshopTool({
+      workspaceDir,
+      config: { skills: { workshop: { maxPending: 200 } } },
+      agentId: "main",
+      env: testState.env,
+    });
+
+    for (let index = 0; index < 51; index += 1) {
+      await tool.execute(`call-create-${index}`, {
+        action: "create",
+        name: `Limit Proposal ${index}`,
+        description: `Proposal ${index}`,
+        proposal_content: `# Limit Proposal ${index}\n`,
+      });
+    }
+    await writeWorkspaceSkills(
+      workspaceDir,
+      Array.from({ length: 51 }, (_, index) => ({
+        name: `limit-proposal-${index}`,
+        description: `Materialized proposal ${index}`,
+      })),
+    );
+
+    let releaseLock: (() => void) | undefined;
+    let markAcquired: (() => void) | undefined;
+    const acquired = new Promise<void>((resolve) => {
+      markAcquired = resolve;
+    });
+    const heldLock = withSkillCollectionLock(
+      workspaceDir,
+      async () => {
+        markAcquired?.();
+        await new Promise<void>((resolve) => {
+          releaseLock = resolve;
+        });
+      },
+      { env: testState.env },
+    );
+    await acquired;
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    const releaseTimer = setTimeout(() => releaseLock?.(), 4_600);
+
+    try {
+      for (const [limit, expectedCount] of [
+        [49, 49],
+        [50, 50],
+        [51, 50],
+      ] as const) {
+        const result = await tool.execute(`call-list-${limit}`, { action: "list", limit });
+        const proposals = (result.details as { proposals: Array<{ status: string }> }).proposals;
+        expect(proposals).toHaveLength(expectedCount);
+        expect(proposals.every((proposal) => proposal.status === "stale")).toBe(true);
+      }
+
+      await expect(
+        tool.execute("call-list-last", {
+          action: "list",
+          query: "Limit Proposal 50",
+          limit: 1,
+        }),
+      ).resolves.toMatchObject({
+        details: { proposals: [expect.objectContaining({ status: "stale" })] },
+      });
+    } finally {
+      clearTimeout(releaseTimer);
+      releaseLock?.();
+      await heldLock;
+      randomSpy.mockRestore();
+    }
+  }, 15_000);
+});

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -2,7 +2,7 @@
 // applying generated skills to the workspace.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { consumeRunSkillUsage, recordRunSkillUsage } from "../../skills/runtime/run-usage.js";
 import { writeWorkspaceSkills } from "../../skills/test-support/e2e-test-helpers.js";
 import { listSkillProposalEvents } from "../../skills/workshop/service.js";
@@ -482,96 +482,6 @@ describe("skill_workshop tool", () => {
 
     expect(tools.some((tool) => tool.name === "skill_workshop")).toBe(false);
   });
-
-  it.each([0, 1.5, "1.5", "25items", "many"])(
-    "rejects invalid list limit %s before touching proposal state",
-    async (limit) => {
-      const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
-      const tool = createSkillWorkshopTool({
-        workspaceDir,
-        config: {},
-        agentId: "main",
-      });
-
-      await expect(tool.execute("call-list-limit", { action: "list", limit })).rejects.toThrow(
-        "limit must be a positive integer",
-      );
-      await expect(fs.access(path.join(stateDir, "skill-workshop"))).rejects.toThrow();
-    },
-  );
-
-  it("reconciles a full pending page while preserving list limits through 50", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
-    const tool = createSkillWorkshopTool({
-      workspaceDir,
-      config: { skills: { workshop: { maxPending: 200 } } },
-      agentId: "main",
-      env: testState.env,
-    });
-
-    for (let index = 0; index < 51; index += 1) {
-      await tool.execute(`call-create-${index}`, {
-        action: "create",
-        name: `Limit Proposal ${index}`,
-        description: `Proposal ${index}`,
-        proposal_content: `# Limit Proposal ${index}\n`,
-      });
-    }
-    await writeWorkspaceSkills(
-      workspaceDir,
-      Array.from({ length: 51 }, (_, index) => ({
-        name: `limit-proposal-${index}`,
-        description: `Materialized proposal ${index}`,
-      })),
-    );
-
-    let releaseLock: (() => void) | undefined;
-    let markAcquired: (() => void) | undefined;
-    const acquired = new Promise<void>((resolve) => {
-      markAcquired = resolve;
-    });
-    const heldLock = withSkillCollectionLock(
-      workspaceDir,
-      async () => {
-        markAcquired?.();
-        await new Promise<void>((resolve) => {
-          releaseLock = resolve;
-        });
-      },
-      { env: testState.env },
-    );
-    await acquired;
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-    const releaseTimer = setTimeout(() => releaseLock?.(), 4_600);
-
-    try {
-      for (const [limit, expectedCount] of [
-        [49, 49],
-        [50, 50],
-        [51, 50],
-      ] as const) {
-        const result = await tool.execute(`call-list-${limit}`, { action: "list", limit });
-        const proposals = (result.details as { proposals: Array<{ status: string }> }).proposals;
-        expect(proposals).toHaveLength(expectedCount);
-        expect(proposals.every((proposal) => proposal.status === "stale")).toBe(true);
-      }
-
-      await expect(
-        tool.execute("call-list-last", {
-          action: "list",
-          query: "Limit Proposal 50",
-          limit: 1,
-        }),
-      ).resolves.toMatchObject({
-        details: { proposals: [expect.objectContaining({ status: "stale" })] },
-      });
-    } finally {
-      clearTimeout(releaseTimer);
-      releaseLock?.();
-      await heldLock;
-      randomSpy.mockRestore();
-    }
-  }, 15_000);
 
   it("creates pending skill proposals without applying them", async () => {
     // Creation writes reviewable proposal artifacts under state, not live skill

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -2,7 +2,7 @@
 // applying generated skills to the workspace.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { consumeRunSkillUsage, recordRunSkillUsage } from "../../skills/runtime/run-usage.js";
 import { writeWorkspaceSkills } from "../../skills/test-support/e2e-test-helpers.js";
 import { listSkillProposalEvents } from "../../skills/workshop/service.js";
@@ -500,12 +500,13 @@ describe("skill_workshop tool", () => {
     },
   );
 
-  it("preserves list limits through 50 and clamps larger requests", async () => {
+  it("reconciles a full pending page while preserving list limits through 50", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
     const tool = createSkillWorkshopTool({
       workspaceDir,
       config: { skills: { workshop: { maxPending: 200 } } },
       agentId: "main",
+      env: testState.env,
     });
 
     for (let index = 0; index < 51; index += 1) {
@@ -516,16 +517,61 @@ describe("skill_workshop tool", () => {
         proposal_content: `# Limit Proposal ${index}\n`,
       });
     }
+    await writeWorkspaceSkills(
+      workspaceDir,
+      Array.from({ length: 51 }, (_, index) => ({
+        name: `limit-proposal-${index}`,
+        description: `Materialized proposal ${index}`,
+      })),
+    );
 
-    for (const [limit, expectedCount] of [
-      [49, 49],
-      [50, 50],
-      [51, 50],
-    ] as const) {
-      const result = await tool.execute(`call-list-${limit}`, { action: "list", limit });
-      expect((result.details as { proposals: unknown[] }).proposals).toHaveLength(expectedCount);
+    let releaseLock: (() => void) | undefined;
+    let markAcquired: (() => void) | undefined;
+    const acquired = new Promise<void>((resolve) => {
+      markAcquired = resolve;
+    });
+    const heldLock = withSkillCollectionLock(
+      workspaceDir,
+      async () => {
+        markAcquired?.();
+        await new Promise<void>((resolve) => {
+          releaseLock = resolve;
+        });
+      },
+      { env: testState.env },
+    );
+    await acquired;
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    const releaseTimer = setTimeout(() => releaseLock?.(), 4_600);
+
+    try {
+      for (const [limit, expectedCount] of [
+        [49, 49],
+        [50, 50],
+        [51, 50],
+      ] as const) {
+        const result = await tool.execute(`call-list-${limit}`, { action: "list", limit });
+        const proposals = (result.details as { proposals: Array<{ status: string }> }).proposals;
+        expect(proposals).toHaveLength(expectedCount);
+        expect(proposals.every((proposal) => proposal.status === "stale")).toBe(true);
+      }
+
+      await expect(
+        tool.execute("call-list-last", {
+          action: "list",
+          query: "Limit Proposal 50",
+          limit: 1,
+        }),
+      ).resolves.toMatchObject({
+        details: { proposals: [expect.objectContaining({ status: "stale" })] },
+      });
+    } finally {
+      clearTimeout(releaseTimer);
+      releaseLock?.();
+      await heldLock;
+      randomSpy.mockRestore();
     }
-  });
+  }, 15_000);
 
   it("creates pending skill proposals without applying them", async () => {
     // Creation writes reviewable proposal artifacts under state, not live skill

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -38,6 +38,7 @@ describe("executeAgentTurn: CLI session routing", () => {
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const followupRun = createFollowupRun();
+    followupRun.run.agentId = "main";
     followupRun.run.provider = "codex-cli";
     followupRun.run.model = "gpt-5.4";
     followupRun.run.extraSystemPrompt = "dynamic inbound metadata\n\nstable group prompt";

--- a/src/auto-reply/reply/agent-runner-execution-runtime.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-runtime.test.ts
@@ -36,6 +36,7 @@ describe("executeAgentTurn: runtime selection", () => {
 
       const executeAgentTurn = await getExecuteAgentTurnForTest();
       const followupRun = createFollowupRun();
+      followupRun.run.agentId = "main";
       followupRun.run.provider = "codex-cli";
       followupRun.run.model = "gpt-5.4";
       followupRun.run.sessionKey = "agent:main:opaque:binding";
@@ -74,6 +75,7 @@ describe("executeAgentTurn: runtime selection", () => {
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const followupRun = createFollowupRun();
+    followupRun.run.agentId = "main";
     followupRun.run.provider = "codex-cli";
     followupRun.run.model = "gpt-5.4";
     followupRun.run.sessionKey = "agent:main:opaque:binding";

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -49,16 +49,17 @@ export async function listSkillProposals(
   const store = storeOptions(options.env);
   const scope = proposalScope(options);
   const manifest = await readSkillProposalManifest(store, scope);
-  await Promise.all(
-    manifest.proposals
-      .filter((proposal) => proposal.kind === "create" && proposal.status === "pending")
-      .map(async (proposal) => {
-        const read = await readSkillProposal(proposal.id, store, scope);
-        if (read) {
-          await reconcilePendingCreateProposal(read, options);
-        }
-      }),
-  );
+  // Every reconciliation takes the same collection lease. Serialize them so a
+  // large manifest cannot make its own waiters exhaust the bounded lease wait.
+  for (const proposal of manifest.proposals) {
+    if (proposal.kind !== "create" || proposal.status !== "pending") {
+      continue;
+    }
+    const read = await readSkillProposal(proposal.id, store, scope);
+    if (read) {
+      await reconcilePendingCreateProposal(read, options);
+    }
+  }
   return await readSkillProposalManifest(store, scope);
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes the remaining red-main failures after steering-authority changes: stale agent-owner fixtures, tests emitting before async steering subscriptions were ready, and Skill Workshop list reconciliation contending with its own collection lease.

Affected main CI runs: 31776785997, 31777506142, and 31777530552. The fixture and timing regressions trace to b5809f5f44e and 54cf346abb2; the Skill Workshop contention path traces to 220b2dcec76. The reported `check-lint` failures were infrastructure cancellations with no lint diagnostic.

The overlapping Gateway and media-authority fixes were dropped after the steering owner landed #123549 on `main`; this PR now contains only the non-overlapping repairs.

## Why This Change Was Made

The tests now model the canonical session owner and wait for observable subscription readiness without weakening behavior assertions. Skill Workshop reconciles pending create proposals serially because every reconciliation takes the same collection lease.

## User Impact

Main CI consistently exercises the intended steering contract, while large Skill Workshop proposal lists no longer create a self-contention timeout under load.

## Evidence

- `src/gateway/server-methods/chat.directive-tags.test.ts`: 192/192, twice on current `main`
- CLI session/runtime fixtures: 21/21, twice
- queued steering readiness: 15/15, twice
- final-media/media-path authority from #123549: 14/14, twice
- Skill Workshop tool: 31/31, twice
- `pnpm tsgo`: passed
- `pnpm tsgo:core:test`: passed
- Exact touched-file oxlint: passed
- Final structured autoreview: clean, no accepted/actionable findings

No `CHANGELOG.md` change.
