### PR TITLE
fix: keep phone Control UI recovery out of node pairing

### DIFF
--- a/skills/node-connect/SKILL.md
+++ b/skills/node-connect/SKILL.md
@@ -1,143 +1,119 @@
 ---
 name: node-connect
-description: "Diagnose OpenClaw Android, iOS, or macOS node pairing, QR/setup code, route, auth, and connection failures."
+description: "Diagnose OpenClaw Control UI browser and native Android, iOS, or macOS node connection failures across route, auth, pairing, QR/setup-code, and reconnect states."
 ---
 
 # Node Connect
 
-Goal: find the one real route from node -> gateway, verify OpenClaw is advertising that route, then fix pairing/auth.
+Goal: fix one exact client against one exact Gateway, then prove that client's fresh connection.
 
-## Topology first
+## 1. Lock the target
 
-Decide which case you are in before proposing fixes:
+Record the target environment/profile, OpenClaw binary, config/state root, Gateway URL/port, and service before changing anything.
 
-- same machine / emulator / USB tunnel
-- same LAN / local Wi-Fi
-- same Tailscale tailnet
-- public URL / reverse proxy
+- If the operator names a deployment wrapper or profile, use it for every config, log, service, device, and node command.
+- Never fall back to a bare `openclaw`, a proof environment, or a similarly named deployment after the target is known.
+- If the global executable is stale or broken, invoke the target through its owner instead of switching installations.
+- Verify that status, config, logs, and process identity all describe the same Gateway.
 
-Do not mix them.
+Do not mutate pairing or auth until the target is unambiguous.
 
-- Local Wi-Fi problem: do not switch to Tailscale unless remote access is actually needed.
-- VPS / remote gateway problem: do not keep debugging `localhost` or LAN IPs.
+## 2. Classify the client
 
-## If ambiguous, ask first
+Classify from the user's words and the Gateway's connection log before choosing commands:
 
-If the setup is unclear or the failure report is vague, ask short clarifying questions before diagnosing.
+- **Control UI browser:** the user says browser, dashboard, Control UI, or webchat; logs show `client=openclaw-control-ui` or `mode=webchat`.
+- **Native mobile/node:** the official app shows Connect, Scan QR, or setup code; logs/request metadata show a native client or `role=node`.
 
-Ask for:
+A phone can be either client. Do not use `openclaw qr` or `openclaw nodes status` for a phone browser; those belong to native mobile/node pairing.
 
-- which route they intend: same machine, same LAN, Tailscale tailnet, or public URL
-- whether they used QR/setup code or manual host/port
-- the exact app text/status/error, quoted exactly if possible
-- whether `openclaw devices list` shows a pending pairing request
+## 3. Observe the failing attempt
 
-Do not guess from `can't connect`.
-
-## Canonical checks
-
-Prefer `openclaw qr --json`. It uses the same setup-code payload Android scans.
+Run these through the locked target:
 
 ```bash
-openclaw config get gateway.mode
+openclaw gateway status --deep
+openclaw logs --follow --json
+openclaw devices list
 openclaw config get gateway.bind
-openclaw config get gateway.tailscale.mode
-openclaw config get gateway.remote.url
 openclaw config get gateway.auth.mode
 openclaw config get gateway.auth.allowTailscale
-openclaw config get plugins.entries.device-pair.config.publicUrl
-openclaw qr --json
-openclaw devices list
-openclaw nodes status
+openclaw config get gateway.tailscale.mode
 ```
 
-If this OpenClaw instance is pointed at a remote gateway, also run:
+Have the client retry once while logs are live. Capture client ID, mode, platform, remote/forwarded address, auth reason or method, device ID, authenticated user, and close code. Correlate those facts to the failing client; a different paired device is not evidence about this one.
 
-```bash
-openclaw qr --remote --json
-```
+Interpret the first failed transition:
 
-If Tailscale is part of the story:
+- No matching Gateway attempt: route, DNS, TLS, origin, or proxy problem.
+- `token_missing`, `password_missing`, mismatch, or Tailscale identity failure: auth failed **before** pairing, so an empty pending list is expected.
+- `pairing required`: route and auth succeeded; approve the exact pending request.
+- Successful connect followed by close `1006`: auth/pairing succeeded; diagnose browser lifecycle, transport, proxy, or reconnect instead of pairing again.
+- `authenticated user connected` / `webchat connected`: identify the auth method and exact client before declaring success.
+
+## 4. Prove the route
+
+Choose one intended topology: same machine, same LAN, same tailnet, or public reverse proxy. Do not mix routes while diagnosing.
+
+- Browser Control UI needs HTTPS or localhost for browser device identity. A remote plain-HTTP Tailnet/LAN URL is not a valid substitute.
+- `gateway.tailscale.mode=off` means OpenClaw is not managing Serve/Funnel. It does not prove that Tailscale or an externally managed Serve route is absent.
+- When Tailscale is involved, inspect live state rather than inferring it from OpenClaw config:
 
 ```bash
 tailscale status --json
+tailscale serve status --json
 ```
 
