### PR TITLE
build(macos): add OPENCLAW_SKIP_MLX_TTS to unblock beta-toolchain builds

### DIFF
--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -31,6 +31,12 @@ pnpm install
 Outputs `dist/OpenClaw.app`. Without an Apple Developer ID certificate, the
 script falls back to ad-hoc signing.
 
+Set `OPENCLAW_SKIP_MLX_TTS=1` to package a dev/proof build without the local
+MLX voice helper. This skips the `openclaw-mlx-tts` binary and its large
+mlx-swift Metal shader stack, which some beta Xcode toolchains cannot compile.
+The resulting app has no on-device MLX voice; it is rejected for `release`
+builds, which must ship the helper.
+
 For dev run modes, signing flags, and Team ID troubleshooting, see
 [apps/macos/README.md](https://github.com/openclaw/openclaw/blob/main/apps/macos/README.md).
 Fast dev loop from repo root: `scripts/restart-mac.sh` (add `--no-sign` for
@@ -69,6 +75,26 @@ xcrun swift --version
 ```
 
 If versions don't match, update macOS/Xcode and re-run the build.
+
+### Build fails: MLX voice helper Metal shaders
+
+On a beta-only Xcode toolchain (for example Xcode 27 with the macOS 27 SDK),
+only the `openclaw-mlx-tts` helper may fail while the main app builds fine. The
+mlx-swift Metal compilation errors non-deterministically (a different `.metal`
+file each run, `Could not read serialized diagnostics file` then a nonzero
+`metal` exit), because the beta `metal` compiler and its separately downloaded
+Metal Toolchain are still unstable. This is an upstream toolchain issue, not an
+OpenClaw one.
+
+If you do not need on-device MLX voice, skip the helper:
+
+```bash
+OPENCLAW_SKIP_MLX_TTS=1 ./scripts/package-mac-app.sh
+```
+
+Otherwise, install the Metal Toolchain
+(`xcodebuild -downloadComponent MetalToolchain`) and build from a stable Xcode
+release.
 
 ### App crashes on permission grant
 

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -25,6 +25,17 @@ MLX_TTS_HELPER_BUILD_ROOT="$MLX_TTS_HELPER_ROOT/.build"
 BUNDLE_ID="${BUNDLE_ID:-ai.openclaw.mac.debug}"
 PKG_VERSION="$(cd "$ROOT_DIR" && node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")"
 BUILD_CONFIG="${BUILD_CONFIG:-debug}"
+# OPENCLAW_SKIP_MLX_TTS=1 packages the app without the local MLX voice helper.
+# The helper pulls in the full mlx-swift Metal shader stack, which some beta
+# Xcode toolchains cannot compile (flaky `metal` diagnostics), needlessly
+# blocking unrelated dev/proof builds. Release builds must always ship the
+# helper (notarization verifies it), so refuse the skip there instead of
+# producing a silently incomplete release bundle.
+SKIP_MLX_TTS="${OPENCLAW_SKIP_MLX_TTS:-0}"
+if [[ "$SKIP_MLX_TTS" == "1" && "$BUILD_CONFIG" == "release" ]]; then
+  echo "ERROR: OPENCLAW_SKIP_MLX_TTS is not allowed for release builds; the MLX voice helper must ship in release." >&2
+  exit 1
+fi
 BUILD_TS="$(openclaw_resolve_build_timestamp)"
 if [[ "$BUILD_CONFIG" == "release" ]]; then
   OPENCLAW_REQUIRE_BUILD_METADATA=1
@@ -431,8 +442,12 @@ for arch in "${BUILD_ARCHS[@]}"; do
   echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [$arch]"
   run_with_locked_swift_packages swift build -c "$BUILD_CONFIG" --product "$PRODUCT" --build-path "$BUILD_PATH" --arch "$arch" -Xlinker -rpath -Xlinker @executable_path/../Frameworks
   restore_swiftpm_resource_sources
-  echo "🔨 Building $MLX_TTS_HELPER_PRODUCT ($BUILD_CONFIG) [$arch]"
-  build_mlx_tts_helper "$arch"
+  if [[ "$SKIP_MLX_TTS" == "1" ]]; then
+    echo "🔇 Skipping $MLX_TTS_HELPER_PRODUCT (OPENCLAW_SKIP_MLX_TTS=1) — app will lack the local MLX voice helper [$arch]"
+  else
+    echo "🔨 Building $MLX_TTS_HELPER_PRODUCT ($BUILD_CONFIG) [$arch]"
+    build_mlx_tts_helper "$arch"
+  fi
 done
 
 BIN_PRIMARY="$(bin_for_arch "$PRIMARY_ARCH")"
@@ -490,17 +505,21 @@ chmod +x "$APP_ROOT/Contents/MacOS/OpenClaw"
 # SwiftPM outputs ad-hoc signed binaries; strip the signature before install_name_tool to avoid warnings.
 /usr/bin/codesign --remove-signature "$APP_ROOT/Contents/MacOS/OpenClaw" 2>/dev/null || true
 
-echo "🚚 Copying MLX TTS helper"
-cp "$(helper_bin_for_arch "$PRIMARY_ARCH")" "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
-if [[ "${#BUILD_ARCHS[@]}" -gt 1 ]]; then
-  HELPER_BIN_INPUTS=()
-  for arch in "${BUILD_ARCHS[@]}"; do
-    HELPER_BIN_INPUTS+=("$(helper_bin_for_arch "$arch")")
-  done
-  /usr/bin/lipo -create "${HELPER_BIN_INPUTS[@]}" -output "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
+if [[ "$SKIP_MLX_TTS" == "1" ]]; then
+  echo "🔇 Skipping MLX TTS helper copy (OPENCLAW_SKIP_MLX_TTS=1) — bundle omits Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
+else
+  echo "🚚 Copying MLX TTS helper"
+  cp "$(helper_bin_for_arch "$PRIMARY_ARCH")" "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
+  if [[ "${#BUILD_ARCHS[@]}" -gt 1 ]]; then
+    HELPER_BIN_INPUTS=()
+    for arch in "${BUILD_ARCHS[@]}"; do
+      HELPER_BIN_INPUTS+=("$(helper_bin_for_arch "$arch")")
+    done
+    /usr/bin/lipo -create "${HELPER_BIN_INPUTS[@]}" -output "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
+  fi
+  chmod +x "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
+  /usr/bin/codesign --remove-signature "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT" 2>/dev/null || true
 fi
-chmod +x "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
-/usr/bin/codesign --remove-signature "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT" 2>/dev/null || true
 
 SPARKLE_FRAMEWORK_PRIMARY="$(sparkle_framework_for_arch "$PRIMARY_ARCH")"
 if [ -d "$SPARKLE_FRAMEWORK_PRIMARY" ]; then

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -827,6 +827,45 @@ describe("package-mac-app plist stamping", () => {
     }
   });
 
+  it("skips the MLX TTS helper build and copy when OPENCLAW_SKIP_MLX_TTS=1", () => {
+    const script = readFileSync(scriptPath, "utf8");
+
+    // Both the per-arch build and the bundle copy are gated on the same flag so
+    // a skipped build never tries to copy a helper binary that was not built.
+    expect(script).toContain(
+      'if [[ "$SKIP_MLX_TTS" == "1" ]]; then\n    echo "🔇 Skipping $MLX_TTS_HELPER_PRODUCT (OPENCLAW_SKIP_MLX_TTS=1)',
+    );
+    expect(script).toContain(
+      'if [[ "$SKIP_MLX_TTS" == "1" ]]; then\n  echo "🔇 Skipping MLX TTS helper copy (OPENCLAW_SKIP_MLX_TTS=1)',
+    );
+  });
+
+  it("refuses OPENCLAW_SKIP_MLX_TTS for release builds but allows it for dev builds", () => {
+    const script = readFileSync(scriptPath, "utf8");
+
+    // Run the real guard snippet from the script (not a copy) so the release
+    // safety invariant stays coupled to source: release bundles must ship the
+    // voice helper, which notarization later verifies.
+    const guardStart = script.indexOf('SKIP_MLX_TTS="${OPENCLAW_SKIP_MLX_TTS:-0}"');
+    const guardEnd = script.indexOf("BUILD_TS=", guardStart);
+    expect(guardStart).toBeGreaterThanOrEqual(0);
+    expect(guardEnd).toBeGreaterThan(guardStart);
+    const guard = script.slice(guardStart, guardEnd);
+
+    const released = runHelper(
+      `set -euo pipefail\nexport OPENCLAW_SKIP_MLX_TTS=1\nBUILD_CONFIG=release\n${guard}\necho reached-build`,
+    );
+    expect(released.status).toBe(1);
+    expect(released.stderr).toContain("not allowed for release builds");
+    expect(released.stdout).not.toContain("reached-build");
+
+    const dev = runHelper(
+      `set -euo pipefail\nexport OPENCLAW_SKIP_MLX_TTS=1\nBUILD_CONFIG=debug\n${guard}\necho reached-build`,
+    );
+    expect(dev.status, dev.stderr).toBe(0);
+    expect(dev.stdout).toContain("reached-build");
+  });
+
   it("falls back to corepack pnpm when the pnpm shim is absent", () => {
     const helperBlock = getPackageManagerHelperBlock();
     const tempRoot = tempDirs.make("openclaw-package-pnpm-root-");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers on a beta-only Xcode toolchain (for example Xcode 27 with the macOS 27 SDK) cannot package the macOS app, even though the main `OpenClaw` product compiles fine. Only the bundled `openclaw-mlx-tts` voice helper fails: it drags in the full `mlx-swift` Metal shader stack, and the beta `metal` compiler dies non-deterministically — a different `.metal` file each run (`steel_attention.metal`, `conv.metal`), reporting `Could not read serialized diagnostics file` then a nonzero exit. This is upstream toolchain instability, but it blocks unrelated dev and proof builds of `scripts/package-mac-app.sh` that do not need on-device voice.

## Why This Change Was Made

Add an `OPENCLAW_SKIP_MLX_TTS=1` opt-out to `scripts/package-mac-app.sh`, matching the existing `SKIP_TSC` / `SKIP_UI_BUILD` sibling toggles. When set, it skips both the per-arch helper build and the bundle copy, printing a loud marker so the resulting app is clearly known to lack the local MLX voice helper. The flag is refused for `release` builds — release must ship the helper (notarization in `mac-elevation-host.sh` verifies it), so a skipped build can never silently become an incomplete release. No attempt is made to pin-bump `mlx-swift`: the failure is non-deterministic toolchain flakiness owned upstream by `ml-explore/mlx-swift` and Apple's beta Metal toolchain, not something a pin change reliably fixes.

## User Impact

Developers and CI on beta Xcode toolchains can now build and package the app with `OPENCLAW_SKIP_MLX_TTS=1 ./scripts/package-mac-app.sh` (the flag also flows through `scripts/restart-mac.sh`). The produced bundle omits on-device MLX voice and says so in the build log; everything else is unchanged. Release builds are unaffected and still ship the helper.

## Evidence

- **Root cause reproduced** on a beta-only Mac: Xcode 27.0 (`27A5237l`), macOS 27.0 SDK, Swift 6.4; `xcrun metal --version` fails with `missing Metal Toolchain`.
- **Tests**: `node scripts/run-vitest.mjs test/scripts/package-mac-app.test.ts` → **49 passed** (47 existing + 2 new). New tests assert both the build and copy are gated on the flag, and execute the real release-guard snippet from the script to prove release is refused and dev is allowed.
- **Autoreview** (Codex `gpt-5.6-sol`, high): clean, "patch is correct (0.99)", no P0 findings.
- `bash -n scripts/package-mac-app.sh`, `oxfmt --check`, and `git diff --check` all clean.
- Production delta confined to `scripts/package-mac-app.sh` (+31/−12; ~7 lines are the explanatory comment); docs and tests counted separately.
