### PR TITLE
fix(shared): validate port range in parseLoopbackProxyPort bare-number branch

### DIFF
--- a/src/shared/tailscale-status.test.ts
+++ b/src/shared/tailscale-status.test.ts
@@ -133,6 +133,56 @@ describe("shared/tailscale-status", () => {
     await expect(resolveTailscaleServeGatewayUrlsWithRunner(18789, run)).resolves.toEqual([]);
   });
 
+  it("accepts a bare port number within the valid range", async () => {
+    const run = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify({
+        TCP: { "443": { HTTPS: true } },
+        Web: {
+          "mac.tail.ts.net:443": {
+            Handlers: { "/": { Proxy: "18789" } },
+          },
+        },
+      }),
+    });
+
+    await expect(resolveTailscaleServeGatewayUrlsWithRunner(18789, run)).resolves.toEqual([
+      "wss://mac.tail.ts.net:443",
+    ]);
+  });
+
+  it("rejects a bare port number outside the valid range", async () => {
+    const run = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify({
+        TCP: { "443": { HTTPS: true } },
+        Web: {
+          "mac.tail.ts.net:443": {
+            Handlers: { "/": { Proxy: "99999" } },
+          },
+        },
+      }),
+    });
+
+    await expect(resolveTailscaleServeGatewayUrlsWithRunner(99999, run)).resolves.toEqual([]);
+  });
+
+  it("rejects a bare port number of zero", async () => {
+    const run = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify({
+        TCP: { "443": { HTTPS: true } },
+        Web: {
+          "mac.tail.ts.net:443": {
+            Handlers: { "/": { Proxy: "0" } },
+          },
+        },
+      }),
+    });
+
+    await expect(resolveTailscaleServeGatewayUrlsWithRunner(0, run)).resolves.toEqual([]);
+  });
+
   it("ignores load-balanced Tailscale Services and public Funnel routes", async () => {
     const run = vi.fn().mockResolvedValue({
       code: 0,

--- a/src/shared/tailscale-status.ts
+++ b/src/shared/tailscale-status.ts
@@ -70,7 +70,8 @@ function extractTailnetHostFromStatusJson(raw: string): string | null {
 function parseLoopbackProxyPort(proxy: string): number | null {
   const trimmed = proxy.trim();
   if (/^\d+$/.test(trimmed)) {
-    return Number.parseInt(trimmed, 10);
+    const port = Number.parseInt(trimmed, 10);
+    return port >= 1 && port <= 65_535 ? port : null;
   }
   const normalized = trimmed.includes("://") ? trimmed : `http://${trimmed}`;
   try {


### PR DESCRIPTION
## Summary

- Problem: `parseLoopbackProxyPort` has two branches: a bare-number branch (line 72-73) and a URL-parsing branch (line 82-83). The URL branch validates `port >= 1 && port <= 65_535` but the bare-number branch returns `Number.parseInt(trimmed, 10)` without any range check, accepting invalid ports like 0, 99999, or negative-equivalent large numbers.
- Solution: Add the same `port >= 1 && port <= 65_535` range validation to the bare-number branch, making both branches consistent.
- What changed: `src/shared/tailscale-status.ts` - added range check to the bare-number branch; `src/shared/tailscale-status.test.ts` - added three regression tests (valid bare port, out-of-range bare port, zero bare port).
- What did NOT change: No API changes, no behavioral changes for valid ports.

## Real behavior proof

- **Behavior or issue addressed:** The bare-number branch of `parseLoopbackProxyPort` accepted out-of-range port numbers (e.g., 0, 99999), which is inconsistent with the URL-parsing branch that validates `port >= 1 && port <= 65_535`. This could allow a Tailscale Serve handler with `Proxy: "99999"` to match a misconfigured gateway port.
- **Real environment tested:** Node.js with vitest, running `resolveTailscaleServeGatewayUrlsWithRunner` against mock serve configs with bare-number proxy values.
- **Exact steps or command run after this patch:**
  ```bash
  npx vitest run src/shared/tailscale-status.test.ts
  ```
- **Evidence after fix:**
  ```text
  Proxy "18789" (valid bare port) with gatewayPort 18789 => matched, URL collected
  Proxy "99999" (out-of-range bare port) with gatewayPort 99999 => rejected, no URL
  Proxy "0" (zero bare port) with gatewayPort 0 => rejected, no URL
  ```
- **Observed result after fix:** Both branches of `parseLoopbackProxyPort` now consistently validate port range (1-65535).
- **What was not tested:** did not run against a live Tailscale instance; only exercised the parsing logic via unit test.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/shared/tailscale-status.test.ts`
- Scenario locked in: A bare port number outside the valid range (0 or 99999) is rejected even when it matches the gateway port.
- Why this is the smallest reliable guardrail: The test directly verifies the range check that was missing from the bare-number branch.

## Root Cause

- Root cause: The function was written with two branches that handle different proxy string formats (bare number vs URL). The URL branch was carefully validated but the bare-number branch was overlooked, creating an inconsistency in port validation.
- Missing detection / guardrail: No test exercised the bare-number branch with out-of-range values, so the inconsistency was invisible.