### PR TITLE
fix(sqlite): prevent cold Windows runners from timing out

### DIFF
--- a/src/infra/sqlite-private-directory.test.ts
+++ b/src/infra/sqlite-private-directory.test.ts
@@ -77,6 +77,20 @@ describe("private Windows SQLite directory diagnostics", () => {
     expect((cause as Error & { cmd?: unknown }).cmd).toBeUndefined();
   });
 
+  it("allows cold PowerShell startup for async and sync directory creation", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    childProcess.execFile.mockImplementation((_file, _args, _options, callback) => {
+      callback(null, Buffer.alloc(0), Buffer.alloc(0));
+    });
+    childProcess.execFileSync.mockReturnValue(Buffer.alloc(0));
+
+    await createPrivateSqliteDirectory("C:\\private");
+    createPrivateSqliteTempDirectorySync("C:\\root", "stage-");
+
+    expect(childProcess.execFile.mock.calls[0]?.[2]).toMatchObject({ timeout: 30_000 });
+    expect(childProcess.execFileSync.mock.calls[0]?.[2]).toMatchObject({ timeout: 30_000 });
+  });
+
   it("reports sync status and string codes from sanitized stderr", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     childProcess.execFileSync.mockImplementation(() => {

--- a/src/infra/sqlite-private-directory.ts
+++ b/src/infra/sqlite-private-directory.ts
@@ -10,6 +10,10 @@ import { decodeWindowsOutputBuffer } from "./windows-encoding.js";
 
 const SQLITE_DIRECTORY_MODE = 0o700;
 const WINDOWS_DIRECTORY_EXISTS_MARKER = "OPENCLAW_SQLITE_DIRECTORY_EXISTS";
+// Cold hosted runners have timed out with only PowerShell's CLIXML preamble emitted,
+// before the encoded SQLite ACL command started. Allow startup module loading and AV
+// scanning to finish without retrying a command that may already have run.
+export const WINDOWS_SQLITE_POWERSHELL_TIMEOUT_MS = 30_000;
 
 // Managed directory creation accepts existing paths. CreateDirectoryW applies the
 // protected DACL atomically while preserving fail-if-exists semantics.
@@ -138,7 +142,7 @@ function runPrivateDirectoryPowerShell(
       {
         encoding: "buffer",
         maxBuffer: 64 * 1024,
-        timeout: 10_000,
+        timeout: WINDOWS_SQLITE_POWERSHELL_TIMEOUT_MS,
         windowsHide: true,
       },
       (error, stdout, stderr) => {
@@ -211,7 +215,7 @@ function createPrivateSqliteDirectorySync(directoryPath: string): void {
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
       {
         maxBuffer: 64 * 1024,
-        timeout: 10_000,
+        timeout: WINDOWS_SQLITE_POWERSHELL_TIMEOUT_MS,
         windowsHide: true,
       },
     );

--- a/src/snapshot/local-repository.ts
+++ b/src/snapshot/local-repository.ts
@@ -30,6 +30,7 @@ import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
   createPrivateSqliteDirectory,
   createPrivateSqliteTempDirectory,
+  WINDOWS_SQLITE_POWERSHELL_TIMEOUT_MS,
 } from "../infra/sqlite-private-directory.js";
 import { publishVerifiedSqliteFile } from "../infra/sqlite-snapshot.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
@@ -1536,7 +1537,7 @@ async function runEncodedWindowsPowerShell(command: string, maxBuffer: number): 
     powershell,
     ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
     {
-      timeoutMs: 10_000,
+      timeoutMs: WINDOWS_SQLITE_POWERSHELL_TIMEOUT_MS,
       maxBuffer,
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows CI could fail SQLite state and snapshot tests when a cold hosted runner took longer than 10 seconds to start Windows PowerShell. The recurring signature was `ETIMEDOUT`/`SIGTERM` with only the CLIXML preamble emitted, before the encoded ACL command ran.

Observed three times on `windows-2025` today, including:

- [run 31805512118](https://github.com/openclaw/openclaw/actions/runs/31805512118): `openclaw-state-ownership.test.ts` failed while creating its private read-only SQLite directory.
- [run 31790997476 attempt 1](https://github.com/openclaw/openclaw/actions/runs/31790997476/attempts/1): `local-repository.windows.test.ts` failed in the MAX_PATH staging/ACL path.

Both failures passed on rerun.

## Why This Change Was Made

The shared Windows SQLite PowerShell startup budget is now 30 seconds for asynchronous private-directory creation, synchronous private-directory creation, and snapshot staging ACL inspection. This remains bounded and does not retry commands that may already have executed.

The private-directory command cannot safely become `mkdir` followed by `icacls.exe`: it constructs a protected DACL for the current user, SYSTEM, and Administrators and supplies it atomically to `CreateDirectoryW`. Keeping that producer preserves fail-if-exists and prevents a temporary ACL exposure window.

## User Impact

Windows operators and CI runners no longer fail SQLite state/snapshot work solely because first-invocation PowerShell module loading or antivirus scanning exceeds 10 seconds. Real hangs still fail after 30 seconds.

## Evidence

- `node scripts/run-vitest.mjs src/infra/sqlite-private-directory.test.ts` — 4 passed
- `node scripts/run-vitest.mjs src/snapshot/local-repository.test.ts --reporter=verbose` — 65 passed, 1 Windows-only skip
- `node scripts/run-vitest.mjs src/state/openclaw-state-ownership.test.ts` — 22 passed
- `pnpm exec oxfmt --check src/infra/sqlite-private-directory.ts src/infra/sqlite-private-directory.test.ts src/snapshot/local-repository.ts` — clean
- `git diff --check` — clean
- Codex autoreview — clean, no accepted/actionable findings

Windows cannot be executed on the development host. Exact-head Windows CI is the final runtime proof for both the state-ownership and MAX_PATH snapshot lanes.
