### PR TITLE
Unify sidebar iconography

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -180,6 +180,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
         ${renderSidebarSessionSectionHeader({
           sectionId,
           disabledReason: params.sectionDragDisabledReason,
+          onToggle: () => params.onToggleSection(sectionId),
           onStartDrag: params.onStartSectionDrag,
           onFinishDrag: params.onFinishSectionDrag,
           onContextMenu: (event) => {

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -513,7 +513,7 @@ function renderCatalogSessionRow(
               openMenu(rect.right, rect.bottom + 4, trigger);
             }}
           >
-            ${icons.moreHorizontal}
+            ${icons.ellipsis}
           </button>
         </span>
       </span>

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -115,6 +115,7 @@ function renderSessionSection(params: {
       ${renderSidebarSessionSectionHeader({
         sectionId: section.id,
         disabledReason: groupWriteAccess.allowed ? undefined : groupWriteAccess.reason,
+        onToggle: () => host.toggleSection(section.id),
         onStartDrag: (sectionId) => host.startSidebarSectionDrag(sectionId),
         onFinishDrag: () => host.finishSidebarSectionDrag(),
         onContextMenu: group

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -228,7 +228,7 @@ function renderSessionSection(params: {
                     );
                   }}
                 >
-                  ${icons.moreHorizontal}
+                  ${icons.ellipsis}
                 </button>
               `
             : nothing}

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -417,7 +417,7 @@ export function renderRecentSession(params: {
                   host.toggleSessionMenu(session, trigger);
                 }}
               >
-                ${icons.moreHorizontal}
+                ${icons.ellipsis}
               </button>
             </span>`}
       </span>

--- a/ui/src/components/app-sidebar-session-section-header.ts
+++ b/ui/src/components/app-sidebar-session-section-header.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { writeSidebarSectionDragData } from "../lib/sessions/drag.ts";
+import { icons } from "./icons.ts";
 
 export function renderSidebarSessionSectionHeader(params: {
   sectionId: string;
@@ -51,7 +52,9 @@ export function renderSidebarSessionSectionHeader(params: {
       }}
       @contextmenu=${params.onContextMenu ?? nothing}
     >
-      <span class="sidebar-session-group-drag-handle" aria-hidden="true"></span>
+      <span class="sidebar-session-group-drag-handle" aria-hidden="true"
+        >${icons.gripVertical}</span
+      >
       ${params.content}
     </div>
   `;

--- a/ui/src/components/app-sidebar-session-section-header.ts
+++ b/ui/src/components/app-sidebar-session-section-header.ts
@@ -16,44 +16,25 @@ export function renderSidebarSessionSectionHeader(params: {
       class="sidebar-recent-sessions__head ${params.disabledReason
         ? ""
         : "sidebar-recent-sessions__head--draggable"}"
-      draggable=${params.disabledReason ? "false" : "true"}
       title=${params.disabledReason ?? nothing}
-      @mousedown=${(event: MouseEvent) => {
-        const header = event.currentTarget as HTMLElement;
-        header.toggleAttribute(
-          "data-section-drag-blocked",
-          Boolean((event.target as HTMLElement).closest("button")),
-        );
-      }}
-      @mouseup=${(event: MouseEvent) => {
-        (event.currentTarget as HTMLElement).removeAttribute("data-section-drag-blocked");
-      }}
-      @dragstart=${(event: DragEvent) => {
-        if (params.disabledReason) {
-          event.preventDefault();
-          return;
-        }
-        const header = event.currentTarget as HTMLElement;
-        const startedFromButton =
-          Boolean((event.target as HTMLElement).closest("button")) ||
-          header.hasAttribute("data-section-drag-blocked");
-        header.removeAttribute("data-section-drag-blocked");
-        if (startedFromButton) {
-          event.preventDefault();
-          return;
-        }
-        if (event.dataTransfer) {
-          writeSidebarSectionDragData(event.dataTransfer, params.sectionId);
-          params.onStartDrag(params.sectionId);
-        }
-      }}
-      @dragend=${(event: DragEvent) => {
-        (event.currentTarget as HTMLElement).removeAttribute("data-section-drag-blocked");
-        params.onFinishDrag();
-      }}
       @contextmenu=${params.onContextMenu ?? nothing}
     >
-      <span class="sidebar-session-group-drag-handle" aria-hidden="true" @click=${params.onToggle}
+      <span
+        class="sidebar-session-group-drag-handle"
+        aria-hidden="true"
+        draggable=${params.disabledReason ? "false" : "true"}
+        @click=${params.onToggle}
+        @dragstart=${(event: DragEvent) => {
+          if (params.disabledReason) {
+            event.preventDefault();
+            return;
+          }
+          if (event.dataTransfer) {
+            writeSidebarSectionDragData(event.dataTransfer, params.sectionId);
+            params.onStartDrag(params.sectionId);
+          }
+        }}
+        @dragend=${params.onFinishDrag}
         >${icons.gripVertical}</span
       >
       ${params.content}

--- a/ui/src/components/app-sidebar-session-section-header.ts
+++ b/ui/src/components/app-sidebar-session-section-header.ts
@@ -13,9 +13,7 @@ export function renderSidebarSessionSectionHeader(params: {
 }) {
   return html`
     <div
-      class="sidebar-recent-sessions__head ${params.disabledReason
-        ? ""
-        : "sidebar-recent-sessions__head--draggable"}"
+      class="sidebar-recent-sessions__head"
       title=${params.disabledReason ?? nothing}
       @contextmenu=${params.onContextMenu ?? nothing}
     >

--- a/ui/src/components/app-sidebar-session-section-header.ts
+++ b/ui/src/components/app-sidebar-session-section-header.ts
@@ -6,6 +6,7 @@ export function renderSidebarSessionSectionHeader(params: {
   sectionId: string;
   content: TemplateResult;
   disabledReason?: string;
+  onToggle: () => void;
   onStartDrag: (sectionId: string) => void;
   onFinishDrag: () => void;
   onContextMenu?: (event: MouseEvent) => void;
@@ -52,7 +53,7 @@ export function renderSidebarSessionSectionHeader(params: {
       }}
       @contextmenu=${params.onContextMenu ?? nothing}
     >
-      <span class="sidebar-session-group-drag-handle" aria-hidden="true"
+      <span class="sidebar-session-group-drag-handle" aria-hidden="true" @click=${params.onToggle}
         >${icons.gripVertical}</span
       >
       ${params.content}

--- a/ui/src/components/icons-tools.ts
+++ b/ui/src/components/icons-tools.ts
@@ -9,6 +9,7 @@ import { html, svg, type SVGTemplateResult, type TemplateResult } from "lit";
 export function strokeIcon(body: SVGTemplateResult): TemplateResult {
   return html`
     <svg
+      data-lucide-icon=""
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -241,6 +242,9 @@ export const toolIcons = {
   moreHorizontal: strokeIcon(svg` <circle cx="12" cy="12" r="1.5" />
     <circle cx="6" cy="12" r="1.5" />
     <circle cx="18" cy="12" r="1.5" />`),
+  ellipsis: strokeIcon(svg` <circle cx="12" cy="12" r="1.25" fill="currentColor" stroke="none" />
+    <circle cx="5" cy="12" r="1.25" fill="currentColor" stroke="none" />
+    <circle cx="19" cy="12" r="1.25" fill="currentColor" stroke="none" />`),
   arrowUpDown: strokeIcon(svg` <path d="m21 16-4 4-4-4" />
     <path d="M17 20V4" />
     <path d="m3 8 4-4 4 4" />

--- a/ui/src/components/icons.test.ts
+++ b/ui/src/components/icons.test.ts
@@ -1,0 +1,35 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import { icons } from "./icons.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("vendored stroke icons", () => {
+  it("exposes the shared presentation marker and SVG stroke contract", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(icons.search, container);
+
+    const svg = container.querySelector("svg");
+    expect(svg?.hasAttribute("data-lucide-icon")).toBe(true);
+    expect(svg?.getAttribute("fill")).toBe("none");
+    expect(svg?.getAttribute("stroke")).toBe("currentColor");
+    expect(svg?.getAttribute("stroke-linecap")).toBe("round");
+    expect(svg?.getAttribute("stroke-linejoin")).toBe("round");
+  });
+
+  it("renders the semantic ellipsis as three solid dots", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(icons.ellipsis, container);
+
+    const circles = [...container.querySelectorAll("circle")];
+    expect(circles).toHaveLength(3);
+    expect(circles.every((circle) => circle.getAttribute("fill") === "currentColor")).toBe(true);
+    expect(circles.every((circle) => circle.getAttribute("stroke") === "none")).toBe(true);
+  });
+});

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -203,6 +203,13 @@ export const icons = {
     <path d="M5 4c5-4 9 4 14 0v11c-5 4-9-4-14 0" />`),
   lock: strokeIcon(svg` <rect width="18" height="11" x="3" y="11" rx="2" />
     <path d="M7 11V7a5 5 0 0 1 10 0v4" />`),
+  hatGlasses: strokeIcon(svg` <path d="M14 18a2 2 0 0 0-4 0" />
+    <path
+      d="m19 11-2.11-6.657a2 2 0 0 0-2.752-1.148l-1.276.61A2 2 0 0 1 12 4H8.5a2 2 0 0 0-1.925 1.456L5 11"
+    />
+    <path d="M2 11h20" />
+    <circle cx="17" cy="18" r="3" />
+    <circle cx="7" cy="18" r="3" />`),
   pencil: strokeIcon(svg` <path
       d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
     />

--- a/ui/src/components/session-row-badges.test.ts
+++ b/ui/src/components/session-row-badges.test.ts
@@ -54,6 +54,8 @@ describe("session row placement badges", () => {
     const badge = container.querySelector(".session-row-badge--incognito");
     expect(badge?.getAttribute("aria-label")).toBe("Incognito session");
     expectTooltipText(badge, "Incognito session");
+    expect(badge?.querySelectorAll("circle")).toHaveLength(2);
+    expect(badge?.querySelector("rect")).toBeNull();
   });
 
   it("renders the durable outbox count and stays quiet when empty", () => {

--- a/ui/src/components/session-row-badges.ts
+++ b/ui/src/components/session-row-badges.ts
@@ -133,7 +133,7 @@ export function renderSessionRowBadges(params: {
     ${params.incognito
       ? renderSessionRowBadge(
           t("sessionsView.incognito"),
-          icons.lock,
+          icons.hatGlasses,
           "session-row-badge--incognito",
         )
       : nothing}

--- a/ui/src/e2e/sidebar-customization.test-support.ts
+++ b/ui/src/e2e/sidebar-customization.test-support.ts
@@ -13,6 +13,8 @@ const sidebarProofArtifactDir = path.join(
 
 export function createSidebarCustomizationSuite(name: string) {
   return createControlUiE2eSuite({
+    browserLaunchOptions:
+      process.env.OPENCLAW_UI_E2E_HEADED === "1" ? { headless: false } : undefined,
     name,
     trackBrowserContexts: true,
     unavailableMessage: (executablePath) =>
@@ -42,6 +44,43 @@ export async function captureSettingsSidebarUiProof(
   await mkdir(sidebarProofArtifactDir, { recursive: true });
   await sidebar.screenshot({
     animations: "disabled",
+    path: path.join(sidebarProofArtifactDir, fileName),
+  });
+}
+
+export async function captureSidebarUiUnionProof(
+  page: Page,
+  locators: Locator[],
+  fileName: string,
+): Promise<void> {
+  if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
+    return;
+  }
+  const boxes = (await Promise.all(locators.map((locator) => locator.boundingBox()))).filter(
+    (box): box is NonNullable<typeof box> => box !== null,
+  );
+  if (boxes.length === 0) {
+    throw new Error("Cannot capture sidebar proof without a visible surface");
+  }
+  const viewport = page.viewportSize();
+  if (!viewport) {
+    throw new Error("Cannot capture sidebar proof without a fixed viewport");
+  }
+  const padding = 16;
+  const left = Math.max(0, Math.min(...boxes.map((box) => box.x)) - padding);
+  const top = Math.max(0, Math.min(...boxes.map((box) => box.y)) - padding);
+  const right = Math.min(
+    viewport.width,
+    Math.max(...boxes.map((box) => box.x + box.width)) + padding,
+  );
+  const bottom = Math.min(
+    viewport.height,
+    Math.max(...boxes.map((box) => box.y + box.height)) + padding,
+  );
+  await mkdir(sidebarProofArtifactDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    clip: { x: left, y: top, width: right - left, height: bottom - top },
     path: path.join(sidebarProofArtifactDir, fileName),
   });
 }

--- a/ui/src/e2e/sidebar-customization.test-support.ts
+++ b/ui/src/e2e/sidebar-customization.test-support.ts
@@ -52,6 +52,7 @@ export async function captureSidebarUiUnionProof(
   page: Page,
   locators: Locator[],
   fileName: string,
+  options: { preserveHover?: boolean } = {},
 ): Promise<void> {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
     return;
@@ -79,7 +80,7 @@ export async function captureSidebarUiUnionProof(
   );
   await mkdir(sidebarProofArtifactDir, { recursive: true });
   await page.screenshot({
-    animations: "disabled",
+    animations: options.preserveHover ? "allow" : "disabled",
     clip: { x: left, y: top, width: right - left, height: bottom - top },
     path: path.join(sidebarProofArtifactDir, fileName),
   });

--- a/ui/src/e2e/sidebar-iconography.e2e.test.ts
+++ b/ui/src/e2e/sidebar-iconography.e2e.test.ts
@@ -1,0 +1,211 @@
+import type { Locator } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { sessionRow, sessionsListResponse } from "./session-management.test-support.ts";
+import {
+  captureSidebarUiUnionProof,
+  createSidebarCustomizationSuite,
+} from "./sidebar-customization.test-support.ts";
+
+const suite = createSidebarCustomizationSuite("Control UI sidebar iconography mocked Gateway E2E");
+
+const visualVariants = [
+  { colorScheme: "light" as const, deviceScaleFactor: 1 },
+  { colorScheme: "light" as const, deviceScaleFactor: 2 },
+  { colorScheme: "dark" as const, deviceScaleFactor: 1 },
+  { colorScheme: "dark" as const, deviceScaleFactor: 2 },
+];
+
+async function expectLucideContract(root: Locator, minimumIconCount = 1) {
+  const metrics = await root.locator("svg[data-lucide-icon]").evaluateAll((icons) =>
+    icons.map((icon) => {
+      const style = getComputedStyle(icon);
+      return {
+        height: Number.parseFloat(style.height),
+        strokeWidth: Number.parseFloat(style.strokeWidth),
+        width: Number.parseFloat(style.width),
+      };
+    }),
+  );
+  expect(metrics.length).toBeGreaterThanOrEqual(minimumIconCount);
+  expect(metrics.every((icon) => icon.height <= 16 && icon.width <= 16)).toBe(true);
+  expect(metrics.every((icon) => icon.strokeWidth === 1.5)).toBe(true);
+}
+
+suite.define(() => {
+  it.each(visualVariants)(
+    "keeps sidebar icons on the shared optical scale in $colorScheme at $deviceScaleFactor x",
+    async ({ colorScheme, deviceScaleFactor }) => {
+      const context = await suite.newBrowserContext({
+        colorScheme,
+        deviceScaleFactor,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      });
+      const page = await context.newPage();
+      const incognitoKey = "agent:main:private-notes";
+      await installMockGateway(page, {
+        methodResponses: {
+          "cron.list": {
+            jobs: [],
+            total: 0,
+            offset: 0,
+            limit: 50,
+            hasMore: false,
+            nextOffset: null,
+          },
+          "models.authStatus": {
+            ts: Date.now(),
+            providers: [
+              {
+                provider: "openai",
+                displayName: "OpenAI",
+                status: "missing",
+                profiles: [],
+              },
+            ],
+          },
+          "sessions.list": sessionsListResponse([
+            sessionRow("agent:main:main", "Main", Date.parse("2026-08-14T16:00:00.000Z"), {
+              pinned: true,
+              unread: true,
+            }),
+            {
+              ...sessionRow(incognitoKey, "Private", Date.parse("2026-08-14T15:59:00.000Z"), {
+                category: "Research",
+              }),
+              incognito: true,
+            },
+          ]),
+        },
+        sessionGroups: ["Research"],
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const sidebarSurface = sidebar.locator(".sidebar-shell");
+        const incognitoRow = sidebar.locator(`[data-session-key="${incognitoKey}"]`);
+        await incognitoRow.waitFor();
+        await sidebar.locator(".sidebar-attention__item").waitFor();
+
+        await expectLucideContract(sidebar, 10);
+
+        const incognitoIcon = incognitoRow.locator(".session-row-badge--incognito svg");
+        await expect.poll(() => incognitoIcon.locator("circle").count()).toBe(2);
+        await expect.poll(() => incognitoIcon.locator("rect").count()).toBe(0);
+        const incognitoBox = await incognitoIcon.boundingBox();
+        expect(incognitoBox?.width).toBeCloseTo(13, 3);
+        expect(incognitoBox?.height).toBeCloseTo(13, 3);
+        const incognitoTextBox = await incognitoRow
+          .locator(".sidebar-recent-session__text")
+          .boundingBox();
+        expect(incognitoBox!.x - (incognitoTextBox!.x + incognitoTextBox!.width)).toBe(8);
+
+        const filter = sidebar.locator(".sidebar-session-sort");
+        const filterMetrics = await filter.evaluate((button) => {
+          const buttonBox = button.getBoundingClientRect();
+          const iconBox = button.querySelector("svg")?.getBoundingClientRect();
+          return {
+            button: [buttonBox.width, buttonBox.height],
+            icon: iconBox ? [iconBox.width, iconBox.height] : null,
+          };
+        });
+        expect(filterMetrics.button).toEqual([28, 28]);
+        expect(filterMetrics.icon).toEqual([13, 13]);
+
+        const variant = `${colorScheme}-${deviceScaleFactor}x`;
+        await captureSidebarUiUnionProof(page, [sidebarSurface], `iconography-${variant}-base.png`);
+
+        const groupHeader = sidebar.locator(
+          '[data-session-section="category:Research"] .sidebar-recent-sessions__head',
+        );
+        await groupHeader.hover();
+        const groupGrip = groupHeader.locator(".sidebar-session-group-drag-handle svg");
+        const groupAction = groupHeader.locator(".sidebar-session-group-actions");
+        await expect.poll(() => groupGrip.isVisible()).toBe(true);
+        await expect.poll(() => groupAction.isVisible()).toBe(true);
+        await expect.poll(() => groupAction.locator('circle[fill="currentColor"]').count()).toBe(3);
+        await groupAction.hover();
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface],
+          `iconography-${variant}-group-controls.png`,
+        );
+        await groupAction.click();
+        const groupMenu = sidebar.locator("wa-dropdown.sidebar-session-group-menu");
+        const groupMenuSurface = groupMenu.locator('[part="menu"]');
+        await groupMenuSurface.waitFor();
+        await expectLucideContract(groupMenu);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, groupMenuSurface],
+          `iconography-${variant}-group-menu.png`,
+        );
+        await page.keyboard.press("Escape");
+
+        await incognitoRow.hover();
+        const sessionAction = incognitoRow.locator("[data-session-menu]");
+        await expect
+          .poll(() => sessionAction.evaluate((button) => getComputedStyle(button).opacity))
+          .toBe("1");
+        const actionBox = await sessionAction.locator("svg").boundingBox();
+        expect(actionBox?.width).toBe(15);
+        expect(actionBox?.height).toBe(15);
+        await sessionAction.click();
+        const sessionMenu = sidebar.locator("wa-dropdown.session-menu");
+        const sessionMenuSurface = sessionMenu.locator('[part="menu"]');
+        await sessionMenuSurface.waitFor();
+        await expectLucideContract(sessionMenu);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, sessionMenuSurface],
+          `iconography-${variant}-session-menu.png`,
+        );
+        await page.keyboard.press("Escape");
+
+        await sidebar.locator(".sidebar-nav__head-action").click();
+        const moreMenu = sidebar.locator("wa-dropdown.sidebar-more-menu");
+        await moreMenu.getByRole("menuitem", { name: "Edit pinned items" }).click();
+        const customizeMenu = sidebar.locator(
+          "wa-dropdown.sidebar-customize-menu:not(.sidebar-more-menu):not(.sidebar-agent-menu)",
+        );
+        const customizeMenuSurface = customizeMenu.locator('[part="menu"]');
+        await customizeMenuSurface.waitFor();
+        await expectLucideContract(customizeMenu);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, customizeMenuSurface],
+          `iconography-${variant}-customizer.png`,
+        );
+        await page.keyboard.press("Escape");
+
+        await sidebar.locator(".sidebar-agent-card__main").click();
+        const agentMenu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
+        const agentMenuSurface = agentMenu.locator('[part="menu"]');
+        await agentMenuSurface.waitFor();
+        await expectLucideContract(agentMenu);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, agentMenuSurface],
+          `iconography-${variant}-agent-menu.png`,
+        );
+        await page.keyboard.press("Escape");
+
+        await sidebar.locator(".sidebar-identity-card").click();
+        const identityMenu = sidebar.locator("wa-dropdown.sidebar-identity-menu");
+        const identityMenuSurface = identityMenu.locator('[part="menu"]');
+        await identityMenuSurface.waitFor();
+        await expectLucideContract(identityMenu);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, identityMenuSurface],
+          `iconography-${variant}-account-menu.png`,
+        );
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+});

--- a/ui/src/e2e/sidebar-iconography.e2e.test.ts
+++ b/ui/src/e2e/sidebar-iconography.e2e.test.ts
@@ -134,10 +134,14 @@ suite.define(() => {
         await groupGrip.click();
         await expect.poll(() => groupToggle.getAttribute("aria-expanded")).toBe(groupExpanded);
         await groupAction.hover();
+        await expect
+          .poll(() => groupAction.evaluate((button) => getComputedStyle(button).opacity))
+          .toBe("1");
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface],
           `iconography-${variant}-group-controls.png`,
+          { preserveHover: true },
         );
         await groupAction.click();
         const groupMenu = sidebar.locator("wa-dropdown.sidebar-session-group-menu");

--- a/ui/src/e2e/sidebar-iconography.e2e.test.ts
+++ b/ui/src/e2e/sidebar-iconography.e2e.test.ts
@@ -123,10 +123,16 @@ suite.define(() => {
         );
         await groupHeader.hover();
         const groupGrip = groupHeader.locator(".sidebar-session-group-drag-handle svg");
+        const groupToggle = groupHeader.locator(".sidebar-session-group-toggle");
         const groupAction = groupHeader.locator(".sidebar-session-group-actions");
         await expect.poll(() => groupGrip.isVisible()).toBe(true);
         await expect.poll(() => groupAction.isVisible()).toBe(true);
         await expect.poll(() => groupAction.locator('circle[fill="currentColor"]').count()).toBe(3);
+        const groupExpanded = await groupToggle.getAttribute("aria-expanded");
+        await groupGrip.click();
+        await expect.poll(() => groupToggle.getAttribute("aria-expanded")).not.toBe(groupExpanded);
+        await groupGrip.click();
+        await expect.poll(() => groupToggle.getAttribute("aria-expanded")).toBe(groupExpanded);
         await groupAction.hover();
         await captureSidebarUiUnionProof(
           page,

--- a/ui/src/e2e/sidebar-iconography.e2e.test.ts
+++ b/ui/src/e2e/sidebar-iconography.e2e.test.ts
@@ -124,7 +124,11 @@ suite.define(() => {
         await groupHeader.hover();
         const groupGrip = groupHeader.locator(".sidebar-session-group-drag-handle svg");
         const groupToggle = groupHeader.locator(".sidebar-session-group-toggle");
-        const groupAction = groupHeader.locator(".sidebar-session-group-actions");
+        // A grouped head carries two action buttons (new session, group menu);
+        // the ellipsis menu is the one these checks measure.
+        const groupAction = groupHeader.locator(
+          '.sidebar-session-group-actions[aria-haspopup="menu"]',
+        );
         await expect.poll(() => groupGrip.isVisible()).toBe(true);
         await expect.poll(() => groupAction.isVisible()).toBe(true);
         await expect.poll(() => groupAction.locator('circle[fill="currentColor"]').count()).toBe(3);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5721,8 +5721,8 @@ td.data-table-key-col {
 }
 
 .session-row-badge svg {
-  width: 12px;
-  height: 12px;
+  width: 13px;
+  height: 13px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.6px;
@@ -5756,8 +5756,8 @@ td.data-table-key-col {
 }
 
 .session-action svg {
-  width: 14px;
-  height: 14px;
+  width: 15px;
+  height: 15px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.6px;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -929,6 +929,8 @@ openclaw-settings-save-indicator {
 
 .sidebar-shell {
   --sidebar-pad-x: 10px;
+  --sidebar-lucide-icon-size: 16px;
+  --sidebar-lucide-stroke-width: 1.5px;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -941,6 +943,25 @@ openclaw-settings-save-indicator {
   border-radius: 0;
   background: transparent;
   box-shadow: none;
+}
+
+/* Top-layer menus do not inherit sidebar ancestry, so every sidebar-owned
+   surface participates explicitly in the same Lucide optical contract. */
+:is(
+    .sidebar-shell,
+    .settings-sidebar,
+    .sidebar-customize-menu,
+    .session-menu,
+    .sidebar-session-sort-menu,
+    .sidebar-hover-card,
+    .shell-chrome-controls__nav-toggle,
+    .topbar-nav-toggle,
+    .chat-pane__nav-toggle
+  )
+  svg[data-lucide-icon] {
+  max-width: var(--sidebar-lucide-icon-size, 16px);
+  max-height: var(--sidebar-lucide-icon-size, 16px);
+  stroke-width: var(--sidebar-lucide-stroke-width, 1.5px);
 }
 
 .sidebar-brand {
@@ -1636,19 +1657,23 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-session-group-drag-handle {
   position: absolute;
   top: 50%;
-  left: 1px;
+  left: 0;
   z-index: 1;
-  width: 4px;
-  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 20px;
   transform: translateY(-50%);
-  border-radius: 3px;
-  background-image: radial-gradient(circle, currentColor 1px, transparent 1.2px);
-  background-position: 0 0;
-  background-size: 4px 4px;
   color: var(--muted);
   opacity: 0;
   cursor: grab;
   transition: opacity var(--duration-fast) ease;
+}
+
+.sidebar-session-group-drag-handle svg {
+  width: 16px;
+  height: 16px;
 }
 
 .sidebar-recent-sessions__head--draggable:hover .sidebar-session-group-drag-handle,
@@ -1665,8 +1690,8 @@ body.update-dialog-open .sidebar-update-card__status {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
   flex: 0 0 auto;
   border: none;
   border-radius: var(--radius-md);
@@ -1697,8 +1722,8 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-sort svg {
-  width: 14px;
-  height: 14px;
+  width: 13px;
+  height: 13px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.7px;
@@ -1749,6 +1774,16 @@ body.update-dialog-open .sidebar-update-card__status {
   stroke-width: 1.7px;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+.sidebar-session-group-actions.sidebar-session-sort {
+  width: 28px;
+  height: 28px;
+}
+
+.sidebar-session-group-actions.sidebar-session-sort svg {
+  width: 13px;
+  height: 13px;
 }
 
 @media (hover: none), (pointer: coarse) {
@@ -2747,8 +2782,8 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   flex: 0 0 auto;
 }
 
@@ -2762,8 +2797,8 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .session-menu__icon svg,
 .session-menu__check svg {
-  width: 14px;
-  height: 14px;
+  width: 15px;
+  height: 15px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.7px;
@@ -3997,6 +4032,10 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   flex: 1 1 auto;
   flex-direction: column;
   min-width: 0;
+}
+
+.sidebar-recent-session__link:has(> .session-row-badges) > .sidebar-recent-session__text {
+  flex-grow: 0;
 }
 
 .sidebar-recent-session__subtitle {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1520,14 +1520,6 @@ body.update-dialog-open .sidebar-update-card__status {
   color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
 }
 
-.sidebar-recent-sessions__head--draggable {
-  cursor: grab;
-}
-
-.sidebar-recent-sessions__head--draggable:active {
-  cursor: grabbing;
-}
-
 .sidebar-session-group-toggle {
   display: flex;
   align-items: center;
@@ -1676,8 +1668,9 @@ body.update-dialog-open .sidebar-update-card__status {
   height: 16px;
 }
 
-.sidebar-recent-sessions__head--draggable:hover .sidebar-session-group-drag-handle,
-.sidebar-recent-sessions__head--draggable:has(:focus-visible) .sidebar-session-group-drag-handle {
+.sidebar-recent-sessions__head:hover .sidebar-session-group-drag-handle[draggable="true"],
+.sidebar-recent-sessions__head:has(:focus-visible)
+  .sidebar-session-group-drag-handle[draggable="true"] {
   opacity: 0.55;
 }
 
@@ -1731,8 +1724,8 @@ body.update-dialog-open .sidebar-update-card__status {
   stroke-linejoin: round;
 }
 
-/* Group header kebab: hidden until hover/keyboard focus like row actions, but always
-   reachable on touch pointers where hover does not exist. */
+/* Keep the reserved action slot hit-testable while hidden so pointer entry can
+   establish header hover and reveal it before the click. */
 .sidebar-session-group-actions {
   display: inline-flex;
   align-items: center;
@@ -1745,7 +1738,6 @@ body.update-dialog-open .sidebar-update-card__status {
   background: transparent;
   color: var(--muted);
   opacity: 0;
-  pointer-events: none;
   transition:
     opacity var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -1757,7 +1749,6 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-session-group-actions[aria-expanded="true"],
 .sidebar-session-group-actions.sidebar-session-sort--filtered {
   opacity: 1;
-  pointer-events: auto;
 }
 
 .sidebar-session-group-actions:hover,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1724,8 +1724,8 @@ body.update-dialog-open .sidebar-update-card__status {
   stroke-linejoin: round;
 }
 
-/* Keep the reserved action slot hit-testable while hidden so pointer entry can
-   establish header hover and reveal it before the click. */
+/* Header hover reveals the reserved action slot; exclude the hidden button
+   from hit testing until it is visible. */
 .sidebar-session-group-actions {
   display: inline-flex;
   align-items: center;
@@ -1738,6 +1738,7 @@ body.update-dialog-open .sidebar-update-card__status {
   background: transparent;
   color: var(--muted);
   opacity: 0;
+  pointer-events: none;
   transition:
     opacity var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -1749,6 +1750,7 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-session-group-actions[aria-expanded="true"],
 .sidebar-session-group-actions.sidebar-session-sort--filtered {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .sidebar-session-group-actions:hover,

--- a/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
@@ -397,7 +397,13 @@ describe("AppSidebar group section ordering", () => {
 
   async function dropGroupBeforeCoding(sidebar: SidebarLifecycleState, group: string) {
     const dataTransfer = createDataTransferStub();
-    dispatchDragEvent(groupHeader(sidebar, group), "dragstart", dataTransfer);
+    const dragHandle = groupHeader(sidebar, group).querySelector(
+      '.sidebar-session-group-drag-handle[draggable="true"]',
+    );
+    if (!dragHandle) {
+      throw new Error(`expected drag handle for ${group}`);
+    }
+    dispatchDragEvent(dragHandle, "dragstart", dataTransfer);
     const coding = section(sidebar, "work");
     dispatchDragEvent(coding, "dragover", dataTransfer, -1);
     dispatchDragEvent(coding, "drop", dataTransfer, -1);

--- a/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
@@ -119,14 +119,19 @@ describe("AppSidebar section reordering", () => {
     return header;
   }
 
-  it("marks every section header draggable and renders a grip", async () => {
+  function groupDragHandle(sidebar: SidebarLifecycleState, sectionId: string) {
+    const handle = groupHeader(sidebar, sectionId).querySelector(
+      ".sidebar-session-group-drag-handle",
+    );
+    if (!handle) {
+      throw new Error(`expected drag handle for section ${sectionId}`);
+    }
+    return handle;
+  }
+
+  it("keeps header buttons outside the dedicated section drag source", async () => {
     const { sidebar } = await mountWithGroups(["Alpha", "Beta"], [], { withCatalog: true });
 
-    expect(groupHeader(sidebar, "category:Alpha").getAttribute("draggable")).toBe("true");
-    expect(groupHeader(sidebar, "ungrouped").getAttribute("draggable")).toBe("true");
-    expect(groupHeader(sidebar, "groups").getAttribute("draggable")).toBe("true");
-    expect(groupHeader(sidebar, "work").getAttribute("draggable")).toBe("true");
-    expect(groupHeader(sidebar, "catalog:codex").getAttribute("draggable")).toBe("true");
     const codingSection = sidebar.querySelector('[data-session-section="work"]');
     const catalogSection = sidebar.querySelector('[data-session-section="catalog:codex"]');
     expect(catalogSection?.parentElement).toBe(codingSection?.parentElement);
@@ -139,9 +144,10 @@ describe("AppSidebar section reordering", () => {
       "work",
       "catalog:codex",
     ]) {
-      expect(
-        groupHeader(sidebar, sectionId).querySelector(".sidebar-session-group-drag-handle"),
-      ).not.toBeNull();
+      const header = groupHeader(sidebar, sectionId);
+      expect(header.getAttribute("draggable")).toBeNull();
+      expect(groupDragHandle(sidebar, sectionId).getAttribute("draggable")).toBe("true");
+      expect(header.querySelector("button")?.closest('[draggable="true"]')).toBeNull();
     }
   });
 
@@ -150,15 +156,17 @@ describe("AppSidebar section reordering", () => {
       scopes: ["operator.read"],
     });
     const header = groupHeader(sidebar, "category:Alpha");
+    const handle = groupDragHandle(sidebar, "category:Alpha");
     const row = sidebar.querySelector('[data-session-key="agent:main:plain"]');
 
-    expect(header.getAttribute("draggable")).toBe("false");
+    expect(header.getAttribute("draggable")).toBeNull();
+    expect(handle.getAttribute("draggable")).toBe("false");
     expect(header.getAttribute("title")).toBeTruthy();
     expect(row?.getAttribute("draggable")).toBe("false");
     expect(row?.getAttribute("title")).toBeTruthy();
 
     const dataTransfer = createDataTransferStub();
-    dispatchDragEvent(header, "dragstart", dataTransfer);
+    dispatchDragEvent(handle, "dragstart", dataTransfer);
     const threadsSection = sidebar.querySelector('[data-session-section="ungrouped"]');
     if (!threadsSection) {
       throw new Error("expected Threads section");
@@ -169,7 +177,7 @@ describe("AppSidebar section reordering", () => {
     expect(harness.groupsPut).not.toHaveBeenCalled();
   });
 
-  it("does not start a section drag from a header action button", async () => {
+  it("does not make a header action button part of the section drag source", async () => {
     const { sidebar } = await mountWithGroups([]);
     const dataTransfer = createDataTransferStub();
     const newSessionButton = groupHeader(sidebar, "ungrouped").querySelector(
@@ -179,8 +187,8 @@ describe("AppSidebar section reordering", () => {
       throw new Error("expected new-session header action");
     }
 
-    newSessionButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-    dispatchDragEvent(groupHeader(sidebar, "ungrouped"), "dragstart", dataTransfer);
+    expect(newSessionButton.closest('[draggable="true"]')).toBeNull();
+    dispatchDragEvent(newSessionButton, "dragstart", dataTransfer);
 
     expect(dataTransfer.types).toEqual([]);
     expect(sidebar.sessionOrganizer.draggingSidebarSection).toBeNull();
@@ -190,7 +198,7 @@ describe("AppSidebar section reordering", () => {
     const { sidebar, harness } = await mountWithGroups(["Alpha", "Beta", "Gamma"]);
     const dataTransfer = createDataTransferStub();
 
-    dispatchDragEvent(groupHeader(sidebar, "category:Gamma"), "dragstart", dataTransfer);
+    dispatchDragEvent(groupDragHandle(sidebar, "category:Gamma"), "dragstart", dataTransfer);
     const alphaSection = sidebar.querySelector('[data-session-section="category:Alpha"]');
     if (!alphaSection) {
       throw new Error("expected Alpha section");
@@ -209,7 +217,7 @@ describe("AppSidebar section reordering", () => {
     const { sidebar, harness } = await mountWithGroups([]);
     const dataTransfer = createDataTransferStub();
 
-    dispatchDragEvent(groupHeader(sidebar, "work"), "dragstart", dataTransfer);
+    dispatchDragEvent(groupDragHandle(sidebar, "work"), "dragstart", dataTransfer);
     const threadsSection = sidebar.querySelector('[data-session-section="ungrouped"]');
     if (!threadsSection) {
       throw new Error("expected Threads section");
@@ -254,7 +262,7 @@ describe("AppSidebar section reordering", () => {
     );
     const dataTransfer = createDataTransferStub();
 
-    dispatchDragEvent(groupHeader(sidebar, "work"), "dragstart", dataTransfer);
+    dispatchDragEvent(groupDragHandle(sidebar, "work"), "dragstart", dataTransfer);
     const threadsSection = sidebar.querySelector('[data-session-section="ungrouped"]');
     if (!threadsSection) {
       throw new Error("expected Threads section");
@@ -273,7 +281,7 @@ describe("AppSidebar section reordering", () => {
     const { sidebar, harness } = await mountWithGroups([], [], { withCatalog: true });
     const dataTransfer = createDataTransferStub();
 
-    dispatchDragEvent(groupHeader(sidebar, "catalog:codex"), "dragstart", dataTransfer);
+    dispatchDragEvent(groupDragHandle(sidebar, "catalog:codex"), "dragstart", dataTransfer);
     const codingSection = sidebar.querySelector('[data-session-section="work"]');
     if (!codingSection) {
       throw new Error("expected Coding section");


### PR DESCRIPTION
## What Problem This Solves

Sidebar controls mixed icon sizes, stroke weights, and ad hoc glyphs, which made navigation, row actions, and menus feel visually unrelated.

## Why This Change Was Made

- Establishes a sidebar-scoped 16px / 1.5px stroke contract without changing custom assets or status primitives.
- Marks hand-vendored stroke icons at their shared `strokeIcon()` owner; no runtime icon dependency is added.
- Adds the filled Ellipsis, GripVertical, and HatGlasses glyphs to the canonical icon registry and uses them for group actions, drag affordance, and private-session metadata.
- Keeps the 28px filter target and menu slots optically aligned while preserving their existing interaction areas.
- Keeps section actions outside the native drag source: only the dedicated grip reorders a section, and the reserved action slot remains hit-testable while visually hidden.
- The chat-header consumer already exists in #123572. Whichever change lands second should remove the duplicate Ellipsis registry hunk during rebase.

## User Impact

Sidebar navigation and actions now share a consistent optical scale in both themes. Private-session state is visible beside the session title, group actions use the intended filled affordance, compact controls retain their current hit targets, and group options remain clickable while sections are reorderable.

## Evidence

- Pre-fix headed reproduction at `43fe0795c677f859faee5f6c3cffac06b5123718`: all 4 variants stopped at the group-options click because the header won hit-testing, so the downstream frames were not counted as captured.
- Attached matrix provenance: exact head `3534467fde5279eddb80f1a896ce04f91cdfbaed`, asserted inside the execution, using the full `/chat` application with `installMockGateway`: [run 31846078585](https://github.com/openclaw/openclaw/actions/runs/31846078585). The headed iconography suite passed 4/4 and emitted all 28 frames shown below.
- Final base refresh provenance: exact head `4a80add7268f8cd9214a1dded17b5e8b46dd9024`, asserted inside a fresh execution of the same full application scenario: [run 31846833423](https://github.com/openclaw/openclaw/actions/runs/31846833423). The focused section-reordering suite passed 8/8, the headed iconography suite passed 4/4, and 28 fresh final-head frames were inspected individually. The intervening base-only change did not touch UI paths.
- Floating surfaces use the union of sidebar and surface bounds, so absolute-positioned menus are complete without unrelated page area.

<img width="2100" height="2000" alt="Sidebar iconography evidence matrix" src="https://github.com/user-attachments/assets/476d27c5-6212-47b1-98fa-3b2734b905e8" />

Rows: light 1x, light 2x, dark 1x, dark 2x. Columns: base, group controls, group menu, session menu, customizer, identity menu, account menu.

