### PR TITLE
fix(cli): return structured system event errors

### DIFF
--- a/src/cli/system-cli.test.ts
+++ b/src/cli/system-cli.test.ts
@@ -160,6 +160,24 @@ describe("system-cli", () => {
     expect(params).not.toHaveProperty("sessionKey");
   });
 
+  it("writes JSON when an implicit machine-output command fails", async () => {
+    callGatewayFromCli.mockRejectedValueOnce(new Error("Gateway unavailable"));
+
+    await runCli(["system", "heartbeat", "last"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+    const [method, gatewayOptions, params, requestOptions] = gatewayCall();
+    expect(method).toBe("last-heartbeat");
+    expect(typeof gatewayOptions).toBe("object");
+    expect(params).toBeUndefined();
+    expect(requestOptions).toEqual({ expectFinal: false });
+    const expectedError = "Error: Gateway unavailable";
+    expect(runtimeLogs).toEqual([JSON.stringify({ error: expectedError }, null, 2)]);
+    expect(runtimeErrors).toEqual([]);
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({ error: expectedError });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
   it.each([
     { args: ["system", "heartbeat", "last"], method: "last-heartbeat", params: undefined },
     {

--- a/src/cli/system-cli.test.ts
+++ b/src/cli/system-cli.test.ts
@@ -76,14 +76,51 @@ describe("system-cli", () => {
 
     expect(runtimeLogs).toEqual([]);
     expect(runtimeErrors[0]).toContain("unwakeable-session-key");
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
   it("handles invalid wake mode as runtime error", async () => {
     await runCli(["system", "event", "--text", "hello", "--mode", "later"]);
 
     expect(callGatewayFromCli).not.toHaveBeenCalled();
+    expect(runtimeLogs).toEqual([]);
     expect(runtimeErrors[0]).toContain("--mode must be now or next-heartbeat");
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
+
+  it.each([
+    {
+      name: "invalid wake mode",
+      args: ["system", "event", "--text", "hello", "--mode", "later", "--json"],
+      gatewayResult: undefined,
+      expectedError: "Error: --mode must be now or next-heartbeat",
+      gatewayCalls: 0,
+    },
+    {
+      name: "rejected Gateway call",
+      args: ["system", "event", "--text", "hello", "--json"],
+      gatewayResult: { ok: false, reason: "unwakeable-session-key" },
+      expectedError: "Error: unwakeable-session-key",
+      gatewayCalls: 1,
+    },
+  ])(
+    "writes JSON when $name fails",
+    async ({ args, gatewayResult, expectedError, gatewayCalls }) => {
+      if (gatewayResult) {
+        callGatewayFromCli.mockResolvedValueOnce(gatewayResult);
+      }
+
+      await runCli(args);
+
+      expect(runtimeLogs).toEqual([JSON.stringify({ error: expectedError }, null, 2)]);
+      expect(runtimeErrors).toEqual([]);
+      expect(defaultRuntime.writeJson).toHaveBeenCalledWith({ error: expectedError });
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+      expect(callGatewayFromCli).toHaveBeenCalledTimes(gatewayCalls);
+    },
+  );
 
   it("forwards --session-key on system event", async () => {
     await runCli([

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -43,7 +43,11 @@ async function runSystemGatewayCommand(
       defaultRuntime.log(successText);
     }
   } catch (err) {
-    defaultRuntime.error(danger(String(err)));
+    if (opts.json) {
+      defaultRuntime.writeJson({ error: String(err) });
+    } else {
+      defaultRuntime.error(danger(String(err)));
+    }
     defaultRuntime.exit(1);
   }
 }

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -35,15 +35,16 @@ async function runSystemGatewayCommand(
   action: () => Promise<unknown>,
   successText?: string,
 ): Promise<void> {
+  const machineOutput = opts.json || successText === undefined;
   try {
     const result = await action();
-    if (opts.json || successText === undefined) {
+    if (machineOutput) {
       defaultRuntime.writeJson(result);
     } else {
       defaultRuntime.log(successText);
     }
   } catch (err) {
-    if (opts.json) {
+    if (machineOutput) {
       defaultRuntime.writeJson({ error: String(err) });
     } else {
       defaultRuntime.error(danger(String(err)));


### PR DESCRIPTION
Closes #123610

## What Problem This Solves

Fixes an issue where `openclaw system event --json` emitted empty stdout and styled human stderr when validation or the Gateway command failed. Automation requesting JSON could not parse the failure response.

## Why This Change Was Made

The system command's existing error owner now computes one machine-output predicate for explicit `--json` and implicit JSON-only commands, then uses it for both success and failure routing. Human event commands retain the current styled stderr path. Flags, modes, Gateway parameters, successful output, and exit status remain unchanged.

## User Impact

Scripts using `system event --json`, heartbeat controls, or system presence now receive structured JSON on both success and failure. Human event users continue seeing the same readable stderr errors.

## Evidence

- Tests-first process proof reproduced exit 1 with empty stdout and `Error: --mode must be now or next-heartbeat` on stderr.
- Regressions cover invalid event mode validation, a rejected event Gateway result in explicit JSON mode, unchanged human event failures, and a rejected `system heartbeat last` Gateway call in implicit machine-output mode.
- Post-fix focused system CLI proof: 14/14 tests passed.
- Source-blind post-fix process proof: exit 1, structured JSON stdout, empty stderr.
- Blacksmith Testbox core + coreTests changed gate passed, including typechecks, type-aware changed lint, dead exports, import cycles, formatting, and storage/schema/architecture guards: https://github.com/openclaw/openclaw/actions/runs/31795865975 (`tbx_01m0002berzghhg33k6m1rqsgw`).
- Final Codex autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Exact reviewed head: `41b5e8f311dbc09194903304aec2e1fb9bb4afac`.

Production delta: +7/-2, net +5. Tests: +55.

AI-assisted: yes. The repair was reviewed against system command registration, explicit and implicit machine-output policy, validation, Gateway result handling, runtime stdout/stderr/exit ownership, documented JSON behavior, and the existing Directory JSON-error precedent.
