### PR TITLE
improve(ui): compact transcript selection controls

### DIFF
--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -171,6 +171,19 @@ suite.define(() => {
         expect(focusedOutline.outlineColor).toBe(focusedOutline.mutedStrongColor);
         await captureUiProof(page, "02-chat-thread-keyboard-focus.png");
 
+        // A selection dragged out of the transcript releases outside it, so the
+        // ring must go with the pointer press rather than the release.
+        const threadBox = await thread.boundingBox();
+        if (!threadBox) {
+          throw new Error("Expected a visible transcript");
+        }
+        await page.mouse.move(threadBox.x + threadBox.width / 2, threadBox.y + 40);
+        await page.mouse.down();
+        await page.mouse.move(threadBox.x - 120, threadBox.y + 40, { steps: 8 });
+        await page.mouse.up();
+        expect(await readFocusOutline(thread)).toMatchObject({ outlineStyle: "none" });
+        expect(await thread.evaluate((element) => element === document.activeElement)).toBe(true);
+
         await page.setViewportSize({ height: 650, width: 1440 });
         // Appearance renders schema-independent theme/UI sections that overflow
         // 650px even against the mock gateway's tiny config fixture; General

--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -139,6 +139,15 @@ suite.define(() => {
         });
         await captureUiProof(page, "01-chat-selectable-transcript.png");
 
+        // The browser turns :focus-visible back on for the pointer-focused
+        // transcript at the first keydown, modifiers included; reaching for Shift
+        // while reading must not frame the reading surface.
+        await page.keyboard.press("Shift");
+        expect(await readFocusOutline(thread)).toMatchObject({
+          focusVisible: true,
+          outlineStyle: "none",
+        });
+
         await thread.focus();
         await page.keyboard.press("Tab");
         await expect

--- a/ui/src/pages/chat/components/chat-selection-popup.test.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.test.ts
@@ -72,6 +72,8 @@ describe("chat selection popup", () => {
       "More details",
       "Ask in side chat",
     ]);
+    // The labels carry the meaning, so the compact toolbar ships no icon art.
+    expect(popup?.querySelectorAll("svg")).toHaveLength(0);
 
     buttons[0]?.click();
     expect(onMoreDetailsSpy).toHaveBeenCalledWith("Let's Encrypt cert");

--- a/ui/src/pages/chat/components/chat-selection-popup.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.ts
@@ -45,34 +45,10 @@ function selectionTextWithinChatBubble(
   return text.trim() ? text : null;
 }
 
-function createSelectionPopupButton(
-  label: string,
-  iconPath: string,
-  onActivate: () => void,
-): HTMLButtonElement {
+function createSelectionPopupButton(label: string, onActivate: () => void): HTMLButtonElement {
   const button = document.createElement("button");
   button.type = "button";
-  button.setAttribute("aria-label", label);
-
-  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  icon.setAttribute("viewBox", "0 0 24 24");
-  icon.setAttribute("width", "14");
-  icon.setAttribute("height", "14");
-  icon.setAttribute("fill", "none");
-  icon.setAttribute("stroke", "currentColor");
-  icon.setAttribute("stroke-width", "2");
-  icon.setAttribute("stroke-linecap", "round");
-  icon.setAttribute("stroke-linejoin", "round");
-  icon.setAttribute("aria-hidden", "true");
-  icon.setAttribute("focusable", "false");
-  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  path.setAttribute("d", iconPath);
-  icon.appendChild(path);
-
-  const text = document.createElement("span");
-  text.textContent = label;
-
-  button.append(icon, text);
+  button.textContent = label;
   // pointerdown would collapse the selection before click fires; the popup
   // must keep the selection alive until the action reads it.
   button.addEventListener("pointerdown", (event) => event.preventDefault());
@@ -98,15 +74,11 @@ function showChatSelectionPopup(
     action(selectionText);
   };
   popup.append(
-    createSelectionPopupButton(
-      t("chat.messages.moreDetails"),
-      "M12 3v2m0 14v2M5.6 5.6l1.5 1.5m9.8 9.8 1.5 1.5M3 12h2m14 0h2M5.6 18.4l1.5-1.5m9.8-9.8 1.5-1.5",
-      () => activate(actions.onMoreDetails),
+    createSelectionPopupButton(t("chat.messages.moreDetails"), () =>
+      activate(actions.onMoreDetails),
     ),
-    createSelectionPopupButton(
-      t("chat.messages.askInSideChat"),
-      "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z",
-      () => activate(actions.onAskSideChat),
+    createSelectionPopupButton(t("chat.messages.askInSideChat"), () =>
+      activate(actions.onAskSideChat),
     ),
   );
   document.body.appendChild(popup);

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -354,7 +354,21 @@ function createMessageActionContextButton(params: {
   return { element: tooltip, button };
 }
 
+// :focus-visible turns back on at the next keypress, modifiers included, so a
+// bare Shift would ring the whole transcript long after a click put focus there.
+// Record how focus arrived on the scroll container and let the ring key off that.
+export function syncTranscriptFocusRing(event: FocusEvent | PointerEvent): void {
+  const thread = event.currentTarget;
+  if (!(thread instanceof HTMLElement)) {
+    return;
+  }
+  const arrivedByKeyboard =
+    event.type === "focusin" && event.target === thread && thread.matches(":focus-visible");
+  thread.toggleAttribute("data-keyboard-focus", arrivedByKeyboard);
+}
+
 export function handleTranscriptSelection(event: PointerEvent, props: TranscriptInteractionProps) {
+  syncTranscriptFocusRing(event);
   if (
     typeof props.onCompanionQuestion !== "function" ||
     typeof props.onCompanionPrefill !== "function"

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -357,6 +357,8 @@ function createMessageActionContextButton(params: {
 // :focus-visible turns back on at the next keypress, modifiers included, so a
 // bare Shift would ring the whole transcript long after a click put focus there.
 // Record how focus arrived on the scroll container and let the ring key off that.
+// Pointer-down owns the clearing half: a drag can be released or cancelled
+// outside the transcript, so no later pointer event is guaranteed to arrive.
 export function syncTranscriptFocusRing(event: FocusEvent | PointerEvent): void {
   const thread = event.currentTarget;
   if (!(thread instanceof HTMLElement)) {
@@ -368,7 +370,6 @@ export function syncTranscriptFocusRing(event: FocusEvent | PointerEvent): void 
 }
 
 export function handleTranscriptSelection(event: PointerEvent, props: TranscriptInteractionProps) {
-  syncTranscriptFocusRing(event);
   if (
     typeof props.onCompanionQuestion !== "function" ||
     typeof props.onCompanionPrefill !== "function"

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -9,6 +9,7 @@ import { t } from "../../../i18n/index.ts";
 import {
   handleTranscriptContextMenu,
   handleTranscriptSelection,
+  syncTranscriptFocusRing,
   type ChatThreadProps,
 } from "./chat-thread-interactions.ts";
 import {
@@ -113,8 +114,14 @@ function renderTranscriptShell(
       aria-live="off"
       aria-relevant="additions"
       tabindex="0"
-      @focusin=${(event: FocusEvent) => transcript.handleFocusIn(event)}
-      @focusout=${(event: FocusEvent) => transcript.handleFocusOut(event)}
+      @focusin=${(event: FocusEvent) => {
+        transcript.handleFocusIn(event);
+        syncTranscriptFocusRing(event);
+      }}
+      @focusout=${(event: FocusEvent) => {
+        transcript.handleFocusOut(event);
+        syncTranscriptFocusRing(event);
+      }}
       @scroll=${props.onChatScroll}
       @wheel=${props.onHistoryIntent ? { handleEvent: props.onHistoryIntent, passive: true } : null}
       @keydown=${(event: KeyboardEvent) => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -122,6 +122,7 @@ function renderTranscriptShell(
         transcript.handleFocusOut(event);
         syncTranscriptFocusRing(event);
       }}
+      @pointerdown=${syncTranscriptFocusRing}
       @scroll=${props.onChatScroll}
       @wheel=${props.onHistoryIntent ? { handleEvent: props.onHistoryIntent, passive: true } : null}
       @keydown=${(event: KeyboardEvent) => {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -351,8 +351,17 @@ openclaw-chat-page {
   background: transparent;
 }
 
-/* The oversized clipped transcript owns its focus ring, so it stays inward to keep every edge visible. */
+/* Browsers turn :focus-visible back on at the next keypress, so the global ring
+   in base.css would frame the whole transcript when a modifier follows a click.
+   The transcript opts out and paints its own ring from the arrival modality
+   latched in syncTranscriptFocusRing; both selectors weigh the same, so source
+   order decides on a real keyboard arrival. The ring stays inward because the
+   oversized clipped transcript would otherwise lose an edge. */
 .chat-thread:focus-visible {
+  outline: none;
+}
+
+.chat-thread[data-keyboard-focus] {
   outline: 2px solid var(--muted-strong);
   outline-offset: -2px;
 }
@@ -1621,11 +1630,16 @@ button.chat-reply-preview--message:disabled {
   outline: none;
 }
 
+/* The actions share one surface: `overflow: hidden` clips their hover fill to
+   the container radius, and coarse pointers keep the platform touch target
+   carried by --menu-item-height. */
 .chat-selection-popup {
   position: fixed;
   z-index: 9999;
   display: flex;
   gap: 2px;
+  height: max(32px, var(--menu-item-height));
+  overflow: hidden;
   padding: var(--menu-padding);
   border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
@@ -1637,15 +1651,16 @@ button.chat-reply-preview--message:disabled {
 .chat-selection-popup button {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
+  padding: 5px 10px;
   border: none;
   background: none;
   color: var(--text);
-  min-height: var(--menu-item-height);
-  border-radius: var(--menu-item-radius);
   font-size: 12px;
   white-space: nowrap;
+}
+
+.chat-selection-popup button + button {
+  border-left: 1px solid var(--border);
 }
 
 .chat-selection-popup button:hover,
@@ -1654,12 +1669,6 @@ button.chat-reply-preview--message:disabled {
   outline: none;
 }
 
-.chat-selection-popup button svg {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-  color: var(--muted);
-}
 .agent-chat__composer-shell {
   display: grid;
   grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## What Problem This Solves

Two papercuts in the chat transcript.

Selecting text in a message pops a toolbar that is much larger than the two
actions it offers: each action carries a decorative icon, the buttons sit inside
a padded tray with a gap between them, and their hover fills round separately, so
a two-item menu reads like a full context menu over the sentence being quoted.

Separately, the transcript is a keyboard-focusable scroll region, and browsers
turn `:focus-visible` back on for the focused element at the next keydown —
modifier keys included. Clicking anywhere in the conversation focuses the
transcript, so the next Shift, or any shortcut over a selection, drew a ring
around the entire reading surface with nothing to explain it.

## Why This Change Was Made

The toolbar becomes one segmented 32px surface: text-only actions, no outer
padding or gap, a single hairline between them, and `overflow: hidden` so hover
is clipped by the shared radius instead of each button rounding itself. Coarse
pointers keep the platform touch target. The actions, their wording, the
selection model, and dismissal behavior are unchanged.

For the ring, the transcript now records how focus arrived instead of asking the
browser after the fact: focus landing on the scroll container itself latches a
keyboard-arrival marker, and focus loss, focus moving into a control, or a
pointer press clears it. Clearing happens on pointer-down because a selection
started inside the transcript can be released or cancelled outside it, so no
later pointer event is guaranteed to arrive. The transcript opts out of the global `:focus-visible` ring and
paints its own ring from that marker, so a later keypress can no longer resurrect
it for a pointer-focused transcript while a real Tab arrival still shows it.

## User Impact

Quoting a message shows a compact two-action toolbar over the text instead of an
oversized menu, and reading a conversation no longer frames the whole transcript
when you press Shift or use a shortcut after clicking. Keyboard users still get a
visible focus indicator when they Tab to the transcript.

## Evidence

Mocked-Gateway Control UI E2E in Chromium, captured on a Linux runner at 1280×820
in both themes, with the same run repeated against the pre-change code for the
before/after pairs.

### Selection toolbar

Measured on the popup element (`before` → `after`): height `40.6px` → `32px`,
padding `4px` → `0px`, gap `2px` → none, `overflow: visible` → `hidden`, icons
`2` → `0`, action padding `6px 10px` → `5px 10px`, separator `0px` → `1px`.
Identical in light and dark.

| | Before | After |
| --- | --- | --- |
| Dark | <img width="420" alt="selection toolbar before, dark" src="https://github.com/user-attachments/assets/3e23a984-89bb-41eb-8beb-314569747963" /> | <img width="420" alt="selection toolbar after, dark" src="https://github.com/user-attachments/assets/78aaaf93-400e-4ce3-8137-23b627384c71" /> |
| Light | <img width="420" alt="selection toolbar before, light" src="https://github.com/user-attachments/assets/f2d7fd6d-1f96-477d-ba4f-886b4b7d343e" /> | <img width="420" alt="selection toolbar after, light" src="https://github.com/user-attachments/assets/08de87fa-d550-4973-b284-e03f6fe92949" /> |

Hover stays clipped to the shared container on both actions, with the hairline
intact; the hovered action reports `--bg-hover` (`rgb(31, 35, 48)` dark,
`rgb(239, 235, 228)` light) while the resting action stays transparent.

<img width="420" alt="hover on More details, dark" src="https://github.com/user-attachments/assets/5b798951-654c-480c-a56e-f8af16893352" />
<img width="420" alt="hover on Ask in side chat, light" src="https://github.com/user-attachments/assets/7093c93b-55f2-46a1-b18b-98b1eebc59c3" />

### Transcript ring

Selecting text with the mouse and then pressing Shift. The browser turns
`:focus-visible` on in both runs (`focusVisible: true`); only the painted ring
differs: `outlineStyle: "solid", outlineWidth: "2px"` before, `outlineStyle:
"none"` after, in light and dark.

| Before | After |
| --- | --- |
| <img width="420" alt="transcript framed after pressing Shift" src="https://github.com/user-attachments/assets/777e9d7d-e22a-4788-bf83-e8f5a6675af9" /> | <img width="420" alt="transcript unframed after pressing Shift" src="https://github.com/user-attachments/assets/52f46c32-5f1b-4d14-809b-700c3bd93de1" /> |

Tabbing to the transcript still shows the ring after the change
(`outlineStyle: "solid"`, `outlineWidth: "2px"`, `outlineOffset: "-2px"`,
`--muted-strong`):

<img width="420" alt="transcript keyboard focus ring preserved" src="https://github.com/user-attachments/assets/c757ba74-1489-4039-ad29-c98e0bb3a48f" />

### Tests

- `ui/src/e2e/app-chrome-interaction.e2e.test.ts` grew two assertions, each of
  which fails without its half of the change (`expected outlineStyle "none",
  received "solid"`): Shift after a pointer selection, and a selection dragged
  out of the transcript and released outside it while the transcript keeps
  focus.
- `ui/src/pages/chat/components/chat-selection-popup.test.ts` (6 tests) covers the
  unchanged action wiring plus the icon-free toolbar.
- `pnpm check:changed` (format, dead-export scan, i18n catalog, typecheck, lint,
  changed test lanes) green on a hosted runner.

Production lines: +2 net, both comment lines (popup −28, transcript interactions
+15, transcript shell +8, stylesheet +7). Tests: +24.
