### PR TITLE
fix(ui): catalog continuation silently drops staged attachments (image-only send does nothing)

### DIFF
--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -79,6 +79,7 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
   const state = {
     agentsList: null,
     assistantAgentId: null,
+    chatAttachments: [],
     chatError: null,
     chatHistoryPagination: { hasMore: false },
     chatLoading: false,
@@ -715,6 +716,70 @@ describe("chat pane catalog continuation lifecycle", () => {
     });
     expect(state.sessionKey).not.toBe("agent:main:continued");
     expect(state.handleSendChat).not.toHaveBeenCalled();
+  });
+
+  it("carries staged attachments through the continuation handoff", async () => {
+    const request = vi.fn().mockResolvedValue({ sessionKey: "agent:main:continued-attachments" });
+    const { key, pane, state } = createCatalogContinuationPane(request);
+    state.chatAttachments = [
+      {
+        id: "att-1",
+        mimeType: "image/png",
+        fileName: "shot.png",
+        dataUrl: "data:image/png;base64,AAAA",
+      },
+    ];
+
+    await pane.continueCatalogSession(key);
+
+    const handoff = consumePaneSessionHandoff(
+      pane.context,
+      pane.paneId,
+      "agent:main:continued-attachments",
+    );
+    expect(handoff?.send).toBe(true);
+    expect(handoff?.attachments).toHaveLength(1);
+    expect(handoff?.attachments[0]).toMatchObject({
+      mimeType: "image/png",
+      fileName: "shot.png",
+      dataUrl: "data:image/png;base64,AAAA",
+    });
+  });
+
+  it("continues an attachment-only draft instead of silently ignoring the send", async () => {
+    const request = vi.fn().mockResolvedValue({ sessionKey: "agent:main:attachment-only" });
+    const { key, pane, state } = createCatalogContinuationPane(request);
+    state.chatMessage = "";
+    state.chatAttachments = [
+      {
+        id: "att-2",
+        mimeType: "image/png",
+        fileName: "only.png",
+        dataUrl: "data:image/png;base64,BBBB",
+      },
+    ];
+
+    await pane.continueCatalogSession(key);
+
+    expect(request).toHaveBeenCalledWith("sessions.catalog.continue", key);
+    const handoff = consumePaneSessionHandoff(
+      pane.context,
+      pane.paneId,
+      "agent:main:attachment-only",
+    );
+    expect(handoff?.send).toBe(true);
+    expect(handoff?.attachments).toHaveLength(1);
+  });
+
+  it("still ignores a continuation with no draft and no attachments", async () => {
+    const request = vi.fn();
+    const { key, pane, state } = createCatalogContinuationPane(request);
+    state.chatMessage = "   ";
+    state.chatAttachments = [];
+
+    await pane.continueCatalogSession(key);
+
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("does not stage or send a continuation rejected by its logical pane", async () => {

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -17,7 +17,10 @@ import {
   areUiSessionKeysEquivalent,
   parseAgentSessionKey,
 } from "../../lib/sessions/session-key.ts";
-import { replaceChatAttachmentsFromEditor } from "./attachment-payload-store.ts";
+import {
+  cloneChatAttachmentsForIndependentOwner,
+  replaceChatAttachmentsFromEditor,
+} from "./attachment-payload-store.ts";
 import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import {
   loadChatHistory,
@@ -535,8 +538,14 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
     const scope = this.captureConnectionScope();
     const state = scope?.state;
     const client = scope?.client;
-    const draft = state?.chatMessage.trim();
-    if (!scope || !state || !client || !draft || !this.catalogSession?.canContinue) {
+    const draft = state?.chatMessage.trim() ?? "";
+    // Attachments count as composed content: an image-only continuation must
+    // send, not silently no-op while the send button looks live.
+    if (!scope || !state || !client || !this.catalogSession?.canContinue) {
+      return;
+    }
+    const attachments = cloneChatAttachmentsForIndependentOwner(state.chatAttachments);
+    if (!draft && attachments.length === 0) {
       return;
     }
     const sourceSessionKey = state.sessionKey;
@@ -573,7 +582,7 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
         return;
       }
       preparePaneSessionHandoff(this.context, this.paneId, result.sessionKey, {
-        attachments: [],
+        attachments,
         draft,
         send: true,
       });


### PR DESCRIPTION
## What Problem This Solves

A continuable catalog session (e.g. an adopted Codex thread) exposes the full attachment surface — file inputs, the plus-menu, and paste-to-attach — and the send button treats staged attachments as composed content. But `continueCatalogSession` required a non-empty **text** draft and always handed `attachments: []` to the adopted session. Two broken flows:

1. **Draft + images**: the message sends, the images silently vanish (and their payloads leak — the handoff replaced the array without releasing them).
2. **Images only, no text**: the send button is enabled and clicking it does *nothing at all* — the continuation early-returns on the empty draft with no error, no event, no recorded reason. Silent failure on an enabled control.

## Why This Change Was Made

The sibling flows already define the correct contract: new-session adoption (`chat-pane-session-creation.ts`) carries `cloneChatAttachmentsForIndependentOwner(state.chatAttachments)` through the pane handoff, and `applySessionHandoff` + `handleSendChat` fully support attachment-bearing sends (`hasAttachments` alone is sufficient to send). The catalog continuation was the one adoption path that dropped them. This change mirrors the sibling: clone the staged attachments into independent ownership, hand them through the continuation handoff, and count attachments as composed content in the guard. Empty draft with no attachments still no-ops.

## User Impact

Continuing a catalog session with staged screenshots/files now delivers them; an image-only continuation sends instead of dead-ending on a live-looking send button.

## Evidence

- New regression tests (chat-pane-history.test.ts): "carries staged attachments through the continuation handoff" and "continues an attachment-only draft instead of silently ignoring the send" — both fail pre-fix (first: handoff has `attachments: []`; second: request never fires), pass post-fix. A third test pins that a whitespace-only draft with no attachments still no-ops.
- Full suite ui/src/pages/chat/chat-pane-history.test.ts 31/31 green; `pnpm tsgo:ui` clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99 correctness.
- Production LOC: +13/−4 (guard restructure + clone carry; the capability cannot be expressed by deletion — the alternative of disabling the attachment surface for catalog panes would remove working sibling capability).

AI-assisted: yes (autonomous QA campaign; autoreview workflow).
