### PR TITLE
improve(ui): organize project and session identity in the chat header

### DIFF
--- a/ui/src/components/icons-tools.ts
+++ b/ui/src/components/icons-tools.ts
@@ -247,9 +247,14 @@ export const toolIcons = {
       d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"
     />
     <path d="m2 2 20 20" />`),
-  moreHorizontal: strokeIcon(svg` <circle cx="12" cy="12" r="1.5" />
-    <circle cx="6" cy="12" r="1.5" />
-    <circle cx="18" cy="12" r="1.5" />`),
+  // Filled on purpose: three stroked rings read as hollow circles at the sizes
+  // this glyph is used at, and thin out further wherever a surface overrides the
+  // shared stroke width. Filling keeps one solid dot triplet everywhere.
+  moreHorizontal: strokeIcon(svg` <g fill="currentColor" stroke="none">
+      <circle cx="5" cy="12" r="1.5" />
+      <circle cx="12" cy="12" r="1.5" />
+      <circle cx="19" cy="12" r="1.5" />
+    </g>`),
   ellipsis: strokeIcon(svg` <circle cx="12" cy="12" r="1.25" fill="currentColor" stroke="none" />
     <circle cx="5" cy="12" r="1.25" fill="currentColor" stroke="none" />
     <circle cx="19" cy="12" r="1.25" fill="currentColor" stroke="none" />`),

--- a/ui/src/e2e/chat-header-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-header-identity.e2e.test.ts
@@ -1,0 +1,208 @@
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
+import {
+  captureUiProofEnabled,
+  chatSessionListResponse,
+  controlUiSessionUrl,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "chat-header-identity");
+
+const LONG_TITLE =
+  "Rework the release readiness checklist and reconcile the production rollout plan";
+
+/**
+ * Session list that puts every header identity state on screen at once: two
+ * distinct creators (which is what turns on creator attribution), a project
+ * with a resolvable icon, and a long title for the truncation case.
+ */
+function identitySessions() {
+  return chatSessionListResponse([
+    {
+      createdActor: { id: "profile-ada", label: "Ada Lovelace", type: "human" },
+      key: "agent:main:session-a",
+      kind: "direct",
+      label: "Header identity trail",
+      spawnedCwd: "/repo/openclaw",
+      updatedAt: 2,
+    },
+    {
+      createdActor: { id: "profile-grace", label: "Grace Hopper", type: "human" },
+      key: "agent:main:session-b",
+      kind: "direct",
+      label: LONG_TITLE,
+      spawnedCwd: "/repo/openclaw",
+      updatedAt: 1,
+    },
+  ]);
+}
+
+suite.define(() => {
+  for (const theme of ["light", "dark"] as const) {
+    it(`groups project, creator, session, and viewers in the ${theme} chat header`, async () => {
+      const context = await suite.newBrowserContext({
+        colorScheme: theme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 560, width: 1120 },
+      });
+      const page = await context.newPage();
+      const capture = async (name: string) => {
+        if (!captureUiProofEnabled) {
+          return;
+        }
+        await mkdir(proofDir, { recursive: true });
+        await page
+          .locator(".chat-pane__header")
+          .first()
+          .screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, `${name}-${theme}.png`),
+          });
+      };
+      // Persisted settings, not just the media query: themeMode only follows the
+      // OS preference while it is "system", so seeding both pins the frame.
+      await page.addInitScript(
+        ({ key, mode }) => {
+          localStorage.setItem(key, JSON.stringify({ theme: "claw", themeMode: mode }));
+        },
+        { key: controlUiBundledSettingsStorageKey(suite.server.baseUrl), mode: theme },
+      );
+      const favicon = await readFile(path.resolve(process.cwd(), "ui/public/favicon.svg"));
+      await page.route("**/__openclaw__/workspace-icon/**", async (route) => {
+        await route.fulfill({ body: favicon, contentType: "image/svg+xml", status: 200 });
+      });
+      await installMockGateway(page, {
+        methodResponses: { "sessions.list": identitySessions() },
+        presenceUsers: [
+          { id: "profile-ada", name: "Ada Lovelace", self: true, watchedSessions: [] },
+          {
+            id: "profile-grace",
+            name: "Grace Hopper",
+            watchedSessions: ["agent:main:session-a"],
+          },
+          { id: "profile-alan", name: "Alan Turing", watchedSessions: ["agent:main:session-a"] },
+        ],
+        sessionKey: "agent:main:session-a",
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const header = page.locator(".chat-pane__header").first();
+        await header.waitFor();
+        await header.locator(".workspace-icon").waitFor();
+        await header.locator(".chat-pane__session-menu-anchor").waitFor();
+        await capture("rest");
+
+        const trail = await header.evaluate((root) => {
+          const box = (selector: string) => {
+            const node = root.querySelector(selector);
+            if (!node) {
+              throw new Error(`missing header element: ${selector}`);
+            }
+            return node.getBoundingClientRect();
+          };
+          const creator = box(".chat-pane__session-identity .session-owner-chip");
+          const creatorStyle = getComputedStyle(
+            root.querySelector(".chat-pane__session-identity .session-owner-chip")!,
+          );
+          const centerY = (selector: string) => {
+            const rect = box(selector);
+            return rect.top + rect.height / 2;
+          };
+          return {
+            creator: { height: creator.height, width: creator.width },
+            creatorShadow: creatorStyle.boxShadow,
+            menuGlyphCenter: centerY(".chat-pane__session-menu-anchor svg"),
+            menuLeft: box(".chat-pane__session-menu-anchor").left,
+            headerCenter: (() => {
+              const rect = root.getBoundingClientRect();
+              return rect.top + rect.height / 2;
+            })(),
+            projectRight: box(".chat-pane__workspace-chip").right,
+            titleLeft: box(".chat-pane__session-title").left,
+            titleTextLeft: box(".chat-pane__session-title-text").left,
+            titleRight: box(".chat-pane__session-title").right,
+            viewerHeight: box(".chat-pane__presence .viewer-avatar").height,
+            // The facepile host renders through display:contents, so the first
+            // avatar is what actually has a position in the row.
+            viewerLeft: box(".chat-pane__presence .viewer-avatar").left,
+          };
+        });
+
+        // Reading order is the ownership story: project, then creator, then the
+        // name, then the controls that act on it, then who else is watching.
+        expect(trail.projectRight).toBeLessThan(trail.titleLeft);
+        expect(trail.titleRight).toBeLessThanOrEqual(trail.menuLeft + 1);
+        expect(trail.menuLeft).toBeLessThan(trail.viewerLeft);
+        // One avatar scale across the trail, and no decoration on it.
+        expect(trail.creator).toEqual({ height: 18, width: 18 });
+        expect(trail.viewerHeight).toBe(18);
+        expect(trail.creatorShadow).toBe("none");
+        // The 48px header centers its 28px actions on the chrome centerline, and
+        // the trail lifts its text 1px above that. A button that moved into the
+        // trail must not inherit the lift, or session management would sit a
+        // pixel above every other action in the row.
+        expect(
+          Math.abs(trail.menuGlyphCenter - trail.headerCenter),
+          JSON.stringify(trail),
+        ).toBeLessThanOrEqual(0.5);
+
+        // Renaming edits in place: same row height, same text origin.
+        await header.locator(".chat-pane__session-title-button").click();
+        const input = header.locator(".chat-pane__session-title-input");
+        await input.waitFor();
+        await capture("rename");
+        const rename = await header.evaluate((root) => {
+          const field = root.querySelector(".chat-pane__session-title-input")!;
+          const style = getComputedStyle(field);
+          return {
+            headerHeight: root.getBoundingClientRect().height,
+            // Where the typed text actually starts: the field's own box, plus the
+            // border and padding drawn inside it.
+            textLeft:
+              field.getBoundingClientRect().left +
+              Number.parseFloat(style.borderLeftWidth) +
+              Number.parseFloat(style.paddingLeft),
+          };
+        });
+        expect(rename.headerHeight).toBe(48);
+        expect(
+          Math.abs(rename.textLeft - trail.titleTextLeft),
+          JSON.stringify({ rename, titleTextLeft: trail.titleTextLeft }),
+        ).toBeLessThanOrEqual(1);
+        await page.keyboard.press("Escape");
+
+        // On a narrow pane a long name truncates, but it never pushes the
+        // session's own controls out of the header.
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:session-b"));
+        await expect
+          .poll(() => header.locator(".chat-pane__session-title-text").textContent())
+          .toBe(LONG_TITLE);
+        await page.setViewportSize({ height: 560, width: 640 });
+        await expect
+          .poll(async () =>
+            header.locator(".chat-pane__session-title-text").evaluate((text) => {
+              const node = text as HTMLElement;
+              return node.scrollWidth > node.clientWidth;
+            }),
+          )
+          .toBe(true);
+        await capture("long-title-narrow");
+        const overflow = await header.evaluate((root) => ({
+          headerRight: root.getBoundingClientRect().right,
+          menuRight: root.querySelector(".chat-pane__session-menu-anchor")!.getBoundingClientRect()
+            .right,
+        }));
+        expect(overflow.menuRight).toBeLessThanOrEqual(overflow.headerRight);
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    });
+  }
+});

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -290,17 +290,34 @@ describe("chat pane header", () => {
     expect(container.querySelector(".chat-pane__palette-open")).toBeNull();
   });
 
-  it("places the session menu last in the header action row", () => {
+  it("groups the session menu, sharing, and viewers with the session it acts on", () => {
     const { container } = mount({
       mergedChrome: true,
       onClosePane: vi.fn(),
       sessionMenuAction: html`<button data-action="session-menu"></button>`,
+      sharingControl: html`<button data-action="sharing"></button>`,
+      presence: html`<span data-slot="presence"></span>`,
     });
+    const controls = container.querySelector(".chat-pane__crumbs .chat-pane__session-controls");
     const actions = container.querySelector(".chat-pane__actions");
 
-    expect(actions?.lastElementChild?.getAttribute("data-action")).toBe("session-menu");
+    expect([...(controls?.children ?? [])].map((child) => child.className)).toEqual([
+      "chat-pane__session-menu-anchor",
+      "chat-pane__sharing-anchor",
+      "",
+    ]);
+    expect(controls?.querySelector('[data-action="session-menu"]')).not.toBeNull();
+    expect(controls?.lastElementChild?.getAttribute("data-slot")).toBe("presence");
+    // Exactly one owner: the pane's action row keeps pane controls only.
+    expect(container.querySelectorAll('[data-action="session-menu"]')).toHaveLength(1);
+    expect(actions?.querySelector('[data-action="session-menu"]')).toBeNull();
     expect(actions?.querySelector(".chat-pane__palette-open")).not.toBeNull();
     expect(actions?.querySelector(".chat-pane__close-pane")).not.toBeNull();
+  });
+
+  it("omits the session control group when the session owns no controls", () => {
+    const { container } = mount({ catalog: true, session: undefined });
+    expect(container.querySelector(".chat-pane__session-controls")).toBeNull();
   });
 
   it("moves session panel shortcuts out of a narrow header while keeping shell actions", () => {
@@ -398,14 +415,15 @@ describe("chat pane header", () => {
     expect(container.querySelector(".chat-pane__placement-chip")).toBeNull();
   });
 
-  it("places pane presence between the identity trail and face control", () => {
+  it("keeps pane-level controls outside the identity trail", () => {
     const { container } = mount({
       presence: html`<span data-slot="presence"></span>`,
       faceControl: html`<span data-slot="face"></span>`,
     });
     const crumbs = container.querySelector(".chat-pane__crumbs");
-    expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("presence");
-    expect(crumbs?.nextElementSibling?.nextElementSibling?.getAttribute("data-slot")).toBe("face");
+    expect(crumbs?.querySelector('[data-slot="presence"]')).not.toBeNull();
+    expect(crumbs?.querySelector('[data-slot="face"]')).toBeNull();
+    expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("face");
   });
 
   it("leads with the project, then a separator, then the session title", () => {
@@ -415,7 +433,7 @@ describe("chat pane header", () => {
     expect(segments).toEqual([
       "chat-pane__workspace-menu",
       "chat-pane__crumb-sep",
-      "chat-pane__session-title chat-pane__session-title-button",
+      "chat-pane__session-identity",
     ]);
     expect(crumbs?.querySelector(".chat-pane__crumb-sep")?.textContent).toBe("/");
     expect(crumbs?.querySelector(".chat-pane__crumb-sep")?.getAttribute("aria-hidden")).toBe(
@@ -433,7 +451,7 @@ describe("chat pane header", () => {
       "chat-pane__crumb-sep",
       "chat-pane__parent-session",
       "chat-pane__crumb-sep",
-      "chat-pane__session-title chat-pane__session-title-button",
+      "chat-pane__session-identity",
     ]);
     const parent = crumbs?.querySelector<HTMLButtonElement>(".chat-pane__parent-session");
     expect(parent?.textContent?.trim()).toBe("Release prep");
@@ -445,8 +463,35 @@ describe("chat pane header", () => {
     const { container } = mount({ workspaceLabel: null, workspaceRoot: null });
     expect(container.querySelector(".chat-pane__crumb-sep")).toBeNull();
     expect(container.querySelector(".chat-pane__crumbs")?.firstElementChild?.className).toContain(
-      "chat-pane__session-title",
+      "chat-pane__session-identity",
     );
+  });
+
+  it("puts the creator immediately before the name it belongs to", () => {
+    const { container } = mount({
+      showOwnerChip: true,
+      session: row({ createdActor: { type: "human", id: "profile-ada", label: "Ada" } }),
+    });
+    const identity = container.querySelector(".chat-pane__session-identity");
+
+    expect(identity?.firstElementChild?.tagName.toLowerCase()).toBe("openclaw-session-owner-chip");
+    expect(identity?.lastElementChild?.className).toContain("chat-pane__session-title");
+    // The project keeps its own segment: creator owns the session, not the workspace.
+    expect(
+      container.querySelector(".chat-pane__workspace-menu openclaw-session-owner-chip"),
+    ).toBeNull();
+  });
+
+  it("holds the title's position and height through a rename", () => {
+    const rest = mount();
+    const editing = mount({ editing: true, renameValue: "Session title" });
+    const restIdentity = rest.container.querySelector(".chat-pane__session-identity");
+    const editIdentity = editing.container.querySelector(".chat-pane__session-identity");
+
+    // Same slot in the same group: renaming replaces the title in place rather
+    // than reflowing the trail around a wider control.
+    expect(restIdentity?.children).toHaveLength(editIdentity?.children.length ?? -1);
+    expect(editIdentity?.lastElementChild?.className).toBe("chat-pane__session-title-input");
   });
 
   it("keeps the rename input inside the trail so the project stays visible", () => {

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -157,6 +157,9 @@ export function resolveChatPaneParentSession(
  * and separators are rendered from one list so a further segment — the parent
  * session of a nested thread, yielding project / parent / child — slots in
  * without moving the project chip or the title.
+ *
+ * Everything the session owns — creator, name, menu, sharing, viewers — renders
+ * inside this trail, leaving the action row for pane-level controls only.
  */
 function renderIdentityCrumbs(
   props: ChatPaneHeaderProps,
@@ -170,7 +173,7 @@ function renderIdentityCrumbs(
   if (parentCrumb) {
     segments.push(parentCrumb);
   }
-  segments.push(renderSessionCrumb(props));
+  segments.push(renderSessionIdentity(props));
   return html`
     <div class="chat-pane__crumbs">
       ${segments.map(
@@ -179,8 +182,41 @@ function renderIdentityCrumbs(
             ? html`<span class="chat-pane__crumb-sep" aria-hidden="true">/</span>`
             : nothing}${segment}`,
       )}
+      ${renderSessionControls(props)}
     </div>
   `;
+}
+
+/**
+ * Creator then name: the avatar answers "whose session" for the title beside it,
+ * which is why it never sits against the project every session shares.
+ */
+function renderSessionIdentity(props: ChatPaneHeaderProps) {
+  return html`<span class="chat-pane__session-identity"
+    >${renderSessionOwnerChip(
+      props.showOwnerChip ? props.session?.createdActor : undefined,
+      "header",
+      "created",
+    )}${renderSessionCrumb(props)}</span
+  >`;
+}
+
+/** Controls the session owns: manage it, share it, see who else is here. */
+function renderSessionControls(props: ChatPaneHeaderProps) {
+  const sharingControl = props.sharingControl ?? nothing;
+  const presence = props.presence ?? nothing;
+  if (props.sessionMenuAction === nothing && sharingControl === nothing && presence === nothing) {
+    return nothing;
+  }
+  return html`<span class="chat-pane__session-controls">
+    ${props.sessionMenuAction === nothing
+      ? nothing
+      : html`<span class="chat-pane__session-menu-anchor">${props.sessionMenuAction}</span>`}
+    ${sharingControl === nothing
+      ? nothing
+      : html`<span class="chat-pane__sharing-anchor">${sharingControl}</span>`}
+    ${presence}
+  </span>`;
 }
 
 function renderParentSessionCrumb(props: ChatPaneHeaderProps): TemplateResult | null {
@@ -586,7 +622,6 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
               </button>
             </openclaw-tooltip>`
           : nothing}
-        ${props.sessionMenuAction}
       </div>
     </div>
   `;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -182,8 +182,49 @@ openclaw-chat-pane {
 
 /* Renaming needs the row's spare width, which the trail must pass through:
    without this the input is trapped inside a shrink-only container. */
-.chat-pane__crumbs:has(.chat-pane__session-title-input) {
+.chat-pane__crumbs:has(.chat-pane__session-title-input),
+.chat-pane__session-identity:has(.chat-pane__session-title-input) {
   flex: 1 1 auto;
+}
+
+/* Creator and title are one unit and share the trail's gap, so the avatar reads
+   as a property of the name it precedes rather than a separate trail segment. */
+.chat-pane__session-identity {
+  display: flex;
+  flex: 0 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+/* The session's own controls sit tighter than the trail's segment gap: their
+   buttons already carry 5px of internal padding, so the optical air matches the
+   6px between segments without the boxes drifting away from the title.
+   The trail lifts itself 1px to put text on the chrome centerline; these are
+   chrome, so they give that pixel back and stay level with the action row. */
+.chat-pane__session-controls {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 2px;
+  margin-inline-start: -2px;
+  transform: translateY(1px);
+}
+
+/* Viewers are people, not controls: they get their own air after the buttons. */
+.chat-pane__session-controls .chat-pane__presence {
+  margin-inline-start: 4px;
+}
+
+/* A custom element defaults to display:inline, so as a flex child it keeps a
+   text line box whose descender space drags the trigger below the row
+   centerline — the same correction the action row applies to its own children. */
+.chat-pane__session-menu-anchor,
+.chat-pane__session-menu-anchor > openclaw-chat-header-session-menu,
+.chat-pane__sharing-anchor {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
 }
 
 /* House separator treatment: an aria-hidden glyph tinted with --muted, spacing
@@ -260,18 +301,27 @@ openclaw-chat-pane {
   text-overflow: ellipsis;
 }
 
+/* Renaming edits the title in place, so the field must occupy the title's box
+   rather than announce itself: the 28px height matches the action buttons the
+   row is already sized for, and border + padding reproduce the display button's
+   text origin (3px 5px pulled back by -5px) so the name does not jump when
+   editing starts or ends. The border is neutral because a rename in progress is
+   not an error or an accent-worthy state. */
 .chat-pane__session-title-input {
   flex: 1 1 auto;
   min-width: 60px;
   height: 28px;
-  padding: 0 7px;
-  border: 1px solid var(--accent);
+  box-sizing: border-box;
+  padding: 2px 4px;
+  margin-inline: -5px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 68%, transparent);
   border-radius: var(--radius-sm);
   background: var(--panel);
   color: var(--text);
   font: inherit;
   font-size: 12px;
   outline: none;
+  caret-color: var(--text);
   user-select: text;
   -webkit-user-select: text;
 }
@@ -517,7 +567,11 @@ openclaw-chat-pane {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--muted);
+  /* The project is context, the session is the subject: holding the project one
+     step below --muted keeps the trail readable while the title stays the only
+     full-contrast text. Pointer and keyboard both restore it, so nothing that
+     can be acted on stays dim. */
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
   font-size: 12px;
   cursor: var(--cursor-action);
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -47,10 +47,15 @@ openclaw-session-owner-chip {
   font-size: 10px;
 }
 
+/* Header identity is one scale: the creator matches the 18px viewer avatars it
+   shares the trail with, and drops the row variant's ring and lift so no avatar
+   in the chat header carries decoration of its own. */
 .session-owner-chip--header {
-  width: 20px;
-  height: 20px;
-  font-size: 10px;
+  width: 18px;
+  height: 18px;
+  border-color: transparent;
+  box-shadow: none;
+  font-size: 9px;
 }
 
 .session-owner-chip .viewer-avatar {


### PR DESCRIPTION
## What Problem This Solves

The chat header showed session identity in pieces spread across the row. The
creator avatar sat after the title, the session's management menu sat at the far
right of the pane action row — next to split, close, and command palette — and
sharing state and active viewers were interleaved with pane controls. Nothing in
the layout said which controls act on the session and which act on the pane, and
the session menu effectively had two candidate homes.

Renaming a session was also visibly disruptive: the edit field used an accent
outline, and its padding did not match the title button it replaced, so the name
shifted horizontally the moment editing started.

## Why This Change Was Made

The header is now one identity trail read left to right: project, then the
session's creator, name, management menu, sharing state, and active viewers.
Everything the session owns lives inside the trail; the action row keeps only
pane-level controls, which leaves exactly one owner for the session menu.

Supporting decisions, all scoped to the header:

- Creator and viewer avatars share one 18px footprint, with no ring or shadow on
  the creator chip.
- The project chip is held one step below `--muted` at rest and returns to full
  contrast on hover and focus, so the session name is the only full-contrast
  text in the trail.
- The rename field keeps the row's 28px control height and reproduces the title
  button's text origin, with a neutral border instead of an accent outline.
- The shared ellipsis glyph is filled rather than stroked, so session management
  reads as solid dots instead of three hollow rings at the sizes it is used at.

Non-goals: sidebar session rows, incognito treatment, and presence backend
behavior are untouched. No session-management actions were added or removed.

## User Impact

The chat header reads as project, then session, then the controls that belong to
that session. The session menu is where the session name is, instead of at the
far edge beside pane controls. Renaming no longer moves the title or changes the
header height, and a long project or session name truncates without pushing the
session menu out of reach.

## Evidence

Focused tests, exact head:

- `ui/src/pages/chat/components/chat-pane-header.test.ts` — 45 passing. Covers
  trail segment order, the creator sitting immediately before the name, the
  single session-menu owner (present in the trail, absent from the action row),
  the control group disappearing for catalog panes, and the rename field
  occupying the title's slot.
- `ui/src/e2e/chat-header-identity.e2e.test.ts` — new, light and dark. Runs a
  real browser against a mocked Gateway and measures the shipped layout:
  reading order across project / creator / title / menu / viewers, the 18px
  avatar parity, absence of shadow on the creator chip, the header height and
  title origin holding across a rename, and a long title truncating on a narrow
  pane while the session menu stays inside the header.

Production LOC delta is positive and load-bearing: the trail gains two grouping
containers and their layout rules, plus the rename and avatar geometry the
thesis depends on.

### Visual proof

Every frame below is a browser screenshot of the Control UI itself running at
this branch head (`d530737`), on a remote Linux box (Ubuntu, Node 24.18.1,
Playwright Chromium 1.62.1). The application is served whole by the repository's
Vite-backed E2E server (`startControlUiE2eServer`); the Gateway is the
repository's canonical in-page mock (`installMockGateway`). No frame is a
fixture, a standalone render, or a composite.

```
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-header-identity.e2e.test.ts
```

2 tests passed (light, dark). Session data for the frames: two sessions with
distinct `createdActor` values so creator attribution renders at all,
`spawnedCwd: /repo/openclaw` behind the project chip, and a presence snapshot
with two non-self viewers watching the active session. Viewport 1120x560, except
the narrow case which is 640 wide. Clip is the header element,
`.chat-pane__header`.

| State | Light | Dark |
| --- | --- | --- |
| Trail at rest — project / creator / title / menu / viewers | <img width="822" src="https://github.com/user-attachments/assets/9a358dd6-eba3-42bd-9ba7-e9d5a7d6cab5"> | <img width="822" src="https://github.com/user-attachments/assets/419fef93-9e40-4e8b-beca-a0d0458558ce"> |
| Project chip at rest | <img width="822" src="https://github.com/user-attachments/assets/1caad063-9c44-43dc-a678-768c1c26b178"> | <img width="822" src="https://github.com/user-attachments/assets/645392f2-26e9-4214-9645-1d90c4892cfe"> |
| Project chip hovered | <img width="822" src="https://github.com/user-attachments/assets/e86ed6d4-d40a-4a3e-95af-3c2e48327f86"> | <img width="822" src="https://github.com/user-attachments/assets/4da79da4-b20d-4675-a0da-bc086281b55a"> |
| Rename in place | <img width="822" src="https://github.com/user-attachments/assets/d844f03b-a4c2-4153-8040-33d3a3d26c1a"> | <img width="822" src="https://github.com/user-attachments/assets/7182854d-8e51-4ca1-8d25-21b9368cabcd"> |
| Long title, narrow pane (640px) | <img width="632" src="https://github.com/user-attachments/assets/6bcfb785-99e4-4f1f-aea0-c76088bcb6ef"> | <img width="632" src="https://github.com/user-attachments/assets/cce6023b-c603-400f-9434-dad8c610ff7c"> |

Computed styles read off the same running page at capture time, which is what
the rest/hover pair is actually claiming:

- Project chip at rest: `color(srgb 0.431373 0.411765 0.376471 / 0.82)` in light,
  `color(srgb 0.545098 0.545098 0.580392 / 0.82)` in dark — the alpha is the
  "one step below `--muted`" the thesis rests on.
- Hovered, it resolves to `rgb(64, 60, 53)` in light and `rgb(188, 188, 192)` in
  dark. In both themes that is exactly the session title's computed color in the
  same frame, so "returns to full contrast" is an identity, not an approximation.

Two things a reviewer should look at rather than take on trust:

- In the rest frames the action row on the right holds only pane controls; the
  ellipsis lives beside the title. That is the single-owner claim, visible.
- In the rename frames the input holds the title's text origin and the header
  height, as claimed — but the session controls (menu, viewers) slide to the
  trailing edge for the duration of the edit, because the trail takes the row's
  spare width while the field is open. That is a consequence of the rename
  width rule, and it is visible in those two frames.
