### PR TITLE
fix(macos): package apps from paths with glob characters

### DIFF
--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -350,7 +350,7 @@ merge_framework_machos() {
 
   while IFS= read -r -d '' file; do
     if /usr/bin/file "$file" | /usr/bin/grep -q "Mach-O"; then
-      local rel="${file#$primary/}"
+      local rel="${file#"$primary"/}"
       local primary_archs
       primary_archs=$(archs_for "$file")
       IFS=' ' read -r -a primary_arch_array <<< "$primary_archs"
@@ -371,7 +371,7 @@ merge_framework_machos() {
           IFS=' ' read -r -a other_arch_array <<< "$other_archs"
           for arch in "${other_arch_array[@]}"; do
             if ! arch_in_list "$arch" "${primary_arch_array[@]}"; then
-              local thin_file="$tmp_dir/$(echo "$rel" | tr '/' '_')-$arch"
+              local thin_file="$tmp_dir/${rel//\//_}-$arch"
               /usr/bin/lipo -thin "$arch" "$other_file" -output "$thin_file"
               missing_files+=("$thin_file")
               primary_arch_array+=("$arch")

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -552,7 +552,7 @@ export function isArtifactSetFresh(params: ArtifactFreshParams) {
   }
   // Repair the mtime fast path so later invocations in this checkout skip
   // without re-reading every input byte.
-  const now = new Date();
+  const now = new Date(Math.max(Date.now(), Math.ceil(newestInputMtimeMs)));
   for (const relativePath of params.outputPaths) {
     const outputPath = resolve(rootDir, relativePath);
     if (fs.existsSync(outputPath)) {

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -47,6 +47,17 @@ function getPackageManagerHelperBlock(): string {
   return script.slice(start, end);
 }
 
+function getMergeFrameworkMachOsBlock(): string {
+  const script = readFileSync(scriptPath, "utf8");
+  const start = script.indexOf("merge_framework_machos()");
+  const end = script.indexOf('PEEKABOO_SOURCE_COMMIT="$(resolve_peekaboo_source_commit)"');
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return script.slice(start, end);
+}
+
 function getSwiftToolchainBlock(): string {
   const script = readFileSync("scripts/lib/swift-toolchain.sh", "utf8");
   const start = script.indexOf("REQUIRED_SWIFT_TOOLS_MAJOR=");
@@ -748,6 +759,57 @@ describe("package-mac-app plist stamping", () => {
     expect(helperCopy).toContain('/usr/bin/lipo -create "${HELPER_BIN_INPUTS[@]}"');
     expect(helperCopy).toContain('chmod +x "$APP_ROOT/Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"');
   });
+
+  it.runIf(process.platform === "darwin")(
+    "merges framework Mach-O binaries when the checkout path contains glob metacharacters",
+    () => {
+      const root = tempDirs.make("openclaw-package-framework-[fixture]-");
+      const primary = path.join(root, "Primary.framework");
+      const secondary = path.join(root, "Secondary.framework");
+      const destination = path.join(root, "Destination.framework");
+      const relativeBinary = path.join("Versions", "A", "OpenClawFixture");
+
+      for (const framework of [primary, secondary, destination]) {
+        mkdirSync(path.dirname(path.join(framework, relativeBinary)), { recursive: true });
+      }
+
+      const fixtureBinary = "/bin/ls";
+      const fixtureArchitectures = spawnSync("/usr/bin/lipo", ["-archs", fixtureBinary], {
+        encoding: "utf8",
+      })
+        .stdout.trim()
+        .split(/\s+/u);
+      const [primaryArchitecture, secondaryArchitecture] = fixtureArchitectures;
+      if (!primaryArchitecture || !secondaryArchitecture) {
+        throw new Error(`${fixtureBinary} must contain at least two architectures`);
+      }
+      const primaryBinary = path.join(primary, relativeBinary);
+      const secondaryBinary = path.join(secondary, relativeBinary);
+      const destinationBinary = path.join(destination, relativeBinary);
+      expect(
+        spawnSync("/usr/bin/lipo", [
+          "-thin",
+          primaryArchitecture,
+          fixtureBinary,
+          "-output",
+          primaryBinary,
+        ]).status,
+      ).toBe(0);
+      expect(spawnSync("/bin/cp", [fixtureBinary, secondaryBinary]).status).toBe(0);
+      writeFileSync(destinationBinary, readFileSync(primaryBinary));
+
+      const result = runHelper(`
+        set -euo pipefail
+        ${getMergeFrameworkMachOsBlock()}
+        merge_framework_machos ${JSON.stringify(primary)} ${JSON.stringify(destination)} ${JSON.stringify(secondary)}
+        /usr/bin/lipo -info ${JSON.stringify(destinationBinary)}
+      `);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(primaryArchitecture);
+      expect(result.stdout).toContain(secondaryArchitecture);
+    },
+  );
 
   it.each([
     { title: "keeps the default backend when Xcode's Metal shim works", shimExit: 0, xcrunExit: 0 },

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -583,6 +583,8 @@ describe("prepare-extension-package-boundary-artifacts", () => {
     // Simulate checkout: inputs newer than restored outputs, bytes unchanged.
     fs.utimesSync(stampPath, new Date(1_000), new Date(1_000));
     fs.utimesSync(outputPath, new Date(1_000), new Date(1_000));
+    const repairTimeMs = Date.now();
+    fs.utimesSync(inputPath, repairTimeMs / 1_000, (repairTimeMs + 0.5) / 1_000);
     const freshParams = {
       rootDir,
       inputPaths: ["src"],
@@ -590,9 +592,17 @@ describe("prepare-extension-package-boundary-artifacts", () => {
       hashStampPath: "dist/.demo.stamp",
     };
 
-    expect(isArtifactSetFresh(freshParams)).toBe(true);
-    // The hash match repairs output mtimes so the next check takes the fast path.
-    expect(fs.statSync(outputPath).mtimeMs).toBeGreaterThanOrEqual(fs.statSync(inputPath).mtimeMs);
+    vi.useFakeTimers();
+    vi.setSystemTime(repairTimeMs);
+    try {
+      expect(isArtifactSetFresh(freshParams)).toBe(true);
+      // Round past fractional filesystem precision so the next check takes the fast path.
+      expect(fs.statSync(outputPath).mtimeMs).toBeGreaterThanOrEqual(
+        fs.statSync(inputPath).mtimeMs,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
 
     fs.appendFileSync(inputPath, "export const demoTwo = 2;\n", "utf8");
     fs.utimesSync(outputPath, new Date(1_000), new Date(1_000));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers packaging the macOS app from a checkout path containing shell glob metacharacters, such as square brackets, would see the universal Sparkle framework merge fail with a misleading missing-file error.

## Why This Change Was Made

The framework merger now treats the primary framework root as a literal prefix when deriving each relative binary path. It also replaces path separators for temporary slice names with Bash parameter expansion, removing an unnecessary subprocess and its masked exit status.

Exact-head CI then exposed an independent current-main race in boundary-artifact freshness: filesystem mtimes can retain fractional milliseconds while `Date` timestamps are integer milliseconds. The artifact owner now rounds its repair floor upward so a content-hash hit really makes every output at least as new as its newest input.

## User Impact

macOS app packaging now works from legal checkout paths containing glob characters. Packaging behavior for ordinary paths is unchanged.

CI artifact caches also keep their promised mtime fast path when an input and repair occur within the same millisecond.

## Evidence

- Pre-fix regression proof: the focused test failed with `ERROR: Missing <absolute primary path> in <secondary framework>` when the temporary checkout path contained `[fixture]`.
- Pre-fix CI artifact proof: exact-head run `31820700472`, job `94834035780`, observed output mtime `1786726580662` below input mtime `1786726580662.0535`.
- Deterministic fractional-mtime regression: failed pre-fix at `1786726813779 < 1786726813779.5`.
- `node scripts/run-vitest.mjs test/scripts/package-mac-app.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts` — 70 passed.
- `shellcheck -x scripts/package-mac-app.sh` — clean.
- `bash -n scripts/package-mac-app.sh` — clean.
- `git diff --check` — clean.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

AI-assisted: yes. The change and focused regression proof were reviewed and understood before submission.
