### PR TITLE
fix(installer): reject unusable prefix installs

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -209,6 +209,10 @@ by default, plus git-checkout installs under the same prefix flow.
     - `git` method: clones/updates a checkout (default `~/openclaw`) and still writes the wrapper to `<prefix>/bin/openclaw`
 
   </Step>
+  <Step title="Verify the installed CLI">
+    Runs `<prefix>/bin/openclaw --version` and stops with an error unless the
+    installed wrapper returns a version.
+  </Step>
   <Step title="Refresh loaded gateway service">
     If a gateway service is already loaded from that same prefix, the script runs
     `openclaw gateway install --force`, which activates the replacement service,

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -211,7 +211,7 @@ by default, plus git-checkout installs under the same prefix flow.
   </Step>
   <Step title="Verify the installed CLI">
     Runs `<prefix>/bin/openclaw --version` and stops with an error unless the
-    installed wrapper returns a version.
+    installed wrapper exits successfully with a nonempty version.
   </Step>
   <Step title="Refresh loaded gateway service">
     If a gateway service is already loaded from that same prefix, the script runs

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1448,14 +1448,6 @@ EOF
   emit_json "{\"event\":\"step\",\"name\":\"openclaw\",\"status\":\"ok\",\"method\":\"git\"}"
 }
 
