### PR TITLE
feat(ui): make sidebar customization transactional

### DIFF
--- a/ui/src/components/app-sidebar-customizer-controller.ts
+++ b/ui/src/components/app-sidebar-customizer-controller.ts
@@ -1,0 +1,233 @@
+import type { ReactiveControllerHost } from "lit";
+import type { RouteId } from "../app-route-paths.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { t } from "../i18n/index.ts";
+import { showToast } from "../lib/toast.ts";
+import {
+  mergeSidebarCustomizerEntries,
+  sidebarCustomizerValuesEqual,
+  type SidebarCustomizerItem,
+  type SidebarCustomizerValue,
+} from "./app-sidebar-customizer.ts";
+import {
+  setStoredSessionCatalogHidden,
+  type SidebarRecentSession,
+} from "./app-sidebar-session-types.ts";
+import type { SessionOrganizerController } from "./session-organizer-controller.ts";
+import type { SidebarMenusController } from "./sidebar-menus-controller.ts";
+
+type SidebarCustomizerSnapshot = SidebarCustomizerValue & {
+  customizableSidebarEntries: readonly string[];
+  pinnedSessions: readonly SidebarRecentSession[];
+};
+
+type SidebarCustomizerHost = ReactiveControllerHost &
+  HTMLElement & {
+    readonly hiddenSessionCatalogIds: ReadonlySet<string>;
+    readonly onUpdateSidebarEntries?: (entries: string[]) => void;
+    readonly sessionOrganizer: Pick<SessionOrganizerController, "patchSession">;
+    readonly sidebarMenus: Pick<SidebarMenusController, "dismissTransientMenus">;
+    readonly updateComplete: Promise<boolean>;
+    findSidebarSessionByKey(sessionKey: string): SidebarRecentSession | undefined;
+    knownSectionOrder(): string[];
+    reconciledSidebarZone(): { sidebarEntries: readonly string[] };
+    sidebarCustomizerContext(): ApplicationContext<RouteId> | undefined;
+    sidebarCustomizerEntries(): SidebarCustomizerItem[];
+  };
+
+export class SidebarCustomizerController {
+  isOpen = false;
+  error: string | null = null;
+
+  private returnFocus: HTMLElement | null = null;
+  private snapshot: SidebarCustomizerSnapshot | null = null;
+
+  constructor(private readonly host: SidebarCustomizerHost) {}
+
+  open(trigger: HTMLElement | null = null): void {
+    this.host.sidebarMenus.dismissTransientMenus();
+    this.returnFocus = trigger;
+    void this.openAfterGroupLoad();
+  }
+
+  private async openAfterGroupLoad(): Promise<void> {
+    const sessions = this.host.sidebarCustomizerContext()?.sessions;
+    const groups = await sessions?.groupsLoad();
+    if (groups === null || sessions !== this.host.sidebarCustomizerContext()?.sessions) {
+      this.reportError("nav.customizeMutationError");
+      return;
+    }
+    const entries = this.host.sidebarCustomizerEntries();
+    this.snapshot = {
+      ...this.value(entries),
+      customizableSidebarEntries: entries.flatMap((item) => (item.entry ? [item.entry] : [])),
+      pinnedSessions: entries.flatMap((item) => {
+        const session = item.sessionKey
+          ? this.host.findSidebarSessionByKey(item.sessionKey)
+          : undefined;
+        return session ? [session] : [];
+      }),
+    };
+    this.error = null;
+    this.isOpen = true;
+    this.host.requestUpdate();
+    void this.host.updateComplete.then(() =>
+      this.host.querySelector<HTMLElement>(".sidebar-customizer button:not([disabled])")?.focus(),
+    );
+  }
+
+  close(): void {
+    this.isOpen = false;
+    this.error = null;
+    this.snapshot = null;
+    const returnFocus = this.returnFocus;
+    this.returnFocus = null;
+    this.host.requestUpdate();
+    void this.host.updateComplete.then(() => {
+      if (returnFocus?.isConnected) {
+        returnFocus.focus();
+      } else {
+        this.host.querySelector<HTMLElement>(".sidebar-nav__more")?.focus();
+      }
+    });
+  }
+
+  private reportError(key: "nav.customizeMutationError" | "nav.customizeRestoreError"): void {
+    this.error = t(key);
+    this.host.requestUpdate();
+    showToast({ message: this.error });
+  }
+
+  async discard(): Promise<void> {
+    const snapshot = this.snapshot;
+    if (!snapshot || !this.isDirty()) {
+      this.close();
+      return;
+    }
+    let failureCount = 0;
+    try {
+      if (this.host.onUpdateSidebarEntries) {
+        this.host.onUpdateSidebarEntries(
+          mergeSidebarCustomizerEntries(
+            this.host.reconciledSidebarZone().sidebarEntries,
+            snapshot.sidebarEntries,
+            snapshot.customizableSidebarEntries,
+          ),
+        );
+      } else {
+        failureCount += 1;
+      }
+    } catch {
+      failureCount += 1;
+    }
+    const snapshotHiddenCatalogIds = new Set(snapshot.hiddenCatalogIds);
+    const catalogIds = new Set([
+      ...this.host.hiddenSessionCatalogIds,
+      ...snapshot.hiddenCatalogIds,
+    ]);
+    for (const catalogId of catalogIds) {
+      try {
+        setStoredSessionCatalogHidden(catalogId, snapshotHiddenCatalogIds.has(catalogId));
+      } catch {
+        failureCount += 1;
+      }
+    }
+    for (const snapshotSession of snapshot.pinnedSessions) {
+      const currentSession = this.host.findSidebarSessionByKey(snapshotSession.key);
+      if (!currentSession?.pinned) {
+        const outcome = await this.host.sessionOrganizer.patchSession(snapshotSession, {
+          pinned: true,
+        });
+        if (outcome !== "completed") {
+          failureCount += 1;
+        }
+      }
+    }
+    const sessions = this.host.sidebarCustomizerContext()?.sessions;
+    if (sessions) {
+      try {
+        const outcome = await sessions.groupsPut([...snapshot.groups], [...snapshot.sectionOrder]);
+        if (outcome !== "completed") {
+          failureCount += 1;
+        }
+      } catch {
+        failureCount += 1;
+      }
+    } else {
+      failureCount += 1;
+    }
+    if (failureCount > 0) {
+      this.reportError("nav.customizeRestoreError");
+    } else {
+      this.close();
+    }
+  }
+
+  private value(
+    entries: readonly SidebarCustomizerItem[] = this.host.sidebarCustomizerEntries(),
+  ): SidebarCustomizerValue {
+    return {
+      sidebarEntries: entries.flatMap((item) => (item.entry && item.visible ? [item.entry] : [])),
+      hiddenCatalogIds: [...this.host.hiddenSessionCatalogIds].toSorted(),
+      groups: [...(this.host.sidebarCustomizerContext()?.sessions.state.groups ?? [])],
+      sectionOrder: this.host.knownSectionOrder(),
+    };
+  }
+
+  isDirty(
+    entries: readonly SidebarCustomizerItem[] = this.host.sidebarCustomizerEntries(),
+  ): boolean {
+    return this.snapshot
+      ? !sidebarCustomizerValuesEqual(this.value(entries), this.snapshot)
+      : false;
+  }
+
+  toggle(item: SidebarCustomizerItem): void {
+    if (item.kind === "entry" && item.entry) {
+      if (!this.host.onUpdateSidebarEntries) {
+        this.reportError("nav.customizeMutationError");
+        return;
+      }
+      const canonical = this.host.reconciledSidebarZone().sidebarEntries;
+      const next = canonical.includes(item.entry)
+        ? canonical.filter((candidate) => candidate !== item.entry)
+        : [...canonical, item.entry];
+      this.host.onUpdateSidebarEntries(next);
+      this.clearError();
+      return;
+    }
+    if (item.id.startsWith("catalog:")) {
+      try {
+        setStoredSessionCatalogHidden(item.id.slice("catalog:".length), item.visible);
+        this.clearError();
+      } catch {
+        this.reportError("nav.customizeMutationError");
+      }
+    }
+  }
+
+  remove(item: SidebarCustomizerItem): void {
+    if (!item.sessionKey) {
+      return;
+    }
+    const session = this.host.findSidebarSessionByKey(item.sessionKey);
+    if (!session) {
+      this.reportError("nav.customizeMutationError");
+      return;
+    }
+    void this.host.sessionOrganizer.patchSession(session, { pinned: false }).then((outcome) => {
+      if (outcome === "completed") {
+        this.clearError();
+      } else if (this.isOpen) {
+        this.reportError("nav.customizeMutationError");
+      }
+    });
+  }
+
+  clearError(): void {
+    if (this.error !== null) {
+      this.error = null;
+      this.host.requestUpdate();
+    }
+  }
+}

