### PR TITLE
fix(cli): keep Skills verifier failures machine-readable

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -1245,9 +1245,25 @@ describe("skills cli commands", () => {
       runCommand(["skills", "verify", "agentreceipt", "--version", "1.0.0", "--tag", "latest"]),
     ).rejects.toThrow("__exit__:1");
 
-    expect(runtimeErrors).toContain("Use either --version or --tag.");
+    expect(JSON.parse(runtimeStdout.at(-1) ?? "{}")).toEqual({
+      error: "Use either --version or --tag.",
+    });
+    expect(runtimeErrors).toStrictEqual([]);
     expect(fetchClawHubSkillVerificationMock).not.toHaveBeenCalled();
     expect(fetchClawHubSkillCardMock).not.toHaveBeenCalled();
+  });
+
+  it("returns JSON when verify workspace selection fails", async () => {
+    defaultRuntime.exit.mockImplementationOnce(() => undefined);
+
+    await runCommand(["skills", "verify", "agentreceipt", "--global", "--agent", "main"]);
+
+    expect(JSON.parse(runtimeStdout.at(-1) ?? "{}")).toEqual({
+      error: "Use either --global or --agent, not both.",
+    });
+    expect(runtimeErrors).toStrictEqual([]);
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(resolveClawHubSkillVerificationTargetMock).not.toHaveBeenCalled();
   });
 
   it("registers explicit --json output for verify", () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -230,10 +230,11 @@ function resolveClawHubTargetWorkspaceDir(
 function resolveClawHubTargetWorkspace(
   command: Command | undefined,
   opts: { agent?: string; global?: boolean },
+  reportError: (message: string) => void = defaultRuntime.error,
 ): Pick<ResolvedSkillsWorkspace, "config" | "workspaceDir"> | undefined {
   const agentId = resolveAgentOption(command, opts);
   if (opts.global && normalizeOptionalString(agentId)) {
-    defaultRuntime.error("Use either --global or --agent, not both.");
+    reportError("Use either --global or --agent, not both.");
     defaultRuntime.exit(1);
     return undefined;
   }
@@ -850,19 +851,23 @@ export function registerSkillsCli(program: Command) {
         command: Command,
       ) => {
         let exitCode: number | undefined;
+        const reportError =
+          hasJsonOutput(opts) || opts.card !== true
+            ? (message: string) => defaultRuntime.writeJson({ error: message })
+            : defaultRuntime.error;
         try {
-          const workspaceDir = resolveClawHubTargetWorkspaceDir(command, opts);
-          if (!workspaceDir) {
+          const workspace = resolveClawHubTargetWorkspace(command, opts, reportError);
+          if (!workspace) {
             return;
           }
           const target = await resolveClawHubSkillVerificationTarget({
-            workspaceDir,
+            workspaceDir: workspace.workspaceDir,
             slug,
             version: opts.version,
             tag: opts.tag,
           });
           if (!target.ok) {
-            defaultRuntime.error(target.error);
+            reportError(target.error);
             exitCode = 1;
           } else {
             const verification = await fetchClawHubSkillVerification({
@@ -878,7 +883,7 @@ export function registerSkillsCli(program: Command) {
             if (opts.card && !hasJsonOutput(opts)) {
               const cardUrl = readVerifiedSkillCardUrl(verification);
               if (!cardUrl.ok) {
-                defaultRuntime.error(cardUrl.error);
+                reportError(cardUrl.error);
                 exitCode = 1;
               } else {
                 const card = await fetchClawHubSkillCard({
@@ -894,7 +899,7 @@ export function registerSkillsCli(program: Command) {
             }
           }
         } catch (err) {
-          defaultRuntime.error(String(err));
+          reportError(String(err));
           defaultRuntime.exit(1);
           return;
         }

--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -254,17 +254,39 @@ describe("skills verify CLI", () => {
     });
   });
 
-  it("rejects a different installed skills.sh reference before network verification", async () => {
+  it.each([
+    ["implicit JSON", []],
+    ["explicit JSON", ["--json"]],
+  ])("returns machine-readable target errors with %s", async (_label, outputArgs: string[]) => {
     await writeInstalledSkillsShSkill("skills-sh:owner-a/repo-a/html");
 
-    await expect(runCommand(["skills", "verify", "skills-sh:owner-b/repo-b/html"])).rejects.toThrow(
-      "__exit__:1",
+    await expect(
+      runCommand(["skills", "verify", "skills-sh:owner-b/repo-b/html", ...outputArgs]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(JSON.parse(mocks.runtimeStdout.at(-1) ?? "{}")).toEqual({
+      error: 'Skill "html" is not tracked from skills-sh:owner-b/repo-b/html.',
+    });
+    expect(mocks.runtimeErrors).toStrictEqual([]);
+    expect(mocks.fetchClawHubSkillVerificationMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["implicit JSON", []],
+    ["explicit JSON", ["--json"]],
+  ])("returns machine-readable runtime errors with %s", async (_label, outputArgs: string[]) => {
+    mocks.fetchClawHubSkillVerificationMock.mockRejectedValueOnce(
+      new Error("ClawHub verification unavailable"),
     );
 
-    expect(mocks.runtimeErrors).toContain(
-      'Skill "html" is not tracked from skills-sh:owner-b/repo-b/html.',
-    );
-    expect(mocks.fetchClawHubSkillVerificationMock).not.toHaveBeenCalled();
+    await expect(
+      runCommand(["skills", "verify", "@demo-owner/weather", ...outputArgs]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(JSON.parse(mocks.runtimeStdout.at(-1) ?? "{}")).toEqual({
+      error: "Error: ClawHub verification unavailable",
+    });
+    expect(mocks.runtimeErrors).toStrictEqual([]);
   });
 
   it("verifies an installed skills.sh skill by slug without a version selector", async () => {


### PR DESCRIPTION
Closes #123756

## What Problem This Solves

Fixes an issue where operators running `openclaw skills verify` would receive exit 1 with empty stdout when target/workspace validation or verification runtime work failed. The command documents and emits a JSON verification envelope by default, and explicit `--json` is the same machine-output contract, so stderr-only failures broke JSON consumers.

## Why This Change Was Made

The verifier now chooses one error writer from its actual output mode and passes it into the existing shared workspace selector. Default verification and explicit `--json` write `{ "error": "..." }` to stdout; `--card` without `--json` keeps human stderr. Install, update, and the rest of the Skills CLI keep their existing output behavior.

This keeps the repair at the command/output owner instead of adding a top-level CLI fallback or duplicating validation branches.

## User Impact

Scripts can parse a stable JSON error result from `skills verify` on both validation and runtime failures while continuing to rely on exit 1. Human Skill Card workflows remain unchanged.

## Evidence

- Reconciled exact head: `835dbf7e9b828e7a548104f94ddd311e14b929fb`, directly based on `e03d1a42f808e58028b285a4962fcc81cccccd64`.
- Pre-fix process reproduction: conflicting `--version`/`--tag` exited 1 with zero-byte stdout and the error only on stderr.
- Focused tests: `node scripts/run-vitest.mjs src/cli/skills-cli.verify.test.ts src/cli/skills-cli.commands.test.ts src/cli/machine-output-modes.test.ts` — 103 passed.
- Targeted dist build, runtime postbuild, and CLI bootstrap import guard passed.
- Source-blind dist-backed CLI proof passed for implicit JSON, explicit `--json`, workspace validation, and the human `--card` control. All four exited 1; the three machine cases emitted a parseable `{error}` object, while `--card` kept the error on stderr.
- Targeted `oxfmt --check` and `git diff --check` passed.
- `node scripts/check-changed.mjs -- src/cli/skills-cli.ts src/cli/skills-cli.verify.test.ts src/cli/skills-cli.commands.test.ts` passed the full `core, coreTests` plan after the wrapper's local fallback.
- Fresh Codex autoreview on the reconciled commit: clean, no accepted/actionable findings, confidence 0.99.
- Production LOC: `+12/-7` (net `+5`). Tests: `+46/-8` (net `+38`).

No config, public API, dependency, protocol, persistence, generated baseline, or changelog changes.
