### PR TITLE
Prefer claim evidence provenance in wiki cache

### DIFF
--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -122,6 +122,22 @@ describe("compileMemoryWikiVault", () => {
     });
 
     await fs.writeFile(
+      path.join(rootDir, "sources", "page.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.page", title: "Page Source" },
+        body: "# Page Source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "claim.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.claim", title: "Claim Source" },
+        body: "# Claim Source\n\n[Claim Sources](../concepts/claim-sources.md)\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
       path.join(rootDir, "concepts", "claim-sources.md"),
       renderWikiMarkdown({
         frontmatter: {
@@ -159,6 +175,14 @@ describe("compileMemoryWikiVault", () => {
     expect(claims.find((claim) => claim.id === "claim.page-fallback")?.sourceIds).toEqual([
       "source.page",
     ]);
+    const conceptPage = await fs.readFile(
+      path.join(rootDir, "concepts", "claim-sources.md"),
+      "utf8",
+    );
+    expect(conceptPage.match(/\[Claim Source\]\(\.\.\/sources\/claim\.md\)/g)).toHaveLength(1);
+    await expect(fs.readFile(path.join(rootDir, "sources", "claim.md"), "utf8")).resolves.toContain(
+      "[Claim Sources](../concepts/claim-sources.md)",
+    );
   });
 
   it("preserves source page bytes while rebuilding derived artifacts", async () => {

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -115,6 +115,52 @@ describe("compileMemoryWikiVault", () => {
     expect(claims.map((claim) => claim.text)).toContain("Alpha is the canonical source page.");
   });
 
+  it("uses claim evidence source IDs before page-level provenance in compiled claims", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    await fs.writeFile(
+      path.join(rootDir, "concepts", "claim-sources.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "concept",
+          id: "concept.claim-sources",
+          title: "Claim Sources",
+          sourceIds: ["source.page"],
+          claims: [
+            {
+              id: "claim.evidence-source",
+              text: "Evidence provenance is claim-specific.",
+              evidence: [
+                { sourceId: "source.claim", lines: "1-3" },
+                { sourceId: "source.claim", lines: "5-7" },
+              ],
+            },
+            {
+              id: "claim.page-fallback",
+              text: "Page provenance remains the fallback.",
+              evidence: [{ path: "memory/example.md", lines: "1-2" }],
+            },
+          ],
+        },
+        body: "# Claim Sources\n",
+      }),
+      "utf8",
+    );
+
+    await compileMemoryWikiVault(config);
+
+    const { claims } = await expectCompiledCache(config);
+    expect(claims.find((claim) => claim.id === "claim.evidence-source")?.sourceIds).toEqual([
+      "source.claim",
+    ]);
+    expect(claims.find((claim) => claim.id === "claim.page-fallback")?.sourceIds).toEqual([
+      "source.page",
+    ]);
+  });
+
   it("preserves source page bytes while rebuilding derived artifacts", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -70,6 +70,9 @@ const COMPILE_PAGE_GROUPS: Array<{ kind: WikiPageKind; dir: string; heading: str
 const READ_PAGE_SUMMARIES_CONCURRENCY = 16;
 const MAX_RELATED_PAGES_PER_SECTION = 12;
 const MAX_SHARED_SOURCE_FANOUT = 24;
+// Page summaries are immutable within a scan. Cache derived claim provenance so
+// quadratic related-link traversal does not rebuild the same arrays per pair.
+const pageSourceIdsCache = new WeakMap<WikiPageSummary, string[]>();
 
 type DashboardPageDefinition = {
   id: string;
@@ -1134,10 +1137,16 @@ function resolveClaimEvidenceSourceIds(claim: WikiClaim): string[] {
 }
 
 function resolvePageSourceIds(page: WikiPageSummary): string[] {
-  return uniqueStrings([
+  const cached = pageSourceIdsCache.get(page);
+  if (cached) {
+    return cached;
+  }
+  const sourceIds = uniqueStrings([
     ...page.sourceIds,
     ...page.claims.flatMap((claim) => resolveClaimEvidenceSourceIds(claim)),
   ]);
+  pageSourceIdsCache.set(page, sourceIds);
+  return sourceIds;
 }
 
 function resolveClaimSourceIds(page: WikiPageSummary, claim: WikiClaim): string[] {

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -1124,6 +1124,13 @@ function sortClaims(page: WikiPageSummary): WikiClaim[] {
   });
 }
 
+function resolveClaimSourceIds(page: WikiPageSummary, claim: WikiClaim): string[] {
+  const evidenceSourceIds = uniqueStrings(
+    claim.evidence.flatMap((entry) => entry.sourceId?.trim() || []),
+  );
+  return evidenceSourceIds.length > 0 ? evidenceSourceIds : page.sourceIds;
+}
+
 function buildCompiledCacheSnapshot(
   pagesInput: WikiPageSummary[],
 ): MemoryWikiCompiledCacheSnapshot {
@@ -1189,7 +1196,7 @@ function buildCompiledCacheSnapshot(
           text: claim.text,
           status: normalizeClaimStatus(claim.status),
           confidence: claim.confidence,
-          sourceIds: page.sourceIds,
+          sourceIds: resolveClaimSourceIds(page, claim),
           evidenceKinds: uniqueStrings(claim.evidence.flatMap((entry) => entry.kind ?? [])),
           privacyTiers: [
             ...new Set(

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -743,13 +743,13 @@ function sharedSourceFanout(
   page: WikiPageSummary,
   allPages: WikiPageSummary[],
 ): Map<string, number> {
-  const sourceIds = new Set(page.sourceIds);
+  const sourceIds = new Set(resolvePageSourceIds(page));
   const counts = new Map<string, number>();
   for (const candidate of allPages) {
     if (candidate.relativePath === page.relativePath) {
       continue;
     }
-    for (const sourceId of candidate.sourceIds) {
+    for (const sourceId of resolvePageSourceIds(candidate)) {
       if (!sourceIds.has(sourceId)) {
         continue;
       }
@@ -765,6 +765,7 @@ function buildRelatedBlockBody(params: {
   allPages: WikiPageSummary[];
 }): string {
   const candidatePages = params.allPages.filter((candidate) => candidate.kind !== "report");
+  const pageSourceIds = resolvePageSourceIds(params.page);
   const sourceFanout = sharedSourceFanout(params.page, candidatePages);
   const pagesById = new Map(
     candidatePages.flatMap((candidate) =>
@@ -772,7 +773,7 @@ function buildRelatedBlockBody(params: {
     ),
   );
   const sourcePages = uniquePages(
-    params.page.sourceIds.flatMap((sourceId) => {
+    pageSourceIds.flatMap((sourceId) => {
       const page = pagesById.get(sourceId);
       return page ? [page] : [];
     }),
@@ -783,7 +784,10 @@ function buildRelatedBlockBody(params: {
       if (candidate.relativePath === params.page.relativePath) {
         return false;
       }
-      if (candidate.sourceIds.includes(params.page.id ?? "")) {
+      if (sourcePages.some((sourcePage) => sourcePage.relativePath === candidate.relativePath)) {
+        return false;
+      }
+      if (resolvePageSourceIds(candidate).includes(params.page.id ?? "")) {
         return true;
       }
       return candidate.linkTargets.some((target) =>
@@ -806,12 +810,13 @@ function buildRelatedBlockBody(params: {
       if (backlinkPages.some((backlink) => backlink.relativePath === candidate.relativePath)) {
         return false;
       }
-      if (params.page.sourceIds.length === 0 || candidate.sourceIds.length === 0) {
+      const candidateSourceIds = resolvePageSourceIds(candidate);
+      if (pageSourceIds.length === 0 || candidateSourceIds.length === 0) {
         return false;
       }
-      return params.page.sourceIds.some(
+      return pageSourceIds.some(
         (sourceId) =>
-          candidate.sourceIds.includes(sourceId) &&
+          candidateSourceIds.includes(sourceId) &&
           (sourceFanout.get(sourceId) ?? 0) <= MAX_SHARED_SOURCE_FANOUT,
       );
     }),
@@ -1124,10 +1129,19 @@ function sortClaims(page: WikiPageSummary): WikiClaim[] {
   });
 }
 
+function resolveClaimEvidenceSourceIds(claim: WikiClaim): string[] {
+  return uniqueStrings(claim.evidence.flatMap((entry) => entry.sourceId?.trim() || []));
+}
+
+function resolvePageSourceIds(page: WikiPageSummary): string[] {
+  return uniqueStrings([
+    ...page.sourceIds,
+    ...page.claims.flatMap((claim) => resolveClaimEvidenceSourceIds(claim)),
+  ]);
+}
+
 function resolveClaimSourceIds(page: WikiPageSummary, claim: WikiClaim): string[] {
-  const evidenceSourceIds = uniqueStrings(
-    claim.evidence.flatMap((entry) => entry.sourceId?.trim() || []),
-  );
+  const evidenceSourceIds = resolveClaimEvidenceSourceIds(claim);
   return evidenceSourceIds.length > 0 ? evidenceSourceIds : page.sourceIds;
 }
 


### PR DESCRIPTION
## Summary

- derive compiled wiki claim `sourceIds` from each claim's evidence
- retain page-level source IDs only when a claim has no source-backed evidence
- deduplicate evidence source IDs while preserving order

## Root cause

The wiki compiler assigned every compiled claim the page's complete `sourceIds` list. On pages that contain claims supported by different sources, the compiled cache therefore attributed every claim to sources that did not support it.

## Impact

Consumers of `.openclaw-wiki/cache/claims.jsonl` now receive claim-specific provenance. Existing pages without source-backed claim evidence retain their page-level provenance as a compatibility fallback.

## Validation

- `corepack pnpm exec vitest run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-wiki/src/compile.test.ts -t 'uses claim evidence source IDs' --maxWorkers=1 --reporter=dot --silent`
- `corepack pnpm exec oxfmt --check extensions/memory-wiki/src/compile.ts extensions/memory-wiki/src/compile.test.ts`
- `git diff --check`
