### PR TITLE
fix(cli): return structured Gmail setup errors

### DIFF
--- a/src/cli/webhooks-cli.test.ts
+++ b/src/cli/webhooks-cli.test.ts
@@ -36,30 +36,56 @@ describe("webhooks cli", () => {
   beforeEach(() => {
     mocks.runtimeErrors.length = 0;
     mocks.defaultRuntime.error.mockClear();
+    mocks.defaultRuntime.writeJson.mockClear();
     mocks.defaultRuntime.exit.mockClear();
     mocks.runGmailSetup.mockClear();
     mocks.runGmailService.mockClear();
   });
 
   it.each([
-    ["setup", "--port", "8080x"],
+    ["setup", "--port", "8080x", true],
     ["setup", "--max-bytes", "10mb"],
     ["setup", "--renew-minutes", "30m"],
     ["run", "--port", "8080x"],
     ["run", "--max-bytes", "10mb"],
     ["run", "--renew-minutes", "30m"],
-  ])("rejects partial gmail %s %s", async (command, flag, value) => {
+  ])("rejects partial gmail %s %s", async (command, flag, value, json = false) => {
     const program = createProgram();
     const args =
       command === "setup"
         ? ["webhooks", "gmail", command, "--account", "default", flag, value]
         : ["webhooks", "gmail", command, flag, value];
+    if (json) {
+      args.push("--json");
+    }
 
     await expect(program.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
 
-    expect(runtimeErrors().join("\n")).toContain(`${flag} must be a positive integer.`);
+    if (json) {
+      expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledWith({
+        error: `Error: ${flag} must be a positive integer.`,
+      });
+      expect(mocks.defaultRuntime.error).not.toHaveBeenCalled();
+    } else {
+      expect(runtimeErrors().join("\n")).toContain(`${flag} must be a positive integer.`);
+    }
     expect(mocks.runGmailSetup).not.toHaveBeenCalled();
     expect(mocks.runGmailService).not.toHaveBeenCalled();
+  });
+
+  it("writes JSON when gmail setup rejects", async () => {
+    mocks.runGmailSetup.mockRejectedValueOnce(new Error("setup failed"));
+    const program = createProgram();
+
+    await expect(
+      program.parseAsync(["webhooks", "gmail", "setup", "--account", "default", "--json"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(mocks.runGmailSetup).toHaveBeenCalledWith(expect.objectContaining({ json: true }));
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledWith({ error: "Error: setup failed" });
+    expect(mocks.defaultRuntime.error).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -71,7 +71,11 @@ export function registerWebhooksCli(program: Command) {
         const parsed = parseGmailSetupOptions(opts);
         await runGmailSetup(parsed);
       } catch (err) {
-        defaultRuntime.error(danger(String(err)));
+        if (opts.json) {
+          defaultRuntime.writeJson({ error: String(err) });
+        } else {
+          defaultRuntime.error(danger(String(err)));
+        }
         defaultRuntime.exit(1);
       }
     });


### PR DESCRIPTION
Closes #123644

## What Problem This Solves

Fixes an issue where `openclaw webhooks gmail setup --json` emitted empty stdout and styled human stderr when option validation or the setup operation failed. Automation requesting JSON could not parse the error.

## Why This Change Was Made

The Gmail setup action's existing catch now writes `{ error: String(err) }` through the runtime JSON owner when `--json` is active and retains the current styled stderr path otherwise. Setup options, validation, tailscale behavior, successful output, and exit status remain unchanged.

## User Impact

Gmail webhook setup now returns machine-readable JSON on both success and failure. Human CLI users continue receiving the same readable stderr errors.

## Evidence

- Tests-first process proof reproduced exit 1 with empty stdout and a colored positive-integer error on stderr for `--port 8080x --json`.
- Regressions cover both strict numeric validation and a rejected setup operation in JSON mode, plus unchanged human validation behavior.
- Post-fix focused proof: 20/20 Webhooks CLI tests and 2/2 Gmail operations tests passed.
- Source-blind post-fix invalid-port proof: exit 1, valid JSON stdout, human mode still uses stderr.
- Blacksmith Testbox core + coreTests changed gate passed, including typechecks, changed lint, dead exports, import cycles, formatting, and storage/schema/architecture guards: https://github.com/openclaw/openclaw/actions/runs/31798833502 (`tbx_01m002jj1tdj7gt0x4xpt54aaz`).
- Final Codex autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Exact reviewed head: `82f0efb07bfef028578285fca11084c1ec409b7f`.

Production delta: +5/-1, net +4. Tests: +29/-3, net +26.

AI-assisted: yes. The repair was reviewed against Gmail setup option parsing, setup operation failures, runtime stdout/stderr/exit ownership, documented JSON behavior, and the existing Directory/system JSON-error precedents.
