### PR TITLE
fix(ui): report connection loss instead of silently dropping session actions

### DIFF
--- a/ui/src/pages/sessions/sessions-page.test-support.ts
+++ b/ui/src/pages/sessions/sessions-page.test-support.ts
@@ -25,6 +25,7 @@ export type TestSessionsPage = HTMLElement & {
   sessionMenu: { key: string; x: number; y: number } | null;
   sessionMenuTrigger: HTMLElement | null;
   checkpointItemsByKey: Record<string, SessionCompactionCheckpoint[]>;
+  checkpointErrorByKey: Record<string, string>;
   checkpointLoadingKey: string | null;
   checkpointBusyKey: string | null;
   sessionMutationPending: boolean;

--- a/ui/src/pages/sessions/sessions-page.test-support.ts
+++ b/ui/src/pages/sessions/sessions-page.test-support.ts
@@ -48,7 +48,7 @@ export type TestSessionsPage = HTMLElement & {
   ) => void;
   patchSession: (
     key: string,
-    patch: { archived?: boolean; pinned?: boolean },
+    patch: { archived?: boolean; pinned?: boolean; label?: string | null },
     scope?: unknown,
     expectedSessionId?: string,
   ) => Promise<unknown>;

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -247,6 +247,35 @@ describe("sessions page lifecycle", () => {
     expect(page.transcriptSearch).toEqual({ status: "idle" });
   });
 
+  it("reports a connection error instead of silently dropping a patch", async () => {
+    const patch = vi.fn();
+    const sessions = createSessions({ patch });
+    const mutableGateway = createGateway({} as GatewayBrowserClient);
+    const page = await createPage(createContext(mutableGateway.gateway, sessions));
+    // Gateway drops while a rename dialog is open; submit lands afterwards.
+    mutableGateway.emit({ phase: "reconnecting", client: null });
+
+    const result = await page.patchSession("agent:main:main", { label: "renamed" });
+
+    expect(result).toBe("failed");
+    expect(patch).not.toHaveBeenCalled();
+    expect(page.error).toBe("Connect to the Gateway to change sessions.");
+  });
+
+  it("shows a connection error in the checkpoints drawer while disconnected", async () => {
+    const mutableGateway = createGateway({} as GatewayBrowserClient);
+    const page = await createPage(createContext(mutableGateway.gateway, createSessions()));
+    mutableGateway.emit({ phase: "reconnecting", client: null });
+
+    await page.loadCheckpoint("agent:main:main");
+
+    // Without the recorded error the drawer would render "No checkpoints"
+    // beside a nonzero checkpoint badge.
+    expect(page.checkpointErrorByKey["agent:main:main"]).toBe(
+      "Connect to the Gateway to change sessions.",
+    );
+  });
+
   it("drops a transcript result after the query changes while it is pending", async () => {
     const response = deferred<SessionsSearchResult>();
     const request = vi.fn(() => response.promise);

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -1144,7 +1144,10 @@ class SessionsPage extends OpenClawLightDomElement {
     expectedSessionId?: string,
   ): Promise<SessionsPageMutationResult> {
     if (!scope) {
-      return "stale";
+      // Nothing was attempted (e.g. rename dialog submitted after the gateway
+      // dropped); say so instead of silently swallowing the edit.
+      this.error = t("sessionsView.actionRequiresConnection");
+      return "failed";
     }
     if (typeof patch.archived === "boolean" && !expectedSessionId?.trim()) {
       this.error = "Session lifecycle action requires a durable session identity.";
@@ -1281,6 +1284,12 @@ class SessionsPage extends OpenClawLightDomElement {
   private async loadCheckpoint(sessionKey: string) {
     const scope = this.captureRequestScope();
     if (!scope) {
+      // Rows stay expandable while disconnected; without an error the drawer
+      // would claim "No checkpoints" beside a nonzero checkpoint badge.
+      this.checkpointErrorByKey = {
+        ...this.checkpointErrorByKey,
+        [sessionKey]: t("sessionsView.actionRequiresConnection"),
+      };
       return;
     }
     this.checkpointTaskKey = sessionKey;


### PR DESCRIPTION
## What Problem This Solves

Two silent dead-ends on the Sessions page around gateway disconnects:
1. A rename (or similar) dialog submitted after the gateway dropped mid-dialog closed with no rename and no message — `patchSession` returned `"stale"` without setting an error when no request scope could be captured, and callers like `renameSession` fire-and-forget the result.
2. Expanding a session row while disconnected left the checkpoints drawer claiming "No checkpoints" directly beside a nonzero checkpoint-count badge — `loadCheckpoint` returned bare, leaving neither items nor an error, so the view fell through to the empty state.

## Why This Change Was Made

Both are the doctrine-worst class: a user action ending with no visible outcome and no recorded reason. The distinction that matters (verified against the existing test contract): a scope *replaced mid-confirmation* is intentionally quiet (test-protected; the global reconnect banner owns it), but a scope that was *never captured* means nothing was attempted — that's unambiguous and must say so. Both paths now publish the existing `sessionsView.actionRequiresConnection` string at their owning error surface: the page error banner for mutations, `checkpointErrorByKey` for the drawer (which already renders a danger callout before the empty state).

## User Impact

Submitting a rename after a connection drop shows "Connect to the Gateway to change sessions." instead of silently discarding the edit; the checkpoints drawer shows the same error instead of a false "No checkpoints".

## Evidence

- 2 new regression tests fail pre-fix, pass post-fix (30 passed total in `sessions-page.test.ts`).
- `pnpm tsgo:ui` clean; oxfmt/oxlint clean.
- Autoreview (Codex, commit mode): clean, overall 0.99.

Production LOC delta: +9 incl. invariant comments; tests +30.
