### PR TITLE
fix(plugins): surface setup-required warnings in chat installs

### DIFF
--- a/src/auto-reply/reply/commands-plugins.install.test.ts
+++ b/src/auto-reply/reply/commands-plugins.install.test.ts
@@ -749,6 +749,8 @@ describe("handleCommands /plugins install", () => {
   it("includes non-blocking ClawHub warnings in successful chat install replies", async () => {
     const warning =
       'ClawHub trust warning for "@openclaw/clawhub-demo@1.2.3": scan=pending; reasons=pending.';
+    const setupWarning =
+      'Installed plugin "clawhub-demo" without enabling it because it requires configuration first. Configure it, then run `openclaw plugins enable clawhub-demo`.';
     const richWarning = `\u001b[33m${warning}\u001b[39m`;
     installPluginFromClawHubMock.mockImplementation(async (params: unknown) => {
       if (!params || typeof params !== "object" || !("logger" in params)) {
@@ -783,7 +785,12 @@ describe("handleCommands /plugins install", () => {
         },
       };
     });
-    persistPluginInstallMock.mockResolvedValue({});
+    persistPluginInstallMock.mockImplementation(
+      async (params: { persistenceLogger?: { warn?: (message: string) => void } }) => {
+        params.persistenceLogger?.warn?.(setupWarning);
+        return { plugins: { entries: { "clawhub-demo": { enabled: false } } } };
+      },
+    );
 
     await withTempHome("openclaw-command-plugins-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();
@@ -797,6 +804,7 @@ describe("handleCommands /plugins install", () => {
       }
       expect(result.reply?.text).toContain('Installed plugin "clawhub-demo"');
       expect(result.reply?.text).toContain(warning);
+      expect(result.reply?.text).toContain(setupWarning);
       expect(result.reply?.text).not.toContain("\u001b");
       expect(mockFirstObjectArg(installPluginFromClawHubMock).logger).toEqual(
         expect.objectContaining({ terminalLinks: false }),

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -488,10 +488,7 @@ export async function persistPluginInstall(params: {
   const runtime = params.runtime ?? defaultRuntime;
   // Terminal diagnostics may contain paths/errors; management receives only producer-authored summaries.
   const warn = (message: string, managementMessage: string): void => {
-    if (params.persistenceLogger?.warn) {
-      params.persistenceLogger.warn(managementMessage);
-      return;
-    }
+    params.persistenceLogger?.warn?.(managementMessage);
     runtime.log(theme.warn(message));
   };
   const installRecords = await tracePluginLifecyclePhaseAsync(

--- a/src/plugins/install-persistence.warning-sink.test.ts
+++ b/src/plugins/install-persistence.warning-sink.test.ts
@@ -61,10 +61,9 @@ describe("plugin install persistence warning audiences", () => {
     expect(warn).toHaveBeenCalledExactlyOnceWith(
       'Installed plugin "workboard" without enabling it because it requires configuration first. Configure it, then run `openclaw plugins enable workboard`.',
     );
-    expect(pluginsCliRuntimeLogs).toEqual([
-      "Installed plugin: workboard",
-      "Restart the gateway to load plugins.",
-    ]);
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("requires configuration first");
+    expect(pluginsCliRuntimeLogs).toContain("Installed plugin: workboard");
+    expect(pluginsCliRuntimeLogs).toContain("Restart the gateway to load plugins.");
   });
 
   it("preserves owner-authored exclusive-slot warnings verbatim", async () => {
@@ -149,25 +148,20 @@ describe("plugin install persistence warning audiences", () => {
 
       if (audience === "terminal") {
         expect(warn).not.toHaveBeenCalled();
-        expect(pluginsCliRuntimeLogs.join("\n")).toContain(cleanupDetail);
-        expect(pluginsCliRuntimeLogs.join("\n")).toContain(refreshDetail);
-        expect(pluginsCliRuntimeLogs.join("\n")).toContain(configuredSource);
-        expect(pluginsCliRuntimeLogs.join("\n")).toContain(install.installPath);
-        return;
+      } else {
+        const warnings = warn.mock.calls.map(([message]) => String(message));
+        expect(warnings).toHaveLength(3);
+        expect(warnings.join("\n")).toContain("previous plugin installation");
+        expect(warnings.join("\n")).toContain("registry");
+        expect(warnings.join("\n")).toContain("shadowed");
+        expect(warnings.join("\n")).not.toContain("/private/");
+        expect(warnings.join("\n")).not.toContain("PRIVATE_NPM_MARKER");
+        expect(warnings.join("\n")).not.toContain("PRIVATE_REFRESH_MARKER");
       }
-
-      const warnings = warn.mock.calls.map(([message]) => String(message));
-      expect(warnings).toHaveLength(3);
-      expect(warnings.join("\n")).toContain("previous plugin installation");
-      expect(warnings.join("\n")).toContain("registry");
-      expect(warnings.join("\n")).toContain("shadowed");
-      expect(warnings.join("\n")).not.toContain("/private/");
-      expect(warnings.join("\n")).not.toContain("PRIVATE_NPM_MARKER");
-      expect(warnings.join("\n")).not.toContain("PRIVATE_REFRESH_MARKER");
-      expect(pluginsCliRuntimeLogs).toEqual([
-        "Installed plugin: workboard",
-        "Restart the gateway to load plugins.",
-      ]);
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain(cleanupDetail);
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain(refreshDetail);
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain(configuredSource);
+      expect(pluginsCliRuntimeLogs.join("\n")).toContain(install.installPath);
     },
   );
 });

--- a/src/plugins/management-service.registry-refresh.test.ts
+++ b/src/plugins/management-service.registry-refresh.test.ts
@@ -240,12 +240,19 @@ describe("plugin management registry refresh", () => {
     );
   });
 
-  it("does not forward source-install loggers into private persistence warnings", async () => {
+  it("returns persistence warnings without forwarding them to source-install loggers", async () => {
     mockClawHubWorkboardInstall();
-    mocks.persistInstall.mockResolvedValue({});
+    const instruction =
+      'Installed plugin "workboard" without enabling it because it requires configuration first.';
+    mocks.persistInstall.mockImplementation(
+      async (params: { persistenceLogger?: { warn?: (message: string) => void } }) => {
+        params.persistenceLogger?.warn?.(instruction);
+        return {};
+      },
+    );
     const logger = { warn: vi.fn() };
 
-    await installManagedPluginSource({
+    const result = await installManagedPluginSource({
       request: { source: "clawhub", spec: "clawhub:community/workboard" },
       snapshot: installSnapshot,
       env: {},
@@ -253,7 +260,7 @@ describe("plugin management registry refresh", () => {
     });
 
     expect(mocks.clawhubInstall).toHaveBeenCalledWith(expect.objectContaining({ logger }));
-    expect(mocks.persistInstall.mock.calls[0]?.[0]).not.toHaveProperty("persistenceLogger");
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: true, warnings: [instruction] });
   });
 });

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -1104,10 +1104,10 @@ async function persistManagedSourceInstall(params: {
   extensionsDir: string;
   invalidateRuntimeCache?: boolean;
   runtime?: RuntimeEnv;
-  persistenceLogger?: PluginInstallLogger;
   successMessage?: string;
   cleanupOnPersistenceFailure?: boolean;
-}): Promise<OpenClawConfig> {
+}): Promise<{ config: OpenClawConfig; warnings: string[] }> {
+  const warnings: string[] = [];
   const persist = () =>
     persistPluginInstall({
       snapshot: params.snapshot,
@@ -1115,17 +1115,17 @@ async function persistManagedSourceInstall(params: {
       install: params.install,
       invalidateRuntimeCache: params.invalidateRuntimeCache,
       runtime: params.runtime,
-      ...(params.persistenceLogger ? { persistenceLogger: params.persistenceLogger } : {}),
+      persistenceLogger: { warn: (message) => warnings.push(message) },
       ...(params.successMessage ? { successMessage: params.successMessage } : {}),
     });
   if (!params.cleanupOnPersistenceFailure) {
-    return await persist();
+    return { config: await persist(), warnings };
   }
   try {
-    return await persist();
+    return { config: await persist(), warnings };
   } catch (error) {
-    const warnings = await cleanupFailedManagedPluginInstall(params);
-    return throwPersistenceFailureWithCleanupWarnings(error, warnings);
+    const cleanupWarnings = await cleanupFailedManagedPluginInstall(params);
+    return throwPersistenceFailureWithCleanupWarnings(error, cleanupWarnings);
   }
 }
 
@@ -1135,8 +1135,6 @@ export async function installManagedPluginSource(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   env?: NodeJS.ProcessEnv;
   logger?: PluginInstallLogger & { terminalLinks?: boolean };
-  // Source loggers can feed chat replies; management diagnostics require explicit private opt-in.
-  persistenceLogger?: PluginInstallLogger;
   safetyOverrides?: InstallSafetyOverrides;
   runtime?: RuntimeEnv;
   invalidateRuntimeCache?: boolean;
@@ -1198,7 +1196,7 @@ export async function installManagedPluginSource(params: {
       request.source === "local" && request.link
         ? false
         : (params.cleanupOnPersistenceFailure ?? true);
-    const config = await persistManagedSourceInstall({
+    const persisted = await persistManagedSourceInstall({
       ...params,
       cleanupOnPersistenceFailure,
       env,
@@ -1209,7 +1207,11 @@ export async function installManagedPluginSource(params: {
       extensionsDir,
       successMessage: completed.successMessage,
     });
-    return { ...installed, config };
+    return {
+      ...installed,
+      config: persisted.config,
+      ...(persisted.warnings.length > 0 ? { warnings: [...new Set(persisted.warnings)] } : {}),
+    };
   };
 
   if (request.source === "local") {
@@ -1449,7 +1451,6 @@ export async function installManagedPlugin(params: {
       snapshot,
       env,
       logger: installLogger,
-      persistenceLogger: installLogger,
       cleanupOnPersistenceFailure: true,
       invalidateRuntimeCache: false,
       runtime: createSilentRuntime(),
@@ -1457,6 +1458,7 @@ export async function installManagedPlugin(params: {
     if (!installed.ok) {
       return throwInstallFailure(installed);
     }
+    warnings.push(...(installed.warnings ?? []));
     const workspace = resolvePluginControlPlaneWorkspace({ config: installed.config, env });
     if (workspace.diagnostic) {
       warnings.push(workspace.diagnostic.message);


### PR DESCRIPTION
Closes #123726

## What Problem This Solves

Fixes an issue where operators installing a plugin through chat would see only a successful install/restart message when required configuration kept that plugin disabled.

## Why This Change Was Made

Managed source installation now owns collection of producer-authored, redacted persistence warnings and returns them through its existing result. Chat and administrative installation consume that same result, while detailed terminal diagnostics stay on the terminal path and source/private paths or markers never enter returned warnings.

This removes the administrative caller's separate persistence-warning reconstruction. No config shape, default, protocol, plugin SDK, or public API changes.

Production LOC: +15/-16 (net -1) | Tests: +36/-27 (net +9)

## User Impact

When required plugin configuration is missing, `/plugins install` now explains that the plugin remains disabled and tells the operator to configure it before running `openclaw plugins enable <plugin-id>`.

## Evidence

- Pre-fix regression: the managed-source result omitted the persistence warning while the plugin was committed disabled.
- Post-rebase focused proof: 87/87 tests passed across chat rendering, managed installation, warning redaction, persistence, and compensation.
- Rebased actual changed gate: https://github.com/openclaw/openclaw/actions/runs/31816833529
- Patch-equivalent built isolated QA Gateway + qa-channel proof: 1/1 passed, with the visible configure/enable instruction and persisted `enabled: false` state: https://github.com/openclaw/openclaw/actions/runs/31813879390
- Post-rebase Codex-backed autoreview: clean, no accepted/actionable findings.
