### PR TITLE
fix(ui): retire persisted steer messages from the composer

### DIFF
--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -483,9 +483,40 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}chat`);
 
-      await page.locator(".agent-chat__composer-combobox textarea").fill("keep this run active");
+      const originalPrompt = "keep this run active";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(originalPrompt);
       await page.getByRole("button", { name: "Send message" }).click();
-      await gateway.waitForRequest("chat.send");
+      const initialSend = await gateway.waitForRequest("chat.send");
+      const activeRunId = requireString(
+        requireRecord(initialSend.params).idempotencyKey,
+        "active chat run id",
+      );
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [activeRunId],
+        clientRunId: activeRunId,
+        hasActiveRun: true,
+        message: {
+          __openclaw: {
+            id: "persisted-original-user",
+            idempotencyKey: `${activeRunId}:user`,
+            seq: 1,
+          },
+          content: [{ text: originalPrompt, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "persisted-original-user",
+        messageSeq: 1,
+        session: {
+          activeRunIds: [activeRunId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
       await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
 
       const followUp = "tighten the active plan";
@@ -493,11 +524,13 @@ suite.define(() => {
       await page.getByRole("button", { name: "Steer into the active run" }).click();
 
       const sends = await waitForRequests(gateway, "chat.send", 2);
-      expect(requireRecord(sends[1]?.params)).toMatchObject({
+      const steerParams = requireRecord(sends[1]?.params);
+      expect(steerParams).toMatchObject({
         deliver: false,
         message: followUp,
         sessionKey: "main",
       });
+      const steerRunId = requireString(steerParams.idempotencyKey, "steer run id");
       const queue = page.locator(".chat-queue");
       await queue.locator(".chat-queue__badge--steered", { hasText: "Steering" }).waitFor({
         timeout: 10_000,
@@ -505,7 +538,57 @@ suite.define(() => {
       await queue.getByText(followUp).waitFor({ timeout: 10_000 });
       if (artifactDir) {
         await page.screenshot({
-          path: `${artifactDir}/steer-default.png`,
+          path: `${artifactDir}/steer-before-persistence.png`,
+          fullPage: true,
+        });
+      }
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [activeRunId],
+        clientRunId: activeRunId,
+        hasActiveRun: true,
+        message: {
+          __openclaw: {
+            id: "persisted-steer-user",
+            idempotencyKey: `${steerRunId}:user`,
+            seq: 2,
+          },
+          content: [{ text: followUp, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "persisted-steer-user",
+        messageSeq: 2,
+        session: {
+          activeRunIds: [activeRunId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+
+      await queue.getByText(followUp).waitFor({ state: "detached", timeout: 10_000 });
+      await expect
+        .poll(() => page.locator(".chat-thread .chat-group.user", { hasText: followUp }).count())
+        .toBe(1);
+      await expect
+        .poll(() =>
+          page.locator(".chat-thread-inner").evaluate(
+            (thread, texts) => {
+              const bubbles = Array.from(thread.querySelectorAll(".chat-bubble"));
+              return texts.map((text) =>
+                bubbles.findIndex((bubble) => bubble.textContent?.includes(text)),
+              );
+            },
+            [originalPrompt, followUp],
+          ),
+        )
+        .toEqual([0, 1]);
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/steer-after-persistence.png`,
           fullPage: true,
         });
       }

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -71,7 +71,7 @@ import {
   clearChatMessagesFromCache,
   type ChatMessageCache,
 } from "./session-message-cache.ts";
