### PR TITLE
chore(deps): automate trusted ClawHub CLI refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,17 @@ updates:
     registries:
       - npm-npmjs
 
+  # npm dependencies - trusted ClawHub release CLI
+  - package-ecosystem: npm
+    directory: /.github/release/clawhub-cli
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 2
+    open-pull-requests-limit: 1
+    registries:
+      - npm-npmjs
+
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/clawhub-cli-contract.yml
+++ b/.github/workflows/clawhub-cli-contract.yml
@@ -1,0 +1,70 @@
+name: ClawHub CLI Contract
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  verify:
+    name: Verify trusted ClawHub CLI contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Detect trusted ClawHub CLI changes
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+          if git diff --quiet "${BASE_SHA}" HEAD -- \
+            .github/dependabot.yml \
+            .github/release/clawhub-cli \
+            .github/workflows/clawhub-cli-contract.yml \
+            .github/workflows/plugin-clawhub-new.yml \
+            scripts/materialize-clawhub-cli.sh \
+            scripts/sync-clawhub-cli-pins.mts \
+            scripts/verify-clawhub-cli-contract.sh; then
+            echo "required=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Setup trusted Node runtime
+        if: steps.scope.outputs.required == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Materialize locked ClawHub CLI
+        if: steps.scope.outputs.required == 'true'
+        id: clawhub_cli
+        run: |
+          set -euo pipefail
+          bash scripts/materialize-clawhub-cli.sh \
+            .github/release/clawhub-cli \
+            "${RUNNER_TEMP}/clawhub-cli" \
+            "${GITHUB_OUTPUT}"
+
+      - name: Verify trusted publisher command contract
+        if: steps.scope.outputs.required == 'true'
+        env:
+          CLAWHUB_CLI: ${{ steps.clawhub_cli.outputs.cli }}
+        run: bash scripts/verify-clawhub-cli-contract.sh "${CLAWHUB_CLI}"

--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -422,22 +422,7 @@ jobs:
       - name: Validate pinned ClawHub trusted publisher CLI support
         env:
           CLAWHUB_CLI: ${{ steps.clawhub_cli.outputs.cli }}
-        run: |
-          set -euo pipefail
-          help_output="$(
-            "${CLAWHUB_CLI}" package trusted-publisher set --help 2>&1 || true
-          )"
-          printf '%s\n' "${help_output}"
-          if ! grep -Fq "Usage: clawhub package trusted-publisher set" <<<"${help_output}"; then
-            echo "::error::CLAW-277 03 - Split OpenClaw plugin ClawHub publishing into OIDC release and token bootstrap workflows requires locked clawhub@0.23.1 to expose 'package trusted-publisher set' before token bootstrap publish can run. The pinned CLI returned parent help or no set command, so this workflow is stopping before creating a ClawHub package row."
-            exit 1
-          fi
-          for required_flag in --repository --workflow-filename; do
-            if ! grep -Fq -- "${required_flag}" <<<"${help_output}"; then
-              echo "::error::CLAW-277 03 - Split OpenClaw plugin ClawHub publishing into OIDC release and token bootstrap workflows requires locked clawhub@0.23.1 trusted-publisher set help to include ${required_flag}."
-              exit 1
-            fi
-          done
+        run: bash scripts/verify-clawhub-cli-contract.sh "${CLAWHUB_CLI}"
 
   pack_bootstrap_plugins:
     name: Pack immutable ClawHub bootstrap artifacts

--- a/package.json
+++ b/package.json
@@ -1568,6 +1568,8 @@
     "deadcode:unused-files": "node --import tsx scripts/check-deadcode-unused-files.mts",
     "deps:root-ownership": "node --import tsx scripts/root-dependency-ownership-audit.mts",
     "deps:root-ownership:check": "node --import tsx scripts/root-dependency-ownership-audit.mts --check",
+    "deps:clawhub-cli-pins:check": "node --import tsx scripts/sync-clawhub-cli-pins.mts --check",
+    "deps:clawhub-cli-pins:sync": "node --import tsx scripts/sync-clawhub-cli-pins.mts --write",
     "deps:changes:report": "node --import tsx scripts/dependency-changes-report.mts",
     "deps:patches:check": "node --import tsx scripts/check-package-patches.mts",
     "deps:pins:check": "node --import tsx scripts/check-dependency-pins.mts",

