### PR TITLE
fix(ui): offer permanent lobster dismissal

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -85,6 +85,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   private projectedSessionRows: SidebarRecentSession[] | undefined;
   private readonly narrationSubscriptions = this.createNarrationSubscriptions();
   private readonly nativeGatewaysChanged = () => this.requestUpdate();
+  private readonly refreshAppearanceSettings = () => this.context?.theme.refresh();
   private readonly hiddenSessionCatalogsChanged = () => {
     this.hiddenSessionCatalogIds = loadStoredHiddenSessionCatalogIds();
   };
@@ -522,6 +523,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
               .visitsEnabled=${this.lobsterPetVisits}
               .soundsEnabled=${this.lobsterPetSounds}
               .gatewayVersion=${this.gatewayVersion}
+              .onVisitsDisabled=${this.refreshAppearanceSettings}
             ></openclaw-lobster-pet>
             ${this.devGitBranch
               ? html`<openclaw-tooltip .content=${this.devGitBranch}>

--- a/ui/src/components/lobster-pet-dismiss-menu.ts
+++ b/ui/src/components/lobster-pet-dismiss-menu.ts
@@ -1,0 +1,52 @@
+import { html, nothing } from "lit";
+import { t } from "../i18n/index.ts";
+import "./menu-surface.ts";
+import "./web-awesome.ts";
+
+export type LobsterPetDismissMenuPosition = { x: number; y: number };
+
+export function renderLobsterPetDismissMenu(params: {
+  position: LobsterPetDismissMenuPosition | null;
+  onDismiss: (permanently: boolean) => void;
+  onClose: () => void;
+}) {
+  const position = params.position;
+  if (!position) {
+    return nothing;
+  }
+  return html`
+    <openclaw-menu-surface>
+      <wa-dropdown
+        class="session-menu lobster-pet-dismiss-menu"
+        .open=${true}
+        placement="bottom-start"
+        .distance=${0}
+        aria-label=${t("quickSettings.appearance.lobsterVisits")}
+        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+          event.preventDefault();
+          if (event.detail.item.value === "dismiss") {
+            params.onDismiss(false);
+          } else if (event.detail.item.value === "dismiss-permanently") {
+            params.onDismiss(true);
+          }
+        }}
+        @wa-after-hide=${params.onClose}
+      >
+        <button
+          slot="trigger"
+          type="button"
+          tabindex="-1"
+          aria-hidden="true"
+          aria-label=${t("quickSettings.appearance.lobsterVisits")}
+          style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+        ></button>
+        <wa-dropdown-item class="session-menu__item" value="dismiss"
+          >${t("common.dismiss")}</wa-dropdown-item
+        >
+        <wa-dropdown-item class="session-menu__item" value="dismiss-permanently"
+          >${t("common.dismissAndDontShowAgain")}</wa-dropdown-item
+        >
+      </wa-dropdown>
+    </openclaw-menu-surface>
+  `;
+}

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -529,10 +529,10 @@ export function renderLobsterPetScene(args: {
   // Extra "· <flavor>" tooltip suffix (elder lore, old-friend returns).
   flavor: string | null;
   bottle: { spotPct: number; opened: boolean; fortune: string } | null;
-  onPointerDown: () => void;
-  onPointerUp: () => void;
+  onPointerDown: (event: PointerEvent) => void;
+  onPointerUp: (event: PointerEvent) => void;
   onPointerCancel: () => void;
-  onContextMenu: (event: Event) => void;
+  onContextMenu: (event: MouseEvent) => void;
   onBottleOpen: () => void;
 }) {
   const anchoredScale = (scale: number) =>

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -42,8 +42,8 @@ function createPet(seed: number, mode: LobsterPetMode = "idle"): LobsterPetEleme
 
 function poke(element: LobsterPetElement): void {
   const sprite = element.querySelector(".lobster-pet");
-  sprite?.dispatchEvent(new Event("pointerdown"));
-  sprite?.dispatchEvent(new Event("pointerup"));
+  sprite?.dispatchEvent(new MouseEvent("pointerdown", { button: 0 }));
+  sprite?.dispatchEvent(new MouseEvent("pointerup", { button: 0 }));
 }
 
 function spriteClasses(element: LobsterPetElement): string {
@@ -311,15 +311,28 @@ describe("lobster pet element", () => {
     expect(getLobsterdexEntries().get(look.palette.id)?.name).toBeTruthy();
   });
 
-  it("right-click shoos it away for the rest of the load", async () => {
+  it("offers a temporary dismissal from the right-click menu", async () => {
     vi.useFakeTimers();
     const element = createPet(42);
     await arrive(element);
 
-    const shoo = new Event("contextmenu", { cancelable: true });
-    element.querySelector(".lobster-pet")?.dispatchEvent(shoo);
+    const sprite = element.querySelector(".lobster-pet");
+    sprite?.dispatchEvent(new MouseEvent("pointerdown", { button: 2 }));
+    const shoo = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    sprite?.dispatchEvent(shoo);
+    sprite?.dispatchEvent(new MouseEvent("pointerup", { button: 2 }));
     await element.updateComplete;
     expect(shoo.defaultPrevented).toBe(true);
+    expect(spritePresent(element)).toBe(true);
+    expect(spriteClasses(element)).not.toContain("lobster-pet--act-startle");
+    expect(
+      [...element.querySelectorAll(".lobster-pet-dismiss-menu wa-dropdown-item")].map((item) =>
+        item.textContent?.trim(),
+      ),
+    ).toEqual(["Dismiss", "Dismiss and don't show again"]);
+
+    element.querySelector<HTMLElement>('wa-dropdown-item[value="dismiss"]')?.click();
+    await element.updateComplete;
 
     const gone = await advanceUntil(element, () => !spritePresent(element), 5_000);
     expect(gone).toBe(true);
@@ -330,6 +343,31 @@ describe("lobster pet element", () => {
     element.mode = "offline";
     await element.updateComplete;
     expect(spritePresent(element)).toBe(false);
+  });
+
+  it("persists permanent dismissal in browser storage", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("localStorage", window.localStorage);
+    const element = createPet(42);
+    await arrive(element);
+
+    element
+      .querySelector(".lobster-pet")
+      ?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await element.updateComplete;
+    element.querySelector<HTMLElement>('wa-dropdown-item[value="dismiss-permanently"]')?.click();
+    await element.updateComplete;
+
+    const persistedSettings = Array.from({ length: localStorage.length }, (_, index) => {
+      const raw = localStorage.getItem(localStorage.key(index) ?? "");
+      try {
+        return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+      } catch {
+        return {};
+      }
+    });
+    expect(persistedSettings).toContainEqual(expect.objectContaining({ lobsterPetVisits: false }));
+    expect(await advanceUntil(element, () => !spritePresent(element), 5_000)).toBe(true);
   });
 
   it("never shows when visits are disabled, offline included", async () => {
@@ -413,6 +451,8 @@ describe("lobster pet element", () => {
     element
       .querySelector(".lobster-pet:not(.lobster-pet--shell)")
       ?.dispatchEvent(new Event("contextmenu", { cancelable: true }));
+    await element.updateComplete;
+    element.querySelector<HTMLElement>('wa-dropdown-item[value="dismiss"]')?.click();
     await element.updateComplete;
     const raw = JSON.parse(
       localStorage.getItem("openclaw.control.lobsterpet.familiarity.v1") ?? "{}",

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -9,9 +9,14 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { isLobsterDay } from "../../../src/shared/lobster-day.js";
+import { patchSettings } from "../app/settings.ts";
 import * as dex from "./lobster-dex.ts";
 import { playLobsterPetChirp, type LobsterPetChirpKind } from "./lobster-pet-audio.ts";
 import * as contract from "./lobster-pet-contract.ts";
+import {
+  renderLobsterPetDismissMenu,
+  type LobsterPetDismissMenuPosition,
+} from "./lobster-pet-dismiss-menu.ts";
 import * as lobsterLook from "./lobster-pet-look.ts";
 import * as plans from "./lobster-pet-plans.ts";
 import { LobsterLedgeTraffic } from "./lobster-pet-traffic.ts";
@@ -46,6 +51,7 @@ class LobsterPet extends LitElement {
   @property({ attribute: false }) runOutcome: contract.LobsterRunOutcome = "ok";
   @property({ attribute: false }) soundsEnabled = false;
   @property({ attribute: false }) gatewayVersion: string | null = null;
+  @property({ attribute: false }) onVisitsDisabled: () => void = () => undefined;
 
   @state() private act: plans.LobsterPetAct | null = null;
   @state() private spotPct = 80;
@@ -56,6 +62,7 @@ class LobsterPet extends LitElement {
   @state() private anchor: plans.LobsterPetAnchor = "ledge";
   @state() private scheduledVisiting = false;
   @state() private dismissed = false;
+  @state() private dismissMenuPosition: LobsterPetDismissMenuPosition | null = null;
   @state() private grumpy = false;
   @state() private vigil = false;
   @state() private outcomePresenceOwner: "vigil" | null = null;
@@ -167,6 +174,7 @@ class LobsterPet extends LitElement {
       this.clearActTimers();
       this.act = null;
       this.dismissed = false;
+      this.dismissMenuPosition = null;
       this.presence = "out";
       this.molted = false;
       this.shellVisible = false;
@@ -201,6 +209,13 @@ class LobsterPet extends LitElement {
         // celebrate or mourn - just acknowledge the change.
         const finishAct = plans.resolveLobsterFinishAct(this.runOutcome);
         this.performAct(finished ? finishAct : "startle", presenceOwner);
+      }
+    }
+    if (changed.has("visitsEnabled")) {
+      if (!this.visitsEnabled) {
+        this.dismissMenuPosition = null;
+      } else if (changed.get("visitsEnabled") === false) {
+        this.dismissed = false;
       }
     }
     // Moving day latches once per load, as soon as the gateway version is
@@ -258,6 +273,7 @@ class LobsterPet extends LitElement {
       return;
     }
     if (!visible && this.presence === "in") {
+      this.dismissMenuPosition = null;
       this.outcomePresenceOwner = null;
       this.clearActTimers();
       this.act = null;
@@ -307,8 +323,8 @@ class LobsterPet extends LitElement {
   // quick tap is a poke. Pokes are fun until they are not: 3 fast pokes turn
   // it grumpy for a minute, 10 send it off in a huff until a later visit.
   // Offline pets are on duty and never huff.
-  private readonly handleHoldStart = () => {
-    if (plans.prefersReducedMotion()) {
+  private readonly handleHoldStart = (event: PointerEvent) => {
+    if (event.button !== 0 || plans.prefersReducedMotion()) {
       return;
     }
     this.holdPetted = false;
@@ -324,7 +340,10 @@ class LobsterPet extends LitElement {
     }, 600);
   };
 
-  private readonly handleHoldEnd = () => {
+  private readonly handleHoldEnd = (event: PointerEvent) => {
+    if (event.button !== 0) {
+      return;
+    }
     if (this.holdTimer !== null) {
       window.clearTimeout(this.holdTimer);
       this.holdTimer = null;
@@ -375,7 +394,7 @@ class LobsterPet extends LitElement {
   private huffOff() {
     this.pokeTimes = [];
     this.grumpy = false;
-    // Ends the current visit only; unlike a right-click dismissal the pet
+    // Ends the current visit only; unlike a menu dismissal the pet
     // still returns on a later scheduled visit.
     this.clearVisitTimers();
     this.scheduledVisiting = false;
@@ -426,12 +445,23 @@ class LobsterPet extends LitElement {
     }
   };
 
-  // Right-click shoos the pet away for the rest of this page load.
-  private readonly handleShoo = (event: Event) => {
+  private readonly openDismissMenu = (event: MouseEvent) => {
     event.preventDefault();
+    event.stopPropagation();
+    this.handleHoldCancel();
+    this.dismissMenuPosition = { x: event.clientX, y: event.clientY };
+  };
+
+  private dismiss(permanently: boolean) {
+    this.dismissMenuPosition = null;
     this.dismissed = true;
     dex.recordLobsterShoo();
-  };
+    if (permanently) {
+      this.visitsEnabled = false;
+      patchSettings({ lobsterPetVisits: false });
+      this.onVisitsDisabled();
+    }
+  }
 
   private clearActTimers() {
     for (const timer of [this.idleTimer, this.actEndTimer, this.enterTimer]) {
@@ -672,7 +702,7 @@ class LobsterPet extends LitElement {
       : identity?.oldFriend
         ? "an old friend"
         : null;
-    return lobsterLook.renderLobsterPetScene({
+    const scene = lobsterLook.renderLobsterPetScene({
       look,
       mode: this.mode,
       presence: this.presence,
@@ -711,9 +741,19 @@ class LobsterPet extends LitElement {
       onPointerDown: this.handleHoldStart,
       onPointerUp: this.handleHoldEnd,
       onPointerCancel: this.handleHoldCancel,
-      onContextMenu: this.handleShoo,
+      onContextMenu: this.openDismissMenu,
       onBottleOpen: this.traffic.openBottle,
     });
+    return [
+      scene,
+      renderLobsterPetDismissMenu({
+        position: this.dismissMenuPosition,
+        onDismiss: (permanently) => this.dismiss(permanently),
+        onClose: () => {
+          this.dismissMenuPosition = null;
+        },
+      }),
+    ];
   }
 }
 if (!customElements.get("openclaw-lobster-pet")) {

--- a/ui/src/e2e/lobster-pet.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet.e2e.test.ts
@@ -103,4 +103,37 @@ suite.define(() => {
 
     await expect.poll(() => page.locator(".lobster-pet--act-pet").count()).toBe(0);
   });
+
+  it("shows a clickable dismissal menu above the clipped footer ledge", async () => {
+    await mountPet({ mode: "offline", outcome: "ok", seed: 42 });
+    await page.evaluate(() => {
+      const pet = document.querySelector<HTMLElement>("openclaw-lobster-pet");
+      if (pet) {
+        Object.assign(pet.style, { bottom: "0", height: "64px", position: "fixed" });
+      }
+    });
+    const sprite = page.locator(".lobster-pet");
+    await sprite.click({ button: "right" });
+
+    const menu = page.locator("wa-dropdown.lobster-pet-dismiss-menu");
+    await menu.waitFor();
+    expect(await sprite.count()).toBe(1);
+    expect(await page.getByText("Dismiss and don't show again", { exact: true }).count()).toBe(1);
+    const bounds = await menu.evaluate((dropdown) => {
+      const rect = dropdown.shadowRoot?.querySelector('[part="menu"]')?.getBoundingClientRect();
+      return rect
+        ? { bottom: rect.bottom, height: rect.height, left: rect.left, top: rect.top }
+        : null;
+    });
+    expect(bounds).not.toBeNull();
+    expect(bounds?.height).toBeGreaterThan(0);
+    expect(bounds?.left).toBeGreaterThanOrEqual(0);
+    expect(bounds?.top).toBeGreaterThanOrEqual(0);
+    expect(bounds?.bottom).toBeLessThanOrEqual(page.viewportSize()?.height ?? 0);
+
+    await page.getByText("Dismiss", { exact: true }).click();
+    await page.clock.runFor(350);
+    await settlePet();
+    await expect.poll(() => sprite.count()).toBe(0);
+  });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -43,6 +43,7 @@ export const en: TranslationMap = {
     delete: "Delete",
     remove: "Remove",
     dismiss: "Dismiss",
+    dismissAndDontShowAgain: "Dismiss and don't show again",
     unselect: "Unselect",
     enabled: "Enabled",
     disabled: "Disabled",

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -52,6 +52,11 @@ openclaw-lobster-pet {
   --lob-glint: var(--lob-glint-seed, #00e5cc);
 }
 
+/* Restore hit testing beneath the pointer-inert decorative pet host. */
+wa-dropdown.lobster-pet-dismiss-menu {
+  pointer-events: auto;
+}
+
 /* The Elder does everything at Elder speed. */
 .lobster-pet--elder {
   transition: left 2.6s ease-in-out;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where right-clicking the sidebar lobster dismissed it immediately, leaving users no way to choose between hiding the current visit and disabling future lobster visits.

## Why This Change Was Made

Right-click now opens the existing top-layer menu surface with **Dismiss** and **Dismiss and don't show again**. The permanent choice reuses the existing browser-local `lobsterPetVisits: false` appearance preference, so it survives reloads and remains reversible from Appearance settings.

## User Impact

Users can dismiss only the current lobster visit or permanently hide future visits from the context menu. Opening the menu no longer pokes, startles, or dismisses the lobster.

## Evidence

| Before right-click | Context menu |
| --- | --- |
| ![Sidebar lobster before right-click](https://gist.githubusercontent.com/clawsweeper/4f64e63576ae8accc3812e9f82708581/raw/98506d1bb61e2dafbbc9c965e3ea40c7695387c7/01-lobster.png) | ![Lobster dismissal menu with both actions](https://gist.githubusercontent.com/clawsweeper/4f64e63576ae8accc3812e9f82708581/raw/3c244b87fa3eaa0c8cbe038fb3632aedaee94706/02-dismiss-menu.png) |

- [Interaction recording](https://gist.githubusercontent.com/clawsweeper/4f64e63576ae8accc3812e9f82708581/raw/acbff3a736bd242da8cb3a62742f4cdef9d0e0bd/lobster-dismissal.webm) and [dismissed-state screenshot](https://gist.githubusercontent.com/clawsweeper/4f64e63576ae8accc3812e9f82708581/raw/03093cdcb18be827cd4124197218bfbf7a585b83/03-dismissed.png). [Artifact bundle](https://gist.github.com/clawsweeper/4f64e63576ae8accc3812e9f82708581).
- `node scripts/run-vitest.mjs ui/src/components/lobster-pet.test.ts` — 52 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/lobster-pet.e2e.test.ts` — 3 tests passed in Chromium.
- `pnpm ui:i18n:verify` — passed.
- `pnpm lint:ui:styles` — passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed -- <changed files>` — complete changed-scope gate passed.
- `pnpm build` — passed, including Control UI and startup-size gates.
- Fresh autoreview completed with no actionable findings.

AI-assisted: yes. I reviewed and understand the implementation and validation.