-resolve_openclaw_version() {
-  local version=""
-  if [[ -x "${PREFIX}/bin/openclaw" ]]; then
-    version="$("${PREFIX}/bin/openclaw" --version 2>/dev/null | head -n 1 | tr -d '\r')"
-  fi
-  echo "$version"
-}
-
 is_gateway_daemon_loaded() {
   local claw="$1"
   if [[ -z "$claw" || ! -x "$claw" ]]; then
@@ -1538,9 +1530,9 @@ main() {
   fi
 
   local installed_version
-  installed_version="$(resolve_openclaw_version)"
-  if [[ -z "$installed_version" ]]; then
-    fail "Installed OpenClaw CLI did not return a version from ${PREFIX}/bin/openclaw."
+  if ! installed_version="$("${PREFIX}/bin/openclaw" --version 2>/dev/null | head -n 1 | tr -d '\r')" ||
+    [[ -z "$installed_version" ]]; then
+    fail "Installed OpenClaw CLI did not return a version successfully from ${PREFIX}/bin/openclaw."
   fi
 
   refresh_gateway_service_if_loaded

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1537,17 +1537,15 @@ main() {
     fail "Unknown install method: ${INSTALL_METHOD} (use npm or git)"
   fi
 
-  refresh_gateway_service_if_loaded
-
   local installed_version
   installed_version="$(resolve_openclaw_version)"
-  if [[ -n "$installed_version" ]]; then
-    emit_json "{\"event\":\"done\",\"ok\":true,\"version\":\"${installed_version//\"/\\\"}\"}"
-    log "OpenClaw installed (${installed_version})."
-  else
-    emit_json "{\"event\":\"done\",\"ok\":true}"
-    log "OpenClaw installed."
+  if [[ -z "$installed_version" ]]; then
+    fail "Installed OpenClaw CLI did not return a version from ${PREFIX}/bin/openclaw."
   fi
+
+  refresh_gateway_service_if_loaded
+  emit_json "{\"event\":\"done\",\"ok\":true,\"version\":\"${installed_version//\"/\\\"}\"}"
+  log "OpenClaw installed (${installed_version})."
 
   if [[ "$RUN_ONBOARD" -eq 1 ]]; then
     "${PREFIX}/bin/openclaw" onboard

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -510,6 +510,42 @@ describe("install-cli.sh", () => {
     },
   );
 
+  it.each([
+    { args: "--json", mode: "JSON" },
+    { args: "", mode: "human" },
+  ])(
+    "rejects a version command that prints output and fails in $mode mode before service refresh",
+    ({ args }) => {
+      const tmp = tempDirs.make("openclaw-install-cli-failed-version-");
+      const prefix = join(tmp, "prefix");
+      const bin = join(prefix, "bin");
+      const openclaw = join(bin, "openclaw");
+      const refreshLog = join(tmp, "gateway-refresh.log");
+      mkdirSync(bin, { recursive: true });
+      writeFileSync(openclaw, '#!/bin/bash\nprintf "OpenClaw 2026.8.1\\n"\nexit 1\n');
+      chmodSync(openclaw, 0o755);
+
+      const result = runInstallCliShell(
+        [
+          "set -euo pipefail",
+          `cd ${JSON.stringify(process.cwd())}`,
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          "install_node() { :; }",
+          "ensure_git() { :; }",
+          "install_openclaw() { :; }",
+          `refresh_gateway_service_if_loaded() { touch ${JSON.stringify(refreshLog)}; }`,
+          `main ${args} --prefix ${JSON.stringify(prefix)} --version 0.0.0`,
+        ].join("\n"),
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain("Installed OpenClaw CLI did not return a version");
+      expect(result.stdout).not.toContain('"event":"done"');
+      expect(result.stdout).not.toContain("OpenClaw installed.");
+      expect(existsSync(refreshLog)).toBe(false);
+    },
+  );
+
   it("keeps HOME for default prefix while OPENCLAW_HOME controls git checkout paths", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-home-"));
     const osHome = join(tmp, "os-home");

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -477,6 +477,41 @@ describe("install-cli.sh", () => {
     }
   });
 
+  it.each([
+    { args: "--json", mode: "JSON" },
+    { args: "", mode: "human" },
+  ])(
+    "rejects a package without a runnable CLI in $mode mode before service refresh",
+    ({ args }) => {
+      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-invalid-package-"));
+      const prefix = join(tmp, "prefix");
+      const refreshLog = join(tmp, "gateway-refresh.log");
+
+      try {
+        const result = runInstallCliShell(
+          [
+            "set -euo pipefail",
+            `cd ${JSON.stringify(process.cwd())}`,
+            `source ${JSON.stringify(SCRIPT_PATH)}`,
+            "install_node() { :; }",
+            "ensure_git() { :; }",
+            'npm_bin() { printf "/usr/bin/true\\n"; }',
+            `refresh_gateway_service_if_loaded() { touch ${JSON.stringify(refreshLog)}; }`,
+            `main ${args} --prefix ${JSON.stringify(prefix)} --version 0.0.0`,
+          ].join("\n"),
+        );
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain("Installed OpenClaw CLI did not return a version");
+        expect(result.stdout).not.toContain('"event":"done"');
+        expect(result.stdout).not.toContain("OpenClaw installed.");
+        expect(existsSync(refreshLog)).toBe(false);
+      } finally {
+        rmSync(tmp, { force: true, recursive: true });
+      }
+    },
+  );
+
   it("keeps HOME for default prefix while OPENCLAW_HOME controls git checkout paths", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-home-"));
     const osHome = join(tmp, "os-home");

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -14,13 +14,15 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import {
   writeNpmBeforePolicyFixture,
   writeNpmFreshnessConflictFixture,
 } from "./install-npm-fixtures.js";
 
 const SCRIPT_PATH = "scripts/install-cli.sh";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runInstallCliShell(script: string, env: NodeJS.ProcessEnv = {}) {
   return spawnSync("/bin/bash", ["-c", script], {
@@ -483,32 +485,28 @@ describe("install-cli.sh", () => {
   ])(
     "rejects a package without a runnable CLI in $mode mode before service refresh",
     ({ args }) => {
-      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-invalid-package-"));
+      const tmp = tempDirs.make("openclaw-install-cli-invalid-package-");
       const prefix = join(tmp, "prefix");
       const refreshLog = join(tmp, "gateway-refresh.log");
 
-      try {
-        const result = runInstallCliShell(
-          [
-            "set -euo pipefail",
-            `cd ${JSON.stringify(process.cwd())}`,
-            `source ${JSON.stringify(SCRIPT_PATH)}`,
-            "install_node() { :; }",
-            "ensure_git() { :; }",
-            'npm_bin() { printf "/usr/bin/true\\n"; }',
-            `refresh_gateway_service_if_loaded() { touch ${JSON.stringify(refreshLog)}; }`,
-            `main ${args} --prefix ${JSON.stringify(prefix)} --version 0.0.0`,
-          ].join("\n"),
-        );
+      const result = runInstallCliShell(
+        [
+          "set -euo pipefail",
+          `cd ${JSON.stringify(process.cwd())}`,
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          "install_node() { :; }",
+          "ensure_git() { :; }",
+          'npm_bin() { printf "/usr/bin/true\\n"; }',
+          `refresh_gateway_service_if_loaded() { touch ${JSON.stringify(refreshLog)}; }`,
+          `main ${args} --prefix ${JSON.stringify(prefix)} --version 0.0.0`,
+        ].join("\n"),
+      );
 
-        expect(result.status).toBe(1);
-        expect(result.stdout).toContain("Installed OpenClaw CLI did not return a version");
-        expect(result.stdout).not.toContain('"event":"done"');
-        expect(result.stdout).not.toContain("OpenClaw installed.");
-        expect(existsSync(refreshLog)).toBe(false);
-      } finally {
-        rmSync(tmp, { force: true, recursive: true });
-      }
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain("Installed OpenClaw CLI did not return a version");
+      expect(result.stdout).not.toContain('"event":"done"');
+      expect(result.stdout).not.toContain("OpenClaw installed.");
+      expect(existsSync(refreshLog)).toBe(false);
     },
   );
 


### PR DESCRIPTION
Closes #123708

## What Problem This Solves

Fixes an issue where users running the local-prefix installer could receive a successful exit and final `done/ok` event when the package command succeeded but the installed OpenClaw wrapper either returned no version or printed a plausible version before exiting nonzero.

## Why This Change Was Made

The shared installer terminal flow now requires `openclaw --version` to exit successfully and return a nonempty first line before refreshing a loaded Gateway service or reporting success. The masking resolver and its success-without-version branch are removed, leaving npm and git installs with one canonical verification boundary.

## User Impact

Incomplete or unusable package artifacts now fail the installer explicitly instead of appearing installed. Valid package installs still refresh an already-loaded service when appropriate and report their installed version.

## Evidence

- Pre-fix regressions: JSON and human cases for a wrapper that printed `OpenClaw 2026.8.1` and exited 1 both incorrectly exited 0; 2 of 50 focused cases failed.
- Final focused test: `node scripts/run-vitest.mjs test/scripts/install-cli.test.ts` — 50 passed after rebase.
- Three-way packaged Testbox proof: https://github.com/openclaw/openclaw/actions/runs/31818411434
  - Tarball without `dist/entry.js`: installer exited 1; no final done event or Gateway-service stage.
  - Tarball whose real entry printed a plausible version and exited 1: wrapper exit 1, installer exit 1; no final done event or Gateway-service stage.
  - Canonical packed tarball: integrity check passed; installer exited 0; installed CLI returned a nonempty version; isolated Gateway service remained not loaded.
- Formatting, Bash syntax, ShellCheck, type-aware Oxlint, and diff checks passed.
- Fresh post-rebase Codex autoreview: clean, no actionable findings, 0.99 patch-correctness verdict.
- Production script delta: +7/-17, net -10. Tests: +70/-1. User-facing docs: +4. No changelog change.
