### PR TITLE
fix: prevent Control UI model scoping E2E cold-boot timeout

### DIFF
--- a/ui/src/e2e/model-agent-scoping.e2e.test.ts
+++ b/ui/src/e2e/model-agent-scoping.e2e.test.ts
@@ -1,6 +1,6 @@
 // Control UI browser proof covers explicit agent ownership for automatic model reads.
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -12,6 +12,7 @@ suite.define(() => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page, {
         defaultAgentId: "writer",
+        deferredMethods: ["connect"],
         models: [{ id: "writer-model", name: "Writer Model", provider: "openai" }],
         methodResponses: {
           connect: {
@@ -20,7 +21,7 @@ suite.define(() => {
               role: "operator",
               scopes: ["operator.admin", "operator.read", "operator.write"],
             },
-            features: { events: [], methods: ["system.info"] },
+            features: { events: [], methods: [] },
             protocol: 4,
             server: { connId: "model-agent-scoping", version: "e2e" },
             snapshot: {
@@ -47,26 +48,40 @@ suite.define(() => {
             scope: "agent",
           },
           "models.authStatus": { ts: Date.now(), providers: [] },
-          "system.info": {
-            hostname: "explicit-fleet.test",
-            machineName: "Explicit Fleet",
-            platform: "darwin",
-          },
         },
       });
 
       await page.goto(`${suite.server.baseUrl}debug`);
+      await gateway.waitForRequest("connect");
+      // Commit the settings takeover before hello so this proof cannot inherit
+      // a transient app sidebar and its unrelated auth-status request.
+      await waitForControlUiRoute(page, { pathname: "/debug", routeId: "debug" });
+      await gateway.resolveDeferred("connect");
       await gateway.waitForRequest("models.list");
-      await gateway.waitForRequest("models.authStatus");
-
-      await page.goto(`${suite.server.baseUrl}settings/appearance`);
-      await gateway.waitForRequest("system.info");
-
+      const modelsListCount = (await gateway.getRequests("models.list")).length;
       const authStatusCount = (await gateway.getRequests("models.authStatus")).length;
-      await page.goto(`${suite.server.baseUrl}settings/model-providers`);
+      await page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: {
+            context: {
+              navigate: (routeId: string, options: { pathname: string }) => void;
+            };
+          };
+        };
+        app.runtime?.context.navigate("model-providers", {
+          pathname: "/settings/model-providers",
+        });
+      });
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/model-providers",
+        routeId: "model-providers",
+      });
       await expect
         .poll(async () => (await gateway.getRequests("models.authStatus")).length)
         .toBeGreaterThan(authStatusCount);
+      await expect
+        .poll(async () => (await gateway.getRequests("models.list")).length)
+        .toBeGreaterThan(modelsListCount);
 
       const modelRequests = [
         ...(await gateway.getRequests("models.list")),


### PR DESCRIPTION
Related: #123650

## What Problem This Solves

Fixes an intermittent Control UI E2E timeout where the explicit-agent scoping proof waited forever for `models.authStatus` during a cold `/debug` boot, even though the page and Gateway were fully healthy.

## Why This Change Was Made

The timeout artifact from run 31800741055 proved this was a route-lifecycle race in the test, not a product auth-fetch deadlock. `/debug` is a settings takeover and does not mount `openclaw-app-sidebar` or `openclaw-sidebar-attention`, so it owns `models.list` but not `models.authStatus`. The old test passed only when the unresolved shell briefly rendered fallback route `chat`, upgraded the transient sidebar, and emitted the unrelated auth request before `/debug` committed.

The test now deterministically commits `/debug` before releasing the deferred Gateway hello, proves the debug page's scoped `models.list`, then navigates in-app to `/settings/model-providers` and proves fresh scoped `models.authStatus` and `models.list` calls at their actual owner. Keeping one document also means the final assertion covers the complete request log instead of only the last full-page navigation.

No production trigger was changed: mounted sidebar subscriptions already replay current Gateway/agent state, chat has its own connected refresh owner, and the Models route/page directly loads auth status.

## User Impact

No user-visible behavior changes. CI no longer depends on a transient sidebar race, while the browser proof still covers selected-agent ownership for every model request it observes.

## Evidence

- Diagnostic artifact: [run 31800741055](https://github.com/openclaw/openclaw/actions/runs/31800741055), shard 7/7.
  - `/debug` settled with `readyState=complete`, connected hello, selected agent `writer`, and the debug page mounted.
  - DOM contained no `openclaw-app-sidebar` or `openclaw-sidebar-attention`.
  - Request log repeated `models.list`, `status`, `health`, and `last-heartbeat`; no `models.authStatus` and no `cron.list` (the sidebar attention task's sibling request).
  - No page errors, failed network requests, or unhandled rejections.
- Deterministic pre-fix regression: defer `connect`, wait for `/debug` route success, release hello, retain old auth wait → failed after 10s at `waitForRequest("models.authStatus")`.
- Deterministic post-fix loop: `model-agent-scoping.e2e.test.ts` passed 30/30; post-rebase exact-head rerun also passed.
- Auth owners/siblings: 4 files / 40 tests passed (`sidebar-attention`, Models loader/page, debug diagnostics).
- Separate terminal failure class: `terminal-embedded.e2e.test.ts` passed 3/3; its readiness/agent handoff was already repaired by #123578.
- Targeted oxlint, `oxfmt --check`, `git diff --check`, and branch autoreview passed cleanly.
- The optional changed-gate Testbox remained queued without an IP or Actions run for over five minutes; the single queued lease was stopped per the test runbook rather than duplicating capacity.

Test-audit gate:

- Observable contract: each mounted model-data owner sends the selected configured agent.
- Credible regression: unresolved-route fallback can transiently mount an unrelated owner and make the test pass by timing.
- Existing unit tests cover each owner independently; this browser integration uniquely covers cold route ordering and cross-route request ownership.
- No test-only production seam or production LOC was added.

Provenance: the invalid `/debug` auth-status wait was introduced in `9496a4b1992` by PR #123415 on August 14, 2026; @joshavant authored and merged that PR.

Production LOC: +0/-0 (net 0) | Tests: +28/-13 (net +15)
