### PR TITLE
fix(gateway): preserve worker tunnel exit diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cloud worker SSH readiness:** reject buffered readiness markers from an exited SSH process while preserving bounded, redacted final failure diagnostics.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cloud worker SSH readiness:** reject buffered readiness markers from an exited SSH process while preserving bounded, redacted final failure diagnostics.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
@@ -63,6 +63,27 @@ describe("worker SSH process runner", () => {
     await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed");
   });
 
+  it("rejects a post-exit ready marker while retaining the final redacted diagnostic", async () => {
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["ssh"], { timeoutMs: 10_000 });
+    const bearer = "secret-credential-value";
+
+    child.emit("exit", 255, null);
+    child.stdout.write(`${WORKER_TUNNEL_READY_MARKER}\n`);
+    child.stderr.write(`Authorization: Bearer ${bearer}\nconnection refused`);
+    child.emit("close", 255, null);
+
+    await expect(process.ready).rejects.toThrow("connection refused");
+    const exit = await process.exited;
+    expect(exit).toMatchObject({
+      code: 255,
+      signal: null,
+      stderrTail: expect.stringContaining("connection refused"),
+    });
+    expect(exit.stderrTail).not.toContain(bearer);
+  });
+
   it("fails stop when a SIGKILLed child never reports exit", async () => {
     vi.useFakeTimers();
     const child = createChild();

--- a/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
@@ -63,6 +63,19 @@ describe("worker SSH process runner", () => {
     await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed");
   });
 
+  it("drains final stderr between exit and close before rejecting readiness", async () => {
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["ssh"], { timeoutMs: 10_000 });
+
+    child.emit("exit", 255, null);
+    child.stderr.write("connection refused");
+    child.emit("close", 255, null);
+
+    await expect(process.exited).resolves.toEqual({ code: 255, signal: null });
+    await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed: connection refused");
+  });
+
   it("fails stop when a SIGKILLed child never reports exit", async () => {
     vi.useFakeTimers();
     const child = createChild();

--- a/src/gateway/worker-environments/tunnel-ssh-runner.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.ts
@@ -58,6 +58,7 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       let closed = false;
       let exitedSettled = false;
       let readySettled = false;
+      let exitEventResult: WorkerSshProcessExit | undefined;
       let resolveReady!: () => void;
       let rejectReady!: (error: Error) => void;
       let resolveExited!: (exit: WorkerSshProcessExit) => void;
@@ -91,7 +92,7 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       child.stdout.setEncoding("utf8");
       child.stdout.on("error", () => {});
       child.stdout.on("data", (chunk: string) => {
-        if (readySettled) {
+        if (readySettled || exitEventResult !== undefined) {
           return;
         }
         stdout = sliceUtf16Safe(`${stdout}${chunk}`, -STDERR_LIMIT);
@@ -118,7 +119,6 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       // "exit" fires before "close", and "close" can be delayed indefinitely while a
       // descendant holds a piped stdio descriptor; settle on the real exit so connected
       // tunnels awaiting `exited` observe termination without depending on stream closure.
-      let exitEventResult: WorkerSshProcessExit | undefined;
       child.once("exit", (code, signal) => {
         exitEventResult = { code, signal };
         child.stdin.destroy();

--- a/src/gateway/worker-environments/tunnel-ssh-runner.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.ts
@@ -11,6 +11,7 @@ export const WORKER_TUNNEL_READY_MARKER = "OPENCLAW_WORKER_TUNNEL_READY";
 
 const STOP_GRACE_MS = 1_500;
 const STOP_KILL_WAIT_MS = 2_000;
+const EXIT_OUTPUT_DRAIN_MS = 100;
 const STDERR_LIMIT = 4_096;
 
 type WorkerSshProcessExit = {
@@ -67,6 +68,7 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       });
       let stdout = "";
       let stderr = "";
+      let exitOutputDrainTimer: ReturnType<typeof setTimeout> | undefined;
       const settleReadyError = () => {
         if (readySettled) {
           return;
@@ -80,6 +82,11 @@ export function createWorkerSshRunner(): WorkerSshRunner {
         }
         exitedSettled = true;
         resolveExited(exit);
+      };
+      const releaseOutputPipes = () => {
+        clearTimeout(exitOutputDrainTimer);
+        child.stdout.destroy();
+        child.stderr.destroy();
       };
       child.stdout.setEncoding("utf8");
       child.stdout.on("error", () => {});
@@ -108,23 +115,26 @@ export function createWorkerSshRunner(): WorkerSshRunner {
           settleExited({ code: null, signal: null });
         }
       });
-      // "exit" fires before "close", and "close" can be delayed indefinitely while a
-      // descendant holds a piped stdio descriptor; settle on the real exit so connected
-      // tunnels awaiting `exited` observe termination without depending on stream closure.
-      let exitEventResult: WorkerSshProcessExit | undefined;
+      // "exit" precedes stdio drain, while "close" can be pinned by a descendant holding a
+      // pipe. Give an unready child one bounded drain window so its failure detail survives
+      // without letting inherited descriptors stall retries indefinitely.
       child.once("exit", (code, signal) => {
-        exitEventResult = { code, signal };
-        settleReadyError();
-        settleExited(exitEventResult);
-        // Release our pipe ends so a descendant holding the other side cannot pin local
-        // descriptors across retries; this also lets "close" fire promptly.
+        settleExited({ code, signal });
         child.stdin.destroy();
-        child.stdout.destroy();
-        child.stderr.destroy();
+        if (readySettled) {
+          releaseOutputPipes();
+        } else {
+          exitOutputDrainTimer = setTimeout(() => {
+            settleReadyError();
+            releaseOutputPipes();
+          }, EXIT_OUTPUT_DRAIN_MS);
+          exitOutputDrainTimer.unref?.();
+        }
       });
       child.once("close", (code, signal) => {
         closed = true;
         settleReadyError();
+        releaseOutputPipes();
         settleExited({ code, signal });
       });
       child.stdin.on("error", () => {});
@@ -141,6 +151,11 @@ export function createWorkerSshRunner(): WorkerSshRunner {
         stop() {
           return (stopPromise ??= (async () => {
             if (closed) {
+              return;
+            }
+            if (exitedSettled) {
+              settleReadyError();
+              releaseOutputPipes();
               return;
             }
             child.kill("SIGTERM");


### PR DESCRIPTION
## What Problem This Solves

A cloud-worker SSH process can emit its terminal `exit` event before buffered stdout and stderr finish draining. During that final I/O turn, an already-exited process could emit the tunnel readiness marker and incorrectly publish a connected cloud-worker desktop tunnel.

## Root Cause

Node's child-process implementation emits `exit` before scheduling `flushStdio`. The worker SSH runner already preserves one final I/O turn for bounded, redacted stderr diagnostics, but its stdout readiness handler did not reject markers observed after terminal exit.

## Fix

- Fence stdout readiness against the runner's existing authoritative exit result.
- Preserve current-main one-turn diagnostic draining, redaction, bounded stderr tails, and prompt exit settlement.
- Cover the exact `exit → readiness marker → secret-bearing stderr → close` ordering and the desktop-tunnel sibling owner.
- Production code is net zero lines; the change reuses the existing lifecycle state instead of adding a timer, fallback, or secondary readiness path.

## Evidence

- Fail-before: the new regression fails on current `main` with `promise resolved "undefined" instead of rejecting`.
- Pass-after: `node scripts/run-vitest.mjs src/gateway/worker-environments/tunnel-ssh-runner.test.ts src/gateway/worker-environments/tunnel.test.ts src/gateway/worker-environments/desktop-tunnel.test.ts` — 30 tests passed across all three owner/sibling suites.
- Formatting, focused core lint, and core production typechecking passed.
- Structured autoreview passed with zero actionable findings.
- The full local changed gate completed 18 stages before an unrelated existing shared-install failure: missing TypeScript declarations for `pako` in `ui/vite.config.ts`. Exact-head CI runs from a fresh dependency installation.

Production LOC: +2/-2 (net 0). Tests: +21/-0. Release-note context is recorded here; the release-owned changelog is unchanged.