-## Read the result, not guesses
+Match the URL the client opened to the listener/proxy route that reached the locked Gateway.
 
-`openclaw qr --json` success means:
+## 5A. Control UI browser lane
 
-- `gatewayUrl`: this is the actual endpoint the app should use.
-- `urlSource`: this tells you which config path won.
+Restore browser auth before looking for a pairing request:
 
-Common good sources:
+- For token/password auth, enter the credential in Control UI settings. Never paste a permanent secret into chat, logs, or a public URL.
+- On the Gateway host, `openclaw dashboard` is the preferred one-time signed browser handoff. `openclaw dashboard --json` exposes a short-lived `browserUrl`; treat it as a secret and use it only when its host is reachable by the intended browser. Never send a loopback `browserUrl` to a remote phone or rewrite its origin.
+- For an intended Tailscale Serve flow, verify the live Serve route and forwarded Tailscale identity. Enable `gateway.auth.allowTailscale` only when the operator intends that trust boundary. A verified Tailscale Control UI connection with browser device identity can authenticate without a pending pairing request.
 
-- `gateway.bind=lan`: same Wi-Fi / LAN only
-- `gateway.bind=tailnet`: direct tailnet access
-- `gateway.tailscale.mode=serve` or `gateway.tailscale.mode=funnel`: Tailscale route
-- `plugins.entries.device-pair.config.publicUrl`: explicit public/reverse-proxy route
-- `gateway.remote.url`: remote gateway route
+After auth succeeds:
 
-## Root-cause map
+- Retry and interpret the new state; never infer the pairing outcome from the pre-auth attempt. Token/password auth can reveal `pairing required`, while verified Tailscale identity can skip that round trip.
+- If logs say `pairing required`, re-list devices and approve the exact request ID.
+- If verified Tailscale identity connects successfully, no pending request and no new paired-device row can be correct.
+- If the browser connects and then repeats `1006`, keep the auth/pairing state and move to reconnect evidence.
 
-If `openclaw qr --json` says `Gateway is only bound to loopback`:
+## 5B. Native mobile/node lane
 
-- remote node cannot connect yet
-- fix the route, then generate a fresh setup code
-- `gateway.bind=auto` is not enough if the effective QR route is still loopback
-- same LAN: use `gateway.bind=lan`
-- same tailnet: prefer `gateway.tailscale.mode=serve` or use `gateway.bind=tailnet`
-- public internet: set a real `plugins.entries.device-pair.config.publicUrl` or `gateway.remote.url`
+Generate the native app's setup payload through the locked target:
 
-If `gateway.bind=tailnet set, but no tailnet IP was found`:
+```bash
+openclaw qr --json
+```
 
-- gateway host is not actually on Tailscale
+Use `gatewayUrl` and `urlSource` to verify the advertised route. If the user cannot scan, copy the short-lived setup code into the official app's manual setup flow. Generate a fresh code after any URL/auth fix or expiry.
 
-If `qr --remote requires gateway.remote.url`:
-
-- remote-mode config is incomplete
-
-If the app says `pairing required`:
-
-- network route and auth worked
-- approve the pending device
+If the app reports `pairing required`:
 
 ```bash
 openclaw devices list
-openclaw devices approve --latest   # preview only; copy the requestId from output
+openclaw devices approve --latest   # preview only; copy the requestId
 openclaw devices approve <requestId>
+openclaw nodes status
 ```
 
-If the app says `bootstrap token invalid or expired`:
+Re-list immediately before approval because a retry can supersede the pending request. Never approve by position, age alone, or similarity to another device.
 
-- old setup code
-- generate a fresh one and rescan
-- do this after any URL/auth fix too
+## 6. Correlate and finish
 
-If the app says `unauthorized`:
+Before any approval, match as many authoritative facts as available: request ID, device ID/public key, client ID, mode/role, platform, remote address, authenticated user, and retry time.
 
