### PR TITLE
fix(cron): show skipped automation tasks as failed

### DIFF
--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1450,9 +1450,7 @@ describe("cron service ops seam coverage", () => {
           expect(restored?.state.lastRunAtMs).toBe(startedAt);
           expect(restored?.state.lastRunStatus).toBe(status);
           expect(runIsolatedAgentJob).not.toHaveBeenCalled();
-          expect(findTaskByRunId(taskRunId)?.status).toBe(
-            status === "error" ? "failed" : "succeeded",
-          );
+          expect(findTaskByRunId(taskRunId)?.status).toBe(status === "ok" ? "succeeded" : "failed");
         } finally {
           stop(state);
         }

--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -164,7 +164,7 @@ describe("cron task run terminal records", () => {
         tryFinishCronTaskRunWithoutHistory(state, {
           taskRunId: runIds[0],
           status: "skipped",
-          error: "cron run skipped before execution",
+          error: "cron: job execution timed out",
           endedAt: 1_501,
         });
         expect(childSessionKey(systemEventJob)).toBeUndefined();
@@ -176,7 +176,7 @@ describe("cron task run terminal records", () => {
         ).toEqual([
           expect.objectContaining({
             status: "failed",
-            error: "cron run skipped before execution",
+            error: "cron: job execution timed out",
           }),
         ]);
       },
@@ -441,7 +441,7 @@ describe("cron task run terminal records", () => {
             action: "finished",
             job,
             status: "skipped",
-            error: "trigger condition not met",
+            error: "cron: job execution timed out",
             runId: "manual:skipped-job:1",
             runAtMs: startedAt,
             durationMs: 0,
@@ -461,7 +461,7 @@ describe("cron task run terminal records", () => {
           status: "failed",
           startedAt,
           endedAt: startedAt,
-          error: "trigger condition not met",
+          error: "cron: job execution timed out",
           detail: {
             kind: "cron-run",
             status: "skipped",

--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -164,9 +164,21 @@ describe("cron task run terminal records", () => {
         tryFinishCronTaskRunWithoutHistory(state, {
           taskRunId: runIds[0],
           status: "skipped",
+          error: "cron run skipped before execution",
           endedAt: 1_501,
         });
         expect(childSessionKey(systemEventJob)).toBeUndefined();
+        expect(
+          listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+            runtime: "cron",
+            sourceId: systemEventJob.id,
+          }),
+        ).toEqual([
+          expect.objectContaining({
+            status: "failed",
+            error: "cron run skipped before execution",
+          }),
+        ]);
       },
     );
   });
@@ -446,7 +458,7 @@ describe("cron task run terminal records", () => {
           runtime: "cron",
           sourceId: job.id,
           agentId: "finn",
-          status: "succeeded",
+          status: "failed",
           startedAt,
           endedAt: startedAt,
           error: "trigger condition not met",

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -5,7 +5,6 @@ import type { DatabaseSync } from "node:sqlite";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
-import { isCronTimeoutErrorText } from "../execution-error-constants.js";
 
 function requireCronAgentId(agentId: string | undefined): string {
   if (!agentId?.trim()) {
@@ -321,7 +320,10 @@ export function tryFinishCronTaskRunWithoutHistory(
   if (!result.taskRunId) {
     return;
   }
-  const error = result.status === "error" ? normalizeCronRunErrorText(result.error) : undefined;
+  const error =
+    result.status !== "ok" && result.error !== undefined
+      ? normalizeCronRunErrorText(result.error)
+      : undefined;
   const quietTriggerEval =
     result.triggerEval?.fired === false
       ? { ...result.triggerEval, fired: false as const }
@@ -330,12 +332,7 @@ export function tryFinishCronTaskRunWithoutHistory(
     finalizeTaskRunByRunIdCore({
       runId: result.taskRunId,
       runtime: "cron",
-      status:
-        result.status === "ok" || result.status === "skipped"
-          ? "succeeded"
-          : isCronTimeoutErrorText(error)
-            ? "timed_out"
-            : "failed",
+      status: cronRunStatusToTaskStatus({ status: result.status, error }),
       endedAt: result.endedAt,
       lastEventAt: result.endedAt,
       error,

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2822,7 +2822,7 @@ describe("cron service timer regressions", () => {
       outcome: "skip",
       status: "skipped",
       error: "agent skipped after removal",
-      taskStatus: "succeeded",
+      taskStatus: "failed",
     },
   ] as const)(
     "finalizes a removed job's $outcome outcome in operator history",

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -267,7 +267,7 @@ export function cronRunStatusToTaskStatus(
   if (entry.status === "ok") {
     return "succeeded";
   }
-  return isCronTimeoutErrorText(entry.error) ? "timed_out" : "failed";
+  return entry.status === "error" && isCronTimeoutErrorText(entry.error) ? "timed_out" : "failed";
 }
 
 /** Reconstructs the unchanged CronRunLogEntry wire shape from a cron task row. */

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -262,9 +262,9 @@ export function cronTaskRecordToScriptRunResult(
 
 /** Maps the cron outcome vocabulary onto generic task terminal states. */
 export function cronRunStatusToTaskStatus(
-  entry: CronRunLogEntry,
+  entry: Pick<CronRunLogEntry, "status" | "error"> & Partial<CronRunLogEntry>,
 ): Extract<TaskStatus, "succeeded" | "failed" | "timed_out"> {
-  if (entry.status === "ok" || entry.status === "skipped") {
+  if (entry.status === "ok") {
     return "succeeded";
   }
   return isCronTimeoutErrorText(entry.error) ? "timed_out" : "failed";

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1632,6 +1632,67 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("reports skipped isolated cron runs as failed tasks", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-run-skipped-task-",
+      cronEnabled: false,
+    });
+    cronIsolatedRun.mockResolvedValueOnce({
+      status: "skipped",
+      error: "model endpoint unavailable",
+    });
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const addRes = await rpcReq(ws, "cron.add", {
+        name: "skipped task projection",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "do work" },
+        delivery: { mode: "none" },
+      });
+      const jobId = expectCronJobIdFromResponse(addRes);
+      const finished = waitForCronEvent(
+        ws,
+        (payload) => payload?.jobId === jobId && payload?.action === "finished",
+      );
+
+      await runCronJobForce(ws, jobId);
+      expect(await finished).toMatchObject({
+        jobId,
+        status: "skipped",
+        error: "model endpoint unavailable",
+      });
+
+      const history = await rpcReq(ws, "cron.runs", { id: jobId, limit: 1 });
+      expect(history.ok).toBe(true);
+      expect(history.payload).toMatchObject({
+        entries: [
+          expect.objectContaining({
+            jobId,
+            status: "skipped",
+            error: "model endpoint unavailable",
+          }),
+        ],
+      });
+
+      const taskList = await rpcReq(ws, "tasks.list", {});
+      expect(taskList.ok).toBe(true);
+      const tasks = (taskList.payload as { tasks?: Array<Record<string, unknown>> } | undefined)
+        ?.tasks;
+      expect(tasks?.find((task) => task.sourceId === jobId)).toMatchObject({
+        runtime: "cron",
+        status: "failed",
+        error: "model endpoint unavailable",
+      });
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  });
+
   test("returns already-running without starting background work", async () => {
     const now = Date.now();
     let resolveRun: ((result: { status: "ok"; summary: string }) => void) | undefined;


### PR DESCRIPTION
Closes #123784

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled. This PR is AI-assisted; the maintainer has reviewed and understands the change.

</details>

## What Problem This Solves

Fixes an issue where operators inspecting a skipped automation run in Tasks or the Control UI would see it reported as a successful green Completed task, even though `cron.runs` correctly recorded that the action was skipped with a reason.

## Why This Change Was Made

The cron-owned task projector now maps only cron `ok` to generic task success. Cron `skipped` maps to the existing failed task state with its authoritative reason, while cron history preserves `skipped`; the no-history finalizer reuses the same projector instead of maintaining duplicate policy. Timeout classification remains limited to real cron `error` outcomes, and cancellation and quiet-trigger semantics are unchanged. There are no protocol, schema, config, or storage changes.

## User Impact

Skipped automations no longer look successfully completed in task lists, status summaries, or the Control UI. Operators see an unsuccessful task with the actual skip reason and can still inspect the cron-specific `skipped` outcome in automation history.

Production LOC: +8/-11 (net -3) | Tests: +78/-7

## Evidence

- Regression-first owner proof on the pre-fix implementation failed exactly two assertions: the task rows were `succeeded` while their cron detail/history was `skipped`.
- Review follow-up red proof confirmed two more owner assertions failed because a `skipped` outcome carrying watchdog-timeout-shaped text projected as `timed_out`; after the one-line status-precedence repair, the same 24-test owner file passed.
- Exact-head owner/history proof: `node scripts/run-vitest.mjs src/cron/task-run-history.test.ts src/cron/service/task-runs.test.ts` — 41/41 passed.
- Exact-head sibling proof: owner/history plus `src/cron/service/ops.test.ts` and `src/cron/service/timer.regression.test.ts` — 176/176 passed, including true watchdog timeouts, one-shot recovery, and removed-job skip outcomes.
- Isolated Gateway RPC proof: `node scripts/run-vitest.mjs src/gateway/server.cron.test.ts -t 'reports skipped isolated cron runs as failed tasks'` — the same run reports `cron.runs: skipped` and `tasks.list: failed` with `model endpoint unavailable`. The complete Gateway cron suite also passed 25/25.
- Real-runtime proof: an isolated process used the actual Gateway cron service and actual isolated-agent model preflight against a closed localhost Ollama port. No runner mock, model request, external channel send, or operator state was involved. The run completed with the same authoritative preflight reason on both surfaces:

```json
{
  "source": "real Gateway cron service + real isolated-agent preflight",
  "runResult": { "ok": true, "ran": true },
  "cronRuns": {
    "status": "skipped",
    "error": "local provider preflight failed ... ECONNREFUSED"
  },
  "tasksList": {
    "runtime": "cron",
    "status": "failed",
    "error": "local provider preflight failed ... ECONNREFUSED"
  }
}
```

- Control UI browser proof (mocked Gateway with the real public task shape), captured in one session:

Before — the skipped automation is incorrectly green **Completed**:

![Before: skipped automation shown as Completed](https://github.com/user-attachments/assets/b9485bec-8eca-40bb-99cc-2cb5ce9f6b56)

After — the same automation is red **Failed** with its preflight reason:

![After: skipped automation shown as Failed with reason](https://github.com/user-attachments/assets/67ba4ab1-ee7f-4390-a167-25c4d316fb92)

- Rebased onto fresh `origin/main` `3289e08c3005515fb8e49379fd18951ef2530507`; targeted formatting and `git diff --check` passed across the exact six-file patch.
- Fresh Codex autoreview on exact head `272a6ef1ce79c230f1aab9f95ac34b8b414327d3`: clean, no accepted/actionable findings, confidence 0.99.
- Local `check:changed` reaches the repository environment-variable ratchet and stops on an inherited current-main baseline (`OPENCLAW_* count 504 exceeds budget 502`). This PR changes no environment/config surface. Exact-head hosted CI remains the landing authority.
