### PR TITLE
feat(llama-cpp): raise default context size to 64K

### DIFF
--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -38,8 +38,9 @@ The default chat model remains:
 `hf:unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf`
 
 Gemma 4 E4B IT Q4_K_M is about 5.0 GB. OpenClaw offers that download only on
-machines with at least 16 GiB of RAM. The default context cap remains 8,192
-tokens. The bundled EmbeddingGemma model is about 0.3 GB.
+machines with at least 16 GiB of RAM. The default context cap is 65,536 tokens,
+which the full agent system prompt requires. The bundled EmbeddingGemma model is
+about 0.3 GB.
 
 Discovery is read-only. It reports a prepared choice only when the managed
 binary, server preset, and selected model already exist; it never installs or
@@ -76,11 +77,11 @@ Example model entry:
   reasoning: false,
   input: ["text"],
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-  contextWindow: 8192,
+  contextWindow: 65536,
   maxTokens: 2048,
   params: {
     modelPath: "~/Models/my-model.Q4_K_M.gguf",
-    contextSize: 8192,
+    contextSize: 65536,
   },
   compat: { supportsTools: true },
 }

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -27,7 +27,10 @@ export const DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE =
 export const DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES = 4_977_171_584;
 export const DEFAULT_LLAMA_CPP_MODEL_SHA256 =
   "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87";
-export const DEFAULT_LLAMA_CPP_CONTEXT_SIZE = 8192;
+// The full OpenClaw agent system prompt alone is ~31K tokens, so 8K overflows on
+// the first turn. 64K leaves real headroom for history and tool output; Gemma 4
+// supports far more, and the 16 GiB offer floor already bounds weaker machines.
+export const DEFAULT_LLAMA_CPP_CONTEXT_SIZE = 65536;
 
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL =
   "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf";


### PR DESCRIPTION
## What problem this solves

The managed llama.cpp default `ctx-size` was **8192**. The full OpenClaw agent system prompt alone is ~31K tokens, so the very first agent turn on a fresh local-model install overflowed the context window and forced immediate compaction. Observed live during the Mac app local-model onboarding: at 8K the turn failed with "Context overflow: prompt too large for the model"; even at 32K the session sat at 93% context with compaction firing. Only at 64K did a clean agent turn complete (47% used).

## Why this change was made

The 8K default predates the external-llama-server migration (#123105) and was never sized against the real agent prompt. Raising the default makes the out-of-box local-model agent actually usable.

- `DEFAULT_LLAMA_CPP_CONTEXT_SIZE`: 8192 → 65536 in `extensions/llama-cpp/src/defaults.ts`.
- Docs (`docs/plugins/llama-cpp.md`) updated to match.

This only changes headroom, not the offer gate: the 16 GiB RAM floor for the default download already bounds weaker machines, and Gemma 4 E4B supports far more than 64K context. Operators can still override per-model via `params.contextSize`.

## User impact

Fresh llama.cpp onboarding now produces a model that can run a real agent turn without immediate context overflow. No migration needed — the value applies at setup/prepare time; existing installs keep whatever context their generated `models.ini` already has until they re-run setup.

## Evidence

- Live Mac app onboarding (profile dev instance): 8K → "Context overflow"; 32K → 93% used + compaction; 64K → clean agent turn "local model online", 47% of 65.5k used.
- `node scripts/run-vitest.mjs extensions/llama-cpp` → 4 files, 24 tests passed.
- The two test literals that mention 8192 pass explicit values (not the constant), so they stay green.
