### PR TITLE
fix(normalization-core): skip quoted prose when locating the JSON start (#122353)

### DIFF
--- a/packages/normalization-core/src/balanced-json.test.ts
+++ b/packages/normalization-core/src/balanced-json.test.ts
@@ -67,6 +67,18 @@ describe("extractBalancedJsonPrefix", () => {
 
     expect(fragment?.json).toBe('{"ok":true}');
   });
+
+  it("does not fall back into an earlier closed span when the unmatched span has no JSON either", () => {
+    // The trailing unterminated span has no delimiter at all, so the fallback
+    // must not retry the earlier, already-closed "first {not}" span just
+    // because it happens to contain a brace - `{not}` isn't valid JSON and
+    // must stay skipped rather than being returned as a false recovery.
+    const raw = '"first {not}" then "unterminated no JSON';
+
+    const fragment = extractBalancedJsonPrefix(raw);
+
+    expect(fragment).toBeNull();
+  });
 });
 
 describe("extractBalancedJsonFragments", () => {

--- a/packages/normalization-core/src/balanced-json.test.ts
+++ b/packages/normalization-core/src/balanced-json.test.ts
@@ -39,6 +39,23 @@ describe("extractBalancedJsonPrefix", () => {
 
     expect(fragment).toBeNull();
   });
+
+  it("still recovers a later valid object after an unterminated leading quote", () => {
+    // A lone, never-closed quote in arbitrary prose must not be treated as
+    // opening a skippable span: doing so would swallow the rest of the text
+    // (including the real JSON) instead of just the malformed prose.
+    const raw = 'banner "unterminated then {"a":1}';
+
+    const fragment = extractBalancedJsonPrefix(raw);
+
+    expect(fragment?.json).toBe('{"a":1}');
+  });
+
+  it("returns null when an unterminated quote leaves no delimiter behind", () => {
+    const fragment = extractBalancedJsonPrefix('banner "unterminated with no json at all');
+
+    expect(fragment).toBeNull();
+  });
 });
 
 describe("extractBalancedJsonFragments", () => {

--- a/packages/normalization-core/src/balanced-json.test.ts
+++ b/packages/normalization-core/src/balanced-json.test.ts
@@ -56,6 +56,17 @@ describe("extractBalancedJsonPrefix", () => {
 
     expect(fragment).toBeNull();
   });
+
+  it("does not resurrect a delimiter from an earlier, already-closed quoted span", () => {
+    // The unterminated-quote fallback must only rescan from its own unclosed
+    // span onward; rescanning from index 0 would pick `{not}` back up out of
+    // the first, already-completed quoted span instead of the real object.
+    const raw = '"first {not}" then "unterminated {"ok":true}';
+
+    const fragment = extractBalancedJsonPrefix(raw);
+
+    expect(fragment?.json).toBe('{"ok":true}');
+  });
 });
 
 describe("extractBalancedJsonFragments", () => {

--- a/packages/normalization-core/src/balanced-json.test.ts
+++ b/packages/normalization-core/src/balanced-json.test.ts
@@ -40,15 +40,14 @@ describe("extractBalancedJsonPrefix", () => {
     expect(fragment).toBeNull();
   });
 
-  it("still recovers a later valid object after an unterminated leading quote", () => {
-    // A lone, never-closed quote in arbitrary prose must not be treated as
-    // opening a skippable span: doing so would swallow the rest of the text
-    // (including the real JSON) instead of just the malformed prose.
-    const raw = 'banner "unterminated then {"a":1}';
+  it("recovers a value found inside the unmatched quote's own span", () => {
+    // A quote still open at end-of-input was never confirmed as prose, so a
+    // literal scan of that span alone may still recover a real value.
+    const raw = 'banner "unterminated [1,2,3]';
 
     const fragment = extractBalancedJsonPrefix(raw);
 
-    expect(fragment?.json).toBe('{"a":1}');
+    expect(fragment?.json).toBe("[1,2,3]");
   });
 
   it("returns null when an unterminated quote leaves no delimiter behind", () => {
@@ -57,23 +56,34 @@ describe("extractBalancedJsonPrefix", () => {
     expect(fragment).toBeNull();
   });
 
-  it("does not resurrect a delimiter from an earlier, already-closed quoted span", () => {
-    // The unterminated-quote fallback must only rescan from its own unclosed
-    // span onward; rescanning from index 0 would pick `{not}` back up out of
-    // the first, already-completed quoted span instead of the real object.
-    const raw = '"first {not}" then "unterminated {"ok":true}';
+  it("never re-enters a completed quoted span, even when nothing else is recoverable", () => {
+    // Quote-safe contract: once a quoted span validly closes, its contents
+    // are prose. When a later unterminated quote makes the rest of the text
+    // ambiguous, the extractor returns no fragment instead of resurrecting
+    // the `{not}` delimiter out of the completed first span.
+    const raw = '"first {not}" then "unterminated no JSON';
 
     const fragment = extractBalancedJsonPrefix(raw);
 
-    expect(fragment?.json).toBe('{"ok":true}');
+    expect(fragment).toBeNull();
   });
 
-  it("does not fall back into an earlier closed span when the unmatched span has no JSON either", () => {
-    // The trailing unterminated span has no delimiter at all, so the fallback
-    // must not retry the earlier, already-closed "first {not}" span just
-    // because it happens to contain a brace - `{not}` isn't valid JSON and
-    // must stay skipped rather than being returned as a false recovery.
-    const raw = '"first {not}" then "unterminated no JSON';
+  it("never extracts parseable JSON that lives inside a completed quoted span", () => {
+    // The quoted text happens to contain valid JSON, but it was quoted as
+    // prose and must stay skipped - parseability is not proof it was a real
+    // value rather than quoted text.
+    const raw = '"{\\"stale\\":true}" then "unterminated no JSON';
+
+    const fragment = extractBalancedJsonPrefix(raw);
+
+    expect(fragment).toBeNull();
+  });
+
+  it("prefers no fragment over quote-blind recovery once spans have closed", () => {
+    // Here the toggle scan pairs the stray quote with the real JSON's own
+    // opening quote, so the object can only be recovered by re-entering a
+    // completed span. The quote-safe contract chooses null over guessing.
+    const raw = 'banner "unterminated then {"a":1}';
 
     const fragment = extractBalancedJsonPrefix(raw);
 

--- a/packages/normalization-core/src/balanced-json.test.ts
+++ b/packages/normalization-core/src/balanced-json.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { extractBalancedJsonFragments, extractBalancedJsonPrefix } from "./balanced-json.js";
+
+describe("extractBalancedJsonPrefix", () => {
+  it("skips an opener inside quoted prose", () => {
+    const raw = 'prefix "notjson{here}" middle {"a":[1,{"b":"c"}]} suffix';
+
+    const fragment = extractBalancedJsonPrefix(raw);
+
+    expect(fragment?.json).toBe('{"a":[1,{"b":"c"}]}');
+  });
+
+  it("skips a bracket inside quoted prose", () => {
+    const raw = 'prose "array[looking]" then [1,2,3] tail';
+
+    const fragment = extractBalancedJsonPrefix(raw);
+
+    expect(fragment?.json).toBe("[1,2,3]");
+  });
+
+  it("keeps skipping prose through an escaped quote, so its brace isn't the start", () => {
+    // The quoted prose contains an escaped quote (`\"`) that must not close
+    // the string early, so the `{no}` inside it stays part of the prose.
+    const raw = 'say "go \\"deep{no}\\" here" then {"ok":true}';
+
+    const fragment = extractBalancedJsonPrefix(raw);
+
+    expect(fragment?.json).toBe('{"ok":true}');
+  });
+
+  it("still extracts a real JSON value with no leading prose", () => {
+    const fragment = extractBalancedJsonPrefix('{"a":1}');
+
+    expect(fragment?.json).toBe('{"a":1}');
+  });
+
+  it("returns null when no balanced value follows any quoted prose", () => {
+    const fragment = extractBalancedJsonPrefix('prefix "notjson{here}" tail');
+
+    expect(fragment).toBeNull();
+  });
+});
+
+describe("extractBalancedJsonFragments", () => {
+  it("skips openers inside quoted prose across multiple fragments", () => {
+    const raw = '"a{1}" first {"x":1} between "b[2]" second [3,4]';
+
+    const fragments = extractBalancedJsonFragments(raw);
+
+    expect(fragments.map((fragment) => fragment.json)).toEqual(['{"x":1}', "[3,4]"]);
+  });
+});

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -15,9 +15,10 @@ function isJsonOpeningDelimiter(
 
 function findLiteralOpeningDelimiter(
   raw: string,
+  fromIndex: number,
   openers: readonly JsonOpeningDelimiter[],
 ): number {
-  let index = 0;
+  let index = fromIndex;
   while (index < raw.length && !isJsonOpeningDelimiter(raw[index], openers)) {
     index += 1;
   }
@@ -25,13 +26,17 @@ function findLiteralOpeningDelimiter(
 }
 
 // Quoted prose before the JSON value is not itself JSON, so a delimiter
-// inside a complete quoted span must not be mistaken for the real start.
-// An unterminated quote can't reliably be told apart from real prose, so it
-// falls back to a literal scan instead of swallowing the rest of the text
-// (which would hide a later, real JSON value from ever being found).
+// inside a complete quoted span must not be mistaken for the real start. An
+// unterminated quote can't reliably be told apart from real prose, so when
+// one is still open at end-of-input, this retries a literal (quote-blind)
+// scan from each quote-opening checkpoint, most recent first, stopping at
+// the first one that recovers a delimiter. This falls back only as far as
+// necessary instead of resurrecting a delimiter from an earlier span that
+// was already validly paired and skipped.
 function findStart(raw: string, openers: readonly JsonOpeningDelimiter[]): number {
   let inString = false;
   let escaped = false;
+  const openQuoteCheckpoints: number[] = [];
   for (let index = 0; index < raw.length; index += 1) {
     const char = raw[index];
     if (inString) {
@@ -46,13 +51,27 @@ function findStart(raw: string, openers: readonly JsonOpeningDelimiter[]): numbe
     }
     if (char === '"') {
       inString = true;
+      openQuoteCheckpoints.push(index);
       continue;
     }
     if (isJsonOpeningDelimiter(char, openers)) {
       return index;
     }
   }
-  return inString ? findLiteralOpeningDelimiter(raw, openers) : raw.length;
+  if (!inString) {
+    return raw.length;
+  }
+  for (let i = openQuoteCheckpoints.length - 1; i >= 0; i -= 1) {
+    const checkpoint = openQuoteCheckpoints[i];
+    if (checkpoint === undefined) {
+      continue;
+    }
+    const candidate = findLiteralOpeningDelimiter(raw, checkpoint, openers);
+    if (candidate < raw.length) {
+      return candidate;
+    }
+  }
+  return raw.length;
 }
 
 /** Extracts the first balanced JSON object/array from text. */

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -25,11 +25,47 @@ function findLiteralOpeningDelimiter(
   return index;
 }
 
-function extractBalancedFrom(
+// Quoted prose before the JSON value is not itself JSON, so a delimiter
+// inside a complete quoted span must not be mistaken for the real start.
+// A quote still open at end-of-input is malformed input rather than prose:
+// its own span was never confirmed as quoted text, so a literal scan inside
+// it is safe, while completed spans before it stay permanently skipped even
+// when that means extracting no fragment at all.
+function findStart(raw: string, openers: readonly JsonOpeningDelimiter[]): number {
+  let inString = false;
+  let escaped = false;
+  let openQuoteIndex = -1;
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      openQuoteIndex = index;
+      continue;
+    }
+    if (isJsonOpeningDelimiter(char, openers)) {
+      return index;
+    }
+  }
+  return inString ? findLiteralOpeningDelimiter(raw, openQuoteIndex, openers) : raw.length;
+}
+
+/** Extracts the first balanced JSON object/array from text. */
+export function extractBalancedJsonPrefix(
   raw: string,
-  start: number,
-  openers: readonly JsonOpeningDelimiter[],
+  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
 ): BalancedJsonFragment | null {
+  const openers = opts.openers ?? (["{", "["] as const);
+  const start = findStart(raw, openers);
   const stack: JsonOpeningDelimiter[] = [];
   let inString = false;
   let escaped = false;
@@ -55,51 +91,6 @@ function extractBalancedFrom(
     }
   }
   return null;
-}
-
-/** Extracts the first balanced JSON object/array from text. */
-export function extractBalancedJsonPrefix(
-  raw: string,
-  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
-): BalancedJsonFragment | null {
-  const openers = opts.openers ?? (["{", "["] as const);
-
-  // Quoted prose before the JSON value is not itself JSON, so a delimiter
-  // inside a complete quoted span must not be mistaken for the real start.
-  let inString = false;
-  let escaped = false;
-  let openQuoteIndex = -1;
-  for (let index = 0; index < raw.length; index += 1) {
-    const char = raw[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      openQuoteIndex = index;
-      continue;
-    }
-    if (isJsonOpeningDelimiter(char, openers)) {
-      return extractBalancedFrom(raw, index, openers);
-    }
-  }
-  if (!inString) {
-    return null;
-  }
-
-  // A quote still open at end-of-input is malformed input rather than prose.
-  // Its own span was never confirmed as quoted text, so a literal scan inside
-  // it is safe; completed quoted spans before it stay permanently skipped,
-  // even when that means extracting no fragment at all.
-  const literalStart = findLiteralOpeningDelimiter(raw, openQuoteIndex, openers);
-  return literalStart < raw.length ? extractBalancedFrom(raw, literalStart, openers) : null;
 }
 
 /** Extracts every balanced JSON object/array fragment from arbitrary text. */

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -25,62 +25,20 @@ function findLiteralOpeningDelimiter(
   return index;
 }
 
-// Quoted prose before the JSON value is not itself JSON, so a delimiter
-// inside a complete quoted span must not be mistaken for the real start. An
-// unterminated quote can't reliably be told apart from real prose, so when
-// one is still open at end-of-input, this retries a literal (quote-blind)
-// scan from each quote-opening checkpoint, most recent first, stopping at
-// the first one that recovers a delimiter. This falls back only as far as
-// necessary instead of resurrecting a delimiter from an earlier span that
-// was already validly paired and skipped.
-function findStart(raw: string, openers: readonly JsonOpeningDelimiter[]): number {
-  let inString = false;
-  let escaped = false;
-  const openQuoteCheckpoints: number[] = [];
-  for (let index = 0; index < raw.length; index += 1) {
-    const char = raw[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      openQuoteCheckpoints.push(index);
-      continue;
-    }
-    if (isJsonOpeningDelimiter(char, openers)) {
-      return index;
-    }
+function isParseableJson(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
   }
-  if (!inString) {
-    return raw.length;
-  }
-  for (let i = openQuoteCheckpoints.length - 1; i >= 0; i -= 1) {
-    const checkpoint = openQuoteCheckpoints[i];
-    if (checkpoint === undefined) {
-      continue;
-    }
-    const candidate = findLiteralOpeningDelimiter(raw, checkpoint, openers);
-    if (candidate < raw.length) {
-      return candidate;
-    }
-  }
-  return raw.length;
 }
 
-/** Extracts the first balanced JSON object/array from text. */
-export function extractBalancedJsonPrefix(
+function extractBalancedFrom(
   raw: string,
-  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
+  start: number,
+  openers: readonly JsonOpeningDelimiter[],
 ): BalancedJsonFragment | null {
-  const openers = opts.openers ?? (["{", "["] as const);
-  const start = findStart(raw, openers);
   const stack: JsonOpeningDelimiter[] = [];
   let inString = false;
   let escaped = false;
@@ -103,6 +61,66 @@ export function extractBalancedJsonPrefix(
       if (stack.length === 0) {
         return { json: raw.slice(start, index + 1), startIndex: start, endIndex: index };
       }
+    }
+  }
+  return null;
+}
+
+/** Extracts the first balanced JSON object/array from text. */
+export function extractBalancedJsonPrefix(
+  raw: string,
+  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
+): BalancedJsonFragment | null {
+  const openers = opts.openers ?? (["{", "["] as const);
+
+  // Quoted prose before the JSON value is not itself JSON, so a delimiter
+  // inside a complete quoted span must not be mistaken for the real start.
+  let inString = false;
+  let escaped = false;
+  const openQuoteCheckpoints: number[] = [];
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      openQuoteCheckpoints.push(index);
+      continue;
+    }
+    if (isJsonOpeningDelimiter(char, openers)) {
+      return extractBalancedFrom(raw, index, openers);
+    }
+  }
+  if (!inString) {
+    return null;
+  }
+
+  // An unterminated quote can't reliably be told apart from real prose, so
+  // retry a literal (quote-blind) scan from each quote-opening checkpoint,
+  // most recent first. A candidate is only accepted once it parses as real
+  // JSON: that's what tells a genuine value hiding behind a malformed quote
+  // apart from actually digging back into already-closed, valid prose (whose
+  // non-JSON contents will fail to parse and must stay skipped).
+  for (let i = openQuoteCheckpoints.length - 1; i >= 0; i -= 1) {
+    const checkpoint = openQuoteCheckpoints[i];
+    if (checkpoint === undefined) {
+      continue;
+    }
+    const literalStart = findLiteralOpeningDelimiter(raw, checkpoint, openers);
+    if (literalStart >= raw.length) {
+      continue;
+    }
+    const fragment = extractBalancedFrom(raw, literalStart, openers);
+    if (fragment && isParseableJson(fragment.json)) {
+      return fragment;
     }
   }
   return null;

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -25,15 +25,6 @@ function findLiteralOpeningDelimiter(
   return index;
 }
 
-function isParseableJson(text: string): boolean {
-  try {
-    JSON.parse(text);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function extractBalancedFrom(
   raw: string,
   start: number,
@@ -77,7 +68,7 @@ export function extractBalancedJsonPrefix(
   // inside a complete quoted span must not be mistaken for the real start.
   let inString = false;
   let escaped = false;
-  const openQuoteCheckpoints: number[] = [];
+  let openQuoteIndex = -1;
   for (let index = 0; index < raw.length; index += 1) {
     const char = raw[index];
     if (inString) {
@@ -92,7 +83,7 @@ export function extractBalancedJsonPrefix(
     }
     if (char === '"') {
       inString = true;
-      openQuoteCheckpoints.push(index);
+      openQuoteIndex = index;
       continue;
     }
     if (isJsonOpeningDelimiter(char, openers)) {
@@ -103,27 +94,12 @@ export function extractBalancedJsonPrefix(
     return null;
   }
 
-  // An unterminated quote can't reliably be told apart from real prose, so
-  // retry a literal (quote-blind) scan from each quote-opening checkpoint,
-  // most recent first. A candidate is only accepted once it parses as real
-  // JSON: that's what tells a genuine value hiding behind a malformed quote
-  // apart from actually digging back into already-closed, valid prose (whose
-  // non-JSON contents will fail to parse and must stay skipped).
-  for (let i = openQuoteCheckpoints.length - 1; i >= 0; i -= 1) {
-    const checkpoint = openQuoteCheckpoints[i];
-    if (checkpoint === undefined) {
-      continue;
-    }
-    const literalStart = findLiteralOpeningDelimiter(raw, checkpoint, openers);
-    if (literalStart >= raw.length) {
-      continue;
-    }
-    const fragment = extractBalancedFrom(raw, literalStart, openers);
-    if (fragment && isParseableJson(fragment.json)) {
-      return fragment;
-    }
-  }
-  return null;
+  // A quote still open at end-of-input is malformed input rather than prose.
+  // Its own span was never confirmed as quoted text, so a literal scan inside
+  // it is safe; completed quoted spans before it stay permanently skipped,
+  // even when that means extracting no fragment at all.
+  const literalStart = findLiteralOpeningDelimiter(raw, openQuoteIndex, openers);
+  return literalStart < raw.length ? extractBalancedFrom(raw, literalStart, openers) : null;
 }
 
 /** Extracts every balanced JSON object/array fragment from arbitrary text. */

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -19,14 +19,11 @@ export function extractBalancedJsonPrefix(
   opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
 ): BalancedJsonFragment | null {
   const openers = opts.openers ?? (["{", "["] as const);
-  let start = 0;
-  while (start < raw.length && !isJsonOpeningDelimiter(raw[start], openers)) {
-    start += 1;
-  }
   const stack: JsonOpeningDelimiter[] = [];
+  let start = -1;
   let inString = false;
   let escaped = false;
-  for (let index = start; index < raw.length; index += 1) {
+  for (let index = 0; index < raw.length; index += 1) {
     const char = raw[index];
     if (inString) {
       if (escaped) {
@@ -36,9 +33,22 @@ export function extractBalancedJsonPrefix(
       } else if (char === '"') {
         inString = false;
       }
-    } else if (char === '"') {
+      continue;
+    }
+    if (char === '"') {
+      // Quoted prose before the JSON value is not itself JSON, so a
+      // delimiter inside it must not be mistaken for the real start (#122353).
       inString = true;
-    } else if (isJsonOpeningDelimiter(char, openers)) {
+      continue;
+    }
+    if (start === -1) {
+      if (isJsonOpeningDelimiter(char, openers)) {
+        start = index;
+        stack.push(char);
+      }
+      continue;
+    }
+    if (isJsonOpeningDelimiter(char, openers)) {
       stack.push(char);
     } else if (stack.length > 0 && char === (stack.at(-1) === "{" ? "}" : "]")) {
       stack.pop();

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -13,14 +13,23 @@ function isJsonOpeningDelimiter(
   return (char === "{" || char === "[") && openers.includes(char);
 }
 
-/** Extracts the first balanced JSON object/array from text. */
-export function extractBalancedJsonPrefix(
+function findLiteralOpeningDelimiter(
   raw: string,
-  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
-): BalancedJsonFragment | null {
-  const openers = opts.openers ?? (["{", "["] as const);
-  const stack: JsonOpeningDelimiter[] = [];
-  let start = -1;
+  openers: readonly JsonOpeningDelimiter[],
+): number {
+  let index = 0;
+  while (index < raw.length && !isJsonOpeningDelimiter(raw[index], openers)) {
+    index += 1;
+  }
+  return index;
+}
+
+// Quoted prose before the JSON value is not itself JSON, so a delimiter
+// inside a complete quoted span must not be mistaken for the real start.
+// An unterminated quote can't reliably be told apart from real prose, so it
+// falls back to a literal scan instead of swallowing the rest of the text
+// (which would hide a later, real JSON value from ever being found).
+function findStart(raw: string, openers: readonly JsonOpeningDelimiter[]): number {
   let inString = false;
   let escaped = false;
   for (let index = 0; index < raw.length; index += 1) {
@@ -36,19 +45,39 @@ export function extractBalancedJsonPrefix(
       continue;
     }
     if (char === '"') {
-      // Quoted prose before the JSON value is not itself JSON, so a
-      // delimiter inside it must not be mistaken for the real start (#122353).
       inString = true;
       continue;
     }
-    if (start === -1) {
-      if (isJsonOpeningDelimiter(char, openers)) {
-        start = index;
-        stack.push(char);
-      }
-      continue;
-    }
     if (isJsonOpeningDelimiter(char, openers)) {
+      return index;
+    }
+  }
+  return inString ? findLiteralOpeningDelimiter(raw, openers) : raw.length;
+}
+
+/** Extracts the first balanced JSON object/array from text. */
+export function extractBalancedJsonPrefix(
+  raw: string,
+  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
+): BalancedJsonFragment | null {
+  const openers = opts.openers ?? (["{", "["] as const);
+  const start = findStart(raw, openers);
+  const stack: JsonOpeningDelimiter[] = [];
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+    } else if (char === '"') {
+      inString = true;
+    } else if (isJsonOpeningDelimiter(char, openers)) {
       stack.push(char);
     } else if (stack.length > 0 && char === (stack.at(-1) === "{" ? "}" : "]")) {
       stack.pop();


### PR DESCRIPTION
Fixes #122353

## Root cause

`extractBalancedJsonPrefix` (`packages/normalization-core/src/balanced-json.ts`) scanned for its first `{`/`[` opening delimiter *before* it started tracking quoted-string state:

```ts
let start = 0;
while (start < raw.length && !isJsonOpeningDelimiter(raw[start], openers)) {
  start += 1;
}
```

So a brace or bracket inside quoted prose that precedes the real JSON value (e.g. `"notjson{here}"`) was picked as the start of the JSON, and the actual JSON value later in the string was never examined.

## Fix

The start search now tracks string/escape state from index `0` instead of only from the discovered `start`. Delimiters encountered inside a quoted span (including one containing an escaped quote) are skipped while searching for the real start, exactly like the balancing loop already does once a start is found. `extractBalancedJsonFragments` composes on top of this function and is fixed as a result.

This helper is used by callers that pull a JSON value out of arbitrary text which may contain quoted prose first: tool-call argument repair, CLI output record parsing, gateway log tail summarization, and credential redaction.

## Malformed-quote contract (maintainer decision requested)

Fixing the reported defect forces a choice about a second, adjacent input class: text where a quote is still **unterminated** at end-of-input. Review iterations established that this class is genuinely ambiguous - `"{\"stale\":true}" then "unterminated no JSON` is byte-for-byte indistinguishable from "a real value hiding behind a malformed quote", so no candidate filter (checkpoint backtracking, `JSON.parse` validation) can separate them. Both were tried and both produced a reviewer-confirmed false positive.

This PR therefore implements the **quote-safe contract**, matching ClawSweeper's recommendation:

| Input class | main today | This PR |
|---|---|---|
| Delimiter inside a **completed** quoted span, real JSON later | returns the prose fragment (the reported bug) | returns the real JSON |
| Delimiter inside a completed quoted span, nothing else | returns the prose fragment | returns `null` |
| Delimiter inside an **unterminated** span (never confirmed as prose) | returns it | returns it (unchanged) |
| Delimiter only inside a completed span, plus a later unterminated quote | returns the prose fragment | returns `null` |

The last row is the intentional behavior change: once a quoted span validly closes, its contents are prose and are never reconsidered, even when that means extracting nothing. The alternative (quote-blind recovery) is what produces the reported bug, so the two cannot both be preserved.

**This is flagged explicitly rather than landed silently.** If maintainers prefer to keep main's quote-blind recovery for that row, it is a small change to the same function plus two test expectations, and I'm happy to flip it.

## Testing

- `packages/normalization-core/src/balanced-json.test.ts` covers:
  - the exact repro from the issue (brace inside quoted prose)
  - a bracket inside quoted prose
  - an escaped quote inside prose that must not end the string early
  - plain JSON with no leading prose, and the no-match case
  - recovery inside an unterminated span's own text
  - the quote-safe contract rows above, including a completed span that quotes **parseable** JSON
  - `extractBalancedJsonFragments` across multiple quoted spans
- `node scripts/run-vitest.mjs run packages/normalization-core/src/balanced-json.test.ts` → 11/11 passed
- Existing suites for every downstream consumer, all passing:
  - `src/agents/cli-output-records.test.ts` (27 tests)
  - `src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts` (31 tests)
  - `src/commands/status-all/gateway.test.ts` (10 tests)
- `tsgo:core` (typecheck) → clean; `oxlint` on touched files → clean
- Live proof on this exact head, exercising the real (unmocked) function directly:
  - `extractBalancedJsonPrefix('prefix "notjson{here}" middle {"a":[1,{"b":"c"}]} suffix')` → `{"a":[1,{"b":"c"}]}` (previously `{here}`)
  - `'banner "unterminated [1,2,3]'` → `[1,2,3]` (recovery inside the unconfirmed span is preserved)
  - `'"first {not}" then "unterminated no JSON'` → `null`
  - `'"{\"stale\":true}" then "unterminated no JSON'` → `null`
  - a synthetic credential-redaction-shaped log line with quoted prose ahead of a real tool-call JSON object now yields exactly the real object, not a fragment carved out of the prose