### PR TITLE
improve(test): speed up LanceDB memory plugin suite

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -39,6 +39,51 @@ import memoryPlugin, {
 import { createLanceDbRuntimeLoader } from "./lancedb-runtime.test-support.js";
 import { installTmpDirHarness } from "./test-helpers.js";
 
+const moduleMocks = vi.hoisted(() => ({
+  createOpenAiClient: vi.fn<(...args: unknown[]) => object>(),
+  ensureGlobalUndiciEnvProxyDispatcher: vi.fn<() => void>(),
+  loadLanceDbModule: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    ensureGlobalUndiciEnvProxyDispatcher: () => {
+      if (moduleMocks.ensureGlobalUndiciEnvProxyDispatcher.getMockImplementation()) {
+        return moduleMocks.ensureGlobalUndiciEnvProxyDispatcher();
+      }
+      return actual.ensureGlobalUndiciEnvProxyDispatcher();
+    },
+  };
+});
+
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openai")>();
+  return {
+    ...actual,
+    default: function MockableOpenAI(...args: ConstructorParameters<typeof actual.default>) {
+      if (moduleMocks.createOpenAiClient.getMockImplementation()) {
+        return moduleMocks.createOpenAiClient(...args);
+      }
+      return Reflect.construct(actual.default, args);
+    },
+  };
+});
+
+vi.mock("./lancedb-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./lancedb-runtime.js")>();
+  return {
+    ...actual,
+    loadLanceDbModule: (...args: Parameters<typeof actual.loadLanceDbModule>) => {
+      if (moduleMocks.loadLanceDbModule.getMockImplementation()) {
+        return moduleMocks.loadLanceDbModule(...args);
+      }
+      return actual.loadLanceDbModule(...args);
+    },
+  };
+});
+
 // Provenance marker OpenClaw appends to every injected inbound-context header.
 // Detectors key on this marker, not label text. Keep byte-identical with
 // src/auto-reply/reply/inbound-context-marker.ts (extensions cannot import core).
@@ -195,10 +240,10 @@ function firstAddedMemory(add: ReturnType<typeof vi.fn>) {
 }
 
 async function withMockedOpenAiMemoryPlugin<T>(params: {
-  ensureGlobalUndiciEnvProxyDispatcher: ReturnType<typeof vi.fn>;
+  ensureGlobalUndiciEnvProxyDispatcher: () => void;
   embeddingsCreate?: ReturnType<typeof vi.fn>;
   openAiPost?: ReturnType<typeof vi.fn>;
-  loadLanceDbModule: ReturnType<typeof vi.fn>;
+  loadLanceDbModule: (...args: unknown[]) => Promise<unknown>;
   run: (dynamicMemoryPlugin: typeof memoryPlugin) => Promise<T>;
 }): Promise<T> {
   const post =
@@ -210,27 +255,20 @@ async function withMockedOpenAiMemoryPlugin<T>(params: {
       return invokeEmbeddingCreate(params.embeddingsCreate, opts.body);
     });
 
-  vi.resetModules();
-  vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
-    ensureGlobalUndiciEnvProxyDispatcher: params.ensureGlobalUndiciEnvProxyDispatcher,
-  }));
-  vi.doMock("openai", () => ({
-    default: class MockOpenAI {
-      post = post;
-    },
-  }));
-  vi.doMock("./lancedb-runtime.js", () => ({
-    loadLanceDbModule: params.loadLanceDbModule,
-  }));
+  moduleMocks.ensureGlobalUndiciEnvProxyDispatcher.mockImplementation(() => {
+    params.ensureGlobalUndiciEnvProxyDispatcher();
+  });
+  moduleMocks.createOpenAiClient.mockImplementation(() => ({ post }));
+  moduleMocks.loadLanceDbModule.mockImplementation(async (...args) => {
+    return await params.loadLanceDbModule(...args);
+  });
 
   try {
-    const { default: dynamicMemoryPlugin } = await import("./index.js");
-    return await params.run(dynamicMemoryPlugin);
+    return await params.run(memoryPlugin);
   } finally {
-    vi.doUnmock("openclaw/plugin-sdk/runtime-env");
-    vi.doUnmock("openai");
-    vi.doUnmock("./lancedb-runtime.js");
-    vi.resetModules();
+    moduleMocks.ensureGlobalUndiciEnvProxyDispatcher.mockReset();
+    moduleMocks.createOpenAiClient.mockReset();
+    moduleMocks.loadLanceDbModule.mockReset();
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The LanceDB memory plugin's main test file repeatedly discarded and rebuilt the full plugin module graph for eight OpenAI-backed scenarios. On a reusable 16-vCPU Blacksmith Testbox, the warm focused suite took 23.54 seconds wall time, 17.94 seconds inside Vitest, and peaked at 2,445,024 KiB RSS.

## Why This Change Was Made

The shared OpenAI test helper now uses stable hoisted pass-through mocks for the three dependencies those scenarios vary, then resets only their implementations between tests. The plugin module remains loaded, while the specialized tests that intentionally need fresh-module lifecycle behavior keep their existing resets.

No production code, assertions, test names, or test count changed.

## User Impact

There is no runtime behavior change. Contributors and CI get a materially faster, lower-memory memory-plugin test lane while retaining all 141 focused tests and 178 tests across the plugin directory.

## Evidence

Controlled warm-cache A/B on the same Testbox (`tbx_01m007yg6y321kcn02jgcv0sh3`, 16 vCPU) and the same focused command:

`/usr/bin/time -v env OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 corepack pnpm test:perf:imports -- extensions/memory-lancedb/index.test.ts`

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall | 23.54 s | 17.15 s | -27% |
| Vitest duration | 17.94 s | 12.47 s | -30% |
| Import | 8.39 s | 5.20 s | -38% |
| Test body | 8.86 s | 6.70 s | -24% |
| CPU user / system | 26.57 / 3.11 s | 19.46 / 2.36 s | -27% / -24% |
| Max RSS | 2,445,024 KiB | 2,070,844 KiB | -15% |

- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31805696642
- Focused file: 141/141 passed.
- Plugin directory: 178/178 passed.
- Exact post-rebase remote changed gate: passed (format, guards, extension test types, and lint).
- Codex autoreview after rebase: clean, no accepted/actionable findings.
- Production LOC: +0/-0. Tests: +58/-20.

AI-assisted: yes. Agent transcript: not attached.
