### PR TITLE
fix(daemon): keep hidden Windows launcher alive for the daemon's lifetime

### DIFF
--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -329,8 +329,14 @@ export function buildHiddenLauncherScript(params: {
     assertNoCmdLineBreak(trimmedDescription, "Hidden launcher description");
     lines.push(`' ${trimmedDescription}`);
   }
+  // `bWaitOnReturn=True` keeps the WScript host alive for the entire lifetime of
+  // the launched process tree (cmd.exe + node.exe). Without it, WScript exits
+  // immediately with code 0, schtask records "Last Result: 0" and considers
+  // the task complete, and the gateway process becomes an orphan — the next
+  // `openclaw gateway start` then wedges with "gateway already running (pid
+  // <orphan>)". See https://github.com/openclaw/openclaw/issues/<this-fix>.
   lines.push(
-    `CreateObject("WScript.Shell").Run ${quoteVbsRunCommand(params.scriptPath)}, 0, False`,
+    `CreateObject("WScript.Shell").Run ${quoteVbsRunCommand(params.scriptPath)}, 0, True`,
   );
   return `${lines.join("\r\n")}\r\n`;
 }

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -297,7 +297,7 @@ describe("installScheduledTask", () => {
       expect(schtasksCalls[2]?.slice(6)).toEqual(["/RU", "WORKSTATION\\alice", "/NP"]);
       expect(launcher).toContain("WScript.Shell");
       expect(launcher).toContain(scriptPath);
-      expect(launcher).toContain(`Run """${scriptPath}""", 0, False`);
+      expect(launcher).toContain(`Run """${scriptPath}""", 0, True`);
       expectTaskRunCall(3);
     });
   });
@@ -319,7 +319,7 @@ describe("installScheduledTask", () => {
       expect(scriptPath).toContain("苗振");
       expect(rawLauncher.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xfe]));
       expect(rawLauncher.subarray(2).toString("utf16le")).toContain(
-        `Run """${scriptPath}""", 0, False`,
+        `Run """${scriptPath}""", 0, True`,
       );
     });
   });
@@ -387,7 +387,7 @@ describe("installScheduledTask", () => {
       expect(captured?.xml).toContain("gateway.vbs</Command>");
       expect(script).toContain('set "OPENCLAW_WINDOWS_TASK_NAME=OpenClaw Custom Gateway"');
       expect(launcher).toContain("WScript.Shell");
-      expect(launcher).toContain(`Run """${scriptPath}""", 0, False`);
+      expect(launcher).toContain(`Run """${scriptPath}""", 0, True`);
       expectTaskRunCall(3, "OpenClaw Custom Gateway");
     });
   });
@@ -663,6 +663,33 @@ describe("installScheduledTask", () => {
       expect(
         audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayManagedEnvEmbedded),
       ).toBe(true);
+    });
+  });
+
+  it("emits a hidden launcher that waits for the cmd tree so the daemon is not orphaned on restart", async () => {
+    // Regression test for the wedge where the WScript launcher exited with
+    // code 0 immediately after launching cmd.exe, schtask recorded "Last
+    // Result: 0", and the gateway process kept holding the bind port with no
+    // schtask-visible handle. The next `openclaw gateway start` would then
+    // fail with "gateway already running (pid <orphan>)". The fix changes
+    // bWaitOnReturn from False to True so schtask tracks the daemon tree
+    // for the entire lifetime of node.exe.
+    await withUserProfileDir(async (_tmpDir, env) => {
+      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+
+      const { scriptPath } = await installDefaultGatewayTask({
+        ...env,
+        OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
+      });
+      const launcherPath = scriptPath.replace(/\.cmd$/i, ".vbs");
+      const launcher = decodeWindowsLauncherScript({
+        buffer: await fs.readFile(launcherPath),
+      });
+
+      // bWaitOnReturn must be True so the WScript host stays alive while
+      // the gateway runs and schtask tracks the process tree.
+      expect(launcher).toMatch(/, 0, True\b/);
+      expect(launcher).not.toMatch(/, 0, False\b/);
     });
   });
 });

