### PR TITLE
fix(ui): gateway client rotation silently discards plain staged attachments

### DIFF
--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -15,6 +15,7 @@ import {
   closeStagedPane,
   discardStateStagedAttachments,
   preparePaneStagedAttachments,
+  replacePaneStagedAttachmentGatewayOwner,
   restorePaneStagedAttachments,
 } from "./chat-pane-attachment-handoff.ts";
 import { createTestChatPane } from "./chat-pane.test-support.ts";
@@ -178,6 +179,37 @@ describe("staged chat attachment pane handoff", () => {
     expect(getChatAttachmentDataUrl(fallback)).toBeNull();
     expect(current.chatAttachments).toEqual([]);
     expect(current.chatComposerFallbackByScope.fallback?.attachments).toEqual([]);
+  });
+
+  it("keeps plain staged attachments across a gateway client rotation", () => {
+    const previousOwner = {} as GatewayBrowserClient;
+    const nextOwner = {} as GatewayBrowserClient;
+    const handoff = createChatAttachmentHandoff();
+    const context = { chatAttachmentHandoff: handoff } as unknown as ApplicationContext;
+    const plainImage = storedAttachment("rotation-image");
+    const plainFile = storedAttachment("rotation-file", "application/pdf");
+    const annotated: ChatAttachment = {
+      ...storedAttachment("rotation-annotation"),
+      browserAnnotation: { pageUrl: "https://example.test" } as never,
+    };
+    const current = state([plainImage, plainFile, annotated]);
+
+    const returned = replacePaneStagedAttachmentGatewayOwner(
+      context,
+      "p1",
+      current,
+      previousOwner,
+      nextOwner,
+    );
+
+    expect(returned).toBe(nextOwner);
+    // Plain payloads are client-local; rotation must not silently discard them.
+    expect(current.chatAttachments).toEqual([plainImage, plainFile]);
+    expect(getChatAttachmentDataUrl(plainImage)).not.toBeNull();
+    expect(getChatAttachmentDataUrl(plainFile)).not.toBeNull();
+    // Annotation Undo context dies with the old client; its payload is released.
+    expect(getChatAttachmentDataUrl(annotated)).toBeNull();
+    discardStateStagedAttachments(current);
   });
 
   it("restores a mixed package only to the exact mounted owner", () => {

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -97,10 +97,21 @@ export function replacePaneStagedAttachmentGatewayOwner(
   if (!nextOwner || previousOwner === nextOwner) {
     return previousOwner;
   }
-  discardStateStagedAttachments(state);
-  state?.requestUpdate?.();
+  // Rotating the client invalidates annotation Undo context owned by the old
+  // client, but plain file/image payloads are client-local data URLs — a gap
+  // reconnect or plugin-install rotation must not silently discard them.
+  if (state) {
+    const dropAnnotations = (attachments: readonly ChatAttachment[]) => {
+      releaseAttachments(attachments.filter((attachment) => attachment.browserAnnotation));
+      return attachments.filter((attachment) => !attachment.browserAnnotation);
+    };
+    state.chatAttachments = dropAnnotations(state.chatAttachments);
+    for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
+      fallback.attachments = dropAnnotations(fallback.attachments);
+    }
+    state.requestUpdate?.();
+  }
   context.chatAttachmentHandoff.clearPane(paneId);
-  // Rotating the token also invalidates any pending annotation Undo owned by the old client.
   return nextOwner;
 }
 

--- a/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
@@ -403,11 +403,13 @@ describe("staged attachment composer adoption", () => {
       phase: "reconnecting",
       hello: null,
     });
-    expect(state.chatAttachments).toEqual([]);
-    expect(state.chatComposerFallbackByScope.fallback?.attachments).toEqual([]);
+    // Rotation invalidates annotation-backed attachments only; plain payloads
+    // are client-local and survive (live state and fallbacks alike).
+    expect(state.chatAttachments).toEqual([ordinary]);
+    expect(state.chatComposerFallbackByScope.fallback?.attachments).toEqual([ordinary]);
     expect(getChatAttachmentDataUrl(current)).toBeNull();
     expect(getChatAttachmentDataUrl(fallback)).toBeNull();
-    expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
+    expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
   });
 
   it("discards a staged package captured without a client when the first client arrives", () => {
@@ -433,9 +435,9 @@ describe("staged attachment composer adoption", () => {
       hello: null,
     });
 
-    expect(state.chatAttachments).toEqual([]);
+    expect(state.chatAttachments).toEqual([ordinary]);
     expect(getChatAttachmentDataUrl(annotation)).toBeNull();
-    expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
+    expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
   });
 
   it("invalidates annotation Undo when the logical Gateway client is replaced", async () => {
@@ -474,9 +476,9 @@ describe("staged attachment composer adoption", () => {
     });
     toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
 
-    expect(state.chatAttachments).toEqual([]);
+    expect(state.chatAttachments).toEqual([ordinary]);
     expect(getChatAttachmentDataUrl(annotation)).toBeNull();
-    expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
+    expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
     toastHost.remove();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`replacePaneStagedAttachmentGatewayOwner` discarded **every** staged composer attachment whenever the gateway client object rotated. The client rotates on event-gap recovery (`onGap` → `connect()` mints a new `GatewayBrowserClient` — the normal laptop sleep/wake path) and after plugin install/enable (`plugins-page.ts` calls `gateway.connect()`), not just on real credential changes. Draft text survives rotation; attachments silently vanish. A user who staged screenshots, slept the laptop, and hit send delivers a text-only message with no error and no recorded reason — silent failure, the worst bug class.

## Why This Change Was Made

The discard's own justification comment ("Rotating the token also invalidates any pending annotation Undo owned by the old client") only applies to browser-annotation attachments, whose Undo context genuinely dies with the old client. Plain file/image attachments are client-local base64 data URLs in the payload store with zero dependency on the gateway client. The mechanism conflated the two. Rotation now releases and drops only annotation-backed attachments (live state and memory fallbacks alike) and keeps the rest; pane-close/handoff discard paths are unchanged.

## User Impact

Staged files and images survive sleep/wake reconnects and plugin installs instead of silently disappearing from the composer.

## Evidence

- New regression test "keeps plain staged attachments across a gateway client rotation" (chat-pane-attachment-handoff.test.ts): fails pre-fix (all attachments discarded), passes post-fix; asserts plain payloads retained, annotation payload released.
- Full handoff suite 7/7 green; chat-pane-lifecycle suite green; `pnpm tsgo:ui` clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99 correctness.
- Production LOC: +14/−3 (selective filter replacing wholesale discard; shared `dropAnnotations` closure covers live + fallback state).

AI-assisted: yes (autonomous QA campaign; autoreview workflow).
