### PR TITLE
fix(exec-auto-reviewer): guard JSON.parse in hasDuplicateJsonObjectKeys with try/catch

### DIFF
--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -181,6 +181,10 @@ describe("parseExecAutoReviewResponse", () => {
       "an unexpected prototype key",
       '{"decision":"allow","risk":"low","__proto__":{"decision":"allow"}}',
     ],
+    [
+      "an escaped backslash in a duplicate key",
+      String.raw`{"decisio\\n":"ask","risk":"low","decisio\\n":"allow"}`,
+    ],
   ])("defers ambiguous reviewer JSON with %s", async (_label, text) => {
     await expect(reviewExecResponse(text)).resolves.toMatchObject({
       decision: "ask",

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -175,11 +175,17 @@ function hasDuplicateJsonObjectKeys(text: string): boolean {
         next += 1;
       }
       if (text[next] === ":") {
-        const key = JSON.parse(text.slice(index, end + 1)) as string;
-        if (keys.has(key)) {
-          return true;
+        try {
+          const key = JSON.parse(text.slice(index, end + 1)) as string;
+          if (keys.has(key)) {
+            return true;
+          }
+          keys.add(key);
+        } catch {
+          // Skip keys that are not valid JSON strings (e.g. malformed escape
+          // sequences) so that a single bad key does not abort the entire
+          // duplicate-key scan and silently bypass the safety check.
         }
-        keys.add(key);
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

The `hasDuplicateJsonObjectKeys` function in `src/agents/exec-auto-reviewer.ts` uses `JSON.parse` to decode individual JSON string keys extracted by its custom character-by-character scanner (line 178). This `JSON.parse` call is unguarded -- unlike the outer `JSON.parse(objectText)` on line 204, which is wrapped in a try/catch that returns a safe fallback.

If the scanner's string-extraction logic ever produces a substring that is not a valid JSON string token (e.g. due to a future change in the scanner or an unanticipated JSON edge case), the unguarded `JSON.parse` throws a `SyntaxError` that propagates uncaught through `parseExecAutoReviewResponse`. This aborts the duplicate-key safety check entirely. Since duplicate keys can silently override an earlier `ask` or `high`-risk decision (as noted in the comment on lines 212-213), an aborted check is a safety gap.

## Evidence

**Before (line 177-183):**
```ts
      if (text[next] === ":") {
        const key = JSON.parse(text.slice(index, end + 1)) as string;
        if (keys.has(key)) {
          return true;
        }
        keys.add(key);
      }
```

**After:**
```ts
      if (text[next] === ":") {
        try {
          const key = JSON.parse(text.slice(index, end + 1)) as string;
          if (keys.has(key)) {
            return true;
          }
          keys.add(key);
        } catch {
          // Skip keys that are not valid JSON strings (e.g. malformed escape
          // sequences) so that a single bad key does not abort the entire
          // duplicate-key scan and silently bypass the safety check.
        }
      }
```

The try/catch ensures that a single unparseable key skips that key and continues scanning the rest of the object, preserving the duplicate-detection safety check rather than aborting it.

A new regression test verifies duplicate-key detection when keys contain escaped backslash sequences:

```ts
[
  "an escaped backslash in a duplicate key",
  String.raw`{"decisio\\n":"ask","risk":"low","decisio\\n":"allow"}`,
],
```

This test confirms that `hasDuplicateJsonObjectKeys` correctly scans the raw text, calls `JSON.parse` on each extracted key token, and detects that the key `decisio\n` (with a literal backslash) appears twice. `parseExecAutoReviewResponse` returns the safe `{ decision: "ask", risk: "unknown" }` fallback.

## Root cause

The `hasDuplicateJsonObjectKeys` function was written with an unguarded `JSON.parse` call, inconsistent with the defensive error-handling pattern used by the surrounding `parseExecAutoReviewResponse` function (which wraps its own `JSON.parse` in try/catch). The fix makes the error handling consistent and ensures the duplicate-key safety check cannot be bypassed by a single unparseable key.