### PR TITLE
refactor(ui): normalize sidebar typography

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -258,6 +258,7 @@ export function renderRecentSession(params: {
     <div
       class=${rowClass}
       data-session-key=${session.key}
+      data-session-unread=${session.unread ? "true" : nothing}
       role=${ifDefined(listItem ? "listitem" : undefined)}
       draggable=${rowDraggable ? "true" : "false"}
       title=${!session.isChild && !groupWriteAccess.allowed ? groupWriteAccess.reason : nothing}

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -516,7 +516,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
 
       const baseline = await readSizes();
       expect(baseline).toMatchObject({
-        childName: 12,
+        childName: 13,
         childTrail: 10,
         coarsePointer: true,
         agentFilter: 16,
@@ -530,7 +530,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
       });
       const scaled = await readSizes();
       expect(scaled.agentFilter).toBeCloseTo(12 * 1.4, 1);
-      expect(scaled.childName).toBeCloseTo(12 * 1.4, 1);
+      expect(scaled.childName).toBeCloseTo(13 * 1.4, 1);
       expect(scaled.childTrail).toBeCloseTo(10 * 1.4, 1);
       expect(scaled.fileSearch).toBeCloseTo(12 * 1.4, 1);
       expect(scaled.settingsSearch).toBeCloseTo(12.5 * 1.4, 1);

--- a/ui/src/e2e/sidebar-typography.e2e.test.ts
+++ b/ui/src/e2e/sidebar-typography.e2e.test.ts
@@ -1,0 +1,274 @@
+import type { Locator } from "playwright";
+import { expect, it } from "vitest";
+import {
+  controlUiSessionUrl,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+import {
+  captureSidebarUiUnionProof,
+  createSidebarCustomizationSuite,
+} from "./sidebar-customization.test-support.ts";
+
+const suite = createSidebarCustomizationSuite("Control UI sidebar typography mocked Gateway E2E");
+
+const visualVariants = [{ colorScheme: "light" as const }, { colorScheme: "dark" as const }];
+
+type TypeMetrics = {
+  family: string;
+  size: string;
+  lineHeight: string;
+  tracking: string;
+  weight: string;
+};
+
+function typeMetrics(locator: Locator): Promise<TypeMetrics> {
+  return locator.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      family: style.fontFamily,
+      size: style.fontSize,
+      lineHeight: style.lineHeight,
+      tracking: style.letterSpacing,
+      weight: style.fontWeight,
+    };
+  });
+}
+
+suite.define(() => {
+  it.each(visualVariants)(
+    "keeps sidebar type roles invariant in $colorScheme",
+    async ({ colorScheme }) => {
+      const context = await suite.newBrowserContext({
+        colorScheme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      });
+      const page = await context.newPage();
+      const baseTime = Date.parse("2026-08-14T16:00:00.000Z");
+      const pinnedKey = "agent:main:pinned";
+      const parentKey = "agent:main:release-plan";
+      const childKey = "agent:main:verify-release";
+      const draftKey = "agent:main:draft";
+      await installMockGateway(page, {
+        featureMethods: ["sessions.catalog.list"],
+        methodResponses: {
+          "sessions.list": {
+            cases: [
+              {
+                match: { spawnedBy: parentKey },
+                response: sessionsListResponse([
+                  sessionRow(childKey, "Verify release evidence", baseTime - 2_000, {
+                    spawnedBy: parentKey,
+                    startedAt: baseTime - 62_000,
+                    status: "done",
+                  }),
+                ]),
+              },
+              {
+                response: sessionsListResponse([
+                  {
+                    ...sessionRow(pinnedKey, "Pinned handoff", baseTime, {
+                      pinned: true,
+                      unread: true,
+                      worktree: {
+                        branch: "feat/pinned-handoff",
+                        repoRoot: "/workspace/openclaw",
+                      },
+                    }),
+                  },
+                  {
+                    ...sessionRow(parentKey, "Release plan", baseTime - 1_000, {
+                      category: "Research",
+                      childSessions: [childKey],
+                      worktree: {
+                        branch: "feat/release-plan",
+                        repoRoot: "/workspace/openclaw",
+                      },
+                    }),
+                  },
+                  {
+                    ...sessionRow(
+                      draftKey,
+                      "Draft with a deliberately long title that must truncate cleanly",
+                      baseTime - 3_000,
+                    ),
+                    visibility: "draft",
+                  },
+                ]),
+              },
+            ],
+          },
+          "sessions.catalog.list": {
+            catalogs: [
+              {
+                id: "codex",
+                label: "Codex",
+                capabilities: { continueSession: true, archive: true },
+                hosts: [
+                  {
+                    hostId: "gateway:local",
+                    label: "Gateway",
+                    kind: "gateway",
+                    connected: true,
+                    sessions: [
+                      {
+                        threadId: "catalog-session",
+                        name: "Catalog session",
+                        cwd: "/workspace/openclaw",
+                        status: "idle",
+                        archived: false,
+                        canContinue: true,
+                        canArchive: true,
+                        updatedAt: baseTime - 4_000,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        sessionGroups: ["Research"],
+        sessionKey: parentKey,
+      });
+
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, parentKey));
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const sidebarSurface = sidebar.locator(".sidebar-shell");
+        const pinnedRow = sidebar.locator(`[data-session-key="${pinnedKey}"]`);
+        const parentRow = sidebar.locator(`[data-session-key="${parentKey}"]`);
+        const draftRow = sidebar.locator(`[data-session-key="${draftKey}"]`);
+        const catalogRow = sidebar.locator('[data-session-key*="catalog-session"]');
+        await parentRow.waitFor();
+        await catalogRow.waitFor();
+
+        await parentRow.locator(".sidebar-child-session-toggle").click();
+        const childRow = sidebar.locator(`[data-session-key="${childKey}"]`);
+        await childRow.waitFor();
+
+        const parentTitle = parentRow.locator(".sidebar-recent-session__name");
+        const titleContract = await typeMetrics(parentTitle);
+        for (const title of [
+          childRow.locator(".sidebar-recent-session__name"),
+          draftRow.locator(".sidebar-recent-session__name"),
+          catalogRow.locator(".sidebar-recent-session__name"),
+        ]) {
+          expect(await typeMetrics(title)).toEqual(titleContract);
+        }
+        const pinnedTitleMetrics = await typeMetrics(
+          pinnedRow.locator(".sidebar-recent-session__name"),
+        );
+        expect({ ...pinnedTitleMetrics, weight: titleContract.weight }).toEqual(titleContract);
+        expect(Number(pinnedTitleMetrics.weight)).toBeGreaterThan(Number(titleContract.weight));
+        await expect
+          .poll(() => parentRow.getAttribute("class"))
+          .toContain("sidebar-recent-session--active");
+
+        const pinnedSubtitle = pinnedRow.locator(".sidebar-recent-session__subtitle");
+        const parentSubtitle = parentRow.locator(".sidebar-recent-session__subtitle");
+        expect(await typeMetrics(pinnedSubtitle)).toEqual(await typeMetrics(parentSubtitle));
+
+        const sectionLabels = sidebar.locator(".sidebar-recent-sessions__label-text");
+        const sectionContract = await typeMetrics(sectionLabels.first());
+        expect(sectionContract).toMatchObject({
+          lineHeight: "11px",
+          size: "11px",
+          tracking: "0.44px",
+          weight: "650",
+        });
+        expect(
+          await sectionLabels.evaluateAll((labels) => labels.map((label) => label.textContent)),
+        ).toEqual(expect.arrayContaining(["Sessions", "Research", "Codex"]));
+
+        const variant = `typography-${colorScheme}`;
+        await captureSidebarUiUnionProof(page, [sidebarSurface], `${variant}-full.png`);
+
+        const navLabel = sidebar
+          .getByRole("link", { name: "Automations" })
+          .locator(".nav-item__text");
+        const navMetrics = await typeMetrics(navLabel);
+        await sidebar.locator(".sidebar-nav__head-action").click();
+        const moreMenu = sidebar.locator("wa-dropdown.sidebar-more-menu");
+        await moreMenu.getByRole("menuitem", { name: "Edit pinned items" }).click();
+        const customizeMenu = sidebar.locator(
+          "wa-dropdown.sidebar-customize-menu:not(.sidebar-more-menu):not(.sidebar-agent-menu)",
+        );
+        const customizeSurface = customizeMenu.locator('[part="menu"]');
+        await customizeSurface.waitFor();
+        expect(
+          await typeMetrics(
+            customizeMenu.locator(".sidebar-customize-menu__item", { hasText: "Automations" }),
+          ),
+        ).toEqual(navMetrics);
+        expect(await typeMetrics(customizeMenu.locator(".sidebar-customize-menu__title"))).toEqual(
+          sectionContract,
+        );
+
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, customizeSurface],
+          `${variant}-customizer.png`,
+        );
+        await page.keyboard.press("Escape");
+
+        await draftRow.hover();
+        await draftRow.locator("[data-session-menu]").click();
+        const sessionMenu = sidebar.locator("wa-dropdown.session-menu");
+        const sessionMenuSurface = sessionMenu.locator('[part="menu"]');
+        await sessionMenuSurface.waitFor();
+        const menuRows = sessionMenu.locator(".session-menu__item");
+        const menuContract = await typeMetrics(menuRows.first());
+        expect(
+          await menuRows.evaluateAll((rows) => rows.map((row) => getComputedStyle(row).lineHeight)),
+        ).toEqual(Array(await menuRows.count()).fill(menuContract.lineHeight));
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, sessionMenuSurface],
+          `${variant}-context-menu.png`,
+        );
+        await page.keyboard.press("Escape");
+
+        await sidebar.locator(".sidebar-identity-card").click();
+        const identityMenu = sidebar.locator("wa-dropdown.sidebar-identity-menu");
+        const identitySurface = identityMenu.locator('[part="menu"]');
+        await identitySurface.waitFor();
+        const buildChip = identityMenu.locator(".sidebar-footer-build");
+        await buildChip.hover();
+        const hoverCard = identityMenu.locator(".sidebar-hover-card");
+        await hoverCard.waitFor({ state: "visible" });
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, identitySurface, hoverCard],
+          `${variant}-hover-card.png`,
+        );
+        await page.keyboard.press("Escape");
+
+        await page.evaluate(() => {
+          document.documentElement.style.zoom = "2";
+        });
+        const zoomMetrics = await draftRow
+          .locator(".sidebar-recent-session__name")
+          .evaluate((name) => {
+            const style = getComputedStyle(name);
+            const box = name.getBoundingClientRect();
+            return {
+              lineHeight: Number.parseFloat(style.lineHeight),
+              height: box.height,
+              overflowY: name.scrollHeight - name.clientHeight,
+              textOverflow: style.textOverflow,
+            };
+          });
+        expect(zoomMetrics.textOverflow).toBe("ellipsis");
+        expect(zoomMetrics.height).toBeGreaterThanOrEqual(zoomMetrics.lineHeight - 0.5);
+        expect(zoomMetrics.overflowY).toBeLessThanOrEqual(1);
+        await captureSidebarUiUnionProof(page, [draftRow], `${variant}-zoom-200.png`);
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+});

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -881,6 +881,26 @@ openclaw-settings-save-indicator {
    Navigation Sidebar
    =========================================== */
 
+:root {
+  --sidebar-type-page-size: calc(13px * var(--control-ui-text-scale));
+  --sidebar-type-page-line-height: 20px;
+  --sidebar-type-page-weight: 500;
+  --sidebar-type-section-size: var(--control-ui-text-xs);
+  --sidebar-type-section-line-height: 1;
+  --sidebar-type-section-weight: 650;
+  --sidebar-type-section-tracking: 0.04em;
+  --sidebar-type-session-size: calc(13px * var(--control-ui-text-scale));
+  --sidebar-type-session-line-height: 20px;
+  --sidebar-type-session-weight: 500;
+  --sidebar-type-session-unread-weight: 650;
+  --sidebar-type-subtitle-size: var(--control-ui-text-xs);
+  --sidebar-type-subtitle-line-height: 16px;
+  --sidebar-type-menu-size: calc(13px * var(--control-ui-text-scale));
+  --sidebar-type-menu-line-height: 20px;
+  --sidebar-type-footer-size: var(--control-ui-text-xs);
+  --sidebar-type-footer-line-height: 1.2;
+}
+
 .shell-nav {
   grid-area: nav;
   position: relative;
@@ -1801,11 +1821,12 @@ body.update-dialog-open .sidebar-update-card__status {
 
 .sidebar-recent-sessions__label-text,
 .sidebar-session-catalog-host__label {
-  font-size: var(--control-ui-text-xs);
-  font-weight: 650;
-  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--muted) 78%, transparent);
+  font-size: var(--sidebar-type-section-size);
+  font-weight: var(--sidebar-type-section-weight);
+  letter-spacing: var(--sidebar-type-section-tracking);
+  line-height: var(--sidebar-type-section-line-height);
   text-transform: uppercase;
-  color: var(--muted);
 }
 
 /* Flex, not grid: WebKit does not re-run a grid flex-item's intrinsic sizing
@@ -2291,9 +2312,17 @@ body.update-dialog-open .sidebar-update-card__status {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: calc(13px * var(--control-ui-text-scale));
-  font-weight: 500;
+  font-family: inherit;
+  font-size: var(--sidebar-type-session-size);
+  font-style: normal;
+  font-weight: var(--sidebar-type-session-weight);
+  letter-spacing: normal;
+  line-height: var(--sidebar-type-session-line-height);
   color: var(--text);
+}
+
+.sidebar-recent-session[data-session-unread="true"] .sidebar-recent-session__name {
+  font-weight: var(--sidebar-type-session-unread-weight);
 }
 
 .sidebar-recent-session--child {
@@ -2310,10 +2339,6 @@ body.update-dialog-open .sidebar-update-card__status {
   .sidebar-recent-session__link
   > :not(.sidebar-session-indicator):not(.sidebar-recent-session__text) {
   margin-left: 6px;
-}
-
-.sidebar-recent-session--child .sidebar-recent-session__name {
-  font-size: var(--control-ui-text-sm);
 }
 
 .sidebar-recent-session--child .session-row-trail {
@@ -2346,7 +2371,6 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-recent-session--active .sidebar-recent-session__name {
-  font-weight: 500;
   color: var(--text-strong);
 }
 
@@ -2527,11 +2551,12 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
 
 .sidebar-customize-menu__title {
   padding: 6px 8px 8px;
-  font-size: var(--control-ui-text-xs);
-  font-weight: 650;
-  letter-spacing: 0.07em;
+  font-size: var(--sidebar-type-section-size);
+  font-weight: var(--sidebar-type-section-weight);
+  letter-spacing: var(--sidebar-type-section-tracking);
+  line-height: var(--sidebar-type-section-line-height);
   text-transform: uppercase;
-  color: var(--muted);
+  color: color-mix(in srgb, var(--muted) 78%, transparent);
 }
 
 .sidebar-customize-menu__provenance {
@@ -2545,10 +2570,11 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   margin: 6px 0 2px;
   padding: 7px 8px 4px;
   border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  color: var(--muted);
-  font-size: calc(10px * var(--control-ui-text-scale));
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--muted) 78%, transparent);
+  font-size: var(--sidebar-type-section-size);
+  font-weight: var(--sidebar-type-section-weight);
+  letter-spacing: var(--sidebar-type-section-tracking);
+  line-height: var(--sidebar-type-section-line-height);
   text-transform: uppercase;
 }
 
@@ -2564,7 +2590,9 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: calc(13px * var(--control-ui-text-scale));
+  font-size: var(--sidebar-type-page-size);
+  font-weight: var(--sidebar-type-page-weight);
+  line-height: var(--sidebar-type-page-line-height);
   text-align: left;
   /* More-menu route rows are anchors acting as chrome (see base.css cursor policy). */
   cursor: var(--cursor-action);
@@ -2702,9 +2730,10 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 .sidebar-session-sort-menu__title {
   padding: 4px 8px 2px;
   color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  font-weight: 650;
-  letter-spacing: 0.05em;
+  font-size: var(--sidebar-type-section-size);
+  font-weight: var(--sidebar-type-section-weight);
+  letter-spacing: var(--sidebar-type-section-tracking);
+  line-height: var(--sidebar-type-section-line-height);
   text-transform: uppercase;
 }
 
@@ -2721,7 +2750,8 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: calc(13px * var(--control-ui-text-scale));
+  font-size: var(--sidebar-type-menu-size);
+  line-height: var(--sidebar-type-menu-line-height);
   text-align: left;
 }
 
@@ -2827,6 +2857,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   color: var(--muted);
   font-family: var(--mono);
   font-size: var(--control-ui-text-xs);
+  font-variant-numeric: tabular-nums;
   line-height: 1;
   text-align: center;
 }
@@ -2835,6 +2866,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   padding: 4px 8px 6px;
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
+  font-variant-numeric: tabular-nums;
 }
 
 .session-menu__separator {
@@ -2927,8 +2959,9 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .nav-item__text {
-  font-size: calc(13px * var(--control-ui-text-scale));
-  font-weight: 500;
+  font-size: var(--sidebar-type-page-size);
+  font-weight: var(--sidebar-type-page-weight);
+  line-height: var(--sidebar-type-page-line-height);
   white-space: nowrap;
 }
 
@@ -2979,8 +3012,6 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .sidebar-zone-entry .sidebar-recent-session__name {
   color: inherit;
-  font-size: calc(13px * var(--control-ui-text-scale));
-  font-weight: 500;
 }
 
 .sidebar-zone-entry .sidebar-recent-session:hover {
@@ -3095,8 +3126,9 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-agent-card__subtitle {
   overflow: hidden;
   color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  line-height: 1.2;
+  font-size: var(--sidebar-type-footer-size);
+  font-variant-numeric: tabular-nums;
+  line-height: var(--sidebar-type-footer-line-height);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -3267,8 +3299,9 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .sidebar-identity-card__subtitle {
   color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  line-height: 1.2;
+  font-size: var(--sidebar-type-footer-size);
+  font-variant-numeric: tabular-nums;
+  line-height: var(--sidebar-type-footer-line-height);
 }
 
 .sidebar-identity-card__subtitle--gateway {
@@ -3340,8 +3373,8 @@ openclaw-tooltip.sidebar-hover-tooltip {
   width: min(320px, calc(100vw - 44px));
   max-width: 100%;
   color: var(--text);
-  font-size: var(--control-ui-text-sm);
-  line-height: 1.35;
+  font-size: var(--sidebar-type-menu-size);
+  line-height: var(--sidebar-type-menu-line-height);
   text-align: left;
 }
 
@@ -3352,10 +3385,11 @@ openclaw-tooltip.sidebar-hover-tooltip {
 }
 
 .sidebar-hover-card__heading {
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  font-weight: 650;
-  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--muted) 78%, transparent);
+  font-size: var(--sidebar-type-section-size);
+  font-weight: var(--sidebar-type-section-weight);
+  letter-spacing: var(--sidebar-type-section-tracking);
+  line-height: var(--sidebar-type-section-line-height);
   text-transform: uppercase;
 }
 
@@ -3451,6 +3485,7 @@ openclaw-tooltip.sidebar-hover-tooltip {
 .sidebar-hover-card__metadata-value--mono {
   font-family: var(--mono);
   font-size: var(--control-ui-text-xs);
+  font-variant-numeric: tabular-nums;
 }
 
 .sidebar-footer-bar__status {
@@ -3529,8 +3564,9 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   min-height: 24px;
   padding: 0 8px;
   color: var(--muted);
-  font-size: var(--control-ui-text-xs);
+  font-size: var(--sidebar-type-menu-size);
   font-weight: 500;
+  line-height: var(--sidebar-type-menu-line-height);
 }
 
 .sidebar-agent-menu__filter {
@@ -3574,7 +3610,9 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   overflow: hidden;
   color: var(--muted);
   font-family: var(--mono);
-  font-size: var(--control-ui-text-xs);
+  font-size: var(--sidebar-type-footer-size);
+  font-variant-numeric: tabular-nums;
+  line-height: var(--sidebar-type-footer-line-height);
   text-overflow: ellipsis;
   white-space: nowrap;
   text-decoration: none;
@@ -4035,7 +4073,10 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--control-ui-text-xs);
+  font-size: var(--sidebar-type-subtitle-size);
+  letter-spacing: normal;
+  line-height: var(--sidebar-type-subtitle-line-height);
+  margin-block-start: 1px;
   color: color-mix(in srgb, var(--muted) 55%, var(--text) 45%);
 }
 

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -128,7 +128,7 @@ describe("Control UI theme contrast", () => {
     }
   });
 
-  it("keeps sidebar metadata on the AA-tested muted token without opacity dimming", () => {
+  it("keeps sidebar metadata on the muted token and settled section treatment", () => {
     const groupLabelRule = readRuleBody(layoutCss, ".settings-sidebar__group-label");
     const buildRule = readRuleBody(layoutCss, ".settings-sidebar__footer .sidebar-footer-build");
     const sessionLabelRule = readRuleBody(
@@ -138,7 +138,9 @@ describe("Control UI theme contrast", () => {
 
     expect(groupLabelRule).toMatch(/color:\s*var\(--muted\)/);
     expect(buildRule).toMatch(/color:\s*var\(--muted\)/);
-    expect(sessionLabelRule).toMatch(/color:\s*var\(--muted\)/);
+    expect(sessionLabelRule).toMatch(
+      /color:\s*color-mix\(in srgb, var\(--muted\) 78%, transparent\)/,
+    );
     expect(readOpacity(sessionLabelRule)).toBe(1);
 
     for (const selector of [


### PR DESCRIPTION
## What Problem This Solves

Sidebar navigation, section labels, session rows, menus, hover cards, and footer metadata used overlapping but inconsistent font declarations. Child and pinned sessions could drift from the normal session-title contract, while customization headings used a separate scale.

Depends on #123613.

## Why This Change Was Made

- Introduces sidebar-specific type roles while preserving the current platform font family and global body scale.
- Gives Pinned, Sessions, Draft, child, catalog, and active rows the same 13px/20px session-title metrics.
- Makes unread the only session state that increases title weight; active selection changes color, not weight.
- Normalizes section labels to uppercase 11px, weight 650, 0.04em tracking, and the shared muted treatment.
- Aligns normal navigation and customization labels, plus menu, hover-card, shortcut, subtitle, and footer metadata roles.
- Applies tabular numerals to shortcut, age, duration, build, and compact metadata surfaces.

## User Impact

The sidebar now reads with one predictable hierarchy across regular, pinned, nested, draft, catalog, customized, and floating states. Text remains on the existing platform family, and 200% zoom preserves line boxes and horizontal truncation.

## Evidence

- 2 focused browser tests passed across light and dark themes.
- Computed-style assertions cover Pinned/normal/child/Draft/catalog title parity, unread versus active weight, subtitle parity, section metrics, customization parity, menu rows, and 200% zoom.
- The headed matrix covered the full sidebar, customization menu, context menu, rich hover card, footer, and 200% zoom: 10 frames inspected individually.
- UI type checking, stylesheet lint, focused UI boundary lint, formatting, dependency policy, i18n, and dead-export checks passed remotely.
- The repository-wide Lit analyzer reports its existing baseline diagnostics; the new semantic unread attribute adds no diagnostic.


---

## Visual proof — real app, mocked Gateway

**How these were produced (literal):**

- Head captured: `43c27f40df5e29f6e75c3f1b780ff6fef71c54ec` — top of Stack A, which contains #123613 → #123626 → #123655 → #123681. The head was asserted inside the run, not assumed.
- The **whole Control UI app** was served by `startControlUiE2eServer` and driven through the canonical mocked Gateway (`installMockGateway`, `ui/src/test-helpers/control-ui-e2e.ts`). No isolated component, no hand-built HTML, no synthetic harness.
- Spec: `ui/src/e2e/sidebar-typography.e2e.test.ts` — result: **passed, 10 frames**.
- Headed Chromium under Xvfb on a Linux remote host (headed, so hover/elevation/compositing actually paint).
- Command:

```sh
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_HEADED=1 CI=1 \
  xvfb-run -a --server-args="-screen 0 2560x1600x24" \
  node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.ui-e2e.config.ts \
    --configLoader runner ui/src/e2e/sidebar-typography.e2e.test.ts
```

- Floating surfaces (menus, tooltips, popovers) are clipped to the **union** of the sidebar box and the surface box with 16px padding via `captureSidebarUiUnionProof`, so absolutely-positioned surfaces are included without unrelated page area.

Each frame shows a populated sidebar: unread pinned row, Pages, a Research group with a parent and its child, a Draft row, and a Codex catalog row — so title parity across row kinds is visible rather than asserted only.

<table><tr><th>state</th><th>light</th><th>dark</th></tr>
<tr><td><b>full</b></td><td><img src="https://github.com/user-attachments/assets/143c47fa-1c82-4dbe-8886-dc5db92712fd" width="320"></td><td><img src="https://github.com/user-attachments/assets/629f23a1-4e3f-47bb-ad09-87a86d5dd2f8" width="320"></td></tr>
<tr><td><b>customizer</b></td><td><img src="https://github.com/user-attachments/assets/7e1a4b4b-3e40-47e9-9b2c-17678476f4e4" width="320"></td><td><img src="https://github.com/user-attachments/assets/de96ffa6-33e5-4df9-b03c-6fcf47dfa4fc" width="320"></td></tr>
<tr><td><b>context-menu</b></td><td><img src="https://github.com/user-attachments/assets/8f887002-6ba5-4962-af72-78bbaee80d64" width="320"></td><td><img src="https://github.com/user-attachments/assets/a81e0701-2729-4982-883b-5a196f1c9e92" width="320"></td></tr>
<tr><td><b>hover-card</b></td><td><img src="https://github.com/user-attachments/assets/8ba73100-96b0-4de3-93c1-744467f8fa4d" width="320"></td><td><img src="https://github.com/user-attachments/assets/f32497d3-eddd-4551-8763-969e7dffa438" width="320"></td></tr>
<tr><td><b>zoom-200</b></td><td><img src="https://github.com/user-attachments/assets/b589a000-37cc-4f77-936e-e37f3e1d9f8c" width="320"></td><td><img src="https://github.com/user-attachments/assets/6e9b7d3f-a7cb-4911-858c-208b1924a089" width="320"></td></tr>
</table>

