### PR TITLE
improve(ui): group coding sessions by project

### DIFF
--- a/src/gateway/session-create-fork-entry.test.ts
+++ b/src/gateway/session-create-fork-entry.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
+import { SESSION_LABEL_MAX_LENGTH, parseSessionLabel } from "../sessions/session-label.js";
 import { buildForkedGatewaySessionEntry } from "./session-create-fork-entry.js";
+import { forkedSessionLabel } from "./session-create-service.js";
 
 describe("buildForkedGatewaySessionEntry", () => {
   it("preserves adopted node ancestry and links the replaced generation", () => {
@@ -39,5 +41,33 @@ describe("buildForkedGatewaySessionEntry", () => {
       sessionId: "parent-generation",
     });
     expect(forked.previousSessionId).toBeUndefined();
+  });
+});
+
+describe("forkedSessionLabel", () => {
+  it("inherits the parent name with the first free copy number", () => {
+    expect(forkedSessionLabel("Release notes", () => false)).toBe("Release notes (2)");
+    expect(forkedSessionLabel("Release notes", (label) => label === "Release notes (2)")).toBe(
+      "Release notes (3)",
+    );
+  });
+
+  it("counts from the original name rather than stacking suffixes", () => {
+    expect(forkedSessionLabel("Release notes (2)", () => false)).toBe("Release notes (2)");
+  });
+
+  it("keeps the suffix inside the label limit a parent may legally fill", () => {
+    const full = "n".repeat(SESSION_LABEL_MAX_LENGTH);
+    const forked = forkedSessionLabel(full, () => false);
+    // A parent is allowed the whole budget; the fork must still validate, so the
+    // inherited base gives way to the suffix instead of overflowing past it.
+    expect(forked).toBeDefined();
+    expect(parseSessionLabel(forked ?? "").ok).toBe(true);
+    expect(forked?.endsWith(" (2)")).toBe(true);
+  });
+
+  it("leaves an unnamed parent unnamed", () => {
+    expect(forkedSessionLabel(undefined, () => false)).toBeUndefined();
+    expect(forkedSessionLabel("   ", () => false)).toBeUndefined();
   });
 });

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -62,6 +62,7 @@ import {
 } from "../sessions/agent-harness-session-key.js";
 import { shouldPreserveSessionAuthProfileOverride } from "../sessions/auth-profile-preservation.js";
 import { isModelSelectionLocked } from "../sessions/model-overrides.js";
+import { SESSION_LABEL_MAX_LENGTH } from "../sessions/session-label.js";
 import {
   isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
@@ -222,6 +223,44 @@ type CreateGatewaySessionResult =
       resetExisting: boolean;
     }
   | { ok: false; error: ErrorShape };
