### PR TITLE
fix(ui): terminal actions disappear during Gateway updates

### DIFF
--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -16,7 +16,6 @@ import {
   isTerminalPanelShortcut,
   TERMINAL_PANEL_TOGGLE_EVENT,
   type PanelToggleElement,
-  type TerminalPanelToggleDetail,
 } from "../components/panel-toggle-contract.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
@@ -113,7 +112,7 @@ export class ShellChromeOwner {
     window.addEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
     window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession);
     window.addEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle, true);
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
   }
@@ -133,11 +132,7 @@ export class ShellChromeOwner {
     window.removeEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
     window.removeEventListener("openclaw:native-new-session", this.handleNativeNewSession);
     window.removeEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.removeEventListener(
-      TERMINAL_PANEL_TOGGLE_EVENT,
-      this.handleDeferredTerminalToggle,
-      true,
-    );
+    window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
   }
@@ -476,10 +471,6 @@ export class ShellChromeOwner {
 
   readonly handleDeferredTerminalToggle = (event: Event): void => {
     const host = this.host;
-    if (event instanceof CustomEvent && typeof event.detail === "object" && event.detail) {
-      (event.detail as TerminalPanelToggleDetail).agentId =
-        host.context?.agentSelection?.state.selectedId?.trim() || null;
-    }
     if (isOptionalElementDefined(host.terminalPanelElement)) {
       return;
     }

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -16,6 +16,7 @@ import {
   isTerminalPanelShortcut,
   TERMINAL_PANEL_TOGGLE_EVENT,
   type PanelToggleElement,
+  type TerminalPanelToggleDetail,
 } from "../components/panel-toggle-contract.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
@@ -40,10 +41,6 @@ import { NAV_WIDTH_MAX, NAV_WIDTH_MIN } from "./settings.ts";
 
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
-};
-
-type TerminalPanelElement = PanelToggleElement & {
-  agentId: string | null;
 };
 
 export function isBrowserPanelAvailable(
@@ -466,35 +463,24 @@ export class ShellChromeOwner {
       .catch(() => undefined);
   };
 
-  deliverPanelEventAfterLoad(
-    element: OptionalCustomElement,
-    event: Event,
-    beforeDeliver?: (panel: PanelToggleElement) => void,
-  ): void {
+  deliverPanelEventAfterLoad(element: OptionalCustomElement, event: Event): void {
     const host = this.host;
     void ensureOptionalElementForHost(host, element)
       .then(async () => {
         // Wait for the host to apply availability after defining the mounted tag.
         await host.updateComplete;
-        const panel = host.querySelector<PanelToggleElement>(element.tagName);
-        if (panel) {
-          beforeDeliver?.(panel);
-          panel.handleToggleRequest(event);
-        }
+        host.querySelector<PanelToggleElement>(element.tagName)?.handleToggleRequest(event);
       })
       .catch(() => undefined);
   }
 
   readonly handleDeferredTerminalToggle = (event: Event): void => {
     const host = this.host;
-    const selectedAgentId = host.context?.agentSelection.state.selectedId?.trim() || null;
+    if (event instanceof CustomEvent && typeof event.detail === "object" && event.detail) {
+      (event.detail as TerminalPanelToggleDetail).agentId =
+        host.context?.agentSelection?.state.selectedId?.trim() || null;
+    }
     if (isOptionalElementDefined(host.terminalPanelElement)) {
-      // This listener runs before the optional panel's listener. Carry the
-      // canonical click-time selection past Lit's deferred property render.
-      const panel = host.querySelector<TerminalPanelElement>(host.terminalPanelElement.tagName);
-      if (panel) {
-        panel.agentId = selectedAgentId;
-      }
       return;
     }
     const context = host.context;
@@ -505,9 +491,7 @@ export class ShellChromeOwner {
     ) {
       return;
     }
-    this.deliverPanelEventAfterLoad(host.terminalPanelElement, event, (panel) => {
-      (panel as TerminalPanelElement).agentId = selectedAgentId;
-    });
+    this.deliverPanelEventAfterLoad(host.terminalPanelElement, event);
   };
 
   readonly handleDeferredBrowserToggle = (event: Event): void => {

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -42,6 +42,10 @@ type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
 };
 
+type TerminalPanelElement = PanelToggleElement & {
+  agentId: string | null;
+};
+
 export function isBrowserPanelAvailable(
   snapshot: ApplicationContext["gateway"]["snapshot"],
 ): boolean {
@@ -112,7 +116,7 @@ export class ShellChromeOwner {
     window.addEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
     window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession);
     window.addEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle, true);
     window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
   }
@@ -132,7 +136,11 @@ export class ShellChromeOwner {
     window.removeEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
     window.removeEventListener("openclaw:native-new-session", this.handleNativeNewSession);
     window.removeEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
+    window.removeEventListener(
+      TERMINAL_PANEL_TOGGLE_EVENT,
+      this.handleDeferredTerminalToggle,
+      true,
+    );
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
   }
@@ -458,20 +466,35 @@ export class ShellChromeOwner {
       .catch(() => undefined);
   };
 
-  deliverPanelEventAfterLoad(element: OptionalCustomElement, event: Event): void {
+  deliverPanelEventAfterLoad(
+    element: OptionalCustomElement,
+    event: Event,
+    beforeDeliver?: (panel: PanelToggleElement) => void,
+  ): void {
     const host = this.host;
     void ensureOptionalElementForHost(host, element)
       .then(async () => {
         // Wait for the host to apply availability after defining the mounted tag.
         await host.updateComplete;
-        host.querySelector<PanelToggleElement>(element.tagName)?.handleToggleRequest(event);
+        const panel = host.querySelector<PanelToggleElement>(element.tagName);
+        if (panel) {
+          beforeDeliver?.(panel);
+          panel.handleToggleRequest(event);
+        }
       })
       .catch(() => undefined);
   }
 
   readonly handleDeferredTerminalToggle = (event: Event): void => {
     const host = this.host;
+    const selectedAgentId = host.context?.agentSelection.state.selectedId?.trim() || null;
     if (isOptionalElementDefined(host.terminalPanelElement)) {
+      // This listener runs before the optional panel's listener. Carry the
+      // canonical click-time selection past Lit's deferred property render.
+      const panel = host.querySelector<TerminalPanelElement>(host.terminalPanelElement.tagName);
+      if (panel) {
+        panel.agentId = selectedAgentId;
+      }
       return;
     }
     const context = host.context;
@@ -482,7 +505,9 @@ export class ShellChromeOwner {
     ) {
       return;
     }
-    this.deliverPanelEventAfterLoad(host.terminalPanelElement, event);
+    this.deliverPanelEventAfterLoad(host.terminalPanelElement, event, (panel) => {
+      (panel as TerminalPanelElement).agentId = selectedAgentId;
+    });
   };
 
   readonly handleDeferredBrowserToggle = (event: Event): void => {

--- a/ui/src/components/panel-toggle-contract.ts
+++ b/ui/src/components/panel-toggle-contract.ts
@@ -8,6 +8,7 @@ export const UI_COMMAND_EVENT = "openclaw:ui-command";
 export type UiCommandDetail = UiCommandParams;
 
 export type TerminalPanelToggleDetail = {
+  agentId?: string | null;
   dock?: "bottom" | "right";
   open?: boolean;
   terminalSessionId?: string;

--- a/ui/src/components/terminal/terminal-panel-reconnect.test.ts
+++ b/ui/src/components/terminal/terminal-panel-reconnect.test.ts
@@ -411,7 +411,9 @@ describe("OpenClawTerminalPanel reconnect", () => {
     );
     panel.closeTerminalPanel();
     releaseRefresh?.(false);
-    await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+    await new Promise((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
 
     expect(panel.terminalPanelOpen).toBe(false);
     expect(requests).toHaveLength(0);

--- a/ui/src/components/terminal/terminal-panel-reconnect.test.ts
+++ b/ui/src/components/terminal/terminal-panel-reconnect.test.ts
@@ -257,4 +257,325 @@ describe("OpenClawTerminalPanel reconnect", () => {
     expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(2);
     expect(controllers[1].dispose).toHaveBeenCalledOnce();
   });
+
+  it("replays and deduplicates explicit terminal actions after a reconnect refresh fence", async () => {
+    createGhosttyTerminalMock
+      .mockResolvedValueOnce(createTerminalController())
+      .mockResolvedValueOnce(createTerminalController())
+      .mockResolvedValueOnce(createTerminalController())
+      .mockResolvedValueOnce(createTerminalController());
+    const requests: Array<{ method: string; params: unknown }> = [];
+    let opened = 0;
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        if (method === "terminal.attach") {
+          const sessionId = (params as { sessionId: string }).sessionId;
+          const buffer = `${sessionId} ready`;
+          return {
+            ...terminalOpenResult(sessionId),
+            buffer,
+            seq: buffer.length,
+          } as T;
+        }
+        if (method === "terminal.open") {
+          opened += 1;
+          return terminalOpenResult(`opened-terminal-${opened}`) as T;
+        }
+        return {} as T;
+      },
+      addEventListener: () => () => {},
+    };
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.agentId = "research";
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+
+    panel.client = null;
+    panel.available = false;
+    await panel.updateComplete;
+
+    let releaseRefresh: ((replacementActivated: boolean) => void) | undefined;
+    vi.mocked(refreshControlUiServiceWorker).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        releaseRefresh = resolve;
+      }),
+    );
+    panel.client = client;
+    panel.available = true;
+    await panel.updateComplete;
+    await vi.waitFor(() => expect(refreshControlUiServiceWorker).toHaveBeenCalledOnce());
+
+    const catalog = { catalogId: "codex", hostId: "gateway:local", threadId: "thread-1" };
+    const requested = new CustomEvent("openclaw:terminal-toggle", {
+      detail: { open: true, terminalSessionId: "requested-terminal" },
+    });
+    panel.handleToggleRequest(requested);
+    panel.handleToggleRequest(requested);
+    const sessions = (
+      panel as unknown as {
+        terminalSessions: {
+          attachSessionById(sessionId: string, agentOwned?: boolean): Promise<void>;
+        };
+      }
+    ).terminalSessions;
+    void sessions.attachSessionById("picked-terminal");
+    void sessions.attachSessionById("picked-terminal");
+    await panel.updateComplete;
+    const newSession = panel.renderRoot.querySelector<HTMLButtonElement>(
+      '[aria-label="New terminal session"]',
+    );
+    expect(newSession?.disabled).toBe(false);
+    newSession?.click();
+    newSession?.click();
+    panel.handleToggleRequest(
+      new CustomEvent("openclaw:terminal-toggle", { detail: { open: true, catalog } }),
+    );
+    panel.handleToggleRequest(
+      new CustomEvent("openclaw:terminal-toggle", { detail: { open: true, catalog } }),
+    );
+    panel.agentId = "main";
+
+    expect(requests).toHaveLength(0);
+    await waitForFast(() => {
+      expect(panel.renderRoot.querySelector(".tp-connecting")?.textContent).toContain(
+        "Connecting to session",
+      );
+    });
+
+    releaseRefresh?.(false);
+    await waitForFast(() => {
+      expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(2);
+      expect(requests.filter((request) => request.method === "terminal.open")).toHaveLength(2);
+    });
+    expect(
+      requests.filter(
+        (request) => request.method === "terminal.attach" || request.method === "terminal.open",
+      ),
+    ).toEqual([
+      { method: "terminal.attach", params: { sessionId: "requested-terminal" } },
+      { method: "terminal.attach", params: { sessionId: "picked-terminal" } },
+      {
+        method: "terminal.open",
+        params: { agentId: "research", cols: 100, rows: 30 },
+      },
+      {
+        method: "terminal.open",
+        params: { agentId: "research", cols: 100, rows: 30, catalog },
+      },
+    ]);
+    expect(panel.renderRoot.querySelectorAll(".tabstrip-tab__badge")).toHaveLength(1);
+  });
+
+  it("cancels captured restore and explicit actions when the panel closes during the fence", async () => {
+    createGhosttyTerminalMock.mockResolvedValue(createTerminalController());
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        return terminalOpenResult("initial-terminal") as T;
+      },
+      addEventListener: () => () => {},
+    };
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+    panel.toggle();
+    await waitForFast(() => {
+      expect(requests.some((request) => request.method === "terminal.open")).toBe(true);
+    });
+
+    panel.client = null;
+    panel.available = false;
+    await panel.updateComplete;
+    requests.splice(0);
+
+    let releaseRefresh: ((replacementActivated: boolean) => void) | undefined;
+    vi.mocked(refreshControlUiServiceWorker).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        releaseRefresh = resolve;
+      }),
+    );
+    panel.client = client;
+    panel.available = true;
+    await panel.updateComplete;
+    await vi.waitFor(() => expect(refreshControlUiServiceWorker).toHaveBeenCalledOnce());
+    panel.handleToggleRequest(
+      new CustomEvent("openclaw:terminal-toggle", {
+        detail: { open: true, terminalSessionId: "cancelled-terminal" },
+      }),
+    );
+    panel.closeTerminalPanel();
+    releaseRefresh?.(false);
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+    expect(panel.terminalPanelOpen).toBe(false);
+    expect(requests).toHaveLength(0);
+    expect(sessionStorage.getItem("openclaw.terminal.actions.v1")).toBeNull();
+  });
+
+  it("retires an older refresh generation without losing its queued action", async () => {
+    createGhosttyTerminalMock.mockResolvedValue(createTerminalController());
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        if (method === "terminal.attach") {
+          return {
+            ...terminalOpenResult("generation-terminal"),
+            buffer: "ready",
+            seq: 5,
+          } as T;
+        }
+        return {} as T;
+      },
+      addEventListener: () => () => {},
+    };
+    const releases: Array<(replacementActivated: boolean) => void> = [];
+    vi.mocked(refreshControlUiServiceWorker).mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          releases.push(resolve);
+        }),
+    );
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+
+    panel.client = null;
+    panel.available = false;
+    await panel.updateComplete;
+    panel.client = client;
+    panel.available = true;
+    await panel.updateComplete;
+    await vi.waitFor(() => expect(releases).toHaveLength(1));
+    panel.handleToggleRequest(
+      new CustomEvent("openclaw:terminal-toggle", {
+        detail: { open: true, terminalSessionId: "generation-terminal" },
+      }),
+    );
+
+    panel.client = null;
+    panel.available = false;
+    await panel.updateComplete;
+    panel.client = client;
+    panel.available = true;
+    await panel.updateComplete;
+    await vi.waitFor(() => expect(releases).toHaveLength(2));
+
+    releases[0]?.(false);
+    await Promise.resolve();
+    expect(requests).toHaveLength(0);
+    releases[1]?.(false);
+    await waitForFast(() => {
+      expect(requests).toContainEqual({
+        method: "terminal.attach",
+        params: { sessionId: "generation-terminal" },
+      });
+    });
+    expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(1);
+  });
+
+  it("shows reload guidance when a fenced action cannot make progress", async () => {
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>() => ({}) as T,
+      addEventListener: () => () => {},
+    };
+    vi.mocked(refreshControlUiServiceWorker).mockReturnValueOnce(new Promise<boolean>(() => {}));
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.catalogReadyTimeoutMs = 10;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+
+    panel.client = null;
+    panel.available = false;
+    await panel.updateComplete;
+    panel.client = client;
+    panel.available = true;
+    await panel.updateComplete;
+    await vi.waitFor(() => expect(refreshControlUiServiceWorker).toHaveBeenCalledOnce());
+    panel.handleToggleRequest(
+      new CustomEvent("openclaw:terminal-toggle", {
+        detail: { open: true, terminalSessionId: "stalled-terminal" },
+      }),
+    );
+
+    await waitForFast(() => {
+      expect(panel.renderRoot.querySelector(".tp-error")?.textContent).toContain(
+        "Reload this page to continue the terminal action",
+      );
+    });
+    expect(panel.renderRoot.querySelector(".tp-connecting")).toBeNull();
+  });
+
+  it("carries an explicit terminal action through an activated-worker reload", async () => {
+    createGhosttyTerminalMock.mockResolvedValue(createTerminalController());
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        if (method === "terminal.attach") {
+          return {
+            ...terminalOpenResult("requested-after-reload"),
+            buffer: "reloaded terminal ready",
+            seq: 23,
+          } as T;
+        }
+        return {} as T;
+      },
+      addEventListener: () => () => {},
+    };
+    const stalePanel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    stalePanel.client = client;
+    stalePanel.available = true;
+    document.body.append(stalePanel);
+
+    stalePanel.client = null;
+    stalePanel.available = false;
+    await stalePanel.updateComplete;
+
+    let activateReplacement: ((replacementActivated: boolean) => void) | undefined;
+    vi.mocked(refreshControlUiServiceWorker).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        activateReplacement = resolve;
+      }),
+    );
+    stalePanel.client = client;
+    stalePanel.available = true;
+    await stalePanel.updateComplete;
+    await vi.waitFor(() => expect(refreshControlUiServiceWorker).toHaveBeenCalledOnce());
+    stalePanel.handleToggleRequest(
+      new CustomEvent("openclaw:terminal-toggle", {
+        detail: { open: true, terminalSessionId: "requested-after-reload" },
+      }),
+    );
+    activateReplacement?.(true);
+    await Promise.resolve();
+    expect(requests).toHaveLength(0);
+
+    stalePanel.remove();
+    const currentPanel = document.createElement(
+      TERMINAL_PANEL_ELEMENT_NAME,
+    ) as OpenClawTerminalPanel;
+    currentPanel.client = client;
+    currentPanel.available = true;
+    document.body.append(currentPanel);
+
+    await waitForFast(() => {
+      expect(requests).toContainEqual({
+        method: "terminal.attach",
+        params: { sessionId: "requested-after-reload" },
+      });
+    });
+    expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(1);
+  });
 });

