### PR TITLE
fix(ci): keep Telegram shards alive after the first isolated file

### DIFF
--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -15,8 +15,10 @@ import {
   resolvePolicyTestTargets,
 } from "./ci-node-test-plan.mts";
 import {
-  createExtensionTestProcessTargetChunks,
+  listExtensionTestFilesForRoots,
   resolveExtensionTestConfig,
+  shouldSplitExtensionTestProcesses,
+  splitExtensionTestJobTargets,
 } from "./extension-test-plan.mts";
 import { buildPluginSdkEntrySources, publicPluginSdkEntrypoints } from "./plugin-sdk-entries.mts";
 
@@ -329,7 +331,10 @@ function createChangedExtensionConfigShards(extensionRoots: string[]) {
   const plans: Array<{ config: string; includePatterns?: string[]; roots: string[] }> = [
     ...rootsByConfig,
   ].flatMap(([config, roots]) => {
-    const chunks = createExtensionTestProcessTargetChunks(config, roots);
+    const testFiles = shouldSplitExtensionTestProcesses(config)
+      ? listExtensionTestFilesForRoots(roots)
+      : [];
+    const chunks = testFiles.length > 0 ? splitExtensionTestJobTargets(config, testFiles) : [roots];
     return chunks.length > 1
       ? chunks.map((includePatterns) => ({ config, includePatterns, roots }))
       : [{ config, roots }];

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -89,15 +89,25 @@ const EXTENSION_TEST_COST_MULTIPLIERS: Record<string, number> = {
   // overstates its real wall-clock cost during CI shard planning.
   "test/vitest/vitest.extensions.config.ts": 1.1,
 };
+export const MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT = 40;
+export const TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT = 1;
+export const TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT = 5;
 const EXTENSION_TEST_PROCESS_FILE_LIMITS = new Map<string, number>([
   // The non-isolated Matrix suite intentionally shares module state within a process.
   // Bound its lifetime so Vite's transformed module graph cannot grow across the whole suite.
-  ["test/vitest/vitest.extension-matrix.config.ts", 40],
+  ["test/vitest/vitest.extension-matrix.config.ts", MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT],
   [
     "test/vitest/vitest.extension-telegram.config.ts",
-    // A 10-file serial worker reached 231s and 2.7 GiB RSS (observed 2026-08).
-    5,
+    // isolate:true re-evaluates the Telegram graph per file. A second file in
+    // the same process stayed silent past the 300s CI watchdog (observed 2026-08,
+    // changed-extensions-config-14/15 on #123528).
+    TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT,
   ],
+]);
+const EXTENSION_TEST_JOB_FILE_LIMITS = new Map<string, number>([
+  // Keep Telegram CI jobs at five files so isolate recycling stays inside one
+  // job instead of minting one runner per test file.
+  ["test/vitest/vitest.extension-telegram.config.ts", TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT],
 ]);
 const EXTENSION_TEST_CONFIG_ROUTES: Array<[(root: string) => boolean, string]> = [
   [isActiveMemoryExtensionRoot, "test/vitest/vitest.extension-active-memory.config.ts"],
@@ -236,15 +246,17 @@ export function listExtensionTestFilesForRoots(roots: string[]) {
   return [...new Set(files)].toSorted((left, right) => left.localeCompare(right));
 }
 
-/** Split an extension config's test files across bounded process lifetimes when required. */
-export function splitExtensionTestProcessTargets(config: string, targets: string[]) {
-  const maxFilesPerProcess = EXTENSION_TEST_PROCESS_FILE_LIMITS.get(config);
-  const orderedTargets = [...new Set(targets)].toSorted((left, right) => left.localeCompare(right));
-  if (!maxFilesPerProcess || orderedTargets.length <= maxFilesPerProcess) {
+function uniqueSortedTargets(targets: string[]) {
+  return [...new Set(targets)].toSorted((left, right) => left.localeCompare(right));
+}
+
+function splitTargetsByFileLimit(targets: string[], maxFilesPerChunk: number) {
+  const orderedTargets = uniqueSortedTargets(targets);
+  if (orderedTargets.length <= maxFilesPerChunk) {
     return [orderedTargets];
   }
 
-  const chunkCount = Math.ceil(orderedTargets.length / maxFilesPerProcess);
+  const chunkCount = Math.ceil(orderedTargets.length / maxFilesPerChunk);
   const baseSize = Math.floor(orderedTargets.length / chunkCount);
   const remainder = orderedTargets.length % chunkCount;
   const chunks = [];
@@ -255,6 +267,28 @@ export function splitExtensionTestProcessTargets(config: string, targets: string
     offset += chunkSize;
   }
   return chunks;
+}
+
+function resolveExtensionTestJobFileLimit(config: string) {
+  return (
+    EXTENSION_TEST_JOB_FILE_LIMITS.get(config) ?? EXTENSION_TEST_PROCESS_FILE_LIMITS.get(config)
+  );
+}
+
+/** Split an extension config's test files across bounded process lifetimes when required. */
+export function splitExtensionTestProcessTargets(config: string, targets: string[]) {
+  const maxFilesPerProcess = EXTENSION_TEST_PROCESS_FILE_LIMITS.get(config);
+  return maxFilesPerProcess
+    ? splitTargetsByFileLimit(targets, maxFilesPerProcess)
+    : [uniqueSortedTargets(targets)];
+}
+
+/** Split an extension config's test files across CI jobs without changing process lifetime. */
+export function splitExtensionTestJobTargets(config: string, targets: string[]) {
+  const maxFilesPerJob = resolveExtensionTestJobFileLimit(config);
+  return maxFilesPerJob
+    ? splitTargetsByFileLimit(targets, maxFilesPerJob)
+    : [uniqueSortedTargets(targets)];
 }
 
 /** Whether a Vitest invocation can safely be split into independent one-shot processes. */

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -89,7 +89,10 @@ import {
 } from "./changed-lanes.mts";
 import { parsePermissiveBooleanToken } from "./lib/arg-utils.mts";
 import { getChangedPathFacts } from "./lib/changed-path-facts.mjs";
-import { createExtensionTestProcessTargetChunks } from "./lib/extension-test-plan.mts";
+import {
+  createExtensionTestProcessTargetChunks,
+  splitExtensionTestProcessTargets,
+} from "./lib/extension-test-plan.mts";
 import {
   GATEWAY_SERVER_TEST_PROCESS_COUNT,
   listGatewayServerTestTargets,
@@ -975,10 +978,25 @@ function createBoundedExtensionPlans(plan: VitestRunPlan, env?: NodeJS.ProcessEn
   if (watchMode || !roots) {
     return [plan];
   }
-  // A CI include file already owns the test scope. Expanding its config here
-  // or emitting local patterns would replace that shard in the run spec.
-  if (env?.[INCLUDE_FILE_ENV_KEY]?.trim()) {
-    return [{ ...plan, includePatterns: null }];
+  // A CI include file already owns the test scope. Keep that file set, but
+  // still honor process lifetime so isolate:true configs cannot re-import
+  // a second heavy file in the same Vitest process.
+  const includeFilePath = env?.[INCLUDE_FILE_ENV_KEY]?.trim();
+  if (includeFilePath) {
+    if (!fs.existsSync(includeFilePath)) {
+      return [{ ...plan, includePatterns: null }];
+    }
+    const scopedTargets = loadIncludePatternsForSpecFilter(env ?? {}) ?? [];
+    const chunks = splitExtensionTestProcessTargets(config, scopedTargets);
+    if (chunks.length <= 1) {
+      return [{ ...plan, includePatterns: null }];
+    }
+    return chunks.map((includePatterns) => ({
+      config,
+      forwardedArgs,
+      includePatterns,
+      watchMode,
+    }));
   }
   const chunks = createExtensionTestProcessTargetChunks(config, roots, forwardedArgs);
   if (chunks.length <= 1) {
@@ -4050,6 +4068,12 @@ export function applyDefaultMultiSpecVitestCachePaths<T extends WatchableVitestS
   params: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
 ): Array<Omit<T, "env"> & { env: NodeJS.ProcessEnv }> {
   if (specs.length <= 1 || specs.some((spec) => spec.watchMode)) {
+    return specs;
+  }
+  // Same-config process lifetimes run one after another and must keep the
+  // restored CI seed. Isolating them would make every Telegram file pay a
+  // silent cold import.
+  if (specs.every((spec) => spec.config === specs[0]?.config)) {
     return specs;
   }
   return applyParallelVitestCachePaths(specs, params);

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -10,6 +10,7 @@ import {
   hasQaSmokeAffectingChange,
   hasSqliteSessionLifecycleAffectingChange,
 } from "../../scripts/lib/ci-changed-node-test-plan.mts";
+import { TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT } from "../../scripts/lib/extension-test-plan.mts";
 import { hasImportGraphImpactOnTargets } from "../../scripts/test-projects.test-support.mts";
 import { listGitTrackedFiles } from "../../src/test-utils/repo-files.js";
 import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
@@ -297,6 +298,24 @@ describe("CI changed Node test plan", () => {
 
     expect(shards).not.toBeNull();
     expect(shards?.flatMap((shard) => shard.configs)).toContain(config);
+  });
+
+  it("packs Telegram process lifetimes into bounded changed-extension jobs", () => {
+    const shards = createChangedExtensionFallbackShards(["extensions/telegram/src/channel.ts"]);
+    const targets = shards.flatMap((shard) => shard.includePatterns ?? []);
+
+    expect(shards.length).toBeGreaterThan(1);
+    expect(
+      shards.every(
+        (shard) =>
+          shard.configs[0] === "test/vitest/vitest.extension-telegram.config.ts" &&
+          (shard.includePatterns?.length ?? 0) > 0 &&
+          (shard.includePatterns?.length ?? 0) <= TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT,
+      ),
+    ).toBe(true);
+    expect(targets.length).toBeGreaterThan(TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT);
+    expect(new Set(targets).size).toBe(targets.length);
+    expect(shards).toHaveLength(Math.ceil(targets.length / TELEGRAM_EXTENSION_TEST_JOB_FILE_LIMIT));
   });
 
   it("preserves Matrix process bounds in mixed package fallbacks", () => {

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -14,6 +14,8 @@ import {
 } from "../../scripts/lib/changed-extensions.mts";
 import {
   DEFAULT_EXTENSION_TEST_SHARD_COUNT,
+  MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT,
+  TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT,
   createExtensionTestProcessTargetChunks,
   createExtensionTestShards,
   listExtensionTestFilesForRoots,
@@ -37,7 +39,7 @@ import { extensionCatchAllExcludedTestRoots } from "../vitest/vitest.extensions.
 
 const scriptPath = path.join(process.cwd(), "scripts", "test-extension.mts");
 const posixIt = process.platform === "win32" ? it.skip : it;
-const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
+const MATRIX_TEST_PROCESS_FILE_LIMIT = MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT;
 
 type RunGroupParams = VitestBatchRunParams;
 
@@ -170,14 +172,26 @@ describe("scripts/test-extension.mts", () => {
     expect(plan.hasTests).toBe(true);
   });
 
-  it("bounds Matrix test files across balanced process lifetimes", () => {
-    const config = "test/vitest/vitest.extension-matrix.config.ts";
-    const roots = [bundledPluginRoot("matrix")];
+  it.each([
+    {
+      name: "Matrix",
+      config: "test/vitest/vitest.extension-matrix.config.ts",
+      root: "matrix",
+      limit: MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT,
+    },
+    {
+      name: "Telegram",
+      config: "test/vitest/vitest.extension-telegram.config.ts",
+      root: "telegram",
+      limit: TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT,
+    },
+  ])("bounds $name test files across balanced process lifetimes", ({ config, root, limit }) => {
+    const roots = [bundledPluginRoot(root)];
     const expectedFiles = listExtensionTestFilesForRoots(roots);
     const chunks = createExtensionTestProcessTargetChunks(config, roots);
 
-    expect(chunks).toHaveLength(expectedMatrixTestProcessCount());
-    expect(chunks.every((chunk) => chunk.length <= MATRIX_TEST_PROCESS_FILE_LIMIT)).toBe(true);
+    expect(chunks).toHaveLength(Math.max(1, Math.ceil(expectedFiles.length / limit)));
+    expect(chunks.every((chunk) => chunk.length <= limit)).toBe(true);
     expect(Math.max(...chunks.map((chunk) => chunk.length))).toBeLessThanOrEqual(
       Math.min(...chunks.map((chunk) => chunk.length)) + 1,
     );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { listExtensionTestFilesForRoots } from "../../scripts/lib/extension-test-plan.mts";
+import {
+  listExtensionTestFilesForRoots,
+  MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT,
+  TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT,
+} from "../../scripts/lib/extension-test-plan.mts";
 import {
   CHANNEL_CONTRACT_CONFIG_PATTERNS,
   DEFAULT_TEST_PROJECTS_VITEST_NO_OUTPUT_HEARTBEAT_MS,
@@ -41,8 +45,8 @@ import {
 } from "../vitest/vitest.contracts-shared.ts";
 
 const normalizeRepoPath = toRepoPath;
-const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
-const TELEGRAM_TEST_PROCESS_FILE_LIMIT = 5;
+const MATRIX_TEST_PROCESS_FILE_LIMIT = MATRIX_EXTENSION_TEST_PROCESS_FILE_LIMIT;
+const TELEGRAM_TEST_PROCESS_FILE_LIMIT = TELEGRAM_EXTENSION_TEST_PROCESS_FILE_LIMIT;
 
 function expectedMatrixTestProcessCount() {
   const testFileCount = listExtensionTestFilesForRoots(["extensions/matrix"]).length;
@@ -2146,6 +2150,64 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
+  it("splits an externally scoped Telegram include file across process lifetimes", () => {
+    const config = "test/vitest/vitest.extension-telegram.config.ts";
+    const files = listExtensionTestFilesForRoots(["extensions/telegram"]).slice(
+      0,
+      TELEGRAM_TEST_PROCESS_FILE_LIMIT + 4,
+    );
+    expect(files.length).toBeGreaterThan(TELEGRAM_TEST_PROCESS_FILE_LIMIT);
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-include-scope-"));
+    try {
+      const includeFile = path.join(tempDir, "ci-shard.json");
+      fs.writeFileSync(includeFile, JSON.stringify(files));
+      const plans = buildVitestRunPlans([config], process.cwd(), () => [], {
+        env: { OPENCLAW_VITEST_INCLUDE_FILE: includeFile },
+      });
+
+      expect(plans).toHaveLength(files.length);
+      expect(
+        plans.every(
+          (plan) =>
+            plan.config === config &&
+            (plan.includePatterns?.length ?? 0) === TELEGRAM_TEST_PROCESS_FILE_LIMIT,
+        ),
+      ).toBe(true);
+      expect(plans.flatMap((plan) => plan.includePatterns ?? [])).toEqual(files);
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("turns a five-file Telegram include file into five one-file run specs", () => {
+    const config = "test/vitest/vitest.extension-telegram.config.ts";
+    const files = listExtensionTestFilesForRoots(["extensions/telegram"]).slice(0, 5);
+    expect(files).toHaveLength(5);
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-include-specs-"));
+    try {
+      const includeFile = path.join(tempDir, "ci-shard.json");
+      fs.writeFileSync(includeFile, JSON.stringify(files));
+      const specs = createVitestRunSpecs([config], {
+        baseEnv: { OPENCLAW_VITEST_INCLUDE_FILE: includeFile },
+        tempDir,
+      });
+
+      expect(specs).toHaveLength(5);
+      expect(
+        specs.every((spec) => spec.config === config && (spec.includePatterns?.length ?? 0) === 1),
+      ).toBe(true);
+      expect(specs.map((spec) => spec.includePatterns?.[0])).toEqual(files);
+      expect(new Set(specs.map((spec) => spec.env.OPENCLAW_VITEST_INCLUDE_FILE)).size).toBe(5);
+      expect(specs.every((spec) => spec.env.OPENCLAW_VITEST_INCLUDE_FILE !== includeFile)).toBe(
+        true,
+      );
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it.each([
     {
       channel: "Telegram",
@@ -3696,6 +3758,34 @@ describe("scripts/test-projects Vitest stall watchdog", () => {
 });
 
 describe("scripts/test-projects Vitest cache isolation", () => {
+  it("keeps same-config process lifetimes on one restored cache", () => {
+    const specs = [
+      {
+        config: "test/vitest/vitest.extension-telegram.config.ts",
+        env: { OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: "/tmp/cache" },
+        includeFilePath: null,
+        includePatterns: ["extensions/telegram/src/a.test.ts"],
+        pnpmArgs: [],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.extension-telegram.config.ts",
+        env: { OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: "/tmp/cache" },
+        includeFilePath: null,
+        includePatterns: ["extensions/telegram/src/b.test.ts"],
+        pnpmArgs: [],
+        watchMode: false,
+      },
+    ];
+
+    expect(
+      applyDefaultMultiSpecVitestCachePaths(specs, {
+        cwd: "/repo",
+        env: { OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: "/tmp/cache" },
+      }),
+    ).toBe(specs);
+  });
+
   it("assigns isolated fs-module caches to multi-spec non-watch runs", () => {
     const specs = applyDefaultMultiSpecVitestCachePaths(
       [

--- a/test/vitest/vitest.extension-telegram.config.ts
+++ b/test/vitest/vitest.extension-telegram.config.ts
@@ -7,6 +7,8 @@ export function createExtensionTelegramVitestConfig(
 ) {
   return createExtensionVitestConfig("telegram", telegramExtensionTestRoots, env, {
     fileParallelism: false,
+    // Conflicting module mocks need a fresh graph per file. Pair with the
+    // one-file process limit so isolate never re-imports inside one worker.
     isolate: true,
   });
 }


### PR DESCRIPTION
Related: #123514, #123534, #123410
Unblocks: #123528

## What Problem This Solves

Resolves a problem where Telegram changed-extension CI would pass the first file in a five-file shard, then stay silent until the 300-second watchdog killed the job. That currently blocks otherwise-ready Telegram PRs, including #123528.

## Why This Change Was Made

Telegram keeps `isolate: true` because its files have conflicting module mocks. A second isolated file in the same Vitest process re-imports the Telegram graph in silence. Hosted logs on #123528 showed file 1 finishing in 118ms-1.5s against the warm cache, then no output through 300s on file 2; the retry repeated the same stall.

This change recycles the Vitest process after each Telegram file and keeps five files packed in one CI job. Same-config sequential processes share the restored transform cache so later files do not pay a cold import. No provider or Telegram runtime behavior changes.

## User Impact

No product behavior change. Telegram extension CI jobs should finish their remaining files instead of dying after the first passing file.

## Evidence

- Before: `checks-node-changed-extensions-config-14/15` on #123528 run 31783075633 exited 143 after a 300s silence following the first passing file; retry repeated the stall.
- Planner probe after the fix: 210 Telegram files remain 42 CI jobs of 5 files; a 5-file include file becomes 5 one-file run specs that share one cache path.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/test-extension.test.ts test/vitest-scoped-config.test.ts` — 562 passed.
- Rebase onto `origin/main` (`8865c2539b1`, including #123570) and rerun: 304/304 owner tests passed.
- `pnpm tsgo` scripts: passed.
- Hosted exact-head CI on this PR is the real proof that the 5-file shards stay under the 300s watchdog.

Production/script-support: +81/-16. Tests: +132/-9. The script growth is the process-lifetime vs CI-job split; collapsing them would mint 210 Telegram jobs.
