### PR TITLE
chore: stabilize Activity and Workboard browser tests

### DIFF
--- a/ui/src/e2e/activity-run-inspector.e2e.test.ts
+++ b/ui/src/e2e/activity-run-inspector.e2e.test.ts
@@ -1,6 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { AuditRunInspectResult } from "../../../packages/gateway-protocol/src/schema/audit-run.js";
 import {
@@ -180,6 +180,23 @@ async function screenshot(page: Page, name: string) {
     fullPage: true,
     path: path.join(proofDir, name),
   });
+}
+
+async function measureWithinAncestor(element: Locator, ancestorSelector: string) {
+  return element.evaluate((node, selector) => {
+    const ancestor = node.closest<HTMLElement>(selector);
+    if (!ancestor) {
+      throw new Error(`Expected element inside ${selector}`);
+    }
+    const elementBounds = node.getBoundingClientRect();
+    const ancestorBounds = ancestor.getBoundingClientRect();
+    return {
+      ancestorBottom: ancestorBounds.bottom,
+      ancestorTop: ancestorBounds.top,
+      elementBottom: elementBounds.bottom,
+      elementTop: elementBounds.top,
+    };
+  }, ancestorSelector);
 }
 
 describeControlUiE2e("Control UI durable Activity run inspector", () => {
@@ -404,15 +421,15 @@ describeControlUiE2e("Control UI durable Activity run inspector", () => {
           ),
         )
         .toBeLessThanOrEqual(1);
-      const finalContentPosition = await Promise.all([
-        inspector.boundingBox(),
-        finalReceiptContent.boundingBox(),
-      ]);
-      expect(finalContentPosition[0]).not.toBeNull();
-      expect(finalContentPosition[1]).not.toBeNull();
-      expect(finalContentPosition[1]!.y).toBeGreaterThanOrEqual(finalContentPosition[0]!.y);
-      expect(finalContentPosition[1]!.y + finalContentPosition[1]!.height).toBeLessThanOrEqual(
-        finalContentPosition[0]!.y + finalContentPosition[0]!.height + 1,
+      const finalContentPosition = await measureWithinAncestor(
+        finalReceiptContent,
+        ".run-inspector",
+      );
+      expect(finalContentPosition.elementTop).toBeGreaterThanOrEqual(
+        finalContentPosition.ancestorTop,
+      );
+      expect(finalContentPosition.elementBottom).toBeLessThanOrEqual(
+        finalContentPosition.ancestorBottom + 1,
       );
       await screenshot(page, "14-bounded-run-inspector.png");
 

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -76,12 +76,12 @@ type UpdatingElement = HTMLElement & {
 };
 
 async function waitForWorkboardRender(page: Page, requestUpdate = false): Promise<void> {
-  await page.locator("openclaw-app").evaluate(async (element, shouldRequestUpdate) => {
-    const app = element as UpdatingElement;
+  await page.locator("openclaw-workboard-page").evaluate(async (element, shouldRequestUpdate) => {
+    const workboardPage = element as UpdatingElement;
     if (shouldRequestUpdate) {
-      app.requestUpdate?.();
+      workboardPage.requestUpdate?.();
     }
-    await app.updateComplete;
+    await workboardPage.updateComplete;
   }, requestUpdate);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves two flaky Control UI browser assertions that could fail under animation-frame skew or CPU contention even though the rendered Activity and Workboard behavior was correct.

The Windows MAX_PATH candidate was investigated but deliberately left unchanged: the recorded CI failure happened during short-path ACL admission before the long-path verification/cleanup scenario began, and the underlying PowerShell error was erased by the current wrapper.

## Why This Change Was Made

Activity now measures the receipt and its scroll owner atomically in one browser evaluation, preserving the containment assertion without widening its tolerance. Workboard selection waits for the `openclaw-workboard-page` render owner that subscribes to canonical Workboard state instead of the unrelated root app update cycle.

No production behavior, timeout, or assertion tolerance changed.

## User Impact

No user-visible product change. Maintainers get reliable browser coverage for Activity evidence reachability and Workboard keyboard selection under loaded CI runners.

## Evidence

| Candidate | Pre-fix evidence | Root cause / disposition | Post-fix proof |
| --- | --- | --- | --- |
| Activity run inspector fractional geometry | Historical local full-shard loops failed 5/20 at the final receipt containment assertion; a fresh focused loop passed 20/20, confirming timing sensitivity | Two independent Playwright `boundingBox()` calls sampled a shared 300 ms shell transform in different animation frames. Replaced with one atomic target/ancestor DOMRect read; existing 1 px allowance remains unchanged. | 30/30 focused runs passed |
| Workboard selection under CPU contention | Previously observed once; fresh focused runs passed 20/20 normal and 10/10 with two sustained CPU loads | Web Awesome dispatches `change` after its update boundary, while the helper waited on `openclaw-app`, which does not subscribe to Workboard state. The helper now waits on the actual `openclaw-workboard-page` owner. | 30/30 normal and 10/10 two-load runs passed; full file 3/3 passed |
| Windows SQLite path beyond MAX_PATH | CI run [31790997476 attempt 1](https://github.com/openclaw/openclaw/actions/runs/31790997476/attempts/1) failed at `provider.create()` while verifying the short repository ACL; attempt 2 passed | Skipped. Long-path staging had not been created, cleanup was not running, and the caught PowerShell cause is discarded. A retry, warm-up, or larger timeout would be speculative and would mask a fail-closed product ACL check. | No code change; follow-up should first preserve the caught cause and reproduce on Windows before changing ACL enumeration or its deadline |

Additional validation:

- Exact rebased head: `f98b5b08ff0a27238a81cbfcd4c101e3d4049585`
- Both complete target files together: 2 files, 9 tests passed
- `node scripts/check-changed.mjs -- <two changed files>`: passed locally after a task-owned Blacksmith Testbox remained queued for nearly eight minutes; included repository guards, formatting, UI i18n, core-test typecheck, and targeted lint
- `oxfmt`: clean
- `git diff --check`: clean
- Autoreview: clean, no accepted/actionable findings
- Production LOC: +0/-0; tests/test support: +31/-14