--- a/ui/src/components/terminal/terminal-panel-reconnect.test.ts
+++ b/ui/src/components/terminal/terminal-panel-reconnect.test.ts
@@ -258,7 +258,7 @@ describe("OpenClawTerminalPanel reconnect", () => {
     expect(controllers[1].dispose).toHaveBeenCalledOnce();
   });
 
-  it("replays and deduplicates explicit terminal actions after a reconnect refresh fence", async () => {
+  it("replays and deduplicates explicit terminal actions after a same-client reconnect fence", async () => {
     createGhosttyTerminalMock
       .mockResolvedValueOnce(createTerminalController())
       .mockResolvedValueOnce(createTerminalController())
@@ -293,7 +293,6 @@ describe("OpenClawTerminalPanel reconnect", () => {
     panel.available = true;
     document.body.append(panel);
 
-    panel.client = null;
     panel.available = false;
     await panel.updateComplete;
 
@@ -303,7 +302,6 @@ describe("OpenClawTerminalPanel reconnect", () => {
         releaseRefresh = resolve;
       }),
     );
-    panel.client = client;
     panel.available = true;
     await panel.updateComplete;
     await vi.waitFor(() => expect(refreshControlUiServiceWorker).toHaveBeenCalledOnce());

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -18,17 +18,13 @@ import {
   TERMINAL_FONT_FAMILY,
   TERMINAL_OUTPUT_ENCODER,
   type TerminalOperation,
-  type TerminalPanelAction,
   type TerminalPanelCatalogReference,
   type TerminalPanelSessionControllerHost,
   type TerminalPanelSessionControllerState,
   type TerminalPanelSessionTab,
 } from "./terminal-panel-session-types.ts";
-import {
-  loadPersistedTerminalActions,
-  loadPersistedTerminalSessionIds,
-  persistTerminalActions,
-} from "./terminal-session-storage.ts";
+import { TerminalPendingActions } from "./terminal-pending-actions.ts";
+import { loadPersistedTerminalSessionIds } from "./terminal-session-storage.ts";
 import { createTerminalStartupInput } from "./terminal-startup-input.ts";
 import { TerminalTabReadinessController } from "./terminal-tab-readiness.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
@@ -48,28 +44,36 @@ export class TerminalPanelSessionController
   private activeClient: TerminalGatewayClient | null = null;
   private activeAvailable = false;
   private hadClient = false;
-  private refreshPending = false;
-  private refreshTimedOut = false;
-  private refreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private lifecycleGeneration = 0;
   private lifecycleAbortController = new AbortController();
   private lifecycleSyncToken = 0;
   private tabSequence = 0;
   private readonly bootQueue = new TerminalTaskQueue();
-  private readonly pendingActions: TerminalPanelAction[];
-  private actionDrainScheduled = false;
+  private readonly pendingActions: TerminalPendingActions;
   private readonly readiness: TerminalTabReadinessController<TerminalPanelSessionTab>;
 
   constructor(private readonly host: TerminalPanelSessionControllerHost) {
     host.addController(this);
-    const persistedActions = loadPersistedTerminalActions();
-    this.pendingActions = persistedActions.some((action) => action.kind !== "restore")
-      ? persistedActions.filter((action) => action.kind !== "restore")
-      : persistedActions;
-    if (this.pendingActions.length !== persistedActions.length) {
-      persistTerminalActions(this.pendingActions);
-    }
-    this.booting = this.pendingActions.length > 0;
+    this.pendingActions = new TerminalPendingActions({
+      bootQueue: this.bootQueue,
+      currentGeneration: () => this.lifecycleGeneration,
+      canRun: () => this.terminalActionsCanRun(),
+      attach: (sessionId, agentOwned) => this.attachSessionNow(sessionId, agentOwned),
+      open: (catalog, agentId) => this.openSessionNow(catalog, agentId),
+      reattach: () => this.reattachPersistedSessions(),
+      ensureInitial: (agentId) => this.ensureInitialSession(agentId),
+      hasTabs: () => this.tabs.length > 0,
+      requestUpdate: () => this.host.requestUpdate(),
+      setBooting: (booting) => this.updateControllerState("booting", booting),
+      timeoutMs: () => this.host.catalogReadyTimeoutMs,
+      showTimeout: () => {
+        this.host.terminalPanelErrorText = t("terminal.refreshRequired");
+      },
+      clearTimeout: () => {
+        this.host.terminalPanelErrorText = null;
+      },
+    });
+    this.booting = this.pendingActions.hasActions;
     this.readiness = new TerminalTabReadinessController<TerminalPanelSessionTab>({
       timeoutMs: () => this.host.catalogReadyTimeoutMs,
       isCurrent: (tab) => this.tabs.includes(tab),
@@ -155,27 +159,21 @@ export class TerminalPanelSessionController
     } else if (shouldRestore) {
       void this.restoreSessions();
     } else {
-      void this.drainPendingActions();
+      void this.pendingActions.drain();
     }
   }
 
   private refreshBeforeReconnectRestore(restore: boolean): void {
     const generation = this.lifecycleGeneration;
-    this.refreshPending = true;
-    this.clearRefreshFailure();
-    this.clearRefreshTimer();
+    this.pendingActions.beginRefreshFence(generation);
     if (restore) {
       void this.restoreSessions();
     }
-    this.armRefreshTimer(generation);
     const release = () => {
       if (generation !== this.lifecycleGeneration || !this.host.isConnected) {
         return;
       }
-      this.clearRefreshTimer();
-      this.refreshPending = false;
-      this.clearRefreshFailure();
-      void this.drainPendingActions();
+      this.pendingActions.releaseRefreshFence();
     };
     void import("../../app/sw-refresh.runtime.ts")
       .then(({ refreshControlUiServiceWorker }) => refreshControlUiServiceWorker())
@@ -187,11 +185,11 @@ export class TerminalPanelSessionController
   }
 
   async restoreSessions(): Promise<void> {
-    await this.queueTerminalAction({ kind: "restore", agentId: this.selectedAgentId() });
+    await this.pendingActions.queue({ kind: "restore", agentId: this.selectedAgentId() });
   }
 
   async openCatalogSession(catalog: TerminalPanelCatalogReference): Promise<void> {
-    await this.queueTerminalAction({
+    await this.pendingActions.queue({
       kind: "catalog",
       agentId: this.selectedAgentId(),
       catalog,
@@ -199,48 +197,17 @@ export class TerminalPanelSessionController
   }
 
   async openRequestedSession(sessionId: string): Promise<void> {
-    await this.queueTerminalAction({ kind: "attach", sessionId, agentOwned: true });
+    await this.pendingActions.queue({ kind: "attach", sessionId, agentOwned: true });
   }
 
   private selectedAgentId(): string | null {
     return this.host.agentId?.trim() || null;
   }
 
-  private actionKey(action: TerminalPanelAction): string {
-    return JSON.stringify(action);
-  }
-
-  private async queueTerminalAction(action: TerminalPanelAction): Promise<void> {
-    let changed = false;
-    if (action.kind !== "restore") {
-      for (let index = this.pendingActions.length - 1; index >= 0; index -= 1) {
-        if (this.pendingActions[index]?.kind === "restore") {
-          this.pendingActions.splice(index, 1);
-          changed = true;
-        }
-      }
-    }
-    const key = this.actionKey(action);
-    if (!this.pendingActions.some((pending) => this.actionKey(pending) === key)) {
-      this.pendingActions.push(action);
-      changed = true;
-    }
-    if (changed) {
-      persistTerminalActions(this.pendingActions);
-    }
-    this.armRefreshTimer(this.lifecycleGeneration);
-    if (this.refreshPending) {
-      this.host.requestUpdate();
-    } else if (this.tabs.length === 0) {
-      this.updateControllerState("booting", true);
-    }
-    await this.drainPendingActions();
-  }
-
   private terminalActionsCanRun(): boolean {
     const client = this.host.client;
     return (
-      !this.refreshPending &&
+      !this.pendingActions.fenced &&
       Boolean(client) &&
       client === this.activeClient &&
       this.host.available &&
@@ -248,100 +215,12 @@ export class TerminalPanelSessionController
     );
   }
 
-  private async drainPendingActions(): Promise<void> {
-    if (
-      this.actionDrainScheduled ||
-      this.pendingActions.length === 0 ||
-      !this.terminalActionsCanRun()
-    ) {
-      return;
-    }
-    this.actionDrainScheduled = true;
-    try {
-      await this.bootQueue.enqueue(async (isCurrent) => {
-        const action = this.pendingActions[0];
-        if (!action || !isCurrent() || !this.terminalActionsCanRun()) {
-          return;
-        }
-        const completed = await this.executeTerminalAction(action);
-        if (!completed || !isCurrent()) {
-          return;
-        }
-        const index = this.pendingActions.indexOf(action);
-        if (index !== -1) {
-          this.pendingActions.splice(index, 1);
-          persistTerminalActions(this.pendingActions);
-        }
-      });
-    } finally {
-      this.actionDrainScheduled = false;
-      if (this.pendingActions.length > 0 && this.terminalActionsCanRun()) {
-        void this.drainPendingActions();
-      } else if (this.pendingActions.length === 0 && this.tabs.length === 0) {
-        this.updateControllerState("booting", false);
-      }
-    }
-  }
-
-  private async executeTerminalAction(action: TerminalPanelAction): Promise<boolean> {
-    if (action.kind === "attach") {
-      return this.attachSessionNow(action.sessionId, action.agentOwned);
-    }
-    if (action.kind === "open") {
-      return this.openSessionNow(undefined, action.agentId);
-    }
-    await this.reattachPersistedSessions();
-    if (!this.terminalActionsCanRun()) {
-      return false;
-    }
-    return action.kind === "catalog"
-      ? this.openSessionNow(action.catalog, action.agentId)
-      : this.ensureInitialSession(action.agentId);
-  }
-
   cancelPendingActions(): void {
-    this.pendingActions.splice(0);
-    persistTerminalActions(this.pendingActions);
-    this.updateControllerState("booting", false);
-    this.clearRefreshFailure();
+    this.pendingActions.cancel();
   }
 
   get waitingForRefresh(): boolean {
-    return this.refreshPending && !this.refreshTimedOut && this.pendingActions.length > 0;
-  }
-
-  private clearRefreshTimer(): void {
-    if (this.refreshTimer !== null) {
-      globalThis.clearTimeout(this.refreshTimer);
-      this.refreshTimer = null;
-    }
-  }
-
-  private clearRefreshFailure(): void {
-    if (this.refreshTimedOut) {
-      this.host.terminalPanelErrorText = null;
-      this.refreshTimedOut = false;
-    }
-  }
-
-  private armRefreshTimer(generation: number): void {
-    if (!this.refreshPending || this.refreshTimer !== null || this.pendingActions.length === 0) {
-      return;
-    }
-    this.refreshTimer = globalThis.setTimeout(() => {
-      this.refreshTimer = null;
-      if (
-        generation !== this.lifecycleGeneration ||
-        !this.host.isConnected ||
-        !this.refreshPending ||
-        this.pendingActions.length === 0
-      ) {
-        return;
-      }
-      this.refreshTimedOut = true;
-      this.host.terminalPanelErrorText = t("terminal.refreshRequired");
-      this.updateControllerState("booting", false);
-    }, this.host.catalogReadyTimeoutMs);
+    return this.pendingActions.waitingForRefresh;
   }
 
   private async reattachPersistedSessions(): Promise<void> {
@@ -416,7 +295,7 @@ export class TerminalPanelSessionController
   }
 
   async attachSessionById(sessionId: string, agentOwned = false): Promise<void> {
-    await this.queueTerminalAction({ kind: "attach", sessionId, agentOwned });
+    await this.pendingActions.queue({ kind: "attach", sessionId, agentOwned });
   }
 
   private async attachSessionNow(sessionId: string, agentOwned: boolean): Promise<boolean> {
@@ -616,7 +495,7 @@ export class TerminalPanelSessionController
   }
 
   async openSession(catalog?: TerminalPanelCatalogReference): Promise<void> {
-    await this.queueTerminalAction(
+    await this.pendingActions.queue(
       catalog
         ? { kind: "catalog", agentId: this.selectedAgentId(), catalog }
         : { kind: "open", agentId: this.selectedAgentId() },
@@ -838,7 +717,7 @@ export class TerminalPanelSessionController
   private captureTerminalOperation(): TerminalOperation | null {
     const client = this.host.client;
     if (
-      this.refreshPending ||
+      this.pendingActions.fenced ||
       !client ||
       client !== this.activeClient ||
       !this.host.available ||
@@ -879,9 +758,7 @@ export class TerminalPanelSessionController
 
   private disposeAllTabs(): void {
     this.lifecycleGeneration += 1;
-    this.clearRefreshTimer();
-    this.refreshPending = false;
-    this.clearRefreshFailure();
+    this.pendingActions.resetLifecycle();
     this.lifecycleAbortController.abort();
     this.lifecycleAbortController = new AbortController();
     this.bootQueue.reset();

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -46,6 +46,7 @@ export class TerminalPanelSessionController
   private activeClient: TerminalGatewayClient | null = null;
   private activeAvailable = false;
   private hadClient = false;
+  private hadAvailable = false;
   private lifecycleGeneration = 0;
   private lifecycleAbortController = new AbortController();
   private lifecycleSyncToken = 0;
@@ -106,13 +107,13 @@ export class TerminalPanelSessionController
     this.activeClient = this.host.client;
     this.activeAvailable = this.host.available;
     this.hadClient = this.host.client !== null;
+    this.hadAvailable = this.host.available;
   }
 
   disconnectHost(): void {
     this.disposeAllTabs();
     this.activeClient = null;
     this.activeAvailable = false;
-    this.hadClient = false;
   }
 
   scheduleLifecycleSync(): void {
@@ -138,12 +139,15 @@ export class TerminalPanelSessionController
     if (!clientChanged && !availabilityChanged) {
       return;
     }
-    const reconnecting = clientChanged && this.hadClient && this.host.client !== null;
+    const becameAvailable = availabilityChanged && this.host.available && this.hadAvailable;
+    const priorEpoch = (clientChanged && this.hadClient) || becameAvailable;
+    const reconnecting = this.host.client !== null && priorEpoch;
     if (clientChanged) {
       this.activeClient = this.host.client;
       this.hadClient ||= this.host.client !== null;
     }
     this.activeAvailable = this.host.available;
+    this.hadAvailable ||= this.host.available;
     const becameUnavailable = availabilityChanged && !this.host.available;
     if (clientChanged || becameUnavailable) {
       this.disposeAllTabs();
@@ -187,23 +191,20 @@ export class TerminalPanelSessionController
   }
 
   async restoreSessions(): Promise<void> {
-    await this.pendingActions.queue({ kind: "restore", agentId: this.selectedAgentId() });
+    const agentId = this.host.agentId?.trim() || null;
+    await this.pendingActions.queue({ kind: "restore", agentId });
   }
 
   async openCatalogSession(catalog: TerminalPanelCatalogReference): Promise<void> {
     await this.pendingActions.queue({
       kind: "catalog",
-      agentId: this.selectedAgentId(),
+      agentId: this.host.agentId?.trim() || null,
       catalog,
     });
   }
 
   async openRequestedSession(sessionId: string): Promise<void> {
     await this.pendingActions.queue({ kind: "attach", sessionId, agentOwned: true });
-  }
-
-  private selectedAgentId(): string | null {
-    return this.host.agentId?.trim() || null;
   }
 
   private terminalActionsCanRun(): boolean {
@@ -499,8 +500,8 @@ export class TerminalPanelSessionController
   async openSession(catalog?: TerminalPanelCatalogReference): Promise<void> {
     await this.pendingActions.queue(
       catalog
-        ? { kind: "catalog", agentId: this.selectedAgentId(), catalog }
-        : { kind: "open", agentId: this.selectedAgentId() },
+        ? { kind: "catalog", agentId: this.host.agentId?.trim() || null, catalog }
+        : { kind: "open", agentId: this.host.agentId?.trim() || null },
     );
   }
 

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -13,7 +13,6 @@ import {
 } from "./terminal-controller-lifecycle.ts";
 import {
   forceTerminalRender,
-  persistLiveTerminalSessions,
   shellBasename,
   TERMINAL_FONT_FAMILY,
   TERMINAL_OUTPUT_ENCODER,
@@ -24,7 +23,10 @@ import {
   type TerminalPanelSessionTab,
 } from "./terminal-panel-session-types.ts";
 import { TerminalPendingActions } from "./terminal-pending-actions.ts";
-import { loadPersistedTerminalSessionIds } from "./terminal-session-storage.ts";
+import {
+  loadPersistedTerminalSessionIds,
+  persistLiveTerminalSessions,
+} from "./terminal-session-storage.ts";
 import { createTerminalStartupInput } from "./terminal-startup-input.ts";
 import { TerminalTabReadinessController } from "./terminal-tab-readiness.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -18,12 +18,17 @@ import {
   TERMINAL_FONT_FAMILY,
   TERMINAL_OUTPUT_ENCODER,
   type TerminalOperation,
+  type TerminalPanelAction,
   type TerminalPanelCatalogReference,
   type TerminalPanelSessionControllerHost,
   type TerminalPanelSessionControllerState,
   type TerminalPanelSessionTab,
 } from "./terminal-panel-session-types.ts";
-import { loadPersistedTerminalSessionIds } from "./terminal-session-storage.ts";
+import {
+  loadPersistedTerminalActions,
+  loadPersistedTerminalSessionIds,
+  persistTerminalActions,
+} from "./terminal-session-storage.ts";
 import { createTerminalStartupInput } from "./terminal-startup-input.ts";
 import { TerminalTabReadinessController } from "./terminal-tab-readiness.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
@@ -44,15 +49,27 @@ export class TerminalPanelSessionController
   private activeAvailable = false;
   private hadClient = false;
   private refreshPending = false;
+  private refreshTimedOut = false;
+  private refreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private lifecycleGeneration = 0;
   private lifecycleAbortController = new AbortController();
   private lifecycleSyncToken = 0;
   private tabSequence = 0;
   private readonly bootQueue = new TerminalTaskQueue();
+  private readonly pendingActions: TerminalPanelAction[];
+  private actionDrainScheduled = false;
   private readonly readiness: TerminalTabReadinessController<TerminalPanelSessionTab>;
 
   constructor(private readonly host: TerminalPanelSessionControllerHost) {
     host.addController(this);
+    const persistedActions = loadPersistedTerminalActions();
+    this.pendingActions = persistedActions.some((action) => action.kind !== "restore")
+      ? persistedActions.filter((action) => action.kind !== "restore")
+      : persistedActions;
+    if (this.pendingActions.length !== persistedActions.length) {
+      persistTerminalActions(this.pendingActions);
+    }
+    this.booting = this.pendingActions.length > 0;
     this.readiness = new TerminalTabReadinessController<TerminalPanelSessionTab>({
       timeoutMs: () => this.host.catalogReadyTimeoutMs,
       isCurrent: (tab) => this.tabs.includes(tab),
@@ -137,20 +154,28 @@ export class TerminalPanelSessionController
       this.refreshBeforeReconnectRestore(shouldRestore);
     } else if (shouldRestore) {
       void this.restoreSessions();
+    } else {
+      void this.drainPendingActions();
     }
   }
 
   private refreshBeforeReconnectRestore(restore: boolean): void {
     const generation = this.lifecycleGeneration;
     this.refreshPending = true;
+    this.clearRefreshFailure();
+    this.clearRefreshTimer();
+    if (restore) {
+      void this.restoreSessions();
+    }
+    this.armRefreshTimer(generation);
     const release = () => {
       if (generation !== this.lifecycleGeneration || !this.host.isConnected) {
         return;
       }
+      this.clearRefreshTimer();
       this.refreshPending = false;
-      if (restore || this.host.terminalPanelOpen) {
-        void this.restoreSessions();
-      }
+      this.clearRefreshFailure();
+      void this.drainPendingActions();
     };
     void import("../../app/sw-refresh.runtime.ts")
       .then(({ refreshControlUiServiceWorker }) => refreshControlUiServiceWorker())
@@ -162,21 +187,161 @@ export class TerminalPanelSessionController
   }
 
   async restoreSessions(): Promise<void> {
-    await this.bootQueue.enqueueSteps(
-      () => this.reattachPersistedSessions(),
-      () => this.ensureInitialSession(),
-    );
+    await this.queueTerminalAction({ kind: "restore", agentId: this.selectedAgentId() });
   }
 
   async openCatalogSession(catalog: TerminalPanelCatalogReference): Promise<void> {
-    await this.bootQueue.enqueueSteps(
-      () => this.reattachPersistedSessions(),
-      () => this.openSessionNow(catalog),
-    );
+    await this.queueTerminalAction({
+      kind: "catalog",
+      agentId: this.selectedAgentId(),
+      catalog,
+    });
   }
 
   async openRequestedSession(sessionId: string): Promise<void> {
-    await this.enqueueAttachSession(sessionId, true);
+    await this.queueTerminalAction({ kind: "attach", sessionId, agentOwned: true });
+  }
+
+  private selectedAgentId(): string | null {
+    return this.host.agentId?.trim() || null;
+  }
+
+  private actionKey(action: TerminalPanelAction): string {
+    return JSON.stringify(action);
+  }
+
+  private async queueTerminalAction(action: TerminalPanelAction): Promise<void> {
+    let changed = false;
+    if (action.kind !== "restore") {
+      for (let index = this.pendingActions.length - 1; index >= 0; index -= 1) {
+        if (this.pendingActions[index]?.kind === "restore") {
+          this.pendingActions.splice(index, 1);
+          changed = true;
+        }
+      }
+    }
+    const key = this.actionKey(action);
+    if (!this.pendingActions.some((pending) => this.actionKey(pending) === key)) {
+      this.pendingActions.push(action);
+      changed = true;
+    }
+    if (changed) {
+      persistTerminalActions(this.pendingActions);
+    }
+    this.armRefreshTimer(this.lifecycleGeneration);
+    if (this.refreshPending) {
+      this.host.requestUpdate();
+    } else if (this.tabs.length === 0) {
+      this.updateControllerState("booting", true);
+    }
+    await this.drainPendingActions();
+  }
+
+  private terminalActionsCanRun(): boolean {
+    const client = this.host.client;
+    return (
+      !this.refreshPending &&
+      Boolean(client) &&
+      client === this.activeClient &&
+      this.host.available &&
+      this.host.isConnected
+    );
+  }
+
+  private async drainPendingActions(): Promise<void> {
+    if (
+      this.actionDrainScheduled ||
+      this.pendingActions.length === 0 ||
+      !this.terminalActionsCanRun()
+    ) {
+      return;
+    }
+    this.actionDrainScheduled = true;
+    try {
+      await this.bootQueue.enqueue(async (isCurrent) => {
+        const action = this.pendingActions[0];
+        if (!action || !isCurrent() || !this.terminalActionsCanRun()) {
+          return;
+        }
+        const completed = await this.executeTerminalAction(action);
+        if (!completed || !isCurrent()) {
+          return;
+        }
+        const index = this.pendingActions.indexOf(action);
+        if (index !== -1) {
+          this.pendingActions.splice(index, 1);
+          persistTerminalActions(this.pendingActions);
+        }
+      });
+    } finally {
+      this.actionDrainScheduled = false;
+      if (this.pendingActions.length > 0 && this.terminalActionsCanRun()) {
+        void this.drainPendingActions();
+      } else if (this.pendingActions.length === 0 && this.tabs.length === 0) {
+        this.updateControllerState("booting", false);
+      }
+    }
+  }
+
+  private async executeTerminalAction(action: TerminalPanelAction): Promise<boolean> {
+    if (action.kind === "attach") {
+      return this.attachSessionNow(action.sessionId, action.agentOwned);
+    }
+    if (action.kind === "open") {
+      return this.openSessionNow(undefined, action.agentId);
+    }
+    await this.reattachPersistedSessions();
+    if (!this.terminalActionsCanRun()) {
+      return false;
+    }
+    return action.kind === "catalog"
+      ? this.openSessionNow(action.catalog, action.agentId)
+      : this.ensureInitialSession(action.agentId);
+  }
+
+  cancelPendingActions(): void {
+    this.pendingActions.splice(0);
+    persistTerminalActions(this.pendingActions);
+    this.updateControllerState("booting", false);
+    this.clearRefreshFailure();
+  }
+
+  get waitingForRefresh(): boolean {
+    return this.refreshPending && !this.refreshTimedOut && this.pendingActions.length > 0;
+  }
+
+  private clearRefreshTimer(): void {
+    if (this.refreshTimer !== null) {
+      globalThis.clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private clearRefreshFailure(): void {
+    if (this.refreshTimedOut) {
+      this.host.terminalPanelErrorText = null;
+      this.refreshTimedOut = false;
+    }
+  }
+
+  private armRefreshTimer(generation: number): void {
+    if (!this.refreshPending || this.refreshTimer !== null || this.pendingActions.length === 0) {
+      return;
+    }
+    this.refreshTimer = globalThis.setTimeout(() => {
+      this.refreshTimer = null;
+      if (
+        generation !== this.lifecycleGeneration ||
+        !this.host.isConnected ||
+        !this.refreshPending ||
+        this.pendingActions.length === 0
+      ) {
+        return;
+      }
+      this.refreshTimedOut = true;
+      this.host.terminalPanelErrorText = t("terminal.refreshRequired");
+      this.updateControllerState("booting", false);
+    }, this.host.catalogReadyTimeoutMs);
   }
 
   private async reattachPersistedSessions(): Promise<void> {
@@ -230,10 +395,11 @@ export class TerminalPanelSessionController
     persistLiveTerminalSessions(this.tabs);
   }
 
-  private async ensureInitialSession(): Promise<void> {
-    if (this.tabs.length === 0 && !this.booting) {
-      await this.openSessionNow();
+  private async ensureInitialSession(agentId: string | null): Promise<boolean> {
+    if (this.tabs.length === 0) {
+      return this.openSessionNow(undefined, agentId);
     }
+    return this.terminalActionsCanRun();
   }
 
   async listSessions(): Promise<TerminalSessionInfo[] | null> {
@@ -250,33 +416,36 @@ export class TerminalPanelSessionController
   }
 
   async attachSessionById(sessionId: string, agentOwned = false): Promise<void> {
-    await this.enqueueAttachSession(sessionId, agentOwned);
+    await this.queueTerminalAction({ kind: "attach", sessionId, agentOwned });
   }
 
-  private async enqueueAttachSession(sessionId: string, agentOwned: boolean): Promise<void> {
-    await this.bootQueue.enqueue(async () => {
-      const existing = this.tabs.find((tab) => tab.gatewaySessionId === sessionId);
-      if (existing) {
-        this.switchTo(existing.id);
-        return;
+  private async attachSessionNow(sessionId: string, agentOwned: boolean): Promise<boolean> {
+    const existing = this.tabs.find((tab) => tab.gatewaySessionId === sessionId);
+    if (existing) {
+      this.switchTo(existing.id);
+      return true;
+    }
+    const operation = this.captureTerminalOperation();
+    if (!operation) {
+      return false;
+    }
+    this.updateControllerState("booting", true);
+    this.host.terminalPanelErrorText = null;
+    try {
+      const attached = await this.attachSession(sessionId, operation, agentOwned);
+      if (attached) {
+        return true;
       }
-      const operation = this.captureTerminalOperation();
-      if (!operation) {
-        return;
+      if (!this.isTerminalOperationCurrent(operation)) {
+        return false;
       }
-      this.updateControllerState("booting", true);
-      this.host.terminalPanelErrorText = null;
-      try {
-        const attached = await this.attachSession(sessionId, operation, agentOwned);
-        if (!attached && this.isTerminalOperationCurrent(operation)) {
-          this.host.terminalPanelErrorText = t("terminal.attachFailed");
-        }
-      } finally {
-        if (this.isTerminalOperationCurrent(operation)) {
-          this.updateControllerState("booting", false);
-        }
+      this.host.terminalPanelErrorText = t("terminal.attachFailed");
+      return true;
+    } finally {
+      if (this.isTerminalOperationCurrent(operation)) {
+        this.updateControllerState("booting", false);
       }
-    });
+    }
   }
 
   /** Boots a tab with a libterminal controller, ready for an open or attach RPC. */
@@ -447,25 +616,37 @@ export class TerminalPanelSessionController
   }
 
   async openSession(catalog?: TerminalPanelCatalogReference): Promise<void> {
-    await this.bootQueue.enqueue(() => this.openSessionNow(catalog));
+    await this.queueTerminalAction(
+      catalog
+        ? { kind: "catalog", agentId: this.selectedAgentId(), catalog }
+        : { kind: "open", agentId: this.selectedAgentId() },
+    );
   }
 
-  private async openSessionNow(catalog?: TerminalPanelCatalogReference): Promise<void> {
+  private async openSessionNow(
+    catalog: TerminalPanelCatalogReference | undefined,
+    agentId: string | null,
+  ): Promise<boolean> {
     const operation = this.captureTerminalOperation();
     if (!operation) {
-      return;
+      return false;
     }
     this.updateControllerState("booting", true);
     this.host.terminalPanelErrorText = null;
     // Freeze the selection for this tab; later agent changes affect only new tabs.
-    const agentId = this.host.agentId?.trim() || undefined;
+    const ownerAgentId = agentId ?? undefined;
     // Tracked outside the try so the catch can dispose a tab whose open failed.
     let createdTab: TerminalPanelSessionTab | undefined;
     try {
       const boot = await this.bootTab(operation, { awaitFirstOutput: Boolean(catalog) });
       createdTab = boot.tab;
       const result = await boot.connection.open(
-        { agentId, cols: boot.cols, rows: boot.rows, ...(catalog ? { catalog } : {}) },
+        {
+          agentId: ownerAgentId,
+          cols: boot.cols,
+          rows: boot.rows,
+          ...(catalog ? { catalog } : {}),
+        },
         boot.sink,
       );
       if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
@@ -477,10 +658,11 @@ export class TerminalPanelSessionController
           boot.tab.cancelled = "lifecycle";
           this.dropFailedTab(boot.tab);
         }
-        return;
+        return false;
       }
       this.adoptSession(boot.tab, result);
       boot.tab.controller.terminal.focus();
+      return true;
     } catch (error) {
       // A failed open (e.g. terminal disabled or a sandboxed agent is refused)
       // must not leave a phantom "live" tab with no server session. Drop it but
@@ -489,7 +671,7 @@ export class TerminalPanelSessionController
         this.dropFailedTab(createdTab);
       }
       if (!this.isTerminalOperationCurrent(operation)) {
-        return;
+        return false;
       }
       this.host.terminalPanelErrorText =
         error instanceof TerminalOpenTimeoutError
@@ -497,6 +679,7 @@ export class TerminalPanelSessionController
           : error instanceof Error
             ? error.message
             : String(error);
+      return true;
     } finally {
       if (this.isTerminalOperationCurrent(operation)) {
         this.updateControllerState("booting", false);
@@ -696,7 +879,9 @@ export class TerminalPanelSessionController
 
   private disposeAllTabs(): void {
     this.lifecycleGeneration += 1;
+    this.clearRefreshTimer();
     this.refreshPending = false;
+    this.clearRefreshFailure();
     this.lifecycleAbortController.abort();
     this.lifecycleAbortController = new AbortController();
     this.bootQueue.reset();

--- a/ui/src/components/terminal/terminal-panel-session-types.ts
+++ b/ui/src/components/terminal/terminal-panel-session-types.ts
@@ -7,7 +7,6 @@ import type { ReactiveControllerHost } from "lit";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
 import type { TerminalPanelTab } from "./terminal-panel-tabs.ts";
 import type { TerminalPanelUploadController } from "./terminal-panel-upload.ts";
-import { persistTerminalSessionIds } from "./terminal-session-storage.ts";
 import type { StartupInputBuffer } from "./terminal-startup-input.ts";
 import type { TerminalTabReadinessState } from "./terminal-tab-readiness.ts";
 
@@ -86,12 +85,4 @@ export function forceTerminalRender(controller: GhosttyTerminalController): void
     // An omitted opacity defaults to 1; repaint without inventing a visible scrollbar.
     term.renderer.render(term.wasmTerm, true, term.viewportY, term, 0);
   }
-}
-
-export function persistLiveTerminalSessions(tabs: readonly TerminalPanelSessionTab[]): void {
-  persistTerminalSessionIds(
-    tabs
-      .filter((tab) => tab.status === "live" && tab.gatewaySessionId)
-      .map((tab) => tab.gatewaySessionId),
-  );
 }

--- a/ui/src/components/terminal/terminal-panel-session-types.ts
+++ b/ui/src/components/terminal/terminal-panel-session-types.ts
@@ -35,6 +35,13 @@ export type TerminalPanelCatalogReference = {
   threadId: string;
 };
 
+/** Explicit terminal work retained until it either runs or reports a visible failure. */
+export type TerminalPanelAction =
+  | { kind: "restore"; agentId: string | null }
+  | { kind: "open"; agentId: string | null }
+  | { kind: "catalog"; agentId: string | null; catalog: TerminalPanelCatalogReference }
+  | { kind: "attach"; sessionId: string; agentOwned: boolean };
+
 export type TerminalPanelSessionControllerState = {
   tabs: TerminalPanelSessionTab[];
   activeId: string | null;

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -184,6 +184,9 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
         ? (event.detail as TerminalPanelToggleDetail)
         : null;
     const dock = detail?.dock === "right" || detail?.dock === "bottom" ? detail.dock : null;
+    if (detail?.agentId !== undefined) {
+      this.agentId = detail.agentId;
+    }
     if (dock) {
       this.dockLayout.setDock(dock, false);
     }

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -211,6 +211,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
 
   closeTerminalPanel(): void {
     this.closeSessionPicker(false);
+    this.terminalSessions.cancelPendingActions();
     this.dockLayout.setOpen(false);
   }
 
@@ -346,6 +347,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       (tab) => tab.id === this.terminalSessions.activeId,
     );
     const connecting =
+      this.terminalSessions.waitingForRefresh ||
       (this.terminalSessions.booting && this.terminalSessions.tabs.length === 0) ||
       activeTab?.status === "connecting";
     const sessionPicker = renderTerminalSessionPicker({

--- a/ui/src/components/terminal/terminal-pending-actions.ts
+++ b/ui/src/components/terminal/terminal-pending-actions.ts
@@ -1,0 +1,195 @@
+import type {
+  TerminalPanelAction,
+  TerminalPanelCatalogReference,
+} from "./terminal-panel-session-types.ts";
+import {
+  loadPersistedTerminalActions,
+  persistTerminalActions,
+} from "./terminal-session-storage.ts";
+import type { TerminalTaskQueue } from "./terminal-task-queue.ts";
+
+type TerminalPendingActionsOptions = {
+  bootQueue: Pick<TerminalTaskQueue, "enqueue">;
+  currentGeneration: () => number;
+  canRun: () => boolean;
+  attach: (sessionId: string, agentOwned: boolean) => Promise<boolean>;
+  open: (
+    catalog: TerminalPanelCatalogReference | undefined,
+    agentId: string | null,
+  ) => Promise<boolean>;
+  reattach: () => Promise<void>;
+  ensureInitial: (agentId: string | null) => Promise<boolean>;
+  hasTabs: () => boolean;
+  requestUpdate: () => void;
+  setBooting: (booting: boolean) => void;
+  timeoutMs: () => number;
+  showTimeout: () => void;
+  clearTimeout: () => void;
+};
+
+/** Keeps admitted terminal actions owned across reconnect generations and document reloads. */
+export class TerminalPendingActions {
+  private readonly actions: TerminalPanelAction[];
+  private refreshPending = false;
+  private refreshTimedOut = false;
+  private refreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private drainScheduled = false;
+
+  constructor(private readonly options: TerminalPendingActionsOptions) {
+    const persisted = loadPersistedTerminalActions();
+    // Explicit user work supersedes a generic reconnect restore. Otherwise the
+    // restored shell would open first and obscure the action the operator chose.
+    this.actions = persisted.some((action) => action.kind !== "restore")
+      ? persisted.filter((action) => action.kind !== "restore")
+      : persisted;
+    if (this.actions.length !== persisted.length) {
+      persistTerminalActions(this.actions);
+    }
+  }
+
+  get hasActions(): boolean {
+    return this.actions.length > 0;
+  }
+
+  get fenced(): boolean {
+    return this.refreshPending;
+  }
+
+  get waitingForRefresh(): boolean {
+    return this.refreshPending && !this.refreshTimedOut && this.actions.length > 0;
+  }
+
+  beginRefreshFence(generation: number): void {
+    this.refreshPending = true;
+    this.clearRefreshFailure();
+    this.clearRefreshTimer();
+    this.armRefreshTimer(generation);
+  }
+
+  releaseRefreshFence(): void {
+    this.clearRefreshTimer();
+    this.refreshPending = false;
+    this.clearRefreshFailure();
+    void this.drain();
+  }
+
+  resetLifecycle(): void {
+    this.clearRefreshTimer();
+    this.refreshPending = false;
+    this.clearRefreshFailure();
+  }
+
+  async queue(action: TerminalPanelAction): Promise<void> {
+    let changed = false;
+    if (action.kind !== "restore") {
+      for (let index = this.actions.length - 1; index >= 0; index -= 1) {
+        if (this.actions[index]?.kind === "restore") {
+          this.actions.splice(index, 1);
+          changed = true;
+        }
+      }
+    }
+    const key = JSON.stringify(action);
+    if (!this.actions.some((pending) => JSON.stringify(pending) === key)) {
+      this.actions.push(action);
+      changed = true;
+    }
+    if (changed) {
+      persistTerminalActions(this.actions);
+    }
+    this.armRefreshTimer(this.options.currentGeneration());
+    if (this.refreshPending) {
+      this.options.requestUpdate();
+    } else if (!this.options.hasTabs()) {
+      this.options.setBooting(true);
+    }
+    await this.drain();
+  }
+
+  async drain(): Promise<void> {
+    if (this.drainScheduled || this.actions.length === 0 || !this.options.canRun()) {
+      return;
+    }
+    this.drainScheduled = true;
+    try {
+      await this.options.bootQueue.enqueue(async (isCurrent) => {
+        const action = this.actions[0];
+        if (!action || !isCurrent() || !this.options.canRun()) {
+          return;
+        }
+        const completed = await this.execute(action);
+        if (!completed || !isCurrent()) {
+          return;
+        }
+        const index = this.actions.indexOf(action);
+        if (index !== -1) {
+          this.actions.splice(index, 1);
+          persistTerminalActions(this.actions);
+        }
+      });
+    } finally {
+      this.drainScheduled = false;
+      if (this.actions.length > 0 && this.options.canRun()) {
+        void this.drain();
+      } else if (this.actions.length === 0 && !this.options.hasTabs()) {
+        this.options.setBooting(false);
+      }
+    }
+  }
+
+  cancel(): void {
+    this.actions.splice(0);
+    persistTerminalActions(this.actions);
+    this.options.setBooting(false);
+    this.clearRefreshFailure();
+  }
+
+  private async execute(action: TerminalPanelAction): Promise<boolean> {
+    if (action.kind === "attach") {
+      return this.options.attach(action.sessionId, action.agentOwned);
+    }
+    if (action.kind === "open") {
+      return this.options.open(undefined, action.agentId);
+    }
+    await this.options.reattach();
+    if (!this.options.canRun()) {
+      return false;
+    }
+    return action.kind === "catalog"
+      ? this.options.open(action.catalog, action.agentId)
+      : this.options.ensureInitial(action.agentId);
+  }
+
+  private clearRefreshTimer(): void {
+    if (this.refreshTimer !== null) {
+      globalThis.clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private clearRefreshFailure(): void {
+    if (this.refreshTimedOut) {
+      this.options.clearTimeout();
+      this.refreshTimedOut = false;
+    }
+  }
+
+  private armRefreshTimer(generation: number): void {
+    if (!this.refreshPending || this.refreshTimer !== null || this.actions.length === 0) {
+      return;
+    }
+    this.refreshTimer = globalThis.setTimeout(() => {
+      this.refreshTimer = null;
+      if (
+        generation !== this.options.currentGeneration() ||
+        !this.refreshPending ||
+        this.actions.length === 0
+      ) {
+        return;
+      }
+      this.refreshTimedOut = true;
+      this.options.showTimeout();
+      this.options.setBooting(false);
+    }, this.options.timeoutMs());
+  }
+}

--- a/ui/src/components/terminal/terminal-session-storage.ts
+++ b/ui/src/components/terminal/terminal-session-storage.ts
@@ -5,6 +5,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
   TerminalPanelAction,
   TerminalPanelCatalogReference,
+  TerminalPanelSessionTab,
 } from "./terminal-panel-session-types.ts";
 
 const TERMINAL_SESSIONS_KEY = "openclaw.terminal.sessions.v1";
@@ -77,6 +78,14 @@ export function persistTerminalSessionIds(ids: readonly string[]): void {
   } catch {
     // Storage may be unavailable (private mode); reattach just won't work.
   }
+}
+
+export function persistLiveTerminalSessions(tabs: readonly TerminalPanelSessionTab[]): void {
+  persistTerminalSessionIds(
+    tabs
+      .filter((tab) => tab.status === "live" && tab.gatewaySessionId)
+      .map((tab) => tab.gatewaySessionId),
+  );
 }
 
 export function loadPersistedTerminalActions(): TerminalPanelAction[] {

--- a/ui/src/components/terminal/terminal-session-storage.ts
+++ b/ui/src/components/terminal/terminal-session-storage.ts
@@ -1,7 +1,60 @@
 // Session ids deliberately use per-tab storage: attach is a takeover, so shared
 // local storage could let one Control UI window steal another window's shells.
 
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type {
+  TerminalPanelAction,
+  TerminalPanelCatalogReference,
+} from "./terminal-panel-session-types.ts";
+
 const TERMINAL_SESSIONS_KEY = "openclaw.terminal.sessions.v1";
+const TERMINAL_ACTIONS_KEY = "openclaw.terminal.actions.v1";
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function catalogReference(value: unknown): TerminalPanelCatalogReference | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  return nonEmptyString(value.catalogId) &&
+    nonEmptyString(value.hostId) &&
+    nonEmptyString(value.threadId)
+    ? {
+        catalogId: value.catalogId,
+        hostId: value.hostId,
+        threadId: value.threadId,
+      }
+    : null;
+}
+
+function terminalAction(value: unknown): TerminalPanelAction | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (value.kind === "attach") {
+    return nonEmptyString(value.sessionId) && typeof value.agentOwned === "boolean"
+      ? {
+          kind: "attach",
+          sessionId: value.sessionId,
+          agentOwned: value.agentOwned,
+        }
+      : null;
+  }
+  const agentId = value.agentId;
+  if (agentId !== null && !nonEmptyString(agentId)) {
+    return null;
+  }
+  if (value.kind === "restore" || value.kind === "open") {
+    return { kind: value.kind, agentId };
+  }
+  if (value.kind === "catalog") {
+    const catalog = catalogReference(value.catalog);
+    return catalog ? { kind: "catalog", agentId, catalog } : null;
+  }
+  return null;
+}
 
 export function loadPersistedTerminalSessionIds(): string[] {
   try {
@@ -23,5 +76,35 @@ export function persistTerminalSessionIds(ids: readonly string[]): void {
     globalThis.sessionStorage?.setItem(TERMINAL_SESSIONS_KEY, JSON.stringify(ids));
   } catch {
     // Storage may be unavailable (private mode); reattach just won't work.
+  }
+}
+
+export function loadPersistedTerminalActions(): TerminalPanelAction[] {
+  try {
+    const raw = globalThis.sessionStorage?.getItem(TERMINAL_ACTIONS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.flatMap((value) => {
+          const action = terminalAction(value);
+          return action ? [action] : [];
+        })
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function persistTerminalActions(actions: readonly TerminalPanelAction[]): void {
+  try {
+    if (actions.length === 0) {
+      globalThis.sessionStorage?.removeItem(TERMINAL_ACTIONS_KEY);
+      return;
+    }
+    globalThis.sessionStorage?.setItem(TERMINAL_ACTIONS_KEY, JSON.stringify(actions));
+  } catch {
+    // In-memory replay still covers an unchanged document when storage is unavailable.
   }
 }

--- a/ui/src/components/terminal/terminal-session-storage.ts
+++ b/ui/src/components/terminal/terminal-session-storage.ts
@@ -72,7 +72,7 @@ export function loadPersistedTerminalSessionIds(): string[] {
   }
 }
 
-export function persistTerminalSessionIds(ids: readonly string[]): void {
+function persistTerminalSessionIds(ids: readonly string[]): void {
   try {
     globalThis.sessionStorage?.setItem(TERMINAL_SESSIONS_KEY, JSON.stringify(ids));
   } catch {

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
@@ -20,11 +21,17 @@ const workerUpdateVersionsStorageKey = "openclaw.control-ui-e2e.worker-update-ve
 
 const buildA = "service-worker-build-a";
 const buildB = "service-worker-build-b";
-const releaseInstallMessageType = "openclaw-control-ui-e2e-release-install";
 
 type BuildAsset = {
   path: string;
   sha256: string;
+};
+
+type InstallGate = {
+  url: string;
+  requested: Promise<void>;
+  release: () => void;
+  close: () => Promise<void>;
 };
 
 let browser: Browser;
@@ -48,7 +55,47 @@ async function findBuildAsset(buildId: string, buildDir = outDir): Promise<Build
   throw new Error(`Production Control UI output did not contain build id ${buildId}`);
 }
 
-async function holdReplacementWorkerInstalling(buildDir: string): Promise<void> {
+async function createInstallGate(): Promise<InstallGate> {
+  let releaseResponse = () => {};
+  let resolveRequested = () => {};
+  const requested = new Promise<void>((resolve) => {
+    resolveRequested = resolve;
+  });
+  const gateServer = createHttpServer((_request, response) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    releaseResponse = () => {
+      if (!response.writableEnded) {
+        response.statusCode = 204;
+        response.end();
+      }
+    };
+    resolveRequested();
+  });
+  await new Promise<void>((resolve, reject) => {
+    gateServer.once("error", reject);
+    gateServer.listen(0, "127.0.0.1", () => {
+      gateServer.off("error", reject);
+      resolve();
+    });
+  });
+  const address = gateServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Install gate did not expose a TCP port");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/release-install`,
+    requested,
+    release: () => releaseResponse(),
+    close: async () => {
+      releaseResponse();
+      await new Promise<void>((resolve, reject) => {
+        gateServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+async function holdReplacementWorkerInstalling(buildDir: string, gateUrl: string): Promise<void> {
   const workerPath = path.join(buildDir, "sw.js");
   const source = await readFile(workerPath, "utf8");
   const install =
@@ -60,7 +107,7 @@ async function holdReplacementWorkerInstalling(buildDir: string): Promise<void> 
     workerPath,
     source.replace(
       install,
-      `event.waitUntil(Promise.all([new Promise((resolve) => { const release = (messageEvent) => { if (messageEvent.data?.type !== ${JSON.stringify(releaseInstallMessageType)}) return; self.removeEventListener("message", release); resolve(); }; self.addEventListener("message", release); }), caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))]));`,
+      `event.waitUntil(Promise.all([fetch(${JSON.stringify(gateUrl)}), caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))]));`,
     ),
   );
 }
@@ -240,6 +287,7 @@ describe("Control UI service-worker production update E2E", () => {
       },
       terminalEnabled: true,
     });
+    let installGate: InstallGate | null = null;
 
     try {
       expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
@@ -258,8 +306,9 @@ describe("Control UI service-worker production update E2E", () => {
 
       const nextOutDir = `${outDir}-next`;
       const previousOutDir = `${outDir}-previous`;
+      installGate = await createInstallGate();
       await buildProductionControlUiE2e(nextOutDir, buildB);
-      await holdReplacementWorkerInstalling(nextOutDir);
+      await holdReplacementWorkerInstalling(nextOutDir, installGate.url);
       const assetB = await findBuildAsset(buildB, nextOutDir);
       expect(assetB.path).not.toBe(assetA.path);
       expect(assetB.sha256).not.toBe(assetA.sha256);
@@ -279,6 +328,7 @@ describe("Control UI service-worker production update E2E", () => {
       await page.evaluate(() => window.history.replaceState(window.history.state, "", "/"));
       const reloaded = page.waitForEvent("domcontentloaded");
       await gateway.setOnline(true);
+      await installGate.requested;
       await page.waitForFunction(async () => {
         const registration = await navigator.serviceWorker.getRegistration();
         return registration?.installing?.state === "installing";
@@ -308,10 +358,7 @@ describe("Control UI service-worker production update E2E", () => {
         .toContain("thread-during-worker-refresh");
       await page.waitForTimeout(300);
       expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
-      await page.evaluate(async (messageType) => {
-        const registration = await navigator.serviceWorker.getRegistration();
-        registration?.installing?.postMessage({ type: messageType });
-      }, releaseInstallMessageType);
+      installGate.release();
       await reloaded;
       await ensureControlledPage(page, pageErrors, buildB);
       await expect.poll(() => readWorkerUpdateVersions(page)).toContain(buildB);
@@ -364,6 +411,7 @@ describe("Control UI service-worker production update E2E", () => {
         });
       }
     } finally {
+      await installGate?.close();
       await context.close();
     }
   }, 120_000);

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -20,6 +20,7 @@ const workerUpdateVersionsStorageKey = "openclaw.control-ui-e2e.worker-update-ve
 
 const buildA = "service-worker-build-a";
 const buildB = "service-worker-build-b";
+const releaseInstallMessageType = "openclaw-control-ui-e2e-release-install";
 
 type BuildAsset = {
   path: string;
@@ -47,7 +48,7 @@ async function findBuildAsset(buildId: string, buildDir = outDir): Promise<Build
   throw new Error(`Production Control UI output did not contain build id ${buildId}`);
 }
 
-async function holdReplacementWorkerInstalling(buildDir: string, delayMs: number): Promise<void> {
+async function holdReplacementWorkerInstalling(buildDir: string): Promise<void> {
   const workerPath = path.join(buildDir, "sw.js");
   const source = await readFile(workerPath, "utf8");
   const install =
@@ -59,7 +60,7 @@ async function holdReplacementWorkerInstalling(buildDir: string, delayMs: number
     workerPath,
     source.replace(
       install,
-      `event.waitUntil(Promise.all([new Promise((resolve) => setTimeout(resolve, ${delayMs})), caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))]));`,
+      `event.waitUntil(Promise.all([new Promise((resolve) => { const release = (messageEvent) => { if (messageEvent.data?.type !== ${JSON.stringify(releaseInstallMessageType)}) return; self.removeEventListener("message", release); resolve(); }; self.addEventListener("message", release); }), caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))]));`,
     ),
   );
 }
@@ -258,7 +259,7 @@ describe("Control UI service-worker production update E2E", () => {
       const nextOutDir = `${outDir}-next`;
       const previousOutDir = `${outDir}-previous`;
       await buildProductionControlUiE2e(nextOutDir, buildB);
-      await holdReplacementWorkerInstalling(nextOutDir, 2_500);
+      await holdReplacementWorkerInstalling(nextOutDir);
       const assetB = await findBuildAsset(buildB, nextOutDir);
       expect(assetB.path).not.toBe(assetA.path);
       expect(assetB.sha256).not.toBe(assetA.sha256);
@@ -307,6 +308,10 @@ describe("Control UI service-worker production update E2E", () => {
         .toContain("thread-during-worker-refresh");
       await page.waitForTimeout(300);
       expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
+      await page.evaluate(async (messageType) => {
+        const registration = await navigator.serviceWorker.getRegistration();
+        registration?.installing?.postMessage({ type: messageType });
+      }, releaseInstallMessageType);
       await reloaded;
       await ensureControlledPage(page, pageErrors, buildB);
       await expect.poll(() => readWorkerUpdateVersions(page)).toContain(buildB);

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -258,7 +258,7 @@ describe("Control UI service-worker production update E2E", () => {
       const nextOutDir = `${outDir}-next`;
       const previousOutDir = `${outDir}-previous`;
       await buildProductionControlUiE2e(nextOutDir, buildB);
-      await holdReplacementWorkerInstalling(nextOutDir, 1_200);
+      await holdReplacementWorkerInstalling(nextOutDir, 2_500);
       const assetB = await findBuildAsset(buildB, nextOutDir);
       expect(assetB.path).not.toBe(assetA.path);
       expect(assetB.sha256).not.toBe(assetA.sha256);
@@ -282,6 +282,29 @@ describe("Control UI service-worker production update E2E", () => {
         const registration = await navigator.serviceWorker.getRegistration();
         return registration?.installing?.state === "installing";
       });
+      await page.waitForFunction(() => {
+        const panel = document.querySelector("openclaw-terminal-panel") as
+          | (HTMLElement & { available: boolean; terminalPanelOpen: boolean })
+          | null;
+        return panel?.available === true && panel.terminalPanelOpen;
+      });
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent("openclaw:terminal-toggle", {
+            detail: {
+              open: true,
+              catalog: {
+                catalogId: "codex",
+                hostId: "gateway:local",
+                threadId: "thread-during-worker-refresh",
+              },
+            },
+          }),
+        );
+      });
+      await expect
+        .poll(() => page.evaluate(() => sessionStorage.getItem("openclaw.terminal.actions.v1")))
+        .toContain("thread-during-worker-refresh");
       await page.waitForTimeout(300);
       expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
       await reloaded;
@@ -311,7 +334,13 @@ describe("Control UI service-worker production update E2E", () => {
         agentId: "research",
         cols: expect.any(Number),
         rows: expect.any(Number),
+        catalog: {
+          catalogId: "codex",
+          hostId: "gateway:local",
+          threadId: "thread-during-worker-refresh",
+        },
       });
+      expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
 
       await expect
         .poll(() => page.evaluate(() => caches.keys()))

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -55,7 +55,9 @@ suite.define(() => {
         };
         shell.runtime?.context?.agentSelection?.set("research");
         window.dispatchEvent(
-          new CustomEvent("openclaw:terminal-toggle", { detail: { open: true } }),
+          new CustomEvent("openclaw:terminal-toggle", {
+            detail: { agentId: "research", open: true },
+          }),
         );
       });
 

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -20,6 +20,15 @@ suite.define(() => {
         defaultAgentId: "main",
         featureMethods: ["terminal.open"],
         methodResponses: {
+          "agents.list": {
+            agents: [
+              { id: "main", identity: { name: "Main" }, name: "Main" },
+              { id: "research", identity: { name: "Research" }, name: "Research" },
+            ],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
           "terminal.open": {
             agentId: "research",
             confined: false,
@@ -33,6 +42,13 @@ suite.define(() => {
 
       expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
       await gateway.waitForRequest("connect");
+      await gateway.waitForRequest("agents.list");
+      await page.waitForFunction(() => {
+        const panel = document.querySelector("openclaw-terminal-panel") as
+          | (HTMLElement & { available: boolean })
+          | null;
+        return customElements.get("openclaw-terminal-panel") !== undefined && panel?.available;
+      });
       await page.evaluate(() => {
         const shell = document.querySelector("openclaw-app-shell") as HTMLElement & {
           runtime?: { context?: { agentSelection?: { set: (agentId: string) => void } } };

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1943,6 +1943,7 @@ export const en: TranslationMap = {
     attachFailed: "Could not attach terminal session",
     connecting: "Connecting to session…",
     connectionTimedOut: "Session did not connect within 30 seconds.",
+    refreshRequired: "Control UI updated. Reload this page to continue the terminal action.",
     tabLabel: "shell {n}",
     tabHint: "{agent} · {cwd}",
     agentOwnedBadge: "agent",


### PR DESCRIPTION
Related: #123526

## What Problem This Solves

Fixes an issue where explicit terminal actions could disappear when an already-open Control UI tab reconnected during a Gateway deployment. Requested terminal attaches, catalog opens, new tabs, and session-picker attaches were accepted by the panel while its service-worker refresh fence was active, but the session controller returned without retaining the action. Closing the panel during that same window could also let a previously captured restore reopen it later.

The regression was introduced by #123526 / `204be378035e6d2fc1a498309f267dce13f97289`, which correctly fenced stale documents but did not give admitted terminal actions a lifecycle owner.

## Why This Change Was Made

The terminal session controller now owns one tab-local action journal across reconnect generations and service-worker activation reloads. It preserves distinct FIFO intent, deduplicates identical actions, freezes the selected agent when the user clicks, lets explicit work supersede implicit restoration, cancels deferred work when the panel closes, and removes an action only after it runs or produces a visible failure. The old document remains fenced when a replacement worker activates; the new document claims the retained action after reload.

A refresh that cannot make progress for 30 seconds stops presenting an indefinite spinner and tells the operator to reload. Session storage remains per-tab because terminal attach is a takeover; sharing the journal across windows could let one window steal another window's action.

Production delta: +323/-45 lines (net +278), justified by the new cross-document terminal lifecycle owner and validated storage boundary. Tests: +351/-1 lines (net +350).

## User Impact

Terminal actions made during a Gateway deployment now complete exactly once on the current Control UI, in the order requested. Closing the terminal cancels deferred work, and a stalled refresh gives a visible recovery instruction instead of silently doing nothing.

## Evidence

- Before-fix regression: the two new owner tests failed on `204be378035e6d2fc1a498309f267dce13f97289`; requested/catalog actions were replaced by a generic restore and activation reload lost the requested session. Testbox run: https://github.com/openclaw/openclaw/actions/runs/31785037564
- Exact head `16df325b8fa7efb93a57f5172137e27b5d1e8c20`: 39/39 focused terminal lifecycle tests passed on Blacksmith Testbox `tbx_01kzzrm1xdgykx541e5cyhv0s4`.
- Production Chromium: two separately built Control UI bundles, replacement worker held in `installing`, zero stale-document `terminal.open` calls, journal present before activation, then exactly one catalog open after reload with click-time `agentId: research`. Same Testbox run: https://github.com/openclaw/openclaw/actions/runs/31787010860
- Exact-head formatting, i18n verification, conflict/ratchet/dependency/dead-export guards passed; the remaining changed gate is running in the core test type shards.
- Final branch autoreview reported no accepted/actionable findings.
