### PR TITLE
fix(tui): deduplicate session identity (AI-assisted)

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -37,7 +37,7 @@ type SelectableOverlay = {
 };
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
 type SetSessionMock = ReturnType<typeof vi.fn> &
-  ((key: string, sessionNotice?: string) => Promise<void>);
+  ((key: string, sessionNotice?: string | false) => Promise<void>);
 type ConsumeCompletedRunMock = ReturnType<typeof vi.fn> & ((runId: string) => boolean);
 type FlushPendingHistoryRefreshMock = ReturnType<typeof vi.fn> & (() => void);
 type RefreshAgentsMock = ReturnType<typeof vi.fn> & (() => Promise<Result<void, string>>);
@@ -1368,7 +1368,7 @@ describe("tui command handlers", () => {
     const uuidParts: string[] = createOptions.key.slice("tui-".length).split("-");
     expect(uuidParts.map((part) => part.length)).toEqual([8, 4, 4, 4, 12]);
     expect(uuidParts.every((part) => /^[0-9a-f]+$/.test(part))).toBe(true);
-    expect(setSessionMock).toHaveBeenCalledWith("agent:main:tui-canonical", "new session");
+    expect(setSessionMock).toHaveBeenCalledWith("agent:main:tui-canonical", false);
     // /reset still resets the shared session
     expect(resetSession).toHaveBeenCalledTimes(1);
     expect(resetSession).toHaveBeenCalledWith("agent:main:main", "reset", undefined);
@@ -1378,6 +1378,29 @@ describe("tui command handlers", () => {
     });
     expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
     expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("confirms a new session when its history reload fails", async () => {
+    let addSystem: ReturnType<typeof vi.fn>;
+    const setSession = vi.fn(async () => {
+      addSystem("history failed: gateway unavailable");
+    }) as SetSessionMock;
+    const harness = createHarness({
+      createSession: vi.fn().mockResolvedValue({
+        ok: true,
+        key: "agent:main:tui-created",
+      }),
+      setSession,
+    });
+    addSystem = harness.addSystem;
+
+    await harness.handleCommand("/new");
+
+    expect(setSession).toHaveBeenCalledWith("agent:main:tui-created", false);
+    expect(addSystem.mock.calls.map(([message]) => message)).toEqual([
+      "history failed: gateway unavailable",
+      "new session",
+    ]);
   });
 
   it("reports a reset after adopting the backend's replacement session key", async () => {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -26,7 +26,8 @@ import {
 import { createEditorSubmitHandler, createSubmitBurstCoalescer } from "./tui-submit.js";
 import type { SessionInfo } from "./tui-types.js";
 
-type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
+type LoadHistoryMock = ReturnType<typeof vi.fn> &
+  ((options?: { sessionNotice?: string | false }) => Promise<void>);
 type RunAuthFlow = NonNullable<Parameters<typeof createCommandHandlers>[0]["runAuthFlow"]>;
 type AbortActiveMock = ReturnType<typeof vi.fn> &
   ((params?: { preferActive?: boolean }) => Promise<void>);
@@ -35,7 +36,8 @@ type SelectableOverlay = {
   onSelect?: (item: { value: string; label?: string; description?: string }) => void;
 };
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
-type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string) => Promise<void>);
+type SetSessionMock = ReturnType<typeof vi.fn> &
+  ((key: string, sessionNotice?: string) => Promise<void>);
 type ConsumeCompletedRunMock = ReturnType<typeof vi.fn> & ((runId: string) => boolean);
 type FlushPendingHistoryRefreshMock = ReturnType<typeof vi.fn> & (() => void);
 type RefreshAgentsMock = ReturnType<typeof vi.fn> & (() => Promise<Result<void, string>>);
@@ -1366,7 +1368,7 @@ describe("tui command handlers", () => {
     const uuidParts: string[] = createOptions.key.slice("tui-".length).split("-");
     expect(uuidParts.map((part) => part.length)).toEqual([8, 4, 4, 4, 12]);
     expect(uuidParts.every((part) => /^[0-9a-f]+$/.test(part))).toBe(true);
-    expect(setSessionMock).toHaveBeenCalledWith("agent:main:tui-canonical");
+    expect(setSessionMock).toHaveBeenCalledWith("agent:main:tui-canonical", "new session");
     // /reset still resets the shared session
     expect(resetSession).toHaveBeenCalledTimes(1);
     expect(resetSession).toHaveBeenCalledWith("agent:main:main", "reset", undefined);
@@ -1405,7 +1407,7 @@ describe("tui command handlers", () => {
     expect(refreshSessionInfo).toHaveBeenCalledOnce();
     expect(harness.state.currentSessionKey).toBe("agent:main:replacement");
     expect(harness.state.currentSessionId).toBe("replacement-session");
-    expect(harness.addSystem).toHaveBeenCalledWith("session agent:main:replacement reset");
+    expect(harness.addSystem).toHaveBeenCalledWith("session reset");
   });
 
   it.each([

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -75,8 +75,8 @@ type CommandHandlerContext = {
   openOverlay: (component: Component) => OverlayHandle;
   closeOverlay: (handle?: OverlayHandle) => void;
   refreshSessionInfo: () => Promise<void>;
-  loadHistory: () => Promise<unknown>;
-  setSession: (key: string) => Promise<void>;
+  loadHistory: (options?: { sessionNotice?: string | false }) => Promise<unknown>;
+  setSession: (key: string, sessionNotice?: string) => Promise<void>;
   refreshAgents: () => Promise<Result<void, string>>;
   abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
   setActivityStatus: (text: string) => void;
@@ -753,8 +753,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         state.sessionInfo.outputTokens = null;
         state.sessionInfo.totalTokens = null;
         tui.requestRender();
-        await setSession(result.key);
-        chatLog.addSystem(`new session: ${result.key}`);
+        await setSession(result.key, "new session");
       } catch (err) {
         chatLog.addSystem(`new session failed: ${formatTuiErrorMessage(err)}`);
       } finally {
@@ -787,12 +786,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           resetResultSelection = captureSessionSelection();
           await refreshSessionInfo();
         } else {
-          await loadHistory();
+          await loadHistory({ sessionNotice: false });
         }
         if (!isCurrentSessionSelection(resetResultSelection)) {
           return;
         }
-        chatLog.addSystem(`session ${state.currentSessionKey} reset`);
+        chatLog.addSystem("session reset");
       } catch (err) {
         if (!isCurrentSessionSelection(resetResultSelection)) {
           return;

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -76,7 +76,7 @@ type CommandHandlerContext = {
   closeOverlay: (handle?: OverlayHandle) => void;
   refreshSessionInfo: () => Promise<void>;
   loadHistory: (options?: { sessionNotice?: string | false }) => Promise<unknown>;
-  setSession: (key: string, sessionNotice?: string) => Promise<void>;
+  setSession: (key: string, sessionNotice?: string | false) => Promise<void>;
   refreshAgents: () => Promise<Result<void, string>>;
   abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
   setActivityStatus: (text: string) => void;
@@ -753,7 +753,8 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         state.sessionInfo.outputTokens = null;
         state.sessionInfo.totalTokens = null;
         tui.requestRender();
-        await setSession(result.key, "new session");
+        await setSession(result.key, false);
+        chatLog.addSystem("new session");
       } catch (err) {
         chatLog.addSystem(`new session failed: ${formatTuiErrorMessage(err)}`);
       } finally {

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -36,7 +36,6 @@ describe("formatTuiFooter", () => {
     expect(
       formatTuiFooter({
         agentLabel: "Main",
-        sessionLabel: "work",
         sessionInfo: {
           model: "gpt-5.6-sol@openai:setup-64cddea3-938c-431e-be3b-aa47090577c7",
           fastMode: "auto",
@@ -50,7 +49,7 @@ describe("formatTuiFooter", () => {
         deliver: true,
       }),
     ).toBe(
-      "agent Main | session work | gpt-5.6-sol high | fast:auto | verbose full | trace:raw | reasoning:stream | deliver:on | tokens 1.2k/128k (1%)",
+      "agent Main | gpt-5.6-sol high | fast:auto | verbose full | trace:raw | reasoning:stream | deliver:on | tokens 1.2k/128k (1%)",
     );
   });
 
@@ -58,17 +57,15 @@ describe("formatTuiFooter", () => {
     expect(
       formatTuiFooter({
         agentLabel: "Main",
-        sessionLabel: "main",
         sessionInfo: { model: "fixture-model" },
         deliver: false,
       }),
-    ).toBe("agent Main | session main | fixture-model | deliver:off | tokens ?");
+    ).toBe("agent Main | fixture-model | deliver:off | tokens ?");
   });
 
   it("wraps the compact summary within the terminal width", () => {
     const summary = formatTuiFooter({
       agentLabel: "Main",
-      sessionLabel: "a-long-session-name",
       sessionInfo: {
         model: "fixture-provider/a-long-model-name",
         traceLevel: "raw",
@@ -91,7 +88,6 @@ describe("formatTuiFooter", () => {
     ];
     const footer = formatTuiFooter({
       agentLabel: `agent-start${attacks[0]}agent-end\nمرحبا`,
-      sessionLabel: `session-start${attacks[2]}session-end\r\nשלום`,
       sessionInfo: {
         model: `provider/model-start${attacks[1]}middle${attacks[3]}${attacks[4]}${attacks[5]}model-end\tUnicode`,
       },
@@ -100,8 +96,6 @@ describe("formatTuiFooter", () => {
 
     expect(footer).toContain("agent-startagent-end");
     expect(footer).toContain("مرحبا");
-    expect(footer).toContain("session-startsession-end");
-    expect(footer).toContain("שלום");
     expect(footer).toContain("model-startmiddlemodel-end Unicode");
     expect(footer).toContain("\u2067");
     expect(footer).toContain("\u2069");
@@ -114,7 +108,6 @@ describe("formatTuiFooter", () => {
   it("renders active goal usage", () => {
     const footer = formatTuiFooter({
       agentLabel: "Main",
-      sessionLabel: "main",
       sessionInfo: {
         goal: {
           schemaVersion: 1,
@@ -138,7 +131,6 @@ describe("formatTuiFooter", () => {
   it("renders resumable blocked goals", () => {
     const footer = formatTuiFooter({
       agentLabel: "Main",
-      sessionLabel: "main",
       sessionInfo: {
         goal: {
           schemaVersion: 1,

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -49,7 +49,6 @@ function formatModelFooter(params: {
 /** Format the compact TUI footer from authoritative session and process state. */
 export function formatTuiFooter(params: {
   agentLabel: string;
-  sessionLabel: string;
   sessionInfo: SessionInfo;
   thinkingLevel?: string | null;
   deliver: boolean;
@@ -65,7 +64,6 @@ export function formatTuiFooter(params: {
     reasoning === "on" ? "reasoning" : reasoning === "stream" ? "reasoning:stream" : null;
   const footer = [
     `agent ${params.agentLabel}`,
-    `session ${params.sessionLabel}`,
     formatModelFooter({ model: sessionInfo.model, thinkingLevel: params.thinkingLevel }),
     formatGoalFooter(sessionInfo.goal),
     fastLabel,

--- a/src/tui/tui-pty-harness-assertion-test-support.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.ts
@@ -475,7 +475,6 @@ async function exerciseSelectorOutputSafety(
     await fixture.run.waitForOutput(
       formatTuiFooter({
         agentLabel: `main (${sessionDisplay.text})`,
-        sessionLabel: "main (Main)",
         sessionInfo: { model: selectedModel, contextTokens: 128 },
         deliver: false,
       }),
@@ -500,7 +499,6 @@ async function exerciseSelectorOutputSafety(
     expect(historyLoad.payload).toMatchObject({ sessionKey: selectedSessionKey });
     await assertTerminalAttackSanitized(fixture, sessionKey, 5_000);
     const expectedAgentLabel = `main (${sessionDisplay.text})`;
-    const expectedSessionLabel = `${sessionKey.text} (${sessionDisplay.text})`;
     await fixture.run.waitForOutput(
       sanitizeRenderableLine(
         `openclaw tui pty fixture - pty-fixture://local - agent ${expectedAgentLabel} - session ${sessionKey.text}`,
@@ -510,7 +508,6 @@ async function exerciseSelectorOutputSafety(
     await fixture.run.waitForOutput(
       formatTuiFooter({
         agentLabel: expectedAgentLabel,
-        sessionLabel: expectedSessionLabel,
         sessionInfo: { model: selectedModel, contextTokens: 128 },
         deliver: false,
       }),

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -638,7 +638,7 @@ describe.sequential("TUI PTY harness", () => {
         (entry) =>
           entry.method === "acceptTaskSuggestion" && objectFieldEquals(entry, "taskId", "task_pty"),
       );
-      await fixture.run.waitForOutput("session agent:main:task-pty");
+      await fixture.run.waitForOutput("session loaded");
     },
     TEST_TIMEOUT_MS,
   );
@@ -998,7 +998,19 @@ describe.sequential("TUI PTY harness", () => {
     "creates a backend session from /new and adopts its canonical key",
     async () => {
       await fixture.run.write("/new\r", { delay: false });
-      await fixture.run.waitForOutput("new session: agent:main:tui-");
+      await fixture.run.waitForOutput("new session");
+      const rows = await waitForSynchronizedFrameRows(
+        fixture.run,
+        (frame) =>
+          frame.some((row) => row.trim() === "new session") &&
+          frame.some((row) => row.includes("agent main (Main)") && row.includes("deliver:off")),
+        TEST_TIMEOUT_MS,
+      );
+      const footerRow = rows.find(
+        (row) => row.includes("agent main (Main)") && row.includes("deliver:off"),
+      );
+      expect(footerRow).toBeDefined();
+      expect(footerRow!).not.toContain("session");
       const created = await fixture.waitForLogEntry((entry) => entry.method === "createSession");
       expect(created.payload).toMatchObject({ agentId: "main" });
       expect(created.payload).not.toHaveProperty("parentSessionKey");

--- a/src/tui/tui-pty-local-test-support.test.ts
+++ b/src/tui/tui-pty-local-test-support.test.ts
@@ -116,7 +116,7 @@ describe("local TUI PTY fixture support", () => {
   });
 
   it("does not replay a session rollover when an old busy notice is redrawn", async () => {
-    const newSessionPrefix = "new session: agent:main:tui-";
+    const newSessionPrefix = "new session";
     const acceptedSession = createDeferred();
     const writes: string[] = [];
     let output = "";

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1173,7 +1173,7 @@ describe("TUI PTY real backends", () => {
 
         const steerResponseOffset = fixture.run.visibleOutput().lastIndexOf("LOCAL_STEER_COMPLETE");
         await waitForOutputAfter(fixture.run, "| idle", steerResponseOffset);
-        await createFreshSession(fixture.run, "new session: agent:main:tui-");
+        await createFreshSession(fixture.run, "new session");
         const freshResponseStart = fixture.run.visibleOutput().length;
         await fixture.run.write("send after local new\r");
         await waitFor({
@@ -1212,9 +1212,10 @@ describe("TUI PTY real backends", () => {
         const firstReplyOffset = lastOutputIndexAfter(fixture.run, reply, 0);
         await waitForOutputAfter(fixture.run, "| idle", firstReplyOffset);
         const newOffset = fixture.run.visibleOutput().length;
-        await createFreshSession(fixture.run, "new session: agent:main:tui-");
+        await createFreshSession(fixture.run, "new session");
         const newOutput = fixture.run.visibleOutput().slice(newOffset);
-        const createdKey = newOutput.match(/new session: (agent:main:tui-\S+)/)?.[1];
+        const createdRest = newOutput.match(/session (tui-[0-9a-f-]+)/)?.[1];
+        const createdKey = createdRest ? `agent:main:${createdRest}` : undefined;
         expect(createdKey).toBeDefined();
         const sessionLabel = `session ${createdKey!.split(":").at(-1)}`;
         await waitForSynchronizedFrameRows(
@@ -1257,7 +1258,7 @@ describe("TUI PTY real backends", () => {
         await fixture.run.waitForOutput(first, LOCAL_OUTPUT_TIMEOUT_MS);
         const firstReplyOffset = fixture.run.visibleOutput().lastIndexOf(first);
         await waitForOutputAfter(fixture.run, "| idle", firstReplyOffset);
-        await createFreshSession(fixture.run, "new session: agent:main:tui-");
+        await createFreshSession(fixture.run, "new session");
         await fixture.run.write("T03_HISTORY_SECOND_PROMPT\r");
         await fixture.run.waitForOutput(second, LOCAL_OUTPUT_TIMEOUT_MS);
         const secondReplyOffset = fixture.run.visibleOutput().lastIndexOf(second);
@@ -1925,9 +1926,12 @@ export default {
         await fixture.waitForOutput("Default model: tui-pty-validation (128k ctx)");
         const newOffset = fixture.run.visibleOutput().length;
         await fixture.run.write("/new\r", { delay: false });
-        await waitForOutputAfter(fixture.run, "new session: agent:", newOffset);
+        await waitForOutputAfter(fixture.run, "new session", newOffset);
         const createdOutput = fixture.run.visibleOutput().slice(newOffset);
-        const createdKey = createdOutput.match(/new session: (agent:\S+)/)?.[1];
+        const createdRest = createdOutput.match(/session (tui-[0-9a-f-]+)/)?.[1];
+        const createdKey = createdRest
+          ? `${fixture.sessionKey.slice(0, fixture.sessionKey.lastIndexOf(":"))}:${createdRest}`
+          : undefined;
         expect(createdKey).toBeDefined();
         expect(createdKey).not.toBe(fixture.sessionKey);
         fixture.trackSessionKey(createdKey!);
@@ -1980,7 +1984,7 @@ export default {
         );
         const selectedInfo = selected.sessionInfo!;
         await fixture.run.write("/reset\r", { delay: false });
-        await fixture.waitForOutput(`session ${createdKey} reset`);
+        await fixture.waitForOutput("session reset");
         const reset = await waitForHistoryMessages(
           controlClient,
           createdKey!,

--- a/src/tui/tui-reset-transition-pty.e2e.test.ts
+++ b/src/tui/tui-reset-transition-pty.e2e.test.ts
@@ -59,7 +59,7 @@ describe("TUI reset transition PTY", () => {
         // Release before the controlled paste coalescer flushes. Admission must use
         // the transition snapshot captured when Enter arrived, not live state.
         await writeFile(resetReleasePath, "released\n", "utf8");
-        await run.waitForOutput("session main (Reset session after)");
+        await run.waitForOutput("session reset");
         await run.waitForOutput("overlap during reset\nnewer suffix", 7_000);
 
         await run.write("\r", { delay: false });

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1809,7 +1809,7 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.updatedAt).toBe(123);
     expect(state.historyLoaded).toBe(true);
     expect(clearAll).toHaveBeenCalled();
-    expect(addSystem).toHaveBeenCalledWith("session agent:main:new");
+    expect(addSystem).not.toHaveBeenCalled();
   });
 
   it("fences pre-reset history and session-info reads when reset commits", async () => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -596,7 +596,7 @@ export function createSessionActions(context: SessionActionContext) {
     }
   };
 
-  const setSession = async (rawKey: string, sessionNotice = "session loaded") => {
+  const setSession = async (rawKey: string, sessionNotice: string | false = "session loaded") => {
     const previousSelection = captureSessionSelection();
     const nextSelection = resolveSessionSelection(rawKey);
     const nextKey = nextSelection.key;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -401,14 +401,15 @@ export function createSessionActions(context: SessionActionContext) {
     applySessionInfoFromPatch(result);
     chatLog.clearAll();
     btw.clear();
-    chatLog.addSystem(`session ${state.currentSessionKey}`);
     state.historyLoaded = true;
     void rememberSessionKey?.(state.currentSessionKey);
     tui.requestRender(true);
     return true;
   };
 
-  const loadHistory = async (): Promise<TuiHistoryLoadResult> => {
+  const loadHistory = async (
+    sessionNotice: string | false = "session loaded",
+  ): Promise<TuiHistoryLoadResult> => {
     // History rebuilds mutate shared UI state after multiple awaits. Only the
     // latest request may render, or a slow reload can replace a newer selection.
     const generation = ++historyLoadGeneration;
@@ -490,7 +491,9 @@ export function createSessionActions(context: SessionActionContext) {
       });
       chatLog.clearAll();
       btw.clear();
-      chatLog.addSystem(`session ${state.currentSessionKey}`);
+      if (sessionNotice) {
+        chatLog.addSystem(sessionNotice);
+      }
       for (const entry of projection.entries) {
         const message = entry.message as Record<string, unknown>;
         if (isCommandMarkedMessage(message)) {
@@ -593,7 +596,7 @@ export function createSessionActions(context: SessionActionContext) {
     }
   };
 
-  const setSession = async (rawKey: string) => {
+  const setSession = async (rawKey: string, sessionNotice = "session loaded") => {
     const previousSelection = captureSessionSelection();
     const nextSelection = resolveSessionSelection(rawKey);
     const nextKey = nextSelection.key;
@@ -632,7 +635,7 @@ export function createSessionActions(context: SessionActionContext) {
     btw.clear();
     updateHeader();
     updateFooter();
-    await loadHistory();
+    await loadHistory(sessionNotice);
   };
 
   const abortActive = async (params?: { preferActive?: boolean }) => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1344,16 +1344,11 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     : undefined;
 
   const updateFooter = () => {
-    const sessionKeyLabel = formatSessionKey(currentSessionKey);
-    const sessionLabel = state.sessionInfo.displayName
-      ? `${sessionKeyLabel} (${state.sessionInfo.displayName})`
-      : sessionKeyLabel;
     const agentLabel = formatAgentLabel(state.currentAgentId);
     footer.setText(
       theme.dim(
         formatTuiFooter({
           agentLabel,
-          sessionLabel,
           sessionInfo: state.sessionInfo,
           thinkingLevel: thinkingLevelOverride ?? state.sessionInfo.thinkingLevel,
           // Delivery is fixed at launch; session switches and patches cannot change it.
@@ -1416,9 +1411,12 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     setSession,
     abortActive,
   } = sessionActions;
-  const loadHistory = async (options?: { retireMissingReconnectRun?: boolean }) => {
+  const loadHistory = async (options?: {
+    retireMissingReconnectRun?: boolean;
+    sessionNotice?: string | false;
+  }) => {
     const activeRunAtStart = state.activeChatRunId;
-    const result = await loadHistorySnapshot();
+    const result = await loadHistorySnapshot(options?.sessionNotice);
     if (result.loaded) {
       if (
         options?.retireMissingReconnectRun === true &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where creating or loading a TUI session repeated the generated session identifier across the header, transcript notices, and footer. Long UUID-like identifiers made `/new` especially noisy and kept occupying the persistent footer.

## Why This Change Was Made

The header remains the sole surface that renders the session key. History loads and lifecycle commands now use concise notices (`session loaded`, `new session`, and `session reset`), while the footer is limited to agent, model, mode, delivery, goal, and token status. `/new` owns its confirmation independently of transcript reload, so a successful creation still reports `new session` when history loading fails.

## User Impact

Operators no longer see generated TUI session IDs repeated throughout the interface. `/new` produces one concise confirmation, and the session ID naturally scrolls away with the header instead of remaining in the footer. If the new session's history cannot reload, operators see both the reload failure and the successful session-creation confirmation.

AI-assisted: yes. I reviewed the implementation and understand the changed TUI rendering and session-transition paths.

## Evidence

- `node scripts/run-vitest.mjs src/tui/tui-formatters.test.ts src/tui/tui-command-handlers.test.ts src/tui/tui-session-actions.test.ts` — 305 tests passed, including create-success/history-failure coverage.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` — 63 real-PTY tests passed on the original presentation change.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts -t 'creates a backend session from /new'` — focused `/new` PTY path passed after review fixes.
- `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts -t 'creates and adopts a fresh local session'` — real embedded-backend lifecycle passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed -- <touched files>` — repository checks passed locally after the delegated worker lacked hydrated dependencies.
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` — clean, no accepted/actionable findings after the review fix.
- Real synchronized PTY-frame assertion verifies `/new` renders `new session` and that the live footer row contains no `session` field.

Before/after screenshots could not be attached because this headless agent environment exposes the real PTY as synchronized text frames but has no GUI terminal screenshot or GitHub binary-upload integration. The real-PTY frame assertion covers the changed visible behavior directly.
