### PR TITLE
test(agents): isolate FIFO read watchdog

### DIFF
--- a/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
@@ -77,6 +77,11 @@ const FORCED_COPY_FAILURE_MUTATION_PYTHON = SANDBOX_PINNED_MUTATION_PYTHON.repla
   "        raise OSError(errno.ENOSPC, 'forced copy failure')\n        copy_completed = True",
 );
 
+const FIFO_READ_WATCHDOG_MUTATION_PYTHON = SANDBOX_PINNED_MUTATION_PYTHON.replace(
+  "def read_file_impl(parent_fd, basename, max_bytes):",
+  "def read_file_impl(parent_fd, basename, max_bytes):\n    import signal\n    signal.alarm(1)",
+);
+
 const FORCED_CREATE_FAILURE_MUTATION_PYTHON = SANDBOX_PINNED_MUTATION_PYTHON.replace(
   "        # exclusive create payload is durable before publication",
   "        raise OSError(errno.ENOSPC, 'forced create failure')\n        # exclusive create payload is durable before publication",
@@ -545,16 +550,12 @@ describe("sandbox pinned mutation helper", () => {
       await fs.mkdir(workspace, { recursive: true });
       expect(spawnSync("mkfifo", [fifoPath]).status).toBe(0);
 
-      const result = spawnSync(
-        "python3",
-        ["-c", SANDBOX_PINNED_MUTATION_PYTHON, "read", workspace, "", "live.pipe"],
-        {
-          encoding: "utf8",
-          stdio: ["pipe", "pipe", "pipe"],
-          timeout: 1_000,
-          killSignal: "SIGKILL",
-        },
-      );
+      const result = runMutationWithSource(FIFO_READ_WATCHDOG_MUTATION_PYTHON, [
+        "read",
+        workspace,
+        "",
+        "live.pipe",
+      ]);
 
       expect(result.error).toBeUndefined();
       expect(result.status).not.toBe(0);


### PR DESCRIPTION
## Summary

- start the FIFO-read watchdog inside the Python helper immediately before the potentially blocking open
- keep the same one-second deadline and the same non-regular-file assertion
- remove host interpreter startup from the behavior deadline

## Root cause

Main CI run 31797790504 failed `checks-node-compact-large-12` because the test's one-second `spawnSync` timeout included Python process startup. Under runner contention, startup consumed the deadline before the helper could prove its `O_NONBLOCK` FIFO rejection. The resulting timeout also dumped the entire embedded helper into the failure, obscuring the invariant under test.

The repair keeps the watchdog at one second but installs it with `signal.alarm(1)` inside the test-only Python variant immediately before `os.open`. A real blocking regression is still killed and fails the existing error-detail assertion; slow host startup no longer creates a false failure.

## Proof

- exact failed run: https://github.com/openclaw/openclaw/actions/runs/31797790504
- removing `O_NONBLOCK` makes the focused regression fail after the watchdog fires
- `node scripts/run-vitest.mjs src/agents/sandbox/fs-bridge-mutation-helper.test.ts -- -t "rejects FIFO reads without blocking"` — passed
- `node scripts/run-vitest.mjs src/agents/sandbox/fs-bridge-mutation-helper.test.ts` — 28 passed
- `node scripts/check-changed.mjs -- src/agents/sandbox/fs-bridge-mutation-helper.test.ts` — passed on Blacksmith Testbox
- autoreview — clean, no accepted/actionable findings

Production LOC: 0. Test LOC: +1 net.
