### PR TITLE
fix(ui): surface companion clear failures

### DIFF
--- a/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
+++ b/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
@@ -1,7 +1,12 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  installMockGateway,
+  navigateToControlUiSession,
+  type MockGatewayControls,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -11,81 +16,151 @@ const suite = createControlUiE2eSuite({
 
 const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 const answer = "Keep this companion answer visible until the reset succeeds.";
+const initiatingSessionKey = "agent:main:companion-clear";
+const nextSessionKey = "agent:main:companion-next";
+const resetError = "Companion reset unavailable during reconnect";
+
+type CompanionSurface = {
+  companion: Locator;
+  gateway: MockGatewayControls;
+  menu: Locator;
+  page: Page;
+};
+
+async function withCompanion(run: (surface: CompanionSurface) => Promise<void>): Promise<void> {
+  if (artifactDir) {
+    await mkdir(artifactDir, { recursive: true });
+  }
+  await suite.withPage(
+    {
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 800, width: 1200 },
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 800, width: 1200 } } }
+        : {}),
+    },
+    async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "sessions.companion.reset": {
+            __mockError: { code: "UNAVAILABLE", message: resetError },
+          },
+          "sessions.companion.state": {
+            cases: [
+              {
+                match: { sessionKey: initiatingSessionKey },
+                response: {
+                  exchanges: [{ question: "What changed?", answer, ts: Date.now() - 1_000 }],
+                },
+              },
+              { match: { sessionKey: nextSessionKey }, response: { exchanges: [] } },
+            ],
+          },
+          "sessions.list": {
+            count: 2,
+            defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+            path: "",
+            sessions: [
+              { key: initiatingSessionKey, kind: "direct", label: "Original", updatedAt: 2 },
+              { key: nextSessionKey, kind: "direct", label: "Next", updatedAt: 1 },
+            ],
+            ts: Date.now(),
+          },
+        },
+        sessionKey: initiatingSessionKey,
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const stateRequest = await gateway.waitForRequest("sessions.companion.state");
+      expect(stateRequest.params).toEqual({
+        agentId: "main",
+        sessionKey: initiatingSessionKey,
+      });
+      const companion = page.locator("openclaw-chat-session-rail");
+      await companion.locator(".chat-session-rail__expand").click();
+      await companion.getByText(answer, { exact: true }).waitFor();
+      const menu = companion.locator("wa-dropdown.chat-session-rail__menu");
+      await run({ companion, gateway, menu, page });
+    },
+  );
+}
+
+async function clearCompanion(menu: Locator): Promise<void> {
+  await menu.getByRole("button", { name: "More companion actions" }).click();
+  await menu.locator('wa-dropdown-item[value="clear"]').click();
+}
 
 suite.define(() => {
   it("shows a reset failure without clearing the thread, then clears after a successful retry", async () => {
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 800, width: 1200 },
-        ...(artifactDir
-          ? { recordVideo: { dir: artifactDir, size: { height: 800, width: 1200 } } }
-          : {}),
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "sessions.companion.reset": {
-              __mockError: {
-                code: "UNAVAILABLE",
-                message: "Companion reset unavailable during reconnect",
-              },
-            },
-            "sessions.companion.state": {
-              exchanges: [{ question: "What changed?", answer, ts: Date.now() - 1_000 }],
-            },
-          },
-          sessionKey: "agent:main:companion-clear",
+    await withCompanion(async ({ companion, gateway, menu, page }) => {
+      await clearCompanion(menu);
+      await gateway.waitForRequest("sessions.companion.reset");
+
+      const alert = page.getByRole("alert").filter({ hasText: resetError });
+      await alert.waitFor({ state: "visible" });
+      await companion.getByText(answer, { exact: true }).waitFor();
+      if (artifactDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "reset-failure.png"),
         });
+      }
 
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const stateRequest = await gateway.waitForRequest("sessions.companion.state");
-        expect(stateRequest.params).toEqual({
-          agentId: "main",
-          sessionKey: "agent:main:companion-clear",
+      await alert.getByRole("button", { name: "Dismiss error" }).click();
+      await gateway.setMethodResponse("sessions.companion.reset", { ok: true });
+      await clearCompanion(menu);
+
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.companion.reset")).length)
+        .toBe(2);
+      await expect.poll(() => companion.getByText(answer, { exact: true }).count()).toBe(0);
+      expect(await page.getByRole("alert").count()).toBe(0);
+      if (artifactDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "reset-success.png"),
         });
-        const companion = page.locator("openclaw-chat-session-rail");
-        await companion.locator(".chat-session-rail__expand").click();
-        await companion.getByText(answer, { exact: true }).waitFor();
+      }
+    });
+  });
 
