### PR TITLE
refactor(runners): prune terminal environments

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -185,8 +185,11 @@ stated honestly (revision 1 undersold this):
   driven to `orphaned` by the reconcile sweep), _gone_ (unpaired or ceiling
   elapsed → normal orphan/reap path). A device-environment reaper keyed on
   unpair/dormancy — not on provider teardown proof — cleans rows,
-  credentials, and staged refs. Device-side GC of per-session workspace dirs
-  and superseded bundles is a milestone exit gate, not an open question:
+  credentials, and staged refs. Unreferenced terminal environment rows retain
+  seven days of operator diagnostics, then prune in bounded post-reconcile
+  batches; any surviving placement keeps its environment provenance.
+  Device-side GC of per-session workspace dirs and superseded bundles is a
+  milestone exit gate, not an open question:
   persistent machines otherwise leak the user's own disk.
 - **Placement `runner-offline`.** Pre-dispatch device loss waits up to 10
   seconds, then returns an operator-visible coordination error without failing

--- a/src/gateway/worker-environments/service-lifetime.test.ts
+++ b/src/gateway/worker-environments/service-lifetime.test.ts
@@ -37,6 +37,14 @@ describe("worker environment service", () => {
     );
   });
 
+  it("prunes terminal environments after provider reconciliation", async () => {
+    const prune = vi.spyOn(support.testState.store, "pruneTerminalEnvironments");
+
+    await support.createService(support.createProvider()).reconcileOnce();
+
+    expect(prune).toHaveBeenCalledOnce();
+  });
+
   it("waits for timed-out provider work during shutdown", async () => {
     let finishProvision: (() => void) | undefined;
     const provisionPending = new Promise<void>((resolve) => {

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -336,6 +336,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
         }),
     );
     await runTasksWithConcurrency({ tasks, limit: 8 });
+    store.pruneTerminalEnvironments();
   };
 
   const reconcileOnce = () => {

--- a/src/gateway/worker-environments/store.test.ts
+++ b/src/gateway/worker-environments/store.test.ts
@@ -63,6 +63,8 @@ const BOOTSTRAP_RECEIPT: WorkerEnvironmentBootstrapReceipt = {
   protocolFeatures: ["workspace-sync-v1", "model-proxy-v1"],
 };
 const CREDENTIAL = ["worker", "credential", "fixture"].join("-");
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const PRUNE_NOW_MS = 10 * DAY_MS;
 
 describe("worker environment store", () => {
   let root: string;
@@ -118,6 +120,19 @@ describe("worker environment store", () => {
       to: "bootstrapping",
       patch: { leaseId, sshEndpoint: SSH_ENDPOINT },
     });
+  }
+
+  function seedOrphaned(environmentId: string, stateChangedAtMs: number) {
+    nowMs = 1_000;
+    const bootstrapping = seedBootstrapping(environmentId, `lease:${environmentId}`);
+    store.transition({
+      environmentId,
+      from: bootstrapping.state,
+      to: "ready",
+      patch: readyPatch(),
+    });
+    nowMs = stateChangedAtMs;
+    return store.transition({ environmentId, from: "ready", to: "orphaned" });
   }
 
   function readyPatch(receipt = BOOTSTRAP_RECEIPT) {
@@ -356,6 +371,77 @@ describe("worker environment store", () => {
       .prepare("DELETE FROM worker_environments WHERE environment_id = ?")
       .run("worker-constraints");
     expect(fallbackPortRows("worker-constraints")).toEqual([]);
+  });
+
+  it("uses the terminal environment index for ordered cleanup", () => {
+    const plan = database.db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT worker_environments.environment_id
+         FROM worker_environments
+         LEFT JOIN worker_session_placements
+           ON worker_session_placements.environment_id = worker_environments.environment_id
+         WHERE worker_environments.state IN ('destroyed', 'failed', 'orphaned')
+           AND worker_environments.state_changed_at_ms <= ?
+           AND worker_session_placements.session_id IS NULL
+         ORDER BY worker_environments.state_changed_at_ms ASC,
+                  worker_environments.environment_id ASC
+         LIMIT ?`,
+      )
+      .all(PRUNE_NOW_MS - 7 * DAY_MS, 2) as Array<{ detail: string }>;
+
+    expect(plan.map((row) => row.detail).join("\n")).toContain(
+      "idx_worker_environments_terminal_changed",
+    );
+  });
+
+  it("prunes only old unreferenced terminal environments and cascades owned rows", () => {
+    seedOrphaned("worker-old-first", DAY_MS);
+    seedOrphaned("worker-old-second", 2 * DAY_MS);
+    seedOrphaned("worker-referenced", 3 * DAY_MS);
+    seedOrphaned("worker-recent", PRUNE_NOW_MS - 1_000);
+    nowMs = 1_000;
+    const ready = seedBootstrapping("worker-ready", "lease:worker-ready");
+    store.transition({
+      environmentId: ready.environmentId,
+      from: ready.state,
+      to: "ready",
+      patch: readyPatch(),
+    });
+    database.db
+      .prepare(
+        `INSERT INTO worker_session_placements (
+          session_id, agent_id, session_key, state, environment_id, recovery_error,
+          created_at_ms, updated_at_ms, state_changed_at_ms
+        ) VALUES ('session-referenced', 'agent-1', 'session-key-1', 'failed', ?,
+          'worker environment disappeared', 1, 1, 1)`,
+      )
+      .run("worker-referenced");
+    database.db
+      .prepare(
+        `INSERT INTO worker_inference_turns (
+          session_id, run_epoch, run_id, turn_id, environment_id, request_hash,
+          state, terminal_json, created_at_ms, updated_at_ms
+        ) VALUES ('session-old', 1, 'run-old', 'turn-old', ?, 'hash-old',
+          'terminal', '{}', 1, 1)`,
+      )
+      .run("worker-old-first");
+    expect(fallbackPortRows("worker-old-first")).toHaveLength(2);
+
+    expect(store.pruneTerminalEnvironments({ nowMs: PRUNE_NOW_MS, limit: 1 })).toBe(1);
+    expect(store.get("worker-old-first")).toBeUndefined();
+    expect(fallbackPortRows("worker-old-first")).toEqual([]);
+    expect(
+      database.db
+        .prepare("SELECT environment_id FROM worker_inference_turns WHERE environment_id = ?")
+        .get("worker-old-first"),
+    ).toBeUndefined();
+
+    expect(store.pruneTerminalEnvironments({ nowMs: PRUNE_NOW_MS, limit: 10 })).toBe(1);
+    expect(store.get("worker-old-second")).toBeUndefined();
+    expect(store.get("worker-referenced")?.state).toBe("orphaned");
+    expect(store.get("worker-recent")?.state).toBe("orphaned");
+    expect(store.get("worker-ready")?.state).toBe("ready");
   });
 
   it("normalizes provider-advertised SSH fallback ports at the durable boundary", () => {

--- a/src/gateway/worker-environments/store.ts
+++ b/src/gateway/worker-environments/store.ts
@@ -41,6 +41,7 @@ import {
   type WorkerEnvironmentState,
   type WorkerEnvironmentUnleasedState,
 } from "./state.js";
+import { pruneExpiredTerminalWorkerEnvironments } from "./terminal-environment-retention.js";
 
 type WorkerEnvironmentProfileSnapshot = WorkerProfile;
 type WorkerEnvironmentSshEndpoint = WorkerSshEndpoint;
@@ -858,6 +859,15 @@ export function createWorkerEnvironmentStore(
       findCredentialByHash(read(), normalizeCredentialHash(credentialHash)),
     list: (): WorkerEnvironmentRecord[] => listRows(read(), false),
     listForReconcile: (): WorkerEnvironmentRecord[] => listRows(read(), true),
+    pruneTerminalEnvironments(params: { nowMs?: number; limit?: number } = {}): number {
+      return write((db) =>
+        pruneExpiredTerminalWorkerEnvironments({
+          db,
+          nowMs: params.nowMs ?? now(),
+          ...(params.limit === undefined ? {} : { limit: params.limit }),
+        }),
+      );
+    },
     reconcileSharedHost(input: {
       environmentId: string;
       state: WorkerEnvironmentState;

--- a/src/gateway/worker-environments/terminal-environment-retention.ts
+++ b/src/gateway/worker-environments/terminal-environment-retention.ts
@@ -1,0 +1,59 @@
+import type { DatabaseSync } from "node:sqlite";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
+
+const TERMINAL_ENVIRONMENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+const TERMINAL_ENVIRONMENT_PRUNE_LIMIT = 256;
+const TERMINAL_STATES = ["destroyed", "failed", "orphaned"] as const;
+
+type RetentionDatabase = Pick<StateDatabase, "worker_environments" | "worker_session_placements">;
+
+function normalizeLimit(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > 1_000) {
+    throw new Error("Worker environment prune limit must be between 1 and 1000");
+  }
+  return value;
+}
+
+/** Deletes only old terminal environments that no placement can still resolve. */
+export function pruneExpiredTerminalWorkerEnvironments(params: {
+  db: DatabaseSync;
+  nowMs: number;
+  limit?: number;
+}): number {
+  if (!Number.isSafeInteger(params.nowMs) || params.nowMs < 0) {
+    throw new Error("Worker environment prune timestamp must be a non-negative safe integer");
+  }
+  const limit = normalizeLimit(params.limit ?? TERMINAL_ENVIRONMENT_PRUNE_LIMIT);
+  const cutoffMs = Math.max(0, params.nowMs - TERMINAL_ENVIRONMENT_RETENTION_MS);
+  const query = getNodeSqliteKysely<RetentionDatabase>(params.db);
+  const environmentIds = executeSqliteQuerySync(
+    params.db,
+    query
+      .selectFrom("worker_environments")
+      .leftJoin(
+        "worker_session_placements",
+        "worker_session_placements.environment_id",
+        "worker_environments.environment_id",
+      )
+      .select("worker_environments.environment_id")
+      .where("worker_environments.state", "in", [...TERMINAL_STATES])
+      .where("worker_environments.state_changed_at_ms", "<=", cutoffMs)
+      .where("worker_session_placements.session_id", "is", null)
+      .orderBy("worker_environments.state_changed_at_ms", "asc")
+      .orderBy("worker_environments.environment_id", "asc")
+      .limit(limit),
+  ).rows.map((row) => row.environment_id);
+  if (environmentIds.length === 0) {
+    return 0;
+  }
+  const result = executeSqliteQuerySync(
+    params.db,
+    query
+      .deleteFrom("worker_environments")
+      .where("environment_id", "in", environmentIds)
+      .where("state", "in", [...TERMINAL_STATES])
+      .where("state_changed_at_ms", "<=", cutoffMs),
+  );
+  return Number(result.numAffectedRows ?? 0n);
+}

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -2045,6 +2045,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_environments_provider_lease
   ON worker_environments(provider_id, lease_id)
   WHERE lease_id IS NOT NULL;
 
+CREATE INDEX IF NOT EXISTS idx_worker_environments_terminal_changed
+  ON worker_environments(state_changed_at_ms, environment_id);
+
 -- Provider-advertised fallback ports preserve stable retry order separately
 -- from the downgrade-sensitive canonical worker environment row.
 CREATE TABLE IF NOT EXISTS worker_environment_ssh_fallback_ports (


### PR DESCRIPTION
Related: #122454

## What Problem This Solves

Terminal worker environment rows were retained forever after provider teardown or authoritative disappearance. Even when no session placement could resolve them, their environment state and cascading child rows accumulated indefinitely in the shared Gateway database.

## Why This Change Was Made

A focused retention owner now deletes only `destroyed`, `failed`, or `orphaned` environments that have been terminal for at least seven days and have no surviving `worker_session_placements` reference. Cleanup runs in deterministic batches of 256 after provider reconciliation, so active lifecycle recovery completes before deletion.

The ordered scan uses a canonical `(state_changed_at_ms, environment_id)` index. Environment deletion remains the final owner action and existing foreign keys cascade SSH fallback ports, credentials, and inference rows. Any placement reference retains the environment profile/provenance needed by reclaimed or failed sessions. No config, protocol, migration, or SQLite schema-version change.

## User Impact

There is no visible workflow change. The Gateway keeps a seven-day diagnostic window for terminal environments while bounding unreachable lifecycle state and preserving every session-owned environment.

AI-assisted implementation; the storage ownership and deletion order were reviewed and verified.

## Evidence

- 190 focused and schema assertions pass across indexed cleanup, bounded retention, reference preservation, child-row cascades, post-reconcile ordering, and shared-state compatibility.
- The complete changed-file gate passes formatting, dead exports, core and core-test typechecks, full core lint, schema-v7, database-first storage, import cycles, docs, webhook, and pairing guards.
- The remote validation backend was unavailable before execution, so the repository-approved trusted local fallback ran the complete changed gate successfully.
- Fresh branch autoreview is clean with no accepted/actionable findings.
- Production delta: +73 lines for indexed terminal retention, store integration, and post-reconcile cleanup. Tests add +94 lines; docs add +3 net lines.
