### PR TITLE
fix(ui): preserve delayed final turn order

### DIFF
--- a/ui/src/e2e/chat-flow.messaging.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.messaging.e2e.test.ts
@@ -136,6 +136,122 @@ suite.define(() => {
     });
   });
 
+  it("keeps a previous final above a newer active turn when events arrive late", async () => {
+    await withChatPage(async (page) => {
+      const gateway = await installMockGateway(page, { historyMessages: [] });
+      const previousRunId = "previous-run";
+      const previousPrompt = "What are groups?";
+      const previousFinal = "Groups organize conversations.";
+      const currentPrompt = "Why were my sessions missing?";
+      const currentPartial = "Checking external sessions...";
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [],
+        clientRunId: previousRunId,
+        hasActiveRun: false,
+        message: {
+          content: [{ text: previousPrompt, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "previous-user",
+        messageSeq: 1,
+        session: {
+          activeRunIds: [],
+          hasActiveRun: false,
+          key: "main",
+          kind: "direct",
+          status: "done",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+
+      await page.locator(".agent-chat__composer-combobox textarea").fill(currentPrompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const currentRunId = requireString(
+        requireRecord(sendRequest.params).idempotencyKey,
+        "current chat run id",
+      );
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [currentRunId],
+        clientRunId: currentRunId,
+        hasActiveRun: true,
+        message: {
+          content: [{ text: currentPrompt, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "current-user",
+        messageSeq: 3,
+        session: {
+          activeRunIds: [currentRunId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: currentPartial,
+        message: {
+          content: [{ text: currentPartial, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId: currentRunId,
+        seq: 1,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [currentRunId],
+        clientRunId: previousRunId,
+        hasActiveRun: true,
+        message: {
+          content: [{ text: previousFinal, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        messageId: "previous-final",
+        messageSeq: 2,
+        session: {
+          activeRunIds: [currentRunId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+
+      const visibleTexts = [previousPrompt, previousFinal, currentPrompt, currentPartial];
+      const expectVisibleOrder = async () => {
+        await expect
+          .poll(() =>
+            page.locator(".chat-thread-inner").evaluate((thread, texts) => {
+              const rows = Array.from(thread.querySelectorAll(".chat-bubble"));
+              return texts.map((text) => rows.findIndex((row) => row.textContent?.includes(text)));
+            }, visibleTexts),
+          )
+          .toEqual([0, 1, 2, 3]);
+      };
+      await expectVisibleOrder();
+
+      await gateway.emitChatFinal({ runId: previousRunId, text: previousFinal });
+      await expectVisibleOrder();
+      await expect
+        .poll(() => page.locator(".chat-group.assistant", { hasText: previousFinal }).count())
+        .toBe(1);
+    });
+  });
+
   it("preserves distinct same-text peer messages through conflicting envelopes and stale history", async () => {
     await withChatPage(async (page) => {
       const gateway = await installMockGateway(page, { historyMessages: [] });

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -65,7 +65,7 @@ function sessionMessageMatchesChat(
   return chatScopedEventSessionMatches(state, event.key, event.agentId ?? undefined);
 }
 
-function applyLiveUserMessage(
+function applyLiveSessionMessage(
   state: ChatPageHost,
   payload: unknown,
   runActive: boolean | undefined,
@@ -81,7 +81,17 @@ function applyLiveUserMessage(
   };
   const sourceMessage = event.message;
   const incoming = readSessionMessageIdentity(sourceMessage, event);
-  if (incoming?.role !== "user") {
+  if (!incoming) {
+    return;
+  }
+  const isPreviousRunAssistant = Boolean(
+    incoming.role === "assistant" &&
+    incoming.sequence !== null &&
+    incoming.runId &&
+    state.chatRunId &&
+    incoming.runId !== state.chatRunId,
+  );
+  if (incoming.role !== "user" && !isPreviousRunAssistant) {
     return;
   }
   // Partial import provenance cannot turn an envelope position into durable
@@ -183,7 +193,10 @@ function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
   }
   const matchesChat = sessionMessageMatchesChat(state, event);
   if (matchesChat) {
-    applyLiveUserMessage(state, payload, event.hasActiveRun ?? undefined);
+    // A previous run can persist its final after the next local run starts.
+    // Admit that sequenced row now so the later unsequenced chat.final replay
+    // replaces it in place instead of appending below the newer user turn.
+    applyLiveSessionMessage(state, payload, event.hasActiveRun ?? undefined);
     void loadChatBranches(state);
   }
   if (matchesChat && event.archived !== null) {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -107,6 +107,107 @@ describe("canonical session message recovery", () => {
     });
   });
 
+  it("keeps a previous run final before a newer active user turn", () => {
+    const previousUser = {
+      role: "user",
+      content: [{ type: "text", text: "What are groups?" }],
+      __openclaw: { id: "previous-user", idempotencyKey: "previous-run:user", seq: 1 },
+    };
+    const currentUser = {
+      role: "user",
+      content: [{ type: "text", text: "Why were my sessions missing?" }],
+      __openclaw: { id: "current-user", idempotencyKey: "current-run:user", seq: 3 },
+    };
+    const persistedFinal = {
+      role: "assistant",
+      content: [{ type: "text", text: "Groups organize conversations." }],
+      __openclaw: { id: "previous-final", seq: 2 },
+    };
+    const { state } = createSessionEventState({
+      chatMessages: [previousUser, currentUser],
+      chatRunId: "current-run",
+      chatStream: "Checking external sessions...",
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        clientRunId: "previous-run",
+        hasActiveRun: true,
+        messageId: "previous-final",
+        messageSeq: 2,
+        message: persistedFinal,
+      },
+    });
+
+    expect(state.chatMessages.map((message) => (message as { role?: string }).role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(state.chatMessages[1]).toMatchObject({
+      content: persistedFinal.content,
+      __openclaw: { id: "previous-final", seq: 2 },
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: "previous-run",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Groups organize conversations." }],
+        },
+      },
+    });
+
+    expect(state.chatMessages.map((message) => (message as { role?: string }).role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(state.chatRunId).toBe("current-run");
+    expect(state.chatStream).toBe("Checking external sessions...");
+  });
+
+  it("leaves the active run assistant message on the terminal stream path", () => {
+    const currentUser = {
+      role: "user",
+      content: [{ type: "text", text: "Current prompt" }],
+      __openclaw: { id: "current-user", idempotencyKey: "current-run:user", seq: 1 },
+    };
+    const { state } = createSessionEventState({
+      chatMessages: [currentUser],
+      chatRunId: "current-run",
+      chatStream: "Current partial reply",
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        clientRunId: "current-run",
+        hasActiveRun: true,
+        messageId: "current-final",
+        messageSeq: 2,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Current final reply" }],
+          __openclaw: { id: "current-final", seq: 2 },
+        },
+      },
+    });
+
+    expect(state.chatMessages).toEqual([currentUser]);
+    expect(state.chatStream).toBe("Current partial reply");
+  });
+
   it("renders distinct live peers immediately and coalesces their stale history", async () => {
     let resolveHistory!: (result: {
       messages: unknown[];


### PR DESCRIPTION
## Summary

- preserve the durable sequence of a delayed previous-run assistant final when a newer local run is active
- keep current-run assistant persistence on the existing streaming/terminal path
- add focused unit coverage and a browser E2E regression for the reported ordering race

## Root cause

The selected-session `session.message` reconciler admitted only user rows. When a previous run's sequenced assistant final persisted after the next run started, the UI discarded that canonical row. Its later unsequenced `chat.final` replay was then appended below the newer user prompt.

## Verification

- red browser proof on `d8a1ebbb492`: bubble order `[previous user, newer user, delayed previous final, current stream]`
- green browser proof on `cc591b21ebf`: `[previous user, previous final, newer user, current stream]` before and after the late terminal replay; one final row
- 317 focused and adjacent unit tests passed
- all 17 `chat-flow.messaging` browser E2E tests passed
- formatting, full lint shards, scoped lint, and UI typecheck passed
- source-blind behavior validation: 4/4 clauses passed
- autoreview: no accepted/actionable findings

Release note: fixes Control UI chat messages appearing above the previous response when terminal events arrive out of order.
