### PR TITLE
chore: capture Control UI E2E timeout diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1670,6 +1670,7 @@ jobs:
       - name: Test Control UI end-to-end
         if: matrix.task == 'control-ui'
         env:
+          OPENCLAW_UI_E2E_DIAGNOSTIC_DIR: .artifacts/control-ui-e2e-timeouts/shard-${{ matrix.shard }}-attempt-${{ github.run_attempt }}
           SHARD_INDEX: ${{ matrix.shard }}
           VITEST_SHARD_COUNT: ${{ matrix.vitest_shard_count }}
         run: >-
@@ -1677,6 +1678,15 @@ jobs:
           --config test/vitest/vitest.ui-e2e.config.ts
           --configLoader runner
           --shard "$SHARD_INDEX/$VITEST_SHARD_COUNT"
+
+      - name: Upload Control UI E2E timeout diagnostics
+        if: failure() && matrix.task == 'control-ui'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: control-ui-e2e-timeout-${{ matrix.shard }}-${{ github.run_attempt }}
+          path: .artifacts/control-ui-e2e-timeouts/shard-${{ matrix.shard }}-attempt-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Test browser extension bootstrap end-to-end
         if: matrix.task == 'browser-extension'

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6488,12 +6488,31 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(scenario.if).toBe("matrix.task == 'control-ui'");
     expect(scenario.env).toEqual({
+      OPENCLAW_UI_E2E_DIAGNOSTIC_DIR:
+        ".artifacts/control-ui-e2e-timeouts/shard-${{ matrix.shard }}-attempt-${{ github.run_attempt }}",
       SHARD_INDEX: "${{ matrix.shard }}",
       VITEST_SHARD_COUNT: "${{ matrix.vitest_shard_count }}",
     });
     expect(scenario.run).toBe(
       'node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner --shard "$SHARD_INDEX/$VITEST_SHARD_COUNT"',
     );
