### PR TITLE
test(ui): stabilize update confirmation focus proof

### DIFF
--- a/ui/src/e2e/update-confirmation.e2e.test.ts
+++ b/ui/src/e2e/update-confirmation.e2e.test.ts
@@ -140,10 +140,10 @@ suite.define(() => {
         await dialog.waitFor();
 
         // The keypress that opened the dialog lands on Cancel, never on the confirm action.
-        const cancelFocused = await page.evaluate(
-          () => document.activeElement?.textContent?.trim() ?? "",
-        );
-        expect(cancelFocused).toBe("Cancel");
+        const cancel = page.getByRole("button", { name: "Cancel", exact: true });
+        await expect
+          .poll(() => cancel.evaluate((element) => document.activeElement === element))
+          .toBe(true);
         expect(await gateway.getRequests("update.run")).toHaveLength(0);
         await page.screenshot({
           animations: "disabled",

--- a/ui/src/e2e/update-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/update-lifecycle.e2e.test.ts
@@ -96,15 +96,10 @@ suite.define(() => {
             updateAvailable: DEV_UPDATE_AVAILABLE,
           });
 
-          await page.getByRole("button", { name: /246 commits behind/ }).press("Enter");
-          const cancel = page.getByRole("button", { name: "Cancel", exact: true });
-          await cancel.waitFor();
-          // Web Awesome applies slotted autofocus on the dialog's next frame;
-          // visibility alone does not mean its keyboard-safe default has settled.
-          await expect
-            .poll(() => cancel.evaluate((element) => document.activeElement === element))
-            .toBe(true);
-          expect(await gateway.getRequests("update.run")).toHaveLength(0);
+          await page.getByRole("button", { name: /246 commits behind/ }).click();
+          await page.getByRole("button", { name: "Update and restart", exact: true }).waitFor();
+          // The modal fades in; capture it settled so the proof is readable.
+          await page.waitForTimeout(500);
           await page.screenshot({ path: path.join(artifactDir, "1-confirm-dialog.png") });
           await page.getByRole("button", { name: "Update and restart", exact: true }).click();
 

--- a/ui/src/e2e/update-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/update-lifecycle.e2e.test.ts
@@ -96,10 +96,15 @@ suite.define(() => {
             updateAvailable: DEV_UPDATE_AVAILABLE,
           });
 
-          await page.getByRole("button", { name: /246 commits behind/ }).click();
-          await page.getByRole("button", { name: "Update and restart", exact: true }).waitFor();
-          // The modal fades in; capture it settled so the proof is readable.
-          await page.waitForTimeout(500);
+          await page.getByRole("button", { name: /246 commits behind/ }).press("Enter");
+          const cancel = page.getByRole("button", { name: "Cancel", exact: true });
+          await cancel.waitFor();
+          // Web Awesome applies slotted autofocus on the dialog's next frame;
+          // visibility alone does not mean its keyboard-safe default has settled.
+          await expect
+            .poll(() => cancel.evaluate((element) => document.activeElement === element))
+            .toBe(true);
+          expect(await gateway.getRequests("update.run")).toHaveLength(0);
           await page.screenshot({ path: path.join(artifactDir, "1-confirm-dialog.png") });
           await page.getByRole("button", { name: "Update and restart", exact: true }).click();
 


### PR DESCRIPTION
Related: #123660

## What Problem This Solves

Fixes an issue where the Control UI update-confirmation E2E could observe the dialog as visible before its keyboard-safe Cancel action received focus. Web Awesome opens the native dialog synchronously, while both Web Awesome and the shared OpenClaw modal adapter apply autofocus on the next animation frame.

## Why This Change Was Made

The owner E2E now polls the actual Cancel element until it becomes `document.activeElement`, instead of reading active-element text immediately after visibility. It still proves that no `update.run` request escapes before explicit confirmation, and the existing continuation proves exactly one request afterward. No dialog or runtime behavior changes.

Production delta: +0/-0. Tests: +4/-4.

## User Impact

No user-visible runtime change. Exact-head UI validation now follows the modal owner's real autofocus lifecycle instead of racing it.

## Evidence

- Direct dependency inspection: Web Awesome 3.10.0 calls `showModal()` and schedules `[autofocus]` focus in `requestAnimationFrame`; the shared OpenClaw adapter schedules slotted autofocus after `wa-show` for content Web Awesome cannot see through the adapter slot.
- Focused Chromium stress passed 7/7 on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/31823389210)).
- The complete update-confirmation and update-lifecycle E2E files passed together: 11/11 ([run](https://github.com/openclaw/openclaw/actions/runs/31823389210)).
- The path-scoped changed gate passed formatting, guards, UI i18n, core test types, and lint ([run](https://github.com/openclaw/openclaw/actions/runs/31823596287)).
- Autoreview on the corrective rewrite: no accepted or actionable findings.
- Exact-head CI is running for `564d867b8a9078c94b2141bbc9ce36672e3a75d9`; the verified patch is byte-identical to the pre-rebase proof (`patch-id c48498b5b7753927c650f1a8ebcabf72d206c9b8`).
