### PR TITLE
feat(ui): add sidebar customization surface

### DIFF
--- a/ui/src/components/app-sidebar-customizer.test.ts
+++ b/ui/src/components/app-sidebar-customizer.test.ts
@@ -23,6 +23,30 @@ describe("sidebar customizer model", () => {
     expect(items.map((item) => item.visible)).toEqual([true, true, true, false]);
   });
 
+  it("keeps pinned sessions in their canonical page positions with a remove action", () => {
+    const items = buildSidebarCustomizerEntries({
+      canonical: ["route:tasks", "session:agent:main:taxes", "route:cron"],
+      enabledRouteIds: ["cron", "tasks", "plugins"],
+      pinnedSessions: new Map([
+        ["agent:main:taxes", { key: "agent:main:taxes", label: "Tax filing research" }],
+      ]),
+      workboards: [],
+    });
+
+    expect(items.map((item) => item.id)).toEqual([
+      "fixed:home",
+      "route:tasks",
+      "session:agent:main:taxes",
+      "route:cron",
+      "route:plugins",
+    ]);
+    expect(items[2]).toMatchObject({
+      label: "Tax filing research",
+      sessionKey: "agent:main:taxes",
+      visible: true,
+    });
+  });
+
   it("only exposes visibility for catalogs with an existing persistence owner", () => {
     const sections = [
       {

--- a/ui/src/components/app-sidebar-customizer.test.ts
+++ b/ui/src/components/app-sidebar-customizer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSidebarCustomizerEntries,
+  buildSidebarCustomizerSections,
+} from "./app-sidebar-customizer.ts";
+import type { SidebarVisibleSections } from "./app-sidebar-session-navigation-logic.ts";
+
+describe("sidebar customizer model", () => {
+  it("keeps Home fixed and orders visible pages before hidden pages", () => {
+    const items = buildSidebarCustomizerEntries({
+      canonical: ["route:tasks", "route:cron"],
+      enabledRouteIds: ["cron", "tasks", "plugins"],
+      workboards: [],
+    });
+
+    expect(items.map((item) => item.id)).toEqual([
+      "fixed:home",
+      "route:tasks",
+      "route:cron",
+      "route:plugins",
+    ]);
+    expect(items[0]).toMatchObject({ reorderable: false, toggleable: false, visible: true });
+    expect(items.map((item) => item.visible)).toEqual([true, true, true, false]);
+  });
+
+  it("only exposes visibility for catalogs with an existing persistence owner", () => {
+    const sections = [
+      {
+        id: "ungrouped",
+        rows: [],
+        totalRowCount: 0,
+        visibleRowCount: 0,
+        visibleLimit: 25,
+        collapsedVisibleRowCount: 0,
+      },
+      {
+        id: "work",
+        work: true,
+        rows: [],
+        totalRowCount: 0,
+        visibleRowCount: 0,
+        visibleLimit: 25,
+        collapsedVisibleRowCount: 0,
+      },
+      {
+        id: "catalog:claude",
+        rows: [],
+        totalRowCount: 0,
+        visibleRowCount: 0,
+        visibleLimit: 25,
+        collapsedVisibleRowCount: 0,
+      },
+    ] as SidebarVisibleSections["sections"];
+
+    const items = buildSidebarCustomizerSections({
+      sections,
+      catalogLabels: new Map([["claude", "Claude Code"]]),
+      hiddenCatalogIds: new Set(["claude"]),
+    });
+
+    expect(
+      items.map(({ id, label, reorderable, toggleable, visible }) => ({
+        id,
+        label,
+        reorderable,
+        toggleable,
+        visible,
+      })),
+    ).toEqual([
+      { id: "ungrouped", label: "Sessions", reorderable: true, toggleable: false, visible: true },
+      { id: "work", label: "Coding", reorderable: true, toggleable: false, visible: true },
+      {
+        id: "catalog:claude",
+        label: "Claude Code",
+        reorderable: true,
+        toggleable: true,
+        visible: false,
+      },
+    ]);
+  });
+});

--- a/ui/src/components/app-sidebar-customizer.ts
+++ b/ui/src/components/app-sidebar-customizer.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import {
   navigationIconForRoute,
+  parseSidebarEntry,
   serializeSidebarEntry,
   SIDEBAR_NAV_ROUTES,
   titleForRoute,
@@ -22,11 +23,13 @@ export type SidebarCustomizerItem = {
   category?: string;
   reorderable?: boolean;
   toggleable?: boolean;
+  sessionKey?: string;
 };
 
 export function buildSidebarCustomizerEntries(params: {
   canonical: readonly string[];
   enabledRouteIds?: readonly NavigationRouteId[];
+  pinnedSessions?: ReadonlyMap<string, { key: string; label: string }>;
   workboards: readonly SidebarWorkboardBoard[];
 }): SidebarCustomizerItem[] {
   const order = new Map(params.canonical.map((entry, index) => [entry, index]));
@@ -67,6 +70,25 @@ export function buildSidebarCustomizerEntries(params: {
       icon: icons.layoutGrid,
       visible: params.canonical.includes(entry),
       fallbackIndex: boardOffset + index,
+    });
+  }
+  for (const [index, entry] of params.canonical.entries()) {
+    const parsed = parseSidebarEntry(entry);
+    if (parsed?.type !== "session") {
+      continue;
+    }
+    const session = params.pinnedSessions?.get(parsed.key);
+    if (!session) {
+      continue;
+    }
+    items.push({
+      id: entry,
+      entry,
+      kind: "entry",
+      label: session.label.trim() || session.key,
+      sessionKey: session.key,
+      visible: true,
+      fallbackIndex: boardOffset + params.workboards.length + index,
     });
   }
   return items.toSorted((a, b) => {
@@ -121,6 +143,7 @@ type SidebarCustomizerParams = {
   entries: readonly SidebarCustomizerItem[];
   sections: readonly SidebarCustomizerItem[];
   onToggle: (item: SidebarCustomizerItem) => void;
+  onRemove: (item: SidebarCustomizerItem) => void;
   onBack: () => void;
   onEntryDragStart: (event: DragEvent, item: SidebarCustomizerItem) => void;
   onEntryDragOver: (event: DragEvent, entry: string) => void;
@@ -142,6 +165,7 @@ function renderCustomizerItem(
   const draggable =
     item.reorderable !== false && (item.kind === "section" || (toggleable && item.visible));
   const showVisibilityControl = toggleable;
+  const removable = item.sessionKey !== undefined;
   const visibilityLabel = t(item.visible ? "nav.customizeHide" : "nav.customizeShow", {
     item: item.label,
   });
@@ -209,24 +233,34 @@ function renderCustomizerItem(
           : ""}"
         >${item.label}</span
       >
-      ${showVisibilityControl
+      ${removable
         ? html`<button
             type="button"
-            class="sidebar-customizer__visibility"
-            aria-label=${visibilityLabel}
-            aria-pressed=${String(item.visible)}
-            ?disabled=${!toggleable}
-            title=${toggleable ? visibilityLabel : ""}
+            class="sidebar-customizer__visibility sidebar-customizer__remove"
+            aria-label=${t("nav.customizeRemove", { item: item.label })}
             @mousedown=${(event: MouseEvent) => event.stopPropagation()}
-            @click=${() => {
-              if (toggleable) {
-                params.onToggle(item);
-              }
-            }}
+            @click=${() => params.onRemove(item)}
           >
-            ${item.visible ? icons.eye : icons.eyeOff}
+            ${icons.x}
           </button>`
-        : nothing}
+        : showVisibilityControl
+          ? html`<button
+              type="button"
+              class="sidebar-customizer__visibility"
+              aria-label=${visibilityLabel}
+              aria-pressed=${String(item.visible)}
+              ?disabled=${!toggleable}
+              title=${toggleable ? visibilityLabel : ""}
+              @mousedown=${(event: MouseEvent) => event.stopPropagation()}
+              @click=${() => {
+                if (toggleable) {
+                  params.onToggle(item);
+                }
+              }}
+            >
+              ${item.visible ? icons.eye : icons.eyeOff}
+            </button>`
+          : nothing}
     </div>
   `;
 }

--- a/ui/src/components/app-sidebar-customizer.ts
+++ b/ui/src/components/app-sidebar-customizer.ts
@@ -1,0 +1,264 @@
+import { html, nothing, type TemplateResult } from "lit";
+import {
+  navigationIconForRoute,
+  serializeSidebarEntry,
+  SIDEBAR_NAV_ROUTES,
+  titleForRoute,
+  type NavigationRouteId,
+} from "../app-navigation.ts";
+import { t } from "../i18n/index.ts";
+import { writeSidebarSectionDragData } from "../lib/sessions/drag.ts";
+import type { SidebarVisibleSections } from "./app-sidebar-session-navigation-logic.ts";
+import type { SidebarWorkboardBoard } from "./app-sidebar-workboard.ts";
+import { icons } from "./icons.ts";
+
+export type SidebarCustomizerItem = {
+  id: string;
+  label: string;
+  icon?: TemplateResult;
+  visible: boolean;
+  kind: "entry" | "section";
+  entry?: string;
+  category?: string;
+  reorderable?: boolean;
+  toggleable?: boolean;
+};
+
+export function buildSidebarCustomizerEntries(params: {
+  canonical: readonly string[];
+  enabledRouteIds?: readonly NavigationRouteId[];
+  workboards: readonly SidebarWorkboardBoard[];
+}): SidebarCustomizerItem[] {
+  const order = new Map(params.canonical.map((entry, index) => [entry, index]));
+  const items: Array<SidebarCustomizerItem & { fallbackIndex: number }> = [
+    {
+      id: "fixed:home",
+      kind: "entry",
+      label: t("nav.home"),
+      icon: icons.home,
+      visible: true,
+      reorderable: false,
+      toggleable: false,
+      fallbackIndex: -1,
+    },
+    ...SIDEBAR_NAV_ROUTES.filter(
+      (routeId) => params.enabledRouteIds?.includes(routeId) ?? true,
+    ).map((routeId, fallbackIndex) => {
+      const entry = serializeSidebarEntry({ type: "route", route: routeId });
+      return {
+        id: entry,
+        entry,
+        kind: "entry" as const,
+        label: titleForRoute(routeId),
+        icon: icons[navigationIconForRoute(routeId)],
+        visible: params.canonical.includes(entry),
+        fallbackIndex,
+      };
+    }),
+  ];
+  const boardOffset = items.length;
+  for (const [index, board] of params.workboards.entries()) {
+    const entry = serializeSidebarEntry({ type: "workboard", boardId: board.id });
+    items.push({
+      id: entry,
+      entry,
+      kind: "entry",
+      label: board.name?.trim() || board.id,
+      icon: icons.layoutGrid,
+      visible: params.canonical.includes(entry),
+      fallbackIndex: boardOffset + index,
+    });
+  }
+  return items.toSorted((a, b) => {
+    if (a.id === "fixed:home" || b.id === "fixed:home") {
+      return a.id === "fixed:home" ? -1 : 1;
+    }
+    const aIndex = order.get(a.entry!);
+    const bIndex = order.get(b.entry!);
+    if (aIndex !== undefined && bIndex !== undefined) {
+      return aIndex - bIndex;
+    }
+    if (aIndex !== undefined) {
+      return -1;
+    }
+    if (bIndex !== undefined) {
+      return 1;
+    }
+    return a.fallbackIndex - b.fallbackIndex;
+  });
+}
+
+export function buildSidebarCustomizerSections(params: {
+  sections: SidebarVisibleSections["sections"];
+  catalogLabels: ReadonlyMap<string, string>;
+  hiddenCatalogIds: ReadonlySet<string>;
+}): SidebarCustomizerItem[] {
+  return params.sections.map((section) => {
+    const catalogId = section.id.startsWith("catalog:")
+      ? section.id.slice("catalog:".length)
+      : null;
+    return {
+      id: section.id,
+      label: catalogId
+        ? (params.catalogLabels.get(catalogId) ?? catalogId)
+        : section.groups
+          ? t("chat.sidebar.groups")
+          : section.work
+            ? t("chat.sidebar.coding")
+            : section.category
+              ? section.category
+              : t("chat.sidebar.threads"),
+      kind: "section",
+      category: section.category,
+      visible: catalogId ? !params.hiddenCatalogIds.has(catalogId) : true,
+      reorderable: true,
+      toggleable: catalogId !== null,
+    };
+  });
+}
+
+type SidebarCustomizerParams = {
+  entries: readonly SidebarCustomizerItem[];
+  sections: readonly SidebarCustomizerItem[];
+  onToggle: (item: SidebarCustomizerItem) => void;
+  onBack: () => void;
+  onEntryDragStart: (event: DragEvent, item: SidebarCustomizerItem) => void;
+  onEntryDragOver: (event: DragEvent, entry: string) => void;
+  onEntryDragLeave: (event: DragEvent) => void;
+  onEntryDrop: (event: DragEvent, entry: string) => void;
+  onSectionDragStart: (sectionId: string) => void;
+  onSectionDragOver: (event: DragEvent, sectionId: string, category?: string) => void;
+  onSectionDragLeave: (event: DragEvent, sectionId: string, category?: string) => void;
+  onSectionDrop: (event: DragEvent, sectionId: string, category?: string) => void;
+  onDragEnd: (kind: SidebarCustomizerItem["kind"]) => void;
+};
+
+function renderCustomizerItem(
+  item: SidebarCustomizerItem,
+  params: SidebarCustomizerParams,
+  index: number,
+) {
+  const toggleable = item.toggleable !== false;
+  const draggable =
+    item.reorderable !== false && (item.kind === "section" || (toggleable && item.visible));
+  const showVisibilityControl = toggleable;
+  const visibilityLabel = t(item.visible ? "nav.customizeHide" : "nav.customizeShow", {
+    item: item.label,
+  });
+  return html`
+    <div
+      class="sidebar-customizer__row ${item.visible
+        ? ""
+        : "sidebar-customizer__row--hidden"} ${!draggable
+        ? "sidebar-customizer__row--fixed"
+        : ""} ${!toggleable && item.kind === "entry"
+        ? "sidebar-customizer__row--disabled"
+        : ""} ${item.kind === "section" ? "sidebar-customizer__row--section" : ""}"
+      data-iconless=${item.icon || item.kind === "section" ? "false" : "true"}
+      role="listitem"
+      draggable=${draggable ? "true" : "false"}
+      style=${`--sidebar-customizer-index: ${index}`}
+      data-sidebar-customizer-id=${item.id}
+      data-session-section=${item.kind === "section" ? item.id : ""}
+      @dragstart=${(event: DragEvent) => {
+        if (!draggable || !event.dataTransfer) {
+          event.preventDefault();
+          return;
+        }
+        if (item.kind === "section") {
+          writeSidebarSectionDragData(event.dataTransfer, item.id);
+          params.onSectionDragStart(item.id);
+          return;
+        }
+        params.onEntryDragStart(event, item);
+      }}
+      @dragover=${(event: DragEvent) => {
+        if (item.kind === "section" && item.reorderable !== false) {
+          params.onSectionDragOver(event, item.id, item.category);
+        } else if (item.entry) {
+          params.onEntryDragOver(event, item.entry);
+        }
+      }}
+      @dragleave=${(event: DragEvent) => {
+        if (item.kind === "section" && item.reorderable !== false) {
+          params.onSectionDragLeave(event, item.id, item.category);
+        } else {
+          params.onEntryDragLeave(event);
+        }
+      }}
+      @drop=${(event: DragEvent) => {
+        if (item.kind === "section" && item.reorderable !== false) {
+          params.onSectionDrop(event, item.id, item.category);
+        } else if (item.entry) {
+          params.onEntryDrop(event, item.entry);
+        }
+      }}
+      @dragend=${() => params.onDragEnd(item.kind)}
+    >
+      ${draggable
+        ? html`<span class="sidebar-customizer__grip" aria-hidden="true"
+            >${icons.gripVertical}</span
+          >`
+        : nothing}
+      ${item.icon
+        ? html`<span class="sidebar-customizer__item-icon" aria-hidden="true">${item.icon}</span>`
+        : nothing}
+      <span
+        class="sidebar-customizer__label ${item.kind === "section"
+          ? "sidebar-customizer__label--section"
+          : ""}"
+        >${item.label}</span
+      >
+      ${showVisibilityControl
+        ? html`<button
+            type="button"
+            class="sidebar-customizer__visibility"
+            aria-label=${visibilityLabel}
+            aria-pressed=${String(item.visible)}
+            ?disabled=${!toggleable}
+            title=${toggleable ? visibilityLabel : ""}
+            @mousedown=${(event: MouseEvent) => event.stopPropagation()}
+            @click=${() => {
+              if (toggleable) {
+                params.onToggle(item);
+              }
+            }}
+          >
+            ${item.visible ? icons.eye : icons.eyeOff}
+          </button>`
+        : nothing}
+    </div>
+  `;
+}
+
+export function renderSidebarCustomizer(params: SidebarCustomizerParams) {
+  return html`
+    <section
+      class="sidebar-customizer"
+      aria-label=${t("nav.customize")}
+      @keydown=${(event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          params.onBack();
+        }
+      }}
+    >
+      <div class="sidebar-customizer__scroll">
+        <div class="sidebar-customizer__list" role="list">
+          ${params.entries.map((item, index) => renderCustomizerItem(item, params, index))}
+        </div>
+        <div class="sidebar-customizer__separator" role="separator"></div>
+        <div class="sidebar-customizer__list" role="list">
+          ${params.sections.map((item, index) =>
+            renderCustomizerItem(item, params, params.entries.length + index),
+          )}
+        </div>
+      </div>
+      <div class="sidebar-customizer__footer">
+        <button type="button" class="btn sidebar-customizer__back" @click=${params.onBack}>
+          ${t("common.back")}
+        </button>
+      </div>
+    </section>
+  `;
+}

--- a/ui/src/components/app-sidebar-nav-menus.ts
+++ b/ui/src/components/app-sidebar-nav-menus.ts
@@ -7,9 +7,7 @@ import {
   isSessionsHubRoute,
   isSettingsNavigationRoute,
   navigationIconForRoute,
-  serializeSidebarEntry,
   type NavigationRouteId,
-  SIDEBAR_NAV_ROUTES,
   type SidebarNavRoute,
   sidebarMoreRoutes,
   titleForRoute,
@@ -18,7 +16,6 @@ import { pathForRoute } from "../app-route-paths.ts";
 import { t } from "../i18n/index.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import { pluginTabSearch } from "../pages/plugin/route.ts";
-import type { SidebarWorkboardBoard, SidebarWorkboardRenderers } from "./app-sidebar-workboard.ts";
 import { icons, type IconName } from "./icons.ts";
 import type { SidebarAutomationAttention } from "./sidebar-attention-items.ts";
 import { consumeDropdownKeyboardDismissal, trackDropdownKeyboardDismissal } from "./web-awesome.ts";
@@ -240,99 +237,6 @@ export function renderSidebarMoreMenu(params: SidebarMoreMenuParams) {
         <wa-dropdown-item class="sidebar-customize-menu__item" value="customize">
           <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.settings2}</span>
           <span class="sidebar-customize-menu__text">${t("nav.customize")}</span>
-        </wa-dropdown-item>
-      </wa-dropdown>
-    </openclaw-menu-surface>
-  `;
-}
-
-type SidebarCustomizeMenuParams = {
-  position: SidebarMenuPosition | null;
-  sidebarEntries: readonly string[];
-  preferencesBrowserOnly: boolean;
-  isRouteEnabled: (routeId: NavigationRouteId) => boolean;
-  workboardBoards: readonly SidebarWorkboardBoard[];
-  workboardRenderers?: SidebarWorkboardRenderers;
-  onToggleRoute: (routeId: SidebarNavRoute) => void;
-  onToggleWorkboardBoard: (boardId: string) => void;
-  onReset: () => void;
-  onTabAway: () => void;
-  onClose: (restoreFocus: boolean) => void;
-};
-
-export function renderSidebarCustomizeMenu(params: SidebarCustomizeMenuParams) {
-  const position = params.position;
-  if (!position) {
-    return nothing;
-  }
-  return html`
-    <openclaw-menu-surface>
-      <wa-dropdown
-        class="sidebar-customize-menu sidebar-pin-editor-menu"
-        .open=${true}
-        placement="bottom-start"
-        .distance=${0}
-        aria-label=${t("nav.customize")}
-        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-          event.preventDefault();
-          const value = event.detail.item.value;
-          if (value === "reset") {
-            params.onReset();
-          } else if (value?.startsWith("workboard:")) {
-            const boardId = value.slice("workboard:".length);
-            if (params.workboardBoards.some((board) => board.id === boardId)) {
-              params.onToggleWorkboardBoard(boardId);
-            }
-          } else if (value && SIDEBAR_NAV_ROUTES.includes(value as SidebarNavRoute)) {
-            params.onToggleRoute(value as SidebarNavRoute);
-          }
-        }}
-        @keydown=${(event: KeyboardEvent) =>
-          trackDropdownKeyboardDismissal(event, params.onTabAway)}
-        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
-      >
-        <button
-          slot="trigger"
-          type="button"
-          tabindex="-1"
-          aria-hidden="true"
-          aria-label=${t("nav.customize")}
-          style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-        ></button>
-        <div class="sidebar-customize-menu__title">${t("nav.customize")}</div>
-        ${params.preferencesBrowserOnly
-          ? html`<div class="sidebar-customize-menu__provenance" role="note">
-              ${t("quickSettings.personal.browserOnly")}
-            </div>`
-          : nothing}
-        ${SIDEBAR_NAV_ROUTES.filter((routeId) => params.isRouteEnabled(routeId)).map((routeId) => {
-          const visible = params.sidebarEntries.includes(
-            serializeSidebarEntry({ type: "route", route: routeId }),
-          );
-          return html`
-            <wa-dropdown-item
-              class="sidebar-customize-menu__item"
-              type="checkbox"
-              value=${routeId}
-              .checked=${visible}
-            >
-              <span slot="icon" class="nav-item__icon" aria-hidden="true"
-                >${icons[navigationIconForRoute(routeId)]}</span
-              >
-              <span class="sidebar-customize-menu__text">${titleForRoute(routeId)}</span>
-            </wa-dropdown-item>
-          `;
-        })}
-        ${params.isRouteEnabled("workboard") && params.workboardBoards.length > 0
-          ? params.workboardRenderers?.renderCustomize(
-              params.workboardBoards,
-              params.sidebarEntries,
-            )
-          : nothing}
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="reset">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
-          <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
         </wa-dropdown-item>
       </wa-dropdown>
     </openclaw-menu-surface>

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -18,6 +18,7 @@ import "./theme-mode-toggle.ts";
 import "./tooltip.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
+import { writeSessionDragData } from "../lib/sessions/drag.ts";
 import { showToast } from "../lib/toast.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { SETTINGS_SEARCH_TARGETS } from "../pages/config/settings-targets.ts";
@@ -499,10 +500,22 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     }
   }
 
+  private removeSidebarCustomizerItem(item: SidebarCustomizerItem): void {
+    if (!item.sessionKey) {
+      return;
+    }
+    const session = this.reconciledSidebarZone().sessionRows.get(item.sessionKey);
+    if (session) {
+      void this.sessionOrganizer.patchSession(session, { pinned: false });
+    }
+  }
+
   private sidebarCustomizerEntries(): SidebarCustomizerItem[] {
+    const sidebarZone = this.reconciledSidebarZone();
     return buildSidebarCustomizerEntries({
-      canonical: this.reconciledSidebarZone().sidebarEntries,
+      canonical: sidebarZone.sidebarEntries,
       enabledRouteIds: this.enabledRouteIds,
+      pinnedSessions: sidebarZone.sessionRows,
       workboards: this.workboardBoards,
     });
   }
@@ -525,6 +538,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       entries: this.sidebarCustomizerEntries(),
       sections: this.sidebarCustomizerSections(),
       onToggle: (item) => this.toggleSidebarCustomizerItem(item),
+      onRemove: (item) => this.removeSidebarCustomizerItem(item),
       onBack: () => this.closeSidebarCustomizer(),
       onEntryDragStart: (event, item) => {
         const entry = item.entry ? parseSidebarEntry(item.entry) : null;
@@ -532,6 +546,12 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
           this.sessionOrganizer.startSidebarRouteDrag(event, entry.route);
         } else if (entry?.type === "workboard") {
           this.sessionOrganizer.startSidebarWorkboardDrag(event, entry.boardId);
+        } else if (entry?.type === "session") {
+          const session = this.reconciledSidebarZone().sessionRows.get(entry.key);
+          if (session && event.dataTransfer) {
+            writeSessionDragData(event.dataTransfer, session.key);
+            this.sessionOrganizer.startSessionDrag(session);
+          }
         }
       },
       onEntryDragOver: (event, entry) =>

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -2,6 +2,7 @@ import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { state } from "lit/decorators.js";
 import type { FsListDirResult } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
+import { parseSidebarEntry } from "../app-navigation.ts";
 import { isSessionRouteId, pathForRoute } from "../app-route-paths.ts";
 import { beginNativeWindowDragFromTopInset } from "../app/native-window-drag.ts";
 import { t } from "../i18n/index.ts";
@@ -21,6 +22,12 @@ import { showToast } from "../lib/toast.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { SETTINGS_SEARCH_TARGETS } from "../pages/config/settings-targets.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
+import {
+  buildSidebarCustomizerEntries,
+  buildSidebarCustomizerSections,
+  renderSidebarCustomizer,
+  type SidebarCustomizerItem,
+} from "./app-sidebar-customizer.ts";
 import { sidebarPluginTabs } from "./app-sidebar-nav-menus.ts";
 import {
   renderAppSidebarAttention,
@@ -79,6 +86,9 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     count: 0,
     severity: null as "danger" | "warning" | null,
   };
+  @state() private sidebarCustomizerOpen = false;
+
+  private sidebarCustomizerReturnFocus: HTMLElement | null = null;
 
   override readonly sessionOrganizer = new SessionOrganizerController(this);
   override readonly sidebarMenus = new SidebarMenusController(this);
@@ -453,6 +463,97 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     });
   }
 
+  openSidebarCustomizer(trigger: HTMLElement | null = null): void {
+    this.sidebarMenus.dismissTransientMenus();
+    this.sidebarCustomizerReturnFocus = trigger;
+    this.sidebarCustomizerOpen = true;
+    void this.updateComplete.then(() =>
+      this.querySelector<HTMLElement>(".sidebar-customizer button:not([disabled])")?.focus(),
+    );
+  }
+
+  private closeSidebarCustomizer(): void {
+    this.sidebarCustomizerOpen = false;
+    const returnFocus = this.sidebarCustomizerReturnFocus;
+    this.sidebarCustomizerReturnFocus = null;
+    void this.updateComplete.then(() => {
+      if (returnFocus?.isConnected) {
+        returnFocus.focus();
+      } else {
+        this.querySelector<HTMLElement>(".sidebar-nav__more")?.focus();
+      }
+    });
+  }
+
+  private toggleSidebarCustomizerItem(item: SidebarCustomizerItem): void {
+    if (item.kind === "entry" && item.entry) {
+      const canonical = this.reconciledSidebarZone().sidebarEntries;
+      const next = canonical.includes(item.entry)
+        ? canonical.filter((candidate) => candidate !== item.entry)
+        : [...canonical, item.entry];
+      this.onUpdateSidebarEntries?.(next);
+      return;
+    }
+    if (item.id.startsWith("catalog:")) {
+      setStoredSessionCatalogHidden(item.id.slice("catalog:".length), item.visible);
+    }
+  }
+
+  private sidebarCustomizerEntries(): SidebarCustomizerItem[] {
+    return buildSidebarCustomizerEntries({
+      canonical: this.reconciledSidebarZone().sidebarEntries,
+      enabledRouteIds: this.enabledRouteIds,
+      workboards: this.workboardBoards,
+    });
+  }
+
+  private sidebarCustomizerSections(): SidebarCustomizerItem[] {
+    const navigationState = this.getSessionNavigationState();
+    const visibleSessions = this.selectedAgentSessionRows(navigationState);
+    const { sections } = this.zonedVisibleSections(visibleSessions);
+    return buildSidebarCustomizerSections({
+      sections,
+      catalogLabels: new Map(
+        this.sessionData.sessionCatalogs.map((catalog) => [catalog.id, catalog.label]),
+      ),
+      hiddenCatalogIds: this.hiddenSessionCatalogIds,
+    });
+  }
+
+  private renderSidebarCustomizer() {
+    return renderSidebarCustomizer({
+      entries: this.sidebarCustomizerEntries(),
+      sections: this.sidebarCustomizerSections(),
+      onToggle: (item) => this.toggleSidebarCustomizerItem(item),
+      onBack: () => this.closeSidebarCustomizer(),
+      onEntryDragStart: (event, item) => {
+        const entry = item.entry ? parseSidebarEntry(item.entry) : null;
+        if (entry?.type === "route") {
+          this.sessionOrganizer.startSidebarRouteDrag(event, entry.route);
+        } else if (entry?.type === "workboard") {
+          this.sessionOrganizer.startSidebarWorkboardDrag(event, entry.boardId);
+        }
+      },
+      onEntryDragOver: (event, entry) =>
+        this.sessionOrganizer.handleSidebarZoneDragOver(event, entry),
+      onEntryDragLeave: (event) => this.sessionOrganizer.handleSidebarZoneDragLeave(event),
+      onEntryDrop: (event, entry) => this.sessionOrganizer.handleSidebarZoneDrop(event, entry),
+      onSectionDragStart: (sectionId) => this.startSidebarSectionDrag(sectionId),
+      onSectionDragOver: (event, sectionId, category) =>
+        this.sectionDragOver(event, sectionId, category),
+      onSectionDragLeave: (event, sectionId, category) =>
+        this.sectionDragLeave(event, sectionId, category),
+      onSectionDrop: (event, sectionId, category) => this.sectionDrop(event, sectionId, category),
+      onDragEnd: (kind) => {
+        if (kind === "section") {
+          this.finishSidebarSectionDrag();
+        } else {
+          this.sessionOrganizer.finishSidebarEntryDrag();
+        }
+      },
+    });
+  }
+
   openCatalogMenu(
     request: CatalogSessionMenuRequest,
     x: number,
@@ -532,87 +633,95 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         }}
       >
         <div class="sidebar-shell" @mousedown=${beginNativeWindowDragFromTopInset}>
-          ${renderAppSidebarBrand(this)}
-          <div
-            class="sidebar-shell__body sidebar-shell__body--scroll-${this.sessionData
-              .sessionsScrollState} ${this.sidebarScrolling
-              ? "sidebar-shell__body--scrolling"
-              : ""}"
-            @scroll=${(event: Event) =>
-              this.handleSidebarScroll(event.currentTarget as HTMLElement)}
-          >
-            <nav class="sidebar-nav" @contextmenu=${this.sidebarMenus.openCustomizeMenuFromContext}>
-              <div
-                class="nav-section__items"
-                @dragover=${(event: DragEvent) =>
-                  this.sessionOrganizer.handleSidebarZoneDragOver(event)}
-                @dragleave=${(event: DragEvent) =>
-                  this.sessionOrganizer.handleSidebarZoneDragLeave(event)}
-                @drop=${(event: DragEvent) => this.sessionOrganizer.handleSidebarZoneDrop(event)}
-              >
-                ${renderAppSidebarHomeRow(this)}
-                ${sidebarZone.entries.map((entry) =>
-                  renderAppSidebarZoneEntry(
-                    this,
-                    entry,
-                    sidebarZone.sessionRows,
-                    sidebarZone.workboardRows,
-                  ),
-                )}
-                ${sidebarPluginTabs(this.context?.gateway.snapshot.hello?.controlUiTabs).map(
-                  (tab) => renderAppSidebarPluginTabEntry(this, tab),
-                )}
-                ${renderAppSidebarMoreRow(this)}
-              </div>
-            </nav>
-            ${this.renderSessions()}
-          </div>
-          <div class="sidebar-shell__footer">
-            ${renderAppSidebarAttention(this)}
-            <openclaw-sidebar-update-card
-              .updateAvailable=${this.updateAvailable}
-              .updateSchedule=${this.updateSchedule}
-              .heldUpdateCampaignId=${this.heldUpdateCampaignId}
-              .updateBusy=${this.updateBusy}
-              .statusBanner=${this.updateStatusBanner}
-              .watchUpdateProgress=${this.watchUpdateProgress}
-              .canUpdate=${this.canUpdate}
-              .canHoldUpdate=${this.canHoldUpdate}
-              .onUpdate=${this.onUpdate}
-              .refreshRequired=${this.refreshRequired}
-              .onRefresh=${this.onRefresh}
-              .onHoldUpdate=${this.onHoldUpdate}
-            ></openclaw-sidebar-update-card>
-            <openclaw-lobster-pet
-              .seed=${lobsterPetSeed(this.sessionKey)}
-              .mode=${resolveLobsterPetMode(
-                !this.offline,
-                this.sessionData.sessionsResult?.sessions,
-              )}
-              .runOutcome=${resolveLobsterRunOutcome(this.sessionData.sessionsResult?.sessions)}
-              .visitsEnabled=${this.lobsterPetVisits}
-              .soundsEnabled=${this.lobsterPetSounds}
-              .gatewayVersion=${this.gatewayVersion}
-              .onVisitsDisabled=${this.refreshAppearanceSettings}
-            ></openclaw-lobster-pet>
-            ${this.devGitBranch
-              ? html`<openclaw-tooltip .content=${this.devGitBranch}>
-                  <div class="sidebar-footer-branch">
-                    <span class="sidebar-footer-branch__icon" aria-hidden="true"
-                      >${icons.gitBranch}</span
+          ${this.sidebarCustomizerOpen
+            ? html`<div class="sidebar-customizer__brand" inert>${renderAppSidebarBrand(this)}</div>
+                ${this.renderSidebarCustomizer()}`
+            : html`${renderAppSidebarBrand(this)}
+                <div
+                  class="sidebar-shell__body sidebar-shell__body--scroll-${this.sessionData
+                    .sessionsScrollState} ${this.sidebarScrolling
+                    ? "sidebar-shell__body--scrolling"
+                    : ""}"
+                  @scroll=${(event: Event) =>
+                    this.handleSidebarScroll(event.currentTarget as HTMLElement)}
+                >
+                  <nav
+                    class="sidebar-nav"
+                    @contextmenu=${this.sidebarMenus.openSidebarCustomizerFromContext}
+                  >
+                    <div
+                      class="nav-section__items"
+                      @dragover=${(event: DragEvent) =>
+                        this.sessionOrganizer.handleSidebarZoneDragOver(event)}
+                      @dragleave=${(event: DragEvent) =>
+                        this.sessionOrganizer.handleSidebarZoneDragLeave(event)}
+                      @drop=${(event: DragEvent) =>
+                        this.sessionOrganizer.handleSidebarZoneDrop(event)}
                     >
-                    <span class="sidebar-footer-branch__name">${this.devGitBranch}</span>
-                  </div>
-                </openclaw-tooltip>`
-              : nothing}
-            ${renderAppSidebarFooterBar(this)}
-          </div>
+                      ${renderAppSidebarHomeRow(this)}
+                      ${sidebarZone.entries.map((entry) =>
+                        renderAppSidebarZoneEntry(
+                          this,
+                          entry,
+                          sidebarZone.sessionRows,
+                          sidebarZone.workboardRows,
+                        ),
+                      )}
+                      ${sidebarPluginTabs(this.context?.gateway.snapshot.hello?.controlUiTabs).map(
+                        (tab) => renderAppSidebarPluginTabEntry(this, tab),
+                      )}
+                      ${renderAppSidebarMoreRow(this)}
+                    </div>
+                  </nav>
+                  ${this.renderSessions()}
+                </div>
+                <div class="sidebar-shell__footer">
+                  ${renderAppSidebarAttention(this)}
+                  <openclaw-sidebar-update-card
+                    .updateAvailable=${this.updateAvailable}
+                    .updateSchedule=${this.updateSchedule}
+                    .heldUpdateCampaignId=${this.heldUpdateCampaignId}
+                    .updateBusy=${this.updateBusy}
+                    .statusBanner=${this.updateStatusBanner}
+                    .watchUpdateProgress=${this.watchUpdateProgress}
+                    .canUpdate=${this.canUpdate}
+                    .canHoldUpdate=${this.canHoldUpdate}
+                    .onUpdate=${this.onUpdate}
+                    .refreshRequired=${this.refreshRequired}
+                    .onRefresh=${this.onRefresh}
+                    .onHoldUpdate=${this.onHoldUpdate}
+                  ></openclaw-sidebar-update-card>
+                  <openclaw-lobster-pet
+                    .seed=${lobsterPetSeed(this.sessionKey)}
+                    .mode=${resolveLobsterPetMode(
+                      !this.offline,
+                      this.sessionData.sessionsResult?.sessions,
+                    )}
+                    .runOutcome=${resolveLobsterRunOutcome(
+                      this.sessionData.sessionsResult?.sessions,
+                    )}
+                    .visitsEnabled=${this.lobsterPetVisits}
+                    .soundsEnabled=${this.lobsterPetSounds}
+                    .gatewayVersion=${this.gatewayVersion}
+                    .onVisitsDisabled=${this.refreshAppearanceSettings}
+                  ></openclaw-lobster-pet>
+                  ${this.devGitBranch
+                    ? html`<openclaw-tooltip .content=${this.devGitBranch}>
+                        <div class="sidebar-footer-branch">
+                          <span class="sidebar-footer-branch__icon" aria-hidden="true"
+                            >${icons.gitBranch}</span
+                          >
+                          <span class="sidebar-footer-branch__name">${this.devGitBranch}</span>
+                        </div>
+                      </openclaw-tooltip>`
+                    : nothing}
+                  ${renderAppSidebarFooterBar(this)}
+                </div>`}
         </div>
-        ${this.sidebarMenus.renderCustomizeMenu()} ${this.sidebarMenus.renderMoreMenu()}
-        ${this.sidebarMenus.renderAgentMenu()} ${this.sidebarMenus.renderIdentityMenu()}
-        ${this.sidebarMenus.renderSessionMenu()} ${this.sidebarMenus.catalogMenu.render()}
-        ${this.sidebarMenus.renderSessionGroupMenu()} ${this.sidebarMenus.renderSessionSortMenu()}
-        ${this.sidebarMenus.renderCatalogViewMenu()}
+        ${this.sidebarMenus.renderMoreMenu()} ${this.sidebarMenus.renderAgentMenu()}
+        ${this.sidebarMenus.renderIdentityMenu()} ${this.sidebarMenus.renderSessionMenu()}
+        ${this.sidebarMenus.catalogMenu.render()} ${this.sidebarMenus.renderSessionGroupMenu()}
+        ${this.sidebarMenus.renderSessionSortMenu()} ${this.sidebarMenus.renderCatalogViewMenu()}
       </aside>
     `;
   }

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -45,7 +45,6 @@ type SidebarMenuAgent = {
 };
 
 interface SidebarMenusControllerState {
-  customizeMenuPosition: { x: number; y: number } | null;
   moreMenuPosition: { x: number; y: number } | null;
   sessionMenu: SidebarSessionMenuState | null;
   sessionMenuWork: SessionMenuWork | null;
@@ -60,7 +59,6 @@ interface SidebarMenusControllerState {
 type SidebarMenusRenderer = {
   renderSidebarAgentMenuForController(controller: SidebarMenusController): unknown;
   renderSidebarCatalogViewMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarCustomizeMenuForController(controller: SidebarMenusController): unknown;
   renderSidebarIdentityMenuForController(controller: SidebarMenusController): unknown;
   renderSidebarMoreMenuForController(controller: SidebarMenusController): unknown;
   renderSidebarSessionGroupMenuForController(controller: SidebarMenusController): unknown;
@@ -86,9 +84,9 @@ export interface SidebarMenusControllerHost
   readonly onPairMobile?: () => void;
   readonly onRetryConnect?: () => void;
   readonly onUpdateSidebarEntries?: (entries: string[]) => void;
+  openSidebarCustomizer(trigger?: HTMLElement | null): void;
   readonly onPreloadRoute?: (routeId: NavigationRouteId) => Promise<void>;
   readonly pinnedAgentIds: readonly string[];
-  readonly preferencesBrowserOnly: boolean;
   readonly selectedSessionKeys: ReadonlySet<string>;
   readonly sessionData: SessionOrganizerControllerHost["sessionData"] &
     Pick<
@@ -135,7 +133,6 @@ export interface SidebarMenusControllerHost
 
 /** Popup ownership and stateless menu-renderer wiring. */
 export class SidebarMenusController implements ReactiveController, SidebarMenusControllerState {
-  customizeMenuPosition: { x: number; y: number } | null = null;
   moreMenuPosition: { x: number; y: number } | null = null;
   sessionMenu: SidebarSessionMenuState | null = null;
   sessionMenuWork: SessionMenuWork | null = null;
@@ -147,7 +144,6 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
   // Anchored by its bottom edge so the footer menu grows upward regardless of height.
   identityMenuPosition: { x: number; bottom: number; width: number } | null = null;
 
-  customizeMenuTrigger: HTMLElement | null = null;
   moreMenuTrigger: HTMLElement | null = null;
   sessionMenuTrigger: HTMLElement | null = null;
   private sessionMenuWorkVersion = 0;
@@ -215,7 +211,6 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
   // keep document-level shortcuts alive even when an ancestor is hidden.
   dismissTransientMenus(): boolean {
     const hadTransientMenu = Boolean(
-      this.customizeMenuPosition ||
       this.moreMenuPosition ||
       this.sessionMenu ||
       this.catalogMenu.isOpen ||
@@ -225,7 +220,6 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
       this.agentMenuPosition ||
       this.identityMenuPosition,
     );
-    this.closeCustomizeMenu();
     this.closeMoreMenu();
     this.closeSessionMenu();
     this.catalogMenu.close();
@@ -256,31 +250,10 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     return this.host.enabledRouteIds?.includes(routeId) ?? true;
   }
 
-  readonly openCustomizeMenuFromContext = (event: MouseEvent) => {
+  readonly openSidebarCustomizerFromContext = (event: MouseEvent) => {
     event.preventDefault();
-    this.openCustomizeMenu(event.clientX, event.clientY);
+    this.host.openSidebarCustomizer(event.currentTarget as HTMLElement);
   };
-
-  openCustomizeMenu(x: number, y: number, trigger: HTMLElement | null = null) {
-    const menuWidth = 240;
-    const menuMaxHeight = 420;
-    this.loadMenuRenderer();
-    this.dismissTransientMenus();
-    this.customizeMenuTrigger = trigger;
-    this.updateState("customizeMenuPosition", {
-      x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
-      y: Math.max(8, Math.min(y, window.innerHeight - menuMaxHeight - 8)),
-    });
-  }
-
-  closeCustomizeMenu(options: { restoreFocus?: boolean } = {}) {
-    const trigger = this.customizeMenuTrigger;
-    this.customizeMenuTrigger = null;
-    this.updateState("customizeMenuPosition", null);
-    if (options.restoreFocus) {
-      trigger?.focus();
-    }
-  }
 
   toggleMoreMenu(trigger: HTMLElement) {
     if (this.moreMenuPosition) {
@@ -477,7 +450,6 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     this.loadMenuRenderer();
     const menuWidth = 240;
     const rect = trigger.getBoundingClientRect();
-    this.closeCustomizeMenu();
     this.closeMoreMenu();
     this.closeSessionMenu();
     this.closeSessionGroupMenu();
@@ -532,10 +504,6 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     if (options.restoreFocus) {
       trigger?.focus();
     }
-  }
-
-  renderCustomizeMenu() {
-    return this.menuRenderer?.renderSidebarCustomizeMenuForController(this) ?? nothing;
   }
 
   renderAgentMenu() {

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -1,6 +1,5 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
-import { DEFAULT_SIDEBAR_ENTRIES, serializeSidebarEntry } from "../app-navigation.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
@@ -16,7 +15,7 @@ import {
   resolveUiConfiguredMainKey,
 } from "../lib/sessions/session-key.ts";
 import { renderSidebarAgentMenu, renderSidebarIdentityMenu } from "./app-sidebar-agent-menu.ts";
-import { renderSidebarCustomizeMenu, renderSidebarMoreMenu } from "./app-sidebar-nav-menus.ts";
+import { renderSidebarMoreMenu } from "./app-sidebar-nav-menus.ts";
 import { formatSidebarTimestamp } from "./app-sidebar-session-catalogs.ts";
 import {
   renderSidebarCatalogViewMenu,
@@ -29,52 +28,6 @@ import type {
   SidebarMenusController,
   SidebarMenusControllerHost,
 } from "./sidebar-menus-controller.ts";
-
-export function renderSidebarCustomizeMenuForController(controller: SidebarMenusController) {
-  const { host } = controller;
-  const position = controller.customizeMenuPosition;
-  const trigger = controller.customizeMenuTrigger;
-  return renderSidebarCustomizeMenu({
-    position,
-    sidebarEntries: host.sidebarEntries,
-    preferencesBrowserOnly: host.preferencesBrowserOnly,
-    isRouteEnabled: (routeId) => controller.isRouteEnabled(routeId),
-    workboardBoards: host.workboardBoards,
-    workboardRenderers: host.workboardRenderers,
-    onTabAway: () => trigger?.focus(),
-    onClose: (restoreFocus) => {
-      if (controller.customizeMenuPosition !== position) {
-        return;
-      }
-      controller.closeCustomizeMenu({ restoreFocus });
-    },
-    onToggleRoute: (routeId) => {
-      const entry = serializeSidebarEntry({ type: "route", route: routeId });
-      const canonical = host.reconciledSidebarZone().sidebarEntries;
-      const next = canonical.includes(entry)
-        ? canonical.filter((candidate) => candidate !== entry)
-        : [...canonical, entry];
-      host.onUpdateSidebarEntries?.(next);
-    },
-    onToggleWorkboardBoard: (boardId) => {
-      const entry = serializeSidebarEntry({ type: "workboard", boardId });
-      const canonical = host.reconciledSidebarZone().sidebarEntries;
-      const next = canonical.includes(entry)
-        ? canonical.filter((candidate) => candidate !== entry)
-        : [...canonical, entry];
-      host.onUpdateSidebarEntries?.(next);
-    },
-    onReset: () => {
-      // Canonical list, not the render list: unknown-state session slots
-      // (other agents, still-loading caches) must survive a route reset.
-      const sessions = host
-        .reconciledSidebarZone()
-        .sidebarEntries.filter((entry) => entry.startsWith("session:"));
-      host.onUpdateSidebarEntries?.([...DEFAULT_SIDEBAR_ENTRIES, ...sessions]);
-      controller.closeCustomizeMenu({ restoreFocus: true });
-    },
-  });
-}
 
 export function renderSidebarAgentMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
@@ -445,11 +398,9 @@ export function renderSidebarMoreMenuForController(controller: SidebarMenusContr
     onPreloadRoute: (routeId, event) => controller.preloadRoute(routeId, event),
     onCancelPreload: (event) => controller.cancelPreload(event),
     onEditPinnedItems: () => {
-      const customizePosition = controller.moreMenuPosition;
       const customizeTrigger = controller.moreMenuTrigger;
-      if (customizePosition) {
-        controller.openCustomizeMenu(customizePosition.x, customizePosition.y, customizeTrigger);
-      }
+      controller.closeMoreMenu();
+      host.openSidebarCustomizer(customizeTrigger);
     },
   });
 }

--- a/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
@@ -553,15 +553,10 @@ suite.define(() => {
         .locator("wa-dropdown.sidebar-more-menu")
         .getByRole("menuitem", { name: "Customize sidebar" })
         .click();
-      const customizeMenu = sidebar.locator(
-        "wa-dropdown.sidebar-customize-menu:not(.sidebar-more-menu):not(.sidebar-agent-menu)",
-      );
-      await expect
-        .poll(() => customizeMenu.locator(".sidebar-customize-menu__provenance").textContent())
-        .toContain("Stored in this browser only");
-      const tasks = customizeMenu.getByRole("menuitemcheckbox", { name: "Tasks" });
-      await tasks.click();
-      await expect.poll(() => tasks.getAttribute("aria-checked")).toBe("true");
+      const customizer = sidebar.locator(".sidebar-customizer");
+      const tasks = customizer.locator('[data-sidebar-customizer-id="route:tasks"]');
+      await tasks.getByRole("button", { name: "Show Tasks in sidebar" }).click();
+      await expect.poll(() => tasks.getAttribute("class")).not.toContain("--hidden");
       await page.waitForTimeout(100);
       expect(await gateway.getRequests("config.patch")).toHaveLength(0);
 
@@ -584,16 +579,7 @@ suite.define(() => {
         .locator("wa-dropdown.sidebar-more-menu")
         .getByRole("menuitem", { name: "Customize sidebar" })
         .click();
-      await expect
-        .poll(() => customizeMenu.locator(".sidebar-customize-menu__provenance").textContent())
-        .toContain("Stored in this browser only");
-      await expect
-        .poll(() =>
-          customizeMenu
-            .getByRole("menuitemcheckbox", { name: "Tasks" })
-            .getAttribute("aria-checked"),
-        )
-        .toBe("true");
+      await expect.poll(() => tasks.getAttribute("class")).not.toContain("--hidden");
       expect(await gateway.getRequests("config.patch")).toHaveLength(0);
     } finally {
       await context.close();

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -244,10 +244,12 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
 
       const sidebar = page.locator("openclaw-app-sidebar");
-      const pinnedItems = sidebar.locator(
+      const visiblePageItems = sidebar.locator(
         '.sidebar-zone-entry[data-sidebar-entry^="route:"] > .nav-item',
       );
-      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual(["Automations", "Plugins"]);
+      await expect
+        .poll(() => trimmedTextContents(visiblePageItems))
+        .toEqual(["Automations", "Plugins"]);
       await expect.poll(() => sidebar.locator(".sidebar-brand").count()).toBe(1);
       // Desktop renders no topbar row: the sidebar owns navigation.
       await expect.poll(() => page.locator(".topbar").isVisible()).toBe(false);
@@ -497,7 +499,7 @@ suite.define(() => {
         .poll(() => page.getByRole("button", { name: "Exit setup" }).isVisible())
         .toBe(false);
       await page.goto(`${suite.server.baseUrl}chat`);
-      await captureUiProof(page, "01-default-pinned.png");
+      await captureUiProof(page, "01-default-sidebar.png");
 
       const moreButton = sidebar.locator(".sidebar-nav__more");
       const moreMenu = sidebar.locator("wa-dropdown.sidebar-more-menu");
@@ -512,54 +514,69 @@ suite.define(() => {
       await expect
         .poll(() => trimmedTextContents(sidebar.locator(".nav-item__text")))
         .toContain("Logbook");
-      await expect.poll(() => trimmedTextContents(pinnedItems)).not.toContain("Logbook");
+      await expect.poll(() => trimmedTextContents(visiblePageItems)).not.toContain("Logbook");
       // Workboard ships disabled, so it stays hidden from navigation entirely.
       await expect
         .poll(() => trimmedTextContents(moreMenu.getByRole("menuitem")))
         .not.toContain("Workboard");
 
       await moreMenu.getByRole("menuitem", { name: "Customize sidebar" }).click();
-      const menu = sidebar.locator(
-        "wa-dropdown.sidebar-customize-menu:not(.sidebar-more-menu):not(.sidebar-agent-menu)",
-      );
-      // The pin editor replaces the More menu in place.
+      const customizer = sidebar.locator(".sidebar-customizer");
+      // The customizer replaces the sidebar body instead of opening a second menu.
       await expect.poll(() => moreMenu.count()).toBe(0);
+      await expect.poll(() => customizer.isVisible()).toBe(true);
+      const homeRow = customizer.locator('[data-sidebar-customizer-id="fixed:home"]');
+      const sessionsRow = customizer.locator('[data-sidebar-customizer-id="ungrouped"]');
+      await expect.poll(() => homeRow.locator("button, .sidebar-customizer__grip").count()).toBe(0);
       await expect
-        .poll(() => trimmedTextContents(menu.getByRole("menuitemcheckbox")))
-        .not.toContain("Workboard");
-      const tasksItem = menu.getByRole("menuitemcheckbox", { name: "Tasks" });
-      await expect.poll(() => tasksItem.getAttribute("aria-checked")).toBe("false");
-      // Ask OpenClaw moved to Settings (#111686): custodian is not a sidebar
-      // nav route anymore, so the pin editor does not offer it.
-      await expect
-        .poll(() => menu.getByRole("menuitemcheckbox", { name: "OpenClaw" }).count())
+        .poll(() => sessionsRow.locator(".sidebar-customizer__visibility").count())
         .toBe(0);
-      await captureUiProof(page, "02-customize-menu.png");
-
-      await tasksItem.click();
+      const tasksRow = customizer.locator('[data-sidebar-customizer-id="route:tasks"]');
+      await expect.poll(() => tasksRow.getAttribute("class")).toContain("--hidden");
+      // Ask OpenClaw moved to Settings (#111686): custodian is not a sidebar
+      // nav route anymore, so the customizer does not offer it.
+      await expect.poll(() => customizer.getByText("OpenClaw", { exact: true }).count()).toBe(0);
+      for (const theme of ["light", "dark"] as const) {
+        await setThemeMode(page, theme);
+        await captureSettingsSidebarProof(customizer, `02-customizer-${theme}.png`);
+      }
+      await page.emulateMedia({ reducedMotion: "reduce" });
       await expect
-        .poll(() => trimmedTextContents(pinnedItems))
+        .poll(() => tasksRow.evaluate((row) => getComputedStyle(row).animationName))
+        .toBe("none");
+
+      await tasksRow.getByRole("button", { name: "Show Tasks in sidebar" }).click();
+      await expect.poll(() => tasksRow.getAttribute("class")).not.toContain("--hidden");
+      await customizer.getByRole("button", { name: "Back" }).click();
+      await expect
+        .poll(() => trimmedTextContents(visiblePageItems))
         .toEqual(["Automations", "Plugins", "Tasks"]);
       await page.reload();
       await expect
-        .poll(() => trimmedTextContents(pinnedItems))
+        .poll(() => trimmedTextContents(visiblePageItems))
         .toEqual(["Automations", "Plugins", "Tasks"]);
-      // The More menu is transient: closed after reload, unpinned routes inside.
+      // The More menu is transient: closed after reload, secondary routes inside.
       await expect.poll(() => moreButton.getAttribute("aria-expanded")).toBe("false");
       await moreButton.click();
       await expect.poll(() => moreButton.getAttribute("aria-expanded")).toBe("true");
-      const editPersistedPinnedItems = moreMenu.getByRole("menuitem", {
+      const editPersistedCustomization = moreMenu.getByRole("menuitem", {
         name: "Customize sidebar",
       });
-      await expect.poll(() => editPersistedPinnedItems.isVisible()).toBe(true);
+      await expect.poll(() => editPersistedCustomization.isVisible()).toBe(true);
       await expect
         .poll(() => trimmedTextContents(moreMenu.getByRole("menuitem")))
         .not.toContain("Tasks");
       await captureUiProof(page, "03-persisted-customization.png");
 
-      await editPersistedPinnedItems.click();
-      await menu.getByRole("menuitem", { name: "Reset pinned items" }).click();
-      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual(["Automations", "Plugins"]);
+      await editPersistedCustomization.click();
+      await customizer
+        .locator('[data-sidebar-customizer-id="route:tasks"]')
+        .getByRole("button", { name: "Hide Tasks from sidebar" })
+        .click();
+      await customizer.getByRole("button", { name: "Back" }).click();
+      await expect
+        .poll(() => trimmedTextContents(visiblePageItems))
+        .toEqual(["Automations", "Plugins"]);
 
       // The shell chrome search button is the command palette entry point.
       const searchButton = page.locator(".shell-chrome-controls__search");

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -545,6 +545,15 @@ suite.define(() => {
         .poll(() => tasksRow.evaluate((row) => getComputedStyle(row).animationName))
         .toBe("none");
 
+      const pinnedSessionRow = customizer.locator(
+        '[data-sidebar-customizer-id="session:agent:main:tax-research"]',
+      );
+      await expect.poll(() => pinnedSessionRow.isVisible()).toBe(true);
+      await pinnedSessionRow
+        .getByRole("button", { name: "Remove Tax filing research from sidebar" })
+        .click();
+      await expect.poll(() => pinnedSessionRow.count()).toBe(0);
+
       await tasksRow.getByRole("button", { name: "Show Tasks in sidebar" }).click();
       await expect.poll(() => tasksRow.getAttribute("class")).not.toContain("--hidden");
       await customizer.getByRole("button", { name: "Back" }).click();

--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -127,31 +127,22 @@ suite.define(() => {
       expect(menuGap).toBeGreaterThanOrEqual(4);
       expect(menuGap).toBeLessThanOrEqual(7);
       await moreMenu.getByRole("menuitem", { name: "Customize sidebar" }).click();
-      const pinItems = sidebar
-        .locator(
-          "wa-dropdown.sidebar-customize-menu:not(.sidebar-more-menu):not(.sidebar-agent-menu)",
-        )
-        .locator('[role="menuitem"], [role="menuitemcheckbox"]');
-      // The pin editor installs roving focus after the outgoing More menu yields.
+      const customizer = sidebar.locator(".sidebar-customizer");
+      const customizerButtons = customizer.getByRole("button");
       await expect
         .poll(() =>
-          pinItems.evaluateAll((items) => items.filter((item) => item.tabIndex === 0).length),
+          customizerButtons.first().evaluate((element) => element === document.activeElement),
         )
-        .toBe(1);
-      await expect
-        .poll(() => pinItems.first().evaluate((element) => element === document.activeElement))
         .toBe(true);
-      await page.keyboard.press("End");
+      await page.keyboard.press("Tab");
       await expect
-        .poll(() => pinItems.last().evaluate((element) => element === document.activeElement))
-        .toBe(true);
-      await page.keyboard.press("Home");
-      await expect
-        .poll(() => pinItems.first().evaluate((element) => element === document.activeElement))
+        .poll(() =>
+          customizerButtons.nth(1).evaluate((element) => element === document.activeElement),
+        )
         .toBe(true);
       await page.keyboard.press("Escape");
 
-      await expect.poll(() => page.locator(".sidebar-customize-menu").count()).toBe(0);
+      await expect.poll(() => customizer.count()).toBe(0);
       await expect
         .poll(() => moreButton.evaluate((element) => element === document.activeElement))
         .toBe(true);
@@ -212,8 +203,8 @@ suite.define(() => {
         .getByRole("menuitem", { name: "Customize sidebar" })
         .click();
       await sidebar
-        .locator("wa-dropdown.sidebar-pin-editor-menu")
-        .getByRole("menuitemcheckbox", { name: "Automations" })
+        .locator('[data-sidebar-customizer-id="route:cron"]')
+        .getByRole("button", { name: "Hide Automations from sidebar" })
         .click();
       await page.keyboard.press("Escape");
 
@@ -232,7 +223,7 @@ suite.define(() => {
     }
   });
 
-  it("moves focus through the sidebar pin editor with menu keys", async () => {
+  it("enters sidebar customization through the More menu keyboard owner", async () => {
     const { context, page } = await openSidebarCustomizationPage(suite);
 
     try {
@@ -247,42 +238,27 @@ suite.define(() => {
             .evaluate((element) => element === document.activeElement),
         )
         .toBe(true);
-      await moreMenu.getByRole("menuitem", { name: "Customize sidebar" }).click();
-      const menu = sidebar.locator(
-        "wa-dropdown.sidebar-customize-menu:not(.sidebar-more-menu):not(.sidebar-agent-menu)",
-      );
-      const menuItems = menu.locator('[role="menuitem"], [role="menuitemcheckbox"]');
-      await expect
-        .poll(() =>
-          menuItems.evaluateAll((items) => items.filter((item) => item.tabIndex === 0).length),
-        )
-        .toBe(1);
-      await expect
-        .poll(() => menuItems.first().evaluate((element) => element === document.activeElement))
-        .toBe(true);
-
-      await page.keyboard.press("ArrowDown");
-      await expect
-        .poll(() => menuItems.nth(1).evaluate((element) => element === document.activeElement))
-        .toBe(true);
       await page.keyboard.press("End");
       await expect
-        .poll(() => menuItems.last().evaluate((element) => element === document.activeElement))
-        .toBe(true);
-      await page.keyboard.press("ArrowDown");
-      await expect
-        .poll(() => menuItems.first().evaluate((element) => element === document.activeElement))
-        .toBe(true);
-      await page.keyboard.press("Tab");
-      await expect.poll(() => menu.count()).toBe(0);
-      await expect
         .poll(() =>
-          page.evaluate(() => {
-            const active = document.activeElement;
-            return active !== document.body && active?.closest(".sidebar-customize-menu") === null;
-          }),
+          moreMenu
+            .getByRole("menuitem", { name: "Customize sidebar" })
+            .evaluate((element) => element === document.activeElement),
         )
         .toBe(true);
+      await page.keyboard.press("Enter");
+      const customizer = sidebar.locator(".sidebar-customizer");
+      const buttons = customizer.getByRole("button");
+      await expect
+        .poll(() => buttons.first().evaluate((element) => element === document.activeElement))
+        .toBe(true);
+
+      await page.keyboard.press("Tab");
+      await expect
+        .poll(() => buttons.nth(1).evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => customizer.count()).toBe(0);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1963,6 +1963,7 @@ export const en: TranslationMap = {
     customize: "Customize sidebar",
     customizeShow: "Show {item} in sidebar",
     customizeHide: "Hide {item} from sidebar",
+    customizeRemove: "Remove {item} from sidebar",
     workboardGroup: "WorkBoard",
   },
   terminal: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1961,7 +1961,8 @@ export const en: TranslationMap = {
     pages: "Pages",
     pinned: "Pinned",
     customize: "Customize sidebar",
-    customizeReset: "Reset pinned items",
+    customizeShow: "Show {item} in sidebar",
+    customizeHide: "Hide {item} from sidebar",
     workboardGroup: "WorkBoard",
   },
   terminal: {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1128,6 +1128,255 @@ openclaw-settings-save-indicator {
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 
+.sidebar-customizer {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  margin: 0 calc(-1 * var(--sidebar-pad-x)) -12px;
+  padding: 4px var(--sidebar-pad-x) 10px;
+  background: var(--sidebar-bg);
+}
+
+.sidebar-customizer__brand {
+  flex: none;
+  opacity: 0.46;
+  pointer-events: none;
+}
+
+.sidebar-customizer__scroll {
+  min-height: 0;
+  flex: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-color: transparent transparent;
+  scrollbar-width: thin;
+}
+
+.sidebar-customizer__scroll::-webkit-scrollbar {
+  width: 4px;
+}
+
+.sidebar-customizer__scroll::-webkit-scrollbar-track,
+.sidebar-customizer__scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+
+.sidebar-customizer__scroll:hover {
+  scrollbar-color: color-mix(in srgb, var(--text) 20%, transparent) transparent;
+}
+
+.sidebar-customizer__scroll:hover::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 20%, transparent);
+}
+
+.sidebar-customizer__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.sidebar-customizer__separator {
+  height: 1px;
+  margin: 8px 6px;
+  background: color-mix(in srgb, var(--border) 76%, transparent);
+}
+
+.sidebar-customizer__row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) 28px;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 9px;
+  border-radius: var(--radius-md);
+  color: var(--text);
+  cursor: grab;
+  animation: sidebar-customizer-item-enter 140ms cubic-bezier(0.2, 0, 0, 1) both;
+  animation-delay: calc(var(--sidebar-customizer-index, 0) * 12ms);
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.sidebar-customizer__row--section {
+  min-height: 34px;
+  padding-inline: 8px 9px;
+}
+
+.sidebar-customizer__row[data-iconless="true"] {
+  grid-template-columns: minmax(0, 1fr) 28px;
+}
+
+.sidebar-customizer__row[data-iconless="true"] .sidebar-customizer__label {
+  grid-column: 1;
+}
+
+.sidebar-customizer__row[data-iconless="true"] .sidebar-customizer__visibility {
+  grid-column: 2;
+}
+
+.sidebar-customizer__row:hover,
+.sidebar-customizer__row:focus-within {
+  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+}
+
+.sidebar-customizer__row:active {
+  cursor: grabbing;
+}
+
+.sidebar-customizer__row--fixed,
+.sidebar-customizer__row--fixed:active {
+  cursor: default;
+}
+
+.sidebar-customizer__row--disabled {
+  color: var(--muted);
+  opacity: 0.52;
+}
+
+.sidebar-customizer__item-icon,
+.sidebar-customizer__grip {
+  grid-column: 1;
+  grid-row: 1;
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  transition: opacity var(--duration-fast) ease;
+}
+
+.sidebar-customizer__item-icon svg,
+.sidebar-customizer__grip svg,
+.sidebar-customizer__visibility svg {
+  width: 15px;
+  height: 15px;
+}
+
+.sidebar-customizer__grip {
+  position: absolute;
+  inset-inline-start: -14px;
+  opacity: 0.58;
+}
+
+.sidebar-customizer__row--section .sidebar-customizer__grip {
+  position: static;
+  inset-inline-start: auto;
+}
+
+.sidebar-customizer__row:hover .sidebar-customizer__grip,
+.sidebar-customizer__row:focus-within .sidebar-customizer__grip {
+  opacity: 0.82;
+}
+
+.sidebar-customizer__row--fixed:hover .sidebar-customizer__item-icon,
+.sidebar-customizer__row--fixed:focus-within .sidebar-customizer__item-icon {
+  opacity: 1;
+}
+
+.sidebar-customizer__row--fixed .sidebar-customizer__grip,
+.sidebar-customizer__row--fixed:hover .sidebar-customizer__grip,
+.sidebar-customizer__row--fixed:focus-within .sidebar-customizer__grip {
+  opacity: 0;
+}
+
+.sidebar-customizer__label {
+  min-width: 0;
+  overflow: hidden;
+  font-size: calc(13px * var(--control-ui-text-scale));
+  font-weight: 500;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-customizer__label--section {
+  font-size: var(--control-ui-text-sm);
+  font-weight: 650;
+  line-height: 16px;
+}
+
+.sidebar-customizer__visibility {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: var(--cursor-action);
+}
+
+.sidebar-customizer__visibility:hover,
+.sidebar-customizer__visibility:focus-visible {
+  background: color-mix(in srgb, var(--bg-active) 78%, transparent);
+  color: var(--text);
+}
+
+.sidebar-customizer__visibility:disabled {
+  background: transparent;
+  color: inherit;
+  cursor: default;
+}
+
+.sidebar-customizer__visibility:focus-visible {
+  outline: none;
+  box-shadow: var(--sidebar-focus-ring);
+}
+
+.sidebar-customizer__row--hidden .sidebar-customizer__label,
+.sidebar-customizer__row--hidden .sidebar-customizer__item-icon {
+  color: var(--muted);
+  opacity: 0.48;
+}
+
+.sidebar-customizer__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: none;
+  padding: 8px 2px 0;
+}
+
+.sidebar-customizer__back {
+  width: 100%;
+  min-height: 40px;
+  border-radius: var(--radius-md);
+  font-weight: 500;
+}
+
+.sidebar-customizer__back,
+:root[data-theme-mode="light"] .sidebar-customizer__back,
+.sidebar-customizer__back:hover,
+:root[data-theme-mode="light"] .sidebar-customizer__back:hover {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
+@keyframes sidebar-customizer-item-enter {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-customizer__row {
+    animation: none;
+  }
+}
+
 /* Ambient health chips (failed cron, expiring model auth) above the footer bar. */
 .sidebar-attention {
   display: flex;


### PR DESCRIPTION
Depends on #123645.

## What Problem This Solves

Sidebar customization is split across a small pin editor and section-specific menus, so operators cannot understand page order, visibility, and section order as one coherent surface.

## Why This Change Was Made

This PR replaces the normal sidebar body with one compact customization mode that reuses the sidebar's own rows, icons, spacing, and drag owners. It implements CUS-01 through CUS-04 and CUS-06 through CUS-08, removes the previous pin-editor popup, and leaves the heterogeneous ordered zone from #123530 unchanged outside the shared renderer.

## User Impact

- Customize sidebar opens from the More menu for pointer and keyboard users.
- Home remains first and fixed.
- Visible and hidden pages share one aligned eye-control rail; visible pages can be reordered.
- Native and catalog sections share the normal label axis and existing section-order behavior.
- Catalog visibility uses its existing browser persistence. Native sections do not show a visibility control because no persistent owner exists for that state.
- Reduced-motion preferences disable the entry reveal.

## Evidence

- Customization end-to-end suite: 6 passed in a headed remote browser.
- Appearance preference end-to-end suite: 5 passed.
- Customizer model unit suite: 2 passed.
- UI typecheck passed before the final focus-return adjustment.
- Light and dark customizer frames were captured and inspected; fixed rows, hidden rows, eye alignment, label alignment, and reduced-motion behavior matched the contract.
- The interaction suite passed 6 of 7 scenarios before the focus-return correction; exact-head rerun remains pending.

