### PR TITLE
fix(runners): bound node workspace disk growth

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -13,22 +13,22 @@ Proposal, revision 2. Supersedes revision 1 in place (2026-08-11, operator
 decision). Implementation in progress; update this table in every PR that
 advances a milestone.
 
-| #   | Milestone                                                  | Status      | PRs                                                                             |
-| --- | ---------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------- |
-| 0   | This plan (revision 2)                                     | landed      | #122454                                                                         |
-| 1a  | Naming: session copy revert                                | landed      | #120667                                                                         |
-| 1b  | Naming: devices consolidation                              | landed      | #120689                                                                         |
-| 1c  | Cleanup: node-pairing → device-pairing merge               | landed      | #120726                                                                         |
-| 2   | `openclaw resume` + web Continue in terminal               | in progress | #120664, #122870                                                                |
-| 3   | `openclaw connect` one-paste onboarding + `/j/` join route | in progress | #120768, #122499                                                                |
-| 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635, #122774, #122923                                     |
-| F   | Real-wire session boundary harness                         | landed      | #121212                                                                         |
-| 5   | Public worker ingress path                                 | landed      | #122578, #122643                                                                |
-| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033, #122966, #123157, #123280 |
-| 7   | Bundle push consent + runner updates                       | not started | —                                                                               |
-| 8   | Stop-and-continue moves                                    | not started | —                                                                               |
-| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                                                               |
-| 10  | Cloud convergence (provisioners run `openclaw connect`)    | not started | —                                                                               |
+| #   | Milestone                                                  | Status      | PRs                                                                                                                          |
+| --- | ---------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 0   | This plan (revision 2)                                     | landed      | #122454                                                                                                                      |
+| 1a  | Naming: session copy revert                                | landed      | #120667                                                                                                                      |
+| 1b  | Naming: devices consolidation                              | landed      | #120689                                                                                                                      |
+| 1c  | Cleanup: node-pairing → device-pairing merge               | landed      | #120726                                                                                                                      |
+| 2   | `openclaw resume` + web Continue in terminal               | in progress | #120664, #122870                                                                                                             |
+| 3   | `openclaw connect` one-paste onboarding + `/j/` join route | in progress | #120768, #122499                                                                                                             |
+| 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635, #122774, #122923                                                                                  |
+| F   | Real-wire session boundary harness                         | landed      | #121212                                                                                                                      |
+| 5   | Public worker ingress path                                 | landed      | #122578, #122643                                                                                                             |
+| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033, #122966, #123157, #123280, #123612, #123641, #123665, #123673, #123700 |
+| 7   | Bundle push consent + runner updates                       | not started | —                                                                                                                            |
+| 8   | Stop-and-continue moves                                    | not started | —                                                                                                                            |
+| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                                                                                                            |
+| 10  | Cloud convergence (provisioners run `openclaw connect`)    | not started | —                                                                                                                            |
 
 Revision history: revision 1 (2026-08-08) established the session/runner
 vocabulary, the naming rulings, and the milestone skeleton after a
@@ -233,9 +233,10 @@ the durable launch identity so an upgrade cannot strand an existing worker.
 Node-local opt-in advertises the current installation; default nodes remain
 non-hosts. The supervisor now owns two atomic durable capacity slots, bounded
 10-second admission, restart reconciliation, and full/free inventory edges.
+Device dormancy expiry, terminal launch/environment retention, and node-host
+workspace-generation GC now bound persistent-machine growth.
 Milestone 7 upgrades this to Gateway-pinned, namespaced bundle bytes. Isolation,
-checkout ownership, device dormancy/reaping, and node-host disk GC remain
-milestone 6 work.
+checkout ownership, and durable offline recovery actions remain milestone 6 work.
 
 ### Trust model (operator-decided, v1)
 

