### PR TITLE
fix(matrix): admit server-less room IDs in groups validator

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -94,7 +94,7 @@ Set `autoJoin: "allowlist"` plus `autoJoinAllowlist` to restrict accepted invite
 ### Allowlist target formats
 
 - DMs (`dm.allowFrom`, `groupAllowFrom`, `groups.<room>.users`): use `@user:server`. Display names are ignored by default (mutable); set `dangerouslyAllowNameMatching: true` only for explicit display-name compatibility.
-- Room allowlist keys (`groups`, legacy alias `rooms`): use `!room:server` or `#alias:server`. Plain names are ignored unless `dangerouslyAllowNameMatching: true`.
+- Room allowlist keys (`groups`, legacy alias `rooms`): use a room ID (`!room:server`, or a server-less `!roomId` as modern homeservers issue) or `#alias:server`. Plain names are ignored unless `dangerouslyAllowNameMatching: true`.
 - Invite allowlists (`autoJoinAllowlist`): use `!room:server`, `#alias:server`, or `*`. Plain names are always rejected.
 
 ### Account ID normalization
@@ -835,7 +835,7 @@ Live directory lookup uses the logged-in Matrix account:
 
 Allowlist-style user fields (`groupAllowFrom`, `dm.allowFrom`, `groups.<room>.users`) accept full Matrix user IDs (safest). Non-ID entries are ignored by default. If `dangerouslyAllowNameMatching: true` is set, exact Matrix directory display-name matches are resolved at startup and whenever the allowlist changes while the monitor is running; unresolvable entries are ignored at runtime.
 
-Room allowlist keys (`groups`, legacy `rooms`) should be room IDs or aliases. Plain room-name keys are ignored by default; `dangerouslyAllowNameMatching: true` restores best-effort lookup against joined room names.
+Room allowlist keys (`groups`, legacy `rooms`) should be room IDs or aliases. Room IDs may include or omit the `:server` suffix — modern homeservers issue server-less `!roomId` forms, and both are matched verbatim for admission. Plain room-name keys are ignored by default; `dangerouslyAllowNameMatching: true` restores best-effort lookup against joined room names.
 
 ### Account and connection
 

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -336,4 +336,32 @@ describe("resolveMatrixMonitorConfig", () => {
       inputs: ["Alice"],
     });
   });
+
+  it("admits server-less (modern) room IDs as exact keys without resolving them (#122739)", async () => {
+    const runtime = createRuntime();
+    const resolveTargets = vi.fn(async () => []);
+
+    // Modern homeservers (e.g. Continuwuity) issue room IDs with no ":server"
+    // suffix. These are valid exact IDs — admission matches them verbatim and
+    // needs no resolution, exactly like the group resolver accepts any
+    // "!"-prefixed target as an exact ID.
+    const roomId = "!kyPsk-bXS5fEmaIzUxZHgs6QVNyVjlbTSjy_ZkN48Ss";
+    const result = await resolveMatrixMonitorConfig({
+      cfg: createConfig(),
+      accountId: "ops",
+      roomsConfig: {
+        [roomId]: { enabled: true },
+      },
+      runtime,
+      resolveTargets,
+    });
+
+    expect(result.roomsConfig).toEqual({
+      [roomId]: { enabled: true },
+    });
+    expect(resolveTargets).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      "matrix rooms must be room IDs or aliases (example: !room:server or #alias:server). Unresolved entries are ignored.",
+    );
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -364,4 +364,33 @@ describe("resolveMatrixMonitorConfig", () => {
       "matrix rooms must be room IDs or aliases (example: !room:server or #alias:server). Unresolved entries are ignored.",
     );
   });
