### PR TITLE
fix(logs): report truncated channel tails

### DIFF
--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -53,6 +53,7 @@ function readJsonPayload() {
   return JSON.parse(String(runtime.log.mock.calls[0]?.[0])) as {
     file: string;
     channel: string;
+    truncated: boolean;
     lines: Array<{ message: string; raw: string }>;
   };
 }
@@ -214,6 +215,21 @@ describe("channelsLogsCommand", () => {
       "first match",
       "second match",
     ]);
+  });
+
+  it("reports when the byte window omits all matching channel records", async () => {
+    const omitted = logLine({ module: "gateway/channels/slack/send", message: "omitted" });
+    const filler = logLine({ module: "gateway/health", message: "x".repeat(1000) });
+    await fs.writeFile(logPath, `${omitted}\n${filler.repeat(1100)}`);
+
+    await channelsLogsCommand({ channel: "slack", json: true }, runtime);
+    expect(readJsonPayload()).toMatchObject({ truncated: true, lines: [] });
+
+    runtime.log.mockClear();
+    await channelsLogsCommand({ channel: "slack" }, runtime);
+    expect(runtime.log.mock.calls.flat().join("\n")).toContain(
+      "Log tail truncated; earlier entries were omitted.",
+    );
   });
 
   it("treats an omitted channel filter as all", async () => {

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -104,16 +104,19 @@ export async function channelsLogsCommand(
     maxBytes: MAX_BYTES,
     filter: (line) => matchesChannel(line, filter),
   });
-  const lines = tail.lines;
+  const { lines, truncated } = tail;
 
   if (opts.json) {
-    writeRuntimeJson(runtime, { file: tail.file, channel, lines });
+    writeRuntimeJson(runtime, { file: tail.file, channel, truncated, lines });
     return;
   }
 
   runtime.log(theme.info(`Log file: ${tail.file}`));
   if (channel !== "all") {
     runtime.log(theme.info(`Channel: ${channel}`));
+  }
+  if (truncated) {
+    runtime.log(theme.warn("Log tail truncated; earlier entries were omitted."));
   }
   if (lines.length === 0) {
     runtime.log(theme.muted("No matching log lines."));


### PR DESCRIPTION
This PR does not close an issue.

## What Problem This Solves

Fixes an issue where operators running `openclaw channels logs` could see `No matching log lines.` even when the bounded tail read had omitted earlier matching records. JSON output also dropped the existing truncation fact, so consumers could not distinguish a complete empty result from an incomplete tail.

## Why This Change Was Made

The shared `readConfiguredParsedLogTail` owner already records one aggregate `truncated` boolean for byte-window or line-limit omission while preserving filtering and redaction. This rewrite keeps that canonical path, always adds the boolean to JSON output, and prints one generic text warning before the empty-result return. It does not add a second reader, fallback, or cause-specific flags.

## User Impact

Operators and JSON consumers can now tell when channel-log output is incomplete. An oversized file that hides every matching record reports truncation instead of presenting an unqualified empty result.

## Evidence

### Direct real CLI before/after

Blacksmith Testbox `tbx_01m0js30xqatazdh7r88qr08tf`, run https://github.com/openclaw/openclaw/actions/runs/32513214467, exercised the actual built CLI path with an isolated state/config and a log larger than the 1,000,000-byte tail window.

For the before case, the task-owned synced checkout used the exact `src/commands/channels/logs.ts` from live `main` `ee79b0a49ae4b0ecd30f9e483c70c0f49f20232c`; `src/logging/log-tail.ts` and `src/cli/channels-cli.ts` were byte-identical between that main SHA and the PR head. Each variant was built through `pnpm openclaw --version`, then invoked through `node openclaw.mjs channels logs --channel slack` and its `--json` form. The fixture and paths were redacted.

Current-main command surface:

```text
Log file: <isolated>/pre/openclaw.log
Channel: slack
No matching log lines.
```

```json
{
  "file": "<isolated>/pre/openclaw.log",
  "channel": "slack",
  "lines": []
}
```

Exact head `c3f1684f0862a0b102bb662ef6bad03c609aa0ee`:

```text
Log file: <isolated>/post/openclaw.log
Channel: slack
Log tail truncated; earlier entries were omitted.
No matching log lines.
```

```json
{
  "file": "<isolated>/post/openclaw.log",
  "channel": "slack",
  "truncated": true,
  "lines": []
}
```

Assertions passed: main had an unqualified empty result, no warning, and no `truncated` field; exact head emitted the warning and returned `truncated: true` with an empty result.

### Additive JSON compatibility

- Code-graph inbound tracing for `channelsLogsCommand` reaches only `registerChannelsCli` and the root CLI registrar; there is no in-repo response consumer.
- Repository searches for `channels logs --json`, `channelsLogsCommand`, and JSON parsing/strict-shape validation found no script, application, plugin, or test that parses this command's response. The only non-command references are the CLI registration tests and `docs/cli/channels.md`.
- The public CLI reference documents the `--json` option but does not publish a closed response schema. The existing object remains `{ file, channel, lines }` compatible for field-selecting consumers and adds the reader-owned boolean as one optional-to-consume property.
- The exact-head direct CLI proof parses the result as JSON and verifies `"truncated": true`; no existing field was removed, renamed, or changed.

### Tests and review

- Focused regression: `src/commands/channels.logs.test.ts` passed 15/15 on the exact head.
- Owner/sibling coverage: `src/logging/log-tail.test.ts` and `src/logging/log-tail-redaction.test.ts` passed 19/19.
- Static proof: targeted Oxfmt, Oxlint, `git diff --check`, core typecheck, repository guards, and the native state schema guard passed.
- Exact-head CI: 148 success, 64 skipped, 1 neutral, 0 failed, 0 pending on https://github.com/openclaw/openclaw/actions/runs/32506161472.
- Fresh autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base ee79b0a49ae4b0ecd30f9e483c70c0f49f20232c --max-priority P1 --stream-engine-output` ran with TruffleHog 3.97.0; credential scan clean; no accepted/actionable P0/P1 findings; patch correctness confidence 0.98.
- LOC split: production `+5/-2` (net `+3`) for the JSON field and operator warning; tests `+16/-0`.
- Main drift: live `main` advanced to `cddc1acdf7f9f2d60de89a5b700fb0261a5dcb6a` after the proof; GitHub compare showed no changes to `src/commands/channels/logs.ts`, `src/logging/log-tail.ts`, or `src/cli/channels-cli.ts` across that advance.

Production growth is the two required output projections of the existing reader-owned fact; there is no duplicate policy or new reader to remove.

Punchcard-Session: golden-timber-willow-68
Punchcard-Session: silver-harbor-harbor-e8
