### PR TITLE
fix(media): prevent truncated files after short writes

### DIFF
--- a/src/media/store.retry.test.ts
+++ b/src/media/store.retry.test.ts
@@ -1,5 +1,7 @@
-// Media store retry tests cover the exact directory-recreation recovery boundary.
+// Media store filesystem-fault tests cover directory recreation and short writes.
 import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -8,6 +10,7 @@ import { FsSafeError } from "../infra/fs-safe.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.doUnmock("../infra/file-store.js");
   vi.unstubAllEnvs();
   vi.resetModules();
@@ -17,7 +20,7 @@ function errnoError(code: string): Error {
   return Object.assign(new Error(code), { code });
 }
 
-describe("media store directory recreation", () => {
+describe("media store filesystem faults", () => {
   it.each([
     {
       name: "ENOTDIR",
@@ -75,5 +78,68 @@ describe("media store directory recreation", () => {
     }
     await expect(result).rejects.toBe(injectedError);
     expect(writeAttempts).toBe(1);
+  });
+
+  it("fully persists a stream chunk after a positive short write", async () => {
+    const stateDir = tempDirs.make("openclaw-media-short-write-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const input = Buffer.from("positive short write");
+    const originalOpen = fs.open.bind(fs);
+    let shortWriteObserved = false;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await originalOpen(...args);
+      if (
+        typeof args[0] !== "string" ||
+        !args[0].includes(`${path.sep}short-write-stream${path.sep}`) ||
+        args[1] !== "wx"
+      ) {
+        return handle;
+      }
+
+      let injectShortWrite = true;
+      const injectedHandle = Object.create(handle) as typeof handle;
+      injectedHandle.close = handle.close.bind(handle);
+      injectedHandle.write = (async (
+        buffer: Buffer,
+        offset = 0,
+        length = buffer.byteLength - offset,
+      ) => {
+        const writeLength = injectShortWrite ? Math.max(1, Math.floor(length / 2)) : length;
+        injectShortWrite = false;
+        shortWriteObserved ||= writeLength < length;
+        return await handle.write(buffer, offset, writeLength);
+      }) as typeof handle.write;
+      injectedHandle.writeFile = (async (data: string | NodeJS.ArrayBufferView) => {
+        const buffer =
+          typeof data === "string"
+            ? Buffer.from(data)
+            : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+        let offset = 0;
+        while (offset < buffer.byteLength) {
+          const { bytesWritten } = await injectedHandle.write(
+            buffer,
+            offset,
+            buffer.byteLength - offset,
+          );
+          offset += bytesWritten;
+        }
+      }) as typeof handle.writeFile;
+      return injectedHandle;
+    });
+
+    const store = await importFreshModule<typeof import("./store.js")>(
+      import.meta.url,
+      "./store.js?scope=positive-short-write",
+    );
+    const saved = await store.saveMediaStream(
+      Readable.from([input]),
+      "text/plain",
+      "short-write-stream",
+      1024,
+    );
+
+    expect(shortWriteObserved).toBe(true);
+    expect(saved.size).toBe(input.byteLength);
+    await expect(fs.readFile(saved.path)).resolves.toEqual(input);
   });
 });

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -487,7 +487,7 @@ async function writeMediaStreamToFile(params: {
         sniffChunks.push(buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer);
         sniffLen += Math.min(buffer.byteLength, remaining);
       }
-      await handle.write(buffer);
+      await handle.writeFile(buffer);
     }
     return {
       sniffBuffer: Buffer.concat(sniffChunks, sniffLen),


### PR DESCRIPTION
Closes #123589

## What Problem This Solves

Fixes an issue where a legal positive short write during media streaming could publish a truncated file while reporting the full input size. The operation appeared successful even though the stored media bytes were incomplete.

## Why This Change Was Made

The media stream writer now uses Node's full-write `FileHandle.writeFile` contract for each awaited chunk instead of treating one `write` call as complete. The existing size cap, MIME sniffing, sibling-temp cleanup, sync/rename publication, and return shape remain unchanged.

## User Impact

Streamed media is fully persisted before publication and size reporting, including on filesystems or fault conditions that complete a write with fewer bytes than requested. Callers no longer receive a successful reference to silently truncated content.

## Evidence

- Tests-first fault injection reproduced the bug: a 20-byte chunk returned a successful 10-byte short write; pre-fix code reported size 20 and published only 10 bytes.
- Post-fix focused media proof: 53/53 passed.
- Node v26 source/docs/types confirm `write` reports `bytesWritten`, while `writeFile` loops over positive short writes and continues from the current handle position.
- Shipped `@openclaw/fs-safe` source uses the same full-write policy for buffer/stream persistence.
- Blacksmith Testbox core + coreTests changed gate passed, including typechecks, changed lint, dead exports, import cycles, formatting, and storage/schema/architecture guards: https://github.com/openclaw/openclaw/actions/runs/31788186944 (`tbx_01kzzsk205arc1c4gkte9vcdp5`).
- Final Codex autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Exact reviewed head: `70fd00fb025a71923cfe0aabab52f42d0cab698a`.

Production delta: +1/-1, net 0. Tests: +68/-2, net +66.

AI-assisted: yes. The repair was reviewed against the complete media stream writer, its atomic publication path, Node and fs-safe full-write contracts, callers, sibling writers, fault cleanup, byte limits, and MIME detection.
