### PR TITLE
test(tasks): bound audit age by execution window

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -209,7 +209,9 @@ describe("tasks commands", () => {
       });
 
       const limitedRuntime = createRuntime();
+      const beforeLimitedAudit = Date.now();
       await tasksAuditCommand({ json: true, limit: 1 }, limitedRuntime);
+      const afterLimitedAudit = Date.now();
 
       const limitedPayload = readFirstJsonLog(limitedRuntime) as { findings: unknown[] };
       const [limitedFinding] = limitedPayload.findings as Array<{ ageMs?: number }>;
@@ -224,8 +226,8 @@ describe("tasks commands", () => {
         token: runningFlow.flowId,
         flow: jsonRoundTrip(runningFlow),
       });
-      expect(limitedFinding?.ageMs).toBeGreaterThanOrEqual(45 * 60_000);
-      expect(limitedFinding?.ageMs).toBeLessThan(45 * 60_000 + 1_000);
+      expect(limitedFinding?.ageMs).toBeGreaterThanOrEqual(45 * 60_000 + beforeLimitedAudit - now);
+      expect(limitedFinding?.ageMs).toBeLessThanOrEqual(45 * 60_000 + afterLimitedAudit - now);
     });
   });
 


### PR DESCRIPTION
## Summary

- bound the task-audit age assertion by timestamps captured around the audited command
- preserve the exact age calculation contract without a fixed wall-clock tolerance
- remove host scheduling sensitivity from the test

## Root cause

Main CI run 31805475852 failed `checks-node-compact-small-28` because the test required a live `Date.now()`-derived age to remain below the fixture age plus one second. Hosted scheduling delayed the audit by 1.734 seconds, so correct production output failed the unrelated wall-clock budget.

The repair captures the start and end of `tasksAuditCommand` and requires the reported age to fall inside that exact execution window. This remains strict about the computed age while tolerating legitimate scheduling delay; it does not add a retry or increase a timeout.

## Proof

- exact failed run: https://github.com/openclaw/openclaw/actions/runs/31805475852
- `node scripts/run-vitest.mjs src/commands/tasks.test.ts -- -t "keeps audit JSON stable and sorts combined findings before limiting"` — passed
- `node scripts/run-vitest.mjs src/commands/tasks.test.ts` — 25 passed
- `node scripts/check-changed.mjs -- src/commands/tasks.test.ts` — passed on Blacksmith Testbox
- autoreview — clean, no accepted/actionable findings

Production LOC: 0. Test LOC: +2 net.
