### PR TITLE
fix(gateway): profile display writes never invalidate the cached session list

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import { readSessionIdentityMutationVersion } from "../../sessions/session-lifecycle-events.js";
 import { readSessionTranscriptUpdateVersion } from "../../sessions/transcript-events.js";
+import { readUserProfileDisplayVersion } from "../../state/user-profiles.js";
 import { readSessionAutomationVersion } from "../session-automation-index.js";
 import { readSessionLifecyclePersistenceVersion } from "../session-lifecycle-state.js";
 import { isGatewayAdmin } from "../session-sharing.js";
@@ -20,6 +21,7 @@ type SessionListFence = {
   sessionsMutationVersion: number;
   sessionTranscriptUpdateVersion: number;
   titleProjectionUnavailableVersion: number;
+  userProfileDisplayVersion: number;
   workerPlacementDiskSpaceVersion: number;
 };
 type SessionListOperation = SessionListFence & { promise: Promise<SessionsListResult> };
@@ -44,6 +46,7 @@ function readSessionListFence(context: GatewayRequestContext): SessionListFence 
     // write without a session mutation must still invalidate reuse.
     sessionTranscriptUpdateVersion: readSessionTranscriptUpdateVersion(),
     titleProjectionUnavailableVersion: readSessionTitleProjectionUnavailableVersion(),
+    userProfileDisplayVersion: readUserProfileDisplayVersion(),
     workerPlacementDiskSpaceVersion: context.workerPlacementDiskSpaceReader?.version() ?? 0,
   };
 }
@@ -57,6 +60,7 @@ function matchesSessionListFence(value: SessionListFence, fence: SessionListFenc
     value.sessionsMutationVersion === fence.sessionsMutationVersion &&
     value.sessionTranscriptUpdateVersion === fence.sessionTranscriptUpdateVersion &&
     value.titleProjectionUnavailableVersion === fence.titleProjectionUnavailableVersion &&
+    value.userProfileDisplayVersion === fence.userProfileDisplayVersion &&
     value.workerPlacementDiskSpaceVersion === fence.workerPlacementDiskSpaceVersion
   );
 }

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -16,6 +16,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { ensureProfileForEmail, setDisplayName } from "../../state/user-profiles.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { bumpSessionAutomationVersion } from "../session-automation-index.js";
 import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
