### PR TITLE
feat(ui): clarify incognito sessions at composition time

### DIFF
--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -213,6 +213,9 @@ export const icons = {
     <path d="M5 4c5-4 9 4 14 0v11c-5 4-9-4-14 0" />`),
   lock: strokeIcon(svg` <rect width="18" height="11" x="3" y="11" rx="2" />
     <path d="M7 11V7a5 5 0 0 1 10 0v4" />`),
+  // The one glyph for incognito sessions. A padlock reads as access control,
+  // which incognito is not: it changes where the session is kept, not who may
+  // open it.
   hatGlasses: strokeIcon(svg` <path d="M14 18a2 2 0 0 0-4 0" />
     <path
       d="m19 11-2.11-6.657a2 2 0 0 0-2.752-1.148l-1.276.61A2 2 0 0 1 12 4H8.5a2 2 0 0 0-1.925 1.456L5 11"

--- a/ui/src/e2e/chat-incognito-composition.e2e.test.ts
+++ b/ui/src/e2e/chat-incognito-composition.e2e.test.ts
@@ -69,7 +69,7 @@ suite.define(() => {
         },
         { key: controlUiBundledSettingsStorageKey(suite.server.baseUrl), mode: theme },
       );
-      await installMockGateway(page, {
+      const gateway = await installMockGateway(page, {
         methodResponses: { "sessions.list": incognitoSessions() },
         sessionKey: INCOGNITO_KEY,
       });
@@ -130,6 +130,24 @@ suite.define(() => {
           "dashed",
         );
         await capture("composer-focus", ".agent-chat__composer-shell");
+        const incognitoBorderColor = await composer.evaluate(
+          (node) => getComputedStyle(node).borderColor,
+        );
+
+        // Losing the connection must not dilute the offline warning: the
+        // composer keeps the warning border rather than the quieter incognito
+        // one, so the urgent, recoverable state stays the loud one.
+        await gateway.setOnline(false);
+        await gateway.closeLatest();
+        await expect
+          .poll(() => composer.locator(".agent-chat__offline-hint").count())
+          .toBeGreaterThan(0);
+        const offlineBorderColor = await composer.evaluate(
+          (node) => getComputedStyle(node).borderColor,
+        );
+        expect(offlineBorderColor).not.toBe(incognitoBorderColor);
+        await capture("composer-offline", ".agent-chat__composer-shell");
+        await gateway.setOnline(true);
 
         // No invented exit: incognito is fixed at creation, so the session menu
         // must not offer a transition the gateway cannot perform.

--- a/ui/src/e2e/chat-incognito-composition.e2e.test.ts
+++ b/ui/src/e2e/chat-incognito-composition.e2e.test.ts
@@ -1,0 +1,163 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
+import {
+  captureUiProofEnabled,
+  chatSessionListResponse,
+  controlUiSessionUrl,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "chat-incognito");
+
+const INCOGNITO_KEY = "agent:main:incognito-session";
+
+/**
+ * An incognito thread beside an ordinary one. Both stay listed: the gateway
+ * serves incognito rows to the operator who created them, and this work changes
+ * how the state is shown, never whether the session can be found.
+ */
+function incognitoSessions() {
+  return chatSessionListResponse([
+    {
+      incognito: true,
+      key: INCOGNITO_KEY,
+      kind: "direct",
+      label: "Draft the incident note",
+      spawnedCwd: "/repo/openclaw",
+      updatedAt: 2,
+    },
+    {
+      key: "agent:main:session-b",
+      kind: "direct",
+      label: "Ordinary session",
+      spawnedCwd: "/repo/openclaw",
+      updatedAt: 1,
+    },
+  ]);
+}
+
+suite.define(() => {
+  for (const theme of ["light", "dark"] as const) {
+    it(`marks incognito at the title and the composer in ${theme} mode`, async () => {
+      const context = await suite.newBrowserContext({
+        colorScheme: theme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 640, width: 1120 },
+      });
+      const page = await context.newPage();
+      const capture = async (name: string, selector: string) => {
+        if (!captureUiProofEnabled) {
+          return;
+        }
+        await mkdir(proofDir, { recursive: true });
+        await page
+          .locator(selector)
+          .first()
+          .screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, `${name}-${theme}.png`),
+          });
+      };
+      await page.addInitScript(
+        ({ key, mode }) => {
+          localStorage.setItem(key, JSON.stringify({ theme: "claw", themeMode: mode }));
+        },
+        { key: controlUiBundledSettingsStorageKey(suite.server.baseUrl), mode: theme },
+      );
+      await installMockGateway(page, {
+        methodResponses: { "sessions.list": incognitoSessions() },
+        sessionKey: INCOGNITO_KEY,
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const header = page.locator(".chat-pane__header").first();
+        const composer = page.locator(".agent-chat__input").first();
+        await header.waitFor();
+        await composer.waitFor();
+
+        // Still discoverable: the sidebar lists the thread and qualifies it.
+        const sidebarRow = page.locator(`[data-session-key="${INCOGNITO_KEY}"]`).first();
+        await sidebarRow.waitFor();
+        expect(await sidebarRow.locator(".session-row-badge--incognito").count()).toBe(1);
+        await capture("sidebar-row", `[data-session-key="${INCOGNITO_KEY}"]`);
+
+        // The qualifier belongs to the session name, not to the project or the
+        // header edge, and it is the same glyph the sidebar row uses.
+        const placement = await header.evaluate((root) => {
+          const badge = root.querySelector<HTMLElement>(".chat-pane__incognito");
+          if (!badge) {
+            throw new Error("missing header incognito qualifier");
+          }
+          return {
+            insideIdentity: Boolean(badge.closest(".chat-pane__session-identity")),
+            label: badge.getAttribute("aria-label"),
+            left: badge.getBoundingClientRect().left,
+            projectRight:
+              root.querySelector(".chat-pane__workspace-chip")?.getBoundingClientRect().right ?? 0,
+            titleLeft:
+              root.querySelector(".chat-pane__session-title")?.getBoundingClientRect().left ?? 0,
+          };
+        });
+        expect(placement.insideIdentity).toBe(true);
+        expect(placement.label).toBe("Incognito session");
+        expect(placement.left).toBeGreaterThan(placement.projectRight);
+        expect(placement.left).toBeLessThan(placement.titleLeft);
+        await capture("header", ".chat-pane__header");
+
+        // The composer carries the explanation and wears the dashed boundary.
+        const note = composer.locator(".agent-chat__incognito-note");
+        expect((await note.locator(".agent-chat__incognito-label").textContent())?.trim()).toBe(
+          "Incognito session",
+        );
+        expect((await note.locator(".agent-chat__incognito-detail").textContent())?.trim()).toBe(
+          "Stays in memory and disappears when the Gateway restarts",
+        );
+        expect(await composer.evaluate((node) => getComputedStyle(node).borderStyle)).toBe(
+          "dashed",
+        );
+        await capture("composer-rest", ".agent-chat__composer-shell");
+
+        // Focus is still legible, and the boundary survives it.
+        await page.locator(".agent-chat__composer-combobox textarea").first().focus();
+        expect(await composer.getAttribute("class")).toContain("agent-chat__input--incognito");
+        expect(await composer.evaluate((node) => getComputedStyle(node).borderStyle)).toBe(
+          "dashed",
+        );
+        await capture("composer-focus", ".agent-chat__composer-shell");
+
+        // No invented exit: incognito is fixed at creation, so the session menu
+        // must not offer a transition the gateway cannot perform.
+        await header.locator(".chat-header-session-menu__trigger").click();
+        const menu = page.locator("wa-dropdown.chat-header-session-menu");
+        await menu.locator("wa-dropdown-item").first().waitFor();
+        expect((await menu.textContent())?.toLowerCase()).not.toContain("incognito");
+        await page.keyboard.press("Escape");
+
+        // Phones drop the explanation and keep the label.
+        await page.setViewportSize({ height: 640, width: 420 });
+        expect(await note.locator(".agent-chat__incognito-label").isVisible()).toBe(true);
+        await expect
+          .poll(() => note.locator(".agent-chat__incognito-detail").isVisible())
+          .toBe(false);
+        await capture("composer-mobile", ".agent-chat__composer-shell");
+
+        // An ordinary session gets none of it.
+        await page.setViewportSize({ height: 640, width: 1120 });
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:session-b"));
+        await expect
+          .poll(() => header.locator(".chat-pane__session-title-text").textContent())
+          .toBe("Ordinary session");
+        expect(await header.locator(".chat-pane__incognito").count()).toBe(0);
+        expect(await composer.getAttribute("class")).not.toContain("agent-chat__input--incognito");
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    });
+  }
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5337,6 +5337,7 @@ export const en: TranslationMap = {
       placeholderWithAttachments: "Add a message or paste more images...",
       offlineHint: "Offline — messages will be queued and sent when the connection returns.",
       offlineQueuedHint: "Offline — {count} queued; messages send when the connection returns.",
+      incognitoRetention: "Stays in memory and disappears when the Gateway restarts",
       preparingModel: "Preparing model...",
       responding: "{name} is responding...",
       sendingMessage: "Sending message...",

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -212,11 +212,26 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
       ${disabledBanner}
       ${showComposerInput
         ? html`<div
-            class="agent-chat__input ${props.offline ? "agent-chat__input--offline" : ""}"
+            class="agent-chat__input ${props.offline
+              ? "agent-chat__input--offline"
+              : ""} ${activeSession?.incognito ? "agent-chat__input--incognito" : ""}"
             @click=${(event: MouseEvent) => focusComposerFromChrome(event, canCompose)}
             @pointerdown=${(event: PointerEvent) => focusComposerFromChrome(event, canCompose)}
             ${ref(state.composerInputRef ?? undefined)}
           >
+            ${activeSession?.incognito
+              ? html`<div class="agent-chat__incognito-note">
+                  <span class="agent-chat__incognito-icon" aria-hidden="true"
+                    >${icons.hatGlasses}</span
+                  >
+                  <span class="agent-chat__incognito-label"
+                    >${t("chat.sessionHeader.incognito")}</span
+                  >
+                  <span class="agent-chat__incognito-detail"
+                    >${t("chat.composer.incognitoRetention")}</span
+                  >
+                </div>`
+              : nothing}
             ${props.offline
               ? html`<div class="agent-chat__offline-hint" role="status" aria-live="polite">
                   ${props.queuedOutboxCount

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -13,7 +13,7 @@ import {
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
   type ShellNavDrawerToggleDetail,
 } from "../../../components/command-palette-contract.ts";
-import { renderSessionRowBadges } from "../../../components/session-row-badges.ts";
+import { renderSessionRowOrigin } from "../../../components/session-row-origin.ts";
 import type { SessionCapability } from "../../../lib/sessions/index.ts";
 import { createTestChatPane } from "../chat-pane.test-support.ts";
 import type { ChatPageHost } from "../chat-state-host.ts";
@@ -718,13 +718,10 @@ describe("chat pane header", () => {
     const rowContainer = document.createElement("div");
     document.body.append(rowContainer);
     containers.push(rowContainer);
-    render(
-      html`${renderSessionRowBadges({ hasAutomation: false, incognito: true })}`,
-      rowContainer,
-    );
+    render(html`${renderSessionRowOrigin({ draft: false, incognito: true })}`, rowContainer);
 
     const headerGlyph = header.container.querySelector(".chat-pane__incognito svg")?.innerHTML;
-    const rowGlyph = rowContainer.querySelector(".session-row-badge--incognito svg")?.innerHTML;
+    const rowGlyph = rowContainer.querySelector(".session-row-origin__qualifier svg")?.innerHTML;
     expect(headerGlyph).toBeTruthy();
     expect(rowGlyph).toBe(headerGlyph);
   });

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -13,6 +13,7 @@ import {
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
   type ShellNavDrawerToggleDetail,
 } from "../../../components/command-palette-contract.ts";
+import { renderSessionRowBadges } from "../../../components/session-row-badges.ts";
 import type { SessionCapability } from "../../../lib/sessions/index.ts";
 import { createTestChatPane } from "../chat-pane.test-support.ts";
 import type { ChatPageHost } from "../chat-state-host.ts";
@@ -697,11 +698,35 @@ describe("chat pane header", () => {
     expect(container.querySelector('wa-dropdown-item[value="copy-path"]')).not.toBeNull();
   });
 
-  it("shows an incognito indicator for in-memory threads", () => {
+  it("qualifies the session title for in-memory threads", () => {
     const { container } = mount({ session: row({ incognito: true }) });
-    expect(container.querySelector(".chat-pane__incognito")?.getAttribute("aria-label")).toBe(
-      "Incognito session",
+    const badge = container.querySelector(".chat-pane__incognito");
+    expect(badge?.getAttribute("aria-label")).toBe("Incognito session");
+    // The qualifier describes this session, so it travels with the title rather
+    // than sitting at the header edge where it reads as a window-level mode.
+    expect(badge?.closest(".chat-pane__session-identity")).not.toBeNull();
+    expect(badge?.nextElementSibling?.className).toContain("chat-pane__session-title");
+    expect(container.querySelector(".chat-pane__workspace-menu .chat-pane__incognito")).toBeNull();
+  });
+
+  it("hides the qualifier for ordinary sessions", () => {
+    expect(mount().container.querySelector(".chat-pane__incognito")).toBeNull();
+  });
+
+  it("draws incognito with the same glyph in the header and the session row", () => {
+    const header = mount({ session: row({ incognito: true }) });
+    const rowContainer = document.createElement("div");
+    document.body.append(rowContainer);
+    containers.push(rowContainer);
+    render(
+      html`${renderSessionRowBadges({ hasAutomation: false, incognito: true })}`,
+      rowContainer,
     );
+
+    const headerGlyph = header.container.querySelector(".chat-pane__incognito svg")?.innerHTML;
+    const rowGlyph = rowContainer.querySelector(".session-row-badge--incognito svg")?.innerHTML;
+    expect(headerGlyph).toBeTruthy();
+    expect(rowGlyph).toBe(headerGlyph);
   });
 
   it("hides one branch and lists multiple branches with the active tip marked", () => {

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -197,7 +197,15 @@ function renderSessionIdentity(props: ChatPaneHeaderProps) {
       props.showOwnerChip ? props.session?.createdActor : undefined,
       "header",
       "created",
-    )}${renderSessionCrumb(props)}</span
+    )}${props.session?.incognito
+      ? html`<span
+          class="chat-pane__incognito"
+          role="img"
+          aria-label=${t("chat.sessionHeader.incognito")}
+          title=${t("chat.sessionHeader.incognito")}
+          >${icons.hatGlasses}</span
+        >`
+      : nothing}${renderSessionCrumb(props)}</span
   >`;
 }
 
@@ -468,15 +476,6 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
               ${icons.menu}
             </button>
           </openclaw-tooltip>`
-        : nothing}
-      ${props.session?.incognito
-        ? html`<span
-            class="chat-pane__incognito"
-            role="img"
-            aria-label=${t("chat.sessionHeader.incognito")}
-            title=${t("chat.sessionHeader.incognito")}
-            >${icons.lock}</span
-          >`
         : nothing}
       ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
       ${renderSessionOwnerChip(

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2455,6 +2455,58 @@ button.chat-reply-preview--message:disabled {
   line-height: 1.3;
 }
 
+/* Incognito belongs to the session, so it frames the whole composer instead of
+   riding along as a transient status line. A dashed edge is the quietest way to
+   say "this box keeps nothing" without borrowing the warning or accent color of
+   a state that is neither a problem nor an action. */
+.agent-chat__input--incognito,
+.agent-chat__input--incognito:focus-within {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--muted) 58%, var(--border));
+}
+
+.agent-chat__incognito-note {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px var(--chat-box-inset);
+  border-bottom: 1px dashed color-mix(in srgb, var(--muted) 30%, transparent);
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.agent-chat__incognito-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.agent-chat__incognito-icon svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 1.5px;
+}
+
+.agent-chat__incognito-label {
+  flex: 0 0 auto;
+  color: var(--text);
+}
+
+.agent-chat__incognito-detail {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* A phone composer cannot spare the line for the explanation, but the label has
+   to survive: the user still needs to know which kind of session they are in. */
+@media (max-width: 640px) {
+  .agent-chat__incognito-detail {
+    display: none;
+  }
+}
+
 @supports (backdrop-filter: blur(1px)) {
   .agent-chat__input {
     backdrop-filter: blur(12px) saturate(1.6);


### PR DESCRIPTION
## What Problem This Solves

Incognito sessions were marked with a padlock, which describes access control —
something incognito does not change. It changes where the session is kept.

The marks were also inconsistent and misplaced. The chat header rendered its
padlock at the extreme left of the header row, before the project, where it read
as a window-level mode rather than a property of the session being viewed. The
sidebar row used the same padlock in its own badge. And the place where a user
actually decides what to type — the composer — said nothing at all, so the one
moment when the retention behavior matters carried no explanation.

## Why This Change Was Made

Incognito is now stated once per surface, with one glyph, in the place that
answers the user's question at that moment:

- One `hat-glasses` glyph replaces the padlock everywhere incognito appears.
- The chat-header qualifier moves next to the session title it describes, inside
  the session identity group.
- The sidebar row keeps its compact qualifier, unchanged in placement.
- The composer carries the explanation: a dashed boundary frames the input and a
  compact note states that the session stays in memory and disappears when the
  Gateway restarts. On viewports at or below 640px the sentence is dropped and
  the label stays.

The composer copy is new rather than reused: the existing string belongs to the
creation toggle and is written as an instruction ("Keep this session only
until…"). The new line describes an existing session and claims only what the
Gateway actually does — in-memory session entry and transcript, gone on restart.
It deliberately does not promise privacy from the model provider or the gateway
operator, matching `docs/concepts/session.md`.

Non-goals: privacy, retention, and gateway behavior are unchanged. No exit or
"leave incognito" control was added, because a session cannot move between
incognito and normal after creation — the gateway rejects it at creation time
(`src/gateway/session-create-service.ts:405-411`, "incognito is immutable and
requires a new session key") and no transition method exists.

## User Impact

Incognito reads the same way in the sidebar, at the session title, and at the
composer, and the composer states plainly what incognito does to the transcript.
Nothing about which sessions are listed, retained, or reachable changes.

## Evidence

Focused tests, exact head:

- `ui/src/pages/chat/components/chat-pane-header.test.ts` — 47 passing. The
  qualifier renders inside the session identity group immediately before the
  title, is absent from the project segment and from ordinary sessions, and
  renders the identical glyph markup as the sidebar row badge.
- `ui/src/components/session-row-badges.test.ts` — the row badge continues to
  render for incognito rows.
- `ui/src/e2e/chat-incognito-composition.e2e.test.ts` — new, light and dark. In a
  real browser against a mocked Gateway: the sidebar lists the incognito thread
  and qualifies it, the header qualifier sits between the project and the title,
  the composer shows the label and the retention sentence with a dashed border,
  the border survives focus, the session menu offers no incognito transition, a
  420px viewport keeps the label and drops the sentence, and an ordinary session
  in the same run shows none of it.

### Visual proof

Every frame below is a browser screenshot of the Control UI itself running at
this branch head (`203ccea`), on a remote Linux box (Ubuntu, Node 24.18.1,
Playwright Chromium 1.62.1). The application is served whole by the repository's
Vite-backed E2E server (`startControlUiE2eServer`); the Gateway is the
repository's canonical in-page mock (`installMockGateway`). No frame is a
fixture, a standalone render, or a composite.

```
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-incognito-composition.e2e.test.ts
```

2 tests passed (light, dark). Session data for the frames: an incognito thread
("Draft the incident note", `incognito: true`) beside an ordinary one, both with
`spawnedCwd: /repo/openclaw`. Viewport 1120x640 except the mobile case, which is
420 wide. Clips are the element under discussion — `.chat-pane__header`, the
sidebar row, `.agent-chat__composer-shell` — except the session-menu frames,
which are the whole viewport so the menu and the composer can be read together.

| State | Light | Dark |
| --- | --- | --- |
| Header — qualifier beside the session title | <img width="822" src="https://github.com/user-attachments/assets/8e83e7d7-6870-42ea-ba81-128ac4ef48c5"> | <img width="822" src="https://github.com/user-attachments/assets/e5ed00ce-ef3d-4a99-a5a3-d08bda236c12"> |
| Sidebar row — same glyph, compact | <img width="237" src="https://github.com/user-attachments/assets/4a6fb5d7-6273-499f-b06f-cf6407b37b42"> | <img width="237" src="https://github.com/user-attachments/assets/2a2bbada-b16e-4971-9c9d-babdbbfb5323"> |
| Composer at rest — dashed edge, label, retention sentence | <img width="768" src="https://github.com/user-attachments/assets/bec061e6-fdbd-4a58-bf47-25dc4f77e796"> | <img width="768" src="https://github.com/user-attachments/assets/8ca1dafb-bf69-4d14-8eb5-31330623ab5f"> |
| Composer focused — boundary survives | <img width="768" src="https://github.com/user-attachments/assets/5bf35d00-4a5c-43e3-9831-f3dd0c163232"> | <img width="768" src="https://github.com/user-attachments/assets/55c1b205-150f-49c1-9118-ecb00db3f41b"> |
| Composer at 420px — label kept, sentence dropped | <img width="404" src="https://github.com/user-attachments/assets/4d2ab033-1d11-4c6d-ad64-0d11c750a5a0"> | <img width="404" src="https://github.com/user-attachments/assets/26c4ba65-3ba2-49c5-be39-8b69a2e6151c"> |
| Session menu open — no incognito entry | <img width="1120" src="https://github.com/user-attachments/assets/7d5ea404-17d1-4b37-8f2c-c9de18275abb"> | <img width="1120" src="https://github.com/user-attachments/assets/ddd03ab4-93cd-45a4-a90d-730f362f9803"> |
| Composer while offline | <img width="768" src="https://github.com/user-attachments/assets/b24bce2f-716d-4a8b-84bd-1d9c470a8e13"> | <img width="768" src="https://github.com/user-attachments/assets/bc58a5b7-3372-4b63-81d8-40bfbdc1afeb"> |

On the "no exit control" claim, the menu was enumerated rather than pattern
matched. Its full item list in the captured frames is: Open in (Cursor, VS Code,
Windsurf, Zed), Panels (background tasks, session files, session companion),
Layout (open split view), Rename…, View (reasoning, tool calls, keep
commentary), Fork, Continue in terminal…, Archive session, Delete…. There is no
incognito entry at any depth.

One thing a reviewer should look at rather than take on trust: the offline
frames. When the connection drops, the composer does not merely prefer the
warning border over the dashed one — the incognito treatment leaves entirely,
note and all, because the session row backing `activeSession` is gone while
disconnected. The urgent state is the loud one, which is the intent, but the
mechanism is disappearance rather than precedence, and for the duration of the
outage the composer stops saying the session is incognito. Nothing in this
change introduces that, and the retention behavior itself is unaffected; it is
called out because the frames show it.

### Sidebar listing of incognito sessions — current contract, for the record

This work does not decide whether incognito sessions belong in the sidebar; it
preserves what ships today. Verified on this head:

- `sessions.list` includes incognito rows. The combined store deliberately
  merges live in-memory incognito databases into the gateway store
  (`src/config/sessions/combined-store-gateway.ts:122-155`, called
  unconditionally at `:306-311` and `:354-359`). The `includeIncognito: false`
  opt-out exists but the gateway list never passes it.
- The only exclusion is identity-scoped, not global:
  `createSessionListEntryFilter` (`src/gateway/session-sharing.ts:723-735`)
  returns no filter for admin-scope or identity-less connections, and filters
  incognito only for a non-admin identity-bearing client. `sessions-read.ts:440-447`
  mirrors that.
- Creating an incognito session requires `operator.admin`
  (`src/gateway/session-create-service.ts:546-556`), so the operator who created
  it always sees it listed.
- `docs/concepts/session.md:82` states the same contract: "On multi-user
  gateways, incognito threads are visible only to admin-scope connections."

So the sessions stay listed and this change only alters how they are marked.
Whether that remains the desired product behavior is a maintainer decision, not
one taken here.

### Adjacent gap, not fixed here

`ui/src/components/app-sidebar-session-catalog-render.ts:481-484` builds its row
badges without passing `incognito`, so catalog/recent rows show no qualifier
even when the session is incognito. It reads as an oversight rather than an
intentional hide, but it sits in the catalog renderer rather than this thesis's
surface, so it is called out here instead of being changed.