-- wrong token/password, or wrong Tailscale expectation
-- for Tailscale Serve, `gateway.auth.allowTailscale` must match the intended flow
-- otherwise use explicit token/password
+Declare success only after a new attempt made after the final change proves all applicable checks:
 
-## Fast heuristics
+- the exact client reaches the locked Gateway;
+- auth succeeds with the intended method/user;
+- the browser shows connected and completes its initial Gateway requests, or the native node appears connected in `openclaw nodes status`;
+- any required approval used the exact request ID;
+- no immediate repeated auth, pairing, or reconnect failure follows.
 
-- Same Wi-Fi setup + gateway advertises `127.0.0.1`, `localhost`, or loopback-only config: wrong.
-- Remote setup + setup/manual uses private LAN IP: wrong.
-- Tailnet setup + gateway advertises LAN IP instead of MagicDNS / tailnet route: wrong.
-- Public URL set but QR still advertises something else: inspect `urlSource`; config is not what you think.
-- `openclaw devices list` shows pending requests: stop changing network config and approve first.
+A generated QR/setup code, launched browser, empty pending list, approval response, paired device count, or successful Tailscale ping is evidence for one transition only. None alone proves the client is connected.
 
-## Fix style
-
-Reply with one concrete diagnosis and one route.
-
-If there is not enough signal yet, ask for setup + exact app text instead of guessing.
-
-Good:
-
-- `The gateway is still loopback-only, so a node on another network can never reach it. Enable Tailscale Serve, restart the gateway, run openclaw qr again, rescan, then approve the pending device pairing.`
-
-Bad:
-
-- `Maybe LAN, maybe Tailscale, maybe port forwarding, maybe public URL.`
+Report one concrete diagnosis, the one route/auth lane used, the exact client evidence, and the remaining failure transition if connection is still incomplete.

--- a/skills/node-connect/SKILL.md
+++ b/skills/node-connect/SKILL.md
@@ -11,16 +11,16 @@ Goal: fix one exact client against one exact Gateway, then prove that client's f
 
 Record the target environment/profile, OpenClaw binary, config/state root, Gateway URL/port, and service before changing anything.
 
-- If the operator names a deployment wrapper or profile, use it for every config, log, service, device, and node command.
-- Never fall back to a bare `openclaw`, a proof environment, or a similarly named deployment after the target is known.
-- If the global executable is stale or broken, invoke the target through its owner instead of switching installations.
-- Verify that status, config, logs, and process identity all describe the same Gateway.
+- Use the named deployment wrapper/profile for every config, log, service, device, and node command.
+- Never drift to a bare `openclaw`, proof environment, or similarly named deployment.
+- If the global executable is stale, invoke the target through its owner.
+- Verify status, config, logs, and process identity describe the same Gateway.
 
 Do not mutate pairing or auth until the target is unambiguous.
 
 ## 2. Classify the client
 
-Classify from the user's words and the Gateway's connection log before choosing commands:
+Classify from the request and Gateway log before choosing commands:
 
 - **Control UI browser:** the user says browser, dashboard, Control UI, or webchat; logs show `client=openclaw-control-ui` or `mode=webchat`.
 - **Native mobile/node:** the official app shows Connect, Scan QR, or setup code; logs/request metadata show a native client or `role=node`.
@@ -35,25 +35,27 @@ Run these through the locked target:
 openclaw gateway status --deep
 openclaw logs --follow --json
 openclaw devices list
+openclaw config get gateway.mode
 openclaw config get gateway.bind
+openclaw config get gateway.remote.url
 openclaw config get gateway.auth.mode
 openclaw config get gateway.auth.allowTailscale
 openclaw config get gateway.tailscale.mode
 ```
 
-Have the client retry once while logs are live. Capture client ID, mode, platform, remote/forwarded address, auth reason or method, device ID, authenticated user, and close code. Correlate those facts to the failing client; a different paired device is not evidence about this one.
+Have the client retry once while logs are live. Correlate its client ID, mode, platform, address, auth result, device ID, user, and close code. Ignore other paired devices.
 
 Interpret the first failed transition:
 
 - No matching Gateway attempt: route, DNS, TLS, origin, or proxy problem.
 - `token_missing`, `password_missing`, mismatch, or Tailscale identity failure: auth failed **before** pairing, so an empty pending list is expected.
 - `pairing required`: route and auth succeeded; approve the exact pending request.
-- Successful connect followed by close `1006`: auth/pairing succeeded; diagnose browser lifecycle, transport, proxy, or reconnect instead of pairing again.
-- `authenticated user connected` / `webchat connected`: identify the auth method and exact client before declaring success.
+- `authenticated user connected` / `webchat connected`: match the exact client; if followed by `1006`, preserve auth/pairing and inspect lifecycle, transport, proxy, or reconnect.
+- `1006` without either application-level connected log does not prove auth/pairing; inspect the earlier handshake transition.
 
 ## 4. Prove the route
 
-Choose one intended topology: same machine, same LAN, same tailnet, or public reverse proxy. Do not mix routes while diagnosing.
+Choose one topology: same machine, LAN, tailnet, or public reverse proxy. Do not mix them.
 
 - Browser Control UI needs HTTPS or localhost for browser device identity. A remote plain-HTTP Tailnet/LAN URL is not a valid substitute.
 - `gateway.tailscale.mode=off` means OpenClaw is not managing Serve/Funnel. It does not prove that Tailscale or an externally managed Serve route is absent.
@@ -64,56 +66,58 @@ tailscale status --json
 tailscale serve status --json
 ```
 
