### PR TITLE
fix(state): preserve orphaned SQLite sidecars

### DIFF
--- a/src/infra/sqlite-files.ts
+++ b/src/infra/sqlite-files.ts
@@ -1,28 +1,49 @@
-import { existsSync, statSync } from "node:fs";
+import fs from "node:fs";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 
 /** SQLite main database plus every journal-mode sidecar that can contain database pages. */
 const SQLITE_DATABASE_FILE_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
 // SQLite WAL format: https://sqlite.org/fileformat2.html#walformat defines a 32-byte header.
 const SQLITE_WAL_HEADER_BYTES = 32;
+const sqliteFilesLog = createSubsystemLogger("state/sqlite");
 
 class SqliteOrphanedSidecarsError extends Error {
-  constructor(pathname: string, sidecarPaths: string[]) {
+  constructor(pathname: string, sidecarPaths: string[], cause: unknown) {
     super(
-      `SQLite database is missing at ${pathname}, but sidecars remain: ${sidecarPaths.join(", ")}. ` +
-        "Refusing to create a replacement database because SQLite can delete orphan WAL or journal state when opening an empty main database. Preserve the complete SQLite family and restore or repair its main database before retrying.",
+      `SQLite database is missing at ${pathname}, and orphaned sidecars could not be quarantined: ${sidecarPaths.join(", ")}. ` +
+        "Refusing to open because SQLite could delete orphan WAL or journal state. Preserve the sidecar bytes, restore the main database, and pair it with the matching sidecar before retrying.",
+      { cause },
     );
     this.name = "SqliteOrphanedSidecarsError";
   }
 }
+
+type QuarantinedSqliteSidecar = {
+  quarantinePath: string;
+  sourcePath: string;
+};
 
 /** Resolves the main database and all possible journal-mode sidecar paths. */
 export function resolveSqliteDatabaseFilePaths(pathname: string): string[] {
   return SQLITE_DATABASE_FILE_SUFFIXES.map((suffix) => `${pathname}${suffix}`);
 }
 
-/** Refuse a fresh database when orphaned sidecars can contain recoverable data. */
-export function assertNoOrphanedSqliteSidecars(pathname: string): void {
-  if (existsSync(pathname)) {
+function resolveOrphanedSidecarQuarantinePath(sourcePath: string, epochMs: number): string {
+  const basePath = `${sourcePath}.orphaned-${epochMs}`;
+  if (!fs.existsSync(basePath)) {
+    return basePath;
+  }
+  for (let suffix = 1; ; suffix += 1) {
+    const candidate = `${basePath}-${suffix}`;
+    if (!fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+/** Preserve durable orphan sidecars before SQLite creates a replacement main database. */
+export function quarantineOrphanedSqliteSidecars(pathname: string): void {
+  if (fs.existsSync(pathname)) {
     return;
   }
   const sidecarPaths = [
@@ -30,11 +51,50 @@ export function assertNoOrphanedSqliteSidecars(pathname: string): void {
     { path: `${pathname}-journal`, minimumBytes: 0 },
   ]
     .filter((sidecar) => {
-      const stat = statSync(sidecar.path, { throwIfNoEntry: false });
+      const stat = fs.statSync(sidecar.path, { throwIfNoEntry: false });
       return stat?.isFile() === true && stat.size > sidecar.minimumBytes;
     })
     .map((sidecar) => sidecar.path);
-  if (sidecarPaths.length > 0) {
-    throw new SqliteOrphanedSidecarsError(pathname, sidecarPaths);
+  if (sidecarPaths.length === 0) {
+    return;
   }
+
+  const epochMs = Date.now();
+  const quarantined: QuarantinedSqliteSidecar[] = [];
+  try {
+    for (const sourcePath of sidecarPaths) {
+      const quarantinePath = resolveOrphanedSidecarQuarantinePath(sourcePath, epochMs);
+      fs.renameSync(sourcePath, quarantinePath);
+      quarantined.push({ quarantinePath, sourcePath });
+    }
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    for (const moved of quarantined.toReversed()) {
+      try {
+        fs.renameSync(moved.quarantinePath, moved.sourcePath);
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    const cause =
+      rollbackErrors.length === 0
+        ? error
+        : new AggregateError(
+            [error, ...rollbackErrors],
+            "orphaned sidecar quarantine rollback failed",
+          );
+    throw new SqliteOrphanedSidecarsError(pathname, sidecarPaths, cause);
+  }
+
+  const moves = quarantined.map(
+    ({ sourcePath, quarantinePath }) => `${sourcePath} -> ${quarantinePath}`,
+  );
+  sqliteFilesLog.warn(
+    `SQLite database is missing at ${pathname}; quarantined orphaned sidecars: ${moves.join(", ")}. ` +
+      "Committed frames could not be applied because the main database is missing. The bytes are preserved. Recovery requires restoring the main database and pairing it with the quarantined file.",
+    {
+      databasePath: pathname,
+      quarantinedSidecars: quarantined,
+    },
+  );
 }

--- a/src/infra/sqlite-files.ts
+++ b/src/infra/sqlite-files.ts
@@ -1,7 +1,9 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 
 /** SQLite main database plus every journal-mode sidecar that can contain database pages. */
 const SQLITE_DATABASE_FILE_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
+// SQLite WAL format: https://sqlite.org/fileformat2.html#walformat defines a 32-byte header.
+const SQLITE_WAL_HEADER_BYTES = 32;
 
 class SqliteOrphanedSidecarsError extends Error {
   constructor(pathname: string, sidecarPaths: string[]) {
@@ -18,12 +20,20 @@ export function resolveSqliteDatabaseFilePaths(pathname: string): string[] {
   return SQLITE_DATABASE_FILE_SUFFIXES.map((suffix) => `${pathname}${suffix}`);
 }
 
-/** Refuse a fresh database when sidecars from a missing SQLite family remain. */
+/** Refuse a fresh database when orphaned sidecars can contain recoverable data. */
 export function assertNoOrphanedSqliteSidecars(pathname: string): void {
   if (existsSync(pathname)) {
     return;
   }
-  const sidecarPaths = resolveSqliteDatabaseFilePaths(pathname).slice(1).filter(existsSync);
+  const sidecarPaths = [
+    { path: `${pathname}-wal`, minimumBytes: SQLITE_WAL_HEADER_BYTES },
+    { path: `${pathname}-journal`, minimumBytes: 0 },
+  ]
+    .filter((sidecar) => {
+      const stat = statSync(sidecar.path, { throwIfNoEntry: false });
+      return stat?.isFile() === true && stat.size > sidecar.minimumBytes;
+    })
+    .map((sidecar) => sidecar.path);
   if (sidecarPaths.length > 0) {
     throw new SqliteOrphanedSidecarsError(pathname, sidecarPaths);
   }

--- a/src/infra/sqlite-files.ts
+++ b/src/infra/sqlite-files.ts
@@ -1,16 +1,19 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 /** SQLite main database plus every journal-mode sidecar that can contain database pages. */
 const SQLITE_DATABASE_FILE_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
 // SQLite WAL format: https://sqlite.org/fileformat2.html#walformat defines a 32-byte header.
 const SQLITE_WAL_HEADER_BYTES = 32;
+const SQLITE_SIDECAR_HASH_BUFFER_BYTES = 1024 * 1024;
 const sqliteFilesLog = createSubsystemLogger("state/sqlite");
 
 class SqliteOrphanedSidecarsError extends Error {
   constructor(pathname: string, sidecarPaths: string[], cause: unknown) {
     super(
-      `SQLite database is missing at ${pathname}, and orphaned sidecars could not be quarantined: ${sidecarPaths.join(", ")}. ` +
+      `SQLite database is missing at ${pathname}, and orphaned sidecars could not be copied: ${sidecarPaths.join(", ")}. ` +
         "Refusing to open because SQLite could delete orphan WAL or journal state. Preserve the sidecar bytes, restore the main database, and pair it with the matching sidecar before retrying.",
       { cause },
     );
@@ -18,7 +21,7 @@ class SqliteOrphanedSidecarsError extends Error {
   }
 }
 
-type QuarantinedSqliteSidecar = {
+type CopiedSqliteSidecar = {
   quarantinePath: string;
   sourcePath: string;
 };
@@ -28,15 +31,57 @@ export function resolveSqliteDatabaseFilePaths(pathname: string): string[] {
   return SQLITE_DATABASE_FILE_SUFFIXES.map((suffix) => `${pathname}${suffix}`);
 }
 
-function resolveOrphanedSidecarQuarantinePath(sourcePath: string, epochMs: number): string {
-  const basePath = `${sourcePath}.orphaned-${epochMs}`;
-  if (!fs.existsSync(basePath)) {
-    return basePath;
+function sha256FileSync(pathname: string): string {
+  const descriptor = fs.openSync(pathname, "r");
+  const digest = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(SQLITE_SIDECAR_HASH_BUFFER_BYTES);
+  try {
+    while (true) {
+      const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) {
+        return digest.digest("hex");
+      }
+      digest.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(descriptor);
   }
-  for (let suffix = 1; ; suffix += 1) {
-    const candidate = `${basePath}-${suffix}`;
-    if (!fs.existsSync(candidate)) {
+}
+
+function findMatchingOrphanedSidecarCopy(
+  sourcePath: string,
+  sourceSize: number,
+): string | undefined {
+  const directory = path.dirname(sourcePath);
+  const prefix = `${path.basename(sourcePath)}.orphaned-`;
+  const candidates = fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.startsWith(prefix))
+    .map((entry) => path.join(directory, entry.name))
+    .filter((candidate) => fs.statSync(candidate).size === sourceSize);
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  const sourceHash = sha256FileSync(sourcePath);
+  for (const candidate of candidates) {
+    if (sha256FileSync(candidate) === sourceHash) {
       return candidate;
+    }
+  }
+  return undefined;
+}
+
+function copyOrphanedSidecar(sourcePath: string, epochMs: number): string {
+  const basePath = `${sourcePath}.orphaned-${epochMs}`;
+  for (let suffix = 0; ; suffix += 1) {
+    const candidate = suffix === 0 ? basePath : `${basePath}-${suffix}`;
+    try {
+      fs.copyFileSync(sourcePath, candidate, fs.constants.COPYFILE_EXCL);
+      return candidate;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
     }
   }
 }
@@ -46,55 +91,49 @@ export function quarantineOrphanedSqliteSidecars(pathname: string): void {
   if (fs.existsSync(pathname)) {
     return;
   }
-  const sidecarPaths = [
+  const sidecars = [
     { path: `${pathname}-wal`, minimumBytes: SQLITE_WAL_HEADER_BYTES },
     { path: `${pathname}-journal`, minimumBytes: 0 },
-  ]
-    .filter((sidecar) => {
-      const stat = fs.statSync(sidecar.path, { throwIfNoEntry: false });
-      return stat?.isFile() === true && stat.size > sidecar.minimumBytes;
-    })
-    .map((sidecar) => sidecar.path);
-  if (sidecarPaths.length === 0) {
+  ].flatMap((sidecar) => {
+    const stat = fs.statSync(sidecar.path, { throwIfNoEntry: false });
+    return stat?.isFile() === true && stat.size > sidecar.minimumBytes
+      ? [{ path: sidecar.path, size: stat.size }]
+      : [];
+  });
+  if (sidecars.length === 0) {
     return;
   }
 
   const epochMs = Date.now();
-  const quarantined: QuarantinedSqliteSidecar[] = [];
+  const copied: CopiedSqliteSidecar[] = [];
   try {
-    for (const sourcePath of sidecarPaths) {
-      const quarantinePath = resolveOrphanedSidecarQuarantinePath(sourcePath, epochMs);
-      fs.renameSync(sourcePath, quarantinePath);
-      quarantined.push({ quarantinePath, sourcePath });
+    for (const sidecar of sidecars) {
+      if (findMatchingOrphanedSidecarCopy(sidecar.path, sidecar.size)) {
+        continue;
+      }
+      const quarantinePath = copyOrphanedSidecar(sidecar.path, epochMs);
+      copied.push({ quarantinePath, sourcePath: sidecar.path });
     }
   } catch (error) {
-    const rollbackErrors: unknown[] = [];
-    for (const moved of quarantined.toReversed()) {
-      try {
-        fs.renameSync(moved.quarantinePath, moved.sourcePath);
-      } catch (rollbackError) {
-        rollbackErrors.push(rollbackError);
-      }
-    }
-    const cause =
-      rollbackErrors.length === 0
-        ? error
-        : new AggregateError(
-            [error, ...rollbackErrors],
-            "orphaned sidecar quarantine rollback failed",
-          );
-    throw new SqliteOrphanedSidecarsError(pathname, sidecarPaths, cause);
+    throw new SqliteOrphanedSidecarsError(
+      pathname,
+      sidecars.map((sidecar) => sidecar.path),
+      error,
+    );
+  }
+  if (copied.length === 0) {
+    return;
   }
 
-  const moves = quarantined.map(
+  const copies = copied.map(
     ({ sourcePath, quarantinePath }) => `${sourcePath} -> ${quarantinePath}`,
   );
   sqliteFilesLog.warn(
-    `SQLite database is missing at ${pathname}; quarantined orphaned sidecars: ${moves.join(", ")}. ` +
+    `SQLite database is missing at ${pathname}; copied orphaned sidecars: ${copies.join(", ")}. ` +
       "Committed frames could not be applied because the main database is missing. The bytes are preserved. Recovery requires restoring the main database and pairing it with the quarantined file.",
     {
       databasePath: pathname,
-      quarantinedSidecars: quarantined,
+      copiedSidecars: copied,
     },
   );
 }

--- a/src/infra/sqlite-files.ts
+++ b/src/infra/sqlite-files.ts
@@ -1,7 +1,30 @@
+import { existsSync } from "node:fs";
+
 /** SQLite main database plus every journal-mode sidecar that can contain database pages. */
 const SQLITE_DATABASE_FILE_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
+
+class SqliteOrphanedSidecarsError extends Error {
+  constructor(pathname: string, sidecarPaths: string[]) {
+    super(
+      `SQLite database is missing at ${pathname}, but sidecars remain: ${sidecarPaths.join(", ")}. ` +
+        "Refusing to create a replacement database because SQLite can delete orphan WAL or journal state when opening an empty main database. Preserve the complete SQLite family and restore or repair its main database before retrying.",
+    );
+    this.name = "SqliteOrphanedSidecarsError";
+  }
+}
 
 /** Resolves the main database and all possible journal-mode sidecar paths. */
 export function resolveSqliteDatabaseFilePaths(pathname: string): string[] {
   return SQLITE_DATABASE_FILE_SUFFIXES.map((suffix) => `${pathname}${suffix}`);
+}
+
+/** Refuse a fresh database when sidecars from a missing SQLite family remain. */
+export function assertNoOrphanedSqliteSidecars(pathname: string): void {
+  if (existsSync(pathname)) {
+    return;
+  }
+  const sidecarPaths = resolveSqliteDatabaseFilePaths(pathname).slice(1).filter(existsSync);
+  if (sidecarPaths.length > 0) {
+    throw new SqliteOrphanedSidecarsError(pathname, sidecarPaths);
+  }
 }

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -5,6 +5,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { enableNodeSqliteKyselyStatementCache } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
+import { assertNoOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
   confirmSqliteFileIntegrity,
   isTerminalSqliteIntegrityError,
@@ -262,6 +263,7 @@ export function openOpenClawAgentDatabase(
     cachedDatabases.set(pathname, database);
     return database;
   }
+  assertNoOrphanedSqliteSidecars(pathname);
   // Latched paths are quarantined; every fresh open fails fast here until
   // doctor repairs the file and clears the latch plus the persisted row.
   const terminalFailure = terminalOpenLatch.get(pathname);

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -5,7 +5,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { enableNodeSqliteKyselyStatementCache } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
-import { assertNoOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
+import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
   confirmSqliteFileIntegrity,
   isTerminalSqliteIntegrityError,
@@ -263,7 +263,7 @@ export function openOpenClawAgentDatabase(
     cachedDatabases.set(pathname, database);
     return database;
   }
-  assertNoOrphanedSqliteSidecars(pathname);
+  quarantineOrphanedSqliteSidecars(pathname);
   // Latched paths are quarantined; every fresh open fails fast here until
   // doctor repairs the file and clears the latch plus the persisted row.
   const terminalFailure = terminalOpenLatch.get(pathname);

--- a/src/state/openclaw-database-orphan-sidecars.test.ts
+++ b/src/state/openclaw-database-orphan-sidecars.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -15,53 +16,139 @@ import {
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 const tempStateDirs = useAutoCleanupTempDirTracker(afterEach);
-const sidecarContents = Buffer.from("recoverable SQLite sidecar pages");
+const databaseKinds = ["state", "agent"] as const;
+const walWithFrameBytes = Buffer.alloc(33, 0x57);
+const rollbackJournalContents = Buffer.from("recoverable rollback journal content");
+const shmIndexContents = Buffer.alloc(32 * 1024, 0x53);
+const emptySidecar = Buffer.alloc(0);
+
+function createWalHeaderOnly(): Buffer {
+  const fixtureDir = fs.realpathSync(tempStateDirs.make("openclaw-wal-header-"));
+  const databasePath = path.join(fixtureDir, "header.sqlite");
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
+    database.exec("CREATE TABLE header_probe (value TEXT);");
+    const wal = fs.readFileSync(`${databasePath}-wal`);
+    if (wal.length <= 32) {
+      throw new Error("SQLite did not write a WAL frame for the header fixture");
+    }
+    return Buffer.from(wal.subarray(0, 32));
+  } finally {
+    database.close();
+  }
+}
+
+const walHeaderOnly = createWalHeaderOnly();
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
 
+function prepareCase(kind: (typeof databaseKinds)[number]) {
+  const stateDir = fs.realpathSync(tempStateDirs.make("openclaw-orphan-sidecar-"));
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const databasePath =
+    kind === "state"
+      ? resolveOpenClawStateSqlitePath(env)
+      : resolveOpenClawAgentSqlitePath({ agentId: "main", env });
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  return { databasePath, env };
+}
+
+function openDatabase(kind: (typeof databaseKinds)[number], env: NodeJS.ProcessEnv) {
+  return kind === "state"
+    ? openOpenClawStateDatabase({ env })
+    : openOpenClawAgentDatabase({ agentId: "main", env });
+}
+
 describe("orphan SQLite sidecar admission", () => {
-  const cases = [
-    { kind: "state" as const, suffix: "-wal" },
-    { kind: "state" as const, suffix: "-shm" },
-    { kind: "state" as const, suffix: "-journal" },
-    { kind: "agent" as const, suffix: "-wal" },
-    { kind: "agent" as const, suffix: "-shm" },
-    { kind: "agent" as const, suffix: "-journal" },
-  ];
+  const blockingCases = [
+    {
+      label: "WAL with bytes beyond its header",
+      suffix: "-wal",
+      contents: walWithFrameBytes,
+      benignSidecars: [
+        { suffix: "-shm", contents: shmIndexContents },
+        { suffix: "-journal", contents: emptySidecar },
+      ],
+    },
+    {
+      label: "non-empty rollback journal",
+      suffix: "-journal",
+      contents: rollbackJournalContents,
+      benignSidecars: [
+        { suffix: "-wal", contents: walHeaderOnly },
+        { suffix: "-shm", contents: shmIndexContents },
+      ],
+    },
+  ] as const;
 
-  for (const testCase of cases) {
-    it(`refuses a missing ${testCase.kind} database with an orphan ${testCase.suffix}`, () => {
-      const stateDir = fs.realpathSync(tempStateDirs.make("openclaw-orphan-sidecar-"));
-      const env = { OPENCLAW_STATE_DIR: stateDir };
-      const databasePath =
-        testCase.kind === "state"
-          ? resolveOpenClawStateSqlitePath(env)
-          : resolveOpenClawAgentSqlitePath({ agentId: "main", env });
-      const sidecarPath = `${databasePath}${testCase.suffix}`;
-      fs.mkdirSync(path.dirname(databasePath), { recursive: true });
-      fs.writeFileSync(sidecarPath, sidecarContents);
+  describe("blocking sidecars", () => {
+    for (const testCase of blockingCases) {
+      for (const kind of databaseKinds) {
+        it(`refuses a missing ${kind} database with a ${testCase.label}`, () => {
+          const { databasePath, env } = prepareCase(kind);
+          const sidecars = [
+            { suffix: testCase.suffix, contents: testCase.contents },
+            ...testCase.benignSidecars,
+          ].map((sidecar) => ({
+            ...sidecar,
+            path: `${databasePath}${sidecar.suffix}`,
+          }));
+          for (const sidecar of sidecars) {
+            fs.writeFileSync(sidecar.path, sidecar.contents);
+          }
 
-      let thrown: unknown;
-      try {
-        if (testCase.kind === "state") {
-          openOpenClawStateDatabase({ env });
-        } else {
-          openOpenClawAgentDatabase({ agentId: "main", env });
-        }
-      } catch (error) {
-        thrown = error;
+          let thrown: unknown;
+          try {
+            openDatabase(kind, env);
+          } catch (error) {
+            thrown = error;
+          }
+
+          expect(thrown).toBeInstanceOf(Error);
+          expect((thrown as Error).name).toBe("SqliteOrphanedSidecarsError");
+          expect((thrown as Error).message).toContain(databasePath);
+          expect((thrown as Error).message).toContain(`${databasePath}${testCase.suffix}`);
+          for (const benign of testCase.benignSidecars) {
+            expect((thrown as Error).message).not.toContain(`${databasePath}${benign.suffix}`);
+          }
+          expect((thrown as Error).message).toContain("Refusing to create a replacement database");
+          expect(fs.existsSync(databasePath)).toBe(false);
+          for (const sidecar of sidecars) {
+            expect(fs.readFileSync(sidecar.path)).toEqual(sidecar.contents);
+          }
+        });
       }
+    }
+  });
 
-      expect(thrown).toBeInstanceOf(Error);
-      expect((thrown as Error).name).toBe("SqliteOrphanedSidecarsError");
-      expect((thrown as Error).message).toContain(databasePath);
-      expect((thrown as Error).message).toContain(sidecarPath);
-      expect((thrown as Error).message).toContain("Refusing to create a replacement database");
-      expect(fs.existsSync(databasePath)).toBe(false);
-      expect(fs.readFileSync(sidecarPath)).toEqual(sidecarContents);
-    });
-  }
+  const nonBlockingCases = [
+    { label: "lone SHM index", suffix: "-shm", contents: shmIndexContents },
+    { label: "zero-byte WAL", suffix: "-wal", contents: emptySidecar },
+    { label: "32-byte header-only WAL", suffix: "-wal", contents: walHeaderOnly },
+    { label: "zero-byte rollback journal", suffix: "-journal", contents: emptySidecar },
+  ] as const;
+
+  describe("non-blocking sidecars", () => {
+    for (const testCase of nonBlockingCases) {
+      for (const kind of databaseKinds) {
+        it(`creates a missing ${kind} database with a ${testCase.label}`, () => {
+          const { databasePath, env } = prepareCase(kind);
+          fs.writeFileSync(`${databasePath}${testCase.suffix}`, testCase.contents);
+
+          const database = openDatabase(kind, env);
+
+          expect(database.db.isOpen).toBe(true);
+          expect(fs.existsSync(databasePath)).toBe(true);
+          expect(database.db.prepare("PRAGMA integrity_check").get()).toEqual({
+            integrity_check: "ok",
+          });
+        });
+      }
+    }
+  });
 });

--- a/src/state/openclaw-database-orphan-sidecars.test.ts
+++ b/src/state/openclaw-database-orphan-sidecars.test.ts
@@ -1,7 +1,7 @@
 // Orphan-sidecar tests prove fresh database opens preserve recoverable SQLite families.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
@@ -17,12 +17,23 @@ import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 const tempStateDirs = useAutoCleanupTempDirTracker(afterEach);
 const databaseKinds = ["state", "agent"] as const;
-const walWithFrameBytes = Buffer.alloc(33, 0x57);
 const rollbackJournalContents = Buffer.from("recoverable rollback journal content");
 const shmIndexContents = Buffer.alloc(32 * 1024, 0x53);
 const emptySidecar = Buffer.alloc(0);
+const loggerMocks = vi.hoisted(() => ({ warn: vi.fn() }));
 
-function createWalHeaderOnly(): Buffer {
+vi.mock("../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) =>
+      subsystem === "state/sqlite"
+        ? { ...actual.createSubsystemLogger(subsystem), warn: loggerMocks.warn }
+        : actual.createSubsystemLogger(subsystem),
+  };
+});
+
+function createWalFixture(): { header: Buffer; withFrames: Buffer } {
   const fixtureDir = fs.realpathSync(tempStateDirs.make("openclaw-wal-header-"));
   const databasePath = path.join(fixtureDir, "header.sqlite");
   const { DatabaseSync } = requireNodeSqlite();
@@ -34,17 +45,22 @@ function createWalHeaderOnly(): Buffer {
     if (wal.length <= 32) {
       throw new Error("SQLite did not write a WAL frame for the header fixture");
     }
-    return Buffer.from(wal.subarray(0, 32));
+    return {
+      header: Buffer.from(wal.subarray(0, 32)),
+      withFrames: Buffer.from(wal),
+    };
   } finally {
     database.close();
   }
 }
 
-const walHeaderOnly = createWalHeaderOnly();
+const walFixture = createWalFixture();
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
+  loggerMocks.warn.mockReset();
+  vi.restoreAllMocks();
 });
 
 function prepareCase(kind: (typeof databaseKinds)[number]) {
@@ -64,12 +80,20 @@ function openDatabase(kind: (typeof databaseKinds)[number], env: NodeJS.ProcessE
     : openOpenClawAgentDatabase({ agentId: "main", env });
 }
 
+function listQuarantinePaths(sourcePath: string): string[] {
+  const prefix = `${path.basename(sourcePath)}.orphaned-`;
+  return fs
+    .readdirSync(path.dirname(sourcePath))
+    .filter((entry) => entry.startsWith(prefix))
+    .map((entry) => path.join(path.dirname(sourcePath), entry));
+}
+
 describe("orphan SQLite sidecar admission", () => {
-  const blockingCases = [
+  const recoverableCases = [
     {
-      label: "WAL with bytes beyond its header",
+      label: "real WAL with committed frames",
       suffix: "-wal",
-      contents: walWithFrameBytes,
+      contents: walFixture.withFrames,
       benignSidecars: [
         { suffix: "-shm", contents: shmIndexContents },
         { suffix: "-journal", contents: emptySidecar },
@@ -80,16 +104,18 @@ describe("orphan SQLite sidecar admission", () => {
       suffix: "-journal",
       contents: rollbackJournalContents,
       benignSidecars: [
-        { suffix: "-wal", contents: walHeaderOnly },
+        { suffix: "-wal", contents: walFixture.header },
         { suffix: "-shm", contents: shmIndexContents },
       ],
     },
   ] as const;
 
-  describe("blocking sidecars", () => {
-    for (const testCase of blockingCases) {
+  describe("recoverable sidecars", () => {
+    for (const testCase of recoverableCases) {
       for (const kind of databaseKinds) {
-        it(`refuses a missing ${kind} database with a ${testCase.label}`, () => {
+        const regression =
+          kind === "state" && testCase.suffix === "-wal" ? " (plugin lifecycle regression)" : "";
+        it(`opens a missing ${kind} database after quarantining a ${testCase.label}${regression}`, () => {
           const { databasePath, env } = prepareCase(kind);
           const sidecars = [
             { suffix: testCase.suffix, contents: testCase.contents },
@@ -103,25 +129,32 @@ describe("orphan SQLite sidecar admission", () => {
             fs.writeFileSync(sidecar.path, sidecar.contents);
           }
 
-          let thrown: unknown;
-          try {
-            openDatabase(kind, env);
-          } catch (error) {
-            thrown = error;
-          }
+          const database = openDatabase(kind, env);
+          const sourcePath = `${databasePath}${testCase.suffix}`;
+          const quarantinePaths = listQuarantinePaths(sourcePath);
 
-          expect(thrown).toBeInstanceOf(Error);
-          expect((thrown as Error).name).toBe("SqliteOrphanedSidecarsError");
-          expect((thrown as Error).message).toContain(databasePath);
-          expect((thrown as Error).message).toContain(`${databasePath}${testCase.suffix}`);
-          for (const benign of testCase.benignSidecars) {
-            expect((thrown as Error).message).not.toContain(`${databasePath}${benign.suffix}`);
+          expect(database.db.isOpen).toBe(true);
+          expect(fs.existsSync(databasePath)).toBe(true);
+          expect(quarantinePaths).toHaveLength(1);
+          expect(fs.readFileSync(quarantinePaths[0])).toEqual(testCase.contents);
+          if (fs.existsSync(sourcePath)) {
+            // A successful WAL-mode open may create a new sidecar at the canonical path.
+            expect(fs.readFileSync(sourcePath)).not.toEqual(testCase.contents);
           }
-          expect((thrown as Error).message).toContain("Refusing to create a replacement database");
-          expect(fs.existsSync(databasePath)).toBe(false);
-          for (const sidecar of sidecars) {
-            expect(fs.readFileSync(sidecar.path)).toEqual(sidecar.contents);
-          }
+          expect(loggerMocks.warn).toHaveBeenCalledOnce();
+          expect(loggerMocks.warn).toHaveBeenCalledWith(
+            expect.stringContaining(quarantinePaths[0]),
+            expect.objectContaining({
+              databasePath,
+              quarantinedSidecars: [{ quarantinePath: quarantinePaths[0], sourcePath }],
+            }),
+          );
+          expect(String(loggerMocks.warn.mock.calls[0]?.[0])).toContain(
+            "Committed frames could not be applied because the main database is missing",
+          );
+          expect(String(loggerMocks.warn.mock.calls[0]?.[0])).toContain(
+            "Recovery requires restoring the main database and pairing it with the quarantined file",
+          );
         });
       }
     }
@@ -130,7 +163,7 @@ describe("orphan SQLite sidecar admission", () => {
   const nonBlockingCases = [
     { label: "lone SHM index", suffix: "-shm", contents: shmIndexContents },
     { label: "zero-byte WAL", suffix: "-wal", contents: emptySidecar },
-    { label: "32-byte header-only WAL", suffix: "-wal", contents: walHeaderOnly },
+    { label: "32-byte header-only WAL", suffix: "-wal", contents: walFixture.header },
     { label: "zero-byte rollback journal", suffix: "-journal", contents: emptySidecar },
   ] as const;
 
@@ -148,8 +181,59 @@ describe("orphan SQLite sidecar admission", () => {
           expect(database.db.prepare("PRAGMA integrity_check").get()).toEqual({
             integrity_check: "ok",
           });
+          expect(listQuarantinePaths(`${databasePath}${testCase.suffix}`)).toEqual([]);
+          expect(loggerMocks.warn).not.toHaveBeenCalled();
         });
       }
     }
+  });
+
+  it("uses a unique suffix instead of overwriting an existing quarantine", () => {
+    const { databasePath, env } = prepareCase("state");
+    const sourcePath = `${databasePath}-wal`;
+    const epochMs = 1_786_738_000_000;
+    const existingQuarantinePath = `${sourcePath}.orphaned-${epochMs}`;
+    const newQuarantinePath = `${existingQuarantinePath}-1`;
+    const existingContents = Buffer.from("previously quarantined WAL");
+    fs.writeFileSync(sourcePath, walFixture.withFrames);
+    fs.writeFileSync(existingQuarantinePath, existingContents);
+    vi.spyOn(Date, "now").mockReturnValue(epochMs);
+
+    const database = openDatabase("state", env);
+
+    expect(database.db.isOpen).toBe(true);
+    expect(fs.readFileSync(existingQuarantinePath)).toEqual(existingContents);
+    expect(fs.readFileSync(newQuarantinePath)).toEqual(walFixture.withFrames);
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining(newQuarantinePath),
+      expect.any(Object),
+    );
+  });
+
+  it("fails closed with the typed error when quarantine rename fails", () => {
+    const { databasePath, env } = prepareCase("state");
+    const sourcePath = `${databasePath}-wal`;
+    fs.writeFileSync(sourcePath, walFixture.withFrames);
+    const renameError = Object.assign(new Error("read-only volume"), { code: "EROFS" });
+    vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
+      throw renameError;
+    });
+
+    let thrown: unknown;
+    try {
+      openDatabase("state", env);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe("SqliteOrphanedSidecarsError");
+    expect((thrown as Error).message).toContain(databasePath);
+    expect((thrown as Error).message).toContain(sourcePath);
+    expect((thrown as Error).message).toContain("restore the main database");
+    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(fs.readFileSync(sourcePath)).toEqual(walFixture.withFrames);
+    expect(listQuarantinePaths(sourcePath)).toEqual([]);
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/state/openclaw-database-orphan-sidecars.test.ts
+++ b/src/state/openclaw-database-orphan-sidecars.test.ts
@@ -95,8 +95,9 @@ describe("orphan SQLite sidecar admission", () => {
             { suffix: testCase.suffix, contents: testCase.contents },
             ...testCase.benignSidecars,
           ].map((sidecar) => ({
-            ...sidecar,
+            contents: sidecar.contents,
             path: `${databasePath}${sidecar.suffix}`,
+            suffix: sidecar.suffix,
           }));
           for (const sidecar of sidecars) {
             fs.writeFileSync(sidecar.path, sidecar.contents);

--- a/src/state/openclaw-database-orphan-sidecars.test.ts
+++ b/src/state/openclaw-database-orphan-sidecars.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -115,7 +116,7 @@ describe("orphan SQLite sidecar admission", () => {
       for (const kind of databaseKinds) {
         const regression =
           kind === "state" && testCase.suffix === "-wal" ? " (plugin lifecycle regression)" : "";
-        it(`opens a missing ${kind} database after quarantining a ${testCase.label}${regression}`, () => {
+        it(`opens a missing ${kind} database after copying a ${testCase.label}${regression}`, () => {
           const { databasePath, env } = prepareCase(kind);
           const sidecars = [
             { suffix: testCase.suffix, contents: testCase.contents },
@@ -150,7 +151,7 @@ describe("orphan SQLite sidecar admission", () => {
             expect.stringContaining(quarantinePath),
             expect.objectContaining({
               databasePath,
-              quarantinedSidecars: [{ quarantinePath, sourcePath }],
+              copiedSidecars: [{ quarantinePath, sourcePath }],
             }),
           );
           expect(String(loggerMocks.warn.mock.calls[0]?.[0])).toContain(
@@ -214,13 +215,33 @@ describe("orphan SQLite sidecar admission", () => {
     );
   });
 
-  it("fails closed with the typed error when quarantine rename fails", () => {
+  it("leaves the live sidecar untouched and reuses an identical preserved copy", () => {
+    const { databasePath } = prepareCase("state");
+    const sourcePath = `${databasePath}-wal`;
+    fs.writeFileSync(sourcePath, walFixture.withFrames);
+
+    quarantineOrphanedSqliteSidecars(databasePath);
+    const quarantinePaths = listQuarantinePaths(sourcePath);
+
+    expect(quarantinePaths).toHaveLength(1);
+    expect(fs.readFileSync(sourcePath)).toEqual(walFixture.withFrames);
+    expect(fs.readFileSync(quarantinePaths[0] ?? "")).toEqual(walFixture.withFrames);
+    loggerMocks.warn.mockClear();
+
+    quarantineOrphanedSqliteSidecars(databasePath);
+
+    expect(listQuarantinePaths(sourcePath)).toEqual(quarantinePaths);
+    expect(fs.readFileSync(sourcePath)).toEqual(walFixture.withFrames);
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with the typed error when quarantine copy fails", () => {
     const { databasePath, env } = prepareCase("state");
     const sourcePath = `${databasePath}-wal`;
     fs.writeFileSync(sourcePath, walFixture.withFrames);
-    const renameError = Object.assign(new Error("read-only volume"), { code: "EROFS" });
-    vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
-      throw renameError;
+    const copyError = Object.assign(new Error("read-only volume"), { code: "EROFS" });
+    vi.spyOn(fs, "copyFileSync").mockImplementationOnce(() => {
+      throw copyError;
     });
 
     let thrown: unknown;

--- a/src/state/openclaw-database-orphan-sidecars.test.ts
+++ b/src/state/openclaw-database-orphan-sidecars.test.ts
@@ -1,0 +1,67 @@
+// Orphan-sidecar tests prove fresh database opens preserve recoverable SQLite families.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "./openclaw-agent-db.js";
+import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+
+const tempStateDirs = useAutoCleanupTempDirTracker(afterEach);
+const sidecarContents = Buffer.from("recoverable SQLite sidecar pages");
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("orphan SQLite sidecar admission", () => {
+  const cases = [
+    { kind: "state" as const, suffix: "-wal" },
+    { kind: "state" as const, suffix: "-shm" },
+    { kind: "state" as const, suffix: "-journal" },
+    { kind: "agent" as const, suffix: "-wal" },
+    { kind: "agent" as const, suffix: "-shm" },
+    { kind: "agent" as const, suffix: "-journal" },
+  ];
+
+  for (const testCase of cases) {
+    it(`refuses a missing ${testCase.kind} database with an orphan ${testCase.suffix}`, () => {
+      const stateDir = fs.realpathSync(tempStateDirs.make("openclaw-orphan-sidecar-"));
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const databasePath =
+        testCase.kind === "state"
+          ? resolveOpenClawStateSqlitePath(env)
+          : resolveOpenClawAgentSqlitePath({ agentId: "main", env });
+      const sidecarPath = `${databasePath}${testCase.suffix}`;
+      fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+      fs.writeFileSync(sidecarPath, sidecarContents);
+
+      let thrown: unknown;
+      try {
+        if (testCase.kind === "state") {
+          openOpenClawStateDatabase({ env });
+        } else {
+          openOpenClawAgentDatabase({ agentId: "main", env });
+        }
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).name).toBe("SqliteOrphanedSidecarsError");
+      expect((thrown as Error).message).toContain(databasePath);
+      expect((thrown as Error).message).toContain(sidecarPath);
+      expect((thrown as Error).message).toContain("Refusing to create a replacement database");
+      expect(fs.existsSync(databasePath)).toBe(false);
+      expect(fs.readFileSync(sidecarPath)).toEqual(sidecarContents);
+    });
+  }
+});

--- a/src/state/openclaw-database-orphan-sidecars.test.ts
+++ b/src/state/openclaw-database-orphan-sidecars.test.ts
@@ -136,17 +136,21 @@ describe("orphan SQLite sidecar admission", () => {
           expect(database.db.isOpen).toBe(true);
           expect(fs.existsSync(databasePath)).toBe(true);
           expect(quarantinePaths).toHaveLength(1);
-          expect(fs.readFileSync(quarantinePaths[0])).toEqual(testCase.contents);
+          const quarantinePath = quarantinePaths.at(0);
+          if (!quarantinePath) {
+            throw new Error(`missing quarantine for ${sourcePath}`);
+          }
+          expect(fs.readFileSync(quarantinePath)).toEqual(testCase.contents);
           if (fs.existsSync(sourcePath)) {
             // A successful WAL-mode open may create a new sidecar at the canonical path.
             expect(fs.readFileSync(sourcePath)).not.toEqual(testCase.contents);
           }
           expect(loggerMocks.warn).toHaveBeenCalledOnce();
           expect(loggerMocks.warn).toHaveBeenCalledWith(
-            expect.stringContaining(quarantinePaths[0]),
+            expect.stringContaining(quarantinePath),
             expect.objectContaining({
               databasePath,
-              quarantinedSidecars: [{ quarantinePath: quarantinePaths[0], sourcePath }],
+              quarantinedSidecars: [{ quarantinePath, sourcePath }],
             }),
           );
           expect(String(loggerMocks.warn.mock.calls[0]?.[0])).toContain(

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -8,6 +8,7 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
+import { assertNoOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
   collectSqliteSchemaIssues,
@@ -207,6 +208,7 @@ export async function preflightOpenClawStateDatabasePath(
     ...(details.reason ? { reason: details.reason } : {}),
   });
   try {
+    assertNoOrphanedSqliteSidecars(resolvedPath);
     const inspectionPath = realpathSync.native(resolvedPath);
     const sidecars = ["-wal", "-shm", "-journal"].filter((suffix) =>
       existsSync(`${inspectionPath}${suffix}`),

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -8,7 +8,6 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
-import { assertNoOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
   collectSqliteSchemaIssues,
@@ -208,7 +207,6 @@ export async function preflightOpenClawStateDatabasePath(
     ...(details.reason ? { reason: details.reason } : {}),
   });
   try {
-    assertNoOrphanedSqliteSidecars(resolvedPath);
     const inspectionPath = realpathSync.native(resolvedPath);
     const sidecars = ["-wal", "-shm", "-journal"].filter((suffix) =>
       existsSync(`${inspectionPath}${suffix}`),

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -16,7 +16,7 @@ import {
   runWithSqliteCoordinator,
   SqliteCoordinatorError,
 } from "../infra/sqlite-coordinator.js";
-import { assertNoOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
+import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
@@ -243,9 +243,9 @@ function acquireOpenClawStateWriteAccess(options: {
   env?: NodeJS.ProcessEnv;
 }): { release: () => void } {
   const resolvedPath = path.resolve(options.databasePath);
-  assertNoOrphanedSqliteSidecars(resolvedPath);
   const access = acquireOpenClawStateOwnershipCoordinator(resolvedPath);
   try {
+    quarantineOrphanedSqliteSidecars(resolvedPath);
     assertOwnershipAllowsWrite(
       inspectOpenClawStateOwnershipAtPathWhileCoordinatorHeld(resolvedPath),
       resolvedPath,
@@ -290,7 +290,7 @@ export async function assertOpenClawStateWriteAllowedAtPath(options: {
   env?: NodeJS.ProcessEnv;
 }): Promise<void> {
   const databasePath = path.resolve(options.databasePath);
-  assertNoOrphanedSqliteSidecars(databasePath);
+  quarantineOrphanedSqliteSidecars(databasePath);
   if (!existsSync(databasePath)) {
     return;
   }

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -16,6 +16,7 @@ import {
   runWithSqliteCoordinator,
   SqliteCoordinatorError,
 } from "../infra/sqlite-coordinator.js";
+import { assertNoOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
@@ -242,6 +243,7 @@ function acquireOpenClawStateWriteAccess(options: {
   env?: NodeJS.ProcessEnv;
 }): { release: () => void } {
   const resolvedPath = path.resolve(options.databasePath);
+  assertNoOrphanedSqliteSidecars(resolvedPath);
   const access = acquireOpenClawStateOwnershipCoordinator(resolvedPath);
   try {
     assertOwnershipAllowsWrite(
@@ -288,6 +290,7 @@ export async function assertOpenClawStateWriteAllowedAtPath(options: {
   env?: NodeJS.ProcessEnv;
 }): Promise<void> {
   const databasePath = path.resolve(options.databasePath);
+  assertNoOrphanedSqliteSidecars(databasePath);
   if (!existsSync(databasePath)) {
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes a startup wedge when `openclaw.sqlite` or `openclaw-agent.sqlite` is missing but a recoverable SQLite WAL or rollback journal remains. SQLite cannot recover a WAL without its matching main database, yet letting a fresh open delete or rewrite that WAL prevents a later main-database restore from recovering its committed frames.

The previous revision preserved those bytes by renaming the durable sidecar before SQLite opened the path. Hosted CI proved that rename is unsafe at database-open time: exact head `c37c86631e2` repeatedly failed in run https://github.com/openclaw/openclaw/actions/runs/31840348637, job `checks-node-compact-small-7`, shard `agentic-commands-agent-channel`, while `src/commands/agents.add.test.ts` opened shared state:

```text
Error: disk I/O error
 ❯ tableExists src/state/openclaw-state-db-schema-helpers.ts:22:6
 ❯ openOpenClawStateDatabase src/state/openclaw-state-db.ts:612:19
 ❯ runOpenClawStateWriteTransaction src/state/openclaw-state-db.ts:653:16
Serialized Error: { code: 'ERR_SQLITE_ERROR', errcode: 522, errstr: 'disk I/O error' }
```

SQLite error 522 is `SQLITE_IOERR_SHORT_READ`. Pulling a WAL out from under another open or memory-mapped connection, or racing another opener into a missing sidecar, can leave that live family inconsistent. Preservation must not mutate the family it is protecting.

## Why This Change Was Made

Fresh database admission now copies only durable orphan sidecars before SQLite opens the path:

- a WAL strictly larger than its 32-byte header;
- a non-empty rollback journal;
- never a lone SHM index, empty WAL/journal, or header-only WAL.

The preserved naming scheme remains `<sidecar>.orphaned-<epochMs>`, with `-1`, `-2`, and so on for collisions. Copies use exclusive creation so an existing archive is never overwritten. The original WAL or journal is left untouched; SQLite may subsequently delete or rewrite the canonical sidecar after the preservation copy exists.

Repeated opens are content-idempotent. Only after the main database is absent and a qualifying durable sidecar exists, OpenClaw scans matching `.orphaned-*` files, filters by byte size, and compares SHA-256. An identical existing copy suppresses another copy and warning. The healthy-main path still returns immediately after the existing main-file probe and performs no new syscall.

After a new copy, the `state/sqlite` logger emits one warning containing the exact source and copied paths:

> SQLite database is missing at `<main>`; copied orphaned sidecars: `<source>` -> `<copy>`. Committed frames could not be applied because the main database is missing. The bytes are preserved. Recovery requires restoring the main database and pairing it with the quarantined file.

If copying fails, OpenClaw fails closed with `SqliteOrphanedSidecarsError` and does not proceed into SQLite. The rename rollback machinery is gone because the live family is never moved. No schema, schema-version, config, or migration change is involved.

## User Impact

Doctor and Gateway startup can continue with a fresh main database after preserving orphan recovery bytes, and agent database creation behaves the same way. Operators get an exact recovery path without a permanent startup wedge and without preservation disturbing a family another connection may still hold.

AI-assisted: yes. The implementation and evidence were reviewed by the author.

## Evidence

### Concurrency regression

- Local stress did **not** reproduce the hosted short read. The exact `agents.add.test.ts` + `plugin-install.test.ts` pair ran 12 times with `OPENCLAW_VITEST_MAX_WORKERS=8` against one shared temporary `OPENCLAW_STATE_DIR`; all 516 test executions passed. The exact-head hosted failure above remains the pre-fix concurrency signal.
- The regression test now calls the preservation owner directly and proves the canonical WAL remains byte-identical after preservation. That assertion fails against the rename implementation.

### SQLite recoverability

- A fresh scenario-C scratch run copied the orphan WAL without changing the source, restored the saved main into a separate family, paired it with the preserved copy, and read `RECOVERABLE-MARKER`.
- Original and copied WAL SHA-256 matched: `4726c8347be9671717d1cb806e529a3b318c4a44d004202cf3c554c220d82fa0`.
- Calling preservation again with the same orphan bytes created no additional copy and emitted no new warning.

### Regression and gates

- `node scripts/run-vitest.mjs src/state/openclaw-database-orphan-sidecars.test.ts` — 15 passed.
- `OPENCLAW_VITEST_MAX_WORKERS=8 node scripts/run-vitest.mjs src/commands/agents.add.test.ts src/commands/channel-setup/plugin-install.test.ts` — 43 passed.
- Broader state/ownership/agent regression set — 199 passed, 4 skipped.
- `node scripts/check-changed.mjs` — Testbox exit 0 after formatting, production/test typechecks, core/extensions/scripts lint, dependency and patch policy, dead exports, native schema-version and database-first guards, and import cycles. Run: https://github.com/openclaw/openclaw/actions/runs/31841465451
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
- Rebased onto current `origin/main`; focused post-rebase proof remains 15/15 and 43/43 green.

Round 4 LOC: production +80/-41 (net +39); tests +27/-6 (net +21). Total PR LOC: production +137/-0; tests +264/-0. The production growth provides collision-safe non-mutating preservation plus bounded size/SHA-256 idempotency while deleting rename rollback behavior.
