### PR TITLE
fix(web-fetch): reject failed provider target statuses

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.test.ts
+++ b/extensions/firecrawl/src/firecrawl-client.test.ts
@@ -550,6 +550,48 @@ describe("parseFirecrawlScrapePayload", () => {
     expect(result.status).toBe(200);
   });
 
+  it.each([
+    ["metadata numeric 404", { metadata: { statusCode: 404 } }, 404],
+    ["data numeric 500", { statusCode: 500 }, 500],
+    ["metadata numeric-string 404", { metadata: { statusCode: "404" } }, 404],
+  ])("rejects unsuccessful target status from %s", (_name, statusFields, statusCode) => {
+    expect(() =>
+      firecrawlClient.parseFirecrawlScrapePayload({
+        ...baseOpts,
+        payload: {
+          data: {
+            markdown: "failed target content",
+            ...statusFields,
+          },
+        },
+      }),
+    ).toThrow(
+      `Firecrawl fetch failed (${statusCode}): target returned an unsuccessful HTTP status.`,
+    );
+  });
+
+  it.each([
+    ["metadata numeric 201", { metadata: { statusCode: 201 } }, 201],
+    ["data numeric-string 200", { statusCode: "200" }, 200],
+    [
+      "data fallback after unparseable metadata",
+      { statusCode: "201", metadata: { statusCode: "unknown" } },
+      201,
+    ],
+  ])("accepts successful target status from %s", (_name, statusFields, statusCode) => {
+    const result = firecrawlClient.parseFirecrawlScrapePayload({
+      ...baseOpts,
+      payload: {
+        data: {
+          markdown: "successful target content",
+          ...statusFields,
+        },
+      },
+    });
+
+    expect(result.status).toBe(statusCode);
+  });
+
   it("falls back to data.url for finalUrl when metadata.sourceURL is absent", () => {
     const result = firecrawlClient.parseFirecrawlScrapePayload({
       ...baseOpts,
@@ -739,15 +781,13 @@ describe("parseFirecrawlScrapePayload", () => {
     expect(result.warning).toBeUndefined();
   });
 
-  it("ignores non-numeric statusCode values", () => {
-    // Firecrawl may return statusCode as a string in some response shapes.
-    // The check is `typeof ... === "number"`, so strings are treated as absent.
+  it("ignores unparseable statusCode values", () => {
     const result = firecrawlClient.parseFirecrawlScrapePayload({
       ...baseOpts,
       payload: {
         data: {
           markdown: "content",
-          statusCode: "200",
+          statusCode: "not-a-status",
         },
       },
     });

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -1,5 +1,6 @@
 // Firecrawl plugin module implements firecrawl client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { parseFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
@@ -561,6 +562,13 @@ export function parseFirecrawlScrapePayload(params: {
     data.metadata && typeof data.metadata === "object"
       ? (data.metadata as Record<string, unknown>)
       : undefined;
+  const rawStatus = parseFiniteNumber(metadata?.statusCode) ?? parseFiniteNumber(data.statusCode);
+  const status = rawStatus === undefined ? undefined : Math.floor(rawStatus);
+  if (status !== undefined && (status < 200 || status >= 300)) {
+    throw new Error(
+      `Firecrawl fetch failed (${status}): target returned an unsuccessful HTTP status.`,
+    );
+  }
   const markdown =
     (typeof data.markdown === "string" && data.markdown) ||
     (typeof data.content === "string" && data.content) ||
@@ -582,10 +590,6 @@ export function parseFirecrawlScrapePayload(params: {
     source: "web_fetch",
     includeWarning: false,
   });
-  const status =
-    (typeof metadata?.statusCode === "number" && metadata.statusCode) ||
-    (typeof data.statusCode === "number" && data.statusCode) ||
-    undefined;
   const title =
     typeof metadata?.title === "string" && metadata.title
       ? wrapBoundedMetadata(metadata.title)

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -41,10 +41,6 @@ const SEARCH_CACHE = new Map<
   string,
   { value: Record<string, unknown>; expiresAt: number; insertedAt: number }
 >();
-const SCRAPE_CACHE = new Map<
-  string,
-  { value: Record<string, unknown>; expiresAt: number; insertedAt: number }
->();
 const DEFAULT_SEARCH_COUNT = 5;
 const FIRECRAWL_SEARCH_MAX_RESULTS = 100;
 const FIRECRAWL_SEARCH_MAX_CONTENT_CHARS = 20_000;
@@ -653,24 +649,6 @@ export async function runFirecrawlScrape(
       ? Math.floor(params.maxChars)
       : DEFAULT_SCRAPE_MAX_CHARS;
   const maxChars = Math.min(requestedMaxChars, maxCharsCap);
-  const cacheKey = normalizeCacheKey(
-    JSON.stringify({
-      type: "firecrawl-scrape",
-      url: params.url,
-      extractMode: params.extractMode,
-      baseUrl,
-      onlyMainContent,
-      maxAgeMs,
-      proxy,
-      storeInCache,
-      maxChars,
-    }),
-  );
-  const cached = readCache(SCRAPE_CACHE, cacheKey);
-  if (cached) {
-    return { ...cached.value, cached: true };
-  }
-
   const endpoint = await resolveEndpoint(baseUrl, "/v2/scrape");
   const payload = await postFirecrawlJson(
     {
@@ -718,12 +696,6 @@ export async function runFirecrawlScrape(
     extractMode: params.extractMode,
     maxChars,
   });
-  writeCache(
-    SCRAPE_CACHE,
-    cacheKey,
-    result,
-    resolveCacheTtlMs(undefined, DEFAULT_CACHE_TTL_MINUTES),
-  );
   return result;
 }
 

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -223,6 +223,45 @@ describe("firecrawl tools", () => {
     expect((failure as Error).message.length).toBeLessThan(5_000);
   });
 
+  it("does not cache failed target statuses and observes recovery", async () => {
+    const targetStatuses = [404, 404, 200];
+    const fetchMock = vi.fn(async () => {
+      const statusCode = targetStatuses.shift();
+      return Response.json({
+        success: true,
+        data: {
+          markdown: `target status ${statusCode}`,
+          metadata: {
+            sourceURL: "https://example.com/firecrawl-target-recovery",
+            statusCode,
+          },
+        },
+      });
+    });
+    global.fetch = fetchMock as typeof fetch;
+    const params = {
+      cfg: {
+        plugins: {
+          entries: { firecrawl: { config: { webFetch: { apiKey: "firecrawl-owner-test" } } } },
+        },
+      } as OpenClawConfig,
+      url: "https://example.com/firecrawl-target-recovery",
+      extractMode: "markdown" as const,
+    };
+
+    await expect(runActualFirecrawlScrape(params)).rejects.toThrow(
+      "Firecrawl fetch failed (404): target returned an unsuccessful HTTP status.",
+    );
+    await expect(runActualFirecrawlScrape(params)).rejects.toThrow(
+      "Firecrawl fetch failed (404): target returned an unsuccessful HTTP status.",
+    );
+    const recovered = await runActualFirecrawlScrape(params);
+
+    expect(recovered.status).toBe(200);
+    expect(recovered.cached).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it.each(["search", "scrape"] as const)(
     "propagates exact %s cancellation into the actual guarded fetch signal",
     async (operation) => {


### PR DESCRIPTION
Closes #123740

## What Problem This Solves

Firecrawl can return a successful API envelope whose scrape metadata contains the target page's HTTP 4xx/5xx status. OpenClaw previously treated that payload as a successful provider result, and the Firecrawl plugin also kept a redundant process-local scrape cache that could hide later same-URL recovery.

## Why This Change Was Made

The target-status invariant is now owned by Firecrawl. Its adapter parses finite numeric and numeric-string status codes from Firecrawl response metadata (with the documented data-level fallback) and rejects target statuses outside 2xx before content normalization or any successful return.

The generic `WebFetchProviderToolDefinition.execute` result remains an untyped record, and core provider normalization is unchanged. Firecrawl's process-local scrape cache is removed; Firecrawl's service-side `maxAge` and `storeInCache` controls remain authoritative, while core continues to cache successful `web_fetch` results.

Current upstream contracts checked:

- Firecrawl scrape API: `maxAge: 0` bypasses index reuse, and `storeInCache: false` prevents storage: https://docs.firecrawl.dev/api-reference/endpoint/scrape
- Firecrawl SDK types document `maxAge`, `storeInCache`, and response `metadata.statusCode`: https://github.com/firecrawl/firecrawl/blob/c54c3f7a6552aa079d4a2fd753d93df15a5656e2/apps/js-sdk/firecrawl/src/v2/types.ts#L209-L216 and https://github.com/firecrawl/firecrawl/blob/c54c3f7a6552aa079d4a2fd753d93df15a5656e2/apps/js-sdk/firecrawl/src/v2/types.ts#L601-L606
- Firecrawl's own scrape tests accept successful envelopes carrying target 404 and 500 statuses: https://github.com/firecrawl/firecrawl/blob/c54c3f7a6552aa079d4a2fd753d93df15a5656e2/apps/api/src/scraper/scrapeURL/scrapeURL.test.ts#L204-L258
- HTTPBingo's weighted status endpoint and 302 redirect contract: https://github.com/mccutchen/go-httpbin/blob/697b6e3b326edfd8915a3b1c36c4a43f367ea3ac/httpbin/handlers.go#L200-L204 and https://github.com/mccutchen/go-httpbin/blob/697b6e3b326edfd8915a3b1c36c4a43f367ea3ac/httpbin/handlers.go#L286-L309

Production LOC: +8/-32 (net -24) | Tests: +83/-4

## User Impact

Firecrawl-backed `web_fetch` no longer returns or locally caches failed target pages as successful content. A later recovery at the same literal URL is observable, while other providers keep their existing untyped result compatibility.

## Evidence

- Parser red/green: with the pre-fix parser restored, the new table produced 5 intended failures, including numeric 404, numeric 500, and numeric-string `"404"`; after restoring the fix, the identical file passed 62/62.
- Focused/core siblings: 178/178 passed across Firecrawl client/tools, provider fallback, direct web fetch, and web-fetch runtime tests.
- Live Firecrawl recovery, cache explicitly bypassed: exact URL `https://httpbingo.org/status/302,404`, `maxAgeMs: 0` (official `maxAge: 0`), and `storeInCache: false`. Between 2026-08-16T04:22:13.281Z and 2026-08-16T04:22:17.496Z, attempts 4-6 were rejected target 404s and attempt 7 was a successful target 200. Totals: 7 attempts; target 404 rejected 3; target 200 success 4; provider 5xx 0; other errors 0; unexpected successes 0.
- Full build passed on Blacksmith Testbox `tbx_01m04cydzhkwr4hdtt73w1mbs5`: https://github.com/openclaw/openclaw/actions/runs/31926510994
- Changed gate passed on the same synced candidate: formatting, extension production/test types, changed-file lint (0 warnings/errors), plugin boundaries, dead-code scans, storage/runtime guards, and import cycles (0).
- Fresh branch autoreview at `10d6545feda09d10651759d3a136d6447a65684d`: clean, no actionable findings; Firecrawl owner-boundary fix confirmed.

No changelog, release, deployment, operator-state, provider-contract, or generic core behavior change is included.
