### PR TITLE
refactor(ai): consolidate Responses replay paths

### DIFF
--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { AuthProfileStore } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
@@ -514,10 +515,7 @@ function createCodexBoundedTurnCollector(
   const completedItems = new Map<string, CodexThreadItem>();
   const assistantTextByItem = new Map<string, string>();
   const assistantItemOrder: string[] = [];
-  let resolveCompletion: (() => void) | undefined;
-  const completion = new Promise<void>((resolve) => {
-    resolveCompletion = resolve;
-  });
+  const { promise: completion, resolve: resolveCompletion } = createDeferred<void>();
 
   const rememberAssistantText = (itemId: string, text: string) => {
     if (!text) {
@@ -566,7 +564,7 @@ function createCodexBoundedTurnCollector(
     if (notification.method === "turn/completed") {
       completedTurn =
         readCodexTurnCompletedNotification(notification.params)?.turn ?? completedTurn;
-      resolveCompletion?.();
+      resolveCompletion();
       return;
     }
     if (notification.method === "error") {
@@ -576,7 +574,7 @@ function createCodexBoundedTurnCollector(
       promptError =
         readCodexErrorNotification(notification.params)?.error.message ??
         `codex app-server ${taskLabel} turn failed`;
-      resolveCompletion?.();
+      resolveCompletion();
     }
   };
 

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -11,6 +11,7 @@ import {
 import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
@@ -87,10 +88,8 @@ function watchCodexNativeCompactionCompletion(params: {
   let compactionItemId: string | undefined;
   let compactionItemCompleted = false;
   let tokensAfter: number | undefined;
-  let resolveCompletion = (_result: CodexNativeCompactionCompletion) => {};
-  const completion = new Promise<CodexNativeCompactionCompletion>((resolve) => {
-    resolveCompletion = resolve;
-  });
+  const { promise: completion, resolve: resolveCompletion } =
+    createDeferred<CodexNativeCompactionCompletion>();
   let removeNotificationHandler = () => {};
   let removeCloseHandler = () => {};
   let removeAbortHandler = () => {};
@@ -110,6 +109,7 @@ function watchCodexNativeCompactionCompletion(params: {
   };
   const complete = () =>
     finish({ completed: true, ...(tokensAfter !== undefined ? { tokensAfter } : {}) });
+  const fail = (reason: string) => finish({ completed: false, reason });
   const retireUnconfirmed = (reason: string) => {
     if (settled || retirementStarted) {
       return;
@@ -118,7 +118,7 @@ function watchCodexNativeCompactionCompletion(params: {
     // Timers started under the short-lived binding lease inherit its async
     // owner. Remote retirement must not reuse that already-released token.
     void runOutsideBindingLease(() => params.retireUnconfirmed())
-      .then(() => finish({ completed: false, reason }))
+      .then(() => fail(reason))
       .catch((error: unknown) => {
         embeddedAgentLog.error("failed to retire unconfirmed codex app-server compaction", {
           threadId: params.threadId,
@@ -150,11 +150,9 @@ function watchCodexNativeCompactionCompletion(params: {
             complete();
             return;
           }
-          finish({
-            completed: false,
-            reason:
-              "codex app-server compaction reached terminal state without a completed compaction item",
-          });
+          fail(
+            "codex app-server compaction reached terminal state without a completed compaction item",
+          );
           return;
         }
         embeddedAgentLog.warn("codex app-server compaction interrupt request failed", {
@@ -251,10 +249,7 @@ function watchCodexNativeCompactionCompletion(params: {
     const turn = isJsonObject(notification.params.turn) ? notification.params.turn : undefined;
     const status = typeof turn?.status === "string" ? turn.status : undefined;
     if (status !== "completed") {
-      finish({
-        completed: false,
-        reason: `codex app-server compaction turn ended with status ${status ?? "unknown"}`,
-      });
+      fail(`codex app-server compaction turn ended with status ${status ?? "unknown"}`);
       return;
     }
     const incompleteReason = !compactionItemId
@@ -263,7 +258,7 @@ function watchCodexNativeCompactionCompletion(params: {
         ? "codex app-server compaction turn completed before its compaction item"
         : undefined;
     if (incompleteReason) {
-      finish({ completed: false, reason: incompleteReason });
+      fail(incompleteReason);
       return;
     }
     complete();
@@ -291,15 +286,14 @@ function watchCodexNativeCompactionCompletion(params: {
         beginInterruptGrace();
       }
     },
-    confirmRequestRejected: () =>
-      finish({ completed: false, reason: "codex app-server rejected the compaction request" }),
+    confirmRequestRejected: () => fail("codex app-server rejected the compaction request"),
     retireUnconfirmedRequest: async (reason: string) => {
       retireUnconfirmed(reason);
       return await completion;
     },
     cancel: () => {
       if (!requestStarted) {
-        finish({ completed: false, reason: "compaction request did not start" });
+        fail("compaction request did not start");
       }
     },
   };

--- a/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
+++ b/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
@@ -70,7 +70,7 @@ export class CodexNativeToolLifecycleProjector {
 
   handleNotification(notification: CodexServerNotification): void {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
-    if (!isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
+    if (!params || !isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
       return;
     }
     if (notification.method === "turn/completed") {

--- a/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
+++ b/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
@@ -19,10 +19,7 @@ import {
   emitCodexNativePreToolUseFailureDiagnostic,
   type CodexNativePreToolUseFailure,
 } from "./native-hook-relay.js";
-import {
-  readCodexNotificationThreadId,
-  readCodexNotificationTurnId,
-} from "./notification-correlation.js";
+import { isCodexNotificationForTurn } from "./notification-correlation.js";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
   isJsonObject,
@@ -73,11 +70,7 @@ export class CodexNativeToolLifecycleProjector {
 
   handleNotification(notification: CodexServerNotification): void {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
-    if (
-      !params ||
-      readCodexNotificationThreadId(params) !== this.threadId ||
-      readCodexNotificationTurnId(params) !== this.turnId
-    ) {
+    if (!isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
       return;
     }
     if (notification.method === "turn/completed") {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -41,8 +41,8 @@ import {
 } from "./event-projector-values.js";
 import type { CodexNativePreToolUseFailure } from "./native-hook-relay.js";
 import {
+  isCodexNotificationForTurn,
   readCodexNotificationThreadId,
-  readCodexNotificationTurnId,
 } from "./notification-correlation.js";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
@@ -221,7 +221,7 @@ export class CodexAppServerEventProjector {
       if (readCodexNotificationThreadId(params) !== this.threadId) {
         return;
       }
-    } else if (!this.isNotificationForTurn(params)) {
+    } else if (!isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
       return;
     }
     this.nativeToolLifecycleProjector.handleNotification(notification);
@@ -640,12 +640,6 @@ export class CodexAppServerEventProjector {
       // Downstream event consumers must not corrupt the canonical Codex turn projection.
       embeddedAgentLog.debug("codex app-server agent event handler threw", { error });
     }
-  }
-
-  private isNotificationForTurn(params: JsonObject): boolean {
-    const threadId = readCodexNotificationThreadId(params);
-    const turnId = readCodexNotificationTurnId(params);
-    return threadId === this.threadId && turnId === this.turnId;
   }
 
   private isHookNotificationForCurrentThread(params: JsonObject): boolean {

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -1,4 +1,5 @@
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
   closeCodexStartupClientBestEffort,
@@ -81,10 +82,7 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     terminalDynamicToolReleaseCheckScheduled: false,
     currentTurnHadNonTerminalDynamicToolResult: false,
   };
-  let resolveCompletion!: () => void;
-  const completion = new Promise<void>((resolve) => {
-    resolveCompletion = resolve;
-  });
+  const { promise: completion, resolve: resolveCompletion } = createDeferred<void>();
   const turnCompletionIdleTimeoutMs = resolveCodexTurnCompletionIdleTimeoutMs(
     options.turnCompletionIdleTimeoutMs ?? appServer.turnCompletionIdleTimeoutMs,
   );

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -74,10 +74,7 @@ import {
   emitCodexNativePreToolUseFailureDiagnostic,
   type CodexNativePreToolUseFailure,
 } from "./native-hook-relay.js";
-import {
-  readCodexNotificationThreadId,
-  readCodexNotificationTurnId,
-} from "./notification-correlation.js";
+import { isCodexNotificationForTurn } from "./notification-correlation.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   mergeCodexThreadConfigs,
@@ -1219,7 +1216,7 @@ class CodexSideQuestionCollector {
       this.pendingNotifications.push(notification);
       return;
     }
-    if (!isNotificationForTurn(params, this.threadId, this.turnId)) {
+    if (!isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
       return;
     }
     if (notification.method === "item/agentMessage/delta") {
@@ -1345,16 +1342,6 @@ function collectAssistantText(turn: CodexTurn): string {
     .map((item) => item.text.trim())
     .filter(Boolean);
   return messages.at(-1) ?? "";
-}
-
-function isNotificationForTurn(params: JsonObject, threadId: string, turnId: string): boolean {
-  return (
-    readCodexNotificationThreadId(params) === threadId && readNotificationTurnId(params) === turnId
-  );
-}
-
-function readNotificationTurnId(record: JsonObject): string | undefined {
-  return readCodexNotificationTurnId(record);
 }
 
 function formatCodexErrorMessage(params: JsonObject, rateLimits: JsonValue | undefined): Error {

--- a/extensions/codex/src/app-server/turn-router.ts
+++ b/extensions/codex/src/app-server/turn-router.ts
@@ -1,5 +1,6 @@
 /** Keyed routing for all turn traffic on one shared Codex app-server client. */
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { CodexAppServerClient } from "./client.js";
 import { redactCodexEventKind } from "./event-projector-diagnostics.js";
 import {
@@ -75,7 +76,7 @@ type CodexNativeTurnCompletionWatch = {
   cancel: () => void;
 };
 
-type Deferred = { promise: Promise<void>; resolve: () => void };
+type Deferred = ReturnType<typeof createDeferred<void>>;
 type PendingNotification = {
   notification: CodexServerNotification;
   receivedAtMs: number;
@@ -143,8 +144,8 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     const route: Route = {
       threadId,
       controller: new AbortController(),
-      ended: deferred(),
-      activated: deferred(),
+      ended: createDeferred<void>(),
+      activated: createDeferred<void>(),
       gate: "open",
       pending: [],
       notificationTail: Promise.resolve(),
@@ -196,10 +197,7 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     if (this.routes.get(threadId)?.completedNativeTurnIds.delete(turnId)) {
       return { completion: Promise.resolve(true), cancel: () => {} };
     }
-    let settle!: (completed: boolean) => void;
-    const completion = new Promise<boolean>((resolve) => {
-      settle = resolve;
-    });
+    const { promise: completion, resolve: settle } = createDeferred<boolean>();
     const watchers =
       this.nativeTurnCompletionWatchers.get(threadId) ?? new Set<NativeTurnCompletionWatcher>();
     this.nativeTurnCompletionWatchers.set(threadId, watchers);
@@ -281,7 +279,7 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     if (route.observedNativeTurn?.completed) {
       route.observedNativeTurn = undefined;
     }
-    route.binding = deferred();
+    route.binding = createDeferred<void>();
   }
 
   private async cancelTurn(route: Route): Promise<void> {
@@ -587,14 +585,6 @@ async function waitForPromiseOrAbort(
   } finally {
     removeAbort?.();
   }
-}
-
-function deferred(): Deferred {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
 }
 
 function abortReason(signal: AbortSignal): Error {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -46,6 +46,7 @@ import { responsesPromptObserver } from "../transports/openai-responses-contract
 import { ResponsesStreamFailure } from "../transports/openai-responses-debug.js";
 import { createResponsesPromptEgressObserver } from "../transports/openai-responses-prompt-observer-internal.js";
 import {
+  commitResponsesEncryptedContentAttempt,
   isInvalidEncryptedContentError,
   resolveNextResponsesEncryptedContentAttempt,
   type ResponsesEncryptedContentAttempt,
@@ -313,6 +314,10 @@ export const streamOpenAICodexResponses: StreamFunction<
         kind: "initial",
         request: await buildBody("checkpoint"),
       };
+      const commitSemanticAttempt = (attempt: ResponsesEncryptedContentAttempt<RequestBody>) =>
+        commitResponsesEncryptedContentAttempt(attempt, (checkpoint) =>
+          suppressOpenAIResponsesCompaction(output, model, options, checkpoint),
+        );
       const observePromptEgress = createResponsesPromptEgressObserver(
         options,
         context.systemPrompt,
@@ -356,14 +361,7 @@ export const streamOpenAICodexResponses: StreamFunction<
               stream,
               model,
               () => {
-                if (activeAttempt.kind === "compaction-stripped") {
-                  suppressOpenAIResponsesCompaction(
-                    output,
-                    model,
-                    options,
-                    activeAttempt.rejectedCompaction,
-                  );
-                }
+                commitSemanticAttempt(activeAttempt);
                 websocketStarted = true;
               },
               requestOptions,
@@ -561,14 +559,7 @@ export const streamOpenAICodexResponses: StreamFunction<
           if (activeSignal?.aborted) {
             throw transportAbortError(activeSignal);
           }
-          if (activeAttempt.kind === "compaction-stripped") {
-            suppressOpenAIResponsesCompaction(
-              output,
-              model,
-              options,
-              activeAttempt.rejectedCompaction,
-            );
-          }
+          commitSemanticAttempt(activeAttempt);
           break;
         }
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -1,31 +1,21 @@
 // OpenAI Responses shared helpers map runtime messages, tools, and stream events.
 import type {
   ResponseCreateParamsStreaming,
-  ResponseFunctionCallOutputItemList,
   ResponseInput,
-  ResponseInputItem,
-  ResponseInputContent,
-  ResponseInputImage,
-  ResponseInputText,
-  ResponseOutputMessage,
-  ResponseReasoningItem,
   ResponseStreamEvent,
 } from "openai/resources/responses/responses.js";
 import { clampThinkingLevel } from "../model-utils.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
-import { transformProviderMessages as transformMessages } from "../provider-transcript-transform.js";
 import {
-  buildOpenAIResponsesCompactionReplayPlan,
   buildOpenAIResponsesReasoningReplayMetadata,
-  buildOpenAIResponsesReplayContext,
   suppressOpenAIResponsesCompaction,
   type OpenAIResponsesReplayMode,
 } from "../transports/openai-responses-compaction-replay.js";
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
 import {
+  createOpenAIResponsesAssistantOutput,
   createResponsesStreamWithEncryptedContentRetry,
-  prepareOpenAIResponsesReasoningItemForReplay,
-  readOpenAIResponsesReasoningReplayBlockMetadata,
+  convertProviderResponsesMessages,
 } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import { createOpenAIResponseHook } from "../transports/openai-transport-shared.js";
@@ -40,96 +30,22 @@ import type {
   Model,
   SimpleStreamOptions,
   StreamOptions,
-  TextSignatureV1,
   Usage,
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { shortHash } from "../utils/hash.js";
 import { projectProviderError } from "../utils/provider-error.js";
-import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   createFirstStreamEventAbortController,
   getFirstStreamEventTimeoutHandler,
   getFirstStreamEventTimeoutMs,
   type FirstStreamEventInternalOptions,
 } from "../utils/stream-first-event-timeout.js";
-import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import {
   resolveOpenAIReasoningEffortForModel,
   supportsOpenAIReasoningEffort,
   supportsOpenAITemperature,
 } from "./openai-reasoning-effort.js";
 import { convertResponsesToolPayload } from "./openai-responses-tools.js";
-import {
-  describeToolResultMediaPlaceholder,
-  extractToolResultText,
-  isImageWithMediaPayload,
-} from "./tool-result-text.js";
-
-// =============================================================================
-// Utilities
-// =============================================================================
-
-const EMPTY_TOOL_RESULT_TEXT = "(no output)";
-
-// itemId is undefined when the id has no separator so replay paths keep
-// omitting the optional item id instead of serializing an empty string.
-function splitResponsesToolCallId(id: string): [callId: string, itemId: string | undefined] {
-  const separatorIndex = id.indexOf("|");
-  return separatorIndex === -1
-    ? [id, undefined]
-    : [id.slice(0, separatorIndex), id.slice(separatorIndex + 1)];
-}
-
-function sanitizeToolResultText(text: string, fallback: string): string {
-  const sanitized = sanitizeSurrogates(text);
-  return sanitized.trim().length > 0 ? sanitized : fallback;
-}
-
-type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
-type ReplayableResponseReasoningItem = Omit<ResponseReasoningItem, "id"> & { id?: string };
-
-function parseTextSignature(
-  signature: string | undefined,
-): { id?: string; phase?: TextSignatureV1["phase"] } | undefined {
-  if (!signature) {
-    return undefined;
-  }
-  if (signature.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(signature) as Partial<TextSignatureV1>;
-      if (parsed.v === 1) {
-        const id = typeof parsed.id === "string" ? parsed.id : undefined;
-        const phase =
-          parsed.phase === "commentary" || parsed.phase === "final_answer"
-            ? parsed.phase
-            : undefined;
-        // A reasoning-dropped replay keeps the phase but omits the paired id.
-        if (id !== undefined || phase !== undefined) {
-          return { id, phase };
-        }
-        return undefined;
-      }
-    } catch {
-      // Fall through to legacy plain-string handling.
-    }
-  }
-  return { id: signature };
-}
-
-function resolveReplayableResponsesMessageId(params: {
-  textSignatureId?: string;
-  fallbackId: string;
-  fallbackOrdinal: number;
-  previousReplayItemWasReasoning: boolean;
-}): string | undefined {
-  if (!params.textSignatureId) {
-    return params.fallbackOrdinal === 0
-      ? params.fallbackId
-      : `${params.fallbackId}_${params.fallbackOrdinal}`;
-  }
-  return params.previousReplayItemWasReasoning ? params.textSignatureId : undefined;
-}
 
 interface OpenAIResponsesStreamOptions {
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
@@ -217,274 +133,13 @@ export function convertResponsesMessages<TApi extends Api>(
   allowedToolCallProviders: ReadonlySet<string>,
   options?: ConvertResponsesMessagesOptions,
 ): ResponseInput {
-  const messages: ResponseInput = [];
-  const shouldReplayResponsesItemIds = options?.replayResponsesItemIds ?? true;
-  const replayContext = buildOpenAIResponsesReplayContext(model, {
-    sessionId: options?.sessionId,
-    authProfileId: options?.authProfileId,
-  });
-
-  const normalizeIdPart = (part: string): string => {
-    const sanitized = part.replace(/[^a-zA-Z0-9_-]/g, "_");
-    const normalized = sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
-    return normalized.replace(/_+$/, "");
-  };
-
-  const buildForeignResponsesItemId = (itemId: string): string => {
-    const normalized = `fc_${shortHash(itemId)}`;
-    return normalized.length > 64 ? normalized.slice(0, 64) : normalized;
-  };
-
-  const normalizeToolCallId = (
-    id: string,
-    targetModel: Model<TApi>,
-    source: AssistantMessage,
-  ): string => {
-    void targetModel;
-    if (!allowedToolCallProviders.has(model.provider)) {
-      return normalizeIdPart(id);
-    }
-    if (!id.includes("|")) {
-      return normalizeIdPart(id);
-    }
-    // The includes("|") guard above guarantees the item id component exists.
-    const [callId, itemId = ""] = splitResponsesToolCallId(id);
-    const normalizedCallId = normalizeIdPart(callId);
-    const isForeignToolCall = source.provider !== model.provider || source.api !== model.api;
-    let normalizedItemId = isForeignToolCall
-      ? buildForeignResponsesItemId(itemId)
-      : normalizeIdPart(itemId);
-    // OpenAI Responses API requires item id to start with "fc"
-    if (!normalizedItemId.startsWith("fc_")) {
-      normalizedItemId = normalizeIdPart(`fc_${normalizedItemId}`);
-    }
-    return `${normalizedCallId}|${normalizedItemId}`;
-  };
-
-  const replayPlan = buildOpenAIResponsesCompactionReplayPlan(context.messages, model, {
-    sessionId: options?.sessionId,
-    authProfileId: options?.authProfileId,
-    mode: options?.replayMode,
-  });
-  const transformedMessages = transformMessages(replayPlan.messages, model, normalizeToolCallId);
-
-  const includeSystemPrompt = options?.includeSystemPrompt ?? true;
-  if (includeSystemPrompt && context.systemPrompt) {
-    const compat = model.compat as { supportsDeveloperRole?: boolean } | undefined;
-    const role =
-      model.reasoning && compat?.supportsDeveloperRole !== false ? "developer" : "system";
-    messages.push({
-      type: "message",
-      role,
-      content: [
-        {
-          type: "input_text",
-          text: sanitizeSurrogates(stripSystemPromptCacheBoundary(context.systemPrompt)),
-        },
-      ],
-    });
-  }
-  if (replayPlan.compaction) {
-    messages.push(replayPlan.compaction);
-  }
-
-  let msgIndex = 0;
-  for (const msg of transformedMessages) {
-    if (msg.role === "user") {
-      if (typeof msg.content === "string") {
-        messages.push({
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: sanitizeSurrogates(msg.content) }],
-        });
-      } else {
-        const content: ResponseInputContent[] = msg.content.map((item): ResponseInputContent => {
-          if (item.type === "text") {
-            return {
-              type: "input_text",
-              text: sanitizeSurrogates(item.text),
-            } satisfies ResponseInputText;
-          }
-          return {
-            type: "input_image",
-            detail: "auto",
-            image_url: `data:${item.mimeType};base64,${item.data}`,
-          } satisfies ResponseInputImage;
-        });
-        if (content.length === 0) {
-          continue;
-        }
-        messages.push({
-          type: "message",
-          role: "user",
-          content,
-        });
-      }
-    } else if (msg.role === "assistant") {
-      const output: ResponseInput = [];
-      let textFallbackOrdinal = 0;
-      const assistantMsg = msg;
-      let previousReplayItemWasReasoning = false;
-      const isDifferentModel =
-        assistantMsg.model !== model.id &&
-        assistantMsg.provider === model.provider &&
-        assistantMsg.api === model.api;
-
-      for (const block of msg.content) {
-        if (block.type === "thinking") {
-          if (block.thinkingSignature) {
-            const reasoningItem = JSON.parse(
-              block.thinkingSignature,
-            ) as ReplayableResponseReasoningItem;
-            const blockMetadata = readOpenAIResponsesReasoningReplayBlockMetadata(
-              block as unknown as Record<string, unknown>,
-            );
-            // Unannotated items retain the shipped public-provider stateless replay contract.
-            // Once capture provenance exists, ciphertext is fenced to that exact route.
-            const replayableReasoningItem = prepareOpenAIResponsesReasoningItemForReplay(
-              reasoningItem,
-              replayContext,
-              blockMetadata,
-              { preserveUnattributedEncryptedContent: true },
-            );
-            if (!shouldReplayResponsesItemIds) {
-              delete replayableReasoningItem.id;
-            }
-            output.push(replayableReasoningItem as ResponseInputItem);
-            previousReplayItemWasReasoning = true;
-          }
-        } else if (block.type === "text") {
-          const textBlock = block;
-          const parsedSignature = parseTextSignature(textBlock.textSignature);
-          let msgId = shouldReplayResponsesItemIds
-            ? resolveReplayableResponsesMessageId({
-                textSignatureId: parsedSignature?.id,
-                fallbackId: `msg_${msgIndex}`,
-                fallbackOrdinal: textFallbackOrdinal,
-                previousReplayItemWasReasoning,
-              })
-            : undefined;
-          if (!parsedSignature?.id) {
-            textFallbackOrdinal += 1;
-          }
-          if (msgId && msgId.length > 64) {
-            msgId = `msg_${shortHash(msgId)}`;
-          }
-          const messageItem: ReplayableResponseOutputMessage = {
-            type: "message",
-            role: "assistant",
-            content: [
-              { type: "output_text", text: sanitizeSurrogates(textBlock.text), annotations: [] },
-            ],
-            status: "completed",
-            ...(msgId ? { id: msgId } : {}),
-            phase: parsedSignature?.phase,
-          };
-          output.push(messageItem as ResponseInputItem);
-          previousReplayItemWasReasoning = false;
-        } else if (block.type === "toolCall") {
-          const toolCall = block;
-          const [callId, itemIdRaw] = splitResponsesToolCallId(toolCall.id);
-          let itemId: string | undefined = shouldReplayResponsesItemIds ? itemIdRaw : undefined;
-
-          // For different-model messages, set id to undefined to avoid pairing validation.
-          // OpenAI tracks which fc_xxx IDs were paired with rs_xxx reasoning items.
-          // By omitting the id, we avoid triggering that validation (like cross-provider does).
-          if (shouldReplayResponsesItemIds && isDifferentModel && itemId?.startsWith("fc_")) {
-            itemId = undefined;
-          }
-
-          output.push({
-            type: "function_call",
-            ...(itemId ? { id: itemId } : {}),
-            call_id: callId,
-            name: toolCall.name,
-            arguments: JSON.stringify(toolCall.arguments),
-          });
-          previousReplayItemWasReasoning = false;
-        }
-      }
-      if (output.length === 0) {
-        continue;
-      }
-      messages.push(...output);
-    } else if (msg.role === "toolResult") {
-      const textResult = extractToolResultText(msg.content);
-      const sanitizedTextResult = sanitizeSurrogates(textResult);
-      const hasImages = msg.content.some(isImageWithMediaPayload);
-      const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-      const hasText = sanitizedTextResult.trim().length > 0;
-      const [callId] = splitResponsesToolCallId(msg.toolCallId);
-
-      let output: string | ResponseFunctionCallOutputItemList;
-      if (hasImages && model.input.includes("image")) {
-        const contentParts: ResponseFunctionCallOutputItemList = [];
-
-        if (hasText) {
-          contentParts.push({
-            type: "input_text",
-            text: sanitizedTextResult,
-          });
-        } else if (mediaPlaceholder === "(see attached media)") {
-          contentParts.push({
-            type: "input_text",
-            text: mediaPlaceholder,
-          });
-        }
-
-        for (const block of msg.content) {
-          if (isImageWithMediaPayload(block)) {
-            contentParts.push({
-              type: "input_image",
-              detail: "auto",
-              image_url: `data:${block.mimeType};base64,${block.data}`,
-            });
-          }
-        }
-
-        output = contentParts;
-      } else {
-        output = sanitizeToolResultText(textResult, mediaPlaceholder ?? EMPTY_TOOL_RESULT_TEXT);
-      }
-
-      messages.push({
-        type: "function_call_output",
-        call_id: callId,
-        output,
-      });
-    }
-    msgIndex++;
-  }
-
-  return messages;
+  return convertProviderResponsesMessages(model, context, allowedToolCallProviders, options);
 }
 
-// =============================================================================
+export const createResponsesAssistantOutput = createOpenAIResponsesAssistantOutput;
+
 // Stream lifecycle
 // =============================================================================
-
-export function createResponsesAssistantOutput<TApi extends Api>(
-  model: Model<TApi>,
-  api: Api = model.api,
-): AssistantMessage {
-  return {
-    role: "assistant",
-    content: [],
-    api,
-    provider: model.provider,
-    model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: "stop",
-    timestamp: Date.now(),
-  };
-}
 
 export function applyResponsesServiceTierPricing(
   usage: Usage,

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -49,6 +49,7 @@ import {
 } from "./openai-responses-params-internal.js";
 import { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
 import {
+  createOpenAIResponsesAssistantOutput,
   createResponsesStreamWithEncryptedContentRetry,
   isInvalidEncryptedContentError,
   resolveNextResponsesEncryptedContentAttempt,
@@ -241,23 +242,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
     const eventStream = createAssistantMessageEventStream();
     const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
     void (async () => {
-      const output: AssistantMessage = {
-        role: "assistant" as const,
-        content: [],
-        api: config.outputApi ?? model.api,
-        provider: model.provider,
-        model: model.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "stop",
-        timestamp: Date.now(),
-      };
+      const output = createOpenAIResponsesAssistantOutput(model, config.outputApi);
       let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
       let continuationClaim: ReturnType<typeof claimOpenAIResponsesHttpContinuation>;
       try {

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -250,6 +250,5 @@ export {
   createOpenAIResponsesAssistantOutput,
   encodeTextSignatureV1,
   prepareOpenAIResponsesReasoningItemForReplay,
-  readOpenAIResponsesReasoningReplayBlockMetadata,
   tagOpenAIResponsesReasoningReplayItem,
 } from "./openai-responses-replay-messages-internal.js";

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -1,50 +1,14 @@
-import type { Api, Context, Model } from "@openclaw/llm-core";
-import type {
-  ResponseFunctionCallOutputItemList,
-  ResponseInput,
-  ResponseInputItem,
-  ResponseInputMessageContentList,
-} from "openai/resources/responses/responses.js";
-import type {
-  BaseOpenAIStreamOptions,
-  OpenAIResponsesCompactionRejection,
-} from "../provider-options.js";
-import {
-  describeToolResultMediaPlaceholder,
-  extractToolResultText,
-  isImageWithMediaPayload,
-} from "../providers/tool-result-text.js";
-import { shortHash } from "../utils/hash.js";
-import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
-import { transformTransportMessages } from "./host-policy.js";
+import type { Model } from "@openclaw/llm-core";
+import type { ResponseInput } from "openai/resources/responses/responses.js";
+import type { OpenAIResponsesCompactionRejection } from "../provider-options.js";
 import type { createOpenAIResponsesClient } from "./openai-responses-client.js";
 import {
-  buildOpenAIResponsesReasoningReplayMetadata,
-  buildOpenAIResponsesReplayContext,
-  buildOpenAIResponsesCompactionReplayPlan,
-  isOpenAIResponsesReplayContext,
-  isSafeResponsesReplayItemId,
-  openAIResponsesReplayContextMatches,
-  type OpenAIResponsesReplayMode,
-} from "./openai-responses-compaction-replay.js";
-import {
   DEFAULT_AZURE_OPENAI_API_VERSION,
-  OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY,
-  OPENAI_RESPONSES_REASONING_REPLAY_META_KEY,
-  OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH,
-  type OpenAIResponsesReasoningReplayMetadata,
-  type OpenAIResponsesReplayContext,
   type OpenAIResponsesRequestParams,
-  type ReplayableResponseOutputMessage,
-  type ReplayableResponseReasoningItem,
 } from "./openai-responses-contracts.js";
 import type { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
-import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
+import { stripEncryptedReasoningContentFields } from "./openai-responses-replay-messages-internal.js";
 import { log } from "./openai-transport-shared.js";
-import {
-  sanitizeNonEmptyTransportPayloadText,
-  sanitizeTransportPayloadText,
-} from "./transport-stream-shared.js";
 
 type ResponsesClientLike = ReturnType<typeof createOpenAIResponsesClient>;
 
@@ -78,41 +42,6 @@ function isOrphanedFunctionCallOutputError(error: unknown): boolean {
   return /No tool call found for function call output with call_id [A-Za-z0-9_-]+/.test(message);
 }
 
-function stripEncryptedReasoningContentFields(value: unknown): {
-  value: unknown;
-  changed: boolean;
-} {
-  if (!value || typeof value !== "object") {
-    return { value, changed: false };
-  }
-  if (Array.isArray(value)) {
-    let changed = false;
-    const next = value.map((item) => {
-      const stripped = stripEncryptedReasoningContentFields(item);
-      changed ||= stripped.changed;
-      return stripped.value;
-    });
-    return changed ? { value: next, changed: true } : { value, changed: false };
-  }
-
-  const source = value as Record<string, unknown>;
-  if (source.type === "compaction") {
-    return { value, changed: false };
-  }
-  let changed = false;
-  const next: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(source)) {
-    if (key === "encrypted_content") {
-      changed = true;
-      continue;
-    }
-    const stripped = stripEncryptedReasoningContentFields(child);
-    changed ||= stripped.changed;
-    next[key] = stripped.value;
-  }
-  return changed ? { value: next, changed: true } : { value, changed: false };
-}
-
 type ResponsesEncryptedContentRequest = { input?: ResponseInput };
 
 type ResponsesEncryptedContentAttemptKind =
@@ -126,6 +55,15 @@ export type ResponsesEncryptedContentAttempt<TRequest extends ResponsesEncrypted
   request: TRequest;
   rejectedCompaction?: OpenAIResponsesCompactionRejection;
 };
+
+export function commitResponsesEncryptedContentAttempt(
+  attempt: ResponsesEncryptedContentAttempt<ResponsesEncryptedContentRequest>,
+  commit: (checkpoint: OpenAIResponsesCompactionRejection | undefined) => void,
+): void {
+  if (attempt.kind === "compaction-stripped") {
+    commit(attempt.rejectedCompaction);
+  }
+}
 
 function stripResponsesRequestEncryptedReasoning<TRequest extends ResponsesEncryptedContentRequest>(
   request: TRequest,
@@ -218,87 +156,6 @@ export async function resolveNextResponsesEncryptedContentAttempt<
   };
 }
 
-export function tagOpenAIResponsesReasoningReplayItem(
-  item: Record<string, unknown>,
-  model: Model,
-  options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId">,
-): Record<string, unknown> {
-  if (!("encrypted_content" in item)) {
-    return item;
-  }
-  return {
-    ...item,
-    [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: buildOpenAIResponsesReasoningReplayMetadata(
-      model,
-      options,
-    ),
-  };
-}
-
-function isOpenAIResponsesReasoningReplayMetadata(
-  value: unknown,
-): value is OpenAIResponsesReasoningReplayMetadata {
-  if (!isOpenAIResponsesReplayContext(value)) {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  return record.v === 1 && record.source === "openai-responses";
-}
-
-export function readOpenAIResponsesReasoningReplayBlockMetadata(
-  block: Record<string, unknown>,
-): OpenAIResponsesReasoningReplayMetadata | null | undefined {
-  if (!Object.hasOwn(block, OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY)) {
-    return undefined;
-  }
-  const value = block[OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY];
-  return isOpenAIResponsesReasoningReplayMetadata(value) ? value : null;
-}
-
-function normalizeOpenAIResponsesReasoningReplayItem(
-  item: ReplayableResponseReasoningItem,
-): ReplayableResponseReasoningItem {
-  const record = item as ReplayableResponseReasoningItem & Record<string, unknown>;
-  if (record.type !== "reasoning" || Array.isArray(record.summary)) {
-    return item;
-  }
-  return { ...record, summary: [] } as ReplayableResponseReasoningItem;
-}
-
-export function prepareOpenAIResponsesReasoningItemForReplay(
-  item: ReplayableResponseReasoningItem,
-  context: OpenAIResponsesReplayContext,
-  blockMetadata?: OpenAIResponsesReasoningReplayMetadata | null,
-  options?: { preserveUnattributedEncryptedContent?: boolean },
-): ReplayableResponseReasoningItem {
-  const record = item as ReplayableResponseReasoningItem & Record<string, unknown>;
-  const hasRawMetadata = Object.hasOwn(record, OPENAI_RESPONSES_REASONING_REPLAY_META_KEY);
-  const { [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: rawMetadata, ...rest } = record;
-  if (!("encrypted_content" in rest)) {
-    return normalizeOpenAIResponsesReasoningReplayItem(rest as ReplayableResponseReasoningItem);
-  }
-  const metadata =
-    blockMetadata !== undefined
-      ? (blockMetadata ?? undefined)
-      : isOpenAIResponsesReasoningReplayMetadata(rawMetadata)
-        ? rawMetadata
-        : undefined;
-  const preserveUnattributed =
-    blockMetadata === undefined &&
-    !hasRawMetadata &&
-    options?.preserveUnattributedEncryptedContent === true;
-  if (
-    preserveUnattributed ||
-    (metadata && openAIResponsesReplayContextMatches(metadata, context))
-  ) {
-    return normalizeOpenAIResponsesReasoningReplayItem(rest as ReplayableResponseReasoningItem);
-  }
-  const stripped = stripEncryptedReasoningContentFields(rest);
-  return normalizeOpenAIResponsesReasoningReplayItem(
-    stripped.value as ReplayableResponseReasoningItem,
-  );
-}
-
 export async function createResponsesStreamWithEncryptedContentRetry(params: {
   client: ResponsesClientLike;
   request: OpenAIResponsesRequestParams;
@@ -322,11 +179,11 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
     const { data, response } = await params.client.responses
       .create(attempt.request as never, params.requestOptions as never)
       .withResponse();
-    if (attempt.kind === "compaction-stripped") {
-      if (attempt.rejectedCompaction) {
-        params.onCompactionRejected?.(attempt.rejectedCompaction);
+    commitResponsesEncryptedContentAttempt(attempt, (checkpoint) => {
+      if (checkpoint) {
+        params.onCompactionRejected?.(checkpoint);
       }
-    }
+    });
     return { stream: data as unknown as AsyncIterable<unknown>, response, attempt };
   };
 
@@ -386,303 +243,13 @@ export function resolveAzureOpenAIApiVersion(env = process.env): string {
   return env.AZURE_OPENAI_API_VERSION?.trim() || DEFAULT_AZURE_OPENAI_API_VERSION;
 }
 
-function normalizeResponsesReplayItemId(
-  id: string | undefined,
-  prefix: string,
-): string | undefined {
-  if (!id) {
-    return undefined;
-  }
-  if (id.length <= OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH) {
-    return id;
-  }
-  return `${prefix}_${shortHash(id)}`;
-}
-
-export function encodeTextSignatureV1(id: string, phase?: "commentary" | "final_answer"): string {
-  return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
-}
-
-function parseTextSignature(
-  signature: string | undefined,
-): { id?: string; phase?: "commentary" | "final_answer" } | undefined {
-  if (!signature) {
-    return undefined;
-  }
-  if (signature.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(signature) as { v?: unknown; id?: unknown; phase?: unknown };
-      if (parsed.v === 1) {
-        const id = typeof parsed.id === "string" ? parsed.id : undefined;
-        const phase =
-          parsed.phase === "commentary" || parsed.phase === "final_answer"
-            ? parsed.phase
-            : undefined;
-        // A reasoning-dropped replay keeps the phase but omits the paired id.
-        if (id !== undefined || phase !== undefined) {
-          return { id, phase };
-        }
-        return undefined;
-      }
-    } catch {
-      // Keep legacy plain-string behavior below.
-    }
-  }
-  return { id: signature };
-}
-
-export function buildResponsesInputMessage(
-  role: "user" | "system" | "developer",
-  content: ResponseInputMessageContentList,
-): ResponseInputItem.Message {
-  return { type: "message", role, content };
-}
-
-export function convertResponsesMessages(
-  model: Model,
-  context: Context,
-  allowedToolCallProviders: Set<string>,
-  options?: {
-    includeSystemPrompt?: boolean;
-    supportsDeveloperRole?: boolean;
-    replayReasoningItems?: boolean;
-    replayResponsesItemIds?: boolean;
-    sessionId?: string;
-    authProfileId?: string;
-    replayMode?: OpenAIResponsesReplayMode;
-  },
-): ResponseInput {
-  const messages: ResponseInput = [];
-  const shouldReplayReasoningItems = options?.replayReasoningItems ?? true;
-  const shouldReplayResponsesItemIds = options?.replayResponsesItemIds ?? true;
-  const replayContext = buildOpenAIResponsesReplayContext(model, {
-    sessionId: options?.sessionId,
-    authProfileId: options?.authProfileId,
-  });
-  const shouldNormalizeSameModelToolCallIds = model.provider === "github-copilot";
-  const sanitizeIdPart = (part: string) => part.replace(/[^a-zA-Z0-9_-]/g, "_").replace(/_+$/, "");
-  const normalizeIdPart = (part: string) => {
-    const sanitized = sanitizeIdPart(part);
-    const normalized = sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
-    return normalized.replace(/_+$/, "");
-  };
-  const buildForeignResponsesItemId = (itemId: string) => {
-    const normalized = `fc_${shortHash(itemId)}`;
-    return normalized.length > 64 ? normalized.slice(0, 64) : normalized;
-  };
-  const buildSameProviderCopilotResponsesItemId = (itemId: string) => {
-    const sanitized = sanitizeIdPart(itemId);
-    const candidate = sanitized.startsWith("fc_") ? sanitized : `fc_${sanitized}`;
-    return candidate.length > 64 ? buildForeignResponsesItemId(itemId) : candidate;
-  };
-  const normalizeToolCallId = (
-    id: string,
-    _targetModel: Model,
-    source: { provider: string; api: Api },
-  ) => {
-    if (!allowedToolCallProviders.has(model.provider)) {
-      return normalizeIdPart(id);
-    }
-    if (!id.includes("|")) {
-      return normalizeIdPart(id);
-    }
-    const separatorIndex = id.indexOf("|");
-    const callId = id.slice(0, separatorIndex);
-    const itemId = id.slice(separatorIndex + 1);
-    const normalizedCallId = normalizeIdPart(callId);
-    const isForeignToolCall = source.provider !== model.provider || source.api !== model.api;
-    let normalizedItemId = isForeignToolCall
-      ? buildForeignResponsesItemId(itemId)
-      : model.provider === "github-copilot"
-        ? buildSameProviderCopilotResponsesItemId(itemId)
-        : normalizeIdPart(itemId);
-    if (!normalizedItemId.startsWith("fc_")) {
-      normalizedItemId = normalizeIdPart(`fc_${normalizedItemId}`);
-    }
-    return `${normalizedCallId}|${normalizedItemId}`;
-  };
-  const replayPlan = buildOpenAIResponsesCompactionReplayPlan(context.messages, model, {
-    sessionId: options?.sessionId,
-    authProfileId: options?.authProfileId,
-    mode: options?.replayMode,
-  });
-  const transformedMessages = transformTransportMessages(
-    replayPlan.messages,
-    model,
-    normalizeToolCallId,
-    {
-      normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds,
-      preserveUnframedToolResults: replayPlan.preserveUnframedToolResults,
-    },
-  );
-  const includeSystemPrompt = options?.includeSystemPrompt ?? true;
-  if (includeSystemPrompt && context.systemPrompt) {
-    messages.push(
-      buildResponsesInputMessage(
-        model.reasoning && options?.supportsDeveloperRole !== false ? "developer" : "system",
-        [
-          {
-            type: "input_text",
-            text: sanitizeTransportPayloadText(
-              stripSystemPromptCacheBoundary(context.systemPrompt),
-            ),
-          },
-        ],
-      ),
-    );
-  }
-  if (replayPlan.compaction) {
-    messages.push(replayPlan.compaction);
-  }
-  let msgIndex = 0;
-  for (const msg of transformedMessages) {
-    if (msg.role === "user") {
-      if (typeof msg.content === "string") {
-        messages.push(
-          buildResponsesInputMessage("user", [
-            { type: "input_text", text: sanitizeTransportPayloadText(msg.content) },
-          ]),
-        );
-      } else {
-        const content = (
-          msg.content.map((item) =>
-            item.type === "text"
-              ? { type: "input_text", text: sanitizeTransportPayloadText(item.text) }
-              : {
-                  type: "input_image",
-                  detail: "auto",
-                  image_url: `data:${item.mimeType};base64,${item.data}`,
-                },
-          ) as ResponseInputMessageContentList
-        ).filter((item) => model.input.includes("image") || item.type !== "input_image");
-        if (content.length > 0) {
-          messages.push(buildResponsesInputMessage("user", content));
-        }
-      }
-    } else if (msg.role === "assistant") {
-      const output: ResponseInput = [];
-      let textFallbackOrdinal = 0;
-      let previousReplayItemWasReasoning = false;
-      const isDifferentModel =
-        msg.model !== model.id && msg.provider === model.provider && msg.api === model.api;
-      for (const block of msg.content) {
-        if (block.type === "thinking") {
-          if (
-            shouldReplayReasoningItems &&
-            block.thinkingSignature &&
-            block.thinkingSignature.startsWith("{")
-          ) {
-            // openai-completions plain-text reasoning paths persist a
-            // provenance tag (e.g. "reasoning", "reasoning_details", "content")
-            // as thinkingSignature rather than a JSON-encoded reasoning item.
-            // Replaying those values would corrupt the next request payload
-            // (OpenRouter returns HTTP 500), so skip non-JSON signatures.
-            const reasoningItem = JSON.parse(
-              block.thinkingSignature,
-            ) as ReplayableResponseReasoningItem;
-            const replayableReasoningItem = prepareOpenAIResponsesReasoningItemForReplay(
-              reasoningItem,
-              replayContext,
-              readOpenAIResponsesReasoningReplayBlockMetadata(
-                block as unknown as Record<string, unknown>,
-              ),
-            );
-            if (!shouldReplayResponsesItemIds) {
-              delete replayableReasoningItem.id;
-            }
-            if (
-              shouldReplayResponsesItemIds &&
-              model.provider === "github-copilot" &&
-              !isSafeResponsesReplayItemId(replayableReasoningItem.id)
-            ) {
-              continue;
-            }
-            output.push(replayableReasoningItem as ResponseInputItem);
-            previousReplayItemWasReasoning = true;
-          }
-        } else if (block.type === "text") {
-          const textSignature = parseTextSignature(block.textSignature);
-          let msgId = resolveReplayableResponsesMessageId({
-            replayResponsesItemIds: shouldReplayResponsesItemIds,
-            textSignatureId: textSignature?.id,
-            fallbackId: `msg_${msgIndex}`,
-            fallbackOrdinal: textFallbackOrdinal,
-            previousReplayItemWasReasoning,
-          });
-          if (!textSignature?.id) {
-            textFallbackOrdinal += 1;
-          }
-          msgId = normalizeResponsesReplayItemId(msgId, "msg");
-          const messageItem: ReplayableResponseOutputMessage = {
-            type: "message",
-            role: "assistant",
-            content: [
-              {
-                type: "output_text",
-                text: sanitizeTransportPayloadText(block.text),
-                annotations: [],
-              },
-            ],
-            status: "completed",
-            ...(msgId ? { id: msgId } : {}),
-            phase: textSignature?.phase,
-          };
-          output.push(messageItem as ResponseInputItem);
-          previousReplayItemWasReasoning = false;
-        } else if (block.type === "toolCall") {
-          const separatorIndex = block.id.indexOf("|");
-          const callId = separatorIndex === -1 ? block.id : block.id.slice(0, separatorIndex);
-          const itemIdRaw = separatorIndex === -1 ? undefined : block.id.slice(separatorIndex + 1);
-          const itemId =
-            shouldReplayResponsesItemIds && !(isDifferentModel && itemIdRaw?.startsWith("fc_"))
-              ? itemIdRaw
-              : undefined;
-          output.push({
-            type: "function_call",
-            ...(itemId ? { id: itemId } : {}),
-            call_id: callId,
-            name: block.name,
-            arguments:
-              typeof block.arguments === "string"
-                ? block.arguments
-                : JSON.stringify(block.arguments ?? {}),
-          });
-          previousReplayItemWasReasoning = false;
-        }
-      }
-      if (output.length > 0) {
-        messages.push(...output);
-      }
-    } else if (msg.role === "toolResult") {
-      const textResult = extractToolResultText(msg.content);
-      const sanitizedTextResult = sanitizeTransportPayloadText(textResult);
-      const hasText = sanitizedTextResult.trim().length > 0;
-      const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-      const hasImages = msg.content.some(isImageWithMediaPayload);
-      const separatorIndex = msg.toolCallId.indexOf("|");
-      const callId =
-        separatorIndex === -1 ? msg.toolCallId : msg.toolCallId.slice(0, separatorIndex);
-      messages.push({
-        type: "function_call_output",
-        call_id: callId,
-        output:
-          hasImages && model.input.includes("image")
-            ? ([
-                ...(hasText
-                  ? [{ type: "input_text", text: sanitizedTextResult }]
-                  : mediaPlaceholder === "(see attached media)"
-                    ? [{ type: "input_text", text: mediaPlaceholder }]
-                    : []),
-                ...msg.content.filter(isImageWithMediaPayload).map((item) => ({
-                  type: "input_image",
-                  detail: "auto",
-                  image_url: `data:${item.mimeType};base64,${item.data}`,
-                })),
-              ] as ResponseFunctionCallOutputItemList)
-            : sanitizeNonEmptyTransportPayloadText(textResult, mediaPlaceholder ?? "(no output)"),
-      });
-    }
-    msgIndex += 1;
-  }
-  return messages;
-}
+export {
+  buildResponsesInputMessage,
+  convertProviderResponsesMessages,
+  convertResponsesMessages,
+  createOpenAIResponsesAssistantOutput,
+  encodeTextSignatureV1,
+  prepareOpenAIResponsesReasoningItemForReplay,
+  readOpenAIResponsesReasoningReplayBlockMetadata,
+  tagOpenAIResponsesReasoningReplayItem,
+} from "./openai-responses-replay-messages-internal.js";

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -1,0 +1,534 @@
+import type { Api, AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import type {
+  ResponseFunctionCallOutputItemList,
+  ResponseInput,
+  ResponseInputItem,
+  ResponseInputMessageContentList,
+} from "openai/resources/responses/responses.js";
+import type { BaseOpenAIStreamOptions } from "../provider-options.js";
+import { transformProviderMessages } from "../provider-transcript-transform.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  isImageWithMediaPayload,
+} from "../providers/tool-result-text.js";
+import { shortHash } from "../utils/hash.js";
+import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
+import { transformTransportMessages } from "./host-policy.js";
+import {
+  buildOpenAIResponsesReasoningReplayMetadata,
+  buildOpenAIResponsesReplayContext,
+  buildOpenAIResponsesCompactionReplayPlan,
+  isOpenAIResponsesReplayContext,
+  isSafeResponsesReplayItemId,
+  openAIResponsesReplayContextMatches,
+  type OpenAIResponsesReplayMode,
+} from "./openai-responses-compaction-replay.js";
+import {
+  OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY,
+  OPENAI_RESPONSES_REASONING_REPLAY_META_KEY,
+  OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH,
+  type OpenAIResponsesReasoningReplayMetadata,
+  type OpenAIResponsesReplayContext,
+  type ReplayableResponseOutputMessage,
+  type ReplayableResponseReasoningItem,
+} from "./openai-responses-contracts.js";
+import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
+import {
+  sanitizeNonEmptyTransportPayloadText,
+  sanitizeTransportPayloadText,
+} from "./transport-stream-shared.js";
+
+export function stripEncryptedReasoningContentFields(value: unknown): {
+  value: unknown;
+  changed: boolean;
+} {
+  if (!value || typeof value !== "object") {
+    return { value, changed: false };
+  }
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item) => {
+      const stripped = stripEncryptedReasoningContentFields(item);
+      changed ||= stripped.changed;
+      return stripped.value;
+    });
+    return changed ? { value: next, changed: true } : { value, changed: false };
+  }
+
+  const source = value as Record<string, unknown>;
+  if (source.type === "compaction") {
+    return { value, changed: false };
+  }
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(source)) {
+    if (key === "encrypted_content") {
+      changed = true;
+      continue;
+    }
+    const stripped = stripEncryptedReasoningContentFields(child);
+    changed ||= stripped.changed;
+    next[key] = stripped.value;
+  }
+  return changed ? { value: next, changed: true } : { value, changed: false };
+}
+
+export function tagOpenAIResponsesReasoningReplayItem(
+  item: Record<string, unknown>,
+  model: Model,
+  options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId">,
+): Record<string, unknown> {
+  if (!("encrypted_content" in item)) {
+    return item;
+  }
+  return {
+    ...item,
+    [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: buildOpenAIResponsesReasoningReplayMetadata(
+      model,
+      options,
+    ),
+  };
+}
+
+function isOpenAIResponsesReasoningReplayMetadata(
+  value: unknown,
+): value is OpenAIResponsesReasoningReplayMetadata {
+  if (!isOpenAIResponsesReplayContext(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return record.v === 1 && record.source === "openai-responses";
+}
+
+export function readOpenAIResponsesReasoningReplayBlockMetadata(
+  block: Record<string, unknown>,
+): OpenAIResponsesReasoningReplayMetadata | null | undefined {
+  if (!Object.hasOwn(block, OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY)) {
+    return undefined;
+  }
+  const value = block[OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY];
+  return isOpenAIResponsesReasoningReplayMetadata(value) ? value : null;
+}
+
+function normalizeOpenAIResponsesReasoningReplayItem(
+  item: ReplayableResponseReasoningItem,
+): ReplayableResponseReasoningItem {
+  const record = item as ReplayableResponseReasoningItem & Record<string, unknown>;
+  if (record.type !== "reasoning" || Array.isArray(record.summary)) {
+    return item;
+  }
+  return { ...record, summary: [] } as ReplayableResponseReasoningItem;
+}
+
+export function prepareOpenAIResponsesReasoningItemForReplay(
+  item: ReplayableResponseReasoningItem,
+  context: OpenAIResponsesReplayContext,
+  blockMetadata?: OpenAIResponsesReasoningReplayMetadata | null,
+  options?: { preserveUnattributedEncryptedContent?: boolean },
+): ReplayableResponseReasoningItem {
+  const record = item as ReplayableResponseReasoningItem & Record<string, unknown>;
+  const hasRawMetadata = Object.hasOwn(record, OPENAI_RESPONSES_REASONING_REPLAY_META_KEY);
+  const { [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: rawMetadata, ...rest } = record;
+  if (!("encrypted_content" in rest)) {
+    return normalizeOpenAIResponsesReasoningReplayItem(rest as ReplayableResponseReasoningItem);
+  }
+  const metadata =
+    blockMetadata !== undefined
+      ? (blockMetadata ?? undefined)
+      : isOpenAIResponsesReasoningReplayMetadata(rawMetadata)
+        ? rawMetadata
+        : undefined;
+  const preserveUnattributed =
+    blockMetadata === undefined &&
+    !hasRawMetadata &&
+    options?.preserveUnattributedEncryptedContent === true;
+  if (
+    preserveUnattributed ||
+    (metadata && openAIResponsesReplayContextMatches(metadata, context))
+  ) {
+    return normalizeOpenAIResponsesReasoningReplayItem(rest as ReplayableResponseReasoningItem);
+  }
+  const stripped = stripEncryptedReasoningContentFields(rest);
+  return normalizeOpenAIResponsesReasoningReplayItem(
+    stripped.value as ReplayableResponseReasoningItem,
+  );
+}
+
+function normalizeResponsesReplayItemId(
+  id: string | undefined,
+  prefix: string,
+): string | undefined {
+  if (!id) {
+    return undefined;
+  }
+  if (id.length <= OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH) {
+    return id;
+  }
+  return `${prefix}_${shortHash(id)}`;
+}
+
+export function encodeTextSignatureV1(id: string, phase?: "commentary" | "final_answer"): string {
+  return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
+}
+
+function parseOpenAIResponsesTextSignature(
+  signature: string | undefined,
+): { id?: string; phase?: "commentary" | "final_answer" } | undefined {
+  if (!signature) {
+    return undefined;
+  }
+  if (signature.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(signature) as { v?: unknown; id?: unknown; phase?: unknown };
+      if (parsed.v === 1) {
+        const id = typeof parsed.id === "string" ? parsed.id : undefined;
+        const phase =
+          parsed.phase === "commentary" || parsed.phase === "final_answer"
+            ? parsed.phase
+            : undefined;
+        // A reasoning-dropped replay keeps the phase but omits the paired id.
+        if (id !== undefined || phase !== undefined) {
+          return { id, phase };
+        }
+        return undefined;
+      }
+    } catch {
+      // Keep legacy plain-string behavior below.
+    }
+  }
+  return { id: signature };
+}
+
+export function buildResponsesInputMessage(
+  role: "user" | "system" | "developer",
+  content: ResponseInputMessageContentList,
+): ResponseInputItem.Message {
+  return { type: "message", role, content };
+}
+
+export function createOpenAIResponsesAssistantOutput(
+  model: Model,
+  api: Api = model.api,
+): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+type ConvertResponsesMessagesOptions = {
+  includeSystemPrompt?: boolean;
+  supportsDeveloperRole?: boolean;
+  replayReasoningItems?: boolean;
+  replayResponsesItemIds?: boolean;
+  sessionId?: string;
+  authProfileId?: string;
+  replayMode?: OpenAIResponsesReplayMode;
+};
+
+function convertResponsesMessagesWithStyle(
+  model: Model,
+  context: Context,
+  allowedToolCallProviders: ReadonlySet<string>,
+  options: ConvertResponsesMessagesOptions | undefined,
+  conversionStyle: "provider" | "transport",
+): ResponseInput {
+  const messages: ResponseInput = [];
+  const providerStyle = conversionStyle === "provider";
+  const shouldReplayReasoningItems = options?.replayReasoningItems ?? true;
+  const shouldReplayResponsesItemIds = options?.replayResponsesItemIds ?? true;
+  const replayContext = buildOpenAIResponsesReplayContext(model, {
+    sessionId: options?.sessionId,
+    authProfileId: options?.authProfileId,
+  });
+  const shouldNormalizeSameModelToolCallIds = model.provider === "github-copilot";
+  const sanitizeIdPart = (part: string) => {
+    const sanitized = part.replace(/[^a-zA-Z0-9_-]/g, "_");
+    return providerStyle ? sanitized : sanitized.replace(/_+$/, "");
+  };
+  const normalizeIdPart = (part: string) => {
+    const sanitized = sanitizeIdPart(part);
+    const normalized = sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
+    return normalized.replace(/_+$/, "");
+  };
+  const buildForeignResponsesItemId = (itemId: string) => {
+    const normalized = `fc_${shortHash(itemId)}`;
+    return normalized.length > 64 ? normalized.slice(0, 64) : normalized;
+  };
+  const buildSameProviderCopilotResponsesItemId = (itemId: string) => {
+    const sanitized = sanitizeIdPart(itemId);
+    const candidate = sanitized.startsWith("fc_") ? sanitized : `fc_${sanitized}`;
+    return candidate.length > 64 ? buildForeignResponsesItemId(itemId) : candidate;
+  };
+  const normalizeToolCallId = (
+    id: string,
+    _targetModel: Model,
+    source: { provider: string; api: Api },
+  ) => {
+    if (!allowedToolCallProviders.has(model.provider)) {
+      return normalizeIdPart(id);
+    }
+    if (!id.includes("|")) {
+      return normalizeIdPart(id);
+    }
+    const separatorIndex = id.indexOf("|");
+    const callId = id.slice(0, separatorIndex);
+    const itemId = id.slice(separatorIndex + 1);
+    const normalizedCallId = normalizeIdPart(callId);
+    const isForeignToolCall = source.provider !== model.provider || source.api !== model.api;
+    let normalizedItemId = isForeignToolCall
+      ? buildForeignResponsesItemId(itemId)
+      : model.provider === "github-copilot"
+        ? providerStyle
+          ? normalizeIdPart(itemId)
+          : buildSameProviderCopilotResponsesItemId(itemId)
+        : normalizeIdPart(itemId);
+    if (!normalizedItemId.startsWith("fc_")) {
+      normalizedItemId = normalizeIdPart(`fc_${normalizedItemId}`);
+    }
+    return `${normalizedCallId}|${normalizedItemId}`;
+  };
+  const replayPlan = buildOpenAIResponsesCompactionReplayPlan(context.messages, model, {
+    sessionId: options?.sessionId,
+    authProfileId: options?.authProfileId,
+    mode: options?.replayMode,
+  });
+  const transformedMessages = providerStyle
+    ? transformProviderMessages(replayPlan.messages, model, normalizeToolCallId)
+    : transformTransportMessages(replayPlan.messages, model, normalizeToolCallId, {
+        normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds,
+        preserveUnframedToolResults: replayPlan.preserveUnframedToolResults,
+      });
+  const includeSystemPrompt = options?.includeSystemPrompt ?? true;
+  if (includeSystemPrompt && context.systemPrompt) {
+    messages.push(
+      buildResponsesInputMessage(
+        model.reasoning &&
+          (providerStyle
+            ? (model.compat as { supportsDeveloperRole?: boolean } | undefined)
+                ?.supportsDeveloperRole !== false
+            : options?.supportsDeveloperRole !== false)
+          ? "developer"
+          : "system",
+        [
+          {
+            type: "input_text",
+            text: sanitizeTransportPayloadText(
+              stripSystemPromptCacheBoundary(context.systemPrompt),
+            ),
+          },
+        ],
+      ),
+    );
+  }
+  if (replayPlan.compaction) {
+    messages.push(replayPlan.compaction);
+  }
+  let msgIndex = 0;
+  for (const msg of transformedMessages) {
+    if (msg.role === "user") {
+      if (typeof msg.content === "string") {
+        messages.push(
+          buildResponsesInputMessage("user", [
+            { type: "input_text", text: sanitizeTransportPayloadText(msg.content) },
+          ]),
+        );
+      } else {
+        const content = (
+          msg.content.map((item) =>
+            item.type === "text"
+              ? { type: "input_text", text: sanitizeTransportPayloadText(item.text) }
+              : {
+                  type: "input_image",
+                  detail: "auto",
+                  image_url: `data:${item.mimeType};base64,${item.data}`,
+                },
+          ) as ResponseInputMessageContentList
+        ).filter(
+          (item) => providerStyle || model.input.includes("image") || item.type !== "input_image",
+        );
+        if (content.length > 0) {
+          messages.push(buildResponsesInputMessage("user", content));
+        } else if (providerStyle) {
+          continue;
+        }
+      }
+    } else if (msg.role === "assistant") {
+      const output: ResponseInput = [];
+      let textFallbackOrdinal = 0;
+      let previousReplayItemWasReasoning = false;
+      const isDifferentModel =
+        msg.model !== model.id && msg.provider === model.provider && msg.api === model.api;
+      for (const block of msg.content) {
+        if (block.type === "thinking") {
+          if (
+            shouldReplayReasoningItems &&
+            block.thinkingSignature &&
+            (providerStyle || block.thinkingSignature.startsWith("{"))
+          ) {
+            // Transport conversion skips openai-completions provenance tags; the provider
+            // conversion retains its shipped parse behavior for every non-empty signature.
+            const reasoningItem = JSON.parse(
+              block.thinkingSignature,
+            ) as ReplayableResponseReasoningItem;
+            const replayableReasoningItem = prepareOpenAIResponsesReasoningItemForReplay(
+              reasoningItem,
+              replayContext,
+              readOpenAIResponsesReasoningReplayBlockMetadata(
+                block as unknown as Record<string, unknown>,
+              ),
+              providerStyle ? { preserveUnattributedEncryptedContent: true } : undefined,
+            );
+            if (!shouldReplayResponsesItemIds) {
+              delete replayableReasoningItem.id;
+            }
+            if (
+              shouldReplayResponsesItemIds &&
+              !providerStyle &&
+              model.provider === "github-copilot" &&
+              !isSafeResponsesReplayItemId(replayableReasoningItem.id)
+            ) {
+              continue;
+            }
+            output.push(replayableReasoningItem as ResponseInputItem);
+            previousReplayItemWasReasoning = true;
+          }
+        } else if (block.type === "text") {
+          const textSignature = parseOpenAIResponsesTextSignature(block.textSignature);
+          let msgId = resolveReplayableResponsesMessageId({
+            replayResponsesItemIds: shouldReplayResponsesItemIds,
+            textSignatureId: textSignature?.id,
+            fallbackId: `msg_${msgIndex}`,
+            fallbackOrdinal: textFallbackOrdinal,
+            previousReplayItemWasReasoning,
+          });
+          if (!textSignature?.id) {
+            textFallbackOrdinal += 1;
+          }
+          msgId = normalizeResponsesReplayItemId(msgId, "msg");
+          const messageItem: ReplayableResponseOutputMessage = {
+            type: "message",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: sanitizeTransportPayloadText(block.text),
+                annotations: [],
+              },
+            ],
+            status: "completed",
+            ...(msgId ? { id: msgId } : {}),
+            phase: textSignature?.phase,
+          };
+          output.push(messageItem as ResponseInputItem);
+          previousReplayItemWasReasoning = false;
+        } else if (block.type === "toolCall") {
+          const separatorIndex = block.id.indexOf("|");
+          const callId = separatorIndex === -1 ? block.id : block.id.slice(0, separatorIndex);
+          const itemIdRaw = separatorIndex === -1 ? undefined : block.id.slice(separatorIndex + 1);
+          const itemId =
+            shouldReplayResponsesItemIds && !(isDifferentModel && itemIdRaw?.startsWith("fc_"))
+              ? itemIdRaw
+              : undefined;
+          output.push({
+            type: "function_call",
+            ...(itemId ? { id: itemId } : {}),
+            call_id: callId,
+            name: block.name,
+            arguments: providerStyle
+              ? JSON.stringify(block.arguments)
+              : typeof block.arguments === "string"
+                ? block.arguments
+                : JSON.stringify(block.arguments ?? {}),
+          });
+          previousReplayItemWasReasoning = false;
+        }
+      }
+      if (output.length > 0) {
+        messages.push(...output);
+      } else if (providerStyle) {
+        continue;
+      }
+    } else if (msg.role === "toolResult") {
+      const textResult = extractToolResultText(msg.content);
+      const sanitizedTextResult = sanitizeTransportPayloadText(textResult);
+      const hasText = sanitizedTextResult.trim().length > 0;
+      const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
+      const hasImages = msg.content.some(isImageWithMediaPayload);
+      const separatorIndex = msg.toolCallId.indexOf("|");
+      const callId =
+        separatorIndex === -1 ? msg.toolCallId : msg.toolCallId.slice(0, separatorIndex);
+      messages.push({
+        type: "function_call_output",
+        call_id: callId,
+        output:
+          hasImages && model.input.includes("image")
+            ? ([
+                ...(hasText
+                  ? [{ type: "input_text", text: sanitizedTextResult }]
+                  : mediaPlaceholder === "(see attached media)"
+                    ? [{ type: "input_text", text: mediaPlaceholder }]
+                    : []),
+                ...msg.content.filter(isImageWithMediaPayload).map((item) => ({
+                  type: "input_image",
+                  detail: "auto",
+                  image_url: `data:${item.mimeType};base64,${item.data}`,
+                })),
+              ] as ResponseFunctionCallOutputItemList)
+            : sanitizeNonEmptyTransportPayloadText(textResult, mediaPlaceholder ?? "(no output)"),
+      });
+    }
+    msgIndex += 1;
+  }
+  return messages;
+}
+
+export function convertResponsesMessages(
+  model: Model,
+  context: Context,
+  allowedToolCallProviders: ReadonlySet<string>,
+  options?: ConvertResponsesMessagesOptions,
+): ResponseInput {
+  return convertResponsesMessagesWithStyle(
+    model,
+    context,
+    allowedToolCallProviders,
+    options,
+    "transport",
+  );
+}
+
+export function convertProviderResponsesMessages<TApi extends Api>(
+  model: Model<TApi>,
+  context: Context,
+  allowedToolCallProviders: ReadonlySet<string>,
+  options?: {
+    includeSystemPrompt?: boolean;
+    replayResponsesItemIds?: boolean;
+    sessionId?: string;
+    authProfileId?: string;
+    replayMode?: OpenAIResponsesReplayMode;
+  },
+): ResponseInput {
+  return convertResponsesMessagesWithStyle(
+    model,
+    context,
+    allowedToolCallProviders,
+    options,
+    "provider",
+  );
+}

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -101,7 +101,7 @@ function isOpenAIResponsesReasoningReplayMetadata(
   return record.v === 1 && record.source === "openai-responses";
 }
 
-export function readOpenAIResponsesReasoningReplayBlockMetadata(
+function readOpenAIResponsesReasoningReplayBlockMetadata(
   block: Record<string, unknown>,
 ): OpenAIResponsesReasoningReplayMetadata | null | undefined {
   if (!Object.hasOwn(block, OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY)) {

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -22,7 +22,7 @@ import {
 import { pickFallbackThinkingLevel } from "../embedded-agent-helpers.js";
 import { resolveAgentRunSessionTarget } from "../run-session-target.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
-import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
+import { sanitizeToolUseResultPairingForModel } from "../session-transcript-repair.js";
 import { agentSessionAutomaticCompaction } from "../sessions/agent-session-compaction.js";
 import { type AgentSession, estimateTokens, SessionManager } from "../sessions/index.js";
 import { getModelRegistryRuntime } from "../sessions/model-registry-runtime.js";
@@ -331,14 +331,12 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           // limitHistoryTurns can orphan tool_result blocks by removing the
           // assistant message that contained the matching tool_use.
           const limited = transcriptPolicy.repairToolUseResultPairing
-            ? sanitizeToolUseResultPairing(truncated, {
-                erroredAssistantResultPolicy: "drop",
-                ...(effectiveModel.api === "openai-responses" ||
-                effectiveModel.api === "azure-openai-responses" ||
-                effectiveModel.api === "openai-chatgpt-responses"
-                  ? { missingToolResultText: "aborted" }
-                  : {}),
-              })
+            ? sanitizeToolUseResultPairingForModel(
+                truncated,
+                effectiveModel.api === "openai-responses" ||
+                  effectiveModel.api === "azure-openai-responses" ||
+                  effectiveModel.api === "openai-chatgpt-responses",
+              )
             : truncated;
           if (limited.length > 0) {
             session.agent.state.messages = limited;

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -41,7 +41,7 @@ import {
 import type { AgentMessage } from "../runtime/index.js";
 import {
   sanitizeToolCallInputs,
-  sanitizeToolUseResultPairing,
+  sanitizeToolUseResultPairingForModel,
   stripToolResultDetails,
 } from "../session-transcript-repair.js";
 import type { SessionManager } from "../sessions/index.js";
@@ -869,12 +869,7 @@ export async function sanitizeSessionHistory(params: {
   // tests plus live OpenAI/Codex and generic replay-repair model tests.
   const openAIRepairedToolCalls =
     isOpenAIResponsesApi && policy.repairToolUseResultPairing
-      ? sanitizeToolUseResultPairing(sanitizedToolCalls, {
-          erroredAssistantResultPolicy: "drop",
-          // Match upstream Codex history normalization for OpenAI Responses:
-          // missing function_call_output entries are model-visible "aborted".
-          missingToolResultText: "aborted",
-        })
+      ? sanitizeToolUseResultPairingForModel(sanitizedToolCalls, true)
       : sanitizedToolCalls;
   const openAISafeToolCalls = isOpenAIResponsesApi
     ? downgradeOpenAIFunctionCallReasoningPairs(
@@ -889,9 +884,7 @@ export async function sanitizeSessionHistory(params: {
     : sanitizedToolCalls;
   const pairedToolCalls =
     !isOpenAIResponsesApi && policy.repairToolUseResultPairing
-      ? sanitizeToolUseResultPairing(openAISafeToolCalls, {
-          erroredAssistantResultPolicy: "drop",
-        })
+      ? sanitizeToolUseResultPairingForModel(openAISafeToolCalls, false)
       : openAISafeToolCalls;
   const sanitizedToolIds =
     policy.sanitizeToolCallIds && policy.toolCallIdMode
@@ -923,15 +916,10 @@ export async function sanitizeSessionHistory(params: {
     providerSanitized = providerResult ?? undefined;
   }
   const sanitizedWithProvider = providerSanitized ?? sanitizedCompactionUsage;
+  // Provider replay hooks may rewrite history, so reassert the same pairing policy afterward.
   const responsesProviderRepaired =
     isOpenAIResponsesApi && policy.repairToolUseResultPairing
-      ? sanitizeToolUseResultPairing(sanitizedWithProvider, {
-          erroredAssistantResultPolicy: "drop",
-          // Provider replay hooks run after the core repair pipeline and may
-          // rewrite history. Keep the final Responses invariant guarded by the
-          // same Codex-compatible repair instead of failing on hook output.
-          missingToolResultText: "aborted",
-        })
+      ? sanitizeToolUseResultPairingForModel(sanitizedWithProvider, true)
       : sanitizedWithProvider;
   const responsesInvariantChecked = isOpenAIResponsesApi
     ? assertOpenAIResponsesToolUseResultInvariant(responsesProviderRepaired)

--- a/src/agents/embedded-agent-runner/run/attempt-history.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history.ts
@@ -27,6 +27,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { assembleHarnessContextEngine } from "../../harness/context-engine-lifecycle.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
+import { sanitizeToolUseResultPairingForModel } from "../../session-transcript-repair.js";
 import type { AgentSession, SessionManager } from "../../sessions/index.js";
 import { buildActiveSubagentSystemPromptAddition } from "../../subagents/registry/subagent-active-context.js";
 import { resolveTranscriptPolicy, type TranscriptPolicy } from "../../transcript-policy.js";
@@ -37,10 +38,7 @@ import type { AttemptContextEngine } from "./attempt-context-engine-helpers.js";
 import type { resolveOrphanRepairPlan } from "./attempt-orphan-repair.js";
 import { prependSystemPromptAddition } from "./attempt-prompt-helpers.js";
 import { isRunnerToolCallBlockType } from "./attempt-tool-call-block-type.js";
-import {
-  loadAttemptSessionEntryAfterQuotaMaintenance,
-  repairAttemptToolUseResultPairing,
-} from "./attempt-transcript-helpers.js";
+import { loadAttemptSessionEntryAfterQuotaMaintenance } from "./attempt-transcript-helpers.js";
 import { estimateRenderedLlmBoundaryTokenPressure } from "./preemptive-compaction.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -541,7 +539,7 @@ export async function prepareEmbeddedAttemptHistory(input: {
       // Truncation can orphan tool_result blocks by removing the assistant message
       // that contained the matching tool_use, so repair the pairs once more.
       return input.transcriptPolicy.repairToolUseResultPairing
-        ? repairAttemptToolUseResultPairing(truncated, input.isOpenAIResponsesApi)
+        ? sanitizeToolUseResultPairingForModel(truncated, input.isOpenAIResponsesApi)
         : truncated;
     })();
     input.cacheTrace?.recordStage("session:limited", { messages: limited });
@@ -603,7 +601,7 @@ export async function prepareEmbeddedAttemptHistory(input: {
         throw new Error("context engine assemble returned no result");
       }
       const assembledMessages = input.transcriptPolicy.repairToolUseResultPairing
-        ? repairAttemptToolUseResultPairing(assembled.messages, input.isOpenAIResponsesApi)
+        ? sanitizeToolUseResultPairingForModel(assembled.messages, input.isOpenAIResponsesApi)
         : assembled.messages;
       if (assembledMessages !== activeSession.messages) {
         activeSession.agent.state.messages = assembledMessages;

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -44,6 +44,7 @@ import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import type { SandboxContext } from "../../sandbox/types.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import { sanitizeToolUseResultPairingForModel } from "../../session-transcript-repair.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
@@ -75,7 +76,6 @@ import {
   formatEmbeddedRunStageSummary,
   shouldWarnEmbeddedRunStageSummary,
 } from "./attempt-stage-timing.js";
-import { repairAttemptToolUseResultPairing } from "./attempt-transcript-helpers.js";
 import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
@@ -378,7 +378,7 @@ export function installEmbeddedAttemptContextGuards(input: {
       ...(input.repairToolUseResultPairing
         ? {
             repairAssembledMessages: (messages) =>
-              repairAttemptToolUseResultPairing(messages, input.isOpenAIResponsesApi),
+              sanitizeToolUseResultPairingForModel(messages, input.isOpenAIResponsesApi),
           }
         : {}),
       getPrePromptMessageCount: input.getPrePromptMessageCount,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
@@ -9,7 +9,10 @@ import {
   validateGeminiTurns,
 } from "../../embedded-agent-helpers.js";
 import type { AgentMessage, StreamFn } from "../../runtime/index.js";
-import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
+import {
+  sanitizeToolUseResultPairing,
+  sanitizeToolUseResultPairingForModel,
+} from "../../session-transcript-repair.js";
 import {
   extractToolCallsFromAssistant,
   extractToolResultIds,
@@ -429,10 +432,7 @@ export function sanitizeReplayToolCallIdsForStream(params: {
 
 /** Downgrades OpenAI Responses replay turns into the stream format expected by runtime callers. */
 export function sanitizeOpenAIResponsesReplayForStream(messages: AgentMessage[]): AgentMessage[] {
-  const repaired = sanitizeToolUseResultPairing(messages, {
-    erroredAssistantResultPolicy: "drop",
-    missingToolResultText: "aborted",
-  });
+  const repaired = sanitizeToolUseResultPairingForModel(messages, true);
   return downgradeOpenAIFunctionCallReasoningPairs(
     normalizeOpenAIResponsesToolCallIds(downgradeOpenAIReasoningBlocks(repaired)),
   );
@@ -479,10 +479,7 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
       (model as { api?: unknown }).api === "azure-openai-responses";
     const replayInputsChanged = sanitized.messages !== messages;
     let nextMessages = isOpenAIResponsesApi
-      ? sanitizeToolUseResultPairing(sanitized.messages, {
-          erroredAssistantResultPolicy: "drop",
-          missingToolResultText: "aborted",
-        })
+      ? sanitizeToolUseResultPairingForModel(sanitized.messages, true)
       : replayInputsChanged
         ? sanitizeToolUseResultPairing(sanitized.messages)
         : sanitized.messages;

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
@@ -13,7 +13,6 @@ import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transc
 import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
-import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
 import { log } from "../logger.js";
 import { canContinueFromMessage, trimToContinuableTail } from "./compaction-timeout.js";
 import { MID_TURN_PRECHECK_ERROR_MESSAGE } from "./midturn-precheck.js";
@@ -23,16 +22,6 @@ type AttemptSessionManager = ReturnType<typeof guardSessionManager>;
 
 export function flushSessionManagerTranscript(sessionManager: AttemptSessionManager): void {
   sessionManager.flushPendingPersistence();
-}
-
-export function repairAttemptToolUseResultPairing(
-  messages: AgentMessage[],
-  isOpenAIResponsesApi: boolean,
-): AgentMessage[] {
-  return sanitizeToolUseResultPairing(messages, {
-    erroredAssistantResultPolicy: "drop",
-    ...(isOpenAIResponsesApi ? { missingToolResultText: "aborted" } : {}),
-  });
 }
 
 function isMidTurnPrecheckAssistantError(message: AgentMessage | undefined): boolean {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -447,6 +447,17 @@ export function sanitizeToolUseResultPairing(
   return repairToolUseResultPairing(messages, options).messages;
 }
 
+export function sanitizeToolUseResultPairingForModel(
+  messages: AgentMessage[],
+  isOpenAIResponsesApi: boolean,
+): AgentMessage[] {
+  return sanitizeToolUseResultPairing(messages, {
+    erroredAssistantResultPolicy: "drop",
+    // Match upstream Codex history normalization for OpenAI Responses.
+    ...(isOpenAIResponsesApi ? { missingToolResultText: "aborted" } : {}),
+  });
+}
+
 type ToolUseRepairReport = {
   messages: AgentMessage[];
   added: Array<Extract<AgentMessage, { role: "toolResult" }>>;


### PR DESCRIPTION
<!-- AI-assisted maintainer-requested refactor. -->

## What Problem This Solves

The compaction campaign added roughly 636 net production lines across #123397, #123485, #123486, #123622, #123640, and related work. Its deep review identified a concrete maintenance risk: OpenAI Responses replay conversion was implemented in parallel in the transport and provider paths, so later compaction, encrypted-reasoning, and full-history fixes had to remain synchronized by hand.

This PR recovers 334 production lines from that neighborhood without changing behavior or tests.

## Why This Change Was Made

Responses message conversion and replay preparation now have one transport-owned implementation with explicit provider-versus-transport policy for the pre-existing semantic differences: transcript transforms, media projection, reasoning provenance, Copilot item IDs, tool argument serialization, and empty-message indexing. The encrypted-content retry state machine remains shared, while the SSE, WebSocket, and SDK dispatch loops stay separate because their retry and acceptance timing differ.

The same pass also consolidates exact Codex notification/deferred plumbing and the repeated model-specific tool-result pairing policy. The strict native-compaction watcher remains independent because it must discover the compaction turn, prove the matching compaction item completed, capture post-compaction usage, and hold its lifecycle fence through terminal confirmation.

## User Impact

No user-visible behavior changes. This is a pure net-negative refactor that reduces drift risk across compaction replay paths while preserving all existing validation, fencing, retry timing, and provider-specific behavior.

Production LOC: +639/-973 (net -334) | Tests: +0/-0

## Evidence

- Focused replay, prompt-observer, provider retry, Codex compact/watch, session-store, and compaction-session matrix: 1,009 tests passed across five Vitest shards.
- CI follow-up proof: `pnpm tsgo:prod`, dependency dead-code, unused-file, and unused-export scans passed; the exact failed lint stripe is clean on rebased `main`.
- Targeted core and Codex extension lint/package-boundary checks passed.
- `pnpm format` and `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings on both the full refactor and follow-up correction.
- Existing tests were not modified or deleted.