--- a/src/node-host/node-worker-capacity.ts
+++ b/src/node-host/node-worker-capacity.ts
@@ -18,6 +18,7 @@ type NodeWorkerCapacityOptions = {
   capacity?: number;
   capacityWaitMs?: number;
   onAvailabilityChanged?: (available: boolean) => void;
+  onTerminal?: () => void;
 };
 
 function capacityAbortReason(signal: AbortSignal): Error {
@@ -40,6 +41,7 @@ export class NodeWorkerCapacity {
   private readonly capacity: number;
   private readonly waitMs: number;
   private readonly onAvailabilityChanged?: (available: boolean) => void;
+  private readonly onTerminal?: () => void;
   private readonly waiters = new Set<() => void>();
   private readonly closeAbort = new AbortController();
   private availability?: boolean;
@@ -51,6 +53,7 @@ export class NodeWorkerCapacity {
     this.capacity = options.capacity ?? DEFAULT_WORKER_CAPACITY;
     this.waitMs = options.capacityWaitMs ?? DEFAULT_CAPACITY_WAIT_MS;
     this.onAvailabilityChanged = options.onAvailabilityChanged;
+    this.onTerminal = options.onTerminal;
     if (!Number.isSafeInteger(this.capacity) || this.capacity < 1) {
       throw new Error("node worker capacity must be a positive safe integer");
     }
@@ -114,6 +117,7 @@ export class NodeWorkerCapacity {
     const receipt = this.store.finish(params);
     if (notify && receipt.state !== "pending" && receipt.state !== "running") {
       this.changed();
+      this.onTerminal?.();
     }
     return receipt;
   }
@@ -124,6 +128,7 @@ export class NodeWorkerCapacity {
     const receipt = this.store.finishCancelled(params);
     if (receipt && receipt.state !== "pending" && receipt.state !== "running") {
       this.changed();
+      this.onTerminal?.();
     }
     return receipt;
   }

--- a/src/node-host/node-worker-retention.ts
+++ b/src/node-host/node-worker-retention.ts
@@ -24,16 +24,19 @@ export class NodeWorkerRetention {
       while (this.pending) {
         this.pending = false;
         try {
-          const deleted = await this.workspace.pruneSupersededGenerations(() =>
+          const result = await this.workspace.pruneSupersededGenerations(() =>
             this.store.listNonterminal(),
           );
-          if (deleted > 0) {
+          if (result.deleted > 0) {
             retentionLog.info("pruned node worker workspace generations", {
-              count: deleted,
+              count: result.deleted,
               reason: "superseded-workspace-generation",
               trigger,
             });
           }
+          // Keep each filesystem pass bounded while draining an inherited backlog.
+          // Every continuation rebuilds latest/active ownership before deleting again.
+          this.pending ||= result.hasMore;
         } catch (error) {
           retentionLog.warn("node worker workspace generation pruning failed", {
             error: formatErrorMessage(error),

--- a/src/node-host/node-worker-retention.ts
+++ b/src/node-host/node-worker-retention.ts
@@ -1,0 +1,50 @@
+import { formatErrorMessage } from "../infra/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { NodeWorkerLaunchStore } from "./node-worker-launch-store.js";
+import type { NodeWorkerWorkspaceRuntime } from "./node-worker-workspace.js";
+
+const retentionLog = createSubsystemLogger("node-host/worker-retention");
+
+/** Coalesces lifecycle-owned maintenance without delaying durable terminal outcomes. */
+export class NodeWorkerRetention {
+  private operation?: Promise<void>;
+  private pending = false;
+
+  constructor(
+    private readonly store: NodeWorkerLaunchStore,
+    private readonly workspace: NodeWorkerWorkspaceRuntime,
+  ) {}
+
+  schedule(trigger: string): Promise<void> {
+    this.pending = true;
+    if (this.operation) {
+      return this.operation;
+    }
+    const operation = (async () => {
+      while (this.pending) {
+        this.pending = false;
+        try {
+          const deleted = await this.workspace.pruneSupersededGenerations(() =>
+            this.store.listNonterminal(),
+          );
+          if (deleted > 0) {
+            retentionLog.info("pruned node worker workspace generations", {
+              count: deleted,
+              reason: "superseded-workspace-generation",
+              trigger,
+            });
+          }
+        } catch (error) {
+          retentionLog.warn("node worker workspace generation pruning failed", {
+            error: formatErrorMessage(error),
+            trigger,
+          });
+        }
+      }
+    })();
+    this.operation = operation.finally(() => {
+      this.operation = undefined;
+    });
+    return this.operation;
+  }
+}

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -35,6 +35,7 @@ import {
   requireNodeWorkerProcessIdentity,
   type NodeWorkerProcessIdentity,
 } from "./node-worker-process-identity.js";
+import { NodeWorkerRetention } from "./node-worker-retention.js";
 import {
   nodeWorkerPlanHash,
   type NodeWorkerLaunchInput,
@@ -45,6 +46,7 @@ import {
   signalOwnedNodeWorkerTree,
   waitForOwnedNodeWorkerTreeDeath,
 } from "./node-worker-tree-control.js";
+import { NodeWorkerWorkspaceRuntime } from "./node-worker-workspace.js";
 
 const STOP_GRACE_MS = 1_000;
 const FORCE_STOP_WAIT_MS = 4_000;
@@ -79,6 +81,15 @@ type ObservedTerminal = ActiveBase & {
   persistenceError?: unknown;
 };
 type ActiveOwnership = RunningChild | ObservedTerminal;
+type NodeWorkerSupervisorOptions = {
+  bundleRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  localInstallation?: NodeWorkerInstallation;
+  capacity?: number;
+  capacityWaitMs?: number;
+  onAvailabilityChanged?: (available: boolean) => void;
+  workspace?: NodeWorkerWorkspaceRuntime;
+};
 
 function sameProcessIdentity(
   left: NodeWorkerProcessIdentity | null,
@@ -111,21 +122,14 @@ class NodeWorkerSupervisor {
   private readonly workerEnv: NodeJS.ProcessEnv;
   private readonly localInstallation?: NodeWorkerInstallation;
   private readonly capacity: NodeWorkerCapacity;
+  private readonly workspace?: NodeWorkerWorkspaceRuntime;
+  private retention?: NodeWorkerRetention;
   private supervisorIdentity?: NodeWorkerProcessIdentity;
   private initializationPromise?: Promise<void>;
   private closed = false;
   private closePromise?: Promise<void>;
 
-  constructor(
-    options: {
-      bundleRoot?: string;
-      env?: NodeJS.ProcessEnv;
-      localInstallation?: NodeWorkerInstallation;
-      capacity?: number;
-      capacityWaitMs?: number;
-      onAvailabilityChanged?: (available: boolean) => void;
-    } = {},
-  ) {
+  constructor(options: NodeWorkerSupervisorOptions = {}) {
     const env = options.env ?? process.env;
     this.bundleRoot = path.resolve(
       options.bundleRoot ?? path.join(resolveStateDir(env), "node-host"),
@@ -133,7 +137,19 @@ class NodeWorkerSupervisor {
     this.store = new NodeWorkerLaunchStore({ env });
     this.workerEnv = snapshotNodeWorkerEnv(env);
     this.localInstallation = options.localInstallation;
-    this.capacity = new NodeWorkerCapacity(this.store, options);
+    this.workspace = options.workspace;
+    this.capacity = new NodeWorkerCapacity(this.store, {
+      ...options,
+      onTerminal: () => void this.retentionOwner().schedule("terminal-transition"),
+    });
+  }
+
+  private retentionOwner(): NodeWorkerRetention {
+    return (this.retention ??= new NodeWorkerRetention(
+      this.store,
+      this.workspace ??
+        new NodeWorkerWorkspaceRuntime({ root: this.bundleRoot, env: this.workerEnv }),
+    ));
   }
 
   private requireSupervisorIdentity(): NodeWorkerProcessIdentity {
@@ -141,9 +157,11 @@ class NodeWorkerSupervisor {
   }
 
   initialize(): Promise<void> {
-    return (this.initializationPromise ??= this.capacity.initialize(async (receipt) => {
-      await this.recoverRunning(receipt, false);
-    }));
+    return (this.initializationPromise ??= this.capacity
+      .initialize(async (receipt) => {
+        await this.recoverRunning(receipt, false);
+      })
+      .then(async () => await this.retentionOwner().schedule("supervisor-start")));
   }
 
   async launch(
@@ -365,6 +383,9 @@ class NodeWorkerSupervisor {
         } catch (error) {
           errors.push(error);
         }
+      }
+      if (this.retention) {
+        await this.retention.schedule("supervisor-close");
       }
       if (errors.length === 1) {
         throw errors[0];
@@ -670,14 +691,7 @@ class NodeWorkerSupervisor {
 }
 
 export function createNodeWorkerSupervisor(
-  options: {
-    bundleRoot?: string;
-    env?: NodeJS.ProcessEnv;
-    localInstallation?: NodeWorkerInstallation;
-    capacity?: number;
-    capacityWaitMs?: number;
-    onAvailabilityChanged?: (available: boolean) => void;
-  } = {},
+  options: NodeWorkerSupervisorOptions = {},
 ): NodeWorkerSupervisor {
   return new NodeWorkerSupervisor(options);
 }

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -364,7 +364,7 @@ async function initializeGitWorkspace(params: {
 
 const workspaceTransferQueues = new Map<string, Promise<void>>();
 
-async function serializeWorkspaceTransfer<T>(
+export async function serializeNodeWorkerWorkspace<T>(
   workspaceDir: string,
   operation: () => Promise<T>,
 ): Promise<T> {
@@ -699,7 +699,7 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
   signal?: AbortSignal;
 }): Promise<string> {
   try {
-    return await serializeWorkspaceTransfer(params.workspaceDir, async () => {
+    return await serializeNodeWorkerWorkspace(params.workspaceDir, async () => {
       await recoverWorkspaceReplacement(params.workspaceDir);
       return params.transfer.direction === "download"
         ? await downloadWorkspace({

--- a/src/node-host/node-worker-workspace-retention.test.ts
+++ b/src/node-host/node-worker-workspace-retention.test.ts
@@ -1,0 +1,139 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
+import {
+  TEST_WORKER_ENDPOINT,
+  testNodeWorkerLaunchIdentity,
+  testWorkerLaunchInput,
+  writeNodeWorkerFixture,
+} from "./node-worker-supervisor.test-support.js";
+
+type Supervisor = ReturnType<typeof createNodeWorkerSupervisor>;
+type LaunchInput = ReturnType<typeof testWorkerLaunchInput>;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function hashPathComponent(value: string, length: number): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, length);
+}
+
+function sessionRoot(bundleRoot: string, input: LaunchInput): string {
+  return path.join(
+    bundleRoot,
+    input.gatewayNamespace,
+    "workspaces",
+    hashPathComponent(input.descriptor.admission.environmentId, 16),
+    hashPathComponent(input.descriptor.admission.sessionId, 32),
+  );
+}
+
+function seedGeneration(bundleRoot: string, input: LaunchInput, generation: number): string {
+  const generationDir = path.join(sessionRoot(bundleRoot, input), String(generation));
+  fs.mkdirSync(generationDir, { recursive: true });
+  fs.writeFileSync(path.join(generationDir, "sentinel.txt"), String(generation));
+  return generationDir;
+}
+
+function generationNames(bundleRoot: string, input: LaunchInput): string[] {
+  return fs
+    .readdirSync(sessionRoot(bundleRoot, input), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .toSorted((left, right) => Number(left) - Number(right));
+}
+
+async function waitForTerminal(supervisor: Supervisor, launchId: string): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      expect((await supervisor.status(launchId))?.state).not.toMatch(/^(?:pending|running)$/u);
+    },
+    { timeout: 5_000 },
+  );
+}
+
+describe("node worker workspace retention", () => {
+  it("prunes superseded workspace generations on supervisor startup", async () => {
+    const root = tempDirs.make("node-worker-workspace-retention-startup-");
+    const { bundleRoot, env, workspaceDir } = writeNodeWorkerFixture(root);
+    const input = testWorkerLaunchInput(workspaceDir, "startup-retention");
+    const latestInput = structuredClone(input);
+    latestInput.descriptor.admission.environmentId = "environment-2";
+    seedGeneration(bundleRoot, input, 1);
+    seedGeneration(bundleRoot, latestInput, 2);
+    const supervisor = createNodeWorkerSupervisor({ bundleRoot, env });
+
+    await supervisor.initialize();
+
+    expect(generationNames(bundleRoot, input)).toEqual([]);
+    expect(generationNames(bundleRoot, latestInput)).toEqual(["2"]);
+    await supervisor.close();
+  });
+
+  it("keeps an active launch generation until its terminal transition", async () => {
+    const root = tempDirs.make("node-worker-workspace-retention-active-");
+    const { bundleRoot, env, workspaceDir } = writeNodeWorkerFixture(root);
+    const activeInput = testWorkerLaunchInput(workspaceDir, "active-retention", "wait");
+    const supervisor = createNodeWorkerSupervisor({ bundleRoot, env });
+    await supervisor.initialize();
+    const activeGeneration = seedGeneration(
+      bundleRoot,
+      activeInput,
+      activeInput.descriptor.admission.ownerEpoch,
+    );
+    const latestGeneration = seedGeneration(
+      bundleRoot,
+      activeInput,
+      activeInput.descriptor.admission.ownerEpoch + 1,
+    );
+    const triggerInput = testWorkerLaunchInput(workspaceDir, "retention-trigger");
+    triggerInput.descriptor.admission.sessionId = "session-2";
+    triggerInput.descriptor.assignment.runId = "run-2";
+    triggerInput.descriptor.assignment.operationalRunInstance = {
+      instanceId: "instance-2",
+      runId: "run-2",
+    };
+    seedGeneration(bundleRoot, triggerInput, triggerInput.placementGeneration);
+
+    await supervisor.launch(activeInput, TEST_WORKER_ENDPOINT);
+    await supervisor.launch(triggerInput, TEST_WORKER_ENDPOINT);
+    await waitForTerminal(supervisor, triggerInput.launchId);
+
+    expect(fs.existsSync(activeGeneration)).toBe(true);
+    expect(fs.existsSync(latestGeneration)).toBe(true);
+
+    await supervisor.cancel(testNodeWorkerLaunchIdentity(activeInput));
+
+    await vi.waitFor(() => expect(fs.existsSync(activeGeneration)).toBe(false));
+    expect(fs.existsSync(latestGeneration)).toBe(true);
+    await supervisor.close();
+  });
+
+  it("keeps workspace generation count bounded across sustained turns", async () => {
+    const root = tempDirs.make("node-worker-workspace-retention-growth-");
+    const { bundleRoot, env, workspaceDir } = writeNodeWorkerFixture(root);
+    const supervisor = createNodeWorkerSupervisor({ bundleRoot, env });
+    const observedCounts: number[] = [];
+
+    for (let generation = 1; generation <= 8; generation += 1) {
+      const input = testWorkerLaunchInput(workspaceDir, `retention-turn-${generation}`);
+      input.placementGeneration = generation;
+      input.descriptor.admission.ownerEpoch = generation;
+      seedGeneration(bundleRoot, input, generation);
+      await supervisor.launch(input, TEST_WORKER_ENDPOINT);
+      await waitForTerminal(supervisor, input.launchId);
+      observedCounts.push(generationNames(bundleRoot, input).length);
+    }
+
+    expect(observedCounts).toEqual(Array.from({ length: 8 }, () => 1));
+    await supervisor.close();
+  });
+});

--- a/src/node-host/node-worker-workspace-retention.test.ts
+++ b/src/node-host/node-worker-workspace-retention.test.ts
@@ -78,6 +78,21 @@ describe("node worker workspace retention", () => {
     await supervisor.close();
   });
 
+  it("drains a workspace backlog across bounded startup passes", async () => {
+    const root = tempDirs.make("node-worker-workspace-retention-backlog-");
+    const { bundleRoot, env, workspaceDir } = writeNodeWorkerFixture(root);
+    const input = testWorkerLaunchInput(workspaceDir, "startup-backlog-retention");
+    for (let generation = 0; generation <= 260; generation += 1) {
+      seedGeneration(bundleRoot, input, generation);
+    }
+    const supervisor = createNodeWorkerSupervisor({ bundleRoot, env });
+
+    await supervisor.initialize();
+
+    expect(generationNames(bundleRoot, input)).toEqual(["260"]);
+    await supervisor.close();
+  });
+
   it("keeps an active launch generation until its terminal transition", async () => {
     const root = tempDirs.make("node-worker-workspace-retention-active-");
     const { bundleRoot, env, workspaceDir } = writeNodeWorkerFixture(root);

--- a/src/node-host/node-worker-workspace-retention.test.ts
+++ b/src/node-host/node-worker-workspace-retention.test.ts
@@ -145,6 +145,7 @@ describe("node worker workspace retention", () => {
       seedGeneration(bundleRoot, input, generation);
       await supervisor.launch(input, TEST_WORKER_ENDPOINT);
       await waitForTerminal(supervisor, input.launchId);
+      await vi.waitFor(() => expect(generationNames(bundleRoot, input)).toHaveLength(1));
       observedCounts.push(generationNames(bundleRoot, input).length);
     }
 

--- a/src/node-host/node-worker-workspace.ts
+++ b/src/node-host/node-worker-workspace.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { isPathInside } from "../infra/path-guards.js";
@@ -12,12 +13,94 @@ import {
   type NodeWorkerWorkspaceExecResult,
 } from "../worker/node-workspace-protocol.js";
 import { snapshotNodeWorkerEnv } from "./node-worker-environment.js";
-import { runNodeWorkerWorkspaceTransfer } from "./node-worker-transfer-client.js";
+import {
+  runNodeWorkerWorkspaceTransfer,
+  serializeNodeWorkerWorkspace,
+} from "./node-worker-transfer-client.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+const WORKSPACE_GENERATION_PRUNE_LIMIT = 256;
+const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+const ENVIRONMENT_HASH_PATTERN = /^[a-f0-9]{16}$/u;
+const SESSION_HASH_PATTERN = /^[a-f0-9]{32}$/u;
+
+type NodeWorkerWorkspaceLaunchReference = {
+  gatewayNamespace: string;
+  environmentId: string;
+  sessionId: string;
+  ownerEpoch: number;
+};
+
+type WorkspaceGeneration = {
+  gatewayNamespace: string;
+  environmentHash: string;
+  sessionHash: string;
+  workspacesRoot: string;
+  generation: number;
+  generationPath: string;
+};
 
 function hashPathComponent(value: string, length: number): string {
   return createHash("sha256").update(value).digest("hex").slice(0, length);
+}
+
+function generationKey(generation: WorkspaceGeneration): string {
+  return [
+    generation.gatewayNamespace,
+    generation.environmentHash,
+    generation.sessionHash,
+    generation.generation,
+  ].join("/");
+}
+
+function launchGenerationKey(reference: NodeWorkerWorkspaceLaunchReference): string {
+  return [
+    reference.gatewayNamespace,
+    hashPathComponent(reference.environmentId, 16),
+    hashPathComponent(reference.sessionId, 32),
+    reference.ownerEpoch,
+  ].join("/");
+}
+
+function parseGenerationName(name: string): number | undefined {
+  const generation = Number(name);
+  return Number.isSafeInteger(generation) && generation >= 0 && String(generation) === name
+    ? generation
+    : undefined;
+}
+
+async function listOwnedDirectories(parent: string): Promise<string[]> {
+  try {
+    return (await fsp.readdir(parent, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+      .map((entry) => entry.name)
+      .toSorted();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function latestSessionGeneration(
+  workspacesRoot: string,
+  sessionHash: string,
+): Promise<number | undefined> {
+  let latest: number | undefined;
+  for (const environmentHash of await listOwnedDirectories(workspacesRoot)) {
+    if (!ENVIRONMENT_HASH_PATTERN.test(environmentHash)) {
+      continue;
+    }
+    const sessionRoot = path.join(workspacesRoot, environmentHash, sessionHash);
+    for (const name of await listOwnedDirectories(sessionRoot)) {
+      const generation = parseGenerationName(name);
+      if (generation !== undefined) {
+        latest = Math.max(latest ?? generation, generation);
+      }
+    }
+  }
+  return latest;
 }
 
 function ensureContainedDirectory(parent: string, name: string): string {
@@ -122,6 +205,108 @@ export class NodeWorkerWorkspaceRuntime {
       GIT_TERMINAL_PROMPT: "0",
       SSH_ASKPASS: "",
     };
+  }
+
+  async pruneSupersededGenerations(
+    listNonterminal: () => readonly NodeWorkerWorkspaceLaunchReference[],
+  ): Promise<number> {
+    const generations: WorkspaceGeneration[] = [];
+    const latestBySession = new Map<string, number>();
+    for (const gatewayNamespace of await listOwnedDirectories(this.root)) {
+      if (!GATEWAY_NAMESPACE_PATTERN.test(gatewayNamespace)) {
+        continue;
+      }
+      const workspacesRoot = path.join(this.root, gatewayNamespace, "workspaces");
+      for (const environmentHash of await listOwnedDirectories(workspacesRoot)) {
+        if (!ENVIRONMENT_HASH_PATTERN.test(environmentHash)) {
+          continue;
+        }
+        const environmentRoot = path.join(workspacesRoot, environmentHash);
+        for (const sessionHash of await listOwnedDirectories(environmentRoot)) {
+          if (!SESSION_HASH_PATTERN.test(sessionHash)) {
+            continue;
+          }
+          const sessionRoot = path.join(environmentRoot, sessionHash);
+          for (const generationName of await listOwnedDirectories(sessionRoot)) {
+            const generation = parseGenerationName(generationName);
+            if (generation === undefined) {
+              continue;
+            }
+            generations.push({
+              gatewayNamespace,
+              environmentHash,
+              sessionHash,
+              workspacesRoot,
+              generation,
+              generationPath: path.join(sessionRoot, generationName),
+            });
+            const sessionKey = `${gatewayNamespace}/${sessionHash}`;
+            latestBySession.set(
+              sessionKey,
+              Math.max(latestBySession.get(sessionKey) ?? generation, generation),
+            );
+          }
+        }
+      }
+    }
+    const initiallyProtected = new Set(listNonterminal().map(launchGenerationKey));
+    const candidates = generations
+      .filter(
+        (generation) =>
+          !initiallyProtected.has(generationKey(generation)) &&
+          generation.generation <
+            (latestBySession.get(`${generation.gatewayNamespace}/${generation.sessionHash}`) ??
+              generation.generation),
+      )
+      .toSorted(
+        (left, right) =>
+          left.generation - right.generation ||
+          left.generationPath.localeCompare(right.generationPath),
+      )
+      .slice(0, WORKSPACE_GENERATION_PRUNE_LIMIT);
+    let deleted = 0;
+    for (const candidate of candidates) {
+      await serializeNodeWorkerWorkspace(candidate.generationPath, async () => {
+        const currentLatest = await latestSessionGeneration(
+          candidate.workspacesRoot,
+          candidate.sessionHash,
+        );
+        if (currentLatest === undefined || candidate.generation >= currentLatest) {
+          return;
+        }
+        let stats: fs.Stats;
+        let sessionRoot: string;
+        let generationPath: string;
+        try {
+          [stats, sessionRoot, generationPath] = await Promise.all([
+            fsp.lstat(candidate.generationPath),
+            fsp.realpath(path.dirname(candidate.generationPath)),
+            fsp.realpath(candidate.generationPath),
+          ]);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return;
+          }
+          throw error;
+        }
+        if (
+          stats.isSymbolicLink() ||
+          !stats.isDirectory() ||
+          path.dirname(generationPath) !== sessionRoot ||
+          !isPathInside(this.root, generationPath)
+        ) {
+          return;
+        }
+        // A launch can claim an older prepared generation while filesystem checks await.
+        // Re-read the durable reservations immediately before removing node-owned bytes.
+        if (new Set(listNonterminal().map(launchGenerationKey)).has(generationKey(candidate))) {
+          return;
+        }
+        await fsp.rm(generationPath, { recursive: true, force: true });
+        deleted += 1;
+      });
+    }
+    return deleted;
   }
 
   async exec(

--- a/src/node-host/node-worker-workspace.ts
+++ b/src/node-host/node-worker-workspace.ts
@@ -209,7 +209,7 @@ export class NodeWorkerWorkspaceRuntime {
 
   async pruneSupersededGenerations(
     listNonterminal: () => readonly NodeWorkerWorkspaceLaunchReference[],
-  ): Promise<number> {
+  ): Promise<{ deleted: number; hasMore: boolean }> {
     const generations: WorkspaceGeneration[] = [];
     const latestBySession = new Map<string, number>();
     for (const gatewayNamespace of await listOwnedDirectories(this.root)) {
@@ -250,7 +250,7 @@ export class NodeWorkerWorkspaceRuntime {
       }
     }
     const initiallyProtected = new Set(listNonterminal().map(launchGenerationKey));
-    const candidates = generations
+    const staleGenerations = generations
       .filter(
         (generation) =>
           !initiallyProtected.has(generationKey(generation)) &&
@@ -262,8 +262,8 @@ export class NodeWorkerWorkspaceRuntime {
         (left, right) =>
           left.generation - right.generation ||
           left.generationPath.localeCompare(right.generationPath),
-      )
-      .slice(0, WORKSPACE_GENERATION_PRUNE_LIMIT);
+      );
+    const candidates = staleGenerations.slice(0, WORKSPACE_GENERATION_PRUNE_LIMIT);
     let deleted = 0;
     for (const candidate of candidates) {
       await serializeNodeWorkerWorkspace(candidate.generationPath, async () => {
@@ -306,7 +306,7 @@ export class NodeWorkerWorkspaceRuntime {
         deleted += 1;
       });
     }
-    return deleted;
+    return { deleted, hasMore: staleGenerations.length > candidates.length };
   }
 
   async exec(

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -324,15 +324,16 @@ export async function prepareNodeHostRuntime(params?: {
     initialInventory,
     start({ client, onInventoryChanged, onManifestChanged, onRunnerAvailabilityChanged }) {
       const mcpAbort = new AbortController();
+      const workerWorkspace = workerInstallation
+        ? new NodeWorkerWorkspaceRuntime({ env })
+        : undefined;
       const workerSupervisor = workerInstallation
         ? createNodeWorkerSupervisor({
             env,
             localInstallation: workerInstallation,
             onAvailabilityChanged: onRunnerAvailabilityChanged,
+            workspace: workerWorkspace,
           })
-        : undefined;
-      const workerWorkspace = workerInstallation
-        ? new NodeWorkerWorkspaceRuntime({ env })
         : undefined;
       if (workerSupervisor) {
         void workerSupervisor.initialize().catch((error: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where persistent node runners accumulated one workspace generation per turn and never reclaimed superseded generations. The 2026-08-14 node-host stress campaign measured exactly +36 generations and +4.78 MiB of node-host disk across 36 sustained turns, about 136 KiB per turn even with small workspaces.

## Why This Change Was Made

The node workspace owner now keeps the latest generation for each gateway-namespaced session plus every generation referenced by a durable pending or running launch. Cleanup runs after supervisor startup and durable terminal transitions, deletes at most 256 generations per pass, shares the existing per-workspace transfer serialization, rechecks active launch ownership immediately before deletion, and logs `superseded-workspace-generation` as the reason. Bundle cleanup remains milestone 7 work because local-install node runners do not push bundle generations yet.

Slot capacity, terminal launch-receipt retention, terminal environment retention, and 14-day device dormancy landed independently in #123612, #123641, #123665, and #123673 and are intentionally not duplicated here.

## User Impact

Persistent node runners no longer grow workspace disk monotonically across turns. Active turns and the newest usable session workspace remain intact, including when cleanup overlaps a workspace transfer.

This change is AI-assisted and was reviewed with the repository autoreview workflow.

## Evidence

- Pre-fix regression: startup retained generations `[1, 2]`; eight sustained turns grew directory count as `[1, 2, 3, 4, 5, 6, 7, 8]`.
- Post-fix growth regression: eight sustained turns remained `[1, 1, 1, 1, 1, 1, 1, 1]`.
- A 261-generation startup backlog drained across multiple bounded passes to the single newest generation.
- Focused regression passed 3 consecutive runs.
- Supervisor/transfer/runtime bundle: 39 tests passed.
- `node scripts/check-changed.mjs ...`: all core/coreTests gates passed, including typecheck, lint, dead exports, import cycles, database-first storage, and schema-version guard.
- `pnpm build`: passed twice on the final implementation shape.
- Autoreview: clean, no accepted/actionable findings.
- ClawSweeper's capped-backlog continuation finding was accepted and fixed on the current head.

Remote proof fallback: Blacksmith Testbox was unavailable because its CLI was absent on the host, and direct AWS Crabbox lacked broker login, so repository policy routed the heavy changed gate and build to the local trusted-source fallback. The release-wide generated-artifact preflight also reports unrelated current-main drift in config-doc and UI/native locale baselines; this PR does not touch those surfaces.
