### PR TITLE
refactor(runners): prune terminal launch receipts

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -204,7 +204,9 @@ stated honestly (revision 1 undersold this):
   the node withdraws `workerRuns` from its live inventory while retaining the
   supervisor dialect, restores it after a durable terminal commit, and gives a
   third launch up to 10 seconds to acquire capacity before failing visibly.
-  Public inventory does not expose machine counters.
+  Public inventory does not expose machine counters. Terminal node launch
+  receipts retain a 24-hour replay window and prune in bounded batches;
+  `pending` and `running` capacity reservations never age out.
 - **Multi-gateway safety.** The worker install/workspace root on a node is
   namespaced by gateway identity so two gateways pairing one machine cannot
   corrupt each other's state.

--- a/src/node-host/node-worker-capacity.ts
+++ b/src/node-host/node-worker-capacity.ts
@@ -83,6 +83,7 @@ export class NodeWorkerCapacity {
       }
       await recoverRunning(receipt);
     }
+    this.store.pruneExpiredTerminal();
     this.refresh();
   }
 

--- a/src/node-host/node-worker-launch-store.test.ts
+++ b/src/node-host/node-worker-launch-store.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { NodeWorkerLaunchStore } from "./node-worker-launch-store.js";
+import { requireNodeWorkerProcessIdentity } from "./node-worker-process-identity.js";
+import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
+import { writeNodeWorkerFixture } from "./node-worker-supervisor.test-support.js";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const NOW_MS = 10 * DAY_MS;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+function fixture() {
+  const env = { OPENCLAW_STATE_DIR: tempDirs.make("node-worker-launch-store-") };
+  const store = new NodeWorkerLaunchStore({ env });
+  store.get("schema-probe");
+  return { database: openOpenClawStateDatabase({ env }).db, env, store };
+}
+
+function insertLaunch(params: {
+  database: ReturnType<typeof openOpenClawStateDatabase>["db"];
+  launchId: string;
+  state: "pending" | "running" | "completed" | "failed" | "interrupted" | "cancelled";
+  completedAtMs?: number;
+  planHash?: string;
+}) {
+  const processIdentity = requireNodeWorkerProcessIdentity(process.pid);
+  const terminal =
+    params.state === "completed" ||
+    params.state === "failed" ||
+    params.state === "interrupted" ||
+    params.state === "cancelled";
+  const completedAtMs = terminal ? (params.completedAtMs ?? NOW_MS) : null;
+  params.database
+    .prepare(
+      `INSERT INTO node_worker_launches (
+        launch_id, plan_hash, gateway_namespace, environment_id, session_id,
+        owner_epoch, placement_generation, run_id, state,
+        supervisor_pid, supervisor_start_time, worker_pid, worker_start_time,
+        result_json, error_text, completed_at_ms, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, 'gateway-1', 'environment-1', 'session-1', 3, 4, 'run-1', ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
+    )
+    .run(
+      params.launchId,
+      params.planHash ?? "a".repeat(64),
+      params.state,
+      processIdentity.pid,
+      processIdentity.startTime,
+      params.state === "running" ? processIdentity.pid : null,
+      params.state === "running" ? processIdentity.startTime : null,
+      params.state === "completed" ? '{"status":"completed"}' : null,
+      terminal && params.state !== "completed" ? `worker ${params.state}` : null,
+      completedAtMs,
+      completedAtMs ?? 1,
+    );
+}
+
+function launchIds(database: ReturnType<typeof openOpenClawStateDatabase>["db"]): string[] {
+  return (
+    database
+      .prepare("SELECT launch_id FROM node_worker_launches ORDER BY launch_id")
+      .all() as Array<{
+      launch_id: string;
+    }>
+  ).map((row) => row.launch_id);
+}
+
+describe("node worker launch store pruning", () => {
+  it("prunes only the oldest expired terminal receipts in bounded batches", () => {
+    const { database, store } = fixture();
+    insertLaunch({ database, launchId: "old-completed", state: "completed", completedAtMs: 1 });
+    insertLaunch({ database, launchId: "old-failed", state: "failed", completedAtMs: 2 });
+    insertLaunch({ database, launchId: "old-cancelled", state: "cancelled", completedAtMs: 3 });
+    insertLaunch({
+      database,
+      launchId: "recent-completed",
+      state: "completed",
+      completedAtMs: NOW_MS - 1_000,
+    });
+    insertLaunch({ database, launchId: "pending", state: "pending" });
+    insertLaunch({ database, launchId: "running", state: "running" });
+
+    expect(store.pruneExpiredTerminal({ nowMs: NOW_MS, limit: 2 })).toBe(2);
+    expect(launchIds(database)).toEqual([
+      "old-cancelled",
+      "pending",
+      "recent-completed",
+      "running",
+    ]);
+
+    expect(store.pruneExpiredTerminal({ nowMs: NOW_MS, limit: 2 })).toBe(1);
+    expect(launchIds(database)).toEqual(["pending", "recent-completed", "running"]);
+  });
+
+  it("prunes expired terminal receipts after restart reconciliation", async () => {
+    const workerFixture = writeNodeWorkerFixture(tempDirs.make("node-worker-launch-restart-"));
+    const store = new NodeWorkerLaunchStore({ env: workerFixture.env });
+    store.get("schema-probe");
+    const database = openOpenClawStateDatabase({ env: workerFixture.env }).db;
+    insertLaunch({
+      database,
+      launchId: "expired-after-restart",
+      state: "completed",
+      completedAtMs: 1,
+    });
+    const supervisor = createNodeWorkerSupervisor({
+      bundleRoot: workerFixture.bundleRoot,
+      env: workerFixture.env,
+    });
+
+    await supervisor.initialize();
+
+    expect(store.get("expired-after-restart")).toBeUndefined();
+    await supervisor.close();
+  });
+
+  it("keeps the exact replay fence while a new claim prunes unrelated receipts", () => {
+    const { database, store } = fixture();
+    const planHash = "b".repeat(64);
+    insertLaunch({
+      database,
+      launchId: "replayed-launch",
+      state: "completed",
+      completedAtMs: 1,
+      planHash,
+    });
+    insertLaunch({ database, launchId: "stale-launch", state: "completed", completedAtMs: 2 });
+    const supervisor = requireNodeWorkerProcessIdentity(process.pid);
+
+    expect(
+      store.claim(
+        {
+          launchId: "replayed-launch",
+          planHash,
+          gatewayNamespace: "gateway-1",
+          environmentId: "environment-1",
+          sessionId: "session-1",
+          ownerEpoch: 3,
+          placementGeneration: 4,
+          runId: "run-1",
+        },
+        supervisor,
+        2,
+        NOW_MS,
+      ),
+    ).toMatchObject({ action: "replay", receipt: { state: "completed" } });
+    expect(launchIds(database)).toEqual(["replayed-launch"]);
+  });
+});

--- a/src/node-host/node-worker-launch-store.test.ts
+++ b/src/node-host/node-worker-launch-store.test.ts
@@ -62,6 +62,16 @@ function insertLaunch(params: {
     );
 }
 
+function hasTerminalExpiryIndex(
+  database: ReturnType<typeof openOpenClawStateDatabase>["db"],
+): boolean {
+  return Boolean(
+    database
+      .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")
+      .get("idx_node_worker_launches_terminal_completed"),
+  );
+}
+
 function launchIds(database: ReturnType<typeof openOpenClawStateDatabase>["db"]): string[] {
   return (
     database
@@ -73,6 +83,39 @@ function launchIds(database: ReturnType<typeof openOpenClawStateDatabase>["db"])
 }
 
 describe("node worker launch store pruning", () => {
+  it("lazily ensures the terminal expiry index for existing databases", () => {
+    const { database, env } = fixture();
+    expect(hasTerminalExpiryIndex(database)).toBe(true);
+    database.exec("DROP INDEX idx_node_worker_launches_terminal_completed");
+    expect(hasTerminalExpiryIndex(database)).toBe(false);
+    closeOpenClawStateDatabaseForTest();
+
+    const reopenedStore = new NodeWorkerLaunchStore({ env });
+    reopenedStore.get("schema-probe");
+    const reopened = openOpenClawStateDatabase({ env }).db;
+
+    expect(hasTerminalExpiryIndex(reopened)).toBe(true);
+  });
+
+  it("uses the terminal expiry index for the ordered pruning query", () => {
+    const { database } = fixture();
+    const plan = database
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT launch_id
+         FROM node_worker_launches
+         WHERE state IN ('completed', 'failed', 'interrupted', 'cancelled')
+           AND completed_at_ms <= ?
+         ORDER BY completed_at_ms ASC, launch_id ASC
+         LIMIT ?`,
+      )
+      .all(NOW_MS - DAY_MS, 2) as Array<{ detail: string }>;
+
+    expect(plan.map((row) => row.detail).join("\n")).toContain(
+      "idx_node_worker_launches_terminal_completed",
+    );
+  });
+
   it("prunes only the oldest expired terminal receipts in bounded batches", () => {
     const { database, store } = fixture();
     insertLaunch({ database, launchId: "old-completed", state: "completed", completedAtMs: 1 });

--- a/src/node-host/node-worker-launch-store.ts
+++ b/src/node-host/node-worker-launch-store.ts
@@ -80,6 +80,8 @@ const TERMINAL_STATES: ReadonlySet<string> = new Set([
   "interrupted",
   "cancelled",
 ]);
+const TERMINAL_RECEIPT_RETENTION_MS = 24 * 60 * 60 * 1_000;
+const TERMINAL_PRUNE_BATCH_LIMIT = 256;
 
 function ensureNodeWorkerLaunchSchema(database: DatabaseSync): void {
   const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(NODE_WORKER_LAUNCH_SCHEMA_START);
@@ -126,6 +128,40 @@ function readNonterminalRows(database: DatabaseSync): NodeWorkerLaunchRow[] {
       .where("state", "in", ["pending", "running"])
       .orderBy("launch_id", "asc"),
   ).rows;
+}
+
+function pruneTerminalRows(params: {
+  database: DatabaseSync;
+  cutoffMs: number;
+  limit: number;
+  excludeLaunchId?: string;
+}): number {
+  let candidates = query(params.database)
+    .selectFrom("node_worker_launches")
+    .select("launch_id")
+    .where("state", "in", ["completed", "failed", "interrupted", "cancelled"])
+    .where("completed_at_ms", "<=", params.cutoffMs)
+    .orderBy("completed_at_ms", "asc")
+    .orderBy("launch_id", "asc")
+    .limit(params.limit);
+  if (params.excludeLaunchId) {
+    candidates = candidates.where("launch_id", "!=", params.excludeLaunchId);
+  }
+  const launchIds = executeSqliteQuerySync(params.database, candidates).rows.map(
+    (row) => row.launch_id,
+  );
+  if (launchIds.length === 0) {
+    return 0;
+  }
+  const result = executeSqliteQuerySync(
+    params.database,
+    query(params.database)
+      .deleteFrom("node_worker_launches")
+      .where("launch_id", "in", launchIds)
+      .where("state", "in", ["completed", "failed", "interrupted", "cancelled"])
+      .where("completed_at_ms", "<=", params.cutoffMs),
+  );
+  return Number(result.numAffectedRows ?? 0n);
 }
 
 function processIdentity(pid: number, startTime: number): NodeWorkerProcessIdentity {
@@ -178,6 +214,12 @@ function validatePlanHash(value: string): void {
 function validateTimestamp(value: number): void {
   if (!Number.isSafeInteger(value) || value < 0) {
     throw new Error("node worker launch timestamp must be a non-negative safe integer");
+  }
+}
+
+function validatePruneLimit(limit: number): void {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1_000) {
+    throw new Error("node worker launch prune limit must be between 1 and 1000");
   }
 }
 
@@ -302,13 +344,24 @@ export class NodeWorkerLaunchStore {
       : undefined;
 
     return this.write("node-worker-launch.claim", (database) => {
+      const finalize = (result: NodeWorkerLaunchClaimResult): NodeWorkerLaunchClaimResult => {
+        // Preserve the exact replay fence while this launch is being resolved;
+        // unrelated receipts age out in the same transaction as admission.
+        pruneTerminalRows({
+          database,
+          cutoffMs: Math.max(0, nowMs - TERMINAL_RECEIPT_RETENTION_MS),
+          limit: TERMINAL_PRUNE_BATCH_LIMIT,
+          excludeLaunchId: claim.launchId,
+        });
+        return result;
+      };
       let current = readRow(database, claim.launchId);
       if (!current) {
         // The pending row is the physical slot reservation. Count and insert stay
         // in one transaction so concurrent supervisors cannot over-admit.
         const nonterminalCount = readNonterminalCount(database);
         if (nonterminalCount >= capacity) {
-          return { action: "at-capacity", nonterminalCount };
+          return finalize({ action: "at-capacity", nonterminalCount });
         }
         executeSqliteQuerySync(
           database,
@@ -333,11 +386,11 @@ export class NodeWorkerLaunchStore {
             updated_at_ms: nowMs,
           }),
         );
-        return {
+        return finalize({
           action: "start",
           receipt: receiptFromRow(requireMatchingRow(database, claim.launchId, claim.planHash)),
           nonterminalCount: readNonterminalCount(database),
-        };
+        });
       }
       if (current.plan_hash !== claim.planHash) {
         throw new Error(`node worker launch ${claim.launchId} was replayed with a different plan`);
@@ -369,11 +422,11 @@ export class NodeWorkerLaunchStore {
             .where("worker_start_time", "is", null),
         );
         current = requireMatchingRow(database, claim.launchId, claim.planHash);
-        return {
+        return finalize({
           action: rowHasSupervisor(current, supervisor) ? "start" : "replay",
           receipt: receiptFromRow(current),
           nonterminalCount: readNonterminalCount(database),
-        };
+        });
       }
       if (
         current.state === "running" &&
@@ -381,17 +434,17 @@ export class NodeWorkerLaunchStore {
         sameObservedOwner(current, observed) &&
         previousOwnerDefinitelyStale
       ) {
-        return {
+        return finalize({
           action: "recover",
           receipt: receiptFromRow(current),
           nonterminalCount: readNonterminalCount(database),
-        };
+        });
       }
-      return {
+      return finalize({
         action: "replay",
         receipt: receiptFromRow(current),
         nonterminalCount: readNonterminalCount(database),
-      };
+      });
     });
   }
 
@@ -403,6 +456,20 @@ export class NodeWorkerLaunchStore {
 
   nonterminalCount(): number {
     return this.write("node-worker-launch.count-nonterminal", readNonterminalCount);
+  }
+
+  pruneExpiredTerminal(params: { nowMs?: number; limit?: number } = {}): number {
+    const nowMs = params.nowMs ?? Date.now();
+    const limit = params.limit ?? TERMINAL_PRUNE_BATCH_LIMIT;
+    validateTimestamp(nowMs);
+    validatePruneLimit(limit);
+    return this.write("node-worker-launch.prune-terminal", (database) =>
+      pruneTerminalRows({
+        database,
+        cutoffMs: Math.max(0, nowMs - TERMINAL_RECEIPT_RETENTION_MS),
+        limit,
+      }),
+    );
   }
 
   get(launchId: string): NodeWorkerLaunchReceipt | undefined {

--- a/src/node-host/node-worker-launch-store.ts
+++ b/src/node-host/node-worker-launch-store.ts
@@ -72,7 +72,7 @@ export type NodeWorkerLaunchClaimResult =
     };
 
 const NODE_WORKER_LAUNCH_SCHEMA_START = "CREATE TABLE IF NOT EXISTS node_worker_launches (";
-const NODE_WORKER_LAUNCH_SCHEMA_END = "\n) STRICT;";
+const NODE_WORKER_LAUNCH_SCHEMA_END = "\n  WHERE completed_at_ms IS NOT NULL;";
 const initializedDatabases = new WeakSet<DatabaseSync>();
 const TERMINAL_STATES: ReadonlySet<string> = new Set([
   "completed",

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -17,6 +17,7 @@ export const FIRST_USE_STATE_TABLES = [
   "execution_decision_facts",
 ] as const;
 export const FIRST_USE_STATE_INDEXES = [
+  "idx_node_worker_launches_terminal_completed",
   "execution_identity_contexts_run_created_idx",
   "execution_decision_facts_context_occurred_idx",
   "execution_decision_facts_run_occurred_idx",

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -929,6 +929,10 @@ CREATE TABLE IF NOT EXISTS node_worker_launches (
   )
 ) STRICT;
 
+CREATE INDEX IF NOT EXISTS idx_node_worker_launches_terminal_completed
+  ON node_worker_launches(completed_at_ms, launch_id)
+  WHERE completed_at_ms IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS voicewake_triggers (
   config_key TEXT NOT NULL,
   position INTEGER NOT NULL,


### PR DESCRIPTION
Related: #122454

## What Problem This Solves

Node hosts retained every terminal worker launch receipt forever. Long-lived paired devices could therefore grow the shared state database indefinitely even though Gateway retry and status ownership is bounded to the active turn lifecycle.

## Why This Change Was Made

Terminal `completed`, `failed`, `interrupted`, and `cancelled` receipts now retain a fixed 24-hour replay window and prune in deterministic batches of 256. Startup reconciliation prunes after settling stale nonterminal work, and each later admission prunes unrelated expired receipts in the same SQLite transaction. A canonical partial `(completed_at_ms, launch_id)` index is registered as first-use state and lazily ensured for existing databases, so admission never scans and sorts the retained journal.

The launch currently being resolved is explicitly excluded so an old exact replay keeps its idempotency fence. `pending` and `running` rows are never age-pruned because they remain physical capacity reservations and restart-recovery inputs. No config, protocol, migration, or SQLite schema-version surface changes.

## User Impact

There is no visible workflow change. Node-host state remains bounded during upgrades and ongoing use while preserving a generous replay window and all active worker ownership.

AI-assisted implementation; the resulting storage and replay invariants were reviewed and verified.

## Evidence

- 187 focused and schema assertions pass across index creation/query planning, deterministic pruning, startup cleanup, exact replay preservation, capacity, restart recovery, and shared-state compatibility.
- The complete changed-file gate passes formatting, dead exports, core and core-test typechecks, lint, schema-v7, database-first storage, import cycles, docs, webhook, and pairing guards.
- The remote validation backend was unavailable before execution, so the repository-approved trusted local fallback ran the complete changed gate successfully.
- Fresh branch autoreview is clean with no accepted/actionable findings.
- Production delta: +73 lines for bounded terminal receipt retention, lazy index registration, and indexed pruning. Tests add +199 lines; docs add +2 net lines.
