### PR TITLE
feat(channels): grade sender identifier authentication in the ingress kernel

### DIFF
--- a/docs/plugins/sdk-channel-ingress.md
+++ b/docs/plugins/sdk-channel-ingress.md
@@ -126,6 +126,51 @@ The audit states are distinct:
   explicitly passes `channelIngress: "unsupported"`. Unsupported never means
   allowed and is not a shortcut for incomplete wiring.
 
+## Identifier authentication
+
+`IdentifierAuthentication` grades an identifier claim as `verified`,
+`asserted`, `unverified`, or `mutable`, strongest to weakest. It is an input to
+channel authorization only. It is not a principal, grant, relationship, or
+execution-identity assurance strength. In particular, an identifier claim of
+`verified` never becomes execution assurance `boundary-verified` or
+`cryptographic`.
+
+The meanings are normative:
+
+- `verified`: the owning trusted transport or session boundary bound this exact
+  identifier to this sender.
+- `asserted`: a trusted boundary vouched for the sender without binding this
+  exact identifier.
+- `unverified`: the identifier is exact and stable, but claimed ownership was
+  not proved.
+- `mutable`: the identifier is a changeable or shared alias, such as a display
+  name.
+
+Declare `verified` only from transport or session metadata controlled by the
+owning boundary. Sender-controlled content, model input, ordinary message
+context, routing metadata, and the integrity of the host admission carrier do
+not establish it.
+
+The kernel preserves the exact redacted allowlist-entry to subject-identifier
+pair that matched. It combines the entry and subject claims by taking the
+weaker claim for that exact pair, then compares it with
+`minIdentifierAuthentication`. Identifiers of the same kind remain distinct,
+so a weak secondary email does not weaken a separately matched verified email.
+
+Existing plugins remain source-compatible during the deprecation window:
+
+| Deprecated field                                   | Exact mapping                        |
+| -------------------------------------------------- | ------------------------------------ |
+| `dangerous: true`                                  | `authentication: "mutable"`          |
+| `dangerous: false` or omitted                      | default `authentication: "asserted"` |
+| `mutableIdentifierMatching: "enabled"`             | minimum `mutable`                    |
+| `mutableIdentifierMatching: "disabled"` or omitted | default minimum `asserted`           |
+
+An explicit `authentication` or `minIdentifierAuthentication` takes
+precedence. The deprecated fields remain through the current Plugin SDK major
+and are planned for removal in the next major after bundled and known external
+plugins migrate.
+
 ## Access groups
 
 `accessGroup:<name>` entries stay redacted. Core resolves static

--- a/docs/plugins/sdk-channel-ingress.md
+++ b/docs/plugins/sdk-channel-ingress.md
@@ -157,6 +157,11 @@ weaker claim for that exact pair, then compares it with
 `minIdentifierAuthentication`. Identifiers of the same kind remain distinct,
 so a weak secondary email does not weaken a separately matched verified email.
 
+A subject that supplies a per-message `authentication` map must claim every
+field it wants counted. A field missing from a supplied map is treated as
+`unverified`, even if its identity descriptor declares a stronger static claim.
+Channels with static strength omit the map entirely.
+
 Existing plugins remain source-compatible during the deprecation window:
 
 | Deprecated field                                   | Exact mapping                        |

--- a/extensions/discord/src/monitor/dm-command-auth.test.ts
+++ b/extensions/discord/src/monitor/dm-command-auth.test.ts
@@ -109,6 +109,19 @@ describe("resolveDiscordDmCommandAccess", () => {
     expect(dmCommandAuthorized(result)).toBe(true);
   });
 