-import { retireHistoryProvenSteeredChips } from "./steer-lifecycle.ts";
+import { retirePersistedSteeredChips } from "./steer-lifecycle.ts";
 import {
   clearToolStreamSegments,
   currentLiveToolCallIds,
@@ -1664,7 +1664,7 @@ async function loadChatHistoryUncached(
     if (Object.hasOwn(res.sessionInfo ?? {}, "activeLeafEntryId")) {
       state.chatDisplayedLeafEntryId = res.sessionInfo?.activeLeafEntryId?.trim() || null;
     }
-    retireHistoryProvenSteeredChips(state);
+    retirePersistedSteeredChips(state);
     state.chatHistoryPagination = reconciledHistory?.pagination ?? nextPagination;
     state.currentSessionId = nextSessionId;
     replaceCachedChatMessages(state, sessionKey, requestAgentId);

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -53,7 +53,11 @@ import {
   reconcileChatRunFromSessionRow,
   reconcileStaleChatRunAfterSessionStatePublication,
 } from "./run-lifecycle.ts";
-import { preserveQueuedUserTurn, retireSteeredChipsForTerminalRun } from "./steer-lifecycle.ts";
+import {
+  preserveQueuedUserTurn,
+  retirePersistedSteeredChips,
+  retireSteeredChipsForTerminalRun,
+} from "./steer-lifecycle.ts";
 import { isAckedSteeredChip } from "./steered-chip.ts";
 import { rememberAuthoritativeTerminal } from "./terminal-message-identity.ts";
 import { handleAgentEvent, handleSessionOperationEvent } from "./tool-stream.ts";
@@ -197,6 +201,7 @@ function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
     // Admit that sequenced row now so the later unsequenced chat.final replay
     // replaces it in place instead of appending below the newer user turn.
     applyLiveSessionMessage(state, payload, event.hasActiveRun ?? undefined);
+    retirePersistedSteeredChips(state);
     void loadChatBranches(state);
   }
   if (matchesChat && event.archived !== null) {

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -251,7 +251,7 @@ export function retireSteeredChipsForTerminalRun(
   return firstPersistedSteerIndex;
 }
 
-export function retireHistoryProvenSteeredChips(state: SteerLifecycleHost): void {
+export function retirePersistedSteeredChips(state: SteerLifecycleHost): void {
   const retired = state.chatQueue.filter(
     (item) =>
       isAckedSteeredChip(item) && chatMessagesContainQueuedSend(state.chatMessages, item, true),


### PR DESCRIPTION
Closes #121755

AI-assisted with Codex; the implementation and evidence were inspected by the maintainer agent.

## What Problem This Solves

Fixes an issue where users steering an active Control UI WebChat run would keep seeing an acknowledged `Steering` item above the composer even after the matching user message had been persisted and rendered in the transcript. The stale chip lasted until terminal cleanup and made the steer look pending; terminal materialization could also place it at the wrong conversation boundary.

## Why This Change Was Made

The live `session.message` path now runs the existing persisted-message retirement owner immediately after the canonical session projection adopts the authoritative user row. The helper is renamed from history-proven to persisted because both live events and history snapshots now use the same lifecycle boundary. Terminal materialization remains the fallback when persistence is missing.

## User Impact

Once a steer is persisted, it appears inline exactly once at its authoritative transcript position and disappears from the composer queue while the original run remains active. Pending, failed, unconfirmed, and not-yet-persisted steers remain visible above the composer.

## Evidence

- Regression reproduced on pre-fix `main`: the focused browser test timed out waiting for the persisted steer chip to detach.
- Fixed focused browser regression: 1 passed.
- Full `chat-flow.follow-ups.e2e.test.ts`: 11 passed.
- Adjacent UI unit tests (`chat-state.test.ts`, `chat-send.test.ts`): 342 passed.
- Final autoreview: clean, no accepted/actionable findings.
- Before authoritative persistence, the accepted steer remains provisional above the composer:

  ![Steer before persistence](https://github.com/user-attachments/assets/3ca661b7-6b81-476c-90fb-b5587ecdf006)

- After the matching persisted user row arrives, it is inline in sequence and the composer chip is gone:

  ![Steer after persistence](https://github.com/user-attachments/assets/008a607b-91d9-4885-b172-59182045de0d)

- Transition video:

  https://github.com/user-attachments/assets/819c3090-640f-4fcb-b7cf-a81528bd633b

Production LOC: +1 behavioral call (helper rename is net-neutral). Tests: +83 net lines extending the existing steering E2E.
