### PR TITLE
fix(slack): preserve dispatch custody for structured payloads

### DIFF
--- a/extensions/slack/src/channel.message-adapter.test.ts
+++ b/extensions/slack/src/channel.message-adapter.test.ts
@@ -132,6 +132,7 @@ describe("slack channel message adapter", () => {
 
     const provePayload = async () => {
       sendSlack.mockClear();
+      const onPlatformSendDispatch = vi.fn();
       const result = await sendPayload({
         cfg,
         to: "C123",
@@ -139,6 +140,7 @@ describe("slack channel message adapter", () => {
         payload: { text: "payload" },
         accountId: "default",
         deliveryQueueId: "queue-1",
+        onPlatformSendDispatch,
         deps: { sendSlack },
       });
       const [to, text, options] = expectLastSendSlackCall();
@@ -146,6 +148,7 @@ describe("slack channel message adapter", () => {
       expect(text).toBe("payload");
       expect(options.accountId).toBe("default");
       expect(options.deliveryQueueId).toBeUndefined();
+      expect(options.onPlatformSendDispatch).toBe(onPlatformSendDispatch);
       expect(result.receipt.platformMessageIds).toEqual(["msg-1"]);
     };
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -254,8 +254,6 @@ function withSlackSendOverride(params: {
   deps?: { [channelId: string]: unknown } | null;
   send: SlackSendFn;
   tokenOverride?: string;
-  deliveryQueueId?: string;
-  onPlatformSendDispatch?: () => Promise<void>;
 }) {
   return {
     ...params.deps,
@@ -267,10 +265,6 @@ function withSlackSendOverride(params: {
       await params.send(to, text, {
         ...opts,
         ...(params.tokenOverride ? { token: params.tokenOverride } : {}),
-        ...(params.deliveryQueueId ? { deliveryQueueId: params.deliveryQueueId } : {}),
-        ...(params.onPlatformSendDispatch
-          ? { onPlatformSendDispatch: params.onPlatformSendDispatch }
-          : {}),
       }),
   };
 }
@@ -531,7 +525,6 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       replyToId: threadTsValue,
       threadId: null,
       deliveryQueueId: undefined,
-      onPlatformSendDispatch: undefined,
       deps: withSlackSendOverride({
         deps: ctx.deps,
         send,
@@ -554,14 +547,10 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       to,
       replyToId: threadTsValue,
       threadId: null,
-      deliveryQueueId: undefined,
-      onPlatformSendDispatch: undefined,
       deps: withSlackSendOverride({
         deps: ctx.deps,
         send,
         tokenOverride,
-        deliveryQueueId: ctx.deliveryQueueId,
-        onPlatformSendDispatch: ctx.onPlatformSendDispatch,
       }),
     });
   },
@@ -581,12 +570,10 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       replyToId: threadTsValue,
       threadId: null,
       deliveryQueueId: undefined,
-      onPlatformSendDispatch: undefined,
       deps: withSlackSendOverride({
         deps: ctx.deps,
         send,
         tokenOverride,
-        onPlatformSendDispatch: ctx.onPlatformSendDispatch,
       }),
     });
   },

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -318,9 +318,6 @@ export const slackOutbound: ChannelOutboundAdapter = {
             text,
             mediaUrl,
             deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
-            onPlatformSendDispatch: useSingleDeliveryMarker
-              ? ctx.onPlatformSendDispatch
-              : undefined,
           }),
         finalize: async () => {
           let lastResult: Awaited<ReturnType<SlackSendFn>> | undefined;
@@ -337,9 +334,6 @@ export const slackOutbound: ChannelOutboundAdapter = {
                 : {}),
               ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
               deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
-              onPlatformSendDispatch: useSingleDeliveryMarker
-                ? ctx.onPlatformSendDispatch
-                : undefined,
             });
           }
           if (!lastResult) {

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -482,9 +482,9 @@ describe("slackOutbound sendPayload", () => {
     expect(client.chat.postMessage.mock.calls.length).toBeGreaterThanOrEqual(3);
     expect(capturedSendOptions).not.toHaveLength(0);
     expect(capturedSendOptions.every((opts) => opts.deliveryQueueId === undefined)).toBe(true);
-    expect(capturedSendOptions.every((opts) => opts.onPlatformSendDispatch === undefined)).toBe(
-      true,
-    );
+    expect(
+      capturedSendOptions.every((opts) => opts.onPlatformSendDispatch === onPlatformSendDispatch),
+    ).toBe(true);
     expect(postedSlackMessage(client, 0)).toMatchObject({
       text: expect.stringContaining("Pipeline <!channel>"),
       mrkdwn: false,
@@ -660,6 +660,37 @@ describe("slackOutbound sendPayload", () => {
       kind: "blocks",
       blocks: [{ type: "divider" }, { type: "actions" }],
     });
+  });
+
+  it("refreshes dispatch custody before each structured fanout request", async () => {
+    const payload: ReplyPayload = {
+      channelData: {
+        slack: { blocks: Array.from({ length: 49 }, () => ({ type: "divider" })) },
+      },
+      presentation: { title: "Deploy status", blocks: [{ type: "divider" }] },
+      interactive: interactiveButtons("Allow", "pluginbind:approval-123:o"),
+    };
+    const onPlatformSendDispatch = vi.fn(async () => undefined);
+
+    const { capturedSendOptions, client } = await sendThroughRealSlack({
+      payload,
+      deliveryQueueId: "queue-1",
+      onPlatformSendDispatch,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(capturedSendOptions).toHaveLength(2);
+    expect(capturedSendOptions.every((opts) => opts.deliveryQueueId === undefined)).toBe(true);
+    expect(
+      capturedSendOptions.every((opts) => opts.onPlatformSendDispatch === onPlatformSendDispatch),
+    ).toBe(true);
+    expect(onPlatformSendDispatch).toHaveBeenCalledTimes(2);
+    for (const [
+      index,
+      dispatchOrder,
+    ] of onPlatformSendDispatch.mock.invocationCallOrder.entries()) {
+      expect(dispatchOrder).toBeLessThan(client.chat.postMessage.mock.invocationCallOrder[index]!);
+    }
   });
 
   it("uses the full ordered table fallback when preserved siblings exceed the block limit", async () => {


### PR DESCRIPTION
Closes #123707

## What Problem This Solves

Fixes an issue where queued Slack structured payload and presentation fanout sends could cross the Slack platform boundary without refreshing final dispatch custody. If cancellation or producer lease loss occurred after adapter entry, recovery no longer had the expected dispatch fence protecting against duplicate recipient-visible delivery.

## Why This Change Was Made

The Slack lazy facade explicitly discarded `onPlatformSendDispatch` for payloads, and the structured fanout owner incorrectly tied callback forwarding to `deliveryQueueId`. The callback now follows the existing send context into every structured platform request, while `deliveryQueueId` remains suppressed for one-to-many fanout because exact provider reconciliation is a distinct single-message contract.

The repair also deletes the duplicate callback/queue-id override plumbing from the facade. Production code is net −19 lines (`+0/-19`); tests are net +34 (`+37/-3`). No config, protocol, storage, authentication, dependency, or public Plugin SDK surface changes.

Provenance: PR #97480 introduced the facade override/nulling shape while adding exact Slack reconciliation, and PR #104539 later coupled structured fanout callback forwarding to its single-message marker.

AI-assisted: yes. The implementation and proof were reviewed by Claude and by the repository Codex autoreview workflow.

## User Impact

Slack structured messages now retain the same cancellation and delivery-lease custody as ordinary text and media sends. Multi-message structured fanout continues to avoid claiming a single exact reconciliation identifier for several Slack messages.

## Evidence

- Pre-fix regression: the focused suite failed at both affected boundaries because the facade and structured fanout delivered `undefined` instead of the callback.
- Focused post-rebase proof: `node scripts/run-vitest.mjs extensions/slack/src/channel.message-adapter.test.ts extensions/slack/src/outbound-payload.test.ts` — 34/34 tests passed.
- Actual changed gate: `node scripts/check-changed.mjs -- extensions/slack/src/channel.ts extensions/slack/src/outbound-adapter.ts extensions/slack/src/channel.message-adapter.test.ts extensions/slack/src/outbound-payload.test.ts` — passed on Blacksmith Testbox lease `tbx_01m00ea864sxtas4kfgjf9g1ts`; run https://github.com/openclaw/openclaw/actions/runs/31814802516.
- Static proof: targeted oxfmt check, type-aware Oxlint, import-cycle/boundary/dead-export/type gates, and `git diff --check` passed.
- Authenticated live proof: one benign structured message was sent once to a redacted Peter-owned Slack DM. The callback fired once before completion, the receipt contained one platform message, and Slack history contained exactly one deterministic marker. The send was not retried.
- Dependency contract: inspected `@slack/web-api@8.0.0` request types and its `chat.postMessage` → `apiCall` transport boundary.
- Rebase proof: stable patch ID remained `3a16cefeb280600d20f4e818d8c562155439735b`; no touched-path owner overlap and no semantic or LOC drift.
- Final branch autoreview: clean, no accepted/actionable findings, confidence 0.98.
