### PR TITLE
fix(gateway): prevent workspace sync truncation on short writes

### DIFF
--- a/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import type { Server } from "node:http";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { NODE_WORKER_WORKSPACE_EXEC_COMMAND } from "../../infra/node-commands.js";
 import { invokeNodeWorkerSupervisorCommand } from "../../node-host/node-worker-supervisor-commands.js";
@@ -15,6 +15,10 @@ import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 async function listen(server: Server): Promise<string> {
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -25,6 +29,86 @@ async function listen(server: Server): Promise<string> {
     throw new Error("workspace transfer test server did not bind");
   }
   return `ws://127.0.0.1:${address.port}`;
+}
+
+function injectUploadWriteFaults() {
+  const originalOpen = fs.open.bind(fs);
+  let beforeRetry: (() => Promise<void>) | undefined;
+  let nextWriteError: Error | undefined;
+  let stagingRoot: string | undefined;
+  let observedShortWrite = false;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await originalOpen(...args);
+    if (
+      typeof args[0] !== "string" ||
+      !args[0].includes(`${path.sep}upload-`) ||
+      path.basename(args[0]) !== "result.txt" ||
+      args[1] !== "wx"
+    ) {
+      return handle;
+    }
+
+    stagingRoot = path.dirname(args[0]);
+    let injectShortWrite = true;
+    const injectedHandle = Object.create(handle) as typeof handle;
+    injectedHandle.close = handle.close.bind(handle);
+    injectedHandle.write = (async (
+      buffer: Buffer,
+      offset = 0,
+      length = buffer.byteLength - offset,
+      position?: number | null,
+    ) => {
+      if (nextWriteError) {
+        const error = nextWriteError;
+        nextWriteError = undefined;
+        throw error;
+      }
+      if (injectShortWrite) {
+        injectShortWrite = false;
+        const writeLength = Math.max(1, Math.floor(length / 2));
+        observedShortWrite ||= writeLength < length;
+        return await handle.write(buffer, offset, writeLength, position);
+      }
+      const retryHook = beforeRetry;
+      beforeRetry = undefined;
+      await retryHook?.();
+      return await handle.write(buffer, offset, length, position);
+    }) as typeof handle.write;
+    return injectedHandle;
+  });
+
+  return {
+    blockNextRetry() {
+      let markStarted!: () => void;
+      let release!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const released = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      beforeRetry = async () => {
+        markStarted();
+        await released;
+      };
+      return { started, release };
+    },
+    failNextWrite(error: Error) {
+      nextWriteError = error;
+    },
+    lastStagingRoot: () => stagingRoot,
+    shortWriteObserved: () => observedShortWrite,
+  };
+}
+
+function retryOrUploadStatus(retryStarted: Promise<void>, upload: Promise<unknown>) {
+  return Promise.race([
+    retryStarted.then(() => "retrying" as const),
+    upload.then(
+      () => "completed" as const,
+      () => "failed" as const,
+    ),
+  ]);
 }
 
 describe("node workspace transfer service", () => {
@@ -130,26 +214,42 @@ describe("node workspace transfer service", () => {
         fs.readFile(path.join(downloaded.workspaceDir, "nested", "input.txt"), "utf8"),
       ).resolves.toBe("nested input\n");
       await fs.writeFile(path.join(downloaded.workspaceDir, "result.txt"), "node result\n");
+      const writeFaults = injectUploadWriteFaults();
+      const persistenceRetry = writeFaults.blockNextRetry();
+      const uploadResult = (token: string) =>
+        runtime.exec(
+          {
+            gatewayNamespace: "gateway-test",
+            environmentId: "environment-1",
+            sessionId: "session-1",
+            generation: 2,
+            argv: ["openclaw-internal-workspace-transfer"],
+            transfer: {
+              direction: "upload",
+              token,
+              baseManifestRef: prepared.snapshot.manifestRef,
+            },
+          },
+          undefined,
+          { url: gatewayUrl },
+        );
       const uploadToken = service.prepareUpload("environment-1", prepared.snapshot.manifestRef);
       expect(() => service.prepareUpload("environment-1", prepared.snapshot.manifestRef)).toThrow(
         "already active",
       );
-      await runtime.exec(
-        {
-          gatewayNamespace: "gateway-test",
-          environmentId: "environment-1",
-          sessionId: "session-1",
-          generation: 2,
-          argv: ["openclaw-internal-workspace-transfer"],
-          transfer: {
-            direction: "upload",
-            token: uploadToken,
-            baseManifestRef: prepared.snapshot.manifestRef,
-          },
-        },
-        undefined,
-        { url: gatewayUrl },
-      );
+      const upload = uploadResult(uploadToken);
+      try {
+        await expect(retryOrUploadStatus(persistenceRetry.started, upload)).resolves.toBe(
+          "retrying",
+        );
+        expect(writeFaults.shortWriteObserved()).toBe(true);
+        expect(() => service.takeUpload("environment-1", prepared.snapshot.manifestRef)).toThrow(
+          "did not complete",
+        );
+      } finally {
+        persistenceRetry.release();
+      }
+      await upload;
       const replay = await fetch(
         `${httpOrigin}/__openclaw__/worker-transfer/v1/environments/environment-1/reconciliations/${prepared.snapshot.manifestRef.slice(7)}`,
         {
@@ -165,6 +265,21 @@ describe("node workspace transfer service", () => {
       await expect(
         fs.readFile(path.join(uploaded.stagingRoot, "result.txt"), "utf8"),
       ).resolves.toBe("node result\n");
+      writeFaults.failNextWrite(new Error("injected terminal upload write failure"));
+      const failedUploadToken = service.prepareUpload(
+        "environment-1",
+        prepared.snapshot.manifestRef,
+      );
+      await expect(uploadResult(failedUploadToken)).rejects.toThrow("workspace-transfer-failed");
+      expect(writeFaults.lastStagingRoot()).toBeDefined();
+      await expect(fs.stat(writeFaults.lastStagingRoot()!)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      const resetUploadToken = service.prepareUpload(
+        "environment-1",
+        prepared.snapshot.manifestRef,
+      );
+      service.revoke("environment-1", resetUploadToken);
       const acceptedToken = service.publishSnapshot("environment-1", {
         manifest: uploaded.current,
         manifestRef: uploaded.currentManifestRef,
@@ -176,6 +291,29 @@ describe("node workspace transfer service", () => {
       expect(service.getSnapshot("environment-1", prepared.snapshot.manifestRef)).toBeUndefined();
       expect(service.getSnapshot("environment-1", uploaded.currentManifestRef)).toBeDefined();
       service.revoke("environment-1", acceptedToken);
+
+      const authorityRetry = writeFaults.blockNextRetry();
+      const retiredUploadToken = service.prepareUpload(
+        "environment-1",
+        prepared.snapshot.manifestRef,
+      );
+      const retiredUpload = uploadResult(retiredUploadToken);
+      try {
+        await expect(retryOrUploadStatus(authorityRetry.started, retiredUpload)).resolves.toBe(
+          "retrying",
+        );
+        environment.ownerEpoch += 1;
+      } finally {
+        authorityRetry.release();
+      }
+      await expect(retiredUpload).rejects.toThrow("workspace-transfer-failed");
+      expect(writeFaults.lastStagingRoot()).toBeDefined();
+      await expect(fs.stat(writeFaults.lastStagingRoot()!)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(() => service.takeUpload("environment-1", prepared.snapshot.manifestRef)).toThrow(
+        "did not complete",
+      );
     } finally {
       await service.closeAll();
       server.closeAllConnections();

--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -241,8 +241,21 @@ async function streamUploadFile(params: {
       throw new Error("Workspace transfer upload ended mid-file");
     }
     hash.update(chunk);
-    await params.handle.write(chunk, 0, chunk.length, offset);
-    params.assertCurrent();
+    let chunkOffset = 0;
+    while (chunkOffset < chunk.length) {
+      const { bytesWritten } = await params.handle.write(
+        chunk,
+        chunkOffset,
+        chunk.length - chunkOffset,
+        offset + chunkOffset,
+      );
+      // A short write adds another await, so each suffix retry needs its own authority fence.
+      params.assertCurrent();
+      if (bytesWritten === 0) {
+        throw new Error("Workspace transfer upload write made no progress");
+      }
+      chunkOffset += bytesWritten;
+    }
     offset += chunk.length;
   }
   if (hash.digest("hex") !== params.entry.sha256) {

--- a/src/gateway/worker-environments/workspace-sync-inventory.ts
+++ b/src/gateway/worker-environments/workspace-sync-inventory.ts
@@ -277,7 +277,7 @@ export async function runWorkspaceInventoryCommandToFile(params: {
           childStdout.pause();
           outputWrite = outputWrite
             .then(async () => {
-              await output.write(chunk);
+              await output.writeFile(chunk);
               childStdout.resume();
             })
             .catch((error: unknown) => {
@@ -345,7 +345,7 @@ async function writeEligibleGitFiles(params: {
     if (buffered.length === 0) {
       return;
     }
-    await output.write(buffered.join(""));
+    await output.writeFile(buffered.join(""));
     buffered = [];
     bufferedBytes = 0;
   };

--- a/src/gateway/worker-environments/workspace-sync-local.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-local.test.ts
@@ -8,14 +8,73 @@ import {
   MAX_WORKSPACE_GIT_CANDIDATES,
   MAX_WORKSPACE_INVENTORY_ENTRIES,
 } from "./workspace-inventory-limits.js";
-import { createGitTransferList, runLocalCommandToFile } from "./workspace-sync-local.js";
+import {
+  createGitTransferList,
+  filterExistingGitTransferList,
+  runLocalCommandToFile,
+} from "./workspace-sync-local.js";
 import { preflightWorkerWorkspace } from "./workspace-sync-preflight.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
+
+function injectPositiveShortWrite(targetPath: string): () => boolean {
+  const originalOpen = fs.open.bind(fs);
+  let shortWriteObserved = false;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await originalOpen(...args);
+    if (
+      typeof args[0] !== "string" ||
+      path.resolve(args[0]) !== path.resolve(targetPath) ||
+      args[1] !== "wx"
+    ) {
+      return handle;
+    }
+
+    let injectShortWrite = true;
+    const injectedHandle = Object.create(handle) as typeof handle;
+    injectedHandle.close = handle.close.bind(handle);
+    injectedHandle.write = (async (
+      data: string | NodeJS.ArrayBufferView,
+      offsetOrPosition: number | null = null,
+      length?: number | null,
+      position?: number | null,
+    ) => {
+      const buffer =
+        typeof data === "string"
+          ? Buffer.from(data)
+          : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+      const offset = typeof data === "string" ? 0 : (offsetOrPosition ?? 0);
+      const requested =
+        typeof data === "string" ? buffer.length : (length ?? buffer.length - offset);
+      const filePosition = typeof data === "string" ? offsetOrPosition : position;
+      const writeLength = injectShortWrite ? Math.max(1, Math.floor(requested / 2)) : requested;
+      injectShortWrite = false;
+      shortWriteObserved ||= writeLength < requested;
+      return await handle.write(buffer, offset, writeLength, filePosition);
+    }) as typeof handle.write;
+    injectedHandle.writeFile = (async (data: string | NodeJS.ArrayBufferView) => {
+      const buffer =
+        typeof data === "string"
+          ? Buffer.from(data)
+          : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+      let offset = 0;
+      while (offset < buffer.length) {
+        const { bytesWritten } = await injectedHandle.write(buffer, offset, buffer.length - offset);
+        if (bytesWritten === 0) {
+          throw new Error("injected file write made no progress");
+        }
+        offset += bytesWritten;
+      }
+    }) as typeof handle.writeFile;
+    return injectedHandle;
+  });
+  return () => shortWriteObserved;
+}
 
 async function git(root: string, ...args: string[]): Promise<string> {
   const result = await runCommandWithTimeout(["git", "-C", root, ...args], {
@@ -41,6 +100,69 @@ async function waitForFile(filePath: string): Promise<void> {
 }
 
 describe("runLocalCommandToFile", () => {
+  it("fully persists bounded stdout after a positive short write", async () => {
+    const root = tempDirs.make("openclaw-workspace-command-short-write-");
+    const outputPath = path.join(root, "output");
+    const expected = Buffer.from("bounded workspace inventory output\n");
+    const shortWriteObserved = injectPositiveShortWrite(outputPath);
+
+    await runLocalCommandToFile({
+      argv: [process.execPath, "-e", "process.stdout.write(process.argv[1])", expected.toString()],
+      outputPath,
+      signal: new AbortController().signal,
+      timeoutMs: 10_000,
+      maxOutputBytes: expected.length,
+    });
+
+    expect(shortWriteObserved()).toBe(true);
+    await expect(fs.readFile(outputPath)).resolves.toEqual(expected);
+  });
+
+  it("fully persists a buffered Git transfer list after a positive short write", async () => {
+    const root = tempDirs.make("openclaw-workspace-list-short-write-");
+    const temporaryDirectory = `${root}-transfer`;
+    const outputPath = path.join(temporaryDirectory, "transfer-list");
+    await fs.mkdir(path.join(root, "nested"));
+    await Promise.all([
+      fs.writeFile(path.join(root, "alpha.txt"), "alpha"),
+      fs.writeFile(path.join(root, "nested", "beta.txt"), "beta"),
+    ]);
+    await git(root, "init", "--quiet");
+    const shortWriteObserved = injectPositiveShortWrite(outputPath);
+
+    await createGitTransferList({
+      gitRoot: root,
+      temporaryDirectory,
+      signal: new AbortController().signal,
+      timeoutMs: 10_000,
+    });
+
+    expect(shortWriteObserved()).toBe(true);
+    await expect(fs.readFile(outputPath)).resolves.toEqual(
+      Buffer.from("alpha.txt\0nested/beta.txt\0"),
+    );
+  });
+
+  it("fully persists a filtered Git transfer list after a positive short write", async () => {
+    const root = tempDirs.make("openclaw-workspace-filter-short-write-");
+    const preparedListPath = path.join(root, "prepared");
+    const outputPath = path.join(root, "filtered");
+    await fs.mkdir(path.join(root, "nested"));
+    await Promise.all([
+      fs.writeFile(path.join(root, "alpha.txt"), "alpha"),
+      fs.writeFile(path.join(root, "nested", "beta.txt"), "beta"),
+      fs.writeFile(preparedListPath, "alpha.txt\0missing.txt\0nested/beta.txt\0"),
+    ]);
+    const shortWriteObserved = injectPositiveShortWrite(outputPath);
+
+    await filterExistingGitTransferList({ gitRoot: root, preparedListPath, outputPath });
+
+    expect(shortWriteObserved()).toBe(true);
+    await expect(fs.readFile(outputPath)).resolves.toEqual(
+      Buffer.from("alpha.txt\0nested/beta.txt\0"),
+    );
+  });
+
   it("force-kills a command that ignores abort termination", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-sync-"));
     const outputPath = path.join(root, "output");

--- a/src/gateway/worker-environments/workspace-sync-local.ts
+++ b/src/gateway/worker-environments/workspace-sync-local.ts
@@ -84,7 +84,7 @@ export async function filterExistingGitTransferList(params: {
         throw error;
       });
       if (stats?.isFile() || stats?.isSymbolicLink()) {
-        await output.write(`${file}\0`);
+        await output.writeFile(`${file}\0`);
       }
     }
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where workspace synchronization could truncate uploaded files, bounded command output, or generated transfer lists when the filesystem completed a legal positive short write. Reconcile uploads were eventually rejected by the staging manifest check, while the local inventory writers could return normally with incomplete files.

## Why This Change Was Made

The workspace-sync owner now enforces full persistence at every raw file-handle boundary:

- delegated reconcile uploads retry the unwritten suffix at exact source and file offsets;
- delegated authority is revalidated after every awaited retry and zero-progress writes fail closed;
- fresh sequential inventory and transfer-list writers use Node's full-write `FileHandle.writeFile()` primitive.

Existing byte limits, digest verification, staging isolation, completed-upload publication, and cleanup remain authoritative. This does not change protocol or persistent state.

## User Impact

Workspace transfers no longer fail or silently emit truncated inventory files solely because an underlying write persisted only a positive prefix. Authority retirement and terminal write failures continue to remove staging and leave the upload unavailable.

## Evidence

- Pre-fix reconcile fault injection failed before the suffix could be persisted; staging validation rejected the truncated file.
- Pre-fix sibling fault injection produced three normally returned but truncated outputs: bounded stdout, buffered Git transfer paths, and filtered NUL paths.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/node-workspace-transfer-service.test.ts src/gateway/worker-environments/workspace-sync-local.test.ts` — 13 tests passed.
- `node scripts/check-changed.mjs -- <five changed workspace paths>` — passed on Blacksmith Testbox (`tbx_01m00gepg8c19qbfw2e3fp2gt1`): https://github.com/openclaw/openclaw/actions/runs/31817841929
- Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh Codex-backed autoreview reported no accepted/actionable findings.
- Production LOC: +18/-5 (net +13). The growth is the explicit positional retry loop required to preserve the delegated-authority fence after each awaited write; the three sequential sibling fixes are net zero. Tests: +278/-18.

Named follow-up: reset claimed uploads after failures that occur before the staging cleanup scope begins. That is a separate lifecycle defect and is intentionally not changed here.

AI-assisted; the final owner boundary, authority behavior, regressions, and proof were independently reviewed.
