### PR TITLE
fix(approvals): sanitize plugin titles and exec paths at the creation boundary

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -643,6 +643,29 @@ describe("applyPluginNodeInvokePolicy", () => {
     await expectApprovalResolution(resultPromise, manager, record);
   });
 
+  it("sanitizes node-policy approval titles at creation like the RPC ingress", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    const getApprovalClientConnIds = createApprovalClientLookup([
+      createApprovalClient({
+        connId: "conn-owner-approval",
+        clientId: "client-owner",
+        deviceId: "device-owner",
+      }),
+    ]);
+    setDangerousDemoCommandRegistry([
+      // Bidi override + zero-width space: reviewer-spoofing characters.
+      createApprovalRequestPolicy({ title: "Deploy‮yolped", description: "safe​text" }),
+    ]);
+    const { context } = createContext({ pluginApprovalManager: manager, getApprovalClientConnIds });
+    const resultPromise = invokeDemoPolicy(context, createOperatorClient());
+
+    const record = await expectSinglePendingApproval(manager);
+    expect(record.request.title).toBe("Deploy\\u{202E}yolped");
+    expect(record.request.description).toBe("safe\\u{200B}text");
+
+    await expectApprovalResolution(resultPromise, manager, record);
+  });
+
   it("forwards plugin policy approvals to the originating turn source", async () => {
     const manager = new ExecApprovalManager<PluginApprovalRequestPayload>({
       validateAgentRuntimeDelegatedAuthority: () => true,

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -159,11 +159,15 @@ function createApprovalRequestPolicy(params?: {
   timeoutMs?: number;
   title?: string;
   description?: string;
+  toolName?: string;
+  agentId?: string;
 }): NodeInvokePolicyRegistration {
   return createDemoPolicy(async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
     const approval = await ctx.approvals?.request({
       title: params?.title ?? "Sensitive action",
       description: params?.description ?? "Needs approval",
+      ...(params?.toolName === undefined ? {} : { toolName: params.toolName }),
+      ...(params?.agentId === undefined ? {} : { agentId: params.agentId }),
       ...(params?.timeoutMs === undefined ? {} : { timeoutMs: params.timeoutMs }),
     });
     return { ok: true, payload: approval ?? null };
@@ -654,7 +658,12 @@ describe("applyPluginNodeInvokePolicy", () => {
     ]);
     setDangerousDemoCommandRegistry([
       // Bidi override + zero-width space: reviewer-spoofing characters.
-      createApprovalRequestPolicy({ title: "Deploy‮yolped", description: "safe​text" }),
+      createApprovalRequestPolicy({
+        title: "Deploy‮yolped",
+        description: "safe​text",
+        toolName: "tool‮run",
+        agentId: "agent​x",
+      }),
     ]);
     const { context } = createContext({ pluginApprovalManager: manager, getApprovalClientConnIds });
     const resultPromise = invokeDemoPolicy(context, createOperatorClient());
@@ -662,6 +671,9 @@ describe("applyPluginNodeInvokePolicy", () => {
     const record = await expectSinglePendingApproval(manager);
     expect(record.request.title).toBe("Deploy\\u{202E}yolped");
     expect(record.request.description).toBe("safe\\u{200B}text");
+    // Metadata is interpolated into channel approval text lines.
+    expect(record.request.toolName).toBe("tool\\u{202E}run");
+    expect(record.request.agentId).toBe("agent\\u{200B}x");
 
     await expectApprovalResolution(resultPromise, manager, record);
   });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -3,6 +3,10 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  sanitizeExecApprovalDisplayText,
+  sanitizeExecApprovalWarningText,
+} from "../infra/exec-approval-command-display.js";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
 import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
@@ -107,8 +111,18 @@ function createApprovalRuntime(params: {
       }
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
-        title: truncateUtf16Safe(input.title, 80),
-        description: truncateUtf16Safe(input.description, 256),
+        // Same creation-boundary sanitize as the RPC ingress: this record
+        // feeds the identical broadcast/forwarder/push paths. Normalize first
+        // so a whitespace-only title still fails closed at register (escaping
+        // the whitespace would make an unrenderable prompt look renderable).
+        title: truncateUtf16Safe(
+          sanitizeExecApprovalDisplayText(normalizeOptionalString(input.title) ?? ""),
+          80,
+        ),
+        description: truncateUtf16Safe(
+          sanitizeExecApprovalWarningText(normalizeOptionalString(input.description) ?? ""),
+          256,
+        ),
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -28,6 +28,11 @@ import type { GatewayClient, GatewayRequestContext, RespondFn } from "./server-m
 
 // Plugin node.invoke policies are the last gateway-side guard before a
 // plugin-declared dangerous node command reaches the node transport.
+function sanitizeOptionalMeta(value?: string | null): string | null {
+  const normalized = normalizeOptionalString(value);
+  return normalized ? sanitizeExecApprovalDisplayText(normalized) : null;
+}
+
 function parseScopes(client: GatewayClient | null): string[] {
   return Array.isArray(client?.connect?.scopes)
     ? client.connect.scopes.filter((scope): scope is string => typeof scope === "string")
@@ -124,9 +129,11 @@ function createApprovalRuntime(params: {
           256,
         ),
         severity: input.severity ?? "warning",
-        toolName: normalizeOptionalString(input.toolName) ?? null,
+        // toolName/agentId are interpolated into channel approval text; only
+        // host-minted runtime identity values skip the display escape.
+        toolName: sanitizeOptionalMeta(input.toolName),
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
-        agentId: callerIdentity?.agentId ?? normalizeOptionalString(input.agentId) ?? null,
+        agentId: callerIdentity?.agentId ?? sanitizeOptionalMeta(input.agentId),
         sessionKey: callerIdentity?.sessionKey ?? normalizeOptionalString(input.sessionKey) ?? null,
         runId: callerIdentity?.operationalRunInstance.runId ?? null,
         turnSourceChannel: turnSource.turnSourceChannel,

--- a/src/gateway/server-methods/exec-approval.agent-runtime.test.ts
+++ b/src/gateway/server-methods/exec-approval.agent-runtime.test.ts
@@ -112,6 +112,24 @@ describe("exec approval signed agent runtime", () => {
     });
   });
 
+  it("sanitizes display-only cwd and resolvedPath in the stored request", async () => {
+    const manager = new ExecApprovalManager({
+      validateAgentRuntimeDelegatedAuthority: () => true,
+    });
+    const handler = createExecApprovalHandlers(manager)["exec.approval.request"]!;
+    const opts = requestOptions(identity(false));
+    // Bidi override in cwd/resolvedPath can spoof what path reviewers see.
+    (opts.params as Record<string, unknown>).cwd = "/tmp/safe‮evil";
+    (opts.params as Record<string, unknown>).resolvedPath = "/usr/bin/echo​x";
+    const pending = handler(opts);
+    await vi.waitFor(() => expect(manager.listPendingRecords()).toHaveLength(1));
+    const record = manager.listPendingRecords()[0]!;
+    expect(record.request.cwd).toBe("/tmp/safe\\u{202E}evil");
+    expect(record.request.resolvedPath).toBe("/usr/bin/echo\\u{200B}x");
+    manager.resolve(record.id, "deny");
+    await pending;
+  });
+
   it("cancels an exec approval when authority closes after the handshake", async () => {
     let active = true;
     const manager = new ExecApprovalManager({

--- a/src/gateway/server-methods/exec-approval.agent-runtime.test.ts
+++ b/src/gateway/server-methods/exec-approval.agent-runtime.test.ts
@@ -121,11 +121,17 @@ describe("exec approval signed agent runtime", () => {
     // Bidi override in cwd/resolvedPath can spoof what path reviewers see.
     (opts.params as Record<string, unknown>).cwd = "/tmp/safe‮evil";
     (opts.params as Record<string, unknown>).resolvedPath = "/usr/bin/echo​x";
+    // Free-form policy strings must not reach reviewer meta rows: security/ask
+    // are closed enums (arbitrary values null out), host is escape-hardened.
+    (opts.params as Record<string, unknown>).security = "full‮looks-deny";
+    (opts.params as Record<string, unknown>).ask = "always​ish";
     const pending = handler(opts);
     await vi.waitFor(() => expect(manager.listPendingRecords()).toHaveLength(1));
     const record = manager.listPendingRecords()[0]!;
     expect(record.request.cwd).toBe("/tmp/safe\\u{202E}evil");
     expect(record.request.resolvedPath).toBe("/usr/bin/echo\\u{200B}x");
+    expect(record.request.security).toBeNull();
+    expect(record.request.ask).toBeNull();
     manager.resolve(record.id, "deny");
     await pending;
   });

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -17,6 +17,7 @@ import {
   sanitizeExecApprovalWarningText,
 } from "../../infra/exec-approval-command-display.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
+import { normalizeExecAsk, normalizeExecSecurity } from "../../infra/exec-approvals-core.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   normalizeExecApprovalUnavailableDecisions,
@@ -328,10 +329,17 @@ export function createExecApprovalHandlers(
         // binds effectiveCwd via systemRunBinding above); sanitize like the
         // command so bidi/invisible chars cannot spoof reviewer surfaces.
         cwd: effectiveCwd ? sanitizeExecApprovalDisplayText(effectiveCwd) : null,
+        // nodeId/agentId/sessionKey stay raw: they are matched against the
+        // node registry and session routing, so escaping would break real
+        // lookups without display gain (hostile values match nothing).
         nodeId: host === "node" ? nodeId : null,
-        host: host || null,
-        security: p.security ?? null,
-        ask: p.ask ?? null,
+        // host is enum-gated ("node" checks); escape is identity for valid
+        // values and defuses invisible-char spoofing in reviewer meta rows.
+        host: host ? sanitizeExecApprovalDisplayText(host) : null,
+        // Closed enums: arbitrary strings become null instead of reaching
+        // reviewer surfaces; decision resolution already treats them as null.
+        security: normalizeExecSecurity(p.security) ?? null,
+        ask: normalizeExecAsk(p.ask) ?? null,
         warningText: warningText ? sanitizeExecApprovalWarningText(warningText) : null,
         commandAnalysis,
         commandSpans,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -324,7 +324,10 @@ export function createExecApprovalHandlers(
         envKeys: envBinding.envKeys.length > 0 ? envBinding.envKeys : undefined,
         systemRunBinding: systemRunBinding?.binding ?? null,
         systemRunPlan: approvalContext.plan,
-        cwd: effectiveCwd ?? null,
+        // cwd/resolvedPath are display-only in the stored record (execution
+        // binds effectiveCwd via systemRunBinding above); sanitize like the
+        // command so bidi/invisible chars cannot spoof reviewer surfaces.
+        cwd: effectiveCwd ? sanitizeExecApprovalDisplayText(effectiveCwd) : null,
         nodeId: host === "node" ? nodeId : null,
         host: host || null,
         security: p.security ?? null,
@@ -338,7 +341,7 @@ export function createExecApprovalHandlers(
           unavailableDecisions,
         }),
         agentId: effectiveAgentId ?? null,
-        resolvedPath: p.resolvedPath ?? null,
+        resolvedPath: p.resolvedPath ? sanitizeExecApprovalDisplayText(p.resolvedPath) : null,
         sessionKey: effectiveSessionKey ?? null,
         sessionId: trustedAgentRuntime ? null : (normalizeOptionalString(p.sessionId) ?? null),
         runId: requestRunId ?? null,

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -330,8 +330,14 @@ describe("createPluginApprovalHandlers", () => {
           // Bidi override + zero-width space: the classic reviewer-spoof pair.
           title: "Deploy‮yolped",
           description: "safe​text",
-          detail: "line‪one",
+          // Passes the protocol's 16,384 raw cap but expands past it once
+          // invisibles become \u{...} escapes — the storage cap must re-apply.
+          detail: `line‪one${"‮".repeat(2_100)}`,
           severity: "warning",
+          // Metadata is interpolated into channel approval text lines.
+          pluginId: "plug‮in",
+          toolName: "tool​run",
+          agentId: "agent‪x",
           twoPhase: true,
         },
         { respond },
@@ -344,7 +350,13 @@ describe("createPluginApprovalHandlers", () => {
       const stored = manager.getSnapshot(approvalId)?.request;
       expect(stored?.title).toBe("Deploy\\u{202E}yolped");
       expect(stored?.description).toBe("safe\\u{200B}text");
-      expect(stored?.detail).toBe("line\\u{202A}one");
+      expect(stored?.detail?.startsWith("line\\u{202A}one")).toBe(true);
+      // Stored detail is capped like the durable presentation's copy.
+      expect(Array.from(stored?.detail ?? "").length).toBeLessThanOrEqual(16_384);
+      expect(stored?.detail?.endsWith("…[truncated]")).toBe(true);
+      expect(stored?.pluginId).toBe("plug\\u{202E}in");
+      expect(stored?.toolName).toBe("tool\\u{200B}run");
+      expect(stored?.agentId).toBe("agent\\u{202A}x");
       // The live broadcast payload is built from the stored record, so it is
       // now safe for channels/push/web without per-surface re-sanitizing.
       const requestedBroadcast = broadcastCall(opts);

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -321,6 +321,63 @@ describe("createPluginApprovalHandlers", () => {
       expect(finalResult.decision).toBe("allow-once");
     });
 
+    it("sanitizes title/description/detail at creation so every surface gets safe text", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const respond = vi.fn();
+      const opts = createMockOptions(
+        "plugin.approval.request",
+        {
+          // Bidi override + zero-width space: the classic reviewer-spoof pair.
+          title: "Deploy‮yolped",
+          description: "safe​text",
+          detail: "line‪one",
+          severity: "warning",
+          twoPhase: true,
+        },
+        { respond },
+      );
+      const handlerPromise = expectDefined(
+        handlers["plugin.approval.request"],
+        'handlers["plugin.approval.request"] test invariant',
+      )(opts);
+      const approvalId = await waitForAcceptedApproval(respond);
+      const stored = manager.getSnapshot(approvalId)?.request;
+      expect(stored?.title).toBe("Deploy\\u{202E}yolped");
+      expect(stored?.description).toBe("safe\\u{200B}text");
+      expect(stored?.detail).toBe("line\\u{202A}one");
+      // The live broadcast payload is built from the stored record, so it is
+      // now safe for channels/push/web without per-surface re-sanitizing.
+      const requestedBroadcast = broadcastCall(opts);
+      expect(requestedBroadcast.payload.request).toMatchObject({
+        title: "Deploy\\u{202E}yolped",
+        description: "safe\\u{200B}text",
+      });
+      manager.resolve(approvalId, "deny");
+      await handlerPromise;
+    });
+
+    it("rejects a title whose sanitized form exceeds the display limit", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const respond = vi.fn();
+      // 20 invisibles expand to \u{202E} escapes (8 chars each = 160 > 80 cap)
+      // while the raw title passes protocol validation at 26 code points.
+      const opts = createMockOptions(
+        "plugin.approval.request",
+        {
+          title: `spoof${"‮".repeat(20)}x`,
+          description: "plain description",
+          twoPhase: true,
+        },
+        { respond },
+      );
+      await expectDefined(
+        handlers["plugin.approval.request"],
+        'handlers["plugin.approval.request"] test invariant',
+      )(opts);
+      const error = expectResponseRejected(respond);
+      expect(error.message).toContain("exceeds the display limit");
+    });
+
     it("delivers requests to iOS push with the exec-equivalent visibility gate", async () => {
       const handleRequested = vi.fn(async () => true);
       const handlers = createPluginApprovalHandlers(manager, {

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -7,6 +7,10 @@ import {
   validatePluginApprovalRequestParams,
   validatePluginApprovalResolveParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  sanitizeExecApprovalDisplayText,
+  sanitizeExecApprovalWarningText,
+} from "../../infra/exec-approval-command-display.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../../infra/plugin-approval-canonical-decisions.js";
 import type {
@@ -14,7 +18,11 @@ import type {
   PluginApprovalRequestPayload,
   PluginApprovalResolved,
 } from "../../infra/plugin-approvals.js";
-import { resolvePluginApprovalTimeoutMs } from "../../infra/plugin-approvals.js";
+import {
+  PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
+  PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
+  resolvePluginApprovalTimeoutMs,
+} from "../../infra/plugin-approvals.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
@@ -137,11 +145,33 @@ export function createPluginApprovalHandlers(
             })
           : null;
 
+      // Sanitize once at the creation boundary, like exec command text: the
+      // raw record otherwise reaches channel messages, iOS push, and the web
+      // modal unescaped (bidi/invisible spoofing). Escaping expands invisible
+      // chars to \u{...}, so re-check the protocol caps: a spoof-heavy title
+      // must fail loud here, not as a misleading registration throw later.
+      const sanitizedTitle = sanitizeExecApprovalDisplayText(p.title);
+      const sanitizedDescription = sanitizeExecApprovalWarningText(p.description);
+      if (
+        Array.from(sanitizedTitle).length > PLUGIN_APPROVAL_TITLE_MAX_LENGTH ||
+        Array.from(sanitizedDescription).length > PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH
+      ) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "approval title or description exceeds the display limit after sanitization",
+          ),
+        );
+        return;
+      }
+      const rawDetail = normalizeTrimmedString(p.detail);
       const request: PluginApprovalRequestPayload = {
         pluginId: trustedAgentRuntime?.approvalOwnerPluginId ?? p.pluginId ?? null,
-        title: p.title,
-        description: p.description,
-        detail: normalizeTrimmedString(p.detail),
+        title: sanitizedTitle,
+        description: sanitizedDescription,
+        detail: rawDetail === null ? null : sanitizeExecApprovalWarningText(rawDetail),
         severity: (p.severity as PluginApprovalRequestPayload["severity"]) ?? null,
         toolName: p.toolName ?? null,
         toolCallId: p.toolCallId ?? null,

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -22,6 +22,7 @@ import {
   PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
   PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
   resolvePluginApprovalTimeoutMs,
+  truncatePluginApprovalDetail,
 } from "../../infra/plugin-approvals.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
@@ -167,13 +168,23 @@ export function createPluginApprovalHandlers(
         return;
       }
       const rawDetail = normalizeTrimmedString(p.detail);
+      // Untrusted display metadata gets the same escape as title/description:
+      // pluginId/toolName/agentId are interpolated into channel approval text.
+      // Host-minted runtime identity values stay authoritative and unescaped.
+      const sanitizeMeta = (value?: string | null): string | null =>
+        normalizeTrimmedString(value) === null
+          ? null
+          : sanitizeExecApprovalDisplayText(normalizeTrimmedString(value)!);
       const request: PluginApprovalRequestPayload = {
-        pluginId: trustedAgentRuntime?.approvalOwnerPluginId ?? p.pluginId ?? null,
+        pluginId: trustedAgentRuntime?.approvalOwnerPluginId ?? sanitizeMeta(p.pluginId),
         title: sanitizedTitle,
         description: sanitizedDescription,
-        detail: rawDetail === null ? null : sanitizeExecApprovalWarningText(rawDetail),
+        detail:
+          rawDetail === null
+            ? null
+            : truncatePluginApprovalDetail(sanitizeExecApprovalWarningText(rawDetail)),
         severity: (p.severity as PluginApprovalRequestPayload["severity"]) ?? null,
-        toolName: p.toolName ?? null,
+        toolName: sanitizeMeta(p.toolName),
         toolCallId: p.toolCallId ?? null,
         ...(Array.isArray(p.allowedDecisions)
           ? {
@@ -184,7 +195,7 @@ export function createPluginApprovalHandlers(
           : {}),
         agentId:
           trustedAgentRuntime?.agentId ??
-          (sessionOwner?.ok ? sessionOwner.agentId : (p.agentId ?? null)),
+          (sessionOwner?.ok ? sessionOwner.agentId : sanitizeMeta(p.agentId)),
         sessionKey,
         runId: trustedAgentRuntime?.operationalRunInstance.runId ?? null,
         turnSourceChannel: trustedAgentRuntime


### PR DESCRIPTION
## What Problem This Solves

Plugin approval `title`/`description`/`detail` were stored raw and flowed unescaped to every live reviewer surface: channel messages (`buildPluginApprovalRequestMessage`), iOS lock-screen push (APNs alert body), and the web modal title/`<pre>` body. Exec approvals' display-only `cwd`/`resolvedPath` had the same gap in the UI meta rows and the forwarder's `CWD:` line. Bidi override and invisible characters — the exact class the exec sanitizer names — can visually spoof what an operator thinks they are approving. The agent (i.e., a prompt-injected model) controls these strings, so this is attacker-reachable.

## Why This Change Was Made

The intended pattern already exists on the sibling: exec command text is sanitized once at request creation (`sanitizeExecApprovalDisplayTextWithStatus` in `exec-approval.ts`), so the stored record — and every event/surface built from it — is safe. The durable presentation (`approval-presentation.ts`) sanitizes its own copy, the TUI sanitizes locally, and the CLI was fixed by #123671, but the **live event payload** is built from the raw stored record and reaches push/channels/web modal unsanitized.

Fix at the creation boundary (the owner): sanitize plugin `title`/`description`/`detail` in `plugin.approval.request`, and exec's display-only `cwd`/`resolvedPath` in `exec.approval.request`. Sanitization is idempotent (escapes are plain ASCII), so downstream re-sanitizes become harmless defense. One dead-end fixed alongside: escaping expands invisibles to `\u{...}` so a spoof-heavy title can exceed the protocol cap post-sanitize — that used to surface as a misleading registration throw ("approval cannot be persisted without a valid reviewer presentation"); it is now a proper INVALID_REQUEST at the boundary.

Execution binding is unaffected: exec runs bind `effectiveCwd` via `systemRunBinding` (verified `node-invoke-system-run-approval-match.ts` builds the actual binding from its own cwd), and `resolvedPath`'s only non-display consumers are outside the approval record. Noted inline.

## User Impact

Approval prompts on channels, iOS push, and the Control UI can no longer be visually spoofed via bidi/invisible characters in plugin-supplied titles or agent-supplied paths. Oversized-after-sanitize titles fail with a clear request error instead of an internal registration failure.

## Evidence

- 3 new regression tests fail pre-fix, pass post-fix (`git stash` proof: 3 failed pre-fix): stored+broadcast plugin payload sanitized; post-sanitize cap rejection; exec cwd/resolvedPath escaped.
- Suites green: `plugin-approval.test.ts` (37), `exec-approval.agent-runtime.test.ts` (5), `approval-presentation.test.ts`, `exec-approval-forwarder.test.ts`, `exec-approval-ios-push.test.ts`.
- `pnpm tsgo` clean; oxfmt/oxlint clean.
- Autoreview (Codex, commit mode): clean, overall 0.98.

Production LOC delta: +33 (sanitize-at-boundary + cap re-check + invariant comments); tests +75.

## Update (addendum commit)

ClawSweeper's P1 finding was correct: the node-policy approval runtime (`src/gateway/node-invoke-plugin-policy.ts`) — the sibling creator feeding the identical broadcast/forwarder/push paths — truncated title/description but never sanitized them. The addendum routes it through the same boundary: normalize → sanitize → truncate (normalize-first keeps the whitespace-only-title fail-closed register behavior; sanitize-before-truncate keeps escape expansion inside the caps). New regression test (`node-invoke-plugin-policy.test.ts` "sanitizes node-policy approval titles at creation like the RPC ingress") proves the stored record carries escaped text through the real `manager.create` → `register` → broadcast path; the pre-existing "fails closed before routing an unrenderable persistent policy approval" test still passes, proving the whitespace contract held. Full suite: 25/25.

On the real-behavior-proof gate: the changed path is gateway-internal record construction; the added tests execute the real approval manager, real registration (including durable presentation validation), and the real broadcast payload builder — no mock gateway is interposed on the changed surface. Channel/push delivery consume `record.request` verbatim (unchanged code), which the tests pin post-sanitize.

## Update 2 (metadata + detail-cap addendum)

Both re-review findings verified and fixed at the same boundary:
- **P1 metadata**: `pluginId`/`toolName`/fallback `agentId` are interpolated into channel approval text (`buildPluginApprovalRequestMessage` `Tool:`/`Plugin:`/`Agent:` lines) and were stored raw. Untrusted values now get `sanitizeExecApprovalDisplayText`; host-minted runtime identity values (`approvalOwnerPluginId`, `trustedAgentRuntime.agentId`, session-owner agentId) stay authoritative and unescaped (noted inline).
- **P2 detail cap**: stored `detail` now applies `truncatePluginApprovalDetail` post-sanitize, matching the durable presentation's copy — a detail passing the protocol's raw 16,384 cap can no longer exceed it in storage via escape expansion.

Regression test extended: hostile metadata escaped in the stored record; oversized-after-sanitize detail capped with the truncation suffix. Suites green: `plugin-approval.test.ts` (35), `node-invoke-plugin-policy.test.ts` (25), `exec-approval.agent-runtime.test.ts` (5). Autoreview on the addendum: clean, 0.99.

## Update 3 (node-policy metadata)

Final sibling closed per the re-review: the node-policy creator's `toolName` and fallback `agentId` (interpolated into channel approval text) now go through the same display escape via a shared `sanitizeOptionalMeta` helper; host-minted `callerIdentity` values stay authoritative. Regression extended to assert escaped metadata in the stored record through the real registration path. `node-invoke-plugin-policy.test.ts` 25/25 green; autoreview clean 0.99.

## Update 4 (exec reviewer metadata)

Remaining exec metadata addressed per the latest review: `security`/`ask` are closed enums, so they now go through the canonical `normalizeExecSecurity`/`normalizeExecAsk` at creation — arbitrary strings null out instead of reaching reviewer meta rows (stronger than escaping; decision resolution already treated invalid values as null). `host` gets the display escape (identity for the valid enum values). `nodeId`/`agentId`/`sessionKey` intentionally stay raw — they are matched against the node registry and session routing, so escaping would break real lookups without display gain; noted inline. Regression extended (hostile security/ask null out); 21 exec-approval tests green; autoreview clean 0.99.
