### PR TITLE
fix: show OS-incompatible always-on skills as unavailable

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -112,7 +112,7 @@ Detailed documentation goes here.
 | `export`   | Named export to use (defaults to `"default"`)        |
 | `os`       | Required platforms (e.g., `["darwin", "linux"]`)     |
 | `requires` | Required `bins`, `anyBins`, `env`, or `config` paths |
-| `always`   | Bypass eligibility checks (boolean)                  |
+| `always`   | Bypass `requires.*` checks on a compatible OS        |
 | `hookKey`  | Config key override (defaults to the hook name)      |
 | `homepage` | Docs URL shown by `openclaw hooks info`              |
 | `install`  | Installation methods                                 |

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -141,7 +141,7 @@ metadata: { "openclaw": { "requires": { "bins": ["gemini"] }, "primaryEnv": "GEM
     | `requires.env` | Each env var must exist in the process or config |
     | `requires.config` | Each `openclaw.json` path must be truthy |
     | `os` | Platform filter: `["darwin"]`, `["linux"]`, `["win32"]` |
-    | `always` | Set `true` to skip all gates and always include the skill |
+    | `always` | Include on a compatible OS even when `requires.*` checks fail |
 
     Full reference: [Skills — Gating](/tools/skills#gating).
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -357,7 +357,9 @@ metadata:
 ```
 
 <ParamField path="always" type="boolean">
-  When `true`, always include the skill and skip all other gates.
+  When `true`, include the skill whenever its `os` requirement is compatible,
+  bypassing `requires.bins`, `requires.anyBins`, `requires.env`, and
+  `requires.config`.
 </ParamField>
 
 <ParamField path="emoji" type="string">
@@ -369,7 +371,9 @@ metadata:
 </ParamField>
 
 <ParamField path="os" type='("darwin" | "linux" | "win32")[]'>
-  Platform filter. When set, the skill is only eligible on a listed OS.
+  Hard platform filter. When set, the skill is only eligible when the local
+  host or a connected remote runtime matches a listed OS. `always` does not
+  override this filter.
 </ParamField>
 
 <ParamField path="requires.bins" type="string[]">

--- a/src/hooks/hooks-status.test.ts
+++ b/src/hooks/hooks-status.test.ts
@@ -45,4 +45,45 @@ describe("hook status", () => {
       blockedReason: "no events defined",
     });
   });
+
+  it("keeps OS incompatibility visible for always-on hooks", () => {
+    const mismatchedOs = process.platform === "darwin" ? "linux" : "darwin";
+    const entry = createHookEntry({
+      source: "openclaw-workspace",
+      events: ["command:new"],
+    });
+    entry.metadata = {
+      ...entry.metadata,
+      events: ["command:new"],
+      always: true,
+      os: [mismatchedOs],
+      requires: { env: ["MISSING_HOOK_ENV"] },
+    };
+
+    const report = buildWorkspaceHookStatus("/tmp/workspace", {
+      entries: [entry],
+      config: {
+        hooks: {
+          internal: {
+            enabled: true,
+            entries: { "session-memory": { enabled: true } },
+          },
+        },
+      },
+    });
+
+    expect(report.hooks[0]).toMatchObject({
+      always: true,
+      requirementsSatisfied: false,
+      loadable: false,
+      blockedReason: "missing requirements",
+      missing: {
+        bins: [],
+        anyBins: [],
+        env: [],
+        config: [],
+        os: [mismatchedOs],
+      },
+    });
+  });
 });

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -125,7 +125,7 @@ function evaluateRuntimeRequires(params: RuntimeRequirementEvalParams): boolean 
   return true;
 }
 
-/** Evaluates OS gating and runtime requirements for skill/plugin entry eligibility. */
+/** Enforces OS compatibility before allowing `always` to bypass runtime requirements. */
 export function evaluateRuntimeEligibility(
   params: {
     os?: string[];

--- a/src/shared/requirements.test.ts
+++ b/src/shared/requirements.test.ts
@@ -121,7 +121,7 @@ describe("requirements evaluation", () => {
     expect(result.eligible).toBe(false);
   });
 
-  it("clears missing requirements when always is true but preserves config checks", () => {
+  it("clears runtime requirements when always is true on a compatible OS", () => {
     const result = evaluate({
       always: true,
       metadata: {
@@ -131,13 +131,32 @@ describe("requirements evaluation", () => {
           env: ["OPENAI_API_KEY"],
           config: ["browser.enabled"],
         },
-        os: ["darwin"],
+        os: ["linux"],
       },
     });
 
     expect(result.missing).toEqual({ bins: [], anyBins: [], env: [], config: [], os: [] });
     expect(result.configChecks).toEqual([{ path: "browser.enabled", satisfied: false }]);
     expect(result.eligible).toBe(true);
+  });
+
+  it("preserves OS incompatibility when always is true", () => {
+    const result = evaluate({
+      always: true,
+      metadata: {
+        requires: { bins: ["node"], env: ["OPENAI_API_KEY"] },
+        os: ["darwin"],
+      },
+    });
+
+    expect(result.missing).toEqual({
+      bins: [],
+      anyBins: [],
+      env: [],
+      config: [],
+      os: ["darwin"],
+    });
+    expect(result.eligible).toBe(false);
   });
 
   it("defaults missing metadata to empty requirements", () => {

--- a/src/shared/requirements.ts
+++ b/src/shared/requirements.ts
@@ -162,24 +162,22 @@ function evaluateRequirements(
   });
   const missingConfig = configChecks.filter((check) => !check.satisfied).map((check) => check.path);
 
-  // `always` keeps diagnostics visible while making runtime eligibility unconditional.
-  const missing = params.always
-    ? { bins: [], anyBins: [], env: [], config: [], os: [] }
-    : {
-        bins: missingBins,
-        anyBins: missingAnyBins,
-        env: missingEnv,
-        config: missingConfig,
-        os: missingOs,
-      };
+  // `always` bypasses runtime requirements, but OS remains a hard compatibility boundary.
+  const missing = {
+    bins: params.always ? [] : missingBins,
+    anyBins: params.always ? [] : missingAnyBins,
+    env: params.always ? [] : missingEnv,
+    config: params.always ? [] : missingConfig,
+    os: missingOs,
+  };
 
   const eligible =
-    params.always ||
-    (missing.bins.length === 0 &&
-      missing.anyBins.length === 0 &&
-      missing.env.length === 0 &&
-      missing.config.length === 0 &&
-      missing.os.length === 0);
+    missing.os.length === 0 &&
+    (params.always ||
+      (missing.bins.length === 0 &&
+        missing.anyBins.length === 0 &&
+        missing.env.length === 0 &&
+        missing.config.length === 0));
 
   return { missing, eligible, configChecks };
 }

--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -383,6 +383,7 @@ describe("buildWorkspaceSkillStatus", () => {
       }),
       frontmatter: {},
       metadata: {
+        always: true,
         os: [mismatchedOs],
         requires: { bins: ["fakebin"] },
         install: [
@@ -410,7 +411,7 @@ describe("buildWorkspaceSkillStatus", () => {
         primaryEnv: undefined,
         emoji: undefined,
         homepage: undefined,
-        always: false,
+        always: true,
         disabled: false,
         blockedByAllowlist: false,
         blockedByAgentFilter: false,
@@ -428,7 +429,7 @@ describe("buildWorkspaceSkillStatus", () => {
         },
         missing: {
           anyBins: [],
-          bins: ["fakebin"],
+          bins: [],
           config: [],
           env: [],
           os: [mismatchedOs],


### PR DESCRIPTION
Related: #122271  
Follow-up to the rejected approach in #122331

## What Problem This Solves

Skill and hook status evaluation disagreed with actual runtime loading when metadata combined `always: true` with an incompatible `os` restriction.

The runtime loader correctly treats `os` as a hard compatibility boundary and excludes the entry. However, status evaluation cleared the missing OS requirement and reported the same entry as eligible. The documentation also incorrectly described `always` as bypassing every gate.

This could make `openclaw skills` output, onboarding, doctor checks, and hook status claim that an entry was available when the runtime would not load it.

## Why This Change Was Made

Keep the established runtime behavior unchanged:

- `os` determines whether the local host or a connected remote runtime can support the entry.
- `always` bypasses `requires.bins`, `requires.anyBins`, `requires.env`, and `requires.config`.
- `always` does not bypass an incompatible `os` restriction.
- Entries without an `os` restriction continue working exactly as before.

The shared status evaluator now preserves OS incompatibility while clearing only the runtime requirements that `always` is intended to bypass. The skills and hooks documentation now states the same contract.

## User Impact

This does not change skill discovery, loading, prompt injection, or execution behavior.

Status and diagnostic surfaces now accurately report OS-incompatible always-on skills and hooks as unavailable instead of claiming they are eligible.

## Evidence

Focused regression coverage verifies:

- an always-on entry remains eligible on a compatible OS despite missing runtime requirements
- an always-on entry remains ineligible on an incompatible OS
- skill status preserves the missing OS requirement
- hook status preserves the missing OS requirement

Validation:

- 7 focused test files passed across 3 Vitest shards
- 76 tests passed
- formatting and documentation checks passed
- AutoReview reported no findings
