### PR TITLE
fix(exec): preserve stderr in node command results

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -151,7 +151,7 @@ function createDirectNodeRun(signal?: AbortSignal): DirectNodeRun {
   };
 }
 
-describe("direct node run cancellation", () => {
+describe("direct node run", () => {
   beforeEach(() => {
     callGatewayToolMock.mockReset();
     callGatewayToolMock.mockResolvedValue({
@@ -178,6 +178,33 @@ describe("direct node run cancellation", () => {
     } else {
       expect(callGatewayToolMock).toHaveBeenCalledWith(...baseArgs);
     }
+  });
+
+  it("surfaces capped stderr and the node error when stdout is also present", async () => {
+    const stdout = "small stdout";
+    const stderr = `${"x".repeat(200_000)}\n... (truncated)`;
+    const errorText = "node command failed";
+    callGatewayToolMock.mockResolvedValueOnce({
+      payload: {
+        success: false,
+        stdout,
+        stderr,
+        error: errorText,
+        exitCode: 1,
+      },
+    });
+
+    const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
+    const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+    expect(visibleText).toContain("... (truncated)");
+    expect(visibleText).toContain(errorText);
+    expect(visibleText).toBe(`${stdout}\n${stderr}\n${errorText}`);
+    expect(result.details).toMatchObject({
+      status: "failed",
+      exitCode: 1,
+      aggregated: visibleText,
+    });
   });
 
   it("never dispatches a direct node run after cancellation", async () => {

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -253,12 +253,13 @@ export function formatNodeRunToolResult(params: {
   const errorText = typeof payloadObj.error === "string" ? payloadObj.error : "";
   const success = typeof payloadObj.success === "boolean" ? payloadObj.success : false;
   const exitCode = typeof payloadObj.exitCode === "number" ? payloadObj.exitCode : null;
+  const output = [stdout, stderr, errorText].filter(Boolean).join("\n");
   return {
     content: [
       {
         type: "text",
         text: renderExecUpdateText({
-          tailText: stdout || stderr || errorText,
+          tailText: output,
           warnings: params.warnings ?? [],
         }),
       },
@@ -267,7 +268,7 @@ export function formatNodeRunToolResult(params: {
       status: success ? "completed" : "failed",
       exitCode,
       durationMs: Date.now() - params.startedAt,
-      aggregated: [stdout, stderr, errorText].filter(Boolean).join("\n"),
+      aggregated: output,
       cwd: params.cwd,
     } satisfies ExecToolDetails,
   };


### PR DESCRIPTION
Closes #123600

## What Problem This Solves

Fixes an issue where `exec host=node` hid stderr, truncation notices, and node error text whenever the command also emitted non-empty stdout. Agents could receive a completed-looking stdout fragment without the diagnostics explaining failure or incomplete output.

## Why This Change Was Made

The node result formatter now builds one combined stdout/stderr/error rendering and uses it for both provider-visible content and `details.aggregated`. Node execution, stream caps, status/exit metadata, timeout/cancel behavior, custody, and warning rendering remain unchanged.

## User Impact

Agents and operators now see the complete node command result, including stderr and the explicit truncation marker, even when stdout is present. Diagnostic details no longer disappear at the provider boundary.

## Evidence

- Tests-first regression reproduced visible output containing exactly `small stdout\n` while stderr's `... (truncated)` marker and `node command failed` text were absent.
- Post-fix focused node exec proof: 96/96 passed.
- The regression asserts provider-visible content contains stdout, capped stderr, truncation notice, and error text, and matches the canonical diagnostic aggregate.
- Blacksmith Testbox core + coreTests changed gate passed, including typechecks, changed lint, dead exports, import cycles, formatting, and storage/schema/architecture guards: https://github.com/openclaw/openclaw/actions/runs/31790868936 (`tbx_01kzzvseq3exagr9jx42651z6z`).
- Final Codex autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Exact reviewed head: `36696a6ad16467cc1a6a40e1aea144681d75fa6f`.

Production delta: +3/-2, net +1. Tests: +28/-1, net +27.

AI-assisted: yes. The repair was reviewed against node system.run capture/truncation, direct invoke failure classification, exec result rendering, provider tool-result projection, local/background sibling formatters, and existing status/custody behavior.