-        const menu = companion.locator("wa-dropdown.chat-session-rail__menu");
-        await menu.getByRole("button", { name: "More companion actions" }).click();
-        await menu.locator('wa-dropdown-item[value="clear"]').click();
-        await gateway.waitForRequest("sessions.companion.reset");
+  it("does not publish a delayed reset rejection into a newly selected session", async () => {
+    await withCompanion(async ({ gateway, menu, page }) => {
+      await gateway.deferNext("sessions.companion.reset");
+      await clearCompanion(menu);
+      await gateway.waitForRequest("sessions.companion.reset");
 
-        const alert = page
-          .getByRole("alert")
-          .filter({ hasText: "Companion reset unavailable during reconnect" });
-        await alert.waitFor({ state: "visible" });
-        await companion.getByText(answer, { exact: true }).waitFor();
-        if (artifactDir) {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(artifactDir, "reset-failure.png"),
-          });
-        }
+      await navigateToControlUiSession(page, nextSessionKey);
+      await gateway.rejectDeferred("sessions.companion.reset", {
+        code: "UNAVAILABLE",
+        message: resetError,
+      });
 
-        await alert.getByRole("button", { name: "Dismiss error" }).click();
-        await gateway.setMethodResponse("sessions.companion.reset", { ok: true });
-        await menu.getByRole("button", { name: "More companion actions" }).click();
-        await menu.locator('wa-dropdown-item[value="clear"]').click();
+      const visiblePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+      expect(await visiblePane.getByRole("alert").filter({ hasText: resetError }).count()).toBe(0);
+      if (artifactDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "stale-reset-error-suppressed.png"),
+        });
+      }
 
-        await expect
-          .poll(async () => (await gateway.getRequests("sessions.companion.reset")).length)
-          .toBe(2);
-        await expect.poll(() => companion.getByText(answer, { exact: true }).count()).toBe(0);
-        expect(await page.getByRole("alert").count()).toBe(0);
-        if (artifactDir) {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(artifactDir, "reset-success.png"),
-          });
-        }
-      },
-    );
+      await navigateToControlUiSession(page, initiatingSessionKey);
+      const initiatingPane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+      expect(await initiatingPane.getByRole("alert").filter({ hasText: resetError }).count()).toBe(
+        0,
+      );
+      await initiatingPane
+        .locator("openclaw-chat-session-rail")
+        .getByText(answer, { exact: true })
+        .waitFor();
+      if (artifactDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "initiating-thread-preserved.png"),
+        });
+      }
+    });
   });
 });

