### PR TITLE
fix(ui): prevent dashboard chat messages from overlapping

### DIFF
--- a/ui/src/e2e/skills-owner-selection.e2e.test.ts
+++ b/ui/src/e2e/skills-owner-selection.e2e.test.ts
@@ -31,10 +31,12 @@ suite.define(() => {
 
       await page.goto(`${suite.server.baseUrl}skills`);
       await gateway.waitForRequest("skills.status");
-      await expect
-        .poll(() => gateway.getRequests("skills.status"))
-        .toEqual([expect.objectContaining({ params: { agentId: "main" } })]);
       await page.getByText("No skills found.").waitFor();
+      const requests = await gateway.getRequests("skills.status");
+      expect(requests.length).toBeGreaterThan(0);
+      expect(requests.map((request) => request.params)).toEqual(
+        requests.map(() => ({ agentId: "main" })),
+      );
     });
   });
 });

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -51,6 +51,27 @@ describe("chat transcript controller", () => {
     }
   });
 
+  it("measures newly inserted rows after Lit connects them", async () => {
+    // Lit invokes ref callbacks while a new row is still detached. Browsers
+    // report a zero offsetHeight there, which must not become the row's
+    // durable virtual size before the following user bubble is positioned.
+    transcriptDomState.detachedRowHeight = 0;
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = threadProps("pane-commentary-insert", "agent:main:session-a", [
+      { role: "assistant", content: "commentary", timestamp: 1_000 },
+      { role: "user", content: "next turn", timestamp: 2_000 },
+    ]);
+
+    render(renderChatThread(props, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+    render(renderChatThread(props, transcript), container);
+
+    expect(transcriptRows(container)[1]?.style.transform).toBe("translateY(100px)");
+  });
+
   it("pauses an unmeasurable restore until loading commits an empty transcript", () => {
     const transcript = createTestTranscript();
     const container = document.body.appendChild(document.createElement("div"));

--- a/ui/src/pages/chat/components/chat-transcript-controller.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.ts
@@ -132,7 +132,22 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
     if (!callback) {
       callback = (element?: Element) => {
         if (element instanceof HTMLElement) {
-          this.virtualizerController.getVirtualizer().measureElement(element);
+          if (element.isConnected) {
+            this.virtualizerController.getVirtualizer().measureElement(element);
+          } else {
+            // Lit invokes refs before the row is connected. Measuring a new
+            // key there records offsetHeight=0, so a following row can share
+            // its transform and paint over it until ResizeObserver catches up.
+            queueMicrotask(() => {
+              if (
+                element.isConnected &&
+                element.dataset.virtualRowKey === key &&
+                this.rowIndexesByKey.has(key)
+              ) {
+                this.virtualizerController.getVirtualizer().measureElement(element);
+              }
+            });
+          }
           return;
         }
         // Re-stamps (e.g. the chat<->dashboard face switch) re-invoke each

--- a/ui/src/pages/chat/components/chat-transcript.test-support.ts
+++ b/ui/src/pages/chat/components/chat-transcript.test-support.ts
@@ -4,7 +4,7 @@ import { resetThreadPresentation } from "./chat-thread-interactions.ts";
 
 export const observedElements = new Set<Element>();
 export const resizeObservers = new Set<RecordingResizeObserver>();
-export const transcriptDomState = { measuredRowHeight: 100 };
+export const transcriptDomState = { measuredRowHeight: 100, detachedRowHeight: 100 };
 
 class RecordingResizeObserver implements ResizeObserver {
   private readonly targets = new Set<Element>();
@@ -95,9 +95,14 @@ export function installTranscriptDomMocks(): void {
   observedElements.clear();
   resizeObservers.clear();
   transcriptDomState.measuredRowHeight = 100;
+  transcriptDomState.detachedRowHeight = 100;
   vi.stubGlobal("ResizeObserver", RecordingResizeObserver);
   vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
-    () => transcriptDomState.measuredRowHeight,
+    function (this: HTMLElement) {
+      return this.isConnected
+        ? transcriptDomState.measuredRowHeight
+        : transcriptDomState.detachedRowHeight;
+    },
   );
   vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
     x: 0,


### PR DESCRIPTION
Related: #113356

## What Problem This Solves

Fixes an issue where dashboard-chat users could see a newly rendered assistant commentary row and the following user message painted on top of each other after the transcript was re-stamped or appended.

## Why This Change Was Made

Lit invokes row refs before newly stamped virtual rows are connected. TanStack Virtual's synchronous first measurement can therefore cache a zero `offsetHeight`; because transcript rows are absolutely positioned, the next row receives the same vertical offset. The first measurement is now deferred to the post-commit microtask when the row is connected, while TanStack's existing ResizeObserver remains the ongoing owner of row-size changes. Stale or removed rows are rejected before measurement.

The exact-head CI run also exposed an unrelated deterministic failure already present on `main`: the Skills owner-selection E2E introduced by #123339 is named to verify that every initial request is scoped to the selected agent, but accidentally required exactly one request. Route and fallback timing can legitimately produce more than one initial status refresh. The test now waits for the page to settle, requires at least one request, and verifies that every captured request targets the displayed default agent.

## User Impact

Dashboard chat messages retain separate vertical positions instead of overlapping during commentary-to-user transitions.

## Evidence

- Reproduced on unmodified `main` with a focused regression: the second row rendered at `translateY(0px)` after the detached first row measured as zero.
- The same regression passes after the fix with the second row at `translateY(100px)`.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-transcript-controller.test.ts ui/src/pages/chat/components/chat-transcript-invalidation.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts` — 19 tests passed.
- `node scripts/run-vitest.mjs ui/src/e2e/skills-owner-selection.e2e.test.ts` — 1 browser E2E passed; the old exact-count assertion failed repeatedly in the full CI shard before correction.
- Targeted `oxfmt`, focused `oxlint`, and `git diff --check` passed.
- Autoreview (`--mode uncommitted`, Codex `gpt-5.6-sol`, high) reported no accepted/actionable findings.
- Provenance: #113356 fixed detached-row pruning during face switches, but newly stamped detached rows still synchronously cached a zero first height; this PR closes that remaining path.

AI-assisted: yes. The code path, dependency behavior, regression, and final diff were manually verified.
