### PR TITLE
improve(ui): unify sidebar section grammar

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -25,7 +25,12 @@ import {
   type CatalogSessionMenuRequest,
   visibleCatalogHosts,
 } from "./app-sidebar-session-catalogs.ts";
-import { renderSidebarSessionSectionHeader } from "./app-sidebar-session-section-header.ts";
+import {
+  renderSidebarSessionSectionHeader,
+  renderSidebarSessionSectionToggle,
+  SIDEBAR_SECTION_NO_STATUS,
+  type SidebarSectionStatus,
+} from "./app-sidebar-session-section-header.ts";
 import { sidebarSessionStateId } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
 import { hasProviderBrandIcon, renderProviderBrandIcon } from "./provider-icon.ts";
@@ -84,17 +89,20 @@ function renderSessionRunSpinner(showTitle = true) {
   ></span>`;
 }
 
-function renderCatalogHeaderStatus(hasActiveRun: boolean, hasUnread: boolean) {
-  if (hasActiveRun) {
-    return renderSessionRunSpinner();
+function catalogHeaderStatus(params: {
+  errorHelp: string | undefined;
+  hasActiveRun: boolean;
+  hasUnread: boolean;
+}): SidebarSectionStatus {
+  if (params.errorHelp) {
+    return { kind: "error", label: params.errorHelp };
   }
-  return hasUnread
-    ? html`<span
-        class="session-unread-dot"
-        role="img"
-        aria-label=${t("sessionsView.unread")}
-      ></span>`
-    : nothing;
+  if (params.hasActiveRun) {
+    return { kind: "running", label: t("sessionsView.activeRun") };
+  }
+  return params.hasUnread
+    ? { kind: "unread", label: t("sessionsView.unread") }
+    : SIDEBAR_SECTION_NO_STATUS;
 }
 
 function catalogErrorMessages(catalog: SessionCatalog): string[] {
@@ -152,6 +160,11 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     }
     const errorMessage = errorMessages.join("; ");
     const errorHelp = t("chat.sidebar.catalogDiscoveryHelp", { error: errorMessage });
+    const headerStatus = catalogHeaderStatus({
+      errorHelp: hasError ? errorHelp : undefined,
+      hasActiveRun,
+      hasUnread,
+    });
     const sectionClass = [
       "sidebar-recent-sessions__group",
       "sidebar-recent-sessions__group--zone-coding",
@@ -179,6 +192,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
       >
         ${renderSidebarSessionSectionHeader({
           sectionId,
+          status: headerStatus,
           disabledReason: params.sectionDragDisabledReason,
           onToggle: () => params.onToggleSection(sectionId),
           onStartDrag: params.onStartSectionDrag,
@@ -194,42 +208,25 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
             });
           },
           content: html`
-            <button
-              type="button"
-              class="sidebar-session-group-toggle"
-              aria-expanded=${String(!collapsed)}
-              aria-label=${hasError ? `${catalog.label}: ${errorHelp}` : catalog.label}
-              title=${hasError ? errorHelp : nothing}
-              @click=${() => params.onToggleSection(sectionId)}
-            >
-              <span
-                class="sidebar-session-group-toggle__lead ${hasBrandIcon
-                  ? "sidebar-session-group-toggle__lead--branded"
-                  : ""}"
-                aria-hidden="true"
-              >
-                ${hasBrandIcon
-                  ? renderProviderBrandIcon(catalog.id, {
+            ${renderSidebarSessionSectionToggle({
+              label: catalog.label,
+              collapsed,
+              status: headerStatus,
+              // The status dot beside this toggle already carries the failure as
+              // its accessible name; repeating it here makes a screen reader
+              // announce the whole catalog error twice for one heading.
+              ariaLabel: catalog.label,
+              title: hasError ? errorHelp : undefined,
+              count: collapsed ? rows.length : undefined,
+              lead: hasBrandIcon
+                ? html`<span class="sidebar-session-group-toggle__lead" aria-hidden="true"
+                    >${renderProviderBrandIcon(catalog.id, {
                       className: "sidebar-session-catalog-provider-icon",
-                    })
-                  : nothing}
-                <span class="sidebar-session-group-toggle__icon"
-                  >${collapsed ? icons.chevronRight : icons.chevronDown}</span
-                >
-              </span>
-              <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
-              ${renderCatalogHeaderStatus(hasActiveRun, hasUnread)}
-              ${hasError || (collapsed && rows.length > 0)
-                ? html`<span
-                    class="sidebar-session-group-count ${hasError
-                      ? "sidebar-session-group-count--error"
-                      : ""}"
-                    data-session-catalog-error=${hasError ? catalog.id : nothing}
-                    aria-hidden="true"
-                    >${hasError ? icons.alertTriangle : rows.length}</span
+                    })}</span
                   >`
-                : nothing}
-            </button>
+                : undefined,
+              onToggle: () => params.onToggleSection(sectionId),
+            })}
             <button
               type="button"
               class="sidebar-session-group-actions sidebar-session-sort sidebar-session-catalog-grouping ${params.creatorFilterActive
@@ -318,13 +315,16 @@ function renderCatalogHostGroup(
               <span class="sidebar-session-group-toggle__icon">${icons.monitor}</span>
             </span>
             <span class="sidebar-session-catalog-host__label">${host.label}</span>
-            <span
-              class="sidebar-session-catalog-host__count ${host.error
-                ? "sidebar-session-catalog-host__count--error"
-                : ""}"
-              aria-hidden="true"
-              >${host.error ? icons.alertTriangle : host.sessions.length}</span
-            >
+            ${host.error
+              ? html`<span
+                  class="sidebar-session-group-status sidebar-session-group-status--error"
+                  data-section-status="error"
+                  role="img"
+                  aria-label=${errorHelp!}
+                ></span>`
+              : html`<span class="sidebar-session-catalog-host__count" aria-hidden="true"
+                  >${host.sessions.length}</span
+                >`}
           </div>`
         : nothing}
       <div class="sidebar-session-catalog-host__sessions" role="list" aria-label=${host.label}>
@@ -333,23 +333,21 @@ function renderCatalogHostGroup(
               const sectionId = `catalog-project:${catalog.id}:${host.hostId}:${group.key}`;
               const collapsed = params.collapsedSections.has(sectionId);
               return html`
-                <div class="sidebar-session-catalog-project" role="listitem">
-                  <button
-                    type="button"
-                    class="sidebar-session-catalog-project__head"
-                    data-session-catalog-project=${group.key}
-                    aria-expanded=${String(!collapsed)}
-                    title=${group.title}
-                    @click=${() => params.onToggleSection(sectionId)}
-                  >
-                    <span class="sidebar-session-catalog-project__icon" aria-hidden="true"
-                      >${collapsed ? icons.chevronRight : icons.chevronDown}</span
-                    >
-                    <span class="sidebar-session-catalog-project__label">${group.label}</span>
-                    <span class="sidebar-session-catalog-project__count" aria-hidden="true"
-                      >${group.sessions.length}</span
-                    >
-                  </button>
+                <div
+                  class="sidebar-session-catalog-project"
+                  data-session-catalog-project=${group.key}
+                  role="listitem"
+                >
+                  ${renderSidebarSessionSectionToggle({
+                    label: group.label,
+                    collapsed,
+                    status: SIDEBAR_SECTION_NO_STATUS,
+                    className: "sidebar-session-catalog-project__head",
+                    labelClassName: "sidebar-session-catalog-project__label",
+                    title: group.title,
+                    count: group.sessions.length,
+                    onToggle: () => params.onToggleSection(sectionId),
+                  })}
                   ${collapsed
                     ? nothing
                     : html`<div

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -12,7 +12,12 @@ import {
   renderSessionTree,
   type SessionListHost,
 } from "./app-sidebar-session-row-render.ts";
-import { renderSidebarSessionSectionHeader } from "./app-sidebar-session-section-header.ts";
+import {
+  renderSidebarSessionSectionHeader,
+  renderSidebarSessionSectionToggle,
+  SIDEBAR_SECTION_NO_STATUS,
+  type SidebarSectionStatus,
+} from "./app-sidebar-session-section-header.ts";
 import {
   rowDemandsVisibility,
   RowVisibilityReason,
@@ -50,6 +55,21 @@ type SessionCatalogRenderSnapshot = {
   terminalAvailable: boolean;
 };
 
+/** An expanded section shows its rows; collapsed, one dot has to stand in for
+    them, and attention outranks a live run because only attention needs acting
+    on. Coding is the one zone whose background runs are worth reporting. */
+function collapsedSectionStatus(section: RenderableSessionSection): SidebarSectionStatus {
+  if (section.rows.some((row) => rowDemandsVisibility(row, RowVisibilityReason.Attention))) {
+    return { kind: "attention", label: t("sessionsView.attentionRequired") };
+  }
+  const running =
+    section.work &&
+    section.rows.some((row) => rowDemandsVisibility(row, RowVisibilityReason.ActiveRun));
+  return running
+    ? { kind: "running", label: t("sessionsView.activeRun") }
+    : SIDEBAR_SECTION_NO_STATUS;
+}
+
 function renderSessionSection(params: {
   host: SidebarSessionListHost;
   section: RenderableSessionSection;
@@ -69,14 +89,7 @@ function renderSessionSection(params: {
         ? group
         : t("chat.sidebar.threads");
   const zone = section.groups ? "groups" : section.work ? "coding" : group ? "category" : "threads";
-  // Collapsed Coding still signals live runs so background work stays visible.
-  const collapsedRunningDot =
-    collapsed &&
-    section.work &&
-    section.rows.some((row) => rowDemandsVisibility(row, RowVisibilityReason.ActiveRun));
-  const collapsedAttentionDot =
-    collapsed &&
-    section.rows.some((row) => rowDemandsVisibility(row, RowVisibilityReason.Attention));
+  const status = collapsed ? collapsedSectionStatus(section) : SIDEBAR_SECTION_NO_STATUS;
   const newSessionAccess = host.readNewSessionAccess();
   const groupWriteAccess = host.readSessionMutationAccess({
     method: "sessions.groups.put",
@@ -114,6 +127,7 @@ function renderSessionSection(params: {
     >
       ${renderSidebarSessionSectionHeader({
         sectionId: section.id,
+        status,
         disabledReason: groupWriteAccess.allowed ? undefined : groupWriteAccess.reason,
         onToggle: () => host.toggleSection(section.id),
         onStartDrag: (sectionId) => host.startSidebarSectionDrag(sectionId),
@@ -125,39 +139,13 @@ function renderSessionSection(params: {
             }
           : undefined,
         content: html`
-          <button
-            type="button"
-            class="sidebar-session-group-toggle"
-            aria-expanded=${String(!collapsed)}
-            aria-label=${label}
-            @click=${() => host.toggleSection(section.id)}
-          >
-            <span class="sidebar-session-group-toggle__lead" aria-hidden="true">
-              <span class="sidebar-session-group-toggle__icon"
-                >${collapsed ? icons.chevronRight : icons.chevronDown}</span
-              >
-            </span>
-            <span class="sidebar-recent-sessions__label-text">${label}</span>
-            ${collapsed && totalRowCount > 0
-              ? html`<span class="sidebar-session-group-count">${totalRowCount}</span>`
-              : nothing}
-            ${collapsedRunningDot
-              ? html`<span
-                  class="session-run-spinner sidebar-session-group-running"
-                  role="img"
-                  aria-label=${t("sessionsView.activeRun")}
-                  title=${t("sessionsView.activeRun")}
-                ></span>`
-              : nothing}
-            ${collapsedAttentionDot
-              ? html`<span
-                  class="sidebar-session-group-attention"
-                  role="img"
-                  aria-label=${t("sessionsView.attentionRequired")}
-                  title=${t("sessionsView.attentionRequired")}
-                ></span>`
-              : nothing}
-          </button>
+          ${renderSidebarSessionSectionToggle({
+            label,
+            collapsed,
+            status,
+            count: collapsed ? totalRowCount : undefined,
+            onToggle: () => host.toggleSection(section.id),
+          })}
           ${section.id === "ungrouped"
             ? html`
                 <button

--- a/ui/src/components/app-sidebar-session-section-header.ts
+++ b/ui/src/components/app-sidebar-session-section-header.ts
@@ -2,9 +2,80 @@ import { html, nothing, type TemplateResult } from "lit";
 import { writeSidebarSectionDragData } from "../lib/sessions/drag.ts";
 import { icons } from "./icons.ts";
 
+/** One signal per section head, so a count and a dot can never compete. */
+export type SidebarSectionStatus =
+  | { kind: "none" }
+  | { kind: "running"; label: string }
+  | { kind: "unread"; label: string }
+  | { kind: "attention"; label: string }
+  | { kind: "error"; label: string };
+
+export const SIDEBAR_SECTION_NO_STATUS: SidebarSectionStatus = { kind: "none" };
+
+function renderSidebarSectionStatus(status: SidebarSectionStatus) {
+  if (status.kind === "none") {
+    return nothing;
+  }
+  const className =
+    status.kind === "running"
+      ? "session-run-spinner sidebar-session-group-status"
+      : `sidebar-session-group-status sidebar-session-group-status--${status.kind}`;
+  return html`<span
+    class=${className}
+    data-section-status=${status.kind}
+    role="img"
+    aria-label=${status.label}
+    title=${status.label}
+  ></span>`;
+}
+
+/**
+ * Shared label/disclosure/count grammar for native groups, provider catalogs,
+ * and project subgroups. A section whose status dot already reports attention
+ * drops its row count, which would otherwise say the same thing twice.
+ */
+export function renderSidebarSessionSectionToggle(params: {
+  label: string;
+  collapsed: boolean;
+  status: SidebarSectionStatus;
+  className?: string;
+  labelClassName?: string;
+  ariaLabel?: string;
+  title?: string;
+  lead?: TemplateResult;
+  count?: number;
+  onToggle: () => void;
+}): TemplateResult {
+  const showCount = params.status.kind === "none" && params.count !== undefined && params.count > 0;
+  return html`<button
+    type="button"
+    class=${params.className ?? "sidebar-session-group-toggle"}
+    aria-expanded=${String(!params.collapsed)}
+    aria-label=${params.ariaLabel ?? params.label}
+    title=${params.title ?? nothing}
+    @click=${() => params.onToggle()}
+  >
+    ${params.lead ?? nothing}
+    <span class=${params.labelClassName ?? "sidebar-recent-sessions__label-text"}
+      >${params.label}</span
+    >
+    <span
+      class="sidebar-session-group-toggle__icon ${params.collapsed
+        ? "sidebar-session-group-toggle__icon--collapsed"
+        : ""}"
+      aria-hidden="true"
+      >${params.collapsed ? icons.chevronRight : icons.chevronDown}</span
+    >
+    ${showCount
+      ? html`<span class="sidebar-session-group-count" aria-hidden="true">${params.count}</span>`
+      : nothing}
+  </button>`;
+}
+
 export function renderSidebarSessionSectionHeader(params: {
   sectionId: string;
   content: TemplateResult;
+  status: SidebarSectionStatus;
   disabledReason?: string;
   onToggle: () => void;
   onStartDrag: (sectionId: string) => void;
@@ -35,7 +106,7 @@ export function renderSidebarSessionSectionHeader(params: {
         @dragend=${params.onFinishDrag}
         >${icons.gripVertical}</span
       >
-      ${params.content}
+      ${params.content} ${renderSidebarSectionStatus(params.status)}
     </div>
   `;
 }

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -24,6 +24,7 @@ import "../test-helpers/app-sidebar-cases/new-group-dialog.ts";
 import "../test-helpers/app-sidebar-cases/narration.ts";
 import "../test-helpers/app-sidebar-cases/outbox-badges.ts";
 import "../test-helpers/app-sidebar-cases/pull-request-state.ts";
+import "../test-helpers/app-sidebar-cases/section-grammar.ts";
 import "../test-helpers/app-sidebar-cases/section-reordering.ts";
 import "../test-helpers/app-sidebar-cases/session-delete-access.ts";
 import "../test-helpers/app-sidebar-cases/session-indicators.ts";

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -376,7 +376,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
             </div>
             <button class="sidebar-session-catalog-project__head">
               <span class="sidebar-session-catalog-project__label">Project</span>
-              <span class="sidebar-session-catalog-project__count">100</span>
+              <span class="sidebar-session-group-count">100</span>
             </button>
             <span class="sidebar-agent-card__name">Agent</span>
             <span class="settings-sidebar__item-label">Settings</span>
@@ -408,7 +408,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
         ".sidebar-recent-session__name",
         ".session-row-trail",
         ".sidebar-session-catalog-host__count",
-        ".sidebar-session-catalog-project__count",
+        ".sidebar-session-group-count",
         ".sidebar-agent-card__name",
         ".settings-sidebar__item-label",
         ".sidebar-file-view__path",
@@ -459,7 +459,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
       for (const selector of [
         ".sidebar-child-session-toggle",
         ".sidebar-session-catalog-host__count",
-        ".sidebar-session-catalog-project__count",
+        ".sidebar-session-group-count",
       ]) {
         const fits = await page.$eval(selector, (node) => node.scrollWidth <= node.clientWidth);
         expect(fits, selector).toBe(true);

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -480,29 +480,34 @@ suite.define(() => {
       }
 
       const touchAffordance = await page
-        .locator(
-          '[data-session-section="catalog:claude"] .sidebar-session-group-toggle__lead--branded',
-        )
-        .evaluate((lead) => {
-          const providerIcon = lead.querySelector<HTMLElement>(
+        .locator('[data-session-section="catalog:claude"] .sidebar-session-group-toggle')
+        .evaluate((toggle) => {
+          const providerIcon = toggle.querySelector<HTMLElement>(
             ".sidebar-session-catalog-provider-icon",
           );
-          const chevron = lead.querySelector<HTMLElement>(".sidebar-session-group-toggle__icon");
-          if (!providerIcon || !chevron) {
-            throw new Error("expected branded catalog provider icon and chevron");
+          const label = toggle.querySelector<HTMLElement>(".sidebar-recent-sessions__label-text");
+          const chevron = toggle.querySelector<HTMLElement>(".sidebar-session-group-toggle__icon");
+          if (!providerIcon || !label || !chevron) {
+            throw new Error("expected branded catalog provider icon, label, and chevron");
           }
           return {
             coarsePointer: matchMedia("(pointer: coarse)").matches,
             noHover: matchMedia("(hover: none)").matches,
             providerOpacity: getComputedStyle(providerIcon).opacity,
             chevronOpacity: getComputedStyle(chevron).opacity,
+            chevronFollowsLabel: Boolean(
+              label.compareDocumentPosition(chevron) & Node.DOCUMENT_POSITION_FOLLOWING,
+            ),
           };
         });
+      // Brand artwork and disclosure no longer share one slot: the icon stays
+      // put and the chevron rests visible where touch has no hover to reveal it.
       expect(touchAffordance).toEqual({
         coarsePointer: true,
         noHover: true,
-        providerOpacity: "0",
+        providerOpacity: "1",
         chevronOpacity: "0.75",
+        chevronFollowsLabel: true,
       });
 
       const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -382,7 +382,7 @@ suite.define(() => {
             gripOpacity: "0.55",
             hoverCapable: true,
             hovered: true,
-            providerOpacity: "0",
+            providerOpacity: "1",
           });
 
         await toggle.click();
@@ -443,7 +443,7 @@ suite.define(() => {
             focusWithin: true,
             gripOpacity: "0.55",
             hovered: false,
-            providerOpacity: "0",
+            providerOpacity: "1",
           });
       },
     );

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -453,9 +453,10 @@ suite.define(() => {
       const openclawProject = section.locator(
         '[data-session-catalog-project="/Users/dev/openclaw"]',
       );
-      const openclawProjectItem = openclawProject.locator("..");
-      const openclawProjectList = openclawProjectItem.locator(":scope > [role=list]");
-      expect(await openclawProjectItem.getAttribute("role")).toBe("listitem");
+      // The project group marker moved onto the listitem itself, so the element
+      // matched here is the list entry rather than its heading button.
+      const openclawProjectList = openclawProject.locator(":scope > [role=list]");
+      expect(await openclawProject.getAttribute("role")).toBe("listitem");
       expect(await openclawProjectList.getAttribute("aria-label")).toBe("Local Codex: openclaw");
       expect(
         await openclawProject.locator(".sidebar-session-catalog-project__label").textContent(),
@@ -906,8 +907,10 @@ suite.define(() => {
 
       const section = page.locator('[data-session-section="catalog:codex"]');
       await section.locator('[data-section-status="error"]').waitFor({ state: "visible" });
+      // The status dot owns the failure as its accessible name; the heading
+      // deliberately stays the plain catalog label so it is announced once.
       await expect
-        .poll(() => section.locator(".sidebar-session-group-toggle").getAttribute("aria-label"))
+        .poll(() => section.locator('[data-section-status="error"]').getAttribute("aria-label"))
         .toContain("Second catalog page unavailable");
       await expect.poll(() => loadMore.getAttribute("aria-busy")).toBe("false");
       expect(await loadMore.isEnabled()).toBe(true);

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -460,9 +460,7 @@ suite.define(() => {
       expect(
         await openclawProject.locator(".sidebar-session-catalog-project__label").textContent(),
       ).toBe("openclaw");
-      expect(
-        await openclawProject.locator(".sidebar-session-catalog-project__count").textContent(),
-      ).toBe("2");
+      expect(await openclawProject.locator(".sidebar-session-group-count").textContent()).toBe("2");
       const projectRows = section.locator(".sidebar-recent-session--catalog-project-child");
       await expect.poll(() => projectRows.count()).toBe(3);
       expect(
@@ -638,9 +636,7 @@ suite.define(() => {
       expect(await section.getByText("Worktree fix session", { exact: true }).count()).toBe(0);
       expect(await section.getByText("Other project session", { exact: true }).count()).toBe(1);
       expect(await openclawProject.count()).toBe(1);
-      expect(
-        await openclawProject.locator(".sidebar-session-catalog-project__count").textContent(),
-      ).toBe("2");
+      expect(await openclawProject.locator(".sidebar-session-group-count").textContent()).toBe("2");
       expect(
         await page.evaluate(
           (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
@@ -909,7 +905,7 @@ suite.define(() => {
       });
 
       const section = page.locator('[data-session-section="catalog:codex"]');
-      await section.locator('[data-session-catalog-error="codex"]').waitFor({ state: "visible" });
+      await section.locator('[data-section-status="error"]').waitFor({ state: "visible" });
       await expect
         .poll(() => section.locator(".sidebar-session-group-toggle").getAttribute("aria-label"))
         .toContain("Second catalog page unavailable");

--- a/ui/src/e2e/session-management.test-support.ts
+++ b/ui/src/e2e/session-management.test-support.ts
@@ -206,16 +206,42 @@ export async function submitInputDialog(page: Page, value: string): Promise<void
   await field.waitFor({ state: "detached" });
 }
 
-export async function captureUiProof(page: Page, fileName: string) {
+const PROOF_CLIP_MARGIN = 12;
+
+/**
+ * Screenshots the state the caller just built. Pass `clip` to frame the union of
+ * those locators: hover cards and row menus are absolutely positioned, so a
+ * frame drawn around the row alone would cut off the surface the capture exists
+ * to show.
+ */
+export async function captureUiProof(
+  page: Page,
+  fileName: string,
+  options: { clip?: readonly Locator[] } = {},
+) {
   if (!captureUiProofEnabled) {
     return;
   }
   await mkdir(uiProofArtifactDir, { recursive: true });
+  const boxes = await Promise.all((options.clip ?? []).map((locator) => locator.boundingBox()));
+  const present = boxes.filter((box) => box !== null);
+  const left = Math.min(...present.map((box) => box.x)) - PROOF_CLIP_MARGIN;
+  const top = Math.min(...present.map((box) => box.y)) - PROOF_CLIP_MARGIN;
+  const clip =
+    present.length === 0
+      ? undefined
+      : {
+          x: Math.max(0, left),
+          y: Math.max(0, top),
+          width: Math.max(...present.map((box) => box.x + box.width)) + PROOF_CLIP_MARGIN - left,
+          height: Math.max(...present.map((box) => box.y + box.height)) + PROOF_CLIP_MARGIN - top,
+        };
   // Dialogs and menus fade in, so an undisabled capture can land mid-transition
   // and prove nothing about the state it was taken for.
   await page.screenshot({
     animations: "disabled",
-    fullPage: true,
+    clip,
+    fullPage: clip === undefined,
     path: path.join(uiProofArtifactDir, fileName),
   });
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -953,6 +953,8 @@ openclaw-settings-save-indicator {
   --sidebar-focus-visible: color-mix(in srgb, var(--text) 34%, transparent);
   --sidebar-divider-active: color-mix(in srgb, var(--text) 42%, transparent);
   --focus-ring: 0 0 0 2px var(--sidebar-focus-visible);
+  --sidebar-subgroup-gap: var(--space-2);
+  --sidebar-lead: 20px;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -1605,7 +1607,6 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-group-toggle__lead {
-  position: relative;
   display: inline-grid;
   width: var(--sidebar-lead);
   height: 16px;
@@ -1613,36 +1614,22 @@ body.update-dialog-open .sidebar-update-card__status {
   place-items: center;
 }
 
-.sidebar-session-group-toggle__icon,
-.sidebar-session-catalog-provider-icon {
-  grid-area: 1 / 1;
+/* Disclosure belongs to the label, not to a left rail. A collapsed section has
+   to advertise the rows it hides; an expanded one already shows them, so its
+   chevron returns only on hover, keyboard focus, or a coarse pointer that has
+   no hover to offer. Losing this makes collapsing undiscoverable on touch. */
+.sidebar-session-group-toggle__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  opacity: 0;
   transition: opacity var(--duration-fast) ease;
 }
 
-.sidebar-session-group-toggle__icon {
-  display: inline-flex;
-  opacity: 0.75;
-}
-
-.sidebar-session-group-toggle__lead--branded .sidebar-session-group-toggle__icon {
-  opacity: 0;
-}
-
-.sidebar-recent-sessions__head:hover
-  .sidebar-session-group-toggle__lead--branded
-  .sidebar-session-catalog-provider-icon,
-.sidebar-recent-sessions__head:has(:focus-visible)
-  .sidebar-session-group-toggle__lead--branded
-  .sidebar-session-catalog-provider-icon {
-  opacity: 0;
-}
-
-.sidebar-recent-sessions__head:hover
-  .sidebar-session-group-toggle__lead--branded
-  .sidebar-session-group-toggle__icon,
-.sidebar-recent-sessions__head:has(:focus-visible)
-  .sidebar-session-group-toggle__lead--branded
-  .sidebar-session-group-toggle__icon {
+.sidebar-session-group-toggle__icon--collapsed,
+.sidebar-recent-sessions__head:hover .sidebar-session-group-toggle__icon,
+.sidebar-recent-sessions__head:has(:focus-visible) .sidebar-session-group-toggle__icon,
+.sidebar-session-catalog-project__head:hover .sidebar-session-group-toggle__icon,
+.sidebar-session-catalog-project__head:focus-visible .sidebar-session-group-toggle__icon {
   opacity: 0.75;
 }
 
@@ -1668,29 +1655,30 @@ body.update-dialog-open .sidebar-update-card__status {
   opacity: 0.7;
 }
 
-.sidebar-session-group-count--error {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--warn);
+/* Status owns the far right of every section head, so revealing the group
+   actions to its left never displaces the signal a user is scanning for. */
+.sidebar-session-group-status {
+  flex: 0 0 auto;
 }
 
-.sidebar-session-group-count--error svg {
-  width: 12px;
-  height: 12px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.8px;
+.sidebar-session-group-status--unread,
+.sidebar-session-group-status--attention,
+.sidebar-session-group-status--error {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
 }
 
-.sidebar-session-group-attention {
-  width: 6px;
-  height: 6px;
-  flex: none;
-  margin-left: 4px;
-  border-radius: 50%;
+.sidebar-session-group-status--unread {
+  background: var(--accent);
+}
+
+.sidebar-session-group-status--attention {
   background: var(--warn);
-  box-shadow: 0 0 6px color-mix(in srgb, var(--warn) 48%, transparent);
+}
+
+.sidebar-session-group-status--error {
+  background: var(--danger);
 }
 
 .sidebar-session-catalog-load-more {
@@ -1813,6 +1801,7 @@ body.update-dialog-open .sidebar-update-card__status {
   justify-content: center;
   height: 22px;
   flex: 0 0 auto;
+  padding: 0;
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -1841,8 +1830,8 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-group-actions svg {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.7px;
@@ -1861,12 +1850,8 @@ body.update-dialog-open .sidebar-update-card__status {
 
 @media (hover: none), (pointer: coarse) {
   /* Touch has no hover, so the chevron must be the resting state or
-     catalog collapsibility becomes undiscoverable. */
-  .sidebar-session-group-toggle__lead--branded .sidebar-session-catalog-provider-icon {
-    opacity: 0;
-  }
-
-  .sidebar-session-group-toggle__lead--branded .sidebar-session-group-toggle__icon {
+     collapsibility becomes undiscoverable. */
+  .sidebar-session-group-toggle__icon {
     opacity: 0.75;
   }
 
@@ -1941,8 +1926,9 @@ body.update-dialog-open .sidebar-update-card__status {
   color: var(--text);
 }
 
-.sidebar-recent-sessions__group[data-session-section^="catalog:"] > .sidebar-recent-sessions__list {
-  gap: var(--sidebar-section-gap);
+.sidebar-recent-sessions__group:has(.sidebar-session-catalog-host)
+  > .sidebar-recent-sessions__list {
+  gap: var(--sidebar-subgroup-gap);
 }
 
 .sidebar-session-catalog-host {
@@ -1978,21 +1964,6 @@ body.update-dialog-open .sidebar-update-card__status {
   text-align: center;
 }
 
-.sidebar-session-catalog-host__count--error {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--warn);
-}
-
-.sidebar-session-catalog-host__count--error svg {
-  width: 11px;
-  height: 11px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.8px;
-}
-
 .sidebar-session-catalog-project__head {
   display: flex;
   align-items: center;
@@ -2018,22 +1989,6 @@ body.update-dialog-open .sidebar-update-card__status {
   color: var(--text);
 }
 
-.sidebar-session-catalog-project__icon {
-  display: inline-grid;
-  width: var(--sidebar-lead);
-  flex: 0 0 var(--sidebar-lead);
-  place-items: center;
-  opacity: 0.75;
-}
-
-.sidebar-session-catalog-project__icon svg {
-  width: 10px;
-  height: 10px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.8px;
-}
-
 /* Structural label, not content: at the session row's 13px/500 a group reads as
    just another session. Type carries the whole split because the head color
    stays near `--text` for readability; case stays as authored (project names). */
@@ -2046,15 +2001,6 @@ body.update-dialog-open .sidebar-update-card__status {
   font-size: calc(12px * var(--control-ui-text-scale));
   font-weight: 650;
   letter-spacing: 0.03em;
-}
-
-.sidebar-session-catalog-project__count {
-  width: calc(20px * var(--control-ui-text-scale));
-  flex: 0 0 calc(20px * var(--control-ui-text-scale));
-  color: color-mix(in srgb, var(--muted) 55%, var(--text) 45%);
-  font-size: calc(10px * var(--control-ui-text-scale));
-  font-variant-numeric: tabular-nums;
-  text-align: center;
 }
 
 .sidebar-session-pagination {
@@ -2078,6 +2024,9 @@ body.update-dialog-open .sidebar-update-card__status {
   color: var(--text);
 }
 
+/* Flush with the section heading it explains, and with the rows it stands in
+   for. A lead indent would read as content nested under the heading rather than
+   as the section reporting that it has none. */
 .sidebar-session-empty-hint {
   display: block;
   padding: 4px 10px 10px var(--sidebar-text-offset);
@@ -2411,8 +2360,7 @@ body.update-dialog-open .sidebar-update-card__status {
   padding-bottom: 3px;
 }
 
-.sidebar-recent-sessions
-  .sidebar-recent-session--child
+.sidebar-recent-session--child
   .sidebar-recent-session__link
   > :not(.sidebar-session-indicator):not(.sidebar-recent-session__text) {
   margin-left: 6px;
@@ -3658,11 +3606,6 @@ openclaw-tooltip.sidebar-hover-tooltip {
   background: var(--danger);
 }
 
-.sidebar-session-group-running {
-  flex: none;
-  margin-left: 4px;
-}
-
 .sidebar-agent-menu__agent-switch {
   min-width: 0;
 }
@@ -4152,6 +4095,8 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* Falls back outside the sidebar, where the shared row primitives are reused
+     by the chat session picker and no sidebar rail token is in scope. */
   width: var(--sidebar-lead, 16px);
   height: 16px;
   flex: 0 0 var(--sidebar-lead, 16px);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2029,7 +2029,9 @@ body.update-dialog-open .sidebar-update-card__status {
    as the section reporting that it has none. */
 .sidebar-session-empty-hint {
   display: block;
-  padding: 4px 10px 10px var(--sidebar-text-offset);
+  /* The hint explains its section, so it starts on the section heading rather
+     than on the row text column the heading no longer shares. */
+  padding: 4px 10px 10px var(--sidebar-inset);
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
 }

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -325,7 +325,7 @@ describe("AppSidebar session attention", () => {
     );
 
     const section = sidebar.querySelector('[data-session-section="ungrouped"]');
-    expect(section?.querySelector(".sidebar-session-group-attention")).not.toBeNull();
+    expect(section?.querySelector('[data-section-status="attention"]')).not.toBeNull();
     expect(section?.querySelector(".sidebar-recent-session")).toBeNull();
   });
 
@@ -380,7 +380,7 @@ describe("AppSidebar session attention", () => {
       expect(
         sidebar
           .querySelector('[data-session-section="ungrouped"]')
-          ?.querySelector(".sidebar-session-group-attention"),
+          ?.querySelector('[data-section-status="attention"]'),
       ).not.toBeNull();
       sidebar.remove();
     }

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-compat.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-compat.ts
@@ -174,11 +174,13 @@ describe("AppSidebar session catalog pagination", () => {
       expect(claudeSection?.querySelector(".sidebar-session-group-count")?.textContent).not.toBe(
         "0",
       );
+      // The status dot owns the failure text; the toggle keeps its plain label
+      // so the error is announced once per heading.
       expect(
-        codexSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
+        codexSection?.querySelector("[data-section-status]")?.getAttribute("aria-label"),
       ).toContain("[unavailable] Codex provider unavailable");
       expect(
-        claudeSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
+        claudeSection?.querySelector("[data-section-status]")?.getAttribute("aria-label"),
       ).toContain("[NODE_LIST_FAILED] Paired nodes could not be listed");
       const claudeTitle =
         claudeSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("title") ?? "";
@@ -188,8 +190,8 @@ describe("AppSidebar session catalog pagination", () => {
       expect(
         codexSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("title"),
       ).toContain("Settings > Automation > Plugins");
-      expect(codexSection?.querySelector('[data-session-catalog-error="codex"]')).not.toBeNull();
-      expect(claudeSection?.querySelector('[data-session-catalog-error="claude"]')).not.toBeNull();
+      expect(codexSection?.querySelector('[data-section-status="error"]')).not.toBeNull();
+      expect(claudeSection?.querySelector('[data-section-status="error"]')).not.toBeNull();
     } finally {
       vi.useRealTimers();
     }
@@ -259,9 +261,9 @@ describe("AppSidebar session catalog pagination", () => {
       await vi.advanceTimersByTimeAsync(0);
       await sidebar.updateComplete;
 
-      expect(section()?.querySelector('[data-session-catalog-error="codex"]')).not.toBeNull();
+      expect(section()?.querySelector('[data-section-status="error"]')).not.toBeNull();
       expect(
-        section()?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
+        section()?.querySelector("[data-section-status]")?.getAttribute("aria-label"),
       ).toContain("Second page unavailable");
       expect(sidebar.sessionData.sessionCatalogs[0]?.error?.code).toBe("UNAVAILABLE");
       expect(sidebar.sessionData.sessionCatalogs[0]?.hosts[0]?.nextCursor).toBe("page-2");
@@ -276,7 +278,7 @@ describe("AppSidebar session catalog pagination", () => {
         catalogId: "codex",
         cursors: { "gateway:local": "page-2" },
       });
-      expect(section()?.querySelector('[data-session-catalog-error="codex"]')).toBeNull();
+      expect(section()?.querySelector('[data-section-status="error"]')).toBeNull();
       expect(sidebar.textContent).toContain("Older");
       expect(loadMore()).toBeNull();
     } finally {

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-errors.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-errors.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
-import { createGatewayHarness, createSessions, mountSidebar } from "../app-sidebar.ts";
+import { catalogPage, createGatewayHarness, createSessions, mountSidebar } from "../app-sidebar.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar session catalog request errors", () => {
@@ -196,6 +196,45 @@ describe("AppSidebar session catalog request errors", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       expect(request).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("announces a catalog failure on one accessible element", async () => {
+    vi.useFakeTimers();
+    try {
+      const page = catalogPage([{ threadId: "t1", name: "Ship it" }]);
+      const failing = {
+        ...page,
+        catalogs: [
+          { ...page.catalogs[0]!, error: { code: "UNAVAILABLE", message: "host is offline" } },
+        ],
+      };
+      const request = vi.fn().mockResolvedValue(failing);
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      const status = sidebar.querySelector('[data-section-status="error"]');
+      expect(status?.getAttribute("aria-label")).toContain("host is offline");
+      // The dot owns the failure; a toggle that repeated it would make a screen
+      // reader read the whole catalog error twice for one heading.
+      const named = [...sidebar.querySelectorAll("[aria-label]")].filter((element) =>
+        element.getAttribute("aria-label")?.includes("host is offline"),
+      );
+      expect(named).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -228,9 +228,9 @@ describe("AppSidebar session catalog pagination", () => {
     await sidebar.updateComplete;
 
     const section = sidebar.querySelector(`[data-session-section="catalog:${id}"]`);
-    const lead = section?.querySelector(".sidebar-session-group-toggle__lead");
-    expect(lead?.querySelector(".sidebar-session-group-toggle__icon")).not.toBeNull();
-    const providerIcon = lead?.querySelector(".sidebar-session-catalog-provider-icon");
+    const toggle = section?.querySelector(".sidebar-session-group-toggle");
+    expect(toggle?.querySelector(".sidebar-session-group-toggle__icon")).not.toBeNull();
+    const providerIcon = toggle?.querySelector(".sidebar-session-catalog-provider-icon");
     expect(providerIcon?.getAttribute("data-provider-icon")).toBe(branded ? id : undefined);
     const hostGroups = section?.querySelectorAll<HTMLElement>("[data-session-catalog-host]");
     expect(Array.from(hostGroups ?? []).map((host) => host.dataset.sessionCatalogHost)).toEqual([
@@ -347,7 +347,9 @@ describe("AppSidebar session catalog pagination", () => {
       ),
     ).not.toBeNull();
     expect(
-      catalogSection?.querySelector(".sidebar-recent-sessions__head .session-unread-dot"),
+      catalogSection?.querySelector(
+        '.sidebar-recent-sessions__head [data-section-status="unread"]',
+      ),
     ).not.toBeNull();
 
     const runningRows = backingRows.map((row) =>

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
@@ -270,9 +270,9 @@ describe("AppSidebar session catalog pagination", () => {
         await sidebar.updateComplete;
 
         const section = sidebar.querySelector('[data-session-section="catalog:codex"]');
-        expect(section?.querySelector('[data-session-catalog-error="codex"]')).not.toBeNull();
+        expect(section?.querySelector('[data-section-status="error"]')).not.toBeNull();
         expect(
-          section?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
+          section?.querySelector("[data-section-status]")?.getAttribute("aria-label"),
         ).toContain(errorOwner === "catalog" ? "Catalog page failed" : "Host page failed");
         expect(sidebar.textContent).toContain("Newest");
         expect(sidebar.sessionData.sessionCatalogs[0]?.hosts[0]?.nextCursor).toBe("page-2");
@@ -280,7 +280,11 @@ describe("AppSidebar session catalog pagination", () => {
         loadMore()?.click();
         await vi.advanceTimersByTimeAsync(0);
         await sidebar.updateComplete;
-        expect(sidebar.querySelector('[data-session-catalog-error="codex"]')).toBeNull();
+        expect(
+          sidebar.querySelector(
+            '[data-session-section="catalog:codex"] [data-section-status="error"]',
+          ),
+        ).toBeNull();
         expect(sidebar.textContent).toContain("Older");
       } finally {
         vi.useRealTimers();

--- a/ui/src/test-helpers/app-sidebar-cases/section-grammar.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/section-grammar.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { createGateway, createSessionsHarness, mountSidebar } from "../app-sidebar.ts";
+import "../../components/app-sidebar.ts";
+
+const sectionSelector = '[data-session-section="ungrouped"]';
+
+function publish(
+  harness: ReturnType<typeof createSessionsHarness>,
+  rows: GatewaySessionRow[],
+): void {
+  harness.publishList({
+    result: {
+      ts: 2,
+      path: "",
+      count: rows.length,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: rows,
+    } satisfies SessionsListResult,
+  });
+}
+
+function plainRow(key: string, overrides: Partial<GatewaySessionRow> = {}): GatewaySessionRow {
+  return { key, kind: "direct", label: key, updatedAt: 2, ...overrides };
+}
+
+async function mountWithRows(rows: GatewaySessionRow[]) {
+  const key = rows[0]?.key ?? "agent:main:only";
+  const harness = createSessionsHarness("main", [key]);
+  const { sidebar } = await mountSidebar(
+    createGateway({} as GatewayBrowserClient),
+    harness.sessions,
+  );
+  publish(harness, rows);
+  await sidebar.updateComplete;
+  return sidebar;
+}
+
+describe("AppSidebar section grammar", () => {
+  it("places the disclosure immediately after the section label", async () => {
+    const sidebar = await mountWithRows([plainRow("agent:main:one")]);
+
+    const toggle = sidebar.querySelector(`${sectionSelector} .sidebar-session-group-toggle`);
+    const label = toggle?.querySelector(".sidebar-recent-sessions__label-text");
+    const chevron = toggle?.querySelector(".sidebar-session-group-toggle__icon");
+
+    expect(label).not.toBeNull();
+    expect(chevron).not.toBeNull();
+    expect(label?.nextElementSibling).toBe(chevron);
+  });
+
+  it("marks the disclosure collapsed so it can rest visible without hover", async () => {
+    const sidebar = await mountWithRows([plainRow("agent:main:one")]);
+    const chevron = () =>
+      sidebar.querySelector(`${sectionSelector} .sidebar-session-group-toggle__icon`);
+
+    expect(chevron()?.classList.contains("sidebar-session-group-toggle__icon--collapsed")).toBe(
+      false,
+    );
+
+    sidebar
+      .querySelector<HTMLButtonElement>(`${sectionSelector} .sidebar-session-group-toggle`)
+      ?.click();
+    await sidebar.updateComplete;
+
+    expect(chevron()?.classList.contains("sidebar-session-group-toggle__icon--collapsed")).toBe(
+      true,
+    );
+  });
+
+  it("keeps status last in the head so revealed actions never displace it", async () => {
+    const sidebar = await mountWithRows([
+      plainRow("agent:main:blocked", {
+        status: "failed",
+        endedAt: 2,
+        lastRunError: "Provider credits exhausted",
+      }),
+    ]);
+
+    sidebar
+      .querySelector<HTMLButtonElement>(`${sectionSelector} .sidebar-session-group-toggle`)
+      ?.click();
+    await sidebar.updateComplete;
+
+    const head = sidebar.querySelector(`${sectionSelector} .sidebar-recent-sessions__head`);
+    const status = head?.querySelector("[data-section-status]");
+    expect(status).not.toBeNull();
+    expect(head?.lastElementChild).toBe(status);
+  });
+
+  it("drops the redundant row count once a status dot carries the attention", async () => {
+    const sidebar = await mountWithRows([
+      plainRow("agent:main:blocked", {
+        status: "failed",
+        endedAt: 2,
+        lastRunError: "Provider credits exhausted",
+      }),
+    ]);
+    const section = () => sidebar.querySelector(sectionSelector);
+
+    sidebar
+      .querySelector<HTMLButtonElement>(`${sectionSelector} .sidebar-session-group-toggle`)
+      ?.click();
+    await sidebar.updateComplete;
+
+    expect(section()?.querySelector('[data-section-status="attention"]')).not.toBeNull();
+    expect(section()?.querySelector(".sidebar-session-group-count")).toBeNull();
+  });
+
+  it("counts a collapsed section that has nothing to flag", async () => {
+    const sidebar = await mountWithRows([plainRow("agent:main:one"), plainRow("agent:main:two")]);
+
+    sidebar
+      .querySelector<HTMLButtonElement>(`${sectionSelector} .sidebar-session-group-toggle`)
+      ?.click();
+    await sidebar.updateComplete;
+
+    const section = sidebar.querySelector(sectionSelector);
+    expect(section?.querySelector("[data-section-status]")).toBeNull();
+    expect(section?.querySelector(".sidebar-session-group-count")?.textContent?.trim()).toBe("2");
+  });
+
+  it("gives a movable group the shared grip glyph", async () => {
+    const sidebar = await mountWithRows([plainRow("agent:main:one")]);
+
+    const handle = sidebar.querySelector(`${sectionSelector} .sidebar-session-group-drag-handle`);
+    expect(handle?.querySelector("svg")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Sidebar section headings do not agree with each other. The disclosure chevron sits in a left rail away from the label it controls, catalog and host failures appear as an amber warning triangle wearing a count's clothing, a collapsed section can show a count *and* a status dot for the same fact, the group menu is a 22px target with a 14px glyph, and a movable group advertises itself with a CSS-drawn dot texture instead of the grip glyph used everywhere else. Provider catalogs additionally hide their brand icon behind a hover swap with the chevron, which makes the catalog look like it is flickering when a pointer crosses the header.

## Why This Change Was Made

Every session section now renders through one shared label/disclosure/count/status grammar instead of four near-copies:

- Disclosure moves to immediately after the section label and becomes state-driven: visible while collapsed, quiet while expanded, and returning on hover, keyboard focus, or a coarse pointer that has no hover to offer. The brand icon keeps its own slot, so the hover swap disappears.
- A single status rail owns the far right of every head. Group actions reveal to its left, so the signal a user is scanning for never moves when the pointer arrives.
- Error state uses the same solid semantic dot as everything else, and a section that shows a status dot no longer repeats the same fact as a numeric count.
- Group menus get a 26px target with a 16px glyph and no user-agent padding compression; movable groups use the shared grip glyph.

Row spacing and the lead rail were scoped to the recents list, so any row rendered outside it silently lost the grammar. Those tokens now belong to the sidebar. The provider-keyed `[data-session-section^="catalog:"]` list gap is likewise replaced by a rule that keys on what a list actually holds.

Non-goals: pinned sessions, session-row state and endcap architecture, coding/project hierarchy, and the section-label type scale itself are all owned elsewhere and are unchanged here. Following the maintainer amendment of 2026-08-14, pinned rows render exactly as `main` renders them after #123530 restored the interleaved sidebar zone; the pinned-parity work this branch originally carried has been removed, including the page-navigation override it had deleted.

## User Impact

Section headings become predictable: the chevron is next to the label that owns it, attention always appears in the same place, and a failing provider catalog reads as a failure instead of an oddly-coloured count. Collapsing a section stays discoverable on touch, where there is no hover to reveal the control.

## Evidence

- Production versus test LOC delta: **production −50** (+233/−283), **tests +196** (+223/−27). The change removes more presentation code than it adds; the growth is the shared section-header owner replacing four inline copies.
- `ui/src/components/app-sidebar.test.ts` — 259 passing, including seven new section-grammar cases covering disclosure order, collapsed-disclosure state, status as the final element of the head, count suppression behind a status dot, the count that remains when there is nothing to flag, and the grip glyph on a movable group. Each fails against the previous markup.
- Existing catalog, attention, and interaction cases were updated to the shared `[data-section-status]` hook rather than the removed provider-specific one, keeping the same assertion strength.
- `ui/src/e2e/claude-sessions.e2e.test.ts` now asserts the touch contract that replaced the hover swap: brand icon fully opaque, chevron resting visible, and disclosure positioned after the label.
- Typecheck (`tsgo`, UI project) and `stylelint` over the changed stylesheet are clean.
- `captureUiProof` accepts a `clip` of locators and frames their union. Every frame below is clipped to the surface it is about instead of shipping a full page and calling it proof.

### Visual matrix

Captured in real Chromium on a Linux proof host under `OPENCLAW_CAPTURE_UI_PROOF=1`.

| State | Light | Dark |
| --- | --- | --- |
| Sidebar column — Sessions with one open row | ![sidebar light](https://github.com/user-attachments/assets/777c4ce4-f245-4871-955b-4e43b9ebd808) | ![sidebar dark](https://github.com/user-attachments/assets/3ee2495d-6e8b-4645-ad9b-a5182a4d0aca) |
| Section head at rest | ![head rest light](https://github.com/user-attachments/assets/6319ebaa-6a92-4a58-ae1c-585b5adb64b7) | ![head rest dark](https://github.com/user-attachments/assets/4a38f587-a6e3-4713-b215-889d3647d469) |
| Section head hovered — disclosure and actions revealed | ![head hover light](https://github.com/user-attachments/assets/48ea3da0-e42c-4826-b292-9e75a4b8aeab) | ![head hover dark](https://github.com/user-attachments/assets/df66db3a-70c2-446c-92c4-705d7ff3f9f8) |
| Section collapsed — count survives the fold | ![head collapsed light](https://github.com/user-attachments/assets/d374dafe-f785-4742-bc91-24214c069dd6) | ![head collapsed dark](https://github.com/user-attachments/assets/16304007-0e07-4a31-9ff3-b025eddee5c4) |

Coding, Codex, Claude Code, Research, and Groups heads share this header owner but reach the page through catalog and group fixtures this scenario does not build; their grammar stays covered by `ui/src/test-helpers/app-sidebar-cases/section-grammar.ts` rather than by a frame from a scenario that cannot produce them.


### Empty-section placeholder alignment

An empty section's placeholder sat one lead indent past the heading it explains,
so a section reporting that it has nothing read as a row nested underneath one.
It is now flush with that heading and with the rows it stands in for.
`ui/src/e2e/session-management.groups.e2e.test.ts` measures both text origins
with a Range and now agrees; before the fix it read 30px against the heading's
10px. The full `ui/src/e2e/session-management` lane passes at this layer.

