### PR TITLE
fix(ui): stale tabs restore terminals without owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI same-version updates:** exchange exact build identities during Gateway connect, fence connected-only work until same-origin clients match, and give service-worker-less/native WebViews one guarded reload plus a visible refresh action instead of restoring ownerless terminals from stale JavaScript.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI same-version updates:** exchange exact build identities during Gateway connect, fence connected-only work until same-origin clients match, and give service-worker-less/native WebViews one guarded reload plus a visible refresh action instead of restoring ownerless terminals from stale JavaScript.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -258,6 +258,7 @@ export type GatewayClientOptions = {
   clientName?: GatewayClientName;
   clientDisplayName?: string;
   clientVersion?: string;
+  clientBuildId?: string;
   platform?: string;
   deviceFamily?: string;
   mode?: GatewayClientMode;
@@ -760,6 +761,7 @@ export class GatewayClient {
           id: clientId,
           displayName: this.opts.clientDisplayName,
           version: this.opts.clientVersion ?? DEFAULT_CLIENT_VERSION,
+          buildId: this.opts.clientBuildId,
           platform,
           deviceFamily,
           mode: clientMode,

--- a/packages/gateway-protocol/src/client-info.ts
+++ b/packages/gateway-protocol/src/client-info.ts
@@ -63,6 +63,8 @@ export type GatewayClientInfo = {
   displayName?: string;
   /** Client app or package version reported by the connecting process. */
   version: string;
+  /** Exact immutable artifact identity when the client can report one. */
+  buildId?: string;
   /** Runtime platform string, such as `darwin`, `ios`, `android`, or `web`. */
   platform: string;
   /** Optional device family used by native clients for display and routing hints. */

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -297,6 +297,12 @@ describe("lazy protocol validators", () => {
     expectRejected(validateConnectParams, [{}]);
     expect(formatValidationErrors(validateConnectParams.errors)).toContain("must have required");
     expectAccepted(validateConnectParams, [connect]);
+    expectAccepted(validateConnectParams, [
+      { ...connect, client: { ...connect.client, buildId: "b".repeat(96) } },
+    ]);
+    expectRejected(validateConnectParams, [
+      { ...connect, client: { ...connect.client, buildId: "b".repeat(97) } },
+    ]);
     expectAccepted(validateConnectParams, [{ ...connect, computerUse: { version: 2 } }]);
     expect(validateConnectParams.errors).toBeNull();
   });

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -297,12 +297,6 @@ describe("lazy protocol validators", () => {
     expectRejected(validateConnectParams, [{}]);
     expect(formatValidationErrors(validateConnectParams.errors)).toContain("must have required");
     expectAccepted(validateConnectParams, [connect]);
-    expectAccepted(validateConnectParams, [
-      { ...connect, client: { ...connect.client, buildId: "b".repeat(96) } },
-    ]);
-    expectRejected(validateConnectParams, [
-      { ...connect, client: { ...connect.client, buildId: "b".repeat(97) } },
-    ]);
     expectAccepted(validateConnectParams, [{ ...connect, computerUse: { version: 2 } }]);
     expect(validateConnectParams.errors).toBeNull();
   });

--- a/packages/gateway-protocol/src/schema/frames.build-id.test.ts
+++ b/packages/gateway-protocol/src/schema/frames.build-id.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { validateConnectParams } from "../index.js";
+
+describe("gateway client build identity", () => {
+  const connect = {
+    minProtocol: 1,
+    maxProtocol: 1,
+    client: { id: "test" as const, version: "1.0.0", platform: "test", mode: "test" as const },
+  };
+
+  it("accepts the bounded artifact id and rejects oversized input", () => {
+    expect(
+      validateConnectParams({
+        ...connect,
+        client: { ...connect.client, buildId: "b".repeat(96) },
+      }),
+    ).toBe(true);
+    expect(
+      validateConnectParams({
+        ...connect,
+        client: { ...connect.client, buildId: "b".repeat(97) },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -40,6 +40,7 @@ export const ConnectParamsSchema = closedObject({
     id: GatewayClientIdSchema,
     displayName: Type.Optional(NonEmptyString),
     version: NonEmptyString,
+    buildId: Type.Optional(Type.String({ minLength: 1, maxLength: 96 })),
     platform: NonEmptyString,
     deviceFamily: Type.Optional(NonEmptyString),
     modelIdentifier: Type.Optional(NonEmptyString),
@@ -85,6 +86,7 @@ export const HelloOkSchema = closedObject({
   protocol: Type.Integer({ minimum: 1 }),
   server: closedObject({
     version: NonEmptyString,
+    buildId: Type.Optional(Type.String({ minLength: 1, maxLength: 96 })),
     connId: NonEmptyString,
   }),
   features: closedObject({

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -87,6 +87,9 @@ export const HelloOkSchema = closedObject({
   server: closedObject({
     version: NonEmptyString,
     buildId: Type.Optional(Type.String({ minLength: 1, maxLength: 96 })),
+    controlUiBuildSource: Type.Optional(
+      Type.Union([Type.Literal("bundled"), Type.Literal("configured")]),
+    ),
     connId: NonEmptyString,
   }),
   features: closedObject({

--- a/scripts/write-build-info.ts
+++ b/scripts/write-build-info.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { normalizeControlUiBuildInfo } from "../ui/src/build-info-normalizers.ts";
 
 const defaultRootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const FULL_GIT_COMMIT_RE = /^[0-9a-f]{40}$/iu;
@@ -22,6 +23,7 @@ export type BuildInfo = {
   version: string | null;
   commit: string | null;
   builtAt: string;
+  buildId: string;
 };
 
 type ResolveBuildInfoOptions = {
@@ -106,11 +108,23 @@ export function resolveBuildInfo(options: ResolveBuildInfoOptions = {}): BuildIn
   const builtAt = explicitTimestamp
     ? normalizeBuildTimestamp(explicitTimestamp)
     : (options.now ?? (() => new Date()))().toISOString();
+  const releaseFlag = env.OPENCLAW_CONTROL_UI_RELEASE_BUILD?.trim();
+  if (releaseFlag && releaseFlag !== "1") {
+    throw new Error("OPENCLAW_CONTROL_UI_RELEASE_BUILD must be 1 when set");
+  }
+  const buildId = normalizeControlUiBuildInfo({
+    version: readPackageVersion(rootDir),
+    commit,
+    builtAt,
+    release: releaseFlag === "1",
+    buildId: env.OPENCLAW_CONTROL_UI_BUILD_ID,
+  }).buildId;
 
   return {
     version: readPackageVersion(rootDir),
     commit,
     builtAt,
+    buildId,
   };
 }
 

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -164,6 +164,8 @@ export type ControlUiBootstrapConfig = {
   assistantAvatarReason?: string | null;
   assistantAgentId?: string;
   serverVersion?: string;
+  /** Exact immutable build serving this Control UI when available. */
+  serverBuildId?: string;
   /**
    * Git branch of a source-checkout (non-release) gateway install. Omitted for
    * package installs and mainline (main/master) checkouts so the UI only flags

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -37,7 +37,7 @@ import { extractOriginalFilename } from "../media/store.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { AVATAR_MAX_BYTES, resolveAvatarMime } from "../shared/avatar-policy.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../version.js";
 import { openGatewayAssistantAvatar, resolveGatewayAssistantAvatar } from "./assistant-avatar.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import { buildAssistantMediaContentDisposition } from "./assistant-media-content-disposition.js";
@@ -1110,6 +1110,10 @@ export async function handleControlUiHttpRequest(
       assistantAvatarReason: avatarMeta.avatarReason,
       ...(assistantAgentId ? { assistantAgentId } : {}),
       serverVersion: resolveRuntimeServiceVersion(process.env),
+      serverBuildId:
+        config?.gateway?.controlUi?.root === undefined
+          ? (resolveRuntimeServiceBuildId() ?? undefined)
+          : undefined,
       devGitBranch: (await resolveDevInstallGitBranch()) ?? undefined,
       localMediaPreviewRoots: [...getAgentScopedMediaLocalRoots(config ?? {}, assistantAgentId)],
       embedSandbox:

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -108,9 +108,10 @@ export async function sendGatewayHello(
   const controlUiWidgetKinds = listControlUiPluginWidgetKinds(scopes);
   // A configured UI root can be built independently from the Gateway. Exact
   // comparison is authoritative only for the package-owned bundled artifact.
-  const serverBuildId = context.configSnapshot.gateway?.controlUi?.root
-    ? null
-    : resolveRuntimeServiceBuildId();
+  const controlUiBuildSource = context.configSnapshot.gateway?.controlUi?.root
+    ? ("configured" as const)
+    : ("bundled" as const);
+  const serverBuildId = controlUiBuildSource === "bundled" ? resolveRuntimeServiceBuildId() : null;
   const helloOk = {
     type: "hello-ok",
     // Admission already verified range overlap; this field reports the server's current protocol.
@@ -118,6 +119,7 @@ export async function sendGatewayHello(
     server: {
       version: resolveRuntimeServiceVersion(process.env),
       ...(serverBuildId ? { buildId: serverBuildId } : {}),
+      controlUiBuildSource,
       connId,
     },
     features: {

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -14,7 +14,7 @@ import {
   recordPairedNodeConnection,
 } from "../../../infra/device-pairing-node.js";
 import { hasMultipleSessionSharingIdentities } from "../../../state/user-profiles.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../../../version.js";
 import { resolveChatAttachmentPolicy } from "../../chat-attachment-policy.js";
 import {
   listControlUiPluginTabs,
@@ -106,12 +106,18 @@ export async function sendGatewayHello(
     requireGatewayAuthGrant: resolvedAuth.mode !== "none",
   });
   const controlUiWidgetKinds = listControlUiPluginWidgetKinds(scopes);
+  // A configured UI root can be built independently from the Gateway. Exact
+  // comparison is authoritative only for the package-owned bundled artifact.
+  const serverBuildId = context.configSnapshot.gateway?.controlUi?.root
+    ? null
+    : resolveRuntimeServiceBuildId();
   const helloOk = {
     type: "hello-ok",
     // Admission already verified range overlap; this field reports the server's current protocol.
     protocol: PROTOCOL_VERSION,
     server: {
       version: resolveRuntimeServiceVersion(process.env),
+      ...(serverBuildId ? { buildId: serverBuildId } : {}),
       connId,
     },
     features: {

--- a/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
@@ -188,6 +188,7 @@ describe("sendGatewayHello update detail scope", () => {
       }),
     );
     expect(helloPayload(context)?.server.buildId).toBe("build-a");
+    expect(helloPayload(context)?.server.controlUiBuildSource).toBe("bundled");
   });
 
   it("omits package build identity for independently built configured UI roots", async () => {
@@ -197,6 +198,7 @@ describe("sendGatewayHello update detail scope", () => {
     await sendGatewayHello(context as never, makeState("operator", ["operator.read"]) as never, {});
 
     expect(helloPayload(context)?.server.buildId).toBeUndefined();
+    expect(helloPayload(context)?.server.controlUiBuildSource).toBe("configured");
   });
 
   it("keeps hello projection and telemetry at effective scopes", async () => {

--- a/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
@@ -71,6 +71,11 @@ vi.mock("./connect-auth-security.js", () => ({
   emitGatewayAuthSecurityEvent: emitGatewayAuthSecurityEventMock,
 }));
 
+vi.mock("../../../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../version.js")>()),
+  resolveRuntimeServiceBuildId: () => "build-a",
+}));
+
 import { sendGatewayHello } from "./connect-hello.js";
 
 function makeContext(role: "operator" | "node", scopes: string[]) {
@@ -182,6 +187,16 @@ describe("sendGatewayHello update detail scope", () => {
         },
       }),
     );
+    expect(helloPayload(context)?.server.buildId).toBe("build-a");
+  });
+
+  it("omits package build identity for independently built configured UI roots", async () => {
+    const context = makeContext("operator", ["operator.read"]);
+    context.configSnapshot = { gateway: { controlUi: { root: "/custom/ui" } } };
+
+    await sendGatewayHello(context as never, makeState("operator", ["operator.read"]) as never, {});
+
+    expect(helloPayload(context)?.server.buildId).toBeUndefined();
   });
 
   it("keeps hello projection and telemetry at effective scopes", async () => {

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -30,7 +30,7 @@ import {
   isBrowserCopilotClient,
   isEphemeralGatewayClient,
 } from "../../../utils/message-channel.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../../../version.js";
 import { verifyAgentRuntimeIdentityToken } from "../../agent-runtime-identity-token.js";
 import { buildAuthenticatedPresenceUser } from "../../authenticated-presence-user.js";
 import {
@@ -490,8 +490,20 @@ export async function attachAuthenticatedGatewayConnect(
   }
 
   if (isWebchatConnect(connectParams)) {
+    const gatewayBuildId = resolveRuntimeServiceBuildId();
+    const clientBuildId = connectParams.client.buildId?.trim();
+    if (
+      connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI &&
+      !context.configSnapshot.gateway?.controlUi?.root &&
+      gatewayBuildId &&
+      clientBuildId !== gatewayBuildId
+    ) {
+      logWsControl.warn(
+        `control ui build mismatch conn=${connId} clientBuild=${formatForLog(clientBuildId ?? "legacy")} gatewayBuild=${formatForLog(gatewayBuildId)}; reload required`,
+      );
+    }
     logWsControl.info(
-      `webchat connected conn=${connId} remote=${remoteAddr ?? "?"} client=${clientLabel} ${connectParams.client.mode} v${connectParams.client.version}`,
+      `webchat connected conn=${connId} remote=${remoteAddr ?? "?"} client=${clientLabel} ${connectParams.client.mode} v${connectParams.client.version} build=${formatForLog(clientBuildId ?? "legacy")}`,
     );
   }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -331,6 +331,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           clientDisplayName: connectParams.client.displayName,
           mode: connectParams.client.mode,
           version: connectParams.client.version,
+          buildId: connectParams.client.buildId,
           platform: connectParams.client.platform,
           deviceFamily: connectParams.client.deviceFamily,
           modelIdentifier: connectParams.client.modelIdentifier,

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createSuiteTempRootTracker } from "./test-helpers/temp-dir.js";
 import {
   VERSION,
+  readBuildIdFromBuildInfoForModuleUrl,
   readVersionFromBuildInfoForModuleUrl,
   resolveCompatibilityHostVersion,
   readVersionFromPackageJsonForModuleUrl,
@@ -87,6 +88,19 @@ describe("version resolution", () => {
       expect(readVersionFromPackageJsonForModuleUrl(moduleUrl)).toBeNull();
       expect(readVersionFromBuildInfoForModuleUrl(moduleUrl)).toBe("4.5.6");
       expect(resolveVersionFromModuleUrl(moduleUrl)).toBe("4.5.6");
+    });
+  });
+
+  it("reads the bounded immutable build id from generated provenance", async () => {
+    await withVersionFixtureDir(async (root) => {
+      const moduleUrl = await ensureModuleFixture(root);
+      await writeJsonFixture(root, "build-info.json", { buildId: "build-a" });
+      expect(readBuildIdFromBuildInfoForModuleUrl(moduleUrl)).toBe("build-a");
+    });
+    await withVersionFixtureDir(async (root) => {
+      const moduleUrl = await ensureModuleFixture(root);
+      await writeJsonFixture(root, "build-info.json", { buildId: "x".repeat(97) });
+      expect(readBuildIdFromBuildInfoForModuleUrl(moduleUrl)).toBeNull();
     });
   });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -47,6 +47,26 @@ function readVersionFromJsonCandidates(
   }
 }
 
+function readBuildIdFromJsonCandidates(moduleUrl: string): string | null {
+  try {
+    const require = createRequire(moduleUrl);
+    for (const candidate of BUILD_INFO_CANDIDATES) {
+      try {
+        const parsed = require(candidate) as { buildId?: unknown };
+        const buildId = normalizeOptionalString(parsed.buildId);
+        if (buildId && buildId.length <= 96) {
+          return buildId;
+        }
+      } catch {
+        // ignore missing or unreadable candidate
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
   for (const value of values) {
     const trimmed = normalizeOptionalString(value);
@@ -69,6 +89,10 @@ export function readVersionFromPackageJsonForModuleUrl(moduleUrl: string): strin
 
 export function readVersionFromBuildInfoForModuleUrl(moduleUrl: string): string | null {
   return readVersionFromJsonCandidates(moduleUrl, BUILD_INFO_CANDIDATES);
+}
+
+export function readBuildIdFromBuildInfoForModuleUrl(moduleUrl: string): string | null {
+  return readBuildIdFromJsonCandidates(moduleUrl);
 }
 
 export function resolveVersionFromModuleUrl(moduleUrl: string): string | null {
@@ -135,6 +159,14 @@ export function resolveRuntimeServiceVersion(
     fallback,
     preference: "env-first",
   });
+}
+
+// Generated build provenance is immutable for a process. Resolve it once so
+// handshakes never poll the filesystem on the connection hot path.
+const RUNTIME_SERVICE_BUILD_ID = readBuildIdFromBuildInfoForModuleUrl(import.meta.url);
+
+export function resolveRuntimeServiceBuildId(): string | null {
+  return RUNTIME_SERVICE_BUILD_ID;
 }
 
 export function resolveCompatibilityHostVersion(

--- a/test/scripts/write-build-info.test.ts
+++ b/test/scripts/write-build-info.test.ts
@@ -40,6 +40,7 @@ describe("write-build-info", () => {
       version: "2026.7.10",
       commit: "abcdef0123456789abcdef0123456789abcdef01",
       builtAt: "2026-07-10T12:34:56.000Z",
+      buildId: "2026.7.10-abcdef012345-2026-07-10T12-34-56.000Z",
     });
   });
 
@@ -58,6 +59,7 @@ describe("write-build-info", () => {
       version: "2026.7.10-beta.1",
       commit: "1234567890abcdef1234567890abcdef12345678",
       builtAt: "2026-07-10T01:02:03.456Z",
+      buildId: "2026.7.10-beta.1-1234567890ab-2026-07-10T01-02-03.456Z",
     });
     expect(execFileSync).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"], {
       cwd: rootDir,
@@ -79,6 +81,20 @@ describe("write-build-info", () => {
         now: () => new Date("2026-07-10T01:02:03.000Z"),
       }).commit,
     ).toBeNull();
+  });
+
+  it("shares explicit release artifact identity with the Control UI", () => {
+    const rootDir = createPackage();
+    expect(
+      resolveBuildInfo({
+        rootDir,
+        env: {
+          GIT_COMMIT: "a".repeat(40),
+          OPENCLAW_BUILD_TIMESTAMP: "2026-07-10T01:02:03.000Z",
+          OPENCLAW_CONTROL_UI_RELEASE_BUILD: "1",
+        },
+      }).buildId,
+    ).toBe("2026.7.10-release-aaaaaaaaaaaa-2026-07-10T01-02-03.000Z");
   });
 
   it("preserves GIT_COMMIT then GIT_SHA explicit input precedence", () => {

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -439,6 +439,7 @@ describe("GatewayBrowserClient", () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",
       token: "shared-auth-token",
+      clientBuildId: "build-a",
     });
 
     const { connectFrame } = await startConnect(client);
@@ -446,6 +447,7 @@ describe("GatewayBrowserClient", () => {
     expect(connectFrame.method).toBe("connect");
     expect(connectFrame.params?.minProtocol).toBe(MIN_CLIENT_PROTOCOL_VERSION);
     expect(connectFrame.params?.maxProtocol).toBe(PROTOCOL_VERSION);
+    expect(connectFrame.params?.client.buildId).toBe("build-a");
     expect(connectFrame.params?.caps).toEqual([
       GATEWAY_CLIENT_CAPS.AGENT_KIND,
       GATEWAY_CLIENT_CAPS.APPROVALS,

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -162,6 +162,7 @@ type ConnectFrame = {
   method?: string;
   params?: {
     auth?: { token?: string; bootstrapToken?: string; password?: string; deviceToken?: string };
+    client: { buildId?: string };
     maxProtocol?: number;
     minProtocol?: number;
     caps?: string[];

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -269,7 +269,7 @@ async function deriveLegacyV4RecoveryScope(material: string | undefined): Promis
 
 async function buildGatewayConnectDevice(params: {
   deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null;
-  client: GatewayConnectClientInfo;
+  client: ConnectParams["client"];
   role: string;
   scopes: string[];
   authToken?: string;

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -165,6 +165,7 @@ export type GatewayBrowserClientOptions = {
   password?: string;
   clientName?: GatewayClientName;
   clientVersion?: string;
+  clientBuildId?: string;
   platform?: string;
   mode?: GatewayClientMode;
   instanceId?: string;
@@ -447,6 +448,7 @@ export class GatewayBrowserClient {
     const client: GatewayConnectClientInfo = {
       id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
       version: this.opts.clientVersion ?? "control-ui",
+      buildId: this.opts.clientBuildId,
       platform: this.opts.platform ?? navigator.platform ?? "web",
       mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT,
       instanceId: this.opts.instanceId,

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -147,8 +147,6 @@ const CONTROL_UI_OPERATOR_SCOPES = [
   "operator.pairing",
 ] as const;
 
-type GatewayConnectClientInfo = ConnectParams["client"];
-
 type ConnectPlan = {
   generation: number;
   params: ConnectParams;
@@ -445,7 +443,7 @@ export class GatewayBrowserClient {
   ): Promise<ConnectPlan> {
     this.recovery = { ...this.recovery, generation, resolved: false };
     const role = CONTROL_UI_OPERATOR_ROLE;
-    const client: GatewayConnectClientInfo = {
+    const client: ConnectParams["client"] = {
       id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
       version: this.opts.clientVersion ?? "control-ui",
       buildId: this.opts.clientBuildId,

--- a/ui/src/app/config.ts
+++ b/ui/src/app/config.ts
@@ -38,6 +38,7 @@ type ApplicationConfig = {
     avatarReason: string | null;
   };
   serverVersion: string | null;
+  serverBuildId?: string | null;
   devGitBranch: string | null;
   localMediaPreviewRoots: string[];
   embedSandboxMode: ControlUiEmbedSandboxMode;
@@ -75,6 +76,7 @@ const DEFAULT_APPLICATION_CONFIG: ApplicationConfig = {
     avatarReason: null,
   },
   serverVersion: null,
+  serverBuildId: null,
   devGitBranch: null,
   localMediaPreviewRoots: [],
   embedSandboxMode: "strict",
@@ -142,6 +144,7 @@ function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): Applicati
       avatarReason: identity.avatarReason ?? null,
     },
     serverVersion: parsed.serverVersion ?? null,
+    serverBuildId: parsed.serverBuildId ?? null,
     devGitBranch:
       typeof parsed.devGitBranch === "string" && parsed.devGitBranch.trim()
         ? parsed.devGitBranch.trim()

--- a/ui/src/app/gateway-store.observers.test.ts
+++ b/ui/src/app/gateway-store.observers.test.ts
@@ -11,7 +11,11 @@ import { createApplicationGateway } from "./gateway-store.ts";
 import { loadSettings } from "./settings.ts";
 
 vi.mock("../build-info.ts", () => ({
-  CONTROL_UI_BUILD_INFO: { version: "2026.7.2" },
+  CONTROL_UI_BUILD_INFO: { version: "2026.7.2", buildId: "test" },
+  controlUiBuildDiffersFrom: (identity: { version?: string | null; buildId?: string | null }) =>
+    identity.buildId
+      ? identity.buildId !== "test"
+      : Boolean(identity.version && identity.version !== "2026.7.2"),
 }));
 
 const HELLO: GatewayHelloOk = {

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -179,6 +179,22 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.phase).toBe("reconnecting");
   });
 
+  it("keeps legacy version fallback on reconnect instead of first admission", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+    const legacyHello = {
+      ...HELLO,
+      server: { version: "2026.7.20", connId: "legacy-conn" },
+    };
+
+    current().opts.onHello?.(legacyHello);
+    expect(gateway.snapshot.phase).toBe("connected");
+
+    current().opts.onClose?.({ code: 1006, reason: "restarting", willRetry: true });
+    current().opts.onHello?.(legacyHello);
+    expect(gateway.snapshot.phase).toBe("reconnecting");
+  });
+
   it("does not compare a separately hosted Control UI with a remote gateway build", () => {
     const settings = { ...loadSettings(), gatewayUrl: "wss://remote.example/ws" };
     const { gateway, current } = createStore({ settings });

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -23,10 +23,16 @@ vi.mock("../build-info.ts", () => ({
     release: false,
     buildId: "test",
   },
-  controlUiBuildDiffersFrom: (identity: { version?: string | null; buildId?: string | null }) =>
-    identity.buildId
-      ? identity.buildId !== "test"
-      : Boolean(identity.version && identity.version !== "2026.7.19"),
+  controlUiBuildDiffersFrom: (identity: {
+    version?: string | null;
+    buildId?: string | null;
+    controlUiBuildSource?: "bundled" | "configured";
+  }) =>
+    identity.controlUiBuildSource === "configured"
+      ? false
+      : identity.buildId
+        ? identity.buildId !== "test"
+        : Boolean(identity.version && identity.version !== "2026.7.19"),
 }));
 
 const HELLO: GatewayHelloOk = {
@@ -181,6 +187,22 @@ describe("createApplicationGateway connection phase", () => {
     current().opts.onHello?.({
       ...HELLO,
       server: { version: "2026.7.19", buildId: "remote-build", connId: "conn-1" },
+    });
+
+    expect(gateway.snapshot.phase).toBe("connected");
+  });
+
+  it("does not compare a configured same-origin Control UI with the gateway package", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onHello?.({
+      ...HELLO,
+      server: {
+        version: "2026.7.20",
+        controlUiBuildSource: "configured",
+        connId: "conn-1",
+      },
     });
 
     expect(gateway.snapshot.phase).toBe("connected");

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -23,6 +23,10 @@ vi.mock("../build-info.ts", () => ({
     release: false,
     buildId: "test",
   },
+  controlUiBuildDiffersFrom: (identity: { version?: string | null; buildId?: string | null }) =>
+    identity.buildId
+      ? identity.buildId !== "test"
+      : Boolean(identity.version && identity.version !== "2026.7.19"),
 }));
 
 const HELLO: GatewayHelloOk = {
@@ -111,6 +115,7 @@ describe("createApplicationGateway connection phase", () => {
       hostname: "127.0.0.1",
       origin: "http://127.0.0.1:18789",
       pathname: "/",
+      href: "http://127.0.0.1:18789/",
     } as Location);
   });
 
@@ -143,6 +148,7 @@ describe("createApplicationGateway connection phase", () => {
 
     expect(current().started).toBe(1);
     expect(current().opts.clientVersion).toBe("2026.7.19");
+    expect(current().opts.clientBuildId).toBe("test");
     expect(gateway.snapshot.phase).toBe("connecting");
 
     current().opts.onHello?.(HELLO);
@@ -153,6 +159,31 @@ describe("createApplicationGateway connection phase", () => {
 
     current().opts.onClose?.({ code: 4008, reason: "connect failed", willRetry: false });
     expect(gateway.snapshot.phase).toBe("offline");
+  });
+
+  it("gates same-origin terminal work on exact build identity", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onHello?.({
+      ...HELLO,
+      server: { version: "2026.7.19", buildId: "new-build", connId: "conn-1" },
+    });
+
+    expect(gateway.snapshot.phase).toBe("reconnecting");
+  });
+
+  it("does not compare a separately hosted Control UI with a remote gateway build", () => {
+    const settings = { ...loadSettings(), gatewayUrl: "wss://remote.example/ws" };
+    const { gateway, current } = createStore({ settings });
+    gateway.start();
+
+    current().opts.onHello?.({
+      ...HELLO,
+      server: { version: "2026.7.19", buildId: "remote-build", connId: "conn-1" },
+    });
+
+    expect(gateway.snapshot.phase).toBe("connected");
   });
 
   it.each([

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -338,8 +338,10 @@ export function createApplicationGateway(
         if (client !== nextClient) {
           return;
         }
+        const exactBuildIdentityAvailable = Boolean(hello.server?.buildId?.trim());
         const controlUiBuildFresh = !(
           isSameOriginGateway(nextConnection.gatewayUrl) &&
+          (exactBuildIdentityAvailable || everConnected) &&
           controlUiBuildDiffersFrom({
             version: hello.server?.version,
             buildId: hello.server?.buildId,

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -9,7 +9,7 @@ import {
   type GatewayEventListener,
   type GatewayHelloOk,
 } from "../api/gateway.ts";
-import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
+import { CONTROL_UI_BUILD_INFO, controlUiBuildDiffersFrom } from "../build-info.ts";
 import { bumpCanvasWidgetFrameConnectionGeneration } from "../lib/chat/canvas-widget-frame-generation.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
@@ -22,6 +22,7 @@ import type {
 } from "./context.ts";
 import { resolveControlUiAuthHeader } from "./control-ui-auth.ts";
 import { loadSettings, patchSettings, persistSessionToken } from "./settings.ts";
+import { scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
 import { readPresenceEntries, resolveSelfPresenceUser } from "./user-profile.ts";
 
 type GatewayClientFactory = (opts: GatewayBrowserClientOptions) => GatewayBrowserClient;
@@ -330,10 +331,37 @@ export function createApplicationGateway(
       password: nextConnection.password.trim() ? nextConnection.password : undefined,
       clientName: "openclaw-control-ui",
       clientVersion: CONTROL_UI_BUILD_INFO.version ?? "dev",
+      clientBuildId: CONTROL_UI_BUILD_INFO.buildId,
       mode: "webchat",
       instanceId: generateUUID(),
       onHello: (hello: GatewayHelloOk) => {
         if (client !== nextClient) {
+          return;
+        }
+        const controlUiBuildFresh = !(
+          isSameOriginGateway(nextConnection.gatewayUrl) &&
+          controlUiBuildDiffersFrom({
+            version: hello.server?.version,
+            buildId: hello.server?.buildId,
+          })
+        );
+        if (!controlUiBuildFresh) {
+          // Keep every connected-only drain fenced. The stale document may
+          // render the shell and refresh action, but it must not mutate state.
+          setSnapshot({
+            ...snapshot,
+            client: nextClient,
+            phase: "reconnecting",
+            hello,
+            canvasPluginSurfaceUrl: null,
+            selfUser: null,
+            lastError: null,
+            lastErrorCode: null,
+          });
+          const targetBuildId = hello.server?.buildId?.trim() || hello.server?.version?.trim();
+          if (targetBuildId) {
+            void scheduleStaleChunkReload({ buildId: targetBuildId });
+          }
           return;
         }
         setAvatarGatewayOrigin(
@@ -529,6 +557,14 @@ export function createApplicationGateway(
     },
   };
   return gateway;
+}
+
+function isSameOriginGateway(gatewayUrl: string): boolean {
+  try {
+    return new URL(gatewayUrl.replace(/^ws/u, "http")).origin === globalThis.location?.origin;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeCanvasPluginSurfaceUrl(value: string | undefined): string | null {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -343,6 +343,7 @@ export function createApplicationGateway(
           controlUiBuildDiffersFrom({
             version: hello.server?.version,
             buildId: hello.server?.buildId,
+            controlUiBuildSource: hello.server?.controlUiBuildSource,
           })
         );
         if (!controlUiBuildFresh) {

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -15,8 +15,12 @@ import {
 import { createApplicationOverlays } from "./overlays.ts";
 
 vi.mock("../build-info.ts", () => ({
-  controlUiVersionDiffersFrom: (gatewayVersion: string | undefined) =>
-    Boolean(gatewayVersion?.trim() && gatewayVersion.trim() !== "1.0.0"),
+  controlUiBuildDiffersFrom: (identity: { version?: string | null; buildId?: string | null }) =>
+    Boolean(
+      identity.buildId?.trim()
+        ? identity.buildId.trim() !== "test"
+        : identity.version?.trim() && identity.version.trim() !== "1.0.0",
+    ),
   reloadControlUiIfStale: vi.fn(),
 }));
 vi.mock("../lib/toast.ts", () => ({ showToast: vi.fn() }));
@@ -235,6 +239,23 @@ describe("device-auth upgrade migration", () => {
 });
 
 describe("Control UI refresh nudge", () => {
+  it("flags an exact build mismatch on the first connection", () => {
+    const gatewayClient = client(async () => []);
+    const harness = createGatewayHarness(null, false);
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.update({
+      client: gatewayClient,
+      phase: "reconnecting",
+      hello: {
+        server: { version: "1.0.0", buildId: "other" },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+
+    expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
+    overlays.dispose();
+  });
+
   it("waits for a reconnect before flagging a version mismatch", () => {
     const gatewayClient = client(async () => []);
     const harness = createGatewayHarness(null, false);

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -15,12 +15,18 @@ import {
 import { createApplicationOverlays } from "./overlays.ts";
 
 vi.mock("../build-info.ts", () => ({
-  controlUiBuildDiffersFrom: (identity: { version?: string | null; buildId?: string | null }) =>
-    Boolean(
-      identity.buildId?.trim()
-        ? identity.buildId.trim() !== "test"
-        : identity.version?.trim() && identity.version.trim() !== "1.0.0",
-    ),
+  controlUiBuildDiffersFrom: (identity: {
+    version?: string | null;
+    buildId?: string | null;
+    controlUiBuildSource?: "bundled" | "configured";
+  }) =>
+    identity.controlUiBuildSource === "configured"
+      ? false
+      : Boolean(
+          identity.buildId?.trim()
+            ? identity.buildId.trim() !== "test"
+            : identity.version?.trim() && identity.version.trim() !== "1.0.0",
+        ),
   reloadControlUiIfStale: vi.fn(),
 }));
 vi.mock("../lib/toast.ts", () => ({ showToast: vi.fn() }));
@@ -253,6 +259,30 @@ describe("Control UI refresh nudge", () => {
     });
 
     expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
+    overlays.dispose();
+  });
+
+  it("does not flag an independently built configured UI root", () => {
+    const gatewayClient = client(async () => []);
+    const harness = createGatewayHarness(null, false);
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.update({
+      client: gatewayClient,
+      phase: "connected",
+      hello: {
+        server: { version: "2.0.0", controlUiBuildSource: "configured" },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+    harness.update({ phase: "stopped", hello: null });
+    harness.update({
+      phase: "connected",
+      hello: {
+        server: { version: "2.0.0", controlUiBuildSource: "configured" },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+
+    expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
     overlays.dispose();
   });
 

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -322,6 +322,7 @@ export function createApplicationOverlays(
     const serverBuildIdentity = {
       version: next.hello?.server?.version,
       buildId: next.hello?.server?.buildId,
+      controlUiBuildSource: next.hello?.server?.controlUiBuildSource,
     };
     const exactBuildIdentityAvailable = Boolean(serverBuildIdentity.buildId?.trim());
     snapshot = {

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -4,7 +4,7 @@ import {
 } from "../../../src/gateway/events.js";
 import type { GatewayEventFrame } from "../api/gateway.ts";
 import type { UpdateHoldResult, UpdateScheduleState } from "../api/types.ts";
-import { controlUiVersionDiffersFrom } from "../build-info.ts";
+import { controlUiBuildDiffersFrom } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
 import {
   closeDevicePairSetup as closeDevicePairSetupState,
@@ -310,6 +310,8 @@ export function createApplicationOverlays(
       if (!next.client) {
         connectedEpoch = 0;
         snapshot = { ...snapshot, controlUiRefreshRequired: false };
+      } else if (next.hello) {
+        snapshot = { ...snapshot, controlUiRefreshRequired: true };
       }
       clearExecApprovalTimers(promptState);
       publish();
@@ -317,6 +319,11 @@ export function createApplicationOverlays(
     }
     const updateSchedule =
       connectedSourceChanged || helloChanged ? readUpdateSchedule(next.hello) : undefined;
+    const serverBuildIdentity = {
+      version: next.hello?.server?.version,
+      buildId: next.hello?.server?.buildId,
+    };
+    const exactBuildIdentityAvailable = Boolean(serverBuildIdentity.buildId?.trim());
     snapshot = {
       ...snapshot,
       ...(connectedSourceChanged || helloChanged
@@ -327,7 +334,8 @@ export function createApplicationOverlays(
           }
         : {}),
       controlUiRefreshRequired: connectedSourceChanged
-        ? connectedEpoch > 0 && controlUiVersionDiffersFrom(next.hello?.server?.version)
+        ? (exactBuildIdentityAvailable || connectedEpoch > 0) &&
+          controlUiBuildDiffersFrom(serverBuildIdentity)
         : snapshot.controlUiRefreshRequired,
     };
     publish();

--- a/ui/src/app/service-worker-refresh.runtime.test.ts
+++ b/ui/src/app/service-worker-refresh.runtime.test.ts
@@ -91,7 +91,9 @@ describe("Control UI service-worker reconnect refresh", () => {
 
     const { refreshControlUiServiceWorker } = await import("./sw-refresh.runtime.ts");
     const refresh = refreshControlUiServiceWorker();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(update).not.toHaveBeenCalled();
 
     state = "activated";

--- a/ui/src/app/service-worker-refresh.runtime.test.ts
+++ b/ui/src/app/service-worker-refresh.runtime.test.ts
@@ -59,6 +59,48 @@ describe("Control UI service-worker reconnect refresh", () => {
     await expect(refresh).resolves.toBe(true);
   });
 
+  it("joins an already-installing replacement without starting a competing update", async () => {
+    let state: ServiceWorkerState = "installing";
+    const listeners = new Set<() => void>();
+    const replacement = {
+      get state() {
+        return state;
+      },
+      addEventListener(_type: "statechange", listener: () => void) {
+        listeners.add(listener);
+      },
+      removeEventListener(_type: "statechange", listener: () => void) {
+        listeners.delete(listener);
+      },
+    } as unknown as ServiceWorker;
+    const update = vi.fn(async () => {
+      throw new Error("must not compete with the active install");
+    });
+    const registration = {
+      active: {} as ServiceWorker,
+      installing: replacement,
+      waiting: null,
+      update,
+    } as unknown as ServiceWorkerRegistration;
+    vi.stubGlobal("navigator", {
+      serviceWorker: {
+        controller: registration.active,
+        getRegistration: vi.fn(async () => registration),
+      },
+    });
+
+    const { refreshControlUiServiceWorker } = await import("./sw-refresh.runtime.ts");
+    const refresh = refreshControlUiServiceWorker();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(update).not.toHaveBeenCalled();
+
+    state = "activated";
+    for (const listener of listeners) {
+      listener();
+    }
+    await expect(refresh).resolves.toBe(true);
+  });
+
   it("releases the reconnect fence when service workers are unavailable", async () => {
     vi.stubGlobal("navigator", {});
     const { refreshControlUiServiceWorker } = await import("./sw-refresh.runtime.ts");

--- a/ui/src/app/sw-refresh.runtime.ts
+++ b/ui/src/app/sw-refresh.runtime.ts
@@ -32,7 +32,17 @@ export async function refreshControlUiServiceWorker(): Promise<boolean> {
   if (!registration) {
     return false;
   }
-  const incumbent = registration.active;
+  // `registration.update()` is not a synchronization primitive: when an
+  // install is already in flight it may reject or briefly hide that worker.
+  // Fence against the document's controller before starting another check.
+  const incumbent = serviceWorker.controller ?? registration.active;
+  const pendingReplacement =
+    registration.installing ??
+    registration.waiting ??
+    (registration.active && registration.active !== incumbent ? registration.active : null);
+  if (pendingReplacement) {
+    return waitForReplacementWorker(pendingReplacement);
+  }
   await registration.update();
   const replacement =
     registration.installing ??

--- a/ui/src/build-info.test.ts
+++ b/ui/src/build-info.test.ts
@@ -20,14 +20,13 @@ describe("Control UI build info", () => {
     vi.resetModules();
 
     try {
-      const { CONTROL_UI_BUILD_INFO, controlUiVersionDiffersFrom } =
-        await import("./build-info.ts");
+      const { CONTROL_UI_BUILD_INFO, controlUiBuildDiffersFrom } = await import("./build-info.ts");
       expect(CONTROL_UI_BUILD_INFO).toBe(injectedBuildInfo);
-      expect(controlUiVersionDiffersFrom(" 2026.7.19 ")).toBe(false);
-      expect(controlUiVersionDiffersFrom("2026.7.20")).toBe(true);
-      expect(controlUiVersionDiffersFrom("2026.7.19", COMMIT.slice(0, 12))).toBe(false);
-      expect(controlUiVersionDiffersFrom("2026.7.19", "f".repeat(40))).toBe(true);
-      expect(controlUiVersionDiffersFrom(undefined)).toBe(false);
+      expect(controlUiBuildDiffersFrom({ version: " 2026.7.19 " })).toBe(false);
+      expect(controlUiBuildDiffersFrom({ version: "2026.7.20" })).toBe(true);
+      expect(controlUiBuildDiffersFrom({ version: undefined })).toBe(false);
+      expect(controlUiBuildDiffersFrom({ version: "2026.7.19", buildId: "test" })).toBe(false);
+      expect(controlUiBuildDiffersFrom({ version: "2026.7.19", buildId: "other" })).toBe(true);
     } finally {
       vi.unstubAllGlobals();
       vi.resetModules();

--- a/ui/src/build-info.test.ts
+++ b/ui/src/build-info.test.ts
@@ -27,6 +27,12 @@ describe("Control UI build info", () => {
       expect(controlUiBuildDiffersFrom({ version: undefined })).toBe(false);
       expect(controlUiBuildDiffersFrom({ version: "2026.7.19", buildId: "test" })).toBe(false);
       expect(controlUiBuildDiffersFrom({ version: "2026.7.19", buildId: "other" })).toBe(true);
+      expect(
+        controlUiBuildDiffersFrom({
+          version: "2026.7.20",
+          controlUiBuildSource: "configured",
+        }),
+      ).toBe(false);
     } finally {
       vi.unstubAllGlobals();
       vi.resetModules();

--- a/ui/src/build-info.ts
+++ b/ui/src/build-info.ts
@@ -29,7 +29,21 @@ export function reloadControlUiIfStale(identity: {
   return false;
 }
 
-export function controlUiVersionDiffersFrom(
+/** Exact artifact comparison when both sides expose it; released legacy
+ * gateways retain the package-version fallback used before build ids shipped. */
+export function controlUiBuildDiffersFrom(identity: {
+  version?: string | null;
+  buildId?: string | null;
+}): boolean {
+  const controlUiBuildId = CONTROL_UI_BUILD_INFO.buildId?.trim();
+  const gatewayBuildId = identity.buildId?.trim();
+  if (controlUiBuildId && controlUiBuildId !== "dev" && gatewayBuildId) {
+    return controlUiBuildId !== gatewayBuildId;
+  }
+  return controlUiVersionDiffersFrom(identity.version ?? undefined);
+}
+
+function controlUiVersionDiffersFrom(
   gatewayVersion: string | undefined,
   gatewayCommit?: string,
 ): boolean {

--- a/ui/src/build-info.ts
+++ b/ui/src/build-info.ts
@@ -29,12 +29,17 @@ export function reloadControlUiIfStale(identity: {
   return false;
 }
 
-/** Exact artifact comparison when both sides expose it; released legacy
- * gateways retain the package-version fallback used before build ids shipped. */
+/** Exact artifact comparison when both sides expose it. Configured roots opt
+ * out explicitly; a missing source denotes a legacy gateway and keeps the
+ * package-version fallback used before build ids shipped. */
 export function controlUiBuildDiffersFrom(identity: {
   version?: string | null;
   buildId?: string | null;
+  controlUiBuildSource?: "bundled" | "configured";
 }): boolean {
+  if (identity.controlUiBuildSource === "configured") {
+    return false;
+  }
   const controlUiBuildId = CONTROL_UI_BUILD_INFO.buildId?.trim();
   const gatewayBuildId = identity.buildId?.trim();
   if (controlUiBuildId && controlUiBuildId !== "dev" && gatewayBuildId) {

--- a/ui/src/e2e/locale-offline-retry.e2e.test.ts
+++ b/ui/src/e2e/locale-offline-retry.e2e.test.ts
@@ -3,6 +3,7 @@ import type { BrowserContext, Page, Route } from "playwright";
 import { expect, it } from "vitest";
 import { SUPPORTED_LOCALES } from "../i18n/lib/registry.ts";
 import {
+  controlUiBundledGatewayUrl,
   installMockGateway,
   startControlUiE2eServer,
   type MockGatewayControls,
@@ -90,7 +91,9 @@ suite.define(() => {
   it("applies a locale whose first chunk request failed after the Gateway reconnects", async () => {
     const context = await createContext();
     const page = await context.newPage();
-    const gateway = await installMockGateway(page);
+    const gateway = await installMockGateway(page, {
+      webSocketPassthroughPrefixes: [`${controlUiBundledGatewayUrl(suite.server.baseUrl)}/?token=`],
+    });
     let abortedLocaleRequests = 0;
     const abortFrenchLocale = async (route: Route) => {
       abortedLocaleRequests += 1;

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -322,6 +322,12 @@ describe("Control UI service-worker production update E2E", () => {
         );
       });
       await gateway.setOnline(false);
+      await page.waitForFunction(() => {
+        const panel = document.querySelector("openclaw-terminal-panel") as
+          | (HTMLElement & { available: boolean })
+          | null;
+        return panel?.available === false;
+      });
       await rename(outDir, previousOutDir);
       await rename(nextOutDir, outDir);
       await rm(previousOutDir, { force: true, recursive: true });

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -162,6 +162,10 @@ async function ensureControlledPage(page: Page, pageErrors: string[], expectedBu
     return value.active?.state === "activated";
   });
   if (!registration.controlled) {
+    // The production preview serves static assets directly. Canonicalize the
+    // first controlled reload so Vite's portable relative asset URLs do not
+    // resolve beneath a client-side deep link such as /chat/research.
+    await page.evaluate(() => window.history.replaceState(window.history.state, "", "/"));
     await page.reload();
   }
   await page.waitForFunction(() => navigator.serviceWorker?.controller?.state === "activated");
@@ -295,6 +299,34 @@ describe("Control UI service-worker production update E2E", () => {
       expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
       await ensureControlledPage(page, pageErrors, buildA);
       await expect.poll(() => readWorkerUpdateVersions(page)).toContain(buildA);
+      await expect
+        .poll(async () =>
+          page.evaluate(() => {
+            const panel = document.querySelector("openclaw-terminal-panel") as
+              | (HTMLElement & { available: boolean })
+              | null;
+            const shell = document.querySelector("openclaw-app-shell") as HTMLElement & {
+              runtime?: {
+                context?: {
+                  config: { current: { terminalEnabled: boolean } };
+                  gateway: { snapshot: { phase: string; hello: unknown } };
+                };
+              };
+            };
+            return {
+              available: panel?.available ?? null,
+              phase: shell?.runtime?.context?.gateway.snapshot.phase ?? null,
+              terminalEnabled: shell?.runtime?.context?.config.current.terminalEnabled ?? null,
+              hasHello: shell?.runtime?.context?.gateway.snapshot.hello != null,
+            };
+          }),
+        )
+        .toMatchObject({
+          available: true,
+          phase: "connected",
+          terminalEnabled: true,
+          hasHello: true,
+        });
 
       const assetA = await findBuildAsset(buildA);
       const initialAsset = await fetchControlledAsset(page, assetA.path);

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -275,6 +275,8 @@ describe("Control UI service-worker production update E2E", () => {
     const gateway = await installMockGateway(page, {
       assistantAgentId: "research",
       defaultAgentId: "research",
+      serverBuildId: buildA,
+      serverVersion: "2026.7.10",
       featureMethods: ["terminal.open"],
       methodResponses: {
         "terminal.open": {
@@ -358,6 +360,7 @@ describe("Control UI service-worker production update E2E", () => {
         .toContain("thread-during-worker-refresh");
       await page.waitForTimeout(300);
       expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
+      await gateway.setServerBuildId(buildB);
       installGate.release();
       await reloaded;
       await ensureControlledPage(page, pageErrors, buildB);

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -13,6 +13,44 @@ const deadSessionScreenshotPath = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_SCR
 const deadSessionVideoDir = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_VIDEO_DIR?.trim();
 
 suite.define(() => {
+  it("fences an SW-less stale build before it can restore an ownerless terminal", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gatewayUrl = suite.server.baseUrl.replace(/^http/u, "ws");
+      await page.addInitScript((url) => {
+        (
+          window as Window & {
+            ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+          }
+        )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+          gatewayUrl: url,
+          token: "native-build-identity-token",
+        };
+      }, gatewayUrl);
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["terminal.open"],
+        serverBuildId: "replacement-build",
+        terminalEnabled: true,
+      });
+
+      expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
+      const firstConnect = await gateway.waitForRequest("connect");
+      expect(firstConnect.params).toMatchObject({ client: { buildId: "e2e" } });
+      await page.waitForFunction(
+        () =>
+          sessionStorage.getItem("openclaw.controlUi.staleChunkReloadBuildId") ===
+          "replacement-build",
+      );
+      await page.getByText("Server updated", { exact: true }).waitFor();
+
+      expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
+      expect(
+        await page.locator("openclaw-terminal-panel").evaluate((element) => {
+          return (element as HTMLElement & { available: boolean }).available;
+        }),
+      ).toBe(false);
+    });
+  });
+
   it("opens a new dock terminal for a selection changed without navigation", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       const gateway = await installMockGateway(page, {

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -51,6 +51,63 @@ suite.define(() => {
     });
   });
 
+  it("keeps an independently built same-origin Control UI connected", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gatewayUrl = suite.server.baseUrl.replace(/^http/u, "ws");
+      await page.addInitScript((url) => {
+        (
+          window as Window & {
+            ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+          }
+        )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+          gatewayUrl: url,
+          token: "native-configured-ui-token",
+        };
+      }, gatewayUrl);
+      const gateway = await installMockGateway(page, {
+        assistantAgentId: "main",
+        controlUiBuildSource: "configured",
+        featureMethods: ["terminal.open"],
+        methodResponses: {
+          "terminal.open": {
+            agentId: "main",
+            confined: false,
+            cwd: "/workspace",
+            sessionId: "configured-ui-terminal",
+            shell: "/bin/bash",
+          },
+        },
+        serverBuildId: "independent-build",
+        serverVersion: "2026.7.20",
+        terminalEnabled: true,
+      });
+
+      expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
+      await gateway.waitForRequest("connect");
+      await page.waitForFunction(() => {
+        const panel = document.querySelector("openclaw-terminal-panel") as
+          | (HTMLElement & { available: boolean })
+          | null;
+        return panel?.available === true;
+      });
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent("openclaw:terminal-toggle", {
+            detail: { agentId: "main", open: true },
+          }),
+        );
+      });
+
+      const terminalOpen = await gateway.waitForRequest("terminal.open");
+      expect(terminalOpen.params).toMatchObject({ agentId: "main" });
+      expect(
+        await page.evaluate(() =>
+          sessionStorage.getItem("openclaw.controlUi.staleChunkReloadBuildId"),
+        ),
+      ).toBeNull();
+    });
+  });
+
   it("opens a new dock terminal for a selection changed without navigation", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       const gateway = await installMockGateway(page, {

--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -622,6 +622,7 @@ describe.runIf(process.env.OPENCLAW_UI_MEMORY_CHROMIUM_E2E === "1")(
       });
       const page = await context.newPage();
       const gateway = await e2e.installMockGateway(page, {
+        webSocketPassthroughPrefixes: [`${e2e.controlUiBundledGatewayUrl(server.baseUrl)}/?token=`],
         featureMethods: [
           "chat.metadata",
           "chat.startup",

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -24,28 +24,61 @@ function waitForMockCycle(): Promise<void> {
 }
 
 describe("mock gateway stateful config", () => {
-  it("takes every mock socket offline before a reconnect", async () => {
-    const script = createControlUiMockGatewayInitScript({});
+  it("takes existing mock sockets offline without closing their replacement", async () => {
+    const passthroughPrefix = "ws://source-ui/?token=";
+    const script = createControlUiMockGatewayInitScript({
+      webSocketPassthroughPrefixes: [passthroughPrefix],
+    });
     window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Exercises the serialized browser fixture.
-    new Function(script)();
+    const priorWebSocket = window.WebSocket;
+    class PassthroughWebSocket extends EventTarget {
+      static readonly CLOSED = 3;
+      static readonly CLOSING = 2;
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      readyState = PassthroughWebSocket.OPEN;
 
-    const first = new WebSocket("ws://mock-gateway/first");
-    const second = new WebSocket("ws://mock-gateway/second");
-    await flushMockTimers();
-    expect(first.readyState).toBe(WebSocket.OPEN);
-    expect(second.readyState).toBe(WebSocket.OPEN);
-
-    const controls = (
-      window as Window & {
-        openclawControlUiE2eGateway?: { setOnline: (online: boolean) => void };
+      close(): void {
+        this.readyState = PassthroughWebSocket.CLOSED;
       }
-    ).openclawControlUiE2eGateway;
-    expect(controls).toBeDefined();
-    controls?.setOnline(false);
+    }
+    window.WebSocket = PassthroughWebSocket as unknown as typeof WebSocket;
 
-    expect(first.readyState).toBe(WebSocket.CLOSED);
-    expect(second.readyState).toBe(WebSocket.CLOSED);
+    try {
+      // oxlint-disable-next-line typescript/no-implied-eval -- Exercises the serialized browser fixture.
+      new Function(script)();
+
+      const passthrough = new WebSocket(`${passthroughPrefix}vite`);
+      const first = new WebSocket("ws://mock-gateway/first");
+      const second = new WebSocket("ws://mock-gateway/second");
+      await flushMockTimers();
+      expect(passthrough.readyState).toBe(WebSocket.OPEN);
+      expect(first.readyState).toBe(WebSocket.OPEN);
+      expect(second.readyState).toBe(WebSocket.OPEN);
+
+      let replacement: WebSocket | undefined;
+      first.addEventListener("close", () => {
+        replacement = new WebSocket("ws://mock-gateway/replacement");
+      });
+
+      const controls = (
+        window as Window & {
+          openclawControlUiE2eGateway?: { setOnline: (online: boolean) => void };
+        }
+      ).openclawControlUiE2eGateway;
+      expect(controls).toBeDefined();
+      controls?.setOnline(false);
+
+      expect(passthrough.readyState).toBe(WebSocket.OPEN);
+      expect(first.readyState).toBe(WebSocket.CLOSED);
+      expect(second.readyState).toBe(WebSocket.CLOSED);
+      expect(replacement?.readyState).toBe(WebSocket.CONNECTING);
+
+      controls?.setOnline(true);
+      expect(replacement?.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      window.WebSocket = priorWebSocket;
+    }
   });
 
   it("round-trips config.set through config.get with an advancing hash", async () => {

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -24,6 +24,30 @@ function waitForMockCycle(): Promise<void> {
 }
 
 describe("mock gateway stateful config", () => {
+  it("takes every mock socket offline before a reconnect", async () => {
+    const script = createControlUiMockGatewayInitScript({});
+    window.sessionStorage.clear();
+    // oxlint-disable-next-line typescript/no-implied-eval -- Exercises the serialized browser fixture.
+    new Function(script)();
+
+    const first = new WebSocket("ws://mock-gateway/first");
+    const second = new WebSocket("ws://mock-gateway/second");
+    await flushMockTimers();
+    expect(first.readyState).toBe(WebSocket.OPEN);
+    expect(second.readyState).toBe(WebSocket.OPEN);
+
+    const controls = (
+      window as Window & {
+        openclawControlUiE2eGateway?: { setOnline: (online: boolean) => void };
+      }
+    ).openclawControlUiE2eGateway;
+    expect(controls).toBeDefined();
+    controls?.setOnline(false);
+
+    expect(first.readyState).toBe(WebSocket.CLOSED);
+    expect(second.readyState).toBe(WebSocket.CLOSED);
+  });
+
   it("round-trips config.set through config.get with an advancing hash", async () => {
     const raw = '{\n  "logging": {\n    "level": "info"\n  }\n}\n';
     const script = createControlUiMockGatewayInitScript({

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -265,6 +265,7 @@ export type ControlUiMockGatewayScenario = {
   devGitBranch?: string;
   /** Exact immutable Control UI artifact served by the mocked Gateway. */
   serverBuildId?: string;
+  controlUiBuildSource?: "bundled" | "configured";
   serverVersion?: string;
   /** Simulate the one-time legacy Control UI device-auth pairing transition. */
   deviceAuthMigrationPending?: boolean;
@@ -798,6 +799,7 @@ function normalizeScenario(
     deferredMethods: scenario.deferredMethods ?? [],
     devGitBranch: scenario.devGitBranch?.trim() || "",
     serverBuildId: scenario.serverBuildId?.trim() || "e2e",
+    controlUiBuildSource: scenario.controlUiBuildSource ?? "bundled",
     serverVersion: scenario.serverVersion?.trim() || "2026.7.10",
     deviceAuthMigrationPending: scenario.deviceAuthMigrationPending ?? false,
     deviceToken: scenario.deviceToken?.trim() || "e2e-device-token",
@@ -1596,6 +1598,7 @@ function installControlUiMockGateway(
           protocol: protocolVersion,
           server: {
             buildId: serverBuildId,
+            controlUiBuildSource: scenario.controlUiBuildSource,
             connId: "control-ui-e2e",
             version: scenario.serverVersion,
           },

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -955,7 +955,12 @@ function installControlUiMockGateway(
   const sessionPatches = new Map<string, Record<string, unknown>>();
   const createdSessions = new Map<string, Record<string, unknown>>();
   const sessionMessageSubscriptions = new Set<string>();
-  const sockets: Array<{ readonly readyState: number; readonly url: string }> = [];
+  const sockets: Array<{
+    readonly readyState: number;
+    readonly url: string;
+    close: (code?: number, reason?: string) => void;
+    openConnection: () => void;
+  }> = [];
   let deviceAuthMigrationPending = scenario.deviceAuthMigrationPending;
   let deviceAuthMigrationDeviceId = "";
   let sessionMessageEventIndex = 0;
@@ -2061,10 +2066,14 @@ function installControlUiMockGateway(
         // The current document can still toggle the in-memory mock.
       }
       if (!online) {
-        MockWebSocket.latest?.close(1006, "mock offline");
+        for (const socket of sockets) {
+          socket.close(1006, "mock offline");
+        }
         return;
       }
-      MockWebSocket.latest?.openConnection();
+      for (const socket of sockets) {
+        socket.openConnection();
+      }
     },
     setServerBuildId(nextBuildId) {
       serverBuildId = nextBuildId;

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -263,6 +263,9 @@ export type ControlUiMockGatewayScenario = {
   deferredMethods?: string[];
   /** Non-release gateway checkout branch surfaced in the sidebar footer. */
   devGitBranch?: string;
+  /** Exact immutable Control UI artifact served by the mocked Gateway. */
+  serverBuildId?: string;
+  serverVersion?: string;
   /** Simulate the one-time legacy Control UI device-auth pairing transition. */
   deviceAuthMigrationPending?: boolean;
   deviceToken?: string;
@@ -460,6 +463,7 @@ export type MockGatewayControls = {
   ) => Promise<void>;
   resolveDeferred: (method: string, payload?: unknown) => Promise<void>;
   setOnline: (online: boolean) => Promise<void>;
+  setServerBuildId: (buildId: string) => Promise<void>;
   setOperatorScopes: (scopes: string[]) => Promise<void>;
   setHistoryMessages: (messages: unknown[]) => Promise<void>;
   setMethodResponse: (method: string, payload: unknown) => Promise<void>;
@@ -793,6 +797,8 @@ function normalizeScenario(
     defaultAgentId,
     deferredMethods: scenario.deferredMethods ?? [],
     devGitBranch: scenario.devGitBranch?.trim() || "",
+    serverBuildId: scenario.serverBuildId?.trim() || "e2e",
+    serverVersion: scenario.serverVersion?.trim() || "2026.7.10",
     deviceAuthMigrationPending: scenario.deviceAuthMigrationPending ?? false,
     deviceToken: scenario.deviceToken?.trim() || "e2e-device-token",
     // Baseline scenarios represent a current Gateway. Tests for unsupported or
@@ -835,7 +841,8 @@ export function createControlUiMockBootstrapConfig(scenario: ControlUiMockGatewa
     devGitBranch: normalizedScenario.devGitBranch || undefined,
     embedSandbox: "scripts",
     localMediaPreviewRoots: [],
-    serverVersion: "e2e",
+    serverVersion: normalizedScenario.serverVersion,
+    serverBuildId: normalizedScenario.serverBuildId,
     terminalEnabled: normalizedScenario.terminalEnabled,
     cliAgentsEnabled: normalizedScenario.cliAgentsEnabled,
   };
@@ -900,6 +907,7 @@ function installControlUiMockGateway(
     requests: BrowserRequest[];
     resolveDeferred: (method: string, payload?: unknown) => void;
     setOnline: (online: boolean) => void;
+    setServerBuildId: (buildId: string) => void;
     setOperatorScopes: (scopes: string[]) => void;
     setHistoryMessages: (messages: unknown[]) => void;
     setMethodResponse: (method: string, payload: unknown) => void;
@@ -917,6 +925,13 @@ function installControlUiMockGateway(
   };
 
   const scenario: BrowserScenario = input.scenario;
+  const serverBuildIdStateKey = "openclaw.control-ui-e2e.serverBuildId";
+  let serverBuildId = scenario.serverBuildId;
+  try {
+    serverBuildId = window.sessionStorage.getItem(serverBuildIdStateKey)?.trim() || serverBuildId;
+  } catch {
+    // The scenario value remains authoritative when browser storage is unavailable.
+  }
   (window as unknown as WindowWithGateway)["__OPENCLAW_CONTROL_UI_BASE_PATH__"] = scenario.basePath;
   const protocolVersion = input.protocolVersion;
   const methodResponseOverridesStorageKey = "openclaw.control-ui-e2e.method-responses.v1";
@@ -1579,7 +1594,11 @@ function installControlUiMockGateway(
             ? { deviceAuthMigration: { pending: true as const } }
             : {}),
           protocol: protocolVersion,
-          server: { connId: "control-ui-e2e", version: "e2e" },
+          server: {
+            buildId: serverBuildId,
+            connId: "control-ui-e2e",
+            version: scenario.serverVersion,
+          },
           policy: {
             maxPayload: 1_048_576,
             maxBufferedBytes: 1_048_576,
@@ -2044,6 +2063,14 @@ function installControlUiMockGateway(
       }
       MockWebSocket.latest?.openConnection();
     },
+    setServerBuildId(nextBuildId) {
+      serverBuildId = nextBuildId;
+      try {
+        window.sessionStorage.setItem(serverBuildIdStateKey, nextBuildId);
+      } catch {
+        // The current document still observes the new identity.
+      }
+    },
     setOperatorScopes(scopes) {
       scenario.operatorScopes = [...scopes];
     },
@@ -2321,6 +2348,21 @@ function createMockGatewayControls(
         }
         gateway.setOnline(nextOnline);
       }, online);
+    },
+    async setServerBuildId(buildId) {
+      await page.evaluate((nextBuildId) => {
+        const gateway = (
+          window as Window & {
+            openclawControlUiE2eGateway?: {
+              setServerBuildId: (buildId: string) => void;
+            };
+          }
+        ).openclawControlUiE2eGateway;
+        if (!gateway) {
+          throw new Error("Mock Gateway is not installed");
+        }
+        gateway.setServerBuildId(nextBuildId);
+      }, buildId);
     },
     async setOperatorScopes(scopes) {
       await page.evaluate((nextScopes) => {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -2066,12 +2066,16 @@ function installControlUiMockGateway(
         // The current document can still toggle the in-memory mock.
       }
       if (!online) {
-        for (const socket of sockets) {
+        // Close handlers can synchronously construct replacements. Snapshot the
+        // transition members so an offline replacement stays ready for recovery.
+        const transitionSockets = sockets.slice();
+        for (const socket of transitionSockets) {
           socket.close(1006, "mock offline");
         }
         return;
       }
-      for (const socket of sockets) {
+      const transitionSockets = sockets.slice();
+      for (const socket of transitionSockets) {
         socket.openConnection();
       }
     },

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -800,7 +800,7 @@ function normalizeScenario(
     devGitBranch: scenario.devGitBranch?.trim() || "",
     serverBuildId: scenario.serverBuildId?.trim() || "e2e",
     controlUiBuildSource: scenario.controlUiBuildSource ?? "bundled",
-    serverVersion: scenario.serverVersion?.trim() || "2026.7.10",
+    serverVersion: scenario.serverVersion?.trim() || "e2e",
     deviceAuthMigrationPending: scenario.deviceAuthMigrationPending ?? false,
     deviceToken: scenario.deviceToken?.trim() || "e2e-device-token",
     // Baseline scenarios represent a current Gateway. Tests for unsupported or


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where already-open Control UI tabs could reconnect after a same-version Gateway deployment and restore a terminal with stale JavaScript that omitted its selected agent owner. The Gateway correctly rejected that ownerless `terminal.open` request, leaving service-worker-less browser contexts and native WebViews with a failed terminal.

Live evidence on deployed `ee6c2cb50df086e83575753313fd5131afe186b6` showed a Control UI reconnect at `2026-08-14T11:55:47.067Z`, followed by an ownerless `terminal.open` rejection at `11:55:48.510Z`.

## Why This Change Was Made

Control UI clients and the Gateway now exchange a bounded, exact build ID generated from the shared immutable build manifest. A same-origin bundled UI whose identity differs stays outside connected-only state drains, disables terminal availability, and performs one guarded reload; if that reload already ran, the existing refresh card remains visible and actionable.

Legacy Gateways retain package-version fallback. Separately hosted UIs skip comparison by origin, while configured same-origin UI roots explicitly advertise that they are independently built. The Gateway still never infers a missing terminal owner.

The mocked browser transport now closes and opens the Gateway socket cohort present at each offline/online transition. Synchronous replacement sockets survive offline and recover later. Private source-Vite suites explicitly pass HMR through the existing native WebSocket seam, so connectivity tests do not reload their own harness.

Production delta: +175/-13 lines (net +162), justified by the end-to-end artifact identity, reconnect admission boundary, and lifecycle-owned pending-worker fence. Tests and test support: +519/-16 lines (net +503).

## User Impact

Operators can leave Control UI tabs and native terminal views open across same-version deployments. Stale bundled documents refresh before any terminal or other connected-only work drains, configured/custom roots remain independent, and a failed automatic refresh presents a visible recovery action instead of an ownerless terminal error.

## Evidence

- Exact-head CI at `ff4a6a98f0b0a5487ec09e15a7d70555a9f8d047` passed all required checks: [run 31835068360](https://github.com/openclaw/openclaw/actions/runs/31835068360).
- Exact build/startup proof passed in [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/31835068360/job/94880637175): Control UI startup JS 11 requests / 324.8 KiB gzip (limits 18 / 325.3 KiB), CSS 1 request / 41.4 KiB (limits 1 / 45.0 KiB); CLI median max RSS was 51.1/100 MB (`--help`), 368.8/425 MB (`plugins list`), 414.5/450 MB (`status`), and 348.8/500 MB (`gateway status`). Built-artifact checks passed 1,244 tests plus the TUI PTY lane.
- Final socket/HMR owner repair: mock/service-worker units 16/16, source-locale E2E 2/2, optional memory Chromium 17/17, UI production/test types, formatting, oxlint, and `git diff --check` passed.
- Final exact-head opaque behavior commands: terminal+service-worker E2E 6/6, UI lifecycle 119/119, and protocol/Gateway/version/tooling 30/30. The opaque runner exposes aggregate test output, so clause-level source-blind attribution remains a recorded proof gap.
- Final full branch autoreview at `ff4a6a98f0b0a5487ec09e15a7d70555a9f8d047`: no accepted/actionable findings (0.94 confidence); final-patch review was also clean (0.99).
- Protocol, generated build manifest, runtime resolver, browser handshake, Gateway store, overlay, and build-info tests: 257 passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/31799345179)).
- Exact verifier patch: formatting, core/UI production types, 109 focused unit/protocol/Gateway/UI tests, and terminal Chromium 5/5 passed ([run](https://github.com/openclaw/openclaw/actions/runs/31804265273)).
- Exact behavior contract: 102 UI tests plus terminal Chromium 5/5, including configured same-origin independence, passed ([run](https://github.com/openclaw/openclaw/actions/runs/31804846089)).
- Legacy/configured admission proof: 46 unit tests plus the formerly failing Workboard/model/plugins and terminal/About browser paths, 15/15 passed ([run](https://github.com/openclaw/openclaw/actions/runs/31808585328)).
- Pending-worker and cross-platform preview proof: macOS isolated A→B 3/3 and combined terminal+service-worker 6/6; owned AWS A→B 3/3 (`cbx_19e93504e0aa`, `run_2821fa968692`).
- Service-worker-less/native-WebView Chromium proof: client build ID is sent, one reload is guarded, the refresh card remains visible, terminal availability stays false, and zero `terminal.open` calls escape; 4/4 passed ([run](https://github.com/openclaw/openclaw/actions/runs/31801513653)).
- Production two-build service-worker activation and owned terminal restoration: passed ([run](https://github.com/openclaw/openclaw/actions/runs/31800496731)).
