### PR TITLE
feat(runners): expire dormant device leases

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -449,7 +449,12 @@ If the device is offline before a turn is dispatched, the Gateway waits up to
 10 seconds and then returns a visible retry/reconnect error while keeping the
 session placement available for a later attempt. Gateway restart likewise
 preserves an idle device placement and reconnects its tunnel lazily on the next
-turn.
+turn. A paired node remains dormant for 14 days after its exact recorded
+disconnect; at that boundary its old worker environment is treated as gone and
+the session placement reconciles normally. Pairing itself remains, so a later
+reconnect can provision a fresh environment. Legacy pairings without exact node
+disconnect history are retained fail-safe rather than expired from unrelated
+device activity.
 
 See [Anthropic: Claude sessions across computers](/providers/anthropic#claude-sessions-across-computers)
 for the Control UI behavior and storage sources.

--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -181,8 +181,9 @@ stated honestly (revision 1 undersold this):
   runner identity = host + workdir + repo).
 - **Persistent-machine lifecycle.** `destroy` = logical lease release.
   Provider `inspect` is tri-state against pairing + presence: _present_,
-  _dormant_ (paired but offline, within a dormancy ceiling — must NOT be
-  driven to `orphaned` by the reconcile sweep), _gone_ (unpaired or ceiling
+  _dormant_ (paired but offline, within the config-free 14-day dormancy
+  ceiling — must NOT be driven to `orphaned` by the reconcile sweep), _gone_
+  (unpaired or ceiling
   elapsed → normal orphan/reap path). A device-environment reaper keyed on
   unpair/dormancy — not on provider teardown proof — cleans rows,
   credentials, and staged refs. Unreferenced terminal environment rows retain

--- a/src/gateway/worker-environments/device-provider.test.ts
+++ b/src/gateway/worker-environments/device-provider.test.ts
@@ -10,13 +10,17 @@ import type { NodeWorkerSupervisorNodeProof } from "../node-registry-private.js"
 import { createDeviceWorkerRuntime } from "./device-provider.js";
 
 const DEVICE_ID = "device-session-host";
+const DAY_MS = 24 * 60 * 60 * 1_000;
 const WORKER_BUILD = {
   bundleHash: "a".repeat(64),
   openclawVersion: "2026.8.12",
   protocolFeatures: ["worker-heartbeat-v1"],
 };
 
-function pairedDevice(deviceId = DEVICE_ID): PairedDevice {
+function pairedDevice(
+  deviceId = DEVICE_ID,
+  nodeSurface?: PairedDevice["nodeSurface"],
+): PairedDevice {
   return {
     deviceId,
     publicKey: `public-key-${deviceId}`,
@@ -30,6 +34,7 @@ function pairedDevice(deviceId = DEVICE_ID): PairedDevice {
         createdAtMs: 1,
       },
     },
+    ...(nodeSurface ? { nodeSurface } : {}),
     createdAtMs: 1,
     approvedAtMs: 1,
   };
@@ -55,8 +60,12 @@ function connectedNode(
 function deviceRuntime(params: {
   getPairedDevice: (deviceId: string) => Promise<PairedDevice | null>;
   listCurrentNodes?: () => Promise<readonly NodeWorkerSupervisorNodeProof[]>;
+  now?: () => number;
 }) {
-  const runtime = createDeviceWorkerRuntime({ getPairedDevice: params.getPairedDevice });
+  const runtime = createDeviceWorkerRuntime({
+    getPairedDevice: params.getPairedDevice,
+    ...(params.now ? { now: params.now } : {}),
+  });
   if (params.listCurrentNodes) {
     runtime.bindNodeTransport({
       listCurrentNodes: params.listCurrentNodes,
@@ -110,16 +119,62 @@ describe("device worker provider", () => {
     );
   });
 
+  it.each([
+    {
+      name: "inside the dormancy ceiling",
+      disconnectedAtMs: 6 * DAY_MS + 1,
+      expected: { status: "dormant" },
+    },
+    {
+      name: "at the dormancy ceiling",
+      disconnectedAtMs: 6 * DAY_MS,
+      expected: { status: "unknown" },
+    },
+    {
+      name: "past the dormancy ceiling",
+      disconnectedAtMs: DAY_MS,
+      expected: { status: "unknown" },
+    },
+    {
+      name: "without exact legacy disconnect history",
+      disconnectedAtMs: undefined,
+      expected: { status: "dormant" },
+    },
+  ])("reports an offline paired node as $name", async ({ disconnectedAtMs, expected }) => {
+    const nowMs = 20 * DAY_MS;
+    const device = pairedDevice(DEVICE_ID, {
+      createdAtMs: 1,
+      approvedAtMs: 1,
+      lastConnectedAtMs: DAY_MS,
+      ...(disconnectedAtMs === undefined ? {} : { lastDisconnectedAtMs: disconnectedAtMs }),
+    });
+    // General device activity must not extend node-worker dormancy.
+    device.lastSeenAtMs = nowMs;
+    const provider = deviceRuntime({
+      getPairedDevice: async () => device,
+      listCurrentNodes: async () => [],
+      now: () => nowMs,
+    }).provider;
+
+    await expect(
+      provider.inspect({ leaseId: "device-lease", profile: { device: DEVICE_ID } }),
+    ).resolves.toEqual(expected);
+  });
+
   it("reports active, dormant, and unknown from pairing plus live presence", async () => {
     let paired: PairedDevice | null = pairedDevice();
     let connected = true;
+    let available = true;
     const runtime = deviceRuntime({
       getPairedDevice: async () => paired,
-      listCurrentNodes: async () => (connected ? [connectedNode()] : []),
+      listCurrentNodes: async () =>
+        connected ? [connectedNode(DEVICE_ID, available ? WORKER_BUILD : null)] : [],
     });
     const provider = runtime.provider;
     const lease = { leaseId: "device-lease", profile: { device: DEVICE_ID } };
 
+    await expect(provider.inspect(lease)).resolves.toEqual({ status: "active", sharedHost: true });
+    available = false;
     await expect(provider.inspect(lease)).resolves.toEqual({ status: "active", sharedHost: true });
     connected = false;
     await expect(provider.inspect(lease)).resolves.toEqual({ status: "dormant" });

--- a/src/gateway/worker-environments/device-provider.ts
+++ b/src/gateway/worker-environments/device-provider.ts
@@ -13,9 +13,11 @@ import type {
 import { createNodeWorkerLaunchAdapter } from "./node-launch-adapter.js";
 
 export const DEVICE_WORKER_PROVIDER_ID = "device";
+const DEVICE_WORKER_DORMANCY_MS = 14 * 24 * 60 * 60 * 1_000;
 
 type DeviceWorkerRuntimeOptions = {
   getPairedDevice: (deviceId: string) => Promise<PairedDevice | null>;
+  now?: () => number;
 };
 
 type DeviceWorkerAvailability = (deviceId: string) => Promise<boolean>;
@@ -52,6 +54,13 @@ function hasPairedNodeRole(device: PairedDevice | null): device is PairedDevice 
   return Boolean(device && hasEffectivePairedDeviceRole(device, "node"));
 }
 
+function isWithinDeviceDormancy(device: PairedDevice, nowMs: number): boolean {
+  const disconnectedAtMs = device.nodeSurface?.lastDisconnectedAtMs;
+  // Legacy or crash-interrupted records have no exact disconnect boundary. Keep
+  // them fail-safe dormant until a later connection lifecycle records one.
+  return disconnectedAtMs === undefined || nowMs - disconnectedAtMs < DEVICE_WORKER_DORMANCY_MS;
+}
+
 function deviceLeaseId(deviceId: string, operationId: string): string {
   const deviceHash = createHash("sha256").update(deviceId).digest("hex");
   const operationHash = createHash("sha256").update(operationId).digest("hex");
@@ -60,16 +69,19 @@ function deviceLeaseId(deviceId: string, operationId: string): string {
 
 /** Core runtime for already-paired node hosts; pairing remains the durable trust owner. */
 export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
+  const now = options.now ?? Date.now;
   let nodeTransport: NodeWorkerSupervisorTransport | undefined;
   const launchAdapter = createNodeWorkerLaunchAdapter({ getTransport: () => nodeTransport });
   const findConnectedNode = async (deviceId: string) =>
-    (await nodeTransport?.listCurrentNodes())?.find(
-      (node) => node.nodeId === deviceId && isSessionCapableNode(node),
-    );
+    (await nodeTransport?.listCurrentNodes())?.find((node) => node.nodeId === deviceId);
+  const findAvailableNode = async (deviceId: string) => {
+    const node = await findConnectedNode(deviceId);
+    return node && isSessionCapableNode(node) ? node : undefined;
+  };
   const isAvailable = async (deviceId: string) => {
     const [paired, connected] = await Promise.all([
       options.getPairedDevice(deviceId),
-      findConnectedNode(deviceId),
+      findAvailableNode(deviceId),
     ]);
     return hasPairedNodeRole(paired) && Boolean(connected);
   };
@@ -96,7 +108,10 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
         return { status: "unknown" };
       }
       const connected = await findConnectedNode(deviceId);
-      return connected ? { status: "active", sharedHost: true } : { status: "dormant" };
+      if (connected) {
+        return { status: "active", sharedHost: true };
+      }
+      return isWithinDeviceDormancy(paired, now()) ? { status: "dormant" } : { status: "unknown" };
     },
     destroy: async () => {},
   };
@@ -109,7 +124,7 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
     // Provisioning reads the node-advertised local-install build through the
     // runtime so node lookups keep one owner; absent means not connected or
     // not session-capable, and the caller fails provisioning closed.
-    resolveWorkerBuild: async (deviceId: string) => (await findConnectedNode(deviceId))?.workerRuns,
+    resolveWorkerBuild: async (deviceId: string) => (await findAvailableNode(deviceId))?.workerRuns,
     bindNodeTransport: (transport: NodeWorkerSupervisorTransport) => {
       nodeTransport = transport;
     },


### PR DESCRIPTION
Related: #122454

## What Problem This Solves

Paired device worker environments remained dormant forever whenever the node was offline. A machine that never returned could keep an old worker lease and placement eligible indefinitely, while unrelated operator/UI activity on a mixed-role device could not authoritatively describe node presence.

## Why This Change Was Made

Device-provider inspection now applies the approved config-free 14-day dormancy ceiling to the node-specific `lastDisconnectedAtMs` fact. Connected supervisor nodes remain active even while their worker slots are full; only new-launch availability requires a live `workerRuns` build. Offline paired nodes remain dormant for less than 14 days, and become existing authoritative `unknown`/gone status at the boundary so normal environment and placement reconciliation owns cleanup.

Legacy or crash-interrupted pairing records without an exact node disconnect stay dormant fail-safe. General device `lastSeenAtMs` never extends worker dormancy, so mixed-role UI/operator activity cannot keep an absent node lease alive. No config, protocol, migration, or schema change.

## User Impact

An offline paired node keeps its session placement recoverable for 14 days. At that boundary, the old worker environment is reconciled as gone instead of persisting forever. Pairing remains intact, so reconnecting later can provision a fresh environment.

AI-assisted implementation; the presence and legacy compatibility boundaries were reviewed and verified.

## Evidence

- 36 focused assertions pass across dormancy boundaries, full-but-connected nodes, provisioning eligibility, generic provider reconciliation, and device placement restart behavior.
- The complete changed-file gate passes formatting, dead exports, core and core-test typechecks, lint, schema-v7, database-first storage, import cycles, docs, webhook, and pairing guards.
- The remote validation backend was unavailable before execution, so the repository-approved trusted local fallback ran the complete changed gate successfully.
- Fresh branch autoreview is clean with no accepted/actionable findings.
- Production delta: +15 lines for node-specific dormancy classification and connected-versus-available separation. Tests add +55 lines; docs add +6 net lines.
