### PR TITLE
fix: managed images render under Control UI base paths

### DIFF
--- a/src/gateway/managed-image-actions.e2e.test.ts
+++ b/src/gateway/managed-image-actions.e2e.test.ts
@@ -26,6 +26,7 @@ describe("managed image actions Gateway E2E", () => {
       throw new Error("OPENCLAW_STATE_DIR is required for managed image E2E fixtures");
     }
     testState.gatewayAuth = { mode: "token", token: GATEWAY_TOKEN };
+    testState.gatewayControlUi = { basePath: "/rosita" };
     testState.sessionStorePath = path.join(stateDir, "sessions.sqlite");
 
     const source = await fs.readFile(
@@ -107,6 +108,13 @@ describe("managed image actions Gateway E2E", () => {
           expect(download.expiresAt).toEqual(expect.any(String));
           const fullUrl = new URL(download.url ?? "", `http://127.0.0.1:${port}`);
           expect(fullUrl.searchParams.get("mediaTicket")).toMatch(/^v1\./u);
+
+          const rootFull = await fetch(fullUrl);
+          expect(rootFull.status).toBe(200);
+          expect(rootFull.headers.get("content-type")).toBe("image/png");
+          expect(Buffer.from(await rootFull.arrayBuffer())).toEqual(source);
+
+          fullUrl.pathname = `/rosita${fullUrl.pathname}`;
 
           const full = await fetch(fullUrl);
           expect(full.status).toBe(200);

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1572,6 +1572,7 @@ export async function handleManagedOutgoingMediaHttpRequest(
   res: ServerResponse,
   opts: {
     auth: ResolvedGatewayAuth;
+    basePath?: string;
     trustedProxies?: string[];
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
@@ -1579,7 +1580,11 @@ export async function handleManagedOutgoingMediaHttpRequest(
   },
 ): Promise<boolean> {
   const requestUrl = new URL(req.url ?? "/", "http://localhost");
-  const match = requestUrl.pathname.match(
+  const requestPath =
+    opts.basePath && requestUrl.pathname.startsWith(`${opts.basePath}/`)
+      ? requestUrl.pathname.slice(opts.basePath.length)
+      : requestUrl.pathname;
+  const match = requestPath.match(
     /^\/api\/chat\/media\/outgoing\/([^/]+)\/([^/]+)\/(full|thumbnail)$/,
   );
   if (!match) {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -575,12 +575,14 @@ export function createGatewayHttpServer(opts: {
 
       addRequestStage(
         "chat-managed-media",
-        scopedRequestPath.startsWith("/api/chat/media/outgoing/"),
+        scopedRequestPath.startsWith("/api/chat/media/outgoing/") ||
+          (controlUiRouteBasePath.length > 0 &&
+            scopedRequestPath.startsWith(`${controlUiRouteBasePath}/api/chat/media/outgoing/`)),
         async () =>
           (await getManagedMediaAttachmentsModule()).handleManagedOutgoingMediaHttpRequest(
             req,
             res,
-            routeAuth,
+            { ...routeAuth, basePath: controlUiRouteBasePath },
           ),
       );
       addRequestStage(

--- a/ui/src/e2e/managed-image-actions.e2e.test.ts
+++ b/ui/src/e2e/managed-image-actions.e2e.test.ts
@@ -1,9 +1,15 @@
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import {
+  captureUiProofEnabled,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+const controlUiBasePath = "/rosita";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "managed-image-actions");
 
 suite.define(() => {
   it("previews, downloads, copies, and opens a ticketed generated image", async () => {
@@ -37,15 +43,18 @@ suite.define(() => {
         },
       });
     });
-    await page.route("**/api/chat/media/outgoing/**", async (route) => {
+    await page.route(`**${controlUiBasePath}/api/chat/media/outgoing/**`, async (route) => {
       const request = route.request();
       const url = new URL(request.url());
+      expect(url.pathname).toMatch(/^\/rosita\/api\/chat\/media\/outgoing\//u);
       expect(url.searchParams.get("mediaTicket")).toBe("ticket-e2e");
       expect(request.headers().authorization).toBeUndefined();
+      expect(request.headers()["x-openclaw-requester-session-key"]).toBeUndefined();
       requestedVariants.push(url.pathname.split("/").at(-1) ?? "");
       await route.fulfill({ body: imageBytes, contentType: "image/png" });
     });
     const gateway = await installMockGateway(page, {
+      basePath: controlUiBasePath,
       historyMessages: [
         {
           role: "assistant",
@@ -79,7 +88,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}${controlUiBasePath.slice(1)}/chat`);
       const image = page.getByAltText("Ticketed generated image");
       await image.waitFor({ state: "visible", timeout: 10_000 });
       await expect
@@ -90,6 +99,13 @@ suite.define(() => {
         )
         .toBe(1280);
       expect(requestedVariants).toEqual(["thumbnail"]);
+      if (captureUiProofEnabled) {
+        await mkdir(proofDir, { recursive: true });
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "ticketed-generated-image-subpath.png"),
+        });
+      }
 
       await page.locator(".chat-image-frame").hover();
       const downloadButton = page.getByRole("button", { name: "Download image" });

--- a/ui/src/e2e/managed-media-base-path.e2e.test.ts
+++ b/ui/src/e2e/managed-media-base-path.e2e.test.ts
@@ -25,7 +25,7 @@ describe("Control UI managed media under a UI base path", () => {
     await server?.close();
   });
 
-  it("keeps origin-root managed-media APIs outside the UI base path", async () => {
+  it("loads managed-media APIs beneath the configured UI base path", async () => {
     const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
     const browser = await chromium.launch({ executablePath });
     const context = await browser.newContext({
@@ -36,13 +36,13 @@ describe("Control UI managed media under a UI base path", () => {
     const page = await context.newPage();
     const sourcePath =
       "/api/chat/media/outgoing/agent%3Amain%3Amain/00000000-0000-4000-8000-000000000001/full";
-    const previewPath = sourcePath.replace(/\/full$/u, "/thumbnail");
+    const previewPath = `/rosita${sourcePath.replace(/\/full$/u, "/thumbnail")}`;
     const imageBytes = await readFile(
       path.join(process.cwd(), "docs/assets/openclaw-banner-dark.png"),
     );
     const requests: Array<{ contentType: string; path: string }> = [];
 
-    await page.route("**/api/chat/media/outgoing/**", async (route) => {
+    await page.route("**/rosita/api/chat/media/outgoing/**", async (route) => {
       const requestPath = new URL(route.request().url()).pathname;
       if (requestPath === previewPath) {
         requests.push({ contentType: "image/png", path: requestPath });
@@ -77,9 +77,7 @@ describe("Control UI managed media under a UI base path", () => {
     });
 
     try {
-      // The Vite harness mounts at `/`; bootstrap models the reverse proxy
-      // prefix that Gateway strips before serving the Control UI.
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${server.baseUrl}rosita/chat`);
       await gateway.waitForRequest("chat.startup");
       const image = page.getByAltText("Managed proof image");
       await image.waitFor({ state: "attached", timeout: 10_000 });

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -1,6 +1,7 @@
 import { html, noChange, nothing, type TemplateResult } from "lit";
 import { AsyncDirective, directive } from "lit/async-directive.js";
 import { until } from "lit/directives/until.js";
+import { normalizeBasePath } from "../../../app-route-paths.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import {
@@ -271,7 +272,7 @@ function resolveManagedOutgoingImageBlobUrlCacheKey(
   variant: ManagedImageVariant = "thumbnail",
 ): string {
   const authToken = opts?.authToken?.trim() ?? "";
-  return `${buildManagedOutgoingImageVariantUrl(source, variant)}::${authToken}::${artifactId?.trim() ?? ""}`;
+  return `${buildManagedOutgoingImageVariantUrl(source, variant, opts?.basePath)}::${authToken}::${artifactId?.trim() ?? ""}`;
 }
 
 function readManagedOutgoingImageBlobUrl(
@@ -296,7 +297,7 @@ async function resolveManagedOutgoingImageBlobUrl(
     "managed-image",
     cacheKey,
     opts?.onRequestUpdate,
-    `${buildManagedOutgoingImageVariantUrl(source, variant)}::${artifactId?.trim() ?? ""}`,
+    `${buildManagedOutgoingImageVariantUrl(source, variant, opts?.basePath)}::${artifactId?.trim() ?? ""}`,
   );
   const cached = readManagedImageBlobUrl(cacheKey);
   if (cached) {
@@ -354,13 +355,25 @@ async function resolveManagedOutgoingImageBlobUrl(
   return resource.pending;
 }
 
-function buildManagedOutgoingImageVariantUrl(source: string, variant: ManagedImageVariant): string {
+function buildManagedOutgoingImageVariantUrl(
+  source: string,
+  variant: ManagedImageVariant,
+  basePath?: string,
+): string {
   try {
     const parsed = new URL(source, window.location.origin);
     parsed.pathname = parsed.pathname.replace(/\/(?:full|thumbnail)$/u, `/${variant}`);
-    return /^https?:\/\//iu.test(source)
-      ? parsed.href
-      : `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    if (/^https?:\/\//iu.test(source)) {
+      return parsed.href;
+    }
+    const normalizedBasePath = normalizeBasePath(basePath ?? "");
+    const pathname =
+      normalizedBasePath &&
+      (parsed.pathname === normalizedBasePath ||
+        parsed.pathname.startsWith(`${normalizedBasePath}/`))
+        ? parsed.pathname
+        : `${normalizedBasePath}${parsed.pathname}`;
+    return `${pathname}${parsed.search}${parsed.hash}`;
   } catch {
     return source.replace(/\/(?:full|thumbnail)(?=$|[?#])/u, `/${variant}`);
   }
@@ -380,7 +393,11 @@ async function fetchManagedOutgoingImageBlob(
           .resolveArtifactDownload({ sessionKey: requesterSessionKey, artifactId })
           .catch(() => null)
       : null;
-  const requestUrl = buildManagedOutgoingImageVariantUrl(artifactDownload?.url ?? source, variant);
+  const requestUrl = buildManagedOutgoingImageVariantUrl(
+    artifactDownload?.url ?? source,
+    variant,
+    opts?.basePath,
+  );
   const headers = new Headers({ Accept: "image/*" });
   const authToken = opts?.authToken?.trim();
   if (!artifactDownload && authToken) {
@@ -393,8 +410,8 @@ async function fetchManagedOutgoingImageBlob(
     controller.abort(new DOMException("managed outgoing image fetch timed out", "TimeoutError"));
   }, MANAGED_OUTGOING_IMAGE_FETCH_TIMEOUT_MS);
   try {
-    // Managed media is a Gateway API at the origin root. Rebasing it under
-    // the Control UI mount path serves the HTML shell instead of image bytes.
+    // Root deployments use /api directly; subpath deployments expose the same
+    // media route beneath the configured Control UI base path.
     const response = await fetch(requestUrl, {
       method: "GET",
       headers,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -4539,7 +4539,7 @@ describe("grouped chat rendering", () => {
       expect(image?.getAttribute("src")).toBe(objectUrl);
       expect(image?.getAttribute("alt")).toBe("Generated image 1");
     });
-    const thumbnailUrl = managedChatImageUrl.replace(/\/full$/u, "/thumbnail");
+    const thumbnailUrl = `/rosita${managedChatImageUrl.replace(/\/full$/u, "/thumbnail")}`;
     const [, fetchInit] = requireFetchCallForUrl(fetchMock, thumbnailUrl);
     expectSameOriginGet(fetchInit);
     expectElement(container, ".chat-message-image-button", HTMLButtonElement).click();
@@ -4552,7 +4552,7 @@ describe("grouped chat rendering", () => {
     activeItem?.release?.();
   });
 
-  it("prefers an artifact ticket without forwarding the gateway bearer", async () => {
+  it("prefixes the Control UI base path on artifact tickets without forwarding the gateway bearer", async () => {
     const artifactId = `artifact_managed_image_${crypto.randomUUID()}`;
     const managedChatImageUrl = `/api/chat/media/outgoing/agent%3Amain%3Amain/${crypto.randomUUID()}/full`;
     const ticketedUrl = `${managedChatImageUrl}?mediaTicket=ticket`;
@@ -4561,7 +4561,7 @@ describe("grouped chat rendering", () => {
       expiresAt: "2026-07-28T05:00:00.000Z",
     }));
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      expect(url).toBe(ticketedUrl.replace(/\/full(?=\?)/u, "/thumbnail"));
+      expect(url).toBe(`/rosita${ticketedUrl.replace(/\/full(?=\?)/u, "/thumbnail")}`);
       const headers = new Headers(init?.headers);
       expect(headers.get("Authorization")).toBeNull();
       expect(headers.get("x-openclaw-requester-session-key")).toBeNull();
@@ -4576,6 +4576,7 @@ describe("grouped chat rendering", () => {
       {
         showToolCalls: false,
         assistantAttachmentAuthToken: "must-not-be-forwarded",
+        basePath: "/rosita",
         resolveArtifactDownload,
       },
     );


### PR DESCRIPTION
Closes #123591

## What Problem This Solves

Fixes an issue where users viewing managed assistant images in a Control UI mounted under a configured base path would see no image because the media request escaped the mount path and the prefixed route fell through to the HTML shell.

## Why This Change Was Made

Root-relative managed-image requests now resolve beneath the configured Control UI base path exactly once, and the gateway claims that matching prefixed media route before SPA fallback. Root-mounted routes, absolute URLs, signed query parameters, and credential isolation remain unchanged.

## User Impact

Managed assistant images now render normally under subpath deployments and retain Preview, Download, Copy, and Open actions. Existing root-mounted deployments continue to work.

## Evidence

- Red component proof on the unmodified base: image request remained at root and no image rendered.
- Red real-gateway proof on the unmodified base: the signed prefixed media route returned HTTP 404.
- Green focused component proof: 2 tests passed.
- Green real-gateway E2E: the same signed ticket returned source-identical PNG bytes from both root and `/rosita` full-image routes; the prefixed thumbnail also returned valid image bytes.
- Green browser E2E at `/rosita/chat`: image decoded at natural width 1280; Preview, Download, Copy, and Open all passed; neither bearer nor requester-session credentials were forwarded.
- Sibling coverage: 207 chat UI tests and 273 managed-image gateway tests passed.
- Full repository gate: `pnpm check:changed` exited 0 in Testbox after formatting, typechecks, full lint, policy guards, import-cycle checks, and selected platform tests.
- Behavior validator: 4/4 clauses passed with no blockers.
- Autoreview: clean, no actionable findings.