### PR TITLE
fix(plugin-sdk): expose current inbound message context

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -265,6 +265,8 @@ type OpenClawCodingToolsOptions = {
   currentThreadTs?: string;
   /** Current inbound message id for action fallbacks (e.g. Telegram react). */
   currentMessageId?: string | number;
+  /** Trusted text of the current inbound message for plugin tool factories. */
+  currentMessageText?: string;
   /** True when the current inbound turn carried audio media. */
   currentInboundAudio?: boolean;
   /** Dynamic audio state for runs that can accept steered input after tool creation. */
@@ -701,6 +703,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             currentMessagingTarget: options?.currentMessagingTarget,
             currentThreadTs: options?.currentThreadTs,
             currentMessageId: options?.currentMessageId,
+            currentMessageText: options?.currentMessageText,
             modelProvider: options?.modelProvider,
             modelId: options?.modelId,
             modelHasVision: options?.modelHasVision,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -285,6 +285,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
           currentMessagingTarget: attempt.currentMessagingTarget,
           currentThreadTs: attempt.currentThreadTs,
           currentMessageId: attempt.currentMessageId,
+          currentMessageText: attempt.prompt,
           currentInboundAudio: attempt.currentInboundAudio,
           ...(attempt.replyOperation
             ? {

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -20,6 +20,19 @@ describe("openclaw plugin tool context", () => {
     expect(result.context.requesterSenderId).toBe("trusted-sender");
   });
 
+  it("forwards trusted current inbound message identity and text", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        currentMessageId: "provider-message-123",
+        currentMessageText: "Please create an order",
+      },
+    });
+
+    expect(result.context.currentMessageId).toBe("provider-message-123");
+    expect(result.context.currentMessageText).toBe("Please create an order");
+  });
+
   it("forwards the trusted owner bit", () => {
     const result = resolveOpenClawPluginToolInputs({
       options: {

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -34,6 +34,8 @@ export type OpenClawPluginToolOptions = {
   modelProvider?: string;
   modelId?: string;
   requesterSenderId?: string | null;
+  currentMessageId?: string | number;
+  currentMessageText?: string;
   senderIsOwner?: boolean;
   conversationReadOrigin?: ConversationReadInvocationOrigin;
   requesterAgentIdOverride?: string;
@@ -113,6 +115,8 @@ export function resolveOpenClawPluginToolInputs(params: {
       deliveryContext,
       nativeChannelId: options?.nativeChannelId,
       requesterSenderId: options?.requesterSenderId ?? undefined,
+      currentMessageId: options?.currentMessageId,
+      currentMessageText: options?.currentMessageText,
       senderIsOwner: options?.senderIsOwner,
       conversationReadOrigin: normalizeConversationReadInvocationOrigin(
         options?.conversationReadOrigin,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -148,6 +148,8 @@ export function createOpenClawTools(
     currentThreadTs?: string;
     /** Current inbound message id for action fallbacks. */
     currentMessageId?: string | number;
+    /** Trusted text of the current inbound message for plugin tool factories. */
+    currentMessageText?: string;
     /** True when the current inbound turn carried audio media. */
     currentInboundAudio?: boolean;
     /** Dynamic audio state for runs that can accept steered input after tool creation. */

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -56,6 +56,10 @@ export type OpenClawPluginToolContext = {
   nativeChannelId?: string;
   /** Trusted sender id from inbound context (runtime-provided, not tool args). */
   requesterSenderId?: string;
+  /** Trusted provider-native id of the current inbound message. */
+  currentMessageId?: string | number;
+  /** Trusted text of the current inbound message. */
+  currentMessageText?: string;
   /** Trusted owner bit from inbound context (runtime-provided, not tool args). */
   senderIsOwner?: boolean;
   /**


### PR DESCRIPTION
## Summary

Expose the trusted current inbound message context to plugin tool factories:

- add `currentMessageId` and `currentMessageText` to `OpenClawPluginToolContext`
- forward both fields through plugin tool context construction
- pass the current inbound prompt as `currentMessageText` during tool preparation
- cover both fields in the plugin-context regression test

## Motivation

A per-turn plugin tool that must preserve provider message identity and bind replies to the current inbound conversation cannot safely reconstruct the current message text from tool arguments. `currentMessageId` already exists in the embedded run path; this patch makes the trusted pair available to plugin tool factories without requiring a timing-sensitive message-hook cache.

## Validation

- `node scripts/run-vitest.mjs src/agents/openclaw-tools.plugin-context.test.ts` — 25/25 pass on latest main
- build compilation phases completed; final runtime-postbuild was correctly blocked by the local Node 24.12.0 SQLite safety gate (upstream requires Node 24.15.0+)
- the equivalent six-file patch built successfully against OpenClaw 2026.6.34 and was validated in an isolated Shadow runtime

The Shadow validation used disabled outbound transports and did not modify the production Gateway.