### PR TITLE
perf(test): reuse Skill Workshop module graphs

### DIFF
--- a/src/cli/skills-cli.workshop-cache.test.ts
+++ b/src/cli/skills-cli.workshop-cache.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -8,6 +8,10 @@ import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
+let gatewaySnapshots: typeof import("../skills/runtime/session-snapshot.js");
+let gatewayRefreshState: typeof import("../skills/runtime/refresh-state.js");
+let gatewayWorkshop: typeof import("../skills/workshop/service.js");
+let registerSkillsCli: (typeof import("./skills-cli.js"))["registerSkillsCli"];
 
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
@@ -50,6 +54,21 @@ vi.mock("../agents/agent-scope.js", () => ({
 }));
 
 describe("skills workshop CLI gateway snapshot invalidation", () => {
+  beforeAll(async () => {
+    // Keep one module graph for each process role. Reusing the graphs preserves
+    // the Gateway/CLI cache boundary without rebuilding the full CLI per test.
+    vi.resetModules();
+    gatewaySnapshots = await import("../skills/runtime/session-snapshot.js");
+    gatewayRefreshState = await import("../skills/runtime/refresh-state.js");
+    gatewayWorkshop = await import("../skills/workshop/service.js");
+    vi.resetModules();
+    ({ registerSkillsCli } = await import("./skills-cli.js"));
+  });
+
+  afterAll(() => {
+    vi.resetModules();
+  });
+
   beforeEach(async () => {
     testState = await createOpenClawTestState({
       layout: "state-only",
@@ -71,20 +90,15 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       }
       return await mocks.gatewayApply(request);
     });
-    vi.resetModules();
   });
 
   afterEach(async () => {
     await testState.cleanup();
     await tempDirs.cleanup();
-    vi.resetModules();
   });
 
   it("applies through the gateway process that owns the cached session skill index", async () => {
     // This first module graph stands in for the long-running Gateway process.
-    const gatewaySnapshots = await import("../skills/runtime/session-snapshot.js");
-    const gatewayRefreshState = await import("../skills/runtime/refresh-state.js");
-    const gatewayWorkshop = await import("../skills/workshop/service.js");
     const proposal = await gatewayWorkshop.proposeCreateSkill({
       workspaceDir: mocks.workspaceDir,
       name: "Gateway Visible",
@@ -113,8 +127,6 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
 
     // A fresh module graph models the short-lived CLI process. Direct application
     // here would bump only the CLI's refresh-state map, leaving the Gateway stale.
-    vi.resetModules();
-    const { registerSkillsCli } = await import("./skills-cli.js");
     const program = new Command();
     program.exitOverride();
     registerSkillsCli(program);
@@ -142,8 +154,7 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
   });
 
   it("does not replay a dispatched gateway apply failure in the CLI process", async () => {
-    const workshop = await import("../skills/workshop/service.js");
-    const proposal = await workshop.proposeCreateSkill({
+    const proposal = await gatewayWorkshop.proposeCreateSkill({
       workspaceDir: mocks.workspaceDir,
       name: "Single Dispatch",
       description: "Apply only in the process that owns snapshot state",
@@ -153,8 +164,6 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       throw new Error("gateway apply failed");
     };
 
-    vi.resetModules();
-    const { registerSkillsCli } = await import("./skills-cli.js");
     const program = new Command();
     program.exitOverride();
     registerSkillsCli(program);
@@ -166,14 +175,13 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       "health",
       "skills.proposals.apply",
     ]);
-    await expect(workshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+    await expect(gatewayWorkshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
       record: { status: "pending" },
     });
   });
 
   it("preserves configless offline apply when no local gateway is listening", async () => {
-    const workshop = await import("../skills/workshop/service.js");
-    const proposal = await workshop.proposeCreateSkill({
+    const proposal = await gatewayWorkshop.proposeCreateSkill({
       workspaceDir: mocks.workspaceDir,
       name: "Offline Upgrade",
       description: "Keep shipped configless Workshop apply behavior",
@@ -186,8 +194,6 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     });
     mocks.callGateway.mockRejectedValueOnce(authError);
 
-    vi.resetModules();
-    const { registerSkillsCli } = await import("./skills-cli.js");
     const program = new Command();
     program.exitOverride();
     registerSkillsCli(program);
@@ -203,14 +209,13 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       timeoutMs: 250,
     });
     expect(mocks.releaseGatewayLock).toHaveBeenCalledTimes(1);
-    await expect(workshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+    await expect(gatewayWorkshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
       record: { status: "applied" },
     });
   });
 
   it("does not bypass Gateway ownership when CLI credentials are missing", async () => {
-    const workshop = await import("../skills/workshop/service.js");
-    const proposal = await workshop.proposeCreateSkill({
+    const proposal = await gatewayWorkshop.proposeCreateSkill({
       workspaceDir: mocks.workspaceDir,
       name: "Gateway Owned Upgrade",
       description: "Keep snapshot invalidation in the running gateway",
@@ -224,8 +229,6 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     mocks.callGateway.mockRejectedValueOnce(authError);
     mocks.acquireGatewayLock.mockRejectedValueOnce(new Error("gateway lock is owned"));
 
-    vi.resetModules();
-    const { registerSkillsCli } = await import("./skills-cli.js");
     const program = new Command();
     program.exitOverride();
     registerSkillsCli(program);
@@ -236,7 +239,7 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     expect(mocks.callGateway).toHaveBeenCalledTimes(1);
     expect(mocks.acquireGatewayLock).toHaveBeenCalledTimes(1);
     expect(mocks.releaseGatewayLock).not.toHaveBeenCalled();
-    await expect(workshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+    await expect(gatewayWorkshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
       record: { status: "pending" },
     });
   });
@@ -281,8 +284,6 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       };
     };
 
-    vi.resetModules();
-    const { registerSkillsCli } = await import("./skills-cli.js");
     const program = new Command();
     program.exitOverride();
     registerSkillsCli(program);


### PR DESCRIPTION
## What Problem This Solves

The Skill Workshop ownership/cache regression suite rebuilt the full CLI module graph and reset Vitest's evaluated-module registry before and after each of five tests. That repeated setup made the suite slower and more memory-intensive without adding isolation relevant to the behaviors under test.

## Why This Change Was Made

The suite now constructs one persistent Gateway module graph and one independent CLI module graph in `beforeAll`, then reuses both while preserving per-test OpenClaw state, temporary workspaces, Gateway delegates, lock mocks, and runtime spies. All five regression tests and their process-ownership boundaries remain intact; no production path or test-only production seam was added.

## User Impact

This is test-only/internal. It shortens Skill Workshop regression execution and reduces memory use while preserving coverage. Production LOC: +0/-0. Tests: +26/-25. No changelog entry is required.

AI-assisted: yes. The patch was manually inspected and received a fresh clean Codex autoreview with no accepted or actionable findings. No agent transcript is included.

## Evidence

All five protected behaviors remain independently covered: Gateway cache invalidation after apply, no local replay after a dispatched failure, Gateway-lock ownership for configless offline apply, no credential-based Gateway ownership bypass, and evaluation of the exact inspected revision through the Gateway plugin registry.

Same-Testbox controlled A/B on `tbx_01m00ky48qfty2y7x9dzrywk61` (two warm samples per state; hydration run https://github.com/openclaw/openclaw/actions/runs/31822611793):

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall | 6.22s | 6.09s | -2.2% |
| Vitest | 3.15s | 2.89s | -8.3% |
| Test body | 1.275s | 0.953s | -25.2% |
| CPU user+sys | 7.54s | 7.25s | -3.8% |
| Max RSS | 770.5 MiB | 745.6 MiB | -3.2% |

Command: `/usr/bin/time -v node scripts/run-vitest.mjs src/cli/skills-cli.workshop-cache.test.ts --maxWorkers=1`, with state-specific module-cache paths. Local controlled warm corroboration was wall 5.98s -> 5.48s (-8.4%) and max RSS 634.2 -> 601.2 MiB (-5.2%). Import timing varied, so no import improvement is claimed.

- Post-rebase focused proof: `node scripts/run-vitest.mjs src/cli/skills-cli.workshop-cache.test.ts --maxWorkers=1` — 5/5 passed; Vitest 2.70s, wrapper 6.09s.
- Sibling proof: `node scripts/run-vitest.mjs src/cli/skills-cli.workshop-cache.test.ts src/cli/skills-cli.workshop.test.ts src/gateway/server-methods/skills.proposals.test.ts --maxWorkers=1` — 19/19 passed.
- Remote changed gate: `corepack pnpm check:changed` — passed in 11m13.819s, including guards/ratchets, format, Knip, temp-report validation, core test typecheck, and focused oxlint.
- `git diff --check origin/main...HEAD` — clean.
- Fresh Codex autoreview — CLEAN; no accepted or actionable findings.

Vitest 4.1.10 contract inspection at `node_modules/vitest/dist/index.d.ts:602`, `node_modules/vitest/dist/chunks/utils.BX5Fg8C4.js:29`, and `node_modules/vitest/dist/chunks/test.DNmyFkvJ.js:3654` confirms that `vi.resetModules()` clears evaluated modules for future imports without clearing mocks or retained top-level namespace references. That supports the two persistent process-role graphs and shared hoisted mock delegates used here.

No full suite was run; the focused suite, sibling owner-boundary suite, remote changed gate, and exact-head PR CI are the scoped proof for this test-only refactor.