+
+const FORK_LABEL_MAX_COPIES = 99;
+
+/**
+ * A fork of a named session inherits that name with a numeric suffix. Two rows
+ * both reading "Release notes" are indistinguishable everywhere a session is
+ * listed, and the name is the only thing a fork does not otherwise inherit.
+ *
+ * This belongs to the producer: a renderer deriving it would have to count
+ * look-alikes at paint time, and would disagree with the stored name the moment
+ * either session were renamed. An unnamed parent stays unnamed - a generated
+ * display name is not a name to copy.
+ */
+export function forkedSessionLabel(
+  parentLabel: string | undefined,
+  isLabelInUse: (label: string) => boolean,
+): string | undefined {
+  const inherited = normalizeOptionalString(parentLabel)
+    ?.replace(/\s*\(\d+\)$/u, "")
+    .trim();
+  if (!inherited) {
+    return undefined;
+  }
+  // A parent may legally use the whole label budget, and the suffix still has to
+  // fit: appending to a full-length name would make the fork fail validation
+  // over a name the operator never typed.
+  const suffixBudget = ` (${FORK_LABEL_MAX_COPIES})`.length;
+  const base = inherited.slice(0, SESSION_LABEL_MAX_LENGTH - suffixBudget).trimEnd();
+  for (let copy = 2; copy <= FORK_LABEL_MAX_COPIES; copy += 1) {
+    const candidate = `${base} (${copy})`;
+    if (!isLabelInUse(candidate)) {
+      return candidate;
+    }
+  }
+  // Accepted tradeoff: past the cap the fork stays unnamed rather than growing
+  // an unbounded suffix search, and falls back to its generated display name.
+  return undefined;
+}
 
 export async function createGatewaySession(params: {
   cfg: OpenClawConfig;
@@ -957,18 +996,23 @@ export async function createGatewaySession(params: {
             };
           }
         }
+        const isLabelInUse = (label: string) =>
+          Object.entries(sessionEntries).some(
+            ([sessionKey, entry]) => sessionKey !== target.canonicalKey && entry.label === label,
+          );
         const patched = await projectSessionsPatchEntry({
           cfg: params.cfg,
           existingEntry: sessionEntries[target.canonicalKey],
-          isLabelInUse: (label) =>
-            Object.entries(sessionEntries).some(
-              ([sessionKey, entry]) => sessionKey !== target.canonicalKey && entry.label === label,
-            ),
+          isLabelInUse,
           storeKey: target.canonicalKey,
           agentId: target.agentId,
           patch: {
             key: target.canonicalKey,
-            label: normalizeOptionalString(params.label),
+            label:
+              normalizeOptionalString(params.label) ??
+              (params.fork === true
+                ? forkedSessionLabel(currentParentSessionEntry?.label, isLabelInUse)
+                : undefined),
             category: normalizeOptionalString(params.category),
             model: catalogModel ?? requestedModel,
             thinkingLevel: requestedThinkingLevel,

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -342,7 +342,6 @@ function renderCatalogHostGroup(
                     className: "sidebar-session-catalog-project__head",
                     labelClassName: "sidebar-session-catalog-project__label",
                     title: group.title,
-                    count: group.sessions.length,
                     onToggle: () => params.onToggleSection(sectionId),
                   })}
                   ${collapsed

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -31,7 +31,11 @@ import {
   type SidebarRecentSession,
 } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
+// Side-effect import: the project header paints the element, so its definition
+// has to be registered even when no other sidebar surface pulled it in.
+import "./workspace-icon.ts";
 import { renderPanelRefreshStatus, type PanelRefreshStatus } from "./panel-refresh-status.ts";
+import { resolveWorkspaceIconSource, type WorkspaceIconSource } from "./workspace-icon.ts";
 
 type RenderableSessionSection = SidebarSessionSection<SidebarRecentSession> & {
   totalRowCount: number;
@@ -119,6 +123,16 @@ function groupWorkSessionsByProject(rows: readonly SidebarRecentSession[]): {
 function renderWorkProjectGroup(host: SidebarSessionListHost, group: WorkProjectGroup) {
   const sectionId = workProjectSectionId(group.key);
   const collapsed = host.collapsedSessionSections.has(sectionId);
+  // Every row in the group shares the checkout, so any of them names the same
+  // workspace; the first is simply the one that is always there.
+  const leadSession = group.rows[0];
+  const iconSource = leadSession
+    ? resolveWorkspaceIconSource({
+        gateway: host.sessionDataContext?.gateway,
+        basePath: host.basePath,
+        sessionKey: leadSession.key,
+      })
+    : null;
   return html`<div
     class="sidebar-session-work-project"
     data-session-work-project=${group.key}
@@ -131,17 +145,36 @@ function renderWorkProjectGroup(host: SidebarSessionListHost, group: WorkProject
       className: "sidebar-session-catalog-project__head",
       labelClassName: "sidebar-session-catalog-project__label",
       title: group.key,
-      lead: html`<span class="sidebar-session-group-toggle__lead" aria-hidden="true"
-        >${icons.folder}</span
-      >`,
+      lead: renderProjectIdentityLead(iconSource),
       onToggle: () => host.toggleSection(sectionId),
     })}
     ${collapsed
       ? nothing
-      : html`<div class="sidebar-recent-sessions__list" role="list" aria-label=${group.label}>
+      : html`<div
+          class="sidebar-session-catalog-project__sessions"
+          role="list"
+          aria-label=${group.label}
+        >
           ${group.rows.map((session) => renderSessionTree({ host, session, project: group.label }))}
         </div>`}
   </div>`;
+}
+
+/**
+ * A project is named by its own mark when the workspace has one; the element
+ * answers a missing icon with the folder glyph, so the fallback lives with the
+ * asset owner instead of being decided again at every header.
+ */
+function renderProjectIdentityLead(source: WorkspaceIconSource | null) {
+  return html`<span class="sidebar-session-group-toggle__lead" aria-hidden="true"
+    >${source
+      ? html`<openclaw-workspace-icon
+          .routeUrl=${source.routeUrl}
+          .authTokens=${source.authTokens}
+          .authReady=${source.authReady}
+        ></openclaw-workspace-icon>`
+      : icons.folder}</span
+  >`;
 }
 
 function renderSessionSection(params: {

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -3,7 +3,12 @@ import type { SessionCatalog } from "../../../packages/gateway-protocol/src/inde
 import type { GatewaySessionRow } from "../api/types.ts";
 import type { CatalogOpenTarget } from "../app/settings.ts";
 import { t } from "../i18n/index.ts";
-import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
+import {
+  projectRootLabel,
+  resolveProjectRoot,
+  workProjectSectionId,
+  type CatalogProjectGrouping,
+} from "../lib/sessions/catalog-project-grouping.ts";
 import { openCatalogSessionInTerminal } from "../lib/sessions/catalog-terminal.ts";
 import type { SidebarSessionSection } from "../lib/sessions/grouping.ts";
 import type { SessionCatalogGroupsRenderer } from "./app-sidebar-session-catalog-render.ts";
@@ -70,6 +75,75 @@ function collapsedSectionStatus(section: RenderableSessionSection): SidebarSecti
     : SIDEBAR_SECTION_NO_STATUS;
 }
 
+type WorkProjectGroup = {
+  key: string;
+  label: string;
+  rows: SidebarRecentSession[];
+};
+
+/**
+ * Coding sessions carry a real checkout or working directory; grouping by it is
+ * the difference between one Coding pile and a list of the projects being worked
+ * on. A session with neither fact stays in the flat tail rather than being
+ * guessed into a project it may not belong to.
+ */
+function groupWorkSessionsByProject(rows: readonly SidebarRecentSession[]): {
+  groups: WorkProjectGroup[];
+  ungrouped: SidebarRecentSession[];
+} {
+  const byPath = new Map<string, WorkProjectGroup>();
+  const groups: WorkProjectGroup[] = [];
+  const ungrouped: SidebarRecentSession[] = [];
+  for (const row of rows) {
+    const projectPath = resolveProjectRoot(row.worktree?.repoRoot ?? row.execCwd);
+    if (!projectPath) {
+      ungrouped.push(row);
+      continue;
+    }
+    let group = byPath.get(projectPath);
+    if (!group) {
+      group = { key: projectPath, label: projectRootLabel(projectPath), rows: [] };
+      byPath.set(projectPath, group);
+      groups.push(group);
+    }
+    group.rows.push(row);
+  }
+  return { groups, ungrouped };
+}
+
+/**
+ * A project heading inside Coding. It shares the section grammar rather than
+ * inventing a second one, and carries no row count: the rows are listed
+ * directly beneath it, so counting them says nothing.
+ */
+function renderWorkProjectGroup(host: SidebarSessionListHost, group: WorkProjectGroup) {
+  const sectionId = workProjectSectionId(group.key);
+  const collapsed = host.collapsedSessionSections.has(sectionId);
+  return html`<div
+    class="sidebar-session-work-project"
+    data-session-work-project=${group.key}
+    role="listitem"
+  >
+    ${renderSidebarSessionSectionToggle({
+      label: group.label,
+      collapsed,
+      status: SIDEBAR_SECTION_NO_STATUS,
+      className: "sidebar-session-catalog-project__head",
+      labelClassName: "sidebar-session-catalog-project__label",
+      title: group.key,
+      lead: html`<span class="sidebar-session-group-toggle__lead" aria-hidden="true"
+        >${icons.folder}</span
+      >`,
+      onToggle: () => host.toggleSection(sectionId),
+    })}
+    ${collapsed
+      ? nothing
+      : html`<div class="sidebar-recent-sessions__list" role="list" aria-label=${group.label}>
+          ${group.rows.map((session) => renderSessionTree({ host, session, project: group.label }))}
+        </div>`}
+  </div>`;
+}
+
 function renderSessionSection(params: {
   host: SidebarSessionListHost;
   section: RenderableSessionSection;
@@ -90,6 +164,7 @@ function renderSessionSection(params: {
         : t("chat.sidebar.threads");
   const zone = section.groups ? "groups" : section.work ? "coding" : group ? "category" : "threads";
   const status = collapsed ? collapsedSectionStatus(section) : SIDEBAR_SECTION_NO_STATUS;
+  const workProjects = section.work ? groupWorkSessionsByProject(section.rows) : null;
   const newSessionAccess = host.readNewSessionAccess();
   const groupWriteAccess = host.readSessionMutationAccess({
     method: "sessions.groups.put",
@@ -233,7 +308,14 @@ function renderSessionSection(params: {
               : nothing}
             ${section.rows.length > 0
               ? html`<div class="sidebar-recent-sessions__list" role="list" aria-label=${label}>
-                  ${section.rows.map((session) => renderSessionTree({ host, session }))}
+                  ${workProjects
+                    ? html`${workProjects.groups.map((project) =>
+                        renderWorkProjectGroup(host, project),
+                      )}
+                      ${workProjects.ungrouped.map((session) =>
+                        renderSessionTree({ host, session }),
+                      )}`
+                    : section.rows.map((session) => renderSessionTree({ host, session }))}
                 </div>`
               : nothing}
             ${renderSessionPagination({

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -1,6 +1,10 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
-import { SIDEBAR_NAV_ROUTES, type NavigationRouteId } from "../app-navigation.ts";
+import {
+  SIDEBAR_NAV_ROUTES,
+  type NavigationRouteId,
+  type SidebarZoneEntry,
+} from "../app-navigation.ts";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
@@ -8,9 +12,14 @@ import {
   isCronSessionKey,
   resolveChannelSessionInfo,
   resolveSessionDisplayName,
+  resolveSessionWorkContext,
   resolveSessionWorkSubtitle,
 } from "../lib/session-display.ts";
 import { isSessionRunActive } from "../lib/session-run-state.ts";
+import {
+  resolveProjectRoot,
+  workProjectSectionId,
+} from "../lib/sessions/catalog-project-grouping.ts";
 import {
   groupSidebarSessionRows,
   sidebarSectionHasHeader,
@@ -209,6 +218,7 @@ export function buildSidebarSessionNavigationState(input: {
       label: resolveSessionDisplayName(row.key, row, { includeSubagentPrefix: false }),
       userLabel: row.label,
       subtitle: resolveSessionWorkSubtitle(row),
+      workContext: resolveSessionWorkContext(row),
       href: sessionNavigationTarget({
         face: resolveSessionPreferredFace(row),
         sessionKey: row.key,
@@ -298,6 +308,44 @@ export type SidebarVisibleSections = {
   expandedRows: SidebarRecentSession[];
   visibleRows: SidebarRecentSession[];
 };
+
+/**
+ * The canonical ordered list of sessions the operator can actually see: pinned
+ * entries first, then the expanded sections. Rows folded inside a collapsed
+ * Coding project are excluded here rather than only in the renderer, because
+ * selection, keyboard range, and batch archive/delete all read this projection
+ * and must not act on a session that is not on screen.
+ */
+export function projectVisibleSessionRows(input: {
+  rows: readonly SidebarRecentSession[];
+  zoned: SidebarVisibleSections;
+  pinnedEntries: readonly SidebarZoneEntry[];
+  collapsedSections: ReadonlySet<string>;
+}): SidebarRecentSession[] {
+  const { sections, visibleRows } = input.zoned;
+  const pinnedByKey = new Map(input.rows.filter((row) => row.pinned).map((row) => [row.key, row]));
+  const pinnedRows = input.pinnedEntries.flatMap((entry) => {
+    const pinned = entry.type === "session" ? pinnedByKey.get(entry.key) : undefined;
+    return pinned ? [pinned] : [];
+  });
+  const collapsedSections = input.collapsedSections;
+  const folded = new Set(
+    sections
+      .filter((section) => section.work)
+      .flatMap((section) => section.rows)
+      .filter((row) => {
+        const projectRoot = resolveProjectRoot(row.worktree?.repoRoot ?? row.execCwd);
+        return (
+          projectRoot !== undefined && collapsedSections.has(workProjectSectionId(projectRoot))
+        );
+      })
+      .map((row) => row.key),
+  );
+  return [
+    ...pinnedRows,
+    ...(folded.size === 0 ? visibleRows : visibleRows.filter((row) => !folded.has(row.key))),
+  ];
+}
 
 export function partitionSidebarVisibleSections(input: {
   rows: SidebarRecentSession[];

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -29,6 +29,7 @@ import {
 import {
   applySidebarSessionCreatorFilter,
   buildReconciledSidebarZone,
+  projectVisibleSessionRows,
   buildSidebarSessionNavigationState,
   collectPromotedMainChildRows,
   compareSidebarSessionRowsByMode,
@@ -374,18 +375,13 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
 
   /** Rows in on-screen order; shift ranges and batch actions share this ordering. */
   protected visibleSessionRowsInOrder(): SidebarRecentSession[] {
-    const navigationState = this.getSessionNavigationState();
-    const rows = this.selectedAgentSessionRows(navigationState);
-    const { visibleRows } = this.zonedVisibleSections(rows);
-    const pinnedByKey = new Map(rows.filter((row) => row.pinned).map((row) => [row.key, row]));
-    const pinnedRows = this.reconciledSidebarZone().entries.flatMap((entry) =>
-      entry.type === "session"
-        ? pinnedByKey.get(entry.key)
-          ? [pinnedByKey.get(entry.key)!]
-          : []
-        : [],
-    );
-    return [...pinnedRows, ...visibleRows];
+    const rows = this.selectedAgentSessionRows(this.getSessionNavigationState());
+    return projectVisibleSessionRows({
+      rows,
+      zoned: this.zonedVisibleSections(rows),
+      pinnedEntries: this.reconciledSidebarZone().entries,
+      collapsedSections: this.collapsedSessionSections,
+    });
   }
 
   selectedVisibleSessions(): SidebarRecentSession[] {

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -165,6 +165,8 @@ export function renderRecentSession(params: {
   session: SidebarRecentSession;
   display?: CatalogBackingSessionDisplay;
   listItem?: boolean;
+  /** Project heading this row already sits under, if any. */
+  project?: string;
 }) {
   const { host, session, display, listItem = true } = params;
   const pinAccess = host.readSessionMutationAccess({
@@ -172,7 +174,7 @@ export function renderRecentSession(params: {
     params: { key: session.key, pinned: !session.pinned },
   });
   const label = display?.label ?? session.label;
-  const subtitleSlot = resolveSidebarSessionSubtitle({
+  const subtitleValue = resolveSidebarSessionSubtitle({
     session,
     hasDisplay: display !== undefined,
     displaySubtitle: display?.subtitle,
@@ -180,7 +182,7 @@ export function renderRecentSession(params: {
     narrationLine: host.sidebarNarrationLines.get(session.key),
     observerDigest: host.sidebarObserverDigests.get(session.key) ?? null,
   });
-  const { narration } = subtitleSlot;
+  const { narration } = subtitleValue;
   const pullRequestState = session.worktree
     ? host.sessionPullRequestIndicatorState(session.key, session.worktree.id)
     : "none";
@@ -361,7 +363,9 @@ export function renderRecentSession(params: {
                   : nothing}${label}</span
               >
             </span>
-            ${session.isChild ? nothing : renderSidebarSessionSubtitle(subtitleSlot)}
+            ${session.isChild
+              ? nothing
+              : renderSidebarSessionSubtitle(subtitleValue, params.project)}
           </span>
           ${!session.isChild && sessionHasBoard(session.key)
             ? html`<span
@@ -447,6 +451,7 @@ export function renderSessionTree(params: {
   host: SessionListHost;
   session: SidebarRecentSession;
   listItem?: boolean;
+  project?: string;
 }): TemplateResult {
   const { host, session, listItem = true } = params;
   const expanded = host.isSessionChildrenExpanded(session);
@@ -460,7 +465,7 @@ export function renderSessionTree(params: {
     data-session-tree=${session.key}
     role=${ifDefined(listItem ? "listitem" : undefined)}
   >
-    ${renderRecentSession({ host, session, listItem: false })}
+    ${renderRecentSession({ host, session, listItem: false, project: params.project })}
     ${expanded
       ? html`<div class="sidebar-session-tree__children">
           ${visibleChildren.length > 0

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -56,9 +56,18 @@ const SIDEBAR_VISIBLE_CHILD_SESSION_LIMIT = 4;
 export interface SessionListHost {
   readonly sessionDataContext:
     | {
-        gateway: { snapshot: { selfUser?: AuthenticatedUser | null } };
+        // `hello`/`connection` are the credential candidates the authenticated
+        // workspace-icon route needs; the sidebar reads them, never stores them.
+        gateway: {
+          snapshot: {
+            selfUser?: AuthenticatedUser | null;
+            hello?: { auth?: { deviceToken?: string | null } | null } | null;
+          };
+          connection: { token?: string | null; password?: string | null };
+        };
       }
     | undefined;
+  readonly basePath: string;
   readonly sidebarLiveActivity: boolean;
   readonly sidebarNarrationLines: ReadonlyMap<string, string>;
   readonly sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest>;

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -9,6 +9,7 @@ import type { SessionRunStatus, SessionWorktreeSummary } from "../api/types.ts";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
+import type { SessionWorkContext } from "../lib/session-display.ts";
 import {
   normalizeCatalogProjectGrouping,
   type CatalogProjectGrouping,
@@ -92,6 +93,9 @@ export type SidebarRecentSession = {
   acpSession?: boolean;
   /** Git checkout this session runs in, when it has one. */
   worktree?: SessionWorktreeSummary;
+  /** Repo, branch, and node behind the work subtitle, kept unpacked so the
+      row can mark a branch as a branch. */
+  workContext?: SessionWorkContext;
   /** Working directory of a session that runs outside a checkout. */
   execCwd?: string;
   placementState?: SessionPlacementState;

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -16,6 +16,7 @@ import "../test-helpers/app-sidebar-cases/catalog-ownership.ts";
 import "../test-helpers/app-sidebar-cases/catalog-terminal-owner.ts";
 import "../test-helpers/app-sidebar-cases/catalog-pages.ts";
 import "../test-helpers/app-sidebar-cases/child-sessions-cap.ts";
+import "../test-helpers/app-sidebar-cases/coding-project-hierarchy.ts";
 import "../test-helpers/app-sidebar-cases/child-sessions.ts";
 import "../test-helpers/app-sidebar-cases/group-mutations.ts";
 import "../test-helpers/app-sidebar-cases/identity-menu.ts";

--- a/ui/src/components/icons-tools.ts
+++ b/ui/src/components/icons-tools.ts
@@ -129,6 +129,14 @@ export const toolIcons = {
     <path
       d="M9 9v1.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0-.39.04"
     />`),
+  // A session whose branch lives in its own checkout. Filled 20px art rather
+  // than a Lucide outline: at the 14px subtitle slot the outline arrows blur
+  // together, and a fork glyph would claim a lineage the session does not have.
+  worktreeCreated: html` <svg viewBox="0 0 20 20" fill="currentColor" stroke="none">
+    <path
+      d="M15.8 11.535c.367 0 .665.298.665.665v5a.665.665 0 0 1-.665.665h-5a.665.665 0 1 1 0-1.33h3.394l-3.565-3.564a.666.666 0 0 1 .942-.942l3.564 3.565V12.2c0-.367.298-.665.665-.665Zm0-9.4c.367 0 .665.298.665.665v5a.665.665 0 0 1-1.33 0V4.405l-5.128 5.128c-.323.324-.558.565-.842.74a2.668 2.668 0 0 1-.771.319c-.324.078-.662.073-1.12.073H1.93a.665.665 0 1 1 0-1.33h5.345c.52 0 .673-.005.809-.037.136-.033.266-.086.385-.16.12-.072.23-.177.598-.545l5.128-5.128H10.8a.665.665 0 0 1 0-1.33h5Z"
+    />
+  </svg>`,
   download: strokeIcon(svg` <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
     <polyline points="7 10 12 15 17 10" />
     <line x1="12" x2="12" y1="15" y2="3" />`),

--- a/ui/src/components/session-row-subtitle.ts
+++ b/ui/src/components/session-row-subtitle.ts
@@ -3,7 +3,9 @@ import { keyed } from "lit/directives/keyed.js";
 import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import { t } from "../i18n/index.ts";
 import { pickFreshestObserverDigest } from "../lib/observer-digest.ts";
+import type { SessionWorkContext } from "../lib/session-display.ts";
 import type { SidebarRecentSession, SidebarSessionAttention } from "./app-sidebar-session-types.ts";
+import { icons } from "./icons.ts";
 
 export function sessionAttentionSubtitle(attention: SidebarSessionAttention): string | undefined {
   switch (attention.kind) {
@@ -31,6 +33,9 @@ type SidebarSessionSubtitle = {
    * renderer would have to compare translated strings to find out.
    */
   awaitingApproval: boolean;
+  /** Set only when the slot is showing the session's Git context, so the
+      renderer can mark the branch instead of guessing which words are one. */
+  work?: SessionWorkContext;
 };
 
 /** Resolves the single subtitle slot without displacing pending attention. */
@@ -80,19 +85,36 @@ export function resolveSidebarSessionSubtitle(params: {
     : session.subtitle && session.workSession && session.subtitle !== session.label
       ? session.subtitle
       : undefined;
+  const workContext = params.hasDisplay ? undefined : session.workContext;
   const finalReply =
     !running && !params.hasDisplay ? session.lastMessagePreview?.trim() || undefined : undefined;
   const subtitle = running
     ? (attention ?? agentStatus ?? observer ?? narration ?? workSubtitle)
     : (attention ?? agentStatus ?? finalReply ?? observer ?? workSubtitle);
+  // Only the work line is Git; attention, status, narration, and a final reply
+  // are prose that must not borrow a branch glyph.
+  const work = subtitle && subtitle === workSubtitle ? workContext : undefined;
   return {
     subtitle,
     narration,
     awaitingApproval: session.attention.kind === "approval" && subtitle === attention,
+    work,
   };
 }
 
-export function renderSidebarSessionSubtitle(value: SidebarSessionSubtitle) {
+/**
+ * Renders the subtitle slot. A Git line gets the branch glyph immediately
+ * before the branch and, for a session in its own checkout, a trailing worktree
+ * marker that the text fade must not reach. Everything else is prose and gets
+ * no glyph at all, so a marked line always means a real Git fact.
+ *
+ * `project` is the group the row already sits under: repeating that name in the
+ * subtitle spends the row's only spare line saying what the heading just said.
+ */
+export function renderSidebarSessionSubtitle(value: SidebarSessionSubtitle, project?: string) {
+  if (value.work) {
+    return renderWorkSubtitle(value.work, project);
+  }
   if (!value.subtitle) {
     return nothing;
   }
@@ -109,4 +131,26 @@ export function renderSidebarSessionSubtitle(value: SidebarSessionSubtitle) {
   // so a waiting session reads as waiting without spending the row's state slot.
   const approval = value.awaitingApproval ? " sidebar-recent-session__subtitle--approval" : "";
   return html`<span class="sidebar-recent-session__subtitle${approval}">${value.subtitle}</span>`;
+}
+
+function renderWorkSubtitle(work: SessionWorkContext, project?: string) {
+  const repo = work.repo && work.repo !== project ? work.repo : undefined;
+  const text = [repo, work.branch, work.node].filter(Boolean).join(" · ");
+  if (!text) {
+    return nothing;
+  }
+  return html`<span class="sidebar-recent-session__subtitle sidebar-recent-session__subtitle--git">
+    ${work.branch
+      ? html`<span class="session-row-git-glyph" aria-hidden="true">${icons.gitBranch}</span>`
+      : nothing}
+    <span class="sidebar-recent-session__subtitle-text">${text}</span>
+    ${work.worktree
+      ? html`<span
+          class="session-row-worktree-glyph"
+          role="img"
+          aria-label=${t("sessionsView.worktreeSession")}
+          >${icons.worktreeCreated}</span
+        >`
+      : nothing}
+  </span>`;
 }

--- a/ui/src/components/workspace-icon.ts
+++ b/ui/src/components/workspace-icon.ts
@@ -2,6 +2,7 @@ import { normalizeRouteBasePath } from "@openclaw/uirouter";
 import { html } from "lit";
 import { property, state } from "lit/decorators.js";
 import { CONTROL_UI_WORKSPACE_ICON_PATH_PREFIX } from "../../../src/gateway/control-ui-contract.js";
+import { resolveControlUiAuthCandidates } from "../app/control-ui-auth.ts";
 import { AuthenticatedAvatarRouteLoader } from "../lib/authenticated-avatar-route.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
@@ -9,6 +10,44 @@ import { icons } from "./icons.ts";
 /** Same-origin Gateway route serving the project icon of a session's workspace. */
 export function workspaceIconRouteUrl(basePath: string, sessionKey: string): string {
   return `${normalizeRouteBasePath(basePath)}${CONTROL_UI_WORKSPACE_ICON_PATH_PREFIX}/${encodeURIComponent(sessionKey)}`;
+}
+
+/** Everything `openclaw-workspace-icon` needs to paint one workspace's mark. */
+export type WorkspaceIconSource = {
+  routeUrl: string;
+  authTokens: readonly string[];
+  authReady: boolean;
+};
+
+/**
+ * The icon route is authenticated, so every surface that paints a workspace
+ * mark needs the same credential candidates. Resolving that here keeps the
+ * answer with the route's owner instead of once per calling component.
+ */
+export function resolveWorkspaceIconSource(params: {
+  gateway:
+    | {
+        snapshot: { hello?: { auth?: { deviceToken?: string | null } | null } | null };
+        connection: { token?: string | null; password?: string | null };
+      }
+    | undefined;
+  basePath: string;
+  sessionKey: string;
+}): WorkspaceIconSource | null {
+  const gateway = params.gateway;
+  if (!gateway) {
+    return null;
+  }
+  const authTokens = resolveControlUiAuthCandidates({
+    hello: gateway.snapshot.hello,
+    settings: { token: gateway.connection.token },
+    password: gateway.connection.password,
+  });
+  return {
+    routeUrl: workspaceIconRouteUrl(params.basePath, params.sessionKey),
+    authTokens,
+    authReady: Boolean(gateway.snapshot.hello || authTokens.length),
+  };
 }
 
 /**

--- a/ui/src/e2e/session-project-hierarchy.e2e.test.ts
+++ b/ui/src/e2e/session-project-hierarchy.e2e.test.ts
@@ -1,0 +1,150 @@
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  expandStoredSessionSections,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+const OPENCLAW_ROOT = "/Users/ada/code/openclaw";
+const CLAWHUB_ROOT = "/Users/ada/code/clawhub";
+const ANCHOR_KEY = "agent:main:anchor";
+
+/**
+ * Two real projects, a session in its own checkout, a long branch, and a
+ * duplicated name — the states a project hierarchy has to survive.
+ */
+function hierarchyFixture() {
+  return sessionsListResponse([
+    sessionRow(ANCHOR_KEY, "Release notes", 9),
+    sessionRow("agent:main:oc-branch", "Sidebar rework", 8, {
+      worktree: { id: "wt-1", branch: "feature/sidebar", repoRoot: OPENCLAW_ROOT },
+    }),
+    sessionRow("agent:main:oc-worktree", "Isolated work", 7, {
+      worktree: {
+        id: "wt-2",
+        branch: "openclaw/session-information-cards",
+        repoRoot: OPENCLAW_ROOT,
+      },
+    }),
+    sessionRow("agent:main:oc-copy", "Sidebar rework (2)", 6, {
+      worktree: { id: "wt-3", branch: "feature/sidebar-copy", repoRoot: OPENCLAW_ROOT },
+    }),
+    sessionRow("agent:main:ch-branch", "Publish flow", 5, {
+      worktree: { id: "wt-4", branch: "main", repoRoot: CLAWHUB_ROOT },
+    }),
+    sessionRow("agent:main:remote", "Remote work", 4, { execNode: "node-b" }),
+  ]);
+}
+
+async function openSidebar(colorScheme: "light" | "dark" = "light") {
+  const context = await suite.browser.newContext({
+    colorScheme,
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1280 },
+  });
+  const page = await context.newPage();
+  await expandStoredSessionSections(page);
+  await installMockGateway(page, {
+    methodResponses: { "sessions.list": hierarchyFixture() },
+    sessionKey: ANCHOR_KEY,
+  });
+  await page.goto(controlUiSessionUrl(suite.server.baseUrl, ANCHOR_KEY));
+  await page.locator("[data-session-work-project]").first().waitFor({ state: "visible" });
+  return { context, page };
+}
+
+suite.define(() => {
+  it("separates the projects being worked on and keeps factless work flat", async () => {
+    const { context, page } = await openSidebar();
+
+    try {
+      const projects = page.locator("[data-session-work-project]");
+      await expect.poll(() => projects.count()).toBe(2);
+      expect(
+        await projects.locator(".sidebar-session-catalog-project__label").allTextContents(),
+      ).toEqual(["openclaw", "clawhub"]);
+      // A project heading counts nothing: its rows are listed right beneath it.
+      expect(await projects.locator(".sidebar-session-group-count").count()).toBe(0);
+      expect(
+        await page
+          .locator('[data-session-work-project] [data-session-key="agent:main:remote"]')
+          .count(),
+      ).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("marks Git facts and never fades away the worktree marker", async () => {
+    const { context, page } = await openSidebar();
+
+    try {
+      const worktreeRow = page.locator('[data-session-key="agent:main:oc-worktree"]');
+      const marker = worktreeRow.locator(".session-row-worktree-glyph");
+      const text = worktreeRow.locator(".sidebar-recent-session__subtitle-text");
+      await marker.waitFor({ state: "visible" });
+
+      // The branch text is what runs out of room; the marker holds its slot.
+      const markerBox = await marker.boundingBox();
+      const textBox = await text.boundingBox();
+      expect(markerBox?.width).toBeGreaterThan(0);
+      expect(markerBox?.x ?? 0).toBeGreaterThan((textBox?.x ?? 0) + (textBox?.width ?? 0) - 1);
+      expect(await worktreeRow.locator(".session-row-git-glyph").count()).toBe(1);
+
+      // A row inside the openclaw group does not repeat "openclaw".
+      expect(await text.textContent()).toBe("session-information-cards");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("captures the hierarchy in both themes, open and collapsed", async () => {
+    for (const colorScheme of ["light", "dark"] as const) {
+      const { context, page } = await openSidebar(colorScheme);
+
+      try {
+        const coding = page.locator('[data-session-section="work"]');
+        const openclaw = page.locator(`[data-session-work-project="${OPENCLAW_ROOT}"]`);
+        const clawhub = page.locator(`[data-session-work-project="${CLAWHUB_ROOT}"]`);
+        const tail = coding.locator('[data-session-key="agent:main:remote"]');
+
+        await captureUiProof(page, `hierarchy-open-${colorScheme}.png`, { clip: [coding] });
+        // A project that owns several checkouts, framed on its own: the branch
+        // row, the worktree marker, and the duplicated name in one group.
+        await captureUiProof(page, `hierarchy-project-openclaw-${colorScheme}.png`, {
+          clip: [openclaw],
+        });
+        // The flat tail belongs to no project; framed with the last group so the
+        // frame shows it sitting outside one rather than inside it.
+        await captureUiProof(page, `hierarchy-ungrouped-${colorScheme}.png`, {
+          clip: [clawhub, tail],
+        });
+
+        const projectHead = openclaw.locator(".sidebar-session-catalog-project__head");
+        await projectHead.click();
+        await expect.poll(() => projectHead.getAttribute("aria-expanded")).toBe("false");
+        await captureUiProof(page, `hierarchy-project-collapsed-${colorScheme}.png`, {
+          clip: [coding],
+        });
+
+        const codingHead = coding.locator(
+          ".sidebar-recent-sessions__head .sidebar-session-group-toggle",
+        );
+        await codingHead.click();
+        await expect.poll(() => codingHead.getAttribute("aria-expanded")).toBe("false");
+        await captureUiProof(page, `hierarchy-section-collapsed-${colorScheme}.png`, {
+          clip: [coding],
+        });
+      } finally {
+        await context.close();
+      }
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -844,6 +844,7 @@ export const en: TranslationMap = {
     archivedByLabel: "Archived by",
     projectLabel: "Project",
     branchLabel: "Branch",
+    worktreeSession: "Runs in its own worktree",
     people: "People",
     allCreators: "All people",
     filterControls: "Session filters",

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -73,23 +73,52 @@ export function repoName(repoRoot: string): string {
   return repoRoot.split(/[\\/]/).findLast(Boolean) ?? repoRoot;
 }
 
-/** Compact "repo ⎇ branch" (plus node host) line for worktree/work sessions. */
-export function resolveSessionWorkSubtitle(row: SessionWorktreeDisplayRow): string | undefined {
+/**
+ * The Git facts behind a work session's subtitle, kept apart so a renderer can
+ * mark the branch as a branch. Packing them into one string was what forced
+ * every surface to guess afterwards which part of the line was Git.
+ */
+export type SessionWorkContext = {
+  repo?: string;
+  branch?: string;
+  node?: string;
+  /** The branch lives in its own checkout, not in the shared one. */
+  worktree: boolean;
+};
+
+export function resolveSessionWorkContext(
+  row: SessionWorktreeDisplayRow,
+): SessionWorkContext | undefined {
   const repoRoot = normalizeOptionalString(row.worktree?.repoRoot);
   const branch = normalizeOptionalString(row.worktree?.branch);
   // execNode is often a raw node id (long hex); never render it in full.
   const rawNode = normalizeOptionalString(row.execNode);
   const node = rawNode ? shortenOpaqueIdRuns(rawNode) : undefined;
   const repo = repoRoot ? repoName(repoRoot) : undefined;
-  const shortBranch = branch?.startsWith(WORKTREE_BRANCH_PREFIX)
-    ? branch.slice(WORKTREE_BRANCH_PREFIX.length)
-    : branch;
-  const checkout = repo ? (shortBranch ? `${repo} ⎇ ${shortBranch}` : repo) : undefined;
-  if (checkout && node) {
-    // Checkout first: it names the work; the node is routing detail.
-    return `${checkout} · ${node}`;
+  const worktree = branch?.startsWith(WORKTREE_BRANCH_PREFIX) ?? false;
+  const shortBranch = worktree ? branch?.slice(WORKTREE_BRANCH_PREFIX.length) : branch;
+  if (!repo && !shortBranch && !node) {
+    return undefined;
   }
-  return checkout ?? node;
+  return { repo, branch: shortBranch, node, worktree };
+}
+
+/** Compact "repo ⎇ branch" (plus node host) line for surfaces that need one string. */
+export function resolveSessionWorkSubtitle(row: SessionWorktreeDisplayRow): string | undefined {
+  const context = resolveSessionWorkContext(row);
+  if (!context) {
+    return undefined;
+  }
+  const checkout = context.repo
+    ? context.branch
+      ? `${context.repo} ⎇ ${context.branch}`
+      : context.repo
+    : undefined;
+  if (checkout && context.node) {
+    // Checkout first: it names the work; the node is routing detail.
+    return `${checkout} · ${context.node}`;
+  }
+  return checkout ?? context.node;
 }
 
 /** Machine identity of a typed session, derived from the session key. */

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -6,6 +6,39 @@ export function normalizeCatalogProjectGrouping(raw: unknown): CatalogProjectGro
   return raw === "none" || raw === "person" ? raw : "project";
 }
 
+/**
+ * The repository a working directory belongs to, or nothing when the path says
+ * nothing useful. Every surface that groups by project has to agree on this, or
+ * one checkout ends up as two projects under two headings.
+ *
+ * Accepted tradeoff: filesystem-root paths are not real session roots and fall
+ * to the flat tail by design. A path at or under `.claude/worktrees/<name>`
+ * folds into its origin repo, matching Claude Code desktop; the lazy prefix
+ * picks the outermost repo root.
+ */
+export function resolveProjectRoot(path: string | undefined): string | undefined {
+  const trimmed = path?.trim().replace(/[\\/]+$/, "");
+  if (!trimmed) {
+    return undefined;
+  }
+  const worktreeMatch = trimmed.match(/^(.*?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]/);
+  return worktreeMatch?.[1] || trimmed;
+}
+
+/**
+ * Section id a Coding project heading collapses under. It is shared so the
+ * renderer that folds the group and the projection that decides which rows are
+ * visible cannot disagree about which id they are talking about.
+ */
+export function workProjectSectionId(projectPath: string): string {
+  return `work-project:${projectPath}`;
+}
+
+/** Folder name a project heading shows for a repository path. */
+export function projectRootLabel(projectPath: string): string {
+  return projectPath.split(/[\\/]/).at(-1) || projectPath;
+}
+
 type CatalogProjectGroup = {
   key: string;
   label: string;
@@ -43,17 +76,7 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
       group.sessions.push(session);
       continue;
     }
-    // Accepted tradeoff: filesystem-root cwds ("/", "C:\") are not real harness
-    // session roots; after trimming they fall to the ungrouped flat tail by design.
-    let projectPath = session.cwd?.trim().replace(/[\\/]+$/, "");
-    if (!projectPath) {
-      ungrouped.push(session);
-      continue;
-    }
-    // Mirror Claude Code desktop: any cwd at or under `.claude/worktrees/<name>`
-    // folds into the origin repo; the lazy prefix picks the outermost repo root.
-    const worktreeMatch = projectPath.match(/^(.*?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]/);
-    projectPath = worktreeMatch?.[1] ?? projectPath;
+    const projectPath = resolveProjectRoot(session.cwd);
     if (!projectPath) {
       ungrouped.push(session);
       continue;
@@ -62,7 +85,7 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
     if (!group) {
       group = {
         key: projectPath,
-        label: projectPath.split(/[\\/]/).at(-1) || projectPath,
+        label: projectRootLabel(projectPath),
         title: projectPath,
         sessions: [],
       };

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1903,6 +1903,23 @@ body.update-dialog-open .sidebar-update-card__status {
     calc(var(--sidebar-inset) + 10px) 0 / 1px 100% no-repeat;
 }
 
+/* Sessions inside a project hang off the project's text axis, so the header
+   reads as their parent rather than as one more row in the same column. The
+   step is the header's own lead slot, which is what puts the rows under the
+   project name instead of under its mark. */
+.sidebar-session-catalog-project__sessions {
+  margin-left: var(--sidebar-lead);
+}
+
+/* Project marks are product artwork, not sidebar glyphs, so they fill the lead
+   slot at its own scale instead of inheriting the Lucide stroke treatment. */
+.sidebar-session-group-toggle__lead .workspace-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  object-fit: contain;
+}
+
 .sidebar-session-tree__loading {
   min-height: 28px;
   padding: 6px var(--sidebar-text-offset);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4205,6 +4205,58 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   color: color-mix(in srgb, var(--muted) 55%, var(--text) 45%);
 }
 
+/* A Git subtitle is a marked line: the branch glyph sits immediately before the
+   branch so a marked line always means a real Git fact, and a session running in
+   its own checkout keeps a trailing marker. Only the text scrolls and fades —
+   the marker must survive the truncation that hides the branch name. */
+.sidebar-recent-session__subtitle--git {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  overflow: visible;
+}
+
+.sidebar-recent-session__subtitle-text {
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-row-git-glyph,
+.session-row-worktree-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex: none;
+  color: var(--muted);
+}
+
+.session-row-git-glyph svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Filled art on a 20px grid: matched optically to the 14px branch glyph rather
+   than boxed to the same number. */
+.session-row-worktree-glyph svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+  stroke: none;
+}
+
+.session-row-worktree-glyph {
+  margin-left: auto;
+}
+
 .sidebar-session-attention__icon {
   display: inline-flex;
   align-items: center;

--- a/ui/src/test-helpers/app-sidebar-cases/coding-project-hierarchy.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/coding-project-hierarchy.ts
@@ -129,6 +129,29 @@ describe("AppSidebar coding project hierarchy", () => {
     ).toBeNull();
   });
 
+  it("names a project by its workspace mark and hangs its sessions off the label", async () => {
+    const sidebar = await mountWithRows([
+      {
+        key: "agent:main:openclaw",
+        kind: "direct",
+        label: "Sidebar rework",
+        updatedAt: 5,
+        worktree: { id: "wt-1", branch: "feature/sidebar", repoRoot: "/Users/ada/code/openclaw" },
+      },
+    ]);
+
+    const project = sidebar.querySelector('[data-session-work-project="/Users/ada/code/openclaw"]');
+    // The mark is the workspace's own asset route; the element itself decides
+    // when to fall back to the folder glyph, so the header must not pre-empt it.
+    expect(
+      project?.querySelector(".sidebar-session-group-toggle__lead openclaw-workspace-icon"),
+    ).not.toBeNull();
+    // Rows sit on the project's text axis: without this they share the header's
+    // left edge and the group reads as a flat list with a label on top.
+    const sessions = project?.querySelector(".sidebar-session-catalog-project__sessions");
+    expect(sessions?.querySelector('[data-session-key="agent:main:openclaw"]')).not.toBeNull();
+  });
+
   it("marks a branch as a branch and leaves prose unmarked", async () => {
     const sidebar = await mountWithRows([
       {

--- a/ui/src/test-helpers/app-sidebar-cases/coding-project-hierarchy.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/coding-project-hierarchy.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { workProjectSectionId } from "../../lib/sessions/catalog-project-grouping.ts";
+import { createGateway, createSessionsHarness, mountSidebar } from "../app-sidebar.ts";
+import "../../components/app-sidebar.ts";
+
+async function mountWithRows(rows: GatewaySessionRow[]) {
+  const harness = createSessionsHarness("main", ["agent:main:main"]);
+  const { sidebar } = await mountSidebar(
+    createGateway({} as GatewayBrowserClient),
+    harness.sessions,
+  );
+  harness.publishList({
+    result: {
+      ts: 2,
+      path: "",
+      count: rows.length,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: rows,
+    } satisfies SessionsListResult,
+  });
+  await sidebar.updateComplete;
+  return sidebar;
+}
+
+function projectLabels(sidebar: Element): string[] {
+  return [...sidebar.querySelectorAll("[data-session-work-project]")].map(
+    (project) =>
+      project.querySelector(".sidebar-session-catalog-project__label")?.textContent?.trim() ?? "",
+  );
+}
+
+function subtitleOf(sidebar: Element, key: string): Element | null {
+  return sidebar.querySelector(`[data-session-key="${key}"] .sidebar-recent-session__subtitle`);
+}
+
+describe("AppSidebar coding project hierarchy", () => {
+  it("groups coding sessions by their real project and leaves factless work flat", async () => {
+    const sidebar = await mountWithRows([
+      {
+        key: "agent:main:openclaw",
+        kind: "direct",
+        label: "Sidebar rework",
+        updatedAt: 5,
+        worktree: { id: "wt-1", branch: "feature/sidebar", repoRoot: "/Users/ada/code/openclaw" },
+      },
+      {
+        key: "agent:main:clawhub",
+        kind: "direct",
+        label: "Publish flow",
+        updatedAt: 4,
+        worktree: { id: "wt-2", branch: "main", repoRoot: "/Users/ada/code/clawhub" },
+      },
+      {
+        key: "agent:main:cwd-only",
+        kind: "direct",
+        label: "Scratch",
+        updatedAt: 3,
+        execNode: "node-a",
+        execCwd: "/Users/ada/code/clawhub",
+      },
+      {
+        key: "agent:main:factless",
+        kind: "direct",
+        label: "Remote work",
+        updatedAt: 2,
+        execNode: "node-b",
+      },
+    ]);
+
+    // Two distinct projects, never one project heading twice.
+    expect(projectLabels(sidebar)).toEqual(["openclaw", "clawhub"]);
+    const clawhub = sidebar.querySelector('[data-session-work-project="/Users/ada/code/clawhub"]');
+    expect(clawhub?.querySelectorAll("[data-session-key]")).toHaveLength(2);
+    expect(
+      sidebar
+        .querySelector('[data-session-key="agent:main:factless"]')
+        ?.closest("[data-session-work-project]"),
+    ).toBeNull();
+  });
+
+  it("stops treating a folded project's rows as visible sessions", async () => {
+    const sidebar = await mountWithRows([
+      {
+        key: "agent:main:openclaw",
+        kind: "direct",
+        label: "Sidebar rework",
+        updatedAt: 5,
+        worktree: { id: "wt-1", branch: "feature/sidebar", repoRoot: "/Users/ada/code/openclaw" },
+      },
+      {
+        key: "agent:main:clawhub",
+        kind: "direct",
+        label: "Publish flow",
+        updatedAt: 4,
+        worktree: { id: "wt-2", branch: "main", repoRoot: "/Users/ada/code/clawhub" },
+      },
+    ]);
+    sidebar.selectedSessionKeys = new Set(["agent:main:openclaw", "agent:main:clawhub"]);
+    await sidebar.updateComplete;
+    expect(sidebar.selectedVisibleSessions().map((row) => row.key)).toEqual([
+      "agent:main:openclaw",
+      "agent:main:clawhub",
+    ]);
+
+    sidebar.toggleSection(workProjectSectionId("/Users/ada/code/openclaw"));
+    await sidebar.updateComplete;
+
+    // Folding a project hides its rows; batch archive and delete read this
+    // projection, so a hidden session must not still be one of their targets.
+    expect(sidebar.querySelector('[data-session-key="agent:main:openclaw"]')).toBeNull();
+    expect(sidebar.selectedVisibleSessions().map((row) => row.key)).toEqual(["agent:main:clawhub"]);
+  });
+
+  it("gives a project heading no row count", async () => {
+    const sidebar = await mountWithRows([
+      {
+        key: "agent:main:openclaw",
+        kind: "direct",
+        label: "Sidebar rework",
+        updatedAt: 5,
+        worktree: { id: "wt-1", branch: "feature/sidebar", repoRoot: "/Users/ada/code/openclaw" },
+      },
+    ]);
+
+    expect(
+      sidebar.querySelector("[data-session-work-project] .sidebar-session-group-count"),
+    ).toBeNull();
+  });
+
+  it("marks a branch as a branch and leaves prose unmarked", async () => {
+    const sidebar = await mountWithRows([
+      {
+        key: "agent:main:git",
+        kind: "direct",
+        label: "Sidebar rework",
+        updatedAt: 5,
+        worktree: { id: "wt-1", branch: "feature/sidebar", repoRoot: "/Users/ada/code/openclaw" },
+      },
+      {
+        key: "agent:main:chat",
+        kind: "direct",
+        label: "Plain chat",
+        updatedAt: 4,
+        lastMessagePreview: "Shipped the release notes",
+      },
+    ]);
+
+    const git = subtitleOf(sidebar, "agent:main:git");
+    expect(git?.querySelector(".session-row-git-glyph")).not.toBeNull();
+    // Inside the openclaw group the row does not repeat "openclaw".
+    expect(git?.querySelector(".sidebar-recent-session__subtitle-text")?.textContent).toBe(
+      "feature/sidebar",
+    );
+
+    const chat = subtitleOf(sidebar, "agent:main:chat");
+    expect(chat?.textContent?.trim()).toBe("Shipped the release notes");
+    expect(chat?.querySelector(".session-row-git-glyph")).toBeNull();
+  });
+
+  it("keeps a trailing worktree marker on a session with its own checkout", async () => {
+    const sidebar = await mountWithRows([
+      {
+        key: "agent:main:worktree",
+        kind: "direct",
+        label: "Isolated work",
+        updatedAt: 5,
+        worktree: {
+          id: "wt-1",
+          branch: "openclaw/sidebar-cards",
+          repoRoot: "/Users/ada/code/openclaw",
+        },
+      },
+      {
+        key: "agent:main:shared",
+        kind: "direct",
+        label: "Shared checkout",
+        updatedAt: 4,
+        worktree: { id: "wt-2", branch: "main", repoRoot: "/Users/ada/code/openclaw" },
+      },
+    ]);
+
+    const worktree = subtitleOf(sidebar, "agent:main:worktree");
+    expect(worktree?.querySelector(".session-row-worktree-glyph")).not.toBeNull();
+    // The branch reads without the worktree prefix the marker already reports.
+    expect(worktree?.querySelector(".sidebar-recent-session__subtitle-text")?.textContent).toBe(
+      "sidebar-cards",
+    );
+    expect(
+      subtitleOf(sidebar, "agent:main:shared")?.querySelector(".session-row-worktree-glyph"),
+    ).toBeNull();
+  });
+});

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -75,6 +75,9 @@ export type SidebarLifecycleState = HTMLElement & {
     home: string;
     entries: Array<{ name: string; path: string; type: "directory" | "file" }>;
   }>;
+  selectedSessionKeys: ReadonlySet<string>;
+  selectedVisibleSessions: () => readonly { key: string }[];
+  toggleSection: (sectionId: string) => void;
   requestUpdate: () => void;
   updateComplete: Promise<boolean>;
   updateAvailable: { currentVersion: string; latestVersion: string; channel: string } | null;


### PR DESCRIPTION
## What Problem This Solves

Coding was a single flat list. Someone working across three repositories saw one pile of sessions and had to read each subtitle to tell which repository it belonged to — except the subtitle could not reliably tell them, because it packed repository, branch, and node host into one string (`openclaw ⎇ feature/sidebar · node-a`) that was then ellipsized at the row's width. The branch, usually the most distinguishing fact, was the part that disappeared first.

Because that line was a single opaque string, nothing downstream could tell which words were Git. A branch got no branch glyph; a status message, a final reply, and live narration all rendered exactly the same as a checkout. A marked line meant nothing, so nothing was marked.

Two more gaps followed from the same flatness:

- A session running in its own worktree had no way to say so. The worktree prefix was silently stripped from the branch name and the fact was simply lost.
- Forking a session produced an unnamed copy. The fork inherits the transcript, the model, and the workspace — everything except a way to tell it apart from its parent in a list where both appear.

The provider catalogs, meanwhile, already grouped by project, and their project subgroups printed a row count directly above the rows they were counting.

## Why This Change Was Made

**Group by the fact, not by the zone.** Coding sessions now group by the checkout they actually run in, falling back to their working directory. The rule that turns a directory into a project root — including folding `.claude/worktrees/<name>` back into its origin repository — moved into one shared function, so the native list and the provider catalogs cannot disagree about which checkout is which project. A session with neither fact is not guessed into a project; it stays in the flat tail.

**One heading grammar.** Project headings reuse the same disclosure, spacing, and label treatment as every other section head rather than inventing a second one. They carry no count: the rows are listed immediately beneath, so counting them adds nothing. The catalog's project subgroups lost their count for the same reason.

**Make the Git line structural.** The packed subtitle string is split at its producer into the facts behind it — repository, branch, node, and whether the branch lives in its own checkout — and the row renders them. The branch glyph sits immediately before the branch text; prose subtitles get no glyph at all, which is what makes a marked line meaningful. Inside a project group the row stops repeating the project's name and spends its one spare line on the branch instead. A session in its own checkout keeps a trailing worktree marker on the same line, outside the fade, so the marker survives the truncation that hides the branch name. There is no fork glyph anywhere: a duplicated session is not a lineage, and a branching icon would claim one.

**Repair duplicate naming at its producer.** Forking a named session now persists the inherited name with the first free copy number. This belongs to the producer, not the renderer: deriving it at paint time would mean counting look-alike names on every render and would disagree with the stored name the moment either session were renamed. Counting from the original name rather than stacking suffixes keeps a fork of a fork readable, and an unnamed parent stays unnamed — a generated display name is not a name worth copying.

## User Impact

- Coding reads as the list of projects being worked on, each collapsible on its own.
- The branch is visible and marked as a branch; a truncated subtitle loses the repository name, not the branch.
- A session in its own worktree says so, and keeps saying so at any sidebar width.
- A forked session arrives with a name that distinguishes it, in the sidebar and everywhere else the session is listed.
- Provider catalogs and native Coding agree on what a project is.

No configuration, no schema change, and no new Gateway calls: every fact was already on the wire.

**Deferred, and named rather than half-done:** project headings use the folder fallback. Wiring the authenticated workspace-icon route so a known project shows its own logo needs the sidebar to carry the auth candidates the chat header already builds, and that plumbing is a change of its own; the heading component degrades to the folder by design in the meantime.

## Evidence

**Rendered sidebar — `ui/src/test-helpers/app-sidebar-cases/coding-project-hierarchy.ts` (4 cases)**
Sessions group by repository root with a working-directory fallback, two distinct repositories produce two headings and never one heading twice, and a session with neither fact stays out of every group; a project heading carries no count; a Git subtitle carries the branch glyph while a last-message subtitle carries none, and a row inside a group does not repeat the group's name; a worktree session keeps its trailing marker and reads its branch without the prefix the marker already reports, while a shared-checkout session gets no marker.

**Producer — `src/gateway/session-create-fork-entry.test.ts`**
A fork inherits the parent name at the first free copy number, counts from the original rather than stacking suffixes, and leaves an unnamed parent unnamed.

**Shared rule — `ui/src/lib/sessions/catalog-project-grouping.test.ts`** continues to pass unchanged against the extracted project-root function, which is what proves the catalogs kept their existing behavior.

**Real layout — `ui/src/e2e/session-project-hierarchy.e2e.test.ts`**
Against a fixture with two repositories, a worktree session, a long branch, a duplicated name, and a factless remote session: two project headings with no counts and the factless row outside both; the worktree marker measurably sits past the end of the branch text, so the fade cannot reach it, and the branch reads without its project prefix.

**Static** — `tsgo` UI, core, and test-shard lanes, `oxlint`, `stylelint`, and the keyless i18n verify are all clean. Full `ui/src/components` and `ui/src/lib/sessions` suites: 1732 passed, with 3 failures that reproduce identically on current `origin/main` (`app-sidebar-session-catalogs` timestamp and two `app-sidebar-session-narration` cases) and are untouched by this stack.

The spec now seeds the stored collapse set before the page loads. Coding ships collapsed on a first visit, so a fresh browser context rendered only a section header and the hierarchy assertions had nothing to look at.

### Visual matrix

Captured in real Chromium on a Linux proof host under `OPENCLAW_CAPTURE_UI_PROOF=1`, each frame clipped to the surface it exists to show.

| State | Light | Dark |
| --- | --- | --- |
| Coding open — two projects, factless work flat below | ![open light](https://github.com/user-attachments/assets/f218fcad-a925-42d5-bba5-2e4f8bef18f6) | ![open dark](https://github.com/user-attachments/assets/cb29aa2c-166e-40ce-80f4-2f59b2276eac) |
| One project, several checkouts — branch, worktree marker, duplicated name | ![project light](https://github.com/user-attachments/assets/599dbc61-e195-449c-8229-7302be12b9cd) | ![project dark](https://github.com/user-attachments/assets/a443b795-6f2d-4d25-af0b-9d52054843d3) |
| Factless work sits outside the last group, not inside it | ![ungrouped light](https://github.com/user-attachments/assets/de3db3da-199e-4494-b654-fdb787459966) | ![ungrouped dark](https://github.com/user-attachments/assets/2e175944-8607-4954-8246-3bc703cfbd7a) |
| One project group collapsed, its sibling untouched | ![project collapsed light](https://github.com/user-attachments/assets/7c1b174a-8590-4b36-9657-68f64b92a8ec) | ![project collapsed dark](https://github.com/user-attachments/assets/f8589523-f37e-4a34-a19e-99a018783c7f) |
| Coding collapsed — one header, count intact | ![section collapsed light](https://github.com/user-attachments/assets/8ab9a940-ef62-4c87-9d4a-4abad6e98739) | ![section collapsed dark](https://github.com/user-attachments/assets/c8e4fe2a-e478-4818-b719-73cdb75884b0) |

Project artwork is the folder fallback on this branch: `renderWorkProjectGroup` has no per-project logo, so no frame claims one.


### Resolved before leaving draft — the hover geometry finding recorded here

The vertical drift this layer's body previously reported as an open finding was
not a geometry change. The row, the endcap, and the sidebar are all unmoved on
hover; what moves is the whole page. The shell plays a 300 ms mount entrance
(`dashboard-enter`, `ui/src/styles/base.css`) that translates the app into
place, and `ui/src/e2e/session-management.overflow.e2e.test.ts` read its resting
box while that animation was still running. Only the resting read was affected:
Playwright settles the page itself before it will hover, so the second read was
the settled one and the difference between them was whatever remained of the
entrance.

Instrumented in a real browser, `.shell` decays through
`3.006px → 0.634px → 0.239px → 0.008px → 0` with `scrollTop` at zero and every
sidebar height constant, and the resting value differs run to run while the
hovered value is always identical. The bisection to this layer was wrong: on the
layer that owns the reveal, unchanged, the case fails 4 runs out of 4 on the
same host.

It is repaired where the assertion lives rather than here — the reveal layer now
settles the entrance before it measures — and that case passes 6 runs out of 6.
