### PR TITLE
fix(cron): reserve migrated heartbeat-task namespace

### DIFF
--- a/src/commands/doctor-heartbeat-task-migration.test.ts
+++ b/src/commands/doctor-heartbeat-task-migration.test.ts
@@ -140,7 +140,7 @@ async function createExistingInboxJob(fixture: Awaited<ReturnType<typeof createF
       wakeMode: "next-heartbeat",
       state: { lastRunAtMs: fixture.nowMs - 10_000 },
     },
-    { enabledExplicit: true, matchesExisting: isHeartbeatTaskCronJob },
+    { enabledExplicit: true, systemOwned: true, matchesExisting: isHeartbeatTaskCronJob },
   );
   return structuredClone("job" in result ? result.job : result);
 }

--- a/src/cron/heartbeat-task.ts
+++ b/src/cron/heartbeat-task.ts
@@ -4,6 +4,11 @@ import type { CronJob } from "./types.js";
 
 const HEARTBEAT_TASK_DECLARATION_PREFIX = "heartbeat-task:";
 
+/** Whether a declaration key belongs to the doctor-owned heartbeat-task namespace. */
+export function isHeartbeatTaskDeclarationKey(declarationKey: string | undefined): boolean {
+  return declarationKey?.startsWith(HEARTBEAT_TASK_DECLARATION_PREFIX) === true;
+}
+
 /** Stable declaration identity; duplicate names add their deterministic occurrence ordinal. */
 export function heartbeatTaskDeclarationKey(
   agentId: string,
@@ -27,7 +32,7 @@ export function isHeartbeatTaskCronJob(job: CronJob): job is CronJob & {
   sessionTarget: "main";
 } {
   return (
-    job.declarationKey?.startsWith(HEARTBEAT_TASK_DECLARATION_PREFIX) === true &&
+    isHeartbeatTaskDeclarationKey(job.declarationKey) &&
     job.payload.kind === "systemEvent" &&
     job.sessionTarget === "main"
   );

--- a/src/cron/service.heartbeat-payload.test.ts
+++ b/src/cron/service.heartbeat-payload.test.ts
@@ -89,16 +89,33 @@ describe("heartbeat payload execution", () => {
       createStartedCronServiceWithFinishedBarrier({ storePath, logger: noopLogger });
     try {
       await cron.start();
-      const added = await cron.add({
-        declarationKey: heartbeatTaskDeclarationKey("main", "inbox"),
-        name: "inbox",
-        agentId: "main",
-        enabled: true,
-        schedule: { kind: "every", everyMs: 60_000 },
-        payload: { kind: "systemEvent", text: "Check urgent inbox items" },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-      });
+      const declarationKey = heartbeatTaskDeclarationKey("main", "inbox");
+      await expect(
+        cron.add({
+          declarationKey,
+          name: "ordinary automation",
+          agentId: "main",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          payload: { kind: "systemEvent", text: "This must use normal cron delivery" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+        }),
+      ).rejects.toThrow(/system-owned/);
+
+      const added = await cron.add(
+        {
+          declarationKey,
+          name: "inbox",
+          agentId: "main",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          payload: { kind: "systemEvent", text: "Check urgent inbox items" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+        },
+        { systemOwned: true },
+      );
       const job = "job" in added ? added.job : added;
 
       await expect(cron.run(job.id, "force")).resolves.toMatchObject({ ok: true });

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -14,6 +14,7 @@ import {
   onCronJobInactive,
   requestActiveCronJobCancellation,
 } from "../active-jobs.js";
+import { isHeartbeatTaskDeclarationKey } from "../heartbeat-task.js";
 import { cloneCronRuntimeAuthority, type CronRuntimeAuthority } from "../runtime-authority.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { removeCronJobBaseSession } from "../session-reaper.js";
@@ -303,11 +304,14 @@ export async function add(
   let pendingSessionCleanup: Promise<void> | undefined;
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
-    // Heartbeat monitors are gateway-converged system jobs; without this
-    // boundary any internal caller could upsert the declaration key and
-    // hijack the monitor despite the transport schemas excluding the kind.
+    const declarationKey = normalizeOptionalString(input.declarationKey);
     if (input.payload?.kind === "heartbeat" && opts?.systemOwned !== true) {
       throw new Error("heartbeat payloads are system-owned; jobs cannot be created with them");
+    }
+    if (isHeartbeatTaskDeclarationKey(declarationKey) && opts?.systemOwned !== true) {
+      throw new Error(
+        'cron declarationKey namespace "heartbeat-task:" is system-owned; jobs cannot be created with it',
+      );
     }
     await ensureLoaded(state, { skipRecompute: true });
     const agentId = resolveEffectiveJobAgentId(input, resolveCurrentDefaultAgentId(state));
@@ -326,7 +330,6 @@ export async function add(
       }
     }
     const normalizedInput = normalizedId ? { ...input, id: normalizedId } : input;
-    const declarationKey = normalizeOptionalString(input.declarationKey);
     const matches = declarationKey
       ? (state.store?.jobs.filter(
           (job) => job.declarationKey === declarationKey && (opts?.matchesExisting?.(job) ?? true),

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -389,7 +389,7 @@ export type CronAddInput = CronJobCreate;
 export type CronAddOptions = {
   matchesExisting?: (job: CronJob) => boolean;
   enabledExplicit?: boolean;
-  /** Gateway-owned system payloads (heartbeat monitors) require this opt-in. */
+  /** Gateway/doctor-owned heartbeat jobs require this opt-in at service creation. */
   systemOwned?: boolean;
   /** Authenticated caller provenance stamped by the service, never public input. */
   scheduledToolPolicy?: CronScheduledToolPolicy;


### PR DESCRIPTION
Closes #123728

## What Problem This Solves

Fixes an issue where users creating a main-session system-event automation could use a declaration key beginning with `heartbeat-task:` and have it silently treated as a doctor-migrated heartbeat task. Cron reported success while bypassing normal event delivery; with heartbeat disabled, the automation produced no operator-visible result.

## Why This Change Was Made

Cron creation now reserves the migrated heartbeat-task declaration namespace behind the existing `systemOwned` service authority. One canonical predicate owns prefix classification and is shared by creation validation and runtime job detection. Existing doctor-migrated rows remain executable, editable, and removable.

This deliberately avoids duplicating namespace policy in the CLI, Gateway schema, public config, protocol, or storage layer. The net-neutral attempt reused the existing ownership option and consolidated prefix detection; the remaining production growth establishes the missing owner boundary.

Production LOC: +14/-6 (net +8) | Tests: +28/-11 (net +17)

## User Impact

Ordinary automation declarations using the reserved `heartbeat-task:` namespace now fail with an explicit system-owned error before persistence. Normal declaration keys continue to create and run as before, and migrated heartbeat tasks remain fully manageable.

## Evidence

- Pre-fix regression: the reserved declaration unexpectedly resolved and persisted instead of rejecting.
- Focused current-main proof:
  - `node scripts/run-vitest.mjs src/cron/service.heartbeat-payload.test.ts src/commands/doctor-heartbeat-task-migration.test.ts`
  - 2 cron tests and 12 doctor-migration tests passed.
- Current changed gate:
  - `node scripts/check-changed.mjs -- src/commands/doctor-heartbeat-task-migration.test.ts src/cron/heartbeat-task.ts src/cron/service.heartbeat-payload.test.ts src/cron/service/ops-mutations.ts src/cron/service/state.ts`
  - Core production/test typechecks, changed-file Oxlint, formatting, import cycles, dependency, database-first, and repository guards passed. Remote workload routing was unavailable, so the wrapper used its documented local fallback.
- Full build passed on Blacksmith Testbox run [31814183883](https://github.com/openclaw/openclaw/actions/runs/31814183883).
- Isolated built CLI/Gateway proof with heartbeat disabled:
  - reserved declaration exited 1 with a system-owned error and persisted no job;
  - an ordinary declaration created, listed, and removed successfully;
  - isolated free port/state, no external delivery.
- Final immutable Codex autoreview: clean; no accepted/actionable findings. It confirmed the best-fix owner boundary and no Gateway, schema, config, protocol, security, or storage contract change.
