### PR TITLE
fix(acp): use octet_length and Buffer.byteLength for UTF-8 byte budget

### DIFF
--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -227,10 +227,10 @@ describe("ACP event ledger", () => {
         const groundTruth = db
           .prepare(
             `SELECT
-               (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(cwd) + 32), 0)
+               (SELECT COALESCE(SUM(octet_length(session_id) + octet_length(session_key) + octet_length(cwd) + 32), 0)
                   FROM acp_replay_sessions)
-             + (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(update_json)
-                   + COALESCE(length(run_id), 0) + 32), 0)
+             + (SELECT COALESCE(SUM(octet_length(session_id) + octet_length(session_key) + octet_length(update_json)
+                   + COALESCE(octet_length(run_id), 0) + 32), 0)
                   FROM acp_replay_events) AS total`,
           )
           .get() as { total: number | bigint };
@@ -395,6 +395,58 @@ describe("ACP event ledger", () => {
     expect(replay.complete).toBe(true);
     expect(replay.sessionKey).toBe("acp:new-session");
     expect(replay.events).toEqual([]);
+  });
+
+  it("counts UTF-8 bytes instead of characters for multi-byte content", async () => {
+    await withTestDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const databasePath = path.join(dir, "openclaw.sqlite");
+      // Use a budget tight enough that byte-count accuracy matters.
+      const ledger = createSqliteAcpEventLedger({
+        path: databasePath,
+        maxSerializedBytes: 512,
+      });
+      await ledger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
+      });
+      // CJK characters: 2 chars but 6 UTF-8 bytes each.
+      await ledger.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "\u4f60\u597d".repeat(100) },
+        },
+      });
+
+      const { DatabaseSync } = requireNodeSqlite();
+      const db = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        const aggregate = db
+          .prepare(
+            "SELECT COALESCE(SUM(estimated_bytes), 0) AS total FROM acp_replay_sessions",
+          )
+          .get() as { total: number | bigint };
+        const groundTruth = db
+          .prepare(
+            `SELECT
+               (SELECT COALESCE(SUM(octet_length(session_id) + octet_length(session_key) + octet_length(cwd) + 32), 0)
+                  FROM acp_replay_sessions)
+             + (SELECT COALESCE(SUM(octet_length(session_id) + octet_length(session_key) + octet_length(update_json)
+                   + COALESCE(octet_length(run_id), 0) + 32), 0)
+                  FROM acp_replay_events) AS total`,
+          )
+          .get() as { total: number | bigint };
+        // The aggregate must match ground truth computed with octet_length.
+        expect(Number(aggregate.total)).toBe(Number(groundTruth.total));
+        // The aggregate must stay within the byte budget.
+        expect(Number(aggregate.total)).toBeLessThanOrEqual(512);
+      } finally {
+        db.close();
+      }
+    });
   });
 
   it("marks replay incomplete when serialized byte retention trims payloads", async () => {

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -138,11 +138,11 @@ function upsertSqliteSession(
     // unbound the byte budget.
     db.prepare(
       `UPDATE acp_replay_sessions
-          SET estimated_bytes = estimated_bytes - length(session_key) - length(cwd) + ?,
+          SET estimated_bytes = estimated_bytes - octet_length(session_key) - octet_length(cwd) + ?,
               session_key = ?, cwd = ?, complete = ?, updated_at = ?
         WHERE session_id = ?`,
     ).run(
-      params.sessionKey.length + cwd.length,
+      Buffer.byteLength(params.sessionKey, "utf8") + Buffer.byteLength(cwd, "utf8"),
       params.sessionKey,
       cwd,
       complete,
@@ -220,7 +220,12 @@ function estimateSessionRowBytes(params: {
   sessionKey: string;
   cwd: string;
 }): number {
-  return params.sessionId.length + params.sessionKey.length + params.cwd.length + 32;
+  return (
+    Buffer.byteLength(params.sessionId, "utf8") +
+    Buffer.byteLength(params.sessionKey, "utf8") +
+    Buffer.byteLength(params.cwd, "utf8") +
+    32
+  );
 }
 
 function estimateEventRowBytes(params: {
@@ -230,10 +235,10 @@ function estimateEventRowBytes(params: {
   updateJson: string;
 }): number {
   return (
-    params.sessionId.length +
-    params.sessionKey.length +
-    params.updateJson.length +
-    (params.runId?.length ?? 0) +
+    Buffer.byteLength(params.sessionId, "utf8") +
+    Buffer.byteLength(params.sessionKey, "utf8") +
+    Buffer.byteLength(params.updateJson, "utf8") +
+    (params.runId ? Buffer.byteLength(params.runId, "utf8") : 0) +
     32
   );
 }
@@ -370,11 +375,11 @@ function appendSqliteUpdate(
   // expressions read the pre-update row, keeping the aggregate exact.
   db.prepare(
     `UPDATE acp_replay_sessions
-        SET estimated_bytes = estimated_bytes - length(session_key) + ?,
+        SET estimated_bytes = estimated_bytes - octet_length(session_key) + ?,
             session_key = ?, updated_at = ?, next_seq = ?
       WHERE session_id = ?`,
   ).run(
-    params.sessionKey.length + eventBytes,
+    Buffer.byteLength(params.sessionKey, "utf8") + eventBytes,
     params.sessionKey,
     now,
     session.nextSeq + 1,


### PR DESCRIPTION
## Summary

- Problem: The SQLite-backed ACP event ledger uses JavaScript `.length` (character count) and SQLite `length()` (character count) to maintain the `estimated_bytes` aggregate used for the `maxSerializedBytes` budget. For multi-byte UTF-8 content (CJK, emoji), character count is significantly smaller than byte count, silently undercounting the budget.
- Solution: Replace JavaScript `.length` with `Buffer.byteLength(str, "utf8")` and SQLite `length()` with `octet_length()` so the aggregate tracks actual UTF-8 bytes, matching the in-memory implementation which already uses `Buffer.byteLength`.
- What changed: `src/acp/event-ledger.ts` - updated `estimateSessionRowBytes`, `estimateEventRowBytes`, and both SQL UPDATE statements; `src/acp/event-ledger.test.ts` - updated ground-truth SQL to use `octet_length()` and added a regression test with CJK content.
- What did NOT change: No API changes, no schema changes, no behavioral changes for ASCII-only content.

## Real behavior proof

- **Behavior or issue addressed:** The byte budget (`maxSerializedBytes`) was undercounted for non-ASCII content, allowing the ledger to grow beyond its configured limit because `length()` returns character count, not byte count.
- **Real environment tested:** Node.js v24 with `node:sqlite` DatabaseSync, running the SQLite-backed ledger against CJK content (200 chars = 600 UTF-8 bytes).
- **Exact steps or command run after this patch:**
  ```bash
  npx vitest run src/acp/event-ledger.test.ts
  ```
- **Evidence after fix:**
  ```text
  CJK content (200 chars, 600 bytes): aggregate matches octet_length ground truth, stays within 512-byte budget
  octet_length('hello') = 5, length('hello') = 5 (ASCII: no difference)
  octet_length('你好') = 6, length('你好') = 2 (CJK: 3x undercount before fix)
  ```
- **Observed result after fix:** The maintained `estimated_bytes` aggregate now matches ground truth computed with `octet_length()`, and the byte budget correctly evicts non-ASCII content.
- **What was not tested:** did not start a live OpenClaw instance; only exercised the SQLite ledger via unit test.

## Regression Test Plan

- Coverage level: Unit test (SQLite-backed)
- Target test file: `src/acp/event-ledger.test.ts`
- Scenario locked in: CJK content (`"你好".repeat(100)`) with a tight 512-byte budget must keep the aggregate within bounds and match `octet_length()` ground truth.
- Why this is the smallest reliable guardrail: The test directly verifies that multi-byte UTF-8 content is counted in bytes, not characters.

## Root Cause

- Root cause: The SQLite implementation was written assuming `.length` and `length()` return byte counts, but both return character counts. The in-memory implementation (`event-ledger.memory.ts`) correctly uses `Buffer.byteLength`, but the SQLite implementation was never aligned.
- Missing detection / guardrail: The existing test ("keeps footprint aggregates consistent") used ASCII-only content and a ground-truth SQL that also used `length()`, so the character-vs-byte discrepancy was invisible.