### PR TITLE
fix(nodes): prevent camera URL truncation on short writes

### DIFF
--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -10,6 +10,19 @@ import { withTempDir } from "../test-utils/temp-dir.js";
 
 type PublishOutputFileAtomically =
   typeof import("./output-file.runtime.js").publishOutputFileAtomically;
+type FsOpen = typeof import("node:fs/promises").open;
+
+const fsMocks = vi.hoisted(() => ({
+  actualOpen: undefined as FsOpen | undefined,
+  open: vi.fn<FsOpen>(),
+}));
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  fsMocks.actualOpen = actual.open;
+  fsMocks.open.mockImplementation(actual.open);
+  return { ...actual, open: fsMocks.open };
+});
 
 const fetchGuardMocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(
@@ -120,6 +133,10 @@ describe("nodes camera helpers", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    if (!fsMocks.actualOpen) {
+      throw new Error("expected actual fs.open implementation");
+    }
+    fsMocks.open.mockImplementation(fsMocks.actualOpen);
   });
 
   it("parses camera.snap payload", () => {
@@ -381,6 +398,7 @@ describe("nodes camera helpers", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -397,6 +415,77 @@ describe("nodes camera helpers", () => {
       expect(fetchGuardMocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
         expect.objectContaining({ requireHttps: true, timeoutMs: 15 * 60_000 }),
       );
+    });
+  });
+
+  it("fully publishes url chunks after a positive short write", async () => {
+    const chunks = [Buffer.from("positive short "), Buffer.from("write")];
+    const expected = Buffer.concat(chunks);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+    stubFetchResponse(new Response(stream, { status: 200 }));
+
+    await withCameraTempDir(async (dir) => {
+      const out = path.join(dir, "short-write.bin");
+      await fs.writeFile(out, "existing-camera");
+      const originalOpen = fsMocks.actualOpen;
+      if (!originalOpen) {
+        throw new Error("expected actual fs.open implementation");
+      }
+      let shortWriteObserved = false;
+      fsMocks.open.mockImplementation(async (...args) => {
+        const handle = await originalOpen(...args);
+        if (typeof args[0] !== "string" || path.dirname(args[0]) !== dir || args[1] !== "wx") {
+          return handle;
+        }
+
+        let injectShortWrite = true;
+        const injectedHandle = Object.create(handle) as typeof handle;
+        injectedHandle.close = handle.close.bind(handle);
+        injectedHandle.write = (async (
+          buffer: Uint8Array,
+          offset = 0,
+          length = buffer.byteLength - offset,
+        ) => {
+          const writeLength = injectShortWrite ? Math.max(1, Math.floor(length / 2)) : length;
+          injectShortWrite = false;
+          shortWriteObserved ||= writeLength < length;
+          return await handle.write(buffer, offset, writeLength);
+        }) as typeof handle.write;
+        injectedHandle.writeFile = (async (data: string | NodeJS.ArrayBufferView) => {
+          const buffer =
+            typeof data === "string"
+              ? Buffer.from(data)
+              : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+          let offset = 0;
+          while (offset < buffer.byteLength) {
+            const { bytesWritten } = await injectedHandle.write(
+              buffer,
+              offset,
+              buffer.byteLength - offset,
+            );
+            offset += bytesWritten;
+          }
+        }) as typeof handle.writeFile;
+        return injectedHandle;
+      });
+
+      await writeCameraPayloadToFile({
+        filePath: out,
+        payload: { url: "https://198.51.100.42/short-write.bin" },
+        expectedHost: "198.51.100.42",
+      });
+
+      expect(shortWriteObserved).toBe(true);
+      await expect(fs.readFile(out)).resolves.toEqual(expected);
+      await expect(fs.stat(out)).resolves.toMatchObject({ size: expected.byteLength });
+      expect(await fs.readdir(dir)).toEqual(["short-write.bin"]);
     });
   });
 

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -213,7 +213,7 @@ async function writeUrlToFile(filePath: string, url: string, opts: { expectedHos
                 `writeUrlToFile: downloaded ${bytes} bytes, exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
               );
             }
-            await fileHandle.write(value);
+            await fileHandle.writeFile(value);
           }
         } catch (err) {
           await reader.cancel().catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where URL-backed camera snapshots and clips could be published as truncated files when the filesystem completed a legal positive short write.

## Why This Change Was Made

The camera downloader now uses Node's full-write `FileHandle.writeFile()` primitive for each response chunk before the existing atomic publisher can expose the destination. Download limits, response cancellation, destination-mode preservation, and temp-file cleanup remain unchanged.

The regression test injects a real positive short write at the file-handle boundary and verifies the complete response bytes, final size, atomic replacement, and absence of leaked temp files.

## User Impact

Camera URL artifacts now contain the complete node response even when the underlying filesystem writes only part of a requested chunk on its first attempt.

## Evidence

- Pre-fix fault injection failed because the published file was missing eight bytes.
- `node scripts/run-vitest.mjs src/cli/nodes-camera.test.ts` — 43 tests passed.
- `node scripts/check-changed.mjs -- src/cli/nodes-camera.ts src/cli/nodes-camera.test.ts` — passed on Blacksmith Testbox (`tbx_01m00ejy8pasfsqg6vd1sz6dgk`): https://github.com/openclaw/openclaw/actions/runs/31815202818
- Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh Codex-backed autoreview reported no accepted/actionable findings.
- Production LOC: +1/-1 (net 0). Tests: +89/-0.

AI-assisted; the final code, dependency contract, regression behavior, and proof were independently reviewed.
