### PR TITLE
feat: compact xAI sessions server-side (AI-assisted)

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -147,6 +147,7 @@ below or under known limits.
 | xAI capability             | OpenClaw surface                        | Status                                               |
 | -------------------------- | --------------------------------------- | ---------------------------------------------------- |
 | Chat / Responses           | `xai/<model>` model provider            | Yes                                                  |
+| Context compaction         | `/compact` and threshold compaction     | Yes via `/v1/responses/compact`                      |
 | Server-side web search     | `web_search` provider `grok`            | Yes                                                  |
 | Server-side X search       | `x_search` tool                         | Yes                                                  |
 | Server-side code execution | `code_execution` tool                   | Yes                                                  |
@@ -601,6 +602,42 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
       },
     }
     ```
+
+  </Accordion>
+
+  <Accordion title="Context compaction">
+    Native `api.x.ai` Responses routes use xAI's server-side
+    [`/responses/compact`](https://docs.x.ai/developers/advanced-api-usage/context-compaction)
+    endpoint by default for manual `/compact` and threshold-driven preflight
+    compaction. The session keeps its OpenClaw transcript unchanged and stores
+    xAI's opaque checkpoint for the next request. Completion notices report
+    the provider's before and after token counts.
+
+    Disable the endpoint for one model with:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          models: {
+            "xai/grok-4.5": {
+              params: { responsesCompactEndpoint: false },
+            },
+          },
+        },
+      },
+    }
+    ```
+
+    Other Responses-compatible providers can opt in with
+    `params.responsesCompactEndpoint: true`; non-Responses routes ignore the
+    setting. OpenAI's native Responses API does not need this option because
+    its `context_management` compaction is already managed by
+    `responsesServerCompaction`.
+
+    Endpoint failures fall back to OpenClaw's client-side summarization.
+    Overflow recovery never calls the endpoint because xAI requires the input
+    to fit the model context window before compaction.
 
   </Accordion>
 

--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -1,0 +1,177 @@
+import {
+  captureOpenAIResponsesCompaction,
+  createOpenAIResponsesTransportStreamFn,
+  requestPreparedOpenAIResponsesCompaction,
+} from "@openclaw/ai/transports";
+import type { AssistantMessage, Context, Model, StreamFn } from "openclaw/plugin-sdk/llm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { wrapXaiProviderStream } from "./stream.js";
+
+const sdkState = vi.hoisted(() => ({
+  clients: [] as Array<Record<string, unknown>>,
+  post: vi.fn(),
+}));
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    constructor(options: Record<string, unknown>) {
+      sdkState.clients.push(options);
+    }
+
+    post = sdkState.post;
+  }
+  return { default: MockOpenAI, AzureOpenAI: MockOpenAI };
+});
+
+const model = {
+  id: "grok-4",
+  name: "Grok 4",
+  api: "openai-responses",
+  provider: "xai",
+  baseUrl: "https://api.x.ai/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 256_000,
+  maxTokens: 8_192,
+} satisfies Model<"openai-responses">;
+
+const usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function wrapResponses(options: { fastMode?: boolean; clientVersion?: string }): StreamFn {
+  const wrapped = wrapXaiProviderStream(
+    {
+      streamFn: createOpenAIResponsesTransportStreamFn(),
+      extraParams: { fastMode: options.fastMode, tool_stream: false },
+    } as never,
+    { clientVersion: options.clientVersion },
+  );
+  if (!wrapped) {
+    throw new Error("expected xAI stream wrapper");
+  }
+  return wrapped;
+}
+
+beforeEach(() => {
+  sdkState.clients.length = 0;
+  sdkState.post.mockReset();
+  sdkState.post.mockResolvedValue({
+    object: "response.compaction",
+    output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
+    usage: { input_tokens: 1_000, output_tokens: 200 },
+  });
+});
+
+describe("xAI server compaction request preparation", () => {
+  it("compacts and replays through the legacy fast-mode wrapper", async () => {
+    const streamFn = wrapResponses({ fastMode: true });
+    const owner: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "remembered" }],
+      api: "openai-responses",
+      provider: "xai",
+      model: "grok-4-fast",
+      usage,
+      stopReason: "stop",
+      timestamp: 2,
+    };
+    const context: Context = {
+      systemPrompt: "Retain the conversation.",
+      messages: [{ role: "user", content: "Remember NORTH-COPPER-17.", timestamp: 1 }, owner],
+    };
+
+    const compacted = await requestPreparedOpenAIResponsesCompaction(streamFn, model, context, {
+      apiKey: "test-key",
+      sessionId: "session-1",
+    });
+
+    expect(sdkState.post).toHaveBeenCalledWith(
+      "/responses/compact",
+      expect.objectContaining({ body: expect.objectContaining({ model: "grok-4-fast" }) }),
+    );
+    captureOpenAIResponsesCompaction(
+      owner,
+      compacted.item,
+      owner.content.length,
+      compacted.model,
+      compacted.replayMetadata,
+    );
+
+    let replayPayload: Record<string, unknown> | undefined;
+    const replayStream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          ...context,
+          messages: [
+            ...context.messages,
+            { role: "user", content: "What was the code?", timestamp: 3 },
+          ],
+        },
+        {
+          apiKey: "test-key",
+          sessionId: "session-1",
+          onPayload: (payload) => {
+            replayPayload = structuredClone(payload as Record<string, unknown>);
+            throw new Error("stop after replay payload capture");
+          },
+        },
+      ),
+    );
+    await replayStream.result();
+
+    expect(replayPayload?.model).toBe("grok-4-fast");
+    expect(replayPayload?.input).toEqual([
+      expect.objectContaining({ role: "system", type: "message" }),
+      expect.objectContaining({ type: "compaction", encrypted_content: "opaque" }),
+      expect.objectContaining({ role: "user", type: "message" }),
+    ]);
+    expect(JSON.stringify(replayPayload)).not.toContain("NORTH-COPPER-17");
+  });
+
+  it("uses the same OAuth proxy headers as a normal turn", async () => {
+    const streamFn = wrapResponses({ clientVersion: "2026.7.2" });
+    const oauthModel = {
+      ...model,
+      id: "grok-4.5",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+    } satisfies Model<"openai-responses">;
+    const context: Context = {
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+    };
+    const options = {
+      apiKey: "test-key",
+      sessionId: "session-1",
+      headers: { "X-Existing": "kept" },
+    };
+
+    await requestPreparedOpenAIResponsesCompaction(streamFn, oauthModel, context, options);
+    const compactHeaders = sdkState.clients[0]?.defaultHeaders;
+
+    const normalStream = await Promise.resolve(
+      streamFn(oauthModel, context, {
+        ...options,
+        onPayload: () => {
+          throw new Error("stop after normal request preparation");
+        },
+      }),
+    );
+    await normalStream.result();
+    const normalHeaders = sdkState.clients[1]?.defaultHeaders;
+
+    expect(compactHeaders).toEqual(normalHeaders);
+    expect(compactHeaders).toMatchObject({
+      "x-existing": "kept",
+      "x-grok-client-version": "2026.7.2",
+      "x-grok-model-override": "grok-4.5",
+      "x-xai-token-auth": "xai-grok-cli",
+    });
+  });
+});

--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -3,7 +3,8 @@ import {
   createOpenAIResponsesTransportStreamFn,
   requestPreparedOpenAIResponsesCompaction,
 } from "@openclaw/ai/transports";
-import type { AssistantMessage, Context, Model, StreamFn } from "openclaw/plugin-sdk/llm";
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { AssistantMessage, Context, Model } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { wrapXaiProviderStream } from "./stream.js";
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -111,6 +111,7 @@
     "typebox": "1.3.6"
   },
   "devDependencies": {
+    "@openclaw/model-catalog-core": "workspace:*",
     "@openclaw/normalization-core": "workspace:*"
   },
   "engines": {

--- a/packages/ai/src/package-dependencies.test.ts
+++ b/packages/ai/src/package-dependencies.test.ts
@@ -44,16 +44,19 @@ async function productionImportsPackage(packageName: string): Promise<boolean> {
 }
 
 describe("@openclaw/ai source dependency contract", () => {
-  it("declares bundled normalization-core imports as a workspace dev dependency", async () => {
-    const manifest = JSON.parse(
-      await fs.readFile(path.join(PACKAGE_ROOT, "package.json"), "utf8"),
-    ) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
+  it.each(["@openclaw/model-catalog-core", "@openclaw/normalization-core"])(
+    "declares bundled %s imports as a workspace dev dependency",
+    async (packageName) => {
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(PACKAGE_ROOT, "package.json"), "utf8"),
+      ) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+      };
 
-    expect(await productionImportsPackage("@openclaw/normalization-core")).toBe(true);
-    expect(manifest.dependencies?.["@openclaw/normalization-core"]).toBeUndefined();
-    expect(manifest.devDependencies?.["@openclaw/normalization-core"]).toBe("workspace:*");
-  });
+      expect(await productionImportsPackage(packageName)).toBe(true);
+      expect(manifest.dependencies?.[packageName]).toBeUndefined();
+      expect(manifest.devDependencies?.[packageName]).toBe("workspace:*");
+    },
+  );
 });

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -104,6 +104,7 @@ describe("responses compact endpoint", () => {
 
   it.each([
     ["native xAI default", model, undefined, true],
+    ["native xAI alias default", { ...model, provider: "x-ai" }, undefined, true],
     ["native xAI opt-out", model, { responsesCompactEndpoint: false }, false],
     [
       "custom Responses opt-in",

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -18,7 +18,10 @@ vi.mock("openai", () => {
 });
 
 import { resolveOpenAIResponsesCompactEndpointPlan } from "./openai-responses-payload-policy.js";
-import { requestOpenAIResponsesCompaction } from "./openai-responses-transport.js";
+import {
+  createOpenAIResponsesTransportStreamFn,
+  requestPreparedOpenAIResponsesCompaction,
+} from "./openai-responses-transport.js";
 
 const model = {
   id: "grok-4.5",
@@ -51,10 +54,12 @@ describe("responses compact endpoint", () => {
       usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
     });
 
-    const result = await requestOpenAIResponsesCompaction(model, context, {
-      apiKey: "test-key",
-      sessionId: "session-1",
-    });
+    const result = await requestPreparedOpenAIResponsesCompaction(
+      createOpenAIResponsesTransportStreamFn(),
+      model,
+      context,
+      { apiKey: "test-key", sessionId: "session-1" },
+    );
 
     expect(sdkState.clients[0]).toMatchObject({
       apiKey: "test-key",
@@ -72,9 +77,15 @@ describe("responses compact endpoint", () => {
         },
       }),
     );
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       item: { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
       usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
+      model,
+      replayMetadata: {
+        source: "openai-responses",
+        provider: "xai",
+        model: "grok-4.5",
+      },
     });
   });
 
@@ -82,7 +93,12 @@ describe("responses compact endpoint", () => {
     sdkState.post.mockResolvedValue({ object: "response.compaction", output: [], usage: {} });
 
     await expect(
-      requestOpenAIResponsesCompaction(model, context, { apiKey: "test-key" }),
+      requestPreparedOpenAIResponsesCompaction(
+        createOpenAIResponsesTransportStreamFn(),
+        model,
+        context,
+        { apiKey: "test-key" },
+      ),
     ).rejects.toThrow("exactly one compaction item");
   });
 

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -1,0 +1,119 @@
+import type { Context, Model } from "@openclaw/llm-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdkState = vi.hoisted(() => ({
+  clients: [] as Array<Record<string, unknown>>,
+  post: vi.fn(),
+}));
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    constructor(options: Record<string, unknown>) {
+      sdkState.clients.push(options);
+    }
+
+    post = sdkState.post;
+  }
+  return { default: MockOpenAI, AzureOpenAI: MockOpenAI };
+});
+
+import { resolveOpenAIResponsesCompactEndpointPlan } from "./openai-responses-payload-policy.js";
+import { requestOpenAIResponsesCompaction } from "./openai-responses-transport.js";
+
+const model = {
+  id: "grok-4.5",
+  name: "Grok 4.5",
+  api: "openai-responses",
+  provider: "xai",
+  baseUrl: "https://api.x.ai/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 256_000,
+  maxTokens: 8_192,
+} satisfies Model<"openai-responses">;
+
+const context = {
+  systemPrompt: "Retain the conversation.",
+  messages: [{ role: "user", content: "Remember NORTH-COPPER-17.", timestamp: 1 }],
+} satisfies Context;
+
+describe("responses compact endpoint", () => {
+  beforeEach(() => {
+    sdkState.clients.length = 0;
+    sdkState.post.mockReset();
+  });
+
+  it("posts the normal Responses input and returns the validated checkpoint with usage", async () => {
+    sdkState.post.mockResolvedValue({
+      object: "response.compaction",
+      output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
+      usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
+    });
+
+    const result = await requestOpenAIResponsesCompaction(model, context, {
+      apiKey: "test-key",
+      sessionId: "session-1",
+    });
+
+    expect(sdkState.clients[0]).toMatchObject({
+      apiKey: "test-key",
+      baseURL: "https://api.x.ai/v1",
+    });
+    expect(sdkState.post).toHaveBeenCalledWith(
+      "/responses/compact",
+      expect.objectContaining({
+        body: {
+          model: "grok-4.5",
+          input: [
+            expect.objectContaining({ role: "system", type: "message" }),
+            expect.objectContaining({ role: "user", type: "message" }),
+          ],
+        },
+      }),
+    );
+    expect(result).toEqual({
+      item: { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
+    });
+  });
+
+  it("rejects responses without exactly one encrypted compaction item", async () => {
+    sdkState.post.mockResolvedValue({ object: "response.compaction", output: [], usage: {} });
+
+    await expect(
+      requestOpenAIResponsesCompaction(model, context, { apiKey: "test-key" }),
+    ).rejects.toThrow("exactly one compaction item");
+  });
+
+  it.each([
+    ["native xAI default", model, undefined, true],
+    ["native xAI opt-out", model, { responsesCompactEndpoint: false }, false],
+    [
+      "custom Responses opt-in",
+      { ...model, provider: "custom", baseUrl: "https://responses.example/v1" },
+      { responsesCompactEndpoint: true },
+      true,
+    ],
+    [
+      "custom Responses default",
+      { ...model, provider: "custom", baseUrl: "https://responses.example/v1" },
+      undefined,
+      false,
+    ],
+    [
+      "non-Responses opt-in",
+      { ...model, api: "openai-completions" },
+      { responsesCompactEndpoint: true },
+      false,
+    ],
+    [
+      "OpenAI default",
+      { ...model, provider: "openai", baseUrl: "https://api.openai.com/v1" },
+      undefined,
+      false,
+    ],
+  ] as const)("resolves the %s gate", (_name, route, extraParams, enabled) => {
+    expect(resolveOpenAIResponsesCompactEndpointPlan(route, extraParams).enabled).toBe(enabled);
+  });
+});

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AssistantMessage, Context, Model, StreamFn } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import OpenAI, { AzureOpenAI } from "openai";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
@@ -154,6 +155,69 @@ export function createOpenAIResponsesClient(
     fetch: buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
   });