--- a/scripts/run-additional-boundary-checks.mts
+++ b/scripts/run-additional-boundary-checks.mts
@@ -88,6 +88,7 @@ export const BOUNDARY_CHECKS = (
       ["run", "lint:plugins:plugin-sdk-subpaths-exported"],
     ],
     ["deps:root-ownership:check", "pnpm", ["deps:root-ownership:check"]],
+    ["deps:clawhub-cli-pins:check", "pnpm", ["deps:clawhub-cli-pins:check"]],
     ["web-fetch-provider-boundary", "pnpm", ["run", "lint:web-fetch-provider-boundaries"]],
     [
       "extension-src-outside-plugin-sdk-boundary",

--- a/scripts/sync-clawhub-cli-pins.mts
+++ b/scripts/sync-clawhub-cli-pins.mts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type ClawHubIdentity = {
+  integrity: string;
+  lockSha256: string;
+  version: string;
+};
+
+const CLAWHUB_PACKAGE_DIR = ".github/release/clawhub-cli";
+const MATERIALIZER_PATH = "scripts/materialize-clawhub-cli.sh";
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function requireRecord(value: unknown, description: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${description} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, description: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${description} must be a non-empty string`);
+  }
+  return value;
+}
+
+export function readClawHubIdentity(rootDir: string): ClawHubIdentity {
+  const packageDir = path.join(rootDir, CLAWHUB_PACKAGE_DIR);
+  const packageJson = requireRecord(
+    readJson(path.join(packageDir, "package.json")),
+    "package.json",
+  );
+  const dependencies = requireRecord(packageJson.dependencies, "package.json dependencies");
+  const declaredVersion = requireString(dependencies.clawhub, "declared clawhub version");
+
+  const lockPath = path.join(packageDir, "package-lock.json");
+  const lockBytes = readFileSync(lockPath);
+  const lockJson = requireRecord(JSON.parse(lockBytes.toString("utf8")), "package-lock.json");
+  const packages = requireRecord(lockJson.packages, "package-lock.json packages");
+  const lockedPackage = requireRecord(packages["node_modules/clawhub"], "locked clawhub package");
+  const lockedVersion = requireString(lockedPackage.version, "locked clawhub version");
+  const integrity = requireString(lockedPackage.integrity, "locked clawhub integrity");
+
+  if (declaredVersion !== lockedVersion) {
+    throw new Error(
+      `declared clawhub version ${declaredVersion} does not match lock version ${lockedVersion}`,
+    );
+  }
+  if (!integrity.startsWith("sha512-")) {
+    throw new Error(`locked clawhub integrity must use sha512: ${integrity}`);
+  }
+
+  return {
+    integrity,
+    lockSha256: createHash("sha256").update(lockBytes).digest("hex"),
+    version: lockedVersion,
+  };
+}
+
+function replaceExactlyOnce(source: string, pattern: RegExp, replacement: string): string {
+  const matches = source.match(new RegExp(pattern.source, "gu")) ?? [];
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one materializer match for ${pattern.source}`);
+  }
+  return source.replace(pattern, replacement);
+}
+
+export function renderClawHubMaterializerPins(source: string, identity: ClawHubIdentity): string {
+  let rendered = replaceExactlyOnce(
+    source,
+    /expected_lock_sha256="[^"]+"/u,
+    `expected_lock_sha256="${identity.lockSha256}"`,
+  );
+  rendered = replaceExactlyOnce(
+    rendered,
+    /expected_clawhub_integrity="[^"]+"/u,
+    `expected_clawhub_integrity="${identity.integrity}"`,
+  );
+  return replaceExactlyOnce(
+    rendered,
+    /\[\[ "\$\{clawhub_version\}" == "[^"]+" \]\]/u,
+    `[[ "\${clawhub_version}" == "${identity.version}" ]]`,
+  );
+}
+
+export function syncClawHubPins(rootDir: string, write: boolean): boolean {
+  const materializerPath = path.join(rootDir, MATERIALIZER_PATH);
+  const source = readFileSync(materializerPath, "utf8");
+  const identity = readClawHubIdentity(rootDir);
+  const rendered = renderClawHubMaterializerPins(source, identity);
+  const changed = rendered !== source;
+
+  if (write && changed) {
+    writeFileSync(materializerPath, rendered);
+  }
+  return changed;
+}
+
+function printUsage(): void {
+  console.log("Usage: node --import tsx scripts/sync-clawhub-cli-pins.mts <--check|--write>");
+}
+
+function main(): void {
+  const [arg] = process.argv.slice(2);
+  if (arg === "--help" || arg === "-h") {
+    printUsage();
+    return;
+  }
+  if (arg !== "--check" && arg !== "--write") {
+    printUsage();
+    process.exitCode = 2;
+    return;
+  }
+
+  const changed = syncClawHubPins(process.cwd(), arg === "--write");
+  if (arg === "--check" && changed) {
+    console.error("ClawHub CLI identity pins are stale. Run pnpm deps:clawhub-cli-pins:sync.");
+    process.exitCode = 1;
+    return;
+  }
+  console.log(changed ? "Updated ClawHub CLI identity pins." : "ClawHub CLI identity pins match.");
+}
+
+const isDirectRun =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectRun) {
+  main();
+}

