### PR TITLE
fix: preserve shared SQLite WAL during auxiliary shutdown

### DIFF
--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import type { DecisionReceiptV1 } from "../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -302,6 +303,41 @@ describe("audit event worker", () => {
       expect(persisted.context_json).not.toContain(raw);
       expect(JSON.stringify(errors)).not.toContain(raw);
     }
+  });
+
+  it("stops without resetting the WAL owned by an active Gateway reader", async () => {
+    const stateDir = tempDirs.make("openclaw-audit-writer-");
+    const database = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    recordAuditEvent(input(), database);
+    closeOpenClawStateDatabaseForTest();
+    const errors: string[] = [];
+    const writer = createAuditEventWriter({ stateDir, onError: (error) => errors.push(error) });
+    await writer.ready;
+    const gateway = openOpenClawStateDatabase(database);
+    gateway.db.exec("BEGIN;");
+    gateway.db.prepare("SELECT count(*) FROM audit_events").get();
+
+    try {
+      expect(
+        writer.record({ ...input(), sourceId: "worker-before-stop", runId: "worker-before-stop" }),
+      ).toBe(true);
+      const stopStartedAt = performance.now();
+      await writer.stop();
+      const stopElapsedMs = performance.now() - stopStartedAt;
+
+      expect(errors).toEqual([]);
+      expect(stopElapsedMs).toBeLessThan(1_000);
+      expect(fs.statSync(`${gateway.path}-wal`).size).toBeGreaterThan(0);
+    } finally {
+      gateway.db.exec("ROLLBACK;");
+      await writer.stop();
+    }
+
+    expect(gateway.db.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+    expect(listAuditEvents({ database, limit: 10 }).events.map((event) => event.runId)).toEqual([
+      "worker-before-stop",
+      "run-1",
+    ]);
   });
 
   it("persists owned unknown and omits inherited evidence through the worker clone boundary", async () => {

--- a/src/audit/audit-event-writer.worker.ts
+++ b/src/audit/audit-event-writer.worker.ts
@@ -107,7 +107,9 @@ port.on("message", (message: AuditWriterRequest) => {
   clearInterval(maintenanceTimer);
   reportMaintenance();
   try {
-    closeOpenClawStateDatabase();
+    // The Gateway may still own a live connection. Leave WAL reset to the
+    // final lifecycle owner instead of waiting on or invalidating its readers.
+    closeOpenClawStateDatabase({ checkpointMode: "PASSIVE" });
   } catch (error) {
     port.postMessage({ type: "maintenance-error", error: String(error) });
   }

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -43,11 +43,12 @@ type OpenClawStateDatabaseCloseResult = {
 /** Close both physical-handle owners while retaining every cleanup failure. */
 function closeOpenClawStateDatabaseHandle(
   database: OpenClawStateDatabase,
+  options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
 ): OpenClawStateDatabaseCloseResult {
   let caught = false;
   const errors: unknown[] = [];
   try {
-    database.walMaintenance.close();
+    database.walMaintenance.close(options);
   } catch (error) {
     caught = true;
     errors.push(error);
@@ -72,8 +73,9 @@ function evictCachedOpenClawStateDatabase(database: OpenClawStateDatabase): bool
   // but it must never remain discoverable as the process-wide shared handle.
   cachedDatabases.delete(database.path);
   notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: database.path });
-  // Eviction is best-effort; the triggering database error remains authoritative.
-  closeOpenClawStateDatabaseHandle(database);
+  // A poisoned cache owner is not the database lifecycle owner. PASSIVE avoids
+  // waiting on readers or resetting recovery frames another connection needs.
+  closeOpenClawStateDatabaseHandle(database, { checkpointMode: "PASSIVE" });
   return true;
 }
 
@@ -197,9 +199,11 @@ function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
 }
 
 /** Close all cached shared state database handles. */
-function closeOpenClawStateDatabase(): void {
+function closeOpenClawStateDatabase(
+  options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
+): void {
   for (const database of cachedDatabases.values()) {
-    database.walMaintenance.close();
+    database.walMaintenance.close(options);
     if (database.db.isOpen) {
       database.db.close();
     }

--- a/src/state/openclaw-state-db.corruption-recovery.test.ts
+++ b/src/state/openclaw-state-db.corruption-recovery.test.ts
@@ -11,6 +11,7 @@ import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
+  evictOpenClawStateDatabaseAfterCorruption,
   getOpenClawStateDatabaseIfOpen,
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -167,6 +168,40 @@ describe("isSqliteCorruptionError", () => {
 });
 
 describe("shared state write transaction corruption recovery", () => {
+  it("preserves the shared WAL when evicting a poisoned cache owner", () => {
+    const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
+    const cached = openOpenClawStateDatabase({ env });
+    insertProbeEvent(env, "committed-before-eviction");
+    const walPath = `${cached.path}-wal`;
+    const walBytesBeforeEviction = fs.statSync(walPath).size;
+    const { DatabaseSync } = requireNodeSqlite();
+    const peer = new DatabaseSync(cached.path);
+
+    try {
+      peer.exec("BEGIN;");
+      peer.prepare("SELECT count(*) FROM diagnostic_events").get();
+      const evictionStartedAt = performance.now();
+      expect(
+        evictOpenClawStateDatabaseAfterCorruption(
+          cached,
+          sqliteError("database disk image is malformed", 11),
+        ),
+      ).toBe(true);
+      const evictionElapsedMs = performance.now() - evictionStartedAt;
+
+      expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+      expect(evictionElapsedMs).toBeLessThan(250);
+      expect(fs.statSync(walPath).size).toBe(walBytesBeforeEviction);
+      expect(peer.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+      expect(
+        peer.prepare("SELECT event_key FROM diagnostic_events WHERE scope = ?").get(PROBE_SCOPE),
+      ).toEqual({ event_key: "committed-before-eviction" });
+    } finally {
+      peer.exec("ROLLBACK;");
+      peer.close();
+    }
+  });
+
   it("evicts the cached handle so a repaired file recovers without a process restart", () => {
     const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
     const { databasePath, healthySnapshot, poisoned } = prepareCorruptedCachedDatabase(env);

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -717,8 +717,10 @@ export function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
 }
 
 /** Close all cached shared state database handles. */
-export function closeOpenClawStateDatabase(): void {
-  stateDbCache.closeOpenClawStateDatabase();
+export function closeOpenClawStateDatabase(
+  options?: Parameters<typeof stateDbCache.closeOpenClawStateDatabase>[0],
+): void {
+  stateDbCache.closeOpenClawStateDatabase(options);
 }
 
 /** Test whether any cached shared state database handle is still open. */


### PR DESCRIPTION
Related: #117262, #123327, #101290

## What Problem This Solves

Fixes an issue where the audit worker or a corruption-driven cache eviction could act like the final owner of the shared state database while the Gateway still had an open connection. Those auxiliary close paths could wait for SQLite's full busy timeout and attempt to reset the WAL file that the live Gateway still needed.

## Why This Change Was Made

Only a proven final owner should use a destructive `TRUNCATE` checkpoint. The audit worker and cache-eviction paths now close with a non-destructive `PASSIVE` checkpoint, while the existing final-owner close behavior remains unchanged.

## User Impact

The Gateway can keep using shared state while the audit worker stops or a poisoned cache handle is evicted. Those auxiliary closes no longer introduce a five-second lock wait, and committed WAL-backed state remains available to surviving connections.

## Evidence

<img width="1280" height="720" alt="Audit worker stops without resetting the shared WAL" src="https://github.com/user-attachments/assets/e47b5514-f945-472a-a0ce-87c1db36c386" />

**What this shows:** With a Gateway read transaction held open, the real audit worker stopped in 27.4 ms, preserved a non-empty 57,712-byte WAL, persisted the queued audit event, and left `PRAGMA quick_check` at `ok` with no worker errors.

**State:** Current branch `c332c871d48`; Node 24.19.0 with SQLite 3.53.3; isolated temporary shared-state database; real audit worker and shared-state connection.

## How to Verify

1. Open the shared state database and hold a Gateway read transaction.
2. Queue an audit event, then stop the audit worker.
3. Confirm the stop completes without the five-second busy timeout, the WAL remains non-empty, the event is durable after the reader releases its transaction, and `PRAGMA quick_check` returns `ok`.

Focused regression coverage:

```sh
node scripts/run-vitest.mjs src/audit/audit-event-writer.test.ts
node scripts/run-vitest.mjs src/state/openclaw-state-db.corruption-recovery.test.ts
node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts
```

## Implementation Notes

This changes checkpoint ownership, not the SQLite schema or the final-owner shutdown contract. It also preserves WAL evidence after a corruption-triggered eviction instead of zeroing it during cleanup.
