### PR TITLE
fix(codex): refresh session meters after /codex compact

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -505,6 +505,7 @@ Keep provider refs and runtime policy separate:
 | Resume a stored Codex CLI session as a paired-node turn    | `/codex sessions --host <node> [filter]`, then `/codex resume <session-id> --host <node> --bind here` |
 | View non-archived Codex sessions across computers          | Enable Codex supervision and open **Codex Sessions**                                                  |
 | Change the bound thread's model, fast-mode, or permissions | `/codex model <model>`, `/codex fast [on\|off\|status]`, `/codex permissions [default\|yolo\|status]` |
+| Compact the current Codex session                          | `/codex compact`                                                                                      |
 | Stop or steer the active turn                              | `/codex stop`, `/codex steer <text>`                                                                  |
 | Detach the current binding                                 | `/codex detach` (alias `/codex unbind`)                                                               |
 | Send Codex feedback only                                   | `/codex diagnostics [note]`                                                                           |
@@ -728,7 +729,9 @@ Common forms:
 - `/codex stop` stops the active turn; `/codex steer <text>` steers it.
 - `/codex model <model>`, `/codex fast [on|off|status]`, and
   `/codex permissions [default|yolo|status]` change per-conversation state.
-- `/codex compact` asks Codex app-server to compact the attached thread.
+- `/codex compact` runs the same completion and session-accounting pipeline as
+  `/compact`, then reports whether Codex compacted the session and the resulting
+  token count. If compaction is skipped or fails, the reply includes the reason.
 - `/codex review` starts Codex native review for the attached thread.
 - `/codex diagnostics [note]` asks before sending Codex feedback for the
   attached thread.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -143,11 +143,13 @@ return {
 };
 ```
 
-The capability is absent when no current session is bound. Do not retain the
-callback beyond the command invocation or reconstruct compaction with session
-store patches and harness calls. The result contains `compacted`, optional
-`reason`, and optional `tokensBefore` and `tokensAfter` snapshots; OpenClaw owns
-all persistence and lifecycle coordination.
+This general capability is available to every plugin command, not only Codex.
+The host gates it to the current invocation and exact bound session generation.
+The capability is absent when no current session is bound; a retained callback
+fails closed after the handler settles. Do not retain it or reconstruct
+compaction with session-store patches and harness calls. The result contains
+`compacted`, optional `reason`, and optional `tokensBefore` and `tokensAfter`
+snapshots; OpenClaw owns all persistence and lifecycle coordination.
 
 ## Runtime namespaces
 

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -121,6 +121,34 @@ return {
 Use `openclaw/plugin-sdk/pair-loop-guard-runtime` directly only for custom
 two-party event loops that do not go through the shared inbound reply runner.
 
+## Plugin command runtime helpers
+
+Plugin command handlers receive request-bound capabilities through
+`ctx.runtimeContext`. When the command is bound to a current session,
+`ctx.runtimeContext.compactCurrent()` runs the same manual compaction
+pipeline as `/compact`, including native agent-harness completion and session
+token accounting:
+
+```typescript
+const compactCurrent = ctx.runtimeContext?.compactCurrent;
+if (!compactCurrent) {
+  return { text: "This command needs a bound session." };
+}
+
+const result = await compactCurrent();
+return {
+  text: result.compacted
+    ? `Compacted to ${result.tokensAfter ?? "an unknown number of"} tokens.`
+    : `Compaction did not complete: ${result.reason ?? "unknown reason"}.`,
+};
+```
+
+The capability is absent when no current session is bound. Do not retain the
+callback beyond the command invocation or reconstruct compaction with session
+store patches and harness calls. The result contains `compacted`, optional
+`reason`, and optional `tokensBefore` and `tokensAfter` snapshots; OpenClaw owns
+all persistence and lifecycle coordination.
+
 ## Runtime namespaces
 
 <AccordionGroup>

--- a/extensions/codex/src/app-server/capabilities.ts
+++ b/extensions/codex/src/app-server/capabilities.ts
@@ -9,7 +9,6 @@ export const CODEX_CONTROL_METHODS = {
   installedApps: "app/installed",
   listApps: "app/list",
   readApps: "app/read",
-  compact: "thread/compact/start",
   feedback: "feedback/upload",
   forkThread: "thread/fork",
   listHooks: "hooks/list",

--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -425,6 +425,14 @@ export async function startThreadAction(
   if (args.length > 0) {
     return `Usage: /codex ${kind}`;
   }
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
+    return `Cannot start Codex ${kind === "compact" ? "compaction" : "review"} because this command did not include a stable binding identity.`;
+  }
+  const binding = await deps.bindingStore.read(target.identity);
+  if (!binding?.threadId) {
+    return `No Codex thread is attached to this OpenClaw session yet.`;
+  }
   if (kind === "compact") {
     const compactCurrent = ctx.runtimeContext?.compactCurrent;
     if (!compactCurrent) {
@@ -434,14 +442,6 @@ export async function startThreadAction(
     return result.compacted
       ? `Compacted Codex session (${result.tokensAfter ?? "unknown"} tokens after).`
       : `Codex compaction did not complete: ${formatCodexDisplayText(result.reason ?? "no reason returned")}.`;
-  }
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
-    return "Cannot start Codex review because this command did not include a stable binding identity.";
-  }
-  const binding = await deps.bindingStore.read(target.identity);
-  if (!binding?.threadId) {
-    return `No Codex thread is attached to this OpenClaw session yet.`;
   }
   const connection = resolveCodexBindingAppServerConnection({
     binding,

--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -1,4 +1,7 @@
-import { MODEL_SELECTION_LOCKED_MESSAGE } from "openclaw/plugin-sdk/model-session-runtime";
+import {
+  MODEL_SELECTION_LOCKED_MESSAGE,
+  resolvePersistedSessionRuntimeId,
+} from "openclaw/plugin-sdk/model-session-runtime";
 import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -436,13 +439,35 @@ export async function startThreadAction(
     return `No Codex thread is attached to this OpenClaw session yet.`;
   }
   if (kind === "compact") {
+    const sessionTarget = ctx.sessionTarget;
+    if (
+      !ctx.sessionId ||
+      !ctx.sessionKey ||
+      !sessionTarget ||
+      sessionTarget.sessionId !== ctx.sessionId ||
+      sessionTarget.sessionKey !== ctx.sessionKey
+    ) {
+      return "Codex compaction is unavailable because this command is not bound to a complete session identity.";
+    }
+    const currentSession = getSessionEntry({
+      storePath: sessionTarget.storePath,
+      sessionKey: ctx.sessionKey,
+      hydrateSkillPromptRefs: false,
+      readConsistency: "latest",
+    });
+    if (
+      currentSession?.sessionId !== ctx.sessionId ||
+      resolvePersistedSessionRuntimeId(currentSession) !== "codex"
+    ) {
+      return "Codex compaction is unavailable because the current OpenClaw session is not using the Codex runtime.";
+    }
     if (target.identity.kind === "conversation") {
       const sessionBinding = ctx.sessionId
         ? await deps.bindingStore.read(
             sessionBindingIdentity({
               sessionId: ctx.sessionId,
               sessionKey: ctx.sessionKey,
-              agentId: resolveCodexConversationControlScope(ctx).agentId,
+              agentId: sessionTarget.agentId,
               config: ctx.config,
             }),
           )

--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -9,6 +9,8 @@ import {
   resolveCodexNativeExecutionBlock,
   resolveCodexNativeSandboxBlock,
 } from "./app-server/sandbox-guard.js";
+import { sessionBindingIdentity } from "./app-server/session-binding.js";
+import { isSameCodexAppServerThreadOwner } from "./app-server/thread-ownership.js";
 import { canMutateCodexHost } from "./command-authorization.js";
 import { formatCodexDisplayText, formatComputerUseStatus } from "./command-formatters.js";
 import {
@@ -434,6 +436,21 @@ export async function startThreadAction(
     return `No Codex thread is attached to this OpenClaw session yet.`;
   }
   if (kind === "compact") {
+    if (target.identity.kind === "conversation") {
+      const sessionBinding = ctx.sessionId
+        ? await deps.bindingStore.read(
+            sessionBindingIdentity({
+              sessionId: ctx.sessionId,
+              sessionKey: ctx.sessionKey,
+              agentId: resolveCodexConversationControlScope(ctx).agentId,
+              config: ctx.config,
+            }),
+          )
+        : undefined;
+      if (!isSameCodexAppServerThreadOwner(binding, sessionBinding)) {
+        return "Codex compaction is unavailable because the conversation-bound thread differs from the current session binding. Resume that thread into the session first.";
+      }
+    }
     const compactCurrent = ctx.runtimeContext?.compactCurrent;
     if (!compactCurrent) {
       return "Codex compaction is unavailable because this command is not bound to a session.";

--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -422,13 +422,22 @@ export async function startThreadAction(
   kind: "compact" | "review",
   args: string[],
 ): Promise<string> {
-  const label = kind === "compact" ? "compaction" : "review";
   if (args.length > 0) {
-    return `Usage: /codex ${label === "compaction" ? "compact" : label}`;
+    return `Usage: /codex ${kind}`;
+  }
+  if (kind === "compact") {
+    const compactCurrent = ctx.runtimeContext?.compactCurrent;
+    if (!compactCurrent) {
+      return "Codex compaction is unavailable because this command is not bound to a session.";
+    }
+    const result = await compactCurrent();
+    return result.compacted
+      ? `Compacted Codex session (${result.tokensAfter ?? "unknown"} tokens after).`
+      : `Codex compaction did not complete: ${formatCodexDisplayText(result.reason ?? "no reason returned")}.`;
   }
   const target = await resolveControlTarget(ctx);
   if (!target) {
-    return `Cannot start Codex ${label} because this command did not include a stable binding identity.`;
+    return "Cannot start Codex review because this command did not include a stable binding identity.";
   }
   const binding = await deps.bindingStore.read(target.identity);
   if (!binding?.threadId) {
@@ -441,10 +450,8 @@ export async function startThreadAction(
   });
   await deps.codexControlRequest(
     pluginConfig,
-    kind === "compact" ? CODEX_CONTROL_METHODS.compact : CODEX_CONTROL_METHODS.review,
-    kind === "review"
-      ? { threadId: binding.threadId, target: { type: "uncommittedChanges" } }
-      : { threadId: binding.threadId },
+    CODEX_CONTROL_METHODS.review,
+    { threadId: binding.threadId, target: { type: "uncommittedChanges" } },
     {
       agentDir: target.agentDir,
       authProfileId: connection.clientAuthProfileId,
@@ -452,5 +459,5 @@ export async function startThreadAction(
       ...(connection.usesSupervisionConnection ? { startOptions: connection.appServer.start } : {}),
     },
   );
-  return `Started Codex ${label} for thread ${formatCodexDisplayText(binding.threadId)}.`;
+  return `Started Codex review for thread ${formatCodexDisplayText(binding.threadId)}.`;
 }

--- a/extensions/codex/src/command-rpc.test.ts
+++ b/extensions/codex/src/command-rpc.test.ts
@@ -73,8 +73,8 @@ describe("Codex command RPC helpers", () => {
 
     await codexControlRequest(
       {},
-      "thread/compact/start",
-      { threadId: "thread-1" },
+      "thread/list",
+      { archived: false },
       {
         authProfileId: null,
       },

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -2849,6 +2849,10 @@ describe("codex command", () => {
   });
 
   it("escapes compaction failure reasons before chat display", async () => {
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { threadId: "thread-123", cwd: "/repo" },
+    );
     const result = await handleCodexCommand(
       createContext("compact", undefined, {
         runtimeContext: {
@@ -3076,14 +3080,19 @@ describe("codex command", () => {
     expect(installCodexComputerUse).not.toHaveBeenCalled();
   });
 
-  it("gates compaction when the command has no bound session", async () => {
+  it("requires a Codex thread binding before host compaction", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const compactCurrent = vi.fn(async () => ({ compacted: true, tokensAfter: 321 }));
 
     await expect(
-      handleCodexCommand(createContext("compact", sessionFile), { deps: createDeps() }),
+      handleCodexCommand(
+        createContext("compact", sessionFile, { runtimeContext: { compactCurrent } }),
+        { deps: createDeps() },
+      ),
     ).resolves.toEqual({
-      text: "Codex compaction is unavailable because this command is not bound to a session.",
+      text: "No Codex thread is attached to this OpenClaw session yet.",
     });
+    expect(compactCurrent).not.toHaveBeenCalled();
   });
 
   it("asks before sending diagnostics feedback for the attached Codex thread", async () => {

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -195,7 +195,7 @@ function supervisedTestBinding(threadId = "thread-supervised"): CodexAppServerTh
 
 async function createLockedSessionContextOverrides(
   sessionKey = "agent:main:test:locked",
-): Promise<Pick<PluginCommandContext, "config" | "sessionKey">> {
+): Promise<{ config: PluginCommandContext["config"]; sessionKey: string }> {
   const storePath = path.join(tempDir, "locked-sessions.json");
   await upsertSessionEntry({
     storePath,
@@ -210,6 +210,30 @@ async function createLockedSessionContextOverrides(
   return {
     config: { session: { store: storePath } },
     sessionKey,
+  };
+}
+
+async function createCodexRuntimeContextOverrides(
+  sessionKey = "agent:main:test:codex-compact",
+): Promise<{
+  config: PluginCommandContext["config"];
+  sessionKey: string;
+  sessionTarget: NonNullable<PluginCommandContext["sessionTarget"]>;
+}> {
+  const storePath = path.join(tempDir, "codex-runtime-sessions.json");
+  await upsertSessionEntry({
+    storePath,
+    sessionKey,
+    entry: {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      agentHarnessId: "codex",
+    },
+  });
+  return {
+    config: { session: { store: storePath } },
+    sessionKey,
+    sessionTarget: { agentId: "main", sessionId: "session-1", sessionKey, storePath },
   };
 }
 
@@ -2735,10 +2759,12 @@ describe("codex command", () => {
 
   it("compacts the current session through the host runtime", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const runtime = await createCodexRuntimeContextOverrides();
     const identity = {
       kind: "session",
       agentId: "main",
       sessionId: "session-1",
+      sessionKey: runtime.sessionKey,
     } as const;
     await writeTestBinding(identity, {
       threadId: "thread-123",
@@ -2765,6 +2791,7 @@ describe("codex command", () => {
     await expect(
       handleCodexCommand(
         createContext("compact", sessionFile, {
+          ...runtime,
           runtimeContext: { compactCurrent },
         }),
         { deps },
@@ -2776,9 +2803,47 @@ describe("codex command", () => {
     expect(codexControlRequest).not.toHaveBeenCalled();
   });
 
-  it("rejects a conversation-bound thread that differs from the current session", async () => {
+  it("rejects a Codex binding on a non-Codex session runtime", async () => {
+    const sessionKey = "agent:main:test:mixed-runtime";
+    const storePath = path.join(tempDir, "mixed-runtime-sessions.json");
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        agentHarnessId: "openclaw",
+      },
+    });
     await writeTestBinding(
-      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { kind: "session", agentId: "main", sessionId: "session-1", sessionKey },
+      { threadId: "thread-codex", cwd: "/repo" },
+    );
+    const compactCurrent = vi.fn(async () => ({ compacted: true, tokensAfter: 321 }));
+
+    const result = await handleCodexCommand(
+      createContext("compact", undefined, {
+        config: { session: { store: storePath } },
+        sessionKey,
+        sessionTarget: { agentId: "main", sessionId: "session-1", sessionKey, storePath },
+        runtimeContext: { compactCurrent },
+      }),
+      { deps: createDeps() },
+    );
+
+    expect(result.text).toContain("not using the Codex runtime");
+    expect(compactCurrent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a conversation-bound thread that differs from the current session", async () => {
+    const runtime = await createCodexRuntimeContextOverrides();
+    await writeTestBinding(
+      {
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: runtime.sessionKey,
+      },
       { threadId: "thread-session", clientId: "client-session", cwd: "/repo" },
     );
     await writeTestBinding(
@@ -2789,6 +2854,7 @@ describe("codex command", () => {
 
     const result = await handleCodexCommand(
       createContext("compact", undefined, {
+        ...runtime,
         runtimeContext: { compactCurrent },
         getCurrentConversationBinding: async () => ({
           bindingId: "binding-1",
@@ -2837,8 +2903,14 @@ describe("codex command", () => {
   });
 
   it("starts supervised compact and review actions through the native user-home connection", async () => {
+    const runtime = await createCodexRuntimeContextOverrides();
     await writeTestBinding(
-      { kind: "session", agentId: "main", sessionId: "session-1" },
+      {
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: runtime.sessionKey,
+      },
       supervisedTestBinding(),
     );
     const codexControlRequest = vi.fn(async () => undefined);
@@ -2847,13 +2919,14 @@ describe("codex command", () => {
 
     await handleCodexCommand(
       createContext("compact", undefined, {
+        ...runtime,
         runtimeContext: {
           compactCurrent: async () => ({ compacted: true, tokensAfter: 321 }),
         },
       }),
       { deps, pluginConfig },
     );
-    await handleCodexCommand(createContext("review"), { deps, pluginConfig });
+    await handleCodexCommand(createContext("review", undefined, runtime), { deps, pluginConfig });
 
     expect(codexControlRequest).toHaveBeenCalledTimes(1);
     for (let callIndex = 0; callIndex < codexControlRequest.mock.calls.length; callIndex += 1) {
@@ -2886,12 +2959,19 @@ describe("codex command", () => {
   });
 
   it("escapes compaction failure reasons before chat display", async () => {
+    const runtime = await createCodexRuntimeContextOverrides();
     await writeTestBinding(
-      { kind: "session", agentId: "main", sessionId: "session-1" },
+      {
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: runtime.sessionKey,
+      },
       { threadId: "thread-123", cwd: "/repo" },
     );
     const result = await handleCodexCommand(
       createContext("compact", undefined, {
+        ...runtime,
         runtimeContext: {
           compactCurrent: async () => ({
             compacted: false,
@@ -3119,16 +3199,36 @@ describe("codex command", () => {
 
   it("requires a Codex thread binding before host compaction", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const runtime = await createCodexRuntimeContextOverrides();
     const compactCurrent = vi.fn(async () => ({ compacted: true, tokensAfter: 321 }));
 
     await expect(
       handleCodexCommand(
-        createContext("compact", sessionFile, { runtimeContext: { compactCurrent } }),
+        createContext("compact", sessionFile, {
+          ...runtime,
+          runtimeContext: { compactCurrent },
+        }),
         { deps: createDeps() },
       ),
     ).resolves.toEqual({
       text: "No Codex thread is attached to this OpenClaw session yet.",
     });
+    expect(compactCurrent).not.toHaveBeenCalled();
+  });
+
+  it("rejects host compaction without a complete captured session target", async () => {
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { threadId: "thread-123", cwd: "/repo" },
+    );
+    const compactCurrent = vi.fn(async () => ({ compacted: true, tokensAfter: 321 }));
+
+    const result = await handleCodexCommand(
+      createContext("compact", undefined, { runtimeContext: { compactCurrent } }),
+      { deps: createDeps() },
+    );
+
+    expect(result.text).toContain("not bound to a complete session identity");
     expect(compactCurrent).not.toHaveBeenCalled();
   });
 
@@ -4759,8 +4859,14 @@ describe("codex command", () => {
 
   it("returns sanitized command failures instead of leaking app-server errors", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const runtime = await createCodexRuntimeContextOverrides();
     await writeTestBinding(
-      { kind: "session", agentId: "main", sessionId: "session-1" },
+      {
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: runtime.sessionKey,
+      },
       { threadId: "thread-123", cwd: "/repo" },
     );
     const failure = () => {
@@ -4786,11 +4892,14 @@ describe("codex command", () => {
       ["steer keep going", createDeps({ steerCodexConversationTurn: vi.fn(failure) })],
       ["model gpt-5.4", createDeps({ setCodexConversationModel: vi.fn(failure) })],
     ] as const) {
-      expectSanitizedFailure(await handleCodexCommand(createContext(args, sessionFile), { deps }));
+      expectSanitizedFailure(
+        await handleCodexCommand(createContext(args, sessionFile, runtime), { deps }),
+      );
     }
     expectSanitizedFailure(
       await handleCodexCommand(
         createContext("compact", sessionFile, {
+          ...runtime,
           runtimeContext: { compactCurrent: vi.fn(failure) },
         }),
         { deps: createDeps() },

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -2776,6 +2776,43 @@ describe("codex command", () => {
     expect(codexControlRequest).not.toHaveBeenCalled();
   });
 
+  it("rejects a conversation-bound thread that differs from the current session", async () => {
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { threadId: "thread-session", clientId: "client-session", cwd: "/repo" },
+    );
+    await writeTestBinding(
+      { kind: "conversation", bindingId: "binding-data-1" },
+      { threadId: "thread-conversation", clientId: "client-conversation", cwd: "/repo" },
+    );
+    const compactCurrent = vi.fn(async () => ({ compacted: true, tokensAfter: 321 }));
+
+    const result = await handleCodexCommand(
+      createContext("compact", undefined, {
+        runtimeContext: { compactCurrent },
+        getCurrentConversationBinding: async () => ({
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: "/plugin",
+          channel: "test",
+          accountId: "default",
+          conversationId: "conversation",
+          boundAt: 1,
+          data: {
+            kind: "codex-app-server-session",
+            version: 2,
+            bindingId: "binding-data-1",
+            workspaceDir: "/repo",
+          },
+        }),
+      }),
+      { deps: createDeps() },
+    );
+
+    expect(result.text).toContain("conversation-bound thread differs");
+    expect(compactCurrent).not.toHaveBeenCalled();
+  });
+
   it("starts review with the generated app-server target shape", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await writeTestBinding(

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -2733,7 +2733,7 @@ describe("codex command", () => {
     });
   });
 
-  it("starts compaction for the attached Codex thread", async () => {
+  it("compacts the current session through the host runtime", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const identity = {
       kind: "session",
@@ -2756,18 +2756,24 @@ describe("codex command", () => {
     });
     const codexControlRequest = vi.fn(async () => undefined);
     const deps = createDeps({ codexControlRequest });
+    const compactCurrent = vi.fn(async () => ({
+      compacted: true,
+      tokensBefore: 900,
+      tokensAfter: 321,
+    }));
 
     await expect(
-      handleCodexCommand(createContext("compact", sessionFile), { deps }),
+      handleCodexCommand(
+        createContext("compact", sessionFile, {
+          runtimeContext: { compactCurrent },
+        }),
+        { deps },
+      ),
     ).resolves.toEqual({
-      text: "Started Codex compaction for thread thread-123.",
+      text: "Compacted Codex session (321 tokens after).",
     });
-    expect(codexControlRequest).toHaveBeenCalledWith(
-      undefined,
-      CODEX_CONTROL_METHODS.compact,
-      { threadId: "thread-123" },
-      expect.objectContaining({ config: {} }),
-    );
+    expect(compactCurrent).toHaveBeenCalledOnce();
+    expect(codexControlRequest).not.toHaveBeenCalled();
   });
 
   it("starts review with the generated app-server target shape", async () => {
@@ -2802,10 +2808,17 @@ describe("codex command", () => {
     const pluginConfig = { supervision: { enabled: true } };
     const deps = createDeps({ codexControlRequest });
 
-    await handleCodexCommand(createContext("compact"), { deps, pluginConfig });
+    await handleCodexCommand(
+      createContext("compact", undefined, {
+        runtimeContext: {
+          compactCurrent: async () => ({ compacted: true, tokensAfter: 321 }),
+        },
+      }),
+      { deps, pluginConfig },
+    );
     await handleCodexCommand(createContext("review"), { deps, pluginConfig });
 
-    expect(codexControlRequest).toHaveBeenCalledTimes(2);
+    expect(codexControlRequest).toHaveBeenCalledTimes(1);
     for (let callIndex = 0; callIndex < codexControlRequest.mock.calls.length; callIndex += 1) {
       expect(mockArg(codexControlRequest, callIndex, 3)).toMatchObject({
         authProfileId: null,
@@ -2835,15 +2848,18 @@ describe("codex command", () => {
     expect(codexControlRequest).not.toHaveBeenCalled();
   });
 
-  it("escapes started thread-action ids before chat display", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    await writeTestBinding(
-      { kind: "session", agentId: "main", sessionId: "session-1" },
-      { threadId: "thread-123 <@U123>", cwd: "/repo" },
+  it("escapes compaction failure reasons before chat display", async () => {
+    const result = await handleCodexCommand(
+      createContext("compact", undefined, {
+        runtimeContext: {
+          compactCurrent: async () => ({
+            compacted: false,
+            reason: "thread-123 <@U123>",
+          }),
+        },
+      }),
+      { deps: createDeps() },
     );
-    const result = await handleCodexCommand(createContext("compact", sessionFile), {
-      deps: createDeps(),
-    });
 
     expect(result.text).toContain("thread-123 &lt;\uff20U123&gt;");
     expect(result.text).not.toContain("<@U123>");
@@ -3060,13 +3076,13 @@ describe("codex command", () => {
     expect(installCodexComputerUse).not.toHaveBeenCalled();
   });
 
-  it("explains compaction when no Codex thread is attached", async () => {
+  it("gates compaction when the command has no bound session", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
 
     await expect(
       handleCodexCommand(createContext("compact", sessionFile), { deps: createDeps() }),
     ).resolves.toEqual({
-      text: "No Codex thread is attached to this OpenClaw session yet.",
+      text: "Codex compaction is unavailable because this command is not bound to a session.",
     });
   });
 
@@ -4719,7 +4735,6 @@ describe("codex command", () => {
       ["mcp", createDeps({ codexControlRequest: vi.fn(failure) })],
       ["skills", createDeps({ codexControlRequest: vi.fn(failure) })],
       ["resume thread-123", createDeps({ codexControlRequest: vi.fn(failure) })],
-      ["compact", createDeps({ codexControlRequest: vi.fn(failure) })],
       ["review", createDeps({ codexControlRequest: vi.fn(failure) })],
       ["stop", createDeps({ stopCodexConversationTurn: vi.fn(failure) })],
       ["steer keep going", createDeps({ steerCodexConversationTurn: vi.fn(failure) })],
@@ -4727,6 +4742,14 @@ describe("codex command", () => {
     ] as const) {
       expectSanitizedFailure(await handleCodexCommand(createContext(args, sessionFile), { deps }));
     }
+    expectSanitizedFailure(
+      await handleCodexCommand(
+        createContext("compact", sessionFile, {
+          runtimeContext: { compactCurrent: vi.fn(failure) },
+        }),
+        { deps: createDeps() },
+      ),
+    );
   });
 
   it("records an approved Codex bind intent without starting a thread", async () => {

--- a/src/auto-reply/reply/commands-compact.runtime.ts
+++ b/src/auto-reply/reply/commands-compact.runtime.ts
@@ -9,6 +9,7 @@ export {
   resolveFreshSessionTotalTokens,
   resolveSessionFilePathOptions,
 } from "../../config/sessions.js";
+export { loadSessionEntryReadOnly as readSessionEntry } from "../../config/sessions/session-accessor.js";
 export { enqueueSystemEvent } from "../../infra/system-events.js";
 export { formatContextUsageShort, formatTokenCount } from "../status.js";
 export { incrementCompactionCount } from "./session-updates.js";

--- a/src/auto-reply/reply/commands-compact.runtime.ts
+++ b/src/auto-reply/reply/commands-compact.runtime.ts
@@ -1,4 +1,20 @@
 /** Runtime facade for compact command dependencies. */
+import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
+
+export function isCurrentSessionEntry(params: {
+  agentId: string;
+  sessionKey: string;
+  storePath: string;
+  expected: Pick<SessionEntry, "sessionId" | "lifecycleRevision">;
+}): boolean {
+  const current = loadSessionEntryReadOnly(params);
+  return (
+    current?.sessionId === params.expected.sessionId &&
+    current.lifecycleRevision === params.expected.lifecycleRevision
+  );
+}
+
 export {
   abortEmbeddedAgentRun,
   compactEmbeddedAgentSession,
@@ -9,7 +25,6 @@ export {
   resolveFreshSessionTotalTokens,
   resolveSessionFilePathOptions,
 } from "../../config/sessions.js";
-export { loadSessionEntryReadOnly as readCurrentSession } from "../../config/sessions/session-accessor.js";
 export { enqueueSystemEvent } from "../../infra/system-events.js";
 export { formatContextUsageShort, formatTokenCount } from "../status.js";
 export { incrementCompactionCount } from "./session-updates.js";

--- a/src/auto-reply/reply/commands-compact.runtime.ts
+++ b/src/auto-reply/reply/commands-compact.runtime.ts
@@ -9,7 +9,7 @@ export {
   resolveFreshSessionTotalTokens,
   resolveSessionFilePathOptions,
 } from "../../config/sessions.js";
-export { loadSessionEntryReadOnly as readSessionEntry } from "../../config/sessions/session-accessor.js";
+export { loadSessionEntryReadOnly as readCurrentSession } from "../../config/sessions/session-accessor.js";
 export { enqueueSystemEvent } from "../../infra/system-events.js";
 export { formatContextUsageShort, formatTokenCount } from "../status.js";
 export { incrementCompactionCount } from "./session-updates.js";

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -848,7 +848,6 @@ describe("handleCompactCommand", () => {
     );
 
     expect(result?.sessionCompaction).toMatchObject({ compacted: true, tokensAfter: 321 });
-    expect(result?.reply?.text).toContain("Compacted");
   });
 
   it("rejects a successor session when compaction accounting did not commit", async () => {

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -97,6 +97,7 @@ function requireIncrementCompactionCountCall(index = 0) {
 describe("handleCompactCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(incrementCompactionCount).mockResolvedValue(1);
     vi.mocked(isCurrentSessionEntry).mockReturnValue(true);
     resolveAgentDirMock.mockImplementation(
       (_cfg: unknown, agentId: string) => `/tmp/workspace/.openclaw/agents/${agentId}/agent`,
@@ -848,6 +849,45 @@ describe("handleCompactCommand", () => {
 
     expect(result?.sessionCompaction).toMatchObject({ compacted: true, tokensAfter: 321 });
     expect(result?.reply?.text).toContain("Compacted");
+  });
+
+  it("rejects a successor session when compaction accounting did not commit", async () => {
+    let currentSessionId = "native-session";
+    vi.mocked(isCurrentSessionEntry).mockImplementation(
+      ({ expected }) => expected.sessionId === currentSessionId,
+    );
+    vi.mocked(incrementCompactionCount).mockImplementationOnce(async () => {
+      currentSessionId = "successor-session";
+      return undefined;
+    });
+    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      compactionKind: "context-engine",
+      result: {
+        summary: "compacted",
+        firstKeptEntryId: "first-kept",
+        sessionId: "successor-session",
+        tokensBefore: 999,
+        tokensAfter: 321,
+      },
+    });
+
+    const result = await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        sessionEntry: { sessionId: "native-session", updatedAt: Date.now() },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(result?.sessionCompaction).toEqual({
+      compacted: false,
+      reason: "command session changed",
+    });
   });
 
   it.each([

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -308,6 +308,10 @@ describe("handleCompactCommand", () => {
 
     expect(result).toEqual({
       shouldContinue: false,
+      sessionCompaction: {
+        compacted: false,
+        reason: "the previous run is still stopping",
+      },
       reply: {
         text: "⚙️ Compaction unavailable: the previous run is still stopping.",
         isStatusNotice: true,

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -15,6 +15,7 @@ vi.mock("./commands-compact.runtime.js", () => ({
   formatContextUsageShort: vi.fn(() => "Context 12.1k"),
   formatTokenCount: vi.fn((value: number) => `${value}`),
   incrementCompactionCount: vi.fn(),
+  isCurrentSessionEntry: vi.fn(() => true),
   isEmbeddedAgentRunAbortableForCompaction: vi.fn().mockReturnValue(false),
   resolveFreshSessionTotalTokens: vi.fn(() => 12_345),
   resolveSessionFilePathOptions: vi.fn(() => ({})),

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -27,6 +27,7 @@ const {
   compactEmbeddedAgentSession,
   formatContextUsageShort,
   incrementCompactionCount,
+  isCurrentSessionEntry,
   isEmbeddedAgentRunAbortableForCompaction,
   waitForEmbeddedAgentRunEnd,
 } = await import("./commands-compact.runtime.js");
@@ -96,6 +97,7 @@ function requireIncrementCompactionCountCall(index = 0) {
 describe("handleCompactCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(isCurrentSessionEntry).mockReturnValue(true);
     resolveAgentDirMock.mockImplementation(
       (_cfg: unknown, agentId: string) => `/tmp/workspace/.openclaw/agents/${agentId}/agent`,
     );
@@ -260,6 +262,33 @@ describe("handleCompactCommand", () => {
     expect(vi.mocked(abortEmbeddedAgentRun)).not.toHaveBeenCalled();
     expect(vi.mocked(waitForEmbeddedAgentRunEnd)).not.toHaveBeenCalled();
     expect(vi.mocked(compactEmbeddedAgentSession)).toHaveBeenCalledOnce();
+  });
+
+  it("does not abort a run after the bound session changes", async () => {
+    vi.mocked(isCurrentSessionEntry).mockReturnValueOnce(false);
+    vi.mocked(isEmbeddedAgentRunAbortableForCompaction).mockReturnValueOnce(true);
+
+    const result = await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+        },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(result?.sessionCompaction).toEqual({
+      compacted: false,
+      reason: "command session changed",
+    });
+    expect(vi.mocked(isEmbeddedAgentRunAbortableForCompaction)).not.toHaveBeenCalled();
+    expect(vi.mocked(abortEmbeddedAgentRun)).not.toHaveBeenCalled();
+    expect(vi.mocked(compactEmbeddedAgentSession)).not.toHaveBeenCalled();
   });
 
   it("waits for an active embedded run before compacting even when abort is rejected", async () => {
@@ -779,6 +808,46 @@ describe("handleCompactCommand", () => {
 
     expect(result?.reply?.text).toContain("Server-side compaction (8614 → 736)");
     expect(requireIncrementCompactionCountCall().compactionKind).toBe("server-endpoint");
+  });
+
+  it("accepts the successor session produced by context-engine accounting", async () => {
+    let currentSessionId = "native-session";
+    vi.mocked(isCurrentSessionEntry).mockImplementation(
+      ({ expected }) => expected.sessionId === currentSessionId,
+    );
+    vi.mocked(incrementCompactionCount).mockImplementationOnce(async () => {
+      currentSessionId = "successor-session";
+      return 1;
+    });
+    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      compactionKind: "context-engine",
+      result: {
+        summary: "compacted",
+        firstKeptEntryId: "first-kept",
+        sessionId: "successor-session",
+        tokensBefore: 999,
+        tokensAfter: 321,
+      },
+    });
+
+    const result = await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        sessionEntry: {
+          sessionId: "native-session",
+          updatedAt: Date.now(),
+        },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(result?.sessionCompaction).toMatchObject({ compacted: true, tokensAfter: 321 });
+    expect(result?.reply?.text).toContain("Compacted");
   });
 
   it.each([

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -31,7 +31,7 @@ import { resolveSessionStorePathForScope } from "../../config/sessions/session-s
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
-import type { CommandHandler } from "./commands-types.js";
+import type { CommandHandler, CommandHandlerResult } from "./commands-types.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 
 const compactRuntimeLoader = createLazyImportLoader(() => import("./commands-compact.runtime.js"));
@@ -84,6 +84,14 @@ function formatCompactionReason(reason?: string): string | undefined {
       ? "context is already under the compaction target"
       : "context is below the compaction threshold"
     : text;
+}
+
+function compactionUnavailable(reason: string, text: string): CommandHandlerResult {
+  return {
+    shouldContinue: false,
+    sessionCompaction: { compacted: false, reason },
+    reply: { text, isStatusNotice: true },
+  };
 }
 
 function resolveManualCompactContextTokenBudget(params: {
@@ -198,13 +206,10 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   }
   const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
   if (!targetSessionEntry?.sessionId) {
-    return {
-      shouldContinue: false,
-      reply: {
-        text: "⚙️ Compaction unavailable (missing session id).",
-        isStatusNotice: true,
-      },
-    };
+    return compactionUnavailable(
+      "missing session id",
+      "⚙️ Compaction unavailable (missing session id).",
+    );
   }
   const runtime = await loadCompactRuntime();
   const sessionId = targetSessionEntry.sessionId;
@@ -212,17 +217,10 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     runtime.abortEmbeddedAgentRun(sessionId);
     const drained = await runtime.waitForEmbeddedAgentRunEnd(sessionId, 15_000);
     if (!drained) {
-      return {
-        shouldContinue: false,
-        sessionCompaction: {
-          compacted: false,
-          reason: "the previous run is still stopping",
-        },
-        reply: {
-          text: "⚙️ Compaction unavailable: the previous run is still stopping.",
-          isStatusNotice: true,
-        },
-      };
+      return compactionUnavailable(
+        "the previous run is still stopping",
+        "⚙️ Compaction unavailable: the previous run is still stopping.",
+      );
     }
   }
   const sessionAgentId = params.sessionKey
@@ -264,6 +262,20 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       params.storePath ??
       resolveSessionStorePathCore(params.cfg.session?.store, { agentId: sessionAgentId }),
   });
+  const isCurrentSession = () =>
+    runtime.isCurrentSessionEntry({
+      agentId: sessionAgentId,
+      sessionKey: params.sessionKey,
+      storePath: compactionStorePath,
+      expected: targetSessionEntry,
+    });
+  const thinkLevel = params.resolvedThinkLevel ?? (await params.resolveDefaultThinkingLevel());
+  if (!isCurrentSession()) {
+    return compactionUnavailable(
+      "command session changed",
+      "⚙️ Compaction unavailable: command session changed.",
+    );
+  }
   const result = await runtime.compactEmbeddedAgentSession({
     abortSignal: params.opts?.abortSignal,
     sessionId,
@@ -305,7 +317,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
             ? undefined
             : targetSessionEntry.agentHarnessId)),
     modelSelectionLocked: targetSessionEntry.modelSelectionLocked === true,
-    thinkLevel: params.resolvedThinkLevel ?? (await params.resolveDefaultThinkingLevel()),
+    thinkLevel,
     bashElevated: {
       enabled: false,
       allowed: false,
@@ -319,6 +331,12 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       senderIsOwner: params.command.senderIsOwner,
     }),
   });
+  if (!isCurrentSession()) {
+    return compactionUnavailable(
+      "command session changed",
+      "⚙️ Compaction unavailable: command session changed.",
+    );
+  }
 
   const tokensAfterCompaction = result.result?.tokensAfter;
   const didCompact = result.ok && result.compacted;

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -204,7 +204,9 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     );
     return { shouldContinue: false };
   }
-  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+  const targetSessionEntry = params.commandInvocationSignal
+    ? params.compactionSessionEntry
+    : (params.sessionStore?.[params.sessionKey] ?? params.sessionEntry);
   if (!targetSessionEntry?.sessionId) {
     return compactionUnavailable(
       "missing session id",

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -72,21 +72,18 @@ function formatCompactionReason(reason?: string): string | undefined {
   if (!text) {
     return undefined;
   }
-
   const classification = classifyCompactionReason(reason);
-  const lower = normalizeLowercaseStringOrEmpty(reason);
-  switch (classification) {
-    case "no_compactable_entries":
-      return "nothing compactable in this session yet";
-    case "below_threshold":
-      return lower.includes("already under target")
-        ? "context is already under the compaction target"
-        : "context is below the compaction threshold";
-    case "already_compacted":
-      return "session is already compacted";
-    default:
-      return text;
+  if (classification === "no_compactable_entries") {
+    return "nothing compactable in this session yet";
   }
+  if (classification === "already_compacted") {
+    return "session is already compacted";
+  }
+  return classification === "below_threshold"
+    ? normalizeLowercaseStringOrEmpty(reason).includes("already under target")
+      ? "context is already under the compaction target"
+      : "context is below the compaction threshold"
+    : text;
 }
 
 function resolveManualCompactContextTokenBudget(params: {
@@ -217,6 +214,10 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     if (!drained) {
       return {
         shouldContinue: false,
+        sessionCompaction: {
+          compacted: false,
+          reason: "the previous run is still stopping",
+        },
         reply: {
           text: "⚙️ Compaction unavailable: the previous run is still stopping.",
           isStatusNotice: true,
@@ -362,6 +363,12 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   runtime.enqueueSystemEvent(line, { sessionKey: params.sessionKey });
   return {
     shouldContinue: false,
+    sessionCompaction: {
+      compacted: didCompact,
+      reason: result.reason,
+      tokensBefore: result.result?.tokensBefore,
+      tokensAfter: tokensAfterCompaction,
+    },
     reply: {
       text: `⚙️ ${line}`,
       isStatusNotice: true,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -213,16 +213,6 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   }
   const runtime = await loadCompactRuntime();
   const sessionId = targetSessionEntry.sessionId;
-  if (runtime.isEmbeddedAgentRunAbortableForCompaction(sessionId)) {
-    runtime.abortEmbeddedAgentRun(sessionId);
-    const drained = await runtime.waitForEmbeddedAgentRunEnd(sessionId, 15_000);
-    if (!drained) {
-      return compactionUnavailable(
-        "the previous run is still stopping",
-        "⚙️ Compaction unavailable: the previous run is still stopping.",
-      );
-    }
-  }
   const sessionAgentId = params.sessionKey
     ? resolveSessionAgentId({
         sessionKey: params.sessionKey,
@@ -262,19 +252,46 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       params.storePath ??
       resolveSessionStorePathCore(params.cfg.session?.store, { agentId: sessionAgentId }),
   });
+  let expectedSession = targetSessionEntry;
   const isCurrentSession = () =>
     runtime.isCurrentSessionEntry({
       agentId: sessionAgentId,
       sessionKey: params.sessionKey,
       storePath: compactionStorePath,
-      expected: targetSessionEntry,
+      expected: expectedSession,
     });
+  const authorityFailure = () => {
+    const reason = params.commandInvocationSignal?.aborted
+      ? "command invocation closed"
+      : !isCurrentSession()
+        ? "command session changed"
+        : undefined;
+    return reason
+      ? compactionUnavailable(reason, `⚙️ Compaction unavailable: ${reason}.`)
+      : undefined;
+  };
+  let failure = authorityFailure();
+  if (failure) {
+    return failure;
+  }
+  if (runtime.isEmbeddedAgentRunAbortableForCompaction(sessionId)) {
+    runtime.abortEmbeddedAgentRun(sessionId);
+    const drained = await runtime.waitForEmbeddedAgentRunEnd(sessionId, 15_000);
+    failure = authorityFailure();
+    if (failure) {
+      return failure;
+    }
+    if (!drained) {
+      return compactionUnavailable(
+        "the previous run is still stopping",
+        "⚙️ Compaction unavailable: the previous run is still stopping.",
+      );
+    }
+  }
   const thinkLevel = params.resolvedThinkLevel ?? (await params.resolveDefaultThinkingLevel());
-  if (!isCurrentSession()) {
-    return compactionUnavailable(
-      "command session changed",
-      "⚙️ Compaction unavailable: command session changed.",
-    );
+  failure = authorityFailure();
+  if (failure) {
+    return failure;
   }
   const result = await runtime.compactEmbeddedAgentSession({
     abortSignal: params.opts?.abortSignal,
@@ -331,11 +348,9 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       senderIsOwner: params.command.senderIsOwner,
     }),
   });
-  if (!isCurrentSession()) {
-    return compactionUnavailable(
-      "command session changed",
-      "⚙️ Compaction unavailable: command session changed.",
-    );
+  failure = authorityFailure();
+  if (failure) {
+    return failure;
   }
 
   const tokensAfterCompaction = result.result?.tokensAfter;
@@ -365,7 +380,16 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       tokensAfter: result.result?.tokensAfter,
       newSessionId: result.result?.sessionId,
       compactionKind: result.compactionKind,
+      expectedSession: targetSessionEntry,
+      authorize: () => params.commandInvocationSignal?.aborted !== true,
     });
+    if (result.result?.sessionId) {
+      expectedSession = { ...expectedSession, sessionId: result.result.sessionId };
+    }
+    failure = authorityFailure();
+    if (failure) {
+      return failure;
+    }
   }
   const totalTokens = didCompact
     ? tokensAfterCompaction

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -370,7 +370,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
         : "Compaction skipped"
       : "Compaction failed";
   if (didCompact) {
-    await runtime.incrementCompactionCount({
+    const compactionCount = await runtime.incrementCompactionCount({
       agentId: sessionAgentId,
       cfg: params.cfg,
       sessionEntry: targetSessionEntry,
@@ -383,6 +383,15 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       expectedSession: targetSessionEntry,
       authorize: () => params.commandInvocationSignal?.aborted !== true,
     });
+    if (compactionCount === undefined) {
+      return (
+        authorityFailure() ??
+        compactionUnavailable(
+          "session accounting failed",
+          "⚙️ Compaction unavailable: session accounting failed.",
+        )
+      );
+    }
     if (result.result?.sessionId) {
       expectedSession = { ...expectedSession, sessionId: result.result.sessionId };
     }

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -347,6 +347,53 @@ describe("handlePluginCommand", () => {
     }
   });
 
+  it("rejects session replacement before the compact capability is invoked", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-compact-rebound-"));
+    const sessionKey = "agent:main:whatsapp:direct:test-user";
+    const storePath = path.join(tempDir, "sessions.json");
+    const entry = {
+      sessionId: "session-plugin-command",
+      lifecycleRevision: "revision-1",
+      updatedAt: Date.now(),
+    };
+    const replacement = {
+      ...entry,
+      sessionId: "replacement-session",
+      lifecycleRevision: "revision-2",
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    const params = buildPluginParams("/card", {
+      commands: { text: true },
+      session: { store: storePath },
+    } as OpenClawConfig);
+    params.storePath = storePath;
+    params.sessionStore = { [sessionKey]: entry };
+    registerTestCommand(undefined, {
+      handler: async (ctx) => {
+        Object.assign(
+          expectDefined(
+            expectDefined(params.sessionStore, "session store")[sessionKey],
+            "session entry",
+          ),
+          replacement,
+        );
+        await replaceSessionEntry({ storePath, sessionKey }, replacement);
+        return { text: JSON.stringify(await ctx.runtimeContext?.compactCurrent?.()) };
+      },
+    });
+
+    try {
+      const response = await handlePluginCommand(params, true);
+      expect(response?.reply?.text).toBe(
+        JSON.stringify({ compacted: false, reason: "command session changed" }),
+      );
+      expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+      expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject(replacement);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("prefers the target session entry from sessionStore for plugin command metadata", async () => {
     const handler = registerTestCommand();
 

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -82,6 +82,12 @@ function buildPluginParams(
       sessionId: "session-plugin-command",
       updatedAt: Date.now(),
     },
+    provider: "openai",
+    model: "gpt-5.4",
+    workspaceDir: "/tmp/openclaw-plugin-command",
+    contextTokens: 10_000,
+    isGroup: false,
+    resolveDefaultThinkingLevel: async () => "medium",
   } as unknown as HandleCommandsParams;
 }
 
@@ -143,12 +149,7 @@ describe("handlePluginCommand", () => {
     const entry = { sessionId: "session-plugin-command", updatedAt: Date.now() };
     params.sessionStore = { [sessionKey]: entry };
     await replaceSessionEntry({ storePath, sessionKey }, entry);
-    params.provider = "openai";
-    params.model = "gpt-5.4";
     params.workspaceDir = tempDir;
-    params.contextTokens = 10_000;
-    params.isGroup = false;
-    params.resolveDefaultThinkingLevel = async () => "medium";
 
     try {
       const response = await handlePluginCommand(params, true);
@@ -224,6 +225,46 @@ describe("handlePluginCommand", () => {
     } as OpenClawConfig);
     params.storePath = storePath;
     params.sessionStore = { [sessionKey]: entry };
+
+    try {
+      const response = await handlePluginCommand(params, true);
+      expect(response?.reply?.text).toBe(
+        JSON.stringify({ compacted: false, reason: "command session changed" }),
+      );
+      expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects session compaction when its lifecycle changes during admission", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-compact-race-"));
+    const sessionKey = "agent:main:whatsapp:direct:test-user";
+    const storePath = path.join(tempDir, "sessions.json");
+    const entry = {
+      sessionId: "session-plugin-command",
+      lifecycleRevision: "revision-1",
+      updatedAt: Date.now(),
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    registerTestCommand(undefined, {
+      handler: async (ctx) => ({
+        text: JSON.stringify(await ctx.runtimeContext?.compactCurrent?.()),
+      }),
+    });
+    const params = buildPluginParams("/card", {
+      commands: { text: true },
+      session: { store: storePath },
+    } as OpenClawConfig);
+    params.storePath = storePath;
+    params.sessionStore = { [sessionKey]: entry };
+    params.resolveDefaultThinkingLevel = async () => {
+      await replaceSessionEntry(
+        { storePath, sessionKey },
+        { ...entry, lifecycleRevision: "revision-2" },
+      );
+      return "medium";
+    };
 
     try {
       const response = await handlePluginCommand(params, true);

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -203,6 +203,53 @@ describe("handlePluginCommand", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it("closes unawaited session compaction when the command handler settles", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-compact-detached-"));
+    const sessionKey = "agent:main:whatsapp:direct:test-user";
+    const storePath = path.join(tempDir, "sessions.json");
+    const entry = { sessionId: "session-plugin-command", updatedAt: Date.now() };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    let releasePreparation = () => {};
+    const preparation = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    let detached:
+      | ReturnType<
+          NonNullable<NonNullable<PluginCommandContext["runtimeContext"]>["compactCurrent"]>
+        >
+      | undefined;
+    registerTestCommand(undefined, {
+      handler: async (ctx) => {
+        detached = expectDefined(ctx.runtimeContext?.compactCurrent, "compact capability")();
+        return { text: "started" };
+      },
+    });
+
+    const params = buildPluginParams("/card", {
+      commands: { text: true },
+      session: { store: storePath },
+    } as OpenClawConfig);
+    params.storePath = storePath;
+    params.sessionStore = { [sessionKey]: entry };
+    params.resolveDefaultThinkingLevel = async () => {
+      await preparation;
+      return "medium";
+    };
+
+    try {
+      await handlePluginCommand(params, true);
+      releasePreparation();
+      await expect(expectDefined(detached, "detached compact result")).resolves.toEqual({
+        compacted: false,
+        reason: "command invocation closed",
+      });
+      expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+    } finally {
+      releasePreparation();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects session compaction when the bound session disappeared", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-compact-gone-"));
     const sessionKey = "agent:main:whatsapp:direct:test-user";

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -1,8 +1,12 @@
 // Tests plugin command dispatch and plugin-scoped command aliases.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import { registerPluginCommandInRegistry } from "../../plugins/command-registration.js";
 import {
   PLUGIN_COMMAND_DISPATCH,
@@ -16,6 +20,14 @@ import { resolveIncognitoOpenClawAgentSqlitePath } from "../../state/openclaw-ag
 import { handlePluginCommand } from "./commands-plugin.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { shouldBypassPluginOwnedBindingForCommand } from "./dispatch-from-config.plugin-binding.js";
+
+const compactEmbeddedAgentSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./commands-compact.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./commands-compact.runtime.js")>()),
+  compactEmbeddedAgentSession: compactEmbeddedAgentSessionMock,
+  isEmbeddedAgentRunAbortableForCompaction: () => false,
+}));
 
 let registry: PluginRegistry;
 
@@ -71,6 +83,7 @@ function buildPluginParams(
 
 describe("handlePluginCommand", () => {
   beforeEach(() => {
+    compactEmbeddedAgentSessionMock.mockReset();
     resetPluginRuntimeStateForTest();
     registry = createEmptyPluginRegistry();
     setActivePluginRegistry(registry);
@@ -96,6 +109,72 @@ describe("handlePluginCommand", () => {
     expect(commandParams.sessionKey).toBe("agent:main:whatsapp:direct:test-user");
     expect(commandParams.sessionId).toBe("session-plugin-command");
     expect(commandParams.commandBody).toBe("/card");
+  });
+
+  it("compacts the bound session through the host runtime and records fresh tokens", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-compact-"));
+    const sessionKey = "agent:main:whatsapp:direct:test-user";
+    const storePath = path.join(tempDir, "sessions.json");
+    const handler = vi.fn(async (ctx: PluginCommandContext) => ({
+      text: JSON.stringify(await ctx.runtimeContext?.compactCurrent?.()),
+    }));
+    expect(
+      registerPluginCommandInRegistry(registry, "test-plugin", {
+        name: "card",
+        description: "Card command",
+        handler,
+      }),
+    ).toEqual({ ok: true });
+    compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      compactionKind: "native-harness",
+      result: { summary: "", firstKeptEntryId: "", tokensBefore: 900, tokensAfter: 321 },
+    });
+    const params = buildPluginParams("/card", {
+      commands: { text: true },
+      session: { store: storePath },
+    } as OpenClawConfig);
+    params.storePath = storePath;
+    params.sessionStore = {
+      [sessionKey]: { sessionId: "session-plugin-command", updatedAt: Date.now() },
+    };
+    params.provider = "openai";
+    params.model = "gpt-5.4";
+    params.workspaceDir = tempDir;
+    params.contextTokens = 10_000;
+    params.isGroup = false;
+    params.resolveDefaultThinkingLevel = async () => "medium";
+
+    try {
+      const response = await handlePluginCommand(params, true);
+
+      expect(response?.reply?.text).toBe(
+        JSON.stringify({ compacted: true, tokensBefore: 900, tokensAfter: 321 }),
+      );
+      expect(params.sessionStore[sessionKey]).toMatchObject({
+        compactionCount: 1,
+        totalTokens: 321,
+        totalTokensFresh: true,
+      });
+      expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+        compactionCount: 1,
+        totalTokens: 321,
+        totalTokensFresh: true,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits session compaction when no bound session exists", async () => {
+    const handler = registerTestCommand();
+    const params = buildPluginParams("/card", { commands: { text: true } } as OpenClawConfig);
+    params.sessionEntry = undefined;
+
+    await handlePluginCommand(params, true);
+
+    expect(firstCommandContext(handler).runtimeContext?.compactCurrent).toBeUndefined();
   });
 
   it("prefers the target session entry from sessionStore for plugin command metadata", async () => {

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -182,6 +182,29 @@ describe("handlePluginCommand", () => {
     expect(firstCommandContext(handler).runtimeContext?.compactCurrent).toBeUndefined();
   });
 
+  it("blocks session compaction for an unauthorized public command", async () => {
+    const handler = vi.fn(async (ctx: PluginCommandContext) => ({
+      text: JSON.stringify(await ctx.runtimeContext?.compactCurrent?.()),
+    }));
+    registerTestCommand(undefined, {
+      requireAuth: false,
+      handler,
+    });
+    const params = buildPluginParams("/card", { commands: { text: true } } as OpenClawConfig);
+    params.command = { ...params.command, isAuthorizedSender: false };
+
+    const result = await handlePluginCommand(params, true);
+
+    expect(result?.reply?.text).toBe(
+      JSON.stringify({ compacted: false, reason: "compaction requires authorization" }),
+    );
+    expect(
+      expectDefined(handler.mock.calls[0]?.[0], "public command context").runtimeContext
+        ?.compactCurrent,
+    ).toBeTypeOf("function");
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("closes retained session compaction when the command handler settles", async () => {
     let retained: NonNullable<PluginCommandContext["runtimeContext"]>["compactCurrent"];
     registerTestCommand(undefined, {

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -6,7 +6,11 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  deleteSessionEntryLifecycle,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import { registerPluginCommandInRegistry } from "../../plugins/command-registration.js";
 import {
   PLUGIN_COMMAND_DISPATCH,
@@ -136,9 +140,9 @@ describe("handlePluginCommand", () => {
       session: { store: storePath },
     } as OpenClawConfig);
     params.storePath = storePath;
-    params.sessionStore = {
-      [sessionKey]: { sessionId: "session-plugin-command", updatedAt: Date.now() },
-    };
+    const entry = { sessionId: "session-plugin-command", updatedAt: Date.now() };
+    params.sessionStore = { [sessionKey]: entry };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
     params.provider = "openai";
     params.model = "gpt-5.4";
     params.workspaceDir = tempDir;
@@ -175,6 +179,61 @@ describe("handlePluginCommand", () => {
     await handlePluginCommand(params, true);
 
     expect(firstCommandContext(handler).runtimeContext?.compactCurrent).toBeUndefined();
+  });
+
+  it("closes retained session compaction when the command handler settles", async () => {
+    let retained: NonNullable<PluginCommandContext["runtimeContext"]>["compactCurrent"];
+    registerTestCommand(undefined, {
+      handler: async (ctx) => {
+        retained = ctx.runtimeContext?.compactCurrent;
+        return { text: "saved" };
+      },
+    });
+
+    await handlePluginCommand(
+      buildPluginParams("/card", { commands: { text: true } } as OpenClawConfig),
+      true,
+    );
+
+    await expect(expectDefined(retained, "retained compact capability")()).resolves.toEqual({
+      compacted: false,
+      reason: "command invocation closed",
+    });
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects session compaction when the bound session disappeared", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-compact-gone-"));
+    const sessionKey = "agent:main:whatsapp:direct:test-user";
+    const storePath = path.join(tempDir, "sessions.json");
+    const entry = { sessionId: "session-plugin-command", updatedAt: Date.now() };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    registerTestCommand(undefined, {
+      handler: async (ctx) => {
+        await deleteSessionEntryLifecycle({
+          storePath,
+          archiveTranscript: false,
+          target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        });
+        return { text: JSON.stringify(await ctx.runtimeContext?.compactCurrent?.()) };
+      },
+    });
+    const params = buildPluginParams("/card", {
+      commands: { text: true },
+      session: { store: storePath },
+    } as OpenClawConfig);
+    params.storePath = storePath;
+    params.sessionStore = { [sessionKey]: entry };
+
+    try {
+      const response = await handlePluginCommand(params, true);
+      expect(response?.reply?.text).toBe(
+        JSON.stringify({ compacted: false, reason: "command session changed" }),
+      );
+      expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("prefers the target session entry from sessionStore for plugin command metadata", async () => {

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -18,6 +18,7 @@ import {
   type PluginCommandExecutionReplyOptions,
 } from "../../plugins/plugin-command-runtime.js";
 import { DEFAULT_AGENT_ID, isUnscopedSessionKeySentinel } from "../../routing/session-key.js";
+import { handleCompactCommand } from "./commands-compact.js";
 import type { CommandHandler, CommandHandlerResult } from "./commands-types.js";
 
 /**
@@ -100,6 +101,18 @@ export const handlePluginCommand: CommandHandler = async (
         ? params.ctx.MessageThreadId
         : undefined,
     threadParentId: normalizeOptionalString(params.ctx.ThreadParentId),
+    ...(sessionTarget
+      ? {
+          runtimeContext: {
+            // Bound-session gating above makes the canonical command outcome authoritative.
+            compactCurrent: async () =>
+              (await handleCompactCommand(
+                { ...params, command: { ...params.command, commandBodyNormalized: "/compact" } },
+                true,
+              ))!.sessionCompaction!,
+          },
+        }
+      : {}),
   });
   const shouldContinue = result.continueAgent === true;
   const { continueAgent: _continueAgent, ...reply } = result;

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -105,16 +105,10 @@ export const handlePluginCommand: CommandHandler = async (
       ? {
           runtimeContext: {
             compactCurrent: async () =>
-              (await import("./commands-compact.runtime.js")).readCurrentSession(sessionTarget)
-                ?.sessionId === sessionTarget.sessionId
-                ? (await handleCompactCommand(
-                    {
-                      ...params,
-                      command: { ...params.command, commandBodyNormalized: "/compact" },
-                    },
-                    true,
-                  ))!.sessionCompaction!
-                : { compacted: false, reason: "command session changed" },
+              (await handleCompactCommand(
+                { ...params, command: { ...params.command, commandBodyNormalized: "/compact" } },
+                true,
+              ))!.sessionCompaction!,
           },
         }
       : {}),

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -104,9 +104,20 @@ export const handlePluginCommand: CommandHandler = async (
     ...(sessionTarget
       ? {
           runtimeContext: {
-            compactCurrent: async () =>
+            compactCurrent: async (invocationSignal) =>
               (await handleCompactCommand(
-                { ...params, command: { ...params.command, commandBodyNormalized: "/compact" } },
+                {
+                  ...params,
+                  command: { ...params.command, commandBodyNormalized: "/compact" },
+                  commandInvocationSignal: invocationSignal,
+                  opts: {
+                    ...params.opts,
+                    abortSignal:
+                      invocationSignal && params.opts?.abortSignal
+                        ? AbortSignal.any([invocationSignal, params.opts.abortSignal])
+                        : (invocationSignal ?? params.opts?.abortSignal),
+                  },
+                },
                 true,
               ))!.sessionCompaction!,
           },

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -105,7 +105,7 @@ export const handlePluginCommand: CommandHandler = async (
       ? {
           runtimeContext: {
             compactCurrent: async () =>
-              (await import("./commands-compact.runtime.js")).readSessionEntry(sessionTarget)
+              (await import("./commands-compact.runtime.js")).readCurrentSession(sessionTarget)
                 ?.sessionId === sessionTarget.sessionId
                 ? (await handleCompactCommand(
                     {

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -104,12 +104,17 @@ export const handlePluginCommand: CommandHandler = async (
     ...(sessionTarget
       ? {
           runtimeContext: {
-            // Bound-session gating above makes the canonical command outcome authoritative.
             compactCurrent: async () =>
-              (await handleCompactCommand(
-                { ...params, command: { ...params.command, commandBodyNormalized: "/compact" } },
-                true,
-              ))!.sessionCompaction!,
+              (await import("./commands-compact.runtime.js")).readSessionEntry(sessionTarget)
+                ?.sessionId === sessionTarget.sessionId
+                ? (await handleCompactCommand(
+                    {
+                      ...params,
+                      command: { ...params.command, commandBodyNormalized: "/compact" },
+                    },
+                    true,
+                  ))!.sessionCompaction!
+                : { compacted: false, reason: "command session changed" },
           },
         }
       : {}),

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -104,8 +104,11 @@ export const handlePluginCommand: CommandHandler = async (
     ...(sessionTarget
       ? {
           runtimeContext: {
-            compactCurrent: async (invocationSignal) =>
-              (await handleCompactCommand(
+            compactCurrent: async (invocationSignal) => {
+              if (!params.command.isAuthorizedSender) {
+                return { compacted: false, reason: "compaction requires authorization" };
+              }
+              const compaction = await handleCompactCommand(
                 {
                   ...params,
                   command: { ...params.command, commandBodyNormalized: "/compact" },
@@ -119,7 +122,14 @@ export const handlePluginCommand: CommandHandler = async (
                   },
                 },
                 true,
-              ))!.sessionCompaction!,
+              );
+              return (
+                compaction?.sessionCompaction ?? {
+                  compacted: false,
+                  reason: "compaction unavailable",
+                }
+              );
+            },
           },
         }
       : {}),

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -31,7 +31,9 @@ export const handlePluginCommand: CommandHandler = async (
   allowTextCommands,
 ): Promise<CommandHandlerResult | null> => {
   const { command, cfg } = params;
-  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+  const targetSessionEntry = structuredClone(
+    params.sessionStore?.[params.sessionKey] ?? params.sessionEntry,
+  );
   const targetAgentId =
     params.sessionKey && !isUnscopedSessionKeySentinel(params.sessionKey)
       ? (resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg }) ??
@@ -113,6 +115,7 @@ export const handlePluginCommand: CommandHandler = async (
                   ...params,
                   command: { ...params.command, commandBodyNormalized: "/compact" },
                   commandInvocationSignal: invocationSignal,
+                  compactionSessionEntry: targetSessionEntry,
                   opts: {
                     ...params.opts,
                     abortSignal:

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -85,6 +85,8 @@ export type HandleCommandsParams = {
   skillCommands?: SkillCommandSpec[];
   loadSkillCommands?: () => Promise<SkillCommandSpec[]>;
   typing?: TypingController;
+  /** Invocation authority for host-bound plugin command capabilities. */
+  commandInvocationSignal?: AbortSignal;
 };
 
 /** Result returned by a command handler. */

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -4,6 +4,7 @@ import type { BlockReplyChunking } from "../../agents/embedded-agent-block-chunk
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import type { SessionEntry, SessionScope } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginCommandContext } from "../../plugins/types.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
 import type { MsgContext } from "../templating.js";
 import type {
@@ -89,6 +90,9 @@ export type HandleCommandsParams = {
 /** Result returned by a command handler. */
 export type CommandHandlerResult = {
   reply?: ReplyPayload;
+  sessionCompaction?: Awaited<
+    ReturnType<NonNullable<NonNullable<PluginCommandContext["runtimeContext"]>["compactCurrent"]>>
+  >;
   shouldContinue: boolean;
 };
 

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -87,6 +87,8 @@ export type HandleCommandsParams = {
   typing?: TypingController;
   /** Invocation authority for host-bound plugin command capabilities. */
   commandInvocationSignal?: AbortSignal;
+  /** Session generation captured when a host-bound compaction capability was admitted. */
+  compactionSessionEntry?: SessionEntry;
 };
 
 /** Result returned by a command handler. */

--- a/src/auto-reply/reply/session-updates.lifecycle.test.ts
+++ b/src/auto-reply/reply/session-updates.lifecycle.test.ts
@@ -265,4 +265,37 @@ describe("session-updates lifecycle hooks", () => {
     });
     expect(loadSessionEntry({ storePath, sessionKey })).not.toHaveProperty("totalTokens");
   });
+
+  it("does not commit accounting when authority closes after the queued updater", async () => {
+    const { storePath, sessionKey, sessionStore, entry } = await createFixture();
+    let authorized = true;
+    let authorizeCalls = 0;
+
+    const result = await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      tokensAfter: 123,
+      expectedSession: entry,
+      authorize: () => {
+        authorizeCalls += 1;
+        if (authorizeCalls === 2) {
+          queueMicrotask(() => {
+            authorized = false;
+          });
+        }
+        return authorized;
+      },
+    });
+
+    expect(result).toBeUndefined();
+    expect(authorizeCalls).toBe(3);
+    expect(sessionStore[sessionKey]).toBe(entry);
+    expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+      sessionId: "s1",
+      compactionCount: 0,
+    });
+    expect(loadSessionEntry({ storePath, sessionKey })).not.toHaveProperty("totalTokens");
+  });
 });

--- a/src/auto-reply/reply/session-updates.lifecycle.test.ts
+++ b/src/auto-reply/reply/session-updates.lifecycle.test.ts
@@ -219,4 +219,50 @@ describe("session-updates lifecycle hooks", () => {
     expect(persisted?.totalTokens).toBe(123);
     expect(persisted?.updatedAt).toBeGreaterThanOrEqual(entry.updatedAt);
   });
+
+  it("does not account compaction against a replaced session", async () => {
+    const { storePath, sessionKey, sessionStore, entry } = await createFixture();
+    const replacement = { ...entry, sessionId: "s2", lifecycleRevision: "revision-2" };
+    await replaceSessionEntry({ storePath, sessionKey }, replacement);
+
+    const result = await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      tokensAfter: 123,
+      expectedSession: { sessionId: "s1", lifecycleRevision: undefined },
+    });
+
+    expect(result).toBeUndefined();
+    expect(sessionStore[sessionKey]).toBe(entry);
+    expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+      sessionId: "s2",
+      lifecycleRevision: "revision-2",
+      compactionCount: 0,
+    });
+    expect(loadSessionEntry({ storePath, sessionKey })).not.toHaveProperty("totalTokens");
+  });
+
+  it("does not account compaction after invocation authority closes", async () => {
+    const { storePath, sessionKey, sessionStore, entry } = await createFixture();
+
+    const result = await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      tokensAfter: 123,
+      expectedSession: entry,
+      authorize: () => false,
+    });
+
+    expect(result).toBeUndefined();
+    expect(sessionStore[sessionKey]).toBe(entry);
+    expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+      sessionId: "s1",
+      compactionCount: 0,
+    });
+    expect(loadSessionEntry({ storePath, sessionKey })).not.toHaveProperty("totalTokens");
+  });
 });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -328,6 +328,8 @@ export async function incrementCompactionCount(params: {
   /** Session id after compaction when a context engine changed identity. */
   newSessionId?: string;
   compactionKind?: EmbeddedAgentCompactResult["compactionKind"];
+  expectedSession?: Pick<SessionEntry, "sessionId" | "lifecycleRevision">;
+  authorize?: () => boolean;
 }): Promise<number | undefined> {
   const {
     agentId,
@@ -341,12 +343,22 @@ export async function incrementCompactionCount(params: {
     tokensAfter,
     newSessionId,
     compactionKind,
+    expectedSession,
+    authorize,
   } = params;
   if (!sessionStore || !sessionKey) {
     return undefined;
   }
   const entry = sessionStore[sessionKey] ?? sessionEntry;
   if (!entry) {
+    return undefined;
+  }
+  const canApply = (current: SessionEntry) =>
+    (authorize?.() ?? true) &&
+    (!expectedSession ||
+      (current.sessionId === expectedSession.sessionId &&
+        current.lifecycleRevision === expectedSession.lifecycleRevision));
+  if (!canApply(entry)) {
     return undefined;
   }
   const incrementBy = Math.max(0, amount);
@@ -380,19 +392,28 @@ export async function incrementCompactionCount(params: {
     updates.totalTokensVersion = undefined;
   }
   const nextEntry = projectCanonicalSessionEntryShape({ ...entry, ...updates });
-  sessionStore[sessionKey] = nextEntry;
   const effectiveStorePath = storePath
     ? resolveSessionStorePathForScope({ agentId, sessionKey, storePath })
     : undefined;
   if (effectiveStorePath) {
+    let committed = false;
     const persistedEntry = await patchSessionEntryCore(
       { ...(agentId ? { agentId } : {}), storePath: effectiveStorePath, sessionKey },
-      () => updates,
-      { fallbackEntry: nextEntry },
+      (current) => {
+        if (!canApply(current)) {
+          return null;
+        }
+        committed = true;
+        return updates;
+      },
+      expectedSession ? {} : { fallbackEntry: nextEntry },
     );
-    if (persistedEntry) {
-      sessionStore[sessionKey] = persistedEntry;
+    if (!committed || !persistedEntry) {
+      return undefined;
     }
+    sessionStore[sessionKey] = persistedEntry;
+  } else {
+    sessionStore[sessionKey] = nextEntry;
   }
   if (sessionIdChanged && cfg) {
     emitCompactionSessionLifecycleHooks({

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -397,17 +397,37 @@ export async function incrementCompactionCount(params: {
     : undefined;
   if (effectiveStorePath) {
     let committed = false;
-    const persistedEntry = await patchSessionEntryCore(
-      { ...(agentId ? { agentId } : {}), storePath: effectiveStorePath, sessionKey },
-      (current) => {
-        if (!canApply(current)) {
-          return null;
-        }
-        committed = true;
-        return updates;
-      },
-      expectedSession ? {} : { fallbackEntry: nextEntry },
-    );
+    const authorityRevoked = new Error("compaction accounting authority revoked");
+    let persistedEntry: SessionEntry | null;
+    try {
+      persistedEntry = await patchSessionEntryCore(
+        { ...(agentId ? { agentId } : {}), storePath: effectiveStorePath, sessionKey },
+        (current) => {
+          if (!canApply(current)) {
+            return null;
+          }
+          committed = true;
+          return updates;
+        },
+        {
+          ...(expectedSession ? {} : { fallbackEntry: nextEntry }),
+          ...(authorize
+            ? {
+                assertCommitAllowed: () => {
+                  if (!authorize()) {
+                    throw authorityRevoked;
+                  }
+                },
+              }
+            : {}),
+        },
+      );
+    } catch (error) {
+      if (error === authorityRevoked) {
+        return undefined;
+      }
+      throw error;
+    }
     if (!committed || !persistedEntry) {
       return undefined;
     }

--- a/src/plugins/plugin-command-execution.ts
+++ b/src/plugins/plugin-command-execution.ts
@@ -19,39 +19,16 @@ import {
   requestPluginConversationBinding,
 } from "./conversation-binding.js";
 import { pluginCommandSupportsChannel } from "./plugin-command-metadata.js";
+import type { PluginCommandDispatchContext } from "./plugin-command-runtime.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import type { PluginCommandContext, PluginCommandResult } from "./types.js";
 
 const MAX_ARGS_LENGTH = 4096;
 
-export type PluginCommandExecutionParams = {
+export type PluginCommandExecutionParams = PluginCommandDispatchContext & {
   command: RegisteredPluginCommand;
   args?: string;
-  senderId?: string;
-  channel: string;
-  channelId?: PluginCommandContext["channelId"];
-  isAuthorizedSender: boolean;
-  senderIsOwner?: boolean;
-  gatewayClientScopes?: PluginCommandContext["gatewayClientScopes"];
-  agentId?: string;
-  sessionKey?: PluginCommandContext["sessionKey"];
-  sessionId?: PluginCommandContext["sessionId"];
-  sessionTarget?: PluginCommandContext["sessionTarget"];
-  sessionFile?: PluginCommandContext["sessionFile"];
-  authProfileId?: string;
-  commandBody: string;
-  config: OpenClawConfig;
-  from?: PluginCommandContext["from"];
-  to?: PluginCommandContext["to"];
-  originatingTo?: string;
-  accountId?: PluginCommandContext["accountId"];
-  messageThreadId?: PluginCommandContext["messageThreadId"];
-  threadParentId?: PluginCommandContext["threadParentId"];
-  diagnosticsSessions?: PluginCommandContext["diagnosticsSessions"];
-  diagnosticsUploadApproved?: PluginCommandContext["diagnosticsUploadApproved"];
-  diagnosticsPreviewOnly?: PluginCommandContext["diagnosticsPreviewOnly"];
-  diagnosticsPrivateRouted?: PluginCommandContext["diagnosticsPrivateRouted"];
 };
 
 function sanitizeArgs(args: string | undefined): string | undefined {
@@ -229,13 +206,16 @@ export async function executeRegisteredPluginCommand(
     messageThreadId: params.messageThreadId,
     threadParentId: params.threadParentId,
     diagnosticsSessions: params.diagnosticsSessions,
-    runtimeContext: buildRuntimeContext({
-      command,
-      config,
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
-      authProfileId: params.authProfileId,
-    }),
+    runtimeContext: {
+      ...buildRuntimeContext({
+        command,
+        config,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        authProfileId: params.authProfileId,
+      }),
+      ...params.runtimeContext,
+    },
     ...(trustedReservedOwner && params.diagnosticsUploadApproved !== undefined
       ? { diagnosticsUploadApproved: params.diagnosticsUploadApproved }
       : {}),

--- a/src/plugins/plugin-command-execution.ts
+++ b/src/plugins/plugin-command-execution.ts
@@ -86,7 +86,7 @@ type PluginCommandLlmCompleteParams = Parameters<
 function buildRuntimeContext(
   command: RegisteredPluginCommand,
   params: PluginCommandDispatchContext,
-  isInvocationOpen: () => boolean,
+  invocationSignal: AbortSignal,
 ): PluginCommandContext["runtimeContext"] {
   const sessionKey = params.sessionKey?.trim();
   const agentId = resolveBoundAgentIdForSession({
@@ -126,11 +126,13 @@ function buildRuntimeContext(
       ? {
           // Command capabilities require this live invocation; retained references fail closed.
           compactCurrent: async () => {
-            if (!isInvocationOpen()) {
+            if (invocationSignal.aborted) {
               return blockedCompaction("command invocation closed");
             }
-            const result = await compactCurrent();
-            return isInvocationOpen() ? result : blockedCompaction("command invocation closed");
+            const result = await compactCurrent(invocationSignal);
+            return invocationSignal.aborted
+              ? blockedCompaction("command invocation closed")
+              : result;
           },
         }
       : {}),
@@ -197,7 +199,7 @@ export async function executeRegisteredPluginCommand(
     command.pluginId === normalizeLowercaseStringOrEmpty(command.name);
   const senderIsOwner =
     canExposeSenderIsOwner(command) || trustedReservedOwner ? params.senderIsOwner : undefined;
-  let commandInvocationOpen = true;
+  const commandInvocationAbort = new AbortController();
   const ctx: PluginCommandContext = {
     senderId,
     channel,
@@ -219,7 +221,7 @@ export async function executeRegisteredPluginCommand(
     messageThreadId: params.messageThreadId,
     threadParentId: params.threadParentId,
     diagnosticsSessions: params.diagnosticsSessions,
-    runtimeContext: buildRuntimeContext(command, params, () => commandInvocationOpen),
+    runtimeContext: buildRuntimeContext(command, params, commandInvocationAbort.signal),
     ...(trustedReservedOwner && params.diagnosticsUploadApproved !== undefined
       ? { diagnosticsUploadApproved: params.diagnosticsUploadApproved }
       : {}),
@@ -280,6 +282,6 @@ export async function executeRegisteredPluginCommand(
     logVerbose(`Plugin command /${command.name} error: ${(error as Error).message}`);
     return { text: "⚠️ Command failed. Please try again later." };
   } finally {
-    commandInvocationOpen = false;
+    commandInvocationAbort.abort("command invocation closed");
   }
 }

--- a/src/plugins/plugin-command-execution.ts
+++ b/src/plugins/plugin-command-execution.ts
@@ -3,7 +3,6 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveBoundAgentIdForSession } from "../agents/session-agent-binding.js";
 import { resolveConversationBindingContext } from "../channels/conversation-binding-context.js";
-import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ADMIN_SCOPE, isOperatorScope } from "../gateway/operator-scopes.js";
 import { logVerbose } from "../globals.js";
@@ -96,7 +95,6 @@ function buildRuntimeContext(
     sessionKey,
   });
   const compactCurrent = params.runtimeContext?.compactCurrent;
-  const sessionTarget = params.sessionTarget;
   if (!sessionKey && !agentId) {
     return undefined;
   }
@@ -124,15 +122,12 @@ function buildRuntimeContext(
         }).complete(request);
       },
     },
-    ...(compactCurrent && sessionTarget
+    ...(compactCurrent && params.sessionTarget
       ? {
-          // Command capabilities require this live invocation and its captured session generation.
+          // Command capabilities require this live invocation; retained references fail closed.
           compactCurrent: async () => {
             if (!isInvocationOpen()) {
               return blockedCompaction("command invocation closed");
-            }
-            if (loadSessionEntryReadOnly(sessionTarget)?.sessionId !== sessionTarget.sessionId) {
-              return blockedCompaction("command session changed");
             }
             const result = await compactCurrent();
             return isInvocationOpen() ? result : blockedCompaction("command invocation closed");

--- a/src/plugins/plugin-command-execution.ts
+++ b/src/plugins/plugin-command-execution.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveBoundAgentIdForSession } from "../agents/session-agent-binding.js";
 import { resolveConversationBindingContext } from "../channels/conversation-binding-context.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ADMIN_SCOPE, isOperatorScope } from "../gateway/operator-scopes.js";
 import { logVerbose } from "../globals.js";
@@ -25,6 +26,7 @@ import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.
 import type { PluginCommandContext, PluginCommandResult } from "./types.js";
 
 const MAX_ARGS_LENGTH = 4096;
+const blockedCompaction = (reason: string) => ({ compacted: false, reason });
 
 export type PluginCommandExecutionParams = PluginCommandDispatchContext & {
   command: RegisteredPluginCommand;
@@ -82,19 +84,19 @@ type PluginCommandLlmCompleteParams = Parameters<
   NonNullable<PluginCommandRuntimeLlm>["complete"]
 >[0];
 
-function buildRuntimeContext(params: {
-  command: RegisteredPluginCommand;
-  config: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-  authProfileId?: string;
-}): PluginCommandContext["runtimeContext"] {
+function buildRuntimeContext(
+  command: RegisteredPluginCommand,
+  params: PluginCommandDispatchContext,
+  isInvocationOpen: () => boolean,
+): PluginCommandContext["runtimeContext"] {
   const sessionKey = params.sessionKey?.trim();
   const agentId = resolveBoundAgentIdForSession({
     config: params.config,
     agentId: params.agentId,
     sessionKey,
   });
+  const compactCurrent = params.runtimeContext?.compactCurrent;
+  const sessionTarget = params.sessionTarget;
   if (!sessionKey && !agentId) {
     return undefined;
   }
@@ -107,10 +109,10 @@ function buildRuntimeContext(params: {
           authority: {
             caller: {
               kind: "plugin",
-              id: params.command.pluginId,
-              name: params.command.pluginName,
+              id: command.pluginId,
+              name: command.pluginName,
             },
-            pluginIdForPolicy: params.command.pluginId,
+            pluginIdForPolicy: command.pluginId,
             requiresBoundAgent: true,
             ...(sessionKey ? { sessionKey } : {}),
             ...(agentId ? { agentId } : {}),
@@ -122,6 +124,21 @@ function buildRuntimeContext(params: {
         }).complete(request);
       },
     },
+    ...(compactCurrent && sessionTarget
+      ? {
+          // Command capabilities require this live invocation and its captured session generation.
+          compactCurrent: async () => {
+            if (!isInvocationOpen()) {
+              return blockedCompaction("command invocation closed");
+            }
+            if (loadSessionEntryReadOnly(sessionTarget)?.sessionId !== sessionTarget.sessionId) {
+              return blockedCompaction("command session changed");
+            }
+            const result = await compactCurrent();
+            return isInvocationOpen() ? result : blockedCompaction("command invocation closed");
+          },
+        }
+      : {}),
   };
 }
 
@@ -185,6 +202,7 @@ export async function executeRegisteredPluginCommand(
     command.pluginId === normalizeLowercaseStringOrEmpty(command.name);
   const senderIsOwner =
     canExposeSenderIsOwner(command) || trustedReservedOwner ? params.senderIsOwner : undefined;
+  let commandInvocationOpen = true;
   const ctx: PluginCommandContext = {
     senderId,
     channel,
@@ -206,16 +224,7 @@ export async function executeRegisteredPluginCommand(
     messageThreadId: params.messageThreadId,
     threadParentId: params.threadParentId,
     diagnosticsSessions: params.diagnosticsSessions,
-    runtimeContext: {
-      ...buildRuntimeContext({
-        command,
-        config,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-        authProfileId: params.authProfileId,
-      }),
-      ...params.runtimeContext,
-    },
+    runtimeContext: buildRuntimeContext(command, params, () => commandInvocationOpen),
     ...(trustedReservedOwner && params.diagnosticsUploadApproved !== undefined
       ? { diagnosticsUploadApproved: params.diagnosticsUploadApproved }
       : {}),
@@ -275,5 +284,7 @@ export async function executeRegisteredPluginCommand(
   } catch (error) {
     logVerbose(`Plugin command /${command.name} error: ${(error as Error).message}`);
     return { text: "⚠️ Command failed. Please try again later." };
+  } finally {
+    commandInvocationOpen = false;
   }
 }

--- a/src/plugins/plugin-command-runtime.ts
+++ b/src/plugins/plugin-command-runtime.ts
@@ -50,7 +50,13 @@ export type PluginCommandDispatchContext = Readonly<{
   diagnosticsUploadApproved?: PluginCommandContext["diagnosticsUploadApproved"];
   diagnosticsPreviewOnly?: PluginCommandContext["diagnosticsPreviewOnly"];
   diagnosticsPrivateRouted?: PluginCommandContext["diagnosticsPrivateRouted"];
-  runtimeContext?: Pick<NonNullable<PluginCommandContext["runtimeContext"]>, "compactCurrent">;
+  runtimeContext?: {
+    compactCurrent?: (
+      signal?: AbortSignal,
+    ) => ReturnType<
+      NonNullable<NonNullable<PluginCommandContext["runtimeContext"]>["compactCurrent"]>
+    >;
+  };
 }>;
 
 /** Opaque capability bound to one selected command in one registry generation. */

--- a/src/plugins/plugin-command-runtime.ts
+++ b/src/plugins/plugin-command-runtime.ts
@@ -50,6 +50,7 @@ export type PluginCommandDispatchContext = Readonly<{
   diagnosticsUploadApproved?: PluginCommandContext["diagnosticsUploadApproved"];
   diagnosticsPreviewOnly?: PluginCommandContext["diagnosticsPreviewOnly"];
   diagnosticsPrivateRouted?: PluginCommandContext["diagnosticsPrivateRouted"];
+  runtimeContext?: Pick<NonNullable<PluginCommandContext["runtimeContext"]>, "compactCurrent">;
 }>;
 
 /** Opaque capability bound to one selected command in one registry generation. */

--- a/src/plugins/plugin-command.types.ts
+++ b/src/plugins/plugin-command.types.ts
@@ -106,6 +106,12 @@ export type PluginCommandContext = {
   /** Host-bound runtime capabilities scoped to this command invocation. */
   runtimeContext?: {
     llm?: Pick<import("./runtime/types-core.js").PluginRuntimeCore["llm"], "complete">;
+    compactCurrent?: () => Promise<{
+      compacted: boolean;
+      reason?: string;
+      tokensBefore?: number;
+      tokensAfter?: number;
+    }>;
   };
   /** Internal diagnostics-only marker that exec approval already authorized upload. */
   diagnosticsUploadApproved?: boolean;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running `/codex compact` received only a start acknowledgement while the session's compaction count and token meter stayed stale.

## Why This Change Was Made

Plugin commands can now request compaction for their currently bound session through a gated host runtime callback. The host runs the canonical manual-compaction pipeline, including native completion watching and session-store accounting; `/codex compact` preserves Codex-thread binding admission, then delegates to that callback instead of exposing the redundant raw compact control method.

Maintainer decision (Peter Steinberger): `compactCurrent` is approved as a general public Plugin SDK capability for all plugin commands. Its documented structured result and lifecycle are supported external contracts; the host gates it to the current command invocation and exact bound session generation.

The dispatcher snapshots the complete admitted session entry and store target. Host-capability calls never fall back to a later live entry. Manual compaction revalidates that exact generation before aborting an active run, starting native work, and committing accounting. The SQLite commit edge rechecks invocation authority inside the synchronous transaction. Retained and detached callbacks fail closed after handler settlement. Unauthorized public commands receive a structured blocked result without compaction.

`/codex compact` additionally requires complete captured session identity, verifies Codex runtime ownership from the captured store path, and permits a conversation-selected target only when it is the same physical Codex owner (`threadId` and `clientId`) as the session binding. Incomplete, replaced, mixed-runtime, or distinct-owner states fail visibly before compaction.

## User Impact

`/codex compact` now waits for the terminal compaction outcome, refreshes `compactionCount` and the fresh post-compaction token snapshot, and reports either the resulting token count or the skip/failure reason. Sessions without an attached Codex thread or exact Codex runtime ownership receive explicit non-compaction outcomes.

## Evidence

- Regression test applied to `origin/main`: failed because the host compaction callback was absent and no session metadata was recorded.
- Invocation regressions prove retained and unawaited callbacks fail with `command invocation closed` after handler settlement, without later native compaction.
- Session regressions cover durable and in-place generation replacement before invocation, replacement during admission, disappearance, queued-updater authority revocation, and commit-time CAS rejection; memory changes only after a matching authorized durable commit.
- Context-engine successor regressions prove the final fence accepts only the successor committed by this invocation and rejects a harness-returned successor when accounting did not commit.
- Codex coverage proves incomplete identity, non-Codex runtime ownership, missing binding, unauthorized public access, and distinct conversation/session physical owners all fail before host compaction.
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-plugin.test.ts src/auto-reply/reply/commands-compact.test.ts src/auto-reply/reply/session-updates.lifecycle.test.ts src/agents/subagents/registry/subagent-registry.steer-restart.test.ts` — 87 tests passed.
- `node scripts/run-vitest.mjs extensions/codex/src/command-rpc.test.ts extensions/codex/src/commands.test.ts` — 179 tests passed.
- ClawSweeper acceptance set including `src/config/sessions/session-accessor.sqlite-active-events.test.ts` — 73 tests passed.
- `pnpm tsgo`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions`, and `pnpm tsgo:extensions:test` — passed.
- `pnpm lint:tmp:session-accessor-boundary`, the exact hosted core lint stripe, focused core/extension oxlint, formatting, and diff checks — passed.
- `pnpm plugin-sdk:surface:check` and `pnpm docs:list` — passed.
- P1 autoreview — clean after the final commit-edge authority repair.
- Pinned Codex contract: `rust-v0.147.0` (`be6e8eac029b`) documents the immediate empty acknowledgement in `codex-rs/app-server/README.md:194,786-799`, submits `Op::Compact` in `codex-rs/app-server/src/request_processors/thread_processor.rs:1876-1888`, and emits token updates from `codex-rs/app-server/src/bespoke_event_handling.rs:1576-1591` through the notification declared in `codex-rs/app-server-protocol/src/protocol/common.rs:1703`.
- Exact-head CI run `31819137872` passed on `21afbd64548690fbf22215221b4ae54f4fb39210`, including `openclaw/ci-gate`.
- Exact-head ClawSweeper review: no actionable findings; Platinum Hermit, ready for maintainer review.

Production LOC: +308/-98 (net +210). Tests: +693/-27. Documentation: +34/-1. The production growth implements the approved public runtime capability and its closure-bound identity, runtime, binding, native-compaction, queued-update, and durable-commit authority; the former raw command-forward capability was removed.
