### PR TITLE
chore: enforce dependency pin policy in CI

### DIFF
--- a/scripts/run-additional-boundary-checks.mts
+++ b/scripts/run-additional-boundary-checks.mts
@@ -90,6 +90,7 @@ export const BOUNDARY_CHECKS = (
       ["run", "lint:plugins:plugin-sdk-subpaths-exported"],
     ],
     ["deps:root-ownership:check", "pnpm", ["deps:root-ownership:check"]],
+    ["deps:pins:check", "pnpm", ["deps:pins:check"]],
     ["web-fetch-provider-boundary", "pnpm", ["run", "lint:web-fetch-provider-boundaries"]],
     [
       "extension-src-outside-plugin-sdk-boundary",

--- a/scripts/run-additional-boundary-checks.mts
+++ b/scripts/run-additional-boundary-checks.mts
@@ -88,6 +88,7 @@ export const BOUNDARY_CHECKS = (
       ["run", "lint:plugins:plugin-sdk-subpaths-exported"],
     ],
     ["deps:root-ownership:check", "pnpm", ["deps:root-ownership:check"]],
+    ["deps:pins:check", "pnpm", ["deps:pins:check"]],
     ["web-fetch-provider-boundary", "pnpm", ["run", "lint:web-fetch-provider-boundaries"]],
     [
       "extension-src-outside-plugin-sdk-boundary",

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -239,6 +239,14 @@ describe("run-additional-boundary-checks", () => {
     });
   });
 
+  it("keeps the dependency pin guard in CI boundary checks", () => {
+    expect(BOUNDARY_CHECKS).toContainEqual({
+      label: "deps:pins:check",
+      command: "pnpm",
+      args: ["deps:pins:check"],
+    });
+  });
+
   it("keeps the Docker E2E package guard in CI boundary checks", () => {
     expect(BOUNDARY_CHECKS).toContainEqual({
       label: "lint:docker-e2e",

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -238,6 +238,14 @@ describe("run-additional-boundary-checks", () => {
     });
   });
 
+  it("keeps the dependency pin guard in CI boundary checks", () => {
+    expect(BOUNDARY_CHECKS).toContainEqual({
+      label: "deps:pins:check",
+      command: "pnpm",
+      args: ["deps:pins:check"],
+    });
+  });
+
   it("keeps the Docker E2E package guard in CI boundary checks", () => {
     expect(BOUNDARY_CHECKS).toContainEqual({
       label: "lint:docker-e2e",


### PR DESCRIPTION
Closes #123687

## What Problem This Solves

OpenClaw has a repository-native dependency pin guard, but required CI did not
run it. Pin violations could therefore be missed when contributors did not run
the changed-file helper locally.

## Why This Change Was Made

Adds the existing `deps:pins:check` command to the required additional boundary
check manifest, next to the existing root dependency ownership check.

This keeps `scripts/check-dependency-pins.mts` as the single policy owner and
adds a focused manifest regression test.

## User Impact

No direct user-visible change. Dependency changes now fail required CI when a
direct dependency pin violates the repository's existing policy.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/run-additional-boundary-checks.test.ts`
  - 22 tests passed.
- `node --import tsx scripts/check-dependency-pins.mts`
  - checked 616 direct specs across 179 tracked package manifests;
  - zero violations.
- `git diff --check`
