### PR TITLE
fix(mac): package portable elevation installer

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -71,14 +71,21 @@ notarization credentials, and its archive is not a general-download artifact.
 
 ```bash
 scripts/mac-elevation-host.sh package
-scripts/mac-elevation-host.sh install \
-  --archive "dist/elevation-host/OpenClaw-<full-source-sha>-stable.zip"
-scripts/mac-elevation-host.sh status
+cd dist/elevation-host
+shasum -a 256 -c "OpenClaw-<full-source-sha>-stable.zip.sha256"
+shasum -a 256 -c "OpenClaw-<full-source-sha>-stable-installer.sh.sha256"
+./OpenClaw-<full-source-sha>-stable-installer.sh install \
+  --archive "OpenClaw-<full-source-sha>-stable.zip"
+./OpenClaw-<full-source-sha>-stable-installer.sh status
 ```
 
 The elevation package is ZIP-only, notarized and stapled, contains exactly
 `OpenClaw.app`, omits Apple Events entitlements, records an immutable receipt,
-and verifies a freshly extracted copy. Installation owns the separate
+and verifies a freshly extracted copy. The same source-addressed artifact set
+includes an executable installer copied from that exact Git commit plus separate
+archive and installer checksum files, so a target Mac does not need a source
+checkout. Transfer the complete set and verify both checksums before running the
+installer. Installation owns the separate
 `ai.openclaw.mac.elevation-host` launchd job with `RunAtLoad` and `KeepAlive`.
 It refuses to replace or race the ordinary `ai.openclaw.mac` Launch at login
 job. `recover` restores the recorded prior bundle after a failed cutover;

--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -40,10 +40,16 @@ publish a general-download elevation archive. Install only a certified, source-a
 authorized release operator:
 
 ```bash
-scripts/mac-elevation-host.sh install \
-  --archive "/path/to/OpenClaw-<full-source-sha>-stable.zip"
-scripts/mac-elevation-host.sh status
+cd /path/to/elevation-artifact-set
+shasum -a 256 -c "OpenClaw-<full-source-sha>-stable.zip.sha256"
+shasum -a 256 -c "OpenClaw-<full-source-sha>-stable-installer.sh.sha256"
+./OpenClaw-<full-source-sha>-stable-installer.sh install \
+  --archive "OpenClaw-<full-source-sha>-stable.zip"
+./OpenClaw-<full-source-sha>-stable-installer.sh status
 ```
+
+Transfer the complete artifact set: archive, receipt, portable installer, and both checksum files. The target Mac does
+not need an OpenClaw source checkout. Verify both checksums before running the installer.
 
 `--elevation-host` is implied by the installed job. It keeps the Bridge, control channel, Mac node, Gateway
 connectivity, and termination handling active while disabling automatic windows, updater startup, Dock promotion,
@@ -55,9 +61,9 @@ uses the separate `ai.openclaw.mac.elevation-host` job and refuses to race or re
 (`ai.openclaw.mac`).
 
 The elevation archive is Foundation-signed, notarized, stapled, named by the full OpenClaw source commit, and contains
-exactly `OpenClaw.app`. Its receipt binds the archive digest, OpenClaw and Peekaboo source revisions, signer, CDHash,
-architectures, entitlement digests, and Apple notarization submission ID. No AppleScript or Apple Events entitlement
-is part of this workflow.
+exactly `OpenClaw.app`. Its receipt binds the archive and installer names and digests, OpenClaw and Peekaboo source
+revisions, signer, CDHash, architectures, entitlement digests, and Apple notarization submission ID. No AppleScript or
+Apple Events entitlement is part of this workflow.
 
 ## Client discovery order
 

