### PR TITLE
fix(backup): fail before publishing unrestorable archives

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -523,7 +523,6 @@ src/commands/agent-via-gateway.ts
 src/commands/agent.test.ts
 src/commands/auth-choice.test.ts
 src/commands/backup-verify.test.ts
-src/commands/backup-verify.ts
 src/commands/channels.add.test.ts
 src/commands/configure.wizard.ts
 src/commands/daemon-install-helpers.test.ts

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -1,4 +1,4 @@
-// Verifies backup archives by validating their manifest, payload entries, and hardlink targets.
+// Verifies backup archives, including payload paths and hardlink/symbolic-link targets.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +7,12 @@ import { toStringifiedError } from "@openclaw/normalization-core/error-coercion"
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import * as tar from "tar";
 import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
+import {
+  assertArchiveSymbolicLinkTarget,
+  isArchivePathWithin,
+  normalizeArchivePath,
+  normalizeArchiveRoot,
+} from "../infra/backup-archive-path-policy.js";
 import { isTransientSqliteBackupPath } from "../infra/backup-volatile-filter.js";
 import { formatDiskSpaceBytes, tryReadDiskSpace } from "../infra/disk-space.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
@@ -15,7 +21,6 @@ import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { isRecord, resolveUserPath } from "../utils.js";
 import { BACKUP_MAX_DECOMPRESSION_RATIO, buildBackupArchivePath } from "./backup-shared.js";
 
-const WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
 const MAX_SQLITE_SNAPSHOT_EXTRACT_BYTES = 64 * 1024 * 1024 * 1024;
 const SQLITE_SNAPSHOT_FREE_SPACE_RESERVE_BYTES = 256 * 1024 * 1024;
@@ -87,45 +92,6 @@ type SqliteSnapshotEntry = NormalizedArchiveEntry & {
 };
 
 type ExpectedSqliteRole = "agent" | "global";
-
-function stripTrailingSlashes(value: string): string {
-  return value.replace(/\/+$/u, "");
-}
-
-function normalizeArchivePath(entryPath: string, label: string): string {
-  const trimmed = stripTrailingSlashes(entryPath.trim());
-  if (!trimmed) {
-    throw new Error(`${label} is empty.`);
-  }
-  if (trimmed.startsWith("/") || WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE.test(trimmed)) {
-    throw new Error(`${label} must be relative: ${entryPath}`);
-  }
-  if (trimmed.includes("\\")) {
-    throw new Error(`${label} must use forward slashes: ${entryPath}`);
-  }
-  if (trimmed.split("/").some((segment) => segment === "." || segment === "..")) {
-    throw new Error(`${label} contains path traversal segments: ${entryPath}`);
-  }
-
-  const normalized = stripTrailingSlashes(path.posix.normalize(trimmed));
-  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
-    throw new Error(`${label} resolves outside the archive root: ${entryPath}`);
-  }
-  return normalized;
-}
-
-function normalizeArchiveRoot(rootName: string): string {
-  const normalized = normalizeArchivePath(rootName, "Backup manifest archiveRoot");
-  if (normalized.includes("/")) {
-    throw new Error(`Backup manifest archiveRoot must be a single path segment: ${rootName}`);
-  }
-  return normalized;
-}
-
-function isArchivePathWithin(child: string, parent: string): boolean {
-  const relative = path.posix.relative(parent, child);
-  return relative === "" || (!relative.startsWith("../") && relative !== "..");
-}
 
 function parseManifest(raw: string): BackupManifest {
   let parsed: unknown;
@@ -307,34 +273,6 @@ function verifyHardlinkTargetsAgainstArchiveRoot(
     if (!entries.has(normalizedTarget)) {
       throw new Error(
         `Archive hardlink target is missing from archive entries: ${target.entryPath} -> ${normalizedTarget}`,
-      );
-    }
-  }
-}
-
-function verifySymbolicLinkTargetsAgainstArchiveRoot(
-  symbolicLinks: Array<{ entryPath: string; linkpath: string }>,
-  archiveRoot: string,
-): void {
-  const normalizedRoot = normalizeArchiveRoot(archiveRoot);
-  for (const link of symbolicLinks) {
-    if (link.linkpath.startsWith("/") || WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE.test(link.linkpath)) {
-      throw new Error(
-        `Archive symbolic link target must be relative: ${link.entryPath} -> ${link.linkpath}`,
-      );
-    }
-    if (link.linkpath.includes("\\")) {
-      throw new Error(
-        `Archive symbolic link target must use forward slashes: ${link.entryPath} -> ${link.linkpath}`,
-      );
-    }
-    const entryPath = normalizeArchivePath(link.entryPath, "Archive symbolic link path");
-    const targetPath = path.posix.normalize(
-      path.posix.join(path.posix.dirname(entryPath), link.linkpath),
-    );
-    if (!isArchivePathWithin(targetPath, normalizedRoot)) {
-      throw new Error(
-        `Archive symbolic link target is outside the declared archive root: ${link.entryPath} -> ${link.linkpath}`,
       );
     }
   }
@@ -764,12 +702,7 @@ export async function verifyBackupArchive(archive: string): Promise<BackupVerify
     }));
   const symbolicLinks = rawEntries
     .filter((entry) => entry.type === "SymbolicLink")
