### PR TITLE
fix: prevent task audit CI flake under load

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -209,7 +209,9 @@ describe("tasks commands", () => {
       });
 
       const limitedRuntime = createRuntime();
+      const auditStartedAt = Date.now();
       await tasksAuditCommand({ json: true, limit: 1 }, limitedRuntime);
+      const auditFinishedAt = Date.now();
 
       const limitedPayload = readFirstJsonLog(limitedRuntime) as { findings: unknown[] };
       const [limitedFinding] = limitedPayload.findings as Array<{ ageMs?: number }>;
@@ -224,8 +226,8 @@ describe("tasks commands", () => {
         token: runningFlow.flowId,
         flow: jsonRoundTrip(runningFlow),
       });
-      expect(limitedFinding?.ageMs).toBeGreaterThanOrEqual(45 * 60_000);
-      expect(limitedFinding?.ageMs).toBeLessThan(45 * 60_000 + 1_000);
+      expect(limitedFinding?.ageMs).toBeGreaterThanOrEqual(auditStartedAt - runningFlow.updatedAt);
+      expect(limitedFinding?.ageMs).toBeLessThanOrEqual(auditFinishedAt - runningFlow.updatedAt);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes a reproducible CI flake where the task-audit command test failed on a loaded shard once setup took slightly more than an arbitrary one-second allowance. The observed failure was `2701057` ms versus a hard upper bound of `2701000` ms in [run 31807211070, job 94789319983](https://github.com/openclaw/openclaw/actions/runs/31807211070/job/94789319983); the other 764 tests in the shard passed.

## Why This Change Was Made

The assertion now brackets `tasksAuditCommand` with wall-clock readings and verifies that the reported age falls within that exact interval relative to the flow's authoritative `updatedAt`. This preserves the existing production behavior and removes the guessed tolerance without widening a timeout.

## User Impact

No user-visible runtime behavior changes. Maintainers get deterministic task-audit CI proof even when the command shard is under load.

## Evidence

- Before: [run 31807211070, job 94789319983](https://github.com/openclaw/openclaw/actions/runs/31807211070/job/94789319983) failed only `src/commands/tasks.test.ts:228` with `expected 2701057 to be less than 2701000`; 764 sibling tests passed.
- Focused Testbox: `corepack pnpm test src/commands/tasks.test.ts` passed 25/25 tests on `provider=blacksmith-testbox`, `tbx_01m009vctzfsvgj4mcrarr9jww`, [run 31808345807](https://github.com/openclaw/openclaw/actions/runs/31808345807).
- Changed gate: `node scripts/check-changed.mjs -- src/commands/tasks.test.ts` passed core test typecheck, lint, formatting, and repository guards on `provider=blacksmith-testbox`, `tbx_01m009y982crweeq2h8kh2syka`, [run 31808475252](https://github.com/openclaw/openclaw/actions/runs/31808475252).
- `git diff --check`
- Structured autoreview: clean, no accepted or actionable findings.

AI-assisted: yes. The change and its test invariant were manually inspected and verified.
