### PR TITLE
fix(together): validate video dimension range in video-generation-provider

### DIFF
--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -426,4 +426,53 @@ describe("together video generation provider", () => {
     expect(media.reference_images).toHaveLength(1);
     expect(body).not.toHaveProperty("reference_images");
   });
+
+  it("rejects video dimensions outside the valid range", async () => {
+    const provider = buildTogetherVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "together",
+        model: "Wan-AI/Wan2.2-T2V-A14B",
+        prompt: "test",
+        cfg: {},
+        size: "99999x99999",
+      }),
+    ).rejects.toThrow(/out of range/i);
+  });
+
+  it("accepts valid video dimensions within range", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({
+        id: "video_456",
+        status: "in_progress",
+      }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          id: "video_456",
+          status: "completed",
+          outputs: { video_url: "https://example.com/together2.mp4" },
+        }),
+      })
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+      });
+
+    const provider = buildTogetherVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "together",
+      model: "Wan-AI/Wan2.2-T2V-A14B",
+      prompt: "test",
+      cfg: {},
+      size: "1280x720",
+    });
+
+    const request = requireFirstPostJsonRequest(postJsonRequestMock, "Together request");
+    const body = requireRecord(request.body, "Together request body");
+    expect(body.width).toBe(1280);
+    expect(body.height).toBe(720);
+  });
 });

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -37,6 +37,8 @@ const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 120;
 const TOGETHER_MIN_DURATION_SECONDS = 1;
 const TOGETHER_MAX_DURATION_SECONDS = 10;
+const TOGETHER_MIN_VIDEO_DIMENSION = 1;
+const TOGETHER_MAX_VIDEO_DIMENSION = 8192;
 
 type TogetherVideoResponse = {
   id?: string;
@@ -234,8 +236,21 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
       if (size) {
         const match = /^(\d+)x(\d+)$/u.exec(size);
         if (match) {
-          body.width = Number.parseInt(match[1] ?? "", 10);
-          body.height = Number.parseInt(match[2] ?? "", 10);
+          const width = asSafeIntegerInRange(Number.parseInt(match[1] ?? "", 10), {
+            min: TOGETHER_MIN_VIDEO_DIMENSION,
+            max: TOGETHER_MAX_VIDEO_DIMENSION,
+          });
+          const height = asSafeIntegerInRange(Number.parseInt(match[2] ?? "", 10), {
+            min: TOGETHER_MIN_VIDEO_DIMENSION,
+            max: TOGETHER_MAX_VIDEO_DIMENSION,
+          });
+          if (width === undefined || height === undefined) {
+            throw new Error(
+              `Together video size "${size}" is out of range; each dimension must be between ${TOGETHER_MIN_VIDEO_DIMENSION} and ${TOGETHER_MAX_VIDEO_DIMENSION} pixels.`,
+            );
+          }
+          body.width = width;
+          body.height = height;
         }
       }
       if (req.inputImages?.[0]) {


### PR DESCRIPTION
## Summary

- Problem: `video-generation-provider.ts` parses video dimensions from a `size` string like `"1280x720"` using `Number.parseInt` without any range validation. Extremely large values like `"99999x99999"` are accepted and sent to the Together API, which could cause server-side errors or excessive resource allocation.
- Solution: Use `asSafeIntegerInRange` (already imported and used for duration validation) to validate each dimension is between 1 and 8192 pixels, throwing a descriptive error if out of range.
- What changed: `extensions/together/video-generation-provider.ts` - added dimension range constants and validation; `extensions/together/video-generation-provider.test.ts` - added tests for valid and out-of-range dimensions.
- What did NOT change: No API changes, no behavioral changes for valid dimension values.

## Real behavior proof

- **Behavior or issue addressed:** Unbounded video dimensions (e.g., `"99999x99999"`) were accepted and forwarded to the Together API without validation, potentially causing server-side errors or rejected requests with unhelpful error messages.
- **Real environment tested:** Node.js with vitest, running `generateVideo` with `"99999x99999"` and `"1280x720"` size values.
- **Exact steps or command run after this patch:**
  ```bash
  npx vitest run extensions/together/video-generation-provider.test.ts
  ```
- **Evidence after fix:**
  ```text
  size "99999x99999" => throws "Together video size "99999x99999" is out of range..."
  size "1280x720" => body.width=1280, body.height=720 (accepted)
  size undefined => no width/height set (unchanged)
  ```
- **Observed result after fix:** Out-of-range dimensions are rejected with a clear error message before the API call is made.
- **What was not tested:** did not make a live Together API call; only exercised the validation logic via unit test.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `extensions/together/video-generation-provider.test.ts`
- Scenario locked in: `size: "99999x99999"` causes `generateVideo` to reject with `/out of range/i`; `size: "1280x720"` is accepted and passed through.
- Why this is the smallest reliable guardrail: The test directly verifies the range check that was missing.

## Root Cause

- Root cause: The size parsing code was written to handle the happy path (valid dimension strings) but did not account for extremely large values that exceed practical video resolution limits.
- Missing detection / guardrail: No test exercised the size parsing with out-of-range values, so the unbounded parsing was invisible.