### PR TITLE
fix(ui): surface Talk input backpressure

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -825,6 +825,82 @@ suite.define(() => {
     });
   });
 
+  it("shows a visible error when relay microphone appends fall behind", async () => {
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const relaySessionId = "relay-e2e-input-backpressure";
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.client.create": {
+            provider: "openai",
+            transport: "gateway-relay",
+            relaySessionId,
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
+          },
+          "talk.session.appendAudio": {},
+          "talk.session.close": {},
+        },
+      });
+      await installTalkBrowserFixtures(page);
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      for (let index = 0; index < 4; index += 1) {
+        await gateway.deferNext("talk.session.appendAudio");
+      }
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await gateway.waitForRequest("talk.client.create");
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  openclawTalkE2eState?: { inputProcessor?: unknown };
+                }
+              ).openclawTalkE2eState?.inputProcessor != null,
+          ),
+        )
+        .toBe(true);
+      await gateway.emitGatewayEvent("talk.event", { relaySessionId, type: "ready" });
+
+      await page.evaluate(() => {
+        const processor = (
+          window as Window & {
+            openclawTalkE2eState?: {
+              inputProcessor?: {
+                onaudioprocess?: (event: {
+                  inputBuffer: { getChannelData: () => Float32Array };
+                }) => void;
+              };
+            };
+          }
+        ).openclawTalkE2eState?.inputProcessor;
+        for (let index = 0; index < 5; index += 1) {
+          processor?.onaudioprocess?.({
+            inputBuffer: { getChannelData: () => new Float32Array(4096).fill(0.1) },
+          });
+        }
+      });
+
+      await expect
+        .poll(() =>
+          gateway.getRequests("talk.session.appendAudio").then((requests) => requests.length),
+        )
+        .toBe(4);
+      await expect
+        .poll(() => page.getByRole("alert").textContent())
+        .toContain("Realtime Talk audio input fell behind");
+      await expect
+        .poll(() => gateway.getRequests("talk.session.close").then((requests) => requests.length))
+        .toBe(1);
+      await captureComposerProof(page, "relay-input-backpressure-error.png");
+    });
+  });
+
   it("closes a stale relay when stop and restart race its create response", async () => {
     await suite.withPage({ locale: "en-US", permissions: ["microphone"] }, async ({ page }) => {
       const currentRelaySessionId = "relay-current-e2e";

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -634,7 +634,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     expect(requestCallsFor(client, "talk.session.close")).toHaveLength(1);
   });
 
-  it("bounds stalled microphone appends and aborts every owner on stop", async () => {
+  it("fails visibly when stalled microphone appends reach the ownership cap", async () => {
     const onStatus = vi.fn();
     const client = createClient();
     let activeAppends = 0;
@@ -673,7 +673,6 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     const appendCalls = requestCallsFor(client, "talk.session.appendAudio");
     expect(appendCalls).toHaveLength(4);
     expect(peakActiveAppends).toBe(4);
-    expect(activeAppends).toBe(4);
     expect(new Set(appendSignals).size).toBe(1);
     expect(
       appendCalls.every(
@@ -681,14 +680,15 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       ),
     ).toBe(true);
 
-    transport.stop();
-    transport.stop();
     await Promise.resolve();
 
     expect(activeAppends).toBe(0);
     expect(appendSignals.every((signal) => signal.aborted)).toBe(true);
     expect(requestCallsFor(client, "talk.session.close")).toHaveLength(1);
-    expect(onStatus).not.toHaveBeenCalled();
+    expect(onStatus).toHaveBeenCalledWith("error", "Realtime Talk audio input fell behind");
+
+    transport.stop();
+    expect(requestCallsFor(client, "talk.session.close")).toHaveLength(1);
   });
 
   it("preserves accepted microphone frame order", async () => {

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -214,13 +214,13 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
         this.cancelOutputForBargeIn();
       }
       const abortController = this.audioAppendAbortController;
-      // Live microphone frames become stale once the Gateway falls behind, so drop new
-      // frames at the ownership cap instead of growing a latency queue.
-      if (
-        !abortController ||
-        abortController.signal.aborted ||
-        this.pendingAudioAppends.size >= MAX_PENDING_AUDIO_APPENDS
-      ) {
+      // Live microphone frames become stale once the Gateway falls behind, so fail at
+      // the ownership cap instead of silently dropping speech or growing a latency queue.
+      if (!abortController || abortController.signal.aborted) {
+        return;
+      }
+      if (this.pendingAudioAppends.size >= MAX_PENDING_AUDIO_APPENDS) {
+        this.failAudioAppend("Realtime Talk audio input fell behind");
         return;
       }
       const pcm = floatToPcm16(samples);
@@ -237,15 +237,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
             timeoutMs: AUDIO_APPEND_TIMEOUT_MS,
           },
         )
-        .catch((error: unknown) => {
-          if (!this.closed && !abortController.signal.aborted) {
-            this.ctx.callbacks.onStatus?.(
-              "error",
-              error instanceof Error ? error.message : String(error),
-            );
-            this.stop();
-          }
-        });
+        .catch((error: unknown) => this.failAudioAppend(error));
       this.pendingAudioAppends.add(request);
       void request.finally(() => {
         this.pendingAudioAppends.delete(request);
@@ -257,6 +249,14 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     this.audioAppendAbortController?.abort();
     this.audioAppendAbortController = null;
     this.pendingAudioAppends.clear();
+  }
+
+  private failAudioAppend(error: unknown): void {
+    if (this.closed) {
+      return;
+    }
+    this.ctx.callbacks.onStatus?.("error", error instanceof Error ? error.message : String(error));
+    this.stop();
   }
 
   private currentStartupError(): Error | null {


### PR DESCRIPTION
Closes #123781

AI-assisted: yes. The change and evidence were reviewed by the maintainer-requested Claude land decision and a fresh Codex autoreview.

## What Problem This Solves

Fixes an issue where browser Talk users could lose speech without any indication when four Gateway-relay microphone append requests were already pending. Talk continued listening even though later captured frames never reached the Gateway.

## Why This Change Was Made

The Gateway-relay browser transport now routes append-capacity overflow through the existing append-failure owner. It shows `Realtime Talk audio input fell behind`, closes the relay once, and aborts its pending appends while preserving the four-request bound, normal append failure and ordering, output behavior, and all public contracts.

The change is limited to the Control UI browser owner. It does not alter configuration, protocol, provider, authentication, native-client behavior, or the changelog.

Production LOC: +16/-16 (net 0) | Tests: +81/-5 (net +76)

## User Impact

Browser Talk no longer silently continues after its microphone uplink falls behind. Users see an actionable error with the existing dismiss and stop controls instead of unknowingly speaking into an incomplete provider input stream.

## Evidence

Before the repair, the focused regression failed with four append requests still active and no status callback. On the rebased PR head:

- `node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-gateway-relay.test.ts` — 40/40 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/browser-talk-start-stop.e2e.test.ts` — 9/9 passed in Chromium.
- `node scripts/check-changed.mjs -- <three changed files>` — passed; the unavailable remote `ci-fast` backend fell back to the supported worktree-scoped local gate.
- `oxfmt --check <three changed files>` and `git diff --check origin/main...HEAD` — passed.
- Source-blind behavior validation — all four contract clauses passed: four-request cap, visible alert, one close with pending-append abort, and available dismiss/stop controls.
- Fresh Codex autoreview on `origin/main...HEAD` — clean, no accepted/actionable findings.
- Rebased patch identity matches approved commit `09ecf115a255a09ada9af30f1a2fb79653be095c` exactly.
- [Exact-head CI run 31826484607](https://github.com/openclaw/openclaw/actions/runs/31826484607) — green on `08bb508ec8dc2cb71afbb254a418ca483da89fc6`.
- [ClawSweeper review run 31826505472](https://github.com/openclaw/clawsweeper/actions/runs/31826505472) — patch correct, security cleared, no findings or rank-up moves.

Sanitized Chromium proof—no private session, account, credential, recording, URL, path, token, or cookie data:

![Realtime Talk input backpressure error](https://github.com/user-attachments/assets/69cd71d8-30d4-4268-a8fa-c10efa8cc12c)