+
+  it("admits an inbound event from a configured server-less room ID end-to-end (#122739)", async () => {
+    // Real config resolution (no mocked resolver) feeds the real room-config
+    // matcher: a server-less room ID flows from channels.matrix.groups into
+    // the admission map, then an inbound event from that room is admitted
+    // rather than dropped. Pre-fix the ID never reached the map, so the
+    // matcher returned allowed=false (silent message loss).
+    const roomId = "!kyPsk-bXS5fEmaIzUxZHgs6QVNyVjlbTSjy_ZkN48Ss";
+    const resolveTargets = vi.fn(async () => []);
+    const { resolveMatrixRoomConfig } = await import("./rooms.js");
+
+    const result = await resolveMatrixMonitorConfig({
+      cfg: createConfig(),
+      accountId: "ops",
+      roomsConfig: { [roomId]: { enabled: true } },
+      runtime: createRuntime(),
+      resolveTargets,
+    });
+
+    expect(result.roomsConfig).toHaveProperty(roomId);
+    const admission = resolveMatrixRoomConfig({
+      rooms: result.roomsConfig,
+      roomId,
+      aliases: [],
+    });
+    expect(admission.allowed).toBe(true);
+    expect(admission.matchSource).toBe("direct");
+    expect(resolveTargets).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/config.ts
+++ b/extensions/matrix/src/matrix/monitor/config.ts
@@ -424,7 +424,13 @@ async function resolveMatrixMonitorRoomsConfig(params: {
       unresolved.push(entry);
       continue;
     }
-    if (cleaned.startsWith("!") && cleaned.includes(":")) {
+    // Matrix room IDs always start with "!"; modern homeservers (e.g.
+    // Continuwuity) issue server-less IDs with no ":server" suffix. Exact IDs
+    // are matched verbatim for admission — no resolution, no server part
+    // needed — matching the group resolver, which accepts any "!"-prefixed
+    // target as an exact ID. Requiring ":" here silently dropped modern room
+    // IDs from the admission list (#122739).
+    if (cleaned.startsWith("!")) {
       if (!nextRooms[cleaned]) {
         nextRooms[cleaned] = roomConfig;
       }

--- a/extensions/matrix/src/matrix/monitor/config.ts
+++ b/extensions/matrix/src/matrix/monitor/config.ts
@@ -424,12 +424,9 @@ async function resolveMatrixMonitorRoomsConfig(params: {
       unresolved.push(entry);
       continue;
     }
-    // Matrix room IDs always start with "!"; modern homeservers (e.g.
-    // Continuwuity) issue server-less IDs with no ":server" suffix. Exact IDs
-    // are matched verbatim for admission — no resolution, no server part
-    // needed — matching the group resolver, which accepts any "!"-prefixed
-    // target as an exact ID. Requiring ":" here silently dropped modern room
-    // IDs from the admission list (#122739).
+    // Exact room IDs ("!"-prefixed) are matched verbatim for admission and
+    // bypass resolution; the server part is optional, matching the group
+    // resolver's exact-ID contract.
     if (cleaned.startsWith("!")) {
       if (!nextRooms[cleaned]) {
         nextRooms[cleaned] = roomConfig;


### PR DESCRIPTION
Closes #122739

## What Problem This Solves

The Matrix plugin's startup validator for `channels.matrix.groups` keys rejects **current-format Matrix room IDs** — the ones modern homeservers (e.g. Continuwuity) issue with no `:server` suffix. Such entries fall into the `unresolved` list and are **silently dropped from the room-admission map**: messages in those rooms are lost exactly as if the entry didn't exist, while `openclaw config get` reads the discarded entries back as live. The only signal is one startup log line.

## Why This Change Was Made

In `extensions/matrix/src/matrix/monitor/config.ts`, the groups validator only treated a key as an exact room ID when it had **both** a `!` prefix **and** a `:` (the legacy `!room:server` shape):

```ts
if (cleaned.startsWith("!") && cleaned.includes(":")) { /* exact room ID */ }
```

A server-less ID like `!kyPsk-bXS5fEmaIzUxZHgs6QVNyVjlbTSjy_ZkN48Ss` passes the `!` prefix but lacks `:`, so it failed this gate and fell through to the unresolved branch, which (with name-matching off by default) pushes it to `unresolved` and skips it.

This contradicts the sibling group resolver (`extensions/matrix/src/resolve-targets.ts`), which already treats **any** `!`-prefixed target as an exact ID:

```ts
if (normalizedTarget?.startsWith("!")) {
  results.push({ input, resolved: true, id: normalizedTarget });
  continue;
}
```

Exact room IDs are matched verbatim for admission — they need no resolution and no server part. The fix drops the `&& cleaned.includes(":")` condition so the validator accepts any `!`-prefixed entry as an exact room ID, aligning with the resolver contract. The `!` prefix unambiguously denotes a room ID (aliases use `#`), so no name-matching or resolution path is affected.

This is the owner-boundary repair: the violated invariant is "an exact `!` room ID is admitted verbatim," and the sibling resolver already encodes it — the validator was the lone outlier. The legacy `!room:server` path is unchanged (still accepted); only the previously-rejected server-less IDs are now admitted.

## User Impact

Operators on modern homeservers who key `channels.matrix.groups` by a real (server-less) room ID — the natural thing to copy from the client — now get working group admission instead of silent message loss. `config get` and the runtime admission map agree. Operators using legacy `!room:server` IDs or `#alias:server` aliases see no behavior change. The Matrix guide now documents the accepted server-less form alongside the legacy shape.

## Evidence

**Pre-fix reproduction (regression test fails for the intended reason):**

`config.test.ts` configures a server-less room ID and asserts it lands in `roomsConfig`:

```
Expected: { "!kyPsk-bXS5fEmaIzUxZHgs6QVNyVjlbTSjy_ZkN48Ss": { enabled: true } }
Received: {}   // server-less ID dropped at the `includes(":")` gate → unresolved → admission map empty
Tests  1 failed | 8 skipped (9)
```

Run on pre-fix code (`includes(":")` restored, new tests kept) — the server-less ID is dropped, exactly the reported silent loss.

**Real-behavior admission proof (configured server-less ID → admitted inbound event):**

`config.test.ts` "admits an inbound event from a configured server-less room ID end-to-end" drives the **real** production chain with no mocked resolver on the exact-ID path: real `resolveMatrixMonitorConfig` builds the admission map from a configured server-less ID, then the real `resolveMatrixRoomConfig` matcher (the function `handler-ingress-access.ts` uses to decide admit/drop) is queried with an inbound event from that room:

- Pre-fix (`includes(":")` restored): the ID never reaches the map → `result.roomsConfig` has no such key → `resolveMatrixRoomConfig` returns `allowed=false` (silent message loss — the inbound event is dropped).
- Post-fix: the ID survives into the map → `resolveMatrixRoomConfig` returns `allowed=true, matchSource="direct"` (admitted).

```
extensions/matrix/src/matrix/monitor/config.test.ts   9 passed   (incl. server-less regression + end-to-end admission proof)
extensions/matrix/src/matrix/monitor/rooms.test.ts    8 passed   (admission matcher — unchanged, no regression)
extensions/matrix/src/resolve-targets.test.ts         6 passed   (sibling resolver — confirms contract alignment)
```

- oxfmt: clean on touched files
- oxlint: clean (max-lines etc.)
- CI: `check-prod-types` pass, `check-test-types` pass, `check-lint` pass, `build-artifacts` pass, all boundary checks pass on head `17b35f7cacd`.
- Production LOC delta: net +7 on the first commit (one condition relaxed to `cleaned.startsWith("!")` plus a short invariant comment at the gate; the `includes(":")` check is removed). The second commit is docs + test only (comment trim, guide update, end-to-end proof). Test/docs lines counted separately.

**Sibling coverage:** the group resolver (`resolve-targets.ts:148-151`) already accepts any `!`-prefixed target as an exact ID; this PR makes the validator agree, so the two `!`-prefixed admission paths no longer diverge. Other Matrix channels (legacy `!room:server`, `#alias:server`, `*`, name-matched entries) are untouched.
