### PR TITLE
chore: keep trusted ClawHub release dependencies current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,23 @@ updates:
     registries:
       - npm-npmjs
 
+  # npm dependencies (trusted ClawHub release CLI)
+  - package-ecosystem: npm
+    directory: /.github/release/clawhub-cli
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 2
+    groups:
+      production:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+    registries:
+      - npm-npmjs
+
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Closes #123689

## What Problem This Solves

The trusted ClawHub release CLI has its own `package-lock.json`, outside the
root pnpm graph, so the existing root npm Dependabot updater does not keep that
release-tool dependency graph current.

## Why This Change Was Made

Adds a dedicated daily npm updater for
`/.github/release/clawhub-cli`, using the existing npm registry configuration,
two-day cooldown, grouped production minor/patch updates, and a bounded PR
limit.

This reuses the repository's existing dependency review flow and does not
change release behavior.

## User Impact

No direct user-visible change. Release maintainers receive routine update PRs
for the trusted ClawHub CLI graph instead of relying on periodic manual audits.

## Evidence

- Parsed `.github/dependabot.yml` with the repository's installed `yaml`
  package.
- Confirmed the new updater resolves to npm directory
  `/.github/release/clawhub-cli`.
- Confirmed the directory contains its tracked `package-lock.json`.
- `git diff --check`