-Match the URL the client opened to the listener/proxy route that reached the locked Gateway.
+Match the client's URL to the listener/proxy route reaching the locked Gateway.
 
 ## 5A. Control UI browser lane
 
 Restore browser auth before looking for a pairing request:
 
-- For token/password auth, enter the credential in Control UI settings. Never paste a permanent secret into chat, logs, or a public URL.
-- On the Gateway host, `openclaw dashboard` is the preferred one-time signed browser handoff. `openclaw dashboard --json` exposes a short-lived `browserUrl`; treat it as a secret and use it only when its host is reachable by the intended browser. Never send a loopback `browserUrl` to a remote phone or rewrite its origin.
-- For an intended Tailscale Serve flow, verify the live Serve route and forwarded Tailscale identity. Enable `gateway.auth.allowTailscale` only when the operator intends that trust boundary. A verified Tailscale Control UI connection with browser device identity can authenticate without a pending pairing request.
+- For token/password auth, enter the credential in Control UI settings. Never put permanent secrets in chat, logs, or URLs.
+- Prefer `openclaw dashboard` on the Gateway host for a one-time signed handoff. Use `--no-open` only when the operator can retrieve that host's clipboard, and keep the host browser/clipboard outside agent tooling. Never capture `dashboard --json`: it can expose the handoff and shared credentials. Never relay, rewrite, or send a loopback handoff URL to a remote phone.
+- For Tailscale Serve, verify the live route and forwarded identity. Enable `gateway.auth.allowTailscale` only for that intended trust boundary. Verified Tailscale Control UI auth with browser device identity can skip pairing.
 
 After auth succeeds:
 
-- Retry and interpret the new state; never infer the pairing outcome from the pre-auth attempt. Token/password auth can reveal `pairing required`, while verified Tailscale identity can skip that round trip.
+- Retry; never infer pairing from the pre-auth attempt. Token/password auth can reveal `pairing required`; verified Tailscale identity can skip it.
 - If logs say `pairing required`, re-list devices and approve the exact request ID.
-- If verified Tailscale identity connects successfully, no pending request and no new paired-device row can be correct.
-- If the browser connects and then repeats `1006`, keep the auth/pairing state and move to reconnect evidence.
+- A successful verified-Tailscale connection may correctly create no pending or paired-device row.
+- After a repeated `1006`, preserve auth/pairing and inspect reconnect evidence.
 
 ## 5B. Native mobile/node lane
 
-Generate the native app's setup payload through the locked target:
+Inspect the native route through the locked target without exposing the setup credential:
 
 ```bash
-openclaw qr --json
+openclaw qr --json | jq '{gatewayUrl, gatewayUrls, auth, access, accessDowngraded, urlSource}'
 ```
 
-Use `gatewayUrl` and `urlSource` to verify the advertised route. If the user cannot scan, copy the short-lived setup code into the official app's manual setup flow. Generate a fresh code after any URL/auth fix or expiry.
+For a CLI controlling a remote Gateway, add `--remote` before `--json`; it selects `gateway.remote.url` and remote credentials. If the redaction filter is unavailable, do not run raw QR JSON in agent-visible output.
+
+Verify `gatewayUrl` and `urlSource`. The setup code is password-equivalent: have the operator copy it from **Control UI → Devices → Pair device**, or run `openclaw qr --setup-code-only` in a terminal outside agent tooling and paste it directly into the official app. Never relay it through agent/chat/tool output. Generate a fresh code after a URL/auth fix or expiry.
 
 If the app reports `pairing required`:
 
 ```bash
 openclaw devices list
-openclaw devices approve --latest   # preview only; copy the requestId
+openclaw devices approve --latest   # preview only; exits without approval
 openclaw devices approve <requestId>
 openclaw nodes status
 ```
 