+}
+
+type OpenAIResponsesCompactEndpointResult = {
+  item: { type: "compaction"; id?: string; encrypted_content: string };
+  usage: Record<string, unknown> & { input_tokens: number; output_tokens: number };
+};
+
+/** POST one normal Responses input to the provider's manual compact endpoint. */
+export async function requestOpenAIResponsesCompaction(
+  model: Model,
+  context: Context,
+  options: OpenAIResponsesOptions,
+): Promise<OpenAIResponsesCompactEndpointResult> {
+  const apiKey = options.apiKey || getEnvApiKey(model.provider) || "";
+  let params = buildOpenAIResponsesParams(model, context, options);
+  const patched = await options.onPayload?.(params, model);
+  if (patched !== undefined) {
+    params = patched as typeof params;
+  }
+  params = sanitizeResponsesImagePayload(params as Record<string, unknown>) as typeof params;
+  const client = createOpenAIResponsesClient(
+    model,
+    context,
+    getAiTransportHost().resolveSecretSentinel(apiKey),
+    options.headers,
+    undefined,
+    options.sessionId,
+  );
+  const response = await client.post<unknown>("/responses/compact", {
+    ...buildOpenAISdkRequestOptions(model, options.signal, {
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries,
+    }),
+    body: { model: model.id, input: params.input },
+  });
+  const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
+  const item = output[0];
+  const usage = isRecord(response) && isRecord(response.usage) ? response.usage : undefined;
+  if (
+    response == null ||
+    !isRecord(response) ||
+    response.object !== "response.compaction" ||
+    output.length !== 1 ||
+    !isRecord(item) ||
+    item.type !== "compaction" ||
+    typeof item.encrypted_content !== "string" ||
+    item.encrypted_content.length === 0 ||
+    !usage ||
+    typeof usage.input_tokens !== "number" ||
+    typeof usage.output_tokens !== "number"
+  ) {
+    throw new Error(
+      "Responses compact endpoint did not return exactly one compaction item with usage",
+    );
+  }
+  return {
+    item: {
+      type: "compaction",
+      ...(typeof item.id === "string" ? { id: item.id } : {}),
+      encrypted_content: item.encrypted_content,
+    },
+    usage: usage as OpenAIResponsesCompactEndpointResult["usage"],
+  };
 }
 
 type ResponsesPricingOptions = Pick<

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -160,32 +160,41 @@ export function createOpenAIResponsesClient(
 type OpenAIResponsesCompactEndpointResult = {
   item: { type: "compaction"; id?: string; encrypted_content: string };
   usage: Record<string, unknown> & { input_tokens: number; output_tokens: number };
+  model: Model;
+  replayMetadata: ReturnType<typeof buildOpenAIResponsesReasoningReplayMetadata>;
 };
 
-/** POST one normal Responses input to the provider's manual compact endpoint. */
-export async function requestOpenAIResponsesCompaction(
-  model: Model,
-  context: Context,
-  options: OpenAIResponsesOptions,
-): Promise<OpenAIResponsesCompactEndpointResult> {
-  const apiKey = options.apiKey || getEnvApiKey(model.provider) || "";
-  let params = buildOpenAIResponsesParams(model, context, options);
-  params = ((await options.onPayload?.(params, model)) as typeof params | undefined) ?? params;
-  params = sanitizeResponsesImagePayload(params as Record<string, unknown>) as typeof params;
-  const client = createOpenAIResponsesClient(
-    model,
-    context,
-    getAiTransportHost().resolveSecretSentinel(apiKey),
-    options.headers,
-    undefined,
-    options.sessionId,
-  );
-  const response = await client.post<unknown>("/responses/compact", {
-    ...buildOpenAISdkRequestOptions(model, options.signal, {
-      timeoutMs: options.timeoutMs,
-      maxRetries: options.maxRetries,
+type ResponsesCompactRequestController = {
+  claimed: boolean;
+  resolve(result: OpenAIResponsesCompactEndpointResult): void;
+  reject(error: unknown): void;
+};
+
+const COMPACT_REQUEST = Symbol("openaiResponsesCompactRequest");
+
+function claimResponsesCompactRequest(options: object | undefined) {
+  const controller = options
+    ? (Reflect.get(options, COMPACT_REQUEST) as ResponsesCompactRequestController | undefined)
+    : undefined;
+  if (controller?.claimed === false) {
+    controller.claimed = true;
+    return controller;
+  }
+  return undefined;
+}
+
+async function postOpenAIResponsesCompaction(params: {
+  client: ReturnType<typeof createOpenAIResponsesClient>;
+  model: Model;
+  request: ReturnType<typeof buildOpenAIResponsesParams>;
+  options: OpenAIResponsesOptions | undefined;
+}): Promise<OpenAIResponsesCompactEndpointResult> {
+  const response = await params.client.post<unknown>("/responses/compact", {
+    ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
+      timeoutMs: params.options?.timeoutMs,
+      maxRetries: params.options?.maxRetries,
     }),
-    body: { model: model.id, input: params.input },
+    body: { model: params.request.model, input: params.request.input },
   });
   const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
   const item = output[0];
@@ -204,7 +213,44 @@ export async function requestOpenAIResponsesCompaction(
   ) {
     throw new Error("Responses compact endpoint did not return exactly one compaction item");
   }
-  return { item, usage } as OpenAIResponsesCompactEndpointResult;
+  return {
+    item,
+    usage,
+    model: params.model,
+    replayMetadata: buildOpenAIResponsesReasoningReplayMetadata(params.model, {
+      authProfileId: params.options?.authProfileId,
+      sessionId: params.options?.sessionId,
+    }),
+  } as OpenAIResponsesCompactEndpointResult;
+}
+
+/** Run a compact-endpoint request through the session's prepared stream stack. */
+export async function requestPreparedOpenAIResponsesCompaction(
+  streamFn: StreamFn,
+  model: Model,
+  context: Context,
+  options: OpenAIResponsesOptions,
+): Promise<OpenAIResponsesCompactEndpointResult> {
+  const preparedOptions = { ...options };
+  let resolveResult!: (result: OpenAIResponsesCompactEndpointResult) => void;
+  let rejectResult!: (error: unknown) => void;
+  const result = new Promise<OpenAIResponsesCompactEndpointResult>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  const controller = { claimed: false, resolve: resolveResult, reject: rejectResult };
+  Reflect.set(preparedOptions, COMPACT_REQUEST, controller);
+  const stream = await Promise.resolve(
+    streamFn(model, context, preparedOptions as Parameters<StreamFn>[2]),
+  );
+  if (!controller.claimed) {
+    throw new Error("Prepared stream did not reach an OpenAI Responses transport");
+  }
+  try {
+    return await result;
+  } finally {
+    await stream.result().catch(() => undefined);
+  }
 }
 
 type ResponsesPricingOptions = Pick<
@@ -242,6 +288,7 @@ type ResponsesTransportExecutorOptions = {
 function createResponsesTransportExecutor(config: ResponsesTransportExecutorOptions): StreamFn {
   return (model, context, options) => {
     const responsesOptions = options as OpenAIResponsesOptions | undefined;
+    const compactRequest = claimResponsesCompactRequest(responsesOptions);
     const eventStream = createAssistantMessageEventStream();
     const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
     void (async () => {
@@ -328,6 +375,25 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           return params;
         };
         const params = await buildRequest("checkpoint");
+        if (compactRequest) {
+          const compacted = await postOpenAIResponsesCompaction({
+            client,
+            model,
+            request: params,
+            options: responsesOptions,
+          });
+          output.usage.input = compacted.usage.input_tokens;
+          output.usage.output = compacted.usage.output_tokens;
+          output.usage.totalTokens = compacted.usage.input_tokens + compacted.usage.output_tokens;
+          compactRequest.resolve(compacted);
+          stream.push({
+            type: "done",
+            reason: output.stopReason as never,
+            message: output as never,
+          });
+          stream.end();
+          return;
+        }
         const sessionId = options?.sessionId;
         const httpContinuationEligible =
           config.httpContinuation &&
@@ -564,6 +630,17 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
         stream.end();
       } catch (error) {
+        if (compactRequest) {
+          compactRequest.reject(error);
+          Object.assign(output, projectProviderError(error, options?.signal));
+          stream.push({
+            type: "error",
+            reason: output.stopReason as never,
+            error: output as never,
+          });
+          stream.end();
+          return;
+        }
         if (error instanceof ResponsesStreamFailure && error.observation) {
           logResponsesFailedNoDetails(error.observation);
         }

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -18,6 +18,10 @@ import { buildGuardedModelFetch } from "./host-policy.js";
 import { emitModelTransportDebug } from "./model-transport-debug.js";
 import { formatModelTransportDebugBaseUrl } from "./model-transport-url.js";
 import {
+  claimResponsesCompactRequest,
+  type OpenAIResponsesCompactEndpointResult,
+} from "./openai-responses-compact-request.js";
+import {
   buildOpenAIResponsesReasoningReplayMetadata,
   suppressOpenAIResponsesCompaction,
   type OpenAIResponsesReplayMode,
@@ -157,32 +161,6 @@ export function createOpenAIResponsesClient(
   });
 }
 
-type OpenAIResponsesCompactEndpointResult = {
-  item: { type: "compaction"; id?: string; encrypted_content: string };
-  usage: Record<string, unknown> & { input_tokens: number; output_tokens: number };
-  model: Model;
-  replayMetadata: ReturnType<typeof buildOpenAIResponsesReasoningReplayMetadata>;
-};
-
-type ResponsesCompactRequestController = {
-  claimed: boolean;
-  resolve(result: OpenAIResponsesCompactEndpointResult): void;
-  reject(error: unknown): void;
-};
-
-const COMPACT_REQUEST = Symbol("openaiResponsesCompactRequest");
-
-function claimResponsesCompactRequest(options: object | undefined) {
-  const controller = options
-    ? (Reflect.get(options, COMPACT_REQUEST) as ResponsesCompactRequestController | undefined)
-    : undefined;
-  if (controller?.claimed === false) {
-    controller.claimed = true;
-    return controller;
-  }
-  return undefined;
-}
-
 async function postOpenAIResponsesCompaction(params: {
   client: ReturnType<typeof createOpenAIResponsesClient>;
   model: Model;
@@ -222,35 +200,6 @@ async function postOpenAIResponsesCompaction(params: {
       sessionId: params.options?.sessionId,
     }),
   } as OpenAIResponsesCompactEndpointResult;
-}
-
-/** Run a compact-endpoint request through the session's prepared stream stack. */
-export async function requestPreparedOpenAIResponsesCompaction(
-  streamFn: StreamFn,
-  model: Model,
-  context: Context,
-  options: OpenAIResponsesOptions,
-): Promise<OpenAIResponsesCompactEndpointResult> {
-  const preparedOptions = { ...options };
-  let resolveResult!: (result: OpenAIResponsesCompactEndpointResult) => void;
-  let rejectResult!: (error: unknown) => void;
-  const result = new Promise<OpenAIResponsesCompactEndpointResult>((resolve, reject) => {
-    resolveResult = resolve;
-    rejectResult = reject;
-  });
-  const controller = { claimed: false, resolve: resolveResult, reject: rejectResult };
-  Reflect.set(preparedOptions, COMPACT_REQUEST, controller);
-  const stream = await Promise.resolve(
-    streamFn(model, context, preparedOptions as Parameters<StreamFn>[2]),
-  );
-  if (!controller.claimed) {
-    throw new Error("Prepared stream did not reach an OpenAI Responses transport");
-  }
-  try {
-    return await result;
-  } finally {
-    await stream.result().catch(() => undefined);
-  }
 }
 
 type ResponsesPricingOptions = Pick<

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -170,10 +170,7 @@ export async function requestOpenAIResponsesCompaction(
 ): Promise<OpenAIResponsesCompactEndpointResult> {
   const apiKey = options.apiKey || getEnvApiKey(model.provider) || "";
   let params = buildOpenAIResponsesParams(model, context, options);
-  const patched = await options.onPayload?.(params, model);
-  if (patched !== undefined) {
-    params = patched as typeof params;
-  }
+  params = ((await options.onPayload?.(params, model)) as typeof params | undefined) ?? params;
   params = sanitizeResponsesImagePayload(params as Record<string, unknown>) as typeof params;
   const client = createOpenAIResponsesClient(
     model,
@@ -194,7 +191,6 @@ export async function requestOpenAIResponsesCompaction(
   const item = output[0];
   const usage = isRecord(response) && isRecord(response.usage) ? response.usage : undefined;
   if (
-    response == null ||
     !isRecord(response) ||
     response.object !== "response.compaction" ||
     output.length !== 1 ||
@@ -206,18 +202,9 @@ export async function requestOpenAIResponsesCompaction(
     typeof usage.input_tokens !== "number" ||
     typeof usage.output_tokens !== "number"
   ) {
-    throw new Error(
-      "Responses compact endpoint did not return exactly one compaction item with usage",
-    );
+    throw new Error("Responses compact endpoint did not return exactly one compaction item");
   }
-  return {
-    item: {
-      type: "compaction",
-      ...(typeof item.id === "string" ? { id: item.id } : {}),
-      encrypted_content: item.encrypted_content,
-    },
-    usage: usage as OpenAIResponsesCompactEndpointResult["usage"],
-  };
+  return { item, usage } as OpenAIResponsesCompactEndpointResult;
 }
 
 type ResponsesPricingOptions = Pick<

--- a/packages/ai/src/transports/openai-responses-compact-request.ts
+++ b/packages/ai/src/transports/openai-responses-compact-request.ts
@@ -1,0 +1,60 @@
+import type { Context, Model, StreamFn } from "@openclaw/llm-core";
+import type {
+  OpenAIResponsesOptions,
+  OpenAIResponsesReasoningReplayMetadata,
+} from "./openai-responses-contracts.js";
+
+export type OpenAIResponsesCompactEndpointResult = {
+  item: { type: "compaction"; id?: string; encrypted_content: string };
+  usage: Record<string, unknown> & { input_tokens: number; output_tokens: number };
+  model: Model;
+  replayMetadata: OpenAIResponsesReasoningReplayMetadata;
+};
+
+type ResponsesCompactRequestController = {
+  claimed: boolean;
+  resolve(result: OpenAIResponsesCompactEndpointResult): void;
+  reject(error: unknown): void;
+};
+
+const COMPACT_REQUEST = Symbol("openaiResponsesCompactRequest");
+
+export function claimResponsesCompactRequest(options: object | undefined) {
+  const controller = options
+    ? (Reflect.get(options, COMPACT_REQUEST) as ResponsesCompactRequestController | undefined)
+    : undefined;
+  if (controller?.claimed === false) {
+    controller.claimed = true;
+    return controller;
+  }
+  return undefined;
+}
+
+/** Run a compact-endpoint request through the session's prepared stream stack. */
+export async function requestPreparedOpenAIResponsesCompaction(
+  streamFn: StreamFn,
+  model: Model,
+  context: Context,
+  options: OpenAIResponsesOptions,
+): Promise<OpenAIResponsesCompactEndpointResult> {
+  const preparedOptions = { ...options };
+  let resolveResult!: (result: OpenAIResponsesCompactEndpointResult) => void;
+  let rejectResult!: (error: unknown) => void;
+  const result = new Promise<OpenAIResponsesCompactEndpointResult>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  const controller = { claimed: false, resolve: resolveResult, reject: rejectResult };
+  Reflect.set(preparedOptions, COMPACT_REQUEST, controller);
+  const stream = await Promise.resolve(
+    streamFn(model, context, preparedOptions as Parameters<StreamFn>[2]),
+  );
+  if (!controller.claimed) {
+    throw new Error("Prepared stream did not reach an OpenAI Responses transport");
+  }
+  try {
+    return await result;
+  } finally {
+    await stream.result().catch(() => undefined);
+  }
+}

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -317,15 +317,14 @@ export function resolveOpenAIResponsesCompactEndpointPlan(
   model: OpenAIResponsesPayloadModel,
   extraParams?: Record<string, unknown>,
 ): { enabled: boolean } {
-  const provider = normalizeOptionalLowercaseString(model.provider);
-  const api = normalizeOptionalLowercaseString(model.api);
   const configured = extraParams?.responsesCompactEndpoint;
-  const nativeXai =
-    provider === "xai" &&
-    resolveBundledOpenAIResponsesEndpointClass(model.baseUrl) === "xai-native";
   return {
     enabled:
-      isOpenAIResponsesApi(api) && (configured === true || (configured !== false && nativeXai)),
+      isOpenAIResponsesApi(normalizeOptionalLowercaseString(model.api)) &&
+      (configured === true ||
+        (configured !== false &&
+          normalizeOptionalLowercaseString(model.provider) === "xai" &&
+          resolveBundledOpenAIResponsesEndpointClass(model.baseUrl) === "xai-native")),
   };
 }
 

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -312,6 +312,23 @@ export function resolveOpenAIResponsesServerCompactionPlan(
   };
 }
 
+/** Resolve the manual Responses compact-endpoint gate for one route. */
+export function resolveOpenAIResponsesCompactEndpointPlan(
+  model: OpenAIResponsesPayloadModel,
+  extraParams?: Record<string, unknown>,
+): { enabled: boolean } {
+  const provider = normalizeOptionalLowercaseString(model.provider);
+  const api = normalizeOptionalLowercaseString(model.api);
+  const configured = extraParams?.responsesCompactEndpoint;
+  const nativeXai =
+    provider === "xai" &&
+    resolveBundledOpenAIResponsesEndpointClass(model.baseUrl) === "xai-native";
+  return {
+    enabled:
+      isOpenAIResponsesApi(api) && (configured === true || (configured !== false && nativeXai)),
+  };
+}
+
 function stripDisabledOpenAIReasoningPayload(payloadObj: Record<string, unknown>): void {
   const reasoning = payloadObj.reasoning;
   if (reasoning === "none") {

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -1,3 +1,4 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 /**
  * OpenAI Responses payload policy.
@@ -318,12 +319,13 @@ export function resolveOpenAIResponsesCompactEndpointPlan(
   extraParams?: Record<string, unknown>,
 ): { enabled: boolean } {
   const configured = extraParams?.responsesCompactEndpoint;
+  const provider = typeof model.provider === "string" ? normalizeProviderId(model.provider) : "";
   return {
     enabled:
       isOpenAIResponsesApi(normalizeOptionalLowercaseString(model.api)) &&
       (configured === true ||
         (configured !== false &&
-          normalizeOptionalLowercaseString(model.provider) === "xai" &&
+          (provider === "xai" || provider === "x-ai") &&
           resolveBundledOpenAIResponsesEndpointClass(model.baseUrl) === "xai-native")),
   };
 }

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -5,12 +5,8 @@ import {
   createAzureOpenAIClient,
   createOpenAIResponsesClient,
   createOpenAIResponsesTransportStreamFn,
-  requestOpenAIResponsesCompaction,
 } from "./openai-responses-client.js";
-import {
-  buildOpenAIResponsesReasoningReplayMetadata,
-  captureOpenAIResponsesCompaction,
-} from "./openai-responses-compaction-replay.js";
+import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
 import {
   buildResponsesFailedNoDetailsObservation,
   normalizeResponsesFailedEvent,
@@ -45,9 +41,9 @@ export {
   createAzureOpenAIResponsesTransportStreamFn,
   createOpenAIResponsesTransportStreamFn,
   buildOpenAIResponsesReasoningReplayMetadata,
-  captureOpenAIResponsesCompaction,
-  requestOpenAIResponsesCompaction,
 };
+export { requestOpenAIResponsesCompaction } from "./openai-responses-client.js";
+export { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
 
 const responsesTesting = {
   getCompat,

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -37,12 +37,8 @@ import {
   getCompat,
 } from "./openai-transport-params.js";
 
-export {
-  createAzureOpenAIResponsesTransportStreamFn,
-  createOpenAIResponsesTransportStreamFn,
-  buildOpenAIResponsesReasoningReplayMetadata,
-};
-export { requestPreparedOpenAIResponsesCompaction } from "./openai-responses-client.js";
+export { createAzureOpenAIResponsesTransportStreamFn, createOpenAIResponsesTransportStreamFn };
+export { requestPreparedOpenAIResponsesCompaction } from "./openai-responses-compact-request.js";
 export { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
 
 const responsesTesting = {

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -42,7 +42,7 @@ export {
   createOpenAIResponsesTransportStreamFn,
   buildOpenAIResponsesReasoningReplayMetadata,
 };
-export { requestOpenAIResponsesCompaction } from "./openai-responses-client.js";
+export { requestPreparedOpenAIResponsesCompaction } from "./openai-responses-client.js";
 export { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
 
 const responsesTesting = {

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -5,8 +5,12 @@ import {
   createAzureOpenAIClient,
   createOpenAIResponsesClient,
   createOpenAIResponsesTransportStreamFn,
+  requestOpenAIResponsesCompaction,
 } from "./openai-responses-client.js";
-import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
+import {
+  buildOpenAIResponsesReasoningReplayMetadata,
+  captureOpenAIResponsesCompaction,
+} from "./openai-responses-compaction-replay.js";
 import {
   buildResponsesFailedNoDetailsObservation,
   normalizeResponsesFailedEvent,
@@ -37,7 +41,13 @@ import {
   getCompat,
 } from "./openai-transport-params.js";
 
-export { createAzureOpenAIResponsesTransportStreamFn, createOpenAIResponsesTransportStreamFn };
+export {
+  createAzureOpenAIResponsesTransportStreamFn,
+  createOpenAIResponsesTransportStreamFn,
+  buildOpenAIResponsesReasoningReplayMetadata,
+  captureOpenAIResponsesCompaction,
+  requestOpenAIResponsesCompaction,
+};
 
 const responsesTesting = {
   getCompat,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2169,6 +2169,9 @@ importers:
         specifier: 1.3.6
         version: 1.3.6
     devDependencies:
+      '@openclaw/model-catalog-core':
+        specifier: workspace:*
+        version: link:../model-catalog-core
       '@openclaw/normalization-core':
         specifier: workspace:*
         version: link:../normalization-core

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -2,6 +2,7 @@
  * Test harness mocks for embedded-agent compaction hook coverage.
  */
 import { vi, type Mock } from "vitest";
+import type { CompactResult } from "../../context-engine/types.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { clearAgentHarnesses } from "../harness/registry.js";
@@ -32,13 +33,11 @@ type MockEmbeddedAgentStreamFn = Mock<
   (model?: unknown, context?: unknown, options?: unknown) => unknown
 >;
 
-export const contextEngineCompactMock = vi.fn(async () => ({
+export const contextEngineCompactMock: Mock<() => Promise<CompactResult>> = vi.fn(async () => ({
   ok: true as boolean,
   compacted: true as boolean,
   reason: undefined as string | undefined,
-  result: { summary: "engine-summary", tokensAfter: 50 } as
-    | { summary: string; tokensAfter: number }
-    | undefined,
+  result: { summary: "engine-summary", tokensBefore: 120, tokensAfter: 50 },
 }));
 
 export const hookRunner = {
@@ -583,7 +582,7 @@ export function resetCompactHooksHarnessMocks(): void {
     ok: true,
     compacted: true,
     reason: undefined,
-    result: { summary: "engine-summary", tokensAfter: 50 },
+    result: { summary: "engine-summary", tokensBefore: 120, tokensAfter: 50 },
   });
   compactWithSafetyTimeoutMock.mockReset();
   compactWithSafetyTimeoutMock.mockImplementation(runCompactWithSafetyTimeoutMock);

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -77,6 +77,8 @@ export const sessionCompactImpl = vi.fn(async () => ({
 }));
 export const sessionManualCompactionMock = vi.fn();
 export const sessionAutomaticCompactionMock = vi.fn();
+export const attemptServerEndpointCompactionMock: Mock<(_params?: unknown) => Promise<unknown>> =
+  vi.fn(async () => undefined);
 export const triggerInternalHookMock: Mock<(event?: unknown) => void> = vi.fn();
 const sanitizeSessionHistoryMock = vi.fn(
   async (params: { messages: unknown[] }) => params.messages,
@@ -236,23 +238,6 @@ export const resolveProviderEntryApiKeyProfileReferenceMock: Mock<() => unknown>
 export const shouldPreferExplicitConfigApiKeyAuthMock = vi.fn(() => false);
 export const registerProviderStreamForModelMock: Mock<(params?: unknown) => unknown> = vi.fn();
 export const applyExtraParamsToAgentMock = vi.fn(() => ({ effectiveExtraParams: {} }));
-export const requestOpenAIResponsesCompactionMock = vi.fn(async () => ({
-  item: { type: "compaction" as const, id: "cmp_test", encrypted_content: "opaque" },
-  usage: { input_tokens: 1_000, output_tokens: 200 },
-}));
-const readSessionTranscriptWatermarkMock = vi.fn(() => ({
-  generation: "generation-1",
-  maxSeq: 2,
-}));
-export const loadTranscriptEventRowsAfterSeqSyncMock: Mock<
-  (...args: unknown[]) => Array<{ event: unknown; seq: number }>
-> = vi.fn(() => []);
-export const rewriteTranscriptEventRowsExactMock: Mock<
-  (
-    scope?: unknown,
-    params?: { rows: Array<{ event: unknown; expectedEventJson: string; seq: number }> },
-  ) => Promise<{ generation: string } | null>
-> = vi.fn(async () => ({ generation: "generation-2" }));
 function createDefaultCompactionAuthStore(): AuthProfileStore {
   return {
     version: 1,
@@ -503,6 +488,8 @@ export function resetCompactSessionStateMocks(): void {
   sessionAbortCompactionMock.mockReset();
   sessionManualCompactionMock.mockReset();
   sessionAutomaticCompactionMock.mockReset();
+  attemptServerEndpointCompactionMock.mockReset();
+  attemptServerEndpointCompactionMock.mockResolvedValue(undefined);
   resolveEffectiveCompactionModeMock.mockReset();
   resolveEffectiveCompactionModeMock.mockReturnValue("default");
   createAgentSessionMock.mockReset();
@@ -531,20 +518,6 @@ export function resetCompactSessionStateMocks(): void {
   registerProviderStreamForModelMock.mockReturnValue(undefined);
   applyExtraParamsToAgentMock.mockReset();
   applyExtraParamsToAgentMock.mockReturnValue({ effectiveExtraParams: {} });
-  requestOpenAIResponsesCompactionMock.mockReset();
-  requestOpenAIResponsesCompactionMock.mockResolvedValue({
-    item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
-    usage: { input_tokens: 1_000, output_tokens: 200 },
-  });
-  readSessionTranscriptWatermarkMock.mockReset();
-  readSessionTranscriptWatermarkMock.mockReturnValue({
-    generation: "generation-1",
-    maxSeq: 2,
-  });
-  loadTranscriptEventRowsAfterSeqSyncMock.mockReset();
-  loadTranscriptEventRowsAfterSeqSyncMock.mockReturnValue([]);
-  rewriteTranscriptEventRowsExactMock.mockReset();
-  rewriteTranscriptEventRowsExactMock.mockResolvedValue({ generation: "generation-2" });
   ensureAuthProfileStoreMock.mockReset();
   ensureAuthProfileStoreMock.mockImplementation(createDefaultCompactionAuthStore);
   ensureAuthProfileStoreWithoutExternalProfilesMock.mockReset();
@@ -676,26 +649,9 @@ export async function loadCompactHooksHarness(): Promise<{
   resetCompactHooksHarnessMocks();
   vi.resetModules();
 
-  vi.doMock("@openclaw/ai/transports", async () => {
-    const actual =
-      await vi.importActual<typeof import("@openclaw/ai/transports")>("@openclaw/ai/transports");
-    return {
-      ...actual,
-      requestOpenAIResponsesCompaction: requestOpenAIResponsesCompactionMock,
-    };
-  });
-
-  vi.doMock("../../config/sessions/session-accessor.js", async () => {
-    const actual = await vi.importActual<
-      typeof import("../../config/sessions/session-accessor.js")
-    >("../../config/sessions/session-accessor.js");
-    return {
-      ...actual,
-      loadTranscriptEventRowsAfterSeqSync: loadTranscriptEventRowsAfterSeqSyncMock,
-      readSessionTranscriptWatermark: readSessionTranscriptWatermarkMock,
-      rewriteTranscriptEventRowsExact: rewriteTranscriptEventRowsExactMock,
-    };
-  });
+  vi.doMock("./server-endpoint-compaction.js", () => ({
+    attemptServerEndpointCompaction: attemptServerEndpointCompactionMock,
+  }));
 
   vi.doMock("../../plugins/hook-runner-global.js", () => ({
     getGlobalHookRunner: () => hookRunner,

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -236,6 +236,23 @@ export const resolveProviderEntryApiKeyProfileReferenceMock: Mock<() => unknown>
 export const shouldPreferExplicitConfigApiKeyAuthMock = vi.fn(() => false);
 export const registerProviderStreamForModelMock: Mock<(params?: unknown) => unknown> = vi.fn();
 export const applyExtraParamsToAgentMock = vi.fn(() => ({ effectiveExtraParams: {} }));
+export const requestOpenAIResponsesCompactionMock = vi.fn(async () => ({
+  item: { type: "compaction" as const, id: "cmp_test", encrypted_content: "opaque" },
+  usage: { input_tokens: 1_000, output_tokens: 200 },
+}));
+const readSessionTranscriptWatermarkMock = vi.fn(() => ({
+  generation: "generation-1",
+  maxSeq: 2,
+}));
+export const loadTranscriptEventRowsAfterSeqSyncMock: Mock<
+  (...args: unknown[]) => Array<{ event: unknown; seq: number }>
+> = vi.fn(() => []);
+export const rewriteTranscriptEventRowsExactMock: Mock<
+  (
+    scope?: unknown,
+    params?: { rows: Array<{ event: unknown; expectedEventJson: string; seq: number }> },
+  ) => Promise<{ generation: string } | null>
+> = vi.fn(async () => ({ generation: "generation-2" }));
 function createDefaultCompactionAuthStore(): AuthProfileStore {
   return {
     version: 1,
@@ -514,6 +531,20 @@ export function resetCompactSessionStateMocks(): void {
   registerProviderStreamForModelMock.mockReturnValue(undefined);
   applyExtraParamsToAgentMock.mockReset();
   applyExtraParamsToAgentMock.mockReturnValue({ effectiveExtraParams: {} });
+  requestOpenAIResponsesCompactionMock.mockReset();
+  requestOpenAIResponsesCompactionMock.mockResolvedValue({
+    item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+    usage: { input_tokens: 1_000, output_tokens: 200 },
+  });
+  readSessionTranscriptWatermarkMock.mockReset();
+  readSessionTranscriptWatermarkMock.mockReturnValue({
+    generation: "generation-1",
+    maxSeq: 2,
+  });
+  loadTranscriptEventRowsAfterSeqSyncMock.mockReset();
+  loadTranscriptEventRowsAfterSeqSyncMock.mockReturnValue([]);
+  rewriteTranscriptEventRowsExactMock.mockReset();
+  rewriteTranscriptEventRowsExactMock.mockResolvedValue({ generation: "generation-2" });
   ensureAuthProfileStoreMock.mockReset();
   ensureAuthProfileStoreMock.mockImplementation(createDefaultCompactionAuthStore);
   ensureAuthProfileStoreWithoutExternalProfilesMock.mockReset();
@@ -644,6 +675,27 @@ export async function loadCompactHooksHarness(): Promise<{
 }> {
   resetCompactHooksHarnessMocks();
   vi.resetModules();
+
+  vi.doMock("@openclaw/ai/transports", async () => {
+    const actual =
+      await vi.importActual<typeof import("@openclaw/ai/transports")>("@openclaw/ai/transports");
+    return {
+      ...actual,
+      requestOpenAIResponsesCompaction: requestOpenAIResponsesCompactionMock,
+    };
+  });
+
+  vi.doMock("../../config/sessions/session-accessor.js", async () => {
+    const actual = await vi.importActual<
+      typeof import("../../config/sessions/session-accessor.js")
+    >("../../config/sessions/session-accessor.js");
+    return {
+      ...actual,
+      loadTranscriptEventRowsAfterSeqSync: loadTranscriptEventRowsAfterSeqSyncMock,
+      readSessionTranscriptWatermark: readSessionTranscriptWatermarkMock,
+      rewriteTranscriptEventRowsExact: rewriteTranscriptEventRowsExactMock,
+    };
+  });
 
   vi.doMock("../../plugins/hook-runner-global.js", () => ({
     getGlobalHookRunner: () => hookRunner,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -2713,7 +2713,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.compactionKind).toBe("server-endpoint");
-    expect(result.result).toMatchObject({ tokensAfter: 200 });
+    expect(result.result).toMatchObject({ kind: "server-endpoint", tokensAfter: 200 });
     expect(result.result).not.toHaveProperty("summary");
   });
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -108,7 +108,7 @@ function mockPendingContextEngineCompaction() {
       ok: true,
       compacted: true,
       reason: undefined,
-      result: { summary: "engine-summary", tokensAfter: 50 },
+      result: { summary: "engine-summary", tokensBefore: 120, tokensAfter: 50 },
     };
   });
   return pending;
@@ -2534,7 +2534,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       ok: true,
       compacted: true,
       reason: undefined,
-      result: { summary: "engine-summary", tokensAfter: 50 },
+      result: { summary: "engine-summary", tokensBefore: 120, tokensAfter: 50 },
     });
     mockResolvedModel();
     mockQueuedRouteAwareModel();

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -32,6 +32,7 @@ import {
   guardSessionManagerMock,
   hookRunner,
   listRegisteredPluginAgentPromptGuidanceMock,
+  loadTranscriptEventRowsAfterSeqSyncMock,
   loadCompactHooksHarness,
   maybeCompactAgentHarnessSessionMock,
   resolveAgentHarnessPolicyMock,
@@ -47,6 +48,8 @@ import {
   resolveSandboxContextMock,
   resolveSessionAgentIdMock,
   resolveSessionAgentIdsMock,
+  requestOpenAIResponsesCompactionMock,
+  rewriteTranscriptEventRowsExactMock,
   rotateTranscriptAfterCompactionMock,
   selectAgentHarnessForPreparedModelProvidersMock,
   selectAgentHarnessMock,
@@ -329,6 +332,111 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       details: { ok: true },
     });
     resetCompactSessionStateMocks();
+  });
+
+  it("captures xAI manual endpoint compaction without rewriting message content", async () => {
+    mockResolvedModel();
+    const assistantEntry = {
+      type: "message" as const,
+      id: "assistant-entry",
+      parentId: "user-entry",
+      timestamp: new Date(2).toISOString(),
+      message: structuredClone(sessionMessages[1]) as Extract<AgentMessage, { role: "assistant" }>,
+    };
+    loadTranscriptEventRowsAfterSeqSyncMock.mockReturnValueOnce([
+      { event: assistantEntry, seq: 2 },
+    ]);
+
+    const result = await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        provider: "xai",
+        model: "grok-4.5",
+        config: {
+          models: {
+            providers: {
+              xai: {
+                api: "openai-responses",
+                baseUrl: "https://api.x.ai/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        trigger: "manual",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      compacted: true,
+      compactionKind: "server-endpoint",
+      result: { tokensBefore: 1_000, tokensAfter: 200 },
+    });
+    expect(requestOpenAIResponsesCompactionMock).toHaveBeenCalledOnce();
+    expect(sessionManualCompactionMock).not.toHaveBeenCalled();
+    const rewritten = rewriteTranscriptEventRowsExactMock.mock.calls[0]?.[1]?.rows[0]?.event as {
+      message?: { content?: unknown; providerReplay?: { replayIndex?: number } };
+    };
+    expect(rewritten.message?.content).toEqual(assistantEntry.message.content);
+    expect(rewritten.message?.providerReplay?.replayIndex).toBe(
+      assistantEntry.message.content.length,
+    );
+  });
+
+  it("never calls the compact endpoint during overflow recovery", async () => {
+    mockResolvedModel();
+
+    const result = await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        provider: "xai",
+        model: "grok-4.5",
+        config: {
+          models: {
+            providers: {
+              xai: {
+                api: "openai-responses",
+                baseUrl: "https://api.x.ai/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        trigger: "overflow",
+      }),
+    );
+
+    expect(result.compacted).toBe(true);
+    expect(requestOpenAIResponsesCompactionMock).not.toHaveBeenCalled();
+    expect(sessionAutomaticCompactionMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to client compaction when the endpoint fails", async () => {
+    mockResolvedModel();
+    requestOpenAIResponsesCompactionMock.mockRejectedValueOnce(new Error("endpoint unavailable"));
+
+    const result = await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        provider: "xai",
+        model: "grok-4.5",
+        config: {
+          models: {
+            providers: {
+              xai: {
+                api: "openai-responses",
+                baseUrl: "https://api.x.ai/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        trigger: "manual",
+      }),
+    );
+
+    expect(result).toMatchObject({ ok: true, compacted: true });
+    expect(result.compactionKind).toBeUndefined();
+    expect(sessionManualCompactionMock).toHaveBeenCalledOnce();
+    expect(rewriteTranscriptEventRowsExactMock).not.toHaveBeenCalled();
   });
 
   it("fails closed before generic compaction for a model-locked native session", async () => {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -13,6 +13,7 @@ import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   acquireAgentRunPreparedModelRuntimeMock,
+  attemptServerEndpointCompactionMock,
   getCurrentPluginMetadataSnapshotMock,
   applyExtraParamsToAgentMock,
   applyAgentCompactionSettingsFromConfigMock,
@@ -32,7 +33,6 @@ import {
   guardSessionManagerMock,
   hookRunner,
   listRegisteredPluginAgentPromptGuidanceMock,
-  loadTranscriptEventRowsAfterSeqSyncMock,
   loadCompactHooksHarness,
   maybeCompactAgentHarnessSessionMock,
   resolveAgentHarnessPolicyMock,
@@ -48,8 +48,6 @@ import {
   resolveSandboxContextMock,
   resolveSessionAgentIdMock,
   resolveSessionAgentIdsMock,
-  requestOpenAIResponsesCompactionMock,
-  rewriteTranscriptEventRowsExactMock,
   rotateTranscriptAfterCompactionMock,
   selectAgentHarnessForPreparedModelProvidersMock,
   selectAgentHarnessMock,
@@ -334,18 +332,12 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     resetCompactSessionStateMocks();
   });
 
-  it("captures xAI manual endpoint compaction without rewriting message content", async () => {
+  it("returns a summaryless xAI manual endpoint result", async () => {
     mockResolvedModel();
-    const assistantEntry = {
-      type: "message" as const,
-      id: "assistant-entry",
-      parentId: "user-entry",
-      timestamp: new Date(2).toISOString(),
-      message: structuredClone(sessionMessages[1]) as Extract<AgentMessage, { role: "assistant" }>,
-    };
-    loadTranscriptEventRowsAfterSeqSyncMock.mockReturnValueOnce([
-      { event: assistantEntry, seq: 2 },
-    ]);
+    attemptServerEndpointCompactionMock.mockResolvedValueOnce({
+      item: { type: "compaction", encrypted_content: "opaque" },
+      usage: { input_tokens: 1_000, output_tokens: 200 },
+    });
 
     const result = await compactEmbeddedAgentSessionDirect(
       wrappedCompactionArgs({
@@ -372,15 +364,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       compactionKind: "server-endpoint",
       result: { tokensBefore: 1_000, tokensAfter: 200 },
     });
-    expect(requestOpenAIResponsesCompactionMock).toHaveBeenCalledOnce();
+    expect(result.result).not.toHaveProperty("summary");
+    expect(attemptServerEndpointCompactionMock).toHaveBeenCalledOnce();
     expect(sessionManualCompactionMock).not.toHaveBeenCalled();
-    const rewritten = rewriteTranscriptEventRowsExactMock.mock.calls[0]?.[1]?.rows[0]?.event as {
-      message?: { content?: unknown; providerReplay?: { replayIndex?: number } };
-    };
-    expect(rewritten.message?.content).toEqual(assistantEntry.message.content);
-    expect(rewritten.message?.providerReplay?.replayIndex).toBe(
-      assistantEntry.message.content.length,
-    );
   });
 
   it("never calls the compact endpoint during overflow recovery", async () => {
@@ -406,13 +392,15 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
 
     expect(result.compacted).toBe(true);
-    expect(requestOpenAIResponsesCompactionMock).not.toHaveBeenCalled();
+    expect(attemptServerEndpointCompactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: "overflow" }),
+    );
     expect(sessionAutomaticCompactionMock).toHaveBeenCalledOnce();
   });
 
   it("falls back to client compaction when the endpoint fails", async () => {
     mockResolvedModel();
-    requestOpenAIResponsesCompactionMock.mockRejectedValueOnce(new Error("endpoint unavailable"));
+    attemptServerEndpointCompactionMock.mockResolvedValueOnce(undefined);
 
     const result = await compactEmbeddedAgentSessionDirect(
       wrappedCompactionArgs({
@@ -436,7 +424,6 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     expect(result).toMatchObject({ ok: true, compacted: true });
     expect(result.compactionKind).toBeUndefined();
     expect(sessionManualCompactionMock).toHaveBeenCalledOnce();
-    expect(rewriteTranscriptEventRowsExactMock).not.toHaveBeenCalled();
   });
 
   it("fails closed before generic compaction for a model-locked native session", async () => {
@@ -2703,6 +2690,31 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
 
     expect(result.compactionKind).toBe("native-harness");
     expect(contextEngineCompactMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves a summaryless server-endpoint result through the legacy engine delegate", async () => {
+    resolveContextEngineMock.mockResolvedValue({
+      info: { ownsCompaction: false },
+      compact: contextEngineCompactMock,
+    });
+    contextEngineCompactMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        firstKeptEntryId: "assistant-entry",
+        tokensBefore: 1_000,
+        tokensAfter: 200,
+        details: { compactionKind: "server-endpoint" },
+      },
+    });
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({ provider: "xai", model: "grok-4.5" }),
+    );
+
+    expect(result.compactionKind).toBe("server-endpoint");
+    expect(result.result).toMatchObject({ kind: "server-endpoint", tokensAfter: 200 });
+    expect(result.result).not.toHaveProperty("summary");
   });
 
   it("binds context-engine compaction runtime LLM to the session agent", async () => {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -2713,7 +2713,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.compactionKind).toBe("server-endpoint");
-    expect(result.result).toMatchObject({ kind: "server-endpoint", tokensAfter: 200 });
+    expect(result.result).toMatchObject({ tokensAfter: 200 });
     expect(result.result).not.toHaveProperty("summary");
   });
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -365,7 +365,12 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       result: { tokensBefore: 1_000, tokensAfter: 200 },
     });
     expect(result.result).not.toHaveProperty("summary");
-    expect(attemptServerEndpointCompactionMock).toHaveBeenCalledOnce();
+    expect(attemptServerEndpointCompactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        streamFn: expect.any(Function),
+        requestOptions: expect.objectContaining({ apiKey: "test" }),
+      }),
+    );
     expect(sessionManualCompactionMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -836,33 +836,42 @@ async function compactResolvedContextEngine(
           normalizeOptionalAgentRuntimeId(preparedHarnessRuntime) === "codex"
             ? "codexNativeCompaction"
             : "nativeHarnessCompaction";
+        const serverEndpointCompaction =
+          (result.result?.details as { compactionKind?: unknown } | undefined)?.compactionKind ===
+            "server-endpoint" && typeof result.result?.tokensAfter === "number";
+        const resultDetails = result.result
+          ? mergeSecondaryNativeHarnessCompactionDetails({
+              details: result.result.details,
+              nativeResult: secondaryNativeHarnessCompaction,
+              detailsKey: secondaryNativeDetailsKey,
+            })
+          : undefined;
         return {
           ok: result.ok,
           compacted: result.compacted,
-          compactionKind:
-            (result.result?.details as { compactionKind?: unknown } | undefined)?.compactionKind ===
-            "server-endpoint"
-              ? "server-endpoint"
-              : "context-engine",
+          compactionKind: serverEndpointCompaction ? "server-endpoint" : "context-engine",
           reason: result.reason,
           result: result.result
-            ? {
-                summary: result.result.summary ?? "",
-                firstKeptEntryId: result.result.firstKeptEntryId ?? "",
-                tokensBefore: result.result.tokensBefore,
-                tokensAfter: result.result.tokensAfter,
-                details: mergeSecondaryNativeHarnessCompactionDetails({
-                  details: result.result.details,
-                  nativeResult: secondaryNativeHarnessCompaction,
-                  detailsKey: secondaryNativeDetailsKey,
-                }),
-                ...(postCompactionSessionId !== params.sessionId
-                  ? { sessionId: postCompactionSessionId }
-                  : {}),
-                ...(postCompactionSessionFile !== params.sessionFile
-                  ? { sessionFile: postCompactionSessionFile }
-                  : {}),
-              }
+            ? serverEndpointCompaction
+              ? {
+                  kind: "server-endpoint",
+                  tokensBefore: result.result.tokensBefore,
+                  tokensAfter: result.result.tokensAfter!,
+                  details: resultDetails,
+                }
+              : {
+                  summary: result.result.summary ?? "",
+                  firstKeptEntryId: result.result.firstKeptEntryId ?? "",
+                  tokensBefore: result.result.tokensBefore,
+                  tokensAfter: result.result.tokensAfter,
+                  details: resultDetails,
+                  ...(postCompactionSessionId !== params.sessionId
+                    ? { sessionId: postCompactionSessionId }
+                    : {}),
+                  ...(postCompactionSessionFile !== params.sessionFile
+                    ? { sessionFile: postCompactionSessionFile }
+                    : {}),
+                }
             : undefined,
         };
       } finally {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -847,7 +847,7 @@ async function compactResolvedContextEngine(
           result: result.result
             ? {
                 ...(serverEndpointCompaction
-                  ? {}
+                  ? { kind: "server-endpoint" as const }
                   : {
                       summary: result.result.summary ?? "",
                       firstKeptEntryId: result.result.firstKeptEntryId ?? "",

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -839,39 +839,33 @@ async function compactResolvedContextEngine(
         const serverEndpointCompaction =
           (result.result?.details as { compactionKind?: unknown } | undefined)?.compactionKind ===
             "server-endpoint" && typeof result.result?.tokensAfter === "number";
-        const resultDetails = result.result
-          ? mergeSecondaryNativeHarnessCompactionDetails({
-              details: result.result.details,
-              nativeResult: secondaryNativeHarnessCompaction,
-              detailsKey: secondaryNativeDetailsKey,
-            })
-          : undefined;
         return {
           ok: result.ok,
           compacted: result.compacted,
           compactionKind: serverEndpointCompaction ? "server-endpoint" : "context-engine",
           reason: result.reason,
           result: result.result
-            ? serverEndpointCompaction
-              ? {
-                  kind: "server-endpoint",
-                  tokensBefore: result.result.tokensBefore,
-                  tokensAfter: result.result.tokensAfter!,
-                  details: resultDetails,
-                }
-              : {
-                  summary: result.result.summary ?? "",
-                  firstKeptEntryId: result.result.firstKeptEntryId ?? "",
-                  tokensBefore: result.result.tokensBefore,
-                  tokensAfter: result.result.tokensAfter,
-                  details: resultDetails,
-                  ...(postCompactionSessionId !== params.sessionId
-                    ? { sessionId: postCompactionSessionId }
-                    : {}),
-                  ...(postCompactionSessionFile !== params.sessionFile
-                    ? { sessionFile: postCompactionSessionFile }
-                    : {}),
-                }
+            ? {
+                ...(serverEndpointCompaction
+                  ? {}
+                  : {
+                      summary: result.result.summary ?? "",
+                      firstKeptEntryId: result.result.firstKeptEntryId ?? "",
+                    }),
+                tokensBefore: result.result.tokensBefore,
+                tokensAfter: result.result.tokensAfter,
+                details: mergeSecondaryNativeHarnessCompactionDetails({
+                  details: result.result.details,
+                  nativeResult: secondaryNativeHarnessCompaction,
+                  detailsKey: secondaryNativeDetailsKey,
+                }),
+                ...(postCompactionSessionId !== params.sessionId
+                  ? { sessionId: postCompactionSessionId }
+                  : {}),
+                ...(postCompactionSessionFile !== params.sessionFile
+                  ? { sessionFile: postCompactionSessionFile }
+                  : {}),
+              }
             : undefined,
         };
       } finally {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -839,7 +839,11 @@ async function compactResolvedContextEngine(
         return {
           ok: result.ok,
           compacted: result.compacted,
-          compactionKind: "context-engine",
+          compactionKind:
+            (result.result?.details as { compactionKind?: unknown } | undefined)?.compactionKind ===
+            "server-endpoint"
+              ? "server-endpoint"
+              : "context-engine",
           reason: result.reason,
           result: result.result
             ? {

--- a/src/agents/embedded-agent-runner/compaction-session-agent.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-agent.ts
@@ -91,7 +91,7 @@ export async function prepareCompactionSessionAgent(params: {
     workspaceDir: params.effectiveWorkspace,
     model: params.effectiveModel,
   });
-  return applyExtraParamsToAgent(
+  const extraParams = applyExtraParamsToAgent(
     params.session.agent as never,
     params.config,
     params.provider,
@@ -125,4 +125,5 @@ export async function prepareCompactionSessionAgent(params: {
       },
     },
   );
+  return { ...extraParams, transportApiKey };
 }

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -509,7 +509,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
                     summary: clientResult.summary,
                     firstKeptEntryId: clientResult.firstKeptEntryId,
                   }
-                : {}),
+                : { kind: "server-endpoint" as const }),
               tokensBefore: serverResult
                 ? tokensBefore
                 : (observedTokenCount ?? clientResult!.tokensBefore),

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -399,6 +399,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             context: { systemPrompt: systemPromptText, messages: session.messages },
             sessionManager,
             extraParams: effectiveExtraParams,
+            customInstructions: params.customInstructions,
             requestOptions: {
               apiKey: transportApiKey,
               sessionId: params.sessionId,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -1,8 +1,20 @@
-import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 /**
  * Executes compaction while owning the transcript lock, session lifecycle,
  * hooks, checkpoint, and optional successor transcript rotation.
  */
+import {
+  buildOpenAIResponsesReasoningReplayMetadata,
+  captureOpenAIResponsesCompaction,
+  requestOpenAIResponsesCompaction,
+  resolveOpenAIResponsesCompactEndpointPlan,
+} from "@openclaw/ai/transports";
+import type { AssistantMessage, Message } from "@openclaw/llm-core";
+import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import {
+  loadTranscriptEventRowsAfterSeqSync,
+  readSessionTranscriptWatermark,
+  rewriteTranscriptEventRowsExact,
+} from "../../config/sessions/session-accessor.js";
 import type { CapturedCompactionCheckpointSnapshot } from "../../gateway/session-compaction-checkpoints.js";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../infra/diagnostic-llm-content.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -241,7 +253,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           applySystemPromptToSession(session, systemPromptText);
           // Compaction builds the same embedded system prompt, so it must flow
           // through the same transport/payload shaping stack as normal turns.
-          await prepareCompactionSessionAgent({
+          const { effectiveExtraParams, transportApiKey } = await prepareCompactionSessionAgent({
             session,
             llmRuntime: getModelRegistryRuntime(modelRegistry).llmRuntime,
             providerStreamFn,
@@ -406,35 +418,131 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             // If token estimation throws on a malformed message, fall back to 0 so
             // the sanity check below becomes a no-op instead of crashing compaction.
           }
-          const activeSession = session;
-          const result = await compactWithSafetyTimeout(
-            () => {
-              setCompactionSafeguardCancelReason(compactionSessionManager, undefined);
-              return resolveEffectiveCompactionMode(params.config) === "default" &&
-                trigger !== "manual"
-                ? activeSession[agentSessionAutomaticCompaction](params.customInstructions)
-                : activeSession.compact(params.customInstructions);
-            },
-            compactionTimeoutMs,
-            {
-              abortSignal: params.abortSignal,
-              onCancel: () => {
-                activeSession.abortCompaction();
-              },
-            },
+          const endpointPlan = resolveOpenAIResponsesCompactEndpointPlan(
+            effectiveModel,
+            effectiveExtraParams,
           );
+          let serverTokensAfter: number | undefined;
+          let serverResult: Awaited<ReturnType<typeof session.compact>> | undefined;
+          if (trigger !== "overflow" && endpointPlan.enabled) {
+            try {
+              const responsesMessages = session.messages.filter(
+                (message): message is Message =>
+                  message.role === "user" ||
+                  message.role === "assistant" ||
+                  message.role === "toolResult",
+              );
+              const lastAssistant = responsesMessages.findLast(
+                (message): message is AssistantMessage => message.role === "assistant",
+              );
+              if (!lastAssistant) {
+                throw new Error("Responses compact endpoint requires a persisted assistant owner");
+              }
+              const compacted = await requestOpenAIResponsesCompaction(
+                effectiveModel,
+                { systemPrompt: systemPromptText, messages: responsesMessages },
+                {
+                  ...effectiveExtraParams,
+                  apiKey: transportApiKey,
+                  signal: params.abortSignal,
+                  sessionId: params.sessionId,
+                  authProfileId: runtimePlan.auth.forwardedAuthProfileId,
+                },
+              );
+              const watermark = readSessionTranscriptWatermark(sessionTarget);
+              const ownerRow = loadTranscriptEventRowsAfterSeqSync(
+                sessionTarget,
+                0,
+                watermark.maxSeq ?? undefined,
+              ).findLast(({ event }) => {
+                const message =
+                  event && typeof event === "object"
+                    ? (event as { message?: { role?: unknown } }).message
+                    : undefined;
+                return message?.role === "assistant";
+              });
+              const ownerEvent = ownerRow?.event as
+                | { id?: unknown; message?: AssistantMessage }
+                | undefined;
+              if (!ownerRow || typeof ownerEvent?.id !== "string" || !ownerEvent.message) {
+                throw new Error("Responses compact endpoint assistant owner was not persisted");
+              }
+              const persistedOwner = structuredClone(ownerEvent.message);
+              captureOpenAIResponsesCompaction(
+                persistedOwner,
+                compacted.item,
+                persistedOwner.content.length,
+                effectiveModel,
+                buildOpenAIResponsesReasoningReplayMetadata(effectiveModel, {
+                  sessionId: params.sessionId,
+                  authProfileId: runtimePlan.auth.forwardedAuthProfileId,
+                }),
+              );
+              const rewritten = await rewriteTranscriptEventRowsExact(sessionTarget, {
+                allowInitialGenerationMaterialization: watermark.generation === null,
+                expectedGeneration: watermark.generation,
+                rows: [
+                  {
+                    event: Object.assign({}, ownerRow.event as object, { message: persistedOwner }),
+                    expectedEventJson: JSON.stringify(ownerRow.event),
+                    seq: ownerRow.seq,
+                  },
+                ],
+              });
+              if (!rewritten || !persistedOwner.providerReplay) {
+                throw new Error("Responses compact endpoint checkpoint was not persisted");
+              }
+              lastAssistant.providerReplay = persistedOwner.providerReplay;
+              serverTokensAfter = compacted.usage.output_tokens;
+              serverResult = {
+                summary: "Server-side Responses compaction",
+                firstKeptEntryId: ownerEvent.id,
+                tokensBefore: compacted.usage.input_tokens,
+                details: {
+                  compactionKind: "server-endpoint",
+                  droppedMessageCount: compacted.usage.dropped_message_count,
+                },
+              };
+            } catch (err) {
+              log.debug("Responses compact endpoint failed; falling back to client compaction", {
+                errorMessage: formatErrorMessage(err),
+              });
+            }
+          }
+          const serverCompaction = serverResult !== undefined;
+          const activeSession = session;
+          const result =
+            serverResult ??
+            (await compactWithSafetyTimeout(
+              () => {
+                setCompactionSafeguardCancelReason(compactionSessionManager, undefined);
+                return resolveEffectiveCompactionMode(params.config) === "default" &&
+                  trigger !== "manual"
+                  ? activeSession[agentSessionAutomaticCompaction](params.customInstructions)
+                  : activeSession.compact(params.customInstructions);
+              },
+              compactionTimeoutMs,
+              {
+                abortSignal: params.abortSignal,
+                onCancel: () => {
+                  activeSession.abortCompaction();
+                },
+              },
+            ));
           const effectiveFirstKeptEntryId = result.firstKeptEntryId;
           const postCompactionLeafId =
             typeof sessionManager.getLeafId === "function"
               ? (sessionManager.getLeafId() ?? undefined)
               : undefined;
           // Estimate tokens after compaction by summing token estimates for remaining messages
-          const tokensAfter = estimateTokensAfterCompaction({
-            messagesAfter: session.messages,
-            observedTokenCount,
-            fullSessionTokensBefore: limitedTranscriptTokensBefore,
-            estimateTokensFn: estimateTokens,
-          });
+          const tokensAfter =
+            serverTokensAfter ??
+            estimateTokensAfterCompaction({
+              messagesAfter: session.messages,
+              observedTokenCount,
+              fullSessionTokensBefore: limitedTranscriptTokensBefore,
+              estimateTokensFn: estimateTokens,
+            });
           const messageCountAfter = session.messages.length;
           const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);
           const activeSessionId = params.sessionId;
@@ -450,20 +558,22 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             agentId: sessionAgentId,
             sessionFile: activeSessionFile,
           });
-          checkpointSnapshotRetained = await persistCompactionCheckpoint({
-            config: params.config,
-            sessionKey: params.sessionKey,
-            sessionId: activeSessionId,
-            trigger: params.trigger,
-            snapshot: checkpointSnapshot,
-            summary: result.summary,
-            firstKeptEntryId: effectiveFirstKeptEntryId,
-            tokensBefore: observedTokenCount ?? result.tokensBefore,
-            tokensAfter,
-            sessionFile: activeSessionFile,
-            leafId: activePostLeafId,
-            createdAt: compactStartedAt,
-          });
+          if (!serverCompaction) {
+            checkpointSnapshotRetained = await persistCompactionCheckpoint({
+              config: params.config,
+              sessionKey: params.sessionKey,
+              sessionId: activeSessionId,
+              trigger: params.trigger,
+              snapshot: checkpointSnapshot,
+              summary: result.summary,
+              firstKeptEntryId: effectiveFirstKeptEntryId,
+              tokensBefore: observedTokenCount ?? result.tokensBefore,
+              tokensAfter,
+              sessionFile: activeSessionFile,
+              leafId: activePostLeafId,
+              createdAt: compactStartedAt,
+            });
+          }
           const postMetrics = diagEnabled
             ? summarizeCompactionMessages(session.messages)
             : undefined;
@@ -504,6 +614,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           return {
             ok: true,
             compacted: true,
+            ...(serverCompaction ? { compactionKind: "server-endpoint" as const } : {}),
             result: {
               summary: result.summary,
               firstKeptEntryId: effectiveFirstKeptEntryId,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -361,7 +361,8 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             metrics: beforeHookMetrics,
             onHookMessages: params.onCompactionHookMessages,
           });
-          const { messageCountOriginal } = beforeHookMetrics;
+          const { messageCountOriginal, tokenCountBefore: limitedTranscriptTokensBefore } =
+            beforeHookMetrics;
           const diagEnabled = log.isEnabled("debug");
           const preMetrics = diagEnabled
             ? summarizeCompactionMessages(session.messages)
@@ -391,22 +392,6 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           }
 
           const compactStartedAt = Date.now();
-          // Measure compactedCount from the original pre-limiting transcript so compaction
-          // lifecycle metrics represent total reduction through the compaction pipeline.
-          const messageCountCompactionInput = messageCountOriginal;
-          // Estimate all limited transcript messages before compaction. This is the
-          // same token domain as messagesAfter; result.tokensBefore can cover only the
-          // summarizable subset.
-          let limitedTranscriptTokensBefore = 0;
-          try {
-            limitedTranscriptTokensBefore = limited.reduce(
-              (sum, msg) => sum + estimateTokens(msg),
-              0,
-            );
-          } catch {
-            // If token estimation throws on a malformed message, fall back to 0 so
-            // the sanity check below becomes a no-op instead of crashing compaction.
-          }
           const serverResult = await attemptServerEndpointCompaction({
             trigger,
             model: effectiveModel,
@@ -448,11 +433,11 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             estimateTokensAfterCompaction({
               messagesAfter: session.messages,
               observedTokenCount,
-              fullSessionTokensBefore: limitedTranscriptTokensBefore,
+              fullSessionTokensBefore: limitedTranscriptTokensBefore ?? 0,
               estimateTokensFn: estimateTokens,
             });
           const messageCountAfter = session.messages.length;
-          const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);
+          const compactedCount = Math.max(0, messageCountOriginal - messageCountAfter);
           const activeSessionFile = formatSqliteSessionFileMarker({
             ...sessionTarget,
             sessionId: params.sessionId,
@@ -524,7 +509,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
                     summary: clientResult.summary,
                     firstKeptEntryId: clientResult.firstKeptEntryId,
                   }
-                : { kind: "server-endpoint" as const }),
+                : {}),
               tokensBefore: serverResult
                 ? tokensBefore
                 : (observedTokenCount ?? clientResult!.tokensBefore),

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -394,11 +394,12 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           const compactStartedAt = Date.now();
           const serverResult = await attemptServerEndpointCompaction({
             trigger,
+            streamFn: session.agent.streamFn,
             model: effectiveModel,
             context: { systemPrompt: systemPromptText, messages: session.messages },
             sessionManager,
+            extraParams: effectiveExtraParams,
             requestOptions: {
-              ...effectiveExtraParams,
               apiKey: transportApiKey,
               sessionId: params.sessionId,
               authProfileId: runtimePlan.auth.forwardedAuthProfileId,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -2,19 +2,7 @@
  * Executes compaction while owning the transcript lock, session lifecycle,
  * hooks, checkpoint, and optional successor transcript rotation.
  */
-import {
-  buildOpenAIResponsesReasoningReplayMetadata,
-  captureOpenAIResponsesCompaction,
-  requestOpenAIResponsesCompaction,
-  resolveOpenAIResponsesCompactEndpointPlan,
-} from "@openclaw/ai/transports";
-import type { AssistantMessage, Message } from "@openclaw/llm-core";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
-import {
-  loadTranscriptEventRowsAfterSeqSync,
-  readSessionTranscriptWatermark,
-  rewriteTranscriptEventRowsExact,
-} from "../../config/sessions/session-accessor.js";
 import type { CapturedCompactionCheckpointSnapshot } from "../../gateway/session-compaction-checkpoints.js";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../infra/diagnostic-llm-content.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -68,6 +56,7 @@ import type { PreparedCompactionRuntime } from "./prepared-compaction-runtime.js
 import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
 import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "./run/attempt.model-diagnostic-events.js";
+import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 import { applySystemPromptToSession } from "./system-prompt.js";
 import { collectRegisteredToolNames, toSessionToolAllowlist } from "./tool-name-allowlist.js";
 import { splitSdkTools } from "./tool-split.js";
@@ -418,125 +407,44 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             // If token estimation throws on a malformed message, fall back to 0 so
             // the sanity check below becomes a no-op instead of crashing compaction.
           }
-          const endpointPlan = resolveOpenAIResponsesCompactEndpointPlan(
-            effectiveModel,
-            effectiveExtraParams,
-          );
-          let serverTokensAfter: number | undefined;
-          let serverResult: Awaited<ReturnType<typeof session.compact>> | undefined;
-          if (trigger !== "overflow" && endpointPlan.enabled) {
-            try {
-              const responsesMessages = session.messages.filter(
-                (message): message is Message =>
-                  message.role === "user" ||
-                  message.role === "assistant" ||
-                  message.role === "toolResult",
-              );
-              const lastAssistant = responsesMessages.findLast(
-                (message): message is AssistantMessage => message.role === "assistant",
-              );
-              if (!lastAssistant) {
-                throw new Error("Responses compact endpoint requires a persisted assistant owner");
-              }
-              const compacted = await requestOpenAIResponsesCompaction(
-                effectiveModel,
-                { systemPrompt: systemPromptText, messages: responsesMessages },
-                {
-                  ...effectiveExtraParams,
-                  apiKey: transportApiKey,
-                  signal: params.abortSignal,
-                  sessionId: params.sessionId,
-                  authProfileId: runtimePlan.auth.forwardedAuthProfileId,
-                },
-              );
-              const watermark = readSessionTranscriptWatermark(sessionTarget);
-              const ownerRow = loadTranscriptEventRowsAfterSeqSync(
-                sessionTarget,
-                0,
-                watermark.maxSeq ?? undefined,
-              ).findLast(({ event }) => {
-                const message =
-                  event && typeof event === "object"
-                    ? (event as { message?: { role?: unknown } }).message
-                    : undefined;
-                return message?.role === "assistant";
-              });
-              const ownerEvent = ownerRow?.event as
-                | { id?: unknown; message?: AssistantMessage }
-                | undefined;
-              if (!ownerRow || typeof ownerEvent?.id !== "string" || !ownerEvent.message) {
-                throw new Error("Responses compact endpoint assistant owner was not persisted");
-              }
-              const persistedOwner = structuredClone(ownerEvent.message);
-              captureOpenAIResponsesCompaction(
-                persistedOwner,
-                compacted.item,
-                persistedOwner.content.length,
-                effectiveModel,
-                buildOpenAIResponsesReasoningReplayMetadata(effectiveModel, {
-                  sessionId: params.sessionId,
-                  authProfileId: runtimePlan.auth.forwardedAuthProfileId,
-                }),
-              );
-              const rewritten = await rewriteTranscriptEventRowsExact(sessionTarget, {
-                allowInitialGenerationMaterialization: watermark.generation === null,
-                expectedGeneration: watermark.generation,
-                rows: [
-                  {
-                    event: Object.assign({}, ownerRow.event as object, { message: persistedOwner }),
-                    expectedEventJson: JSON.stringify(ownerRow.event),
-                    seq: ownerRow.seq,
-                  },
-                ],
-              });
-              if (!rewritten || !persistedOwner.providerReplay) {
-                throw new Error("Responses compact endpoint checkpoint was not persisted");
-              }
-              lastAssistant.providerReplay = persistedOwner.providerReplay;
-              serverTokensAfter = compacted.usage.output_tokens;
-              serverResult = {
-                summary: "Server-side Responses compaction",
-                firstKeptEntryId: ownerEvent.id,
-                tokensBefore: compacted.usage.input_tokens,
-                details: {
-                  compactionKind: "server-endpoint",
-                  droppedMessageCount: compacted.usage.dropped_message_count,
-                },
-              };
-            } catch (err) {
-              log.debug("Responses compact endpoint failed; falling back to client compaction", {
-                errorMessage: formatErrorMessage(err),
-              });
-            }
-          }
-          const serverCompaction = serverResult !== undefined;
+          const serverResult = await attemptServerEndpointCompaction({
+            trigger,
+            model: effectiveModel,
+            context: { systemPrompt: systemPromptText, messages: session.messages },
+            sessionManager,
+            requestOptions: {
+              ...effectiveExtraParams,
+              apiKey: transportApiKey,
+              sessionId: params.sessionId,
+              authProfileId: runtimePlan.auth.forwardedAuthProfileId,
+              timeoutMs: compactionTimeoutMs,
+              signal: params.abortSignal,
+            },
+          });
           const activeSession = session;
-          const result =
-            serverResult ??
-            (await compactWithSafetyTimeout(
-              () => {
-                setCompactionSafeguardCancelReason(compactionSessionManager, undefined);
-                return resolveEffectiveCompactionMode(params.config) === "default" &&
-                  trigger !== "manual"
-                  ? activeSession[agentSessionAutomaticCompaction](params.customInstructions)
-                  : activeSession.compact(params.customInstructions);
-              },
-              compactionTimeoutMs,
-              {
-                abortSignal: params.abortSignal,
-                onCancel: () => {
-                  activeSession.abortCompaction();
+          const clientResult = serverResult
+            ? undefined
+            : await compactWithSafetyTimeout(
+                () => {
+                  setCompactionSafeguardCancelReason(compactionSessionManager, undefined);
+                  return resolveEffectiveCompactionMode(params.config) === "default" &&
+                    trigger !== "manual"
+                    ? activeSession[agentSessionAutomaticCompaction](params.customInstructions)
+                    : activeSession.compact(params.customInstructions);
                 },
-              },
-            ));
-          const effectiveFirstKeptEntryId = result.firstKeptEntryId;
-          const postCompactionLeafId =
-            typeof sessionManager.getLeafId === "function"
-              ? (sessionManager.getLeafId() ?? undefined)
-              : undefined;
+                compactionTimeoutMs,
+                {
+                  abortSignal: params.abortSignal,
+                  onCancel: () => {
+                    activeSession.abortCompaction();
+                  },
+                },
+              );
+          const effectiveFirstKeptEntryId = clientResult?.firstKeptEntryId;
+          const tokensBefore = serverResult?.usage.input_tokens ?? clientResult!.tokensBefore;
           // Estimate tokens after compaction by summing token estimates for remaining messages
           const tokensAfter =
-            serverTokensAfter ??
+            serverResult?.usage.output_tokens ??
             estimateTokensAfterCompaction({
               messagesAfter: session.messages,
               observedTokenCount,
@@ -545,32 +453,30 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             });
           const messageCountAfter = session.messages.length;
           const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);
-          const activeSessionId = params.sessionId;
           const activeSessionFile = formatSqliteSessionFileMarker({
             ...sessionTarget,
-            sessionId: activeSessionId,
+            sessionId: params.sessionId,
           });
-          const activePostLeafId = postCompactionLeafId;
           await runPostCompactionSideEffects({
             config: params.config,
             sessionKey: params.sessionKey,
-            sessionId: activeSessionId,
+            sessionId: params.sessionId,
             agentId: sessionAgentId,
             sessionFile: activeSessionFile,
           });
-          if (!serverCompaction) {
+          if (clientResult) {
             checkpointSnapshotRetained = await persistCompactionCheckpoint({
               config: params.config,
               sessionKey: params.sessionKey,
-              sessionId: activeSessionId,
+              sessionId: params.sessionId,
               trigger: params.trigger,
               snapshot: checkpointSnapshot,
-              summary: result.summary,
+              summary: clientResult.summary,
               firstKeptEntryId: effectiveFirstKeptEntryId,
-              tokensBefore: observedTokenCount ?? result.tokensBefore,
+              tokensBefore: observedTokenCount ?? clientResult.tokensBefore,
               tokensAfter,
               sessionFile: activeSessionFile,
-              leafId: activePostLeafId,
+              leafId: sessionManager.getLeafId?.() ?? undefined,
               createdAt: compactStartedAt,
             });
           }
@@ -593,7 +499,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           }
           await runAfterCompactionHooks({
             hookRunner,
-            sessionId: activeSessionId,
+            sessionId: params.sessionId,
             sessionAgentId,
             hookSessionKey,
             missingSessionKey,
@@ -603,26 +509,32 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             tokensAfter,
             compactedCount,
             sessionFile: activeSessionFile,
-            ...(activeSessionId !== params.sessionId
-              ? { previousSessionId: params.sessionId }
-              : {}),
-            summaryLength: typeof result.summary === "string" ? result.summary.length : undefined,
-            tokensBefore: result.tokensBefore,
+            summaryLength: clientResult?.summary.length,
+            tokensBefore,
             firstKeptEntryId: effectiveFirstKeptEntryId,
             onHookMessages: params.onCompactionHookMessages,
           });
           return {
             ok: true,
             compacted: true,
-            ...(serverCompaction ? { compactionKind: "server-endpoint" as const } : {}),
+            ...(serverResult ? { compactionKind: "server-endpoint" as const } : {}),
             result: {
-              summary: result.summary,
-              firstKeptEntryId: effectiveFirstKeptEntryId,
-              tokensBefore: observedTokenCount ?? result.tokensBefore,
+              ...(clientResult
+                ? {
+                    summary: clientResult.summary,
+                    firstKeptEntryId: clientResult.firstKeptEntryId,
+                  }
+                : { kind: "server-endpoint" as const }),
+              tokensBefore: serverResult
+                ? tokensBefore
+                : (observedTokenCount ?? clientResult!.tokensBefore),
               tokensAfter,
-              details: result.details,
-              sessionId: undefined,
-              sessionFile: undefined,
+              details: serverResult
+                ? {
+                    compactionKind: "server-endpoint" as const,
+                    droppedMessageCount: serverResult.usage.dropped_message_count,
+                  }
+                : clientResult!.details,
             },
           };
         } catch (err) {

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -148,4 +148,23 @@ describe("attemptServerEndpointCompaction", () => {
     await expect(result).resolves.toBeUndefined();
     expect(requestPreparedCompactionMock).not.toHaveBeenCalled();
   });
+
+  it("preserves custom instructions by falling back to client compaction", async () => {
+    const { result } = attempt({ customInstructions: "Retain the security caveats." });
+
+    await expect(result).resolves.toBeUndefined();
+    expect(requestPreparedCompactionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not compact transcript entries that remain after the checkpoint owner", async () => {
+    const messages = createSession().messages.concat({
+      role: "user",
+      content: "trailing turn",
+      timestamp: 3,
+    });
+    const { result } = attempt({ context: { systemPrompt: "system", messages } });
+
+    await expect(result).resolves.toBeUndefined();
+    expect(requestPreparedCompactionMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -12,7 +12,6 @@ vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
   requestPreparedOpenAIResponsesCompaction: requestPreparedCompactionMock,
 }));
 
-import { buildOpenAIResponsesReasoningReplayMetadata } from "@openclaw/ai/transports";
 import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 
 const model = {
@@ -78,9 +77,14 @@ beforeEach(() => {
     item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
     usage: { input_tokens: 1_000, output_tokens: 200, dropped_message_count: 1 },
     model,
-    replayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
-      sessionId: "session-1",
-    }),
+    replayMetadata: {
+      v: 1,
+      source: "openai-responses",
+      provider: "xai",
+      api: "openai-responses",
+      model: "grok-4.5",
+      baseUrlHash: "test-base-url",
+    },
   });
 });
 

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -1,5 +1,6 @@
-import type { AgentMessage, Model } from "openclaw/plugin-sdk/agent-core";
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import type { Model } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { requestCompactionMock } = vi.hoisted(() => ({
@@ -32,6 +33,18 @@ function createSession() {
   sessionManager.appendMessage({
     role: "assistant",
     content: [{ type: "text", text: "remembered" }],
+    api: "openai-responses",
+    provider: "xai",
+    model: "grok-4.5",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
     timestamp: 2,
   });
   const messages = sessionManager
@@ -75,10 +88,11 @@ describe("attemptServerEndpointCompaction", () => {
     const owner = session.sessionManager
       .getBranch()
       .findLast((entry) => entry.type === "message" && entry.message.role === "assistant");
-    expect(owner?.type === "message" ? owner.message.content : undefined).toEqual([
-      { type: "text", text: "remembered" },
-    ]);
-    expect(owner?.type === "message" ? owner.message.providerReplay : undefined).toMatchObject({
+    if (!owner || owner.type !== "message" || owner.message.role !== "assistant") {
+      throw new Error("expected persisted assistant checkpoint owner");
+    }
+    expect(owner.message.content).toEqual([{ type: "text", text: "remembered" }]);
+    expect(owner.message.providerReplay).toMatchObject({
       type: "openai-responses-compaction",
       id: "cmp_test",
       data: "opaque",
@@ -95,7 +109,11 @@ describe("attemptServerEndpointCompaction", () => {
             "abort",
             () => {
               requestAborted = true;
-              reject(options.signal?.reason);
+              reject(
+                options.signal?.reason instanceof Error
+                  ? options.signal.reason
+                  : new Error("request aborted"),
+              );
             },
             { once: true },
           );

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -1,0 +1,117 @@
+import type { AgentMessage, Model } from "openclaw/plugin-sdk/agent-core";
+import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requestCompactionMock } = vi.hoisted(() => ({
+  requestCompactionMock: vi.fn(),
+}));
+
+vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@openclaw/ai/transports")>()),
+  requestOpenAIResponsesCompaction: requestCompactionMock,
+}));
+
+import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
+
+const model = {
+  id: "grok-4.5",
+  name: "Grok 4.5",
+  api: "openai-responses",
+  provider: "xai",
+  baseUrl: "https://api.x.ai/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 256_000,
+  maxTokens: 8_192,
+} satisfies Model;
+
+function createSession() {
+  const sessionManager = SessionManager.inMemory();
+  sessionManager.appendMessage({ role: "user", content: "remember copper", timestamp: 1 });
+  sessionManager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text: "remembered" }],
+    timestamp: 2,
+  });
+  const messages = sessionManager
+    .getBranch()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => entry.message as AgentMessage);
+  return { sessionManager, messages };
+}
+
+function attempt(overrides: Partial<Parameters<typeof attemptServerEndpointCompaction>[0]> = {}) {
+  const session = createSession();
+  return {
+    session,
+    result: attemptServerEndpointCompaction({
+      trigger: "manual",
+      model,
+      context: { systemPrompt: "system", messages: session.messages },
+      sessionManager: session.sessionManager,
+      requestOptions: { apiKey: "test", sessionId: "session-1", timeoutMs: 1_000 },
+      ...overrides,
+    }),
+  };
+}
+
+beforeEach(() => {
+  requestCompactionMock.mockReset();
+  requestCompactionMock.mockResolvedValue({
+    item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+    usage: { input_tokens: 1_000, output_tokens: 200, dropped_message_count: 1 },
+  });
+});
+
+describe("attemptServerEndpointCompaction", () => {
+  it("persists a summaryless checkpoint through the SessionManager rewrite owner", async () => {
+    const { session, result } = attempt();
+
+    await expect(result).resolves.toEqual({
+      item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+      usage: { input_tokens: 1_000, output_tokens: 200, dropped_message_count: 1 },
+    });
+    const owner = session.sessionManager
+      .getBranch()
+      .findLast((entry) => entry.type === "message" && entry.message.role === "assistant");
+    expect(owner?.type === "message" ? owner.message.content : undefined).toEqual([
+      { type: "text", text: "remembered" },
+    ]);
+    expect(owner?.type === "message" ? owner.message.providerReplay : undefined).toMatchObject({
+      type: "openai-responses-compaction",
+      id: "cmp_test",
+      data: "opaque",
+      replayIndex: 1,
+    });
+  });
+
+  it("aborts a pending endpoint request at the compaction timeout", async () => {
+    let requestAborted = false;
+    requestCompactionMock.mockImplementationOnce(
+      async (_model: unknown, _context: unknown, options: { signal?: AbortSignal }) =>
+        await new Promise((_resolve, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => {
+              requestAborted = true;
+              reject(options.signal?.reason);
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    const { result } = attempt({ requestOptions: { apiKey: "test", timeoutMs: 10 } });
+
+    await expect(result).resolves.toBeUndefined();
+    expect(requestAborted).toBe(true);
+  });
+
+  it("does not call the endpoint during overflow recovery", async () => {
+    const { result } = attempt({ trigger: "overflow" });
+
+    await expect(result).resolves.toBeUndefined();
+    expect(requestCompactionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -3,15 +3,16 @@ import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { requestCompactionMock } = vi.hoisted(() => ({
-  requestCompactionMock: vi.fn(),
+const { requestPreparedCompactionMock } = vi.hoisted(() => ({
+  requestPreparedCompactionMock: vi.fn(),
 }));
 
 vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@openclaw/ai/transports")>()),
-  requestOpenAIResponsesCompaction: requestCompactionMock,
+  requestPreparedOpenAIResponsesCompaction: requestPreparedCompactionMock,
 }));
 
+import { buildOpenAIResponsesReasoningReplayMetadata } from "@openclaw/ai/transports";
 import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 
 const model = {
@@ -60,9 +61,11 @@ function attempt(overrides: Partial<Parameters<typeof attemptServerEndpointCompa
     session,
     result: attemptServerEndpointCompaction({
       trigger: "manual",
+      streamFn: vi.fn(),
       model,
       context: { systemPrompt: "system", messages: session.messages },
       sessionManager: session.sessionManager,
+      extraParams: {},
       requestOptions: { apiKey: "test", sessionId: "session-1", timeoutMs: 1_000 },
       ...overrides,
     }),
@@ -70,10 +73,14 @@ function attempt(overrides: Partial<Parameters<typeof attemptServerEndpointCompa
 }
 
 beforeEach(() => {
-  requestCompactionMock.mockReset();
-  requestCompactionMock.mockResolvedValue({
+  requestPreparedCompactionMock.mockReset();
+  requestPreparedCompactionMock.mockResolvedValue({
     item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
     usage: { input_tokens: 1_000, output_tokens: 200, dropped_message_count: 1 },
+    model,
+    replayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
+      sessionId: "session-1",
+    }),
   });
 });
 
@@ -81,7 +88,7 @@ describe("attemptServerEndpointCompaction", () => {
   it("persists a summaryless checkpoint through the SessionManager rewrite owner", async () => {
     const { session, result } = attempt();
 
-    await expect(result).resolves.toEqual({
+    await expect(result).resolves.toMatchObject({
       item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
       usage: { input_tokens: 1_000, output_tokens: 200, dropped_message_count: 1 },
     });
@@ -102,8 +109,13 @@ describe("attemptServerEndpointCompaction", () => {
 
   it("aborts a pending endpoint request at the compaction timeout", async () => {
     let requestAborted = false;
-    requestCompactionMock.mockImplementationOnce(
-      async (_model: unknown, _context: unknown, options: { signal?: AbortSignal }) =>
+    requestPreparedCompactionMock.mockImplementationOnce(
+      async (
+        _streamFn: unknown,
+        _model: unknown,
+        _context: unknown,
+        options: { signal?: AbortSignal },
+      ) =>
         await new Promise((_resolve, reject) => {
           options.signal?.addEventListener(
             "abort",
@@ -130,6 +142,6 @@ describe("attemptServerEndpointCompaction", () => {
     const { result } = attempt({ trigger: "overflow" });
 
     await expect(result).resolves.toBeUndefined();
-    expect(requestCompactionMock).not.toHaveBeenCalled();
+    expect(requestPreparedCompactionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -15,9 +15,7 @@ type SessionManagerLike = Parameters<
   typeof rewriteTranscriptEntriesInSessionManager
 >[0]["sessionManager"];
 
-export type ServerEndpointCompactionResult = Awaited<
-  ReturnType<typeof requestOpenAIResponsesCompaction>
->;
+type ServerEndpointCompactionResult = Awaited<ReturnType<typeof requestOpenAIResponsesCompaction>>;
 
 /** Try provider-owned compaction and persist its replay checkpoint on the session owner. */
 export async function attemptServerEndpointCompaction(params: {

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -27,9 +27,11 @@ export async function attemptServerEndpointCompaction(params: {
   sessionManager: SessionManagerLike;
   extraParams: Record<string, unknown>;
   requestOptions: Parameters<typeof requestPreparedOpenAIResponsesCompaction>[3];
+  customInstructions?: string;
 }): Promise<ServerEndpointCompactionResult | undefined> {
   if (
     params.trigger === "overflow" ||
+    params.customInstructions?.trim() ||
     !resolveOpenAIResponsesCompactEndpointPlan(params.model, params.extraParams).enabled
   ) {
     return undefined;
@@ -39,6 +41,9 @@ export async function attemptServerEndpointCompaction(params: {
       (message): message is Message =>
         message.role === "user" || message.role === "assistant" || message.role === "toolResult",
     );
+    if (messages.at(-1)?.role !== "assistant") {
+      return undefined;
+    }
     const owner = params.sessionManager
       .getBranch()
       .findLast((entry) => entry.type === "message" && entry.message.role === "assistant");

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -1,0 +1,88 @@
+import {
+  buildOpenAIResponsesReasoningReplayMetadata,
+  captureOpenAIResponsesCompaction,
+  requestOpenAIResponsesCompaction,
+  resolveOpenAIResponsesCompactEndpointPlan,
+} from "@openclaw/ai/transports";
+import type { Message } from "@openclaw/llm-core";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type { AgentMessage } from "../runtime/index.js";
+import { compactWithSafetyTimeout } from "./compaction-safety-timeout.js";
+import { log } from "./logger.js";
+import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
+
+type SessionManagerLike = Parameters<
+  typeof rewriteTranscriptEntriesInSessionManager
+>[0]["sessionManager"];
+
+export type ServerEndpointCompactionResult = Awaited<
+  ReturnType<typeof requestOpenAIResponsesCompaction>
+>;
+
+/** Try provider-owned compaction and persist its replay checkpoint on the session owner. */
+export async function attemptServerEndpointCompaction(params: {
+  trigger: "budget" | "overflow" | "manual";
+  model: Parameters<typeof requestOpenAIResponsesCompaction>[0];
+  context: { systemPrompt: string; messages: readonly AgentMessage[] };
+  sessionManager: SessionManagerLike;
+  requestOptions: Parameters<typeof requestOpenAIResponsesCompaction>[2];
+}): Promise<ServerEndpointCompactionResult | undefined> {
+  if (
+    params.trigger === "overflow" ||
+    !resolveOpenAIResponsesCompactEndpointPlan(
+      params.model,
+      params.requestOptions as Record<string, unknown>,
+    ).enabled
+  ) {
+    return undefined;
+  }
+  try {
+    const messages = params.context.messages.filter(
+      (message): message is Message =>
+        message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+    );
+    const owner = params.sessionManager
+      .getBranch()
+      .findLast((entry) => entry.type === "message" && entry.message.role === "assistant");
+    if (!owner || owner.type !== "message" || owner.message.role !== "assistant") {
+      throw new Error("Responses compact endpoint requires a persisted assistant owner");
+    }
+    const compacted = await compactWithSafetyTimeout(
+      (signal) =>
+        requestOpenAIResponsesCompaction(
+          params.model,
+          { systemPrompt: params.context.systemPrompt, messages },
+          { ...params.requestOptions, signal },
+        ),
+      params.requestOptions.timeoutMs,
+      params.requestOptions.signal ? { abortSignal: params.requestOptions.signal } : undefined,
+    );
+    const replacement = structuredClone(owner.message);
+    captureOpenAIResponsesCompaction(
+      replacement,
+      compacted.item,
+      replacement.content.length,
+      params.model,
+      buildOpenAIResponsesReasoningReplayMetadata(params.model, {
+        sessionId: params.requestOptions.sessionId,
+        authProfileId: params.requestOptions.authProfileId,
+      }),
+    );
+    const rewritten = rewriteTranscriptEntriesInSessionManager({
+      sessionManager: params.sessionManager,
+      replacements: [{ entryId: owner.id, message: replacement }],
+      preserveReplacementCompactionReplay: true,
+    });
+    if (replacement.providerReplay?.type !== "openai-responses-compaction" || !rewritten.changed) {
+      throw new Error(
+        `Responses compact endpoint checkpoint was not persisted: ${rewritten.reason}`,
+      );
+    }
+    return compacted;
+  } catch (err) {
+    log.debug("Responses compact endpoint failed; falling back to client compaction", {
+      errorMessage: formatErrorMessage(err),
+    });
+    return undefined;
+  }
+}

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -80,9 +80,9 @@ export async function attemptServerEndpointCompaction(params: {
     }
     return compacted;
   } catch (err) {
-    log.debug("Responses compact endpoint failed; falling back to client compaction", {
-      errorMessage: formatErrorMessage(err),
-    });
+    log.debug(
+      `Responses compact endpoint failed; falling back to client compaction: ${formatErrorMessage(err)}`,
+    );
     return undefined;
   }
 }

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -1,7 +1,6 @@
 import {
-  buildOpenAIResponsesReasoningReplayMetadata,
   captureOpenAIResponsesCompaction,
-  requestOpenAIResponsesCompaction,
+  requestPreparedOpenAIResponsesCompaction,
   resolveOpenAIResponsesCompactEndpointPlan,
 } from "@openclaw/ai/transports";
 import type { Message } from "@openclaw/llm-core";
@@ -15,22 +14,23 @@ type SessionManagerLike = Parameters<
   typeof rewriteTranscriptEntriesInSessionManager
 >[0]["sessionManager"];
 
-type ServerEndpointCompactionResult = Awaited<ReturnType<typeof requestOpenAIResponsesCompaction>>;
+type ServerEndpointCompactionResult = Awaited<
+  ReturnType<typeof requestPreparedOpenAIResponsesCompaction>
+>;
 
 /** Try provider-owned compaction and persist its replay checkpoint on the session owner. */
 export async function attemptServerEndpointCompaction(params: {
   trigger: "budget" | "overflow" | "manual";
-  model: Parameters<typeof requestOpenAIResponsesCompaction>[0];
+  streamFn: Parameters<typeof requestPreparedOpenAIResponsesCompaction>[0];
+  model: Parameters<typeof requestPreparedOpenAIResponsesCompaction>[1];
   context: { systemPrompt: string; messages: readonly AgentMessage[] };
   sessionManager: SessionManagerLike;
-  requestOptions: Parameters<typeof requestOpenAIResponsesCompaction>[2];
+  extraParams: Record<string, unknown>;
+  requestOptions: Parameters<typeof requestPreparedOpenAIResponsesCompaction>[3];
 }): Promise<ServerEndpointCompactionResult | undefined> {
   if (
     params.trigger === "overflow" ||
-    !resolveOpenAIResponsesCompactEndpointPlan(
-      params.model,
-      params.requestOptions as Record<string, unknown>,
-    ).enabled
+    !resolveOpenAIResponsesCompactEndpointPlan(params.model, params.extraParams).enabled
   ) {
     return undefined;
   }
@@ -47,7 +47,8 @@ export async function attemptServerEndpointCompaction(params: {
     }
     const compacted = await compactWithSafetyTimeout(
       (signal) =>
-        requestOpenAIResponsesCompaction(
+        requestPreparedOpenAIResponsesCompaction(
+          params.streamFn,
           params.model,
           { systemPrompt: params.context.systemPrompt, messages },
           { ...params.requestOptions, signal },
@@ -60,11 +61,8 @@ export async function attemptServerEndpointCompaction(params: {
       replacement,
       compacted.item,
       replacement.content.length,
-      params.model,
-      buildOpenAIResponsesReasoningReplayMetadata(params.model, {
-        sessionId: params.requestOptions.sessionId,
-        authProfileId: params.requestOptions.authProfileId,
-      }),
+      compacted.model,
+      compacted.replayMetadata,
     );
     const rewritten = rewriteTranscriptEntriesInSessionManager({
       sessionManager: params.sessionManager,

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -176,6 +176,57 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
     ]);
   });
 
+  it("preserves a newly captured compaction checkpoint on its replacement owner", () => {
+    const sessionManager = SessionManager.inMemory();
+    appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "compact this", timestamp: 1 }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("checkpoint owner"),
+        timestamp: 2,
+      }),
+    ]);
+    const owner = requireValue(
+      findAssistantEntryByText(sessionManager, "checkpoint owner"),
+      "checkpoint owner",
+    );
+    if (owner.type !== "message" || owner.message.role !== "assistant") {
+      throw new Error("expected assistant checkpoint owner");
+    }
+    const checkpoint = {
+      v: 1,
+      type: "openai-responses-compaction",
+      id: "cmp_new",
+      data: "opaque",
+      replayIndex: owner.message.content.length,
+      provider: "xai",
+      api: "openai-responses",
+      model: "grok-4.5",
+      baseUrlHash: "base-url",
+    };
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: owner.id,
+          message: { ...owner.message, providerReplay: checkpoint } as AgentMessage,
+        },
+      ],
+      preserveReplacementCompactionReplay: true,
+    });
+
+    expect(result.changed).toBe(true);
+    const rewrittenOwner = requireValue(
+      findAssistantEntryByText(sessionManager, "checkpoint owner"),
+      "rewritten checkpoint owner",
+    );
+    if (rewrittenOwner.type !== "message" || rewrittenOwner.message.role !== "assistant") {
+      throw new Error("expected rewritten assistant checkpoint owner");
+    }
+    expect(rewrittenOwner.message.providerReplay).toEqual(checkpoint);
+  });
+
   it("preserves active-branch labels after rewritten entries are re-appended", () => {
     const { sessionManager, toolResultEntryId } = createReadRewriteSession();
     const summaryEntry = requireValue(

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -126,6 +126,8 @@ function appendBranchEntry(params: {
 export function rewriteTranscriptEntriesInSessionManager(params: {
   sessionManager: SessionManagerLike;
   replacements: TranscriptRewriteReplacement[];
+  /** Preserve a checkpoint freshly captured on an explicit replacement. */
+  preserveReplacementCompactionReplay?: boolean;
 }): TranscriptRewriteResult {
   const replacementsById = new Map(
     params.replacements
@@ -197,7 +199,9 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
             appendMessage,
           })
         : appendMessage(
-            stripStalePrefixReplay(replacement) as Parameters<
+            (params.preserveReplacementCompactionReplay
+              ? replacement
+              : stripStalePrefixReplay(replacement)) as Parameters<
               typeof params.sessionManager.appendMessage
             >[0],
           );

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -270,26 +270,16 @@ export type EmbeddedAgentCompactResult = {
     code?: string;
     rawError?: string;
   };
-  result?:
-    | {
-        kind: "server-endpoint";
-        summary?: never;
-        firstKeptEntryId?: never;
-        tokensBefore: number;
-        tokensAfter: number;
-        details?: unknown;
-        sessionId?: never;
-        sessionFile?: never;
-      }
-    | {
-        summary: string;
-        firstKeptEntryId: string;
-        tokensBefore: number;
-        tokensAfter?: number;
-        details?: unknown;
-        sessionId?: string;
-        sessionFile?: string;
-      };
+  result?: {
+    /** Server-endpoint compaction has no transcript summary or first-kept entry. */
+    summary?: string;
+    firstKeptEntryId?: string;
+    tokensBefore: number;
+    tokensAfter?: number;
+    details?: unknown;
+    sessionId?: string;
+    sessionFile?: string;
+  };
 };
 
 export type EmbeddedFullAccessBlockedReason = "sandbox" | "host-policy" | "channel" | "runtime";

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -270,15 +270,26 @@ export type EmbeddedAgentCompactResult = {
     code?: string;
     rawError?: string;
   };
-  result?: {
-    summary: string;
-    firstKeptEntryId: string;
-    tokensBefore: number;
-    tokensAfter?: number;
-    details?: unknown;
-    sessionId?: string;
-    sessionFile?: string;
-  };
+  result?:
+    | {
+        kind: "server-endpoint";
+        summary?: never;
+        firstKeptEntryId?: never;
+        tokensBefore: number;
+        tokensAfter: number;
+        details?: unknown;
+        sessionId?: never;
+        sessionFile?: never;
+      }
+    | {
+        summary: string;
+        firstKeptEntryId: string;
+        tokensBefore: number;
+        tokensAfter?: number;
+        details?: unknown;
+        sessionId?: string;
+        sessionFile?: string;
+      };
 };
 
 export type EmbeddedFullAccessBlockedReason = "sandbox" | "host-policy" | "channel" | "runtime";

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -261,7 +261,7 @@ export type EmbeddedAgentRunResult = {
 export type EmbeddedAgentCompactResult = {
   ok: boolean;
   compacted: boolean;
-  compactionKind?: "context-engine" | "native-harness";
+  compactionKind?: "context-engine" | "native-harness" | "server-endpoint";
   reason?: string;
   /** Structured failure metadata used by model fallback classification. */
   failure?: {

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -271,6 +271,8 @@ export type EmbeddedAgentCompactResult = {
     rawError?: string;
   };
   result?: {
+    /** Identifies summaryless provider compaction in RPC and UI consumers. */
+    kind?: "server-endpoint";
     /** Server-endpoint compaction has no transcript summary or first-kept entry. */
     summary?: string;
     firstKeptEntryId?: string;

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3680,7 +3680,7 @@ describe("runMemoryFlushIfNeeded", () => {
       ok: true,
       compacted: true,
       compactionKind: "server-endpoint",
-      result: { tokensBefore: 8_614, tokensAfter: 736 },
+      result: { kind: "server-endpoint", tokensBefore: 8_614, tokensAfter: 736 },
     });
 
     await runPreflightCompactionIfNeeded({

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3676,6 +3676,12 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 0,
     };
     const onCompactionNotice = vi.fn();
+    compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      compactionKind: "server-endpoint",
+      result: { tokensBefore: 8_614, tokensAfter: 736 },
+    });
 
     await runPreflightCompactionIfNeeded({
       cfg: {
@@ -3705,7 +3711,11 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
-    expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "end");
+    expect(onCompactionNotice).toHaveBeenNthCalledWith(
+      2,
+      "end",
+      "🧹 Server-side compaction complete (8.6k → 736)",
+    );
   });
 
   it("emits an incomplete preflight compaction notice when post-compaction state update throws", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3680,7 +3680,7 @@ describe("runMemoryFlushIfNeeded", () => {
       ok: true,
       compacted: true,
       compactionKind: "server-endpoint",
-      result: { kind: "server-endpoint", tokensBefore: 8_614, tokensAfter: 736 },
+      result: { tokensBefore: 8_614, tokensAfter: 736 },
     });
 
     await runPreflightCompactionIfNeeded({

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -57,6 +57,7 @@ import { resolveMemoryFlushPlan, type MemoryFlushPlan } from "../../plugins/memo
 import { CommandLane } from "../../process/lanes.js";
 import { isIncognitoSessionKey, isUnscopedSessionKeySentinel } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { formatTokenCount } from "../../utils/token-format.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -681,7 +682,7 @@ export async function runPreflightCompactionIfNeeded(params: {
   storePath?: string;
   isHeartbeat: boolean;
   replyOperation: ReplyOperation;
-  onCompactionNotice?: (phase: CompactionNoticePhase) => Promise<void> | void;
+  onCompactionNotice?: (phase: CompactionNoticePhase, text?: string) => Promise<void> | void;
 }): Promise<SessionEntry | undefined> {
   const deps = {
     compactEmbeddedAgentSession: memoryDeps.compactEmbeddedAgentSession,
@@ -869,9 +870,13 @@ export async function runPreflightCompactionIfNeeded(params: {
   );
 
   params.replyOperation.setPhase("preflight_compacting");
-  const notifyCompaction = async (phase: CompactionNoticePhase) => {
+  const notifyCompaction = async (phase: CompactionNoticePhase, text?: string) => {
     try {
-      await params.onCompactionNotice?.(phase);
+      if (text) {
+        await params.onCompactionNotice?.(phase, text);
+      } else {
+        await params.onCompactionNotice?.(phase);
+      }
     } catch (err) {
       logVerbose(`preflightCompaction notice delivery failed: ${String(err)}`);
     }
@@ -882,9 +887,12 @@ export async function runPreflightCompactionIfNeeded(params: {
     startedCompactionNotice = true;
     await notifyCompaction("start");
   };
-  const notifyTerminalCompaction = async (phase: "end" | "incomplete" | "skipped") => {
+  const notifyTerminalCompaction = async (
+    phase: "end" | "incomplete" | "skipped",
+    text?: string,
+  ) => {
     terminalCompactionNoticeSent = true;
-    await notifyCompaction(phase);
+    await notifyCompaction(phase, text);
   };
   try {
     await notifyStartCompaction();
@@ -974,12 +982,19 @@ export async function runPreflightCompactionIfNeeded(params: {
       storePath: compactionStorePath,
       tokensAfter: result.result?.tokensAfter,
       newSessionId: result.result?.sessionId,
+      compactionKind: result.compactionKind,
     });
     await appendPostCompactionRefreshPrompt({
       cfg: params.cfg,
       followupRun: params.followupRun,
     });
-    await notifyTerminalCompaction("end");
+    const serverNotice =
+      result.compactionKind === "server-endpoint" &&
+      typeof result.result?.tokensBefore === "number" &&
+      typeof result.result.tokensAfter === "number"
+        ? `🧹 Server-side compaction complete (${formatTokenCount(result.result.tokensBefore)} → ${formatTokenCount(result.result.tokensAfter)})`
+        : undefined;
+    await notifyTerminalCompaction("end", serverNotice);
     entry = params.sessionStore?.[params.sessionKey] ?? entry;
     if (entry) {
       const previousSessionId = params.followupRun.run.sessionId;

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -376,12 +376,13 @@ export async function runReplyAgent(
   });
   const compactionNoticeMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
   const sendDirectCompactionNotice = shouldNotifyUserAboutCompaction(cfg)
-    ? async (phase: CompactionNoticePhase) => {
+    ? async (phase: CompactionNoticePhase, text?: string) => {
         if (!opts?.onBlockReply) {
           return;
         }
         const noticePayload = createCompactionNoticePayload({
           phase,
+          text,
           currentMessageId: compactionNoticeMessageId,
           applyReplyToMode,
         });

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -717,6 +717,7 @@ describe("handleCompactCommand", () => {
       compacted: true,
       compactionKind: "server-endpoint",
       result: {
+        kind: "server-endpoint",
         tokensBefore: 8_614,
         tokensAfter: 736,
       },

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -711,6 +711,34 @@ describe("handleCompactCommand", () => {
     expect(result?.reply?.text).toContain("Compaction skipped");
   });
 
+  it("reports server-side compaction with before and after tokens", async () => {
+    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      compactionKind: "server-endpoint",
+      result: {
+        summary: "Server-side Responses compaction",
+        firstKeptEntryId: "assistant-entry",
+        tokensBefore: 8_614,
+        tokensAfter: 736,
+      },
+    });
+
+    const result = await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        sessionEntry: { sessionId: "server-session", updatedAt: Date.now() },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(result?.reply?.text).toContain("Server-side compaction (8614 → 736)");
+    expect(requireIncrementCompactionCountCall().compactionKind).toBe("server-endpoint");
+  });
+
   it.each([
     {
       owner: "Codex",

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -717,8 +717,7 @@ describe("handleCompactCommand", () => {
       compacted: true,
       compactionKind: "server-endpoint",
       result: {
-        summary: "Server-side Responses compaction",
-        firstKeptEntryId: "assistant-entry",
+        kind: "server-endpoint",
         tokensBefore: 8_614,
         tokensAfter: 736,
       },

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -717,7 +717,6 @@ describe("handleCompactCommand", () => {
       compacted: true,
       compactionKind: "server-endpoint",
       result: {
-        kind: "server-endpoint",
         tokensBefore: 8_614,
         tokensAfter: 736,
       },

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -320,11 +320,15 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   const compactLabel =
     result.ok || isBenignCompactionSkipResult(result)
       ? didCompact
-        ? typeof tokensAfterCompaction !== "number"
-          ? "Compaction finished (resulting context unknown)"
-          : result.result?.tokensBefore != null
-            ? `Compacted (${runtime.formatTokenCount(result.result.tokensBefore)} → ${runtime.formatTokenCount(tokensAfterCompaction)})`
-            : "Compacted"
+        ? result.compactionKind === "server-endpoint" &&
+          typeof tokensAfterCompaction === "number" &&
+          result.result?.tokensBefore != null
+          ? `Server-side compaction (${runtime.formatTokenCount(result.result.tokensBefore)} → ${runtime.formatTokenCount(tokensAfterCompaction)})`
+          : typeof tokensAfterCompaction !== "number"
+            ? "Compaction finished (resulting context unknown)"
+            : result.result?.tokensBefore != null
+              ? `Compacted (${runtime.formatTokenCount(result.result.tokensBefore)} → ${runtime.formatTokenCount(tokensAfterCompaction)})`
+              : "Compacted"
         : "Compaction skipped"
       : "Compaction failed";
   if (didCompact) {

--- a/src/auto-reply/reply/compaction-notice.ts
+++ b/src/auto-reply/reply/compaction-notice.ts
@@ -40,11 +40,12 @@ export function shouldNotifyUserAboutCompaction(cfg?: OpenClawConfig): boolean {
 
 export function createCompactionNoticePayload(params: {
   phase: CompactionNoticePhase;
+  text?: string;
   currentMessageId?: string;
   applyReplyToMode?: (payload: ReplyPayload) => ReplyPayload;
 }): ReplyPayload {
   const payload: ReplyPayload = {
-    text: COMPACTION_NOTICE_TEXT[params.phase],
+    text: params.text ?? COMPACTION_NOTICE_TEXT[params.phase],
     ...(params.currentMessageId ? { replyToId: params.currentMessageId } : {}),
     replyToCurrent: true,
     isCompactionNotice: true,

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -338,15 +338,17 @@ export async function admitFollowupTurn(params: {
       return generationRotated;
     };
     const previousCompactionCount = activeEntry?.compactionCount ?? 0;
-    let pendingTerminalCompactionNotice: Exclude<CompactionNoticePhase, "start"> | undefined;
+    let pendingTerminalCompactionNotice:
+      | { phase: Exclude<CompactionNoticePhase, "start">; text?: string }
+      | undefined;
     let compactionNoticeGenerationInvalidated = false;
     const notifyPreflightCompaction =
       turn.sendPolicy === "allow" &&
       queued.currentInboundEventKind !== "room_event" &&
       shouldNotifyUserAboutCompaction(config)
-        ? async (phase: CompactionNoticePhase) => {
+        ? async (phase: CompactionNoticePhase, text?: string) => {
             if (phase !== "start") {
-              pendingTerminalCompactionNotice = phase;
+              pendingTerminalCompactionNotice = { phase, text };
               return;
             }
             const noticeEntry = readTurnSessionEntry();
@@ -459,7 +461,8 @@ export async function admitFollowupTurn(params: {
     ) {
       await params.onCompactionNoticePayload?.(
         createCompactionNoticePayload({
-          phase: pendingTerminalCompactionNotice,
+          phase: pendingTerminalCompactionNotice.phase,
+          text: pendingTerminalCompactionNotice.text,
           currentMessageId: resolveFollowupCurrentMessageId(turn.queued),
         }),
         turn,

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -526,6 +526,11 @@ describe("incrementCompactionCount", () => {
       compactionKind: "native-harness" as const,
       expectedIds: { "claude-cli": "claude-session", "codex-cli": "codex-session" },
     },
+    {
+      action: "preserves",
+      compactionKind: "server-endpoint" as const,
+      expectedIds: { "claude-cli": "claude-session", "codex-cli": "codex-session" },
+    },
   ])("$action CLI bindings after $compactionKind compaction", async (testCase) => {
     const entry = {
       sessionId: "s1",
@@ -558,7 +563,7 @@ describe("incrementCompactionCount", () => {
         : undefined,
     );
     expect(stored.claudeCliSessionId).toBe(
-      testCase.compactionKind === "native-harness" ? "claude-session" : undefined,
+      testCase.compactionKind === "context-engine" ? undefined : "claude-session",
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where xAI Grok sessions could replay provider compaction checkpoints but OpenClaw could not create one through xAI's manual `POST /responses/compact` endpoint. Manual `/compact` and threshold-driven compaction therefore had to summarize and rewrite the OpenClaw transcript client-side.

## Why This Change Was Made

The shared Responses transport now builds the same input as a normal turn, reuses its client/auth/header/request policy, validates xAI's one-item compaction response, and returns the opaque checkpoint with usage. One route-plan resolver enables this by default only for native `api.x.ai` Responses routes, supports `responsesCompactEndpoint: false`, and allows explicit opt-in on other Responses-compatible routes.

Manual and budget/preflight compaction attempt the endpoint before client summarization; overflow recovery never does because xAI requires the conversation to fit first. The endpoint attempt is bounded by the existing compaction timeout. Success captures `providerReplay` on the last assistant replacement and persists it through the canonical `SessionManager` transcript-rewrite seam. There is no raw row scan, direct SQLite rewrite, duplicate in-memory mutation, transcript-summary fabrication, CLI thread, or OpenClaw history rewrite. Failures log once at debug and fall through to client summarization.

The result is explicitly `server-endpoint`, has no synthetic summary or first-kept entry, and reports provider usage tokens before/after. Session compaction counts and fresh token totals use the existing embedded result/accounting plumbing; the CLI compaction recorder remains intentionally unused because this path has no CLI thread or transcript rewrite.

Production LOC: +309/-103 (net +206) | Tests/test support: +483/-9 | Docs: +37

The owner refactor deletes the direct session-accessor row surgery and keeps one persistence path. The remaining production growth is the transport endpoint capability and validation, route/result ownership, timeout/fallback handling, canonical checkpoint capture, and token-bearing manual/preflight outcomes. This is above the requested +150 target; I did not hide that by weakening the response validation, timeout, persistence proof, or visible outcome.

## User Impact

xAI users get server-side context compaction by default on native Grok Responses routes. `/compact` reports the provider's token reduction, threshold compaction uses the same endpoint, and later turns replay the opaque checkpoint without resending the conversational prefix. Operators can opt out per model.

Other Responses-compatible providers can opt in with `params.responsesCompactEndpoint: true`. OpenAI's native Responses route remains unchanged because its existing `context_management` path already owns automatic server compaction.

AI-assisted: yes. The implementation and live evidence were reviewed and verified by the author.

## Evidence

### Live contract probe before implementation

- `GET /v1/models` selected public model `grok-4.5`.
- `POST /v1/responses/compact` returned HTTP 200, object `response.compaction`, and exactly one encrypted compaction item.
- Sanitized shape: encrypted content length `4,908`; usage `input_tokens=8,614`, `output_tokens=736`, `reasoning_tokens=325`, `dropped_message_count=3`.
- A follow-up `POST /v1/responses` with `[compaction item, new user message]` completed normally at `input_tokens=1,277` and reproduced the seeded answer key.

### Exact-head OpenClaw path

Used PR head `35d8d506421`, an isolated `OPENCLAW_STATE_DIR`, an isolated loopback Gateway on port `19089`, the native embedded `xai/grok-4.5` route, and a process-only API key.

Manual RPC:

```text
sessions compact agent:main:xai-compact-live
POST https://api.x.ai/v1/responses/compact
status=200
kind=server-endpoint
tokensBefore=11911
tokensAfter=839
droppedMessageCount=2
summaryField=absent
```

Persisted active-branch checkpoint through `SessionManager`:

```text
lastAssistantEntry=501eb9d6
replayIndex=2
ownerContentLength=2
encryptedContentLength=59098
compactionCount=5
totalTokens=839
totalTokensFresh=true
totalTokensVersion=1
```

First turn after compaction:

```text
inputItems=3
inputItemShape=message:system,compaction,message:user
compactionItems=1
compactionInputIndexes=1
reply=NORTH-COPPER-17
```

The transport log retained only SHA-256 hashes for the checkpoint id and payload. The Gateway shut down cleanly in `280ms`.

### Automated proof

- Pre-fix endpoint regression: 8/8 new transport/gate cases failed because the endpoint helper and resolver did not exist.
- Pre-fix owner regression: the new `SessionManager` test failed because the rewrite seam stripped the newly captured checkpoint; it now preserves only the explicitly fresh replacement checkpoint.
- Focused Vitest: 332 tests passed across transport, endpoint helper, transcript rewrite, embedded compaction, manual command, preflight notices, follow-up admission, and session accounting.
- Post-cleanup affected-shard rerun: 233 tests passed.
- Pending endpoint regression proves the composed timeout signal aborts the request and returns `undefined`, after which the direct compaction integration uses client summarization.
- CI repair checks: core test types, targeted core lint, and production/full-tree/script unused-export scans all pass locally.
- `pnpm tsgo`
- `pnpm format <changed files>`
- `pnpm check:docs` (0 lint issues and 0 broken internal links; docs/config examples passed)
- Final autoreview: clean, no accepted/actionable findings; TruffleHog clean.
