### PR TITLE
fix(cli): guard against NaN in health-route timeout parsing

### DIFF
--- a/src/cli/gateway-cli/health-route.test.ts
+++ b/src/cli/gateway-cli/health-route.test.ts
@@ -126,6 +126,32 @@ describe("runGatewayHealthJsonRoute", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("falls back to default timeout when rpc.timeout is non-numeric", async () => {
+    const runtime = createRuntime();
+    const error = new Error("gateway unavailable");
+    const callGateway = vi.fn(async () => {
+      throw error;
+    });
+    const emitReachableGatewayAuthDiagnostic = vi.fn(async () => false);
+
+    await runGatewayHealthJsonRoute(
+      { rpc: { json: true, timeout: "not-a-number" } },
+      runtime as never,
+      {
+        callGateway,
+        readBestEffortConfig: async () => ({}),
+        emitReachableGatewayAuthDiagnostic: emitReachableGatewayAuthDiagnostic as never,
+        formatGatewayAuthErrorJson: vi.fn(() => null) as never,
+        formatGatewayClientRequestErrorJson: vi.fn(() => null) as never,
+        formatGatewayTransportErrorJson: vi.fn(() => null) as never,
+      },
+    );
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 10_000 }),
+    );
+  });
+
   it("preserves structured auth errors when reachability is unknown", async () => {
     const runtime = createRuntime();
     const error = new Error("gateway health requires credentials");

--- a/src/cli/gateway-cli/health-route.ts
+++ b/src/cli/gateway-cli/health-route.ts
@@ -83,11 +83,12 @@ export async function runGatewayHealthJsonRoute(
     if (!emitReachableGatewayAuthDiagnostic || !readBestEffortConfig) {
       throw error;
     }
+    const parsedTimeout = Number(rpc.timeout ?? "10000");
     const handled = await emitReachableGatewayAuthDiagnostic({
       error,
       config: rpc.config ?? (await readBestEffortConfig()),
       runtime,
-      timeoutMs: Number(rpc.timeout ?? "10000"),
+      timeoutMs: Number.isFinite(parsedTimeout) ? parsedTimeout : 10_000,
       token: rpc.token,
       password: rpc.password,
       localPortOverride: rpc.localPortOverride,


### PR DESCRIPTION
## Summary

- Problem: `Number(rpc.timeout ?? "10000")` at line 90 produces `NaN` when `rpc.timeout` is a non-numeric string (e.g., `"abc"`). The `??` operator only catches `null`/`undefined`, so `NaN` propagates to `emitReachableGatewayAuthDiagnostic` as `timeoutMs`.
- Solution: Parse the timeout first, then fall back to `10_000` when `Number.isFinite()` returns false, ensuring the diagnostic always receives a valid timeout.
- What changed: `src/cli/gateway-cli/health-route.ts` - added `Number.isFinite()` guard; `src/cli/gateway-cli/health-route.test.ts` - added regression test with non-numeric timeout.
- What did NOT change: No API changes, no behavioral changes for valid timeout strings.

## Real behavior proof

- **Behavior or issue addressed:** A non-numeric `rpc.timeout` string (e.g., `"not-a-number"`) caused `Number()` to return `NaN`, which was passed as `timeoutMs` to `emitReachableGatewayAuthDiagnostic`, potentially causing undefined behavior in the diagnostic flow.
- **Real environment tested:** Node.js with vitest, running `runGatewayHealthJsonRoute` with `rpc.timeout: "not-a-number"` and a mocked `emitReachableGatewayAuthDiagnostic`.
- **Exact steps or command run after this patch:**
  ```bash
  npx vitest run src/cli/gateway-cli/health-route.test.ts
  ```
- **Evidence after fix:**
  ```text
  rpc.timeout = "not-a-number" => Number("not-a-number") = NaN => fallback to 10_000
  rpc.timeout = "10000" => Number("10000") = 10000 => used as-is
  rpc.timeout = undefined => Number("10000") = 10000 => used as-is
  ```
- **Observed result after fix:** `emitReachableGatewayAuthDiagnostic` receives `timeoutMs: 10_000` when `rpc.timeout` is non-numeric, matching the intended default.
- **What was not tested:** did not start a live gateway; only exercised the error path via unit test.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/cli/gateway-cli/health-route.test.ts`
- Scenario locked in: `rpc.timeout: "not-a-number"` causes `emitReachableGatewayAuthDiagnostic` to be called with `timeoutMs: 10_000`.
- Why this is the smallest reliable guardrail: The test directly verifies the NaN fallback that was missing.

## Root Cause

- Root cause: The `??` (nullish coalescing) operator only catches `null` and `undefined`, but `Number()` returns `NaN` for non-numeric strings, which is a valid number type that `??` does not intercept.
- Missing detection / guardrail: No test exercised the error path with a non-numeric timeout string, so the NaN propagation was invisible.