@@ -327,6 +328,29 @@ describe("sessions.list single-flight", () => {
       // historically bumped only the automation memo, so cached lists served
       // stale badges forever.
       bumpSessionAutomationVersion();
+      await listSessions({ client, context, request });
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("invalidates a completed result when a user profile display write happens", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+      const clock = vi.spyOn(Date, "now").mockReturnValue(60_400);
+      const profile = ensureProfileForEmail("renamed@example.com");
+
+      const first = await listSessions({ client, context, request });
+      clock.mockReturnValue(60_401);
+      expect(await listSessions({ client, context, request })).toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+
+      // projectSessionActor resolves createdActor/archivedBy labels and avatars
+      // fresh per row build via resolveCurrentUserProfileDisplay, but a cache
+      // hit skips that rebuild, so a rename needs its own fence input.
+      setDisplayName(profile.id, "Renamed Person");
       await listSessions({ client, context, request });
       expect(loader.calls).toHaveBeenCalledTimes(2);
     });

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -559,7 +559,7 @@ describe("user profiles", () => {
 
   it("bumps the sessions.list display fence only when linkEmail actually merges two profiles", () => {
     const options = stateOptions();
-    const source = ensureProfileForEmail("source@example.com", options);
+    ensureProfileForEmail("source@example.com", options);
     const target = ensureProfileForEmail("target@example.com", options);
     const before = readUserProfileDisplayVersion();
 

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -18,6 +18,7 @@ import {
   getUserProfileDisplay,
   linkEmail,
   listProfiles,
+  readUserProfileDisplayVersion,
   resolveUserProfileId,
   setAvatar,
   setDisplayName,
@@ -492,5 +493,83 @@ describe("user profiles", () => {
     expect(formatUserProfileAvatarEtag(png?.sha256 ?? "", png?.mime ?? "image/png")).not.toBe(
       formatUserProfileAvatarEtag(webp?.sha256 ?? "", webp?.mime ?? "image/png"),
     );
+  });
+
+  it("bumps the sessions.list display fence on setDisplayName writes", () => {
+    const options = stateOptions();
+    const profile = ensureProfileForEmail("ada@example.com", options);
+    const before = readUserProfileDisplayVersion();
+
+    setDisplayName(profile.id, "Ada Lovelace", options);
+
+    expect(readUserProfileDisplayVersion()).toBe(before + 1);
+  });
+
+  it("bumps the sessions.list display fence only when setAvatar actually writes", () => {
+    const options = stateOptions();
+    const profile = ensureProfileForEmail("ada@example.com", options);
+    const before = readUserProfileDisplayVersion();
+
+    expect(setAvatar(profile.id, new Uint8Array(512 * 1024 + 1), "image/png", options).ok).toBe(
+      false,
+    );
+    expect(readUserProfileDisplayVersion()).toBe(before);
+
+    expect(setAvatar(profile.id, new Uint8Array([1, 2, 3]), "image/png", options).ok).toBe(true);
+    expect(readUserProfileDisplayVersion()).toBe(before + 1);
+  });
+
+  it("bumps the sessions.list display fence only while Tailscale name adoption fills an empty slot", () => {
+    const options = stateOptions();
+    const profile = ensureProfileForTailscaleIdentity(
+      { login: "ada@github", name: "Ada Provider" },
+      options,
+    );
+    setDisplayName(profile.id, null, options);
+    const before = readUserProfileDisplayVersion();
+
+    ensureProfileForTailscaleIdentity({ login: "ada@github", name: "Ada Adopted" }, options);
+    expect(readUserProfileDisplayVersion()).toBe(before + 1);
+
+    ensureProfileForTailscaleIdentity({ login: "ada@github", name: "Provider Changed" }, options);
+    expect(readUserProfileDisplayVersion()).toBe(before + 1);
+  });
+
+  it("bumps the sessions.list display fence only while Tailscale avatar adoption fills an empty slot", async () => {
+    const options = stateOptions();
+    const bytes = fixtureImage("ui/public/favicon-32.png");
+    const identity = {
+      login: "ada@github",
+      name: "Ada Provider",
+      profilePic: "https://avatars.example.test/profile",
+    };
+    const profile = ensureProfileForTailscaleIdentity(identity, options);
+    const before = readUserProfileDisplayVersion();
+
+    await adoptTailscaleProfileAvatar(profile.id, identity.profilePic, options, {
+      fetchImpl: imageFetch(bytes, "image/png"),
+    });
+    expect(readUserProfileDisplayVersion()).toBe(before + 1);
+
+    await adoptTailscaleProfileAvatar(profile.id, identity.profilePic, options, {
+      fetchImpl: imageFetch(bytes, "image/png"),
+    });
+    expect(readUserProfileDisplayVersion()).toBe(before + 1);
+  });
+
+  it("bumps the sessions.list display fence only when linkEmail actually merges two profiles", () => {
+    const options = stateOptions();
+    const source = ensureProfileForEmail("source@example.com", options);
+    const target = ensureProfileForEmail("target@example.com", options);
+    const before = readUserProfileDisplayVersion();
+
+    // A brand-new alias on target does not change what any existing id resolves to.
+    linkEmail("new-alias@example.com", target.id, options);
+    expect(readUserProfileDisplayVersion()).toBe(before);
+
+    // Moving source's only alias merges source into target, so getUserProfileDisplay(source.id)
+    // now resolves through the one-hop merge to target's display name/avatar.
+    linkEmail("source@example.com", target.id, options);
+    expect(readUserProfileDisplayVersion()).toBe(before + 1);
   });
 });

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -107,6 +107,20 @@ type UserProfileListRow = Pick<
 const ensuredDatabases = new WeakSet<DatabaseSync>();
 const MAX_USER_PROFILE_DISPLAY_NAME_LENGTH = 256;
 
+// sessions.list cache fence input. projectSessionActor re-resolves the
+// actor label/avatar per row via resolveCurrentUserProfileDisplay on every
+// fresh row build, but a cache hit skips that rebuild, so every write that
+// changes what a profile id resolves to (rename, avatar upload, Tailscale-
+// identity adoption of an empty field, or a merge that re-points an id's
+// one-hop resolution target) needs its own fence input the same way the
+// sessions.list writers in this campaign (#123253/#123259/#123290) added
+// theirs.
+let userProfileDisplayVersion = 0;
+
+export function readUserProfileDisplayVersion(): number {
+  return userProfileDisplayVersion;
+}
+
 function profileDb(db: DatabaseSync) {
   return getNodeSqliteKysely<UserProfilesDatabase>(db);
 }
@@ -413,6 +427,7 @@ function adoptDisplayNameIfEmpty(
           .set({ display_name: displayName, updated_at: now })
           .where("id", "=", profile.id),
       );
+      userProfileDisplayVersion += 1;
       return toUserProfile({ ...profile, display_name: displayName, updated_at: now });
     },
     options,
@@ -455,6 +470,7 @@ async function adoptAvatarIfEmpty(params: {
           })
           .where("id", "=", profile.id),
       );
+      userProfileDisplayVersion += 1;
       return toUserProfile({
         ...profile,
         avatar: avatar.bytes,
@@ -589,6 +605,10 @@ export function linkEmail(
             .set({ merged_into: target.id, updated_at: now })
             .where("merged_into", "=", existingAlias.profile_id),
         );
+        // Every merged id's one-hop resolution now points at target, so its
+        // display/avatar changes too even though this write never touched
+        // display_name/avatar directly.
+        userProfileDisplayVersion += 1;
       } else {
         executeSqliteQuerySync(
           db,
@@ -622,6 +642,7 @@ export function setDisplayName(
           .set({ display_name: name, updated_at: now })
           .where("id", "=", profile.id),
       );
+      userProfileDisplayVersion += 1;
       return selectUserProfileListItemById(db, profile.id);
     },
     options,
@@ -655,6 +676,7 @@ export function setAvatar(
           .set({ avatar: bytes, avatar_mime: mime, avatar_sha256: sha256, updated_at: now })
           .where("id", "=", profile.id),
       );
+      userProfileDisplayVersion += 1;
       return selectUserProfileListItemById(db, profile.id);
     },
     options,


### PR DESCRIPTION
## Summary

**Prompt request:** Add a `sessions.list` cache fence version covering every write that changes what
a profile id resolves to — `setDisplayName`, `setAvatar`, the two Tailscale-identity adoption paths,
and `linkEmail` merges (5 mutation paths, collectively "profile display-resolution writes" below) —
so a cached response can no longer serve a stale actor label/avatar.

This PR does not close an issue.

## What changed since the last review

Only the proof changed; the diff is byte-identical to the reviewed head `fd95c59461d5`. The previous
capture drove the real cache gate but handed it a stub `run()` that returned an empty result, so it
showed the cache deciding to rebuild and explicitly said it did not observe the resolved actor value.
Review was right that this is not the same thing. The harness now calls the production
`buildGatewaySessionRow` inside `run()`, so the rows the cache stores and returns are really
projected, and the capture reads the actor label and avatar off them. Both the stale-value defect and
its repair are now observed rather than inferred.

### Status of the first scan's before-merge items

- **Add real behavior proof** — the direct production-path proof is done in this revision (cache gate + real row builder + real profile resolver); see Real behavior proof below. The end-to-end Gateway/UI capture is **not** done — the 2026-08-15 re-review names that as the remaining gap.
- **Merge risk: the harness stubs row loading and returns an empty result, so it proves the
  cache decision but not that a real actor label or avatar changes** — done; the harness now
  builds the row with the production `buildGatewaySessionRow` and the capture reads the label and
  avatar off the returned row on both sides.
- **Merge risk: production grows by 26 lines; the eight-line production comment should be
  compressed to the repository's concise invariant form** — not done in this revision. This round
  was scoped to closing the proof gap and the diff is deliberately byte-identical to the reviewed
  head, so the comment is unchanged. It is a wording change with no behavioral effect and I am
  happy to compress it on request.
- **Next step: contributor-supplied real behavior proof is still required before merge** — supplied for the direct production path; see the qualification on the first item.

The 2026-08-15 re-review raised the live dev-Gateway / Control-UI capture as the remaining proof gap.
That is not yet done; see the end of the proof section for why the previously stated blocker for it
does not actually hold and what would be involved.

### The two red checks on this head

`check-lint` and, with it, the `openclaw/ci-gate` aggregate are red on this head. The cause is not a
lint error: the job log ends with `The runner has received a shutdown signal ... The operation was
canceled` and `[oxlint] FAILED (exit 143)` — SIGTERM, while `[oxlint:core]` was still running after
120s ([job log](https://github.com/openclaw/openclaw/actions/runs/31818966393/job/94828129270)). The
run is also from the original submission and has not been re-attempted since. Locally on this exact
head, `node scripts/run-oxlint.mjs` over the four changed files exits 0. I cannot re-run upstream CI as a
contributor, so I am supplying the cause rather than presenting the gate as green. The local check
covers only the four changed files, not CI's full workload, so a re-run is what would establish
whether this was transient; I will push a rebase if you would rather see a fresh head go green.

## What Problem This Solves

After a profile display-resolution write (rename, avatar change, or merge — see Why This Change Was
Made), the `sessions.list` completed-result cache has no fence input that changes, so it keeps
matching and serving the pre-change result. The Control UI's "created by" / "archived by" owner-chip
renders whatever actor label/avatar `sessions.list` returns, so by construction it keeps showing the
stale value for as long as the cache entry keeps matching and has not separately expired
(`resolveSessionListExpiration` gives entries covering only settled sessions with no
`agentStatus.expiresAt` no time-based expiry) — which is until some unrelated fence field happens to
bump. The fence input is the only thing that unblocks a stale entry; a page reload leaves it
unchanged, and waiting only helps for the uncommon entries that carry a time-based expiry (per
above).

## Why This Change Was Made

`src/gateway/server-methods/sessions-list-cache.ts`'s `SessionListFence` type declares 8 monotonic
version fields (`agentRunIndexVersion`, `lifecyclePersistenceVersion`, `sessionAutomationVersion`,
`sessionIdentityMutationVersion`, `sessionsMutationVersion`, `sessionTranscriptUpdateVersion`,
`titleProjectionUnavailableVersion`, `workerPlacementDiskSpaceVersion`), one per distinct writer of
row-relevant state, but none of them covered a profile display mutation. `respondWithCachedSessionList`
serves the cached `completed.result` directly on a fence match without rebuilding rows, so
`projectSessionActor` — which resolves the actor label/avatar fresh via
`resolveCurrentUserProfileDisplay` on every row build — never re-runs on a cache hit. This fix adds
one `userProfileDisplayVersion` fence field and bumps it in `src/state/user-profiles.ts` at every
writer that changes what a profile id resolves to. Like the 8 existing fields, it is a process-local
in-memory counter with no persistence: it resets to 0 on gateway restart, which is fine because the
`sessions.list` completed-result cache is itself an in-memory `Map` that starts empty on the same
restart.

- `setDisplayName` — direct rename
- `setAvatar` — direct avatar change
- `adoptDisplayNameIfEmpty` (called from `ensureProfileForTailscaleIdentity`) — Tailscale-identity
  adoption of an empty display-name slot
- `adoptAvatarIfEmpty` (called from `adoptTailscaleProfileAvatar`) — Tailscale-identity adoption of
  an empty avatar slot
- `linkEmail`'s merge branch — merging the last alias off a source profile sets its `merged_into`,
  so `getUserProfileDisplay(sourceId)`'s one-hop resolution starts returning the target profile's
  name/avatar without any `display_name`/`avatar` column write on the source row itself

This is the same structural gap [PR #123253](https://github.com/openclaw/openclaw/pull/123253)
(`sessionAutomationVersion`), [PR #123259](https://github.com/openclaw/openclaw/pull/123259)
(terminal persistence), and [PR #123290](https://github.com/openclaw/openclaw/pull/123290)
(transcript commits) already fixed for 3 other `sessions.list` writers in the same campaign — each
of those PRs added exactly one fence field for its own writer, and this PR follows the same shape
for the profile-display writers, meaning every write in
`user-profiles.ts` that changes what an *existing* profile id resolves to for
`resolveCurrentUserProfileDisplay`. Profile creation (`ensureProfileForEmail`,
`ensureProfileForProviderIdentity`) only inserts a brand-new row and cannot change any other,
already-existing profile id's `display_name`/`avatar`/`merged_into`. A newly created id also cannot
appear in any `sessions.list` result computed before it existed. So creation has no stale row to
invalidate and needs no fence input.

## Non-Scope

Production changes are limited to `src/state/user-profiles.ts` and
`src/gateway/server-methods/sessions-list-cache.ts`: adding the one `userProfileDisplayVersion` fence
field and wiring it into the 5 profile display-resolution writers named above. The diff also touches
the two matching test files (`src/state/user-profiles.test.ts`,
`src/gateway/server-methods/sessions-read-cache.test.ts`) — 4 files total, +26/-0 production and
+103/-0 tests. See Evidence below for the state of the live-video capture.

## User Impact

A profile display-resolution write now invalidates a matching completed `sessions.list` cache entry,
so the next fetch rebuilds the row and re-resolves the actor instead of serving one projected before
the change. The session-list actor label/avatar (owner-chip "created by" / "archived by") therefore
reflects current profile data instead of staying stale until an unrelated cache invalidation happens
to occur. What the proof below establishes is the rebuild and the re-resolved actor value on the
returned row; the transport above `sessions.list` and the owner-chip rendering are unchanged by this
diff and are not exercised there.

## Evidence

### Focused tests (one command, two vitest project configs, 55/55 green in aggregate)

```
node scripts/run-vitest.mjs src/state/user-profiles.test.ts src/gateway/server-methods/sessions-read-cache.test.ts
```

The two files run under different vitest project configs (`unit` and `gateway`), so one command run
prints two summary blocks — 29 + 26 = 55 total, both green:

```
# unit config: src/state/user-profiles.test.ts
 Test Files  1 passed (1)
      Tests  29 passed (29)

# gateway config: src/gateway/server-methods/sessions-read-cache.test.ts
 Test Files  1 passed (1)
      Tests  26 passed (26)
```

Each writer above has a dedicated regression test. Each was individually teeth-checked: removed
only that writer's own `userProfileDisplayVersion += 1;` line (leaving the other 4 in place), ran
the test, confirmed the failure below, then restored the line:

| writer | test | result with only this writer's bump line removed |
|---|---|---|
| `setDisplayName` | `bumps the sessions.list display fence on setDisplayName writes` | `AssertionError: expected +0 to be 1` |
| `setAvatar` | `bumps the sessions.list display fence only when setAvatar actually writes` | `AssertionError: expected +0 to be 1` |
| Tailscale name adoption | `bumps the sessions.list display fence only while Tailscale name adoption fills an empty slot` | `AssertionError: expected 1 to be 2` |
| Tailscale avatar adoption | `bumps the sessions.list display fence only while Tailscale avatar adoption fills an empty slot` | `AssertionError: expected +0 to be 1` |
| `linkEmail` merge | `bumps the sessions.list display fence only when linkEmail actually merges two profiles` | `AssertionError: expected +0 to be 1` |
| gateway cache integration (`src/gateway/server-methods/sessions-read-cache.test.ts`) | `invalidates a completed result when a user profile display write happens` | `AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times` |

The last row is the only one that also removes the `SessionListFence` field and its wiring in
`sessions-list-cache.ts` (the whole diff reverted), since that test exercises the shared cache
function rather than a single writer.

The `linkEmail` merge case is included because it changes `getUserProfileDisplay`'s resolution
target for the source profile id the same way a direct rename does, even though it never writes
`display_name`/`avatar` on that row — a fence scoped to only the 4 direct writers would still leave
merges unfenced.

## Real behavior proof

Behavior addressed: a `sessions.list` response keeps serving the pre-write actor display after a profile display write, because a fence match reuses the completed result and the row — and with it `projectSessionActor` -> `resolveCurrentUserProfileDisplay` — is never rebuilt. This capture observes the resolved `createdActor` value on the returned row, not only the cache's rebuild decision.
Real environment tested: Linux x86_64, node v24.18.0, against a live SQLite state database in an isolated temp state root. Baseline `621220aea9ba` is this PR's merge base; candidate `fd95c59461d5` is this PR's head. The harness drives production code only — the real exported `respondWithCachedSessionList` (the cache gate), the real `setDisplayName` and `setAvatar` (two of the producers this PR wires), and the real `buildGatewaySessionRow` inside the `run()` callback, so every rebuilt row goes through the production `projectSessionActor` -> `resolveCurrentUserProfileDisplay` path and reads the durable profile. State isolation is `OPENCLAW_STATE_DIR` pointed at a fresh temp root before any production module is imported: the resolver takes no database argument, so this is the only way the seeded profile and the production resolver open the same file. Display names are synthetic ("Proof Actor Before" / "Proof Actor After") and the avatar is a 67-byte synthetic 1x1 PNG; no real identity, token or secret is involved. Both sides run one harness source, staged into each by the proof runner, which takes no branch on which side it is running.

Exact steps or command run after this patch:

```sh
# The harness drives these production modules directly, which is what the
# capture's stderr shows it importing on each side:
#   src/gateway/server-methods/sessions-list-cache.ts  (cache gate under test)
#   src/state/user-profiles.ts                         (producers + fence version)
#   src/gateway/session-utils.ts                       (real session-row builder)
clawproof work start profile-rename-sessions-list-fence --baseline 621220aea9baa22b002be1f4cd10230be2767f3d
git -C ~/.clawproof/work-items/profile-rename-sessions-list-fence/after reset --hard fd95c59461d58bf20f2c287ff54282cffefd6488
clawproof build plan profile-rename-sessions-list-fence --worktree before --apply
clawproof build plan profile-rename-sessions-list-fence --worktree after --apply
clawproof prove profile-rename-sessions-list-fence --scenario default --final --problem-file docs/work-items/profile-rename-sessions-list-fence/proof/problem.md
ocw proof import profile-rename-sessions-list-fence
```

Before (pre-fix):

```text
===== BEFORE (baseline 621220aea9ba, unfixed source) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/before/src/gateway/server-methods/sessions-list-cache.ts]
[harness: importing [REDACTED:path]/before/src/state/user-profiles.ts]
[harness: importing [REDACTED:path]/before/src/gateway/session-utils.ts]
[harness: seeded profile 21d030d8-003d-475e-a6e7-a441fd91e858 with display name "Proof Actor Before"]
[harness: running profile-rename-must-refresh-cached-actor-display]
[harness: renamed profile 21d030d8-003d-475e-a6e7-a441fd91e858 to "Proof Actor After"]
[harness: running no-profile-write-must-still-reuse-cache]
[harness: running avatar-upload-must-refresh-cached-actor-avatar]
[harness: uploaded 67-byte synthetic png avatar (ok=true)]
--- harness.stdout ---
{
  "moduleUnderTest": "src/gateway/server-methods/sessions-list-cache.ts",
  "results": [
    {
      "case": "profile-rename-must-refresh-cached-actor-display",
      "profileId": "21d030d8-003d-475e-a6e7-a441fd91e858",
      "firstRespondOk": true,
      "secondRespondOk": true,
      "firstActorLabel": "Proof Actor Before",
      "secondActorLabel": "Proof Actor Before",
      "actorDisplayRefreshed": false,
      "runCallsAfterFirstList": 1,
      "runCallsAfterSecondList": 1,
      "secondListRebuiltInsteadOfCached": false,
      "error": null
    },
    {
      "case": "no-profile-write-must-still-reuse-cache",
      "profileId": "21d030d8-003d-475e-a6e7-a441fd91e858",
      "firstActorLabel": "Proof Actor After",
      "secondActorLabel": "Proof Actor After",
      "actorLabelUnchanged": true,
      "runCallsAfterFirstList": 1,
      "runCallsAfterSecondList": 1,
      "secondListRebuiltInsteadOfCached": false,
      "error": null
    },
    {
      "case": "avatar-upload-must-refresh-cached-actor-avatar",
      "profileId": "21d030d8-003d-475e-a6e7-a441fd91e858",
      "avatarWriteOk": true,
      "avatarBytes": 67,
      "firstActorAvatarUrl": null,
      "secondActorAvatarUrl": null,
      "actorAvatarRefreshed": false,
      "runCallsAfterFirstList": 1,
      "runCallsAfterSecondList": 1,
      "secondListRebuiltInsteadOfCached": false,
      "error": null
    }
  ]
}

```

Evidence after fix:

```text
===== AFTER (candidate fd95c59461d5, fix applied) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/after/src/gateway/server-methods/sessions-list-cache.ts]
[harness: importing [REDACTED:path]/after/src/state/user-profiles.ts]
[harness: importing [REDACTED:path]/after/src/gateway/session-utils.ts]
[harness: seeded profile bfb631d8-f2aa-4abe-b790-a597114a2d96 with display name "Proof Actor Before"]
[harness: running profile-rename-must-refresh-cached-actor-display]
[harness: renamed profile bfb631d8-f2aa-4abe-b790-a597114a2d96 to "Proof Actor After"]
[harness: running no-profile-write-must-still-reuse-cache]
[harness: running avatar-upload-must-refresh-cached-actor-avatar]
[harness: uploaded 67-byte synthetic png avatar (ok=true)]
--- harness.stdout ---
{
  "moduleUnderTest": "src/gateway/server-methods/sessions-list-cache.ts",
  "results": [
    {
      "case": "profile-rename-must-refresh-cached-actor-display",
      "profileId": "bfb631d8-f2aa-4abe-b790-a597114a2d96",
      "firstRespondOk": true,
      "secondRespondOk": true,
      "firstActorLabel": "Proof Actor Before",
      "secondActorLabel": "Proof Actor After",
      "actorDisplayRefreshed": true,
      "runCallsAfterFirstList": 1,
      "runCallsAfterSecondList": 2,
      "secondListRebuiltInsteadOfCached": true,
      "error": null
    },
    {
      "case": "no-profile-write-must-still-reuse-cache",
      "profileId": "bfb631d8-f2aa-4abe-b790-a597114a2d96",
      "firstActorLabel": "Proof Actor After",
      "secondActorLabel": "Proof Actor After",
      "actorLabelUnchanged": true,
      "runCallsAfterFirstList": 1,
      "runCallsAfterSecondList": 1,
      "secondListRebuiltInsteadOfCached": false,
      "error": null
    },
    {
      "case": "avatar-upload-must-refresh-cached-actor-avatar",
      "profileId": "bfb631d8-f2aa-4abe-b790-a597114a2d96",
      "avatarWriteOk": true,
      "avatarBytes": 67,
      "firstActorAvatarUrl": null,
      "secondActorAvatarUrl": "/api/users/bfb631d8-f2aa-4abe-b790-a597114a2d96/avatar?v=e9ea8426b0adbf89b9d303a897bbe38bbbf930ffb1885dc9f41b4df9685a1cf5-png",
      "actorAvatarRefreshed": true,
      "runCallsAfterFirstList": 1,
      "runCallsAfterSecondList": 2,
      "secondListRebuiltInsteadOfCached": true,
      "error": null
    }
  ]
}
```

Observed result after fix: both runs exited 0 on the same harness bytes; only the production code they import differs.

- `profile-rename-must-refresh-cached-actor-display` — baseline: the rename lands in the profile store but the second `sessions.list` reuses the cached result, so the row still reads `Proof Actor Before` (`actorDisplayRefreshed` false, `runCallsAfterSecondList` stays 1). Candidate: the second call rebuilds and the same row reads `Proof Actor After` (`actorDisplayRefreshed` true, `runCallsAfterSecondList` 2). This is the observed stale-actor-label defect and its repair, read off the projected row.
- `avatar-upload-must-refresh-cached-actor-avatar` — baseline: after `setAvatar` the projected actor still carries no `avatarUrl` (`actorAvatarRefreshed` false, run count stays 1). Candidate: the rebuilt row carries the avatar URL with the new content hash (`actorAvatarRefreshed` true, run count 2). A second producer, same fence. Note the limit: this observes an avatar appearing for a profile that had none, not one uploaded avatar being replaced by another; both go through the same `setAvatar` fence bump, but only the first transition is captured here.
- `no-profile-write-must-still-reuse-cache` (control) — identical on both sides: no profile write between the two reads, the label does not move and `runCallsAfterSecondList` stays 1. Without this, a harness that rebuilt unconditionally would be indistinguishable from a working fence.
What was not tested: no Control UI or browser was driven. The harness calls the shared cache gate and the shared row builder directly rather than through a gateway RPC round-trip and a rendered owner chip, so the transport above `sessions.list` and `session-owner-chip.ts` (unmodified by this diff — it renders whatever `createdActor` it is given) are not exercised. A live Control UI video was not captured in this round. An earlier revision of this body claimed that capture was blocked because a bare token-authenticated dev-gateway connection never gets an `authenticatedUserProfile`; that reason was wrong and I am withdrawing it. `users.setDisplayName` gates on `canMutateProfile`, which also admits a connection carrying the `operator.admin` scope, so a rename can be driven through the real RPC inside the gateway process — which is what the in-process fence counter requires — without any Tailscale or email identity. So the UI capture looks feasible; it simply is not done yet, and this round was deliberately scoped to replacing the stubbed row loader. Of the five producers this PR wires, this capture exercises two (`setDisplayName`, `setAvatar`); the Tailscale-adoption and `linkEmail` merge paths are covered by the focused tests above, not by this capture.
