### PR TITLE
test(ui-e2e): scale Control UI wait budget for loaded CI runners

### DIFF
--- a/ui/src/e2e/approval-page.e2e.test.ts
+++ b/ui/src/e2e/approval-page.e2e.test.ts
@@ -6,7 +6,11 @@ import type {
   AllowedApprovalSnapshot,
   PendingApprovalSnapshot,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiE2eWaitTimeoutMs,
+  installMockGateway,
+  type MockGatewayControls,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -109,7 +113,7 @@ async function createSurface(params: {
   });
   openContexts.add(context);
   const page = await context.newPage();
-  page.setDefaultTimeout(10_000);
+  page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
   await page.clock.setFixedTime(new Date(APPROVAL_NOW_MS));
   const pageErrors: string[] = [];
   page.on("pageerror", (error) => pageErrors.push(String(error)));

--- a/ui/src/e2e/chat-file-links.e2e.test.ts
+++ b/ui/src/e2e/chat-file-links.e2e.test.ts
@@ -5,6 +5,7 @@ import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
+  controlUiE2eWaitTimeoutMs,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -38,7 +39,7 @@ describeControlUiE2e("Control UI chat file links", () => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    page.setDefaultTimeout(15_000);
+    page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
     try {
       const gateway = await installMockGateway(page, {
         historyMessages: [
@@ -192,7 +193,7 @@ describeControlUiE2e("Control UI chat file links", () => {
     });
     try {
       const page = await context.newPage();
-      page.setDefaultTimeout(15_000);
+      page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
       const gateway = await installMockGateway(page, {
         methodResponses: {
           "sessions.files.get": {

--- a/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
+++ b/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
@@ -7,6 +7,7 @@ import { chromium, type Browser, type BrowserContext, type Page } from "playwrig
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
+  controlUiE2eWaitTimeoutMs,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -132,7 +133,7 @@ async function newRecordedPage(label: string): Promise<RecordedPage> {
       viewport,
     });
     page = await context.newPage();
-    page.setDefaultTimeout(10_000);
+    page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
     return { browser, context, page, rawVideoDir };
   } catch (error) {
     await page?.close().catch(() => {});

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -3,7 +3,7 @@
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { controlUiE2eWaitTimeoutMs, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -123,7 +123,7 @@ async function openChat(
       viewport: { height: 900, width: 1280 },
     });
     page = await context.newPage();
-    page.setDefaultTimeout(15_000);
+    page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
     const gateway = await installMockGateway(page, {
       deferredMethods,
       methodResponses: { "models.authStatus": authStatus, ...extraMethodResponses },

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../src/test-utils/openclaw-test-state.js";
 import {
   canRunPlaywrightChromium,
+  controlUiE2eWaitTimeoutMs,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
@@ -470,7 +471,7 @@ async function createBrowserPage(
   const page = await context.newPage();
   const errors: string[] = [];
   page.on("pageerror", (error) => errors.push(String(error)));
-  page.setDefaultTimeout(15_000);
+  page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
   const evidenceStartIndex = proxy.evidence.length;
   const response = await page.goto(withGatewayUrl(baseUrl, gatewayUrl), {
     timeout: controlUiSettleTimeoutMs,

--- a/ui/src/e2e/control-ui-credentials.e2e.test.ts
+++ b/ui/src/e2e/control-ui-credentials.e2e.test.ts
@@ -7,6 +7,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
   canRunPlaywrightChromium,
+  controlUiE2eWaitTimeoutMs,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -51,7 +52,7 @@ async function createCredentialPage(): Promise<{
   });
   openContexts.add(context);
   const page = await context.newPage();
-  page.setDefaultTimeout(10_000);
+  page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
   const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
   const response = await page.goto(server.baseUrl);
   expect(response?.status()).toBe(200);

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -2,6 +2,7 @@ import { chromium, type Browser, type BrowserContext, type Page } from "playwrig
 import { afterAll, afterEach, beforeAll, describe } from "vitest";
 import {
   canRunPlaywrightChromium,
+  controlUiE2eWaitTimeoutMs,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
@@ -57,6 +58,8 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
       throw new Error("Control UI E2E browser accessed before suite setup");
     }
     const context = await browser.newContext(contextOptions);
+    // Harness owns the wait budget; per-test setDefaultTimeout sprinkles defeat CI scaling.
+    context.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
     openBrowserContexts.add(context);
     return context;
   };

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -7,6 +7,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
   canRunPlaywrightChromium,
+  controlUiE2eWaitTimeoutMs,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -34,7 +35,7 @@ async function createPage(): Promise<Page> {
   });
   openContexts.add(context);
   const page = await context.newPage();
-  page.setDefaultTimeout(10_000);
+  page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
   return page;
 }
 

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -236,8 +236,6 @@ suite.define(() => {
         viewport: { height: 900, width: 1440 },
       },
       async ({ page }) => {
-        page.setDefaultTimeout(10_000);
-
         const gateway = await installMockGateway(page, {
           historyMessages: [
             {
@@ -407,8 +405,6 @@ suite.define(() => {
         viewport: { height: 900, width: 1440 },
       },
       async ({ page }) => {
-        page.setDefaultTimeout(10_000);
-
         const gateway = await installMockGateway(page, {
           assistantAgentId: "work",
           defaultAgentId: "work",

--- a/ui/src/pages/workboard/workboard-routing.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-routing.e2e.test.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { expect, it } from "vitest";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
-import { installMockGateway, waitForControlUiRoute } from "../../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiE2eWaitTimeoutMs,
+  installMockGateway,
+  waitForControlUiRoute,
+} from "../../test-helpers/control-ui-e2e.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI Workboard routing",
@@ -64,7 +68,7 @@ async function newRecordedPage(label: string): Promise<{
     viewport: { width: 1600, height: 1000 },
   });
   const page = await context.newPage();
-  page.setDefaultTimeout(10_000);
+  page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
   return { context, page, rawVideoDir };
 }
 

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -14,6 +14,7 @@ import type {
   WorkboardStatus,
 } from "../../lib/workboard/index.ts";
 import {
+  controlUiE2eWaitTimeoutMs,
   installMockGateway,
   type MockGatewayControls,
   type MockGatewayRequest,
@@ -302,7 +303,7 @@ async function newRecordedPage(label: string): Promise<RecordedPage> {
       viewport,
     });
     page = await context.newPage();
-    page.setDefaultTimeout(10_000);
+    page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
     return { context, page, rawVideoDir };
   } catch (error) {
     await page?.close().catch(() => {});

--- a/ui/src/test-helpers/control-ui-e2e-readiness.ts
+++ b/ui/src/test-helpers/control-ui-e2e-readiness.ts
@@ -1,4 +1,5 @@
 import type { Page } from "playwright";
+import { controlUiE2eWaitTimeoutMs } from "./control-ui-e2e.ts";
 
 /** A sent connect request is not the delivered Gateway handshake. */
 export async function waitForControlUiGatewayReady(page: Page): Promise<void> {
@@ -23,11 +24,11 @@ export async function waitForControlUiGatewayReconnecting(page: Page): Promise<v
         return app?.runtime?.context?.gateway?.snapshot?.phase === "reconnecting";
       },
       undefined,
-      { timeout: 10_000 },
+      { timeout: controlUiE2eWaitTimeoutMs },
     ),
     page
       .locator(".sidebar-identity-card__status", { hasText: "Reconnecting…" })
-      .waitFor({ state: "visible", timeout: 10_000 }),
+      .waitFor({ state: "visible", timeout: controlUiE2eWaitTimeoutMs }),
   ]);
 }
 

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -81,6 +81,12 @@ type ControlUiRouteTarget = {
 // wait browser-local, but allow enough time for the router to finish committing.
 const CONTROL_UI_ROUTE_TIMEOUT_MS = 60_000;
 
+// Loaded CI runners regularly stall real Chromium renders past 10s; the larger
+// CI budget trades failure latency, not coverage (mirrors the ui-e2e vitest
+// config's expect.poll budget). Local runs keep the snappy 10s deadline.
+export const controlUiE2eWaitTimeoutMs =
+  process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true" ? 30_000 : 10_000;
+
 /**
  * Wait for the browser router to commit a route, not merely update the URL.
  * Browser-local polling keeps readiness independent of host-side CDP scheduling.
@@ -2268,7 +2274,7 @@ function createMockGatewayControls(page: Page, defaultSessionKey: string): MockG
           return Boolean(gateway?.requests.some((request) => request.method === targetMethod));
         },
         method,
-        { timeout: 10_000 },
+        { timeout: controlUiE2eWaitTimeoutMs },
       );
       const requests = await getRequests(method);
       const request = requests.at(-1);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the `ui-e2e` lane fails intermittently on loaded CI runners with `TimeoutError: page.waitForFunction: Timeout 10000ms exceeded`, forcing maintainers to rerun a red job that has nothing wrong with it.

Two failures observed 2026-08-14, both green on rerun:

- `ui/src/e2e/model-agent-scoping.e2e.test.ts` — "scopes every automatic model request in a cold explicit fleet" (run 31776290645)
- `ui/src/e2e/terminal-embedded.e2e.test.ts` — "opens a new dock terminal for a selection changed without navigation" (run 31789504347)

The 10s deadline was not Playwright's default (30s) — it was repo-imposed, and no single place owned it. The shared mock-Gateway `waitForRequest` helper hardcoded `{ timeout: 10_000 }`, the readiness helper hardcoded two more, and twelve per-test `page.setDefaultTimeout(10_000 | 15_000)` sprinkles each picked their own number. Both failing tests time out inside `waitForRequest`, so no per-test value could have saved them.

## Why This Change Was Made

The e2e harness now owns the wait budget through one exported constant, `controlUiE2eWaitTimeoutMs` in `ui/src/test-helpers/control-ui-e2e.ts`: 30s under CI, 10s locally, so local runs keep failing fast. It sits beside the existing `CONTROL_UI_ROUTE_TIMEOUT_MS` and follows the reasoning already recorded in `test/vitest/vitest.ui-e2e.config.ts`, which raised `expect.poll` to 15s for exactly this CI-load reason — correctness here is the eventual state, so a larger budget trades failure latency, not coverage.

Suite-created contexts get the budget via `context.setDefaultTimeout` in `newBrowserContext`, which is why the two overrides in `critical-observer-notice.e2e.test.ts` are deleted rather than rewritten. The nine remaining `setDefaultTimeout` calls live in files that build contexts outside the suite (own harness or direct `browser.newContext`), so they keep the call and take the shared value.

CI detection is an exact-string check on `CI` / `GITHUB_ACTIONS`, matching the convention in `scripts/lib/local-heavy-check-runtime.mts`, so a `CI=false` environment does not silently pick the long budget.

Non-goals: per-call explicit `{ timeout: ... }` arguments inside individual tests are untouched, as are the vitest configs and CI workflows. This does not claim to fix any underlying render slowness — it stops a load-sensitive deadline from being reported as a product failure.

## User Impact

No product behavior changes; this is test-harness only. Maintainers get a `ui-e2e` lane that stops failing on runner contention, and one place to tune the budget instead of fourteen. Net production LOC: 0 (all changed files are tests or test helpers; +40/−20 across 13 files).

## Evidence

All proof run locally in this worktree. Both previously flaky tests, in both the CI and local branches of the constant:

```
$ CI=true node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
    ui/src/e2e/model-agent-scoping.e2e.test.ts ui/src/e2e/terminal-embedded.e2e.test.ts
 Test Files  2 passed (2)
      Tests  4 passed (4)
   Duration  10.67s

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
    ui/src/e2e/model-agent-scoping.e2e.test.ts ui/src/e2e/terminal-embedded.e2e.test.ts
 Test Files  2 passed (2)
      Tests  4 passed (4)
   Duration  10.74s
```

Every touched file, plus the five files that import the readiness helper whose import edge changed (`CI=true`, three runs):

```
 Test Files  5 passed (5)    # readiness-helper importers
      Tests  36 passed (36)

 Test Files  4 passed (4)    # deleted-override + sprinkle-swap files
      Tests  18 passed (18)

 Test Files  6 passed (6)    # workboard, chat-file-links, chat-large-paste, quota-pill, auth-transports
      Tests  15 passed (15)
```

17 e2e files, 73 tests, all green.

Guards:

```
$ node scripts/run-tsgo.mjs -p tsconfig.ui.json                                  # clean
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.ui-pages-e2e.json # clean
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.ui-other.json     # clean
$ ./node_modules/.bin/oxfmt --check <touched helpers>                             # All matched files use the correct format
$ git diff --check                                                                # clean
```

Autoreview (Codex `gpt-5.6-sol`, xhigh): `autoreview clean: no accepted/actionable findings reported`.

Proof gap: the flake is a load-dependent CI condition, so the fix cannot be demonstrated failing-then-passing locally — a local run never hits the 10s ceiling. The e2e lane in this PR's CI is the real proof surface. `node scripts/check-changed.mjs` could not complete here: its Blacksmith Testbox delegation failed warmup (`blacksmith failed: signal: killed`), so the equivalent typecheck/format lanes were run directly, as shown above.

No screenshots: this PR changes no rendered surface.