--- a/scripts/sync-clawhub-cli-pins.mts
+++ b/scripts/sync-clawhub-cli-pins.mts
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -99,7 +108,20 @@ export function syncClawHubPins(rootDir: string, write: boolean): boolean {
   const changed = rendered !== source;
 
   if (write && changed) {
-    writeFileSync(materializerPath, rendered);
+    const temporaryPath = `${materializerPath}.${process.pid}.tmp`;
+    rmSync(temporaryPath, { force: true });
+    try {
+      const descriptor = openSync(temporaryPath, "w", statSync(materializerPath).mode);
+      try {
+        writeFileSync(descriptor, rendered);
+        fsyncSync(descriptor);
+      } finally {
+        closeSync(descriptor);
+      }
+      renameSync(temporaryPath, materializerPath);
+    } finally {
+      rmSync(temporaryPath, { force: true });
+    }
   }
   return changed;
 }

--- a/scripts/verify-clawhub-cli-contract.sh
+++ b/scripts/verify-clawhub-cli-contract.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+clawhub_cli="${1:?locked ClawHub CLI path is required}"
+help_output="$(
+  "${clawhub_cli}" package trusted-publisher set --help 2>&1 || true
+)"
+printf '%s\n' "${help_output}"
+
+if ! grep -Fq "Usage: clawhub package trusted-publisher set" <<<"${help_output}"; then
+  echo "::error::The locked ClawHub CLI must expose 'package trusted-publisher set' before trusted plugin publishing can run."
+  exit 1
+fi
+
+for required_flag in --repository --workflow-filename; do
+  if ! grep -Fq -- "${required_flag}" <<<"${help_output}"; then
+    echo "::error::The locked ClawHub CLI trusted-publisher command must include ${required_flag}."
+    exit 1
+  fi
+done

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -32,6 +32,7 @@ type Workflow = {
 };
 
 const source = readFileSync(".github/workflows/plugin-clawhub-new.yml", "utf8");
+const contractWorkflowSource = readFileSync(".github/workflows/clawhub-cli-contract.yml", "utf8");
 const workflow = parse(source) as Workflow;
 const jobs = workflow.jobs ?? {};
 const materializerSource = readFileSync("scripts/materialize-clawhub-cli.sh", "utf8");
