### PR TITLE
fix(ui): prevent duplicate dashboard pins after reload

### DIFF
--- a/src/chat/canvas-render.ts
+++ b/src/chat/canvas-render.ts
@@ -108,6 +108,10 @@ function normalizePreferredHeight(value: number | undefined): number | undefined
     : undefined;
 }
 
+export function isCanvasBoardWidgetName(value: unknown): value is string {
+  return typeof value === "string" && /^[a-z0-9][a-z0-9._-]{0,63}$/u.test(value);
+}
+
 function coerceCanvasPreview(
   record: Record<string, unknown> | undefined,
 ): CanvasPreview | undefined {
@@ -145,10 +149,9 @@ function coerceCanvasPreview(
   const viewUrl = getRecordStringField(view, "url") ?? getRecordStringField(view, "entryUrl");
   const viewId = getRecordStringField(view, "id") ?? getRecordStringField(view, "docId");
   const requestedBoardWidgetName = getRecordStringField(view, "boardWidgetName");
-  const boardWidgetName =
-    requestedBoardWidgetName && /^[a-z0-9][a-z0-9._-]{0,63}$/u.test(requestedBoardWidgetName)
-      ? requestedBoardWidgetName
-      : undefined;
+  const boardWidgetName = isCanvasBoardWidgetName(requestedBoardWidgetName)
+    ? requestedBoardWidgetName
+    : undefined;
   if (mcpAppViewId && viewId === mcpAppViewId) {
     return {
       kind: "canvas",

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -347,7 +347,7 @@ describe("message-normalizer", () => {
       ]);
     });
 
-    it("preserves a canvas preview sandbox ceiling from history", () => {
+    it("preserves canvas dashboard identity and sandbox ceiling from history", () => {
       const result = normalizeMessage({
         role: "assistant",
         content: [
@@ -359,6 +359,7 @@ describe("message-normalizer", () => {
               render: "url",
               url: "/__openclaw__/canvas/documents/cv_widget/index.html",
               sandbox: "scripts",
+              boardWidgetName: "release-status",
             },
           },
         ],
@@ -366,8 +367,29 @@ describe("message-normalizer", () => {
 
       expect(result.content[0]).toMatchObject({
         type: "canvas",
-        preview: { sandbox: "scripts" },
+        preview: { sandbox: "scripts", boardWidgetName: "release-status" },
       });
+    });
+
+    it("drops invalid canvas dashboard identity from history", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "canvas",
+            preview: {
+              kind: "canvas",
+              surface: "assistant_message",
+              render: "url",
+              url: "/__openclaw__/canvas/documents/cv_widget/index.html",
+              boardWidgetName: "Invalid widget name",
+            },
+          },
+        ],
+      });
+
+      expect(result.content[0]).toMatchObject({ type: "canvas" });
+      expect(result.content[0]).not.toHaveProperty("preview.boardWidgetName");
     });
 
     it("ignores [embed] shortcodes inside fenced code blocks", () => {

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -5,7 +5,10 @@
 import { mediaKindFromMime } from "@openclaw/media-core/constants";
 import { asRecord as asMessageRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
-import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
+import {
+  extractCanvasShortcodes,
+  isCanvasBoardWidgetName,
+} from "../../../../src/chat/canvas-render.js";
 import {
   isToolCallContentType,
   isToolResultContentType,
@@ -111,6 +114,9 @@ function coerceCanvasPreview(
     return null;
   }
   const mcpApp = isRecord(preview.mcpApp) ? preview.mcpApp : undefined;
+  const boardWidgetName = isCanvasBoardWidgetName(preview.boardWidgetName)
+    ? preview.boardWidgetName
+    : undefined;
   return {
     kind: "canvas",
     surface: "assistant_message",
@@ -126,6 +132,7 @@ function coerceCanvasPreview(
     ...(preview.sandbox === "strict" || preview.sandbox === "scripts"
       ? { sandbox: preview.sandbox }
       : {}),
+    ...(boardWidgetName ? { boardWidgetName } : {}),
     ...(typeof mcpApp?.viewId === "string" && mcpApp.viewId.trim()
       ? {
           mcpApp: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users clicking **Pin to dashboard** on an already-pinned Canvas card could create a duplicate widget in the default dashboard tab after the chat message was restored from transcript history. The card looked unpinned because its stable dashboard widget identity was dropped during Control UI message normalization.

## Why This Change Was Made

Preserve schema-valid `boardWidgetName` values alongside the other Canvas preview fields at the transcript normalization boundary. The Canvas parser and restored-history normalizer share one widget-name validator, so invalid stored values remain omitted under the existing dashboard-name contract. The existing widget renderer and board provider already use this identity to recognize the pinned widget and disable the pin action, so no duplicate pin policy or downstream guard is added.

## User Impact

Pinned Canvas cards remain visibly pinned after transcript restoration. Clicking the card action can no longer create a second copy under a derived name solely because history normalization lost the original widget identity.

## Evidence

- Before fix: `node scripts/run-vitest.mjs ui/src/lib/chat/message-normalizer.test.ts` failed because the normalized preview omitted `boardWidgetName`.
- After fix: the same suite passes all 75 tests, including valid-identity preservation and invalid-identity rejection.
- Related surface proof: Canvas parser, message normalizer, and widget-card suites pass all 89 tests.
- Upstream flaky-lane proof: `skills-owner-selection.e2e.test.ts` passes after rebasing onto #123713, which repaired its repeated correctly-scoped request assertion.
- Required changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed -- ui/src/lib/chat/message-normalizer.ts ui/src/lib/chat/message-normalizer.test.ts` passed.
- Autoreview: clean, no accepted/actionable findings; patch rated correct at 0.99.
- Live pre-fix observation: an already-pinned named card accepted a stale pin click and added a second derived-name widget to the default tab.

Production LOC: +15/-5, net +10 (one shared Canvas widget-name validator plus stable identity preservation)  
Tests: +24/-2, net +22 (valid and invalid Canvas-history regressions)