--- a/ui/src/components/app-sidebar-customizer.test.ts
+++ b/ui/src/components/app-sidebar-customizer.test.ts
@@ -3,6 +3,7 @@ import {
   buildSidebarCustomizerEntries,
   buildSidebarCustomizerSections,
   mergeSidebarCustomizerEntries,
+  sidebarCustomizerValuesEqual,
 } from "./app-sidebar-customizer.ts";
 import type { SidebarVisibleSections } from "./app-sidebar-session-navigation-logic.ts";
 
@@ -15,6 +16,33 @@ describe("sidebar customizer model", () => {
         ["route:cron", "route:plugins", "route:tasks"],
       ),
     ).toEqual(["fixed:current", "route:cron", "route:plugins"]);
+  });
+
+  it("returns to pristine when the current values match the baseline", () => {
+    const baseline = {
+      sidebarEntries: ["route:cron", "route:plugins"],
+      hiddenCatalogIds: ["claude"],
+      groups: ["Research"],
+      sectionOrder: ["work", "ungrouped"],
+    };
+
+    expect(
+      sidebarCustomizerValuesEqual(
+        {
+          sidebarEntries: [...baseline.sidebarEntries],
+          hiddenCatalogIds: [...baseline.hiddenCatalogIds],
+          groups: [...baseline.groups],
+          sectionOrder: [...baseline.sectionOrder],
+        },
+        baseline,
+      ),
+    ).toBe(true);
+    expect(
+      sidebarCustomizerValuesEqual(
+        { ...baseline, sidebarEntries: [...baseline.sidebarEntries, "route:tasks"] },
+        baseline,
+      ),
+    ).toBe(false);
   });
 
   it("keeps Home fixed and orders visible pages before hidden pages", () => {

--- a/ui/src/components/app-sidebar-customizer.test.ts
+++ b/ui/src/components/app-sidebar-customizer.test.ts
@@ -2,10 +2,21 @@ import { describe, expect, it } from "vitest";
 import {
   buildSidebarCustomizerEntries,
   buildSidebarCustomizerSections,
+  mergeSidebarCustomizerEntries,
 } from "./app-sidebar-customizer.ts";
 import type { SidebarVisibleSections } from "./app-sidebar-session-navigation-logic.ts";
 
 describe("sidebar customizer model", () => {
+  it("restores customizable entries without replacing other current entries", () => {
+    expect(
+      mergeSidebarCustomizerEntries(
+        ["fixed:current", "route:tasks"],
+        ["route:cron", "route:plugins"],
+        ["route:cron", "route:plugins", "route:tasks"],
+      ),
+    ).toEqual(["fixed:current", "route:cron", "route:plugins"]);
+  });
+
   it("keeps Home fixed and orders visible pages before hidden pages", () => {
     const items = buildSidebarCustomizerEntries({
       canonical: ["route:tasks", "route:cron"],

--- a/ui/src/components/app-sidebar-customizer.ts
+++ b/ui/src/components/app-sidebar-customizer.ts
@@ -26,6 +26,29 @@ export type SidebarCustomizerItem = {
   sessionKey?: string;
 };
 
+export type SidebarCustomizerValue = {
+  sidebarEntries: readonly string[];
+  hiddenCatalogIds: readonly string[];
+  groups: readonly string[];
+  sectionOrder: readonly string[];
+};
+
+function equalStringArrays(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+export function sidebarCustomizerValuesEqual(
+  left: SidebarCustomizerValue,
+  right: SidebarCustomizerValue,
+): boolean {
+  return (
+    equalStringArrays(left.sidebarEntries, right.sidebarEntries) &&
+    equalStringArrays(left.hiddenCatalogIds, right.hiddenCatalogIds) &&
+    equalStringArrays(left.groups, right.groups) &&
+    equalStringArrays(left.sectionOrder, right.sectionOrder)
+  );
+}
+
 export function mergeSidebarCustomizerEntries(
   current: readonly string[],
   snapshot: readonly string[],

--- a/ui/src/components/app-sidebar-customizer.ts
+++ b/ui/src/components/app-sidebar-customizer.ts
@@ -26,6 +26,23 @@ export type SidebarCustomizerItem = {
   sessionKey?: string;
 };
 
+export function mergeSidebarCustomizerEntries(
+  current: readonly string[],
+  snapshot: readonly string[],
+  customizable: readonly string[],
+): string[] {
+  const customizableEntries = new Set(customizable);
+  const remaining = [...snapshot];
+  const merged = current.flatMap((entry) => {
+    if (!customizableEntries.has(entry)) {
+      return [entry];
+    }
+    const replacement = remaining.shift();
+    return replacement ? [replacement] : [];
+  });
+  return [...merged, ...remaining];
+}
+
 export function buildSidebarCustomizerEntries(params: {
   canonical: readonly string[];
   enabledRouteIds?: readonly NavigationRouteId[];

--- a/ui/src/components/app-sidebar-customizer.ts
+++ b/ui/src/components/app-sidebar-customizer.ts
@@ -142,8 +142,11 @@ export function buildSidebarCustomizerSections(params: {
 type SidebarCustomizerParams = {
   entries: readonly SidebarCustomizerItem[];
   sections: readonly SidebarCustomizerItem[];
+  dirty: boolean;
+  error: string | null;
   onToggle: (item: SidebarCustomizerItem) => void;
   onRemove: (item: SidebarCustomizerItem) => void;
+  onDone: () => void;
   onBack: () => void;
   onEntryDragStart: (event: DragEvent, item: SidebarCustomizerItem) => void;
   onEntryDragOver: (event: DragEvent, entry: string) => void;
@@ -288,9 +291,15 @@ export function renderSidebarCustomizer(params: SidebarCustomizerParams) {
           )}
         </div>
       </div>
+      ${params.error
+        ? html`<div class="sidebar-customizer__error" role="alert">${params.error}</div>`
+        : nothing}
       <div class="sidebar-customizer__footer">
+        <button type="button" class="btn primary sidebar-customizer__done" @click=${params.onDone}>
+          ${t("nav.customizeDone")}
+        </button>
         <button type="button" class="btn sidebar-customizer__back" @click=${params.onBack}>
-          ${t("common.back")}
+          ${params.dirty ? t("nav.customizeDiscard") : t("common.back")}
         </button>
       </div>
     </section>

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -18,15 +18,15 @@ import "./theme-mode-toggle.ts";
 import "./tooltip.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
-import { readSidebarSectionDragData, writeSessionDragData } from "../lib/sessions/drag.ts";
+import { writeSessionDragData } from "../lib/sessions/drag.ts";
 import { showToast } from "../lib/toast.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { SETTINGS_SEARCH_TARGETS } from "../pages/config/settings-targets.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
+import { SidebarCustomizerController } from "./app-sidebar-customizer-controller.ts";
 import {
   buildSidebarCustomizerEntries,
   buildSidebarCustomizerSections,
-  mergeSidebarCustomizerEntries,
   renderSidebarCustomizer,
   type SidebarCustomizerItem,
 } from "./app-sidebar-customizer.ts";
@@ -69,7 +69,7 @@ import {
   resolveLobsterRunOutcome,
 } from "./lobster-pet-contract.ts";
 import { SessionOrganizerController } from "./session-organizer-controller.ts";
-import { type SidebarAutomationAttentionChangeDetail } from "./sidebar-attention.ts";
+import type { SidebarAutomationAttentionChangeDetail } from "./sidebar-attention.ts";
 import { SidebarMenusController } from "./sidebar-menus-controller.ts";
 // The shared loader retries transient chunk failures online; a deploy-pruned
 // chunk still stays off until reload when that retry fails, by design.
@@ -88,22 +88,9 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     count: 0,
     severity: null as "danger" | "warning" | null,
   };
-  @state() private sidebarCustomizerOpen = false;
-  @state() private sidebarCustomizerDirty = false;
-  @state() private sidebarCustomizerError: string | null = null;
-
-  private sidebarCustomizerReturnFocus: HTMLElement | null = null;
-  private sidebarCustomizerDraggedEntry: string | null = null;
-  private sidebarCustomizerSnapshot: {
-    sidebarEntries: readonly string[];
-    customizableSidebarEntries: readonly string[];
-    hiddenCatalogIds: ReadonlySet<string>;
-    groups: readonly string[];
-    sectionOrder: readonly string[];
-  } | null = null;
-
   override readonly sessionOrganizer = new SessionOrganizerController(this);
   override readonly sidebarMenus = new SidebarMenusController(this);
+  private readonly sidebarCustomizer = new SidebarCustomizerController(this);
 
   sessionGroupDefaults(name: string) {
     if (this.context?.sessions.groupsStatus() !== "ready") {
@@ -476,156 +463,14 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   }
 
   openSidebarCustomizer(trigger: HTMLElement | null = null): void {
-    this.sidebarMenus.dismissTransientMenus();
-    this.sidebarCustomizerReturnFocus = trigger;
-    void this.openSidebarCustomizerAfterGroupLoad();
+    this.sidebarCustomizer.open(trigger);
   }
 
-  private async openSidebarCustomizerAfterGroupLoad(): Promise<void> {
-    const sessions = this.context?.sessions;
-    const groups = await sessions?.groupsLoad();
-    if (groups === null) {
-      this.reportSidebarCustomizerError("nav.customizeMutationError");
-      return;
-    }
-    if (sessions !== this.context?.sessions) {
-      this.reportSidebarCustomizerError("nav.customizeMutationError");
-      return;
-    }
-    const sidebarCustomizerEntries = this.sidebarCustomizerEntries();
-    this.sidebarCustomizerSnapshot = {
-      sidebarEntries: sidebarCustomizerEntries.flatMap((item) =>
-        item.entry && item.visible ? [item.entry] : [],
-      ),
-      customizableSidebarEntries: sidebarCustomizerEntries.flatMap((item) =>
-        item.entry ? [item.entry] : [],
-      ),
-      hiddenCatalogIds: new Set(this.hiddenSessionCatalogIds),
-      groups: [...(this.context?.sessions.state.groups ?? [])],
-      sectionOrder: this.knownSectionOrder(),
-    };
-    this.sidebarCustomizerDirty = false;
-    this.sidebarCustomizerError = null;
-    this.sidebarCustomizerOpen = true;
-    void this.updateComplete.then(() =>
-      this.querySelector<HTMLElement>(".sidebar-customizer button:not([disabled])")?.focus(),
-    );
+  sidebarCustomizerContext() {
+    return this.context;
   }
 
-  private closeSidebarCustomizer(): void {
-    this.sidebarCustomizerOpen = false;
-    this.sidebarCustomizerDirty = false;
-    this.sidebarCustomizerError = null;
-    this.sidebarCustomizerSnapshot = null;
-    const returnFocus = this.sidebarCustomizerReturnFocus;
-    this.sidebarCustomizerReturnFocus = null;
-    void this.updateComplete.then(() => {
-      if (returnFocus?.isConnected) {
-        returnFocus.focus();
-      } else {
-        this.querySelector<HTMLElement>(".sidebar-nav__more")?.focus();
-      }
-    });
-  }
-
-  private reportSidebarCustomizerError(
-    key: "nav.customizeMutationError" | "nav.customizeRestoreError",
-  ): void {
-    this.sidebarCustomizerError = t(key);
-    showToast({ message: this.sidebarCustomizerError });
-  }
-
-  private async discardSidebarCustomizerChanges(): Promise<void> {
-    const snapshot = this.sidebarCustomizerSnapshot;
-    if (!snapshot || !this.sidebarCustomizerDirty) {
-      this.closeSidebarCustomizer();
-      return;
-    }
-    let failed = false;
-    const updateSidebarEntries = this.onUpdateSidebarEntries;
-    try {
-      if (updateSidebarEntries) {
-        updateSidebarEntries(
-          mergeSidebarCustomizerEntries(
-            this.reconciledSidebarZone().sidebarEntries,
-            snapshot.sidebarEntries,
-            snapshot.customizableSidebarEntries,
-          ),
-        );
-      } else {
-        failed = true;
-      }
-    } catch {
-      failed = true;
-    }
-    const catalogIds = new Set([...this.hiddenSessionCatalogIds, ...snapshot.hiddenCatalogIds]);
-    for (const catalogId of catalogIds) {
-      try {
-        setStoredSessionCatalogHidden(catalogId, snapshot.hiddenCatalogIds.has(catalogId));
-      } catch {
-        failed = true;
-      }
-    }
-    const sessions = this.context?.sessions;
-    if (sessions) {
-      try {
-        const outcome = await sessions.groupsPut([...snapshot.groups], [...snapshot.sectionOrder]);
-        if (outcome !== "completed") {
-          failed = true;
-        }
-      } catch {
-        failed = true;
-      }
-    } else {
-      failed = true;
-    }
-    if (failed) {
-      this.reportSidebarCustomizerError("nav.customizeRestoreError");
-    } else {
-      this.closeSidebarCustomizer();
-    }
-  }
-
-  private markSidebarCustomizerDirty(): void {
-    this.sidebarCustomizerDirty = true;
-    this.sidebarCustomizerError = null;
-  }
-
-  private toggleSidebarCustomizerItem(item: SidebarCustomizerItem): void {
-    if (item.kind === "entry" && item.entry) {
-      if (!this.onUpdateSidebarEntries) {
-        this.reportSidebarCustomizerError("nav.customizeMutationError");
-        return;
-      }
-      const canonical = this.reconciledSidebarZone().sidebarEntries;
-      const next = canonical.includes(item.entry)
-        ? canonical.filter((candidate) => candidate !== item.entry)
-        : [...canonical, item.entry];
-      this.onUpdateSidebarEntries(next);
-      this.markSidebarCustomizerDirty();
-      return;
-    }
-    if (item.id.startsWith("catalog:")) {
-      try {
-        setStoredSessionCatalogHidden(item.id.slice("catalog:".length), item.visible);
-        this.markSidebarCustomizerDirty();
-      } catch {
-        this.reportSidebarCustomizerError("nav.customizeMutationError");
-      }
-    }
-  }
-
-  private removeSidebarCustomizerItem(item: SidebarCustomizerItem): void {
-    if (!item.sessionKey) {
-      return;
-    }
-    const session = this.reconciledSidebarZone().sessionRows.get(item.sessionKey);
-    if (session) {
-      void this.sessionOrganizer.patchSession(session, { pinned: false });
-    }
-  }
-
-  private sidebarCustomizerEntries(): SidebarCustomizerItem[] {
+  sidebarCustomizerEntries(): SidebarCustomizerItem[] {
     const sidebarZone = this.reconciledSidebarZone();
     return buildSidebarCustomizerEntries({
       canonical: sidebarZone.sidebarEntries,
@@ -649,17 +494,17 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   }
 
   private renderSidebarCustomizer() {
+    const entries = this.sidebarCustomizerEntries();
     return renderSidebarCustomizer({
-      entries: this.sidebarCustomizerEntries(),
+      entries,
       sections: this.sidebarCustomizerSections(),
-      dirty: this.sidebarCustomizerDirty,
-      error: this.sidebarCustomizerError,
-      onToggle: (item) => this.toggleSidebarCustomizerItem(item),
-      onRemove: (item) => this.removeSidebarCustomizerItem(item),
-      onDone: () => this.closeSidebarCustomizer(),
-      onBack: () => void this.discardSidebarCustomizerChanges(),
+      dirty: this.sidebarCustomizer.isDirty(entries),
+      error: this.sidebarCustomizer.error,
+      onToggle: (item) => this.sidebarCustomizer.toggle(item),
+      onRemove: (item) => this.sidebarCustomizer.remove(item),
+      onDone: () => this.sidebarCustomizer.close(),
+      onBack: () => void this.sidebarCustomizer.discard(),
       onEntryDragStart: (event, item) => {
-        this.sidebarCustomizerDraggedEntry = item.entry ?? null;
         const entry = item.entry ? parseSidebarEntry(item.entry) : null;
         if (entry?.type === "route") {
           this.sessionOrganizer.startSidebarRouteDrag(event, entry.route);
@@ -677,12 +522,8 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         this.sessionOrganizer.handleSidebarZoneDragOver(event, entry),
       onEntryDragLeave: (event) => this.sessionOrganizer.handleSidebarZoneDragLeave(event),
       onEntryDrop: (event, entry) => {
-        const draggedEntry = this.sidebarCustomizerDraggedEntry;
+        this.sidebarCustomizer.clearError();
         this.sessionOrganizer.handleSidebarZoneDrop(event, entry);
-        this.sidebarCustomizerDraggedEntry = null;
-        if (draggedEntry && draggedEntry !== entry) {
-          this.markSidebarCustomizerDirty();
-        }
       },
       onSectionDragStart: (sectionId) => this.startSidebarSectionDrag(sectionId),
       onSectionDragOver: (event, sectionId, category) =>
@@ -690,17 +531,13 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       onSectionDragLeave: (event, sectionId, category) =>
         this.sectionDragLeave(event, sectionId, category),
       onSectionDrop: (event, sectionId, category) => {
-        const sourceSectionId = readSidebarSectionDragData(event.dataTransfer);
+        this.sidebarCustomizer.clearError();
         this.sessionOrganizer.sectionDrop(event, sectionId, category);
-        if (sourceSectionId && sourceSectionId !== sectionId) {
-          this.markSidebarCustomizerDirty();
-        }
       },
       onDragEnd: (kind) => {
         if (kind === "section") {
           this.finishSidebarSectionDrag();
         } else {
-          this.sidebarCustomizerDraggedEntry = null;
           this.sessionOrganizer.finishSidebarEntryDrag();
         }
       },
@@ -786,7 +623,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         }}
       >
         <div class="sidebar-shell" @mousedown=${beginNativeWindowDragFromTopInset}>
-          ${this.sidebarCustomizerOpen
+          ${this.sidebarCustomizer.isOpen
             ? html`<div class="sidebar-customizer__brand" inert>${renderAppSidebarBrand(this)}</div>
                 ${this.renderSidebarCustomizer()}`
             : html`${renderAppSidebarBrand(this)}

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -88,8 +88,16 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     severity: null as "danger" | "warning" | null,
   };
   @state() private sidebarCustomizerOpen = false;
+  @state() private sidebarCustomizerDirty = false;
+  @state() private sidebarCustomizerError: string | null = null;
 
   private sidebarCustomizerReturnFocus: HTMLElement | null = null;
+  private sidebarCustomizerSnapshot: {
+    sidebarEntries: readonly string[];
+    hiddenCatalogIds: ReadonlySet<string>;
+    groups: readonly string[];
+    sectionOrder: readonly string[];
+  } | null = null;
 
   override readonly sessionOrganizer = new SessionOrganizerController(this);
   override readonly sidebarMenus = new SidebarMenusController(this);
@@ -467,6 +475,14 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   openSidebarCustomizer(trigger: HTMLElement | null = null): void {
     this.sidebarMenus.dismissTransientMenus();
     this.sidebarCustomizerReturnFocus = trigger;
+    this.sidebarCustomizerSnapshot = {
+      sidebarEntries: [...this.reconciledSidebarZone().sidebarEntries],
+      hiddenCatalogIds: new Set(this.hiddenSessionCatalogIds),
+      groups: [...(this.context?.sessions.state.groups ?? [])],
+      sectionOrder: this.knownSectionOrder(),
+    };
+    this.sidebarCustomizerDirty = false;
+    this.sidebarCustomizerError = null;
     this.sidebarCustomizerOpen = true;
     void this.updateComplete.then(() =>
       this.querySelector<HTMLElement>(".sidebar-customizer button:not([disabled])")?.focus(),
@@ -475,6 +491,9 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
 
   private closeSidebarCustomizer(): void {
     this.sidebarCustomizerOpen = false;
+    this.sidebarCustomizerDirty = false;
+    this.sidebarCustomizerError = null;
+    this.sidebarCustomizerSnapshot = null;
     const returnFocus = this.sidebarCustomizerReturnFocus;
     this.sidebarCustomizerReturnFocus = null;
     void this.updateComplete.then(() => {
@@ -486,17 +505,81 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     });
   }
 
+  private reportSidebarCustomizerError(
+    key: "nav.customizeMutationError" | "nav.customizeRestoreError",
+  ): void {
+    this.sidebarCustomizerError = t(key);
+    showToast({ message: this.sidebarCustomizerError });
+  }
+
+  private async discardSidebarCustomizerChanges(): Promise<void> {
+    const snapshot = this.sidebarCustomizerSnapshot;
+    if (!snapshot || !this.sidebarCustomizerDirty) {
+      this.closeSidebarCustomizer();
+      return;
+    }
+    let failed = false;
+    const updateSidebarEntries = this.onUpdateSidebarEntries;
+    try {
+      if (updateSidebarEntries) {
+        updateSidebarEntries([...snapshot.sidebarEntries]);
+      } else {
+        failed = true;
+      }
+    } catch {
+      failed = true;
+    }
+    const catalogIds = new Set([...this.hiddenSessionCatalogIds, ...snapshot.hiddenCatalogIds]);
+    for (const catalogId of catalogIds) {
+      try {
+        setStoredSessionCatalogHidden(catalogId, snapshot.hiddenCatalogIds.has(catalogId));
+      } catch {
+        failed = true;
+      }
+    }
+    const sessions = this.context?.sessions;
+    if (sessions) {
+      try {
+        await sessions.groupsPut([...snapshot.groups], [...snapshot.sectionOrder]);
+      } catch {
+        failed = true;
+      }
+    } else {
+      failed = true;
+    }
+    if (failed) {
+      this.reportSidebarCustomizerError("nav.customizeRestoreError");
+    } else {
+      this.closeSidebarCustomizer();
+    }
+  }
+
+  private markSidebarCustomizerDirty(): void {
+    this.sidebarCustomizerDirty = true;
+    this.sidebarCustomizerError = null;
+  }
+
   private toggleSidebarCustomizerItem(item: SidebarCustomizerItem): void {
     if (item.kind === "entry" && item.entry) {
+      if (!this.onUpdateSidebarEntries) {
+        this.reportSidebarCustomizerError("nav.customizeMutationError");
+        return;
+      }
       const canonical = this.reconciledSidebarZone().sidebarEntries;
       const next = canonical.includes(item.entry)
         ? canonical.filter((candidate) => candidate !== item.entry)
         : [...canonical, item.entry];
-      this.onUpdateSidebarEntries?.(next);
+      this.onUpdateSidebarEntries(next);
+      this.markSidebarCustomizerDirty();
       return;
     }
     if (item.id.startsWith("catalog:")) {
-      setStoredSessionCatalogHidden(item.id.slice("catalog:".length), item.visible);
+      try {
+        setStoredSessionCatalogHidden(item.id.slice("catalog:".length), item.visible);
+        this.markSidebarCustomizerDirty();
+      } catch {
+        this.reportSidebarCustomizerError("nav.customizeMutationError");
+      }
     }
   }
 
@@ -537,9 +620,12 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     return renderSidebarCustomizer({
       entries: this.sidebarCustomizerEntries(),
       sections: this.sidebarCustomizerSections(),
+      dirty: this.sidebarCustomizerDirty,
+      error: this.sidebarCustomizerError,
       onToggle: (item) => this.toggleSidebarCustomizerItem(item),
       onRemove: (item) => this.removeSidebarCustomizerItem(item),
-      onBack: () => this.closeSidebarCustomizer(),
+      onDone: () => this.closeSidebarCustomizer(),
+      onBack: () => void this.discardSidebarCustomizerChanges(),
       onEntryDragStart: (event, item) => {
         const entry = item.entry ? parseSidebarEntry(item.entry) : null;
         if (entry?.type === "route") {
@@ -557,13 +643,19 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       onEntryDragOver: (event, entry) =>
         this.sessionOrganizer.handleSidebarZoneDragOver(event, entry),
       onEntryDragLeave: (event) => this.sessionOrganizer.handleSidebarZoneDragLeave(event),
-      onEntryDrop: (event, entry) => this.sessionOrganizer.handleSidebarZoneDrop(event, entry),
+      onEntryDrop: (event, entry) => {
+        this.markSidebarCustomizerDirty();
+        this.sessionOrganizer.handleSidebarZoneDrop(event, entry);
+      },
       onSectionDragStart: (sectionId) => this.startSidebarSectionDrag(sectionId),
       onSectionDragOver: (event, sectionId, category) =>
         this.sectionDragOver(event, sectionId, category),
       onSectionDragLeave: (event, sectionId, category) =>
         this.sectionDragLeave(event, sectionId, category),
-      onSectionDrop: (event, sectionId, category) => this.sectionDrop(event, sectionId, category),
+      onSectionDrop: (event, sectionId, category) => {
+        this.markSidebarCustomizerDirty();
+        this.sectionDrop(event, sectionId, category);
+      },
       onDragEnd: (kind) => {
         if (kind === "section") {
           this.finishSidebarSectionDrag();

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -18,7 +18,7 @@ import "./theme-mode-toggle.ts";
 import "./tooltip.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
-import { writeSessionDragData } from "../lib/sessions/drag.ts";
+import { readSidebarSectionDragData, writeSessionDragData } from "../lib/sessions/drag.ts";
 import { showToast } from "../lib/toast.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { SETTINGS_SEARCH_TARGETS } from "../pages/config/settings-targets.ts";
@@ -26,6 +26,7 @@ import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import {
   buildSidebarCustomizerEntries,
   buildSidebarCustomizerSections,
+  mergeSidebarCustomizerEntries,
   renderSidebarCustomizer,
   type SidebarCustomizerItem,
 } from "./app-sidebar-customizer.ts";
@@ -92,8 +93,10 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   @state() private sidebarCustomizerError: string | null = null;
 
   private sidebarCustomizerReturnFocus: HTMLElement | null = null;
+  private sidebarCustomizerDraggedEntry: string | null = null;
   private sidebarCustomizerSnapshot: {
     sidebarEntries: readonly string[];
+    customizableSidebarEntries: readonly string[];
     hiddenCatalogIds: ReadonlySet<string>;
     groups: readonly string[];
     sectionOrder: readonly string[];
@@ -475,8 +478,28 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   openSidebarCustomizer(trigger: HTMLElement | null = null): void {
     this.sidebarMenus.dismissTransientMenus();
     this.sidebarCustomizerReturnFocus = trigger;
+    void this.openSidebarCustomizerAfterGroupLoad();
+  }
+
+  private async openSidebarCustomizerAfterGroupLoad(): Promise<void> {
+    const sessions = this.context?.sessions;
+    const groups = await sessions?.groupsLoad();
+    if (groups === null) {
+      this.reportSidebarCustomizerError("nav.customizeMutationError");
+      return;
+    }
+    if (sessions !== this.context?.sessions) {
+      this.reportSidebarCustomizerError("nav.customizeMutationError");
+      return;
+    }
+    const sidebarCustomizerEntries = this.sidebarCustomizerEntries();
     this.sidebarCustomizerSnapshot = {
-      sidebarEntries: [...this.reconciledSidebarZone().sidebarEntries],
+      sidebarEntries: sidebarCustomizerEntries.flatMap((item) =>
+        item.entry && item.visible ? [item.entry] : [],
+      ),
+      customizableSidebarEntries: sidebarCustomizerEntries.flatMap((item) =>
+        item.entry ? [item.entry] : [],
+      ),
       hiddenCatalogIds: new Set(this.hiddenSessionCatalogIds),
       groups: [...(this.context?.sessions.state.groups ?? [])],
       sectionOrder: this.knownSectionOrder(),
@@ -522,7 +545,13 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     const updateSidebarEntries = this.onUpdateSidebarEntries;
     try {
       if (updateSidebarEntries) {
-        updateSidebarEntries([...snapshot.sidebarEntries]);
+        updateSidebarEntries(
+          mergeSidebarCustomizerEntries(
+            this.reconciledSidebarZone().sidebarEntries,
+            snapshot.sidebarEntries,
+            snapshot.customizableSidebarEntries,
+          ),
+        );
       } else {
         failed = true;
       }
@@ -540,7 +569,10 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     const sessions = this.context?.sessions;
     if (sessions) {
       try {
-        await sessions.groupsPut([...snapshot.groups], [...snapshot.sectionOrder]);
+        const outcome = await sessions.groupsPut([...snapshot.groups], [...snapshot.sectionOrder]);
+        if (outcome !== "completed") {
+          failed = true;
+        }
       } catch {
         failed = true;
       }
@@ -627,6 +659,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       onDone: () => this.closeSidebarCustomizer(),
       onBack: () => void this.discardSidebarCustomizerChanges(),
       onEntryDragStart: (event, item) => {
+        this.sidebarCustomizerDraggedEntry = item.entry ?? null;
         const entry = item.entry ? parseSidebarEntry(item.entry) : null;
         if (entry?.type === "route") {
           this.sessionOrganizer.startSidebarRouteDrag(event, entry.route);
@@ -644,8 +677,12 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         this.sessionOrganizer.handleSidebarZoneDragOver(event, entry),
       onEntryDragLeave: (event) => this.sessionOrganizer.handleSidebarZoneDragLeave(event),
       onEntryDrop: (event, entry) => {
-        this.markSidebarCustomizerDirty();
+        const draggedEntry = this.sidebarCustomizerDraggedEntry;
         this.sessionOrganizer.handleSidebarZoneDrop(event, entry);
+        this.sidebarCustomizerDraggedEntry = null;
+        if (draggedEntry && draggedEntry !== entry) {
+          this.markSidebarCustomizerDirty();
+        }
       },
       onSectionDragStart: (sectionId) => this.startSidebarSectionDrag(sectionId),
       onSectionDragOver: (event, sectionId, category) =>
@@ -653,13 +690,17 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       onSectionDragLeave: (event, sectionId, category) =>
         this.sectionDragLeave(event, sectionId, category),
       onSectionDrop: (event, sectionId, category) => {
-        this.markSidebarCustomizerDirty();
-        this.sectionDrop(event, sectionId, category);
+        const sourceSectionId = readSidebarSectionDragData(event.dataTransfer);
+        this.sessionOrganizer.sectionDrop(event, sectionId, category);
+        if (sourceSectionId && sourceSectionId !== sectionId) {
+          this.markSidebarCustomizerDirty();
+        }
       },
       onDragEnd: (kind) => {
         if (kind === "section") {
           this.finishSidebarSectionDrag();
         } else {
+          this.sidebarCustomizerDraggedEntry = null;
           this.sessionOrganizer.finishSidebarEntryDrag();
         }
       },

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -200,9 +200,20 @@ suite.define(() => {
     });
     const page = await context.newPage();
     const video = page.video();
-    await installMockGateway(page, {
+    const gateway = await installMockGateway(page, {
       controlUiTabs: [{ group: "control", id: "logbook", label: "Logbook", pluginId: "logbook" }],
+      featureMethods: ["sessions.catalog.list"],
       methodResponses: {
+        "sessions.catalog.list": {
+          catalogs: [
+            {
+              id: "claude",
+              label: "Claude Code",
+              capabilities: { continueSession: true, archive: false },
+              hosts: [],
+            },
+          ],
+        },
         "config.get": {
           config: {},
           hash: "settings-search-e2e",
@@ -532,7 +543,9 @@ suite.define(() => {
         .poll(() => sessionsRow.locator(".sidebar-customizer__visibility").count())
         .toBe(0);
       const tasksRow = customizer.locator('[data-sidebar-customizer-id="route:tasks"]');
+      const claudeRow = customizer.locator('[data-sidebar-customizer-id="catalog:claude"]');
       await expect.poll(() => tasksRow.getAttribute("class")).toContain("--hidden");
+      await expect.poll(() => claudeRow.getAttribute("class")).not.toContain("--hidden");
       // Ask OpenClaw moved to Settings (#111686): custodian is not a sidebar
       // nav route anymore, so the customizer does not offer it.
       await expect.poll(() => customizer.getByText("OpenClaw", { exact: true }).count()).toBe(0);
@@ -555,11 +568,22 @@ suite.define(() => {
       await expect.poll(() => pinnedSessionRow.count()).toBe(0);
 
       await tasksRow.getByRole("button", { name: "Show Tasks in sidebar" }).click();
+      await claudeRow.getByRole("button", { name: "Hide Claude Code from sidebar" }).click();
       await expect.poll(() => tasksRow.getAttribute("class")).not.toContain("--hidden");
-      await customizer.getByRole("button", { name: "Back" }).click();
+      await expect
+        .poll(() => customizer.getByRole("button", { name: "Discard changes" }).isVisible())
+        .toBe(true);
+      for (const theme of ["light", "dark"] as const) {
+        await setThemeMode(page, theme);
+        await captureSettingsSidebarProof(customizer, `04-customizer-dirty-${theme}.png`);
+      }
+      await customizer.getByRole("button", { name: "Done" }).click();
       await expect
         .poll(() => trimmedTextContents(visiblePageItems))
         .toEqual(["Automations", "Plugins", "Tasks"]);
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), hiddenSessionCatalogsStorageKey),
+      ).toBe('["claude"]');
       await page.reload();
       await expect
         .poll(() => trimmedTextContents(visiblePageItems))
@@ -578,14 +602,61 @@ suite.define(() => {
       await captureUiProof(page, "03-persisted-customization.png");
 
       await editPersistedCustomization.click();
+      await expect
+        .poll(() => customizer.getByRole("button", { name: "Back" }).isVisible())
+        .toBe(true);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => customizer.count()).toBe(0);
+      await expect
+        .poll(() => trimmedTextContents(visiblePageItems))
+        .toEqual(["Automations", "Plugins", "Tasks"]);
+
+      await moreButton.click();
+      await moreMenu.getByRole("menuitem", { name: "Customize sidebar" }).click();
       await customizer
         .locator('[data-sidebar-customizer-id="route:tasks"]')
         .getByRole("button", { name: "Hide Tasks from sidebar" })
         .click();
-      await customizer.getByRole("button", { name: "Back" }).click();
+      await customizer
+        .locator('[data-sidebar-customizer-id="catalog:claude"]')
+        .getByRole("button", { name: "Show Claude Code in sidebar" })
+        .click();
+      const groupWritesBefore = (await gateway.getRequests("sessions.groups.put")).length;
+      await customizer
+        .locator('[data-sidebar-customizer-id="work"]')
+        .dragTo(customizer.locator('[data-sidebar-customizer-id="ungrouped"]'));
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.groups.put")).length)
+        .toBeGreaterThan(groupWritesBefore);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => customizer.count()).toBe(0);
+      await expect
+        .poll(() => trimmedTextContents(visiblePageItems))
+        .toEqual(["Automations", "Plugins", "Tasks"]);
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), hiddenSessionCatalogsStorageKey),
+      ).toBe('["claude"]');
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.groups.put")).length)
+        .toBeGreaterThan(groupWritesBefore + 1);
+
+      await moreButton.click();
+      await moreMenu.getByRole("menuitem", { name: "Customize sidebar" }).click();
+      await customizer
+        .locator('[data-sidebar-customizer-id="route:tasks"]')
+        .getByRole("button", { name: "Hide Tasks from sidebar" })
+        .click();
+      await customizer
+        .locator('[data-sidebar-customizer-id="catalog:claude"]')
+        .getByRole("button", { name: "Show Claude Code in sidebar" })
+        .click();
+      await customizer.getByRole("button", { name: "Done" }).click();
       await expect
         .poll(() => trimmedTextContents(visiblePageItems))
         .toEqual(["Automations", "Plugins"]);
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), hiddenSessionCatalogsStorageKey),
+      ).toBe("[]");
 
       // The shell chrome search button is the command palette entry point.
       const searchButton = page.locator(".shell-chrome-controls__search");
@@ -692,6 +763,49 @@ suite.define(() => {
       if (video) {
         await video.saveAs(path.join(uiProofArtifactDir, "settings-search-flow.webm"));
       }
+    }
+  });
+
+  it("keeps the customizer open with a visible error when restore is rejected", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["sessions.groups.put"],
+      featureMethods: ["sessions.groups.list", "sessions.groups.put"],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const sidebar = page.locator("openclaw-app-sidebar");
+      await sidebar.locator(".sidebar-nav__more").click();
+      await sidebar
+        .locator("wa-dropdown.sidebar-more-menu")
+        .getByRole("menuitem", { name: "Customize sidebar" })
+        .click();
+      const customizer = sidebar.locator(".sidebar-customizer");
+      await customizer
+        .locator('[data-sidebar-customizer-id="route:tasks"]')
+        .getByRole("button", { name: "Show Tasks in sidebar" })
+        .click();
+      await page.keyboard.press("Escape");
+      await gateway.waitForRequest("sessions.groups.put");
+      await gateway.rejectDeferred("sessions.groups.put", {
+        code: "UNAVAILABLE",
+        message: "section catalog unavailable",
+      });
+
+      await expect
+        .poll(() => customizer.getByRole("alert").textContent())
+        .toContain("Couldn't restore every sidebar change");
+      await expect.poll(() => customizer.isVisible()).toBe(true);
+      await customizer.getByRole("button", { name: "Discard changes" }).click();
+      await expect.poll(() => customizer.count()).toBe(0);
+    } finally {
+      await context.close();
     }
   });
 

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   waitForControlUiSettingsTakeover,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { sessionRow, sessionsListResponse } from "./session-management.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI sidebar customization mocked Gateway E2E",
@@ -202,7 +203,12 @@ suite.define(() => {
     const video = page.video();
     const gateway = await installMockGateway(page, {
       controlUiTabs: [{ group: "control", id: "logbook", label: "Logbook", pluginId: "logbook" }],
-      featureMethods: ["sessions.catalog.list", "sessions.groups.list", "sessions.groups.put"],
+      featureMethods: [
+        "sessions.catalog.list",
+        "sessions.groups.list",
+        "sessions.groups.put",
+        "sessions.patch",
+      ],
       methodResponses: {
         "sessions.catalog.list": {
           catalogs: [
@@ -214,6 +220,14 @@ suite.define(() => {
             },
           ],
         },
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", 2),
+          sessionRow("agent:main:tax-research", "Tax filing research", 1, {
+            pinned: true,
+            pinnedAt: 1,
+          }),
+        ]),
+        "sessions.patch": { ok: true },
         "config.get": {
           config: {},
           hash: "settings-search-e2e",
@@ -558,6 +572,18 @@ suite.define(() => {
         .poll(() => tasksRow.evaluate((row) => getComputedStyle(row).animationName))
         .toBe("none");
 
+      await tasksRow.getByRole("button", { name: "Show Tasks in sidebar" }).click();
+      await expect
+        .poll(() => customizer.getByRole("button", { name: "Discard changes" }).isVisible())
+        .toBe(true);
+      await tasksRow.getByRole("button", { name: "Hide Tasks from sidebar" }).click();
+      await expect
+        .poll(() => customizer.getByRole("button", { name: "Back" }).isVisible())
+        .toBe(true);
+      await expect
+        .poll(() => customizer.getByRole("button", { name: "Discard changes" }).count())
+        .toBe(0);
+
       const pinnedSessionRow = customizer.locator(
         '[data-sidebar-customizer-id="session:agent:main:tax-research"]',
       );
@@ -566,6 +592,12 @@ suite.define(() => {
         .getByRole("button", { name: "Remove Tax filing research from sidebar" })
         .click();
       await expect.poll(() => pinnedSessionRow.count()).toBe(0);
+      await customizer.getByRole("button", { name: "Discard changes" }).click();
+      await expect.poll(() => customizer.count()).toBe(0);
+
+      await moreButton.click();
+      await moreMenu.getByRole("menuitem", { name: "Customize sidebar" }).click();
+      await expect.poll(() => pinnedSessionRow.isVisible()).toBe(true);
 
       await tasksRow.getByRole("button", { name: "Show Tasks in sidebar" }).click();
       await claudeRow.getByRole("button", { name: "Hide Claude Code from sidebar" }).click();
@@ -628,6 +660,7 @@ suite.define(() => {
       await expect
         .poll(async () => (await gateway.getRequests("sessions.groups.put")).length)
         .toBeGreaterThan(groupWritesBefore);
+      await customizer.getByRole("button", { name: "Discard changes" }).focus();
       await page.keyboard.press("Escape");
       await expect.poll(() => customizer.count()).toBe(0);
       await expect
@@ -802,7 +835,13 @@ suite.define(() => {
         .poll(() => customizer.getByRole("alert").textContent())
         .toContain("Couldn't restore every sidebar change");
       await expect.poll(() => customizer.isVisible()).toBe(true);
-      await customizer.getByRole("button", { name: "Discard changes" }).click();
+      await expect
+        .poll(() => customizer.getByRole("button", { name: "Back" }).isVisible())
+        .toBe(true);
+      await expect
+        .poll(() => customizer.getByRole("button", { name: "Discard changes" }).count())
+        .toBe(0);
+      await customizer.getByRole("button", { name: "Back" }).click();
       await expect.poll(() => customizer.count()).toBe(0);
     } finally {
       await context.close();

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -202,7 +202,7 @@ suite.define(() => {
     const video = page.video();
     const gateway = await installMockGateway(page, {
       controlUiTabs: [{ group: "control", id: "logbook", label: "Logbook", pluginId: "logbook" }],
-      featureMethods: ["sessions.catalog.list"],
+      featureMethods: ["sessions.catalog.list", "sessions.groups.list", "sessions.groups.put"],
       methodResponses: {
         "sessions.catalog.list": {
           catalogs: [

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1961,6 +1961,12 @@ export const en: TranslationMap = {
     pages: "Pages",
     pinned: "Pinned",
     customize: "Customize sidebar",
+    customizeDone: "Done",
+    customizeDiscard: "Discard changes",
+    customizeMutationError:
+      "Couldn't apply this sidebar change. Review the current state and try again.",
+    customizeRestoreError:
+      "Couldn't restore every sidebar change. Review the current state and try again.",
     customizeShow: "Show {item} in sidebar",
     customizeHide: "Hide {item} from sidebar",
     customizeRemove: "Remove {item} from sidebar",

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -107,6 +107,43 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
+  it("coalesces concurrent group catalog loads until the catalog is hydrated", async () => {
+    const listed = createDeferred<{
+      groups: Array<{ name: string }>;
+      sectionOrder: string[];
+    }>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.groups.list") {
+        return await listed.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client, ["sessions.groups.list"]);
+    const sessions = createSessionCapability(gateway);
+
+    const first = sessions.groupsLoad();
+    const second = sessions.groupsLoad();
+    let secondSettled = false;
+    void second.then(() => {
+      secondSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(secondSettled).toBe(false);
+
+    listed.resolve({
+      groups: [{ name: "Research" }],
+      sectionOrder: ["category:Research", "ungrouped"],
+    });
+    await Promise.all([first, second]);
+
+    expect(sessions.state.groups).toEqual(["Research"]);
+    expect(sessions.state.sectionOrder).toEqual(["category:Research", "ungrouped"]);
+    sessions.dispose();
+  });
+
   it("automatically retries an explicitly retryable group catalog failure", async () => {
     let groupsCalls = 0;
     const request = vi.fn(async (method: string) => {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1314,7 +1314,8 @@ openclaw-settings-save-indicator {
 }
 
 .sidebar-customizer__visibility:hover,
-.sidebar-customizer__visibility:focus-visible {
+.sidebar-customizer__visibility:focus-visible,
+.sidebar-customizer__done:focus-visible {
   background: color-mix(in srgb, var(--bg-active) 78%, transparent);
   color: var(--text);
 }
@@ -1344,11 +1345,31 @@ openclaw-settings-save-indicator {
   padding: 8px 2px 0;
 }
 
-.sidebar-customizer__back {
+.sidebar-customizer__error {
+  margin: 8px 2px 0;
+  color: var(--danger);
+  font-size: var(--control-ui-text-xs);
+  line-height: 1.4;
+}
+
+.sidebar-customizer__back,
+.sidebar-customizer__done {
   width: 100%;
   min-height: 40px;
   border-radius: var(--radius-md);
   font-weight: 500;
+}
+
+.sidebar-customizer__done.btn.primary,
+.sidebar-customizer__done.btn.primary:hover {
+  border-color: var(--danger);
+  background: var(--danger);
+  color: white;
+  box-shadow: none;
+}
+
+.sidebar-customizer__done.btn.primary:hover {
+  background: var(--danger-solid-hover);
 }
 
 .sidebar-customizer__back,


### PR DESCRIPTION
Depends on #123656.

## What Problem This Solves

Customization writes are live, so a secondary Back or Escape action can otherwise leave some page, catalog, or section-order changes committed while implying that the edit was abandoned.

## Why This Change Was Made

This PR implements TRX-01 through TRX-04 and preserves the TRX-05 rejection of copy-only discard. Opening the customizer snapshots the existing persistence owners in memory. Done accepts their current writes; Back, Discard changes, and Escape re-emit the snapshot to each owner and wait for the group catalog write before closing. The sidebar preference snapshot contains only entries owned by the customizer and preserves every current entry outside that set during restoration.

No persistence surface or concurrency protocol is added. The existing sessions.groups.put owner replaces the whole catalog without compare-and-swap, so concurrent external group changes can be overwritten by snapshot restoration; that pre-existing writer race is explicitly deferred to the owner rather than expanded here.

Named deferred decision: current main has no persistent owner for native-section visibility. The customizer therefore omits native-section eye controls. A maintainer decision is required before that visibility can join the transaction.

## User Impact

- The pristine secondary action reads Back.
- The first supported visibility or ordering mutation changes it to Discard changes.
- Done keeps page order, catalog visibility, group catalog, and section order changes.
- Discard changes or Escape restores all existing owners together.
- A rejected restore keeps the customizer open and presents a visible error with a retry path.

## Evidence

- Added end-to-end coverage for pristine Back, Done persistence, multi-owner Discard, Escape parity, group-order restoration, and rejected-restore visibility.
- Added light and dark pristine/dirty frame capture and reduced-motion assertions.
- Focused customizer and session-state suites passed at the exact head: 37 tests.

