### PR TITLE
improve(test): cut core tooling 3 runtime

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-stability-runtime-contract.ts
+++ b/test/e2e/qa-lab/runtime/gateway-stability-runtime-contract.ts
@@ -1,0 +1,30 @@
+// Pure CLI contract shared by the Gateway stability script and fast unit coverage.
+import path from "node:path";
+
+export type GatewayStabilityRuntimeOptions = {
+  artifactBase: string;
+  repoRoot: string;
+};
+
+export function parseGatewayStabilityRuntimeOptions(
+  argv: readonly string[],
+  repoRoot = process.cwd(),
+): GatewayStabilityRuntimeOptions {
+  let artifactBase: string | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    const value = argv[index + 1];
+    if (option !== "--artifact-base") {
+      throw new Error(`unknown argument: ${option}`);
+    }
+    if (!value || value.startsWith("--")) {
+      throw new Error("--artifact-base requires a value");
+    }
+    artifactBase = value;
+    index += 1;
+  }
+  if (!artifactBase) {
+    throw new Error("--artifact-base is required");
+  }
+  return { artifactBase: path.resolve(repoRoot, artifactBase), repoRoot };
+}

--- a/test/e2e/qa-lab/runtime/gateway-stability-runtime.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-stability-runtime.test.ts
@@ -1,40 +1,25 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
-import { runGatewayStabilityRuntime } from "./gateway-stability-runtime.js";
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parseGatewayStabilityRuntimeOptions } from "./gateway-stability-runtime-contract.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+describe("gateway stability runtime CLI", () => {
+  it("keeps the full operator workflow in the QA script scenario", () => {
+    const scenario = fs.readFileSync(
+      "qa/scenarios/observability/gateway-stability-runtime.yaml",
+      "utf8",
+    );
+    expect(scenario).toContain("kind: script");
+    expect(scenario).toContain("path: test/e2e/qa-lab/runtime/gateway-stability-runtime.ts");
+  });
 
-describe("gateway stability runtime evidence", () => {
-  it(
-    "proves live RPC, bounded retention, bundle filtering, and export",
-    { timeout: 240_000 },
-    async () => {
-      const artifactBase = tempDirs.make("gateway-stability-runtime-");
-      const evidence = await runGatewayStabilityRuntime({
-        artifactBase,
-        repoRoot: process.cwd(),
-      });
-
-      const result = evidence.entries[0]?.result;
-      expect(result?.status, result?.failure?.reason).toBe("pass");
-      const summary = JSON.parse(
-        await fs.readFile(path.join(artifactBase, "gateway-stability-summary.json"), "utf8"),
-      ) as {
-        liveRpcCapacity: number;
-        retainedCount: number;
-        droppedCount: number;
-        filteredEvents: number;
-        bundleReason: string;
-        supportBytes: number;
-      };
-      expect(summary.liveRpcCapacity).toBe(1000);
-      expect(summary.retainedCount).toBe(1000);
-      expect(summary.droppedCount).toBeGreaterThan(0);
-      expect(summary.filteredEvents).toBe(3);
-      expect(summary.bundleReason).toBe("qa_gateway_stability");
-      expect(summary.supportBytes).toBeGreaterThan(0);
-    },
-  );
+  it("requires one bounded artifact destination", () => {
+    expect(parseGatewayStabilityRuntimeOptions(["--artifact-base", "artifacts"], "/repo")).toEqual({
+      artifactBase: "/repo/artifacts",
+      repoRoot: "/repo",
+    });
+    expect(() => parseGatewayStabilityRuntimeOptions([])).toThrow("--artifact-base is required");
+    expect(() => parseGatewayStabilityRuntimeOptions(["--artifact-base", "--other"])).toThrow(
+      "--artifact-base requires a value",
+    );
+  });
 });

--- a/test/e2e/qa-lab/runtime/gateway-stability-runtime.ts
+++ b/test/e2e/qa-lab/runtime/gateway-stability-runtime.ts
@@ -23,17 +23,16 @@ import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
 } from "../../../helpers/openclaw-test-instance.js";
+import {
+  type GatewayStabilityRuntimeOptions,
+  parseGatewayStabilityRuntimeOptions,
+} from "./gateway-stability-runtime-contract.js";
 import { createQaScriptEvidenceWriter } from "./script-evidence.js";
 
 const SOURCE_PATH = "test/e2e/qa-lab/runtime/gateway-stability-runtime.ts";
 const SCENARIO_ID = "gateway-stability-runtime";
 const SYNTHETIC_EVENT_COUNT = 1_205;
 const PRIVATE_CHAT_ID = "qa-private-stability-chat";
