### PR TITLE
fix(gateway): report unsupported node events

### DIFF
--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -1221,7 +1221,7 @@ export const handleNodeEvent = async (
       }
     }
     default:
-      return undefined;
+      return { ok: true, event: evt.event, handled: false, reason: "unsupported_event" };
   }
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -364,11 +364,24 @@ describe("gateway role enforcement", () => {
       expect(invokeRes.ok).toBe(false);
       expect(invokeRes.error?.message ?? "").toContain("unauthorized role");
 
-      nodeClient = await connectNodeClientWithPairing({
+      nodeClient = await connectNodeClientWithNodePairing({
         port,
         commands: [],
         instanceId: "node-role-enforcement",
         displayName: "node-role-enforcement",
+      });
+
+      const unsupportedEvent = await nodeClient.request<{
+        ok: boolean;
+        event?: string;
+        handled?: boolean;
+        reason?: string;
+      }>("node.event", { event: "test.unsupported", payload: { ok: true } });
+      expect(unsupportedEvent).toEqual({
+        ok: true,
+        event: "test.unsupported",
+        handled: false,
+        reason: "unsupported_event",
       });
 
       const binsPayload = await nodeClient.request("skills.bins", {});


### PR DESCRIPTION
Closes #123717

## What Problem This Solves

Fixes an issue where paired node clients sending an unsupported `node.event` received only `{ok:true}`, making the event look handled even though no event owner accepted it.

## Why This Change Was Made

The node-event dispatcher now records the intentional non-outcome at the owner boundary by returning the existing `NodeEventResult` shape with `handled:false` and `reason:"unsupported_event"`. Supported event branches are unchanged, and there is no protocol, schema, or version change.

## User Impact

Node clients can distinguish an unsupported event from a successfully handled one instead of receiving a misleading bare acknowledgement.

## Evidence

- Pre-fix paired-node WebSocket reproduction received exactly `{ok:true}` and failed the new assertion for the declared structured result.
- Post-fix isolated Gateway proof: `node scripts/run-vitest.mjs src/gateway/server-node-events.test.ts src/gateway/server.roles-allowlist-update.test.ts` — 85/85 passed.
- Post-rebase changed gate: `node scripts/check-changed.mjs` — passed core production/test typechecks, changed lint/format, dependency, architecture, database, and repository guards. Testbox routing reported no ready provider, so the repository wrapper used its documented trusted-source local fallback.
- Final Codex autoreview on exact head `40c4b7f1569ffb1bf7aaa4d6f7900b722350530f` — clean, no actionable findings, confidence 0.99.
- Production LOC: +1/-1 (net 0). Tests: +14/-1.

AI-assisted: yes. The implementation, tests, and proof were reviewed by the maintainer before publication.