--- a/scripts/mac-elevation-host.sh
+++ b/scripts/mac-elevation-host.sh
@@ -327,14 +327,16 @@ write_receipt() {
 
 package_host() {
   [[ "$(uname -s)" == 'Darwin' ]] || fail 'elevation packaging requires macOS'
-  local source_commit prefix zip_path receipt_path checksum_path notary_result
+  local source_commit prefix zip_path receipt_path checksum_path installer_path installer_checksum_path notary_result
   source_commit="$(git -C "$ROOT_DIR" rev-parse HEAD)"
   [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]] || fail 'could not resolve exact source commit'
   prefix="OpenClaw-${source_commit}-stable"
   zip_path="$OUTPUT_DIR/${prefix}.zip"
   receipt_path="$OUTPUT_DIR/${prefix}.json"
   checksum_path="$zip_path.sha256"
-  for output in "$zip_path" "$receipt_path" "$checksum_path"; do
+  installer_path="$OUTPUT_DIR/${prefix}-installer.sh"
+  installer_checksum_path="$installer_path.sha256"
+  for output in "$zip_path" "$receipt_path" "$checksum_path" "$installer_path" "$installer_checksum_path"; do
     [[ ! -e "$output" ]] || fail "immutable elevation output already exists: $output"
   done
   mkdir -p "$OUTPUT_DIR"
@@ -364,8 +366,16 @@ package_host() {
   extract_archive "$tmp_zip" extracted
   [[ "$(plist_value "$extracted" OpenClawGitCommit)" == "$source_commit" ]] ||
     fail 'extracted elevation source mismatch'
-  local archive_sha notary_id main_archs helper_archs main_entitlements helper_entitlements
+  local archive_sha installer_sha committed_installer_sha notary_id
+  local main_archs helper_archs main_entitlements helper_entitlements
   archive_sha="$(shasum -a 256 "$tmp_zip" | awk '{print $1}')"
+  local tmp_installer="${installer_path}.tmp.$$"
+  cp "$ROOT_DIR/scripts/mac-elevation-host.sh" "$tmp_installer"
+  chmod 555 "$tmp_installer"
+  installer_sha="$(shasum -a 256 "$tmp_installer" | awk '{print $1}')"
+  committed_installer_sha="$(git -C "$ROOT_DIR" show "${source_commit}:scripts/mac-elevation-host.sh" | shasum -a 256 | awk '{print $1}')"
+  [[ "$installer_sha" == "$committed_installer_sha" ]] ||
+    fail 'portable installer does not match the selected source commit'
   notary_id="$(jq -r '.id // empty' "$notary_result")"
   [[ -n "$notary_id" ]] || fail 'accepted notarization id was not recorded'
   main_archs="$(lipo -archs "$extracted/Contents/MacOS/OpenClaw")"
@@ -373,9 +383,14 @@ package_host() {
   main_entitlements="$(entitlements_for "$extracted/Contents/MacOS/OpenClaw" | shasum -a 256 | awk '{print $1}')"
   helper_entitlements="$(entitlements_for "$extracted/Contents/MacOS/openclaw-mlx-tts" | shasum -a 256 | awk '{print $1}')"
   mv "$tmp_zip" "$zip_path"
+  mv "$tmp_installer" "$installer_path"
   jq -n \
     --arg archive "$(basename "$zip_path")" \
     --arg archiveSha256 "$archive_sha" \
+    --arg archiveChecksum "$(basename "$checksum_path")" \
+    --arg installer "$(basename "$installer_path")" \
+    --arg installerSha256 "$installer_sha" \
+    --arg installerChecksum "$(basename "$installer_checksum_path")" \
     --arg sourceCommit "$source_commit" \
     --arg peekabooCommit "$(plist_value "$extracted" PeekabooSourceCommit)" \
     --arg version "$version" \
@@ -388,13 +403,17 @@ package_host() {
     --arg mainEntitlementsSha256 "$main_entitlements" \
     --arg helperEntitlementsSha256 "$helper_entitlements" \
     --arg notarizationId "$notary_id" \
-    '{archive:$archive,archiveSha256:$archiveSha256,sourceCommit:$sourceCommit,peekabooCommit:$peekabooCommit,version:$version,build:$build,authority:$authority,teamIdentifier:$teamIdentifier,cdhash:$cdhash,architectures:{main:$mainArchitectures,helper:$helperArchitectures},entitlementsSha256:{main:$mainEntitlementsSha256,helper:$helperEntitlementsSha256},notarizationId:$notarizationId}' >"${receipt_path}.tmp.$$"
+    '{archive:$archive,archiveSha256:$archiveSha256,archiveChecksum:$archiveChecksum,installer:$installer,installerSha256:$installerSha256,installerChecksum:$installerChecksum,sourceCommit:$sourceCommit,peekabooCommit:$peekabooCommit,version:$version,build:$build,authority:$authority,teamIdentifier:$teamIdentifier,cdhash:$cdhash,architectures:{main:$mainArchitectures,helper:$helperArchitectures},entitlementsSha256:{main:$mainEntitlementsSha256,helper:$helperEntitlementsSha256},notarizationId:$notarizationId}' >"${receipt_path}.tmp.$$"
   chmod 444 "${receipt_path}.tmp.$$"
   mv "${receipt_path}.tmp.$$" "$receipt_path"
   printf '%s  %s\n' "$archive_sha" "$(basename "$zip_path")" >"${checksum_path}.tmp.$$"
   chmod 444 "${checksum_path}.tmp.$$"
   mv "${checksum_path}.tmp.$$" "$checksum_path"
-  printf 'Elevation archive: %s\nReceipt: %s\nSHA-256: %s\n' "$zip_path" "$receipt_path" "$archive_sha"
+  printf '%s  %s\n' "$installer_sha" "$(basename "$installer_path")" >"${installer_checksum_path}.tmp.$$"
+  chmod 444 "${installer_checksum_path}.tmp.$$"
+  mv "${installer_checksum_path}.tmp.$$" "$installer_checksum_path"
+  printf 'Elevation archive: %s\nInstaller: %s\nReceipt: %s\nArchive SHA-256: %s\nInstaller SHA-256: %s\n' \
+    "$zip_path" "$installer_path" "$receipt_path" "$archive_sha" "$installer_sha"
 }
 
 install_host() {

--- a/test/scripts/mac-elevation-host.test.ts
+++ b/test/scripts/mac-elevation-host.test.ts
@@ -143,16 +143,18 @@ describe("mac elevation host command contract", () => {
     expect(script).not.toContain("osascript");
   });
 
-  it("scopes prerequisites to each lifecycle command", () => {
+  it("runs a copied lifecycle installer without a source checkout", () => {
     const tempRoot = tempDirs.make("openclaw-elevation-uninstall-");
     const binDir = path.join(tempRoot, "bin");
+    const installerPath = path.join(tempRoot, "portable-installer.sh");
     mkdirSync(binDir);
+    writeExecutable(installerPath, readFileSync(scriptPath, "utf8"));
     const launchctl = path.join(binDir, "launchctl");
     writeFileSync(launchctl, "#!/bin/sh\nexit 0\n", "utf8");
     chmodSync(launchctl, 0o755);
 
-    const result = spawnSync("/bin/bash", [scriptPath, "uninstall"], {
-      cwd: process.cwd(),
+    const result = spawnSync("/bin/bash", [installerPath, "uninstall"], {
+      cwd: tempRoot,
       encoding: "utf8",
       env: {
         HOME: tempRoot,
@@ -212,6 +214,14 @@ describe("mac elevation host command contract", () => {
     expect(script).toContain("SKIP_DMG=1");
     expect(script).toContain("NOTARY_RESULT_FILE");
     expect(script).toContain("archiveSha256");
+    expect(script).toContain("archiveChecksum");
+    expect(script).toContain('installer_path="$OUTPUT_DIR/${prefix}-installer.sh"');
+    expect(script).toContain("installerSha256");
+    expect(script).toContain("installerChecksum");
+    expect(script).toContain(
+      'git -C "$ROOT_DIR" show "${source_commit}:scripts/mac-elevation-host.sh"',
+    );
+    expect(script).toContain("portable installer does not match the selected source commit");
     expect(script).toContain("notarizationId");
     expect(script).toContain("entitlementsSha256");
     expect(script).toContain("elevation archive root must contain exactly OpenClaw.app");


### PR DESCRIPTION
## Summary

- include a source-addressed portable elevation-host installer in every immutable artifact set
- emit independent archive and installer checksum files and bind their names and hashes in the receipt
- reject packaging if the copied installer differs from the selected Git commit
- document checksum verification and installation on a Mac without a source checkout

## Root cause

The canonical package contained the notarized app archive, receipt, and archive checksum, but the lifecycle installer remained only in the source checkout. A target Mac without that checkout could receive valid app bytes yet could not perform the documented transactional install, status, recovery, or uninstall workflow.

The packaging command now copies its self-contained lifecycle script from the exact selected commit, makes it executable, verifies its content against the committed Git blob, and publishes it beside the app archive. Signing, notarization, app contents, launchd ownership, TCC behavior, and the ZIP's single-app root contract are unchanged.

## Proof

- regression: copied installer runs `uninstall` from an isolated directory with no source checkout
- focused elevation/signing/notarization/lane suite: 176 passed
- changed-file gate: Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/31806149928, exit 0
- checks included formatting, root test typecheck, script lint, dependency guards, and macOS packaging/daemon/tooling suites
- autoreview: clean, no accepted or actionable findings

## Release note

Elevation-host packages now carry a checksum-pinned portable installer, so a target Mac can verify and install the immutable artifact set without cloning OpenClaw.
