### PR TITLE
fix(worker): surface gateway admission failures

### DIFF
--- a/src/cli/worker-cli.ts
+++ b/src/cli/worker-cli.ts
@@ -1,5 +1,9 @@
 import { Option, type Command } from "commander";
 import { signalProcessTree } from "../process/kill-tree.js";
+import {
+  NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+  type NodeWorkerConnectionFailureMessage,
+} from "../worker/node-supervisor-protocol.js";
 import type { WorkerCommandLifetime } from "../worker/worker-command.runtime.js";
 
 const WORKER_START_MESSAGE_TYPE = "openclaw-worker-start-v1";
@@ -66,6 +70,20 @@ function createWorkerIpcLifetime(): WorkerCommandLifetime {
   return {
     started: startedPromise,
     signal: abortController.signal,
+    reportConnectionFailure: (cause) => {
+      if (disposed || !process.connected || typeof process.send !== "function") {
+        return;
+      }
+      const message: NodeWorkerConnectionFailureMessage = {
+        type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+        cause: cause ?? null,
+      };
+      try {
+        process.send(message, () => {});
+      } catch {
+        // The disconnect handler owns worker shutdown when the supervisor is gone.
+      }
+    },
     terminateOwnedTree: () => {
       signalProcessTree(process.pid, "SIGKILL", {
         detached: process.platform !== "win32",

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -142,6 +142,39 @@ function workspaceTransfer(): NodeWorkspaceTransferService {
 }
 
 describe("node worker tunnel manager", () => {
+  it("projects a terminal gateway connection failure into the launch result", async () => {
+    const record = environment();
+    const errorText =
+      "worker could not reach gateway gateway.example: certificate rejected; check TLS pin/publicUrl configuration";
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: () => record,
+      getTransport: transport,
+      launchNodeWorker: vi.fn<NodeWorkerLaunch>(async (request) => ({
+        launchId: request.input.launchId,
+        planHash: "b".repeat(64),
+        environmentId: request.input.descriptor.admission.environmentId,
+        sessionId: request.input.descriptor.admission.sessionId,
+        ownerEpoch: request.input.descriptor.admission.ownerEpoch,
+        placementGeneration: request.input.placementGeneration,
+        runId: request.input.descriptor.assignment.runId,
+        state: "cancelled",
+        errorText,
+      })),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: workspaceTransfer(),
+    });
+    const handle = await manager.start(startRequest());
+
+    await expect(
+      handle.launchTurn({ plan: plan(), placementGeneration: 4 }),
+    ).resolves.toMatchObject({
+      code: 1,
+      killed: true,
+      stderr: errorText,
+    });
+  });
+
   it("reuses only the exact same epoch binding", async () => {
     const record = environment();
     const manager = createNodeWorkerTunnelManager({

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -458,7 +458,12 @@ describe("worker turn launcher failure recovery", () => {
     expect(message).not.toContain(secret);
     expect(hasLoneSurrogate(message)).toBe(false);
     const placement = placements.get(SESSION_ID);
-    expect(placement).toMatchObject({ state: "failed", recoveryError: message, turnClaim: null });
+    expect(placement).toMatchObject({
+      state: "failed",
+      recoveryError: message,
+      terminalReason: message,
+      turnClaim: null,
+    });
     expect(hasLoneSurrogate(placement?.recoveryError ?? "")).toBe(false);
     expect(stopTunnel).toHaveBeenCalledWith(ENVIRONMENT_ID, OWNER_EPOCH);
     expect(destroy).toHaveBeenCalledWith(ENVIRONMENT_ID);

--- a/src/node-host/node-worker-supervisor.test-support.ts
+++ b/src/node-host/node-worker-supervisor.test-support.ts
@@ -84,7 +84,20 @@ const writeResultAndExit = (value) => {
   exitWorker(0);
 };
 const mode = descriptor.assignment.prompt;
-if (mode === "wait") {
+if (mode === "connection-failure") {
+  process.send(
+    {
+      type: "openclaw-worker-connection-failure-v1",
+      cause: "certificate rejected " + descriptor.admission.credential,
+    },
+    () =>
+      fs.writeFileSync(
+        path.join(descriptor.assignment.workspaceDir, "connection-failure-reported"),
+        "reported",
+      ),
+  );
+  setInterval(() => {}, 1000);
+} else if (mode === "wait") {
   setInterval(() => {}, 1000);
 } else if (mode === "tree") {
   grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -611,6 +611,32 @@ describe("node worker supervisor", () => {
     await supervisor.close();
   });
 
+  it("records the child's last gateway connection failure when cancelling admission", async () => {
+    const { supervisor, workspaceDir } = fixture();
+    const input = launchInput(workspaceDir, "connection-failure-launch", "connection-failure");
+    expect(
+      await supervisor.launch(input, {
+        kind: "websocket",
+        url: "wss://gateway.example/__openclaw__/worker",
+      }),
+    ).toMatchObject({
+      state: "running",
+    });
+    await vi.waitFor(() =>
+      expect(fs.existsSync(path.join(workspaceDir, "connection-failure-reported"))).toBe(true),
+    );
+
+    const cancelled = await supervisor.cancel(testNodeWorkerLaunchIdentity(input));
+    expect(cancelled).toMatchObject({
+      state: "cancelled",
+      errorText: expect.stringMatching(
+        /^worker could not reach gateway gateway\.example: certificate rejected .+; check TLS pin\/publicUrl configuration$/u,
+      ),
+    });
+    expect(cancelled?.errorText).not.toContain(TEST_WORKER_CREDENTIAL);
+    await supervisor.close();
+  });
+
   it.each([
     ["cancel", "cancelled"],
     ["close", "interrupted"],

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -12,6 +12,8 @@ import {
   parseWorkerLaunchPlan,
   type WorkerLaunchDescriptor,
 } from "../worker/launch-descriptor.js";
+import { parseNodeWorkerConnectionFailureMessage } from "../worker/node-supervisor-protocol.js";
+import { formatWorkerConnectionFailure } from "../worker/worker-connection-contract.js";
 import type { WorkerConnectionEndpoint } from "../worker/worker-connection-endpoint.js";
 import type { NodeWorkerInstallation } from "./node-worker-build.js";
 import { NodeWorkerCapacity } from "./node-worker-capacity.js";
@@ -68,6 +70,7 @@ type RunningChild = ActiveBase & {
   journalReady: Promise<void>;
   releaseJournal: () => void;
   scrubber: NodeWorkerCredentialScrubber;
+  connectionFailure: { errorText?: string };
   stopState?: StopState;
 };
 type TerminalOutcome = Readonly<{
@@ -472,6 +475,9 @@ class NodeWorkerSupervisor {
   }): Promise<NodeWorkerLaunchReceipt> {
     const credential = params.descriptor.admission.credential;
     const scrubber = createNodeWorkerCredentialScrubber(credential);
+    // Turn cancellation can beat the child's admission retry deadline. Retain the
+    // producer's latest cause so the durable terminal receipt does not become generic.
+    const connectionFailure: { errorText?: string } = {};
     registerSecretValueForRedaction(credential);
     let adapter: ChildAdapter;
     try {
@@ -487,6 +493,22 @@ class NodeWorkerSupervisor {
         env: this.workerEnv,
         exactEnv: true,
         ownedWorker: true,
+        onWorkerMessage: (message) => {
+          const diagnostic = parseNodeWorkerConnectionFailureMessage(message);
+          if (!diagnostic) {
+            return;
+          }
+          connectionFailure.errorText = diagnostic.cause
+            ? formatWorkerConnectionFailure(
+                params.descriptor.connectionEndpoint,
+                sanitizeNodeWorkerDiagnostic(
+                  diagnostic.cause,
+                  "node worker gateway connection failed",
+                  scrubber.scrub,
+                ),
+              )
+            : undefined;
+        },
         input: JSON.stringify(params.descriptor),
       });
     } catch (error) {
@@ -550,6 +572,7 @@ class NodeWorkerSupervisor {
       planHash: params.planHash,
       releaseJournal,
       scrubber,
+      connectionFailure,
       supervisor: params.supervisor,
       worker,
     } as RunningChild;
@@ -613,9 +636,10 @@ class NodeWorkerSupervisor {
         outcome = Object.freeze({
           state: active.stopState,
           errorText:
-            active.stopState === "cancelled"
+            active.connectionFailure.errorText ??
+            (active.stopState === "cancelled"
               ? "node worker launch cancelled"
-              : "node worker launch interrupted during node-host shutdown",
+              : "node worker launch interrupted during node-host shutdown"),
         });
       } else if (exit.code === 0 && exit.signal === null) {
         try {
@@ -638,22 +662,22 @@ class NodeWorkerSupervisor {
         const exitLabel = exit.signal ? `signal ${exit.signal}` : `exit code ${String(exit.code)}`;
         outcome = Object.freeze({
           state: "failed",
-          errorText: sanitizeNodeWorkerDiagnostic(
-            `node worker failed with ${exitLabel}${detail ? `: ${detail}` : ""}`,
-            "node worker failed",
-            active.scrubber.scrub,
-          ),
+          errorText:
+            active.connectionFailure.errorText ??
+            sanitizeNodeWorkerDiagnostic(
+              `node worker failed with ${exitLabel}${detail ? `: ${detail}` : ""}`,
+              "node worker failed",
+              active.scrubber.scrub,
+            ),
         });
       }
     } catch (error) {
       await active.journalReady;
       outcome = Object.freeze({
         state: active.stopState ?? "failed",
-        errorText: sanitizeNodeWorkerDiagnostic(
-          error,
-          "node worker wait failed",
-          active.scrubber.scrub,
-        ),
+        errorText:
+          active.connectionFailure.errorText ??
+          sanitizeNodeWorkerDiagnostic(error, "node worker wait failed", active.scrubber.scrub),
       });
     } finally {
       active.adapter.dispose();

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -88,6 +88,7 @@ export async function createChildAdapter(params: {
   ownedWorker?: true;
   /** Preserve the supplied environment exactly by skipping environment-mutating spawn wrappers. */
   exactEnv?: true;
+  onWorkerMessage?: (message: unknown) => void;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
@@ -146,6 +147,15 @@ export async function createChildAdapter(params: {
   if (params.ownedWorker !== undefined && (!child.connected || !child.channel)) {
     spawned.child.kill("SIGKILL");
     throw new Error("worker lifecycle IPC channel was not created");
+  }
+  if (params.onWorkerMessage) {
+    child.on("message", (message) => {
+      try {
+        params.onWorkerMessage?.(message);
+      } catch {
+        // Worker diagnostics cannot change child supervision.
+      }
+    });
   }
   const disconnectWorkerIpc = () => {
     if (!child.connected) {

--- a/src/worker/node-supervisor-protocol.test.ts
+++ b/src/worker/node-supervisor-protocol.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+  parseNodeWorkerConnectionFailureMessage,
   parseNodeWorkerSupervisorReceipt,
   type NodeWorkerSupervisorIdentity,
 } from "./node-supervisor-protocol.js";
@@ -18,6 +20,30 @@ const identity: NodeWorkerSupervisorIdentity = {
 };
 
 describe("node worker supervisor wire receipt", () => {
+  it("accepts only bounded worker connection diagnostics", () => {
+    expect(
+      parseNodeWorkerConnectionFailureMessage({
+        type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+        cause: "certificate rejected",
+      }),
+    ).toEqual({
+      type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+      cause: "certificate rejected",
+    });
+    expect(
+      parseNodeWorkerConnectionFailureMessage({
+        type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+        cause: null,
+      }),
+    ).toEqual({ type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE, cause: null });
+    expect(
+      parseNodeWorkerConnectionFailureMessage({
+        type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+        cause: "x".repeat(64 * 1024 + 1),
+      }),
+    ).toBeNull();
+  });
+
   it.each([
     { ...identity, state: "pending" },
     { ...identity, state: "running" },

--- a/src/worker/node-supervisor-protocol.ts
+++ b/src/worker/node-supervisor-protocol.ts
@@ -8,6 +8,8 @@ const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 const NODE_WORKER_SUPERVISOR_CANCEL_REQUEST_MAX_BYTES = 4 * 1024;
 const NODE_WORKER_RESULT_JSON_MAX_BYTES = 64 * 1024;
 const NODE_WORKER_ERROR_TEXT_MAX_BYTES = 4 * 1024;
+const NODE_WORKER_CONNECTION_FAILURE_CAUSE_MAX_BYTES = 64 * 1024;
+export const NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE = "openclaw-worker-connection-failure-v1";
 
 export type NodeWorkerLaunchInput = {
   launchId: string;
@@ -46,6 +48,11 @@ export type NodeWorkerSupervisorReceipt =
   | NodeWorkerSupervisorActiveReceipt
   | NodeWorkerSupervisorCompletedReceipt
   | NodeWorkerSupervisorErrorReceipt;
+
+export type NodeWorkerConnectionFailureMessage = {
+  type: typeof NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE;
+  cause: string | null;
+};
 
 function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
   return (
@@ -264,6 +271,26 @@ function isBoundedErrorText(value: unknown): value is string {
     Buffer.byteLength(value, "utf8") <= NODE_WORKER_ERROR_TEXT_MAX_BYTES &&
     !/[\r\n]/u.test(value)
   );
+}
+
+export function parseNodeWorkerConnectionFailureMessage(
+  value: unknown,
+): NodeWorkerConnectionFailureMessage | null {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["type", "cause"]) ||
+    value.type !== NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE ||
+    (value.cause !== null &&
+      (typeof value.cause !== "string" ||
+        value.cause.length === 0 ||
+        Buffer.byteLength(value.cause, "utf8") > NODE_WORKER_CONNECTION_FAILURE_CAUSE_MAX_BYTES))
+  ) {
+    return null;
+  }
+  return {
+    type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
+    cause: value.cause,
+  };
 }
 
 export function parseNodeWorkerSupervisorReceipt(

--- a/src/worker/worker-command.runtime.test.ts
+++ b/src/worker/worker-command.runtime.test.ts
@@ -64,9 +64,16 @@ function lifetimeHarness() {
     resolveStarted = resolve;
   });
   const dispose = vi.fn();
+  const reportConnectionFailure = vi.fn();
   const terminateOwnedTree = vi.fn();
   return {
-    contract: { dispose, signal: controller.signal, started, terminateOwnedTree },
+    contract: {
+      dispose,
+      reportConnectionFailure,
+      signal: controller.signal,
+      started,
+      terminateOwnedTree,
+    },
     disconnectAfterStart: () => controller.abort(new Error("worker supervisor lifetime ended")),
     disconnectBeforeStart: () => resolveStarted(false),
     dispose,

--- a/src/worker/worker-command.runtime.ts
+++ b/src/worker/worker-command.runtime.ts
@@ -11,6 +11,7 @@ type RunWorkerCommandOptions = {
 
 export type WorkerCommandLifetime = {
   dispose: () => void;
+  reportConnectionFailure: (cause: string | undefined) => void;
   signal: AbortSignal;
   started: Promise<boolean>;
   terminateOwnedTree: () => void;
@@ -76,7 +77,12 @@ export async function runWorkerCommand(options: RunWorkerCommandOptions): Promis
     }
     process.once("SIGINT", stop);
     process.once("SIGTERM", stop);
-    const result = await runWorkerDescriptor(descriptor, { signal: abortController.signal });
+    const result = await runWorkerDescriptor(descriptor, {
+      signal: abortController.signal,
+      ...(options.lifetime
+        ? { onConnectionFailure: options.lifetime.reportConnectionFailure }
+        : {}),
+    });
     const encoded = `${JSON.stringify(result)}\n`;
     options.output.write(encoded);
   } finally {

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -1,4 +1,5 @@
 import { toStructuredErrorObject } from "@openclaw/normalization-core/error-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { ClientOptions, WebSocket } from "ws";
 import type {
   WorkerConnectParams,
@@ -46,6 +47,7 @@ export type WorkerConnectionOptions = {
   requestTimeoutMs?: number;
   createSocket?: (url: string, options: ClientOptions) => WebSocket;
   heartbeatStatus?: () => WorkerHeartbeatParams["status"];
+  onConnectionFailure?: (error: Error | undefined) => void;
 };
 
 export class WorkerConnectionInterruptedError extends Error {
@@ -98,4 +100,22 @@ export function resolvePositiveTimeout(value: number | undefined, fallback: numb
 
 export function toWorkerConnectionError(error: unknown): Error {
   return toStructuredErrorObject(error);
+}
+
+export function formatWorkerConnectionFailure(
+  endpoint: WorkerConnectionEndpoint,
+  error: unknown,
+): string {
+  const target =
+    endpoint.kind === "websocket"
+      ? truncateUtf16Safe(new URL(endpoint.url).host, 128)
+      : truncateUtf16Safe(endpoint.socketPath, 128);
+  const cause =
+    truncateUtf16Safe(toWorkerConnectionError(error).message.replace(/\s+/gu, " ").trim(), 160) ||
+    "connection failed";
+  const hint =
+    endpoint.kind === "websocket"
+      ? "check TLS pin/publicUrl configuration"
+      : "check the local gateway socket";
+  return `worker could not reach gateway ${target}: ${cause}; ${hint}`;
 }

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -1,3 +1,4 @@
+import net from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
 import {
@@ -9,11 +10,16 @@ import {
   WORKER_PROTOCOL_FEATURES,
   WORKER_RPC_SET_VERSION,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { WORKER_PUBLIC_INGRESS_PATH } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type {
   WorkerInferenceEventFrame,
   WorkerInferenceTerminalFrame,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
-import { toWorkerConnectionError } from "./worker-connection-contract.js";
+import {
+  formatWorkerConnectionFailure,
+  toWorkerConnectionError,
+  WorkerAdmissionDeadlineExceededError,
+} from "./worker-connection-contract.js";
 import { WorkerConnectionEndpointError } from "./worker-connection-endpoint.js";
 import { WorkerConnectionFrameDispatcher } from "./worker-connection-frames.js";
 import { createWorkerConnection, type WorkerConnectionState } from "./worker-connection.js";
@@ -149,6 +155,50 @@ describe("worker connection endpoint failures", () => {
     await expect(connection.start()).rejects.toBeInstanceOf(WorkerConnectionEndpointError);
     expect(connection.state).toMatchObject({ kind: "failed" });
     expect(createSocket).not.toHaveBeenCalled();
+  });
+
+  it("reports the last unreachable gateway cause with an operator hint", async () => {
+    const port = await new Promise<number>((resolve, reject) => {
+      const server = net.createServer();
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("test server did not allocate a TCP port"));
+          return;
+        }
+        server.close((error) => (error ? reject(error) : resolve(address.port)));
+      });
+    });
+    const endpoint = {
+      kind: "websocket" as const,
+      url: `ws://127.0.0.1:${port}${WORKER_PUBLIC_INGRESS_PATH}`,
+    };
+    const failures: string[] = [];
+    const connection = createWorkerConnection({
+      endpoint,
+      connectParams: FRAME_CONNECT_PARAMS,
+      admissionTimeoutMs: 25,
+      admissionDeadlineMs: 100,
+      reconnectBackoff: { initialMs: 1, maxMs: 1, factor: 1, jitter: 0 },
+      onConnectionFailure: (error) => {
+        if (error) {
+          failures.push(formatWorkerConnectionFailure(endpoint, error));
+        }
+      },
+    });
+
+    try {
+      await expect(connection.start()).rejects.toBeInstanceOf(WorkerAdmissionDeadlineExceededError);
+      expect(failures.at(-1)).toMatch(
+        new RegExp(
+          `^worker could not reach gateway 127\\.0\\.0\\.1:${port}: .*ECONNREFUSED.*; check TLS pin/publicUrl configuration$`,
+          "u",
+        ),
+      );
+    } finally {
+      await connection.stop();
+    }
   });
 });
 

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -19,6 +19,7 @@ import {
   formatWorkerConnectionFailure,
   toWorkerConnectionError,
   WorkerAdmissionDeadlineExceededError,
+  WorkerConnectionStoppedError,
 } from "./worker-connection-contract.js";
 import { WorkerConnectionEndpointError } from "./worker-connection-endpoint.js";
 import { WorkerConnectionFrameDispatcher } from "./worker-connection-frames.js";
@@ -198,6 +199,58 @@ describe("worker connection endpoint failures", () => {
       );
     } finally {
       await connection.stop();
+    }
+  });
+
+  it("does not report local cancellation as a gateway connection failure", async () => {
+    let acceptConnection!: (socket: net.Socket) => void;
+    const accepted = new Promise<net.Socket>((resolve) => {
+      acceptConnection = resolve;
+    });
+    const server = net.createServer(acceptConnection);
+    const port = await new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("test server did not allocate a TCP port"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+    const failures: Error[] = [];
+    const connection = createWorkerConnection({
+      endpoint: {
+        kind: "websocket",
+        url: `ws://127.0.0.1:${port}${WORKER_PUBLIC_INGRESS_PATH}`,
+      },
+      connectParams: FRAME_CONNECT_PARAMS,
+      onConnectionFailure: (error) => {
+        if (error) {
+          failures.push(error);
+        }
+      },
+    });
+    const starting = connection.start();
+    const peer = await accepted;
+
+    try {
+      await connection.stop();
+      await expect(starting).rejects.toBeInstanceOf(WorkerConnectionStoppedError);
+      expect(failures).toEqual([]);
+    } finally {
+      peer.destroy();
+      await connection.stop();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
     }
   });
 });

--- a/src/worker/worker-connection.ts
+++ b/src/worker/worker-connection.ts
@@ -278,8 +278,14 @@ export class WorkerConnection {
         }
       }
       try {
-        return await this.connectOnce(attempt, Math.min(this.admissionTimeoutMs, remainingMs));
+        const hello = await this.connectOnce(
+          attempt,
+          Math.min(this.admissionTimeoutMs, remainingMs),
+        );
+        this.reportConnectionFailure(undefined);
+        return hello;
       } catch (error) {
+        this.reportConnectionFailure(toWorkerConnectionError(error));
         if (error instanceof WorkerAdmissionError) {
           if (error.retryable) {
             attempt += 1;
@@ -439,6 +445,14 @@ export class WorkerConnection {
   private transition(state: WorkerConnectionState): void {
     this.stateValue = state;
     notifyListeners(this.stateListeners, state);
+  }
+
+  private reportConnectionFailure(error: Error | undefined): void {
+    try {
+      this.options.onConnectionFailure?.(error);
+    } catch {
+      // Diagnostics must never change connection retry or admission behavior.
+    }
   }
 
   private finishFenced(reason: WorkerFencedReason): void {

--- a/src/worker/worker-connection.ts
+++ b/src/worker/worker-connection.ts
@@ -285,6 +285,9 @@ export class WorkerConnection {
         this.reportConnectionFailure(undefined);
         return hello;
       } catch (error) {
+        if (this.isTerminal()) {
+          throw this.terminalError();
+        }
         this.reportConnectionFailure(toWorkerConnectionError(error));
         if (error instanceof WorkerAdmissionError) {
           if (error.retryable) {
@@ -297,9 +300,6 @@ export class WorkerConnection {
         if (error instanceof WorkerConnectionEndpointError) {
           this.finishFailed(error);
           throw error;
-        }
-        if (this.isTerminal()) {
-          throw this.terminalError();
         }
         attempt += 1;
       }

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -48,7 +48,10 @@ async function assertWorkspaceDirectory(workspaceDir: string): Promise<string> {
 
 export async function runWorkerDescriptor(
   descriptor: WorkerLaunchDescriptor,
-  options: { signal?: AbortSignal } = {},
+  options: {
+    signal?: AbortSignal;
+    onConnectionFailure?: (cause: string | undefined) => void;
+  } = {},
 ): Promise<WorkerRuntimeResult> {
   const workspaceDir = await assertWorkspaceDirectory(descriptor.assignment.workspaceDir);
   const stateDir = await mkdtemp(path.join(tmpdir(), "openclaw-worker-"));
@@ -65,6 +68,7 @@ export async function runWorkerDescriptor(
   const connection = createWorkerConnection({
     endpoint: descriptor.connectionEndpoint,
     connectParams: buildWorkerConnectParams(descriptor),
+    onConnectionFailure: (error) => options.onConnectionFailure?.(error?.message),
   });
   const abortFromCaller = () => {
     abortController.abort(options.signal?.reason);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where node-worker turns could remain apparently `running` and later die as `gateway_draining` timeouts when the worker could not connect back to the Gateway. Repeated TLS validation, connection-refused, or admission failures were discarded when launch cancellation won, leaving operators with no reason or next step.

A stress campaign initially misdiagnosed this as a broader node-turn P0: the real trigger was intentional hostname validation for an explicitly configured, unpinned `publicUrl`, but the launch receipt contained only `node worker launch cancelled`. That missing fact made the control-plane symptom indistinguishable from an agent/runtime stall.

## Why This Change Was Made

The worker connection owner now reports its latest failed connection attempt over the existing private child-supervisor IPC channel and clears it after successful admission. The supervisor validates and credential-scrubs that bounded diagnostic before committing it to the durable terminal launch receipt; the existing Gateway failure path projects the same reason into the placement record.

The resulting text is shaped as `worker could not reach gateway <host>: <cause>; check TLS pin/publicUrl configuration`. Retry timing, TLS validation policy, pairing setup behavior, config, storage schemas, and public Gateway protocol are unchanged.

## User Impact

Operators now see why a node worker could not reach its Gateway and what to check next, both in the terminal agent failure and in durable launch/placement state. A bad TLS route no longer masquerades as a silent worker hang.

## Evidence

- Pre-fix regression: cancelling a child after it reported a connection failure produced `node worker launch cancelled`; the same test passes with the recorded, scrubbed cause.
- Focused matrix, three consecutive runs: 6 files, 71 assertions per run, covering randomized `ECONNREFUSED`, in-flight local cancellation, diagnostic bounds, credential scrubbing, terminal receipt projection, and placement terminal reason.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 node scripts/check-changed.mjs`
- `pnpm build` (3m24s)
- Built black-box bad-TLS run against a fresh isolated Gateway/node pair: the agent ended with `self-signed certificate` plus `check TLS pin/publicUrl configuration`; the node receipt was `failed`, and Gateway `recovery_error` and `terminal_reason` preserved the same text.
- ClawSweeper P1 follow-up: terminal state now wins before diagnostic reporting, with a real accepted-but-unadmitted socket cancellation regression.
- Autoreview: clean, no accepted/actionable findings; follow-up review confidence 0.99.

Production LOC: +141/-18 (net +123) | Tests: +217/-4 (net +213). The production growth is the bounded typed IPC ownership boundary required to preserve a producer-authored fact across cancellation; no parallel runtime path or compatibility shim was added.

AI-assisted: yes. Maintainer-reviewed implementation and proof completed with Codex.
