### PR TITLE
fix(ui): open image attachments in a lightbox

### DIFF
--- a/ui/src/components/image-lightbox.test.ts
+++ b/ui/src/components/image-lightbox.test.ts
@@ -133,6 +133,51 @@ describe("openclaw-image-lightbox", () => {
     expect(createObjectUrl).not.toHaveBeenCalled();
   });
 
+  it("omits the original action for active blob image formats", async () => {
+    fetchImage.mockResolvedValueOnce({
+      blob: async () => new Blob(["svg"], { type: "image/svg+xml" }),
+    });
+    render(
+      html`<openclaw-image-lightbox
+        src="blob:untrusted-svg"
+        title="Untrusted SVG"
+      ></openclaw-image-lightbox>`,
+      container,
+    );
+    const modal = container.querySelector("openclaw-image-lightbox");
+    if (!modal) {
+      throw new Error("missing image lightbox");
+    }
+    await modal.updateComplete;
+
+    await vi.waitFor(() => expect(fetchImage).toHaveBeenCalledWith("blob:untrusted-svg"));
+    expect(modal.shadowRoot?.querySelector(".open-original")).toBeNull();
+    expect(createObjectUrl).not.toHaveBeenCalled();
+  });
+
+  it("keeps the original action for inert blob image formats", async () => {
+    render(
+      html`<openclaw-image-lightbox
+        src="blob:safe-png"
+        title="Safe PNG"
+      ></openclaw-image-lightbox>`,
+      container,
+    );
+    const modal = container.querySelector("openclaw-image-lightbox");
+    if (!modal) {
+      throw new Error("missing image lightbox");
+    }
+    await modal.updateComplete;
+
+    await vi.waitFor(() =>
+      expect(modal.shadowRoot?.querySelector<HTMLAnchorElement>(".open-original")?.href).toBe(
+        "blob:safe-png",
+      ),
+    );
+    expect(fetchImage).toHaveBeenCalledWith("blob:safe-png");
+    expect(createObjectUrl).not.toHaveBeenCalled();
+  });
+
   it("keeps Tab focus within the lightbox actions", async () => {
     const { modal } = await renderLightbox();
     const root = modal.shadowRoot;

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -11,7 +11,7 @@ export type ImageLightboxItem = {
   release?: () => void;
 };
 
-const SAFE_DATA_IMAGE_BLOB_TYPES = new Set([
+const SAFE_TOP_LEVEL_IMAGE_BLOB_TYPES = new Set([
   "image/avif",
   "image/gif",
   "image/jpeg",
@@ -261,15 +261,18 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       this.openOriginalUrl = "";
       return;
     }
-    if (source.slice(0, 5).toLowerCase() !== "data:") {
+    const sourcePrefix = source.slice(0, 5).toLowerCase();
+    const isDataUrl = sourcePrefix === "data:";
+    const isBlobUrl = sourcePrefix === "blob:";
+    if (!isDataUrl && !isBlobUrl) {
       this.openOriginalUrl = source;
       return;
     }
     this.openOriginalUrl = "";
-    const sourceType = dataUrlMimeType(source);
-    // Top-level blob documents inherit the app origin. Only inert raster formats
-    // may be promoted from opaque-origin data URLs into an original-image link.
-    if (!sourceType || !SAFE_DATA_IMAGE_BLOB_TYPES.has(sourceType)) {
+    const sourceType = isDataUrl ? dataUrlMimeType(source) : undefined;
+    // Reject active data formats before fetching. Incoming blob URLs still need
+    // their fetched MIME checked because top-level blobs inherit the app origin.
+    if (isDataUrl && (!sourceType || !SAFE_TOP_LEVEL_IMAGE_BLOB_TYPES.has(sourceType))) {
       return;
     }
     try {
@@ -278,8 +281,12 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       if (
         !this.isConnected ||
         request !== this.originalUrlRequest ||
-        !SAFE_DATA_IMAGE_BLOB_TYPES.has(mimeTypeEssence(blob.type))
+        !SAFE_TOP_LEVEL_IMAGE_BLOB_TYPES.has(mimeTypeEssence(blob.type))
       ) {
+        return;
+      }
+      if (isBlobUrl) {
+        this.openOriginalUrl = source;
         return;
       }
       this.originalBlobUrl = URL.createObjectURL(blob);

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -149,7 +149,7 @@ suite.define(() => {
     });
   });
 
-  it("previews and removes a picked image without object URL support", async () => {
+  it("enlarges and removes a picked image without object URL support", async () => {
     await withNewSessionPage(async (page) => {
       await page.addInitScript(() => {
         Object.defineProperty(URL, "createObjectURL", { configurable: true, value: undefined });
@@ -163,9 +163,21 @@ suite.define(() => {
 
       const attachment = page.locator(".chat-attachment-thumb");
       const preview = attachment.locator('img[alt="Attachment preview"]');
+      const previewButton = page.getByRole("button", { name: "Open image favicon-32.png" });
       await preview.waitFor({ state: "visible" });
       await expect.poll(() => preview.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
       await captureUiProof(page, "new-session-picked-image-preview.png");
+      await previewButton.click();
+      const lightbox = page.locator("openclaw-image-lightbox");
+      const dialog = page.getByRole("dialog", { name: "Image preview: favicon-32.png" });
+      await dialog.waitFor({ state: "visible" });
+      await expect(lightbox.getAttribute("title")).resolves.toBe("favicon-32.png");
+      await captureUiProof(page, "new-session-picked-image-lightbox.png");
+      await page.keyboard.press("Escape");
+      await lightbox.waitFor({ state: "detached" });
+      await previewButton.press("Enter");
+      await dialog.waitFor({ state: "visible" });
+      await page.keyboard.press("Escape");
       await page.getByRole("button", { name: "Remove attachment" }).click();
       await expect.poll(() => attachment.count()).toBe(0);
       await captureUiProof(page, "new-session-picked-image-removed.png");

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
@@ -181,6 +182,28 @@ suite.define(() => {
       await page.getByRole("button", { name: "Remove attachment" }).click();
       await expect.poll(() => attachment.count()).toBe(0);
       await captureUiProof(page, "new-session-picked-image-removed.png");
+    });
+  });
+
+  it("keeps blob-backed SVG previews out of original-document navigation", async () => {
+    await withNewSessionPage(async (page) => {
+      await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}new`);
+
+      await page.locator(".agent-chat__photo-input").setInputFiles({
+        name: "untrusted.svg",
+        mimeType: "image/svg+xml",
+        buffer: Buffer.from(
+          "<svg xmlns='http://www.w3.org/2000/svg'><rect width='1' height='1'/></svg>",
+        ),
+      });
+
+      const previewButton = page.getByRole("button", { name: "Open image untrusted.svg" });
+      await expect.poll(() => previewButton.locator("img").getAttribute("src")).toMatch(/^blob:/u);
+      await previewButton.click();
+      await page.getByRole("dialog", { name: "Image preview: untrusted.svg" }).waitFor();
+      await expect(page.getByRole("link", { name: "Open original" }).count()).resolves.toBe(0);
+      await captureUiProof(page, "new-session-svg-lightbox.png");
     });
   });
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -45,11 +45,7 @@ import type {
   ChatQueuedEditProps,
 } from "./components/chat-composer-types.ts";
 import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
-import {
-  inlineChatImageFromEvent,
-  isImageLightboxEvent,
-  openInlineChatImage,
-} from "./components/chat-image-lightbox.ts";
+import { isImageLightboxEvent, openInlineChatImage } from "./components/chat-image-lightbox.ts";
 import type { ArtifactDownloadResolver } from "./components/chat-message-media.ts";
 import { renderChatPullRequests } from "./components/chat-pull-requests.ts";
 import type { SessionRailCommand, SessionRailMode } from "./components/chat-session-rail.ts";
@@ -311,13 +307,10 @@ export function renderChat(props: ChatProps) {
     !props.stream &&
     props.queue.length === 0;
   const openImage = props.onOpenImage
-    ? (item: ImageLightboxItem, requestVersion?: number) => {
-        if (requestVersion === undefined) {
-          props.onOpenImage?.(item);
-        } else {
-          props.onOpenImage?.(item, requestVersion);
-        }
-      }
+    ? (item: ImageLightboxItem, requestVersion?: number) =>
+        requestVersion === undefined
+          ? props.onOpenImage?.(item)
+          : props.onOpenImage?.(item, requestVersion)
     : undefined;
   const openImmediateImage = props.onOpenImage
     ? (item: ImageLightboxItem) => openImage?.(item, props.onRequestOpenImage?.())
@@ -478,6 +471,7 @@ export function renderChat(props: ChatProps) {
     onClearReply: props.onClearReply,
     onAttachmentsChange: props.onAttachmentsChange,
     onRemoveAttachment: props.onRemoveAttachment,
+    onOpenImage: openImmediateImage,
   });
   const scrollToBottomButton =
     props.showNewMessages && props.onScrollToBottom
@@ -518,8 +512,10 @@ export function renderChat(props: ChatProps) {
         if (isImageLightboxEvent(event)) {
           return;
         }
-        if ((event.key === "Enter" || event.key === " ") && inlineChatImageFromEvent(event)) {
-          openInlineChatImage(event, openImmediateImage);
+        if (
+          (event.key === "Enter" || event.key === " ") &&
+          openInlineChatImage(event, openImmediateImage)
+        ) {
           return;
         }
         if (event.key === "Escape" && props.replyTarget && !event.defaultPrevented) {

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -2,6 +2,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { icons } from "../../../components/icons.ts";
+import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import "../../../components/tooltip.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
@@ -37,6 +38,7 @@ export type ChatAttachmentControlsProps = {
   onRemoveAttachment?: (attachment: ChatAttachment) => void;
   onDraftChange?: (next: string) => void;
   onPendingReadsChange?: (delta: 1 | -1) => void;
+  onOpenImage?: (item: ImageLightboxItem) => void;
   onRequestUpdate?: () => void;
   readSignal?: AbortSignal;
 };
@@ -568,6 +570,32 @@ function removeBrowserAnnotationAttachment(
   props.onAttachmentsChange?.(next);
 }
 
+function renderAttachmentImage(
+  attachment: ChatAttachment,
+  alt: string,
+  title: string,
+  props: ChatAttachmentControlsProps,
+): ReturnType<typeof html> | typeof nothing {
+  const src = getChatAttachmentPreviewUrl(attachment);
+  if (!src) {
+    return nothing;
+  }
+  if (!props.onOpenImage) {
+    return html`<img src=${src} alt=${alt} />`;
+  }
+  const open = () => props.onOpenImage?.({ src, title });
+  return html`
+    <button
+      type="button"
+      class="chat-message-image-button chat-attachment-image-button"
+      aria-label=${t("chat.imageLightbox.open", { title })}
+      @click=${open}
+    >
+      <img src=${src} alt=${alt} />
+    </button>
+  `;
+}
+
 function renderBrowserAnnotationAttachment(
   attachment: ChatAttachment,
   annotation: BrowserAnnotationAttachment,
@@ -585,7 +613,6 @@ function renderBrowserAnnotationAttachment(
     { count: String(annotation.markedRegionCount) },
   );
   const removeLabel = t("chat.composer.removeBrowserAnnotation", { name: identity });
-  const previewUrl = getChatAttachmentPreviewUrl(attachment);
 
   return html`
     <div
@@ -595,9 +622,12 @@ function renderBrowserAnnotationAttachment(
       aria-label=${`${t("chat.composer.browserAnnotation")}: ${identity}`}
     >
       <div class="chat-browser-annotation-card__preview">
-        ${previewUrl
-          ? html`<img src=${previewUrl} alt=${t("chat.composer.browserAnnotationPreview")} />`
-          : nothing}
+        ${renderAttachmentImage(
+          attachment,
+          t("chat.composer.browserAnnotationPreview"),
+          identity,
+          props,
+        )}
       </div>
       <div class="chat-attachment-file__body chat-browser-annotation-card__body">
         <span class="chat-browser-annotation-card__label"
@@ -651,10 +681,12 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
                   .join(" ")}
               >
                 ${att.mimeType.startsWith("image/") && getChatAttachmentPreviewUrl(att)
-                  ? html`<img
-                      src=${getChatAttachmentPreviewUrl(att)!}
-                      alt=${t("chat.composer.attachmentPreview")}
-                    />`
+                  ? renderAttachmentImage(
+                      att,
+                      t("chat.composer.attachmentPreview"),
+                      att.fileName?.trim() || t("chat.imageLightbox.untitled"),
+                      props,
+                    )
                   : isLargePastedTextAttachment(att)
                     ? html`
                         <div class="chat-attachment-file chat-attachment-file--pasted-text">

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -3,7 +3,7 @@ import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { SessionsListResult } from "../../../api/types.ts";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import type { ChatSendShortcut } from "../../../app/settings.ts";
-import type { ChatAttachment, ChatQueueItem } from "../../../lib/chat/chat-types.ts";
+import type { ChatQueueItem } from "../../../lib/chat/chat-types.ts";
 import type { SlashCommandDef } from "../../../lib/chat/commands.ts";
 import type { ControlUiFollowUpMode } from "../../../lib/chat/follow-up-mode.ts";
 import type { ProviderUsageDisplayProps } from "../../../lib/provider-quota-summary.ts";
@@ -20,6 +20,7 @@ import type { RealtimeTalkLevelSignal } from "../realtime-talk-level.ts";
 import type { RealtimeTalkStatus } from "../realtime-talk.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
 import type { CompactionStatus, FallbackStatus, PlanStatus } from "../tool-stream.ts";
+import type { ChatAttachmentControlsProps } from "./chat-attachments.ts";
 import type {
   ChatComposerPlusMenuProps,
   ChatComposerPlusMenuView,
@@ -61,7 +62,7 @@ type ChatComposerDisabledBannerContent = {
 export type ChatComposerDisabledBanner = ChatComposerDisabledBannerContent &
   ({ kind: "above-composer" } | { kind: "composer-replacement" });
 
-export type ChatComposerProps = {
+export type ChatComposerProps = ChatAttachmentControlsProps & {
   paneId: string;
   sessionKey: string;
   currentAgentId: string;
@@ -91,13 +92,8 @@ export type ChatComposerProps = {
   assistantName: string;
   sendShortcut?: ChatSendShortcut;
   followUpMode?: ControlUiFollowUpMode;
-  attachmentLimits?: { maxBytes: number; maxImageBytes: number };
-  attachments?: ChatAttachment[];
-  getAttachments?: () => ChatAttachment[];
   pendingAttachmentReads?: number;
   getPendingAttachmentReads?: () => number;
-  readSignal?: AbortSignal;
-  onPendingReadsChange?: (delta: 1 | -1) => void;
   replyTarget?: {
     messageId: string;
     text: string;
@@ -120,9 +116,7 @@ export type ChatComposerProps = {
   typingActors?: readonly { id: string; label: string }[];
   onTypingChange?: (typing: boolean) => void;
   composerControls?: TemplateResult | typeof nothing;
-  getDraft?: () => string;
   onDraftChange: (next: string) => void;
-  onRequestUpdate?: () => void;
   onHistoryKeydown?: (input: ChatInputHistoryKeyInput) => ChatInputHistoryKeyResult;
   onSlashIntent?: () => void | Promise<void>;
   onSend: () => void;
@@ -140,8 +134,6 @@ export type ChatComposerProps = {
   queuedEdit?: ChatQueuedEditProps;
   onNewSession: () => void;
   onClearReply?: () => void;
-  onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
-  onRemoveAttachment?: (attachment: ChatAttachment) => void;
   onGoalCommand?: (command: string) => void;
   onGatewayQuestionChange?: () => void;
   onGatewayQuestionSubmit?: (id: string, answers: Record<string, string[]>) => void | Promise<void>;

--- a/ui/src/pages/chat/components/chat-image-lightbox.ts
+++ b/ui/src/pages/chat/components/chat-image-lightbox.ts
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import "../../../components/image-lightbox.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { t } from "../../../i18n/index.ts";
-import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
+import { openResolvedImage } from "./chat-message-image-open.ts";
 
 export function isImageLightboxEvent(event: Event): boolean {
   return event
@@ -12,7 +12,7 @@ export function isImageLightboxEvent(event: Event): boolean {
     );
 }
 
-export function inlineChatImageFromEvent(event: Event): HTMLImageElement | null {
+function inlineChatImageFromEvent(event: Event): HTMLImageElement | null {
   const target = event
     .composedPath()
     .find(
@@ -31,29 +31,26 @@ export function inlineChatImageFromEvent(event: Event): HTMLImageElement | null 
 export function openInlineChatImage(
   event: Event,
   onOpenImage: ((item: ImageLightboxItem) => void) | undefined,
-) {
+): boolean {
   if (event.defaultPrevented) {
-    return;
+    return false;
   }
   const image = inlineChatImageFromEvent(event);
   if (!image) {
-    return;
+    return false;
   }
   event.preventDefault();
   const src = image.currentSrc || image.src;
   const title = image.alt.trim() || t("chat.imageLightbox.untitled");
-  if (onOpenImage) {
-    onOpenImage({ src, title });
-  } else {
-    openExternalUrlSafe(src, { allowDataImage: true });
-  }
+  openResolvedImage(onOpenImage, src, title);
+  return true;
 }
 
 export function renderChatImageLightbox(
   item: ImageLightboxItem | null | undefined,
-  onClose: (() => void) | undefined,
+  onClose: () => void,
 ) {
-  if (!item || !onClose) {
+  if (!item) {
     return nothing;
   }
   return html`

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -21,8 +21,9 @@ import {
 } from "../../../lib/chat/tool-display.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { type EditorId, openEditor } from "../../../lib/editor-links.ts";
-import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
+import { openInlineChatImage } from "./chat-image-lightbox.ts";
+import { openResolvedImage } from "./chat-message-image-open.ts";
 import "./session-diff-panel.ts";
 import { renderChatSidebarEditorMenu } from "./chat-sidebar-editor-menu.ts";
 import type { FileEditorViewHandle } from "./file-editor-view.ts";
@@ -499,18 +500,6 @@ function resolveSidebarCanvasSandbox(
     : "allow-scripts";
 }
 
-function openSidebarImage(
-  onOpenImage: ((item: ImageLightboxItem) => void) | undefined,
-  src: string,
-  title: string,
-) {
-  if (onOpenImage) {
-    onOpenImage({ src, title });
-  } else {
-    openExternalUrlSafe(src, { allowDataImage: true });
-  }
-}
-
 type MarkdownSidebarProps = {
   content: ChatDetailContent | null;
   error: string | null;
@@ -643,7 +632,7 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
                               class="chat-tool-card__preview-image-button"
                               aria-label=${t("chat.imageLightbox.open", { title })}
                               @click=${() =>
-                                openSidebarImage(props.onOpenImage, content.src, title)}
+                                openResolvedImage(props.onOpenImage, content.src, title)}
                             >
                               <img
                                 class="chat-tool-card__preview-image"
@@ -1308,21 +1297,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
   };
 
   private readonly handlePanelClick = (event: Event) => {
-    const imageButton = event
-      .composedPath()
-      .find(
-        (target): target is HTMLElement =>
-          target instanceof HTMLElement &&
-          target.classList.contains("markdown-inline-image-button"),
-      );
-    const image = imageButton?.querySelector<HTMLImageElement>(".markdown-inline-image");
-    if (image) {
-      event.preventDefault();
-      openSidebarImage(
-        this.onOpenImage ?? undefined,
-        image.currentSrc || image.src,
-        image.alt.trim() || t("chat.imageLightbox.untitled"),
-      );
+    if (openInlineChatImage(event, this.onOpenImage ?? undefined)) {
       return;
     }
     handleMarkdownCodeBlockCopy(event);

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { icons } from "../../components/icons.ts";
+import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
@@ -46,6 +47,7 @@ type NewSessionComposerOptions = {
   onAttachmentsChange: (attachments: ChatAttachment[]) => void;
   onPendingReadsChange: (delta: 1 | -1) => void;
   onInput: (message: string) => void;
+  onOpenImage?: (item: ImageLightboxItem) => void;
   onVisibilityChange?: (visibility: NewSessionVisibility) => void;
   onSubmit: () => void;
 };
@@ -207,6 +209,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
     onAttachmentsChange: options.onAttachmentsChange,
     onDraftChange: options.onInput,
     onPendingReadsChange: options.onPendingReadsChange,
+    onOpenImage: options.onOpenImage,
     readSignal: options.readSignal,
   };
   const attachmentDropHandlers = createChatAttachmentDropHandlers({
@@ -304,6 +307,7 @@ export function renderNewSessionDraftComposer(options: {
   messageLocked?: boolean;
   incognitoDisabledReason?: string;
   onInput: (message: string) => void;
+  onOpenImage?: (item: ImageLightboxItem) => void;
   onVisibilityChange?: (visibility: NewSessionVisibility) => void;
   onSubmit: () => void;
 }) {
@@ -340,6 +344,7 @@ export function renderNewSessionDraftComposer(options: {
     },
     onPendingReadsChange: (delta) => options.attachmentDraft.updatePending(readSignal, delta),
     onInput: options.onInput,
+    onOpenImage: options.onOpenImage,
     onVisibilityChange: options.onVisibilityChange,
     onSubmit: options.onSubmit,
   });

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -1,10 +1,11 @@
 import { consume } from "@lit/context";
 import { html, nothing } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { beginNativeWindowDragFromTopInset } from "../../app/native-window-drag.ts";
 import { loadSettings } from "../../app/settings.ts";
+import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import "../../components/tooltip.ts";
 import "../../components/web-awesome-popover.ts";
 import { t } from "../../i18n/index.ts";
@@ -17,6 +18,7 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/chat.css";
 import "../../styles/new-session.css";
+import { renderChatImageLightbox } from "../chat/components/chat-image-lightbox.ts";
 import { renderWelcomeState } from "../chat/components/chat-welcome.ts";
 import * as catalog from "./catalog-target.ts";
 import type { SubmissionOutcomeReason } from "./cloud-recovery-state.ts";
@@ -57,6 +59,7 @@ class NewSessionPage extends OpenClawLightDomElement {
   private connectMachineError: string | null = null;
   private connectMachineSetup: DevicePairSetup | null = null;
   private connectMachineRequestId = 0;
+  @state() private imageLightbox: ImageLightboxItem | null = null;
   private readonly gateway: DraftGatewayState;
   private readonly browser: DraftPlaceBrowser;
   private readonly place: DraftPlaceState;
@@ -596,6 +599,9 @@ class NewSessionPage extends OpenClawLightDomElement {
               this.setMessageFromUser(message);
             }
           },
+          onOpenImage: (item) => {
+            this.imageLightbox = item;
+          },
           onVisibilityChange: (visibility) => {
             if (!this.submission.submitting && !this.submission.pendingCloud.sessionKey) {
               this.submission.setVisibility(visibility);
@@ -682,6 +688,9 @@ class NewSessionPage extends OpenClawLightDomElement {
             this.closeConnectMachine();
             this.context?.navigate("devices");
           },
+        })}
+        ${renderChatImageLightbox(this.imageLightbox, () => {
+          this.imageLightbox = null;
         })}
       </div>
     `;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4126,6 +4126,11 @@ button.chat-reply-preview--message:disabled {
   object-fit: cover;
 }
 
+.chat-attachment-image-button {
+  width: 100%;
+  height: 100%;
+}
+
 .chat-attachment-remove {
   position: absolute;
   top: 4px;


### PR DESCRIPTION
## What Problem This Solves

Image attachments selected in the chat composer or New Session composer could only be viewed as small thumbnails. Unlike images in the transcript and detail sidebar, there was no way to enlarge them before sending.

## Why This Change Was Made

The attachment renderer now exposes the existing image-lightbox callback used by the rest of the Control UI. Active chat reuses its existing lightbox state, while New Session owns equivalent temporary state. The shared image-opening path also replaces duplicate sidebar behavior. Before exposing a blob-backed preview as an original-document link, the lightbox verifies that the fetched blob is an inert raster MIME type.

## User Impact

Clicking an image attachment once opens it in the existing lightbox. Escape closes the preview, and keyboard activation remains supported. This applies to regular image attachments and browser annotation previews in both composers. Active blob formats such as SVG remain previewable but do not receive an original-document link.

## Evidence

- `chat-view.test.ts`: 252 tests passed
- Image lightbox unit tests: 8 tests passed
- New Session attachment E2E: 13 tests passed
- Single-click, Escape, and Enter behavior covered by E2E
- Blob-backed SVG navigation regression failed before the fix and passes after it
- Live Gateway manual test passed from this worktree
- Autoreview: patch correct, confidence 0.94
