### PR TITLE
improve(test): skip idle Gateway session servers

### DIFF
--- a/src/gateway/server.sessions.create.projects.test.ts
+++ b/src/gateway/server.sessions.create.projects.test.ts
@@ -11,12 +11,12 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { testState } from "./test-helpers.js";
 import {
   directSessionReq,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();

--- a/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
@@ -20,11 +20,11 @@ import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
   threadBindingMocks,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 const execFileAsync = promisify(execFile);
 
 async function initializeRemoteBackedGitWorkspace(root: string): Promise<string> {

--- a/src/gateway/server.sessions.recover.test.ts
+++ b/src/gateway/server.sessions.recover.test.ts
@@ -5,10 +5,10 @@ import {
   directSessionReq,
   seedSessionTranscript,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 test("sessions.recover rolls over one tombstone and returns its continuation outcome", async () => {
   const { storePath } = await createSessionStoreDir();


### PR DESCRIPTION
## What Problem This Solves

Three Gateway session-handler suites were starting full loopback Gateway servers even though every assertion calls the session handlers directly and none of the tests opens a client connection. That incidental lifecycle work more than doubled the focused shard's wall time and added substantial memory pressure.

## Why This Change Was Made

Use the existing handler-only session harness in the project creation, worktree deletion lifecycle, and recovery suites. The session store setup, handler dispatch, SQLite state, Git/worktree operations, lifecycle ordering, authority checks, and all 13 assertions remain unchanged. Real Gateway transport coverage remains in the client-bearing session suites and RPC wire-contract tests.

## User Impact

No runtime behavior change. Developers and CI receive materially faster feedback from these Gateway session regressions with lower peak memory use.

## Evidence

Measured with the identical serial command on the same reusable Blacksmith Testbox (`tbx_01kzzqgpgrd809mdtcxt78tjy5`): https://github.com/openclaw/openclaw/actions/runs/31785664201

```text
node scripts/run-vitest.mjs \
  src/gateway/server.sessions.create.projects.test.ts \
  src/gateway/server.sessions.delete-worktree-lifecycle.test.ts \
  src/gateway/server.sessions.recover.test.ts \
  --maxWorkers=1 --reporter=verbose
```

| Metric | Full Gateway harness | Handler-only harness | Gain |
| --- | ---: | ---: | ---: |
| Wall time | 24.87s | 11.08s average | -13.79s (-55.4%) |
| Vitest duration | 21.68s | 8.13s average | -13.56s (-62.5%) |
| Test-body time | 14.40s | 5.74s average | -8.67s (-60.2%) |
| Max RSS | 2,002,168 KiB | 1,456,634 KiB average | -545,534 KiB (-27.2%) |
| CPU user / system | 30.08s / 4.82s | 12.13s / 2.05s average | lower in both |

The two post-change samples were 9.95s and 12.21s wall with 1,482,084 KiB and 1,431,184 KiB max RSS. All 13 tests passed in every measured run.

Additional proof:

- Precise `coreTests` changed gate passed on the same Testbox, including formatting, type checking, lint, boundary guards, and dead-export checks.
- Rebased focused run passed all 13 tests.
- Fresh mandatory autoreview reported no accepted or actionable findings.
- Production LOC: +0/-0. Tests: three import/call-site substitutions, net +0/-0.

AI-assisted. No transcript attached.
