### PR TITLE
fix(lint): grandfather oversized commands-compact test file

### DIFF
--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -1139,3 +1139,5 @@ describe("handleCompactCommand", () => {
     expect(requireCompactEmbeddedAgentSessionCall().contextTokenBudget).toBe(777_777);
   });
 });
+
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

`check-lint` fails on current main: `src/auto-reply/reply/commands-compact.test.ts` exceeds the 1000-line `oxlint` max-lines budget (1049 lines after #123640's additions). This blocks CI for every PR based on current main — including #123541, which is otherwise fully green.

## Evidence

Adds the same file-level disable already used by the other grandfathered oversized test files:

```ts
/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
```

Precedents: `openclaw-state-db.test.ts`, `openclaw-agent-db.test.ts`, `resolve-route.test.ts`, etc.

Command run after this patch: `oxlint --type-aware --tsconfig config/tsconfig/oxlint.json src/auto-reply/reply/commands-compact.test.ts`

Observed result: **0 warnings, 0 errors.**