-    .map((entry) => {
-      if (!entry.linkpath) {
-        throw new Error(`Archive symbolic link is missing its target: ${entry.path}`);
-      }
-      return { entryPath: entry.path, linkpath: entry.linkpath };
-    });
+    .map((entry) => ({ entryPath: entry.path, linkpath: entry.linkpath }));
   const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
 
   const manifestMatches = entries.filter((entry) => isRootManifestEntry(entry.normalized));
@@ -799,7 +732,9 @@ export async function verifyBackupArchive(archive: string): Promise<BackupVerify
     manifest.archiveRoot,
     normalizedEntrySet,
   );
-  verifySymbolicLinkTargetsAgainstArchiveRoot(symbolicLinks, manifest.archiveRoot);
+  for (const link of symbolicLinks) {
+    assertArchiveSymbolicLinkTarget({ ...link, archiveRoot: manifest.archiveRoot });
+  }
   await verifySqliteSnapshots({ archivePath, entries, manifest });
 
   const result: BackupVerifyResult = {
@@ -834,4 +769,3 @@ export async function backupVerifyCommand(
 export const testApi = {
   assertSqliteExtractionBudget,
 };
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/infra/backup-archive-path-policy.ts
+++ b/src/infra/backup-archive-path-policy.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { isWindowsDrivePath } from "./archive-path.js";
+
+// Creation and verification must agree on which archive paths can be restored.
+function assertPortableRelativePathSyntax(
+  value: string,
+  label: string,
+  reportedValue = value,
+): void {
+  if (value.startsWith("/") || isWindowsDrivePath(value)) {
+    throw new Error(`${label} must be relative: ${reportedValue}`);
+  }
+  if (value.includes("\\")) {
+    throw new Error(`${label} must use forward slashes: ${reportedValue}`);
+  }
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/u, "");
+}
+
+export function normalizeArchivePath(entryPath: string, label: string): string {
+  const trimmed = stripTrailingSlashes(entryPath.trim());
+  if (!trimmed) {
+    throw new Error(`${label} is empty.`);
+  }
+  assertPortableRelativePathSyntax(trimmed, label, entryPath);
+  if (trimmed.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new Error(`${label} contains path traversal segments: ${entryPath}`);
+  }
+
+  const normalized = stripTrailingSlashes(path.posix.normalize(trimmed));
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(`${label} resolves outside the archive root: ${entryPath}`);
+  }
+  return normalized;
+}
+
+export function normalizeArchiveRoot(rootName: string): string {
+  const normalized = normalizeArchivePath(rootName, "Backup manifest archiveRoot");
+  if (normalized.includes("/")) {
+    throw new Error(`Backup manifest archiveRoot must be a single path segment: ${rootName}`);
+  }
+  return normalized;
+}
+
+export function isArchivePathWithin(child: string, parent: string): boolean {
+  const relative = path.posix.relative(parent, child);
+  return relative === "" || (!relative.startsWith("../") && relative !== "..");
+}
+
+export function assertArchiveSymbolicLinkTarget(params: {
+  archiveRoot: string;
+  entryPath: string;
+  linkpath?: string;
+}): void {
+  if (!params.linkpath) {
+    throw new Error(`Archive symbolic link is missing its target: ${params.entryPath}`);
+  }
+  assertPortableRelativePathSyntax(
+    params.linkpath,
+    "Archive symbolic link target",
+    `${params.entryPath} -> ${params.linkpath}`,
+  );
+  const entryPath = normalizeArchivePath(params.entryPath, "Archive symbolic link path");
+  const targetPath = path.posix.normalize(
+    path.posix.join(path.posix.dirname(entryPath), params.linkpath),
+  );
+  if (!isArchivePathWithin(targetPath, normalizeArchiveRoot(params.archiveRoot))) {
+    throw new Error(
+      `Archive symbolic link target is outside the declared archive root: ${params.entryPath} -> ${params.linkpath}`,
+    );
+  }
+}

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -2199,6 +2199,35 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("rejects absolute symlink targets before publishing the archive", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-absolute-symlink-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputPath = state.path("absolute-symlink.tar.gz");
+        const outsideTarget = state.path("outside-target.txt");
+        await fs.writeFile(outsideTarget, "outside\n", "utf8");
+        await fs.symlink(outsideTarget, state.statePath("ordinary-link"));
+
+        await expect(
+          createBackupArchive({
+            output: outputPath,
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 4, 9, 8, 33, 0),
+          }),
+        ).rejects.toThrow(/Archive symbolic link target must be relative/iu);
+        await expect(fs.access(outputPath)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    );
+  });
+
   it("preserves noncanonical symlinked SQLite paths without dereferencing them", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -25,6 +25,7 @@ import {
 } from "../state/openclaw-state-snapshot-sanitizer.js";
 import { resolveHomeDir, resolveUserPath, shortenHomePath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
+import { assertArchiveSymbolicLinkTarget } from "./backup-archive-path-policy.js";
 import {
   cleanupBackupArchivePublication,
   createBackupArchivePublication,
@@ -855,9 +856,10 @@ export async function createBackupArchive(
     const volatilePlan = { stateDirs: [stateAsset?.sourcePath ?? plan.stateDir] };
     let skippedVolatileCount = 0;
     let skippedPluginSkills = false;
-    // node-tar invokes filters from async stat callbacks, so throwing inside
-    // the filter is uncaught. Omit unexpected SQLite and reject after tar settles.
+    // node-tar invokes filter/onWriteEntry from async filesystem callbacks, so
+    // collect violations there and reject only after tar settles.
     const unexpectedSqliteSourcePaths: string[] = [];
+    let archiveSymlinkViolation: Error | undefined;
     const tarFilter = (
       entryPath: string,
       entryStat: import("node:fs").Stats | import("tar").ReadEntry,
@@ -921,6 +923,7 @@ export async function createBackupArchive(
         skippedVolatileCount = 0;
         skippedPluginSkills = false;
         unexpectedSqliteSourcePaths.length = 0;
+        archiveSymlinkViolation = undefined;
         const prepared = await writeArchiveStreamToFile({
           archivePath: attemptTempArchivePath,
           createArchiveStream: (reportProgress) =>
@@ -943,12 +946,25 @@ export async function createBackupArchive(
                       reportProgress({ phase: "raw", entryPath: sourceEntryPath, bytes });
                     });
                   }
-                  entry.path = remapArchiveEntryPath({
+                  const archiveEntryPath = remapArchiveEntryPath({
                     entryPath: entry.path,
                     manifestPath,
                     archiveRoot,
                     sourcePathRemaps,
                   });
+                  if (entry.type === "SymbolicLink" && !archiveSymlinkViolation) {
+                    try {
+                      assertArchiveSymbolicLinkTarget({
+                        archiveRoot,
+                        entryPath: archiveEntryPath,
+                        linkpath: entry.linkpath,
+                      });
+                    } catch (error) {
+                      archiveSymlinkViolation =
+                        error instanceof Error ? error : new Error(String(error));
+                    }
+                  }
+                  entry.path = archiveEntryPath;
                 },
               },
               [
@@ -963,13 +979,16 @@ export async function createBackupArchive(
           },
         });
         const unexpectedSqliteSourcePath = unexpectedSqliteSourcePaths[0];
-        if (unexpectedSqliteSourcePath) {
+        const archiveValidationError = unexpectedSqliteSourcePath
+          ? new Error(
+              `SQLite state appeared after snapshot discovery: ${unexpectedSqliteSourcePath}. Retry backup so it can be snapshotted.`,
+            )
+          : archiveSymlinkViolation;
+        if (archiveValidationError) {
           if (!removePreparedBackupArchive(prepared)) {
             publication.pendingCleanupArchives.push(prepared);
           }
-          throw new Error(
-            `SQLite state appeared after snapshot discovery: ${unexpectedSqliteSourcePath}. Retry backup so it can be snapshotted.`,
-          );
+          throw archiveValidationError;
         }
         return prepared;
       },


### PR DESCRIPTION
Related: #123504

AI-assisted: Yes. The implementation and validation were completed with Codex assistance and reviewed by the maintainer.

## What Problem This Solves

Fixes an issue where users backing up state or workspaces containing ordinary absolute or archive-escaping symbolic links could receive a successful backup result even though later `backup verify` and mandatory restore verification rejected the archive.

## Why This Change Was Made

One shared archive path and symbolic-link policy now owns both creation and verification. Creation records callback violations and aborts atomic publication after tar settles, while preserving safe relative links and the regenerable plugin-skills skip.

## User Impact

Unsupported symbolic links now fail visibly during backup creation and leave no final archive behind. Supported relative links still round-trip and pass archive verification.

## Evidence

- Pre-fix focused regression: `src/infra/backup-create.test.ts` resolved successfully and published an archive instead of rejecting an absolute symbolic-link target.
- Post-fix focused proof: 2 passed, 71 skipped, covering rejection before publication and preservation of a safe relative in-root link.
- Verifier and restore sibling proof: 35 passed, 1 skipped.
- Isolated black-box CLI proof: an absolute link exited 1 with `Archive symbolic link target must be relative` and left no final archive; a relative in-root link created successfully and reported `Archive verification: passed`.
- Full changed gate passed for `core`, `coreTests`, and `tooling`, including core/test typechecks, full core lint, scripts lint, import cycles, and guards. A second Testbox attempt remained queued for 15 minutes and never started, so the trusted-source local fallback supplied the successful full changed-gate result.
- Final Codex autoreview was clean with no accepted or actionable findings (overall correct 0.94).
- LOC: production +111/-84 (net +27); tests +29/-0; tooling baseline +0/-1. The production increase is the producer-side violation capture and atomic-abort path; verifier policy moved into the shared owner rather than being duplicated.
