### PR TITLE
fix(qa): preserve Telegram reply defaults in live canary

### DIFF
--- a/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.test.ts
@@ -104,7 +104,6 @@ describe("Telegram QA API boundary", () => {
         sut: {
           botToken: "placeholder",
           dmPolicy: "disabled",
-          replyToMode: "first",
           groups: {
             "-100123": {
               groupPolicy: "allowlist",
@@ -115,6 +114,7 @@ describe("Telegram QA API boundary", () => {
         },
       },
     });
+    expect(config.channels?.telegram?.accounts?.sut?.replyToMode).toBeUndefined();
   });
 
   it("disables mention gating only inside the exact leased QA group", () => {

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.ts
@@ -330,7 +330,6 @@ export function buildTelegramQaConfig(
             enabled: true,
             botToken: params.sutToken,
             dmPolicy: "disabled",
-            replyToMode: "first",
             groups: {
               [params.groupId]: {
                 groupPolicy: "allowlist",

--- a/qa/scenarios/channels/channel-canary.yaml
+++ b/qa/scenarios/channels/channel-canary.yaml
@@ -63,7 +63,4 @@ flow:
             expr: matchingOutbound.length === 1
             message:
               expr: "`expected one canary reply, saw ${matchingOutbound.length}; transcript=${formatTransportTranscript(state, { conversationId: config.conversationId })}`"
-        - assert:
-            expr: "transport.id !== 'telegram' || Boolean(outbound.replyToId)"
-            message: Telegram canary reply was not threaded to the driver message
       detailsExpr: outbound.text


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram live QA always enabled threaded replies, so the canary changed Telegram delivery behavior instead of testing the normal `replyToMode: "off"` default. This could hide default-path streaming and finalization regressions.

## Why This Change Was Made

The older bot-to-bot runner set `replyToMode: "first"` for observation, and QA Lab migration #108430 added a Telegram-only threading assertion that preserved the workaround. The adapter already observes the SUT message directly. The fix removes both assumptions and leaves Telegram's production default in control.

## User Impact

Telegram QA now exercises the same reply policy operators get by default. The shared canary still requires exactly one visible reply in the originating conversation.

## Evidence

Regression before the fix:

```text
expected 'first' to be undefined
1 failed, 15 passed
```

Exact-head local proof:

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/telegram extensions/qa-lab/src/scenario-catalog-channels.test.ts
6 files, 62 tests passed

pnpm format:check --no-error-on-unmatched-pattern -- <changed files>
passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json <changed TypeScript files>
passed

Extension production TSGo and the full test typecheck graph
passed

git diff --check
passed
```

Production LOC: +0/-1. Scenario policy: +0/-3. Tests: +1/-1.

### Exact-head review and live proof

- SHA: `f6351ab84ccf4d7af58a88e392b0381a165a050e`
- Hosted CI: GREEN, 0 pending; 10 superseded contexts ignored.
- ClawSweeper local review: PASS; 0 findings, 0 security concerns, no maintainer decision, 0 Rank-up moves.
- Telegram real-user group proof: live channel patch derived from `buildTelegramQaConfig`; `replyToMode` omitted. Two model requests produced one progress message with two same-ID edits and a separate `OPENCLAW_E2E_DRAFTPROOF` final. Native replies: 0; quotes: 0; deletes: 0.