### PR TITLE
fix(cron): terminalize the receipt when a mutation fences a queued reservation

### DIFF
--- a/src/cron/service/ops.run-admission-cleanup.test.ts
+++ b/src/cron/service/ops.run-admission-cleanup.test.ts
@@ -344,6 +344,67 @@ describe("cron service run admission cleanup", () => {
     }
   });
 
+  it("terminalizes the receipt when a disable fences a still-queued reservation", async () => {
+    vi.useRealTimers();
+    const store = opsRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:05.000Z");
+    const job = createDueIsolatedJob({
+      id: "queued-disable-before-admission",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    // Saturate admission so the timer's reservation persists but execution
+    // parks as a waiter — the pre-activation window a disable can race.
+    const releaseBlockers = createDeferred();
+    const blockers = Array.from({ length: DEFAULT_CRON_MAX_CONCURRENT_RUNS }, () =>
+      runWithCronAdmission(state, async () => {
+        await releaseBlockers.promise;
+      }),
+    );
+
+    const timer = onTimer(state);
+    await vi.waitFor(async () => {
+      const queuedAtMs = (await loadCronStore(store.storePath)).jobs[0]?.state.queuedAtMs;
+      if (queuedAtMs !== dueAt) {
+        throw new Error("reservation not persisted yet");
+      }
+    });
+
+    // Operator disables while the run is queued: the durable marker is wiped,
+    // so the executor's fence branch must terminalize the running receipt.
+    await update(state, job.id, { enabled: false });
+    releaseBlockers.resolve();
+    await Promise.all(blockers);
+    await timer;
+
+    expect(state.queuedRunReservationsByJobId.has(job.id)).toBe(false);
+    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    const receipt = openOpenClawStateDatabase()
+      .db.prepare(
+        "SELECT status FROM cron_run_receipts WHERE store_key = ? AND job_id = ? ORDER BY started_at_ms DESC, receipt_id DESC LIMIT 1",
+      )
+      .get(cronStoreKey(store.storePath), job.id) as { status: string } | undefined;
+    expect(receipt?.status).toBe("skipped");
+
+    // The job must stay claimable: a leaked running receipt would self-fence
+    // every later reservation into the foreign-receipt monitor forever.
+    await update(state, job.id, { enabled: true });
+    await expect(run(state, job.id, "force")).resolves.toMatchObject({ ok: true, ran: true });
+  });
+
   it("releases immediate and queued admission slots in FIFO order after failures", async () => {
     const store = opsRegressionFixtures.makeStorePath();
     const releaseFirst = createDeferred();

--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -563,6 +563,25 @@ export async function executeQueuedCronRun(params: {
         !isQueuedCronRunReservationCurrent(state, params.jobId, params.reservationIdentity) ||
         job.state.queuedAtMs !== params.reservedAtMs
       ) {
+        const ownership = state.queuedRunReservationsByJobId.get(params.jobId);
+        if (ownership?.identity === params.reservationIdentity) {
+          // A concurrent disable/remove wiped the queued marker while this
+          // reservation waited on admission. Its receipt is still running and
+          // locally owned; abandoning it here would self-fence the job forever
+          // (every later reservation hits the receipt-conflict monitor), so
+          // terminalize like cleanupQueuedCronRunReservations does. locked()
+          // is non-reentrant, hence the direct finish instead of that helper.
+          try {
+            finishCronRunReceipt({
+              handle: ownership.runReceipt,
+              status: "skipped",
+              finishedAtMs: state.deps.nowMs(),
+              error: "cron reservation fenced by concurrent mutation",
+            });
+          } catch {
+            // finishCronRunReceipt retained ownership and scheduled a retry.
+          }
+        }
         releaseQueuedCronRun(state, params.jobId, params.reservationIdentity);
         return undefined;
       }


### PR DESCRIPTION
## What Problem This Solves

Disabling (or removing) a cron job while its scheduled run is still *queued* on admission — reserved, but not yet activated — permanently self-fences the job. The job stays enabled-looking with a due next run and never fires again until gateway restart: the worst class per repo doctrine (action ends in no outcome with no recorded reason).

## Why This Change Was Made

The timer persists a queued reservation (durable `queuedAtMs` + a `running` run receipt, locally owned) and then waits on the shared admission cap. A concurrent operator disable wipes `queuedAtMs` (`ops-mutations.ts`); remove deletes the row. When the parked executor finally runs, its fence branch in `executeQueuedCronRun` (`src/cron/service/run-admission.ts`) released only the in-memory reservation map entry — never terminalizing the durable receipt nor releasing local ownership.

Recovery cannot repair it: `recoverNonTerminalCronRunReceipts` iterates only jobs with durable queued/running markers (both gone), and `ownerDefinitelyStale` is false for our own live pid while the receipt sits in `locallyOwnedReceipts`. On re-enable, every reservation attempt hits `adjudicateActiveCronRunReceiptInDatabase` → `CronRunReceiptConflictError` → the foreign-receipt monitor re-classifies the leaked receipt "live" every 2s forever.

The fix mirrors the established siblings that own the same invariant ("every abandon path terminalizes and releases its exact receipt", `run-receipt-store.ts:33`): the manual-run path (`ops-run-preparation.ts` finishes before the marker-match check) and the not-runnable path (`timer-scheduler.ts`). The fence branch now finishes the receipt as `skipped` via `finishCronRunReceipt` — which also releases local ownership and self-schedules a durable retry on SQLite failure — before dropping the reservation. Direct finish rather than `cleanupQueuedCronRunReservations` because `locked()` is non-reentrant and the branch already holds the lock (noted inline).

## User Impact

Disabling and re-enabling an automation (or removing/recreating it) around its scheduled fire time no longer bricks it. The job stays claimable; the abandoned reservation is recorded as a `skipped` receipt with an explicit reason.

## Evidence

- New regression test reproduces the exact race (admission saturated → reservation persisted → disable → fence): fails pre-fix (`1 failed | 24 passed`; leaked receipt stays `running` and re-enabled force run is fenced), passes post-fix (`25 passed`), including re-enable → `run(force)` succeeding.
- Sibling suites green: `ops.regression.test.ts`, `ops.run-admission.test.ts`, `run-admission-conflict.test.ts`, `run-receipt-settlement.test.ts`, `run-recovery.test.ts`.
- `pnpm tsgo` clean; oxfmt/oxlint clean.
- Autoreview (Codex, commit mode): clean, "no accepted/actionable findings", overall 0.98.

Production LOC delta: +19 (fence-branch receipt terminalization + required invariant comment); tests +61.