--- a/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
+++ b/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
@@ -1,0 +1,91 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "session companion clear",
+  startServerBeforeBrowser: true,
+});
+
+const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const answer = "Keep this companion answer visible until the reset succeeds.";
+
+suite.define(() => {
+  it("shows a reset failure without clearing the thread, then clears after a successful retry", async () => {
+    if (artifactDir) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 800, width: 1200 },
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { height: 800, width: 1200 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.companion.reset": {
+              __mockError: {
+                code: "UNAVAILABLE",
+                message: "Companion reset unavailable during reconnect",
+              },
+            },
+            "sessions.companion.state": {
+              exchanges: [{ question: "What changed?", answer, ts: Date.now() - 1_000 }],
+            },
+          },
+          sessionKey: "agent:main:companion-clear",
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const stateRequest = await gateway.waitForRequest("sessions.companion.state");
+        expect(stateRequest.params).toEqual({
+          agentId: "main",
+          sessionKey: "agent:main:companion-clear",
+        });
+        const companion = page.locator("openclaw-chat-session-rail");
+        await companion.locator(".chat-session-rail__expand").click();
+        await companion.getByText(answer, { exact: true }).waitFor();
+
+        const menu = companion.locator("wa-dropdown.chat-session-rail__menu");
+        await menu.getByRole("button", { name: "More companion actions" }).click();
+        await menu.locator('wa-dropdown-item[value="clear"]').click();
+        await gateway.waitForRequest("sessions.companion.reset");
+
+        const alert = page
+          .getByRole("alert")
+          .filter({ hasText: "Companion reset unavailable during reconnect" });
+        await alert.waitFor({ state: "visible" });
+        await companion.getByText(answer, { exact: true }).waitFor();
+        if (artifactDir) {
+          await page.screenshot({
+            fullPage: true,
+            path: path.join(artifactDir, "reset-failure.png"),
+          });
+        }
+
+        await alert.getByRole("button", { name: "Dismiss error" }).click();
+        await gateway.setMethodResponse("sessions.companion.reset", { ok: true });
+        await menu.getByRole("button", { name: "More companion actions" }).click();
+        await menu.locator('wa-dropdown-item[value="clear"]').click();
+
+        await expect
+          .poll(async () => (await gateway.getRequests("sessions.companion.reset")).length)
+          .toBe(2);
+        await expect.poll(() => companion.getByText(answer, { exact: true }).count()).toBe(0);
+        expect(await page.getByRole("alert").count()).toBe(0);
+        if (artifactDir) {
+          await page.screenshot({
+            fullPage: true,
+            path: path.join(artifactDir, "reset-success.png"),
+          });
+        }
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -417,7 +417,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     const agentId = resolveChatAgentId(state);
     await this.sessionCompanionThreads
       .reset(state.sessionKey, (key) => resetSessionCompanion(state.client!, key, agentId), agentId)
-      .catch(() => undefined);
+      .catch((error: unknown) => this.publishHeaderError(error));
   };
   protected resetConfirmation:
     | {

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -57,7 +57,6 @@ import {
   ChatSessionCompanionThreads,
   requestSessionCompanionAnswer,
   requestSessionCompanionState,
-  resetSessionCompanion,
 } from "./chat-session-companion.ts";
 import { ChatStateController } from "./chat-state-controller.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -409,16 +408,6 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     );
   }
 
-  protected readonly clearSessionCompanion = async () => {
-    const state = this.state;
-    if (!state?.connected || !state.client || !state.sessionKey) {
-      return;
-    }
-    const agentId = resolveChatAgentId(state);
-    await this.sessionCompanionThreads
-      .reset(state.sessionKey, (key) => resetSessionCompanion(state.client!, key, agentId), agentId)
-      .catch((error: unknown) => this.publishHeaderError(error));
-  };
   protected resetConfirmation:
     | {
         sessionKey: string;

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -27,6 +27,7 @@ import {
   CHAT_COMPOSER_TEXTAREA_SELECTOR,
   type ChatPaneConnectionScope,
 } from "./chat-pane-shared.ts";
+import { resetSessionCompanion } from "./chat-session-companion.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
 import {
@@ -35,6 +36,26 @@ import {
 } from "./components/chat-session-sharing.ts";
 
 export abstract class ChatPaneSharing extends ChatPaneBase {
+  protected readonly clearSessionCompanion = () => {
+    const scope = this.captureConnectionScope();
+    const key = scope?.state.sessionKey;
+    if (!scope || !key) {
+      return;
+    }
+    const agentId = resolveChatAgentId(scope.state);
+    void this.sessionCompanionThreads
+      .reset(key, (sessionKey) => resetSessionCompanion(scope.client, sessionKey, agentId), agentId)
+      .catch((error: unknown) => {
+        if (
+          this.presented &&
+          this.isConnectionScopeCurrent(scope) &&
+          scope.state.sessionKey === key
+        ) {
+          this.publishHeaderError(error);
+        }
+      });
+  };
+
   protected setSessionSharingState(cacheKey: string, state: ChatSessionSharingState): void {
     this.sessionSharingStates = new Map(this.sessionSharingStates).set(cacheKey, state);
   }
@@ -142,8 +163,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       loading: false,
       error: String(error),
     });
-    // Sharing errors stay with their session; the visible page slot belongs
-    // only to the selected session after same-connection navigation.
+    // Sharing errors stay with their session; the visible slot belongs only to the selected session.
     if (areUiSessionKeysEquivalent(this.state?.sessionKey, sessionKey)) {
       this.publishHeaderError(error);
     }
@@ -252,33 +272,24 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
   }
 
   protected captureConnectionScope(): ChatPaneConnectionScope | null {
-    const context = this.context;
     const state = this.state;
-    const client = state?.client;
-    if (
-      !this.isConnected ||
-      !state?.connected ||
-      !client ||
-      this.connectedClient !== client ||
-      context.gateway.snapshot.phase !== "connected" ||
-      context.gateway.snapshot.client !== client
-    ) {
+    if (!state?.client) {
       return null;
     }
-    return {
-      context,
+    const scope = {
+      context: this.context,
       state,
-      client,
+      client: state.client,
       generation: this.connectionGeneration,
-      sessions: context.sessions,
+      sessions: this.context.sessions,
     };
+    return this.isConnectionScopeCurrent(scope) ? scope : null;
   }
 
   protected isConnectionScopeCurrent(scope: ChatPaneConnectionScope): boolean {
     return (
       this.isConnected &&
       this.context === scope.context &&
-      this.context.sessions === scope.sessions &&
       this.state === scope.state &&
       scope.state.connected &&
       scope.state.client === scope.client &&

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -36,14 +36,14 @@ import {
 } from "./components/chat-session-sharing.ts";
 
 export abstract class ChatPaneSharing extends ChatPaneBase {
-  protected readonly clearSessionCompanion = () => {
+  protected readonly clearSessionCompanion = async () => {
     const scope = this.captureConnectionScope();
     const key = scope?.state.sessionKey;
     if (!scope || !key) {
       return;
     }
     const agentId = resolveChatAgentId(scope.state);
-    void this.sessionCompanionThreads
+    await this.sessionCompanionThreads
       .reset(key, (sessionKey) => resetSessionCompanion(scope.client, sessionKey, agentId), agentId)
       .catch((error: unknown) => {
         if (


### PR DESCRIPTION
Closes #123711

## What Problem This Solves

Control UI operators clearing a Session companion received no feedback when `sessions.companion.reset` rejected. The companion thread correctly remained visible, but the rejection was swallowed, so the action appeared to do nothing.

## Why This Change Was Made

Rejected resets now use the chat pane's existing header-error publisher. The companion thread controller remains the state owner and still clears local exchanges only after reset success.

The accepted ClawSweeper session-state finding is addressed: the clear action captures the initiating session and connection scope before awaiting the RPC, and publishes a rejection only while that same pane, session, client, and connection generation remain current. Navigating away during a delayed rejection cannot attach the old failure to another session or retain it on the hidden initiating pane.

The connection-scope capture now delegates validation to its existing canonical current-scope predicate instead of duplicating the same policy. Production remains neutral at `+28/-28` across the final three-file diff. No protocol, config, persistence, public API, or product-policy surface changes.

## User Impact

When a companion clear fails in the current session, operators keep the existing thread and see the Gateway error in the normal chat header. Retrying after recovery clears the thread. If they navigate away while the reset is pending, the delayed failure is suppressed instead of appearing in either session.

## Exact-head Chromium evidence

Failure feedback preserves the companion thread:

![Rejected clear preserves the companion and shows the error](https://github.com/user-attachments/assets/c51a3f37-2732-4192-a714-fb0b76cef2de)

Successful retry clears it:

![Successful retry clears the companion](https://github.com/user-attachments/assets/175b54e0-eafd-4666-bd3f-2f492a52dc70)

Delayed rejection after navigating to `Next` produces no stale alert:

![The newly selected session has no stale reset error](https://github.com/user-attachments/assets/9bcb1ddc-3738-44ff-948c-71e7c7e2f529)

Returning to `Original` shows the initiating thread still intact and no recorded stale error:

![The initiating thread remains intact without a stale error](https://github.com/user-attachments/assets/0cb6ff0e-27e8-4bf9-b3ae-a355075f4be8)

Failure/retry recording:

https://github.com/user-attachments/assets/40310dbb-e9fd-4b1d-9471-8a679903e131

Delayed rejection/navigation recording:

https://github.com/user-attachments/assets/c101e7e9-d0f1-4d7a-86da-94e518557740

## Verification

- Authentic pre-fix browser failure: the delayed rejection was recorded on the hidden initiating pane and resurfaced after navigating back (`expected alert count 0, received 1`).
- Current-main blocker resolved by test-only PR #123765 at `0cd18e1fb9ff0c83fe10e0cf613b2031184afb8d`; the companion patch rebased without overlap.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-session-companion-clear.e2e.test.ts` — 2 tests passed on rebased head `39d1bc015e626b5e76b53a768de7aa0404880279`.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-session-rail.test.ts ui/src/pages/chat/chat-pane-sharing.test.ts` — 69 tests passed.
- Targeted oxfmt, type-aware Oxlint, and `git diff --check` — passed.
- `node scripts/check-changed.mjs` — passed all planned `coreTests, ui` lanes; Testbox was unavailable and the repository wrapper explicitly completed the fallback locally.
- Fresh post-rebase Codex autoreview — clean, no accepted/actionable findings (0.96 confidence).
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31826329003 — green on attempt 2 after one unrelated `service-worker-update.e2e.test.ts` retry; the same failure reproduced on detached current main.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 123724` — passed with `GATES_MODE=hosted_exact_or_recent_parent`, reusing exact-head hosted CI; no separate Testbox lease was allocated.
