### PR TITLE
refactor(ui): unify sidebar chrome grid

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -253,7 +253,8 @@ export function renderRecentSession(params: {
     requiredScope: "operator.write",
   });
   const rowDraggable = !session.isChild && groupWriteAccess.allowed;
-  // Always reserve the lead so every title shares the section-label text line.
+  // Leading state occupies the shared icon rail without owning text alignment.
+  const showLead = leadingIndicator !== nothing || session.visibility === "draft";
   const row = html`
     <div
       class=${rowClass}

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -253,8 +253,7 @@ export function renderRecentSession(params: {
     requiredScope: "operator.write",
   });
   const rowDraggable = !session.isChild && groupWriteAccess.allowed;
-  // Leading state occupies the shared icon rail without owning text alignment.
-  const showLead = leadingIndicator !== nothing || session.visibility === "draft";
+  // Always reserve the lead so every title shares the section-label text line.
   const row = html`
     <div
       class=${rowClass}

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -73,6 +73,7 @@ const sidebarChromeImport = createIdleImport(() =>
 class AppSidebar extends AppSidebarSessionNavigationElement implements SessionListHost {
   @state() sidebarNarrationLines: ReadonlyMap<string, string> = new Map();
   @state() sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest> = new Map();
+  @state() private sidebarScrolling = false;
 
   override readonly sessionOrganizer = new SessionOrganizerController(this);
   override readonly sidebarMenus = new SidebarMenusController(this);
@@ -103,6 +104,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   // dropped because the controller aligns from cumulative snapshots.
   private narration: SidebarSessionNarrationController | null = null;
   private narrationLoad: Promise<void> | null = null;
+  private sidebarScrollIdleTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private sessionNavigationState: SidebarSessionNavigationState | undefined;
   private projectedSessionRows: SidebarRecentSession[] | undefined;
   private readonly narrationSubscriptions = this.createNarrationSubscriptions();
@@ -185,7 +187,25 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     );
     this.narration?.disconnect();
     this.catalogRendererImport.dispose();
+    if (this.sidebarScrollIdleTimer) {
+      globalThis.clearTimeout(this.sidebarScrollIdleTimer);
+      this.sidebarScrollIdleTimer = null;
+    }
     super.disconnectedCallback();
+  }
+
+  private handleSidebarScroll(element: HTMLElement) {
+    this.sessionData.updateSessionsScrollState(element);
+    this.sidebarScrolling = true;
+    if (this.sidebarScrollIdleTimer) {
+      globalThis.clearTimeout(this.sidebarScrollIdleTimer);
+    }
+    // Keep the otherwise-hidden thumb visible through a scroll gesture, then
+    // return it to rest without leaving a permanent rail beside the divider.
+    this.sidebarScrollIdleTimer = globalThis.setTimeout(() => {
+      this.sidebarScrollIdleTimer = null;
+      this.sidebarScrolling = false;
+    }, 500);
   }
 
   protected override willUpdate(changed: PropertyValues<this>) {
@@ -489,9 +509,11 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
           ${renderAppSidebarBrand(this)}
           <div
             class="sidebar-shell__body sidebar-shell__body--scroll-${this.sessionData
-              .sessionsScrollState}"
+              .sessionsScrollState} ${this.sidebarScrolling
+              ? "sidebar-shell__body--scrolling"
+              : ""}"
             @scroll=${(event: Event) =>
-              this.sessionData.updateSessionsScrollState(event.currentTarget as HTMLElement)}
+              this.handleSidebarScroll(event.currentTarget as HTMLElement)}
           >
             <nav class="sidebar-nav" @contextmenu=${this.sidebarMenus.openCustomizeMenuFromContext}>
               ${renderAppSidebarPagesHead(this)}

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -225,7 +225,7 @@ suite.define(() => {
       const groupGap = await page.evaluate(() => {
         const sidebar = document.querySelector(".sidebar");
         return sidebar
-          ? Number.parseInt(getComputedStyle(sidebar).getPropertyValue("--sidebar-group-gap"), 10)
+          ? Number.parseInt(getComputedStyle(sidebar).getPropertyValue("--sidebar-section-gap"), 10)
           : Number.NaN;
       });
       expect(groupGap).toBeGreaterThan(0);
@@ -497,29 +497,29 @@ suite.define(() => {
       );
       expect(threadRowMetrics).toEqual([
         {
-          height: 30,
-          minHeight: "30px",
+          height: 32,
+          minHeight: "32px",
           nameFontSize: "13px",
           paddingBottom: "3px",
           paddingTop: "3px",
         },
         {
-          height: 30,
-          minHeight: "30px",
+          height: 32,
+          minHeight: "32px",
           nameFontSize: "13px",
           paddingBottom: "3px",
           paddingTop: "3px",
         },
         {
-          height: 30,
-          minHeight: "30px",
+          height: 32,
+          minHeight: "32px",
           nameFontSize: "13px",
           paddingBottom: "3px",
           paddingTop: "3px",
         },
         {
-          height: 30,
-          minHeight: "30px",
+          height: 32,
+          minHeight: "32px",
           nameFontSize: "13px",
           paddingBottom: "3px",
           paddingTop: "3px",

--- a/ui/src/e2e/sidebar-chrome-grid.e2e.test.ts
+++ b/ui/src/e2e/sidebar-chrome-grid.e2e.test.ts
@@ -1,0 +1,412 @@
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  controlUiSessionUrl,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+import {
+  captureSidebarUiUnionProof,
+  createSidebarCustomizationSuite,
+} from "./sidebar-customization.test-support.ts";
+
+const suite = createSidebarCustomizationSuite("Control UI sidebar chrome grid mocked Gateway E2E");
+const visualVariants = [{ colorScheme: "light" as const }, { colorScheme: "dark" as const }];
+
+function configResponse(colorScheme: "light" | "dark") {
+  const config = { ui: { prefs: { locale: "en", themeMode: colorScheme } } };
+  const hash = `sidebar-grid-${colorScheme}`;
+  return {
+    appliedConfigHash: hash,
+    config,
+    configRevisionHash: hash,
+    hash,
+    issues: [],
+    raw: JSON.stringify(config),
+    valid: true,
+  };
+}
+
+async function left(locator: Locator) {
+  return Math.round((await locator.boundingBox())?.x ?? Number.NaN);
+}
+
+async function center(locator: Locator) {
+  const box = await locator.boundingBox();
+  return Math.round(box ? box.x + box.width / 2 : Number.NaN);
+}
+
+async function surfaceBounds(locator: Locator) {
+  const box = await locator.boundingBox();
+  return box
+    ? { left: Math.round(box.x), right: Math.round(box.x + box.width) }
+    : { left: Number.NaN, right: Number.NaN };
+}
+
+async function background(locator: Locator) {
+  return locator.evaluate((element) => getComputedStyle(element).backgroundColor);
+}
+
+async function waitForAnimations(locator: Locator) {
+  await locator.evaluate(async (element) => {
+    await Promise.all(
+      element
+        .getAnimations({ subtree: true })
+        .map((animation) => animation.finished.catch(() => undefined)),
+    );
+  });
+}
+
+async function installGridGuides(page: Page, sidebar: Locator, text: Locator, control: Locator) {
+  await page.addStyleTag({
+    content: `
+      .sidebar[data-grid-proof]::before,
+      .sidebar[data-grid-proof]::after {
+        content: "";
+        position: absolute;
+        inset-block: 0;
+        z-index: 220;
+        width: 1px;
+        pointer-events: none;
+      }
+      .sidebar[data-grid-proof]::before {
+        inset-inline-start: var(--grid-proof-text);
+        background: rgb(255 64 64 / 0.82);
+      }
+      .sidebar[data-grid-proof]::after {
+        inset-inline-start: var(--grid-proof-rail);
+        background: rgb(40 180 255 / 0.82);
+      }
+    `,
+  });
+  const [sidebarBox, textBox, controlBox] = await Promise.all([
+    sidebar.boundingBox(),
+    text.boundingBox(),
+    control.boundingBox(),
+  ]);
+  if (!sidebarBox || !textBox || !controlBox) {
+    throw new Error("expected visible sidebar grid anchors");
+  }
+  await sidebar.evaluate(
+    (element, offsets) => {
+      element.setAttribute("data-grid-proof", "");
+      (element as HTMLElement).style.setProperty("--grid-proof-text", `${offsets.text}px`);
+      (element as HTMLElement).style.setProperty("--grid-proof-rail", `${offsets.rail}px`);
+    },
+    {
+      rail: controlBox.x + controlBox.width / 2 - sidebarBox.x,
+      text: textBox.x - sidebarBox.x,
+    },
+  );
+}
+
+async function capture(page: Page, sidebarSurface: Locator, fileName: string) {
+  await captureSidebarUiUnionProof(page, [sidebarSurface], fileName);
+}
+
+suite.define(() => {
+  it.each(visualVariants)(
+    "keeps sidebar chrome on one structural grid in $colorScheme",
+    async ({ colorScheme }) => {
+      const context = await suite.newBrowserContext({
+        colorScheme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 600, width: 1440 },
+      });
+      const page = await context.newPage();
+      const baseTime = Date.parse("2026-08-14T16:00:00.000Z");
+      const pinnedKey = "agent:main:pinned";
+      const parentKey = "agent:main:release-plan";
+      const childKey = "agent:main:verify-release";
+      const draftKey = "agent:main:draft";
+      const overflowRows = Array.from({ length: 18 }, (_, index) =>
+        sessionRow(
+          `agent:main:overflow-${index}`,
+          `Overflow session ${String(index + 1).padStart(2, "0")}`,
+          baseTime - (index + 10) * 1_000,
+        ),
+      );
+      await installMockGateway(page, {
+        featureMethods: ["sessions.catalog.list"],
+        methodResponses: {
+          "config.get": configResponse(colorScheme),
+          "sessions.list": {
+            cases: [
+              {
+                match: { spawnedBy: parentKey },
+                response: sessionsListResponse([
+                  sessionRow(childKey, "Verify release evidence", baseTime - 2_000, {
+                    spawnedBy: parentKey,
+                    startedAt: baseTime - 62_000,
+                    status: "done",
+                  }),
+                ]),
+              },
+              {
+                response: sessionsListResponse([
+                  sessionRow(pinnedKey, "Pinned handoff", baseTime, { pinned: true }),
+                  sessionRow(parentKey, "Release plan", baseTime - 1_000, {
+                    category: "Research",
+                    childSessions: [childKey],
+                  }),
+                  {
+                    ...sessionRow(draftKey, "Draft session", baseTime - 3_000),
+                    visibility: "draft",
+                  },
+                  ...overflowRows,
+                ]),
+              },
+            ],
+          },
+          "sessions.catalog.list": {
+            catalogs: [
+              {
+                id: "codex",
+                label: "Codex",
+                capabilities: { continueSession: true, archive: true },
+                hosts: [
+                  {
+                    hostId: "gateway:local",
+                    label: "Gateway",
+                    kind: "gateway",
+                    connected: true,
+                    sessions: [
+                      {
+                        threadId: "catalog-session",
+                        name: "Catalog session",
+                        cwd: "/workspace/openclaw",
+                        status: "idle",
+                        archived: false,
+                        canContinue: true,
+                        canArchive: true,
+                        updatedAt: baseTime - 4_000,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        sessionGroups: ["Research"],
+        sessionKey: parentKey,
+      });
+
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, parentKey));
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const sidebarRoot = sidebar.locator(".sidebar");
+        const sidebarSurface = sidebar.locator(".sidebar-shell");
+        const body = sidebar.locator(".sidebar-shell__body");
+        const shellNav = page.locator(".shell-nav");
+        const resizer = page.getByRole("separator", { name: "Resize sidebar" });
+        const homeRow = sidebar.locator(".nav-item--home");
+        const pageRow = sidebar.getByRole("link", { name: "Automations" });
+        const pageText = homeRow.locator(".nav-item__text");
+        const pageControl = sidebar.locator(".sidebar-nav__head-action");
+        const pinnedRow = sidebar.locator(`[data-session-key="${pinnedKey}"]`);
+        const parentRow = sidebar.locator(`[data-session-key="${parentKey}"]`);
+        const draftRow = sidebar.locator(`[data-session-key="${draftKey}"]`);
+        await parentRow.waitFor();
+        await parentRow.locator(".sidebar-child-session-toggle").click();
+        const childRow = sidebar.locator(`[data-session-key="${childKey}"]`);
+        const catalogRow = sidebar.locator('[data-session-key*="catalog-session"]');
+        await childRow.waitFor();
+        await catalogRow.waitFor();
+        await expect
+          .poll(() => parentRow.getAttribute("class"))
+          .toContain("sidebar-recent-session--active");
+        await expect
+          .poll(() => page.locator("html").getAttribute("data-theme-mode"))
+          .toBe(colorScheme);
+
+        const textAnchors = [
+          pageText,
+          sidebar.locator(".sidebar-nav__head .sidebar-recent-sessions__label-text"),
+          pinnedRow.locator(".sidebar-recent-session__name"),
+          parentRow.locator(".sidebar-recent-session__name"),
+          draftRow.locator(".sidebar-recent-session__name"),
+          catalogRow.locator(".sidebar-recent-session__name"),
+          sidebar.locator(".sidebar-identity-card__name"),
+        ];
+        const textAxis = await left(pageText);
+        expect(await Promise.all(textAnchors.map(left))).toEqual(
+          Array(textAnchors.length).fill(textAxis),
+        );
+        expect(await left(childRow.locator(".sidebar-recent-session__name"))).toBe(textAxis + 16);
+
+        const trailingAnchors = [
+          pageControl,
+          pinnedRow.locator("[data-session-menu]"),
+          draftRow.locator("[data-session-menu]"),
+          sidebar.locator(".sidebar-identity-card__chevron"),
+        ];
+        const trailingAxis = await center(pageControl);
+        expect(await Promise.all(trailingAnchors.map(center))).toEqual(
+          Array(trailingAnchors.length).fill(trailingAxis),
+        );
+
+        const pageSurface = await surfaceBounds(homeRow);
+        for (const row of [pinnedRow, parentRow, draftRow]) {
+          expect(await surfaceBounds(row)).toEqual(pageSurface);
+        }
+        expect(await body.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+          true,
+        );
+
+        const sessionSelected = await background(parentRow);
+        expect(sessionSelected).not.toBe("rgba(0, 0, 0, 0)");
+        await installGridGuides(page, sidebarRoot, pageText, pageControl);
+        await capture(page, sidebarSurface, `grid-${colorScheme}-current-selected.png`);
+
+        await homeRow.click();
+        await expect.poll(() => homeRow.getAttribute("class")).toContain("nav-item--active");
+        await waitForAnimations(homeRow);
+        expect(await background(homeRow)).toBe(sessionSelected);
+        await capture(page, sidebarSurface, `grid-${colorScheme}-page-selected.png`);
+        await parentRow.locator(".sidebar-recent-session__link").click();
+        await expect
+          .poll(() => parentRow.getAttribute("class"))
+          .toContain("sidebar-recent-session--active");
+
+        await pageRow.hover();
+        await waitForAnimations(pageRow);
+        const pageHover = await background(pageRow);
+        await capture(page, sidebarSurface, `grid-${colorScheme}-page-hover.png`);
+        await draftRow.hover();
+        await waitForAnimations(draftRow);
+        expect(await background(draftRow)).toBe(pageHover);
+        await capture(page, sidebarSurface, `grid-${colorScheme}-session-hover.png`);
+
+        await pageRow.focus();
+        await page.keyboard.press("Shift+Tab");
+        await page.keyboard.press("Tab");
+        expect(await pageRow.evaluate((element) => element.matches(":focus-visible"))).toBe(true);
+        expect(await pageRow.evaluate((element) => getComputedStyle(element).boxShadow)).not.toBe(
+          "none",
+        );
+        await capture(page, sidebarSurface, `grid-${colorScheme}-page-focus.png`);
+
+        const draftLink = draftRow.locator(".sidebar-recent-session__link");
+        await draftLink.focus();
+        await page.keyboard.press("Shift+Tab");
+        await page.keyboard.press("Tab");
+        expect(await draftLink.evaluate((element) => element.matches(":focus-visible"))).toBe(true);
+        expect(await draftRow.evaluate((element) => getComputedStyle(element).boxShadow)).not.toBe(
+          "none",
+        );
+        await capture(page, sidebarSurface, `grid-${colorScheme}-session-focus.png`);
+
+        await page.locator("#control-ui-main").focus();
+        await page.mouse.move(700, 700);
+        const scrollbarRest = await body.evaluate(
+          (element) => getComputedStyle(element).scrollbarColor,
+        );
+        await capture(page, sidebarSurface, `grid-${colorScheme}-scrollbar-rest.png`);
+        await body.hover();
+        const scrollbarHover = await body.evaluate(
+          (element) => getComputedStyle(element).scrollbarColor,
+        );
+        expect(scrollbarHover).not.toBe(scrollbarRest);
+        await page.mouse.wheel(0, 700);
+        await expect
+          .poll(() => body.getAttribute("class"))
+          .toContain("sidebar-shell__body--scrolling");
+        await page.mouse.move(700, 700);
+        expect(await body.evaluate((element) => getComputedStyle(element).scrollbarColor)).toBe(
+          scrollbarHover,
+        );
+        await capture(page, sidebarSurface, `grid-${colorScheme}-scrollbar-active.png`);
+        await expect
+          .poll(() => body.getAttribute("class"))
+          .not.toContain("sidebar-shell__body--scrolling");
+
+        await body.evaluate((element) => element.scrollTo({ top: 0 }));
+        const restDivider = await resizer.evaluate((element) => ({
+          railColor: getComputedStyle(element).getPropertyValue("--rail-divider-color").trim(),
+          shell: getComputedStyle(element.previousElementSibling!).borderInlineEndColor,
+          targetWidth: element.getBoundingClientRect().width,
+        }));
+        expect(restDivider.railColor).toBe("transparent");
+        expect(restDivider.shell).not.toBe("rgba(0, 0, 0, 0)");
+        expect(restDivider.targetWidth).toBe(6);
+        await resizer.hover();
+        const activeDivider = await resizer.evaluate((element) => ({
+          activeColor: getComputedStyle(element).getPropertyValue("--accent").trim(),
+          globalAccent: getComputedStyle(document.documentElement)
+            .getPropertyValue("--accent")
+            .trim(),
+          hovered: element.matches(":hover"),
+          shell: getComputedStyle(element.previousElementSibling!).borderInlineEndColor,
+        }));
+        expect(activeDivider.hovered).toBe(true);
+        expect(activeDivider.activeColor).not.toBe(activeDivider.globalAccent);
+        expect(activeDivider.shell).toBe("rgba(0, 0, 0, 0)");
+        await capture(page, sidebarSurface, `grid-${colorScheme}-resize-hover.png`);
+
+        const resizerBounds = await resizer.boundingBox();
+        if (!resizerBounds) {
+          throw new Error("expected visible sidebar resizer");
+        }
+        const resizerX = resizerBounds.x + resizerBounds.width / 2;
+        const resizerY = resizerBounds.y + resizerBounds.height / 2;
+        await page.mouse.move(resizerX, resizerY);
+        await page.mouse.down();
+        await page.mouse.move(resizerX + 22, resizerY);
+        await expect
+          .poll(async () => Math.round((await shellNav.boundingBox())?.width ?? 0))
+          .toBe(280);
+        await capture(page, sidebarSurface, `grid-${colorScheme}-resize-drag-280.png`);
+        await page.mouse.up();
+        await capture(page, sidebarSurface, `grid-${colorScheme}-width-280.png`);
+
+        await resizer.focus();
+        await expect
+          .poll(() => resizer.evaluate((element) => getComputedStyle(element).outlineStyle))
+          .toBe("none");
+        await page.keyboard.press("End");
+        await expect
+          .poll(async () => Math.round((await shellNav.boundingBox())?.width ?? 0))
+          .toBe(400);
+        expect(await Promise.all(textAnchors.map(left))).toEqual(
+          Array(textAnchors.length).fill(await left(pageText)),
+        );
+        expect(await body.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+          true,
+        );
+        await installGridGuides(page, sidebarRoot, pageText, pageControl);
+        await capture(page, sidebarSurface, `grid-${colorScheme}-width-400.png`);
+
+        await page.locator("html").evaluate((element) => {
+          element.setAttribute("dir", "rtl");
+        });
+        const viewportWidth = page.viewportSize()!.width;
+        const rtlStarts = await Promise.all(
+          textAnchors.map(async (locator) => {
+            const box = await locator.boundingBox();
+            return Math.round(viewportWidth - (box?.x ?? Number.NaN) - (box?.width ?? Number.NaN));
+          }),
+        );
+        expect(rtlStarts).toEqual(Array(rtlStarts.length).fill(rtlStarts[0]));
+        const rtlParent = await parentRow.locator(".sidebar-recent-session__name").boundingBox();
+        const rtlChild = await childRow.locator(".sidebar-recent-session__name").boundingBox();
+        expect(
+          Math.round(
+            viewportWidth -
+              rtlChild!.x -
+              rtlChild!.width -
+              (viewportWidth - rtlParent!.x - rtlParent!.width),
+          ),
+        ).toBe(16);
+        expect(await body.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+          true,
+        );
+        await capture(page, sidebarSurface, `grid-${colorScheme}-rtl-400.png`);
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+});

--- a/ui/src/e2e/sidebar-chrome-grid.e2e.test.ts
+++ b/ui/src/e2e/sidebar-chrome-grid.e2e.test.ts
@@ -222,9 +222,10 @@ suite.define(() => {
           .poll(() => page.locator("html").getAttribute("data-theme-mode"))
           .toBe(colorScheme);
 
+        // The Pages head label is sr-only: it is deliberately taken out of the
+        // visual flow, so it has no column to share and cannot anchor the axis.
         const textAnchors = [
           pageText,
-          sidebar.locator(".sidebar-nav__head .sidebar-recent-sessions__label-text"),
           pinnedRow.locator(".sidebar-recent-session__name"),
           parentRow.locator(".sidebar-recent-session__name"),
           draftRow.locator(".sidebar-recent-session__name"),

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5740,7 +5740,7 @@ td.data-table-key-col {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
+  width: var(--sidebar-trailing-slot, 20px);
   height: 24px;
   padding: 0;
   border: none;
@@ -5765,9 +5765,15 @@ td.data-table-key-col {
   stroke-linejoin: round;
 }
 
-.session-action:hover:not(:disabled) {
+.session-action:hover:not(:disabled),
+.session-action:focus-visible:not(:disabled) {
   background: color-mix(in srgb, var(--bg-hover) 92%, transparent);
   color: var(--text);
+}
+
+.session-action:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--sidebar-focus-visible);
 }
 
 .session-action:disabled {
@@ -5822,7 +5828,7 @@ td.data-table-key-col {
 }
 
 .session-row-host--pinned .session-action--pin {
-  color: var(--accent);
+  color: var(--text);
 }
 
 .session-run-spinner {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -974,6 +974,7 @@ openclaw-settings-save-indicator {
   --sidebar-text-start: 34px;
   --sidebar-tree-depth: 16px;
   --sidebar-trailing-slot: 20px;
+  --sidebar-header-action-size: 22px;
   --sidebar-scrollbar-gutter: 8px;
   --sidebar-lucide-icon-size: 16px;
   --sidebar-lucide-stroke-width: 1.5px;
@@ -1750,12 +1751,21 @@ body.update-dialog-open .sidebar-update-card__status {
   cursor: grabbing;
 }
 
+/* Header action surfaces may overflow the 20px rail; symmetric margins keep
+   their centers on the shared trailing axis. */
+.sidebar-session-sort,
+.sidebar-session-group-actions,
+.sidebar-nav__head-action {
+  width: var(--sidebar-header-action-size);
+  margin-inline: calc((var(--sidebar-trailing-slot) - var(--sidebar-header-action-size)) / 2);
+}
+
 .sidebar-session-sort {
+  --sidebar-header-action-size: 28px;
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--sidebar-trailing-slot);
   height: 28px;
   flex: 0 0 auto;
   border: none;
@@ -1803,7 +1813,6 @@ body.update-dialog-open .sidebar-update-card__status {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--sidebar-trailing-slot);
   height: 22px;
   flex: 0 0 auto;
   border: none;
@@ -1844,7 +1853,6 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-group-actions.sidebar-session-sort {
-  width: var(--sidebar-trailing-slot);
   height: 28px;
 }
 
@@ -3286,7 +3294,6 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--sidebar-trailing-slot);
   height: 22px;
   flex: none;
   border: none;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2565,6 +2565,12 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-zone-entry {
+  /* Pinned and plugin entries sit outside .sidebar-recent-sessions but draw the
+     same row, so they read the same inset/lead/gap instead of their own. */
+  --sidebar-inset: 8px;
+  --sidebar-lead: 20px;
+  --sidebar-row-gap: 8px;
+
   min-width: 0;
   border-radius: var(--radius-md);
   transition:
@@ -3075,7 +3081,6 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .nav-item.nav-item--active {
   color: var(--text-strong);
   background: var(--sidebar-row-surface-selected);
-  border-color: transparent;
 }
 
 .nav-item.active .nav-item__icon,
@@ -3098,8 +3103,6 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-zone-entry .sidebar-recent-session {
   position: relative;
   min-height: 32px;
-  padding: 0 8px;
-  border: 1px solid transparent;
   background: transparent;
   color: var(--muted);
   transition:
@@ -3110,9 +3113,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .sidebar-zone-entry .sidebar-recent-session__link {
-  gap: 8px;
   min-height: 30px;
-  padding: 0;
 }
 
 .sidebar-zone-entry .sidebar-recent-session__name {
@@ -3122,7 +3123,6 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-zone-entry .sidebar-recent-session:hover {
   color: var(--text);
   background: var(--sidebar-row-surface-hover);
-  border-color: transparent;
 }
 
 .sidebar-zone-entry .sidebar-recent-session.sidebar-recent-session--active {
@@ -3358,14 +3358,20 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .sidebar-identity-card {
+  /* The footer identity is a sidebar row like any other: same inset, same lead
+     column, same gap, so its name lands on the shared text axis. */
+  --sidebar-inset: 8px;
+  --sidebar-lead: 20px;
+  --sidebar-row-gap: 8px;
+
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) var(--sidebar-trailing-slot);
+  grid-template-columns: var(--sidebar-lead) minmax(0, 1fr) var(--sidebar-trailing-slot);
   align-items: center;
-  gap: 8px;
+  gap: var(--sidebar-row-gap);
   width: 100%;
   min-width: 0;
   padding-block: 5px;
-  padding-inline-start: var(--sidebar-row-inset);
+  padding-inline-start: var(--sidebar-inset);
   padding-inline-end: 0;
   border: none;
   border-radius: var(--radius-md);
@@ -4146,14 +4152,9 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
+  width: var(--sidebar-lead, 16px);
   height: 16px;
-  flex: 0 0 16px;
-}
-
-.sidebar-recent-sessions .sidebar-session-indicator {
-  width: var(--sidebar-lead);
-  flex-basis: var(--sidebar-lead);
+  flex: 0 0 var(--sidebar-lead, 16px);
 }
 
 .sidebar-session-indicator > .session-row-draft-indicator:not(:only-child) {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1587,7 +1587,7 @@ body.update-dialog-open .sidebar-update-card__status {
   align-items: center;
   gap: 8px;
   min-height: 24px;
-  padding: 0;
+  padding: 0 10px 0 var(--sidebar-inset);
   color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
 }
 
@@ -1597,8 +1597,7 @@ body.update-dialog-open .sidebar-update-card__status {
   gap: var(--sidebar-row-gap);
   min-width: 0;
   flex: 1 1 auto;
-  padding-block: 2px;
-  padding-inline-start: calc(var(--sidebar-text-start) - var(--sidebar-lead));
+  padding: 2px 0;
   border: none;
   background: transparent;
   color: inherit;
@@ -1911,8 +1910,12 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-tree__children {
-  margin-inline-start: calc(var(--sidebar-tree-depth) - 1px);
-  border-inline-start: 1px solid color-mix(in srgb, var(--border-strong) 52%, transparent);
+  margin-left: var(--sidebar-lead);
+  background: linear-gradient(
+      color-mix(in srgb, var(--border-strong) 52%, transparent),
+      color-mix(in srgb, var(--border-strong) 52%, transparent)
+    )
+    calc(var(--sidebar-inset) + 10px) 0 / 1px 100% no-repeat;
 }
 
 .sidebar-session-tree__loading {
@@ -2077,7 +2080,7 @@ body.update-dialog-open .sidebar-update-card__status {
 
 .sidebar-session-empty-hint {
   display: block;
-  padding: 4px 10px 10px var(--sidebar-text-start);
+  padding: 4px 10px 10px var(--sidebar-text-offset);
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
 }
@@ -2168,29 +2171,15 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-recent-session__link {
-  position: relative;
   display: flex;
   align-items: center;
   gap: var(--sidebar-row-gap);
   flex: 1 1 auto;
   min-width: 0;
-  min-height: 30px;
-  padding-block: 3px;
-  padding-inline: var(--sidebar-text-start) 4px;
+  padding: 3px 4px 3px var(--sidebar-inset);
   color: inherit;
   cursor: var(--cursor-action);
   text-decoration: none;
-}
-
-.sidebar-recent-sessions
-  .sidebar-recent-session__link
-  > :not(.sidebar-session-indicator):not(.sidebar-recent-session__text) {
-  margin-left: 8px;
-}
-
-.sidebar-recent-session__link > .sidebar-session-indicator {
-  position: absolute;
-  inset-inline-start: var(--sidebar-row-inset);
 }
 
 .sidebar-child-session-toggle {
@@ -2989,7 +2978,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   justify-content: flex-start;
   gap: 8px;
   min-height: 32px;
-  padding-inline-start: var(--sidebar-row-inset);
+  padding: 0 8px;
   border-radius: var(--radius-md);
   border: 0;
   background: var(--sidebar-row-surface);
@@ -3109,9 +3098,9 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-zone-entry .sidebar-recent-session {
   position: relative;
   min-height: 32px;
-  padding: 0;
-  border: 0;
-  background: var(--sidebar-row-surface);
+  padding: 0 8px;
+  border: 1px solid transparent;
+  background: transparent;
   color: var(--muted);
   transition:
     border-color var(--duration-fast) ease,
@@ -3121,10 +3110,9 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .sidebar-zone-entry .sidebar-recent-session__link {
-  gap: 0;
+  gap: 8px;
   min-height: 30px;
-  padding-block: 3px;
-  padding-inline: var(--sidebar-text-start) 4px;
+  padding: 0;
 }
 
 .sidebar-zone-entry .sidebar-recent-session__name {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -953,7 +953,6 @@ openclaw-settings-save-indicator {
   --sidebar-focus-visible: color-mix(in srgb, var(--text) 34%, transparent);
   --sidebar-divider-active: color-mix(in srgb, var(--text) 42%, transparent);
   --focus-ring: 0 0 0 2px var(--sidebar-focus-visible);
-  --scrollbar-size: 10px;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -2078,7 +2077,7 @@ body.update-dialog-open .sidebar-update-card__status {
 
 .sidebar-session-empty-hint {
   display: block;
-  padding: 4px 10px 10px var(--sidebar-text-offset);
+  padding: 4px 10px 10px var(--sidebar-text-start);
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -908,18 +908,31 @@ openclaw-settings-save-indicator {
   display: flex;
   min-height: 100%;
   overflow: visible;
-  border-right: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  border-inline-end: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
   transition: width var(--shell-focus-duration) var(--shell-focus-ease);
 }
 
-/* 1px overlay on the nav border edge; the divider paints its own centered
-   line, so the host needs no background here. */
+/* The shell border owns the resting boundary. The wider resize target stays
+   transparent until interaction, when it temporarily takes over that line. */
 .sidebar-resizer {
   grid-area: nav;
   align-self: stretch;
   justify-self: end;
   z-index: 20;
-  width: 1px;
+  width: 6px;
+  --accent: var(--sidebar-divider-active, var(--text));
+  --rail-divider-active-size: 1px;
+  --rail-divider-color: transparent;
+}
+
+/* The active hairline is the focus indicator; the divider component's outer
+   outline would paint a second boundary beside the shell. */
+.sidebar-resizer:focus-visible {
+  outline: none;
+}
+
+.shell:has(.sidebar-resizer:is(:hover, :focus-visible, .dragging)) .shell-nav {
+  border-inline-end-color: transparent;
 }
 
 .shell:has(.sidebar-resizer.dragging) {
@@ -930,9 +943,17 @@ openclaw-settings-save-indicator {
   /* Sticky headers inside the sidebar reuse --sidebar-bg so scrolled rows
      never shine through with a mismatched tone. */
   --sidebar-bg: color-mix(in srgb, var(--bg) 96%, var(--bg-elevated) 4%);
-  /* One rhythm for every group boundary in the sidebar (Pages and each
-     session section) so the column reads as separate shelves, not one list. */
-  --sidebar-group-gap: var(--space-4);
+  --sidebar-section-gap: var(--space-3);
+  --sidebar-heading-row-gap: 2px;
+  --sidebar-row-gap: 1px;
+  --sidebar-row-surface: transparent;
+  --sidebar-row-surface-hover: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+  --sidebar-row-surface-selected: color-mix(in srgb, var(--text) 10%, transparent);
+  --sidebar-row-surface-pressed: color-mix(in srgb, var(--text) 14%, transparent);
+  --sidebar-focus-visible: color-mix(in srgb, var(--text) 34%, transparent);
+  --sidebar-divider-active: color-mix(in srgb, var(--text) 42%, transparent);
+  --focus-ring: 0 0 0 2px var(--sidebar-focus-visible);
+  --scrollbar-size: 10px;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -949,6 +970,11 @@ openclaw-settings-save-indicator {
 
 .sidebar-shell {
   --sidebar-pad-x: 10px;
+  --sidebar-row-inset: var(--sidebar-pad-x);
+  --sidebar-text-start: 34px;
+  --sidebar-tree-depth: 16px;
+  --sidebar-trailing-slot: 20px;
+  --sidebar-scrollbar-gutter: 8px;
   --sidebar-lucide-icon-size: 16px;
   --sidebar-lucide-stroke-width: 1.5px;
   display: flex;
@@ -1063,15 +1089,40 @@ openclaw-settings-save-indicator {
      horizontal scrollbar beside the divider. */
   overflow-x: hidden;
   overflow-y: auto;
-  /* Cancel the shell's horizontal padding so the thumb hugs its right edge;
-     both values share --sidebar-pad-x so they cannot drift. */
-  margin-right: calc(-1 * var(--sidebar-pad-x));
-  padding-right: var(--sidebar-pad-x);
+  padding-inline-end: var(--sidebar-scrollbar-gutter);
+  scrollbar-color: transparent transparent;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+}
+
+.sidebar-shell__body::-webkit-scrollbar,
+.sidebar-shell__body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar-shell__body::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: var(--radius-full);
+  background: transparent;
+  background-clip: content-box;
+}
+
+.sidebar:hover .sidebar-shell__body,
+.sidebar-shell__body:focus-within,
+.sidebar-shell__body--scrolling {
+  scrollbar-color: color-mix(in srgb, currentColor 22%, transparent) transparent;
+}
+
+.sidebar:hover .sidebar-shell__body::-webkit-scrollbar-thumb,
+.sidebar-shell__body:focus-within::-webkit-scrollbar-thumb,
+.sidebar-shell__body--scrolling::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, currentColor 22%, transparent);
 }
 
 .sidebar-shell__footer {
   flex-shrink: 0;
-  padding: 4px 0 0;
+  padding-block-start: 4px;
+  padding-inline-end: calc(var(--sidebar-scrollbar-gutter) + var(--scrollbar-size));
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 
@@ -1425,9 +1476,9 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-sessions {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 0 8px;
-  margin-top: var(--sidebar-group-gap);
+  gap: var(--sidebar-heading-row-gap);
+  padding: 0;
+  margin-top: var(--sidebar-section-gap);
   border-radius: var(--radius-md);
   transition:
     background var(--duration-fast) ease,
@@ -1465,8 +1516,8 @@ body.update-dialog-open .sidebar-update-card__status {
 
   display: flex;
   flex-direction: column;
-  gap: var(--sidebar-group-gap);
-  margin: 0 -8px;
+  gap: var(--sidebar-section-gap);
+  margin: 0;
   /* Sessions are app chrome, not hyperlinks: the whole region follows the
      base.css cursor policy so it tracks the window it is running in. */
   cursor: var(--cursor-action);
@@ -1505,7 +1556,7 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-recent-sessions__group {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sidebar-heading-row-gap);
   min-height: 28px;
   border-radius: var(--radius-md);
   transition:
@@ -1536,7 +1587,7 @@ body.update-dialog-open .sidebar-update-card__status {
   align-items: center;
   gap: 8px;
   min-height: 24px;
-  padding: 0 10px 0 var(--sidebar-inset);
+  padding: 0;
   color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
 }
 
@@ -1546,7 +1597,8 @@ body.update-dialog-open .sidebar-update-card__status {
   gap: var(--sidebar-row-gap);
   min-width: 0;
   flex: 1 1 auto;
-  padding: 2px 0;
+  padding-block: 2px;
+  padding-inline-start: calc(var(--sidebar-text-start) - var(--sidebar-lead));
   border: none;
   background: transparent;
   color: inherit;
@@ -1703,7 +1755,7 @@ body.update-dialog-open .sidebar-update-card__status {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
+  width: var(--sidebar-trailing-slot);
   height: 28px;
   flex: 0 0 auto;
   border: none;
@@ -1728,6 +1780,7 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-sort:hover,
+.sidebar-session-sort:focus-visible,
 .sidebar-session-sort[aria-expanded="true"],
 .sidebar-session-sort[aria-pressed="true"] {
   background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
@@ -1750,7 +1803,7 @@ body.update-dialog-open .sidebar-update-card__status {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
+  width: var(--sidebar-trailing-slot);
   height: 22px;
   flex: 0 0 auto;
   border: none;
@@ -1774,6 +1827,7 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-group-actions:hover,
+.sidebar-session-group-actions:focus-visible,
 .sidebar-session-group-actions[aria-expanded="true"] {
   background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
   color: var(--text);
@@ -1790,7 +1844,7 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-group-actions.sidebar-session-sort {
-  width: 28px;
+  width: var(--sidebar-trailing-slot);
   height: 28px;
 }
 
@@ -1841,7 +1895,7 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-session-catalog-project__sessions {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sidebar-row-gap);
   min-width: 0;
 }
 
@@ -1850,12 +1904,8 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-session-tree__children {
-  margin-left: var(--sidebar-lead);
-  background: linear-gradient(
-      color-mix(in srgb, var(--border-strong) 52%, transparent),
-      color-mix(in srgb, var(--border-strong) 52%, transparent)
-    )
-    calc(var(--sidebar-inset) + 10px) 0 / 1px 100% no-repeat;
+  margin-inline-start: calc(var(--sidebar-tree-depth) - 1px);
+  border-inline-start: 1px solid color-mix(in srgb, var(--border-strong) 52%, transparent);
 }
 
 .sidebar-session-tree__loading {
@@ -1882,7 +1932,7 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-recent-sessions__group[data-session-section^="catalog:"] > .sidebar-recent-sessions__list {
-  gap: 8px;
+  gap: var(--sidebar-section-gap);
 }
 
 .sidebar-session-catalog-host {
@@ -2061,18 +2111,21 @@ body.update-dialog-open .sidebar-update-card__status {
   display: flex;
   align-items: center;
   min-width: 0;
-  min-height: 30px;
-  padding-right: 4px;
+  min-height: 32px;
+  padding: 0;
+  border: 0;
   border-radius: var(--radius-md);
+  background: var(--sidebar-row-surface);
   color: var(--muted);
   cursor: var(--cursor-action);
   transition:
     background var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
     color var(--duration-fast) ease;
 }
 
 .sidebar-recent-session:hover {
-  background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
+  background: var(--sidebar-row-surface-hover);
   color: var(--text);
 }
 
@@ -2082,27 +2135,55 @@ body.update-dialog-open .sidebar-update-card__status {
    Doubled class outranks .sidebar-recent-session:hover so the selection fill
    does not degrade to the weaker hover fill while the row is under pointer. */
 .sidebar-recent-session.sidebar-recent-session--active {
-  background: color-mix(in srgb, var(--text) 10%, transparent);
+  background: var(--sidebar-row-surface-selected);
   color: var(--text-strong);
 }
 
-/* Multi-select is an accent wash so it stays distinguishable by hue from the
-   neutral --active fill when a selection includes the active row. */
+/* Multi-select stays neutral but slightly stronger than the active fill, so
+   selection never borrows the danger-leaning accent color. */
 .sidebar-recent-session.sidebar-recent-session--selected {
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  background: var(--sidebar-row-surface-pressed);
   color: var(--text-strong);
+}
+
+.sidebar-recent-session:has(> .sidebar-recent-session__link:focus-visible) {
+  box-shadow: inset 0 0 0 1px var(--sidebar-focus-visible);
+}
+
+.sidebar-recent-session:not(.sidebar-recent-session--active):not(
+  .sidebar-recent-session--selected
+):has(> .sidebar-recent-session__link:focus-visible) {
+  background: var(--sidebar-row-surface-hover);
+}
+
+.sidebar-recent-session__link:focus-visible {
+  outline: none;
 }
 
 .sidebar-recent-session__link {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--sidebar-row-gap);
   flex: 1 1 auto;
   min-width: 0;
-  padding: 3px 4px 3px var(--sidebar-inset);
+  min-height: 30px;
+  padding-block: 3px;
+  padding-inline: var(--sidebar-text-start) 4px;
   color: inherit;
   cursor: var(--cursor-action);
   text-decoration: none;
+}
+
+.sidebar-recent-sessions
+  .sidebar-recent-session__link
+  > :not(.sidebar-session-indicator):not(.sidebar-recent-session__text) {
+  margin-left: 8px;
+}
+
+.sidebar-recent-session__link > .sidebar-session-indicator {
+  position: absolute;
+  inset-inline-start: var(--sidebar-row-inset);
 }
 
 .sidebar-child-session-toggle {
@@ -2375,7 +2456,7 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-recent-session__aside {
-  padding-right: 2px;
+  padding-inline-end: 0;
 }
 
 /* The trailing aside overlays the row so action-only rows retain the full
@@ -2385,7 +2466,7 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-recent-session:not(.sidebar-recent-session--child) > .sidebar-recent-session__aside {
   position: absolute;
   top: 50%;
-  right: 2px;
+  inset-inline-end: 0;
   transform: translateY(-50%);
   pointer-events: none;
 }
@@ -2395,7 +2476,7 @@ body.update-dialog-open .sidebar-update-card__status {
    same link-relative geometry as toggle-less rows, so one mask fits both. */
 .sidebar-recent-session:not(.sidebar-recent-session--child):has(> .sidebar-child-session-toggle)
   > .sidebar-recent-session__aside {
-  right: calc(var(--sidebar-child-session-toggle-width) + 4px);
+  inset-inline-end: calc(var(--sidebar-child-session-toggle-width) + 4px);
 }
 
 /* State-bearing rows reserve the larger state/action maximum throughout the
@@ -2484,7 +2565,7 @@ body.update-dialog-open .sidebar-update-card__status {
 
 .nav-section__items {
   display: grid;
-  gap: 2px;
+  gap: var(--sidebar-row-gap);
 }
 
 .sidebar-zone-entry {
@@ -2820,6 +2901,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .session-menu__check {
+  width: var(--sidebar-trailing-slot, 20px);
   color: var(--accent);
 }
 
@@ -2900,16 +2982,16 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   justify-content: flex-start;
   gap: 8px;
   min-height: 32px;
-  padding: 0 8px;
+  padding-inline-start: var(--sidebar-row-inset);
   border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  background: transparent;
+  border: 0;
+  background: var(--sidebar-row-surface);
   color: var(--muted);
   cursor: var(--cursor-action);
   text-decoration: none;
   transition:
-    border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
     color var(--duration-fast) ease,
     transform var(--duration-fast) ease;
 }
@@ -2984,8 +3066,8 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .nav-item:hover {
   color: var(--text);
-  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
-  border-color: color-mix(in srgb, var(--border) 72%, transparent);
+  background: var(--sidebar-row-surface-hover);
+  border-color: transparent;
   text-decoration: none;
 }
 
@@ -2994,25 +3076,35 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .nav-item.active,
-.nav-item--active {
+.nav-item.nav-item--active {
   color: var(--text-strong);
-  background: color-mix(in srgb, var(--accent-subtle) 88%, var(--bg-elevated) 12%);
-  border-color: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: var(--sidebar-row-surface-selected);
+  border-color: transparent;
 }
 
 .nav-item.active .nav-item__icon,
-.nav-item--active .nav-item__icon {
+.nav-item.nav-item--active .nav-item__icon {
   opacity: 1;
-  color: var(--accent);
+  color: var(--text-strong);
+}
+
+.nav-item:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--sidebar-focus-visible);
+}
+
+.nav-item:not(.active):not(.nav-item--active):focus-visible {
+  background: var(--sidebar-row-surface-hover);
+  color: var(--text);
 }
 
 /* Pinned sessions share the page-nav visual contract while retaining session actions. */
 .sidebar-zone-entry .sidebar-recent-session {
   position: relative;
   min-height: 32px;
-  padding: 0 8px;
-  border: 1px solid transparent;
-  background: transparent;
+  padding: 0;
+  border: 0;
+  background: var(--sidebar-row-surface);
   color: var(--muted);
   transition:
     border-color var(--duration-fast) ease,
@@ -3022,9 +3114,10 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .sidebar-zone-entry .sidebar-recent-session__link {
-  gap: 8px;
+  gap: 0;
   min-height: 30px;
-  padding: 0;
+  padding-block: 3px;
+  padding-inline: var(--sidebar-text-start) 4px;
 }
 
 .sidebar-zone-entry .sidebar-recent-session__name {
@@ -3033,14 +3126,14 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .sidebar-zone-entry .sidebar-recent-session:hover {
   color: var(--text);
-  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
-  border-color: color-mix(in srgb, var(--border) 72%, transparent);
+  background: var(--sidebar-row-surface-hover);
+  border-color: transparent;
 }
 
 .sidebar-zone-entry .sidebar-recent-session.sidebar-recent-session--active {
   color: var(--text-strong);
-  background: color-mix(in srgb, var(--accent-subtle) 88%, var(--bg-elevated) 12%);
-  border-color: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: var(--sidebar-row-surface-selected);
+  border-color: transparent;
 }
 
 .sidebar-zone-entry .sidebar-recent-session__aside {
@@ -3078,8 +3171,8 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .sidebar-agent-card__main:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 48%, transparent);
-  outline-offset: 1px;
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--sidebar-focus-visible);
 }
 
 .sidebar-agent-card__avatar {
@@ -3185,15 +3278,15 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   right: 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  padding: 2px 8px 2px 12px;
+  padding-block: 2px;
+  padding-inline-start: var(--sidebar-text-start);
 }
 
 .sidebar-nav__head-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
+  width: var(--sidebar-trailing-slot);
   height: 22px;
   flex: none;
   border: none;
@@ -3224,7 +3317,15 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-nav__head-action:hover,
 .sidebar-nav__head-action:focus-visible {
   color: var(--text);
-  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+  background: var(--sidebar-row-surface-hover);
+}
+
+.sidebar-nav__head-action:focus-visible,
+.sidebar-session-sort:focus-visible,
+.sidebar-session-group-actions:focus-visible,
+.sidebar-child-session-toggle:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--sidebar-focus-visible);
 }
 
 .sidebar-nav__head-action svg {
@@ -3239,8 +3340,13 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 /* Home keeps run state plus outbox/draft counts together at the row edge. */
 .nav-item__state {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--sidebar-trailing-slot);
+  height: var(--sidebar-trailing-slot);
   flex: none;
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .sidebar-home-session-states {
@@ -3254,16 +3360,19 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-footer-bar {
   display: flex;
   align-items: center;
-  padding: 6px 12px;
+  padding: 6px 0;
 }
 
 .sidebar-identity-card {
-  display: flex;
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) var(--sidebar-trailing-slot);
   align-items: center;
   gap: 8px;
   width: 100%;
   min-width: 0;
-  padding: 5px 6px;
+  padding-block: 5px;
+  padding-inline-start: var(--sidebar-row-inset);
+  padding-inline-end: 0;
   border: none;
   border-radius: var(--radius-md);
   background: transparent;
@@ -3281,14 +3390,15 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .sidebar-identity-card:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 48%, transparent);
-  outline-offset: 1px;
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--sidebar-focus-visible);
 }
 
 .sidebar-identity-card .viewer-avatar--footer {
   width: 26px;
   height: 26px;
   flex: none;
+  justify-self: center;
   font-size: 10px;
 }
 
@@ -3368,6 +3478,10 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .sidebar-identity-card__chevron {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--sidebar-trailing-slot);
+  height: var(--sidebar-trailing-slot);
   flex: none;
   color: var(--muted);
 }

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -224,7 +224,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
 .shell--mobile-nav .nav-item {
   margin: 0;
   min-height: 40px;
-  padding-inline-start: var(--sidebar-row-inset);
+  padding: 0 12px 0 8px;
   font-size: calc(13px * var(--control-ui-text-scale));
   border-radius: var(--radius-md);
   white-space: nowrap;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -215,6 +215,8 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
 
 .shell--mobile-nav .sidebar-shell {
   --sidebar-pad-x: 16px;
+  --sidebar-row-inset: 12px;
+  --sidebar-text-start: 36px;
   padding: 18px var(--sidebar-pad-x) 14px;
   border-radius: 0;
 }
@@ -222,7 +224,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
 .shell--mobile-nav .nav-item {
   margin: 0;
   min-height: 40px;
-  padding: 0 12px 0 8px;
+  padding-inline-start: var(--sidebar-row-inset);
   font-size: calc(13px * var(--control-ui-text-scale));
   border-radius: var(--radius-md);
   white-space: nowrap;


### PR DESCRIPTION
## What Problem This Solves

Sidebar page rows, session families, section labels, footer controls, the scrollbar, and the resize boundary currently use different insets, trailing rails, state fills, and divider ownership.

## Why This Change Was Made

This PR establishes one shared structural grid and neutral chrome contract for the full sidebar. It builds on the transient-surface layer and depends on #123655.

## User Impact

- Page, pinned, recent, draft, child, and catalog rows begin from the same text axis.
- Child sessions use one structural depth step while controls and footer content share one trailing rail.
- Hover, selected, pressed, and keyboard-focus states use the same neutral surface family; red remains reserved for destructive or error states.
- The scrollbar stays hidden at rest, appears during interaction without shifting content, and the resize boundary has one visible owner.
- The layout preserves its grid at 280 px, 400 px, and in RTL.

## Evidence

- Two mocked-Gateway browser scenarios passed in light and dark mode.
- 26 headed visual frames were inspected individually: current/page selection, page/session hover, page/session keyboard focus, scrollbar rest/active, resize hover/drag, 280 px, 400 px, and RTL.
- Geometry assertions cover the shared text axis, 16 px child depth, trailing-control axis, equal row surfaces, stable scrollbar gutter, a single divider, resize behavior, overflow, and RTL.
- Formatting, style, lint, UI type, test type, and boundary checks passed.


---

## Visual proof — real app, mocked Gateway

**How these were produced (literal):**

- Head captured: `43c27f40df5e29f6e75c3f1b780ff6fef71c54ec` — top of Stack A, which contains #123613 → #123626 → #123655 → #123681. The head was asserted inside the run, not assumed.
- The **whole Control UI app** was served by `startControlUiE2eServer` and driven through the canonical mocked Gateway (`installMockGateway`, `ui/src/test-helpers/control-ui-e2e.ts`). No isolated component, no hand-built HTML, no synthetic harness.
- Spec: `ui/src/e2e/sidebar-chrome-grid.e2e.test.ts` — result: **passed, 26 frames**.
- Headed Chromium under Xvfb on a Linux remote host (headed, so hover/elevation/compositing actually paint).
- Command:

```sh
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_HEADED=1 CI=1 \
  xvfb-run -a --server-args="-screen 0 2560x1600x24" \
  node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.ui-e2e.config.ts \
    --configLoader runner ui/src/e2e/sidebar-chrome-grid.e2e.test.ts
```

- Floating surfaces (menus, tooltips, popovers) are clipped to the **union** of the sidebar box and the surface box with 16px padding via `captureSidebarUiUnionProof`, so absolutely-positioned surfaces are included without unrelated page area.

**Reading the guides:** the red and cyan 1px lines are **not product chrome**. `installGridGuides` injects them via `page.addStyleTag` at coordinates taken from real `boundingBox()` measurements — red at the measured text axis, cyan at the measured trailing-control centre. Rows landing on the red line are landing on the same axis.

The sidebar is populated (pinned entry in the mixed pages zone, Pages rows, a Research group with parent + child, Draft, and overflow sessions) so the shared axis is exercised across every row kind at once, including the mixed zone where pages and pinned sessions interleave.

<table><tr><th>state</th><th>light</th><th>dark</th></tr>
<tr><td><b>current-selected</b></td><td><img src="https://github.com/user-attachments/assets/32aa6a03-32c5-499a-89ac-9174fe623785" width="320"></td><td><img src="https://github.com/user-attachments/assets/ca2d4ca7-fdcd-4a61-bf49-5f398cfdb73d" width="320"></td></tr>
<tr><td><b>page-selected</b></td><td><img src="https://github.com/user-attachments/assets/a086b93e-9740-4414-9553-99b00ef6465d" width="320"></td><td><img src="https://github.com/user-attachments/assets/a7d60323-0a57-4452-8089-e5c42798ef2b" width="320"></td></tr>
<tr><td><b>page-hover</b></td><td><img src="https://github.com/user-attachments/assets/35a41e8e-7000-42ce-85b3-d2a8ed03229a" width="320"></td><td><img src="https://github.com/user-attachments/assets/5c299d6a-b0b7-4bc7-a85c-5af0cd9ce9c3" width="320"></td></tr>
<tr><td><b>page-focus</b></td><td><img src="https://github.com/user-attachments/assets/27f53164-d082-4c62-906d-99d336443e91" width="320"></td><td><img src="https://github.com/user-attachments/assets/73b07771-e68e-4a51-a878-28608019a7a1" width="320"></td></tr>
<tr><td><b>session-hover</b></td><td><img src="https://github.com/user-attachments/assets/2896f60f-c46b-478e-b334-fba5a148d52a" width="320"></td><td><img src="https://github.com/user-attachments/assets/5b1e97e0-2937-4c54-bd26-5d805030351a" width="320"></td></tr>
<tr><td><b>session-focus</b></td><td><img src="https://github.com/user-attachments/assets/e6cabb7c-7aae-4bcd-b096-b4f201aaa642" width="320"></td><td><img src="https://github.com/user-attachments/assets/69c2ae34-6753-4c04-8c36-5b35cbeea5d1" width="320"></td></tr>
<tr><td><b>scrollbar-rest</b></td><td><img src="https://github.com/user-attachments/assets/2fec3174-6ec1-44f2-b26e-498ae97a2580" width="320"></td><td><img src="https://github.com/user-attachments/assets/8be7f44d-1f43-4899-8401-e59257aa04e8" width="320"></td></tr>
<tr><td><b>scrollbar-active</b></td><td><img src="https://github.com/user-attachments/assets/c8ea7a04-7a24-43b6-8e26-f9c4ddaa2284" width="320"></td><td><img src="https://github.com/user-attachments/assets/eadc6101-6d93-44a1-b64d-2ebdc463e7ee" width="320"></td></tr>
<tr><td><b>resize-hover</b></td><td><img src="https://github.com/user-attachments/assets/d86b9769-1922-48cf-a236-5bb650753b38" width="320"></td><td><img src="https://github.com/user-attachments/assets/bb0326b2-a37d-466d-8f4f-3c5585fd1466" width="320"></td></tr>
<tr><td><b>width-280</b></td><td><img src="https://github.com/user-attachments/assets/0503ed82-b181-4531-a9ea-fd522c4b332c" width="320"></td><td><img src="https://github.com/user-attachments/assets/42ebfca8-d0b3-40fe-8d2c-0f5ff44b9f2b" width="320"></td></tr>
<tr><td><b>width-400</b></td><td><img src="https://github.com/user-attachments/assets/10183d41-04ab-4afd-a379-0654f7b47b4c" width="320"></td><td><img src="https://github.com/user-attachments/assets/1e8d60b9-7610-4f0d-b792-7d1e6d8c02d1" width="320"></td></tr>
<tr><td><b>rtl-400</b></td><td><img src="https://github.com/user-attachments/assets/026ee391-6aed-4006-a8c5-dbc0695648ee" width="320"></td><td><img src="https://github.com/user-attachments/assets/a0142351-e328-4c56-877c-385563d844cf" width="320"></td></tr>
</table>

**One caveat, stated rather than hidden:** the spec emits 26 frames but only **24 are distinct**. `grid-light-resize-drag-280` and `grid-dark-resize-drag-280` are byte-identical (md5) to their `width-280` counterparts, reproduced across two independent runs. Those two frames evidence the 280px axis result, but they do **not** show an active drag state, so they are omitted above rather than presented as separate proof.

