### PR TITLE
improve(mac): guard elevation signing identity against drift

### DIFF
--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -320,6 +320,9 @@ verify_team_ids() {
   fi
 }
 
+# Sign-time twin of verify_elevation_app in mac-elevation-host.sh, which asserts the same identity
+# invariants but requires an already notarized and stapled bundle. Dropping this check defers every
+# elevation identity failure until after an Apple notarization submission has been spent.
 verify_elevation_signature() {
   [[ "$SIGNING_VARIANT" == "elevation-host" ]] || return 0
 

--- a/scripts/mac-elevation-host.sh
+++ b/scripts/mac-elevation-host.sh
@@ -166,6 +166,9 @@ verify_universal_machos() {
   done < <(find "$app" -type f -perm -111 -print0)
 }
 
+# Canonical elevation identity check: a strict superset of verify_elevation_signature in
+# codesign-mac-app.sh, and the only one that runs post-notarization and on the target Mac at install
+# time. Dropping it lets the portable installer accept an archive nobody re-verified after signing.
 verify_elevation_app() {
   local app="$1"
   [[ -d "$app" && ! -L "$app" ]] || fail "elevation app not found or symlinked: $app"

--- a/test/scripts/mac-elevation-host.test.ts
+++ b/test/scripts/mac-elevation-host.test.ts
@@ -7,6 +7,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const scriptPath = "scripts/mac-elevation-host.sh";
+const codesignScriptPath = "scripts/codesign-mac-app.sh";
 
 function writeExecutable(filePath: string, contents: string): void {
   writeFileSync(filePath, contents, "utf8");
@@ -227,6 +228,24 @@ describe("mac elevation host command contract", () => {
     expect(script).toContain("elevation archive root must contain exactly OpenClaw.app");
     expect(script).toContain("codesign --verify --strict --test-requirement='=notarized'");
     expect(script).toContain('spctl --assess --type execute "$app"');
+  });
+
+  it("keeps portable signing identity aligned with the signer", () => {
+    const portableScript = readFileSync(scriptPath, "utf8");
+    const codesignScript = readFileSync(codesignScriptPath, "utf8");
+    const constant = (source: string, name: string) =>
+      source.match(new RegExp(`^${name}="([^"]+)"$`, "m"))?.[1];
+
+    expect(
+      [
+        constant(portableScript, "EXPECTED_TEAM_ID"),
+        constant(portableScript, "EXPECTED_AUTHORITY"),
+      ],
+      "mac-elevation-host.sh is a self-contained portable installer, so its duplicated signing constants must match codesign-mac-app.sh",
+    ).toEqual([
+      constant(codesignScript, "ELEVATION_TEAM_ID"),
+      constant(codesignScript, "ELEVATION_IDENTITY"),
+    ]);
   });
 
   it.skipIf(process.platform !== "darwin")(


### PR DESCRIPTION
Related: #123675

## What Problem This Solves

The elevation host asserts the same signing identity in two places, and nothing keeps them in sync.

`scripts/mac-elevation-host.sh` ships as the portable installer that #123675 added to the artifact set, so it is deliberately self-contained and cannot source shared constants. That forces it to carry its own copies of the Developer ID team identifier and authority string, duplicating `ELEVATION_TEAM_ID` / `ELEVATION_IDENTITY` in `scripts/codesign-mac-app.sh`. If one side is ever rotated without the other, packaging still succeeds and the divergence only surfaces on a target Mac, as an install-time rejection of an artifact that was signed correctly.

The same neighborhood has a second trap. `verify_elevation_signature()` (sign time) and `verify_elevation_app()` (post-notarization and install time) assert overlapping invariants, and the overlap reads like redundancy. It is not: the second requires an already notarized and stapled bundle, so it cannot run at sign time. Deleting the first as "duplicate" would silently defer every elevation identity failure until after an Apple notarization submission has been spent.

## Why This Change Was Made

A test now reads both scripts and asserts the team identifier and full authority string agree, with a failure message naming the portable-installer reason so the next reader understands why the duplication is intentional rather than deleting one copy. Each of the two verification functions gets a short comment stating which boundary it owns and what breaks if it is removed.

Deduplicating the constants themselves was considered and rejected: sourcing a shared file would break the self-contained contract that makes the installer portable, which is the whole point of #123675. Guarding the duplication is the cheaper correct answer.

A `write_immutable_output` helper collapsing the repeated `tmp` / `chmod 444` / `mv` idiom in `package_host()` was also built and then dropped. It did not pay rent — it cost more production lines than it saved — and the natural pipe form regressed failure handling: because `cat` succeeds on EOF, a failing `jq` would still have been chmod'd and `mv`'d into place, leaving an empty but real-looking receipt at the canonical path and tripping the `immutable elevation output already exists` guard on every later run. The existing explicit form is fail-closed and stays.

## User Impact

No user-visible or operator-visible behavior change. No artifact bytes, filenames, modes, receipt fields, signing, notarization, or install behavior are touched. Maintainers get a build-time failure instead of a target-Mac failure if the two signing-identity copies ever drift.

## Evidence

Production diff is six comment lines; the rest is test coverage.

```
$ git diff --numstat
3	0	scripts/codesign-mac-app.sh
3	0	scripts/mac-elevation-host.sh
19	0	test/scripts/mac-elevation-host.test.ts
```

The guard fails on drift. Flipping `EXPECTED_TEAM_ID` to `DRIFTEDTEAM` in the portable installer:

```
× keeps portable signing identity aligned with the signer
AssertionError: mac-elevation-host.sh is a self-contained portable installer, so its
duplicated signing constants must match codesign-mac-app.sh
- Expected
+ Received
[
-   "DRIFTEDTEAM",
+   "FWJYW4S8P8",
    "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)",
]
Test Files  1 failed (1)
```

Restored, both suites pass:

```
$ node scripts/run-vitest.mjs test/scripts/mac-elevation-host.test.ts test/scripts/codesign-mac-app.test.ts
 Test Files  2 passed (2)
      Tests  22 passed (22)
[test] passed 1 Vitest shard in 4.91s
```

`git diff --check` clean. The rejected pipe refactor was verified as a real regression before dropping it, rather than assumed:

```
--- NEW (pipe into helper) ---   script exit=17
  -r--r--r--  receipt.json              <- canonical path created, empty
--- OLD (direct redirect) ---   script exit=17
  -rw-r--r--  receipt.json.tmp.24718    <- canonical path never created
```

### CI history

Two earlier runs went red on breakage this branch did not cause and does not touch: a dead CLI wrapper in `src/cli/skills-cli.ts` failing `check-prod-types` and `check-lint-core`, and `src/gateway/server-maintenance.test.ts` crossing the 1000 counted-line test cap. Both were repaired on `main` by #123794 (`3289e08c3005515fb8e49379fd18951ef2530507`), and this branch is rebased onto that fix. This PR touches zero files under `src/`.
