### PR TITLE
fix(macos): node worker no longer restarts after stop

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -665,7 +665,6 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         preserveStart: Bool = false,
         notifyUnexpectedExit: Bool = false) -> Task<Void, Never>?
     {
-        if let processCleanupTask = self.processCleanupTask { return processCleanupTask }
         let wasReady = self.manifest != nil
         self.startTimer?.cancel()
         self.startTimer = nil
@@ -677,6 +676,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         if !preserveStart {
             self.finishStartLocked(.failure(WorkerError.unavailable(reason)))
         }
+        if let processCleanupTask = self.processCleanupTask { return processCleanupTask }
         let pending = self.invokeContinuations
         self.invokeContinuations.removeAll()
         self.pendingInvokeControls.removeAll()

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -366,6 +366,58 @@ struct MacNodeHostWorkerTests {
         await worker.stop()
     }
 
+    @Test func `stop cancels a changed launch during worker cleanup`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-worker-restart-stop-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let cleanupStartedPIDFile = directory.appendingPathComponent("cleanup-started.pid")
+        let replacementPIDFile = directory.appendingPathComponent("replacement.pid")
+        defer {
+            TestProcessSupport.killLeakedProcesses(in: [replacementPIDFile, cleanupStartedPIDFile])
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let worker = MacNodeHostWorker(session: GatewayNodeSession())
+        let firstScript = """
+        trap 'printf "%s\n" "$$" > "$1"; /bin/sleep 0.2; exit 0' TERM
+        printf '%s\n' '{"type":"ready","version":"first","manifest":{"caps":[],"commands":[],"pathEnv":"/bin"}}'
+        while :; do /bin/sleep 1; done
+        """
+        let replacementScript = """
+        printf '%s\n' "$$" > "$1"
+        printf '%s\n' '{"type":"ready","version":"replacement","manifest":{"caps":[],"commands":[],"pathEnv":"/bin"}}'
+        while :; do /bin/sleep 1; done
+        """
+
+        _ = try await worker.start(launch: MacNodeHostWorkerLaunch(command: [
+            "/bin/sh",
+            "-c",
+            firstScript,
+            "worker",
+            cleanupStartedPIDFile.path,
+        ]))
+        let replacement = Task {
+            try await worker.start(launch: MacNodeHostWorkerLaunch(command: [
+                "/bin/sh",
+                "-c",
+                replacementScript,
+                "worker",
+                replacementPIDFile.path,
+            ]))
+        }
+        _ = try await TestProcessSupport.waitForPID(in: cleanupStartedPIDFile)
+
+        await worker.stop()
+
+        switch await replacement.result {
+        case .success:
+            Issue.record("changed launch succeeded after stop returned")
+            await worker.stop()
+        case .failure:
+            break
+        }
+        #expect(TestProcessSupport.pollPID(in: replacementPIDFile) == nil)
+    }
+
     @Test func `stop waits for the worker leader and reaps its descendants`() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("openclaw-worker-stop-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping the macOS node worker during an in-progress changed-launch cleanup could return and then relaunch a worker afterward.

## Why This Change Was Made

`stopLocked` used to return the existing cleanup task before applying non-preserving stop semantics. This moves cleanup deduplication after failing and clearing the pending start continuation, retaining that continuation as the single restart authority.

This work and its regression test were developed with AI assistance and reviewed by the maintainer.

## User Impact

Terminal stop and shutdown remain terminal even when they race worker replacement. Ordinary changed-launch replacement still works.

## Evidence

- Pre-fix focused regression: failed with `changed launch succeeded after stop returned`.
- Post-fix: `MacNodeHostWorkerTests` 18/18 passed, `MacNodeHostWorkerPipeTests` 1/1 passed, and `MacNodeModeCoordinatorTests` 35/35 passed.
- Formatting, lint, and diff-check passed.
- Fresh Codex autoreview completed cleanly with no actionable findings.
- Production LOC: +1/-1 (net 0). Tests: +52/-0.
