### PR TITLE
fix(ui): remove archived sessions from active sidebar

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -166,6 +166,7 @@ describe("sidebar navigation lineage ownership", () => {
       roots: [navigationParent, controlParent],
       agentRows: [navigationParent, controlParent, child],
       childRowsByParent: {},
+      archivedFilter: "active",
       loadingChildKeys: new Set(),
       knownSessionAttention: [],
       toSidebarSession: (row, isChild) =>
@@ -198,6 +199,7 @@ describe("sidebar navigation lineage ownership", () => {
         roots: [navigationParent],
         agentRows: [navigationParent, childRow],
         childRowsByParent: {},
+        archivedFilter: "active",
         loadingChildKeys: new Set(),
         knownSessionAttention: [],
         toSidebarSession: (row, isChild) => ({
@@ -234,6 +236,7 @@ describe("sidebar navigation lineage ownership", () => {
       roots: [controlParent],
       agentRows: [controlParent, childWithBlankParent],
       childRowsByParent: {},
+      archivedFilter: "active",
       loadingChildKeys: new Set(),
       knownSessionAttention: [],
       toSidebarSession: (row, isChild) =>

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -649,12 +649,9 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const lineageRouteAgentId = normalizeAgentId(
       parseAgentSessionKey(navigationState.routeSessionKey)?.agentId ?? "",
     );
-    const lineageSelected = Boolean(
-      lineageRoot && areUiSessionKeysEquivalent(lineageRoot.key, navigationState.routeSessionKey),
-    );
     if (
       lineageRoot &&
-      (lineageSelected || sessionMatchesArchivedFilter(lineageRoot, this.sessionsStatusFilter)) &&
+      sessionMatchesArchivedFilter(lineageRoot, this.sessionsStatusFilter) &&
       (lineageAgentId === selected || lineageRouteAgentId === selected) &&
       !adopted.has(lineageRoot.key) &&
       !areUiSessionKeysEquivalent(lineageRoot.key, mainSessionKey) &&
@@ -688,6 +685,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       roots: orderedRootRows.filter((row) => !adopted.has(row.key)),
       agentRows: rows,
       childRowsByParent: this.sessionData.childSessionRowsByParent,
+      archivedFilter: this.sessionsStatusFilter,
       loadingChildKeys: this.sessionData.loadingChildSessionKeys,
       knownSessionAttention: this.attention.knownSessionAttention(),
       toSidebarSession: navigationState.toSidebarSession,

--- a/ui/src/components/app-sidebar-session-tree.ts
+++ b/ui/src/components/app-sidebar-session-tree.ts
@@ -1,4 +1,5 @@
 import type { GatewaySessionRow } from "../api/types.ts";
+import { sessionMatchesArchivedFilter, type SessionArchivedFilter } from "../lib/sessions/index.ts";
 import {
   areUiSessionKeysEquivalent,
   resolveUiSessionNavigationParentKey,
@@ -22,6 +23,7 @@ export function projectSessionTree(params: {
   roots: readonly GatewaySessionRow[];
   agentRows: readonly GatewaySessionRow[];
   childRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>;
+  archivedFilter: SessionArchivedFilter;
   loadingChildKeys: ReadonlySet<string>;
   knownSessionAttention: readonly SidebarKnownSessionAttention[];
   toSidebarSession: (row: GatewaySessionRow, isChild?: boolean) => SidebarRecentSession;
@@ -30,6 +32,7 @@ export function projectSessionTree(params: {
     roots,
     agentRows,
     childRowsByParent,
+    archivedFilter,
     loadingChildKeys,
     knownSessionAttention,
     toSidebarSession,
@@ -79,7 +82,9 @@ export function projectSessionTree(params: {
     nextAncestors.add(row.key);
     const children = childSessionKeys.flatMap((key) => {
       const child = rowsByKey.get(key);
-      return child && !nextAncestors.has(key) ? [build(child, true, nextAncestors)] : [];
+      return child && sessionMatchesArchivedFilter(child, archivedFilter) && !nextAncestors.has(key)
+        ? [build(child, true, nextAncestors)]
+        : [];
     });
     const projected = toSidebarSession(row, isChild);
     const projectedRunningChildCount = children.reduce(

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -362,7 +362,9 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.childSessionGeneration += 1;
     this.childSessionRowsByParent = options.preserveActiveLineage
       ? preserveActiveSessionLineageRows(
-          this.activeSessionLineageRouteKey,
+          this.activeSessionLineageSelectedRow?.archived === true
+            ? null
+            : this.activeSessionLineageRouteKey,
           this.childSessionRowsByParent,
         )
       : {};

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -285,7 +285,7 @@ suite.define(() => {
     }
   });
 
-  it("keeps the selected session through archive refreshes and restores the composer", async () => {
+  it("keeps the selected chat open, removes its archived row, and restores the composer", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -453,6 +453,7 @@ suite.define(() => {
       await gateway.setMethodResponse("sessions.describe", {
         session: { ...selectedWithoutDerivedTitle, archived: true },
       });
+      await captureUiProof(page, "archived-session-before.png");
       await selectedRow.hover();
       await selectedRow.getByRole("button", { name: "Open session menu" }).click();
       await activateSelfRemovingControl(
@@ -472,11 +473,11 @@ suite.define(() => {
         reason: "update",
         sessionKey: selected.key,
       });
-      await expect.poll(() => selectedRow.textContent()).toContain("Archive refresh 2");
 
-      await assertSelectedRoute();
-      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
-      await expect.poll(() => selectedRow.textContent()).toContain("Archive refresh 2");
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe(controlUiSessionPath(selected.key));
+      await selectedRow.waitFor({ state: "detached", timeout: 10_000 });
       expect(
         await page.evaluate(
           () => (window as Window & { archiveTitleHistory?: string[] }).archiveTitleHistory ?? [],
@@ -522,16 +523,20 @@ suite.define(() => {
       ).not.toContain("New session — OpenClaw");
       const archivedNotice = activePane.locator(".agent-chat__disabled-banner");
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
-      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
+      await expect
+        .poll(() => archivedNotice.textContent())
+        .toContain("This session has been archived.");
       await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
+      await captureUiProof(page, "archived-session-hidden-with-undo.png");
 
       await archiveToast.getByRole("button", { name: "Dismiss" }).click();
       await archiveToast.waitFor({ state: "detached" });
-      await activateSelfRemovingControl(archivedNotice.getByRole("button", { name: "Unarchive" }));
+      await activateSelfRemovingControl(archivedNotice.getByRole("button", { name: "Undo" }));
       await waitForPatch(
         gateway,
         (params) => params.key === selected.key && params.archived === false,
       );
+      await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
       await gateway.emitGatewayEvent("sessions.changed", {
         ...selected,
         archived: false,
@@ -540,7 +545,6 @@ suite.define(() => {
       });
 
       await assertSelectedRoute();
-      await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
       await expect
         .poll(() =>
@@ -652,8 +656,10 @@ suite.define(() => {
         .poll(() => new URL(page.url()).pathname)
         .toBe(controlUiSessionPath(archived.key));
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
-      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
-      await archivedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
+      await expect
+        .poll(() => archivedNotice.textContent())
+        .toContain("This session has been archived.");
+      await expect.poll(() => archivedRow.count()).toBe(0);
     } finally {
       await context.close();
     }
@@ -691,22 +697,20 @@ suite.define(() => {
       const selectedRow = page.locator(
         `.sidebar-recent-session[data-session-key="${archived.key}"]`,
       );
-      await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
-      await expect
-        .poll(() => selectedRow.getAttribute("class"))
-        .toContain("sidebar-recent-session--active");
-      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
-      await expect.poll(() => page.getByText("Archived planning", { exact: true }).count()).toBe(2);
+      await expect.poll(() => selectedRow.count()).toBe(0);
+      await expect.poll(() => page.getByText("Archived planning", { exact: true }).count()).toBe(1);
 
       const archivedNotice = activePane.locator(".agent-chat__disabled-banner");
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
-      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
+      await expect
+        .poll(() => archivedNotice.textContent())
+        .toContain("This session has been archived.");
       await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
 
       await gateway.setMethodResponse("sessions.describe", {
         session: { ...archived, archived: false },
       });
-      await activateSelfRemovingControl(archivedNotice.getByRole("button", { name: "Unarchive" }));
+      await activateSelfRemovingControl(archivedNotice.getByRole("button", { name: "Undo" }));
       await waitForPatch(
         gateway,
         (params) => params.key === archived.key && params.archived === false,
@@ -719,6 +723,10 @@ suite.define(() => {
       });
 
       await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
+      await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(() => selectedRow.getAttribute("class"))
+        .toContain("sidebar-recent-session--active");
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
       await expect
         .poll(() =>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4572,7 +4572,7 @@ export const en: TranslationMap = {
       preparingContext: "Preparing this turn…",
       startingModel: "Waiting for a response…",
     },
-    archivedSessionDisabled: "This session is archived. Unarchive it to continue the conversation.",
+    archivedSessionDisabled: "This session has been archived.",
     sessionRoute: {
       chooseTitle: "Choose a session",
       multipleMatches: "More than one session matches {shortId}.",

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -183,7 +183,7 @@ describe("resolveSessionNavigation", () => {
     );
   });
 
-  it("keeps the selected archived session ahead of an active-filtered result", () => {
+  it("keeps an archived selection routed but removes it from the active-filtered list", () => {
     const selectedSession = {
       key: "agent:main:archived",
       kind: "direct" as const,
@@ -198,15 +198,8 @@ describe("resolveSessionNavigation", () => {
       archivedFilter: "active",
     });
 
-    expect(navigation.visibleSessions.map((row) => row.key)).toEqual([
-      selectedSession.key,
-      "agent:main:recent",
-    ]);
-    expect(navigation.visibleSessions[0]).toMatchObject({
-      key: selectedSession.key,
-      archived: true,
-    });
-    expect(navigation.activeRowKey).toBe(selectedSession.key);
+    expect(navigation.visibleSessions.map((row) => row.key)).toEqual(["agent:main:recent"]);
+    expect(navigation.activeRowKey).toBeNull();
     expect(navigation.selectedSession).toMatchObject({
       key: selectedSession.key,
       archived: true,

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -280,8 +280,7 @@ export function filterVisibleSessionRows(
   return rows.filter((row) => {
     if (
       row.key === options.currentSessionKey &&
-      ((options.archivedFilter ?? "active") === "active" ||
-        sessionMatchesArchivedFilter(row, options.archivedFilter))
+      sessionMatchesArchivedFilter(row, options.archivedFilter)
     ) {
       return true;
     }
@@ -352,14 +351,17 @@ export function resolveSessionNavigation(input: SessionNavigationInput): Session
     showSystem: input.showSystem,
     archivedFilter: input.archivedFilter,
   }).toSorted(input.compareSessions ?? compareSessionRowsByUpdatedAt);
-  // The sidebar is the session list, not a recent-session preview. Keep every
-  // active row in its sorted slot so selecting a session never reshuffles or
-  // hides another one behind a separate route.
+  // Keep every active row in its sorted slot.
   let visibleSessions = sortedSessions;
   let activeRow = visibleSessions.find(matchesCurrentSession);
-  if (!activeRow && activeSession && input.archivedFilter !== "archived") {
-    // Deep-linked and archived sessions still need a visible selected row.
-    activeRow = sortedSessions.find(matchesCurrentSession) ?? activeSession;
+  if (
+    !activeRow &&
+    activeSession &&
+    input.archivedFilter !== "archived" &&
+    sessionMatchesArchivedFilter(activeSession, input.archivedFilter)
+  ) {
+    // Deep-linked active sessions still need a visible selected row.
+    activeRow = activeSession;
     visibleSessions = [activeRow, ...visibleSessions.filter((row) => row !== activeRow)];
   }
   return {

--- a/ui/src/pages/chat/chat-composer-disabled-banner.test.ts
+++ b/ui/src/pages/chat/chat-composer-disabled-banner.test.ts
@@ -47,8 +47,8 @@ describe("archived session composer banner", () => {
       canSend: false,
       disabledBanner: {
         kind: "composer-replacement",
-        text: "This session is archived. Unarchive it to continue the conversation.",
-        actionLabel: "Unarchive",
+        text: "This session has been archived.",
+        actionLabel: "Undo",
         disabledReason: reason,
         onAction,
       },

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -205,15 +205,15 @@ describe("renderChatComposer controls", () => {
       onAbort,
       disabledBanner: {
         kind: "composer-replacement",
-        text: "This session is archived. Unarchive it to continue the conversation.",
-        actionLabel: "Unarchive",
+        text: "This session has been archived.",
+        actionLabel: "Undo",
         onAction,
       },
       typingActors: [{ id: "ayaan", label: "Ayaan" }],
     });
 
     const banner = container.querySelector(".agent-chat__disabled-banner");
-    expect(banner?.textContent).toContain("This session is archived.");
+    expect(banner?.textContent).toContain("This session has been archived.");
     expect(container.querySelector(".agent-chat__input")).toBeNull();
     expect(container.querySelector("textarea")).toBeNull();
     expect(container.querySelector(".agent-chat__typing-indicator--outside")).toBeNull();

--- a/ui/src/pages/chat/chat-pane-session-creation.ts
+++ b/ui/src/pages/chat/chat-pane-session-creation.ts
@@ -47,7 +47,7 @@ export abstract class ChatPaneSessionCreation extends ChatPaneRetainedPresentati
       return {
         kind: "composer-replacement" as const,
         text: t("chat.archivedSessionDisabled"),
-        actionLabel: t("common.unarchive"),
+        actionLabel: t("common.undo"),
         disabledReason: !params.selectedSessionId
           ? "Session lifecycle action requires a durable session identity."
           : params.unarchiveAccess.allowed

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -513,7 +513,7 @@ describe("AppSidebar agent chip", () => {
     );
   });
 
-  it("keeps the selected archived child when its archived parent is filtered out", async () => {
+  it("hides a selected archived child while keeping its active parent", async () => {
     const request = vi.fn(async (_method: string, params: { key: string }) => ({
       session:
         params.key === "agent:worker:child"
@@ -528,8 +528,8 @@ describe("AppSidebar agent chip", () => {
           : {
               key: "agent:main:parent",
               kind: "direct" as const,
-              label: "Archived parent",
-              archived: true,
+              label: "Active parent",
+              archived: false,
               updatedAt: 1,
               childSessions: ["agent:worker:child"],
             },
@@ -544,19 +544,9 @@ describe("AppSidebar agent chip", () => {
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await waitForFast(() =>
-      expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).not.toBeNull(),
+      expect(sidebar.querySelector('[data-session-key="agent:main:parent"]')).not.toBeNull(),
     );
-    expect(sidebar.querySelector('[data-session-key="agent:main:parent"]')).toBeNull();
-    expect(
-      sidebar.querySelector(
-        '[data-session-key="agent:worker:child"] .sidebar-session__archive-glyph',
-      ),
-    ).not.toBeNull();
-    expect(
-      sidebar
-        .querySelector('[data-session-key="agent:worker:child"]')
-        ?.classList.contains("sidebar-recent-session--active"),
-    ).toBe(true);
+    expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).toBeNull();
   });
 
   it("retries a failed child load after collapsing and reopening the parent", async () => {


### PR DESCRIPTION
Closes #121436

## What Problem This Solves

Fixes an issue where users who archived the session they were viewing would still see that archived session in the active Control UI sidebar. The archive succeeded, but the selected-row exception made the active list look unchanged.

## Why This Change Was Made

The active sidebar now applies its archive filter consistently to routed roots and child sessions while retaining the routed archived descriptor solely for the open chat, title, and Undo state. Archived lineage cache rows are dropped on canonical refresh so a stale pre-archive child cannot be projected back into the active tree.

The prior policy was introduced in #113882. This PR reverses only the sidebar-membership decision: the chat route remains open, cold-loaded archived links still resolve, and Undo restores the row and composer in place.

## User Impact

Archiving the current session removes it from the active sidebar immediately. The open chat remains available with a clear archived banner and Undo action; Undo restores the session to the sidebar without navigation.

## Evidence

- Failing pre-fix regression: `ui/src/lib/sessions/navigation.test.ts` returned `agent:main:archived` in an active-filtered list.
- `node scripts/run-vitest.mjs ui/src/lib/sessions/navigation.test.ts ui/src/components/app-sidebar-session-navigation-logic.test.ts ui/src/components/app-sidebar.test.ts ui/src/pages/chat/chat-composer.test.ts ui/src/pages/chat/chat-composer-disabled-banner.test.ts` — 333 passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.archive.e2e.test.ts` — 9 passed. Browser assertions cover archive, immediate row removal, route/title continuity, cold-load behavior, navigation away/back, Undo restoration, and composer restoration.
- `node scripts/check-changed.mjs -- <12 changed UI paths>` — passed after the unavailable remote backend fell back locally; includes format, i18n, typecheck, lint, dead-code, dependency, and repository guard lanes.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.
- Visual proof was captured and inspected locally as sanitized before/after screenshots (`archived-session-before.png`, `archived-session-hidden-with-undo.png`). The after image shows the selected session absent from Sessions while its breadcrumb/chat remain open with the Undo banner. This bot environment has no authenticated GitHub attachment uploader, so the files could not be attached to the PR; the deterministic E2E assertions cover the same states.

Production/test LOC: production +23/−16 (net +7), tests/test-support +42/−48 (net −6). The small production growth makes archive filtering an explicit tree-projection contract and prevents archived lineage caches from bypassing it.

AI-assisted: yes. The original Peter-authored implementation was preserved and refreshed against current `main`; the current-lineage cache interaction and proof updates were completed with Codex.
