### PR TITLE
fix(claws): wrap JSON.parse in rowToRef with descriptive error

### DIFF
--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateCronAddParams } from "../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseForTest, openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { installClawCronJobs, readClawCronRefs } from "./cron.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { parseClawManifest } from "./schema.js";
@@ -221,5 +221,22 @@ describe("installClawCronJobs", () => {
     expect(jobs.size).toBe(1);
     expect(first[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
     expect(second[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
+  });
+
+  it("throws a descriptive error when job_json is corrupted", async () => {
+    const current = await fixture();
+    const add = vi.fn(async () => ({ created: true, job: { id: "scheduler-1" } }));
+    await installClawCronJobs(current.plan, { env: current.env, gateway: { add } });
+    closeOpenClawStateDatabaseForTest();
+
+    const database = openOpenClawStateDatabase({ env: current.env });
+    database.db
+      .prepare("UPDATE claw_cron_refs SET job_json = ? WHERE agent_id = ?")
+      .run("not-valid-json", "worker-two");
+    closeOpenClawStateDatabaseForTest();
+
+    expect(() => readClawCronRefs("worker-two", { env: current.env })).toThrow(
+      /Failed to parse cron job JSON/i,
+    );
   });
 });

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -59,6 +59,14 @@ export class ClawCronInstallError extends Error {
 }
 
 function rowToRef(row: CronRefRow): PersistedClawCronRef {
+  let job: ClawCronJob;
+  try {
+    job = JSON.parse(row.job_json) as ClawCronJob;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse cron job JSON for agent ${row.agent_id}, declaration ${row.declaration_key}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   return {
     schemaVersion: CLAW_CRON_REF_SCHEMA_VERSION,
     agentId: row.agent_id,
@@ -66,7 +74,7 @@ function rowToRef(row: CronRefRow): PersistedClawCronRef {
     declarationKey: row.declaration_key,
     ...(row.scheduler_job_id ? { schedulerJobId: row.scheduler_job_id } : {}),
     status: row.status,
-    job: JSON.parse(row.job_json) as ClawCronJob,
+    job,
     ...(row.error ? { error: row.error } : {}),
     createdAtMs: Number(row.created_at_ms),
     updatedAtMs: Number(row.updated_at_ms),


### PR DESCRIPTION
## Summary

- Problem: `rowToRef` in `cron.ts` calls `JSON.parse(row.job_json)` without a try/catch. If the `job_json` column is corrupted in the SQLite database, a raw `SyntaxError` propagates with no context about which cron ref or agent is affected.
- Solution: Wrap `JSON.parse` in a try/catch and throw a descriptive `Error` that includes the agent ID and declaration key for debugging.
- What changed: `src/claws/cron.ts` - added try/catch with descriptive error; `src/claws/cron.test.ts` - added regression test that corrupts `job_json` and verifies the error message.
- What did NOT change: No API changes, no behavioral changes for valid JSON.

## Real behavior proof

- **Behavior or issue addressed:** A corrupted `job_json` value in the `claw_cron_refs` table caused an opaque `SyntaxError` with no indication of which agent or cron declaration was affected, making database recovery difficult.
- **Real environment tested:** Node.js with vitest, using SQLite-backed cron refs with a corrupted `job_json` column.
- **Exact steps or command run after this patch:**
  ```bash
  npx vitest run src/claws/cron.test.ts
  ```
- **Evidence after fix:**
  ```text
  job_json = "not-valid-json" => throws "Failed to parse cron job JSON for agent worker-two, declaration claw:worker-two:daily-report: ..."
  job_json = '{"id":"daily-report"}' => parsed successfully
  ```
- **Observed result after fix:** The error message now identifies the agent and declaration key, making it easy to locate and repair the corrupted row.
- **What was not tested:** did not test against a live cron scheduler; only exercised the parsing logic via unit test.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/claws/cron.test.ts`
- Scenario locked in: Corrupting `job_json` to `"not-valid-json"` causes `readClawCronRefs` to throw an error matching `/Failed to parse cron job JSON/i`.
- Why this is the smallest reliable guardrail: The test directly verifies the descriptive error wrapping that was missing.

## Root Cause

- Root cause: The `rowToRef` function was written to parse `job_json` assuming the database always contains valid JSON, but database corruption (partial writes, schema migrations, manual edits) can produce invalid JSON.
- Missing detection / guardrail: No test exercised the corrupted-JSON path, so the raw SyntaxError propagation was invisible.