@@ -353,6 +354,21 @@ describe("Plugin ClawHub New workflow", () => {
     expect(source).not.toContain("CLAWHUB_CLI_PACKAGE");
     expect(source).toContain("OPENCLAW_CLAWHUB_CLI: ${{ steps.clawhub_cli.outputs.cli }}");
     expect(source).toContain('"${OPENCLAW_CLAWHUB_CLI}" package trusted-publisher set');
+  });
+
+  it("uses the same no-secret command-contract proof for updates and releases", () => {
+    expect(
+      step(
+        job("validate_bootstrap_trusted_publisher_cli"),
+        "Validate pinned ClawHub trusted publisher CLI support",
+      ).run,
+    ).toBe('bash scripts/verify-clawhub-cli-contract.sh "${CLAWHUB_CLI}"');
+    expect(contractWorkflowSource).toContain("pull_request:");
+    expect(contractWorkflowSource).toContain("scripts/materialize-clawhub-cli.sh");
+    expect(contractWorkflowSource).toContain(
+      'bash scripts/verify-clawhub-cli-contract.sh "${CLAWHUB_CLI}"',
+    );
+    expect(contractWorkflowSource).not.toContain("secrets.");
   });
 
   it("bounds every job and keeps secretless validation active in dry-run mode", () => {

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -42,6 +43,7 @@ const clawhubCliLock = JSON.parse(
 ) as {
   packages?: Record<string, { integrity?: string; version?: string }>;
 };
+const clawhubCliLockBytes = readFileSync(".github/release/clawhub-cli/package-lock.json");
 
 function job(name: string): Job {
   const value = jobs[name];
@@ -327,20 +329,22 @@ describe("Plugin ClawHub New workflow", () => {
   });
 
   it("uses one lockfile-only ClawHub CLI graph and absolute binary path", () => {
-    expect(clawhubCliPackage.dependencies).toEqual({ clawhub: "0.23.1" });
-    expect(clawhubCliLock.packages?.["node_modules/clawhub"]).toMatchObject({
-      integrity:
-        "sha512-YvUImhsVaM90BUAv3uP7lfABziwR5XL3ch2Owa+GvNxwQ2xzZFmZC0yVjAtQbvep+dDDS16nUGRwKx7jqnTOEA==",
-      version: "0.23.1",
-    });
+    const lockedClawHub = clawhubCliLock.packages?.["node_modules/clawhub"];
+    if (!lockedClawHub?.integrity || !lockedClawHub.version) {
+      throw new Error("trusted ClawHub CLI lock identity is incomplete");
+    }
+    expect(lockedClawHub.version).toBe(clawhubCliPackage.dependencies?.clawhub);
+    expect(lockedClawHub.integrity).toMatch(/^sha512-/u);
     expect(materializerSource).toContain("npm ci");
     expect(materializerSource).toContain('cd "${destination}"');
     expect(materializerSource).not.toContain('--prefix "${destination}"');
     expect(materializerSource).toContain("--ignore-scripts");
     expect(materializerSource).toContain("--omit=dev");
     expect(materializerSource).toContain(
-      "f44f670d70f13a8cde566a174cae5be682ad98456ec7a85aafd497f7d8c71816",
+      createHash("sha256").update(clawhubCliLockBytes).digest("hex"),
     );
+    expect(materializerSource).toContain(lockedClawHub.integrity);
+    expect(materializerSource).toContain(`== "${lockedClawHub.version}"`);
     expect(materializerSource).toContain("lock_sha256=");
     expect(materializerSource).toContain("integrity=${clawhub_integrity}");
     expect(materializerSource).toContain("cli=${clawhub_cli}");

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -31,6 +31,16 @@ function createOutputBuffer() {
   };
 }
 
+describe("boundary check manifest", () => {
+  it("keeps trusted ClawHub CLI pin synchronization in required CI", () => {
+    expect(BOUNDARY_CHECKS).toContainEqual({
+      label: "deps:clawhub-cli-pins:check",
+      command: "pnpm",
+      args: ["deps:clawhub-cli-pins:check"],
+    });
+  });
+});
+
 function runCli(...args: string[]) {
   return spawnSync(
     process.execPath,

--- a/test/scripts/sync-clawhub-cli-pins.test.ts
+++ b/test/scripts/sync-clawhub-cli-pins.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  readClawHubIdentity,
+  renderClawHubMaterializerPins,
+} from "../../scripts/sync-clawhub-cli-pins.mts";
+
+describe("ClawHub CLI pin synchronization", () => {
+  it("reads the exact identity from the trusted package graph", () => {
+    const identity = readClawHubIdentity(process.cwd());
+
+    expect(identity.version).toMatch(/^\d+\.\d+\.\d+/u);
+    expect(identity.integrity).toMatch(/^sha512-/u);
+    expect(identity.lockSha256).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it("updates all materializer identity pins together", () => {
+    const rendered = renderClawHubMaterializerPins(
+      [
+        'expected_lock_sha256="old-lock"',
+        'expected_clawhub_integrity="sha512-old"',
+        '[[ "${clawhub_version}" == "0.0.0" ]] || {',
+      ].join("\n"),
+      {
+        integrity: "sha512-new",
+        lockSha256: "new-lock",
+        version: "1.2.3",
+      },
+    );
+
+    expect(rendered).toContain('expected_lock_sha256="new-lock"');
+    expect(rendered).toContain('expected_clawhub_integrity="sha512-new"');
+    expect(rendered).toContain('[[ "${clawhub_version}" == "1.2.3" ]]');
+  });
+});

--- a/test/scripts/sync-clawhub-cli-pins.test.ts
+++ b/test/scripts/sync-clawhub-cli-pins.test.ts
@@ -1,7 +1,19 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   readClawHubIdentity,
   renderClawHubMaterializerPins,
+  syncClawHubPins,
 } from "../../scripts/sync-clawhub-cli-pins.mts";
 
 describe("ClawHub CLI pin synchronization", () => {
@@ -30,5 +42,48 @@ describe("ClawHub CLI pin synchronization", () => {
     expect(rendered).toContain('expected_lock_sha256="new-lock"');
     expect(rendered).toContain('expected_clawhub_integrity="sha512-new"');
     expect(rendered).toContain('[[ "${clawhub_version}" == "1.2.3" ]]');
+  });
+
+  it("atomically replaces the materializer while preserving its mode", () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-clawhub-pins-"));
+    const packageDir = path.join(rootDir, ".github", "release", "clawhub-cli");
+    const materializerPath = path.join(rootDir, "scripts", "materialize-clawhub-cli.sh");
+    try {
+      mkdirSync(packageDir, { recursive: true });
+      mkdirSync(path.dirname(materializerPath), { recursive: true });
+      writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({ dependencies: { clawhub: "1.2.3" } }),
+      );
+      writeFileSync(
+        path.join(packageDir, "package-lock.json"),
+        JSON.stringify({
+          packages: {
+            "node_modules/clawhub": {
+              integrity: "sha512-new",
+              version: "1.2.3",
+            },
+          },
+        }),
+      );
+      writeFileSync(
+        materializerPath,
+        [
+          'expected_lock_sha256="old-lock"',
+          'expected_clawhub_integrity="sha512-old"',
+          '[[ "${clawhub_version}" == "0.0.0" ]] || {',
+        ].join("\n"),
+      );
+      chmodSync(materializerPath, 0o755);
+
+      expect(syncClawHubPins(rootDir, true)).toBe(true);
+
+      const rendered = readFileSync(materializerPath, "utf8");
+      expect(rendered).toContain('expected_clawhub_integrity="sha512-new"');
+      expect(rendered).toContain('[[ "${clawhub_version}" == "1.2.3" ]]');
+      expect(statSync(materializerPath).mode & 0o777).toBe(0o755);
+    } finally {
+      rmSync(rootDir, { force: true, recursive: true });
+    }
   });
 });

--- a/test/scripts/verify-clawhub-cli-contract.test.ts
+++ b/test/scripts/verify-clawhub-cli-contract.test.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function runContract(help: string) {
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), "openclaw-clawhub-contract-"));
+  const fixturePath = path.join(fixtureDir, "clawhub");
+  try {
+    writeFileSync(fixturePath, `#!/usr/bin/env bash\nprintf '%s\\n' ${JSON.stringify(help)}\n`);
+    chmodSync(fixturePath, 0o755);
+    return spawnSync("bash", ["scripts/verify-clawhub-cli-contract.sh", fixturePath], {
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(fixtureDir, { force: true, recursive: true });
+  }
+}
+
+describe("ClawHub CLI command contract", () => {
+  it("accepts the trusted-publisher command with required flags", () => {
+    const result = runContract(
+      "Usage: clawhub package trusted-publisher set\n--repository\n--workflow-filename",
+    );
+
+    expect(result.status).toBe(0);
+  });
+
+  it("rejects a CLI that drops a required flag", () => {
+    const result = runContract("Usage: clawhub package trusted-publisher set\n--repository");
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("--workflow-filename");
+  });
+});


### PR DESCRIPTION
## Summary

- add daily Dependabot discovery for the isolated trusted ClawHub release-tool graph
- add `deps:clawhub-cli-pins:sync` to refresh the lock SHA-256, package integrity, and exact version together
- enforce `deps:clawhub-cli-pins:check` in required boundary CI
- atomically replace synchronized pins while preserving the materializer mode
- run the same no-secret trusted-publisher command-and-flags proof for update PRs and releases

## Why

Generic Dependabot coverage alone was unsafe because `scripts/materialize-clawhub-cli.sh` intentionally rejects any lock whose SHA-256, ClawHub integrity, or version does not match its reviewed pins. Identity synchronization alone was also insufficient because an updated executable could retain valid bytes while dropping the trusted-publisher command used later by the credential-bearing release path.

This keeps both invariants intact: reviewed identity pins and pre-merge command-contract proof. The PR remains a draft for release/security-owner review of the trusted update boundary.

## Validation

- exact repository formatter and linter pass
- workflow actionlint passes
- ClawHub pin check passes
- 39 focused workflow, boundary-runner, synchronization, and command-contract tests pass
- the committed lock materializes `clawhub@0.23.1` and proves `package trusted-publisher set`, `--repository`, and `--workflow-filename`

Progresses #123689. Supersedes the incomplete approach in #123692.