### PR TITLE
fix(gateway): session loading multiplies Git checkout probes

### DIFF
--- a/src/gateway/server-methods/sessions-files.checkout-probe.test.ts
+++ b/src/gateway/server-methods/sessions-files.checkout-probe.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sessionsFilesHandlers } from "./sessions-files.js";
+import {
+  createSessionFilesHandlerInvoker,
+  createVisibleMessagesMock,
+  expectOkPayload,
+  prepareSessionFilesTest,
+  removeWorkspaceFixture,
+} from "./sessions-files.test-support.js";
+
+const hoisted = vi.hoisted(() => ({
+  execOpenPath: vi.fn(),
+  loadSessionEntry: vi.fn(),
+  readSessionTranscriptVisibleMessageDeltaCore: vi.fn(),
+  resolveAgentWorkspaceDir: vi.fn(),
+  resolveDefaultAgentId: vi.fn(),
+  runGit: vi.fn(),
+}));
+
+vi.mock("../../agents/worktrees/git.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/worktrees/git.js")>()),
+  runGit: hoisted.runGit,
+}));
+
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/agent-scope.js")>()),
+  resolveAgentWorkspaceDir: hoisted.resolveAgentWorkspaceDir,
+  resolveDefaultAgentId: hoisted.resolveDefaultAgentId,
+}));
+
+vi.mock("../session-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../session-utils.js")>()),
+  loadGatewaySessionEntryReadOnly: hoisted.loadSessionEntry,
+  loadSessionEntry: hoisted.loadSessionEntry,
+}));
+
+vi.mock("../session-transcript-readers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../session-transcript-readers.js")>()),
+  readSessionTranscriptVisibleMessageDeltaCore:
+    hoisted.readSessionTranscriptVisibleMessageDeltaCore,
+}));
+
+const invoke = createSessionFilesHandlerInvoker(sessionsFilesHandlers);
+const mockVisibleMessages = createVisibleMessagesMock(
+  hoisted.readSessionTranscriptVisibleMessageDeltaCore,
+);
+
+describe("sessions.files checkout probes", () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = prepareSessionFilesTest(hoisted, mockVisibleMessages);
+  });
+
+  afterEach(() => removeWorkspaceFixture(workspaceRoot));
+
+  it("coalesces only concurrent list probes", async () => {
+    let finishProbe: (result: { code: number; stderr: string; stdout: string }) => void = () => {};
+    hoisted.runGit.mockImplementationOnce(
+      async () =>
+        await new Promise((resolve) => {
+          finishProbe = resolve;
+        }),
+    );
+
+    const first = invoke("sessions.files.list", { sessionKey: "agent:main:main" });
+    const second = invoke("sessions.files.list", { sessionKey: "agent:main:main" });
+    await vi.waitFor(() => expect(hoisted.runGit).toHaveBeenCalledOnce());
+
+    finishProbe({ code: 0, stderr: "", stdout: `${workspaceRoot}\n` });
+    const [firstPayload, secondPayload] = await Promise.all([
+      first.then(expectOkPayload),
+      second.then(expectOkPayload),
+    ]);
+    expect(firstPayload.gitCheckout).toBe(true);
+    expect(secondPayload.gitCheckout).toBe(true);
+
+    hoisted.runGit.mockResolvedValueOnce({ code: 1, stderr: "not a checkout", stdout: "" });
+    const freshPayload = expectOkPayload(
+      await invoke("sessions.files.list", { sessionKey: "agent:main:main" }),
+    );
+    expect(freshPayload.gitCheckout).toBe(false);
+    expect(hoisted.runGit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -26,6 +26,7 @@ import { FsSafeError } from "../../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { getOrCreatePromise } from "../../shared/lazy-promise.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import {
   readSessionTranscriptVisibleMessageDeltaCore,
@@ -85,6 +86,9 @@ const MAX_PREVIEW_BYTES = WORKSPACE_PREVIEW_MAX_BYTES;
 const MAX_BROWSER_ENTRIES = 250;
 const MAX_SEARCH_ENTRIES = 500;
 const MAX_SEARCH_VISITED_ENTRIES = 5_000;
+// Share only overlapping probes; settled entries must evict so later requests
+// re-read authoritative checkout state instead of inheriting a stale result.
+const gitCheckoutStatusProbes = new Map<string, Promise<boolean>>();
 const TOUCHED_FILES_CACHE_LIMIT = 16;
 const TOUCHED_FILES_DELTA_MAX_MESSAGES = 1_000;
 const TOUCHED_FILES_DELTA_MAX_BYTES = 1_000_000;
@@ -739,6 +743,26 @@ async function loadSessionFiles(params: {
   };
 }
 
+async function loadGitCheckoutStatus(diffCwd: string | undefined): Promise<boolean | undefined> {
+  if (!diffCwd) {
+    return undefined;
+  }
+  const cacheKey = path.resolve(diffCwd);
+  return await getOrCreatePromise(
+    gitCheckoutStatusProbes,
+    cacheKey,
+    async () => {
+      try {
+        const result = await runGit(cacheKey, ["rev-parse", "--show-toplevel"]);
+        return result.code === 0 && Boolean(result.stdout.trim());
+      } catch {
+        return false;
+      }
+    },
+    { evictOnSettled: true },
+  );
+}
+
 async function buildListResult(params: {
   sessionKey: string;
   agentId?: string;
@@ -752,15 +776,7 @@ async function buildListResult(params: {
 }> {
   const loaded = await loadSessionFiles(params);
   const root = loaded.root;
-  let gitCheckout: boolean | undefined;
-  if (loaded.diffCwd) {
-    try {
-      const result = await runGit(loaded.diffCwd, ["rev-parse", "--show-toplevel"]);
-      gitCheckout = result.code === 0 && Boolean(result.stdout.trim());
-    } catch {
-      gitCheckout = false;
-    }
-  }
+  const gitCheckout = await loadGitCheckoutStatus(loaded.diffCwd);
   const workspaceFiles = root
     ? loaded.files.filter((file) =>
         Boolean(resolveTouchedFilePath({ root, fileRoot: loaded.fileRoot, filePath: file.path })),

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -26,6 +26,7 @@ import { FsSafeError } from "../../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { getOrCreatePromise } from "../../shared/lazy-promise.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import {
   readSessionTranscriptVisibleMessageDeltaCore,
@@ -85,6 +86,7 @@ const MAX_PREVIEW_BYTES = WORKSPACE_PREVIEW_MAX_BYTES;
 const MAX_BROWSER_ENTRIES = 250;
 const MAX_SEARCH_ENTRIES = 500;
 const MAX_SEARCH_VISITED_ENTRIES = 5_000;
+const gitCheckoutStatusProbes = new Map<string, Promise<boolean>>();
 const TOUCHED_FILES_CACHE_LIMIT = 16;
 const TOUCHED_FILES_DELTA_MAX_MESSAGES = 1_000;
 const TOUCHED_FILES_DELTA_MAX_BYTES = 1_000_000;
@@ -739,6 +741,26 @@ async function loadSessionFiles(params: {
   };
 }
 
+async function loadGitCheckoutStatus(diffCwd: string | undefined): Promise<boolean | undefined> {
+  if (!diffCwd) {
+    return undefined;
+  }
+  const cacheKey = path.resolve(diffCwd);
+  return await getOrCreatePromise(
+    gitCheckoutStatusProbes,
+    cacheKey,
+    async () => {
+      try {
+        const result = await runGit(cacheKey, ["rev-parse", "--show-toplevel"]);
+        return result.code === 0 && Boolean(result.stdout.trim());
+      } catch {
+        return false;
+      }
+    },
+    { evictOnSettled: true },
+  );
+}
+
 async function buildListResult(params: {
   sessionKey: string;
   agentId?: string;
@@ -752,15 +774,7 @@ async function buildListResult(params: {
 }> {
   const loaded = await loadSessionFiles(params);
   const root = loaded.root;
-  let gitCheckout: boolean | undefined;
-  if (loaded.diffCwd) {
-    try {
-      const result = await runGit(loaded.diffCwd, ["rev-parse", "--show-toplevel"]);
-      gitCheckout = result.code === 0 && Boolean(result.stdout.trim());
-    } catch {
-      gitCheckout = false;
-    }
-  }
+  const gitCheckout = await loadGitCheckoutStatus(loaded.diffCwd);
   const workspaceFiles = root
     ? loaded.files.filter((file) =>
         Boolean(resolveTouchedFilePath({ root, fileRoot: loaded.fileRoot, filePath: file.path })),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent session file requests for the same workspace each started their own Git checkout probe, multiplying subprocess work during session loading.

## Why This Change Was Made

The Gateway shares only the in-flight checkout probe for a resolved workspace path and evicts it when the burst settles. Both workspace status and active session file-list paths use the same owner, while later requests still perform a fresh authoritative probe.

## User Impact

Concurrent session loading performs one Git checkout probe per workspace burst instead of one per request, reducing host work and latency without caching completed checkout state.

## Evidence

- Stacked AWS proof: `run_93bc5f35cb87` passed 31 focused owner tests, including checkout-probe coalescing, and `check:changed` exited 0.
- Exact-head checkout-probe proof passed 2/2 tests; targeted formatting, type-aware lint, and `git diff --check` passed.
- Fresh Codex/Sol autoreview reported no actionable findings.

## Stack Relation

Part **3 of 3**. Base: #123535 at `471534df1e84c26d29c8538ffe38fbd2aa3f967c`. Exact head: `9121b5caf1bb4af4161624da7759b3ec0d8fab5f`.

Stack root: #123482.

AI-assisted: yes. The change was reviewed with the repository autoreview workflow.
