### PR TITLE
refactor(ui): unify sidebar transient surfaces

### DIFF
--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -314,7 +314,7 @@ class SessionMenu extends OpenClawLightDomElement {
   }
 
   override render() {
-    const menuWidth = 240;
+    const menuWidth = 232;
     const menuMaxHeight = 460;
     const clampedX = Math.max(8, Math.min(this.anchor.x, window.innerWidth - menuWidth - 8));
     const clampedY = Math.max(8, Math.min(this.anchor.y, window.innerHeight - menuMaxHeight - 8));

--- a/ui/src/components/terminal/terminal-panel-styles.ts
+++ b/ui/src/components/terminal/terminal-panel-styles.ts
@@ -41,10 +41,10 @@ export const terminalPanelStyles = css`
     max-height: min(420px, var(--tp-session-menu-max-height));
     overflow-y: auto;
     padding: var(--menu-padding);
-    border: 1px solid var(--border-strong);
+    border: 1px solid var(--overlay-border);
     border-radius: var(--menu-radius);
     background: var(--bg-elevated);
-    box-shadow: var(--shadow-md);
+    box-shadow: var(--overlay-shadow);
   }
   .tp-session-menu__header {
     display: flex;

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -114,7 +114,7 @@ describe("openclaw-tooltip", () => {
     );
   });
 
-  it("skins the body and arrow through shared Web Awesome tokens", async () => {
+  it("skins the body and removes the arrow through shared overlay tokens", async () => {
     const { tooltip } = createTooltip("Styled tooltip");
     document.body.append(tooltip);
     await tooltip.updateComplete;
@@ -126,7 +126,9 @@ describe("openclaw-tooltip", () => {
     expect(styles).toContain("--wa-tooltip-border-color:");
     expect(styles).toContain("--wa-tooltip-border-width: 1px");
     expect(styles).toContain("--wa-tooltip-border-style: solid");
-    expect(styles).toContain("--wa-tooltip-arrow-size: 6px");
+    expect(styles).toContain("--wa-tooltip-arrow-size: 0px");
+    expect(styles).toContain("var(--overlay-border)");
+    expect(styles).toContain("var(--overlay-shadow)");
   });
 
   it("projects rich content into the Web Awesome tooltip", async () => {

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -124,22 +124,25 @@ class Tooltip extends OpenClawLitElement {
 
     wa-tooltip {
       --max-width: var(--openclaw-tooltip-max-width, min(260px, calc(100vw - 16px)));
-      --wa-tooltip-arrow-size: 6px;
-      --wa-tooltip-background-color: color-mix(in srgb, var(--card) 94%, black 6%);
-      --wa-tooltip-border-color: color-mix(in srgb, var(--border-strong) 84%, transparent);
+      --wa-tooltip-arrow-size: 0px;
+      --wa-tooltip-background-color: var(
+        --openclaw-tooltip-background-color,
+        color-mix(in srgb, var(--bg-elevated) 97%, var(--text) 3%)
+      );
+      --wa-tooltip-border-color: var(--openclaw-tooltip-border-color, var(--overlay-border));
       --wa-tooltip-border-width: 1px;
       --wa-tooltip-border-style: solid;
       --wa-tooltip-content-color: var(--text);
-      --wa-tooltip-border-radius: var(--radius-md);
+      --wa-tooltip-border-radius: var(--openclaw-tooltip-border-radius, var(--radius-md));
       font-family: var(--font-body);
     }
 
     wa-tooltip::part(body) {
-      padding: 7px 9px;
-      box-shadow: var(--shadow-md);
-      font-size: 12px;
+      padding: var(--openclaw-tooltip-padding, 5px 7px);
+      box-shadow: var(--openclaw-tooltip-shadow, var(--overlay-shadow));
+      font-size: 11px;
       font-weight: 500;
-      line-height: 1.35;
+      line-height: 1.25;
       overflow-wrap: anywhere;
     }
 

--- a/ui/src/e2e/sidebar-customization.test-support.ts
+++ b/ui/src/e2e/sidebar-customization.test-support.ts
@@ -52,7 +52,7 @@ export async function captureSidebarUiUnionProof(
   page: Page,
   locators: Locator[],
   fileName: string,
-  options: { preserveHover?: boolean } = {},
+  options: { animations?: "allow" | "disabled" } = {},
 ): Promise<void> {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
     return;
@@ -80,7 +80,7 @@ export async function captureSidebarUiUnionProof(
   );
   await mkdir(sidebarProofArtifactDir, { recursive: true });
   await page.screenshot({
-    animations: options.preserveHover ? "allow" : "disabled",
+    animations: options.animations ?? "disabled",
     clip: { x: left, y: top, width: right - left, height: bottom - top },
     path: path.join(sidebarProofArtifactDir, fileName),
   });

--- a/ui/src/e2e/sidebar-iconography.e2e.test.ts
+++ b/ui/src/e2e/sidebar-iconography.e2e.test.ts
@@ -145,7 +145,7 @@ suite.define(() => {
           page,
           [sidebarSurface],
           `iconography-${variant}-group-controls.png`,
-          { preserveHover: true },
+          { animations: "allow" },
         );
         await groupAction.click();
         const groupMenu = sidebar.locator("wa-dropdown.sidebar-session-group-menu");

--- a/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
+++ b/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
@@ -16,11 +16,18 @@ const suite = createSidebarCustomizationSuite(
   "Control UI sidebar transient surfaces mocked Gateway E2E",
 );
 
-const visualVariants = [{ colorScheme: "light" as const }, { colorScheme: "dark" as const }];
+const visualVariants = [
+  { colorScheme: "light", resolvedTheme: "light", theme: "claw" },
+  { colorScheme: "dark", resolvedTheme: "dark", theme: "claw" },
+  { colorScheme: "light", resolvedTheme: "openknot-light", theme: "knot" },
+  { colorScheme: "dark", resolvedTheme: "openknot", theme: "knot" },
+  { colorScheme: "light", resolvedTheme: "dash-light", theme: "dash" },
+  { colorScheme: "dark", resolvedTheme: "dash", theme: "dash" },
+] as const;
 
-function configResponse(colorScheme: "light" | "dark") {
-  const config = { ui: { prefs: { locale: "en", themeMode: colorScheme } } };
-  const hash = `transient-surfaces-${colorScheme}`;
+function configResponse(theme: "claw" | "knot" | "dash", colorScheme: "light" | "dark") {
+  const config = { ui: { prefs: { locale: "en", theme, themeMode: colorScheme } } };
+  const hash = `transient-surfaces-${theme}-${colorScheme}`;
   return {
     appliedConfigHash: hash,
     config,
@@ -53,10 +60,21 @@ async function waitForAnimations(surface: Locator) {
   });
 }
 
+async function computedShadowFromToken(root: Locator, token: "--overlay-shadow" | "--shadow-md") {
+  return root.evaluate((_, tokenName) => {
+    const probe = document.createElement("div");
+    probe.style.boxShadow = `var(${tokenName})`;
+    document.body.append(probe);
+    const shadow = getComputedStyle(probe).boxShadow;
+    probe.remove();
+    return shadow;
+  }, token);
+}
+
 suite.define(() => {
   it.each(visualVariants)(
-    "keeps sidebar transient surfaces on one contract in $colorScheme",
-    async ({ colorScheme }) => {
+    "keeps sidebar transient surfaces on one contract in $theme $colorScheme",
+    async ({ colorScheme, resolvedTheme, theme }) => {
       const context = await suite.newBrowserContext({
         colorScheme,
         locale: "en-US",
@@ -73,7 +91,7 @@ suite.define(() => {
           "sessions.patch",
         ],
         methodResponses: {
-          "config.get": configResponse(colorScheme),
+          "config.get": configResponse(theme, colorScheme),
           "sessions.list": sessionsListResponse([
             sessionRow("agent:main:main", "Main", Date.parse("2026-08-14T16:00:00.000Z")),
             {
@@ -97,6 +115,8 @@ suite.define(() => {
         await expect
           .poll(() => page.locator("html").getAttribute("data-theme-mode"))
           .toBe(colorScheme);
+        const root = page.locator("html");
+        await expect.poll(() => root.getAttribute("data-theme")).toBe(resolvedTheme);
 
         const newSessionButton = sidebar.locator(".sidebar-brand__new-thread");
         await newSessionButton.hover();
@@ -105,7 +125,13 @@ suite.define(() => {
         await tooltipSurface.waitFor({ state: "visible" });
         await waitForAnimations(tooltipSurface);
         const tooltipContract = await surfaceMetrics(tooltipSurface);
-        expect(tooltipContract.boxShadow).not.toBe("none");
+        const overlayShadow = await computedShadowFromToken(root, "--overlay-shadow");
+        const expectedShadow = await computedShadowFromToken(
+          root,
+          theme === "claw" ? "--overlay-shadow" : "--shadow-md",
+        );
+        expect(overlayShadow).toBe(expectedShadow);
+        expect(tooltipContract.boxShadow).toBe(overlayShadow);
         expect(
           await tooltip
             .locator("wa-tooltip")
@@ -116,7 +142,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, tooltipSurface],
-          `transient-${colorScheme}-tooltip.png`,
+          `transient-${theme}-${colorScheme}-tooltip.png`,
           { animations: "allow" },
         );
 
@@ -203,7 +229,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, sessionMenuSurface],
-          `transient-${colorScheme}-session-default-disabled.png`,
+          `transient-${theme}-${colorScheme}-session-default-disabled.png`,
           { animations: "allow" },
         );
 
@@ -215,7 +241,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, sessionMenuSurface],
-          `transient-${colorScheme}-session-hover.png`,
+          `transient-${theme}-${colorScheme}-session-hover.png`,
           { animations: "allow" },
         );
         await deleteItem.hover();
@@ -226,7 +252,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, sessionMenuSurface],
-          `transient-${colorScheme}-session-delete-hover.png`,
+          `transient-${theme}-${colorScheme}-session-delete-hover.png`,
           { animations: "allow" },
         );
         await page.mouse.move(700, 700);
@@ -239,7 +265,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, sessionMenuSurface],
-          `transient-${colorScheme}-session-focus.png`,
+          `transient-${theme}-${colorScheme}-session-focus.png`,
           { animations: "allow" },
         );
         await page.keyboard.press("Escape");
@@ -259,7 +285,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, moreMenuSurface],
-          `transient-${colorScheme}-navigation-menu.png`,
+          `transient-${theme}-${colorScheme}-navigation-menu.png`,
           { animations: "allow" },
         );
         await page.keyboard.press("Escape");
@@ -272,7 +298,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, identitySurface],
-          `transient-${colorScheme}-identity-menu.png`,
+          `transient-${theme}-${colorScheme}-identity-menu.png`,
           { animations: "allow" },
         );
         const buildChip = identityMenu.locator(".sidebar-footer-build");
@@ -289,7 +315,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [sidebarSurface, identitySurface, richTooltip],
-          `transient-${colorScheme}-rich-popover.png`,
+          `transient-${theme}-${colorScheme}-rich-popover.png`,
           { animations: "allow" },
         );
 
@@ -308,7 +334,7 @@ suite.define(() => {
         await captureSidebarUiUnionProof(
           page,
           [languageRow, listbox],
-          `transient-${colorScheme}-select-listbox.png`,
+          `transient-${theme}-${colorScheme}-select-listbox.png`,
           { animations: "allow" },
         );
       } finally {

--- a/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
+++ b/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
@@ -1,0 +1,319 @@
+import type { Locator } from "playwright";
+import { expect, it } from "vitest";
+import { waitForControlUiSettingsTakeover } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiSessionUrl,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+import {
+  captureSidebarUiUnionProof,
+  createSidebarCustomizationSuite,
+} from "./sidebar-customization.test-support.ts";
+
+const suite = createSidebarCustomizationSuite(
+  "Control UI sidebar transient surfaces mocked Gateway E2E",
+);
+
+const visualVariants = [{ colorScheme: "light" as const }, { colorScheme: "dark" as const }];
+
+function configResponse(colorScheme: "light" | "dark") {
+  const config = { ui: { prefs: { locale: "en", themeMode: colorScheme } } };
+  const hash = `transient-surfaces-${colorScheme}`;
+  return {
+    appliedConfigHash: hash,
+    config,
+    configRevisionHash: hash,
+    hash,
+    issues: [],
+    raw: JSON.stringify(config),
+    valid: true,
+  };
+}
+
+async function surfaceMetrics(surface: Locator) {
+  return surface.evaluate((element) => {
+    const style = getComputedStyle(element);
+    const box = element.getBoundingClientRect();
+    return {
+      borderColor: style.borderColor,
+      borderRadius: style.borderRadius,
+      boxShadow: style.boxShadow,
+      padding: style.padding,
+      width: box.width,
+    };
+  });
+}
+
+async function waitForAnimations(surface: Locator) {
+  await surface.evaluate(async (element) => {
+    const animations = element.getAnimations({ subtree: true });
+    await Promise.all(animations.map((animation) => animation.finished.catch(() => undefined)));
+  });
+}
+
+suite.define(() => {
+  it.each(visualVariants)(
+    "keeps sidebar transient surfaces on one contract in $colorScheme",
+    async ({ colorScheme }) => {
+      const context = await suite.newBrowserContext({
+        colorScheme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      });
+      const page = await context.newPage();
+      const sessionKey = "agent:main:release-notes";
+      await installMockGateway(page, {
+        featureMethods: [
+          "sessions.create",
+          "sessions.delete",
+          "sessions.groups.put",
+          "sessions.patch",
+        ],
+        methodResponses: {
+          "config.get": configResponse(colorScheme),
+          "sessions.list": sessionsListResponse([
+            sessionRow("agent:main:main", "Main", Date.parse("2026-08-14T16:00:00.000Z")),
+            {
+              ...sessionRow(sessionKey, "Release notes", Date.parse("2026-08-14T15:59:00.000Z"), {
+                category: "Research",
+              }),
+              modelSelectionLocked: true,
+            },
+          ]),
+        },
+        sessionGroups: ["Research"],
+        sessionKey,
+      });
+
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const sidebarSurface = sidebar.locator(".sidebar-shell");
+        const session = sidebar.locator(`[data-session-key="${sessionKey}"]`);
+        await session.waitFor();
+        await expect
+          .poll(() => page.locator("html").getAttribute("data-theme-mode"))
+          .toBe(colorScheme);
+
+        const newSessionButton = sidebar.locator(".sidebar-brand__new-thread");
+        await newSessionButton.hover();
+        const tooltip = newSessionButton.locator("xpath=..");
+        const tooltipSurface = tooltip.locator("wa-tooltip[open] .body");
+        await tooltipSurface.waitFor({ state: "visible" });
+        await waitForAnimations(tooltipSurface);
+        const tooltipContract = await surfaceMetrics(tooltipSurface);
+        expect(tooltipContract.boxShadow).not.toBe("none");
+        expect(
+          await tooltip
+            .locator("wa-tooltip")
+            .evaluate((element) =>
+              getComputedStyle(element).getPropertyValue("--wa-tooltip-arrow-size"),
+            ),
+        ).toBe("0px");
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, tooltipSurface],
+          `transient-${colorScheme}-tooltip.png`,
+          { animations: "allow" },
+        );
+
+        await page.mouse.move(700, 700);
+        await session.hover();
+        await session.locator("[data-session-menu]").click();
+        const sessionMenu = sidebar.locator("wa-dropdown.session-menu");
+        const sessionMenuSurface = sessionMenu.locator('[part="menu"]');
+        await sessionMenuSurface.waitFor();
+        await expect
+          .poll(async () => (await sessionMenuSurface.boundingBox())?.width ?? 0)
+          .toBeGreaterThanOrEqual(224);
+        await waitForAnimations(sessionMenuSurface);
+        const menuContract = await surfaceMetrics(sessionMenuSurface);
+        expect(menuContract).toMatchObject({
+          borderColor: tooltipContract.borderColor,
+          borderRadius: "12px",
+          boxShadow: tooltipContract.boxShadow,
+          padding: "6px",
+        });
+        expect(menuContract.width).toBeGreaterThanOrEqual(224);
+        expect(menuContract.width).toBeLessThanOrEqual(232);
+
+        const pinItem = sessionMenu.getByRole("menuitem", { name: /Pin session/ });
+        const pinGeometry = await pinItem.evaluate((element) => {
+          const icon = element.querySelector(".session-menu__icon")!.getBoundingClientRect();
+          const label = element.querySelector(".session-menu__text")!.getBoundingClientRect();
+          const row = element.getBoundingClientRect();
+          return {
+            gap: label.left - icon.right,
+            icon: [icon.width, icon.height],
+            rowHeight: row.height,
+          };
+        });
+        expect(pinGeometry.icon).toEqual([16, 16]);
+        expect(pinGeometry.gap).toBeGreaterThanOrEqual(9);
+        expect(pinGeometry.gap).toBeLessThanOrEqual(11);
+        expect(pinGeometry.rowHeight).toBe(36);
+
+        const shortcut = pinItem.locator(".session-menu__shortcut");
+        const shortcutContract = await shortcut.evaluate((element) => {
+          const style = getComputedStyle(element);
+          const box = element.getBoundingClientRect();
+          return {
+            borderWidth: style.borderWidth,
+            fontSize: style.fontSize,
+            fontWeight: style.fontWeight,
+            height: box.height,
+            paddingInline: style.paddingInline,
+            width: box.width,
+          };
+        });
+        expect(shortcutContract).toMatchObject({
+          borderWidth: "0px",
+          fontSize: "11px",
+          fontWeight: "500",
+          height: 18,
+          paddingInline: "7px",
+        });
+        expect(shortcutContract.width).toBeGreaterThanOrEqual(24);
+
+        const disabledItem = sessionMenu.getByRole("menuitem", { name: /^Fork/ });
+        expect(await disabledItem.isDisabled()).toBe(true);
+        expect(await disabledItem.getAttribute("aria-disabled")).toBe("true");
+        expect(
+          await disabledItem.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return { cursor: style.cursor, opacity: style.opacity };
+          }),
+        ).toEqual({ cursor: "default", opacity: "0.42" });
+
+        const deleteItem = sessionMenu.getByRole("menuitem", { name: /Delete/ });
+        await expect
+          .poll(() => deleteItem.locator(".session-menu__text").textContent())
+          .toBe("Delete…");
+        expect(await deleteItem.locator(".session-menu__shortcut").textContent()).toBe("D");
+        const deleteRest = await deleteItem.evaluate((element) => ({
+          background: getComputedStyle(element).backgroundColor,
+          icon: getComputedStyle(element.querySelector(".session-menu__icon")!).color,
+          text: getComputedStyle(element).color,
+        }));
+        expect(deleteRest.background).toBe("rgba(0, 0, 0, 0)");
+        expect(deleteRest.icon).toBe(deleteRest.text);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, sessionMenuSurface],
+          `transient-${colorScheme}-session-default-disabled.png`,
+          { animations: "allow" },
+        );
+
+        await pinItem.hover();
+        await expect
+          .poll(() => pinItem.evaluate((element) => getComputedStyle(element).backgroundColor))
+          .not.toBe("rgba(0, 0, 0, 0)");
+        await waitForAnimations(pinItem);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, sessionMenuSurface],
+          `transient-${colorScheme}-session-hover.png`,
+          { animations: "allow" },
+        );
+        await deleteItem.hover();
+        await expect
+          .poll(() => deleteItem.evaluate((element) => getComputedStyle(element).backgroundColor))
+          .not.toBe(deleteRest.background);
+        await waitForAnimations(deleteItem);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, sessionMenuSurface],
+          `transient-${colorScheme}-session-delete-hover.png`,
+          { animations: "allow" },
+        );
+        await page.mouse.move(700, 700);
+        await page.keyboard.press("Home");
+        const focusedItem = sessionMenu.locator("wa-dropdown-item:focus");
+        await expect.poll(() => focusedItem.count()).toBe(1);
+        expect(await focusedItem.evaluate((element) => element.matches(":focus-visible"))).toBe(
+          true,
+        );
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, sessionMenuSurface],
+          `transient-${colorScheme}-session-focus.png`,
+          { animations: "allow" },
+        );
+        await page.keyboard.press("Escape");
+
+        await sidebar.locator(".sidebar-nav__head-action").click();
+        const moreMenu = sidebar.locator("wa-dropdown.sidebar-more-menu");
+        const moreMenuSurface = moreMenu.locator('[part="menu"]');
+        await moreMenuSurface.waitFor();
+        await waitForAnimations(moreMenuSurface);
+        expect(await surfaceMetrics(moreMenuSurface)).toMatchObject({
+          borderColor: tooltipContract.borderColor,
+          borderRadius: "12px",
+          boxShadow: tooltipContract.boxShadow,
+          padding: "6px",
+        });
+        expect(await moreMenu.locator(".session-menu__shortcut").count()).toBe(0);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, moreMenuSurface],
+          `transient-${colorScheme}-navigation-menu.png`,
+          { animations: "allow" },
+        );
+        await page.keyboard.press("Escape");
+
+        await sidebar.locator(".sidebar-identity-card").click();
+        const identityMenu = sidebar.locator("wa-dropdown.sidebar-identity-menu");
+        const identitySurface = identityMenu.locator('[part="menu"]');
+        await identitySurface.waitFor();
+        await waitForAnimations(identitySurface);
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, identitySurface],
+          `transient-${colorScheme}-identity-menu.png`,
+          { animations: "allow" },
+        );
+        const buildChip = identityMenu.locator(".sidebar-footer-build");
+        await buildChip.hover();
+        const richTooltip = identityMenu
+          .locator("openclaw-tooltip.sidebar-hover-tooltip")
+          .locator("wa-tooltip[open] .body");
+        await richTooltip.waitFor({ state: "visible" });
+        await waitForAnimations(richTooltip);
+        expect(await surfaceMetrics(richTooltip)).toMatchObject({
+          borderColor: tooltipContract.borderColor,
+          boxShadow: tooltipContract.boxShadow,
+        });
+        await captureSidebarUiUnionProof(
+          page,
+          [sidebarSurface, identitySurface, richTooltip],
+          `transient-${colorScheme}-rich-popover.png`,
+          { animations: "allow" },
+        );
+
+        await page.goto(`${suite.server.baseUrl}settings/appearance`);
+        await waitForControlUiSettingsTakeover(page);
+        const languageRow = page.locator("#settings-language .settings-row");
+        const languageSelect = languageRow.locator("wa-select");
+        await languageSelect.click();
+        const listbox = languageSelect.locator('[part="listbox"]');
+        await listbox.waitFor({ state: "visible" });
+        await waitForAnimations(listbox);
+        expect(await surfaceMetrics(listbox)).toMatchObject({
+          borderColor: tooltipContract.borderColor,
+          boxShadow: tooltipContract.boxShadow,
+        });
+        await captureSidebarUiUnionProof(
+          page,
+          [languageRow, listbox],
+          `transient-${colorScheme}-select-listbox.png`,
+          { animations: "allow" },
+        );
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+});

--- a/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
+++ b/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
@@ -71,6 +71,21 @@ async function computedShadowFromToken(root: Locator, token: "--overlay-shadow" 
   }, token);
 }
 
+// Menu panel geometry is a token contract, not two literals: the radius is the
+// shared 10px base times whatever corner scale the engine opted into, and the
+// padding is the same --menu-padding every transient menu reads. Restating them
+// as numbers pins the test to one engine's superellipse support.
+async function menuPanelContract(root: Locator) {
+  return root.evaluate(() => {
+    const style = getComputedStyle(document.documentElement);
+    const scale = Number.parseFloat(style.getPropertyValue("--openclaw-corner-radius-scale")) || 1;
+    return {
+      borderRadius: `${10 * scale}px`,
+      padding: style.getPropertyValue("--menu-padding").trim(),
+    };
+  });
+}
+
 suite.define(() => {
   it.each(visualVariants)(
     "keeps sidebar transient surfaces on one contract in $theme $colorScheme",
@@ -156,12 +171,13 @@ suite.define(() => {
           .poll(async () => (await sessionMenuSurface.boundingBox())?.width ?? 0)
           .toBeGreaterThanOrEqual(224);
         await waitForAnimations(sessionMenuSurface);
+        const panelContract = await menuPanelContract(root);
         const menuContract = await surfaceMetrics(sessionMenuSurface);
         expect(menuContract).toMatchObject({
           borderColor: tooltipContract.borderColor,
-          borderRadius: "12px",
+          borderRadius: panelContract.borderRadius,
           boxShadow: tooltipContract.boxShadow,
-          padding: "6px",
+          padding: panelContract.padding,
         });
         expect(menuContract.width).toBeGreaterThanOrEqual(224);
         expect(menuContract.width).toBeLessThanOrEqual(232);
@@ -277,9 +293,9 @@ suite.define(() => {
         await waitForAnimations(moreMenuSurface);
         expect(await surfaceMetrics(moreMenuSurface)).toMatchObject({
           borderColor: tooltipContract.borderColor,
-          borderRadius: "12px",
+          borderRadius: panelContract.borderRadius,
           boxShadow: tooltipContract.boxShadow,
-          padding: "6px",
+          padding: panelContract.padding,
         });
         expect(await moreMenu.locator(".session-menu__shortcut").count()).toBe(0);
         await captureSidebarUiUnionProof(

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -960,7 +960,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           // the item edge stays optically parallel to the menu edge.
           borderRadius: `${menuRadius - 4}px`,
           fontSize: "13px",
-          minHeight: "28px",
+          minHeight: "36px",
           padding: "0px 8px",
         },
       });

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -645,6 +645,7 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.6);
+  --overlay-shadow: var(--shadow-md);
 
   --grid-line: rgba(255, 255, 255, 0.025);
 }
@@ -711,6 +712,7 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.08);
+  --overlay-shadow: var(--shadow-md);
 
   --grid-line: rgba(0, 0, 0, 0.04);
 }
@@ -786,6 +788,7 @@
   --shadow-sm: 0 1px 2px rgba(10, 6, 4, 0.35);
   --shadow-md: 0 4px 16px rgba(10, 6, 4, 0.45);
   --shadow-lg: 0 12px 32px rgba(10, 6, 4, 0.55);
+  --overlay-shadow: var(--shadow-md);
 
   --grid-line: rgba(255, 240, 225, 0.03);
 }
@@ -850,6 +853,7 @@
   --shadow-sm: 0 1px 2px rgba(60, 40, 20, 0.06);
   --shadow-md: 0 4px 12px rgba(60, 40, 20, 0.08);
   --shadow-lg: 0 12px 28px rgba(60, 40, 20, 0.1);
+  --overlay-shadow: var(--shadow-md);
 
   --grid-line: rgba(80, 50, 20, 0.04);
 }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -209,6 +209,11 @@
   --shadow-xl: 0 24px 48px rgba(0, 0, 0, 0.5);
   --shadow-glow: 0 0 24px var(--accent-glow);
 
+  /* Transient surfaces use one edge and elevation treatment. Persistent
+     panels and dialogs keep their independent elevation hierarchy. */
+  --overlay-border: color-mix(in srgb, var(--border-strong) 64%, transparent);
+  --overlay-shadow: 0 1px 2px rgb(0 0 0 / 0.18), 0 8px 24px rgb(0 0 0 / 0.24);
+
   /* Spacing scale. Settings surfaces use these (see
      ui/docs/design-system/settings-design.md); elsewhere raw px padding/gap is
      grandfathered — adopt the scale when rewriting a rule, don't mass-migrate. */
@@ -258,8 +263,8 @@
      = panel radius 10. Shared knobs keep transient menus from drifting again. */
   --menu-radius: var(--radius-md);
   --menu-item-radius: var(--radius-sm);
-  --menu-item-height: 28px;
-  --menu-padding: 4px;
+  --menu-item-height: 36px;
+  --menu-padding: 6px;
 
   /* Transitions - Crisp and responsive */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
@@ -557,6 +562,8 @@
   --shadow-lg: 0 12px 28px rgba(60, 42, 24, 0.09);
   --shadow-xl: 0 24px 48px rgba(60, 42, 24, 0.11);
   --shadow-glow: 0 0 20px var(--accent-glow);
+  --overlay-border: color-mix(in srgb, var(--border-strong) 64%, transparent);
+  --overlay-shadow: 0 1px 2px rgb(60 42 24 / 0.035), 0 8px 24px rgb(60 42 24 / 0.065);
 
   --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23444' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 
@@ -1062,7 +1069,7 @@ wa-dropdown-item {
 }
 
 wa-dropdown-item[disabled] {
-  cursor: not-allowed;
+  cursor: default;
 }
 
 /* Keep Web Awesome's checkbox rail trailing so it cannot shift menu icons and labels. */
@@ -1078,6 +1085,15 @@ wa-dropdown-item[type="checkbox"]::part(checkmark) {
 wa-dropdown-item[type="checkbox"] {
   display: flex;
   align-items: center;
+}
+
+/* Web Awesome owns these popup panels in shadow DOM, so shared tokens enter
+   through exported parts; feature styles continue to own content geometry. */
+wa-dropdown::part(menu),
+wa-popover::part(body),
+wa-select::part(listbox) {
+  border-color: var(--overlay-border);
+  box-shadow: var(--overlay-shadow);
 }
 
 button,

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -264,7 +264,7 @@
   --menu-radius: var(--radius-md);
   --menu-item-radius: var(--radius-sm);
   --menu-item-height: 36px;
-  --menu-padding: 6px;
+  --menu-padding: 4px;
 
   /* Transitions - Crisp and responsive */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -116,10 +116,10 @@ openclaw-board-view {
 .board-widget__menu::part(menu) {
   min-width: 190px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .board-tabs__overflow-item {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -582,11 +582,11 @@ openclaw-chat-page {
   z-index: 70;
   width: min(300px, calc(100vw - 42px));
   padding: 12px;
-  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--popover) 96%, var(--card));
   color: var(--popover-foreground);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--overlay-shadow);
   animation: fade-in 150ms var(--ease-out);
 }
 
@@ -1593,10 +1593,10 @@ button.chat-reply-preview--message:disabled {
   position: fixed;
   z-index: 9999;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   min-width: 160px;
   animation: menu-in 140ms var(--ease-out);
 }
@@ -1627,10 +1627,10 @@ button.chat-reply-preview--message:disabled {
   display: flex;
   gap: 2px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   animation: fade-in 0.12s var(--ease-out);
 }
 
@@ -2777,10 +2777,10 @@ button.chat-reply-preview--message:disabled {
 .agent-chat__attach-menu::part(menu) {
   width: 152px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .agent-chat__attach-menu-option {
@@ -3358,10 +3358,10 @@ button.chat-reply-preview--message:disabled {
 .chat-talk-input-picker::part(menu) {
   width: min(300px, calc(100vw - 24px));
   padding: 6px;
-  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-elevated) 96%, var(--card));
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .chat-talk-input-picker__heading {
@@ -3875,9 +3875,9 @@ button.chat-reply-preview--message:disabled {
   max-height: 288px;
   overflow: hidden;
   background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   z-index: 30;
   margin-bottom: 4px;
 }
@@ -4395,10 +4395,10 @@ button.chat-reply-preview--message:disabled {
 }
 
 .chat-controls__inline-select-menu {
-  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-elevated) 96%, var(--card));
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .chat-controls__inline-select-option {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1465,10 +1465,10 @@ openclaw-session-discussion {
 .sidebar-file-view__editor-menu::part(menu) {
   min-width: 132px;
   padding: 5px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 78%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .sidebar-file-view__editor-item {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -333,10 +333,10 @@ openclaw-chat-pane {
 .chat-pane__placement-menu::part(menu) {
   width: 250px;
   padding: 6px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 78%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: 8px;
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--overlay-shadow);
 }
 
 .chat-pane__placement-chip {
@@ -369,10 +369,10 @@ openclaw-chat-pane {
 
 .chat-pane__gateway-menu::part(menu) {
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .chat-pane__gateway-menu-item {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -779,10 +779,10 @@
 .chat-tool-card__widget-actions::part(menu) {
   min-width: 176px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .chat-tool-card__widget-actions-trigger,

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -748,10 +748,10 @@ openclaw-github-link-hovercard-provider {
   width: min(440px, calc(100vw - 24px));
   min-height: 112px;
   padding: 16px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 88%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--card) 96%, var(--bg) 4%);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--overlay-shadow);
   color: var(--text);
   font-family: var(--font-body);
   /* Interactive by design: hover intent and text selection both need the card to
@@ -3609,10 +3609,10 @@ td.data-table-key-col {
   max-height: 320px;
   overflow-y: auto;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   color: var(--text);
 }
 

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -242,13 +242,13 @@
   top: calc(100% + 8px);
   right: 0;
   width: min(280px, calc(100vw - 48px));
-  border: 1px solid var(--border);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   padding: var(--space-3);
   display: grid;
   gap: var(--space-3);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--overlay-shadow);
 }
 
 .cron-error-banner {
@@ -1054,17 +1054,17 @@
 .cron-job-menu::part(menu) {
   min-width: 170px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .cron-filter-dropdown__details::part(menu) {
   width: min(300px, calc(100vw - 48px));
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2521,14 +2521,14 @@ body.update-dialog-open .sidebar-update-card__status {
   position: fixed;
   z-index: 120;
   min-width: 224px;
-  max-width: 264px;
+  max-width: 232px;
   max-height: 420px;
   overflow-y: auto;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   animation: menu-in 140ms var(--ease-out);
 }
 
@@ -2539,14 +2539,14 @@ wa-dropdown.sidebar-customize-menu {
 
 wa-dropdown.sidebar-customize-menu::part(menu) {
   min-width: 224px;
-  max-width: 264px;
+  max-width: 232px;
   max-height: 420px;
   overflow-y: auto;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .sidebar-customize-menu__title {
@@ -2581,7 +2581,7 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
 .sidebar-customize-menu__item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
   min-height: var(--menu-item-height);
   padding: 0 8px;
@@ -2621,7 +2621,7 @@ wa-dropdown-item.sidebar-customize-menu__item {
 .sidebar-customize-menu__item > a {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
   color: inherit;
   text-decoration: none;
@@ -2642,7 +2642,7 @@ wa-dropdown-item.sidebar-customize-menu__item {
 }
 
 .sidebar-customize-menu__separator {
-  margin: 6px 4px;
+  margin: 6px 8px;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 
@@ -2660,12 +2660,12 @@ wa-dropdown-item.sidebar-customize-menu__item {
   position: fixed;
   z-index: 121;
   min-width: 224px;
-  max-width: 264px;
+  max-width: 232px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   animation: menu-in 140ms var(--ease-out);
 }
 
@@ -2676,12 +2676,12 @@ wa-dropdown.session-menu {
 
 wa-dropdown.session-menu::part(menu) {
   min-width: 224px;
-  max-width: 264px;
+  max-width: 232px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 /* Popover hosts live in the top layer so menus escape in-page stacking
@@ -2705,10 +2705,10 @@ openclaw-session-menu[popover] {
   min-width: 176px;
   max-width: 220px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   animation: menu-in 140ms var(--ease-out);
 }
 
@@ -2721,10 +2721,10 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   min-width: 176px;
   max-width: 220px;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .sidebar-session-sort-menu__title {
@@ -2741,7 +2741,7 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 .sidebar-session-sort-menu__item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
   min-height: var(--menu-item-height);
   padding: 0 8px;
@@ -2778,7 +2778,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .session-menu__item:hover:not(:disabled):not([aria-disabled="true"]),
-.session-menu__item:focus-visible,
+.session-menu__item:focus-visible:not(:disabled):not([aria-disabled="true"]),
 .sidebar-session-sort-menu__item:hover,
 .sidebar-session-sort-menu__item:focus-visible {
   background: var(--bg-hover);
@@ -2787,11 +2787,20 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .session-menu__item:disabled,
 .session-menu__item[aria-disabled="true"] {
   opacity: 0.42;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .session-menu__item--destructive {
   color: var(--danger);
+}
+
+.session-menu__item--destructive:hover:not(:disabled):not([aria-disabled="true"]),
+.session-menu__item--destructive:focus-visible {
+  background: color-mix(in srgb, var(--danger) 6%, transparent);
+}
+
+.session-menu__item--destructive .session-menu__icon {
+  color: inherit;
 }
 
 /* Web Awesome renders checkbox marks before the label. Selection state in this
@@ -2820,8 +2829,8 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .session-menu__icon svg,
 .session-menu__check svg {
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.7px;
@@ -2852,11 +2861,19 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
    one rail beside the labels. */
 .session-menu__shortcut,
 .chat-controls__model-option-action kbd {
+  display: inline-flex;
   flex: 0 0 auto;
-  min-width: 12px;
+  min-width: 24px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 7px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
   color: var(--muted);
   font-family: var(--mono);
-  font-size: var(--control-ui-text-xs);
+  font-size: calc(11px * var(--control-ui-text-scale));
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
   line-height: 1;
   text-align: center;
@@ -2870,7 +2887,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .session-menu__separator {
-  margin: 4px 8px;
+  margin: 6px 8px;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -205,10 +205,10 @@
   max-height: min(420px, 58dvh);
   overflow-y: auto;
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
   color: var(--text);
 }
 

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -247,10 +247,10 @@ wa-popover.new-session-page__select::part(body) {
   min-width: 224px;
   max-width: min(320px, calc(100vw - 24px));
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .new-session-page__menu-title {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -769,10 +769,10 @@ wa-select.settings-select::part(listbox) {
      would let the listbox overflow when the popup has little room to open. */
   max-height: min(320px, var(--auto-size-available-height, calc(100vh - 48px)));
   padding: 6px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 86%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--overlay-shadow);
   color: var(--text);
 }
 

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -550,10 +550,10 @@
   min-width: 220px;
   max-width: min(320px, calc(100vw - 48px));
   padding: var(--menu-padding);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--overlay-border);
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--overlay-shadow);
 }
 
 .usage-filter-option {

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -417,12 +417,10 @@
      would let the listbox overflow when the popup has little room to open. */
   max-height: min(320px, var(--auto-size-available-height, calc(100vh - 48px)));
   padding: 6px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 86%, transparent);
+  border: 1px solid var(--overlay-border);
   border-radius: 8px;
   background: color-mix(in srgb, var(--bg-elevated) 94%, var(--bg) 6%);
-  box-shadow:
-    0 16px 40px color-mix(in srgb, black 34%, transparent),
-    inset 0 1px 0 color-mix(in srgb, white 5%, transparent);
+  box-shadow: var(--overlay-shadow);
 }
 
 .workboard-field--wide {


### PR DESCRIPTION
## What Problem This Solves

Sidebar tooltips, menus, listboxes, popovers, and context actions currently use competing borders, shadows, dimensions, and state treatments.

## Why This Change Was Made

This PR introduces one transient-surface contract across shared Web Awesome parts and custom popup surfaces, while keeping dialogs, persistent cards, and focus rings outside that contract. It also normalizes sidebar context-menu geometry, shortcut keycaps, disabled rows, and destructive actions.

Depends on #123626.

## User Impact

- Tooltips are arrowless and use the same restrained elevation as menus and popovers.
- Sidebar context menus use consistent width, padding, radius, row height, icon rhythm, and shortcut hints.
- Disabled actions remain legible without hover affordance; Delete stays quiet at rest and gains a subtle danger hover.
- Light and dark modes present the same transient-surface hierarchy.

## Evidence

- 19 focused tooltip tests passed.
- 2 mocked-Gateway browser scenarios passed across light and dark modes.
- 18 headed visual frames were inspected: tooltip; default/disabled, hover, focus, and Delete-hover session menus; navigation menu; identity menu; rich popover; and select/listbox in both themes.
- Formatting, UI style lint, UI production/test typechecks, focused TypeScript lint, and raw-window-open boundary checks passed.


---

## Visual proof — real app, mocked Gateway

**How these were produced (literal):**

- Head captured: `43c27f40df5e29f6e75c3f1b780ff6fef71c54ec` — top of Stack A, which contains #123613 → #123626 → #123655 → #123681. The head was asserted inside the run, not assumed.
- The **whole Control UI app** was served by `startControlUiE2eServer` and driven through the canonical mocked Gateway (`installMockGateway`, `ui/src/test-helpers/control-ui-e2e.ts`). No isolated component, no hand-built HTML, no synthetic harness.
- Spec: `ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts` — result: **passed, 18 frames**.
- Headed Chromium under Xvfb on a Linux remote host (headed, so hover/elevation/compositing actually paint).
- Command:

```sh
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_HEADED=1 CI=1 \
  xvfb-run -a --server-args="-screen 0 2560x1600x24" \
  node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.ui-e2e.config.ts \
    --configLoader runner ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
```

- Floating surfaces (menus, tooltips, popovers) are clipped to the **union** of the sidebar box and the surface box with 16px padding via `captureSidebarUiUnionProof`, so absolutely-positioned surfaces are included without unrelated page area.

One frame per transient surface, in both modes: arrowless tooltip; session context menu at rest/hover/keyboard-focus and with Delete hovered; navigation menu; identity menu; rich hover popover; and the select listbox.

<table><tr><th>surface</th><th>light</th><th>dark</th></tr>
<tr><td><b>tooltip</b></td><td><img src="https://github.com/user-attachments/assets/540bde76-55e2-41e4-8cff-78d5e1507fd9" width="320"></td><td><img src="https://github.com/user-attachments/assets/76f8d443-cc9f-4285-bdff-a88d7fe4940e" width="320"></td></tr>
<tr><td><b>session-default-disabled</b></td><td><img src="https://github.com/user-attachments/assets/c4a07271-19cd-401a-9e9e-48b056aa63de" width="320"></td><td><img src="https://github.com/user-attachments/assets/e41eff2b-f6af-4828-bef6-499ea1b597bb" width="320"></td></tr>
<tr><td><b>session-hover</b></td><td><img src="https://github.com/user-attachments/assets/9bc90c28-595d-4476-907f-5f9b48e184ac" width="320"></td><td><img src="https://github.com/user-attachments/assets/62f0f41c-2bf1-4417-a7c5-17acaac2a6ac" width="320"></td></tr>
<tr><td><b>session-focus</b></td><td><img src="https://github.com/user-attachments/assets/f04bfd85-6432-4125-9eeb-63a31acf75df" width="320"></td><td><img src="https://github.com/user-attachments/assets/05e2ec4d-49b5-44d6-9573-adb407af9890" width="320"></td></tr>
<tr><td><b>session-delete-hover</b></td><td><img src="https://github.com/user-attachments/assets/c68c349d-00a1-4828-875b-802d7371821b" width="320"></td><td><img src="https://github.com/user-attachments/assets/f5f876e0-ff0a-407a-b33e-030d7b9c41e1" width="320"></td></tr>
<tr><td><b>navigation-menu</b></td><td><img src="https://github.com/user-attachments/assets/6b1601ed-80bf-491b-be0f-7161ed4c3fe6" width="320"></td><td><img src="https://github.com/user-attachments/assets/8f8ff792-3707-45e6-82aa-2fe1d3988581" width="320"></td></tr>
<tr><td><b>identity-menu</b></td><td><img src="https://github.com/user-attachments/assets/49a35c07-0bf2-47b7-a403-9a2c36dea192" width="320"></td><td><img src="https://github.com/user-attachments/assets/d9d5998b-688a-49a9-a29c-1b28d8b6244f" width="320"></td></tr>
<tr><td><b>rich-popover</b></td><td><img src="https://github.com/user-attachments/assets/9f90bc18-3f9f-452e-be6f-8c872a6a67d2" width="320"></td><td><img src="https://github.com/user-attachments/assets/b24c6ce6-7e9b-4814-8666-2a6409401a41" width="320"></td></tr>
<tr><td><b>select-listbox</b></td><td><img src="https://github.com/user-attachments/assets/dd66c59e-8a75-42c5-b867-f902036ab1b9" width="320"></td><td><img src="https://github.com/user-attachments/assets/e29cc663-0394-44c2-9b87-00a12aeea83c" width="320"></td></tr>
</table>