+    const timeoutDiagnostics = expectDefined(
+      uiE2e.steps.find(
+        (step: WorkflowStep) => step.name === "Upload Control UI E2E timeout diagnostics",
+      ),
+      "Control UI E2E timeout diagnostic upload",
+    );
+    expect(timeoutDiagnostics).toEqual({
+      name: "Upload Control UI E2E timeout diagnostics",
+      if: "failure() && matrix.task == 'control-ui'",
+      uses: UPLOAD_ARTIFACT_V7,
+      with: {
+        name: "control-ui-e2e-timeout-${{ matrix.shard }}-${{ github.run_attempt }}",
+        path: ".artifacts/control-ui-e2e-timeouts/shard-${{ matrix.shard }}-attempt-${{ github.run_attempt }}",
+        "if-no-files-found": "ignore",
+        "retention-days": 7,
+      },
+    });
     const browserExtension = expectDefined(
       uiE2e.steps.find(
         (step: WorkflowStep) => step.name === "Test browser extension bootstrap end-to-end",

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1,12 +1,12 @@
 // Control UI test helper supports control ui e2e setup.
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { createServer as createNetServer } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
-import type { Locator, Page } from "playwright";
+import type { ConsoleMessage, Locator, Page, Request } from "playwright";
 import type { InlineConfig, Plugin, PreviewServer, ViteDevServer } from "vite";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../src/gateway/control-ui-contract.js";
@@ -337,6 +337,109 @@ const DEFAULT_CONTROL_UI_E2E_BUILD_INFO: ControlUiBuildInfo = {
 };
 
 let sharedControlUiE2eServerBaseUrl: string | null = null;
+
+const CONTROL_UI_E2E_DIAGNOSTIC_RING_LIMIT = 200;
+const controlUiE2ePageDiagnostics = new WeakMap<Page, ControlUiE2eDiagnosticEvent[]>();
+const controlUiE2eUnhandledRejectionPages = new WeakSet<Page>();
+let controlUiE2eDiagnosticSequence = 0;
+
+type ControlUiE2eDiagnosticEvent = {
+  at: string;
+  details: Record<string, unknown>;
+  source: "console" | "pageerror" | "requestfailed";
+};
+
+function installControlUiE2ePageDiagnosticRing(page: Page): ControlUiE2eDiagnosticEvent[] {
+  const existing = controlUiE2ePageDiagnostics.get(page);
+  if (existing) {
+    return existing;
+  }
+  const events: ControlUiE2eDiagnosticEvent[] = [];
+  const push = (event: ControlUiE2eDiagnosticEvent) => {
+    events.push(event);
+    if (events.length > CONTROL_UI_E2E_DIAGNOSTIC_RING_LIMIT) {
+      events.splice(0, events.length - CONTROL_UI_E2E_DIAGNOSTIC_RING_LIMIT);
+    }
+  };
+  const onConsole = (message: ConsoleMessage) => {
+    push({
+      at: new Date().toISOString(),
+      details: {
+        location: message.location(),
+        text: message.text(),
+        type: message.type(),
+      },
+      source: "console",
+    });
+  };
+  const onPageError = (error: Error) => {
+    push({
+      at: new Date().toISOString(),
+      details: { message: error.message, name: error.name, stack: error.stack ?? null },
+      source: "pageerror",
+    });
+  };
+  const onRequestFailed = (request: Request) => {
+    push({
+      at: new Date().toISOString(),
+      details: {
+        errorText: request.failure()?.errorText ?? null,
+        method: request.method(),
+        resourceType: request.resourceType(),
+        url: request.url(),
+      },
+      source: "requestfailed",
+    });
+  };
+  page.on("console", onConsole);
+  page.on("pageerror", onPageError);
+  page.on("requestfailed", onRequestFailed);
+  page.once("close", () => {
+    page.off("console", onConsole);
+    page.off("pageerror", onPageError);
+    page.off("requestfailed", onRequestFailed);
+    controlUiE2ePageDiagnostics.delete(page);
+  });
+  controlUiE2ePageDiagnostics.set(page, events);
+  return events;
+}
+
+async function installControlUiE2eUnhandledRejectionRing(page: Page): Promise<void> {
+  if (controlUiE2eUnhandledRejectionPages.has(page)) {
+    return;
+  }
+  controlUiE2eUnhandledRejectionPages.add(page);
+  await page.addInitScript(() => {
+    const windowWithDiagnostics = window as Window & {
+      __OPENCLAW_CONTROL_UI_E2E_UNHANDLED_REJECTIONS__?: Array<{
+        at: string;
+        reason: unknown;
+      }>;
+    };
+    const events: Array<{ at: string; reason: unknown }> = [];
+    windowWithDiagnostics["__OPENCLAW_CONTROL_UI_E2E_UNHANDLED_REJECTIONS__"] = events;
+    window.addEventListener("unhandledrejection", (event) => {
+      let reason: unknown;
+      if (event.reason instanceof Error) {
+        reason = {
+          message: event.reason.message,
+          name: event.reason.name,
+          stack: event.reason.stack ?? null,
+        };
+      } else {
+        try {
+          reason = structuredClone(event.reason) as unknown;
+        } catch {
+          reason = String(event.reason);
+        }
+      }
+      events.push({ at: new Date().toISOString(), reason });
+      if (events.length > 200) {
+        events.splice(0, events.length - 200);
+      }
+    });
+  });
+}
 
 export function setSharedControlUiE2eServerBaseUrl(baseUrl: string | null): void {
   sharedControlUiE2eServerBaseUrl = baseUrl;
@@ -805,6 +908,7 @@ function installControlUiMockGateway(
       hasMultipleSessionSharingIdentities: boolean;
     }) => void;
     socketCount: () => number;
+    socketStates: () => Array<{ readyState: number; state: string; url: string }>;
     socketUrls: () => string[];
   };
   type WindowWithGateway = Window & {
@@ -834,7 +938,7 @@ function installControlUiMockGateway(
   const sessionPatches = new Map<string, Record<string, unknown>>();
   const createdSessions = new Map<string, Record<string, unknown>>();
   const sessionMessageSubscriptions = new Set<string>();
-  const sockets: Array<{ readonly url: string }> = [];
+  const sockets: Array<{ readonly readyState: number; readonly url: string }> = [];
   let deviceAuthMigrationPending = scenario.deviceAuthMigrationPending;
   let deviceAuthMigrationDeviceId = "";
   let sessionMessageEventIndex = 0;
@@ -1970,6 +2074,20 @@ function installControlUiMockGateway(
     socketCount() {
       return sockets.length;
     },
+    socketStates() {
+      return sockets.map((socket) => ({
+        readyState: socket.readyState,
+        state:
+          socket.readyState === MockWebSocket.CONNECTING
+            ? "connecting"
+            : socket.readyState === MockWebSocket.OPEN
+              ? "open"
+              : socket.readyState === MockWebSocket.CLOSING
+                ? "closing"
+                : "closed",
+        url: socket.url,
+      }));
+    },
     socketUrls() {
       return sockets.map((socket) => socket.url);
     },
@@ -2004,6 +2122,7 @@ export async function installMockGateway(
   scenario: ControlUiMockGatewayScenario = {},
 ): Promise<MockGatewayControls> {
   const normalizedScenario = normalizeScenario(scenario);
+  const diagnosticEvents = installControlUiE2ePageDiagnosticRing(page);
   await page.route(`**${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`, (route) =>
     route.fulfill({
       body: JSON.stringify(createControlUiMockBootstrapConfig(normalizedScenario)),
@@ -2011,11 +2130,16 @@ export async function installMockGateway(
       status: 200,
     }),
   );
+  await installControlUiE2eUnhandledRejectionRing(page);
   await page.addInitScript({ content: createControlUiMockGatewayInitScript(normalizedScenario) });
-  return createMockGatewayControls(page, normalizedScenario.sessionKey);
+  return createMockGatewayControls(page, normalizedScenario.sessionKey, diagnosticEvents);
 }
 
-function createMockGatewayControls(page: Page, defaultSessionKey: string): MockGatewayControls {
+function createMockGatewayControls(
+  page: Page,
+  defaultSessionKey: string,
+  diagnosticEvents: ControlUiE2eDiagnosticEvent[],
+): MockGatewayControls {
   const emitGatewayEvent = async (event: string, payload?: unknown) => {
     await page.evaluate(
       ({ eventName, eventPayload }) => {
@@ -2262,20 +2386,34 @@ function createMockGatewayControls(page: Page, defaultSessionKey: string): MockG
       }, policy);
     },
     async waitForRequest(method) {
-      await page.waitForFunction(
-        (targetMethod) => {
-          const gateway = (
-            window as Window & {
-              openclawControlUiE2eGateway?: {
-                requests: MockGatewayRequest[];
-              };
-            }
-          ).openclawControlUiE2eGateway;
-          return Boolean(gateway?.requests.some((request) => request.method === targetMethod));
-        },
-        method,
-        { timeout: controlUiE2eWaitTimeoutMs },
-      );
+      try {
+        await page.waitForFunction(
+          (targetMethod) => {
+            const gateway = (
+              window as Window & {
+                openclawControlUiE2eGateway?: {
+                  requests: MockGatewayRequest[];
+                };
+              }
+            ).openclawControlUiE2eGateway;
+            return Boolean(gateway?.requests.some((request) => request.method === targetMethod));
+          },
+          method,
+          { timeout: controlUiE2eWaitTimeoutMs },
+        );
+      } catch (error) {
+        if (error instanceof Error && error.name === "TimeoutError") {
+          try {
+            await captureControlUiE2eRequestTimeout(page, method, error, diagnosticEvents);
+          } catch (captureError) {
+            console.error("[control-ui-e2e] failed to capture request-timeout diagnostics", {
+              captureError,
+              method,
+            });
+          }
+        }
+        throw error;
+      }
       const requests = await getRequests(method);
       const request = requests.at(-1);
       if (!request) {
@@ -2284,6 +2422,179 @@ function createMockGatewayControls(page: Page, defaultSessionKey: string): MockG
       return request;
     },
   };
+}
+
+async function captureControlUiE2eRequestTimeout(
+  page: Page,
+  method: string,
+  timeoutError: Error,
+  diagnosticEvents: ControlUiE2eDiagnosticEvent[],
+): Promise<void> {
+  const configuredDir = process.env.OPENCLAW_UI_E2E_DIAGNOSTIC_DIR?.trim();
+  const artifactDir = path.resolve(
+    configuredDir || path.join(resolveRepoRoot(), ".artifacts", "control-ui-e2e-timeouts", "local"),
+  );
+  mkdirSync(artifactDir, { recursive: true });
+  const safeMethod = method.replaceAll(/[^a-zA-Z0-9_.-]+/gu, "-");
+  const captureId = `${new Date().toISOString().replaceAll(/[:.]/gu, "-")}-${String(++controlUiE2eDiagnosticSequence).padStart(2, "0")}-${safeMethod}`;
+  const screenshotName = `${captureId}.png`;
+  const screenshotPath = path.join(artifactDir, screenshotName);
+  const reportPath = path.join(artifactDir, `${captureId}.json`);
+  const captureErrors: string[] = [];
+  let browserState: unknown = null;
+  try {
+    browserState = await page.evaluate(() => {
+      const copy = (value: unknown): unknown => {
+        try {
+          return structuredClone(value) as unknown;
+        } catch {
+          return String(value);
+        }
+      };
+      type Runtime = {
+        context?: {
+          agents?: {
+            state?: {
+              agentsError?: unknown;
+              agentsList?: unknown;
+              agentsLoading?: unknown;
+              connected?: unknown;
+            };
+          };
+          agentSelection?: { state?: unknown };
+          gateway?: { snapshot?: { assistantAgentId?: unknown; hello?: unknown; phase?: unknown } };
+          router?: { getState?: () => unknown };
+        };
+        router?: { getState?: () => unknown };
+      };
+      type MockGateway = {
+        requests?: MockGatewayRequest[];
+        socketStates?: () => Array<{ readyState: number; state: string; url: string }>;
+        socketUrls?: () => string[];
+      };
+      const windowState = window as Window & {
+        __OPENCLAW_CONTROL_UI_E2E_UNHANDLED_REJECTIONS__?: unknown[];
+        openclawControlUiE2eGateway?: MockGateway;
+      };
+      const app = document.querySelector("openclaw-app") as
+        | (HTMLElement & { runtime?: Runtime })
+        | null;
+      const shell = document.querySelector("openclaw-app-shell") as
+        | (HTMLElement & { runtime?: Runtime })
+        | null;
+      const runtime = app?.runtime ?? shell?.runtime;
+      const context = runtime?.context;
+      const agentsState = context?.agents?.state;
+      const gatewaySnapshot = context?.gateway?.snapshot;
+      const routerState = runtime?.router?.getState?.() ?? context?.router?.getState?.();
+      const summarizeMatches = (matches: unknown): unknown =>
+        Array.isArray(matches)
+          ? matches.map((match) => {
+              if (!match || typeof match !== "object") {
+                return copy(match);
+              }
+              const record = match as Record<string, unknown>;
+              return {
+                pathname: copy(record.pathname ?? record.path ?? null),
+                routeId: copy(record.routeId ?? record.id ?? null),
+              };
+            })
+          : copy(matches ?? []);
+      const customElementCounts: Record<string, number> = {};
+      for (const element of document.querySelectorAll("*")) {
+        const name = element.localName;
+        if (!name.includes("-")) {
+          continue;
+        }
+        customElementCounts[name] = (customElementCounts[name] ?? 0) + 1;
+      }
+      return {
+        app: {
+          agentSelection: copy(context?.agentSelection?.state ?? null),
+          gateway: {
+            assistantAgentId: copy(gatewaySnapshot?.assistantAgentId ?? null),
+            hello: copy(gatewaySnapshot?.hello ?? null),
+            phase: copy(gatewaySnapshot?.phase ?? null),
+          },
+          roster: {
+            agentsError: copy(agentsState?.agentsError ?? null),
+            agentsList: copy(agentsState?.agentsList ?? null),
+            agentsLoading: copy(agentsState?.agentsLoading ?? null),
+            connected: copy(agentsState?.connected ?? null),
+          },
+          router:
+            routerState && typeof routerState === "object"
+              ? {
+                  matches: summarizeMatches((routerState as { matches?: unknown }).matches),
+                  pendingMatches: summarizeMatches(
+                    (routerState as { pendingMatches?: unknown }).pendingMatches,
+                  ),
+                  resolvedLocation: copy(
+                    (routerState as { resolvedLocation?: unknown }).resolvedLocation ?? null,
+                  ),
+                  status: copy((routerState as { status?: unknown }).status ?? null),
+                }
+              : copy(routerState ?? null),
+        },
+        document: {
+          customElementCounts,
+          hasApp: Boolean(app),
+          hasShell: Boolean(shell),
+          readyState: document.readyState,
+          title: document.title,
+          url: window.location.href,
+        },
+        mockGateway: {
+          installed: Boolean(windowState.openclawControlUiE2eGateway),
+          requests: copy(windowState.openclawControlUiE2eGateway?.requests ?? []),
+          socketStates: copy(windowState.openclawControlUiE2eGateway?.socketStates?.() ?? []),
+          socketUrls: copy(windowState.openclawControlUiE2eGateway?.socketUrls?.() ?? []),
+        },
+        unhandledRejections: copy(
+          windowState["__OPENCLAW_CONTROL_UI_E2E_UNHANDLED_REJECTIONS__"] ?? [],
+        ),
+      };
+    });
+  } catch (error) {
+    captureErrors.push(`page.evaluate: ${String(error)}`);
+  }
+  let screenshotWritten = false;
+  try {
+    await page.screenshot({ fullPage: true, path: screenshotPath });
+    screenshotWritten = true;
+  } catch (error) {
+    captureErrors.push(`page.screenshot: ${String(error)}`);
+  }
+  const report = {
+    schemaVersion: 1,
+    awaitedMethod: method,
+    browserState,
+    captureErrors,
+    capturedAt: new Date().toISOString(),
+    ci: {
+      githubJob: process.env.GITHUB_JOB ?? null,
+      runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
+      runId: process.env.GITHUB_RUN_ID ?? null,
+      shardIndex: process.env.SHARD_INDEX ?? null,
+      vitestShardCount: process.env.VITEST_SHARD_COUNT ?? null,
+    },
+    pageEvents: [...diagnosticEvents],
+    page: {
+      closed: page.isClosed(),
+      url: page.url(),
+    },
+    screenshot: screenshotWritten ? screenshotName : null,
+    timeout: {
+      message: timeoutError.message,
+      name: timeoutError.name,
+      stack: timeoutError.stack ?? null,
+    },
+  };
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  console.error(`[control-ui-e2e] request timeout diagnostics: ${reportPath}`);
+  if (screenshotWritten) {
+    console.error(`[control-ui-e2e] request timeout screenshot: ${screenshotPath}`);
+  }
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational problem where intermittent Control UI mocked-Gateway timeouts reported only the missing RPC method, leaving no evidence about browser boot, Gateway handshake, route ownership, or prior page failures.

## Why This Change Was Made

The mocked Control UI harness now keeps capped browser diagnostic rings and captures a structured runtime snapshot plus full-page screenshot only when `waitForRequest` actually times out. CI uploads the shard/attempt-scoped directory only on failure and ignores an empty directory. This does not change the wait timeout or production behavior.

## User Impact

No user-visible product change. Maintainers will get an actionable timeout artifact instead of a bare `waitForRequest` stack when this intermittent CI failure recurs.

## Evidence

- Exact-hang investigation: `model-agent-scoping` reproduced 0/10 times on PR #123595's exact shard and 0/10 times under two-process CPU contention, motivating evidence capture instead of a speculative product fix.
- Green E2E proof after rebase: `debug-diagnostics`, `model-agent-scoping`, and `terminal-embedded` — 3 files / 5 tests passed; diagnostic artifact count remained 0.
- Synthetic timeout scratch proof (scratch test removed before commit): expected exit 1 after the unchanged wait deadline; wrote exactly one JSON report and one PNG with `captureErrors: []`.
- Owning workflow guard: 1 passed (`gates current Control UI changes on ordinary and real-Gateway Chromium E2E`). The broader file reached 119 passed / 2 skipped; its one unrelated temporary-topology fixture failed because the fixture checkout could not resolve `tsx`.
- `node --import tsx scripts/check-workflows.mts` passed, including zizmor.
- Blacksmith Testbox changed gate passed on run 31799321185: core/UI/root-test typechecks, changed-file and scripts lint, format, dependency, dead-export, i18n, and architecture guards.
- `oxfmt --check`, `git diff --check`, and branch autoreview passed cleanly.
- Production LOC: 0. Changes are limited to E2E test support, its workflow upload contract, and the workflow guard.

Synthetic JSON excerpt (abridged; generated IDs and loopback port omitted):

```json
{
  "schemaVersion": 1,
  "awaitedMethod": "never.sent",
  "captureErrors": [],
  "page": { "closed": false, "url": "http://127.0.0.1:<port>/chat/main" },
  "browserState": {
    "app": {
      "gateway": { "phase": "connected", "hello": { "type": "hello-ok" } },
      "agentSelection": { "selectedId": "main", "scopeId": "main" },
      "roster": { "connected": true, "agentsLoading": false },
      "router": { "status": "success", "matches": [{ "routeId": "chat" }] }
    },
    "document": { "readyState": "complete", "hasApp": true, "hasShell": true },
    "mockGateway": {
      "requests": ["<24 full request records captured>"],
      "socketStates": [{ "readyState": 1, "state": "open", "url": "ws://127.0.0.1:<port>" }]
    },
    "unhandledRejections": [{ "reason": { "message": "synthetic-timeout-rejection" } }]
  },
  "pageEvents": [
    { "source": "console" },
    { "source": "pageerror" },
    { "source": "requestfailed" }
  ],
  "screenshot": "<capture-id>.png"
}
```