-Re-list immediately before approval because a retry can supersede the pending request. Never approve by position, age alone, or similarity to another device.
+`--latest` only previews the current request; never treat it as approval. Re-list immediately before the exact-ID command because retries can supersede the request. Never approve by position, age, or similarity.
 
 ## 6. Correlate and finish
 
-Before any approval, match as many authoritative facts as available: request ID, device ID/public key, client ID, mode/role, platform, remote address, authenticated user, and retry time.
+Before approval, match available request, device/public-key, client, mode/role, platform, address, user, and retry-time facts.
 
 Declare success only after a new attempt made after the final change proves all applicable checks:
 
 - the exact client reaches the locked Gateway;
-- auth succeeds with the intended method/user;
-- the browser shows connected and completes its initial Gateway requests, or the native node appears connected in `openclaw nodes status`;
-- any required approval used the exact request ID;
-- no immediate repeated auth, pairing, or reconnect failure follows.
+- intended auth succeeds;
+- the browser completes initial requests, or the native node appears in `openclaw nodes status`;
+- approval used the exact request ID; and
+- no immediate auth, pairing, or reconnect failure follows.
 
-A generated QR/setup code, launched browser, empty pending list, approval response, paired device count, or successful Tailscale ping is evidence for one transition only. None alone proves the client is connected.
+A QR/setup code, launched browser, empty pending list, approval, paired-device count, or Tailscale ping proves only one transition.
 
-Report one concrete diagnosis, the one route/auth lane used, the exact client evidence, and the remaining failure transition if connection is still incomplete.
+Report the diagnosis, chosen route/auth lane, exact-client evidence, and any remaining failed transition.


### PR DESCRIPTION
## What Problem This Solves

Agents helping an operator connect a phone to the Control UI could send a browser through the native QR/node workflow. In the observed failure, the browser reached the Gateway but failed shared auth before pairing, so the pending list was empty; the old skill still preferred native QR output and could mistake another paired device for the phone.

## Why This Change Was Made

The bundled `node-connect` skill now locks every command to the named Gateway, classifies Control UI browsers separately from native mobile/node clients, and follows the first failed route/auth/pairing/reconnect transition. The repair stays at the skill owner: the dashboard already owns browser handoff, the QR CLI owns native app setup, Gateway auth precedes pairing, and verified Tailscale Control UI auth can skip pairing.

The review also hardened the native lane: agent-visible route inspection redacts the password-equivalent setup code, operator handoff remains outside agent tooling, remote targets retain `qr --remote`, `1006` is not treated as auth proof without an application-level connected event, and `--latest` remains preview-only before exact-request approval.

This is AI-assisted. I reviewed the complete change and the underlying Gateway auth/pairing, dashboard, QR, device-approval, Tailscale, and reconnect contracts.

## User Impact

- Phone browsers recover Control UI auth instead of entering native-node pairing.
- Native apps retain local and remote QR/manual-code setup without exposing credentials to the agent transcript.
- Empty pending lists before auth, externally managed Tailscale Serve, superseded requests, unrelated paired devices, and reconnect loops are handled explicitly.
- Success requires a fresh connection from the intended client.

## Evidence

- Red source-blind replay on unmodified `main`: an Android Chrome Control UI fixture with `token_missing`, no scanner, an empty pending list, a stale global CLI, and another paired desktop incorrectly prescribed native QR/node commands.
- Green source-blind contract on the proposed head: 8/8 clauses passed for browser pre-auth, local native manual setup, remote native routing, externally managed Serve, qualified `1006`, superseded requests, transcript-secret safety, and exact-target success.
- Independent security review: no blockers after keeping dashboard/QR secrets outside agent-visible output and restoring `--remote`.
- Independent skill review: best-fit and land-ready; no routing, compatibility, overreach, or context-cost blocker.
- `python3 skills/skill-creator/scripts/quick_validate.py skills/node-connect` — pass.
- Autoreview: `gpt-5.6-sol`, high reasoning, TruffleHog clean, no accepted/actionable findings.
- Full skill delta versus current `main`: +68/-88 (net -20). Tests: +0/-0.
- No screenshots: this changes agent guidance, not rendered UI.

Best-fix verdict: the skill is the canonical owner of the incorrect troubleshooting decision. Changing runtime auth/pairing behavior or adding a second overlapping skill would repair the wrong layer.
