### PR TITLE
fix: node workspace transfers fail after successful turns

### DIFF
--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -26,6 +26,18 @@ import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-ser
 import type { WorkerEnvironmentRecord } from "./store.js";
 import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 
+const workspaceInfo = vi.hoisted(() => vi.fn());
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/worker-workspace" ? { ...logger, info: workspaceInfo } : logger;
+    },
+  };
+});
+
 const BUILD = {
   bundleHash: "a".repeat(64),
   openclawVersion: "2026.8.13",
@@ -227,6 +239,7 @@ describe("node worker tunnel manager", () => {
   });
 
   it("preserves a typed workspace transfer cause from the node", async () => {
+    workspaceInfo.mockClear();
     const record = environment();
     const localPath = tempDirs.make("node-worker-transfer-error-");
     const rawManifest = serializeWorkerWorkspaceManifest({
@@ -272,6 +285,13 @@ describe("node worker tunnel manager", () => {
       name: NodeWorkerWorkspaceTransferError.name,
       code: NODE_WORKSPACE_TRANSFER_ERROR_CODE,
       message: "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+    });
+    expect(workspaceInfo).toHaveBeenCalledWith("worker workspace sync path selected", {
+      environmentId: "environment-1",
+      sessionId: "session-1",
+      path: "gateway-push",
+      reason: "not-git-workspace",
+      originAttemptMs: expect.any(Number),
     });
   });
 

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -15,6 +15,10 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
 import { parseWorkerLaunchPlan } from "../../worker/launch-descriptor.js";
 import type { NodeWorkerSupervisorReceipt } from "../../worker/node-supervisor-protocol.js";
+import {
+  NODE_WORKSPACE_TRANSFER_ERROR_CODE,
+  NodeWorkerWorkspaceTransferError,
+} from "../../worker/node-workspace-transfer-protocol.js";
 import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
 import type { createDeviceWorkerRuntime } from "./device-provider.js";
 import { createNodeWorkerTunnelManager } from "./node-worker-tunnel.js";
@@ -220,6 +224,55 @@ describe("node worker tunnel manager", () => {
       }),
     );
     expect(outputs).toEqual([]);
+  });
+
+  it("preserves a typed workspace transfer cause from the node", async () => {
+    const record = environment();
+    const localPath = tempDirs.make("node-worker-transfer-error-");
+    const rawManifest = serializeWorkerWorkspaceManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [],
+    });
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    const nodeTransport = transport();
+    nodeTransport.invoke = vi.fn(async () => ({
+      ok: false,
+      error: {
+        code: NODE_WORKSPACE_TRANSFER_ERROR_CODE,
+        message: "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+      },
+    }));
+    const transfer = {
+      prepareSync: vi.fn(async () => ({
+        snapshot: {
+          manifest: { version: 1 as const, baseCommit: null, entries: [] },
+          manifestRef,
+          rawManifest,
+          root: localPath,
+        },
+        token: "download-token",
+      })),
+      close: vi.fn(async () => {}),
+      revoke: vi.fn(),
+    } as unknown as NodeWorkspaceTransferService;
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: () => record,
+      getTransport: () => nodeTransport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: transfer,
+    });
+    const handle = await manager.start(startRequest());
+
+    await expect(
+      handle.syncWorkspace({ localPath, sessionId: "session-1", generation: 1 }),
+    ).rejects.toMatchObject({
+      name: NodeWorkerWorkspaceTransferError.name,
+      code: NODE_WORKSPACE_TRANSFER_ERROR_CODE,
+      message: "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+    });
   });
 
   it("cancels a replacement start before it can install a late handle", async () => {

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -18,7 +18,10 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
-import { createNodeWorkerWorkspaceFallback } from "./node-worker-workspace-fallback.js";
+import {
+  createNodeWorkerWorkspaceFallback,
+  recordNodeSyncPath,
+} from "./node-worker-workspace-fallback.js";
 import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
 import type { WorkerEnvironmentRecord } from "./store.js";
 import type {
@@ -567,9 +570,11 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
             signal: entry.abortController.signal,
           });
           try {
+            const originStartedAt = performance.now();
             const origin = await workspace.trySyncWorkspace(request, prepared.snapshot.manifestRef);
-            if (origin) {
-              return origin;
+            recordNodeSyncPath(entry.environmentId, entry.sessionId, origin, originStartedAt);
+            if (origin.kind === "synced") {
+              return origin.result;
             }
             const transferred = await exec({
               argv: ["openclaw-internal-workspace-transfer"],

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -10,6 +10,10 @@ import {
   type NodeWorkerWorkspaceExecInput,
   type NodeWorkerWorkspaceExecResult,
 } from "../../worker/node-workspace-protocol.js";
+import {
+  NODE_WORKSPACE_TRANSFER_ERROR_CODE,
+  NodeWorkerWorkspaceTransferError,
+} from "../../worker/node-workspace-transfer-protocol.js";
 import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
@@ -288,13 +292,17 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       }
       if (!result.ok) {
         const code = result.error?.code ?? "UNAVAILABLE";
+        if (code === NODE_WORKSPACE_TRANSFER_ERROR_CODE) {
+          throw new NodeWorkerWorkspaceTransferError(
+            result.error?.message ?? "workspace-transfer-failed: transfer did not complete",
+          );
+        }
         if (command.transportRetry === "idempotent" && RETRYABLE_TRANSPORT_CODES.has(code)) {
           await sleepWithAbort(Math.min(RETRY_DELAY_MS, remainingMs), signal);
           continue;
         }
         throw new Error(
-          result.error?.message &&
-            (code === "INVALID_REQUEST" || result.error.message.startsWith("workspace-transfer-"))
+          result.error?.message && code === "INVALID_REQUEST"
             ? `node workspace command failed (${code}): ${result.error.message}`
             : `node workspace command failed (${code})`,
         );

--- a/src/gateway/worker-environments/node-worker-workspace-fallback.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
 import type { WorkerWorkspaceSyncRequest, WorkerWorkspaceSyncResult } from "./tunnel-contract.js";
 import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
@@ -8,6 +9,7 @@ const GIT_TIMEOUT_MS = 60_000;
 const COMMIT_PATTERN = /^[a-f0-9]{40}(?:[a-f0-9]{24})?$/u;
 const MANIFEST_REF_PATTERN = /^sha256:[a-f0-9]{64}$/u;
 const GIT_NONINTERACTIVE_ARGS = ["-c", "credential.helper=", "-c", "core.askPass="];
+const workspaceSyncLog = createSubsystemLogger("gateway/worker-workspace");
 
 type WorkspaceExec = (params: {
   argv: string[];
@@ -18,6 +20,41 @@ type WorkspaceExec = (params: {
 }) => Promise<SpawnResult & { workspaceDir: string }>;
 
 type GitIdentity = { commit: string; origin: string; root: string };
+type OriginFallbackReason =
+  | "clone-failed"
+  | "checkout-failed"
+  | "inspection-failed"
+  | "manifest-capture-failed"
+  | "manifest-mismatch"
+  | "not-git-workspace"
+  | "not-repository-root"
+  | "origin-unavailable"
+  | "origin-unpublished"
+  | "workspace-dirty"
+  | "workspace-transfer-required";
+
+type OriginInspection =
+  | { kind: "eligible"; identity: GitIdentity }
+  | { kind: "fallback"; reason: OriginFallbackReason };
+
+type OriginSyncOutcome =
+  | { kind: "synced"; result: WorkerWorkspaceSyncResult }
+  | { kind: "fallback"; reason: OriginFallbackReason };
+
+export function recordNodeSyncPath(
+  environmentId: string,
+  sessionId: string,
+  outcome: OriginSyncOutcome,
+  originStartedAt: number,
+): void {
+  workspaceSyncLog.info("worker workspace sync path selected", {
+    environmentId,
+    sessionId,
+    path: outcome.kind === "synced" ? "origin" : "gateway-push",
+    reason: outcome.kind === "synced" ? "published-origin" : outcome.reason,
+    originAttemptMs: performance.now() - originStartedAt,
+  });
+}
 
 async function localGit(root: string, args: string[]): Promise<string> {
   const result = await runCommandWithTimeout(
@@ -80,35 +117,46 @@ async function requiresWorkspaceTransfer(root: string): Promise<boolean> {
   }
 }
 
-async function inspectEligibleOrigin(localPath: string): Promise<GitIdentity | undefined> {
+async function inspectEligibleOrigin(localPath: string): Promise<OriginInspection> {
   try {
     const canonicalPath = await fs.realpath(localPath);
-    const root = await fs.realpath(await localGit(canonicalPath, ["rev-parse", "--show-toplevel"]));
+    let root: string;
+    try {
+      root = await fs.realpath(await localGit(canonicalPath, ["rev-parse", "--show-toplevel"]));
+    } catch {
+      return { kind: "fallback", reason: "not-git-workspace" };
+    }
     if (root !== canonicalPath) {
-      return undefined;
+      return { kind: "fallback", reason: "not-repository-root" };
     }
     if (await requiresWorkspaceTransfer(root)) {
-      return undefined;
+      return { kind: "fallback", reason: "workspace-transfer-required" };
     }
     const [status, commit, rawOrigin] = await Promise.all([
       localGit(root, ["status", "--porcelain=v1", "--untracked-files=all"]),
       localGit(root, ["rev-parse", "HEAD"]),
       localGit(root, ["remote", "get-url", "origin"]).catch(() => ""),
     ]);
-    const origin = credentialFreeHttpOrigin(rawOrigin);
-    if (status || !COMMIT_PATTERN.test(commit) || !origin) {
-      return undefined;
+    if (status) {
+      return { kind: "fallback", reason: "workspace-dirty" };
     }
-    const refs = await localGit(root, ["ls-remote", "--heads", "--tags", "--", origin]).catch(
-      () => "",
-    );
+    const origin = credentialFreeHttpOrigin(rawOrigin);
+    if (!COMMIT_PATTERN.test(commit) || !origin) {
+      return { kind: "fallback", reason: "origin-unavailable" };
+    }
+    let refs: string;
+    try {
+      refs = await localGit(root, ["ls-remote", "--heads", "--tags", "--", origin]);
+    } catch {
+      return { kind: "fallback", reason: "origin-unavailable" };
+    }
     return refs
       .split("\n")
       .some((line) => line.slice(0, commit.length) === commit && /\srefs\//u.test(line))
-      ? { commit, origin, root }
-      : undefined;
+      ? { kind: "eligible", identity: { commit, origin, root } }
+      : { kind: "fallback", reason: "origin-unpublished" };
   } catch {
-    return undefined;
+    return { kind: "fallback", reason: "inspection-failed" };
   }
 }
 
@@ -122,11 +170,12 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
     async trySyncWorkspace(
       request: WorkerWorkspaceSyncRequest,
       expectedManifestRef: string,
-    ): Promise<WorkerWorkspaceSyncResult | undefined> {
-      const identity = await inspectEligibleOrigin(request.localPath);
-      if (!identity) {
-        return undefined;
+    ): Promise<OriginSyncOutcome> {
+      const inspection = await inspectEligibleOrigin(request.localPath);
+      if (inspection.kind === "fallback") {
+        return inspection;
       }
+      const { identity } = inspection;
       const cloned = await exec({
         argv: [
           "git",
@@ -144,7 +193,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
         transportRetry: "never",
       });
       if (!succeeded(cloned)) {
-        return undefined;
+        return { kind: "fallback", reason: "clone-failed" };
       }
       const checkedOut = await exec({
         argv: [
@@ -159,7 +208,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
         transportRetry: "never",
       });
       if (!succeeded(checkedOut) || checkedOut.workspaceDir !== cloned.workspaceDir) {
-        return undefined;
+        return { kind: "fallback", reason: "checkout-failed" };
       }
       const captured = await exec({
         argv: [
@@ -174,14 +223,16 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
         transportRetry: "idempotent",
       });
       const manifestRef = captured.stdout.trim();
-      if (
-        !succeeded(captured) ||
-        !MANIFEST_REF_PATTERN.test(manifestRef) ||
-        manifestRef !== expectedManifestRef
-      ) {
-        return undefined;
+      if (!succeeded(captured) || !MANIFEST_REF_PATTERN.test(manifestRef)) {
+        return { kind: "fallback", reason: "manifest-capture-failed" };
       }
-      return { mode: "git", remoteWorkspaceDir: checkedOut.workspaceDir, manifestRef };
+      if (manifestRef !== expectedManifestRef) {
+        return { kind: "fallback", reason: "manifest-mismatch" };
+      }
+      return {
+        kind: "synced",
+        result: { mode: "git", remoteWorkspaceDir: checkedOut.workspaceDir, manifestRef },
+      };
     },
   };
 }

--- a/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeAgentAssistantMessage } from "../../agents/test-helpers/agent-message-fixtures.js";
 import type { SpawnResult } from "../../process/exec.js";
+import { NodeWorkerWorkspaceTransferError } from "../../worker/node-workspace-transfer-protocol.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import type { WorkerTunnelHandle } from "./tunnel-contract.js";
 import {
@@ -30,7 +31,9 @@ describe("worker turn launcher terminal results", () => {
   it("retains a cloud result when reconciliation fails after worker finishing", async () => {
     seedActivePlacement();
     const destroy = vi.fn(async () => attachedEnvironment());
-    const tunnelFailure = new Error("worker tunnel disconnected before workspace reconcile");
+    const tunnelFailure = new NodeWorkerWorkspaceTransferError(
+      "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+    );
     const tunnel: WorkerTunnelHandle = {
       environmentId: ENVIRONMENT_ID,
       ownerEpoch: OWNER_EPOCH,
@@ -99,7 +102,7 @@ describe("worker turn launcher terminal results", () => {
       ),
     ).rejects.toMatchObject({
       message:
-        "Cloud worker finished, but its workspace result could not be reconciled: worker tunnel disconnected before workspace reconcile",
+        "Cloud worker finished, but its workspace result could not be reconciled: workspace-transfer-failed: gateway TLS fingerprint mismatch",
     });
 
     expect(placements.get(SESSION_ID)).toMatchObject({

--- a/src/node-host/invoke-worker-supervisor.test.ts
+++ b/src/node-host/invoke-worker-supervisor.test.ts
@@ -9,6 +9,10 @@ import {
 } from "../infra/node-commands.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  NODE_WORKSPACE_TRANSFER_ERROR_CODE,
+  NodeWorkerWorkspaceTransferError,
+} from "../worker/node-workspace-transfer-protocol.js";
 import { handleInvoke } from "./invoke.js";
 import type { NodeWorkerLaunchReceipt } from "./node-worker-launch-store.js";
 import type { NodeWorkerSupervisorControl } from "./node-worker-supervisor-contract.js";
@@ -427,5 +431,35 @@ describe("node-host worker supervisor commands", () => {
     const message = result?.error?.message ?? "";
     expect(message).not.toContain("private/path");
     expect(message.length).toBeLessThan(256);
+  });
+
+  it("preserves a typed workspace transfer failure across node invoke", async () => {
+    const workspace = {
+      exec: vi.fn(async () => {
+        throw new NodeWorkerWorkspaceTransferError(
+          "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+        );
+      }),
+    } as unknown as NodeWorkerWorkspaceRuntime;
+
+    const { result } = await invokePrivate({
+      command: NODE_WORKER_WORKSPACE_EXEC_COMMAND,
+      paramsJSON: JSON.stringify({
+        gatewayNamespace: "gateway-1",
+        environmentId: "environment-1",
+        sessionId: "session-1",
+        generation: 4,
+        argv: ["openclaw-internal-workspace-transfer"],
+      }),
+      workspace,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: NODE_WORKSPACE_TRANSFER_ERROR_CODE,
+        message: "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+      },
+    });
   });
 });

--- a/src/node-host/node-worker-supervisor-commands.ts
+++ b/src/node-host/node-worker-supervisor-commands.ts
@@ -10,6 +10,10 @@ import {
   type NodeWorkerWorkspaceExecResult,
 } from "../worker/node-workspace-protocol.js";
 import {
+  NODE_WORKSPACE_TRANSFER_ERROR_CODE,
+  NodeWorkerWorkspaceTransferError,
+} from "../worker/node-workspace-transfer-protocol.js";
+import {
   parseWorkerConnectionEndpoint,
   type WorkerConnectionEndpoint,
 } from "../worker/worker-connection-endpoint.js";
@@ -30,7 +34,12 @@ type NodeWorkerSupervisorCommandResult =
       ok: true;
       payload: NodeWorkerSupervisorReceipt | NodeWorkerWorkspaceExecResult | null;
     }
-  | { handled: true; ok: false; code: "INVALID_REQUEST" | "UNAVAILABLE"; message: string };
+  | {
+      handled: true;
+      ok: false;
+      code: "INVALID_REQUEST" | "UNAVAILABLE" | typeof NODE_WORKSPACE_TRANSFER_ERROR_CODE;
+      message: string;
+    };
 
 function resolveWorkerConnectionEndpoint(params: {
   gatewayUrl?: string;
@@ -128,12 +137,15 @@ export async function invokeNodeWorkerSupervisorCommand(params: {
     };
   } catch (error) {
     const invalid = error instanceof Error && error.message.startsWith("INVALID_REQUEST:");
-    const transferFailure =
-      error instanceof Error && error.message.startsWith("workspace-transfer-");
+    const transferFailure = error instanceof NodeWorkerWorkspaceTransferError;
     return {
       handled: true,
       ok: false,
-      code: invalid ? "INVALID_REQUEST" : "UNAVAILABLE",
+      code: invalid
+        ? "INVALID_REQUEST"
+        : transferFailure
+          ? NODE_WORKSPACE_TRANSFER_ERROR_CODE
+          : "UNAVAILABLE",
       message: invalid || transferFailure ? error.message : "node worker supervisor command failed",
     };
   }

--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -1,9 +1,11 @@
 import { createHash, X509Certificate } from "node:crypto";
 import fs from "node:fs/promises";
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
-import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import https, { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import type { Socket } from "node:net";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import type { TLSSocket } from "node:tls";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
 import { serializeWorkerWorkspaceManifest } from "../gateway/worker-environments/workspace-manifest.js";
@@ -144,7 +146,7 @@ describe("node worker transfer client", () => {
     }
   });
 
-  it("revalidates the TLS pin on pooled manifest and blob requests", async () => {
+  it("reuses the validated TLS pin for a pooled socket", async () => {
     const root = tempDirs.make("node-worker-transfer-tls-");
     const workspaceDir = path.join(root, "workspace");
     const body = Buffer.from("pinned transfer\n");
@@ -204,6 +206,16 @@ describe("node worker transfer client", () => {
     });
     const gatewayUrl = (await listen(server)).replace(/^ws/u, "wss");
     const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
+    const gatewayPort = Number(new URL(gatewayUrl).port);
+    let hidPeerCertificate = false;
+    const hidePeerCertificate = (socket: Socket) => {
+      if (socket.remotePort !== gatewayPort || hidPeerCertificate) {
+        return;
+      }
+      hidPeerCertificate = true;
+      (socket as TLSSocket).getPeerCertificate = (() => ({})) as TLSSocket["getPeerCertificate"];
+    };
+    https.globalAgent.on("free", hidePeerCertificate);
     try {
       await expect(
         runNodeWorkerWorkspaceTransfer({
@@ -217,6 +229,7 @@ describe("node worker transfer client", () => {
       ).resolves.toBe(manifestRef);
       expect(requestCount).toBe(2);
       expect(connectionCount).toBe(1);
+      expect(hidPeerCertificate).toBe(true);
 
       await fs.writeFile(path.join(workspaceDir, "changed.txt"), "changed on node\n");
       uploadManifestRef = (
@@ -238,19 +251,162 @@ describe("node worker transfer client", () => {
       ).resolves.toBe(uploadManifestRef);
       expect(requestCount).toBe(3);
       expect(connectionCount).toBe(1);
+    } finally {
+      https.globalAgent.off("free", hidePeerCertificate);
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
 
+  it("rejects a wrong TLS pin on a new socket", async () => {
+    const root = tempDirs.make("node-worker-transfer-wrong-pin-");
+    const rawManifest = serializeWorkerWorkspaceManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [],
+    });
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    let requestCount = 0;
+    const server = createHttpsServer(
+      { cert: TEST_TLS_CERT_PEM, key: TEST_TLS_KEY_PEM },
+      (_req, res) => {
+        requestCount += 1;
+        res.writeHead(200).end(rawManifest);
+      },
+    );
+    const gatewayUrl = (await listen(server)).replace(/^ws/u, "wss");
+    try {
       await expect(
         runNodeWorkerWorkspaceTransfer({
           gatewayUrl,
           gatewayTlsFingerprint: "00".repeat(32),
           environmentId: "environment-wrong-pin",
-          workspaceDir: path.join(root, "wrong-pin-workspace"),
+          workspaceDir: path.join(root, "workspace"),
           manifestHome: root,
           transfer: { direction: "download", token: "wrong-pin-token", manifestRef },
         }),
-      ).rejects.toThrow("workspace-transfer-failed");
-      expect(requestCount).toBe(3);
+      ).rejects.toThrow("gateway TLS fingerprint mismatch");
+      expect(requestCount).toBe(0);
     } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("cleans up error listeners across repeated download and upload backpressure", async () => {
+    const root = tempDirs.make("node-worker-transfer-backpressure-");
+    const workspaceDir = path.join(root, "workspace");
+    const body = Buffer.alloc(2 * 1024 * 1024, "a");
+    const sha256 = createHash("sha256").update(body).digest("hex");
+    const rawManifest = serializeWorkerWorkspaceManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [
+        {
+          path: "large.bin",
+          type: "file",
+          mode: 0o644,
+          size: body.byteLength,
+          sha256,
+        },
+      ],
+    });
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    let uploadManifestRef: string | undefined;
+    const server = createHttpServer((req, res) => {
+      void (async () => {
+        if (req.url?.endsWith("/manifest")) {
+          res.writeHead(200, { "content-length": String(Buffer.byteLength(rawManifest)) });
+          res.end(rawManifest);
+          return;
+        }
+        if (req.url?.endsWith(`/blobs/${sha256}`)) {
+          res.writeHead(200, { "content-length": String(body.byteLength) });
+          res.end(body);
+          return;
+        }
+        if (req.method === "POST" && req.url?.includes("/reconciliations/")) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 50);
+          });
+          for await (const chunk of req) {
+            void chunk;
+          }
+          const response = Buffer.from(JSON.stringify({ manifestRef: uploadManifestRef }));
+          res.writeHead(200, {
+            "content-type": "application/json",
+            "content-length": String(response.byteLength),
+          });
+          res.end(response);
+          return;
+        }
+        res.writeHead(404).end();
+      })().catch((error: unknown) => {
+        res.destroy(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+    const outputProbes: DrainProbe[] = [];
+    const requestProbes: DrainProbe[] = [];
+    const createWriteStream = fsSync.createWriteStream.bind(fsSync);
+    const writeStreamSpy = vi.spyOn(fsSync, "createWriteStream").mockImplementation((...args) => {
+      const stream = createWriteStream(...args);
+      outputProbes.push(observeDrainListeners(stream));
+      return stream;
+    });
+    const request = http.request.bind(http);
+    const requestSpy = vi.spyOn(http, "request").mockImplementation(((
+      url: URL,
+      options: RequestOptions,
+    ) => {
+      const clientRequest = request(url, options);
+      requestProbes.push(observeDrainListeners(clientRequest));
+      return clientRequest;
+    }) as typeof http.request);
+    const gatewayUrl = await listen(server);
+    try {
+      await expect(
+        runNodeWorkerWorkspaceTransfer({
+          gatewayUrl,
+          environmentId: "environment-backpressure",
+          workspaceDir,
+          manifestHome: root,
+          transfer: { direction: "download", token: "download-token", manifestRef },
+        }),
+      ).resolves.toBe(manifestRef);
+
+      await fs.writeFile(path.join(workspaceDir, "large.bin"), Buffer.alloc(body.byteLength, "b"));
+      uploadManifestRef = (
+        await readActualWorkspaceManifest({ root: workspaceDir, baseCommit: null })
+      ).manifestRef;
+      await expect(
+        runNodeWorkerWorkspaceTransfer({
+          gatewayUrl,
+          environmentId: "environment-backpressure",
+          workspaceDir,
+          manifestHome: root,
+          transfer: {
+            direction: "upload",
+            token: "upload-token",
+            baseManifestRef: manifestRef,
+          },
+        }),
+      ).resolves.toBe(uploadManifestRef);
+
+      const outputProbe = outputProbes.find((probe) => probe.drains > 10);
+      const requestProbe = requestProbes.find((probe) => probe.drains > 10);
+      expect(outputProbe?.drains).toBeGreaterThan(10);
+      expect(outputProbe?.maxErrorListeners).toBeLessThanOrEqual(1);
+      expect(outputProbe?.emitter.listenerCount("error")).toBe(0);
+      expect(requestProbe?.drains).toBeGreaterThan(10);
+      expect(requestProbe?.maxErrorListeners).toBeLessThanOrEqual(2);
+      expect(requestProbe?.emitter.listenerCount("error")).toBe(0);
+    } finally {
+      writeStreamSpy.mockRestore();
+      requestSpy.mockRestore();
       server.closeAllConnections();
       await new Promise<void>((resolve) => {
         server.close(() => resolve());

--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -19,6 +19,20 @@ import { readActualWorkspaceManifest } from "../gateway/worker-environments/work
 import { runCommandBuffered, runExec } from "../process/exec.js";
 import { runNodeWorkerWorkspaceTransfer } from "./node-worker-transfer-client.js";
 
+const transferDebug = vi.hoisted(() => vi.fn());
+vi.mock("../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "node-host/worker-workspace"
+        ? { ...logger, debug: transferDebug }
+        : logger;
+    },
+  };
+});
+
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 type DrainProbe = {
@@ -443,6 +457,7 @@ describe("node worker transfer client", () => {
   });
 
   it("materializes a Git workspace with argv-only commands", async () => {
+    transferDebug.mockClear();
     const root = tempDirs.make("node-worker-transfer-git-");
     const source = path.join(root, "source");
     const workspaceDir = path.join(root, "workspace");
@@ -510,6 +525,17 @@ describe("node worker transfer client", () => {
       );
       await expect(git(workspaceDir, ["rev-parse", "HEAD"])).resolves.toBe(commit);
       await expect(git(workspaceDir, ["status", "--porcelain=v1"])).resolves.toBe("");
+      expect(transferDebug).toHaveBeenCalledWith(
+        "node worker workspace transfer completed",
+        expect.objectContaining({
+          environmentId: "environment-git",
+          direction: "download",
+          outcome: "succeeded",
+          durationMs: expect.any(Number),
+          packDownloadMs: expect.any(Number),
+          blobApplyMs: expect.any(Number),
+        }),
+      );
     } finally {
       server.closeAllConnections();
       await new Promise<void>((resolve) => {

--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -1,6 +1,12 @@
 import { createHash, X509Certificate } from "node:crypto";
+import type { EventEmitter } from "node:events";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import http, {
+  createServer as createHttpServer,
+  type RequestOptions,
+  type Server as HttpServer,
+} from "node:http";
 import https, { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
 import type { Socket } from "node:net";
 import path from "node:path";
@@ -14,6 +20,28 @@ import { runCommandBuffered, runExec } from "../process/exec.js";
 import { runNodeWorkerWorkspaceTransfer } from "./node-worker-transfer-client.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+type DrainProbe = {
+  emitter: EventEmitter;
+  drains: number;
+  maxErrorListeners: number;
+};
+
+function observeDrainListeners(emitter: EventEmitter): DrainProbe {
+  const probe = { emitter, drains: 0, maxErrorListeners: 0 };
+  emitter.on("newListener", (event) => {
+    if (event === "error") {
+      probe.maxErrorListeners = Math.max(
+        probe.maxErrorListeners,
+        emitter.listenerCount("error") + 1,
+      );
+    }
+  });
+  emitter.on("drain", () => {
+    probe.drains += 1;
+  });
+  return probe;
+}
 
 async function listen(server: HttpServer | HttpsServer): Promise<string> {
   await new Promise<void>((resolve, reject) => {

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { once } from "node:events";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import http, { type ClientRequest, type IncomingMessage } from "node:http";
@@ -118,7 +119,7 @@ function waitForTlsPin(request: ClientRequest, expectedRaw?: string): Promise<vo
   });
 }
 
-function openRequest(params: {
+async function openRequest(params: {
   gatewayUrl: string;
   tlsFingerprint?: string;
   routePath: string;
@@ -129,27 +130,25 @@ function openRequest(params: {
   writeBody?: (request: ClientRequest) => Promise<void>;
 }): Promise<IncomingMessage> {
   const url = transferUrl(params.gatewayUrl, params.routePath);
-  return new Promise<IncomingMessage>((resolve, reject) => {
-    const transport = url.protocol === "https:" ? https : http;
-    const request = transport.request(url, {
-      method: params.method,
-      headers: { authorization: `Bearer ${params.token}`, ...params.headers },
-      signal: params.signal,
-      ...(url.protocol === "https:" && params.tlsFingerprint ? { rejectUnauthorized: false } : {}),
-    });
-    request.once("response", resolve);
-    request.once("error", reject);
-    const send = async () => {
-      if (url.protocol === "https:") {
-        await waitForTlsPin(request, params.tlsFingerprint);
-      }
-      await params.writeBody?.(request);
-      request.end();
-    };
-    void send().catch((error: unknown) =>
-      request.destroy(error instanceof Error ? error : new Error(String(error))),
-    );
+  const transport = url.protocol === "https:" ? https : http;
+  const request = transport.request(url, {
+    method: params.method,
+    headers: { authorization: `Bearer ${params.token}`, ...params.headers },
+    signal: params.signal,
+    ...(url.protocol === "https:" && params.tlsFingerprint ? { rejectUnauthorized: false } : {}),
   });
+  const response = once(request, "response").then(([message]) => message as IncomingMessage);
+  const send = async () => {
+    if (url.protocol === "https:") {
+      await waitForTlsPin(request, params.tlsFingerprint);
+    }
+    await params.writeBody?.(request);
+    request.end();
+  };
+  void send().catch((error: unknown) =>
+    request.destroy(error instanceof Error ? error : new Error(String(error))),
+  );
+  return await response;
 }
 
 async function readResponseBody(response: IncomingMessage, maxBytes: number): Promise<Buffer> {
@@ -211,16 +210,12 @@ async function downloadFile(params: {
       }
       hash.update(chunk);
       if (!output.write(chunk)) {
-        await new Promise<void>((resolve, reject) => {
-          output.once("drain", resolve);
-          output.once("error", reject);
-        });
+        await once(output, "drain");
       }
     }
-    await new Promise<void>((resolve, reject) => {
-      output.once("error", reject);
-      output.end(resolve);
-    });
+    const finished = once(output, "finish");
+    output.end();
+    await finished;
   } catch (error) {
     output.destroy();
     await fsp.rm(params.destination, { force: true });
@@ -583,10 +578,7 @@ async function writeChunk(request: ClientRequest, chunk: Buffer): Promise<void> 
   if (request.write(chunk)) {
     return;
   }
-  await new Promise<void>((resolve, reject) => {
-    request.once("drain", resolve);
-    request.once("error", reject);
-  });
+  await once(request, "drain");
 }
 
 async function uploadFile(request: ClientRequest, filePath: string): Promise<void> {

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -16,6 +16,7 @@ import { REMOTE_WORKSPACE_MANIFEST_JS } from "../gateway/worker-environments/wor
 import { isPathInside } from "../infra/path-guards.js";
 import { tempWorkspace } from "../infra/private-temp-workspace.js";
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runCommandWithTimeout, runExec } from "../process/exec.js";
 import {
   nodeWorkspaceTransferBlobPath,
@@ -29,6 +30,7 @@ import {
 const TRANSFER_TIMEOUT_MS = 10 * 60_000;
 const TRANSFER_RESULT_MAX_BYTES = 64 * 1024;
 const validatedTlsSocketPins = new WeakMap<TLSSocket, string>();
+const transferLog = createSubsystemLogger("node-host/worker-workspace");
 
 function transferUrl(gatewayUrl: string, routePath: string): URL {
   const gateway = new URL(gatewayUrl);
@@ -483,6 +485,8 @@ async function downloadWorkspace(params: {
   transfer: Extract<NodeWorkerWorkspaceTransferInput, { direction: "download" }>;
   signal?: AbortSignal;
 }): Promise<string> {
+  const startedAt = performance.now();
+  let packDownloadMs: number | undefined;
   const raw = await downloadBuffer(
     {
       gatewayUrl: params.gatewayUrl,
@@ -508,6 +512,7 @@ async function downloadWorkspace(params: {
   try {
     if (manifest.baseCommit) {
       const packPath = path.join(staging, ".openclaw-base.pack");
+      const packStartedAt = performance.now();
       await downloadFile({
         request: {
           gatewayUrl: params.gatewayUrl,
@@ -522,6 +527,7 @@ async function downloadWorkspace(params: {
         },
         destination: packPath,
       });
+      packDownloadMs = performance.now() - packStartedAt;
       await initializeGitWorkspace({
         workspaceDir: staging,
         manifestHome: params.manifestHome,
@@ -530,6 +536,7 @@ async function downloadWorkspace(params: {
         signal: params.signal,
       });
     }
+    const blobApplyStartedAt = performance.now();
     for (const directory of manifest.directories ?? []) {
       await fsp.mkdir(workspacePath(staging, directory), { recursive: true, mode: 0o700 });
     }
@@ -556,6 +563,7 @@ async function downloadWorkspace(params: {
       });
       await fsp.chmod(destination, entry.mode);
     }
+    const blobApplyMs = performance.now() - blobApplyStartedAt;
     const observed = await captureManifest({
       workspaceDir: staging,
       manifestHome: params.manifestHome,
@@ -568,6 +576,14 @@ async function downloadWorkspace(params: {
       );
     }
     await replaceWorkspace(params.workspaceDir, staging);
+    transferLog.debug("node worker workspace transfer completed", {
+      environmentId: params.environmentId,
+      direction: "download",
+      outcome: "succeeded",
+      durationMs: performance.now() - startedAt,
+      ...(packDownloadMs === undefined ? {} : { packDownloadMs }),
+      blobApplyMs,
+    });
     return observed;
   } finally {
     await stagingWorkspace.cleanup();

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -18,6 +18,7 @@ import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { runCommandWithTimeout, runExec } from "../process/exec.js";
 import {
   nodeWorkspaceTransferBlobPath,
+  NodeWorkerWorkspaceTransferError,
   nodeWorkspaceTransferManifestPath,
   nodeWorkspaceTransferPackPath,
   nodeWorkspaceTransferReconcilePath,
@@ -26,6 +27,7 @@ import {
 
 const TRANSFER_TIMEOUT_MS = 10 * 60_000;
 const TRANSFER_RESULT_MAX_BYTES = 64 * 1024;
+const validatedTlsSocketPins = new WeakMap<TLSSocket, string>();
 
 function transferUrl(gatewayUrl: string, routePath: string): URL {
   const gateway = new URL(gatewayUrl);
@@ -50,17 +52,26 @@ function waitForTlsPin(request: ClientRequest, expectedRaw?: string): Promise<vo
   }
   const expected = normalizeFingerprint(expectedRaw);
   if (!expected) {
-    return Promise.reject(new Error("gateway TLS fingerprint is invalid"));
+    return Promise.reject(
+      new NodeWorkerWorkspaceTransferError(
+        "workspace-transfer-failed: gateway TLS fingerprint is invalid",
+      ),
+    );
   }
   return new Promise<void>((resolve, reject) => {
     let settled = false;
+    let tlsSocket: TLSSocket | undefined;
     let fail: (error: Error) => void = () => {};
+    let verify: () => void = () => {};
+    let bindSocket: (socket: import("node:net").Socket) => void = () => {};
     const finish = (error?: Error) => {
       if (settled) {
         return;
       }
       settled = true;
       request.off("error", fail);
+      request.off("socket", bindSocket);
+      tlsSocket?.off("secureConnect", verify);
       if (error) {
         reject(error);
       } else {
@@ -69,24 +80,41 @@ function waitForTlsPin(request: ClientRequest, expectedRaw?: string): Promise<vo
     };
     fail = (error: Error) => finish(error);
     request.once("error", fail);
-    request.once("socket", (socket) => {
-      const tlsSocket = socket as TLSSocket;
-      const verify = () => {
-        const actual = normalizeFingerprint(tlsSocket.getPeerCertificate().fingerprint256 ?? "");
+    bindSocket = (socket) => {
+      tlsSocket = socket as TLSSocket;
+      const validated = validatedTlsSocketPins.get(tlsSocket);
+      if (validated) {
         finish(
-          !actual || expected !== actual
-            ? new Error("gateway TLS fingerprint mismatch")
-            : undefined,
+          validated === expected
+            ? undefined
+            : new NodeWorkerWorkspaceTransferError(
+                "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+              ),
         );
+        return;
+      }
+      verify = () => {
+        const actual = normalizeFingerprint(tlsSocket!.getPeerCertificate().fingerprint256 ?? "");
+        if (!actual || expected !== actual) {
+          finish(
+            new NodeWorkerWorkspaceTransferError(
+              "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+            ),
+          );
+          return;
+        }
+        validatedTlsSocketPins.set(tlsSocket!, actual);
+        finish();
       };
-      // Pooled sockets completed their TLS handshake before this request existed.
+      // A pooled socket was verified when its secureConnect event completed.
       const peerFingerprint = tlsSocket.getPeerCertificate().fingerprint256;
       if (request.reusedSocket || peerFingerprint) {
         verify();
       } else {
         tlsSocket.once("secureConnect", verify);
       }
-    });
+    };
+    request.once("socket", bindSocket);
   });
 }
 
@@ -145,9 +173,13 @@ async function requireOk(response: IncomingMessage): Promise<void> {
   }
   const body = (await readResponseBody(response, TRANSFER_RESULT_MAX_BYTES)).toString("utf8");
   if (response.statusCode === 413 && body.includes("workspace_transfer_limit")) {
-    throw new Error("workspace-transfer-limit: gateway rejected workspace transfer caps");
+    throw new NodeWorkerWorkspaceTransferError(
+      "workspace-transfer-limit: gateway rejected workspace transfer caps",
+    );
   }
-  throw new Error(`workspace-transfer-failed: gateway returned ${response.statusCode ?? 0}`);
+  throw new NodeWorkerWorkspaceTransferError(
+    `workspace-transfer-failed: gateway returned ${response.statusCode ?? 0}`,
+  );
 }
 
 async function downloadBuffer(params: Parameters<typeof openRequest>[0], maxBytes: number) {
@@ -674,9 +706,12 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
           });
     });
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith("workspace-transfer-")) {
+    if (error instanceof NodeWorkerWorkspaceTransferError) {
       throw error;
     }
-    throw new Error("workspace-transfer-failed: transfer did not complete", { cause: error });
+    throw new NodeWorkerWorkspaceTransferError(
+      "workspace-transfer-failed: transfer did not complete",
+      { cause: error },
+    );
   }
 }

--- a/src/worker/node-workspace-transfer-protocol.ts
+++ b/src/worker/node-workspace-transfer-protocol.ts
@@ -1,4 +1,14 @@
 export const NODE_WORKSPACE_TRANSFER_PATH = "/__openclaw__/worker-transfer/v1";
+export const NODE_WORKSPACE_TRANSFER_ERROR_CODE = "WORKSPACE_TRANSFER_FAILED";
+
+export class NodeWorkerWorkspaceTransferError extends Error {
+  readonly code = NODE_WORKSPACE_TRANSFER_ERROR_CODE;
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "NodeWorkerWorkspaceTransferError";
+  }
+}
 
 export type NodeWorkerWorkspaceTransferInput =
   | {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where node-hosted turns could be reported as failed after their tools and transcript had already completed when HTTPS workspace reconciliation reused a validated TLS socket whose peer-certificate accessor no longer returned a fingerprint. Retrying that false failure could repeat already-applied side effects.

The same stress campaign found cumulative stream listeners during large transfers and no operator-visible explanation when the published-origin fast path fell back to the much slower Gateway push.

Evidence source: the 2026-08-14 node-host STRESS TEST at exact revision `252bb545b47ab3c3d5bbf09a20f52728f174b3cd`, captured in `/tmp/openclaw-node-host-stress-evidence-20260814/REPORT.md`. It reproduced the TLS failure three times, observed 33 `MaxListenersExceededWarning` diagnostics per node, and measured silent Gateway-push fallbacks at 133–157 seconds.

## Why This Change Was Made

TLS pins are now validated once per underlying socket: a pooled socket reuses its recorded normalized fingerprint, while every new socket must still present a nonempty matching fingerprint. A typed private `WORKSPACE_TRANSFER_FAILED` error preserves the safe concrete mismatch through node invoke, the Gateway tunnel, and the launcher.

Backpressure waits now use Node's paired event primitive, which removes the losing `error` or `drain` listener. The same cleanup covers response and final-write waits. Origin selection now returns a closed fallback reason; the Gateway records the chosen `origin` or `gateway-push` path at info level, while the node records total, pack-download, and blob-apply timings at debug level. No config key, SQLite surface, public protocol version, or metrics framework was added.

AI-assisted: yes. The implementation and tests were reviewed with the repository autoreview workflow, and I verified the owner boundaries and Node runtime contracts directly.

## User Impact

Operators can trust that a successfully completed node-hosted turn will not be turned into a false TLS-pin failure merely because its HTTP request reused an already-validated socket. Large workspace transfers no longer accumulate backpressure listeners, and logs now explain why an origin clone was skipped and where transfer time was spent.

## Evidence

- Focused proof passed three consecutive times on the final tree: 32 assertions per pass across the real pooled HTTPS transfer, wrong-pin new-socket refusal, typed node RPC/tunnel/launcher cause propagation, large download/upload backpressure, and sync-path telemetry.
- Large-blob regression performs a real 2 MiB download and reconciliation upload, proves more than ten drain cycles in both directions, and keeps error-listener counts bounded at zero after completion.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 ... node scripts/check-changed.mjs --timed` passed every selected core/core-test formatting, typecheck, lint, dead-code, import-cycle, database-first, and guard lane.
- Remote attempt `run_b0b846f0286c` (`provider=daytona`, lease `cbx_17d638ef5eed`) failed before checks because raw sync omitted Git metadata; the lease was released and the documented trusted-source local fallback passed.
- `pnpm build` passed, including all nine unified build invocations, runtime postbuild checks, public Plugin SDK export verification, and Control UI build.
- `pnpm protocol:gen` reproduced `dist/protocol.schema.json` with no generated diff.
- All nine changed files pass `oxfmt --check`; `git diff --check` is clean.
- Final branch autoreview: clean, no accepted/actionable findings; TruffleHog clean.

Production LOC: +210/-81 (net +129: typed cross-RPC diagnostic boundary plus sync-path/stage observability; the listener repair itself is net-negative) | Tests: +329/-9
