### PR TITLE
fix(cli): keep Doctor machine-output failures on stdout

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   runtime: {
     log: vi.fn(),
     error: vi.fn(),
+    writeJson: vi.fn(),
     exit: vi.fn(),
   },
   runDoctorLintCli: vi.fn(),
@@ -196,6 +197,23 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });
 
+  it("writes JSON errors for conflicting shared-state SQLite modes", async () => {
+    const message = "doctor shared-state SQLite maintenance can only be combined with --json.";
+
+    await runMaintenanceCli([
+      "doctor",
+      "--state-sqlite",
+      "compact",
+      "--session-sqlite",
+      "compact",
+      "--json",
+    ]);
+
+    expect(runtime.writeJson).toHaveBeenCalledWith({ error: message });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
   it("rejects shared-state SQLite maintenance combined with lint mode", async () => {
     await runMaintenanceCli(["doctor", "--state-sqlite", "compact", "--lint"]);
 
@@ -232,18 +250,28 @@ describe("registerMaintenanceCommands doctor action", () => {
   });
 
   it.each([
-    ["without JSON", ["--session-sqlite-agent", "main"]],
-    ["with JSON", ["--json", "--session-sqlite-agent", "main"]],
-  ])("rejects session sqlite selectors without session sqlite mode %s", async (_label, args) => {
-    await runMaintenanceCli(["doctor", ...args]);
+    ["without JSON", false, ["--session-sqlite-agent", "main"]],
+    ["with JSON", true, ["--json", "--session-sqlite-agent", "main"]],
+  ])(
+    "rejects session sqlite selectors without session sqlite mode %s",
+    async (_label, json, args) => {
+      const message =
+        "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.";
 
-    expect(doctorCommand).not.toHaveBeenCalled();
-    expect(runDoctorLintCli).not.toHaveBeenCalled();
-    expect(runtime.error).toHaveBeenCalledWith(
-      "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.",
-    );
-    expect(runtime.exit).toHaveBeenCalledWith(2);
-  });
+      await runMaintenanceCli(["doctor", ...args]);
+
+      expect(doctorCommand).not.toHaveBeenCalled();
+      expect(runDoctorLintCli).not.toHaveBeenCalled();
+      if (json) {
+        expect(runtime.writeJson).toHaveBeenCalledWith({ error: message });
+        expect(runtime.error).not.toHaveBeenCalled();
+      } else {
+        expect(runtime.error).toHaveBeenCalledWith(message);
+        expect(runtime.writeJson).not.toHaveBeenCalled();
+      }
+      expect(runtime.exit).toHaveBeenCalledWith(2);
+    },
+  );
 
   it("runs doctor lint mode without invoking repair doctor", async () => {
     runDoctorLintCli.mockResolvedValue(1);
@@ -313,13 +341,15 @@ describe("registerMaintenanceCommands doctor action", () => {
   });
 
   it("rejects JSON repair mode before running doctor", async () => {
+    const message =
+      "doctor --json runs read-only lint checks and cannot be combined with --repair, --fix, or --force.";
+
     await runMaintenanceCli(["doctor", "--json", "--repair"]);
 
     expect(doctorCommand).not.toHaveBeenCalled();
     expect(runDoctorLintCli).not.toHaveBeenCalled();
-    expect(runtime.error).toHaveBeenCalledWith(
-      "doctor --json runs read-only lint checks and cannot be combined with --repair, --fix, or --force.",
-    );
+    expect(runtime.writeJson).toHaveBeenCalledWith({ error: message });
+    expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });
 
@@ -344,13 +374,34 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });
 
-  it("exits with code 2 when doctor lint mode fails before findings are emitted", async () => {
+  it("writes JSON to stdout when doctor JSON mode fails before findings are emitted", async () => {
     runDoctorLintCli.mockRejectedValue(new Error("lint failed"));
 
-    await runMaintenanceCli(["doctor", "--lint"]);
+    await runMaintenanceCli(["doctor", "--json"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("Error: lint failed");
+    expect(runtime.writeJson).toHaveBeenCalledWith({ error: "Error: lint failed" });
+    expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
+  it("keeps Doctor lint failures on stderr for an interactive terminal", async () => {
+    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    runDoctorLintCli.mockRejectedValue(new Error("lint failed"));
+
+    try {
+      await runMaintenanceCli(["doctor", "--lint"]);
+
+      expect(runtime.error).toHaveBeenCalledWith("Error: lint failed");
+      expect(runtime.writeJson).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(2);
+    } finally {
+      if (stdoutDescriptor) {
+        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
   });
 
   it("rejects lint-only selectors outside lint mode", async () => {

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -363,6 +363,18 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });
 
+  it("writes JSON when another Doctor machine mode rejects lint selectors", async () => {
+    const message = "doctor lint options require --lint. Use `openclaw doctor --lint ...`.";
+
+    await runMaintenanceCli(["doctor", "--post-upgrade", "--json", "--only", "core/example"]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runDoctorLintCli).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith({ error: message });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
   it("rejects --all outside doctor lint mode", async () => {
     await runMaintenanceCli(["doctor", "--all"]);
 

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -113,11 +113,17 @@ describe("registerMaintenanceCommands doctor action", () => {
   });
 
   it("writes JSON when Doctor maintenance fails before producing a report", async () => {
-    doctorCommand.mockRejectedValue(new Error("maintenance failed"));
+    const token = "sk-abcdefghijklmnopqrstuv";
+    doctorCommand.mockRejectedValue(
+      new Error(`maintenance failed: Authorization: Bearer ${token}`),
+    );
 
     await runMaintenanceCli(["doctor", "--state-sqlite", "compact", "--json"]);
 
-    expect(runtime.writeJson).toHaveBeenCalledWith({ error: "Error: maintenance failed" });
+    expect(runtime.writeJson).toHaveBeenCalledWith({
+      error: expect.stringContaining("Error: maintenance failed: Authorization: Bearer"),
+    });
+    expect(JSON.stringify(runtime.writeJson.mock.calls)).not.toContain(token);
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -121,7 +121,7 @@ describe("registerMaintenanceCommands doctor action", () => {
     await runMaintenanceCli(["doctor", "--state-sqlite", "compact", "--json"]);
 
     expect(runtime.writeJson).toHaveBeenCalledWith({
-      error: expect.stringContaining("Error: maintenance failed: Authorization: Bearer"),
+      error: expect.stringContaining("maintenance failed: Authorization: Bearer"),
     });
     expect(JSON.stringify(runtime.writeJson.mock.calls)).not.toContain(token);
     expect(runtime.error).not.toHaveBeenCalled();
@@ -407,7 +407,7 @@ describe("registerMaintenanceCommands doctor action", () => {
 
     await runMaintenanceCli(["doctor", "--json"]);
 
-    expect(runtime.writeJson).toHaveBeenCalledWith({ error: "Error: lint failed" });
+    expect(runtime.writeJson).toHaveBeenCalledWith({ error: "lint failed" });
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });
@@ -420,7 +420,7 @@ describe("registerMaintenanceCommands doctor action", () => {
     try {
       await runMaintenanceCli(["doctor", "--lint"]);
 
-      expect(runtime.error).toHaveBeenCalledWith("Error: lint failed");
+      expect(runtime.error).toHaveBeenCalledWith("lint failed");
       expect(runtime.writeJson).not.toHaveBeenCalled();
       expect(runtime.exit).toHaveBeenCalledWith(2);
     } finally {

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -112,6 +112,16 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).not.toHaveBeenCalledWith(0);
   });
 
+  it("writes JSON when Doctor maintenance fails before producing a report", async () => {
+    doctorCommand.mockRejectedValue(new Error("maintenance failed"));
+
+    await runMaintenanceCli(["doctor", "--state-sqlite", "compact", "--json"]);
+
+    expect(runtime.writeJson).toHaveBeenCalledWith({ error: "Error: maintenance failed" });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
   it("maps --fix to repair=true", async () => {
     doctorCommand.mockResolvedValue(undefined);
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -147,11 +147,7 @@ export function registerMaintenanceCommands(program: Command) {
             });
             defaultRuntime.exit(exitCode);
           },
-          (err) =>
-            exitDoctorError(
-              formatError(new Error(String(err))),
-              opts.json === true || !process.stdout.isTTY,
-            ),
+          (err) => exitDoctorError(formatError(err), opts.json === true || !process.stdout.isTTY),
         );
         return;
       }
@@ -200,9 +196,7 @@ export function registerMaintenanceCommands(program: Command) {
           });
           defaultRuntime.exit(0);
         },
-        opts.json
-          ? (err: unknown) => exitDoctorError(formatError(new Error(String(err))), true)
-          : undefined,
+        opts.json ? (err: unknown) => exitDoctorError(formatError(err), true) : undefined,
       );
     });
   setCommandJsonMode(doctor, "output", isDoctorMachineOutput);

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -162,7 +162,7 @@ export function registerMaintenanceCommands(program: Command) {
       if (hasLintOnlyDoctorOptions(opts)) {
         return exitDoctorError(
           "doctor lint options require --lint. Use `openclaw doctor --lint ...`.",
-          false,
+          opts.json === true,
         );
       }
       await runCommandWithRuntime(defaultRuntime, async () => {

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -147,9 +147,7 @@ export function registerMaintenanceCommands(program: Command) {
             });
             defaultRuntime.exit(exitCode);
           },
-          (err) => {
-            exitDoctorError(String(err), opts.json === true || !process.stdout.isTTY);
-          },
+          (err) => exitDoctorError(String(err), opts.json === true || !process.stdout.isTTY),
         );
         return;
       }
@@ -165,34 +163,41 @@ export function registerMaintenanceCommands(program: Command) {
           opts.json === true,
         );
       }
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const { doctorCommand } = await import("../../commands/doctor.js");
-        const stateSqlite = parseDoctorStateSqliteMode(opts.stateSqlite, opts.json === true);
-        const sessionSqlite = parseDoctorSessionSqliteMode(opts.sessionSqlite, opts.json === true);
-        await doctorCommand(defaultRuntime, {
-          workspaceSuggestions: opts.workspaceSuggestions,
-          yes: Boolean(opts.yes),
-          repair: Boolean(opts.repair) || Boolean(opts.fix),
-          force: Boolean(opts.force),
-          nonInteractive: Boolean(opts.nonInteractive),
-          generateGatewayToken: Boolean(opts.generateGatewayToken),
-          allowExec: Boolean(opts.allowExec),
-          deep: Boolean(opts.deep),
-          postUpgrade: Boolean(opts.postUpgrade),
-          ...(stateSqlite ? { stateSqlite } : {}),
-          ...(sessionSqlite ? { sessionSqlite } : {}),
-          ...(typeof opts.sessionSqliteStore === "string"
-            ? { sessionSqliteStore: opts.sessionSqliteStore }
-            : {}),
-          ...(typeof opts.sessionSqliteAgent === "string"
-            ? { sessionSqliteAgent: opts.sessionSqliteAgent }
-            : {}),
-          sessionSqliteAllAgents: Boolean(opts.sessionSqliteAllAgents),
-          sessionSqliteGithubIssue: Boolean(opts.githubIssue),
-          json: Boolean(opts.json),
-        });
-        defaultRuntime.exit(0);
-      });
+      await runCommandWithRuntime(
+        defaultRuntime,
+        async () => {
+          const { doctorCommand } = await import("../../commands/doctor.js");
+          const stateSqlite = parseDoctorStateSqliteMode(opts.stateSqlite, opts.json === true);
+          const sessionSqlite = parseDoctorSessionSqliteMode(
+            opts.sessionSqlite,
+            opts.json === true,
+          );
+          await doctorCommand(defaultRuntime, {
+            workspaceSuggestions: opts.workspaceSuggestions,
+            yes: Boolean(opts.yes),
+            repair: Boolean(opts.repair) || Boolean(opts.fix),
+            force: Boolean(opts.force),
+            nonInteractive: Boolean(opts.nonInteractive),
+            generateGatewayToken: Boolean(opts.generateGatewayToken),
+            allowExec: Boolean(opts.allowExec),
+            deep: Boolean(opts.deep),
+            postUpgrade: Boolean(opts.postUpgrade),
+            ...(stateSqlite ? { stateSqlite } : {}),
+            ...(sessionSqlite ? { sessionSqlite } : {}),
+            ...(typeof opts.sessionSqliteStore === "string"
+              ? { sessionSqliteStore: opts.sessionSqliteStore }
+              : {}),
+            ...(typeof opts.sessionSqliteAgent === "string"
+              ? { sessionSqliteAgent: opts.sessionSqliteAgent }
+              : {}),
+            sessionSqliteAllAgents: Boolean(opts.sessionSqliteAllAgents),
+            sessionSqliteGithubIssue: Boolean(opts.githubIssue),
+            json: Boolean(opts.json),
+          });
+          defaultRuntime.exit(0);
+        },
+        opts.json ? (err: unknown) => exitDoctorError(String(err), true) : undefined,
+      );
     });
   setCommandJsonMode(doctor, "output", isDoctorMachineOutput);
 
@@ -306,10 +311,7 @@ function hasSessionSqliteOnlyDoctorOptions(opts: {
 }
 
 function parseDoctorStateSqliteMode(value: unknown, json: boolean): "compact" | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (value === "compact") {
+  if (value === undefined || value === "compact") {
     return value;
   }
   exitDoctorError("Invalid --state-sqlite mode. Use compact.", json);
@@ -320,10 +322,8 @@ function parseDoctorSessionSqliteMode(
   value: unknown,
   json: boolean,
 ): "dry-run" | "import" | "validate" | "inspect" | "compact" | "restore" | "recover" | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
   if (
+    value === undefined ||
     value === "dry-run" ||
     value === "import" ||
     value === "validate" ||

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -3,7 +3,7 @@ import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { defaultRuntime } from "../../runtime.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
+import { formatErrorMessage as formatError, runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
 import { isDoctorMachineOutput } from "../doctor-output-mode.js";
 import { setCommandJsonMode } from "./json-mode.js";
@@ -147,7 +147,11 @@ export function registerMaintenanceCommands(program: Command) {
             });
             defaultRuntime.exit(exitCode);
           },
-          (err) => exitDoctorError(String(err), opts.json === true || !process.stdout.isTTY),
+          (err) =>
+            exitDoctorError(
+              formatError(new Error(String(err))),
+              opts.json === true || !process.stdout.isTTY,
+            ),
         );
         return;
       }
@@ -196,7 +200,9 @@ export function registerMaintenanceCommands(program: Command) {
           });
           defaultRuntime.exit(0);
         },
-        opts.json ? (err: unknown) => exitDoctorError(String(err), true) : undefined,
+        opts.json
+          ? (err: unknown) => exitDoctorError(formatError(new Error(String(err))), true)
+          : undefined,
       );
     });
   setCommandJsonMode(doctor, "output", isDoctorMachineOutput);

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -31,6 +31,15 @@ const STATE_SQLITE_CONFLICTING_OPTION_NAMES = [
   "only",
 ] as const;
 
+function exitDoctorError(message: string, json: boolean): void {
+  if (json) {
+    defaultRuntime.writeJson({ error: message });
+  } else {
+    defaultRuntime.error(message);
+  }
+  defaultRuntime.exit(2);
+}
+
 /** Register maintenance commands that inspect or mutate local OpenClaw state. */
 export function registerMaintenanceCommands(program: Command) {
   const doctor = program
@@ -104,11 +113,10 @@ export function registerMaintenanceCommands(program: Command) {
         typeof opts.stateSqlite === "string" &&
         hasExplicitOptions(command, STATE_SQLITE_CONFLICTING_OPTION_NAMES)
       ) {
-        defaultRuntime.error(
+        return exitDoctorError(
           "doctor shared-state SQLite maintenance can only be combined with --json.",
+          opts.json === true,
         );
-        defaultRuntime.exit(2);
-        return;
       }
       const jsonImpliesLint =
         opts.json === true &&
@@ -118,11 +126,10 @@ export function registerMaintenanceCommands(program: Command) {
         typeof opts.sessionSqlite !== "string" &&
         !hasSessionSqliteOnlyDoctorOptions(opts);
       if (jsonImpliesLint && (opts.repair === true || opts.fix === true || opts.force === true)) {
-        defaultRuntime.error(
+        return exitDoctorError(
           "doctor --json runs read-only lint checks and cannot be combined with --repair, --fix, or --force.",
+          true,
         );
-        defaultRuntime.exit(2);
-        return;
       }
       if (opts.lint === true || jsonImpliesLint) {
         await runCommandWithRuntime(
@@ -141,30 +148,27 @@ export function registerMaintenanceCommands(program: Command) {
             defaultRuntime.exit(exitCode);
           },
           (err) => {
-            defaultRuntime.error(String(err));
-            defaultRuntime.exit(2);
+            exitDoctorError(String(err), opts.json === true || !process.stdout.isTTY);
           },
         );
         return;
       }
       if (hasSessionSqliteOnlyDoctorOptions(opts)) {
-        defaultRuntime.error(
+        return exitDoctorError(
           "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.",
+          opts.json === true,
         );
-        defaultRuntime.exit(2);
-        return;
       }
       if (hasLintOnlyDoctorOptions(opts)) {
-        defaultRuntime.error(
+        return exitDoctorError(
           "doctor lint options require --lint. Use `openclaw doctor --lint ...`.",
+          false,
         );
-        defaultRuntime.exit(2);
-        return;
       }
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { doctorCommand } = await import("../../commands/doctor.js");
-        const stateSqlite = parseDoctorStateSqliteMode(opts.stateSqlite);
-        const sessionSqlite = parseDoctorSessionSqliteMode(opts.sessionSqlite);
+        const stateSqlite = parseDoctorStateSqliteMode(opts.stateSqlite, opts.json === true);
+        const sessionSqlite = parseDoctorSessionSqliteMode(opts.sessionSqlite, opts.json === true);
         await doctorCommand(defaultRuntime, {
           workspaceSuggestions: opts.workspaceSuggestions,
           yes: Boolean(opts.yes),
@@ -301,20 +305,20 @@ function hasSessionSqliteOnlyDoctorOptions(opts: {
   );
 }
 
-function parseDoctorStateSqliteMode(value: unknown): "compact" | undefined {
+function parseDoctorStateSqliteMode(value: unknown, json: boolean): "compact" | undefined {
   if (value === undefined) {
     return undefined;
   }
   if (value === "compact") {
     return value;
   }
-  defaultRuntime.error("Invalid --state-sqlite mode. Use compact.");
-  defaultRuntime.exit(2);
+  exitDoctorError("Invalid --state-sqlite mode. Use compact.", json);
   throw new Error("unreachable");
 }
 
 function parseDoctorSessionSqliteMode(
   value: unknown,
+  json: boolean,
 ): "dry-run" | "import" | "validate" | "inspect" | "compact" | "restore" | "recover" | undefined {
   if (value === undefined) {
     return undefined;
@@ -330,9 +334,9 @@ function parseDoctorSessionSqliteMode(
   ) {
     return value;
   }
-  defaultRuntime.error(
+  exitDoctorError(
     "Invalid --session-sqlite mode. Use dry-run, import, validate, inspect, compact, restore, or recover.",
+    json,
   );
-  defaultRuntime.exit(2);
   throw new Error("unreachable");
 }


### PR DESCRIPTION
Closes #123750

## What Problem This Solves

Fixes an issue where automation using Doctor's JSON or piped lint modes received empty stdout when a validation or runtime failure occurred before lint findings were produced. The command exited nonzero, but the only diagnostic was human-formatted stderr.

## Why This Change Was Made

Doctor's command owner now has one failure exit that selects structured stdout for machine-output modes and human stderr for interactive lint. The same owner covers explicit JSON validation, non-TTY lint, shared/session SQLite machine-mode validation, invalid mode parsing, and pre-report maintenance failures. Caught errors pass through the existing redacting formatter before either output path; flags, findings, success payloads, and repair behavior are unchanged.

Production growth is +4 lines. The helper replaces five duplicated exit branches; the remaining growth carries the machine-vs-human output fact into the two mode parsers without a test-only seam.

## User Impact

Scripts can parse one JSON error object from stdout for every Doctor machine-output failure while still receiving exit code 2. Interactive `doctor --lint` users continue to see failures on stderr.

The compatibility decision requested by ClawSweeper is explicitly accepted: Doctor's documented machine-output contract supersedes scraping pre-findings human stderr. Automation in a machine-output mode should parse the JSON error envelope from stdout.

## Evidence

- Before, built CLI at `493a3e46b3f2921269cfb0af5dfc86efb569ceaa`: `doctor --json --severity-min nope` exited 2 with stdout 0 bytes and the error only on stderr.
- After, exact source hashes on head `7020afff5eff5a955fbfc1c3fdcd2748775e5a16` were built in isolated Linux AWS Crabbox run [`run_b781a36fdd26`](https://crabbox.openclaw.ai/portal/runs/run_b781a36fdd26):
  - explicit `doctor --json --severity-min nope`: exit 2, parseable 86-byte JSON stdout, stderr 0 bytes
  - piped `doctor --lint --severity-min nope`: exit 2, parseable 86-byte JSON stdout, stderr 0 bytes
  - `doctor --post-upgrade --json --only core/example`: exit 2, parseable 87-byte JSON stdout, stderr 0 bytes
  - `doctor --session-sqlite inspect --json --only core/example`: exit 2, parseable 87-byte JSON stdout, stderr 0 bytes
  - state-SQLite compaction with a real `ENOTDIR` before report creation: exit 2, parseable 128-byte JSON stdout, stderr 0 bytes; a synthetic bearer-token-shaped path segment was redacted
  - source hashes verified before build; lease `cbx_55dabe840557` released after proof
- `node scripts/run-vitest.mjs src/cli/program/register.maintenance.test.ts src/cli/cli-utils.test.ts src/infra/errors.test.ts` — 91/91 passed, including all 39 Doctor registration regressions.
- Targeted oxfmt, type-aware Oxlint, `git diff --check`, and `node scripts/check-changed.mjs --dry-run -- <changed paths>` passed.
- Exact-head CI [`31833378264`](https://github.com/openclaw/openclaw/actions/runs/31833378264) — green, including changed gates and aggregate `openclaw/ci-gate`.
- Fresh Codex-backed autoreview on the final branch: clean, no accepted/actionable findings, overall 0.98.
- Latest ClawSweeper review on the exact head reports no correctness or security findings and identifies this command owner as the best fix.
- Production LOC: +61/-57 (net +4). Tests: +96/-17 (net +79).

AI-assisted: Codex implemented and proved the repair; Claude independently approved the complete patch and landing decision.
