### PR TITLE
fix(cli): approval listings no longer execute stored terminal escapes

### DIFF
--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -3,6 +3,7 @@
 import { splitAnsiSegments } from "./ansi-sequences.js";
 import { splitGraphemes, truncateToVisibleWidth, visibleWidth } from "./ansi.js";
 import { displayString } from "./display-string.js";
+import { sanitizeTerminalText } from "./safe-text.js";
 
 type Align = "left" | "right" | "center";
 
@@ -536,6 +537,22 @@ function normalizeWidth(n: number | undefined): number | undefined {
 
 export function getTerminalTableWidth(minWidth = 60, fallbackWidth = 120): number {
   return Math.max(minWidth, process.stdout.columns ?? fallbackWidth);
+}
+
+/** Render untrusted single-line values without changing renderTable's trusted ANSI contract. */
+export function renderTerminalSafeTable(opts: RenderTableOptions): string {
+  return renderTable({
+    ...opts,
+    columns: opts.columns.map((column) => ({
+      ...column,
+      header: sanitizeTerminalText(column.header),
+    })),
+    rows: opts.rows.map((row) =>
+      Object.fromEntries(
+        Object.entries(row).map(([key, value]) => [key, sanitizeTerminalText(value)]),
+      ),
+    ),
+  });
 }
 
 export function renderTable(opts: RenderTableOptions): string {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -317,6 +317,29 @@ describe("exec approvals CLI", () => {
     expect(output).not.toContain("Exists");
   });
 
+  it("sanitizes stored allowlist patterns in human output without changing JSON", async () => {
+    const pattern = "/tmp/safe\u001b[31mred\u001b[0m\u001b]0;pwned\u0007\nnext\trow\rback\bspace🦞";
+    localSnapshot.file = {
+      version: 1,
+      agents: { "*": { allowlist: [{ pattern }] } },
+    };
+
+    await runApprovalsCommand(["approvals", "get"]);
+
+    const output = defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
+    expect(output).not.toMatch(/[\u0007\u0008\u001b\u007f-\u009f]/u);
+    expect(output).toContain("safered\\nnext\\trow\\rbackspace🦞");
+
+    defaultRuntime.writeJson.mockClear();
+    await runApprovalsCommand(["approvals", "get", "--json"]);
+
+    const file = requireRecord(writtenJson().file, "JSON approvals file");
+    const agents = requireRecord(file.agents, "JSON approvals agents");
+    const wildcard = requireRecord(agents["*"], "JSON wildcard agent");
+    const allowlist = requireArray(wildcard.allowlist, "JSON wildcard allowlist");
+    expect(requireRecord(allowlist[0], "JSON allowlist entry").pattern).toBe(pattern);
+  });
+
   it("adds effective policy to json output", async () => {
     localSnapshot.file = {
       version: 1,

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -327,7 +327,16 @@ describe("exec approvals CLI", () => {
     await runApprovalsCommand(["approvals", "get"]);
 
     const output = defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
-    expect(output).not.toMatch(/[\u0007\u0008\u001b\u007f-\u009f]/u);
+    const hasUnsafeControl = Array.from(output).some((char) => {
+      const codePoint = char.codePointAt(0) ?? -1;
+      return (
+        codePoint === 0x07 ||
+        codePoint === 0x08 ||
+        codePoint === 0x1b ||
+        (codePoint >= 0x7f && codePoint <= 0x9f)
+      );
+    });
+    expect(hasUnsafeControl).toBe(false);
     expect(output).toContain("safered\\nnext\\trow\\rbackspace🦞");
 
     defaultRuntime.writeJson.mockClear();

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -17,7 +17,10 @@ import {
 } from "../../packages/gateway-protocol/src/index.js";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
-import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
+import {
+  getTerminalTableWidth,
+  renderTerminalSafeTable,
+} from "../../packages/terminal-core/src/table.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
@@ -534,7 +537,7 @@ function renderPendingApprovals(entries: PendingApprovalCliEntry[]): void {
   const now = Date.now();
   defaultRuntime.log(`${theme.heading("Pending approvals")} ${theme.muted(`(${entries.length})`)}`);
   defaultRuntime.log(
-    renderTable({
+    renderTerminalSafeTable({
       width: getTerminalTableWidth(),
       columns: [
         { key: "ID", header: "ID", minWidth: 16, flex: true },
@@ -827,7 +830,7 @@ function renderEffectivePolicy(params: { report: EffectivePolicyReport }) {
     Notes: `${summary.security.note}; ${summary.ask.note}`,
   }));
   defaultRuntime.log(
-    renderTable({
+    renderTerminalSafeTable({
       width: getTerminalTableWidth(),
       columns: [
         { key: "Scope", header: "Scope", minWidth: 12 },
@@ -901,7 +904,7 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
 
   defaultRuntime.log(heading("Approvals"));
   defaultRuntime.log(
-    renderTable({
+    renderTerminalSafeTable({
       width: tableWidth,
       columns: [
         { key: "Field", header: "Field", minWidth: 8 },
@@ -920,7 +923,7 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
   defaultRuntime.log("");
   defaultRuntime.log(heading("Allowlist"));
   defaultRuntime.log(
-    renderTable({
+    renderTerminalSafeTable({
       width: tableWidth,
       columns: [
         { key: "Target", header: "Target", minWidth: 10 },
@@ -951,7 +954,7 @@ function renderNativeApprovalsSnapshot(snapshot: NativeExecApprovalsSnapshot, ta
   ];
   defaultRuntime.log(heading("Approvals"));
   defaultRuntime.log(
-    renderTable({
+    renderTerminalSafeTable({
       width: getTerminalTableWidth(),
       columns: [
         { key: "Field", header: "Field", minWidth: 8 },
@@ -968,7 +971,7 @@ function renderNativeApprovalsSnapshot(snapshot: NativeExecApprovalsSnapshot, ta
   defaultRuntime.log("");
   defaultRuntime.log(heading("Rules"));
   defaultRuntime.log(
-    renderTable({
+    renderTerminalSafeTable({
       width: getTerminalTableWidth(),
       columns: [
         { key: "Pattern", header: "Pattern", minWidth: 20, flex: true },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators inspecting stored exec approval policies could execute terminal control sequences when an allowlist pattern, agent key, path, or native-rule field contained ANSI or C0/C1 control characters.

The supported `approvals allowlist add` path accepted these values and both its confirmation output and `approvals get` rendered them through the trusted-ANSI table primitive. JSON output correctly preserved and escaped the stored values.

## Why This Change Was Made

Adds an explicit terminal-safe table entry point that sanitizes every header and cell before delegating to the existing layout engine. All approval tables now use that boundary, while the low-level table renderer keeps its deliberate trusted styling, hyperlink, and multiline contract.

## User Impact

Approval listings now display hostile newlines, tabs, and carriage returns as visible escapes, remove terminal escape/control sequences, and preserve printable Unicode such as 🦞. Machine-readable JSON remains exact.

## Evidence

- Supported scratch-profile reproduction before the fix: 3 ESC bytes, 1 BEL, 1 backspace, and 1 tab reached human output; the embedded newline expanded the row.
- Same reproduction after the fix: 0 ESC, BEL, backspace, carriage-return, or tab bytes; `\n`, `\t`, and `\r` remained visible; 🦞 remained intact.
- Regression test first failed on the raw-control assertion, then passed after routing approval tables through the safe renderer. JSON exactness is asserted in the same test.
- Focused Vitest: 89 tests passed across the terminal table and both exec-approvals suites.
- Exact-scope `node scripts/check-changed.mjs`: passed formatting, typechecks, lint, dead-code, dependency, database, import-cycle, and architecture guards on the rebased head.
- Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +27/-7 (net +20) for the explicit reusable terminal-safety boundary and six approval-table call sites. Tests: +32/-0.