-
-export type GatewayStabilityRuntimeOptions = {
-  artifactBase: string;
-  repoRoot: string;
-};
 
 type StabilitySnapshot = {
   capacity: number;
@@ -70,26 +69,6 @@ type GatewayStabilitySummary = {
   supportArchive: string;
   supportBytes: number;
 };
-
-function parseOptions(argv: string[], repoRoot = process.cwd()): GatewayStabilityRuntimeOptions {
-  let artifactBase: string | undefined;
-  for (let index = 0; index < argv.length; index += 1) {
-    const option = argv[index];
-    const value = argv[index + 1];
-    if (option !== "--artifact-base") {
-      throw new Error(`unknown argument: ${option}`);
-    }
-    if (!value || value.startsWith("--")) {
-      throw new Error("--artifact-base requires a value");
-    }
-    artifactBase = value;
-    index += 1;
-  }
-  if (!artifactBase) {
-    throw new Error("--artifact-base is required");
-  }
-  return { artifactBase: path.resolve(repoRoot, artifactBase), repoRoot };
-}
 
 function parseCliJson<T>(
   label: string,
@@ -322,7 +301,7 @@ export async function runGatewayStabilityRuntime(options: GatewayStabilityRuntim
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  runGatewayStabilityRuntime(parseOptions(process.argv.slice(2)))
+  runGatewayStabilityRuntime(parseGatewayStabilityRuntimeOptions(process.argv.slice(2)))
     .then((evidence) => {
       const status = evidence.entries[0]?.result.status;
       process.stdout.write(`gateway-stability-runtime: ${status}\n`);

--- a/test/e2e/qa-lab/runtime/otel-generation-config-watcher-contract.ts
+++ b/test/e2e/qa-lab/runtime/otel-generation-config-watcher-contract.ts
@@ -31,7 +31,7 @@ export function parseOtelGenerationConfigWatcherOptions(
   return { artifactBase, repoRoot };
 }
 
-function isSpanId(value: string | undefined): value is string {
+export function isSpanId(value: string | undefined): value is string {
   return typeof value === "string" && /^[0-9a-f]{16}$/u.test(value);
 }
 

--- a/test/e2e/qa-lab/runtime/otel-generation-config-watcher-contract.ts
+++ b/test/e2e/qa-lab/runtime/otel-generation-config-watcher-contract.ts
@@ -1,0 +1,93 @@
+// Pure contracts shared by the OTEL watcher script and its fast unit coverage.
+import path from "node:path";
+import { formatErrorMessage } from "../../../../src/infra/errors.js";
+import type { CapturedSpan } from "./otel-test-support.js";
+
+export type OtelGenerationConfigWatcherOptions = {
+  artifactBase: string;
+  repoRoot: string;
+};
+
+export function parseOtelGenerationConfigWatcherOptions(
+  argv: readonly string[],
+  repoRoot = process.cwd(),
+): OtelGenerationConfigWatcherOptions {
+  let artifactBase = path.join(repoRoot, ".artifacts", "qa-e2e", "otel-generation-config-watcher");
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--output-dir") {
+      const value = argv[++index];
+      if (!value) {
+        throw new Error("--output-dir requires a value");
+      }
+      artifactBase = path.resolve(repoRoot, value);
+      continue;
+    }
+    if (arg === "--") {
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return { artifactBase, repoRoot };
+}
+
+function isSpanId(value: string | undefined): value is string {
+  return typeof value === "string" && /^[0-9a-f]{16}$/u.test(value);
+}
+
+export function inspectOtelParentGraph(
+  spans: readonly CapturedSpan[],
+  expectedExternalParentSpanId: string,
+): {
+  externalParentSpanIds: string[];
+  valid: boolean;
+} {
+  const spansById = new Map(
+    spans.flatMap((span) => (isSpanId(span.spanId) ? ([[span.spanId, span]] as const) : [])),
+  );
+  if (spansById.size !== spans.length) {
+    return { externalParentSpanIds: [], valid: false };
+  }
+  const externalParentSpanIds = new Set<string>();
+  for (const span of spans) {
+    const visited = new Set<string>();
+    let current: CapturedSpan | undefined = span;
+    while (current) {
+      if (!isSpanId(current.parentSpanId)) {
+        return { externalParentSpanIds: [...externalParentSpanIds].toSorted(), valid: false };
+      }
+      if (visited.has(current.parentSpanId)) {
+        return { externalParentSpanIds: [...externalParentSpanIds].toSorted(), valid: false };
+      }
+      visited.add(current.parentSpanId);
+      const parent = spansById.get(current.parentSpanId);
+      if (!parent) {
+        externalParentSpanIds.add(current.parentSpanId);
+        if (current.parentSpanId !== expectedExternalParentSpanId) {
+          return { externalParentSpanIds: [...externalParentSpanIds].toSorted(), valid: false };
+        }
+      }
+      current = parent;
+    }
+  }
+  return {
+    externalParentSpanIds: [...externalParentSpanIds].toSorted(),
+    valid:
+      externalParentSpanIds.size === 1 && externalParentSpanIds.has(expectedExternalParentSpanId),
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+export function sanitizeOtelWatcherFailure(error: unknown, repoRoot: string): string {
+  return formatErrorMessage(error)
+    .replace(new RegExp(escapeRegExp(repoRoot), "gu"), "<repo>")
+    .replace(/https?:\/\/(?:127\.0\.0\.1|localhost):\d+/giu, "<local-endpoint>")
+    .replace(/qa-suite-[0-9a-f-]{20,}/giu, "<gateway-token>")
+    .replace(/(?:\/private)?\/var\/folders\/[^\s'"]+/gu, "<temp-path>")
+    .replace(/\/tmp\/[^\s'"]+/gu, "<temp-path>")
+    .replace(/[a-z]:\\[^\s'"]+/giu, "<absolute-path>")
+    .slice(0, 2_000);
+}

--- a/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.test.ts
@@ -1,78 +1,33 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
 import {
-  runOtelGenerationConfigWatcherRuntime,
-  testing,
-} from "./otel-generation-config-watcher-runtime.js";
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  inspectOtelParentGraph,
+  parseOtelGenerationConfigWatcherOptions,
+  sanitizeOtelWatcherFailure,
+} from "./otel-generation-config-watcher-contract.js";
 
 describe("OTEL generation config watcher runtime", () => {
-  it(
-    "keeps all three signals on the active same-PID provider generation",
-    { timeout: 300_000 },
-    async () => {
-      const artifactBase = tempDirs.make("otel-generation-config-watcher-");
-
-      const { evidence, summary } = await runOtelGenerationConfigWatcherRuntime({
-        artifactBase,
-        repoRoot: process.cwd(),
-      });
-
-      expect(evidence.schemaVersion).toBe(2);
-      expect(evidence.entries[0]?.result.status).toBe("pass");
-      expect(summary).toMatchObject({
-        collectorAPostReadyRequestCount: 0,
-        failures: [],
-        noRespawn: true,
-        passed: true,
-        pid: { same: true },
-        readyAfterMutation: true,
-        restartLogObserved: true,
-      });
-      for (const [collector, parentSpanId] of [
-        [summary.collectorA, "1111111111111111"],
-        [summary.collectorB, "2222222222222222"],
-      ] as const) {
-        expect(collector).toMatchObject({
-          externalParentSpanIds: [parentSpanId],
-          failedRequestCount: 0,
-          logCorrelationValid: true,
-          parentGraphValid: true,
-          requiredSpanNames: ["openclaw.model.call", "openclaw.run"],
-          traceparentAccepted: true,
-        });
-        expect(collector?.signalRequestCounts).toMatchObject({
-          logs: expect.any(Number),
-          metrics: expect.any(Number),
-          traces: expect.any(Number),
-        });
-        expect(collector?.signalRequestCounts.logs).toBeGreaterThan(0);
-        expect(collector?.signalRequestCounts.metrics).toBeGreaterThan(0);
-        expect(collector?.signalRequestCounts.traces).toBeGreaterThan(0);
-      }
-
-      const summaryText = await fs.readFile(
-        path.join(artifactBase, "otel-generation-config-watcher-summary.json"),
-        "utf8",
-      );
-      expect(summaryText).not.toContain(artifactBase);
-      expect(summaryText).not.toContain("http://127.0.0.1");
-      const evidenceText = await fs.readFile(path.join(artifactBase, "qa-evidence.json"), "utf8");
-      expect(evidenceText).not.toContain(artifactBase);
-    },
-  );
+  it("keeps the full same-PID proof in the QA script scenario", () => {
+    const scenario = fs.readFileSync(
+      "qa/scenarios/observability/otel-generation-config-watcher.yaml",
+      "utf8",
+    );
+    expect(scenario).toContain("kind: script");
+    expect(scenario).toContain(
+      "path: test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.ts",
+    );
+  });
 
   it("rejects missing output-dir values", () => {
-    expect(() => testing.parseOptions(["--output-dir"])).toThrow("--output-dir requires a value");
+    expect(() => parseOtelGenerationConfigWatcherOptions(["--output-dir"])).toThrow(
+      "--output-dir requires a value",
+    );
   });
 
   it("redacts local failure details before writing artifacts", () => {
     const localEndpoint = `http://${["127", "0", "0", "1"].join(".")}:4318`;
     const gatewayToken = "qa-suite-12345678-1234-1234-1234-123456789abc";
-    const failure = testing.sanitizeProofFailure(
+    const failure = sanitizeOtelWatcherFailure(
       new Error(
         `failed at /workspace/repo/test.ts via ${localEndpoint} in /tmp/openclaw-qa-suite-private with ${gatewayToken}`,
       ),
@@ -97,8 +52,8 @@ describe("OTEL generation config watcher runtime", () => {
       parent: true,
       traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     };
-    const inspect = (spans: Parameters<typeof testing.inspectParentGraph>[0]) =>
-      testing.inspectParentGraph(spans, externalParentSpanId);
+    const inspect = (spans: Parameters<typeof inspectOtelParentGraph>[0]) =>
+      inspectOtelParentGraph(spans, externalParentSpanId);
     expect(
       inspect([
         { ...base, parentSpanId: externalParentSpanId, spanId: rootSpanId },

--- a/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.ts
+++ b/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.ts
@@ -21,9 +21,14 @@ import {
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
 import {
+  inspectOtelParentGraph,
+  type OtelGenerationConfigWatcherOptions,
+  parseOtelGenerationConfigWatcherOptions,
+  sanitizeOtelWatcherFailure,
+} from "./otel-generation-config-watcher-contract.js";
+import {
   type CapturedLogRecord,
   type CapturedRequest,
-  type CapturedSpan,
   startLocalOtlpReceiver,
 } from "./otel-test-support.js";
 import { createQaScriptEvidenceWriter } from "./script-evidence.js";
@@ -35,10 +40,7 @@ const SIGNAL_TIMEOUT_MS = 60_000;
 const RESTART_TIMEOUT_MS = 120_000;
 const POST_STOP_SETTLE_MS = 500;
 
-type RuntimeOptions = {
-  artifactBase: string;
-  repoRoot: string;
-};
+type RuntimeOptions = OtelGenerationConfigWatcherOptions;
 
 type GenerationTarget = {
   marker: string;
@@ -103,26 +105,6 @@ function assertContract(condition: unknown, message: string): asserts condition 
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseOptions(argv: readonly string[], repoRoot = process.cwd()): RuntimeOptions {
-  let artifactBase = path.join(repoRoot, ".artifacts", "qa-e2e", "otel-generation-config-watcher");
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--output-dir") {
-      const value = argv[++index];
-      if (!value) {
-        throw new Error("--output-dir requires a value");
-      }
-      artifactBase = path.resolve(repoRoot, value);
-      continue;
-    }
-    if (arg === "--") {
-      continue;
-    }
-    throw new Error(`Unknown argument: ${arg}`);
-  }
-  return { artifactBase, repoRoot };
 }
 
 function rawDataText(data: RawData): string {
@@ -352,56 +334,10 @@ function isTraceId(value: string | undefined): value is string {
   return typeof value === "string" && /^[0-9a-f]{32}$/u.test(value);
 }
 
-function isSpanId(value: string | undefined): value is string {
-  return typeof value === "string" && /^[0-9a-f]{16}$/u.test(value);
-}
-
-function inspectParentGraph(
-  spans: readonly CapturedSpan[],
-  expectedExternalParentSpanId: string,
-): {
-  externalParentSpanIds: string[];
-  valid: boolean;
-} {
-  const spansById = new Map(
-    spans.flatMap((span) => (isSpanId(span.spanId) ? ([[span.spanId, span]] as const) : [])),
-  );
-  if (spansById.size !== spans.length) {
-    return { externalParentSpanIds: [], valid: false };
-  }
-  const externalParentSpanIds = new Set<string>();
-  for (const span of spans) {
-    const visited = new Set<string>();
-    let current: CapturedSpan | undefined = span;
-    while (current) {
-      if (!isSpanId(current.parentSpanId)) {
-        return { externalParentSpanIds: [...externalParentSpanIds].toSorted(), valid: false };
-      }
-      if (visited.has(current.parentSpanId)) {
-        return { externalParentSpanIds: [...externalParentSpanIds].toSorted(), valid: false };
-      }
-      visited.add(current.parentSpanId);
-      const parent = spansById.get(current.parentSpanId);
-      if (!parent) {
-        externalParentSpanIds.add(current.parentSpanId);
-        if (current.parentSpanId !== expectedExternalParentSpanId) {
-          return { externalParentSpanIds: [...externalParentSpanIds].toSorted(), valid: false };
-        }
-      }
-      current = parent;
-    }
-  }
-  return {
-    externalParentSpanIds: [...externalParentSpanIds].toSorted(),
-    valid:
-      externalParentSpanIds.size === 1 && externalParentSpanIds.has(expectedExternalParentSpanId),
-  };
-}
-
 function inspectGeneration(receiver: LocalReceiver, target: GenerationTarget): GenerationEvidence {
   const spans = receiver.capturedSpans.filter((span) => span.traceId === target.traceId);
   const logs = receiver.capturedLogRecords.filter((record) => record.traceId === target.traceId);
-  const graph = inspectParentGraph(spans, target.parentSpanId);
+  const graph = inspectOtelParentGraph(spans, target.parentSpanId);
   const spanNames = [...new Set(spans.map((span) => span.name))].toSorted();
   const metricNames = [
     ...new Set(
@@ -668,25 +604,10 @@ function createWriter(options: RuntimeOptions) {
   });
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-}
-
-function sanitizeProofFailure(error: unknown, repoRoot: string): string {
-  return formatErrorMessage(error)
-    .replace(new RegExp(escapeRegExp(repoRoot), "gu"), "<repo>")
-    .replace(/https?:\/\/(?:127\.0\.0\.1|localhost):\d+/giu, "<local-endpoint>")
-    .replace(/qa-suite-[0-9a-f-]{20,}/giu, "<gateway-token>")
-    .replace(/(?:\/private)?\/var\/folders\/[^\s'"]+/gu, "<temp-path>")
-    .replace(/\/tmp\/[^\s'"]+/gu, "<temp-path>")
-    .replace(/[a-z]:\\[^\s'"]+/giu, "<absolute-path>")
-    .slice(0, 2_000);
-}
-
 function failedSummary(error: unknown, repoRoot: string): OtelGenerationConfigWatcherSummary {
   return {
     collectorAPostReadyRequestCount: null,
-    failures: [sanitizeProofFailure(error, repoRoot)],
+    failures: [sanitizeOtelWatcherFailure(error, repoRoot)],
     noRespawn: false,
     passed: false,
     pid: {
@@ -728,7 +649,9 @@ export async function runOtelGenerationConfigWatcherRuntime(options: RuntimeOpti
 }
 
 async function main(): Promise<void> {
-  const result = await runOtelGenerationConfigWatcherRuntime(parseOptions(process.argv.slice(2)));
+  const result = await runOtelGenerationConfigWatcherRuntime(
+    parseOtelGenerationConfigWatcherOptions(process.argv.slice(2)),
+  );
   process.stdout.write(
     `${SCENARIO_ID}: ${result.summary.passed ? "passed" : "failed"}; evidence=${QA_EVIDENCE_FILENAME}\n`,
   );
@@ -736,13 +659,6 @@ async function main(): Promise<void> {
     process.exitCode = 1;
   }
 }
-
-export const testing = {
-  inspectGeneration,
-  inspectParentGraph,
-  parseOptions,
-  sanitizeProofFailure,
-};
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   main().catch((error: unknown) => {

--- a/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.ts
+++ b/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.ts
@@ -22,6 +22,7 @@ import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
 import {
   inspectOtelParentGraph,
+  isSpanId,
   type OtelGenerationConfigWatcherOptions,
   parseOtelGenerationConfigWatcherOptions,
   sanitizeOtelWatcherFailure,

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -1,9 +1,9 @@
-// Regression coverage for the non-isolated runner's cross-file cleanup: when a
-// sibling file fails during collection, vitest skips onAfterRunSuite for it, so
-// cleanup must run from onAfterRunFiles or the crashed file's evaluated real
-// modules stay cached and the next file's vi.mock factories silently never apply.
+// Regression coverage for the non-isolated runner's cross-file cleanup. Keep
+// every producer/observer pair in one child run: the contract is file-to-file
+// cleanup, not five independent Vitest process boots.
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -11,13 +11,13 @@ import { expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(import.meta.dirname, "..");
+const require = createRequire(import.meta.url);
 
 function childEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
     // Drop parent Vitest state so the child run resolves its own config, and
-    // drop GITHUB_ACTIONS so the child's github-actions reporter cannot emit
-    // ::error annotations that the parent CI job renders as its own failures.
+    // drop GITHUB_ACTIONS so the child's reporter cannot annotate the parent.
     if (
       key.startsWith("VITEST") ||
       key.startsWith("OPENCLAW_VITEST") ||
@@ -28,62 +28,156 @@ function childEnv(): NodeJS.ProcessEnv {
     }
     env[key] = value;
   }
-  // "CI" in env alone turns tinyrainbow colors on; NO_COLOR overrides every
-  // enable path, keeping the plain-text substring assertions below stable.
   env.NO_COLOR = "1";
+  delete env.OPENCLAW_SKIP_CHANNELS;
+  delete env.OPENCLAW_SKIP_CRON;
   return env;
 }
 
-it("applies vi.mock factories after a sibling file fails during collection", async () => {
+function fixtureFiles(): Record<string, string> {
+  const gatewayMocksPath = JSON.stringify(
+    path.join(repoRoot, "src", "gateway", "test-helpers.mocks.ts"),
+  );
+  const runtimeStorePath = JSON.stringify(
+    path.join(repoRoot, "src", "plugin-sdk", "runtime-store.ts"),
+  );
+  const sessionSuspensionPath = JSON.stringify(
+    path.join(repoRoot, "src", "agents", "session-suspension.ts"),
+  );
+  const agentRunRegistryPath = JSON.stringify(
+    path.join(repoRoot, "src", "infra", "agent-run-registry.ts"),
+  );
+  const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
+
+  return {
+    "01-dep.ts": 'export function flavor(): string {\n  return "real";\n}\n',
+    "01-mid.ts": [
+      'import { flavor } from "./01-dep.js";',
+      "export function describeFlavor(): string {",
+      "  return `flavor:${flavor()}`;",
+      "}",
+      "",
+    ].join("\n"),
+    // Evaluate the real importer graph, then fail collection. The following
+    // file must still apply its mock after onAfterRunFiles cleanup.
+    "01-a-crash.test.ts": 'import "./01-mid.js";\nthrow new Error("synthetic collect failure");\n',
+    "01-b-mock.test.ts": [
+      'import { expect, it, vi } from "vitest";',
+      'vi.mock("./01-dep.js", () => ({ flavor: () => "mocked" }));',
+      'const { describeFlavor } = await import("./01-mid.js");',
+      'it("applies mocks after a sibling collection failure", () => {',
+      '  expect(describeFlavor()).toBe("flavor:mocked");',
+      "});",
+      "",
+    ].join("\n"),
+    "02-a-gateway-env.test.ts": [
+      `import ${gatewayMocksPath};`,
+      'import { expect, it } from "vitest";',
+      'it("seeds gateway helper env", () => {',
+      '  expect(process.env.OPENCLAW_SKIP_CHANNELS).toBe("1");',
+      '  expect(process.env.OPENCLAW_SKIP_CRON).toBe("1");',
+      "});",
+      "",
+    ].join("\n"),
+    "02-b-gateway-env.test.ts": [
+      'import { expect, it } from "vitest";',
+      'it("restores gateway helper env", () => {',
+      "  expect(process.env.OPENCLAW_SKIP_CHANNELS).toBeUndefined();",
+      "  expect(process.env.OPENCLAW_SKIP_CRON).toBeUndefined();",
+      "});",
+      "",
+    ].join("\n"),
+    "03-a-runtime-store.test.ts": [
+      `import { createPluginRuntimeStore } from ${runtimeStorePath};`,
+      'import { expect, it } from "vitest";',
+      'const store = createPluginRuntimeStore({ pluginId: "fixture", errorMessage: "missing" });',
+      'it("seeds a named runtime slot", () => {',
+      '  store.setRuntime({ source: "first-file" });',
+      '  expect(store.getRuntime()).toEqual({ source: "first-file" });',
+      "});",
+      "",
+    ].join("\n"),
+    "03-b-runtime-store.test.ts": [
+      `import { createPluginRuntimeStore } from ${runtimeStorePath};`,
+      'import { expect, it } from "vitest";',
+      'const store = createPluginRuntimeStore({ pluginId: "fixture", errorMessage: "missing" });',
+      'it("clears named runtime slots", () => {',
+      "  expect(store.tryGetRuntime()).toBeNull();",
+      "});",
+      "",
+    ].join("\n"),
+    "04-a-session-suspension.test.ts": [
+      `import { fenceSessionSuspensionWritesForGatewayShutdown } from ${sessionSuspensionPath};`,
+      'import { expect, it } from "vitest";',
+      'const testApi = (globalThis as Record<PropertyKey, { isSessionSuspensionWriteCleanupActiveForTest(): boolean }>)[Symbol.for("openclaw.sessionSuspensionTestApi")];',
+      'it("seeds the session suspension shutdown fence", () => {',
+      "  fenceSessionSuspensionWritesForGatewayShutdown();",
+      "  expect(testApi?.isSessionSuspensionWriteCleanupActiveForTest()).toBe(true);",
+      "});",
+      "",
+    ].join("\n"),
+    "04-b-session-suspension.test.ts": [
+      `import ${sessionSuspensionPath};`,
+      'import { expect, it } from "vitest";',
+      'const testApi = (globalThis as Record<PropertyKey, { isSessionSuspensionWriteCleanupActiveForTest(): boolean }>)[Symbol.for("openclaw.sessionSuspensionTestApi")];',
+      'it("clears the session suspension shutdown fence", () => {',
+      "  expect(testApi?.isSessionSuspensionWriteCleanupActiveForTest()).toBe(false);",
+      "});",
+      "",
+    ].join("\n"),
+    "05-a-agent-run.test.ts": [
+      `import { getAgentRunContext, registerAgentRunContext } from ${agentRunRegistryPath};`,
+      `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
+      'import { expect, it } from "vitest";',
+      'it("seeds process-global run contexts", () => {',
+      '  registerAgentRunContext("unrelated-run-a", { sessionKey: "session-a" });',
+      '  registerAgentRunContext("unrelated-run-b", { sessionKey: "session-b" });',
+      '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
+      "  let sequence;",
+      "  const unsubscribe = onAgentEvent((event) => { sequence = event.seq; });",
+      '  emitAgentEvent({ runId: "reused-run", stream: "assistant", data: {} });',
+      "  unsubscribe();",
+      '  expect(getAgentRunContext("unrelated-run-a")).toBeDefined();',
+      '  expect(getAgentRunContext("unrelated-run-b")).toBeDefined();',
+      "  expect(sequence).toBe(1);",
+      "});",
+      "",
+    ].join("\n"),
+    "05-b-agent-run.test.ts": [
+      `import { clearAgentRunContext, getAgentRunContext, registerAgentRunContext, sweepStaleRunContexts } from ${agentRunRegistryPath};`,
+      `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
+      'import { expect, it } from "vitest";',
+      'it("clears agent run registry state", () => {',
+      '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
+      "  let sequence;",
+      "  const unsubscribe = onAgentEvent((event) => { sequence = event.seq; });",
+      '  emitAgentEvent({ runId: "reused-run", stream: "assistant", data: {} });',
+      "  unsubscribe();",
+      "  expect(sequence).toBe(1);",
+      '  clearAgentRunContext("reused-run");',
+      '  registerAgentRunContext("target-run", { sessionKey: "target-session" });',
+      "  expect(sweepStaleRunContexts(-1)).toBe(1);",
+      '  expect(getAgentRunContext("target-run")).toBeUndefined();',
+      "});",
+      "",
+    ].join("\n"),
+  };
+}
+
+it("cleans every shared runner surface between files", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-non-isolated-runner-"));
   try {
-    const write = (name: string, content: string) =>
-      fs.writeFile(path.join(root, name), content, "utf-8");
-    // The child project resolves vitest through the repository install.
-    await fs.symlink(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
-    );
-    await write("dep.ts", 'export function flavor(): string {\n  return "real";\n}\n');
-    await write(
-      "mid.ts",
-      [
-        'import { flavor } from "./dep.js";',
-        "export function describeFlavor(): string {",
-        "  return `flavor:${flavor()}`;",
-        "}",
-        "",
-      ].join("\n"),
-    );
-    // Evaluates the real mid->dep chain into the shared module cache, then
-    // fails collection so runSuite early-returns without onAfterRunSuite.
-    await write(
-      "a-crash.test.ts",
-      'import "./mid.js";\nthrow new Error("synthetic collect failure");\n',
-    );
-    // Mocks the leaf module and observes it through the cached importer; with a
-    // poisoned cache this sees "flavor:real" instead of the mocked value.
-    await write(
-      "b-mock.test.ts",
-      [
-        'import { expect, it, vi } from "vitest";',
-        'vi.mock("./dep.js", () => ({ flavor: () => "mocked" }));',
-        'const { describeFlavor } = await import("./mid.js");',
-        'it("sees the mocked module through its importer", () => {',
-        '  expect(describeFlavor()).toBe("flavor:mocked");',
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "vitest.config.ts",
+    const vitestPackageDir = path.dirname(require.resolve("vitest/package.json"));
+    await fs.symlink(path.dirname(vitestPackageDir), path.join(root, "node_modules"), "junction");
+    for (const [name, content] of Object.entries(fixtureFiles())) {
+      await fs.writeFile(path.join(root, name), content, "utf8");
+    }
+    await fs.writeFile(
+      path.join(root, "vitest.config.ts"),
       [
         `import { sharedVitestConfig } from ${JSON.stringify(path.join(repoRoot, "test", "vitest", "vitest.shared.config.ts"))};`,
         'import { defineConfig } from "vitest/config";',
         'import { BaseSequencer } from "vitest/node";',
-        "// Alphabetical order keeps a-crash collected before b-mock regardless of",
-        "// the duration cache; the leak only reproduces in that order.",
         "class AlphabeticalSequencer extends BaseSequencer {",
         '  override async sort(files: Parameters<BaseSequencer["sort"]>[0]) {',
         "    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));",
@@ -102,355 +196,28 @@ it("applies vi.mock factories after a sibling file fails during collection", asy
         "});",
         "",
       ].join("\n"),
+      "utf8",
     );
 
-    const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
     const result = await execFileAsync(
       process.execPath,
-      [vitestEntry, "run", "--root", root, "--config", path.join(root, "vitest.config.ts")],
+      [
+        path.join(vitestPackageDir, "vitest.mjs"),
+        "run",
+        "--root",
+        root,
+        "--config",
+        path.join(root, "vitest.config.ts"),
+      ],
       { cwd: repoRoot, env: childEnv(), maxBuffer: 16 * 1024 * 1024 },
     ).catch((error: unknown) => error as { stdout?: string; stderr?: string });
     const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
 
-    // The crash file must fail collection first, and the mock file must still
-    // pass; a poisoned module cache turns b-mock into the second failure.
+    // The collection failure is intentional. Every behavior test after it must
+    // pass; any leaked surface turns the summary into a second failure.
     expect(output).toContain("synthetic collect failure");
-    expect(output).toContain("1 failed | 1 passed");
-  } finally {
-    await fs.rm(root, { recursive: true, force: true });
-  }
-});
-
-it("restores gateway helper env stubs between files", async () => {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-env-runner-"));
-  try {
-    const write = (name: string, content: string) =>
-      fs.writeFile(path.join(root, name), content, "utf-8");
-    const gatewayMocksPath = JSON.stringify(
-      path.join(repoRoot, "src", "gateway", "test-helpers.mocks.ts"),
-    );
-    const sharedVitestConfigPath = JSON.stringify(
-      path.join(repoRoot, "test", "vitest", "vitest.shared.config.ts"),
-    );
-    await fs.symlink(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
-    );
-    await write(
-      "a-import.test.ts",
-      [
-        `import ${gatewayMocksPath};`,
-        'import { expect, it } from "vitest";',
-        'it("applies the gateway test defaults", () => {',
-        '  expect(process.env.OPENCLAW_SKIP_CHANNELS).toBe("1");',
-        '  expect(process.env.OPENCLAW_SKIP_CRON).toBe("1");',
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "b-observe.test.ts",
-      [
-        'import { expect, it } from "vitest";',
-        'it("starts without gateway test env from the previous file", () => {',
-        "  expect(process.env.OPENCLAW_SKIP_CHANNELS).toBeUndefined();",
-        "  expect(process.env.OPENCLAW_SKIP_CRON).toBeUndefined();",
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "vitest.config.ts",
-      [
-        `import { sharedVitestConfig } from ${sharedVitestConfigPath};`,
-        'import { defineConfig } from "vitest/config";',
-        'import { BaseSequencer } from "vitest/node";',
-        "class AlphabeticalSequencer extends BaseSequencer {",
-        '  override async sort(files: Parameters<BaseSequencer["sort"]>[0]) {',
-        "    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));",
-        "  }",
-        "}",
-        "export default defineConfig({",
-        `  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},`,
-        "  resolve: sharedVitestConfig.resolve,",
-        "  test: {",
-        "    isolate: false,",
-        "    fileParallelism: false,",
-        "    maxWorkers: 1,",
-        "    sequence: { sequencer: AlphabeticalSequencer },",
-        `    runner: ${JSON.stringify(path.join(repoRoot, "test", "non-isolated-runner.ts"))},`,
-        "  },",
-        "});",
-        "",
-      ].join("\n"),
-    );
-
-    const env = childEnv();
-    delete env.OPENCLAW_SKIP_CHANNELS;
-    delete env.OPENCLAW_SKIP_CRON;
-    const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
-    const result = await execFileAsync(
-      process.execPath,
-      [vitestEntry, "run", "--root", root, "--config", path.join(root, "vitest.config.ts")],
-      { cwd: repoRoot, env, maxBuffer: 16 * 1024 * 1024 },
-    );
-    expect(`${result.stdout}\n${result.stderr}`).toContain("2 passed");
-  } finally {
-    await fs.rm(root, { recursive: true, force: true });
-  }
-});
-
-it("clears named plugin runtime slots between files", async () => {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runtime-store-runner-"));
-  try {
-    const write = (name: string, content: string) =>
-      fs.writeFile(path.join(root, name), content, "utf-8");
-    const runtimeStorePath = JSON.stringify(
-      path.join(repoRoot, "src", "plugin-sdk", "runtime-store.ts"),
-    );
-    await fs.symlink(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
-    );
-    await write(
-      "a-seed.test.ts",
-      [
-        `import { createPluginRuntimeStore } from ${runtimeStorePath};`,
-        'import { expect, it } from "vitest";',
-        'const store = createPluginRuntimeStore({ pluginId: "fixture", errorMessage: "missing" });',
-        'it("seeds a named runtime slot", () => {',
-        '  store.setRuntime({ source: "first-file" });',
-        '  expect(store.getRuntime()).toEqual({ source: "first-file" });',
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "b-observe.test.ts",
-      [
-        `import { createPluginRuntimeStore } from ${runtimeStorePath};`,
-        'import { expect, it } from "vitest";',
-        'const store = createPluginRuntimeStore({ pluginId: "fixture", errorMessage: "missing" });',
-        'it("starts without a runtime from the previous file", () => {',
-        "  expect(store.tryGetRuntime()).toBeNull();",
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "vitest.config.ts",
-      [
-        `import { sharedVitestConfig } from ${JSON.stringify(path.join(repoRoot, "test", "vitest", "vitest.shared.config.ts"))};`,
-        'import { defineConfig } from "vitest/config";',
-        'import { BaseSequencer } from "vitest/node";',
-        "class AlphabeticalSequencer extends BaseSequencer {",
-        '  override async sort(files: Parameters<BaseSequencer["sort"]>[0]) {',
-        "    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));",
-        "  }",
-        "}",
-        "export default defineConfig({",
-        `  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},`,
-        "  resolve: sharedVitestConfig.resolve,",
-        "  test: {",
-        "    isolate: false,",
-        "    fileParallelism: false,",
-        "    maxWorkers: 1,",
-        "    sequence: { sequencer: AlphabeticalSequencer },",
-        `    runner: ${JSON.stringify(path.join(repoRoot, "test", "non-isolated-runner.ts"))},`,
-        "  },",
-        "});",
-        "",
-      ].join("\n"),
-    );
-
-    const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
-    const result = await execFileAsync(
-      process.execPath,
-      [vitestEntry, "run", "--root", root, "--config", path.join(root, "vitest.config.ts")],
-      { cwd: repoRoot, env: childEnv(), maxBuffer: 16 * 1024 * 1024 },
-    ).catch((error: unknown) => error as { stdout?: string; stderr?: string });
-    const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-
-    expect(output).toContain("2 passed");
+    expect(output).toContain("1 failed | 9 passed");
     expect(output).not.toContain("first-file");
-  } finally {
-    await fs.rm(root, { recursive: true, force: true });
-  }
-});
-
-it("clears the session suspension shutdown fence between files", async () => {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-suspension-runner-"));
-  try {
-    const write = (name: string, content: string) =>
-      fs.writeFile(path.join(root, name), content, "utf-8");
-    const sessionSuspensionPath = JSON.stringify(
-      path.join(repoRoot, "src", "agents", "session-suspension.ts"),
-    );
-    const sharedVitestConfigPath = JSON.stringify(
-      path.join(repoRoot, "test", "vitest", "vitest.shared.config.ts"),
-    );
-    await fs.symlink(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
-    );
-    await write(
-      "a-seed.test.ts",
-      [
-        `import { fenceSessionSuspensionWritesForGatewayShutdown } from ${sessionSuspensionPath};`,
-        'import { expect, it } from "vitest";',
-        'const testApi = (globalThis as Record<PropertyKey, { isSessionSuspensionWriteCleanupActiveForTest(): boolean }>)[Symbol.for("openclaw.sessionSuspensionTestApi")];',
-        'it("seeds the real process-global shutdown fence", () => {',
-        "  fenceSessionSuspensionWritesForGatewayShutdown();",
-        "  expect(testApi?.isSessionSuspensionWriteCleanupActiveForTest()).toBe(true);",
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "b-observe.test.ts",
-      [
-        `import ${sessionSuspensionPath};`,
-        'import { expect, it } from "vitest";',
-        'const testApi = (globalThis as Record<PropertyKey, { isSessionSuspensionWriteCleanupActiveForTest(): boolean }>)[Symbol.for("openclaw.sessionSuspensionTestApi")];',
-        'it("starts without real suspension state from the previous file", () => {',
-        "  expect(testApi?.isSessionSuspensionWriteCleanupActiveForTest()).toBe(false);",
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "vitest.config.ts",
-      [
-        `import { sharedVitestConfig } from ${sharedVitestConfigPath};`,
-        'import { defineConfig } from "vitest/config";',
-        'import { BaseSequencer } from "vitest/node";',
-        "class AlphabeticalSequencer extends BaseSequencer {",
-        '  override async sort(files: Parameters<BaseSequencer["sort"]>[0]) {',
-        "    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));",
-        "  }",
-        "}",
-        "export default defineConfig({",
-        `  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},`,
-        "  resolve: sharedVitestConfig.resolve,",
-        "  test: {",
-        "    isolate: false,",
-        "    fileParallelism: false,",
-        "    maxWorkers: 1,",
-        "    sequence: { sequencer: AlphabeticalSequencer },",
-        `    runner: ${JSON.stringify(path.join(repoRoot, "test", "non-isolated-runner.ts"))},`,
-        "  },",
-        "});",
-        "",
-      ].join("\n"),
-    );
-
-    const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
-    const result = await execFileAsync(
-      process.execPath,
-      [vitestEntry, "run", "--root", root, "--config", path.join(root, "vitest.config.ts")],
-      { cwd: repoRoot, env: childEnv(), maxBuffer: 16 * 1024 * 1024 },
-    );
-    expect(`${result.stdout}\n${result.stderr}`).toContain("2 passed");
-  } finally {
-    await fs.rm(root, { recursive: true, force: true });
-  }
-});
-
-it("clears agent run registry state between files", async () => {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-registry-runner-"));
-  try {
-    const write = (name: string, content: string) =>
-      fs.writeFile(path.join(root, name), content, "utf-8");
-    const agentRunRegistryPath = JSON.stringify(
-      path.join(repoRoot, "src", "infra", "agent-run-registry.ts"),
-    );
-    const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
-    const sharedVitestConfigPath = JSON.stringify(
-      path.join(repoRoot, "test", "vitest", "vitest.shared.config.ts"),
-    );
-    await fs.symlink(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
-    );
-    await write(
-      "a-seed.test.ts",
-      [
-        `import { getAgentRunContext, registerAgentRunContext } from ${agentRunRegistryPath};`,
-        `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
-        'import { expect, it } from "vitest";',
-        'it("seeds process-global run contexts", () => {',
-        '  registerAgentRunContext("unrelated-run-a", { sessionKey: "session-a" });',
-        '  registerAgentRunContext("unrelated-run-b", { sessionKey: "session-b" });',
-        '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
-        "  let sequence;",
-        "  const unsubscribe = onAgentEvent((event) => { sequence = event.seq; });",
-        '  emitAgentEvent({ runId: "reused-run", stream: "assistant", data: {} });',
-        "  unsubscribe();",
-        '  expect(getAgentRunContext("unrelated-run-a")).toBeDefined();',
-        '  expect(getAgentRunContext("unrelated-run-b")).toBeDefined();',
-        "  expect(sequence).toBe(1);",
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "b-observe.test.ts",
-      [
-        `import { clearAgentRunContext, getAgentRunContext, registerAgentRunContext, sweepStaleRunContexts } from ${agentRunRegistryPath};`,
-        `import { emitAgentEvent, onAgentEvent } from ${agentEventsPath};`,
-        'import { expect, it } from "vitest";',
-        'it("restarts sequence state and sweeps only its own target context", () => {',
-        '  registerAgentRunContext("reused-run", { sessionKey: "reused-session" });',
-        "  let sequence;",
-        "  const unsubscribe = onAgentEvent((event) => { sequence = event.seq; });",
-        '  emitAgentEvent({ runId: "reused-run", stream: "assistant", data: {} });',
-        "  unsubscribe();",
-        "  expect(sequence).toBe(1);",
-        '  clearAgentRunContext("reused-run");',
-        '  registerAgentRunContext("target-run", { sessionKey: "target-session" });',
-        "  expect(sweepStaleRunContexts(-1)).toBe(1);",
-        '  expect(getAgentRunContext("target-run")).toBeUndefined();',
-        "});",
-        "",
-      ].join("\n"),
-    );
-    await write(
-      "vitest.config.ts",
-      [
-        `import { sharedVitestConfig } from ${sharedVitestConfigPath};`,
-        'import { defineConfig } from "vitest/config";',
-        'import { BaseSequencer } from "vitest/node";',
-        "class AlphabeticalSequencer extends BaseSequencer {",
-        '  override async sort(files: Parameters<BaseSequencer["sort"]>[0]) {',
-        "    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));",
-        "  }",
-        "}",
-        "export default defineConfig({",
-        `  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},`,
-        "  resolve: sharedVitestConfig.resolve,",
-        "  test: {",
-        "    isolate: false,",
-        "    fileParallelism: false,",
-        "    maxWorkers: 1,",
-        "    sequence: { sequencer: AlphabeticalSequencer },",
-        `    runner: ${JSON.stringify(path.join(repoRoot, "test", "non-isolated-runner.ts"))},`,
-        "  },",
-        "});",
-        "",
-      ].join("\n"),
-    );
-
-    const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
-    const result = await execFileAsync(
-      process.execPath,
-      [vitestEntry, "run", "--root", root, "--config", path.join(root, "vitest.config.ts")],
-      { cwd: repoRoot, env: childEnv(), maxBuffer: 16 * 1024 * 1024 },
-    );
-    expect(`${result.stdout}\n${result.stderr}`).toContain("2 passed");
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -1,5 +1,4 @@
 // Plugin npm runtime build tests validate plugin runtime package builds.
-import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -11,19 +10,11 @@ import {
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  resolvePluginNpmCommand,
-  withAugmentedPluginNpmManifestForPackage,
-} from "../scripts/lib/plugin-npm-package-manifest.mts";
-import {
   buildPluginNpmRuntime,
   listMissingPluginNpmRuntimeHostExports,
   listPublishablePluginPackageDirs,
   resolvePluginNpmRuntimeBuildPlan,
 } from "../scripts/lib/plugin-npm-runtime-build.mts";
-import {
-  createPluginModuleLoaderCache,
-  getCachedPluginSourceModuleLoader,
-} from "../src/plugins/plugin-module-loader-cache.js";
 import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -229,72 +220,20 @@ describe("plugin npm runtime build planning", () => {
     expect(plan.runtimeBuildOutputs).toContain("./dist/setup-api.js");
   });
 
-  it("packs the Zalo public setup API with its lazy runtime surface", async () => {
+  it("plans the Zalo public setup API with its lazy package surface", () => {
     const packageDir = path.join(repoRoot, "extensions", "zalo");
     const plan = expectPluginNpmRuntimeBuildPlan(
-      await buildPluginNpmRuntime({
+      resolvePluginNpmRuntimeBuildPlan({
         repoRoot,
         packageDir,
-        logLevel: "silent",
       }),
     );
-    const consumerDir = tempDirs.make("openclaw-zalo-packed-setup-");
-    let packedFiles: string[] = [];
-    let setupApiPath = "";
-
-    withAugmentedPluginNpmManifestForPackage(
-      { repoRoot, packageDir, bundleDependencies: false },
-      () => {
-        const invocation = resolvePluginNpmCommand([
-          "pack",
-          "--json",
-          "--ignore-scripts",
-          "--pack-destination",
-          consumerDir,
-        ]);
-        const pack = spawnSync(invocation.command, invocation.args, {
-          cwd: packageDir,
-          encoding: "utf8",
-          ...(invocation.env ? { env: invocation.env } : {}),
-          ...(invocation.shell !== undefined ? { shell: invocation.shell } : {}),
-          stdio: ["ignore", "pipe", "pipe"],
-          ...(invocation.windowsVerbatimArguments !== undefined
-            ? { windowsVerbatimArguments: invocation.windowsVerbatimArguments }
-            : {}),
-        });
-        expect(pack.status, pack.stderr).toBe(0);
-        const [packedPackage] = JSON.parse(pack.stdout) as [
-          { filename: string; files: Array<{ path: string }> },
-        ];
-        packedFiles = packedPackage.files.map((file) => file.path);
-        const extract = spawnSync(
-          "tar",
-          ["-xzf", path.join(consumerDir, packedPackage.filename), "-C", consumerDir],
-          {
-            encoding: "utf8",
-            stdio: ["ignore", "pipe", "pipe"],
-          },
-        );
-        expect(extract.status, extract.stderr).toBe(0);
-        setupApiPath = path.join(consumerDir, "package", "dist", "setup-api.js");
-      },
-    );
-
+    expect(plan.entry["setup-api"]).toBe(path.join(packageDir, "setup-api.ts"));
+    expect(plan.entry["setup-surface"]).toBe(path.join(packageDir, "setup-surface.ts"));
     expect(plan.runtimeBuildOutputs).toContain("./dist/setup-api.js");
-    const loadSetupApi = getCachedPluginSourceModuleLoader({
-      cache: createPluginModuleLoaderCache(),
-      modulePath: setupApiPath,
-      importerUrl: import.meta.url,
-      devSourceRoot: repoRoot,
-    });
-    const setupApi = loadSetupApi(setupApiPath) as {
-      zaloSetupWizard: { channel: string };
-    };
-    expect(setupApi.zaloSetupWizard.channel).toBe("zalo");
     expect(plan.runtimeBuildOutputs).toContain("./dist/setup-surface.js");
     expect(plan.runtimeBuildOutputs).not.toContain("./dist/src/setup-surface.js");
-    expect(packedFiles).toContain("dist/setup-surface.js");
-    expect(packedFiles).not.toContain("dist/src/setup-surface.js");
+    expect(plan.packageFiles).toContain("dist/**");
   });
 
   it("keeps published Codex runtime imports resolvable from the host package", async () => {


### PR DESCRIPTION
## What Problem This Solves

The five-stripe tooling split left `core-tooling-3` at 373 seconds of CI job wall time in run 31799237399. Four test files accounted for 149.66 seconds of test-body time because normal unit CI was repeatedly running package builds, full QA script scenarios, and fresh nested Vitest processes.

## Why This Change Was Made

This keeps all 83 files in the same LPT stripe while moving expensive proofs to their correct owners. The Zalo regression now tests the production package-build plan while the existing generic package build remains the integration smoke; five shared-runner cleanup variants execute in one child Vitest process; and the OTel/stability wrapper tests cover extracted pure contracts while their unchanged full operator workflows remain registered as QA Lab script scenarios.

No product code, CI stripe definition, or runner tuning changed.

## User Impact

Maintainers get a substantially shorter `core-tooling-3` critical path without losing the package-build, shared-runner cleanup, OTel generation, or Gateway stability proofs.

## Evidence

CI baseline from run 31799237399 (`checks-node-compact-small-34`):

| File | Before, CI file duration | After, focused tooling run |
| --- | ---: | ---: |
| `test/plugin-npm-runtime-build.test.ts` | 55.327s | 0.69s |
| `test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.test.ts` | 47.722s | 0.007s |
| `test/non-isolated-runner.test.ts` | 29.073s | 19.095s |
| `test/e2e/qa-lab/runtime/gateway-stability-runtime.test.ts` | 17.539s | 0.001s |
| Total | 149.661s | 19.793s |

The focused post-rebase tooling run passed 19/19 tests in 20.43s. Earlier same-machine repetitions put the consolidated nested-runner proof between 10.09s and 13.60s; the table conservatively uses the slower post-rebase sample.

Full stripe baseline: 83/83 files passed, 1,092 tests passed, Vitest 289.44s, CI job wall 373s. Exact PR-head full-stripe timing is pending in [CI run 31802607054](https://github.com/openclaw/openclaw/actions/runs/31802607054); all compact Node jobs were capacity-queued at handoff, including [the target job](https://github.com/openclaw/openclaw/actions/runs/31802607054/job/94774119115).

Coverage notes:

- The Zalo-specific full build/pack duplicate was replaced by assertions against `resolvePluginNpmRuntimeBuildPlan`; the same file retains real msteams, Codex, and llama.cpp runtime builds as integration smokes.
- All five parent shared-runner tests were consolidated into one child process containing the same producer/observer pairs: one intentional collection failure plus nine passing behavior tests.
- The full OTel same-PID restart and Gateway stability/export producers remain unchanged and registered under their existing QA Lab script scenarios. Normal tooling Vitest now protects their scenario routing and extracted parser/redaction/trace-graph contracts instead of executing each operator workflow a second time.

Validation:

- focused tooling run: 19/19 passed
- `oxfmt --check`: clean
- `git diff --check`: clean
- Codex autoreview: no accepted/actionable findings
