### PR TITLE
fix(ui): invisible autosave reconnect latch silently drops every Settings edit after gateway replacement

### DIFF
--- a/ui/src/components/settings-save-indicator.ts
+++ b/ui/src/components/settings-save-indicator.ts
@@ -88,6 +88,17 @@ class SettingsSaveIndicator extends LitElement {
         >
           ${t("configView.retry")}
         </button>`;
+    } else if (props.status === "paused") {
+      // Reconnect latch: autosave is off for this draft until an explicit
+      // Save; without this row the form silently never saves again.
+      content = html` <span>${t("configView.autoSavePaused")}</span>
+        <button
+          class="btn btn--xs settings-save-indicator__action"
+          type="button"
+          @click=${props.onRetry}
+        >
+          ${t("configView.saveNow")}
+        </button>`;
     } else if (props.status === "conflict") {
       modifier = " settings-save-indicator--danger";
       content = html` <span>${t("configView.autoSaveConflict")}</span>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1654,6 +1654,8 @@ export const en: TranslationMap = {
     applying: "Applying…",
     autoSaveSaving: "Saving…",
     autoSaveSaved: "Saved",
+    autoSavePaused: "Autosave paused after reconnect",
+    saveNow: "Save",
     autoSaveFailed: "Save failed",
     autoSaveConflict: "Settings changed elsewhere",
     retry: "Retry",

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -393,12 +393,17 @@ function syncConfigDraft(state: RuntimeConfigState, nextForm: Record<string, unk
 /**
  * Any mutation invalidates a lingering "Saved"/"Save failed" indicator: a
  * dirty edit is about to reschedule, and a clean revert makes the old
- * failure moot (its error is cleared too). Two states persist regardless:
- * "saving" reports the in-flight request, and "conflict" marks the snapshot
- * itself stale — only a reload clears it, no local edit can.
+ * failure moot (its error is cleared too). Three states persist regardless:
+ * "saving" reports the in-flight request, "conflict" marks the snapshot
+ * itself stale, and "paused" marks the reconnect latch — only an explicit
+ * Save/Apply or discard clears it, no local edit can.
  */
 function resetStaleAutoSaveStatus(state: RuntimeConfigState) {
-  if (state.configAutoSaveStatus === "saving" || state.configAutoSaveStatus === "conflict") {
+  if (
+    state.configAutoSaveStatus === "saving" ||
+    state.configAutoSaveStatus === "conflict" ||
+    state.configAutoSaveStatus === "paused"
+  ) {
     return;
   }
   if (!state.configFormDirty && state.configAutoSaveStatus === "error") {

--- a/ui/src/lib/config/config-state-model.ts
+++ b/ui/src/lib/config/config-state-model.ts
@@ -7,7 +7,7 @@ import type { ConfigSnapshot, ConfigUiHints } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { normalizeAgentId } from "../sessions/session-key.ts";
 
-export type ConfigAutoSaveStatus = "idle" | "saving" | "saved" | "error" | "conflict";
+export type ConfigAutoSaveStatus = "idle" | "saving" | "saved" | "error" | "conflict" | "paused";
 export type RuntimeConfigState = {
   client: GatewayBrowserClient | null;
   connected: boolean;

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -112,6 +112,9 @@ export function createConfigWriteCoordinator({
   const clearAutoSaveDraftConnection = () => {
     autoSaveDraftConnection = null;
     autoSaveRequiresExplicitSubmit = false;
+    if (state.configAutoSaveStatus === "paused") {
+      state.configAutoSaveStatus = "idle";
+    }
   };
   const captureAutoSaveDraftConnection = () => {
     if (
@@ -138,6 +141,9 @@ export function createConfigWriteCoordinator({
       epoch: currentConfigConnectionEpoch(state),
     };
     autoSaveRequiresExplicitSubmit = false;
+    if (state.configAutoSaveStatus === "paused") {
+      state.configAutoSaveStatus = "idle";
+    }
   };
   const canAutoSaveDraftOnCurrentConnection = () =>
     !autoSaveRequiresExplicitSubmit &&
@@ -396,8 +402,14 @@ export function createConfigWriteCoordinator({
       if (draftBelongsToPreviousConnection) {
         // A retained draft belongs to the Gateway connection where the edit
         // began. Preserve it across replacement, but require an explicit
-        // Save/Apply or reload before the new Gateway may receive it.
+        // Save/Apply or reload before the new Gateway may receive it. The
+        // latch must be visible: without a rendered state the form looks
+        // normal while every subsequent edit silently never saves.
         autoSaveRequiresExplicitSubmit = true;
+        // Conflict outranks the latch: that snapshot is stale regardless.
+        if (state.configAutoSaveStatus !== "conflict") {
+          state.configAutoSaveStatus = "paused";
+        }
       }
       if (autoSaveInFlight !== null || manualSubmitInFlight !== null) {
         // The epoch guard already blocks these flights from mutating state;

--- a/ui/src/lib/config/runtime-config-capability.test.ts
+++ b/ui/src/lib/config/runtime-config-capability.test.ts
@@ -321,13 +321,24 @@ describe("runtime config capability", () => {
     await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS * 2);
     expect(server.submissions).toHaveLength(0);
     expect(runtimeConfig.state.configFormDirty).toBe(true);
+    // The latch must be operator-visible: without a rendered state the form
+    // looks normal while every subsequent edit silently never saves.
+    expect(runtimeConfig.state.configAutoSaveStatus).toBe("paused");
+
+    // Further edits do not clear the latch state.
+    runtimeConfig.patchForm(["count"], 3);
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS * 2);
+    expect(server.submissions).toHaveLength(0);
+    expect(runtimeConfig.state.configAutoSaveStatus).toBe("paused");
 
     await expect(runtimeConfig.save()).resolves.toBe(true);
     expect(server.submissions).toEqual([
-      { method: "config.set", raw: '{\n  "count": 2\n}\n', baseHash: "hash-1" },
+      { method: "config.set", raw: '{\n  "count": 3\n}\n', baseHash: "hash-1" },
     ]);
     expect(runtimeConfig.state.configFormDirty).toBe(false);
     expect(runtimeConfig.state.configNeedsApply).toBe(true);
+    // Explicit save rebinds the draft and clears the paused indicator.
+    expect(runtimeConfig.state.configAutoSaveStatus).not.toBe("paused");
     runtimeConfig.dispose();
   });
 


### PR DESCRIPTION
## What Problem This Solves

When the gateway connection is replaced while a Settings form draft is dirty (gateway restart, event-gap reconnect after sleep), autosave intentionally latches off (`autoSaveRequiresExplicitSubmit`) until an explicit Save — the retained bytes belong to the old connection. But the latch was completely invisible: the save indicator renders nothing on "idle", form mode has no Save button, and the status was reset to idle on disconnect. The operator sees a perfectly normal-looking form where **every subsequent edit silently never saves**, and the dispose-time teardown flush is blocked by the same guard, so closing the tab drops everything. A recorded fact existed in the coordinator with no read where the user needed it — the worst bug class (silent failure) on a default path.

## Why This Change Was Made

The latch's own arm/clear transitions are the correct owner for the visible state, so the fix projects a fifth `ConfigAutoSaveStatus` value, `"paused"`: armed exactly where `autoSaveRequiresExplicitSubmit` is set (conflict outranks it — that snapshot is stale regardless), cleared exactly where the latch clears (explicit Save/Apply binding, discard), and deliberately excluded from `resetStaleAutoSaveStatus` so local edits cannot wipe it (mirroring "saving"/"conflict" persistence). The indicator renders "Autosave paused after reconnect" with a Save button wired to the existing `onRetry → runtimeConfig.save()` plumbing — no new component, no new callback surface.

## User Impact

After a gateway restart with unsaved Settings edits, the form now shows a persistent "Autosave paused after reconnect — Save" row instead of silently discarding all further work.

## Evidence

- Extended regression "keeps a stranded dirty draft unsaved until an explicit save after replacement" (runtime-config-capability.test.ts) now pins: paused becomes visible on replacement, survives further edits (which still don't autosave), and clears after explicit save. Fails pre-fix (`expected 'idle' to be 'paused'`).
- Existing conflict-persistence test proves conflict still outranks the latch; full ui/src/lib/config suites + settings-save-indicator suite green; `pnpm tsgo:ui` clean; oxfmt/oxlint clean.
- Autoreview (Codex, gpt-5.6-sol high): clean, 0.99 correctness.
- Production LOC: +36/−7 (new visible state is new surface by design — the alternative of auto-resuming autosave on the new connection would silently submit bytes the operator composed against a different gateway, the exact hazard the latch exists to prevent).

AI-assisted: yes (autonomous QA campaign; autoreview workflow).
