### PR TITLE
fix(ui): fork active sessions from stable history

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -6728,7 +6728,7 @@
       "surface": "android",
       "sites": [
         {
-          "kind": "ui-call",
+          "kind": "conditional-branch",
           "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt"
         }
       ]
@@ -6741,6 +6741,17 @@
         {
           "kind": "ui-call",
           "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt"
+        }
+      ]
+    },
+    {
+      "id": "native.android.e5ad8016516600bb",
+      "source": "Fork from last completed message",
+      "surface": "android",
+      "sites": [
+        {
+          "kind": "conditional-branch",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt"
         }
       ]
     },
@@ -29750,7 +29761,7 @@
       "surface": "apple",
       "sites": [
         {
-          "kind": "ui-call",
+          "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/CommandCenterSupport.swift"
         },
         {
@@ -29775,6 +29786,29 @@
         {
           "kind": "ui-call",
           "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.d6c01cfe9e53e179",
+      "source": "Fork from last completed message",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/ios/Sources/Design/CommandCenterSupport.swift"
+        },
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift"
+        },
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift"
+        },
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift"
         }
       ]
     },

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -1686,7 +1686,8 @@ class MainViewModel private constructor(
   suspend fun forkChatSession(
     parentKey: String,
     ownerAgentId: String? = null,
-  ): String? = ensureRuntime().forkChatSession(parentKey, ownerAgentId)
+    fromLastCompleted: Boolean = false,
+  ): String? = ensureRuntime().forkChatSession(parentKey, ownerAgentId, fromLastCompleted)
 
   suspend fun rewindChatAtEntry(entryId: String): SessionRewindResult? = ensureRuntime().rewindChatAtEntry(entryId)
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -5207,7 +5207,8 @@ class NodeRuntime private constructor(
   suspend fun forkChatSession(
     parentKey: String,
     ownerAgentId: String? = null,
-  ): String? = chat.forkSession(parentKey, ownerAgentId)
+    fromLastCompleted: Boolean = false,
+  ): String? = chat.forkSession(parentKey, ownerAgentId, fromLastCompleted)
 
   suspend fun rewindChatAtEntry(entryId: String): SessionRewindResult? = chat.rewindSessionAtEntryResult(chatSessionKey.value, entryId)
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -1232,6 +1232,7 @@ class ChatController internal constructor(
   suspend fun forkSession(
     parentKey: String,
     ownerAgentId: String? = null,
+    fromLastCompleted: Boolean = false,
   ): String? {
     val sessionKey = parentKey.trim().takeIf { it.isNotEmpty() } ?: return null
     val capturedOwnerAgentId =
@@ -1243,6 +1244,7 @@ class ChatController internal constructor(
         buildJsonObject {
           put("parentSessionKey", JsonPrimitive(sessionKey))
           put("fork", JsonPrimitive(true))
+          if (fromLastCompleted) put("forkFrom", JsonPrimitive("last-completed"))
           // Keep the fork under the selected row's captured agent; omitting agentId can
           // create the child under a newer gateway default for unscoped parent keys.
           capturedOwnerAgentId?.let { put("agentId", JsonPrimitive(it)) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
@@ -376,7 +376,13 @@ internal fun SessionsScreen(
               onRename = { renameSessionTarget = session.toActionTarget(activeGatewayStableId) },
               onFork = {
                 coroutineScope.launch {
-                  viewModel.forkChatSession(session.key, session.ownerAgentId)?.let { newKey ->
+                  viewModel
+                    .forkChatSession(
+                      session.key,
+                      session.ownerAgentId,
+                      fromLastCompleted = session.hasActiveRun == true,
+                    )
+                    ?.let { newKey ->
                     viewModel.switchChatSession(newKey, session.ownerAgentId)
                     onOpenChat()
                   }
@@ -727,7 +733,11 @@ private fun SessionRow(
             menuExpanded = false
             onRename()
           }
-          SessionMenuItem(nativeString("Fork")) {
+          SessionMenuItem(
+            nativeString(
+              if (session.hasActiveRun == true) "Fork from last completed message" else "Fork",
+            ),
+          ) {
             menuExpanded = false
             onFork()
           }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
@@ -376,13 +376,13 @@ internal fun SessionsScreen(
               onRename = { renameSessionTarget = session.toActionTarget(activeGatewayStableId) },
               onFork = {
                 coroutineScope.launch {
-                  viewModel
-                    .forkChatSession(
+                  val newKey =
+                    viewModel.forkChatSession(
                       session.key,
                       session.ownerAgentId,
                       fromLastCompleted = session.hasActiveRun == true,
                     )
-                    ?.let { newKey ->
+                  if (newKey != null) {
                     viewModel.switchChatSession(newKey, session.ownerAgentId)
                     onOpenChat()
                   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
@@ -413,6 +413,7 @@ class ChatControllerCommandControlsTest {
       val create = requests.first { it.first == "sessions.create" }.second.orEmpty()
       assertTrue(create.contains("\"parentSessionKey\":\"main\""))
       assertTrue(create.contains("\"fork\":true"))
+      assertFalse(create.contains("\"forkFrom\""))
       // The active unqualified parent keeps the captured default-agent owner.
       assertTrue(create.contains("\"agentId\":\"main\""))
 
@@ -427,6 +428,10 @@ class ChatControllerCommandControlsTest {
       val capturedOwnerCreate = requests.last { it.first == "sessions.create" }.second.orEmpty()
       assertTrue(capturedOwnerCreate.contains("\"parentSessionKey\":\"custom\""))
       assertTrue(capturedOwnerCreate.contains("\"agentId\":\"owner-a\""))
+
+      controller.forkSession("main", fromLastCompleted = true)
+      val activeCreate = requests.last { it.first == "sessions.create" }.second.orEmpty()
+      assertTrue(activeCreate.contains("\"forkFrom\":\"last-completed\""))
       assertTrue(requests.any { it.first == "sessions.list" })
       assertEquals(
         false,

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -460,6 +460,10 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         _ = try await self.requestSessionMutation(request)
     }
 
+    func forkSession(parentKey: String) async throws -> String {
+        try await self.forkSession(parentKey: parentKey, fromLastCompleted: false)
+    }
+
     func forkSession(parentKey: String, fromLastCompleted: Bool) async throws -> String {
         let target = self.sessionTarget(for: parentKey)
         let childAgentID = target.agentID ?? OpenClawChatSessionKey.agentID(from: target.sessionKey)

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -460,12 +460,13 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         _ = try await self.requestSessionMutation(request)
     }
 
-    func forkSession(parentKey: String) async throws -> String {
+    func forkSession(parentKey: String, fromLastCompleted: Bool) async throws -> String {
         let target = self.sessionTarget(for: parentKey)
         let childAgentID = target.agentID ?? OpenClawChatSessionKey.agentID(from: target.sessionKey)
         let request = OpenClawChatGatewayRequests.forkSession(
             parentSessionKey: target.sessionKey,
-            agentID: childAgentID)
+            agentID: childAgentID,
+            fromLastCompleted: fromLastCompleted)
         let response = try await requestSessionMutation(request)
         return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: response).key
     }

--- a/apps/ios/Sources/Design/CommandCenterSupport.swift
+++ b/apps/ios/Sources/Design/CommandCenterSupport.swift
@@ -183,7 +183,12 @@ struct CommandSessionActionsModifier: ViewModifier {
                     self.actionButton("Rename…", systemImage: "pencil") {
                         self.beginRename()
                     }
-                    self.actionButton("Fork", systemImage: "arrow.triangle.branch") {
+                    self.actionButton(
+                        self.session.hasActiveRun == true
+                            ? OpenClawTextValue.localized("Fork from last completed message")
+                            : OpenClawTextValue.localized("Fork"),
+                        systemImage: "arrow.triangle.branch")
+                    {
                         self.actions.fork()
                     }
                     self.groupMenu

--- a/apps/ios/Sources/Design/CommandCenterTab.swift
+++ b/apps/ios/Sources/Design/CommandCenterTab.swift
@@ -668,7 +668,9 @@ struct CommandCenterTab: View {
     private func forkSession(_ session: OpenClawChatSessionEntry) {
         Task {
             do {
-                let key = try await self.appModel.makeChatTransport().forkSession(parentKey: session.key)
+                let key = try await self.appModel.makeChatTransport().forkSession(
+                    parentKey: session.key,
+                    fromLastCompleted: session.hasActiveRun == true)
                 if let dashboardModel {
                     await dashboardModel.refreshSessions(appModel: self.appModel)
                 } else {
@@ -1346,7 +1348,9 @@ struct CommandSessionsScreen: View {
     private func forkSession(_ session: OpenClawChatSessionEntry) {
         Task {
             do {
-                let key = try await self.appModel.makeChatTransport().forkSession(parentKey: session.key)
+                let key = try await self.appModel.makeChatTransport().forkSession(
+                    parentKey: session.key,
+                    fromLastCompleted: session.hasActiveRun == true)
                 await self.refreshSessions()
                 self.openSessionKey(key)
             } catch {

--- a/apps/ios/Sources/RootSidebar.swift
+++ b/apps/ios/Sources/RootSidebar.swift
@@ -849,7 +849,9 @@ struct RootSidebar: View {
     private func forkSession(_ session: OpenClawChatSessionEntry) {
         Task {
             do {
-                let key = try await self.appModel.makeChatTransport().forkSession(parentKey: session.key)
+                let key = try await self.appModel.makeChatTransport().forkSession(
+                    parentKey: session.key,
+                    fromLastCompleted: session.hasActiveRun == true)
                 self.appModel.openChat(sessionKey: key)
                 self.selectSidebarDestination(.chat)
                 await self.model.refreshSessions(appModel: self.appModel)

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -106,7 +106,7 @@ struct IOSGatewayChatTransportTests {
         for key in ["Matrix:Channel:Room", "global", "agent:ops:main"] {
             try await transport.patchSession(key: key, pinned: true)
             try await transport.deleteSession(key: key)
-            _ = try await transport.forkSession(parentKey: key)
+            _ = try await transport.forkSession(parentKey: key, fromLastCompleted: false)
         }
 
         let requests = await recorder.all()

--- a/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
@@ -118,11 +118,12 @@ extension MacGatewayChatTransport {
             ifCurrentServerLease: serverLease)
     }
 
-    func forkSession(parentKey: String) async throws -> String {
+    func forkSession(parentKey: String, fromLastCompleted: Bool) async throws -> String {
         let target = self.sessionTarget(for: parentKey)
         let request = OpenClawChatGatewayRequests.forkSession(
             parentSessionKey: target.sessionKey,
-            agentID: target.agentID)
+            agentID: target.agentID,
+            fromLastCompleted: fromLastCompleted)
         let data = try await self.requestSessionAction(request)
         return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: data).key
     }

--- a/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
@@ -118,6 +118,10 @@ extension MacGatewayChatTransport {
             ifCurrentServerLease: serverLease)
     }
 
+    func forkSession(parentKey: String) async throws -> String {
+        try await self.forkSession(parentKey: parentKey, fromLastCompleted: false)
+    }
+
     func forkSession(parentKey: String, fromLastCompleted: Bool) async throws -> String {
         let target = self.sessionTarget(for: parentKey)
         let request = OpenClawChatGatewayRequests.forkSession(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayRequest.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayRequest.swift
@@ -380,12 +380,16 @@ public enum OpenClawChatGatewayRequests {
 
     public static func forkSession(
         parentSessionKey: String,
-        agentID: String?) -> OpenClawChatGatewayRequest
+        agentID: String?,
+        fromLastCompleted: Bool = false) -> OpenClawChatGatewayRequest
     {
         var params: [String: AnyCodable] = [
             "parentSessionKey": AnyCodable(parentSessionKey),
             "fork": AnyCodable(true),
         ]
+        if fromLastCompleted {
+            params["forkFrom"] = AnyCodable("last-completed")
+        }
         self.add(agentID, to: &params, key: "agentId")
         return OpenClawChatGatewayRequest(
             method: "sessions.create",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift
@@ -271,7 +271,11 @@ struct ChatSessionSidebar: View {
                     fromLastCompleted: session.hasActiveRun == true)
             }
         } label: {
-            self.actionLabel(String(localized: "Fork"), systemImage: "arrow.triangle.branch")
+            self.actionLabel(
+                session.hasActiveRun == true
+                    ? String(localized: "Fork from last completed message")
+                    : String(localized: "Fork"),
+                systemImage: "arrow.triangle.branch")
         }
         Button {
             self.viewModel.setSessionUnread(key: session.key, unread: session.unread != true)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift
@@ -265,7 +265,11 @@ struct ChatSessionSidebar: View {
                 systemImage: session.pinned == true ? "pin.slash" : "pin")
         }
         Button {
-            Task { await self.viewModel.forkSession(key: session.key) }
+            Task {
+                await self.viewModel.forkSession(
+                    key: session.key,
+                    fromLastCompleted: session.hasActiveRun == true)
+            }
         } label: {
             self.actionLabel(String(localized: "Fork"), systemImage: "arrow.triangle.branch")
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -351,7 +351,10 @@ public struct ChatSessionsSheet: View {
                     }
                 } label: {
                     self.actionLabel(
-                        LocalizedStringKey(String(localized: "Fork")),
+                        LocalizedStringKey(
+                            session.hasActiveRun == true
+                                ? String(localized: "Fork from last completed message")
+                                : String(localized: "Fork")),
                         systemImage: "arrow.triangle.branch")
                 }
                 Button {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -344,7 +344,11 @@ public struct ChatSessionsSheet: View {
                     }
                 }
                 Button {
-                    Task { await self.viewModel.forkSession(key: session.key) }
+                    Task {
+                        await self.viewModel.forkSession(
+                            key: session.key,
+                            fromLastCompleted: session.hasActiveRun == true)
+                    }
                 } label: {
                     self.actionLabel(
                         LocalizedStringKey(String(localized: "Fork")),

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -744,6 +744,7 @@ public protocol OpenClawChatTransport: Sendable {
         unread: Bool?) async throws
     func acquireSessionMutationRouteLease() async -> OpenClawChatSessionMutationRouteLease?
     func deleteSession(key: String) async throws
+    func forkSession(parentKey: String) async throws -> String
     func forkSession(parentKey: String, fromLastCompleted: Bool) async throws -> String
     func rewindSession(sessionKey: String, entryId: String) async throws -> OpenClawChatRewindResponse
     func forkSessionAtMessage(
@@ -1091,11 +1092,15 @@ extension OpenClawChatTransport {
             userInfo: [NSLocalizedDescriptionKey: "sessions.delete not supported by this transport"])
     }
 
-    public func forkSession(parentKey _: String, fromLastCompleted _: Bool) async throws -> String {
+    public func forkSession(parentKey _: String) async throws -> String {
         throw NSError(
             domain: "OpenClawChatTransport",
             code: 0,
             userInfo: [NSLocalizedDescriptionKey: "sessions.create fork not supported by this transport"])
+    }
+
+    public func forkSession(parentKey: String, fromLastCompleted _: Bool) async throws -> String {
+        try await self.forkSession(parentKey: parentKey)
     }
 
     public func rewindSession(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -744,7 +744,7 @@ public protocol OpenClawChatTransport: Sendable {
         unread: Bool?) async throws
     func acquireSessionMutationRouteLease() async -> OpenClawChatSessionMutationRouteLease?
     func deleteSession(key: String) async throws
-    func forkSession(parentKey: String) async throws -> String
+    func forkSession(parentKey: String, fromLastCompleted: Bool) async throws -> String
     func rewindSession(sessionKey: String, entryId: String) async throws -> OpenClawChatRewindResponse
     func forkSessionAtMessage(
         sessionKey: String,
@@ -1091,7 +1091,7 @@ extension OpenClawChatTransport {
             userInfo: [NSLocalizedDescriptionKey: "sessions.delete not supported by this transport"])
     }
 
-    public func forkSession(parentKey _: String) async throws -> String {
+    public func forkSession(parentKey _: String, fromLastCompleted _: Bool) async throws -> String {
         throw NSError(
             domain: "OpenClawChatTransport",
             code: 0,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -375,11 +375,15 @@ extension OpenClawChatViewModel {
         }
     }
 
-    public func forkSession(key: String) async {
+    public func forkSession(key: String, fromLastCompleted: Bool? = nil) async {
         guard self.canCreateSessionForImmediateSwitch() else { return }
         let initiatingSession = self.currentSessionSnapshot()
         do {
-            let createdKey = try await self.transport.forkSession(parentKey: key)
+            let stableBoundary = fromLastCompleted ??
+                (self.sessions.first(where: { $0.key == key })?.hasActiveRun == true)
+            let createdKey = try await self.transport.forkSession(
+                parentKey: key,
+                fromLastCompleted: stableBoundary)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !createdKey.isEmpty else { return }
             guard self.isCurrentSession(initiatingSession), self.canCreateSessionForImmediateSwitch() else {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -390,7 +390,10 @@ public struct OpenClawChatWindowShell: View {
                 Task { await self.viewModel.forkSession(key: self.activeSessionKey) }
             } label: {
                 chatWindowActionLabel(
-                    LocalizedStringKey(String(localized: "Fork")),
+                    LocalizedStringKey(
+                        self.activeSessionEntry?.hasActiveRun == true
+                            ? String(localized: "Fork from last completed message")
+                            : String(localized: "Fork")),
                     systemImage: "arrow.triangle.branch")
             }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8445,6 +8445,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let parentsessionkey: String?
     public let spawndepth: Int?
     public let fork: Bool?
+    public let forkfrom: String?
     public let emitcommandhooks: Bool?
     public let succeedsparent: Bool?
     public let task: String?
@@ -8469,6 +8470,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         parentsessionkey: String? = nil,
         spawndepth: Int? = nil,
         fork: Bool? = nil,
+        forkfrom: String? = nil,
         emitcommandhooks: Bool? = nil,
         succeedsparent: Bool? = nil,
         task: String? = nil,
@@ -8492,6 +8494,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.parentsessionkey = parentsessionkey
         self.spawndepth = spawndepth
         self.fork = fork
+        self.forkfrom = forkfrom
         self.emitcommandhooks = emitcommandhooks
         self.succeedsparent = succeedsparent
         self.task = task
@@ -8517,6 +8520,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case parentsessionkey = "parentSessionKey"
         case spawndepth = "spawnDepth"
         case fork
+        case forkfrom = "forkFrom"
         case emitcommandhooks = "emitCommandHooks"
         case succeedsparent = "succeedsParent"
         case task

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
@@ -158,6 +158,13 @@ struct ChatGatewayRequestTests {
         #expect(fork.params["parentSessionKey"]?.value as? String == "agent:reviewer:telegram:group:1")
         #expect(fork.params["agentId"]?.value as? String == "reviewer")
         #expect(fork.params["fork"]?.value as? Bool == true)
+        #expect(fork.params["forkFrom"] == nil)
+
+        let activeFork = OpenClawChatGatewayRequests.forkSession(
+            parentSessionKey: "agent:reviewer:telegram:group:1",
+            agentID: "reviewer",
+            fromLastCompleted: true)
+        #expect(activeFork.params["forkFrom"]?.value as? String == "last-completed")
 
         let create = OpenClawChatGatewayRequests.createSession(
             key: "agent:reviewer:new",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -27,6 +27,7 @@ private func sessionActionOutboxCommand(
 
 private actor SessionActionTransportState {
     var forkedParentKeys: [String] = []
+    var forkedFromLastCompleted: [Bool] = []
     var rewoundMessages: [(sessionKey: String, entryID: String)] = []
     var forkedMessages: [(sessionKey: String, entryID: String)] = []
     var branchListSessionKeys: [String] = []
@@ -42,8 +43,9 @@ private actor SessionActionTransportState {
     var createdAgentIDs: [String?] = []
     var createdParentKeys: [String?] = []
 
-    func recordFork(_ key: String) {
+    func recordFork(_ key: String, fromLastCompleted: Bool) {
         self.forkedParentKeys.append(key)
+        self.forkedFromLastCompleted.append(fromLastCompleted)
     }
 
     func recordRewind(sessionKey: String, entryID: String) {
@@ -211,8 +213,8 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         throw NSError(domain: "SessionActionTransport", code: 1)
     }
 
-    func forkSession(parentKey: String) async throws -> String {
-        await self.state.recordFork(parentKey)
+    func forkSession(parentKey: String, fromLastCompleted: Bool) async throws -> String {
+        await self.state.recordFork(parentKey, fromLastCompleted: fromLastCompleted)
         await self.forkGate?.suspendCompletion()
         return "forked"
     }
@@ -327,6 +329,10 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
 
     func forkedParentKeys() async -> [String] {
         await self.state.forkedParentKeys
+    }
+
+    func stableForkFlags() async -> [Bool] {
+        await self.state.forkedFromLastCompleted
     }
 
     func rewoundMessages() async -> [(sessionKey: String, entryID: String)] {
@@ -1114,6 +1120,16 @@ struct ChatViewModelSessionActionTests {
             localized: "Remove attachments or wait for delivery to resolve before starting a new chat."))
     }
 
+    @Test func `fork routes active sessions through the completed-message boundary`() async {
+        let transport = SessionActionTransport()
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.sessions = [self.entry(key: "main", hasActiveRun: true)]
+
+        await viewModel.forkSession(key: "main")
+
+        #expect(await transport.stableForkFlags() == [true])
+    }
+
     @Test func `fork completion does not override newer navigation`() async {
         let forkGate = SessionActionCompletionGate()
         let transport = SessionActionTransport(forkGate: forkGate)
@@ -1277,7 +1293,11 @@ struct ChatViewModelSessionActionTests {
         ]
     }
 
-    private func entry(key: String, sessionId: String? = nil) -> OpenClawChatSessionEntry {
+    private func entry(
+        key: String,
+        sessionId: String? = nil,
+        hasActiveRun: Bool? = nil) -> OpenClawChatSessionEntry
+    {
         OpenClawChatSessionEntry(
             key: key,
             kind: nil,
@@ -1297,6 +1317,7 @@ struct ChatViewModelSessionActionTests {
             totalTokens: nil,
             modelProvider: nil,
             model: nil,
-            contextTokens: nil)
+            contextTokens: nil,
+            hasActiveRun: hasActiveRun)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -25,6 +25,23 @@ private func sessionActionOutboxCommand(
         lastError: nil)
 }
 
+private actor LegacyForkTransportState {
+    var parentKeys: [String] = []
+
+    func record(_ parentKey: String) {
+        self.parentKeys.append(parentKey)
+    }
+}
+
+private final class LegacyForkTransport: @unchecked Sendable, OpenClawChatTransport {
+    let state = LegacyForkTransportState()
+
+    func forkSession(parentKey: String) async throws -> String {
+        await self.state.record(parentKey)
+        return "legacy-child"
+    }
+}
+
 private actor SessionActionTransportState {
     var forkedParentKeys: [String] = []
     var forkedFromLastCompleted: [Bool] = []
@@ -1128,6 +1145,18 @@ struct ChatViewModelSessionActionTests {
         await viewModel.forkSession(key: "main")
 
         #expect(await transport.stableForkFlags() == [true])
+    }
+
+    @Test func `boundary-aware fork remains compatible with legacy transports`() async throws {
+        let legacy = LegacyForkTransport()
+        let transport: any OpenClawChatTransport = legacy
+
+        let childKey = try await transport.forkSession(
+            parentKey: "main",
+            fromLastCompleted: true)
+
+        #expect(childKey == "legacy-child")
+        #expect(await legacy.state.parentKeys == ["main"])
     }
 
     @Test func `fork completion does not override newer navigation`() async {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -36,9 +36,31 @@ private actor LegacyForkTransportState {
 private final class LegacyForkTransport: @unchecked Sendable, OpenClawChatTransport {
     let state = LegacyForkTransportState()
 
+    func requestHistory(sessionKey _: String) async throws -> OpenClawChatHistoryPayload {
+        throw CancellationError()
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        throw CancellationError()
+    }
+
     func forkSession(parentKey: String) async throws -> String {
         await self.state.record(parentKey)
         return "legacy-child"
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        false
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        AsyncStream { $0.finish() }
     }
 }
 

--- a/packages/gateway-protocol/src/schema/sessions-create.ts
+++ b/packages/gateway-protocol/src/schema/sessions-create.ts
@@ -25,6 +25,12 @@ export const SessionsCreateParamsSchema = closedObject({
   fork: Type.Optional(
     Type.Boolean({ description: "Fork the parent transcript; requires parentSessionKey." }),
   ),
+  forkFrom: Type.Optional(
+    Type.Literal("last-completed", {
+      description:
+        "Fork through the parent's last completed assistant message; requires fork=true.",
+    }),
+  ),
   emitCommandHooks: Type.Optional(Type.Boolean()),
   succeedsParent: Type.Optional(
     Type.Boolean({

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -40,6 +40,7 @@ type ForkSessionFromParentParams = {
   config?: OpenClawConfig;
   sessionKey: string;
   storePath?: string;
+  forkFrom?: "last-completed";
 
   /** Cross-agent forks land the child transcript in the target agent's store. */
   targetStorePath?: string;
@@ -121,6 +122,7 @@ export async function forkSessionFromParent(
     parentSessionKey: params.parentSessionKey,
     sessionKey: params.sessionKey,
     storePath,
+    ...(params.forkFrom ? { forkFrom: params.forkFrom } : {}),
     ...(params.targetStorePath ? { targetStorePath: params.targetStorePath } : {}),
   });
   return fork.status === "created" ? fork.transcript : null;

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -5,6 +5,7 @@ import {
   resolveSessionParentForkDecision,
   type SessionParentForkDecision,
   type ParentForkedSessionTranscript,
+  type ForkSessionFromParentTranscriptResult,
 } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -126,6 +127,22 @@ export async function forkSessionFromParent(
     ...(params.targetStorePath ? { targetStorePath: params.targetStorePath } : {}),
   });
   return fork.status === "created" ? fork.transcript : null;
+}
+
+export async function forkSessionFromParentWithDecision(
+  params: ForkSessionFromParentParams,
+): Promise<ForkSessionFromParentTranscriptResult> {
+  assertParentSessionForkAllowed(params.parentEntry);
+  return await forkSessionFromParentTranscript({
+    agentId: params.agentId,
+    enforceTokenLimit: true,
+    parentEntry: params.parentEntry,
+    parentSessionKey: params.parentSessionKey,
+    sessionKey: params.sessionKey,
+    storePath: resolveParentForkStorePath(params),
+    ...(params.forkFrom ? { forkFrom: params.forkFrom } : {}),
+    ...(params.targetStorePath ? { targetStorePath: params.targetStorePath } : {}),
+  });
 }
 
 function normalizeForkTarget(params: { canonicalKey: string; storeKeys?: readonly string[] }): {

--- a/src/config/sessions/session-accessor.sqlite-parent-fork.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-fork.ts
@@ -182,6 +182,7 @@ function readTranscriptContextUsage(
 
 export function resolveParentForkSourceTranscript(
   fileEntries: readonly TranscriptEvent[],
+  forkFrom?: "last-completed",
 ): ParentForkSourceTranscript | null {
   if (fileEntries.length === 0) {
     return null;
@@ -198,28 +199,47 @@ export function resolveParentForkSourceTranscript(
     appendPath,
     appendParentId: tree.appendParentId,
   });
-  const branchEntries = mergedPath.nodes.flatMap((node) => {
+  const visibleBranchEntries = mergedPath.nodes.flatMap((node) => {
     if (!isRecord(node.entry)) {
       return [];
     }
     const parentId = node.selectedParentId;
     return [node.entry.parentId === parentId ? node.entry : { ...node.entry, parentId }];
   });
+  const branchEntries =
+    forkFrom === "last-completed"
+      ? visibleBranchEntries.slice(0, findLastCompletedAssistantIndex(visibleBranchEntries) + 1)
+      : visibleBranchEntries;
   const pathEntryIds = new Set(
     branchEntries.flatMap((entry) =>
       isRecord(entry) && typeof entry.id === "string" ? [entry.id] : [],
     ),
   );
   const lastLeafUpdateNode = tree.nodes.findLast((node) => node.leafId !== undefined);
+  const lastBranchEntry = branchEntries.at(-1);
+  const lastBranchEntryId =
+    isRecord(lastBranchEntry) && typeof lastBranchEntry.id === "string" ? lastBranchEntry.id : null;
   return {
-    appendParentId: mergedPath.appendParentId,
-    ...(lastLeafUpdateNode?.appendMode ? { appendMode: lastLeafUpdateNode.appendMode } : {}),
+    appendParentId: forkFrom === "last-completed" ? lastBranchEntryId : mergedPath.appendParentId,
+    ...(forkFrom !== "last-completed" && lastLeafUpdateNode?.appendMode
+      ? { appendMode: lastLeafUpdateNode.appendMode }
+      : {}),
     branchEntries,
     cwd: typeof header?.cwd === "string" ? header.cwd : undefined,
     labelsToWrite: collectBranchLabels({ allEntries: entries, pathEntryIds }),
-    leafId: tree.leafId,
-    preserveLeafControl: isSessionTranscriptLeafControl(lastLeafUpdateNode?.entry),
+    leafId: forkFrom === "last-completed" ? lastBranchEntryId : tree.leafId,
+    preserveLeafControl:
+      forkFrom !== "last-completed" && isSessionTranscriptLeafControl(lastLeafUpdateNode?.entry),
   };
+}
+
+function findLastCompletedAssistantIndex(entries: readonly TranscriptEvent[]): number {
+  return entries.findLastIndex((entry) => {
+    const message = isRecord(entry) && isRecord(entry.message) ? entry.message : undefined;
+    // Tool-use assistant messages are mid-turn checkpoints. Any other persisted
+    // assistant message is a stable boundary, including legacy rows without a reason.
+    return message?.role === "assistant" && message.stopReason !== "toolUse";
+  });
 }
 
 function collectBranchLabels(params: {

--- a/src/config/sessions/session-accessor.sqlite-parent-fork.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-fork.ts
@@ -45,9 +45,12 @@ function formatParentForkTooLargeMessage(params: {
 export function planParentForkDecision(
   parentEntry: SessionEntry,
   transcriptEstimate?: SqliteTranscriptParentTokenEstimate,
+  options: { preferTranscriptEstimate?: boolean } = {},
 ): SessionParentForkDecision {
   const maxTokens = DEFAULT_PARENT_FORK_MAX_TOKENS;
-  const parentTokens = resolveFreshSessionTotalTokens(parentEntry) ?? transcriptEstimate?.tokens;
+  const parentTokens = options.preferTranscriptEstimate
+    ? transcriptEstimate?.tokens
+    : (resolveFreshSessionTotalTokens(parentEntry) ?? transcriptEstimate?.tokens);
   if (typeof parentTokens === "number" && parentTokens > maxTokens) {
     return {
       status: "skip",

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -73,6 +73,7 @@ export async function forkSessionTranscriptFromParent(
         result = forkSqliteParentTranscriptInTransaction(database, resolved, {
           parentEntry: params.parentEntry,
           parentSessionKey: params.parentSessionKey,
+          forkFrom: params.forkFrom,
           targetSessionId: params.targetSessionId,
           targetSessionKey: params.sessionKey,
         });
@@ -91,6 +92,7 @@ export async function forkSessionTranscriptFromParent(
   const sourceDatabase = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const source = resolveParentForkSourceTranscript(
     loadTranscriptEventsFromDatabase(sourceDatabase, params.parentEntry.sessionId),
+    params.forkFrom,
   );
   if (!source) {
     return { status: "failed" };
@@ -344,6 +346,7 @@ function forkSqliteParentTranscriptInTransaction(
   params: {
     parentEntry: SessionEntry;
     parentSessionKey: string;
+    forkFrom?: "last-completed";
     targetSessionId?: string;
     targetSessionKey: string;
   },
@@ -353,6 +356,7 @@ function forkSqliteParentTranscriptInTransaction(
   }
   const source = resolveParentForkSourceTranscript(
     loadTranscriptEventsFromDatabase(database, params.parentEntry.sessionId),
+    params.forkFrom,
   );
   if (!source) {
     return { status: "failed" };

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -71,6 +71,7 @@ export async function forkSessionTranscriptFromParent(
       let result: ForkSessionFromParentTranscriptResult = { status: "failed" };
       runOpenClawAgentWriteTransaction((database) => {
         result = forkSqliteParentTranscriptInTransaction(database, resolved, {
+          enforceTokenLimit: params.enforceTokenLimit,
           parentEntry: params.parentEntry,
           parentSessionKey: params.parentSessionKey,
           forkFrom: params.forkFrom,
@@ -96,6 +97,10 @@ export async function forkSessionTranscriptFromParent(
   );
   if (!source) {
     return { status: "failed" };
+  }
+  const limitDecision = resolveParentForkLimitDecision(params, source);
+  if (limitDecision) {
+    return { status: "too-large", decision: limitDecision };
   }
   const parentSessionFile = formatLegacySqliteSessionMarkerForScope({
     ...resolved,
@@ -344,6 +349,7 @@ function forkSqliteParentTranscriptInTransaction(
   database: OpenClawAgentDatabase,
   resolved: ResolvedSqliteScope,
   params: {
+    enforceTokenLimit?: boolean;
     parentEntry: SessionEntry;
     parentSessionKey: string;
     forkFrom?: "last-completed";
@@ -360,6 +366,10 @@ function forkSqliteParentTranscriptInTransaction(
   );
   if (!source) {
     return { status: "failed" };
+  }
+  const limitDecision = resolveParentForkLimitDecision(params, source);
+  if (limitDecision) {
+    return { status: "too-large", decision: limitDecision };
   }
   const sessionId = params.targetSessionId ?? randomUUID();
   const targetScope = {
@@ -384,6 +394,24 @@ function forkSqliteParentTranscriptInTransaction(
       sessionId,
     },
   };
+}
+
+function resolveParentForkLimitDecision(
+  params: Pick<
+    ForkSessionFromParentTranscriptParams,
+    "enforceTokenLimit" | "forkFrom" | "parentEntry"
+  >,
+  source: ParentForkSourceTranscript,
+): Extract<SessionParentForkDecision, { status: "skip" }> | undefined {
+  if (!params.enforceTokenLimit) {
+    return undefined;
+  }
+  const decision = planParentForkDecision(
+    params.parentEntry,
+    estimateTranscriptPromptTokens(source.branchEntries),
+    { preferTranscriptEstimate: params.forkFrom === "last-completed" },
+  );
+  return decision.status === "skip" ? decision : undefined;
 }
 
 function writeSqliteForkedChildTranscriptInTransaction(

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -609,6 +609,10 @@ export type ForkSessionFromParentTranscriptResult =
       status: "created";
       transcript: ParentForkedSessionTranscript;
     }
+  | {
+      status: "too-large";
+      decision: Extract<SessionParentForkDecision, { status: "skip" }>;
+    }
   | { status: "missing-parent" }
   | { status: "failed" };
 
@@ -620,6 +624,8 @@ export type ForkSessionFromParentTranscriptParams = {
   storePath: string;
   /** Optional stable boundary used when the parent may still be appending. */
   forkFrom?: "last-completed";
+  /** Enforce the parent-fork context cap against the selected source. */
+  enforceTokenLimit?: boolean;
   /** Stable target identity for lifecycle-owned hidden or resumable sessions. */
   targetSessionId?: string;
   /** Cross-agent forks land the child transcript in the target agent's store. */

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -362,8 +362,6 @@ export type SessionTranscriptWriteTransactionContext = {
   sessionId: string;
   sessionKey: string;
   storePath: string;
-  /** Optional stable boundary used when the parent may still be appending. */
-  forkFrom?: "last-completed";
 };
 
 export type SessionTranscriptTurnUpdateMode = "inline" | "file-only" | "none";
@@ -620,6 +618,8 @@ export type ForkSessionFromParentTranscriptParams = {
   parentSessionKey: string;
   sessionKey: string;
   storePath: string;
+  /** Optional stable boundary used when the parent may still be appending. */
+  forkFrom?: "last-completed";
   /** Stable target identity for lifecycle-owned hidden or resumable sessions. */
   targetSessionId?: string;
   /** Cross-agent forks land the child transcript in the target agent's store. */

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -362,6 +362,8 @@ export type SessionTranscriptWriteTransactionContext = {
   sessionId: string;
   sessionKey: string;
   storePath: string;
+  /** Optional stable boundary used when the parent may still be appending. */
+  forkFrom?: "last-completed";
 };
 
 export type SessionTranscriptTurnUpdateMode = "inline" | "file-only" | "none";

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -525,6 +525,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       // A plain New Chat with no cwd must not inherit the prior session cwd.
       clearSpawnedCwd: p.worktree !== true && !sessionCwd,
       fork: p.fork,
+      forkFrom: p.forkFrom,
       succeedsParent: p.succeedsParent,
       emitCommandHooks: p.emitCommandHooks,
       resetMainWhenUnspecified: !hasInitialTurn,

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -3881,6 +3881,21 @@ test("sessions.create rejects fork without parentSessionKey", async () => {
   });
 });
 
+test("sessions.create rejects forkFrom without fork", async () => {
+  await createSessionStoreDir();
+
+  const created = await directSessionReq("sessions.create", {
+    parentSessionKey: "main",
+    forkFrom: "last-completed",
+  });
+
+  expect(created.ok).toBe(false);
+  expect(created.error).toMatchObject({
+    code: "INVALID_REQUEST",
+    message: "forkFrom requires fork=true",
+  });
+});
+
 test("sessions.create rejects fork when the parent exceeds the fork size cap", async () => {
   const { dir } = await createSessionStoreDir();
   testState.sessionConfig = { scope: "per-sender" };
@@ -3925,6 +3940,64 @@ test("sessions.create rejects fork while the parent session is active", async ()
       code: "UNAVAILABLE",
       message: "Parent session main is still active; try again in a moment.",
     });
+  } finally {
+    embeddedRunMock.activeIds.delete(parentSessionId);
+    testState.sessionConfig = undefined;
+  }
+});
+
+test("sessions.create forks an active parent from its last completed message", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.sessionConfig = { scope: "per-sender" };
+  const parentSessionId = "sess-active-completed-fork-parent";
+  await writeSessionStore({ entries: { main: sessionStoreEntry(parentSessionId) } });
+  await seedSessionTranscript({
+    sessionId: parentSessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    messages: [
+      { role: "user", content: "completed question" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "completed answer" }],
+        stopReason: "stop",
+      },
+      { role: "user", content: "active question" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "active tool call" }],
+        stopReason: "toolUse",
+      },
+    ],
+  });
+  embeddedRunMock.activeIds.add(parentSessionId);
+  try {
+    const created = await directSessionReq<{ key: string; sessionId: string }>("sessions.create", {
+      parentSessionKey: "main",
+      fork: true,
+      forkFrom: "last-completed",
+    });
+
+    expect(created.ok, JSON.stringify(created.error)).toBe(true);
+    const messages = await loadTranscriptEvents({
+      sessionId: created.payload?.sessionId ?? "",
+      sessionKey: created.payload?.key ?? "",
+      storePath,
+    });
+    expect(
+      messages.flatMap((entry) =>
+        entry &&
+        typeof entry === "object" &&
+        "type" in entry &&
+        entry.type === "message" &&
+        "message" in entry
+          ? [entry.message]
+          : [],
+      ),
+    ).toEqual([
+      expect.objectContaining({ role: "user", content: "completed question" }),
+      expect.objectContaining({ role: "assistant", stopReason: "stop" }),
+    ]);
   } finally {
     embeddedRunMock.activeIds.delete(parentSessionId);
     testState.sessionConfig = undefined;

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -3950,7 +3950,17 @@ test("sessions.create forks an active parent from its last completed message", a
   const { storePath } = await createSessionStoreDir();
   testState.sessionConfig = { scope: "per-sender" };
   const parentSessionId = "sess-active-completed-fork-parent";
-  await writeSessionStore({ entries: { main: sessionStoreEntry(parentSessionId) } });
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(parentSessionId, {
+        // The in-flight tail can make the whole parent exceed the cap; only the
+        // selected completed prefix should govern this fork.
+        totalTokens: 200_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      }),
+    },
+  });
   await seedSessionTranscript({
     sessionId: parentSessionId,
     sessionKey: "agent:main:main",

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -24,9 +24,8 @@ import {
 } from "../agents/model-selection.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import {
-  forkSessionFromParent,
+  forkSessionFromParentWithDecision,
   MODEL_SELECTION_LOCKED_PARENT_FORK_MESSAGE,
-  resolveParentForkDecision,
 } from "../auto-reply/reply/session-fork.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
@@ -1122,24 +1121,9 @@ export async function createGatewaySession(params: {
             error: errorShape(ErrorCodes.UNAVAILABLE, "failed to resolve parent session for fork"),
           };
         }
-        // Operator forks honor the same oversized-parent cap as subagent forks;
-        // an explicit fork of an unusable parent fails loudly instead of
-        // silently producing an empty child.
-        const forkDecision = await resolveParentForkDecision({
-          parentEntry: currentParentSessionEntry,
-          agentId: parentSessionTarget.agentId,
-          storePath: parentSessionTarget.storePath,
-        });
-        if (forkDecision.status === "skip") {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `parent session is too large to fork (${forkDecision.parentTokens}/${forkDecision.maxTokens} tokens)`,
-            ),
-          };
-        }
-        const fork = await forkSessionFromParent({
+        // The storage owner selects one source for both size admission and copying,
+        // so an active tail cannot make a smaller stable prefix fail the cap.
+        const forkResult = await forkSessionFromParentWithDecision({
           parentEntry: currentParentSessionEntry,
           agentId: parentSessionTarget.agentId,
           parentSessionKey: forkParentSessionKey,
@@ -1149,12 +1133,22 @@ export async function createGatewaySession(params: {
           targetStorePath: target.storePath,
           ...(params.forkFrom ? { forkFrom: params.forkFrom } : {}),
         });
-        if (!fork) {
+        if (forkResult.status === "too-large") {
+          return {
+            ok: false,
+            error: errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `parent session is too large to fork (${forkResult.decision.parentTokens}/${forkResult.decision.maxTokens} tokens)`,
+            ),
+          };
+        }
+        if (forkResult.status !== "created") {
           return {
             ok: false,
             error: errorShape(ErrorCodes.UNAVAILABLE, "failed to fork parent session transcript"),
           };
         }
+        const fork = forkResult.transcript;
         return {
           ...initialized,
           entry: buildForkedGatewaySessionEntry(

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -265,6 +265,7 @@ export async function createGatewaySession(params: {
   clearExecBinding?: boolean;
   clearSpawnedCwd?: boolean;
   fork?: boolean;
+  forkFrom?: "last-completed";
   /**
    * Controls whether a distinct child terminates its parent. Omission preserves
    * the legacy rollover; callers use `false` for a parallel child.
@@ -466,6 +467,12 @@ export async function createGatewaySession(params: {
     return {
       ok: false,
       error: errorShape(ErrorCodes.INVALID_REQUEST, "fork requires parentSessionKey"),
+    };
+  }
+  if (params.forkFrom && params.fork !== true) {
+    return {
+      ok: false,
+      error: errorShape(ErrorCodes.INVALID_REQUEST, "forkFrom requires fork=true"),
     };
   }
   if (params.spawnDepth !== undefined) {
@@ -758,7 +765,10 @@ export async function createGatewaySession(params: {
             canonicalParentSessionKey,
             currentParentEntry.sessionId,
           ]));
-      if (parentHasActiveWork) {
+      if (
+        parentHasActiveWork &&
+        (params.forkFrom !== "last-completed" || params.emitCommandHooks === true)
+      ) {
         return {
           ok: false,
           error: errorShape(
@@ -1137,6 +1147,7 @@ export async function createGatewaySession(params: {
           storePath: parentSessionTarget.storePath,
           // Keep the fork transcript owned by the child store across agent boundaries.
           targetStorePath: target.storePath,
+          ...(params.forkFrom ? { forkFrom: params.forkFrom } : {}),
         });
         if (!fork) {
           return {

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -66,15 +66,20 @@ describe("sidebar session live-run projection", () => {
   });
 
   it.each([
-    ["legacy running status", { status: "running" }, true],
-    ["confirmed active run", { status: "running", hasActiveRun: true }, true],
-    ["stale running status", { status: "running", hasActiveRun: false }, false],
-    ["completed run with a stale active flag", { status: "done", hasActiveRun: true }, false],
-    ["failed run with a stale active flag", { status: "failed", hasActiveRun: true }, false],
-    ["archived active run", { status: "running", hasActiveRun: true, archived: true }, false],
-  ] as const)("normalizes %s before publishing sidebar state", (_name, row, expected) => {
-    expect(projectSidebarSession(row).hasActiveRun).toBe(expected);
-  });
+    ["legacy running status", { status: "running" }, true, undefined],
+    ["confirmed active run", { status: "running", hasActiveRun: true }, true, true],
+    ["stale running status", { status: "running", hasActiveRun: false }, false, false],
+    ["completed run with a stale active flag", { status: "done", hasActiveRun: true }, false, true],
+    ["failed run with a stale active flag", { status: "failed", hasActiveRun: true }, false, true],
+    ["archived active run", { status: "running", hasActiveRun: true, archived: true }, false, true],
+  ] as const)(
+    "normalizes %s without dropping Gateway liveness",
+    (_name, row, expected, gatewayHasActiveRun) => {
+      const projected = projectSidebarSession(row);
+      expect(projected.hasActiveRun).toBe(expected);
+      expect(projected.gatewayHasActiveRun).toBe(gatewayHasActiveRun);
+    },
+  );
 
   it("carries active cloud disk pressure into the existing sidebar badge model", () => {
     const projected = projectSidebarSession({

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -194,6 +194,7 @@ export function buildSidebarSessionNavigationState(input: {
       visuallyActive: input.highlightCurrentSession && row.key === navigation.currentSessionKey,
       // Normalize optional gateway state before collapsing it to the sidebar's required fact.
       hasActiveRun: row.archived !== true && isSessionRunActive(row),
+      gatewayHasActiveRun: row.hasActiveRun,
       activeRunIds: row.archived === true ? undefined : row.activeRunIds,
       modelSelectionLocked: row.modelSelectionLocked === true,
       kind: row.kind,

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -67,6 +67,8 @@ export type SidebarRecentSession = {
   active: boolean;
   visuallyActive: boolean;
   hasActiveRun: boolean;
+  /** Raw Gateway liveness used for operations even when display status is terminal. */
+  gatewayHasActiveRun?: boolean;
   activeRunIds?: readonly string[];
   modelSelectionLocked: boolean;
   kind?: string;

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -44,6 +44,7 @@ async function mountMenu(
     onAction?: (action: SessionMenuAction) => void;
     onClose?: () => void;
     actionDisabledReasons?: Partial<Record<SessionMenuActionKind, string>>;
+    forkFromLastCompleted?: boolean;
   } = {},
 ): Promise<SessionMenuElement> {
   const container = document.createElement("div");
@@ -68,6 +69,7 @@ async function mountMenu(
       .disabled=${false}
       .actionDisabledReasons=${options.actionDisabledReasons ?? {}}
       .forkDisabled=${false}
+      .forkFromLastCompleted=${options.forkFromLastCompleted ?? false}
       .archiveAllowed=${options.archiveAllowed ?? true}
       .deleteAllowed=${options.deleteAllowed ??
       (session.archived || (options.archiveAllowed ?? true))}
@@ -157,6 +159,12 @@ describe("session menu", () => {
       "Archive session",
       "Delete…",
     ]);
+  });
+
+  it("names the stable fork boundary for an active session", async () => {
+    const menu = await mountMenu({ forkFromLastCompleted: true });
+
+    expect(menuItemLabels(menu)).toContain("Fork from last completed message");
   });
 
   it("renders only batch actions with counts for a multi-selection", async () => {

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -70,6 +70,7 @@ class SessionMenu extends OpenClawLightDomElement {
     Record<SessionMenuActionKind, string>
   > = {};
   @property({ attribute: false }) forkDisabled = false;
+  @property({ attribute: false }) forkFromLastCompleted = false;
   @property({ attribute: false }) archiveAllowed = false;
   @property({ attribute: false }) deleteAllowed = false;
   @property({ attribute: false }) cloudWorkerStopAllowed = false;
@@ -362,7 +363,13 @@ class SessionMenu extends OpenClawLightDomElement {
                 title=${this.actionTitle("fork")}
               >
                 <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.copy}</span>
-                <span class="session-menu__text">${t("sessionsView.forkSession")}</span>
+                <span class="session-menu__text"
+                  >${t(
+                    this.forkFromLastCompleted
+                      ? "sessionsView.forkFromLastCompleted"
+                      : "sessionsView.forkSession",
+                  )}</span
+                >
                 ${menuShortcutHint("f")}
               </wa-dropdown-item>
             `}

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -19,7 +19,7 @@ import type { SessionOrganizerControllerHost } from "./session-organizer-control
 export type SessionActionRow = Pick<
   SidebarRecentSession,
   "key" | "sessionId" | "label" | "pinned" | "archived" | "active"
-> & { hasActiveRun?: boolean };
+> & { gatewayHasActiveRun?: boolean; hasActiveRun?: boolean };
 
 export type SessionActionHost = Pick<
   SessionOrganizerControllerHost,

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -19,7 +19,7 @@ import type { SessionOrganizerControllerHost } from "./session-organizer-control
 export type SessionActionRow = Pick<
   SidebarRecentSession,
   "key" | "sessionId" | "label" | "pinned" | "archived" | "active"
->;
+> & { hasActiveRun?: boolean };
 
 export type SessionActionHost = Pick<
   SessionOrganizerControllerHost,

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -458,7 +458,9 @@ export async function forkSession(
   const createParams = {
     parentSessionKey: session.key,
     fork: true,
-    ...(session.hasActiveRun ? { forkFrom: "last-completed" as const } : {}),
+    ...((session.gatewayHasActiveRun ?? session.hasActiveRun)
+      ? { forkFrom: "last-completed" as const }
+      : {}),
     agentId,
   };
   if (

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -458,6 +458,7 @@ export async function forkSession(
   const createParams = {
     parentSessionKey: session.key,
     fork: true,
+    ...(session.hasActiveRun ? { forkFrom: "last-completed" as const } : {}),
     agentId,
   };
   if (

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -196,7 +196,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
           cloudWorkerStopAction: session.cloudWorkerStopAction,
         })}
         .forkDisabled=${host.sessionData.sessionsLoading || session.modelSelectionLocked}
-        .forkFromLastCompleted=${session.hasActiveRun}
+        .forkFromLastCompleted=${session.gatewayHasActiveRun ?? session.hasActiveRun}
         .archiveAllowed=${archiveAllowed}
         .deleteAllowed=${deleteAllowed}
         .cloudWorkerStopAllowed=${cloudWorkerStopAllowed}

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -196,6 +196,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
           cloudWorkerStopAction: session.cloudWorkerStopAction,
         })}
         .forkDisabled=${host.sessionData.sessionsLoading || session.modelSelectionLocked}
+        .forkFromLastCompleted=${session.hasActiveRun}
         .archiveAllowed=${archiveAllowed}
         .deleteAllowed=${deleteAllowed}
         .cloudWorkerStopAllowed=${cloudWorkerStopAllowed}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -983,6 +983,7 @@ export const en: TranslationMap = {
     markUnreadCount: "Mark {count} as unread",
     markReadCount: "Mark {count} as read",
     forkSession: "Fork",
+    forkFromLastCompleted: "Fork from last completed message",
     forkedSession: "Forked session",
     openPullRequest: "Open PR",
     openInEditorMenu: "Open in",

--- a/ui/src/lib/sessions/create.ts
+++ b/ui/src/lib/sessions/create.ts
@@ -16,6 +16,7 @@ export type SessionCreateParams = {
   currentSessionKey?: string;
   parentSessionKey?: string;
   fork?: boolean;
+  forkFrom?: "last-completed";
   succeedsParent?: boolean;
   label?: string;
   model?: string;

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -467,6 +467,7 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
               .layoutActions=${layoutMenuActions}
               .actionDisabledReasons=${actionDisabledReasons}
               .forkDisabled=${this.state.sessionsLoading || row.modelSelectionLocked === true}
+              .forkFromLastCompleted=${row.hasActiveRun === true}
               .archiveAllowed=${archiveAllowed}
               .deleteAllowed=${deleteAllowed}
               .onOpen=${() => {

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -80,7 +80,8 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       pinned: row.pinned === true,
       archived: row.archived === true,
       active: true,
-      hasActiveRun: row.hasActiveRun === true,
+      hasActiveRun: row.hasActiveRun ?? row.status === "running",
+      gatewayHasActiveRun: row.hasActiveRun,
     };
     try {
       const operations = await (this.headerSessionOperationsLoad ??=

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -80,6 +80,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       pinned: row.pinned === true,
       archived: row.archived === true,
       active: true,
+      hasActiveRun: row.hasActiveRun === true,
     };
     try {
       const operations = await (this.headerSessionOperationsLoad ??=

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -113,6 +113,7 @@ describe("chat pane header state", () => {
       key: "agent:main:current",
       kind: "direct",
       updatedAt: 0,
+      hasActiveRun: true,
     } satisfies GatewaySessionRow;
 
     await pane.handleHeaderSessionAction({ kind: "fork" }, session);
@@ -120,6 +121,7 @@ describe("chat pane header state", () => {
     expect(create).toHaveBeenCalledWith({
       parentSessionKey: session.key,
       fork: true,
+      forkFrom: "last-completed",
       agentId: "main",
     });
     expect(onPaneSessionChange).toHaveBeenCalledWith("single", "agent:main:forked");

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -51,6 +51,7 @@ async function mountMenu(
     layoutActions?: HeaderMenuQuickAction[];
     actionDisabledReasons?: Partial<Record<HeaderMenuActionKind, string>>;
     forkDisabled?: boolean;
+    forkFromLastCompleted?: boolean;
     archiveAllowed?: boolean;
     deleteAllowed?: boolean;
     onOpen?: () => void;
@@ -74,6 +75,7 @@ async function mountMenu(
       .layoutActions=${options.layoutActions ?? []}
       .actionDisabledReasons=${options.actionDisabledReasons ?? {}}
       .forkDisabled=${options.forkDisabled ?? false}
+      .forkFromLastCompleted=${options.forkFromLastCompleted ?? false}
       .archiveAllowed=${options.archiveAllowed ?? true}
       .deleteAllowed=${options.deleteAllowed ?? true}
       .onOpen=${options.onOpen ?? (() => {})}
@@ -296,6 +298,12 @@ describe("chat header session menu", () => {
       new KeyboardEvent("keydown", { key: "r", bubbles: true, cancelable: true }),
     );
     expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("names the stable fork boundary for an active session", async () => {
+    const menu = await mountMenu({ forkFromLastCompleted: true });
+
+    expect(item(menu, "Fork from last completed message")).toBeDefined();
   });
 
   it("emits terminal continuation only while the current Gateway is connected", async () => {

--- a/ui/src/pages/chat/components/chat-header-session-menu.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.ts
@@ -42,6 +42,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
     Record<HeaderMenuActionKind, string>
   > = {};
   @property({ attribute: false }) forkDisabled = false;
+  @property({ attribute: false }) forkFromLastCompleted = false;
   @property({ attribute: false }) archiveAllowed = false;
   @property({ attribute: false }) deleteAllowed = false;
   @property({ attribute: false }) onOpen: () => void = () => {};
@@ -251,7 +252,13 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
           title=${this.actionTitle("fork")}
         >
           <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.copy}</span>
-          <span class="session-menu__text">${t("sessionsView.forkSession")}</span>
+          <span class="session-menu__text"
+            >${t(
+              this.forkFromLastCompleted
+                ? "sessionsView.forkFromLastCompleted"
+                : "sessionsView.forkSession",
+            )}</span
+          >
           ${menuShortcutHint("f")}
         </wa-dropdown-item>
         <wa-dropdown-item

--- a/ui/src/pages/sessions/sessions-page.test-support.ts
+++ b/ui/src/pages/sessions/sessions-page.test-support.ts
@@ -53,7 +53,7 @@ export type TestSessionsPage = HTMLElement & {
     expectedSessionId?: string,
   ) => Promise<unknown>;
   archiveSessionWithUndo: (row: GatewaySessionRow) => Promise<void>;
-  forkSession: (key: string) => Promise<void>;
+  forkSession: (key: string, fromLastCompleted?: boolean) => Promise<void>;
   branchCheckpoint: (sessionKey: string, checkpointId: string) => Promise<void>;
   restoreCheckpoint: (sessionKey: string, checkpointId: string) => Promise<void>;
   addToWorkboard: (session: GatewaySessionRow) => Promise<void>;

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -936,4 +936,21 @@ describe("sessions page lifecycle", () => {
 
     expect(context.navigate).not.toHaveBeenCalled();
   });
+
+  it("forks an active session from its last completed message", async () => {
+    const create = vi.fn(async () => "active-fork");
+    const sessions = createSessions({ create });
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, sessions);
+    const page = await createPage(context);
+
+    await page.forkSession("main", true);
+
+    expect(create).toHaveBeenCalledWith({
+      parentSessionKey: "main",
+      fork: true,
+      forkFrom: "last-completed",
+      agentId: "main",
+    });
+  });
 });

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -950,7 +950,6 @@ describe("sessions page lifecycle", () => {
       parentSessionKey: "main",
       fork: true,
       forkFrom: "last-completed",
-      agentId: "main",
     });
   });
 });

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -1214,7 +1214,7 @@ class SessionsPage extends OpenClawLightDomElement {
     });
   }
 
-  private async forkSession(key: string) {
+  private async forkSession(key: string, fromLastCompleted = false) {
     const scope = this.captureRequestScope();
     if (!scope) {
       return;
@@ -1223,6 +1223,7 @@ class SessionsPage extends OpenClawLightDomElement {
     const createParams = {
       parentSessionKey: key,
       fork: true,
+      ...(fromLastCompleted ? { forkFrom: "last-completed" as const } : {}),
       ...(agentId ? { agentId } : {}),
     };
     if (!this.requireMutationAccess(scope, { method: "sessions.create", params: createParams })) {
@@ -1496,6 +1497,7 @@ class SessionsPage extends OpenClawLightDomElement {
           cloudWorkerStopAction,
         })}
         .forkDisabled=${row.modelSelectionLocked === true}
+        .forkFromLastCompleted=${row.hasActiveRun === true}
         .archiveAllowed=${archiveAllowed}
         .deleteAllowed=${deleteAllowed}
         .cloudWorkerStopAllowed=${cloudWorkerStopAllowed}
@@ -1526,7 +1528,7 @@ class SessionsPage extends OpenClawLightDomElement {
               void this.renameSession(row);
               break;
             case "fork":
-              void this.forkSession(row.key);
+              void this.forkSession(row.key, row.hasActiveRun === true);
               break;
             case "workboard":
               void this.addToWorkboard(row);

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -150,6 +150,46 @@ describe("AppSidebar session source lifecycle", () => {
     expect(menu.querySelector<HTMLButtonElement>('[data-shortcut="f"]')?.disabled).toBe(true);
   });
 
+  it("forks from stable history when Gateway liveness outlives display status", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const sessions = createSessionsHarness("main", ["agent:main:active"]);
+    const state = createSessionState("main", ["agent:main:active"]);
+    const row = state.result?.sessions[0];
+    if (!row) {
+      throw new Error("Expected active session row");
+    }
+    row.status = "done";
+    row.hasActiveRun = true;
+    sessions.publishList({ result: state.result, agentId: state.agentId });
+    const { sidebar } = await mountSidebar(gateway, sessions.sessions);
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+
+    sidebar
+      .querySelector<HTMLButtonElement>(
+        '[data-session-key="agent:main:active"] [data-session-menu="true"]',
+      )
+      ?.click();
+    await sidebar.updateComplete;
+
+    const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+    if (!menu) {
+      throw new Error("Expected sidebar session menu");
+    }
+    await menu.updateComplete;
+    expect(menu.forkFromLastCompleted).toBe(true);
+    menu.onAction({ kind: "fork" });
+
+    await vi.waitFor(() =>
+      expect(sessions.create).toHaveBeenCalledWith({
+        parentSessionKey: "agent:main:active",
+        fork: true,
+        forkFrom: "last-completed",
+        agentId: "main",
+      }),
+    );
+  });
+
   it("resets cached rows and creation order when the sessions source changes", async () => {
     const client = {} as GatewayBrowserClient;
     const gateway = createGateway(client);

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -89,6 +89,8 @@ export type LobsterPetElement = HTMLElement & {
 
 export type TestSessionMenu = HTMLElement & {
   forkDisabled: boolean;
+  forkFromLastCompleted: boolean;
+  onAction: (action: { kind: "fork" }) => void;
   selectionCount: number;
   readonly updateComplete: Promise<boolean>;
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who forked a session while its agent was working received a backend rejection even though the Control UI offered the action.

## Why This Change Was Made

Active-session forks now request an explicit stable boundary and copy the transcript only through the most recent completed assistant message. The in-flight user/tool turn stays in the parent. Inactive forks keep their existing full-transcript behavior, and active menus name the boundary as “Fork from last completed message.”

This is additive to the Gateway contract (`forkFrom: "last-completed"`) and keeps rewind, branch switching, model-selection-locked sessions, and command-hook rollover behavior unchanged. The published one-argument Swift transport API is preserved; the new overload delegates compatibly for legacy conformers while updated iOS/macOS transports implement the stable-boundary route.

## User Impact

Users can fork a working session immediately without stopping it or waiting for completion. The new session opens from the last completed response, while the parent continues running normally.

## Evidence

- Exact-head CI [run 31839608406](https://github.com/openclaw/openclaw/actions/runs/31839608406) passed all 143 jobs.
- Shared OpenClawKit and macOS Swift tests passed, including a regression that compiles and routes an old-style one-argument transport conformer.
- iOS builds, lifecycle tests, and screenshot capture passed.
- Android Play/Wear/third-party builds, tests, and ktlint passed.
- Gateway, protocol, Control UI, real-Gateway/E2E, lint, type, security, and Node matrices passed.
- Gateway coverage verifies that an active parent with a completed turn followed by an in-flight tool-use turn forks only through the completed turn.
- Storage coverage verifies that both the 100K token cap and copy operation use the same selected stable prefix.
- `git diff --check origin/main...HEAD` passed.
- Guarded review artifacts validated with zero findings and `READY FOR /prepare-pr`.
- A live active-fork visual was requested from Mantis, but the supplied capture did not show the resulting child boundary. This maintainer-authored PR is outside the external-contributor proof gate; no unsupported visual proof is claimed.

AI-assisted implementation; the change, compatibility boundary, and owner paths were reviewed directly.
