### PR TITLE
improve(ui): make sidebar updates a focused call to action

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -319,9 +319,10 @@ LaunchAgent when possible. If the Gateway cannot make that handoff safely,
 `update.run` reports a safe shell command instead of running the package
 manager in-process.
 
-The Control UI sidebar update card shows **Update Gateway** when it will start
+The Control UI sidebar update card offers a single **Update** action that starts
 this `update.run` flow directly. This covers browser-hosted Control UI, remote
-Gateways, and manually managed local Gateways.
+Gateways, and manually managed local Gateways. The card itself stays a quiet
+status line; the confirmation it opens is what names the update target.
 
 Manual updates started from the Control UI always ask first. The first click on
 the sidebar update card or on **Settings → Updates → Update now** opens a
@@ -330,8 +331,9 @@ and the restart impact; it sends nothing until you choose **Update and restart**
 Cancel, Escape, and dismissing the dialog leave the Gateway untouched. Automatic
 campaigns, the CLI, and `update.run` API clients are unaffected.
 
-In the signed macOS app, a local app-owned Gateway changes that card to
-**Update Mac app + Gateway**. Sparkle updates the app first; after relaunch, the
+In the signed macOS app, a local app-owned Gateway keeps the same **Update**
+action, and its confirmation names the Mac app and the Gateway as the combined
+target. Sparkle updates the app first; after relaunch, the
 app runs `openclaw update --tag <app-version> --json`, restarts its Gateway,
 and verifies health in a setup-style progress window. The window appears only
 when that managed Gateway needs update, repair, or installation; app-only updates relaunch

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1469,6 +1469,13 @@ async function createChatPickerScenario(
     assistantAgentId: "main",
     assistantName: "Molty",
     defaultAgentId: "main",
+    serverBuildId: "mock",
+    serverVersion: "2026.7.10",
+    updateAvailable: {
+      channel: "stable",
+      currentVersion: "2026.7.10",
+      latestVersion: "2026.8.14",
+    },
     // Advertised Gateway methods gate session actions (see
     // ui/src/lib/session-method-access.ts). Omitting the mutation methods left
     // every session context-menu row disabled, so the harness could not show
@@ -1497,6 +1504,7 @@ async function createChatPickerScenario(
       "sessions.create",
       "system.info",
       "terminal.open",
+      "update.run",
     ],
     // Terminal has a second gate beyond the advertised method (see
     // ui/src/lib/terminal-availability.ts).
@@ -1517,6 +1525,11 @@ async function createChatPickerScenario(
     methodResponses: {
       ...buildBackgroundTasksMock(baseTime),
       ...cronMocks,
+      "update.run": {
+        ok: true,
+        restart: null,
+        result: { after: { version: "2026.8.14" }, status: "ok" },
+      },
       "users.self": { profile: selfProfile },
       // Talk settings page pickers: realtime catalog with the model/voice
       // suggestion lists the gateway emits for provider entries.

--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -422,7 +422,9 @@ describe("OpenClaw shell update affordance", () => {
     await card?.updateComplete;
     expect(card?.canUpdate).toBe(true);
     const restoreDialogPolyfill = installDialogPolyfill();
-    card?.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    const updateButton = card?.querySelector<HTMLButtonElement>(".sidebar-update-card__cta");
+    expect(updateButton?.textContent?.trim()).toBe("Update");
+    updateButton?.click();
     const { modal } = await waitForRenderedModalDialog(document.body);
     [...modal.querySelectorAll("button")]
       .find((button) => button.textContent?.trim() === "Update and restart")

--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -12,10 +12,7 @@ import {
   installDialogPolyfill,
   waitForConfirmDialogActions,
 } from "../test-helpers/modal-dialog.ts";
-import { createStorageMock } from "../test-helpers/storage.ts";
 import "./sidebar-update-card.ts";
-
-const DISMISS_KEY = "openclaw:control-ui:update-banner-dismissed:v1";
 
 /** Resolve the update confirmation the card opens, then let its dispatch settle. */
 async function resolveUpdateConfirmation(
@@ -41,7 +38,6 @@ type SidebarUpdateCardElement = HTMLElement & {
 };
 
 let originalWebkit: PropertyDescriptor | undefined;
-let originalLocalStorage: PropertyDescriptor | undefined;
 let restoreDialogPolyfill: () => void;
 
 async function mount(
@@ -65,11 +61,6 @@ async function mount(
 beforeEach(() => {
   restoreDialogPolyfill = installDialogPolyfill();
   originalWebkit = Object.getOwnPropertyDescriptor(window, "webkit");
-  originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: createStorageMock(),
-  });
 });
 
 afterEach(() => {
@@ -77,11 +68,6 @@ afterEach(() => {
   cancelOpenModalDialogs();
   document.body.replaceChildren();
   restoreDialogPolyfill();
-  if (originalLocalStorage) {
-    Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
-  } else {
-    Reflect.deleteProperty(globalThis, "localStorage");
-  }
   if (originalWebkit) {
     Object.defineProperty(window, "webkit", originalWebkit);
   } else {
@@ -134,15 +120,7 @@ describe("SidebarUpdateCard", () => {
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
-  it("does not render a dismiss button for the refresh state", async () => {
-    const element = await mount(null);
-    element.refreshRequired = true;
-    await element.updateComplete;
-
-    expect(element.querySelector(".sidebar-update-card__dismiss")).toBeNull();
-  });
-
-  it("labels a direct Gateway update and confirms before invoking its action", async () => {
+  it("renders one explicit CTA and confirms before invoking a direct Gateway update", async () => {
     const element = await mount({
       currentVersion: "1.0.0",
       latestVersion: "2.0.0",
@@ -151,14 +129,22 @@ describe("SidebarUpdateCard", () => {
     const onUpdate = vi.fn();
     element.onUpdate = onUpdate;
 
-    const action = element.querySelector<HTMLButtonElement>(".sidebar-update-card__action");
+    const availability = element.querySelector<HTMLElement>(".sidebar-update-card__availability");
+    const action = element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta");
     expect(element.querySelector(".sidebar-update-card")?.getAttribute("role")).toBe("status");
+    expect(availability?.tagName).toBe("DIV");
+    expect(availability?.hasAttribute("tabindex")).toBe(false);
     expect(element.querySelector(".sidebar-update-card__text")?.textContent).toBe(
-      "Update Gateway · v2.0.0",
+      "New version available",
     );
+    expect(action?.textContent?.trim()).toBe("Update");
+    expect(availability?.querySelectorAll("button")).toHaveLength(1);
     expect(element.querySelector(".sidebar-update-card__copy")).toBeNull();
     expect(element.querySelector(".sidebar-update-card__subtitle")).toBeNull();
     expect(element.querySelector(".sidebar-update-card__arrow")).toBeNull();
+    availability?.click();
+    expect(document.querySelector("openclaw-modal-dialog")).toBeNull();
+    expect(onUpdate).not.toHaveBeenCalled();
     action?.click();
     await waitForConfirmDialogActions();
 
@@ -176,14 +162,14 @@ describe("SidebarUpdateCard", () => {
     const onUpdate = vi.fn();
     element.onUpdate = onUpdate;
 
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta")?.click();
     await resolveUpdateConfirmation("Cancel");
 
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
   it.each(["2026.7.2", "2026.7.2-beta.5"])(
-    "identifies a beta update when its available version is %s",
+    "keeps the availability copy stable when the beta version is %s",
     async (latestVersion) => {
       const element = await mount({
         currentVersion: "2026.7.1-2",
@@ -192,7 +178,7 @@ describe("SidebarUpdateCard", () => {
       });
 
       expect(element.querySelector(".sidebar-update-card__text")?.textContent).toBe(
-        `Update Gateway · v${latestVersion} (beta)`,
+        "New version available",
       );
     },
   );
@@ -204,19 +190,6 @@ describe("SidebarUpdateCard", () => {
       expect(element.querySelector(".sidebar-update-card")).toBeNull();
     },
   );
-
-  it("renders nothing for a dismissed version and channel", async () => {
-    localStorage.setItem(
-      DISMISS_KEY,
-      JSON.stringify({ latestVersion: "2.0.0", channel: "beta", dismissedAtMs: 1 }),
-    );
-    const element = await mount({
-      currentVersion: "1.0.0",
-      latestVersion: "2.0.0",
-      channel: "beta",
-    });
-    expect(element.querySelector(".sidebar-update-card")).toBeNull();
-  });
 
   it("labels and routes a coordinated Mac app and managed Gateway update", async () => {
     const postMessage = vi.fn();
@@ -232,9 +205,10 @@ describe("SidebarUpdateCard", () => {
     const onUpdate = vi.fn();
     element.onUpdate = onUpdate;
 
-    const action = element.querySelector<HTMLButtonElement>(".sidebar-update-card__action");
-    expect(action?.textContent).toContain("Update Mac app + Gateway");
-    expect(action?.textContent).toContain("v2.0.0");
+    const action = element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta");
+    expect(element.querySelector(".sidebar-update-card__text")?.textContent).toBe(
+      "New version available",
+    );
     action?.click();
     await waitForConfirmDialogActions();
 
@@ -244,13 +218,13 @@ describe("SidebarUpdateCard", () => {
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
-  it("updates the visible target when native ownership changes", async () => {
+  it("keeps availability copy stable when native ownership changes", async () => {
     const element = await mount({
       currentVersion: "1.0.0",
       latestVersion: "2.0.0",
       channel: "stable",
     });
-    expect(element.textContent).toContain("Update Gateway");
+    expect(element.textContent).toContain("New version available");
 
     Object.defineProperty(window, "webkit", {
       configurable: true,
@@ -258,12 +232,12 @@ describe("SidebarUpdateCard", () => {
     });
     window.dispatchEvent(new CustomEvent(NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT));
     await element.updateComplete;
-    expect(element.textContent).toContain("Update Mac app + Gateway");
+    expect(element.textContent).toContain("New version available");
 
     Reflect.deleteProperty(window, "webkit");
     window.dispatchEvent(new CustomEvent(NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT));
     await element.updateComplete;
-    expect(element.textContent).toContain("Update Gateway");
+    expect(element.textContent).toContain("New version available");
   });
 
   it("uses a newly installed native bridge before its availability event arrives", async () => {
@@ -275,13 +249,13 @@ describe("SidebarUpdateCard", () => {
     const onUpdate = vi.fn();
     const postMessage = vi.fn();
     element.onUpdate = onUpdate;
-    expect(element.textContent).toContain("Update Gateway");
+    expect(element.textContent).toContain("New version available");
 
     Object.defineProperty(window, "webkit", {
       configurable: true,
       value: { messageHandlers: { openclawUpdate: { postMessage } } },
     });
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta")?.click();
     await resolveUpdateConfirmation("Update Mac app and restart");
 
     expect(postMessage).toHaveBeenCalledExactlyOnceWith({ type: "start-update" });
@@ -330,17 +304,17 @@ describe("SidebarUpdateCard", () => {
 
     window.dispatchEvent(new CustomEvent(NATIVE_UPDATE_DECLINED_EVENT));
     await element.updateComplete;
-    expect(element.textContent).toContain("Update Gateway");
+    expect(element.textContent).toContain("New version available");
 
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta")?.click();
     await resolveUpdateConfirmation("Update and restart");
     expect(onUpdate).toHaveBeenCalledTimes(2);
     expect(postMessage).not.toHaveBeenCalled();
 
     window.dispatchEvent(new CustomEvent(NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT));
     await element.updateComplete;
-    expect(element.textContent).toContain("Update Mac app + Gateway");
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    expect(element.textContent).toContain("New version available");
+    element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta")?.click();
     await resolveUpdateConfirmation("Update Mac app and restart");
     expect(postMessage).toHaveBeenCalledExactlyOnceWith({ type: "start-update" });
     expect(onUpdate).toHaveBeenCalledTimes(2);
@@ -366,8 +340,8 @@ describe("SidebarUpdateCard", () => {
     document.body.append(element);
     await element.updateComplete;
 
-    expect(element.textContent).toContain("Update Gateway");
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    expect(element.textContent).toContain("New version available");
+    element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta")?.click();
     await resolveUpdateConfirmation("Update and restart");
     expect(onUpdate).toHaveBeenCalledTimes(2);
     expect(postMessage).not.toHaveBeenCalled();
@@ -387,7 +361,7 @@ describe("SidebarUpdateCard", () => {
         },
       },
     );
-    expect(element.textContent).toContain("246 commits behind");
+    expect(element.textContent).toContain("New version available");
 
     element.updateBusy = true;
     await element.updateComplete;
@@ -395,8 +369,7 @@ describe("SidebarUpdateCard", () => {
     expect(action?.disabled).toBe(true);
     expect(action?.textContent).toContain("Updating Gateway…");
     // The stale call to action must not survive into the install.
-    expect(element.textContent).not.toContain("246 commits behind");
-    expect(element.querySelector(".sidebar-update-card__dismiss")).toBeNull();
+    expect(element.textContent).not.toContain("New version available");
 
     // The restarting Gateway takes its update metadata with it; the card is the
     // operator's only remaining sign that an install is still running.
@@ -406,7 +379,7 @@ describe("SidebarUpdateCard", () => {
     expect(element.textContent).toContain("Updating Gateway…");
   });
 
-  it("renders a quiet live countdown, hides dismissal, and stops ticking on disconnect", async () => {
+  it("renders a quiet live countdown and stops ticking on disconnect", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const clearInterval = vi.spyOn(globalThis, "clearInterval");
@@ -436,7 +409,6 @@ describe("SidebarUpdateCard", () => {
     expect(card?.hasAttribute("role")).toBe(false);
     expect(timer?.getAttribute("aria-live")).toBe("off");
     expect(timer?.textContent).toContain("Updating in 0:54 · v2.0.0");
-    expect(element.querySelector(".sidebar-update-card__dismiss")).toBeNull();
     expect(element.querySelector(".sidebar-update-card__hold")?.textContent?.trim()).toBe(
       "Hold 1 h",
     );
@@ -557,63 +529,10 @@ describe("SidebarUpdateCard", () => {
     const onUpdate = vi.fn();
     element.onUpdate = onUpdate;
 
-    const action = element.querySelector<HTMLButtonElement>(".sidebar-update-card__action");
+    const action = element.querySelector<HTMLButtonElement>(".sidebar-update-card__cta");
     expect(action?.disabled).toBe(true);
     expect(action?.title).toContain("Administrator access is required");
     action?.click();
     expect(onUpdate).not.toHaveBeenCalled();
-  });
-
-  it("persists dismissal and hides the card", async () => {
-    const element = await mount({
-      currentVersion: "1.0.0",
-      latestVersion: "2.0.0",
-      channel: "stable",
-    });
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__dismiss")?.click();
-    await element.updateComplete;
-
-    expect(JSON.parse(localStorage.getItem(DISMISS_KEY) ?? "null")).toMatchObject({
-      latestVersion: "2.0.0",
-      channel: "stable",
-    });
-    expect(element.querySelector(".sidebar-update-card")).toBeNull();
-  });
-
-  it("hides the card when dismissal persistence fails", async () => {
-    const storage = createStorageMock();
-    storage.setItem = () => {
-      throw new Error("quota exceeded");
-    };
-    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
-    const update = { currentVersion: "1.0.0", latestVersion: "3.0.0", channel: "stable" };
-    const element = await mount(update);
-
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__dismiss")?.click();
-    await element.updateComplete;
-
-    expect(element.querySelector(".sidebar-update-card")).toBeNull();
-    element.remove();
-    const replacement = await mount(update);
-    expect(replacement.querySelector(".sidebar-update-card")).not.toBeNull();
-  });
-
-  it("shows a newer update after dismissing an older version", async () => {
-    const element = await mount({
-      currentVersion: "1.0.0",
-      latestVersion: "2.0.0",
-      channel: "stable",
-    });
-    element.querySelector<HTMLButtonElement>(".sidebar-update-card__dismiss")?.click();
-    await element.updateComplete;
-
-    element.updateAvailable = {
-      currentVersion: "1.0.0",
-      latestVersion: "3.0.0",
-      channel: "stable",
-    };
-    await element.updateComplete;
-
-    expect(element.querySelector(".sidebar-update-card")?.textContent).toContain("v3.0.0");
   });
 });

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -15,48 +15,7 @@ import {
 import { t } from "../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { PollController } from "../lit/poll-controller.ts";
-import { getSafeLocalStorage } from "../local-storage.ts";
 import { icons } from "./icons.ts";
-
-const UPDATE_BANNER_DISMISS_KEY = "openclaw:control-ui:update-banner-dismissed:v1";
-
-type DismissedUpdate = {
-  latestVersion: string;
-  channel: string | null;
-  dismissedAtMs: number;
-};
-
-function updateKey(update: UpdateAvailable): string {
-  return `${update.latestVersion}\u0000${update.channel}`;
-}
-
-function isDismissed(update: UpdateAvailable): boolean {
-  try {
-    const raw = getSafeLocalStorage()?.getItem(UPDATE_BANNER_DISMISS_KEY);
-    if (!raw) {
-      return false;
-    }
-    const dismissed = JSON.parse(raw) as Partial<DismissedUpdate>;
-    return dismissed.latestVersion === update.latestVersion && dismissed.channel === update.channel;
-  } catch {
-    return false;
-  }
-}
-
-function dismiss(update: UpdateAvailable): void {
-  try {
-    getSafeLocalStorage()?.setItem(
-      UPDATE_BANNER_DISMISS_KEY,
-      JSON.stringify({
-        latestVersion: update.latestVersion,
-        channel: update.channel,
-        dismissedAtMs: Date.now(),
-      } satisfies DismissedUpdate),
-    );
-  } catch {
-    // Dismissal persistence is best effort.
-  }
-}
 
 class SidebarUpdateCard extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) updateAvailable: UpdateAvailable | null = null;
@@ -73,7 +32,6 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) refreshRequired = false;
   @property({ attribute: false }) onRefresh: () => void = () => undefined;
   @property({ attribute: false }) onHoldUpdate: () => Promise<boolean> = async () => false;
-  @state() private dismissedUpdateKey: string | null = null;
   @state() private holdingCampaignId: string | null = null;
   @state() private nativeUpdateAvailable = hasNativeUpdateBridge();
   private nativeUpdateDeclined = false;
@@ -102,6 +60,22 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
     ) {
       this.onUpdate();
     }
+  };
+
+  private readonly startUpdate = () => {
+    const busy = this.updateBusy || this.updateSchedule?.campaign?.state === "applying";
+    if (busy || !this.canUpdate) {
+      return;
+    }
+    void confirmAndStartUpdate({
+      startGatewayUpdate: () => this.onUpdate(),
+      ...(this.watchUpdateProgress ? { watchUpdateProgress: this.watchUpdateProgress } : {}),
+      updateAvailable: this.updateAvailable,
+      updateSchedule: this.updateSchedule,
+      // Read the bridge at click time: a Mac app that installed it after the
+      // last availability event still owns this update.
+      viaNativeApp: !this.nativeUpdateDeclined && hasNativeUpdateBridge(),
+    });
   };
 
   override connectedCallback() {
@@ -180,15 +154,7 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
     // metadata while it restarts, and the card must not vanish or fall back to
     // the stale "update available" call to action mid-install.
     const statusBanner = this.statusBanner;
-    if (
-      !campaign &&
-      !busy &&
-      !statusBanner &&
-      (!update ||
-        (!hasVersionUpdate && !hasGitUpdate) ||
-        this.dismissedUpdateKey === updateKey(update) ||
-        isDismissed(update))
-    ) {
+    if (!campaign && !busy && !statusBanner && (!update || (!hasVersionUpdate && !hasGitUpdate))) {
       return nothing;
     }
     const title = this.nativeUpdateAvailable
@@ -197,15 +163,18 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
     const betaChannelSuffix = update?.channel === "beta" ? " (beta)" : "";
     const campaignLabel = formatUpdateCampaignLabel(this.updateSchedule);
     const targetLabel = formatUpdateTargetLabel(this.updateSchedule, update);
+    const availabilityOnly = !campaign && !busy && !statusBanner;
     const text = campaignLabel
       ? targetLabel
         ? t("updates.sidebar.campaignTarget", { status: campaignLabel, target: targetLabel })
         : campaignLabel
       : busy
         ? t("updates.sidebar.updating")
-        : targetLabel
-          ? `${title} · ${targetLabel}${betaChannelSuffix}`
-          : title;
+        : availabilityOnly
+          ? t("updates.sidebar.available")
+          : targetLabel
+            ? `${title} · ${targetLabel}${betaChannelSuffix}`
+            : title;
     const countdownActive =
       campaign?.state === "countdown" || campaign?.state === "waiting-for-idle";
     const holdActive = campaign?.holdUntilMs !== undefined && campaign.holdUntilMs > Date.now();
@@ -230,40 +199,41 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
         ${this.renderStatus()}
         ${actionable
           ? html`<div class="sidebar-update-card__actions">
-              <button
-                class="sidebar-update-card__action ${campaign
-                  ? "sidebar-update-card__action--undismissable"
-                  : ""} ${busy ? "sidebar-update-card__action--busy" : ""}"
-                type="button"
-                title=${this.canUpdate ? nothing : t("updates.adminRequired")}
-                ?disabled=${busy || !this.canUpdate}
-                @click=${() => {
-                  if (busy || !this.canUpdate) {
-                    return;
-                  }
-                  void confirmAndStartUpdate({
-                    startGatewayUpdate: () => this.onUpdate(),
-                    ...(this.watchUpdateProgress
-                      ? { watchUpdateProgress: this.watchUpdateProgress }
-                      : {}),
-                    updateAvailable: this.updateAvailable,
-                    updateSchedule: this.updateSchedule,
-                    // Read the bridge at click time: a Mac app that installed it
-                    // after the last availability event still owns this update.
-                    viaNativeApp: !this.nativeUpdateDeclined && hasNativeUpdateBridge(),
-                  });
-                }}
-              >
-                <span class="sidebar-update-card__icon" aria-hidden="true"
-                  >${busy ? icons.refresh : icons.download}</span
-                >
-                <span
-                  class="sidebar-update-card__text"
-                  role=${countdownActive ? "timer" : nothing}
-                  aria-live=${countdownActive ? "off" : nothing}
-                  >${text}</span
-                >
-              </button>
+              ${availabilityOnly
+                ? html`<div class="sidebar-update-card__availability">
+                    <span class="sidebar-update-card__icon" aria-hidden="true"
+                      >${icons.refresh}</span
+                    >
+                    <span class="sidebar-update-card__text">${text}</span>
+                    <button
+                      class="sidebar-update-card__cta"
+                      type="button"
+                      title=${this.canUpdate ? nothing : t("updates.adminRequired")}
+                      ?disabled=${!this.canUpdate}
+                      @click=${this.startUpdate}
+                    >
+                      ${t("updates.sidebar.action")}
+                    </button>
+                  </div>`
+                : html`<button
+                    class="sidebar-update-card__action ${busy
+                      ? "sidebar-update-card__action--busy"
+                      : ""}"
+                    type="button"
+                    title=${this.canUpdate ? nothing : t("updates.adminRequired")}
+                    ?disabled=${busy || !this.canUpdate}
+                    @click=${this.startUpdate}
+                  >
+                    <span class="sidebar-update-card__icon" aria-hidden="true"
+                      >${busy ? icons.refresh : icons.download}</span
+                    >
+                    <span
+                      class="sidebar-update-card__text"
+                      role=${countdownActive ? "timer" : nothing}
+                      aria-live=${countdownActive ? "off" : nothing}
+                      >${text}</span
+                    >
+                  </button>`}
               ${showHold && campaign
                 ? html`
                     <button
@@ -282,21 +252,6 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
                 : nothing}
             </div>`
           : nothing}
-        ${campaign || busy || !update || statusBanner
-          ? nothing
-          : html`
-              <button
-                class="sidebar-update-card__dismiss"
-                type="button"
-                aria-label=${t("chat.dismissUpdateBanner")}
-                @click=${() => {
-                  this.dismissedUpdateKey = updateKey(update);
-                  dismiss(update);
-                }}
-              >
-                ${icons.x}
-              </button>
-            `}
       </div>
     `;
   }

--- a/ui/src/e2e/sidebar-footer-proof.test-support.ts
+++ b/ui/src/e2e/sidebar-footer-proof.test-support.ts
@@ -19,7 +19,7 @@ export function createSidebarFooterProofSuite(name: string, buildInfo?: ControlU
   return createControlUiE2eSuite({
     name,
     browserLaunchOptions: { headless: process.env.OPENCLAW_UI_E2E_HEADED !== "1" },
-    startServer: buildInfo ? () => startControlUiE2eServer(buildInfo, { source: true }) : undefined,
+    startServer: () => startControlUiE2eServer(buildInfo, { source: true }),
     startServerBeforeBrowser: true,
     trackBrowserContexts: true,
     unavailableMessage: (executablePath) =>
@@ -30,6 +30,7 @@ export function createSidebarFooterProofSuite(name: string, buildInfo?: ControlU
 export async function openSidebarFooterProofPage(
   suite: ReturnType<typeof createSidebarFooterProofSuite>,
   options: NonNullable<Parameters<typeof installMockGateway>[1]> = {},
+  beforeNavigation?: (page: Page) => Promise<void>,
 ) {
   const context = await suite.newBrowserContext({
     locale: "en-US",
@@ -37,6 +38,7 @@ export async function openSidebarFooterProofPage(
     viewport: { height: 900, width: 1440 },
   });
   const page = await context.newPage();
+  await beforeNavigation?.(page);
   const gateway = await installMockGateway(page, {
     ...options,
     presenceUsers: [SIDEBAR_PROOF_USER],

--- a/ui/src/e2e/sidebar-footer-proof.test-support.ts
+++ b/ui/src/e2e/sidebar-footer-proof.test-support.ts
@@ -29,6 +29,7 @@ export function createSidebarFooterProofSuite(name: string, buildInfo?: ControlU
 
 export async function openSidebarFooterProofPage(
   suite: ReturnType<typeof createSidebarFooterProofSuite>,
+  options: NonNullable<Parameters<typeof installMockGateway>[1]> = {},
 ) {
   const context = await suite.newBrowserContext({
     locale: "en-US",
@@ -36,11 +37,14 @@ export async function openSidebarFooterProofPage(
     viewport: { height: 900, width: 1440 },
   });
   const page = await context.newPage();
-  await installMockGateway(page, { presenceUsers: [SIDEBAR_PROOF_USER] });
+  const gateway = await installMockGateway(page, {
+    ...options,
+    presenceUsers: [SIDEBAR_PROOF_USER],
+  });
   await page.goto(`${suite.server.baseUrl}chat`);
   const sidebar = page.locator("openclaw-app-sidebar");
   await sidebar.locator(".sidebar-identity-card").waitFor();
-  return { context, page, sidebar };
+  return { context, gateway, page, sidebar };
 }
 
 export async function setSidebarProofTheme(page: Page, mode: "dark" | "light") {

--- a/ui/src/e2e/sidebar-update-cta.e2e.test.ts
+++ b/ui/src/e2e/sidebar-update-cta.e2e.test.ts
@@ -66,6 +66,29 @@ suite.define(() => {
         expect((await copy.textContent())?.trim()).toBe("New version available");
         expect(await availability.getByRole("button").count()).toBe(1);
         expect(await sidebar.locator(".sidebar-update-card__dismiss").count()).toBe(0);
+        expect(
+          await availability.locator(".sidebar-update-card__icon").evaluate((element) => {
+            const icon = element.getBoundingClientRect();
+            const svg = element.querySelector("svg")?.getBoundingClientRect();
+            const style = getComputedStyle(element);
+            const infoProbe = document.createElement("span");
+            infoProbe.style.color = "var(--info)";
+            document.body.append(infoProbe);
+            const infoColor = getComputedStyle(infoProbe).color;
+            infoProbe.remove();
+            return {
+              backgroundColor: style.backgroundColor,
+              usesInfoColor: style.color === infoColor,
+              size: [icon.width, icon.height],
+              svgSize: svg ? [svg.width, svg.height] : null,
+            };
+          }),
+        ).toEqual({
+          backgroundColor: "rgba(0, 0, 0, 0)",
+          usesInfoColor: true,
+          size: [26, 26],
+          svgSize: [16, 16],
+        });
 
         const restSurface = await surfaceStyle(availability);
         const restCta = await surfaceStyle(cta);

--- a/ui/src/e2e/sidebar-update-cta.e2e.test.ts
+++ b/ui/src/e2e/sidebar-update-cta.e2e.test.ts
@@ -1,0 +1,119 @@
+import type { Locator } from "playwright";
+import { expect, it } from "vitest";
+import {
+  captureUnionProof,
+  createSidebarFooterProofSuite,
+  openSidebarFooterProofPage,
+  setSidebarProofTheme,
+} from "./sidebar-footer-proof.test-support.ts";
+
+const UPDATE_AVAILABLE = {
+  channel: "stable",
+  currentVersion: "1.0.0",
+  latestVersion: "2.0.0",
+} as const;
+
+const UPDATE_RUN_RESPONSE = {
+  ok: true,
+  restart: null,
+  result: { after: { version: "2.0.0" }, status: "ok" },
+} as const;
+
+async function surfaceStyle(locator: Locator) {
+  return locator.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      boxShadow: style.boxShadow,
+      cursor: style.cursor,
+      transform: style.transform,
+    };
+  });
+}
+
+const suite = createSidebarFooterProofSuite("Control UI sidebar update CTA E2E");
+
+suite.define(() => {
+  it.each(["light", "dark"] as const)(
+    "keeps the informational update strip static in %s mode",
+    async (theme) => {
+      const opened = await openSidebarFooterProofPage(suite, {
+        methodResponses: { "update.run": UPDATE_RUN_RESPONSE },
+      });
+      try {
+        const { gateway, page, sidebar } = opened;
+        const footer = sidebar.locator(".sidebar-footer-bar");
+        await setSidebarProofTheme(page, theme);
+        await page.mouse.move(0, 0);
+
+        expect(await sidebar.locator(".sidebar-update-card").count()).toBe(0);
+        await captureUnionProof(page, "sidebar-update-cta", `${theme}-no-update-footer.png`, [
+          footer,
+        ]);
+
+        await gateway.emitGatewayEvent("update.available", {
+          updateAvailable: UPDATE_AVAILABLE,
+        });
+        const card = sidebar.locator(".sidebar-update-card");
+        const availability = sidebar.locator(".sidebar-update-card__availability");
+        const copy = availability.locator(".sidebar-update-card__text");
+        const cta = availability.getByRole("button", { name: "Update", exact: true });
+        await availability.waitFor();
+
+        expect(await card.getAttribute("role")).toBe("status");
+        expect(await card.getAttribute("tabindex")).toBeNull();
+        expect(await availability.getAttribute("role")).toBeNull();
+        expect((await copy.textContent())?.trim()).toBe("New version available");
+        expect(await availability.getByRole("button").count()).toBe(1);
+        expect(await sidebar.locator(".sidebar-update-card__dismiss").count()).toBe(0);
+
+        const restSurface = await surfaceStyle(availability);
+        const restCta = await surfaceStyle(cta);
+        await captureUnionProof(page, "sidebar-update-cta", `${theme}-update-rest.png`, [
+          availability,
+          footer,
+        ]);
+
+        await copy.hover();
+        await copy.click();
+        expect(await page.getByRole("dialog").count()).toBe(0);
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        expect(await surfaceStyle(availability)).toEqual(restSurface);
+        await captureUnionProof(page, "sidebar-update-cta", `${theme}-container-click.png`, [
+          availability,
+          footer,
+        ]);
+
+        await cta.hover();
+        await expect.poll(() => surfaceStyle(cta)).not.toEqual(restCta);
+        expect(await surfaceStyle(availability)).toEqual(restSurface);
+        await captureUnionProof(page, "sidebar-update-cta", `${theme}-cta-hover.png`, [
+          availability,
+          footer,
+          cta,
+        ]);
+
+        await page.mouse.move(0, 0);
+        await cta.focus();
+        await captureUnionProof(page, "sidebar-update-cta", `${theme}-cta-focus.png`, [
+          availability,
+          footer,
+          cta,
+        ]);
+
+        await page.keyboard.press("Enter");
+        const dialog = page.getByRole("dialog");
+        await dialog.waitFor();
+        expect(await dialog.getAttribute("aria-label")).toBe("Update Gateway");
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        await captureUnionProof(page, "sidebar-update-cta", `${theme}-confirmation.png`, [
+          availability,
+          footer,
+          dialog,
+        ]);
+      } finally {
+        await suite.closeBrowserContext(opened.context);
+      }
+    },
+  );
+});

--- a/ui/src/e2e/sidebar-update-cta.e2e.test.ts
+++ b/ui/src/e2e/sidebar-update-cta.e2e.test.ts
@@ -1,4 +1,4 @@
-import type { Locator } from "playwright";
+import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import {
   captureUnionProof,
@@ -28,6 +28,26 @@ async function surfaceStyle(locator: Locator) {
       cursor: style.cursor,
       transform: style.transform,
     };
+  });
+}
+
+async function installLongPortugueseUpdateCopy(page: Page) {
+  const translations = JSON.stringify({
+    updates: {
+      sidebar: {
+        available: "Uma nova versão do OpenClaw está disponível",
+        action: "Atualizar",
+      },
+    },
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem("openclaw.i18n.locale", "pt-BR");
+  });
+  await page.route("**/src/i18n/locales/pt-BR.ts*", (route) => {
+    return route.fulfill({
+      contentType: "application/javascript",
+      body: `export const pt_BR = ${translations};`,
+    });
   });
 }
 
@@ -139,4 +159,57 @@ suite.define(() => {
       }
     },
   );
+
+  it("keeps long Portuguese update copy inside the supported sidebar width", async () => {
+    const opened = await openSidebarFooterProofPage(
+      suite,
+      {
+        methodResponses: { "update.run": UPDATE_RUN_RESPONSE },
+        updateAvailable: UPDATE_AVAILABLE,
+      },
+      installLongPortugueseUpdateCopy,
+    );
+    try {
+      const { page, sidebar } = opened;
+      await setSidebarProofTheme(page, "light");
+
+      const availability = sidebar.locator(".sidebar-update-card__availability");
+      const copy = availability.locator(".sidebar-update-card__text");
+      const cta = availability.getByRole("button", { name: "Atualizar", exact: true });
+      await expect
+        .poll(() => copy.textContent())
+        .toBe("Uma nova versão do OpenClaw está disponível");
+      expect(await page.locator("html").getAttribute("lang")).toBe("pt-BR");
+      expect(
+        await availability.evaluate((element) => {
+          const container = element.getBoundingClientRect();
+          const text = element.querySelector(".sidebar-update-card__text");
+          const action = element.querySelector(".sidebar-update-card__cta");
+          if (!(text instanceof HTMLElement) || !(action instanceof HTMLElement)) {
+            return null;
+          }
+          const textBox = text.getBoundingClientRect();
+          const actionBox = action.getBoundingClientRect();
+          return {
+            containerFits: element.scrollWidth <= element.clientWidth,
+            textTruncates: text.scrollWidth > text.clientWidth,
+            textInside: textBox.left >= container.left && textBox.right <= container.right,
+            actionInside: actionBox.left >= container.left && actionBox.right <= container.right,
+          };
+        }),
+      ).toEqual({
+        containerFits: true,
+        textTruncates: true,
+        textInside: true,
+        actionInside: true,
+      });
+      await captureUnionProof(page, "sidebar-update-cta", "light-update-pt-BR.png", [
+        availability,
+        sidebar.locator(".sidebar-footer-bar"),
+        cta,
+      ]);
+    } finally {
+      await suite.closeBrowserContext(opened.context);
+    }
+  });
 });

--- a/ui/src/e2e/update-coalesced.e2e.test.ts
+++ b/ui/src/e2e/update-coalesced.e2e.test.ts
@@ -17,7 +17,7 @@ const MANAGED_UPDATE_HANDOFF_RESPONSE = {
 } as const;
 
 suite.define(() => {
-  it("identifies a beta release in the visible Gateway update card", async () => {
+  it("renders the informational CTA for a beta release", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-beta-channel");
     await suite.withPage(
       {
@@ -39,11 +39,8 @@ suite.define(() => {
           },
         });
 
-        await page
-          .getByRole("button", {
-            name: /Update Gateway · v2026\.7\.2-beta\.5 \(beta\)/u,
-          })
-          .waitFor({ timeout: 10_000 });
+        await page.getByText("New version available", { exact: true }).waitFor({ timeout: 10_000 });
+        await page.getByRole("button", { name: "Update", exact: true }).waitFor();
         await page.screenshot({ path: path.join(artifactDir, "beta-update-card.png") });
         expect(await gateway.getRequests("update.run")).toHaveLength(0);
       },
@@ -81,7 +78,7 @@ suite.define(() => {
           },
         });
 
-        await page.getByRole("button", { name: /Update Gateway/ }).click();
+        await page.getByRole("button", { name: "Update", exact: true }).click();
         await page.getByRole("button", { name: "Update and restart", exact: true }).click();
         const dialog = page.locator("openclaw-modal-dialog");
         await dialog
@@ -132,7 +129,7 @@ suite.define(() => {
           },
         });
 
-        await page.getByRole("button", { name: /Update Gateway/ }).click();
+        await page.getByRole("button", { name: "Update", exact: true }).click();
         await page.getByRole("button", { name: "Update and restart", exact: true }).click();
         await page.getByRole("button", { name: "Updating…", exact: true }).waitFor();
 
@@ -221,7 +218,7 @@ suite.define(() => {
             },
           });
 
-          await page.getByRole("button", { name: /Update Gateway/ }).click();
+          await page.getByRole("button", { name: "Update", exact: true }).click();
           await page.getByRole("button", { name: "Update and restart", exact: true }).click();
           await gateway.waitForRequest("update.run");
           if (responseFirst) {
@@ -294,7 +291,7 @@ suite.define(() => {
         },
       });
 
-      await page.getByRole("button", { name: /Update Mac app \+ Gateway/ }).click();
+      await page.getByRole("button", { name: "Update", exact: true }).click();
       await page.getByRole("button", { name: "Update Mac app and restart", exact: true }).click();
       expect(
         await page.evaluate(
@@ -307,7 +304,7 @@ suite.define(() => {
         Reflect.deleteProperty(window, "webkit");
         window.dispatchEvent(new CustomEvent(eventName));
       }, NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT);
-      await page.getByRole("button", { name: /Update Gateway/ }).click();
+      await page.getByRole("button", { name: "Update", exact: true }).click();
       await page.getByRole("button", { name: "Update and restart", exact: true }).click();
 
       expect(await gateway.getRequests("update.run")).toHaveLength(1);

--- a/ui/src/e2e/update-confirmation.e2e.test.ts
+++ b/ui/src/e2e/update-confirmation.e2e.test.ts
@@ -34,7 +34,7 @@ async function openUpdateCard(page: Page, baseUrl: string) {
   expect((await page.goto(`${baseUrl}chat`))?.status()).toBe(200);
   await gateway.waitForRequest("chat.startup");
   await gateway.emitGatewayEvent("update.available", { updateAvailable: UPDATE_AVAILABLE });
-  const updateButton = page.getByRole("button", { name: /Update Gateway/ });
+  const updateButton = page.getByRole("button", { name: "Update", exact: true });
   await updateButton.waitFor({ timeout: 10_000 });
   return { gateway, updateButton };
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -394,6 +394,8 @@ export const en: TranslationMap = {
       commitsBehind: "{count} commits behind",
     },
     sidebar: {
+      available: "New version available",
+      action: "Update",
       campaignTarget: "{status} · {target}",
       updating: "Updating Gateway…",
     },
@@ -4919,7 +4921,6 @@ export const en: TranslationMap = {
     commandPaletteTitle: "Search or jump to… (⌘K)",
     openCommandPalette: "Open command palette",
     updating: "Updating…",
-    dismissUpdateBanner: "Dismiss update banner",
     actions: {
       copyAsMarkdown: "Copy as markdown",
       dismissError: "Dismiss error",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1556,50 +1556,30 @@ html.openclaw-native-macos
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
-  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+  padding: 4px 34px 4px 8px;
+  border: 1px solid color-mix(in srgb, var(--info) 18%, var(--border));
   border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--info-subtle) 48%, var(--bg-elevated));
   color: var(--text);
   text-align: left;
 }
 
 .sidebar-update-card__action {
-  background: color-mix(in srgb, var(--accent-subtle) 48%, var(--bg-elevated));
   cursor: var(--cursor-action);
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease;
 }
 
-.sidebar-update-card__availability {
-  gap: 5px;
-  border-color: color-mix(in srgb, var(--info) 18%, var(--border));
-  background: color-mix(in srgb, var(--info) 8%, var(--bg-elevated));
-}
-
-.sidebar-update-card__availability .sidebar-update-card__icon {
-  width: 18px;
-  height: 18px;
-}
-
-.sidebar-update-card__availability .sidebar-update-card__icon svg {
-  width: 13px;
-  height: 13px;
-}
-
-.sidebar-update-card__availability .sidebar-update-card__text {
-  font-size: var(--control-ui-text-xs);
-}
-
 .sidebar-update-card__action:hover:not(:disabled),
 .sidebar-update-card__action:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
-  background: color-mix(in srgb, var(--accent-subtle) 72%, var(--bg-elevated));
+  border-color: color-mix(in srgb, var(--info) 36%, var(--border));
+  background: color-mix(in srgb, var(--info) 10%, var(--bg-elevated));
 }
 
 .sidebar-update-card__action:focus-visible,
 .sidebar-update-card__hold:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 48%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--info) 48%, transparent);
   outline-offset: 1px;
 }
 
@@ -1688,8 +1668,8 @@ body.update-dialog-open .sidebar-update-card__status {
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--info) 14%, transparent);
+  color: var(--info);
 }
 
 .sidebar-update-card__text {
@@ -1709,7 +1689,7 @@ body.update-dialog-open .sidebar-update-card__status {
   min-height: 24px;
   display: inline-flex;
   align-items: center;
-  padding: 3px 7px;
+  padding: 3px 11px;
   border: 0;
   border-radius: var(--radius-full);
   background: var(--info);
@@ -1763,7 +1743,7 @@ body.update-dialog-open .sidebar-update-card__status {
   height: 16px;
   stroke: currentColor;
   fill: none;
-  stroke-width: 1.7px;
+  stroke-width: 1.5px;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
@@ -1772,11 +1752,32 @@ body.update-dialog-open .sidebar-update-card__status {
   margin: 0 0 2px;
 }
 
+.sidebar-shell__footer .sidebar-update-card__action,
 .sidebar-shell__footer .sidebar-update-card__availability {
   min-height: 40px;
   padding: 6px 10px;
   border: 0;
   border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--info) 8%, var(--bg-elevated));
+}
+
+.sidebar-shell__footer .sidebar-update-card__action:hover:not(:disabled),
+.sidebar-shell__footer .sidebar-update-card__action:focus-visible {
+  border-color: transparent;
+  background: color-mix(in srgb, var(--info) 12%, var(--bg-elevated));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--info) 12%, transparent);
+}
+
+.sidebar-shell__footer .sidebar-update-card__icon {
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  color: var(--info);
+}
+
+.sidebar-shell__footer .sidebar-update-card__text {
+  font-size: calc(13px * var(--control-ui-text-scale));
+  font-weight: 500;
 }
 
 .sidebar-nav {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1506,7 +1506,6 @@ openclaw-settings-save-indicator {
 }
 
 .sidebar-update-card {
-  position: relative;
   margin: 0 8px 10px;
 }
 
@@ -1549,23 +1548,47 @@ html.openclaw-native-macos
   margin-top: calc(var(--openclaw-native-titlebar-height, 50px) + 2px);
 }
 
-.sidebar-update-card__action {
+.sidebar-update-card__action,
+.sidebar-update-card__availability {
   min-width: 0;
   flex: 1 1 auto;
   min-height: 34px;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 34px 4px 8px;
+  padding: 4px 8px;
   border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
   border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--accent-subtle) 48%, var(--bg-elevated));
   color: var(--text);
-  cursor: var(--cursor-action);
   text-align: left;
+}
+
+.sidebar-update-card__action {
+  background: color-mix(in srgb, var(--accent-subtle) 48%, var(--bg-elevated));
+  cursor: var(--cursor-action);
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease;
+}
+
+.sidebar-update-card__availability {
+  gap: 5px;
+  border-color: color-mix(in srgb, var(--info) 18%, var(--border));
+  background: color-mix(in srgb, var(--info) 8%, var(--bg-elevated));
+}
+
+.sidebar-update-card__availability .sidebar-update-card__icon {
+  width: 18px;
+  height: 18px;
+}
+
+.sidebar-update-card__availability .sidebar-update-card__icon svg {
+  width: 13px;
+  height: 13px;
+}
+
+.sidebar-update-card__availability .sidebar-update-card__text {
+  font-size: var(--control-ui-text-xs);
 }
 
 .sidebar-update-card__action:hover:not(:disabled),
@@ -1575,8 +1598,7 @@ html.openclaw-native-macos
 }
 
 .sidebar-update-card__action:focus-visible,
-.sidebar-update-card__hold:focus-visible,
-.sidebar-update-card__dismiss:focus-visible {
+.sidebar-update-card__hold:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 48%, transparent);
   outline-offset: 1px;
 }
@@ -1658,21 +1680,13 @@ body.update-dialog-open .sidebar-update-card__status {
   background: color-mix(in srgb, var(--warn) 10%, transparent);
 }
 
-.sidebar-update-card__action--undismissable {
-  padding-right: 8px;
-}
-
-.sidebar-update-card__icon,
-.sidebar-update-card__dismiss {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .sidebar-update-card__icon {
+  display: inline-flex;
   width: 24px;
   height: 24px;
   flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--accent) 14%, transparent);
   color: var(--accent);
@@ -1688,6 +1702,41 @@ body.update-dialog-open .sidebar-update-card__status {
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.sidebar-update-card__cta {
+  flex: 0 0 auto;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 7px;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: var(--info);
+  color: var(--bg-elevated);
+  cursor: var(--cursor-action);
+  font: inherit;
+  font-size: calc(12px * var(--control-ui-text-scale));
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  transition:
+    background var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.sidebar-update-card__cta:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--info) 90%, white);
+}
+
+.sidebar-update-card__cta:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--info) 28%, transparent);
+}
+
+.sidebar-update-card__cta:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .sidebar-update-card__text--stacked {
@@ -1709,28 +1758,7 @@ body.update-dialog-open .sidebar-update-card__status {
   white-space: nowrap;
 }
 
-.sidebar-update-card__dismiss {
-  position: absolute;
-  top: 50%;
-  right: 5px;
-  transform: translateY(-50%);
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--muted);
-  cursor: var(--cursor-action);
-}
-
-.sidebar-update-card__dismiss:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.sidebar-update-card__icon svg,
-.sidebar-update-card__dismiss svg {
+.sidebar-update-card__icon svg {
   width: 16px;
   height: 16px;
   stroke: currentColor;
@@ -1738,6 +1766,17 @@ body.update-dialog-open .sidebar-update-card__status {
   stroke-width: 1.7px;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+.sidebar-shell__footer .sidebar-update-card {
+  margin: 0 0 2px;
+}
+
+.sidebar-shell__footer .sidebar-update-card__availability {
+  min-height: 40px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--radius-md);
 }
 
 .sidebar-nav {

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -53,7 +53,7 @@ describe("AppSidebar update card wiring", () => {
     const card = footer?.querySelector("openclaw-sidebar-update-card");
     expect(card).not.toBeNull();
     const restoreDialogPolyfill = installDialogPolyfill();
-    card?.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    card?.querySelector<HTMLButtonElement>(".sidebar-update-card__cta")?.click();
     const { modal } = await waitForRenderedModalDialog(document.body);
     [...modal.querySelectorAll("button")]
       .find((button) => button.textContent?.trim() === "Update and restart")

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -10,7 +10,7 @@ import type { ConsoleMessage, Frame, Locator, Page, Request } from "playwright";
 import type { InlineConfig, Plugin, PreviewServer, ViteDevServer } from "vite";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../src/gateway/control-ui-contract.js";
-import type { ModelCatalogEntry } from "../api/types.ts";
+import type { ModelCatalogEntry, UpdateAvailable } from "../api/types.ts";
 import { normalizeControlUiBuildInfo } from "../build-info-normalizers.ts";
 import type { ControlUiBuildInfo } from "../build-info.ts";
 
@@ -321,6 +321,7 @@ export type ControlUiMockGatewayScenario = {
   sessionGroupDefaults?: Record<string, { cwd?: string; worktree?: boolean }>;
   terminalEnabled?: boolean;
   cliAgentsEnabled?: boolean;
+  updateAvailable?: UpdateAvailable | null;
   workspace?: string;
   workspaceGit?: boolean;
 };
@@ -882,6 +883,7 @@ function normalizeScenario(
     sessionGroupDefaults: scenario.sessionGroupDefaults ?? {},
     terminalEnabled: scenario.terminalEnabled ?? false,
     cliAgentsEnabled: scenario.cliAgentsEnabled ?? false,
+    updateAvailable: scenario.updateAvailable ?? null,
     workspace: scenario.workspace ?? "",
     workspaceGit: scenario.workspaceGit ?? false,
   };
@@ -1684,6 +1686,7 @@ function installControlUiMockGateway(
           },
           snapshot: {
             ...presenceSnapshot(params),
+            ...(scenario.updateAvailable ? { updateAvailable: scenario.updateAvailable } : {}),
             sessionDefaults: {
               defaultAgentId: scenario.defaultAgentId,
               mainKey: "main",


### PR DESCRIPTION
Depends on #123582.

## What Problem This Solves

The sidebar update surface looked and behaved like one large button. Operators could not distinguish status from the action, and the whole card appeared interactive even though the intended decision is a single explicit update action.

## Why This Change Was Made

- Keeps availability as a quiet, non-focusable status surface.
- Gives the update action one compact, explicit CTA.
- Preserves the existing confirmation flow, native-app ownership, managed campaigns, progress, and failure recovery.
- Removes browser-persisted dismissal so an available update does not silently disappear.

## User Impact

Available updates are easier to scan and harder to trigger accidentally. Clicking the informational copy does nothing; activating **Update** opens the existing confirmation dialog. Update state remains separate from operational Issues.

## Evidence

- 19 focused update-card assertions passed.
- 264 sidebar wiring and settings assertions passed.
- 15 browser scenarios passed across the new CTA, confirmation, coalescing, failure, and native ownership paths.
- 12 light/dark visual states inspected: no update, rest, informational-surface click, CTA hover, CTA focus, and confirmation.
- Changed-surface formatting, typechecks, lint, localization, dead-code, and repository guards passed.

\n\n<!-- stack-d-exact-head-visual-proof -->
### Exact-head visual proof

Captured after the final informational styling and localization-fit pass at PR head `3e5280bc46a`, within stack head `5e2e13c58f3`. The final headed matrix passed 7/7 flows across the stack ([run](https://github.com/openclaw/openclaw/actions/runs/31848940782)).

| Light | Dark |
| --- | --- |
| ![Informational update CTA in light mode](https://github.com/user-attachments/assets/0f3b1118-e70a-4223-9777-4bdf6f3e0154) | ![Informational update CTA in dark mode](https://github.com/user-attachments/assets/378aa04e-cba8-4126-be86-f777efc8b8b3) |

#### Long localization fit

![Portuguese update copy truncates inside the supported sidebar width while the Atualizar action remains fully visible](https://github.com/user-attachments/assets/3d0409db-ff37-4527-9407-6458c43662c7)

Manual comparison confirmed the quiet info-blue surface, blue refresh icon, dark status copy, primary blue CTA, and 2px separation from the account footer. The pt-BR frame verifies deliberate single-line ellipsis: the strip has no horizontal overflow and the complete **Atualizar** action remains inside the supported sidebar width.