### PR TITLE
fix(matrix): reject invalid tokens when userId is configured

### DIFF
--- a/extensions/matrix/src/matrix/probe.test.ts
+++ b/extensions/matrix/src/matrix/probe.test.ts
@@ -40,20 +40,38 @@ describe("probeMatrix", () => {
     });
   });
 
-  it("trims provided userId before client creation", async () => {
-    await probeMatrix({
+  it("authenticates a configured userId instead of trusting the local client identity", async () => {
+    createMatrixClientMock.mockImplementation(async (params: { userId?: string }) => {
+      return {
+        getUserId: vi.fn(async () => {
+          if (params.userId) {
+            return params.userId;
+          }
+          throw Object.assign(new Error("Invalid access token"), {
+            statusCode: 401,
+          });
+        }),
+      };
+    });
+
+    const result = await probeMatrix({
       homeserver: "https://matrix.example.org",
-      accessToken: "tok",
+      accessToken: "expired-token",
       userId: "  @bot:example.org  ",
       timeoutMs: 500,
     });
 
     expect(createMatrixClientMock).toHaveBeenCalledWith({
       homeserver: "https://matrix.example.org",
-      userId: "@bot:example.org",
-      accessToken: "tok",
+      userId: undefined,
+      accessToken: "expired-token",
       persistStorage: false,
       localTimeoutMs: 500,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      status: 401,
+      error: "Invalid access token",
     });
   });
 
@@ -68,7 +86,7 @@ describe("probeMatrix", () => {
 
     expect(createMatrixClientMock).toHaveBeenCalledWith({
       homeserver: "https://matrix.example.org",
-      userId: "@bot:example.org",
+      userId: undefined,
       accessToken: "tok",
       persistStorage: false,
       localTimeoutMs: 500,
@@ -112,7 +130,7 @@ describe("probeMatrix", () => {
 
     expect(createMatrixClientMock).toHaveBeenCalledWith({
       homeserver: "https://matrix.example.org",
-      userId: "@bot:example.org",
+      userId: undefined,
       accessToken: "tok",
       deviceId: "ABCDEF",
       persistStorage: false,

--- a/extensions/matrix/src/matrix/probe.ts
+++ b/extensions/matrix/src/matrix/probe.ts
@@ -52,7 +52,8 @@ export async function probeMatrix(params: {
       const inputUserId = normalizeOptionalString(params.userId);
       const client = await createMatrixClient({
         homeserver: params.homeserver,
-        userId: inputUserId,
+        // A seeded userId makes getUserId() a local getter; probes must force whoami auth.
+        userId: undefined,
         accessToken: params.accessToken,
         deviceId: params.deviceId,
         persistStorage: false,
@@ -62,8 +63,11 @@ export async function probeMatrix(params: {
         ssrfPolicy: params.ssrfPolicy,
         dispatcherPolicy: params.dispatcherPolicy,
       });
-      // The client wrapper resolves user ID via whoami when needed.
-      return { ...result, ok: true, userId: (await client.getUserId()) ?? null };
+      const userId = await client.getUserId();
+      if (inputUserId && inputUserId !== userId) {
+        return { ...result, error: "Matrix access token user does not match configured userId" };
+      }
+      return { ...result, ok: true, userId };
     },
     (error) => ({
       ok: false,


### PR DESCRIPTION
Closes #123763

## What Problem This Solves

Fixes an issue where `openclaw channels status --probe` could report a Matrix account as working with an invalid access token whenever that account also configured `userId`. The probe trusted the local configured identity instead of authenticating the token.

## Why This Change Was Made

The Matrix probe now creates its non-persistent client without seeding the configured `userId`, so the existing wrapper `getUserId()` path authenticates through `/account/whoami`. It then rejects a valid token whose authenticated identity differs from the configured user.

This keeps the repair inside the Matrix plugin owner. It does not change core channel-status policy, configuration, the public Plugin SDK, auth storage, migrations, dependencies, or the changelog.

Dependency contract: in [`matrix-js-sdk@41.9.0`, `getUserId()` returns the configured credential identity](https://github.com/matrix-org/matrix-js-sdk/blob/v41.9.0/src/client.ts#L1663-L1670), while [`whoami()` performs authenticated I/O](https://github.com/matrix-org/matrix-js-sdk/blob/v41.9.0/src/client.ts#L8838-L8843). OpenClaw's wrapper calls whoami only when no local user ID is seeded.

## User Impact

Matrix operators can trust an explicit channel probe: invalid tokens now fail with the Matrix status/error, valid matching tokens pass, and tokens for a different configured Matrix user fail with an actionable identity-mismatch error.

## Evidence

Exact reviewed head: `36b400f851cdf2631184023e9a585313f61f25e4`

Before the fix, the focused regression failed 1/7 because the authenticated identity path was never reached when `userId` was configured.

After the fix:

- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/probe.test.ts` — 7/7 passed.
- `node scripts/run-vitest.mjs extensions/matrix/src/channel.account-paths.test.ts` — 2/2 passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/channels.status.test.ts` — 15/15 passed.
- Targeted `oxfmt --check` and `git diff --check` passed.
- `node scripts/check-changed.mjs -- extensions/matrix/src/matrix/probe.ts extensions/matrix/src/matrix/probe.test.ts` passed all selected extension/test typecheck, lint, dependency, plugin-boundary, database/media/runtime, and import-cycle gates. The remote `ci-fast` provider was unavailable, so the repository wrapper used its documented local fallback.
- Fresh Codex-backed autoreview: clean, no accepted/actionable findings; `patch is correct` (0.99).

The final head was mechanically rebased onto repaired main `36c440aa2b1e5bb6821945956295f7b01a553f06` after current-main CI fixes landed. All focused proof, the changed gate, and autoreview were rerun on the final head. The changed gate passed with the environment ratchet restored to 502/502.

Controlled local Matrix HTTP proof used synthetic credentials and made no sends:

```json
{
  "invalid": { "ok": false, "status": 401, "error": "Invalid access token" },
  "matching": { "ok": true, "userId": "@bot:example.org" },
  "mismatched": { "ok": false, "error": "Matrix access token user does not match configured userId" },
  "jsonProbeOk": false,
  "humanProbeFailed": true,
  "requestCount": 3,
  "onlyWhoamiGets": true,
  "sends": 0
}
```

Production LOC: +7/-3 (net +4). The four added lines enforce the authenticated-identity boundary and configured/token identity match without adding a second probe path. Tests: +25/-7.

## ClawSweeper Review

The merge-risk move is resolved by explicit maintainer decision: production net +4 is approved because the authenticated-versus-configured identity comparison is the required owner-boundary invariant. ClawSweeper also concluded that no safe net-neutral refactor is evident, identified no actionable finding or security concern, and judged this the best fix location. The optional exact-head-check move remains the landing gate and will be completed before merge.

AI-assisted: yes. The operator approved the invariant and landing; the implementation, dependency source, tests, controlled behavior proof, and final diff were independently reviewed.