+  it("authorizes a matching Discord tag when name matching is enabled", async () => {
+    const result = await resolveDiscordDmCommandAccess({
+      accountId: "default",
+      dmPolicy: "allowlist",
+      configuredAllowFrom: ["alice#0001"],
+      sender: { id: "999", name: "alice", tag: "alice#0001" },
+      allowNameMatching: true,
+      readStoreAllowFrom: async () => [],
+    });
+
+    expect(result.senderAccess.allowed).toBe(true);
+  });
+
   it("blocks open DMs when configured allowlist does not match", async () => {
     const result = await resolveDiscordDmCommandAccess({
       accountId: "default",

--- a/extensions/discord/src/monitor/dm-command-auth.ts
+++ b/extensions/discord/src/monitor/dm-command-auth.ts
@@ -41,13 +41,18 @@ function normalizeDiscordIdEntry(entry: string): string | null {
 
 function normalizeDiscordNameEntry(entry: string): string | null {
   const text = entry.trim();
-  if (!text || text === "*" || normalizeDiscordIdEntry(text)) {
+  if (!text || text === "*" || normalizeDiscordIdEntry(text) || /#\d{4}$/.test(text)) {
     return null;
   }
   const nameSlug = normalizeDiscordAllowList([text], DISCORD_ALLOW_LIST_PREFIXES)
     ?.names.values()
     .next().value;
   return typeof nameSlug === "string" && nameSlug ? nameSlug : null;
+}
+
+function normalizeDiscordTagEntry(entry: string): string | null {
+  const text = entry.trim();
+  return /#\d{4}$/.test(text) ? normalizeDiscordNameSubject(text) : null;
 }
 
 function normalizeDiscordNameSubject(value: string): string | null {
@@ -66,7 +71,7 @@ const discordIngressIdentity = defineStableChannelIngressIdentity({
   aliases: (
     [
       ["discordUserName", normalizeDiscordNameEntry],
-      ["discordUserTag", () => null],
+      ["discordUserTag", normalizeDiscordTagEntry],
     ] as const
   ).map(([key, normalizeEntry]) => ({
     key,

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -30,9 +30,12 @@ const feishuIngressIdentity = defineStableChannelIngressIdentity({
   sensitivity: "pii",
   aliases: [
     {
+      // One configured entry is deliberately ambiguous between open_id and
+      // user_id, so it normalizes under both same-kind fields and matches
+      // whichever sender candidate carries the value under exact-field binding.
       key: "feishu-alt-id",
       kind: FEISHU_ID_KIND,
-      normalizeEntry: () => null,
+      normalizeEntry: normalizeFeishuAllowEntry,
       normalizeSubject: normalizeFeishuAllowEntry,
       sensitivity: "pii",
     },

--- a/extensions/irc/src/inbound.behavior.test.ts
+++ b/extensions/irc/src/inbound.behavior.test.ts
@@ -433,35 +433,38 @@ describe("irc inbound behavior", () => {
     );
   });
 
-  it("admits a sender matching a full nick!user@host DM allowlist entry", async () => {
-    const coreRuntime = createPluginRuntimeMock();
-    const runtime = createRuntimeEnv();
-    setIrcRuntime(coreRuntime as never);
+  it.each(["alice!ident@example.com", "alice@example.com"])(
+    "admits a sender matching the host-bound DM allowlist entry %s",
+    async (entry) => {
+      const coreRuntime = createPluginRuntimeMock();
+      const runtime = createRuntimeEnv();
+      setIrcRuntime(coreRuntime as never);
 
-    await handleIrcInbound({
-      message: createMessage({
-        target: "alice",
-        senderNick: "alice",
-        senderUser: "ident",
-        senderHost: "example.com",
-        text: "hello",
-      }),
-      account: createAccount({
-        config: {
-          dmPolicy: "allowlist",
-          allowFrom: ["alice!ident@example.com"],
-          groupPolicy: "allowlist",
-          groupAllowFrom: [],
-        },
-      }),
-      config: { channels: { irc: {} } } as CoreConfig,
-      runtime,
-      sendReply: vi.fn(async () => {}),
-    });
+      await handleIrcInbound({
+        message: createMessage({
+          target: "alice",
+          senderNick: "alice",
+          senderUser: "ident",
+          senderHost: "example.com",
+          text: "hello",
+        }),
+        account: createAccount({
+          config: {
+            dmPolicy: "allowlist",
+            allowFrom: [entry],
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+          },
+        }),
+        config: { channels: { irc: {} } } as CoreConfig,
+        runtime,
+        sendReply: vi.fn(async () => {}),
+      });
 
-    expect(
-      (coreRuntime.channel.inbound.dispatchReply as unknown as { mock: { calls: unknown[][] } })
-        .mock.calls.length,
-    ).toBe(1);
-  });
+      expect(
+        (coreRuntime.channel.inbound.dispatchReply as unknown as { mock: { calls: unknown[][] } })
+          .mock.calls.length,
+      ).toBe(1);
+    },
+  );
 });

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -61,7 +61,7 @@ const ircIngressIdentity = defineStableChannelIngressIdentity({
     {
       key: "irc-id-nick-host",
       kind: "stable-id" as const,
-      normalizeEntry: () => null,
+      normalizeEntry: normalizeIrcNickHostEntry,
       normalizeSubject: normalizeLowercaseStringOrEmpty,
       sensitivity: "pii" as const,
     },
@@ -116,10 +116,15 @@ function isHostlessNickUser(value: string): boolean {
 
 function normalizeIrcStableEntry(value: string): string | null {
   const normalized = normalizeIrcAllowEntry(value);
-  if (!normalized || normalized === "*" || !hasVerifiedHost(normalized)) {
+  if (!normalized.includes("!") || !hasVerifiedHost(normalized)) {
     return null;
   }
   return normalized;
+}
+
+function normalizeIrcNickHostEntry(value: string): string | null {
+  const normalized = normalizeIrcAllowEntry(value);
+  return !normalized.includes("!") && hasVerifiedHost(normalized) ? normalized : null;
 }
 
 function normalizeIrcNickUserEntry(value: string): string | null {

--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -511,6 +511,21 @@ describe("authorizeSlackSystemEventSender", () => {
 });
 
 describe("resolveSlackCommandIngress", () => {
+  it("matches a slugged allowlist entry against a spaced sender name", async () => {
+    const result = await resolveSlackCommandIngress({
+      ctx: makeAuthorizeCtx({ allowNameMatching: true }),
+      senderId: "U123",
+      senderName: "Alice Smith",
+      channelId: "D123",
+      channelType: "im",
+      ownerAllowFromLower: ["alice-smith"],
+      allowTextCommands: true,
+      hasControlCommand: true,
+    });
+
+    expect(result.commandAccess.authorized).toBe(true);
+  });
+
   it.each([
     ["allows the workspace-qualified user in its workspace", "T11111111", "allow", true],
     ["blocks the same bare user ID in another workspace", "T22222222", "block", false],

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -116,8 +116,7 @@ function normalizeSlackNameSlugEntry(entry: string): string | null {
   if (!name) {
     return null;
   }
-  const slug = normalizeSlackSlug(name);
-  return slug && slug !== name ? slug : null;
+  return normalizeSlackSlug(name) || null;
 }
 
 const slackIngressIdentity = defineStableChannelIngressIdentity({

--- a/extensions/twitch/src/access-control.ts
+++ b/extensions/twitch/src/access-control.ts
@@ -36,12 +36,12 @@ const twitchUserIdentity = defineStableChannelIngressIdentity({
 const twitchRoleIdentity = defineStableChannelIngressIdentity({
   key: "role-moderator",
   kind: "role",
-  normalizeEntry: normalizeTwitchRole,
+  normalizeEntry: normalizeTwitchModeratorRole,
   normalizeSubject: normalizeTwitchRole,
   aliases: ["owner", "vip", "subscriber"].map((role) => ({
     key: `role-${role}`,
     kind: "role",
-    normalizeEntry: () => null,
+    normalizeEntry: (value: string) => normalizeSpecificTwitchRole(value, role),
     normalizeSubject: normalizeTwitchRole,
   })),
   isWildcardEntry: (entry) => normalizeTwitchRole(entry) === "all",
@@ -182,6 +182,15 @@ function normalizeTwitchRole(value: string): string | null {
     role === "all"
     ? role
     : null;
+}
+
+function normalizeTwitchModeratorRole(value: string): string | null {
+  return normalizeSpecificTwitchRole(value, "moderator");
+}
+
+function normalizeSpecificTwitchRole(value: string, expected: string): string | null {
+  const role = normalizeTwitchRole(value);
+  return role === expected ? role : null;
 }
 
 function reasonForTwitchIngressDecision(decision: { reasonCode: IngressReasonCode }): string {

--- a/extensions/twitch/src/monitor.test.ts
+++ b/extensions/twitch/src/monitor.test.ts
@@ -15,8 +15,9 @@ const mocks = vi.hoisted(() => ({
   createIngress: vi.fn(),
   getClient: vi.fn(async () => ({})),
   getRuntime: vi.fn(),
+  ingressAccept: vi.fn<(message: TwitchChatMessage) => Promise<void>>(),
   ingressStart: vi.fn(),
-  ingressStop: vi.fn(async () => undefined),
+  ingressStop: vi.fn<() => Promise<void>>(),
   onMessage: vi.fn(),
   runInbound: vi.fn(),
   sendMessage: vi.fn(),
@@ -80,8 +81,8 @@ describe("monitorTwitchProvider", () => {
             onAbandoned: () => Promise<void>;
           },
         ) => Promise<void>;
-      }) => ({
-        accept: async (message: TwitchChatMessage) => {
+      }) => {
+        mocks.ingressAccept.mockImplementation(async (message: TwitchChatMessage) => {
           await options.deliver(message, {
             admission: "exclusive",
             abortSignal: new AbortController().signal,
@@ -89,10 +90,17 @@ describe("monitorTwitchProvider", () => {
             onDeferred: () => undefined,
             onAbandoned: async () => undefined,
           });
-        },
-        start: mocks.ingressStart,
-        stop: mocks.ingressStop,
-      }),
+        });
+        // Real ingress stop drains accepted deliveries before the next monitor starts.
+        mocks.ingressStop.mockImplementation(async () => {
+          await Promise.all(mocks.ingressAccept.mock.results.map((result) => result.value));
+        });
+        return {
+          accept: mocks.ingressAccept,
+          start: mocks.ingressStart,
+          stop: mocks.ingressStop,
+        };
+      },
     );
     mocks.getRuntime.mockReturnValue({
       logging: {
@@ -203,7 +211,9 @@ describe("monitorTwitchProvider", () => {
           message: "hello bot",
           channel: "testchannel",
         });
-        await vi.waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledOnce());
+        expect(mocks.ingressAccept).toHaveBeenCalledOnce();
+        await mocks.ingressAccept.mock.results[0]?.value;
+        expect(mocks.sendMessage).toHaveBeenCalledOnce();
         expect(mocks.sendMessage).toHaveBeenCalledWith(
           account,
           "testchannel",
@@ -307,7 +317,9 @@ describe("monitorTwitchProvider", () => {
         channel: "testchannel",
       });
 
-      await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce());
+      expect(mocks.ingressAccept).toHaveBeenCalledOnce();
+      await mocks.ingressAccept.mock.results[0]?.value;
+      expect(settled).toHaveBeenCalledOnce();
       expect(settled).toHaveBeenCalledWith({ visibleReplySent: expectedVisible });
       if (expectedText) {
         expect(mocks.sendMessage).toHaveBeenCalledWith(

--- a/src/auto-reply/reply/channel-run-admission.test.ts
+++ b/src/auto-reply/reply/channel-run-admission.test.ts
@@ -70,6 +70,12 @@ describe("channel run admission", () => {
       expect(fallback).toBe(first);
       expect(identityWork).toHaveLength(1);
       expect(decisions).toHaveLength(1);
+      expect(decisions).toMatchObject([
+        {
+          decision: { reasonCode: "channel_ingress_attribution_only" },
+          enforcement: { policyRefs: [], contextFieldsUsed: [] },
+        },
+      ]);
       expect(consumeChannelAdmissionEvidence(evidence)).toMatchObject({
         ingressState: "unknown",
       });
@@ -78,6 +84,50 @@ describe("channel run admission", () => {
       await expect(prepared.admit("embedded")).rejects.toThrow(
         "prepared execution context is already closed",
       );
+    } finally {
+      clearDecisionSink();
+      clearIdentitySink();
+      clearCollection();
+    }
+  });
+
+  it("explains identifier-authentication effects in the existing redacted receipt", async () => {
+    const decisions: unknown[] = [];
+    const clearCollection = configureChannelAdmissionEvidenceCollection(true);
+    const clearIdentitySink = configureExecutionIdentityAdmissionSink(() => true);
+    const clearDecisionSink = configureChannelAdmissionDecisionSink((receipt) => {
+      decisions.push(receipt);
+      return true;
+    });
+    try {
+      const prepared = prepareChannelRunAdmission({
+        cfg: identityConfig,
+        runId: "run-auth",
+        agentId: "main",
+        ingressKind: "channel",
+        boundary: "test.channel",
+        evidence: createChannelParticipantAdmissionEvidence({
+          channelId: "test",
+          participantId: "private-person-value",
+          identifierAuthentication: "affected",
+        }),
+      });
+
+      await prepared.admit("embedded");
+
+      expect(decisions).toEqual([
+        expect.objectContaining({
+          receiptId: expect.stringContaining(":channel-admission"),
+          decision: expect.objectContaining({
+            reasonCode: "channel_ingress_identifier_authentication_applied",
+          }),
+          enforcement: expect.objectContaining({
+            policyRefs: ["channel.identifier-authentication"],
+            contextFieldsUsed: ["channel.identifier-authentication"],
+          }),
+        }),
+      ]);
+      expect(JSON.stringify(decisions)).not.toContain("private-person-value");
     } finally {
       clearDecisionSink();
       clearIdentitySink();

--- a/src/auto-reply/reply/channel-run-admission.test.ts
+++ b/src/auto-reply/reply/channel-run-admission.test.ts
@@ -73,6 +73,12 @@ describe("channel run admission", () => {
       expect(identityWork).toHaveLength(1);
       expect(decisions).toHaveLength(1);
       expect(admittedContexts).toEqual([first]);
+      expect(decisions).toMatchObject([
+        {
+          decision: { reasonCode: "channel_ingress_attribution_only" },
+          enforcement: { policyRefs: [], contextFieldsUsed: [] },
+        },
+      ]);
       expect(consumeChannelAdmissionEvidence(evidence)).toMatchObject({
         ingressState: "unknown",
       });
@@ -81,6 +87,50 @@ describe("channel run admission", () => {
       await expect(prepared.admit("embedded")).rejects.toThrow(
         "prepared execution context is already closed",
       );
+    } finally {
+      clearDecisionSink();
+      clearIdentitySink();
+      clearCollection();
+    }
+  });
+
+  it("explains identifier-authentication effects in the existing redacted receipt", async () => {
+    const decisions: unknown[] = [];
+    const clearCollection = configureChannelAdmissionEvidenceCollection(true);
+    const clearIdentitySink = configureExecutionIdentityAdmissionSink(() => true);
+    const clearDecisionSink = configureChannelAdmissionDecisionSink((receipt) => {
+      decisions.push(receipt);
+      return true;
+    });
+    try {
+      const prepared = prepareChannelRunAdmission({
+        cfg: identityConfig,
+        runId: "run-auth",
+        agentId: "main",
+        ingressKind: "channel",
+        boundary: "test.channel",
+        evidence: createChannelParticipantAdmissionEvidence({
+          channelId: "test",
+          participantId: "private-person-value",
+          identifierAuthentication: "affected",
+        }),
+      });
+
+      await prepared.admit("embedded");
+
+      expect(decisions).toEqual([
+        expect.objectContaining({
+          receiptId: expect.stringContaining(":channel-admission"),
+          decision: expect.objectContaining({
+            reasonCode: "channel_ingress_identifier_authentication_applied",
+          }),
+          enforcement: expect.objectContaining({
+            policyRefs: ["channel.identifier-authentication"],
+            contextFieldsUsed: ["channel.identifier-authentication"],
+          }),
+        }),
+      ]);
+      expect(JSON.stringify(decisions)).not.toContain("private-person-value");
     } finally {
       clearDecisionSink();
       clearIdentitySink();

--- a/src/auto-reply/reply/channel-run-admission.test.ts
+++ b/src/auto-reply/reply/channel-run-admission.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../agents/admitted-run-context.js";
 import { configureExecutionIdentityAdmissionSink } from "../../audit/execution-identity-admission.js";
 import {
+  combineChannelAdmissionEvidence,
   configureChannelAdmissionDecisionSink,
   configureChannelAdmissionEvidenceCollection,
   consumeChannelAdmissionEvidence,
@@ -94,49 +95,59 @@ describe("channel run admission", () => {
     }
   });
 
-  it("explains identifier-authentication effects in the existing redacted receipt", async () => {
-    const decisions: unknown[] = [];
-    const clearCollection = configureChannelAdmissionEvidenceCollection(true);
-    const clearIdentitySink = configureExecutionIdentityAdmissionSink(() => true);
-    const clearDecisionSink = configureChannelAdmissionDecisionSink((receipt) => {
-      decisions.push(receipt);
-      return true;
-    });
-    try {
-      const prepared = prepareChannelRunAdmission({
-        cfg: identityConfig,
-        runId: "run-auth",
-        agentId: "main",
-        ingressKind: "channel",
-        boundary: "test.channel",
-        evidence: createChannelParticipantAdmissionEvidence({
-          channelId: "test",
-          participantId: "private-person-value",
-          identifierAuthentication: "affected",
-        }),
+  it.each([false, true])(
+    "explains identifier-authentication effects in the receipt with an unevaluated contribution: %s",
+    async (includeUnevaluated) => {
+      const decisions: unknown[] = [];
+      const clearCollection = configureChannelAdmissionEvidenceCollection(true);
+      const clearIdentitySink = configureExecutionIdentityAdmissionSink(() => true);
+      const clearDecisionSink = configureChannelAdmissionDecisionSink((receipt) => {
+        decisions.push(receipt);
+        return true;
       });
+      try {
+        const prepared = prepareChannelRunAdmission({
+          cfg: identityConfig,
+          runId: "run-auth",
+          agentId: "main",
+          ingressKind: "channel",
+          boundary: "test.channel",
+          evidence: combineChannelAdmissionEvidence(
+            (includeUnevaluated
+              ? (["affected", "not-evaluated"] as const)
+              : (["affected"] as const)
+            ).map((identifierAuthentication) =>
+              createChannelParticipantAdmissionEvidence({
+                channelId: "test",
+                participantId: "private-person-value",
+                identifierAuthentication,
+              }),
+            ),
+          ),
+        });
 
-      await prepared.admit("embedded");
+        await prepared.admit("embedded");
 
-      expect(decisions).toEqual([
-        expect.objectContaining({
-          receiptId: expect.stringContaining(":channel-admission"),
-          decision: expect.objectContaining({
-            reasonCode: "channel_ingress_identifier_authentication_applied",
+        expect(decisions).toEqual([
+          expect.objectContaining({
+            receiptId: expect.stringContaining(":channel-admission"),
+            decision: expect.objectContaining({
+              reasonCode: "channel_ingress_identifier_authentication_applied",
+            }),
+            enforcement: expect.objectContaining({
+              policyRefs: ["channel.identifier-authentication"],
+              contextFieldsUsed: ["channel.identifier-authentication"],
+            }),
           }),
-          enforcement: expect.objectContaining({
-            policyRefs: ["channel.identifier-authentication"],
-            contextFieldsUsed: ["channel.identifier-authentication"],
-          }),
-        }),
-      ]);
-      expect(JSON.stringify(decisions)).not.toContain("private-person-value");
-    } finally {
-      clearDecisionSink();
-      clearIdentitySink();
-      clearCollection();
-    }
-  });
+        ]);
+        expect(JSON.stringify(decisions)).not.toContain("private-person-value");
+      } finally {
+        clearDecisionSink();
+        clearIdentitySink();
+        clearCollection();
+      }
+    },
+  );
 
   it("does not consume a cancelled pre-admission carrier or label internal ACP as a person", async () => {
     const identityWork: unknown[] = [];

--- a/src/auto-reply/reply/channel-run-admission.ts
+++ b/src/auto-reply/reply/channel-run-admission.ts
@@ -39,13 +39,14 @@ export function consumeChannelRunAdmission(evidence: ChannelAdmissionEvidence | 
     }),
     onAdmitted: (context) => {
       const token = context.executionIdentityToken;
-      if (token && admission.decisionCoverage) {
+      if (token && admission.decisionCoverage && admission.identifierAuthentication) {
         recordChannelAdmissionDecision({
           contextId: token.contextId,
           executionId: token.executionId,
           runId: token.runId,
           occurredAt: token.createdAt,
           coverageState: admission.decisionCoverage,
+          identifierAuthentication: admission.identifierAuthentication,
         });
       }
     },

--- a/src/channels/message-access/admission-decision-receipt.ts
+++ b/src/channels/message-access/admission-decision-receipt.ts
@@ -1,0 +1,83 @@
+import type { DecisionReceiptV1 } from "../../../packages/gateway-protocol/src/index.js";
+
+export type ChannelAdmissionDecisionReceiptInput = {
+  contextId: string;
+  executionId: string;
+  runId: string;
+  occurredAt: number;
+  coverageState: "enforced" | "attribution-only" | "unknown" | "unsupported";
+  identifierAuthentication: "affected" | "evaluated" | "not-evaluated" | "unknown";
+};
+
+/** Project one owner-native channel decision into the shared receipt contract. */
+export function createChannelAdmissionDecisionReceipt(
+  params: ChannelAdmissionDecisionReceiptInput,
+): DecisionReceiptV1 {
+  const missingEvidence =
+    params.coverageState === "unknown"
+      ? ["channel.admission_evidence"]
+      : params.coverageState === "unsupported"
+        ? ["channel.adapter_identity"]
+        : params.coverageState === "attribution-only"
+          ? ["decision.participant_effect"]
+          : [];
+  const identifierPolicyEvaluated =
+    params.identifierAuthentication === "affected" ||
+    params.identifierAuthentication === "evaluated";
+  return {
+    schemaVersion: 1,
+    receiptId: `${params.contextId}:channel-admission`,
+    contextId: params.contextId,
+    executionId: params.executionId,
+    runId: params.runId,
+    occurredAt: params.occurredAt,
+    action: {
+      family: "channel",
+      operation: "admission",
+      summary: "Channel ingress admitted this agent execution.",
+    },
+    decision: {
+      outcome:
+        params.coverageState === "unknown" || params.coverageState === "unsupported"
+          ? "unknown"
+          : "allowed",
+      reasonCode:
+        params.identifierAuthentication === "affected"
+          ? "channel_ingress_identifier_authentication_applied"
+          : params.coverageState === "enforced"
+            ? "channel_ingress_participant_enforced"
+            : params.coverageState === "attribution-only"
+              ? "channel_ingress_attribution_only"
+              : params.coverageState === "unsupported"
+                ? "channel_ingress_identity_unsupported"
+                : "channel_ingress_identity_unknown",
+    },
+    enforcement: {
+      coverageState: params.coverageState,
+      evaluatorRef: "channel-ingress",
+      policyRefs: identifierPolicyEvaluated ? ["channel.identifier-authentication"] : [],
+      grantRefs: [],
+      contextFieldsUsed: [
+        ...(params.coverageState === "enforced" ? ["invoker.principal"] : []),
+        ...(params.identifierAuthentication === "affected"
+          ? ["channel.identifier-authentication"]
+          : []),
+      ],
+    },
+    source: {
+      owner: "channel-ingress",
+      recordRef: `${params.contextId}:channel-admission`,
+      decisionBoundary: "channel-ingress.run-admission",
+    },
+    missingEvidence,
+    remediation:
+      params.coverageState === "enforced"
+        ? []
+        : [
+            {
+              code: "treat_as_diagnostic_provenance",
+              text: "Treat this receipt as diagnostic provenance, not authorization.",
+            },
+          ],
+  };
+}

--- a/src/channels/message-access/admission-evidence.test.ts
+++ b/src/channels/message-access/admission-evidence.test.ts
@@ -15,7 +15,11 @@ import {
 } from "./admission-evidence.js";
 import { resolveStableChannelMessageIngress } from "./runtime.js";
 
-async function buildAdmittedContext(participantId: string, allowFrom = [participantId]) {
+async function buildAdmittedContext(
+  participantId: string,
+  allowFrom = [participantId],
+  authentication?: "verified" | "asserted" | "unverified" | "mutable",
+) {
   const record = {};
   const epoch = {};
   const owner = { channelId: "test", record, epoch, isLive: () => true };
@@ -23,7 +27,11 @@ async function buildAdmittedContext(participantId: string, allowFrom = [particip
   const channelIngress = await resolveStableChannelMessageIngress({
     channelId: "test",
     accountId: "acct:primary",
-    subject: { stableId: participantId },
+    identity: authentication ? { authentication: "verified" } : undefined,
+    subject: {
+      stableId: participantId,
+      ...(authentication ? { authentication: { stableId: authentication } } : {}),
+    },
     conversation: { kind: "direct", id: "dm-1" },
     contextBinding: {
       agentId: "main",
@@ -33,6 +41,7 @@ async function buildAdmittedContext(participantId: string, allowFrom = [particip
     },
     dmPolicy: "allowlist",
     groupPolicy: "allowlist",
+    ...(authentication ? { policy: { minIdentifierAuthentication: "unverified" } } : {}),
     allowFrom,
   });
   try {
@@ -78,6 +87,7 @@ describe("channel admission evidence", () => {
         },
         assuranceRef: "channel-admission",
         decisionCoverage: "enforced",
+        identifierAuthentication: "not-evaluated",
       });
       expect(Object.isFrozen(consumed)).toBe(true);
       expect(Object.isFrozen(consumed.invoker)).toBe(true);
@@ -85,6 +95,25 @@ describe("channel admission evidence", () => {
         ingressState: "unknown",
         invoker: { state: "unknown" },
         decisionCoverage: "unknown",
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("carries only the redacted identifier-policy explanation through host-owned evidence", async () => {
+    const cleanup = configureChannelAdmissionEvidenceCollection(true);
+    try {
+      const context = await buildAdmittedContext(
+        "private-person",
+        ["private-person"],
+        "unverified",
+      );
+      const consumed = inspectChannelContext(context);
+
+      expect(consumed).toMatchObject({
+        ingressState: "present",
+        identifierAuthentication: "evaluated",
       });
     } finally {
       cleanup();
@@ -201,6 +230,7 @@ describe("channel admission evidence", () => {
         },
         assuranceRef: "channel-admission",
         decisionCoverage: "enforced",
+        identifierAuthentication: "not-evaluated",
       });
       expect(
         consumeChannelAdmissionEvidence(

--- a/src/channels/message-access/admission-evidence.test.ts
+++ b/src/channels/message-access/admission-evidence.test.ts
@@ -21,6 +21,7 @@ async function buildAdmittedContext(
   participantId: string,
   allowFrom = [participantId],
   resolveGatewayContext?: GatewayContextResolver,
+  authentication?: "verified" | "asserted" | "unverified" | "mutable",
 ) {
   const record = {};
   const epoch = {};
@@ -35,7 +36,11 @@ async function buildAdmittedContext(
   const channelIngress = await resolveStableChannelMessageIngress({
     channelId: "test",
     accountId: "acct:primary",
-    subject: { stableId: participantId },
+    identity: authentication ? { authentication: "verified" } : undefined,
+    subject: {
+      stableId: participantId,
+      ...(authentication ? { authentication: { stableId: authentication } } : {}),
+    },
     conversation: { kind: "direct", id: "dm-1" },
     contextBinding: {
       agentId: "main",
@@ -45,6 +50,7 @@ async function buildAdmittedContext(
     },
     dmPolicy: "allowlist",
     groupPolicy: "allowlist",
+    ...(authentication ? { policy: { minIdentifierAuthentication: "unverified" } } : {}),
     allowFrom,
   });
   try {
@@ -106,6 +112,7 @@ describe("channel admission evidence", () => {
         },
         assuranceRef: "channel-admission",
         decisionCoverage: "enforced",
+        identifierAuthentication: "not-evaluated",
       });
       expect(Object.isFrozen(consumed)).toBe(true);
       expect(Object.isFrozen(consumed.invoker)).toBe(true);
@@ -113,6 +120,26 @@ describe("channel admission evidence", () => {
         ingressState: "unknown",
         invoker: { state: "unknown" },
         decisionCoverage: "unknown",
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("carries only the redacted identifier-policy explanation through host-owned evidence", async () => {
+    const cleanup = configureChannelAdmissionEvidenceCollection(true);
+    try {
+      const context = await buildAdmittedContext(
+        "private-person",
+        ["private-person"],
+        undefined,
+        "unverified",
+      );
+      const consumed = inspectChannelContext(context);
+
+      expect(consumed).toMatchObject({
+        ingressState: "present",
+        identifierAuthentication: "evaluated",
       });
     } finally {
       cleanup();
@@ -229,6 +256,7 @@ describe("channel admission evidence", () => {
         },
         assuranceRef: "channel-admission",
         decisionCoverage: "enforced",
+        identifierAuthentication: "not-evaluated",
       });
       expect(
         consumeChannelAdmissionEvidence(

--- a/src/channels/message-access/admission-evidence.test.ts
+++ b/src/channels/message-access/admission-evidence.test.ts
@@ -112,7 +112,7 @@ describe("channel admission evidence", () => {
         },
         assuranceRef: "channel-admission",
         decisionCoverage: "enforced",
-        identifierAuthentication: "not-evaluated",
+        identifierAuthentication: "evaluated",
       });
       expect(Object.isFrozen(consumed)).toBe(true);
       expect(Object.isFrozen(consumed.invoker)).toBe(true);
@@ -256,7 +256,7 @@ describe("channel admission evidence", () => {
         },
         assuranceRef: "channel-admission",
         decisionCoverage: "enforced",
-        identifierAuthentication: "not-evaluated",
+        identifierAuthentication: "evaluated",
       });
       expect(
         consumeChannelAdmissionEvidence(

--- a/src/channels/message-access/admission-evidence.ts
+++ b/src/channels/message-access/admission-evidence.ts
@@ -1,6 +1,10 @@
 import type { DecisionReceiptV1 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import {
+  createChannelAdmissionDecisionReceipt,
+  type ChannelAdmissionDecisionReceiptInput,
+} from "./admission-decision-receipt.js";
+import {
   finalizedContextScopeKey,
   INVALID_SCOPE_VALUE,
   ownDataValue,
@@ -23,6 +27,7 @@ type ChannelAdmissionContribution = Readonly<{
   decision?: Readonly<{
     participantAware: boolean;
     outcomeAffecting: boolean;
+    identifierAuthentication: "affected" | "evaluated" | "not-evaluated";
   }>;
 }>;
 
@@ -45,6 +50,7 @@ type ConsumedChannelAdmissionEvidence = Readonly<{
   invoker: { state: "present"; kind: "person"; rawPrincipalRef: string } | { state: "unknown" };
   assuranceRef?: string;
   decisionCoverage?: "enforced" | "attribution-only" | "unknown" | "unsupported";
+  identifierAuthentication?: "affected" | "evaluated" | "not-evaluated" | "unknown";
 }>;
 
 type ChannelIngressResolutionBinding = Readonly<{
@@ -52,6 +58,7 @@ type ChannelIngressResolutionBinding = Readonly<{
   accountId?: string;
   rawPrincipalRef: string | number | null | undefined;
   participantOutcomeAffecting: boolean;
+  identifierAuthentication: "affected" | "evaluated" | "not-evaluated";
   owner?: ChannelAdmissionEvidenceOwner;
   ownerEpoch?: object;
   scope?: ChannelIngressResolutionScope;
@@ -210,6 +217,7 @@ export function recordChannelIngressResolution(params: {
   accountId?: string;
   rawPrincipalRef: string | number | null | undefined;
   participantOutcomeAffecting: boolean;
+  identifierAuthentication: "affected" | "evaluated" | "not-evaluated";
   scope: ChannelIngressResolutionScope;
 }): ResolvedChannelMessageIngress {
   const owner = state.ownerByChannelId.get(params.channelId);
@@ -221,6 +229,7 @@ export function recordChannelIngressResolution(params: {
       accountId: params.accountId,
       rawPrincipalRef: params.rawPrincipalRef,
       participantOutcomeAffecting: params.participantOutcomeAffecting,
+      identifierAuthentication: params.identifierAuthentication,
       owner: activeOwner,
       ownerEpoch: activeOwner?.epoch,
       scope: Object.freeze({ conversation: Object.freeze({ ...params.scope.conversation }) }),
@@ -430,6 +439,7 @@ export function prepareHostChannelContextAdmissionEvidence(params: {
             decision: Object.freeze({
               participantAware: contribution.participant.state === "present",
               outcomeAffecting: binding.participantOutcomeAffecting,
+              identifierAuthentication: binding.identifierAuthentication,
             }),
           }),
         });
@@ -611,6 +621,7 @@ export function consumeChannelAdmissionEvidence(
       ingressState: "unsupported",
       invoker: { state: "unknown" },
       decisionCoverage: "unsupported",
+      identifierAuthentication: "unknown",
     });
   }
 
@@ -626,12 +637,26 @@ export function consumeChannelAdmissionEvidence(
       ingressState: "unknown",
       invoker: { state: "unknown" },
       decisionCoverage: "unknown",
+      identifierAuthentication: "unknown",
     });
   }
 
   const everyDecisionEnforced = contributions.every(
     (item) => item.decision?.participantAware && item.decision.outcomeAffecting,
   );
+  const identifierAuthentication = contributions.every(
+    (item) => item.decision?.identifierAuthentication === "affected",
+  )
+    ? "affected"
+    : contributions.every((item) => item.decision?.identifierAuthentication === "not-evaluated")
+      ? "not-evaluated"
+      : contributions.every(
+            (item) =>
+              item.decision?.identifierAuthentication === "affected" ||
+              item.decision?.identifierAuthentication === "evaluated",
+          )
+        ? "evaluated"
+        : "unknown";
   return freezeConsumed({
     ingressState: "present",
     invoker: {
@@ -641,74 +666,18 @@ export function consumeChannelAdmissionEvidence(
     },
     assuranceRef: "channel-admission",
     decisionCoverage: everyDecisionEnforced ? "enforced" : "attribution-only",
+    identifierAuthentication,
   });
 }
 
 /** Queue the channel decision after its exact identity tuple on the shared audit FIFO. */
 export function recordChannelAdmissionDecision(params: {
-  contextId: string;
-  executionId: string;
-  runId: string;
-  occurredAt: number;
-  coverageState: NonNullable<ConsumedChannelAdmissionEvidence["decisionCoverage"]>;
+  contextId: ChannelAdmissionDecisionReceiptInput["contextId"];
+  executionId: ChannelAdmissionDecisionReceiptInput["executionId"];
+  runId: ChannelAdmissionDecisionReceiptInput["runId"];
+  occurredAt: ChannelAdmissionDecisionReceiptInput["occurredAt"];
+  coverageState: ChannelAdmissionDecisionReceiptInput["coverageState"];
+  identifierAuthentication: ChannelAdmissionDecisionReceiptInput["identifierAuthentication"];
 }): boolean {
-  const missingEvidence =
-    params.coverageState === "unknown"
-      ? ["channel.admission_evidence"]
-      : params.coverageState === "unsupported"
-        ? ["channel.adapter_identity"]
-        : params.coverageState === "attribution-only"
-          ? ["decision.participant_effect"]
-          : [];
-  return (
-    state.decisionSink?.({
-      schemaVersion: 1,
-      receiptId: `${params.contextId}:channel-admission`,
-      contextId: params.contextId,
-      executionId: params.executionId,
-      runId: params.runId,
-      occurredAt: params.occurredAt,
-      action: {
-        family: "channel",
-        operation: "admission",
-        summary: "Channel ingress admitted this agent execution.",
-      },
-      decision: {
-        outcome:
-          params.coverageState === "unknown" || params.coverageState === "unsupported"
-            ? "unknown"
-            : "allowed",
-        reasonCode:
-          params.coverageState === "enforced"
-            ? "channel_ingress_participant_enforced"
-            : params.coverageState === "attribution-only"
-              ? "channel_ingress_attribution_only"
-              : params.coverageState === "unsupported"
-                ? "channel_ingress_identity_unsupported"
-                : "channel_ingress_identity_unknown",
-      },
-      enforcement: {
-        coverageState: params.coverageState,
-        evaluatorRef: "channel-ingress",
-        policyRefs: [],
-        grantRefs: [],
-        contextFieldsUsed: params.coverageState === "enforced" ? ["invoker.principal"] : [],
-      },
-      source: {
-        owner: "channel-ingress",
-        recordRef: `${params.contextId}:channel-admission`,
-        decisionBoundary: "channel-ingress.run-admission",
-      },
-      missingEvidence,
-      remediation:
-        params.coverageState === "enforced"
-          ? []
-          : [
-              {
-                code: "treat_as_diagnostic_provenance",
-                text: "Treat this receipt as diagnostic provenance, not authorization.",
-              },
-            ],
-    }) ?? false
-  );
+  return state.decisionSink?.(createChannelAdmissionDecisionReceipt(params)) ?? false;
 }

--- a/src/channels/message-access/admission-evidence.ts
+++ b/src/channels/message-access/admission-evidence.ts
@@ -675,18 +675,14 @@ export function consumeChannelAdmissionEvidence(
   const everyDecisionEnforced = contributions.every(
     (item) => item.decision?.participantAware && item.decision.outcomeAffecting,
   );
-  const identifierAuthentication = contributions.every(
+  const identifierAuthentication = contributions.some(
     (item) => item.decision?.identifierAuthentication === "affected",
   )
     ? "affected"
-    : contributions.every((item) => item.decision?.identifierAuthentication === "not-evaluated")
-      ? "not-evaluated"
-      : contributions.every(
-            (item) =>
-              item.decision?.identifierAuthentication === "affected" ||
-              item.decision?.identifierAuthentication === "evaluated",
-          )
-        ? "evaluated"
+    : contributions.some((item) => item.decision?.identifierAuthentication === "evaluated")
+      ? "evaluated"
+      : contributions.every((item) => item.decision?.identifierAuthentication === "not-evaluated")
+        ? "not-evaluated"
         : "unknown";
   return freezeConsumed({
     ingressState: "present",

--- a/src/channels/message-access/admission-evidence.ts
+++ b/src/channels/message-access/admission-evidence.ts
@@ -2,6 +2,10 @@ import type { DecisionReceiptV1 } from "../../../packages/gateway-protocol/src/i
 import type { GatewayContextResolver } from "../../gateway/server-methods/types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import {
+  createChannelAdmissionDecisionReceipt,
+  type ChannelAdmissionDecisionReceiptInput,
+} from "./admission-decision-receipt.js";
+import {
   finalizedContextScopeKey,
   INVALID_SCOPE_VALUE,
   ownDataValue,
@@ -24,6 +28,7 @@ type ChannelAdmissionContribution = Readonly<{
   decision?: Readonly<{
     participantAware: boolean;
     outcomeAffecting: boolean;
+    identifierAuthentication: "affected" | "evaluated" | "not-evaluated";
   }>;
 }>;
 
@@ -46,6 +51,7 @@ type ConsumedChannelAdmissionEvidence = Readonly<{
   invoker: { state: "present"; kind: "person"; rawPrincipalRef: string } | { state: "unknown" };
   assuranceRef?: string;
   decisionCoverage?: "enforced" | "attribution-only" | "unknown" | "unsupported";
+  identifierAuthentication?: "affected" | "evaluated" | "not-evaluated" | "unknown";
 }>;
 
 type ChannelIngressResolutionBinding = Readonly<{
@@ -53,6 +59,7 @@ type ChannelIngressResolutionBinding = Readonly<{
   accountId?: string;
   rawPrincipalRef: string | number | null | undefined;
   participantOutcomeAffecting: boolean;
+  identifierAuthentication: "affected" | "evaluated" | "not-evaluated";
   owner?: ChannelAdmissionEvidenceOwner;
   ownerEpoch?: object;
   scope?: ChannelIngressResolutionScope;
@@ -215,6 +222,7 @@ export function recordChannelIngressResolution(params: {
   accountId?: string;
   rawPrincipalRef: string | number | null | undefined;
   participantOutcomeAffecting: boolean;
+  identifierAuthentication: "affected" | "evaluated" | "not-evaluated";
   scope: ChannelIngressResolutionScope;
 }): ResolvedChannelMessageIngress {
   const owner = state.ownerByChannelId.get(params.channelId);
@@ -226,6 +234,7 @@ export function recordChannelIngressResolution(params: {
       accountId: params.accountId,
       rawPrincipalRef: params.rawPrincipalRef,
       participantOutcomeAffecting: params.participantOutcomeAffecting,
+      identifierAuthentication: params.identifierAuthentication,
       owner: activeOwner,
       ownerEpoch: activeOwner?.epoch,
       scope: Object.freeze({ conversation: Object.freeze({ ...params.scope.conversation }) }),
@@ -435,6 +444,7 @@ export function prepareHostChannelContextAdmissionEvidence(params: {
             decision: Object.freeze({
               participantAware: contribution.participant.state === "present",
               outcomeAffecting: binding.participantOutcomeAffecting,
+              identifierAuthentication: binding.identifierAuthentication,
             }),
           }),
         });
@@ -642,6 +652,7 @@ export function consumeChannelAdmissionEvidence(
       ingressState: "unsupported",
       invoker: { state: "unknown" },
       decisionCoverage: "unsupported",
+      identifierAuthentication: "unknown",
     });
   }
 
@@ -657,12 +668,26 @@ export function consumeChannelAdmissionEvidence(
       ingressState: "unknown",
       invoker: { state: "unknown" },
       decisionCoverage: "unknown",
+      identifierAuthentication: "unknown",
     });
   }
 
   const everyDecisionEnforced = contributions.every(
     (item) => item.decision?.participantAware && item.decision.outcomeAffecting,
   );
+  const identifierAuthentication = contributions.every(
+    (item) => item.decision?.identifierAuthentication === "affected",
+  )
+    ? "affected"
+    : contributions.every((item) => item.decision?.identifierAuthentication === "not-evaluated")
+      ? "not-evaluated"
+      : contributions.every(
+            (item) =>
+              item.decision?.identifierAuthentication === "affected" ||
+              item.decision?.identifierAuthentication === "evaluated",
+          )
+        ? "evaluated"
+        : "unknown";
   return freezeConsumed({
     ingressState: "present",
     invoker: {
@@ -672,74 +697,18 @@ export function consumeChannelAdmissionEvidence(
     },
     assuranceRef: "channel-admission",
     decisionCoverage: everyDecisionEnforced ? "enforced" : "attribution-only",
+    identifierAuthentication,
   });
 }
 
 /** Queue the channel decision after its exact identity tuple on the shared audit FIFO. */
 export function recordChannelAdmissionDecision(params: {
-  contextId: string;
-  executionId: string;
-  runId: string;
-  occurredAt: number;
-  coverageState: NonNullable<ConsumedChannelAdmissionEvidence["decisionCoverage"]>;
+  contextId: ChannelAdmissionDecisionReceiptInput["contextId"];
+  executionId: ChannelAdmissionDecisionReceiptInput["executionId"];
+  runId: ChannelAdmissionDecisionReceiptInput["runId"];
+  occurredAt: ChannelAdmissionDecisionReceiptInput["occurredAt"];
+  coverageState: ChannelAdmissionDecisionReceiptInput["coverageState"];
+  identifierAuthentication: ChannelAdmissionDecisionReceiptInput["identifierAuthentication"];
 }): boolean {
-  const missingEvidence =
-    params.coverageState === "unknown"
-      ? ["channel.admission_evidence"]
-      : params.coverageState === "unsupported"
-        ? ["channel.adapter_identity"]
-        : params.coverageState === "attribution-only"
-          ? ["decision.participant_effect"]
-          : [];
-  return (
-    state.decisionSink?.({
-      schemaVersion: 1,
-      receiptId: `${params.contextId}:channel-admission`,
-      contextId: params.contextId,
-      executionId: params.executionId,
-      runId: params.runId,
-      occurredAt: params.occurredAt,
-      action: {
-        family: "channel",
-        operation: "admission",
-        summary: "Channel ingress admitted this agent execution.",
-      },
-      decision: {
-        outcome:
-          params.coverageState === "unknown" || params.coverageState === "unsupported"
-            ? "unknown"
-            : "allowed",
-        reasonCode:
-          params.coverageState === "enforced"
-            ? "channel_ingress_participant_enforced"
-            : params.coverageState === "attribution-only"
-              ? "channel_ingress_attribution_only"
-              : params.coverageState === "unsupported"
-                ? "channel_ingress_identity_unsupported"
-                : "channel_ingress_identity_unknown",
-      },
-      enforcement: {
-        coverageState: params.coverageState,
-        evaluatorRef: "channel-ingress",
-        policyRefs: [],
-        grantRefs: [],
-        contextFieldsUsed: params.coverageState === "enforced" ? ["invoker.principal"] : [],
-      },
-      source: {
-        owner: "channel-ingress",
-        recordRef: `${params.contextId}:channel-admission`,
-        decisionBoundary: "channel-ingress.run-admission",
-      },
-      missingEvidence,
-      remediation:
-        params.coverageState === "enforced"
-          ? []
-          : [
-              {
-                code: "treat_as_diagnostic_provenance",
-                text: "Treat this receipt as diagnostic provenance, not authorization.",
-              },
-            ],
-    }) ?? false
-  );
+  return state.decisionSink?.(createChannelAdmissionDecisionReceipt(params)) ?? false;
 }

--- a/src/channels/message-access/allowlist.ts
+++ b/src/channels/message-access/allowlist.ts
@@ -4,6 +4,12 @@
  * Merges allowlists, applies mutable identifier policy, and redacts access-graph facts.
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  identifierAuthenticationFrom,
+  meetsIdentifierAuthentication,
+  minimumIdentifierAuthenticationFrom,
+  weakestIdentifierAuthentication,
+} from "./identifier-authentication.js";
 import type {
   ChannelIngressPolicyInput,
   ChannelIngressState,
@@ -84,45 +90,84 @@ function mergeResolvedAllowlists(
 }
 
 /**
- * Applies mutable identifier matching policy to an already-resolved allowlist.
+ * Applies identifier authentication to exact matched entry/subject pairs.
  */
-export function applyMutableIdentifierPolicy(
+function applyIdentifierAuthenticationPolicy(
   allowlist: ResolvedIngressAllowlist,
   policy: ChannelIngressPolicyInput,
 ): ResolvedIngressAllowlist {
-  if (policy.mutableIdentifierMatching === "enabled") {
-    return allowlist;
+  const minimum = minimumIdentifierAuthenticationFrom(policy);
+  const pairsByEntry = new Map<string, NonNullable<typeof allowlist.match.matchedPairs>>();
+  for (const pair of allowlist.match.matchedPairs ?? []) {
+    const pairs = pairsByEntry.get(pair.opaqueEntryId) ?? [];
+    pairs.push(pair);
+    pairsByEntry.set(pair.opaqueEntryId, pairs);
   }
-  const dangerousEntryIds = new Set(
-    allowlist.normalizedEntries
-      .filter((entry) => entry.dangerous)
-      .map((entry) => entry.opaqueEntryId),
+  const rejectedEntryIds = new Set<string>();
+  for (const entry of allowlist.normalizedEntries) {
+    const entryAuthentication = identifierAuthenticationFrom(entry);
+    const pairs = pairsByEntry.get(entry.opaqueEntryId);
+    const pairStrengths = pairs?.map((pair) =>
+      pair.subjectAuthentication
+        ? weakestIdentifierAuthentication(entryAuthentication, pair.subjectAuthentication)
+        : entryAuthentication,
+    );
+    const accepted =
+      pairStrengths && pairStrengths.length > 0
+        ? pairStrengths.some((strength) => meetsIdentifierAuthentication(strength, minimum))
+        : meetsIdentifierAuthentication(entryAuthentication, minimum);
+    if (!accepted) {
+      rejectedEntryIds.add(entry.opaqueEntryId);
+    }
+  }
+  const matchedEntryIds = allowlist.matchedEntryIds.filter((id) => !rejectedEntryIds.has(id));
+  const matchedPairs = allowlist.match.matchedPairs?.filter(
+    (pair) => !rejectedEntryIds.has(pair.opaqueEntryId),
   );
-  if (dangerousEntryIds.size === 0) {
-    return allowlist;
-  }
-  // Username-like mutable identifiers can be present for diagnostics, but when the policy
-  // disables them they must not authorize a sender.
-  const matchedEntryIds = allowlist.matchedEntryIds.filter((id) => !dangerousEntryIds.has(id));
   const disabledEntries: RedactedIngressEntryDiagnostic[] = [
     ...allowlist.disabledEntries,
     ...allowlist.normalizedEntries
-      .filter((entry) => entry.dangerous)
+      .filter((entry) => rejectedEntryIds.has(entry.opaqueEntryId))
       .map((entry) => ({
         opaqueEntryId: entry.opaqueEntryId,
-        reasonCode: "mutable_identifier_disabled" as const,
+        reasonCode:
+          identifierAuthenticationFrom(entry) === "mutable"
+            ? ("mutable_identifier_disabled" as const)
+            : ("identifier_authentication_too_weak" as const),
       })),
   ];
+  const affectedMatch = matchedEntryIds.length !== allowlist.matchedEntryIds.length;
   return {
     ...allowlist,
     disabledEntries,
     matchedEntryIds,
-    hasMatchableEntries: allowlist.normalizedEntries.some((entry) => !entry.dangerous),
+    hasMatchableEntries: allowlist.normalizedEntries.some(
+      (entry) => !rejectedEntryIds.has(entry.opaqueEntryId),
+    ),
     match: {
       matched: matchedEntryIds.length > 0,
       matchedEntryIds,
+      ...(matchedPairs ? { matchedPairs } : {}),
+    },
+    authentication: {
+      evaluated:
+        policy.minIdentifierAuthentication !== undefined ||
+        policy.mutableIdentifierMatching !== undefined ||
+        (allowlist.match.matchedPairs?.some((pair) => pair.subjectAuthentication !== undefined) ??
+          false),
+      threshold: minimum,
+      affectedMatch,
+      rejectedEntryIds: [...rejectedEntryIds],
     },
   };
+}
+
+/** @deprecated Use `applyIdentifierAuthenticationPolicy`. */
+export function applyMutableIdentifierPolicy(
+  allowlist: ResolvedIngressAllowlist,
+  policy: ChannelIngressPolicyInput,
+): ResolvedIngressAllowlist {
+  return applyIdentifierAuthenticationPolicy(allowlist, policy);
 }
 
 /**
@@ -148,5 +193,5 @@ export function effectiveGroupSenderAllowlist(params: {
     // Route sender policies other than inherit replace the channel-level sender allowlist.
     effective = route.senderAllowlist;
   }
-  return applyMutableIdentifierPolicy(effective, params.policy);
+  return applyIdentifierAuthenticationPolicy(effective, params.policy);
 }

--- a/src/channels/message-access/allowlist.ts
+++ b/src/channels/message-access/allowlist.ts
@@ -58,33 +58,62 @@ export function redactedAllowlistDiagnostics(
 function mergeResolvedAllowlists(
   allowlists: readonly ResolvedIngressAllowlist[],
 ): ResolvedIngressAllowlist {
-  const matches = allowlists.map((allowlist) => allowlist.match);
+  const scopedAllowlists: ResolvedIngressAllowlist[] = [];
+  for (const [index, allowlist] of allowlists.entries()) {
+    const prefix = `source-${index + 1}:`;
+    const normalizedEntries = [];
+    for (const entry of allowlist.normalizedEntries) {
+      normalizedEntries.push({ ...entry, opaqueEntryId: `${prefix}${entry.opaqueEntryId}` });
+    }
+    const matchedPairs = [];
+    for (const pair of allowlist.match.matchedPairs ?? []) {
+      matchedPairs.push({ ...pair, opaqueEntryId: `${prefix}${pair.opaqueEntryId}` });
+    }
+    const matchedEntryIds = allowlist.matchedEntryIds.map((id) => `${prefix}${id}`);
+    scopedAllowlists.push({
+      ...allowlist,
+      normalizedEntries,
+      matchedEntryIds,
+      match: {
+        ...allowlist.match,
+        matchedEntryIds,
+        ...(matchedPairs.length > 0 ? { matchedPairs } : {}),
+      },
+    });
+  }
+  const matches = scopedAllowlists.map((allowlist) => allowlist.match);
   const matchedEntryIds = uniqueStrings(
-    allowlists.flatMap((allowlist) => allowlist.matchedEntryIds),
+    scopedAllowlists.flatMap((allowlist) => allowlist.matchedEntryIds),
   );
+  const matchedPairs = scopedAllowlists.flatMap((allowlist) => allowlist.match.matchedPairs ?? []);
   return {
-    rawEntryCount: allowlists.reduce((sum, allowlist) => sum + allowlist.rawEntryCount, 0),
-    normalizedEntries: allowlists.flatMap((allowlist) => allowlist.normalizedEntries),
-    invalidEntries: allowlists.flatMap((allowlist) => allowlist.invalidEntries),
-    disabledEntries: allowlists.flatMap((allowlist) => allowlist.disabledEntries),
+    rawEntryCount: scopedAllowlists.reduce((sum, allowlist) => sum + allowlist.rawEntryCount, 0),
+    normalizedEntries: scopedAllowlists.flatMap((allowlist) => allowlist.normalizedEntries),
+    invalidEntries: scopedAllowlists.flatMap((allowlist) => allowlist.invalidEntries),
+    disabledEntries: scopedAllowlists.flatMap((allowlist) => allowlist.disabledEntries),
     matchedEntryIds,
-    hasConfiguredEntries: allowlists.some((allowlist) => allowlist.hasConfiguredEntries),
-    hasMatchableEntries: allowlists.some((allowlist) => allowlist.hasMatchableEntries),
-    hasWildcard: allowlists.some((allowlist) => allowlist.hasWildcard),
+    hasConfiguredEntries: scopedAllowlists.some((allowlist) => allowlist.hasConfiguredEntries),
+    hasMatchableEntries: scopedAllowlists.some((allowlist) => allowlist.hasMatchableEntries),
+    hasWildcard: scopedAllowlists.some((allowlist) => allowlist.hasWildcard),
     accessGroups: {
       referenced: uniqueStrings(
-        allowlists.flatMap((allowlist) => allowlist.accessGroups.referenced),
+        scopedAllowlists.flatMap((allowlist) => allowlist.accessGroups.referenced),
       ),
-      matched: uniqueStrings(allowlists.flatMap((allowlist) => allowlist.accessGroups.matched)),
-      missing: uniqueStrings(allowlists.flatMap((allowlist) => allowlist.accessGroups.missing)),
+      matched: uniqueStrings(
+        scopedAllowlists.flatMap((allowlist) => allowlist.accessGroups.matched),
+      ),
+      missing: uniqueStrings(
+        scopedAllowlists.flatMap((allowlist) => allowlist.accessGroups.missing),
+      ),
       unsupported: uniqueStrings(
-        allowlists.flatMap((allowlist) => allowlist.accessGroups.unsupported),
+        scopedAllowlists.flatMap((allowlist) => allowlist.accessGroups.unsupported),
       ),
-      failed: uniqueStrings(allowlists.flatMap((allowlist) => allowlist.accessGroups.failed)),
+      failed: uniqueStrings(scopedAllowlists.flatMap((allowlist) => allowlist.accessGroups.failed)),
     },
     match: {
       matched: matches.some((match) => match.matched) || matchedEntryIds.length > 0,
       matchedEntryIds,
+      ...(matchedPairs.length > 0 ? { matchedPairs } : {}),
     },
   };
 }

--- a/src/channels/message-access/allowlist.ts
+++ b/src/channels/message-access/allowlist.ts
@@ -1,29 +1,28 @@
 /**
  * Channel ingress allowlist diagnostics.
  *
- * Merges allowlists, applies mutable identifier policy, and redacts access-graph facts.
+ * Merges allowlists, applies identifier authentication policy, and redacts access-graph facts.
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
-  identifierAuthenticationFrom,
   meetsIdentifierAuthentication,
   minimumIdentifierAuthenticationFrom,
   weakestIdentifierAuthentication,
 } from "./identifier-authentication.js";
 import type {
   ChannelIngressPolicyInput,
-  ChannelIngressState,
+  NormalizedIngressState,
   IngressReasonCode,
   RedactedIngressAllowlistFacts,
   RedactedIngressEntryDiagnostic,
-  ResolvedIngressAllowlist,
+  NormalizedIngressAllowlist,
 } from "./types.js";
 
 /**
  * Returns the first access-group related failure reason for an allowlist.
  */
 export function allowlistFailureReason(
-  allowlist: ResolvedIngressAllowlist,
+  allowlist: NormalizedIngressAllowlist,
 ): IngressReasonCode | null {
   if (allowlist.accessGroups.failed.length > 0) {
     return "access_group_failed";
@@ -41,7 +40,7 @@ export function allowlistFailureReason(
  * Projects an allowlist into redacted diagnostics safe for ingress access graphs.
  */
 export function redactedAllowlistDiagnostics(
-  allowlist: ResolvedIngressAllowlist,
+  allowlist: NormalizedIngressAllowlist,
   reasonCode: IngressReasonCode,
 ): RedactedIngressAllowlistFacts {
   return {
@@ -56,9 +55,9 @@ export function redactedAllowlistDiagnostics(
 }
 
 function mergeResolvedAllowlists(
-  allowlists: readonly ResolvedIngressAllowlist[],
-): ResolvedIngressAllowlist {
-  const scopedAllowlists: ResolvedIngressAllowlist[] = [];
+  allowlists: readonly NormalizedIngressAllowlist[],
+): NormalizedIngressAllowlist {
+  const scopedAllowlists: NormalizedIngressAllowlist[] = [];
   for (const [index, allowlist] of allowlists.entries()) {
     const prefix = `source-${index + 1}:`;
     const normalizedEntries = [];
@@ -121,10 +120,10 @@ function mergeResolvedAllowlists(
 /**
  * Applies identifier authentication to exact matched entry/subject pairs.
  */
-function applyIdentifierAuthenticationPolicy(
-  allowlist: ResolvedIngressAllowlist,
+export function applyIdentifierAuthenticationPolicy(
+  allowlist: NormalizedIngressAllowlist,
   policy: ChannelIngressPolicyInput,
-): ResolvedIngressAllowlist {
+): NormalizedIngressAllowlist {
   const minimum = minimumIdentifierAuthenticationFrom(policy);
   const pairsByEntry = new Map<string, NonNullable<typeof allowlist.match.matchedPairs>>();
   for (const pair of allowlist.match.matchedPairs ?? []) {
@@ -134,17 +133,14 @@ function applyIdentifierAuthenticationPolicy(
   }
   const rejectedEntryIds = new Set<string>();
   for (const entry of allowlist.normalizedEntries) {
-    const entryAuthentication = identifierAuthenticationFrom(entry);
     const pairs = pairsByEntry.get(entry.opaqueEntryId);
     const pairStrengths = pairs?.map((pair) =>
-      pair.subjectAuthentication
-        ? weakestIdentifierAuthentication(entryAuthentication, pair.subjectAuthentication)
-        : entryAuthentication,
+      weakestIdentifierAuthentication(entry.authentication, pair.subjectAuthentication),
     );
     const accepted =
       pairStrengths && pairStrengths.length > 0
         ? pairStrengths.some((strength) => meetsIdentifierAuthentication(strength, minimum))
-        : meetsIdentifierAuthentication(entryAuthentication, minimum);
+        : meetsIdentifierAuthentication(entry.authentication, minimum);
     if (!accepted) {
       rejectedEntryIds.add(entry.opaqueEntryId);
     }
@@ -160,7 +156,7 @@ function applyIdentifierAuthenticationPolicy(
       .map((entry) => ({
         opaqueEntryId: entry.opaqueEntryId,
         reasonCode:
-          identifierAuthenticationFrom(entry) === "mutable"
+          entry.authentication === "mutable"
             ? ("mutable_identifier_disabled" as const)
             : ("identifier_authentication_too_weak" as const),
       })),
@@ -182,8 +178,7 @@ function applyIdentifierAuthenticationPolicy(
       evaluated:
         policy.minIdentifierAuthentication !== undefined ||
         policy.mutableIdentifierMatching !== undefined ||
-        (allowlist.match.matchedPairs?.some((pair) => pair.subjectAuthentication !== undefined) ??
-          false),
+        Boolean(allowlist.match.matchedPairs?.length),
       threshold: minimum,
       affectedMatch,
       rejectedEntryIds: [...rejectedEntryIds],
@@ -191,21 +186,13 @@ function applyIdentifierAuthenticationPolicy(
   };
 }
 
-/** @deprecated Use `applyIdentifierAuthenticationPolicy`. */
-export function applyMutableIdentifierPolicy(
-  allowlist: ResolvedIngressAllowlist,
-  policy: ChannelIngressPolicyInput,
-): ResolvedIngressAllowlist {
-  return applyIdentifierAuthenticationPolicy(allowlist, policy);
-}
-
 /**
  * Resolves the sender allowlist used for group/channel ingress after route overrides.
  */
 export function effectiveGroupSenderAllowlist(params: {
-  state: ChannelIngressState;
+  state: NormalizedIngressState;
   policy: ChannelIngressPolicyInput;
-}): ResolvedIngressAllowlist {
+}): NormalizedIngressAllowlist {
   let effective =
     params.policy.groupAllowFromFallbackToAllowFrom &&
     !params.state.allowlists.group.hasConfiguredEntries

--- a/src/channels/message-access/decision.ts
+++ b/src/channels/message-access/decision.ts
@@ -11,6 +11,11 @@ import {
 } from "../mention-gating.js";
 import { applyMutableIdentifierPolicy, redactedAllowlistDiagnostics } from "./allowlist.js";
 import {
+  DEFAULT_IDENTIFIER_AUTHENTICATION,
+  meetsIdentifierAuthentication,
+  minimumIdentifierAuthenticationFrom,
+} from "./identifier-authentication.js";
+import {
   applyEventAuthModeToSenderGate,
   senderGateForDirect,
   senderGateForGroup,
@@ -116,6 +121,12 @@ function commandGate(params: {
     allowed: authorized,
     reasonCode: shouldBlock ? "control_command_unauthorized" : "command_authorized",
     match: mergeCommandMatch(owner.match, group.match),
+    identifierAuthentication: {
+      evaluated: Boolean(owner.authentication?.evaluated || group.authentication?.evaluated),
+      affectedMatch: Boolean(
+        owner.authentication?.affectedMatch || group.authentication?.affectedMatch,
+      ),
+    },
     command: {
       useAccessGroups,
       allowTextCommands: command.allowTextCommands,
@@ -138,6 +149,7 @@ function mergeCommandMatch(
 
 function eventGate(params: {
   state: ChannelIngressState;
+  policy: ChannelIngressPolicyInput;
   senderGate: AccessGraphGate;
   commandGate: AccessGraphGate;
 }): AccessGraphGate {
@@ -171,8 +183,22 @@ function eventGate(params: {
     if (!params.state.event.hasOriginSubject) {
       return eventResult(false, "origin_subject_missing");
     }
-    const matched = params.state.event.originSubjectMatched;
-    return eventResult(matched, matched ? "event_authorized" : "origin_subject_not_matched");
+    const matched =
+      params.state.event.originSubjectMatched &&
+      meetsIdentifierAuthentication(
+        params.state.event.originSubjectAuthentication ?? DEFAULT_IDENTIFIER_AUTHENTICATION,
+        minimumIdentifierAuthenticationFrom(params.policy),
+      );
+    return {
+      ...eventResult(matched, matched ? "event_authorized" : "origin_subject_not_matched"),
+      identifierAuthentication: {
+        evaluated:
+          params.policy.minIdentifierAuthentication !== undefined ||
+          params.policy.mutableIdentifierMatching !== undefined ||
+          params.state.event.originSubjectAuthentication !== undefined,
+        affectedMatch: params.state.event.originSubjectMatched && !matched,
+      },
+    };
   }
   return eventResult(
     params.senderGate.allowed,
@@ -337,7 +363,7 @@ export function decideChannelIngress(
     return decisiveDecision({ admission: "drop", decision: "block", gate: command, gates });
   }
 
-  const event = eventGate({ state, senderGate: eventModeSender, commandGate: command });
+  const event = eventGate({ state, policy, senderGate: eventModeSender, commandGate: command });
   gates.push(event);
   if (!event.allowed) {
     return decisiveDecision({ admission: "drop", decision: "block", gate: event, gates });

--- a/src/channels/message-access/decision.ts
+++ b/src/channels/message-access/decision.ts
@@ -9,7 +9,7 @@ import {
   allowedImplicitMentionKindsFromConfig,
   resolveInboundMentionDecision,
 } from "../mention-gating.js";
-import { applyMutableIdentifierPolicy, redactedAllowlistDiagnostics } from "./allowlist.js";
+import { applyIdentifierAuthenticationPolicy, redactedAllowlistDiagnostics } from "./allowlist.js";
 import {
   DEFAULT_IDENTIFIER_AUTHENTICATION,
   meetsIdentifierAuthentication,
@@ -24,7 +24,7 @@ import type {
   AccessGraphGate,
   ChannelIngressDecision,
   ChannelIngressPolicyInput,
-  ChannelIngressState,
+  NormalizedIngressState,
   RedactedIngressMatch,
 } from "./types.js";
 
@@ -43,7 +43,7 @@ function decisiveDecision(params: {
   };
 }
 
-function routeGates(state: ChannelIngressState): AccessGraphGate[] {
+function routeGates(state: NormalizedIngressState): AccessGraphGate[] {
   // Route gates run first because a matched route can block dispatch before sender,
   // command, or mention policy needs to evaluate.
   return state.routeFacts.map((route) => ({
@@ -57,7 +57,7 @@ function routeGates(state: ChannelIngressState): AccessGraphGate[] {
   }));
 }
 
-function routeSenderEmptyGate(state: ChannelIngressState): AccessGraphGate | null {
+function routeSenderEmptyGate(state: NormalizedIngressState): AccessGraphGate | null {
   // deny-when-empty route sender policy means the route matched but has no sender list to
   // authorize against, so it becomes an explicit route block.
   const route = state.routeFacts.find(
@@ -85,7 +85,7 @@ function routeSenderEmptyGate(state: ChannelIngressState): AccessGraphGate | nul
 }
 
 function commandGate(params: {
-  state: ChannelIngressState;
+  state: NormalizedIngressState;
   policy: ChannelIngressPolicyInput;
 }): AccessGraphGate {
   const command = params.policy.command;
@@ -100,10 +100,16 @@ function commandGate(params: {
     };
   }
   const useAccessGroups = command.useAccessGroups ?? true;
-  // Command authorization combines owner and group allowlists after mutable-id policy so
+  // Command authorization combines owner and group allowlists after authentication policy so
   // command control cannot be granted by identifiers the current policy rejects.
-  const owner = applyMutableIdentifierPolicy(params.state.allowlists.commandOwner, params.policy);
-  const group = applyMutableIdentifierPolicy(params.state.allowlists.commandGroup, params.policy);
+  const owner = applyIdentifierAuthenticationPolicy(
+    params.state.allowlists.commandOwner,
+    params.policy,
+  );
+  const group = applyIdentifierAuthenticationPolicy(
+    params.state.allowlists.commandGroup,
+    params.policy,
+  );
   const authorized = resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups,
     modeWhenAccessGroupsOff: command.modeWhenAccessGroupsOff,
@@ -148,7 +154,7 @@ function mergeCommandMatch(
 }
 
 function eventGate(params: {
-  state: ChannelIngressState;
+  state: NormalizedIngressState;
   policy: ChannelIngressPolicyInput;
   senderGate: AccessGraphGate;
   commandGate: AccessGraphGate;
@@ -208,7 +214,7 @@ function eventGate(params: {
 
 function activationMetadata(params: {
   activation?: ChannelIngressPolicyInput["activation"];
-  mentionFacts: ChannelIngressState["mentionFacts"];
+  mentionFacts: NormalizedIngressState["mentionFacts"];
   shouldSkip: boolean;
   effectiveWasMentioned?: boolean;
   shouldBypassMention?: boolean;
@@ -253,7 +259,7 @@ function resolveAllowedImplicitMentionKinds(activation: ChannelIngressPolicyInpu
 }
 
 function activationGate(params: {
-  state: ChannelIngressState;
+  state: NormalizedIngressState;
   policy: ChannelIngressPolicyInput;
   commandGate: AccessGraphGate;
 }): AccessGraphGate {
@@ -307,7 +313,7 @@ function activationGate(params: {
 }
 
 export function decideChannelIngress(
-  state: ChannelIngressState,
+  state: NormalizedIngressState,
   policy: ChannelIngressPolicyInput,
 ): ChannelIngressDecision {
   const gates: AccessGraphGate[] = routeGates(state);

--- a/src/channels/message-access/identifier-authentication.test.ts
+++ b/src/channels/message-access/identifier-authentication.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import {
+  meetsIdentifierAuthentication,
+  weakestIdentifierAuthentication,
+  type IdentifierAuthentication,
+} from "./identifier-authentication.js";
+import type { ResolveStableChannelMessageIngressParams } from "./runtime-types.js";
+import { resolveStableChannelMessageIngress } from "./runtime.js";
+
+const strengths: IdentifierAuthentication[] = ["mutable", "unverified", "asserted", "verified"];
+
+function base(
+  overrides: Partial<ResolveStableChannelMessageIngressParams> = {},
+): ResolveStableChannelMessageIngressParams {
+  return {
+    channelId: "test",
+    accountId: "default",
+    subject: { stableId: "sender-1" },
+    conversation: { kind: "direct", id: "dm-1" },
+    dmPolicy: "allowlist",
+    groupPolicy: "allowlist",
+    allowFrom: ["sender-1"],
+    ...overrides,
+  };
+}
+
+describe("identifier authentication", () => {
+  it("orders the scale and combines exact claims by the weaker strength", () => {
+    for (const [actualIndex, actual] of strengths.entries()) {
+      for (const [minimumIndex, minimum] of strengths.entries()) {
+        expect(meetsIdentifierAuthentication(actual, minimum)).toBe(actualIndex >= minimumIndex);
+        expect(weakestIdentifierAuthentication(actual, minimum)).toBe(
+          strengths[Math.min(actualIndex, minimumIndex)],
+        );
+      }
+    }
+  });
+
+  it("combines each matched entry with the exact same-kind subject identifier", async () => {
+    const identity = {
+      key: "primary-email",
+      kind: "email" as const,
+      authentication: "verified" as const,
+      aliases: [
+        {
+          key: "secondary-email",
+          kind: "email" as const,
+          authentication: "verified" as const,
+        },
+      ],
+    };
+    const subject = {
+      stableId: "strong@example.test",
+      aliases: { "secondary-email": "weak@example.test" },
+      authentication: {
+        "primary-email": "verified" as const,
+        "secondary-email": "unverified" as const,
+      },
+    };
+
+    const strong = await resolveStableChannelMessageIngress(
+      base({
+        identity,
+        subject,
+        allowFrom: ["strong@example.test"],
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+    const weak = await resolveStableChannelMessageIngress(
+      base({
+        identity,
+        subject,
+        allowFrom: ["weak@example.test"],
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(strong.senderAccess.allowed).toBe(true);
+    expect(weak.senderAccess).toMatchObject({
+      allowed: false,
+      reasonCode: "dm_policy_not_allowlisted",
+    });
+    const pairs = strong.state.allowlists.dm.match.matchedPairs;
+    expect(pairs).toHaveLength(2);
+    expect(pairs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          opaqueSubjectId: "primary-email",
+          subjectAuthentication: "verified",
+        }),
+      ]),
+    );
+    expect(pairs?.every((pair) => pair.opaqueSubjectId === "primary-email")).toBe(true);
+    expect(JSON.stringify(strong.state)).not.toContain("strong@example.test");
+    expect(JSON.stringify(weak.state)).not.toContain("weak@example.test");
+  });
+
+  it("preserves the shipped dangerous and mutableIdentifierMatching mappings", async () => {
+    const params = base({
+      identity: { dangerous: true },
+      subject: { stableId: "display-name" },
+      allowFrom: ["display-name"],
+    });
+    const disabled = await resolveStableChannelMessageIngress(params);
+    const enabled = await resolveStableChannelMessageIngress({
+      ...params,
+      policy: { mutableIdentifierMatching: "enabled" },
+    });
+
+    expect(disabled.senderAccess.allowed).toBe(false);
+    expect(disabled.senderAccess.gate?.allowlist?.disabledEntryCount).toBeGreaterThan(0);
+    expect(enabled.senderAccess.allowed).toBe(true);
+  });
+
+  it("does not let a wildcard without an exact primary identifier claim verified", async () => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        identity: { authentication: "verified" },
+        subject: {},
+        allowFrom: ["*"],
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(result.senderAccess).toMatchObject({
+      allowed: false,
+      reasonCode: "dm_policy_not_allowlisted",
+    });
+  });
+
+  it.each([
+    {
+      name: "group sender",
+      patch: {
+        conversation: { kind: "group" as const, id: "room-1" },
+        allowFrom: [],
+        groupAllowFrom: ["sender-1"],
+      },
+      check: (result: Awaited<ReturnType<typeof resolveStableChannelMessageIngress>>) =>
+        result.senderAccess.allowed,
+    },
+    {
+      name: "command owner",
+      patch: {
+        command: {
+          allowTextCommands: true,
+          hasControlCommand: true,
+          commandOwnerAllowFrom: ["sender-1"],
+        },
+      },
+      check: (result: Awaited<ReturnType<typeof resolveStableChannelMessageIngress>>) =>
+        result.commandAccess.authorized,
+    },
+    {
+      name: "route sender",
+      patch: {
+        conversation: { kind: "group" as const, id: "room-1" },
+        allowFrom: [],
+        groupAllowFrom: ["other"],
+        route: {
+          id: "route-1",
+          senderPolicy: "replace" as const,
+          senderAllowFrom: ["sender-1"],
+        },
+      },
+      check: (result: Awaited<ReturnType<typeof resolveStableChannelMessageIngress>>) =>
+        result.routeAccess.allowed && result.senderAccess.allowed,
+    },
+  ])("applies the exact-pair threshold to $name gates", async ({ patch, check }) => {
+    const common = {
+      identity: { authentication: "verified" as const },
+      subject: {
+        stableId: "sender-1",
+        authentication: { stableId: "unverified" as const },
+      },
+      policy: { minIdentifierAuthentication: "verified" as const },
+    };
+    const result = await resolveStableChannelMessageIngress(base({ ...patch, ...common }));
+    expect(check(result)).toBe(false);
+  });
+
+  it("applies the threshold to access-group and origin-subject gates", async () => {
+    const accessGroup = await resolveStableChannelMessageIngress(
+      base({
+        identity: { authentication: "verified" },
+        subject: {
+          stableId: "sender-1",
+          authentication: { stableId: "unverified" },
+        },
+        allowFrom: ["access-group:operators"],
+        accessGroups: {
+          operators: { type: "message.senders", members: { test: ["sender-1"] } },
+        },
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+    const origin = await resolveStableChannelMessageIngress(
+      base({
+        identity: { authentication: "verified" },
+        subject: {
+          stableId: "sender-1",
+          authentication: { stableId: "unverified" },
+        },
+        event: {
+          kind: "reaction",
+          authMode: "origin-subject",
+          mayPair: false,
+          originSubject: {
+            identifiers: [
+              {
+                opaqueId: "origin-stable",
+                kind: "stable-id",
+                value: "sender-1",
+                authentication: "verified",
+              },
+            ],
+          },
+        },
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(accessGroup.senderAccess.allowed).toBe(false);
+    expect(origin.ingress).toMatchObject({
+      admission: "drop",
+      reasonCode: "origin_subject_not_matched",
+    });
+  });
+});

--- a/src/channels/message-access/identifier-authentication.test.ts
+++ b/src/channels/message-access/identifier-authentication.test.ts
@@ -318,7 +318,7 @@ describe("identifier authentication", () => {
           stableId: "sender-1",
           authentication: { stableId: "unverified" },
         },
-        allowFrom: ["access-group:operators"],
+        allowFrom: ["accessGroup:operators"],
         accessGroups: {
           operators: { type: "message.senders", members: { test: ["sender-1"] } },
         },
@@ -355,6 +355,51 @@ describe("identifier authentication", () => {
     expect(origin.ingress).toMatchObject({
       admission: "drop",
       reasonCode: "origin_subject_not_matched",
+    });
+  });
+
+  it.each([
+    {
+      name: "runtime resolver",
+      patch: {
+        resolveAccessGroupMembership: async () => true,
+      },
+    },
+    {
+      name: "precomputed membership",
+      patch: {
+        accessGroupMembership: [
+          {
+            kind: "matched" as const,
+            groupName: "audience",
+            source: "dynamic" as const,
+            matchedEntryIds: ["access-group:audience"],
+          },
+        ],
+      },
+    },
+  ])("fails $name access-group matches closed at a verified minimum", async ({ patch }) => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        ...patch,
+        allowFrom: ["accessGroup:audience"],
+        accessGroups: {
+          audience: {
+            type: "discord.channelAudience",
+            guildId: "guild-1",
+            channelId: "channel-1",
+          },
+        },
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(result.senderAccess).toMatchObject({
+      allowed: false,
+      reasonCode: "dm_policy_not_allowlisted",
+      gate: {
+        identifierAuthentication: { evaluated: true, affectedMatch: true },
+      },
     });
   });
 });

--- a/src/channels/message-access/identifier-authentication.test.ts
+++ b/src/channels/message-access/identifier-authentication.test.ts
@@ -81,7 +81,7 @@ describe("identifier authentication", () => {
       reasonCode: "dm_policy_not_allowlisted",
     });
     const pairs = strong.state.allowlists.dm.match.matchedPairs;
-    expect(pairs).toHaveLength(2);
+    expect(pairs).toHaveLength(1);
     expect(pairs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -93,6 +93,39 @@ describe("identifier authentication", () => {
     expect(pairs?.every((pair) => pair.opaqueSubjectId === "primary-email")).toBe(true);
     expect(JSON.stringify(strong.state)).not.toContain("strong@example.test");
     expect(JSON.stringify(weak.state)).not.toContain("weak@example.test");
+  });
+
+  it("does not cross-bind same-kind authentication between identity fields", async () => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        identity: {
+          key: "primary-email",
+          kind: "email",
+          authentication: "asserted",
+          aliases: [{ key: "alias-email", kind: "email", authentication: "verified" }],
+        },
+        subject: {
+          stableId: "shared@example.test",
+          authentication: { "primary-email": "asserted" },
+        },
+        allowFrom: ["shared@example.test"],
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(result.senderAccess).toMatchObject({
+      allowed: false,
+      reasonCode: "dm_policy_not_allowlisted",
+    });
+    expect(result.state.allowlists.dm.match.matchedPairs).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          opaqueEntryId: "entry-1:alias-email",
+          opaqueSubjectId: "primary-email",
+        }),
+      ]),
+    );
+    expect(JSON.stringify(result.state)).not.toContain("shared@example.test");
   });
 
   it("preserves the shipped dangerous and mutableIdentifierMatching mappings", async () => {
@@ -177,6 +210,104 @@ describe("identifier authentication", () => {
     };
     const result = await resolveStableChannelMessageIngress(base({ ...patch, ...common }));
     expect(check(result)).toBe(false);
+  });
+
+  it("preserves exact-pair authentication through inherited route lists", async () => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        conversation: { kind: "group", id: "room-1" },
+        identity: { authentication: "verified" },
+        subject: {
+          stableId: "sender-1",
+          authentication: { stableId: "unverified" },
+        },
+        allowFrom: [],
+        groupAllowFrom: ["other"],
+        route: {
+          id: "route-1",
+          senderPolicy: "inherit",
+          senderAllowFrom: ["sender-1"],
+        },
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(result.routeAccess.allowed).toBe(true);
+    expect(result.senderAccess).toMatchObject({
+      allowed: false,
+      reasonCode: "group_policy_not_allowlisted",
+      gate: {
+        identifierAuthentication: { evaluated: true, affectedMatch: true },
+      },
+    });
+    expect(JSON.stringify(result.state)).not.toContain("sender-1");
+  });
+
+  it("namespaces exact pairs from inherited route lists", async () => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        conversation: { kind: "group", id: "room-1" },
+        identity: {
+          authentication: (value) => (value === "sender-1" ? "verified" : "asserted"),
+        },
+        subject: {
+          stableId: "sender-1",
+          authentication: { stableId: "verified" },
+        },
+        allowFrom: [],
+        groupAllowFrom: ["other"],
+        route: {
+          id: "route-1",
+          senderPolicy: "inherit",
+          senderAllowFrom: ["sender-1"],
+        },
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(result.senderAccess).toMatchObject({
+      allowed: true,
+      reasonCode: "group_policy_allowed",
+    });
+    expect(result.senderAccess.gate?.match?.matchedEntryIds).toEqual(["source-2:entry-1:stableId"]);
+  });
+
+  it("does not cross-bind same-kind origin-subject fields", async () => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        identity: {
+          key: "primary-email",
+          kind: "email",
+          aliases: [{ key: "alias-email", kind: "email" }],
+        },
+        subject: {
+          stableId: "shared@example.test",
+          authentication: { "primary-email": "verified" },
+        },
+        event: {
+          kind: "reaction",
+          authMode: "origin-subject",
+          mayPair: false,
+          originSubject: {
+            identifiers: [
+              {
+                opaqueId: "alias-email",
+                kind: "email",
+                value: "shared@example.test",
+                authentication: "verified",
+              },
+            ],
+          },
+        },
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(result.ingress).toMatchObject({
+      admission: "drop",
+      reasonCode: "origin_subject_not_matched",
+    });
+    expect(JSON.stringify(result.state)).not.toContain("shared@example.test");
   });
 
   it("applies the threshold to access-group and origin-subject gates", async () => {

--- a/src/channels/message-access/identifier-authentication.test.ts
+++ b/src/channels/message-access/identifier-authentication.test.ts
@@ -145,6 +145,73 @@ describe("identifier authentication", () => {
     expect(enabled.senderAccess.allowed).toBe(true);
   });
 
+  it("floors an alias missing from a supplied authentication map to unverified", async () => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        identity: {
+          authentication: "verified",
+          aliases: [{ key: "alias", authentication: "verified" }],
+        },
+        subject: {
+          stableId: "sender-1",
+          aliases: { alias: "alias-1" },
+          authentication: { stableId: "verified" },
+        },
+        allowFrom: ["alias-1"],
+      }),
+    );
+
+    expect(result.senderAccess.allowed).toBe(false);
+    expect(result.state.allowlists.dm.match.matchedPairs).toEqual([
+      {
+        opaqueEntryId: "entry-1:alias",
+        opaqueSubjectId: "alias",
+        subjectAuthentication: "unverified",
+      },
+    ]);
+  });
+
+  it("preserves verified static strength when the authentication map is absent", async () => {
+    const result = await resolveStableChannelMessageIngress(
+      base({
+        identity: { authentication: "verified" },
+        policy: { minIdentifierAuthentication: "verified" },
+      }),
+    );
+
+    expect(result.senderAccess.allowed).toBe(true);
+    expect(result.state.allowlists.dm.match.matchedPairs).toEqual([
+      {
+        opaqueEntryId: "entry-1:stableId",
+        opaqueSubjectId: "stableId",
+        subjectAuthentication: "verified",
+      },
+    ]);
+  });
+
+  it.each(["disabled", "enabled"] as const)(
+    "keeps mutable alias matching %s with only the primary claim supplied",
+    async (mutableIdentifierMatching) => {
+      const result = await resolveStableChannelMessageIngress(
+        base({
+          identity: {
+            key: "member-id",
+            aliases: [{ key: "display-name", kind: "username", dangerous: true }],
+          },
+          subject: {
+            stableId: "member-1",
+            aliases: { "display-name": "Echo" },
+            authentication: { "member-id": "asserted" },
+          },
+          allowFrom: ["Echo"],
+          policy: { mutableIdentifierMatching },
+        }),
+      );
+
+      expect(result.senderAccess.allowed).toBe(mutableIdentifierMatching === "enabled");
+    },
+  );
+
   it("does not let a wildcard without an exact primary identifier claim verified", async () => {
     const result = await resolveStableChannelMessageIngress(
       base({

--- a/src/channels/message-access/identifier-authentication.ts
+++ b/src/channels/message-access/identifier-authentication.ts
@@ -1,0 +1,48 @@
+/** Ordered strength of one identifier-authentication claim. */
+export type IdentifierAuthentication = "verified" | "asserted" | "unverified" | "mutable";
+
+const IDENTIFIER_AUTHENTICATION_RANK: Record<IdentifierAuthentication, number> = {
+  verified: 3,
+  asserted: 2,
+  unverified: 1,
+  mutable: 0,
+};
+
+/** Existing channels remain asserted until they opt into a more precise claim. */
+export const DEFAULT_IDENTIFIER_AUTHENTICATION: IdentifierAuthentication = "asserted";
+
+export function meetsIdentifierAuthentication(
+  actual: IdentifierAuthentication,
+  minimum: IdentifierAuthentication,
+): boolean {
+  return IDENTIFIER_AUTHENTICATION_RANK[actual] >= IDENTIFIER_AUTHENTICATION_RANK[minimum];
+}
+
+/** Entry and subject claims combine by taking the weaker exact-pair claim. */
+export function weakestIdentifierAuthentication(
+  entry: IdentifierAuthentication,
+  subject: IdentifierAuthentication,
+): IdentifierAuthentication {
+  return IDENTIFIER_AUTHENTICATION_RANK[entry] <= IDENTIFIER_AUTHENTICATION_RANK[subject]
+    ? entry
+    : subject;
+}
+
+export function identifierAuthenticationFrom(params: {
+  authentication?: IdentifierAuthentication;
+  dangerous?: boolean;
+}): IdentifierAuthentication {
+  return (
+    params.authentication ?? (params.dangerous ? "mutable" : DEFAULT_IDENTIFIER_AUTHENTICATION)
+  );
+}
+
+export function minimumIdentifierAuthenticationFrom(params: {
+  minIdentifierAuthentication?: IdentifierAuthentication;
+  mutableIdentifierMatching?: "disabled" | "enabled";
+}): IdentifierAuthentication {
+  return (
+    params.minIdentifierAuthentication ??
+    (params.mutableIdentifierMatching === "enabled" ? "mutable" : DEFAULT_IDENTIFIER_AUTHENTICATION)
+  );
+}

--- a/src/channels/message-access/runtime-identity.ts
+++ b/src/channels/message-access/runtime-identity.ts
@@ -1,4 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
+import type { IdentifierAuthentication } from "./identifier-authentication.js";
 /**
  * Channel ingress identity adapter helpers.
  *
@@ -56,6 +57,15 @@ function fieldDangerous(field: ResolvedIdentityField, value: string): boolean | 
   return typeof field.dangerous === "function" ? field.dangerous(value) : field.dangerous;
 }
 
+function fieldAuthentication(
+  field: ResolvedIdentityField,
+  value: string,
+): IdentifierAuthentication | undefined {
+  return typeof field.authentication === "function"
+    ? field.authentication(value)
+    : field.authentication;
+}
+
 function identityFields(identity: ChannelIngressIdentityDescriptor): ResolvedIdentityField[] {
   const fields: ResolvedIdentityField[] = [
     {
@@ -85,6 +95,7 @@ function adapterEntry(params: {
   entryIndex: number;
   value: string;
   fallbackSuffix?: string;
+  wildcard?: boolean;
 }): ChannelIngressAdapterEntry {
   return {
     opaqueEntryId:
@@ -96,6 +107,8 @@ function adapterEntry(params: {
       }) ?? `entry-${params.entryIndex + 1}:${params.fallbackSuffix ?? params.field.key}`,
     kind: params.field.kind,
     value: params.value,
+    ...(params.wildcard ? { wildcard: true } : {}),
+    authentication: fieldAuthentication(params.field, params.entry),
     dangerous: fieldDangerous(params.field, params.entry),
     sensitivity: params.field.sensitivity,
   };
@@ -119,6 +132,7 @@ export function createIdentityAdapter(
               entryIndex,
               value: "*",
               fallbackSuffix: "wildcard",
+              wildcard: true,
             }),
           ];
         }
@@ -137,25 +151,61 @@ export function createIdentityAdapter(
       };
     },
     matchSubject({ subject, entries, context }) {
-      const subjectKeys = new Set(
-        subject.identifiers.flatMap((identifier) => {
-          const field = fields.find((candidate) => candidate.kind === identifier.kind);
-          if (!field) {
-            return [];
-          }
-          const value = normalizeFieldValue(field, identifier.value, "subject");
-          return value ? [identityMatchKey({ kind: identifier.kind, value })] : [];
-        }),
-      );
-      const matchedEntryIds = entries
-        .filter((entry) => {
-          const fallback = entry.value === "*" || subjectKeys.has(identityMatchKey(entry));
-          return identity.matchEntry?.({ subject, entry, context }) ?? fallback;
-        })
-        .map((entry) => entry.opaqueEntryId);
+      const normalizedSubjects = subject.identifiers.flatMap((identifier) => {
+        const field = fields.find((candidate) => candidate.kind === identifier.kind);
+        if (!field) {
+          return [];
+        }
+        const value = normalizeFieldValue(field, identifier.value, "subject");
+        return value ? [{ identifier, value }] : [];
+      });
+      const matchedPairs = entries.flatMap((entry) => {
+        const legacyMatch = identity.matchEntry?.({ subject, entry, context });
+        if (legacyMatch === false) {
+          return [];
+        }
+        const candidates = entry.wildcard
+          ? normalizedSubjects.filter(({ identifier }) => identifier.kind === fields[0]?.kind)
+          : normalizedSubjects.filter(
+              ({ identifier, value }) =>
+                identifier.kind === entry.kind &&
+                identityMatchKey({ kind: identifier.kind, value }) === identityMatchKey(entry),
+            );
+        if (candidates.length === 0) {
+          // A legacy positive whole-subject matcher has no exact subject provenance. Preserve
+          // its shipped asserted behavior, but never reinterpret it as a stronger claim.
+          return legacyMatch === true
+            ? [
+                {
+                  opaqueEntryId: entry.opaqueEntryId,
+                  opaqueSubjectId: "legacy-subject-match",
+                  subjectAuthentication: "asserted" as const,
+                },
+              ]
+            : entry.wildcard
+              ? [
+                  {
+                    opaqueEntryId: entry.opaqueEntryId,
+                    opaqueSubjectId: "wildcard-subject",
+                    subjectAuthentication: "asserted" as const,
+                  },
+                ]
+              : [];
+        }
+        return candidates.map(({ identifier }) => {
+          const pair = {
+            opaqueEntryId: entry.opaqueEntryId,
+            opaqueSubjectId: identifier.opaqueId,
+            subjectAuthentication: identifier.authentication,
+          };
+          return pair;
+        });
+      });
+      const matchedEntryIds = [...new Set(matchedPairs.map((pair) => pair.opaqueEntryId))];
       return {
         matched: matchedEntryIds.length > 0,
         matchedEntryIds,
+        matchedPairs,
       };
     },
   };
@@ -177,6 +227,7 @@ export function createIdentitySubject(
         opaqueId: field.key,
         kind: field.kind,
         value,
+        authentication: input.authentication?.[field.key],
         dangerous: fieldDangerous(field, value),
         sensitivity: field.sensitivity,
       },

--- a/src/channels/message-access/runtime-identity.ts
+++ b/src/channels/message-access/runtime-identity.ts
@@ -107,6 +107,7 @@ function adapterEntry(params: {
       }) ?? `entry-${params.entryIndex + 1}:${params.fallbackSuffix ?? params.field.key}`,
     kind: params.field.kind,
     value: params.value,
+    identityFieldKey: params.field.key,
     ...(params.wildcard ? { wildcard: true } : {}),
     authentication: fieldAuthentication(params.field, params.entry),
     dangerous: fieldDangerous(params.field, params.entry),
@@ -152,7 +153,10 @@ export function createIdentityAdapter(
     },
     matchSubject({ subject, entries, context }) {
       const normalizedSubjects = subject.identifiers.flatMap((identifier) => {
-        const field = fields.find((candidate) => candidate.kind === identifier.kind);
+        const field = fields.find(
+          (candidate) =>
+            candidate.key === identifier.opaqueId && candidate.kind === identifier.kind,
+        );
         if (!field) {
           return [];
         }
@@ -168,6 +172,7 @@ export function createIdentityAdapter(
           ? normalizedSubjects.filter(({ identifier }) => identifier.kind === fields[0]?.kind)
           : normalizedSubjects.filter(
               ({ identifier, value }) =>
+                identifier.opaqueId === entry.identityFieldKey &&
                 identifier.kind === entry.kind &&
                 identityMatchKey({ kind: identifier.kind, value }) === identityMatchKey(entry),
             );

--- a/src/channels/message-access/runtime-identity.ts
+++ b/src/channels/message-access/runtime-identity.ts
@@ -11,10 +11,9 @@ import type {
   ChannelIngressIdentityDescriptor,
   ChannelIngressIdentityField,
   ChannelIngressIdentitySubjectInput,
-  ChannelIngressSubject,
   StableChannelIngressIdentityParams,
 } from "./runtime-types.js";
-import type { InternalMatchMaterial } from "./types.js";
+import type { NormalizedIngressEntry, NormalizedIngressSubject } from "./types.js";
 
 type ResolvedIdentityField = Required<Pick<ChannelIngressIdentityField, "key" | "kind">> &
   Omit<ChannelIngressIdentityField, "key" | "kind">;
@@ -96,7 +95,8 @@ function adapterEntry(params: {
   value: string;
   fallbackSuffix?: string;
   wildcard?: boolean;
-}): ChannelIngressAdapterEntry {
+}): NormalizedIngressEntry {
+  const dangerous = fieldDangerous(params.field, params.entry);
   return {
     opaqueEntryId:
       params.identity.resolveEntryId?.({
@@ -109,8 +109,9 @@ function adapterEntry(params: {
     value: params.value,
     identityFieldKey: params.field.key,
     ...(params.wildcard ? { wildcard: true } : {}),
-    authentication: fieldAuthentication(params.field, params.entry),
-    dangerous: fieldDangerous(params.field, params.entry),
+    authentication:
+      fieldAuthentication(params.field, params.entry) ?? (dangerous ? "mutable" : "asserted"),
+    dangerous,
     sensitivity: params.field.sensitivity,
   };
 }
@@ -197,14 +198,11 @@ export function createIdentityAdapter(
                 ]
               : [];
         }
-        return candidates.map(({ identifier }) => {
-          const pair = {
-            opaqueEntryId: entry.opaqueEntryId,
-            opaqueSubjectId: identifier.opaqueId,
-            subjectAuthentication: identifier.authentication,
-          };
-          return pair;
-        });
+        return candidates.map(({ identifier }) => ({
+          opaqueEntryId: entry.opaqueEntryId,
+          opaqueSubjectId: identifier.opaqueId,
+          subjectAuthentication: identifier.authentication,
+        }));
       });
       const matchedEntryIds = [...new Set(matchedPairs.map((pair) => pair.opaqueEntryId))];
       return {
@@ -219,21 +217,28 @@ export function createIdentityAdapter(
 export function createIdentitySubject(
   identity: ChannelIngressIdentityDescriptor,
   input: ChannelIngressIdentitySubjectInput,
-): ChannelIngressSubject {
+): NormalizedIngressSubject {
   const fields = identityFields(identity);
-  const identifiers: InternalMatchMaterial[] = fields.flatMap((field, index) => {
+  const identifiers: NormalizedIngressSubject["identifiers"] = fields.flatMap((field, index) => {
     const rawValue = index === 0 ? input.stableId : input.aliases?.[field.key];
     if (rawValue == null) {
       return [];
     }
     const value = String(rawValue);
+    const dangerous = fieldDangerous(field, value);
+    // A supplied map owns every per-message claim; omitted fields must not inherit
+    // a stronger static declaration from the identity descriptor.
+    const authentication =
+      input.authentication !== undefined
+        ? (input.authentication[field.key] ?? "unverified")
+        : (fieldAuthentication(field, value) ?? (dangerous ? "mutable" : "asserted"));
     return [
       {
         opaqueId: field.key,
         kind: field.kind,
         value,
-        authentication: input.authentication?.[field.key],
-        dangerous: fieldDangerous(field, value),
+        authentication,
+        dangerous,
         sensitivity: field.sensitivity,
       },
     ];

--- a/src/channels/message-access/runtime-types.ts
+++ b/src/channels/message-access/runtime-types.ts
@@ -5,6 +5,7 @@
  */
 import type { AccessGroupConfig } from "../../config/types.access-groups.js";
 import type { InboundEventKind } from "../inbound-event/kind.js";
+import type { IdentifierAuthentication } from "./identifier-authentication.js";
 import type {
   AccessGroupMembershipFact,
   AccessGraphGate,
@@ -43,7 +44,11 @@ export type ChannelIngressIdentityField = {
   normalizeEntry?: (value: string) => string | null | undefined;
   /** Normalizes inbound subject values for this identity field. */
   normalizeSubject?: (value: string) => string | null | undefined;
-  /** Marks identifiers as dangerous in diagnostics, for example mutable display names. */
+  /** Static strength of this identity field. `verified` requires owning-boundary metadata. */
+  authentication?:
+    | IdentifierAuthentication
+    | ((value: string) => IdentifierAuthentication | undefined);
+  /** @deprecated Use `authentication: "mutable"`. Remove in the next Plugin SDK major. */
   dangerous?: boolean | ((value: string) => boolean | undefined);
   /** Redaction hint for diagnostics and access graph consumers. */
   sensitivity?: "normal" | "pii";
@@ -92,6 +97,8 @@ export type ChannelIngressIdentitySubjectInput = {
   stableId?: string | number | null;
   /** Optional identity aliases keyed by `ChannelIngressIdentityAlias.key`. */
   aliases?: Record<string, string | number | null | undefined>;
+  /** Per-message claims keyed by the exact identity field key. */
+  authentication?: Record<string, IdentifierAuthentication | undefined>;
 };
 
 /** Minimal config subset consumed by the ingress resolver. */
@@ -257,7 +264,9 @@ export type CreateChannelIngressResolverParams = Pick<
   defaultGroupPolicy?: ChannelIngressPolicyInput["groupPolicy"];
   /** Default group allowlist fallback behavior. */
   groupAllowFromFallbackToAllowFrom?: boolean;
-  /** Mutable identifier matching policy for this resolver. */
+  /** Weakest exact-pair identifier claim allowed to authorize. */
+  minIdentifierAuthentication?: ChannelIngressPolicyInput["minIdentifierAuthentication"];
+  /** @deprecated Maps to `minIdentifierAuthentication`; remove in the next Plugin SDK major. */
   mutableIdentifierMatching?: ChannelIngressPolicyInput["mutableIdentifierMatching"];
 };
 

--- a/src/channels/message-access/runtime-types.ts
+++ b/src/channels/message-access/runtime-types.ts
@@ -23,9 +23,6 @@ import type {
   RouteGateFacts,
 } from "./types.js";
 
-/** Redacted subject identity assembled from a stable id plus optional platform aliases. */
-export type ChannelIngressSubject = InternalChannelIngressSubject;
-
 /** Normalized allowlist entry material produced by a channel identity adapter. */
 export type ChannelIngressAdapterEntry = InternalNormalizedEntry;
 
@@ -69,7 +66,7 @@ export type ChannelIngressIdentityDescriptor = {
   isWildcardEntry?: (value: string) => boolean;
   /** Optional custom match hook for platform-specific identity equivalence. */
   matchEntry?: (params: {
-    subject: ChannelIngressSubject;
+    subject: InternalChannelIngressSubject;
     entry: ChannelIngressAdapterEntry;
     context: "dm" | "group" | "route" | "command";
   }) => boolean | undefined;

--- a/src/channels/message-access/runtime.ts
+++ b/src/channels/message-access/runtime.ts
@@ -194,6 +194,8 @@ function resolveResolverPolicy(params: {
     groupAllowFromFallbackToAllowFrom:
       params.input.policy?.groupAllowFromFallbackToAllowFrom ??
       params.base.groupAllowFromFallbackToAllowFrom,
+    minIdentifierAuthentication:
+      params.input.policy?.minIdentifierAuthentication ?? params.base.minIdentifierAuthentication,
     mutableIdentifierMatching:
       params.input.policy?.mutableIdentifierMatching ?? params.base.mutableIdentifierMatching,
     ...(params.input.policy?.activation ? { activation: params.input.policy.activation } : {}),
@@ -691,5 +693,12 @@ export async function resolveChannelMessageIngress(
       !(isGroup
         ? state.allowlists.group.hasWildcard
         : state.allowlists.dm.hasWildcard || state.allowlists.pairingStore.hasWildcard),
+    identifierAuthentication: ingress.graph.gates.some(
+      (gate) => gate.identifierAuthentication?.affectedMatch,
+    )
+      ? "affected"
+      : ingress.graph.gates.some((gate) => gate.identifierAuthentication?.evaluated)
+        ? "evaluated"
+        : "not-evaluated",
   });
 }

--- a/src/channels/message-access/sender-gates.ts
+++ b/src/channels/message-access/sender-gates.ts
@@ -38,6 +38,14 @@ function senderGate(params: {
     match: params.match,
     sender: { policy: params.policy },
     allowlist: redactedAllowlistDiagnostics(params.allowlistSource, params.reasonCode),
+    ...(params.allowlistSource.authentication
+      ? {
+          identifierAuthentication: {
+            evaluated: params.allowlistSource.authentication.evaluated,
+            affectedMatch: params.allowlistSource.authentication.affectedMatch,
+          },
+        }
+      : {}),
   };
 }
 

--- a/src/channels/message-access/sender-gates.ts
+++ b/src/channels/message-access/sender-gates.ts
@@ -5,15 +5,15 @@
  */
 import {
   allowlistFailureReason,
-  applyMutableIdentifierPolicy,
+  applyIdentifierAuthenticationPolicy,
   effectiveGroupSenderAllowlist,
   redactedAllowlistDiagnostics,
 } from "./allowlist.js";
 import type {
   AccessGraphGate,
   ChannelIngressPolicyInput,
-  ChannelIngressState,
-  ResolvedIngressAllowlist,
+  NormalizedIngressState,
+  NormalizedIngressAllowlist,
 } from "./types.js";
 
 function senderGate(params: {
@@ -24,7 +24,7 @@ function senderGate(params: {
   reasonCode: AccessGraphGate["reasonCode"];
   match: AccessGraphGate["match"];
   policy: ChannelIngressPolicyInput["dmPolicy"] | ChannelIngressPolicyInput["groupPolicy"];
-  allowlistSource: ResolvedIngressAllowlist;
+  allowlistSource: NormalizedIngressAllowlist;
 }): AccessGraphGate {
   // Sender gates always include redacted allowlist facts so diagnostics can explain an
   // allow/block result without exposing raw sender ids.
@@ -53,11 +53,11 @@ function senderGate(params: {
  * Evaluates direct-message sender policy against DM and pairing-store allowlists.
  */
 export function senderGateForDirect(params: {
-  state: ChannelIngressState;
+  state: NormalizedIngressState;
   policy: ChannelIngressPolicyInput;
 }): AccessGraphGate {
-  const dm = applyMutableIdentifierPolicy(params.state.allowlists.dm, params.policy);
-  const pairingStore = applyMutableIdentifierPolicy(
+  const dm = applyIdentifierAuthenticationPolicy(params.state.allowlists.dm, params.policy);
+  const pairingStore = applyIdentifierAuthenticationPolicy(
     params.state.allowlists.pairingStore,
     params.policy,
   );
@@ -128,7 +128,7 @@ export function senderGateForDirect(params: {
  * Evaluates group/channel sender policy after route sender allowlist overrides are applied.
  */
 export function senderGateForGroup(params: {
-  state: ChannelIngressState;
+  state: NormalizedIngressState;
   policy: ChannelIngressPolicyInput;
 }): AccessGraphGate {
   const group = effectiveGroupSenderAllowlist(params);
@@ -174,7 +174,7 @@ export function senderGateForGroup(params: {
  * Applies event auth mode to sender gates for non-message callbacks.
  */
 export function applyEventAuthModeToSenderGate(params: {
-  state: ChannelIngressState;
+  state: NormalizedIngressState;
   senderGate: AccessGraphGate;
 }): AccessGraphGate {
   if (params.state.event.authMode === "inbound" || params.senderGate.allowed) {

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -323,6 +323,15 @@ async function resolveAccessGroupEntries(params: {
     const fact = factByName.get(groupName);
     if (fact?.kind === "matched") {
       accessGroups.matched.push(groupName);
+      for (const opaqueEntryId of fact.matchedEntryIds) {
+        // Dynamic membership proves the group predicate, not a stronger sender identifier.
+        // Model it as asserted so raised authentication thresholds fail closed.
+        normalizedEntries.push({
+          opaqueEntryId,
+          kind: "plugin:access-group-membership",
+          authentication: "asserted",
+        });
+      }
       matches.push({ matched: true, matchedEntryIds: fact.matchedEntryIds });
       continue;
     }

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -27,7 +27,7 @@ import type {
 } from "./types.js";
 
 function redactedEntries(entries: readonly InternalNormalizedEntry[]) {
-  return entries.map(({ value: _value, ...entry }) => entry);
+  return entries.map(({ value: _value, identityFieldKey: _identityFieldKey, ...entry }) => entry);
 }
 
 function emptyMatch(): RedactedIngressMatch {
@@ -165,11 +165,18 @@ async function normalizeSubjectIdentifiersForMatch(params: {
         entries.matchable
           // Origin subjects are identity material, not configured allowlists.
           // Do not let a subject value normalize into adapter wildcard semantics.
-          .filter((entry) => entry.kind === identifier.kind && entry.value !== "*")
+          .filter(
+            (entry) =>
+              entry.kind === identifier.kind &&
+              (entry.identityFieldKey === undefined ||
+                entry.identityFieldKey === identifier.opaqueId) &&
+              entry.value !== "*",
+          )
           .map((entry, entryIndex) => ({
             opaqueEntryId: `${params.opaquePrefix}-${identifierIndex + 1}:${entryIndex + 1}`,
             kind: entry.kind,
             value: entry.value,
+            identityFieldKey: entry.identityFieldKey,
             authentication: identifier.authentication,
             dangerous: entry.dangerous,
             sensitivity: entry.sensitivity,
@@ -230,7 +237,11 @@ async function originSubjectAuthentication(
   let strongest: IdentifierAuthentication | undefined;
   for (const originIdentifier of origin.identifiers) {
     for (const current of input.subject.identifiers) {
-      if (current.kind !== originIdentifier.kind || current.value !== originIdentifier.value) {
+      if (
+        current.opaqueId !== originIdentifier.opaqueId ||
+        current.kind !== originIdentifier.kind ||
+        current.value !== originIdentifier.value
+      ) {
         continue;
       }
       strongest = strongerAuthentication(

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -8,6 +8,11 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { parseAccessGroupAllowFromEntry } from "../allow-from.js";
+import {
+  identifierAuthenticationFrom,
+  weakestIdentifierAuthentication,
+  type IdentifierAuthentication,
+} from "./identifier-authentication.js";
 import type {
   AccessGroupMembershipFact,
   ChannelIngressState,
@@ -31,9 +36,24 @@ function emptyMatch(): RedactedIngressMatch {
 
 function mergeMatches(matches: readonly RedactedIngressMatch[]): RedactedIngressMatch {
   const matchedEntryIds = uniqueStrings(matches.flatMap((match) => match.matchedEntryIds));
+  const matchedPairs = matches.flatMap((match) => match.matchedPairs ?? []);
+  const seenPairs = new Set<string>();
+  const uniquePairs = matchedPairs.filter((pair) => {
+    const key = JSON.stringify([
+      pair.opaqueEntryId,
+      pair.opaqueSubjectId,
+      pair.subjectAuthentication ?? null,
+    ]);
+    if (seenPairs.has(key)) {
+      return false;
+    }
+    seenPairs.add(key);
+    return true;
+  });
   return {
     matched: matches.some((match) => match.matched) || matchedEntryIds.length > 0,
     matchedEntryIds,
+    ...(uniquePairs.length > 0 ? { matchedPairs: uniquePairs } : {}),
   };
 }
 
@@ -150,6 +170,7 @@ async function normalizeSubjectIdentifiersForMatch(params: {
             opaqueEntryId: `${params.opaquePrefix}-${identifierIndex + 1}:${entryIndex + 1}`,
             kind: entry.kind,
             value: entry.value,
+            authentication: identifier.authentication,
             dangerous: entry.dangerous,
             sensitivity: entry.sensitivity,
           }))
@@ -159,19 +180,67 @@ async function normalizeSubjectIdentifiersForMatch(params: {
   return normalized.flat();
 }
 
-async function originSubjectMatched(input: ChannelIngressStateInput): Promise<boolean> {
+function strongerAuthentication(
+  left: IdentifierAuthentication | undefined,
+  right: IdentifierAuthentication,
+): IdentifierAuthentication {
+  if (!left) {
+    return right;
+  }
+  return weakestIdentifierAuthentication(left, right) === left ? right : left;
+}
+
+function matchedAuthentication(params: {
+  entries: readonly InternalNormalizedEntry[];
+  match: RedactedIngressMatch;
+}): IdentifierAuthentication | undefined {
+  const entries = new Map(params.entries.map((entry) => [entry.opaqueEntryId, entry] as const));
+  let strongest: IdentifierAuthentication | undefined;
+  for (const pair of params.match.matchedPairs ?? []) {
+    const entry = entries.get(pair.opaqueEntryId);
+    if (!entry) {
+      continue;
+    }
+    const entryStrength = identifierAuthenticationFrom(entry);
+    const strength = pair.subjectAuthentication
+      ? weakestIdentifierAuthentication(entryStrength, pair.subjectAuthentication)
+      : entryStrength;
+    strongest = strongerAuthentication(strongest, strength);
+  }
+  if (!strongest) {
+    // Legacy adapters return only matched entry ids. Preserve their asserted/static behavior,
+    // but do not assign a per-message claim without an exact subject edge.
+    for (const entryId of params.match.matchedEntryIds) {
+      const entry = entries.get(entryId);
+      if (entry) {
+        strongest = strongerAuthentication(strongest, identifierAuthenticationFrom(entry));
+      }
+    }
+  }
+  return strongest;
+}
+
+async function originSubjectAuthentication(
+  input: ChannelIngressStateInput,
+): Promise<IdentifierAuthentication | undefined> {
   const origin = input.event.originSubject;
   if (!origin) {
-    return false;
+    return undefined;
   }
-  if (
-    origin.identifiers.some((identifier) =>
-      input.subject.identifiers.some(
-        (current) => current.kind === identifier.kind && current.value === identifier.value,
-      ),
-    )
-  ) {
-    return true;
+  let strongest: IdentifierAuthentication | undefined;
+  for (const originIdentifier of origin.identifiers) {
+    for (const current of input.subject.identifiers) {
+      if (current.kind !== originIdentifier.kind || current.value !== originIdentifier.value) {
+        continue;
+      }
+      strongest = strongerAuthentication(
+        strongest,
+        weakestIdentifierAuthentication(
+          identifierAuthenticationFrom(originIdentifier),
+          identifierAuthenticationFrom(current),
+        ),
+      );
+    }
   }
 
   const context = eventSubjectMatchContext(input);
@@ -188,7 +257,10 @@ async function originSubjectMatched(input: ChannelIngressStateInput): Promise<bo
       context,
     });
     if (currentMatch.matched) {
-      return true;
+      const authentication = matchedAuthentication({ entries: originEntries, match: currentMatch });
+      if (authentication) {
+        strongest = strongerAuthentication(strongest, authentication);
+      }
     }
   }
 
@@ -198,15 +270,18 @@ async function originSubjectMatched(input: ChannelIngressStateInput): Promise<bo
     context,
     opaquePrefix: "current",
   });
-  if (currentEntries.length === 0) {
-    return false;
+  if (currentEntries.length > 0) {
+    const originMatch = await input.adapter.matchSubject({
+      subject: origin,
+      entries: currentEntries,
+      context,
+    });
+    const authentication = matchedAuthentication({ entries: currentEntries, match: originMatch });
+    if (authentication) {
+      strongest = strongerAuthentication(strongest, authentication);
+    }
   }
-  const originMatch = await input.adapter.matchSubject({
-    subject: origin,
-    entries: currentEntries,
-    context,
-  });
-  return originMatch.matched;
+  return strongest;
 }
 
 async function resolveAccessGroupEntries(params: {
@@ -378,7 +453,7 @@ export async function resolveChannelIngressState(
         context: "command",
       }),
       resolveRouteFacts(input),
-      originSubjectMatched(input),
+      originSubjectAuthentication(input),
     ]);
   return {
     channelId: input.channelId,
@@ -389,7 +464,8 @@ export async function resolveChannelIngressState(
       authMode: input.event.authMode,
       mayPair: input.event.mayPair,
       hasOriginSubject: input.event.originSubject != null,
-      originSubjectMatched: eventOriginMatched,
+      originSubjectMatched: eventOriginMatched !== undefined,
+      ...(eventOriginMatched ? { originSubjectAuthentication: eventOriginMatched } : {}),
     },
     mentionFacts: input.mentionFacts,
     routeFacts,

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -15,18 +15,36 @@ import {
 } from "./identifier-authentication.js";
 import type {
   AccessGroupMembershipFact,
-  ChannelIngressState,
+  NormalizedIngressState,
   ChannelIngressStateInput,
   InternalChannelIngressAdapter,
   InternalChannelIngressSubject,
-  InternalNormalizedEntry,
+  NormalizedIngressSubject,
+  NormalizedIngressEntry,
   RedactedIngressEntryDiagnostic,
   RedactedIngressMatch,
-  ResolvedRouteGateFacts,
-  ResolvedIngressAllowlist,
+  NormalizedIngressAllowlist,
 } from "./types.js";
 
-function redactedEntries(entries: readonly InternalNormalizedEntry[]) {
+type NormalizedStateInput = Omit<ChannelIngressStateInput, "subject" | "event"> & {
+  subject: NormalizedIngressSubject;
+  event: Omit<ChannelIngressStateInput["event"], "originSubject"> & {
+    originSubject?: NormalizedIngressSubject;
+  };
+};
+
+function normalizeSubjectAuthentication(
+  subject: InternalChannelIngressSubject,
+): NormalizedIngressSubject {
+  return {
+    identifiers: subject.identifiers.map((identifier) => ({
+      ...identifier,
+      authentication: identifierAuthenticationFrom(identifier),
+    })),
+  };
+}
+
+function redactedEntries(entries: readonly NormalizedIngressEntry[]) {
   return entries.map(({ value: _value, identityFieldKey: _identityFieldKey, ...entry }) => entry);
 }
 
@@ -42,7 +60,7 @@ function mergeMatches(matches: readonly RedactedIngressMatch[]): RedactedIngress
     const key = JSON.stringify([
       pair.opaqueEntryId,
       pair.opaqueSubjectId,
-      pair.subjectAuthentication ?? null,
+      pair.subjectAuthentication,
     ]);
     if (seenPairs.has(key)) {
       return false;
@@ -77,7 +95,7 @@ function accessGroupFactByName(
 
 async function normalizeAndMatch(params: {
   adapter: InternalChannelIngressAdapter;
-  subject: InternalChannelIngressSubject;
+  subject: NormalizedIngressSubject;
   accountId: string;
   entries: readonly string[];
   context: "dm" | "group" | "route" | "command";
@@ -100,16 +118,20 @@ async function normalizeAndMatch(params: {
     context: params.context,
     accountId: params.accountId,
   });
+  const matchable = normalized.matchable.map((entry) => ({
+    ...entry,
+    authentication: identifierAuthenticationFrom(entry),
+  }));
   const match =
-    normalized.matchable.length > 0
+    matchable.length > 0
       ? await params.adapter.matchSubject({
           subject: params.subject,
-          entries: normalized.matchable,
+          entries: matchable,
           context: params.context,
         })
       : emptyMatch();
   return {
-    normalizedEntries: redactedEntries(normalized.matchable),
+    normalizedEntries: redactedEntries(matchable),
     invalidEntries: normalized.invalid,
     disabledEntries: normalized.disabled,
     match,
@@ -130,10 +152,7 @@ function directAllowlistEntries(entries: readonly string[]): string[] {
   return entries.filter((entry) => parseAccessGroupAllowFromEntry(entry) == null);
 }
 
-function groupSenderEntries(params: {
-  groupName: string;
-  input: ChannelIngressStateInput;
-}): string[] {
+function groupSenderEntries(params: { groupName: string; input: NormalizedStateInput }): string[] {
   const group = params.input.accessGroups?.[params.groupName];
   if (!group || group.type !== "message.senders") {
     return [];
@@ -144,16 +163,16 @@ function groupSenderEntries(params: {
   ]);
 }
 
-function eventSubjectMatchContext(input: ChannelIngressStateInput): "dm" | "group" {
+function eventSubjectMatchContext(input: NormalizedStateInput): "dm" | "group" {
   return input.conversation.kind === "direct" ? "dm" : "group";
 }
 
 async function normalizeSubjectIdentifiersForMatch(params: {
-  input: ChannelIngressStateInput;
-  subject: InternalChannelIngressSubject;
+  input: NormalizedStateInput;
+  subject: NormalizedIngressSubject;
   context: "dm" | "group";
   opaquePrefix: string;
-}): Promise<InternalNormalizedEntry[]> {
+}): Promise<NormalizedIngressEntry[]> {
   const normalized = await Promise.all(
     params.subject.identifiers.map(async (identifier, identifierIndex) => {
       const entries = await params.input.adapter.normalizeEntries({
@@ -198,7 +217,7 @@ function strongerAuthentication(
 }
 
 function matchedAuthentication(params: {
-  entries: readonly InternalNormalizedEntry[];
+  entries: readonly NormalizedIngressEntry[];
   match: RedactedIngressMatch;
 }): IdentifierAuthentication | undefined {
   const entries = new Map(params.entries.map((entry) => [entry.opaqueEntryId, entry] as const));
@@ -208,10 +227,10 @@ function matchedAuthentication(params: {
     if (!entry) {
       continue;
     }
-    const entryStrength = identifierAuthenticationFrom(entry);
-    const strength = pair.subjectAuthentication
-      ? weakestIdentifierAuthentication(entryStrength, pair.subjectAuthentication)
-      : entryStrength;
+    const strength = weakestIdentifierAuthentication(
+      entry.authentication,
+      pair.subjectAuthentication,
+    );
     strongest = strongerAuthentication(strongest, strength);
   }
   if (!strongest) {
@@ -220,7 +239,7 @@ function matchedAuthentication(params: {
     for (const entryId of params.match.matchedEntryIds) {
       const entry = entries.get(entryId);
       if (entry) {
-        strongest = strongerAuthentication(strongest, identifierAuthenticationFrom(entry));
+        strongest = strongerAuthentication(strongest, entry.authentication);
       }
     }
   }
@@ -228,7 +247,7 @@ function matchedAuthentication(params: {
 }
 
 async function originSubjectAuthentication(
-  input: ChannelIngressStateInput,
+  input: NormalizedStateInput,
 ): Promise<IdentifierAuthentication | undefined> {
   const origin = input.event.originSubject;
   if (!origin) {
@@ -246,10 +265,7 @@ async function originSubjectAuthentication(
       }
       strongest = strongerAuthentication(
         strongest,
-        weakestIdentifierAuthentication(
-          identifierAuthenticationFrom(originIdentifier),
-          identifierAuthenticationFrom(current),
-        ),
+        weakestIdentifierAuthentication(originIdentifier.authentication, current.authentication),
       );
     }
   }
@@ -296,7 +312,7 @@ async function originSubjectAuthentication(
 }
 
 async function resolveAccessGroupEntries(params: {
-  input: ChannelIngressStateInput;
+  input: NormalizedStateInput;
   context: "dm" | "group" | "route" | "command";
   referenced: readonly string[];
 }): Promise<{
@@ -304,10 +320,10 @@ async function resolveAccessGroupEntries(params: {
   invalidEntries: RedactedIngressEntryDiagnostic[];
   disabledEntries: RedactedIngressEntryDiagnostic[];
   matches: RedactedIngressMatch[];
-  accessGroups: ResolvedIngressAllowlist["accessGroups"];
+  accessGroups: NormalizedIngressAllowlist["accessGroups"];
 }> {
   const factByName = accessGroupFactByName(params.input.accessGroupMembership);
-  const accessGroups: ResolvedIngressAllowlist["accessGroups"] = {
+  const accessGroups: NormalizedIngressAllowlist["accessGroups"] = {
     referenced: [...params.referenced],
     matched: [],
     missing: [],
@@ -380,10 +396,10 @@ async function resolveAccessGroupEntries(params: {
 }
 
 async function resolveIngressAllowlist(params: {
-  input: ChannelIngressStateInput;
+  input: NormalizedStateInput;
   rawEntries: Array<string | number> | undefined;
   context: "dm" | "group" | "route" | "command";
-}): Promise<ResolvedIngressAllowlist> {
+}): Promise<NormalizedIngressAllowlist> {
   const entries = normalizeStringEntries(params.rawEntries ?? []);
   const referenced = referencedAccessGroups(entries);
   const directEntries = directAllowlistEntries(entries);
@@ -415,12 +431,12 @@ async function resolveIngressAllowlist(params: {
 }
 
 async function resolveRouteFacts(
-  input: ChannelIngressStateInput,
-): Promise<ResolvedRouteGateFacts[]> {
+  input: NormalizedStateInput,
+): Promise<NormalizedIngressState["routeFacts"]> {
   const routeFacts = [...(input.routeFacts ?? [])].toSorted(
     (left, right) => left.precedence - right.precedence || left.id.localeCompare(right.id),
   );
-  const resolved: ResolvedRouteGateFacts[] = [];
+  const resolved: NormalizedIngressState["routeFacts"] = [];
   for (const route of routeFacts) {
     const senderAllowFrom =
       route.senderAllowFrom ??
@@ -451,8 +467,18 @@ async function resolveRouteFacts(
 }
 
 export async function resolveChannelIngressState(
-  input: ChannelIngressStateInput,
-): Promise<ChannelIngressState> {
+  rawInput: ChannelIngressStateInput,
+): Promise<NormalizedIngressState> {
+  const input: NormalizedStateInput = {
+    ...rawInput,
+    subject: normalizeSubjectAuthentication(rawInput.subject),
+    event: {
+      ...rawInput.event,
+      originSubject: rawInput.event.originSubject
+        ? normalizeSubjectAuthentication(rawInput.event.originSubject)
+        : undefined,
+    },
+  };
   const [dm, pairingStore, group, commandOwner, commandGroup, routeFacts, eventOriginMatched] =
     await Promise.all([
       resolveIngressAllowlist({ input, rawEntries: input.allowlists.dm, context: "dm" }),

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -7,6 +7,7 @@ import type { ResolvedChannelImplicitMentions } from "../../config/implicit-ment
 import type { AccessGroupConfig } from "../../config/types.access-groups.js";
 import type { ChatChannelId } from "../ids.js";
 import type { InboundImplicitMentionKind, InboundMentionFacts } from "../mention-gating.js";
+import type { IdentifierAuthentication } from "./identifier-authentication.js";
 
 /** Channel identifier used in ingress diagnostics and config lookups. */
 export type ChannelIngressChannelId = ChatChannelId;
@@ -24,6 +25,8 @@ export type ChannelIngressIdentifierKind =
 type MatchableIdentifier = {
   opaqueId: string;
   kind: ChannelIngressIdentifierKind;
+  authentication?: IdentifierAuthentication;
+  /** @deprecated Use `authentication: "mutable"`. Remove in the next Plugin SDK major. */
   dangerous?: boolean;
   sensitivity?: "normal" | "pii";
 };
@@ -42,6 +45,9 @@ export type InternalChannelIngressSubject = {
 type ChannelIngressNormalizedEntry = {
   opaqueEntryId: string;
   kind: ChannelIngressIdentifierKind;
+  wildcard?: boolean;
+  authentication?: IdentifierAuthentication;
+  /** @deprecated Use `authentication: "mutable"`. Remove in the next Plugin SDK major. */
   dangerous?: boolean;
   sensitivity?: "normal" | "pii";
 };
@@ -61,6 +67,14 @@ export type RedactedIngressEntryDiagnostic = {
 export type RedactedIngressMatch = {
   matched: boolean;
   matchedEntryIds: string[];
+  /** Exact redacted entry-to-subject edges retained for authentication policy. */
+  matchedPairs?: RedactedIngressMatchedPair[];
+};
+
+type RedactedIngressMatchedPair = {
+  opaqueEntryId: string;
+  opaqueSubjectId: string;
+  subjectAuthentication?: IdentifierAuthentication;
 };
 
 /** Public normalization result for a set of allowlist entries. */
@@ -129,6 +143,19 @@ export type ResolvedIngressAllowlist = {
     failed: string[];
   };
   match: RedactedIngressMatch;
+  authentication?: RedactedIdentifierAuthenticationResult;
+};
+
+type RedactedIdentifierAuthenticationResult = {
+  evaluated: boolean;
+  threshold: IdentifierAuthentication;
+  affectedMatch: boolean;
+  rejectedEntryIds: string[];
+};
+
+type RedactedIdentifierAuthenticationDecision = {
+  evaluated: boolean;
+  affectedMatch: boolean;
 };
 
 /** Redacted allowlist facts safe to expose in the access graph. */
@@ -191,6 +218,7 @@ export type ChannelIngressEventInput = {
 type RedactedChannelIngressEvent = Omit<ChannelIngressEventInput, "originSubject"> & {
   hasOriginSubject: boolean;
   originSubjectMatched: boolean;
+  originSubjectAuthentication?: IdentifierAuthentication;
 };
 
 /** Complete raw input to the shared ingress state resolver. */
@@ -225,6 +253,8 @@ export type ChannelIngressPolicyInput = {
   dmPolicy: "pairing" | "allowlist" | "open" | "disabled";
   groupPolicy: "allowlist" | "open" | "disabled";
   groupAllowFromFallbackToAllowFrom?: boolean;
+  minIdentifierAuthentication?: IdentifierAuthentication;
+  /** @deprecated `enabled` maps to minimum `mutable`; otherwise minimum `asserted`. Remove in the next Plugin SDK major. */
   mutableIdentifierMatching?: "disabled" | "enabled";
   activation?: {
     requireMention: boolean;
@@ -295,6 +325,7 @@ export type IngressReasonCode =
   | "access_group_unsupported"
   | "access_group_failed"
   | "mutable_identifier_disabled"
+  | "identifier_authentication_too_weak"
   | "no_policy_match";
 
 /** One evaluated gate in the ordered ingress access graph. */
@@ -307,6 +338,7 @@ export type AccessGraphGate = {
   reasonCode: IngressReasonCode;
   match?: RedactedIngressMatch;
   allowlist?: RedactedIngressAllowlistFacts;
+  identifierAuthentication?: RedactedIdentifierAuthenticationDecision;
   sender?: {
     policy: ChannelIngressPolicyInput["dmPolicy"] | ChannelIngressPolicyInput["groupPolicy"];
   };

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -55,6 +55,7 @@ type ChannelIngressNormalizedEntry = {
 /** Internal normalized allowlist entry with its raw comparable value retained. */
 export type InternalNormalizedEntry = ChannelIngressNormalizedEntry & {
   value: string;
+  identityFieldKey?: string;
 };
 
 /** Redacted diagnostic for an invalid, disabled, or unsupported allowlist entry. */

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -32,13 +32,18 @@ type MatchableIdentifier = {
 };
 
 /** Internal identifier material with the raw comparable value retained. */
-export type InternalMatchMaterial = MatchableIdentifier & {
+type InternalMatchMaterial = MatchableIdentifier & {
   value: string;
 };
 
 /** Internal subject representation used by the shared ingress kernel. */
 export type InternalChannelIngressSubject = {
   identifiers: InternalMatchMaterial[];
+};
+
+/** SDK inputs remain optional; kernel consumers receive resolved authentication. */
+export type NormalizedIngressSubject = {
+  identifiers: Array<InternalMatchMaterial & { authentication: IdentifierAuthentication }>;
 };
 
 /** Public, redacted form of a normalized allowlist entry. */
@@ -58,6 +63,10 @@ export type InternalNormalizedEntry = ChannelIngressNormalizedEntry & {
   identityFieldKey?: string;
 };
 
+export type NormalizedIngressEntry = InternalNormalizedEntry & {
+  authentication: IdentifierAuthentication;
+};
+
 /** Redacted diagnostic for an invalid, disabled, or unsupported allowlist entry. */
 export type RedactedIngressEntryDiagnostic = {
   opaqueEntryId?: string;
@@ -75,7 +84,7 @@ export type RedactedIngressMatch = {
 type RedactedIngressMatchedPair = {
   opaqueEntryId: string;
   opaqueSubjectId: string;
-  subjectAuthentication?: IdentifierAuthentication;
+  subjectAuthentication: IdentifierAuthentication;
 };
 
 /** Public normalization result for a set of allowlist entries. */
@@ -99,8 +108,8 @@ export type InternalChannelIngressAdapter = {
   }): InternalChannelIngressNormalizeResult | Promise<InternalChannelIngressNormalizeResult>;
 
   matchSubject(params: {
-    subject: InternalChannelIngressSubject;
-    entries: readonly InternalNormalizedEntry[];
+    subject: NormalizedIngressSubject;
+    entries: readonly NormalizedIngressEntry[];
     context: "dm" | "group" | "route" | "command";
   }): RedactedIngressMatch | Promise<RedactedIngressMatch>;
 };
@@ -145,6 +154,12 @@ export type ResolvedIngressAllowlist = {
   };
   match: RedactedIngressMatch;
   authentication?: RedactedIdentifierAuthenticationResult;
+};
+
+export type NormalizedIngressAllowlist = Omit<ResolvedIngressAllowlist, "normalizedEntries"> & {
+  normalizedEntries: Array<
+    ChannelIngressNormalizedEntry & { authentication: IdentifierAuthentication }
+  >;
 };
 
 type RedactedIdentifierAuthenticationResult = {
@@ -193,10 +208,7 @@ export type RouteGateFacts = {
 };
 
 /** Route gate facts after any route-specific sender allowlist is normalized. */
-export type ResolvedRouteGateFacts = Omit<
-  RouteGateFacts,
-  "senderAllowFrom" | "senderAllowFromSource"
-> & {
+type ResolvedRouteGateFacts = Omit<RouteGateFacts, "senderAllowFrom" | "senderAllowFromSource"> & {
   senderAllowlist?: ResolvedIngressAllowlist;
 };
 
@@ -386,6 +398,17 @@ export type ChannelIngressState = {
     commandOwner: ResolvedIngressAllowlist;
     commandGroup: ResolvedIngressAllowlist;
   };
+};
+
+export type NormalizedIngressState = Omit<ChannelIngressState, "allowlists" | "routeFacts"> & {
+  allowlists: {
+    [K in keyof ChannelIngressState["allowlists"]]: NormalizedIngressAllowlist;
+  };
+  routeFacts: Array<
+    Omit<ResolvedRouteGateFacts, "senderAllowlist"> & {
+      senderAllowlist?: NormalizedIngressAllowlist;
+    }
+  >;
 };
 
 /** Final runtime admission action for the inbound event. */

--- a/test/helpers/channel-admission-evidence.ts
+++ b/test/helpers/channel-admission-evidence.ts
@@ -13,6 +13,7 @@ export function createChannelParticipantAdmissionEvidence(params: {
   channelId: string;
   accountId?: string;
   participantId: string | number;
+  identifierAuthentication?: "affected" | "evaluated" | "not-evaluated";
 }): ChannelAdmissionEvidence | undefined {
   return bindTestChannelParticipantAdmissionEvidence({ ...params, context: {} });
 }
@@ -23,6 +24,7 @@ export function bindTestChannelParticipantAdmissionEvidence(params: {
   channelId: string;
   accountId?: string;
   participantId: string | number;
+  identifierAuthentication?: "affected" | "evaluated" | "not-evaluated";
 }): ChannelAdmissionEvidence | undefined {
   const result = {
     state: {
@@ -48,6 +50,7 @@ export function bindTestChannelParticipantAdmissionEvidence(params: {
       accountId: params.accountId,
       rawPrincipalRef: params.participantId,
       participantOutcomeAffecting: false,
+      identifierAuthentication: params.identifierAuthentication ?? "not-evaluated",
       scope: {
         conversation: { kind: "direct", id: "test-conversation" },
         contextBinding: {


### PR DESCRIPTION
Kernel PR of the accepted RFC ([openclaw/rfcs#51](https://github.com/openclaw/rfcs/pull/51), tracking #124218). Replaces the closed original #116281. Refreshed 2026-08-27 by maintainer review: rebased onto current `main`, four review findings applied, and the exact-field compatibility repairs relocated into this PR so it lands green on its own. #123793 remains the inseparable SDK/migration follow-up; keep both in the same release.

## What Problem This Solves

Core models one axis of identifier trust: `dangerous` (mutable) versus everything else. A session-authenticated Discord snowflake and an attacker-typed SMTP `From:` header are indistinguishable to the allowlist gate. This PR adds the RFC's ordered identifier-authentication scale (`verified > asserted > unverified > mutable`) evaluated as `min(entry, subject) >= minIdentifierAuthentication` (default `asserted` — exactly today's behavior), with exact entry-to-subject match provenance, a per-message subject strength map, receipt integration, and the `identifier_authentication_too_weak` reason code. Threat-model item T-ACCESS-002 / recommendation R-008.

## Why This Change Was Made

- **Exact match provenance.** Same-kind matching is bound to the exact identity field (`identityFieldKey`); effective strength is computed per matched entry/subject pair. This resolves the RFC's per-kind-collapse question: a weak same-kind sibling can neither weaken nor borrow from a separately matched identifier.
- **Exact-field compatibility repairs (relocated from #123793, plus three newly found).** Five bundled channels relied on cross-field same-kind matching and would have regressed silently: Twitch role aliases (4 main tests fail without the fix), Discord legacy discriminator tags, Slack already-slugged name entries, IRC `nick@host` entries, and Feishu ambiguous open_id/user_id entries (caught by exact-head CI's wider extension shard; the ambiguous entry now normalizes under both same-kind fields). Each repair is a bounded entry-normalization fix binding entries to their exact owning field, with a failing-before regression test.
- **Missing-claim floor (review decision).** A subject that supplies a per-message `authentication` map floors any omitted field key to `unverified`; an absent map keeps static field resolution. Without this, a per-message channel declaring a `verified` ceiling would fail open on any code path that forgot the map — the exact incident class the RFC closes. Channels with static strength omit the map entirely and are unaffected.
- **Single-resolution invariant.** Strength is resolved once at normalization intake and is required on internal normalized shapes; downstream consumers read it directly. SDK-visible input shapes keep the optional contract.
- **One canonical gate.** `applyMutableIdentifierPolicy` (internal-only, not SDK surface) is renamed to `applyIdentifierAuthenticationPolicy` with all callers migrated; no deprecated internal alias remains.
- **Receipt fidelity.** Aggregated admission evidence reports `affected` when any contribution's outcome was changed by the policy (previously required all).

Shipped `dangerous` and `mutableIdentifierMatching` remain named deprecations with exact mappings (`dangerous: true` → `mutable`; enabled matching → minimum `mutable`); defaults are unchanged for every existing deployment. `IdentifierAuthentication` is channel-authorization policy input only — never execution-identity assurance.

## User Impact

No behavior change on any default path. Release-note context for plugin authors: (1) `IngressReasonCode` gains `identifier_authentication_too_weak` — exhaustive switches over the union need a new arm; (2) same-kind allowlist matching is now bound to the exact identity field — an external channel plugin whose entry normalizers place entries under a different field than the subject's same-kind identifier must bind entries to the owning field (see the five bundled repairs in this PR for the pattern); previously such entries matched by kind.

## Evidence

- Head: `c93dffd90c98` on current `main`; original three commits preserve @omarshahine's authorship.
- Focused: kernel + admission + SDK-runtime suites 63/63; channel regressions Discord 77, Twitch 24/24.
- Pre-fix reproductions recorded per repair: Twitch 4 failing (vip/subscriber/owner/multi-role), Discord tag 1 failing, Slack slugged-name 1 failing, IRC nick@host 1 failing, Feishu 3 files failing on exact-head CI run 33050839866; kernel floor regression admitted a spoofed omitted-claim alias before the fix.
- Full sibling sweep: 8,661 tests across discord/slack/msteams/googlechat/mattermost/irc/twitch — all passing; full `pnpm test:extensions` on the stack head green except one pre-existing order-dependent WhatsApp failure reproduced identically on clean `origin/main` (`monitor-inbox.policy.test.ts`, passes in isolation; unrelated, follow-up filed).
- `check:changed` full plan passed (guards, typechecks, lint, doctor contracts); `pnpm build` green including plugin-SDK export checks.
- Real-behavior proof (mock-gateway harness, real ephemeral gateway + qa-channel transport, mock provider): scenario `channel-sender-allowlist` — blocked observer produced no outbound, allowlisted driver received the exact marker. Verdict:

```json
{"scenarios":[{"name":"Channel sender allowlist block and override","status":"pass","steps":[{"name":"blocks observer and allows driver","status":"pass","details":"QA-ALLOWLIST-OVERRIDE-OK"}]}],"counts":{"total":1,"passed":1,"failed":0,"skipped":0}}
```

- Production LOC +696/−226 (net +470) | tests +643/−39 | docs +50. Growth is the accepted-RFC capability (gate, provenance, receipt projection); the review pass itself was net +58 production, having also deleted the internal wrapper, downstream strength fallbacks, and three dead type exports.
