### PR TITLE
fix(ci): record startup JS growth in the Control UI budget baseline

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 329483,
-  "reason": "cumulative chat/session UI growth (#122296, #122713, #122870, #122876); CI-measured build-artifacts bytes",
-  "updatedAt": "2026-08-13"
+  "startupJsGzipBytes": 330513,
+  "reason": "config-form draft/JSON preservation guards (#123502); CI-measured build-artifacts bytes",
+  "updatedAt": "2026-08-14"
 }


### PR DESCRIPTION
## What Problem This Solves

`build-artifacts` is red on `main` (run 31797901898 at c3ae887f465, and every open PR's merge-ref build): the Control UI startup-JS gzip check reports `startup JS gzip: 322.8 KiB exceeds 322.8 KiB (330512 B vs 330507 B)` — 5 bytes over the 329483 B baseline + 1024 B tolerance.

## Why This Change Was Made

The config-form draft/JSON preservation fix #123502 added a small amount of startup-bundle code, consuming the last of the tolerance headroom. The growth is legitimate (it ships a real bug fix), so per the checker's own contract the baseline records the CI-measured bytes: 330513 B (the freshest merge-ref build; `main` itself measured 330512 B — 1 byte of gzip jitter between builds). Delta over the previous baseline is 1030 B, within the 4096 B ratchet and far below the 358400 B committed cap. Same fix class and shape as add6b20bd28 and d699ed01986.

## User Impact

None at runtime. Restores green `build-artifacts` on `main` and unblocks every open PR's CI (including #123633, where this failure surfaced).

## Evidence

- Red main: run 31797901898 (`build-artifacts`, c3ae887f465) — `330512 B vs 330507 B` violation; prior main run 31796884793 (37a63bf) had build-artifacts green, isolating the growth to c3ae887f465 (#123502), the only startup-bundle-touching commit in the window.
- Same violation on PR merge-ref builds: #123633 run 31798273737 measured 330513 B.
- Baseline update follows `scripts/check-control-ui-performance.mts` policy: CI bytes (local zlib emits smaller streams), ratchet-checked, reason recorded.