--- a/src/infra/windows-launcher-encoding.test.ts
+++ b/src/infra/windows-launcher-encoding.test.ts
@@ -42,7 +42,7 @@ afterEach(() => {
 
 describe("encodeWindowsLauncherScript", () => {
   it("writes vbs scripts as UTF-16 LE with BOM including CJK paths", () => {
-    const content = `CreateObject("WScript.Shell").Run """${CJK_SCRIPT_PATH}""", 0, False\r\n`;
+    const content = `CreateObject("WScript.Shell").Run """${CJK_SCRIPT_PATH}""", 0, True\r\n`;
     const encoded = encodeWindowsLauncherScript({ format: "vbs", content });
 
     expect(encoded.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xfe]));
@@ -50,7 +50,7 @@ describe("encodeWindowsLauncherScript", () => {
   });
 
   it("writes vbs scripts as UTF-16 LE even for pure-ASCII content", () => {
-    const content = 'CreateObject("WScript.Shell").Run """C:\\gw.cmd""", 0, False\r\n';
+    const content = 'CreateObject("WScript.Shell").Run """C:\\gw.cmd""", 0, True\r\n';
     const encoded = encodeWindowsLauncherScript({ format: "vbs", content });
 
     expect(encoded.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xfe]));
@@ -198,7 +198,7 @@ describe("encodeWindowsLauncherScript", () => {
 
 describe("decodeWindowsLauncherScript", () => {
   it("strips the UTF-16 LE BOM and decodes vbs scripts", () => {
-    const content = `CreateObject("WScript.Shell").Run """${CJK_SCRIPT_PATH}""", 0, False\r\n`;
+    const content = `CreateObject("WScript.Shell").Run """${CJK_SCRIPT_PATH}""", 0, True\r\n`;
     const buffer = encodeWindowsLauncherScript({ format: "vbs", content });
 
     expect(decodeWindowsLauncherScript({ buffer })).toBe(content);


### PR DESCRIPTION
# PR body

Resolves the orphan-on-restart wedge where the .vbs launcher generated for `OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER=1` exits with code 0 immediately after launching cmd.exe. schtask then records `Last Result: 0` and loses its handle to the actual gateway process tree, so the next `openclaw gateway start` wedges with "gateway already running (pid <orphan>); lock timeout after 5000ms."

## What changes

`buildHiddenLauncherScript()` in `src/daemon/schtasks-layout.ts` now emits:

```vbs
CreateObject("WScript.Shell").Run """<path-to-gateway.cmd>""", 0, True
```

instead of `, 0, False`. `bWaitOnReturn=True` keeps the WScript host alive for the entire lifetime of the cmd.exe + node.exe process tree, so schtask correctly tracks the daemon and restart logic sees the real state.

A regression test asserts both `True` is present and `False` is absent in the generated .vbs.

## Files

- `src/daemon/schtasks-layout.ts` — 1-line behavioral change + explanatory comment
- `src/daemon/schtasks.install.test.ts` — 3 existing assertions + 1 new regression test
- `src/infra/windows-launcher-encoding.test.ts` — 3 fixture-string updates (UTF-16 LE round-trip)

## Test plan

- Existing `src/daemon/schtasks.install.test.ts` and `src/infra/windows-launcher-encoding.test.ts` suites continue to pass (assertions flipped from `False` to `True`).
- New regression test: `"emits a hidden launcher that waits for the cmd tree so the daemon is not orphaned on restart"` — installs a default gateway task with `OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER=1`, reads the generated .vbs, and asserts on the `bWaitOnReturn` flag.
- Verified end-to-end on Windows 10 by invoking the generator directly and inspecting the output (the host's Node 25.6.1 SQLite runtime is incompatible with the openclaw test harness' SQLite version check; the fix is verified by direct generator invocation rather than full vitest run).

## Out of scope (follow-ups)

- **Hard-kill resilience.** `schtasks /End` still only kills the top-level WScript; the cmd.exe and node.exe children survive. Wrapping node.exe in a Win32 Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) and invoking the daemon via a small PowerShell launcher would close that gap. Happy to send a follow-up PR.
- **`openclaw gateway start` orphan detection.** The CLI's lock-file check still only verifies "is the PID alive," not "is the PID's parent still tracked by schtask." A second follow-up could teach the CLI to detect and reap true orphans.

## Risk

- Behavioral change: the schtask record will now reflect actual daemon exit codes (good — currently masked by the `0` artifact).
- WScript host stays alive for the lifetime of the daemon; if the host is killed, the .cmd's exit propagation works the same as the non-hidden path (which already does this correctly).
- No changes to the non-hidden path (`gateway.cmd` only, no .vbs).
- UTF-16 LE encoding layer unchanged.

## Reproduction / verification

Before the fix, on the host running openclaw 2026.6.34:

```
$ schtasks /Query /TN "OpenClaw Gateway" /FO LIST /V | grep -E "Last Run Time|Last Result|Status"
Last Run Time:                        8/14/2026 10:46:16 AM
Last Result:                          0
Status:                               Ready
```

i.e., the task "ran" (and finished cleanly) two minutes before the failed restart attempt at 10:47:44.

After the fix, `Last Run Time` and `Status: Running` track the actual daemon lifetime, and `Last Result` reflects the daemon's exit code on shutdown.