### PR TITLE
fix(node-host): prevent false TLS mismatch after turns

### DIFF
--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -10,6 +10,7 @@ import http, {
 import https, { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
 import { connect as connectNet, type Socket } from "node:net";
 import path from "node:path";
+import type { Duplex } from "node:stream";
 import type { TLSSocket } from "node:tls";
 import { installGlobalProxy } from "@openclaw/proxyline";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -391,7 +392,7 @@ describe("node worker transfer client", () => {
       },
     );
     const gatewayUrl = (await listen(target)).replace(/^ws/u, "wss");
-    const proxySockets = new Set<Socket>();
+    const proxySockets = new Set<Duplex>();
     let connectCount = 0;
     const proxy = createHttpServer();
     proxy.on("connect", (req, clientSocket, head) => {

--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -250,6 +250,7 @@ describe("node worker transfer client", () => {
     const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
     const gatewayPort = Number(new URL(gatewayUrl).port);
     let hidPeerCertificate = false;
+    let pinnedAgent: https.Agent | undefined;
     const hidePeerCertificate = (socket: Socket) => {
       if (socket.remotePort !== gatewayPort || hidPeerCertificate) {
         return;
@@ -257,7 +258,15 @@ describe("node worker transfer client", () => {
       hidPeerCertificate = true;
       (socket as TLSSocket).getPeerCertificate = (() => ({})) as TLSSocket["getPeerCertificate"];
     };
-    https.globalAgent.on("free", hidePeerCertificate);
+    const request = https.request.bind(https);
+    const requestSpy = vi.spyOn(https, "request").mockImplementation(((url, options) => {
+      const clientRequest = request(url, options);
+      if (!pinnedAgent && options.agent instanceof https.Agent) {
+        pinnedAgent = options.agent;
+        pinnedAgent.on("free", hidePeerCertificate);
+      }
+      return clientRequest;
+    }) as typeof https.request);
     try {
       await expect(
         runNodeWorkerWorkspaceTransfer({
@@ -294,7 +303,79 @@ describe("node worker transfer client", () => {
       expect(requestCount).toBe(3);
       expect(connectionCount).toBe(1);
     } finally {
-      https.globalAgent.off("free", hidePeerCertificate);
+      pinnedAgent?.off("free", hidePeerCertificate);
+      requestSpy.mockRestore();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("performs a full pinned handshake on a replacement socket", async () => {
+    const root = tempDirs.make("node-worker-transfer-tls-resumed-");
+    const workspaceDir = path.join(root, "workspace");
+    const body = Buffer.from("resumed pinned transfer\n");
+    const sha256 = createHash("sha256").update(body).digest("hex");
+    const rawManifest = serializeWorkerWorkspaceManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [
+        {
+          path: "result.txt",
+          type: "file",
+          mode: 0o644,
+          size: body.byteLength,
+          sha256,
+        },
+      ],
+    });
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    const sessionReuse: boolean[] = [];
+    const server = createHttpsServer(
+      {
+        cert: TEST_TLS_CERT_PEM,
+        key: TEST_TLS_KEY_PEM,
+        maxVersion: "TLSv1.2",
+      },
+      (req, res) => {
+        if (req.url?.endsWith("/manifest")) {
+          res.writeHead(200, {
+            connection: "close",
+            "content-length": String(Buffer.byteLength(rawManifest)),
+          });
+          res.end(rawManifest);
+          return;
+        }
+        if (req.url?.endsWith(`/blobs/${sha256}`)) {
+          res.writeHead(200, {
+            connection: "close",
+            "content-length": String(body.byteLength),
+          });
+          res.end(body);
+          return;
+        }
+        res.writeHead(404, { connection: "close" }).end();
+      },
+    );
+    server.on("secureConnection", (socket) => {
+      sessionReuse.push(socket.isSessionReused());
+    });
+    const gatewayUrl = (await listen(server)).replace(/^ws/u, "wss");
+    const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
+    try {
+      await expect(
+        runNodeWorkerWorkspaceTransfer({
+          gatewayUrl,
+          gatewayTlsFingerprint: fingerprint,
+          environmentId: "environment-tls-resumed",
+          workspaceDir,
+          manifestHome: root,
+          transfer: { direction: "download", token: "test-token", manifestRef },
+        }),
+      ).resolves.toBe(manifestRef);
+      expect(sessionReuse).toEqual([false, false]);
+    } finally {
       server.closeAllConnections();
       await new Promise<void>((resolve) => {
         server.close(() => resolve());

--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -7,14 +7,11 @@ import http, {
   type RequestOptions,
   type Server as HttpServer,
 } from "node:http";
-import https, {
-  createServer as createHttpsServer,
-  type RequestOptions as HttpsRequestOptions,
-  type Server as HttpsServer,
-} from "node:https";
-import type { Socket } from "node:net";
+import https, { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import { connect as connectNet, type Socket } from "node:net";
 import path from "node:path";
 import type { TLSSocket } from "node:tls";
+import { installGlobalProxy } from "@openclaw/proxyline";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
@@ -254,7 +251,7 @@ describe("node worker transfer client", () => {
     const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
     const gatewayPort = Number(new URL(gatewayUrl).port);
     let hidPeerCertificate = false;
-    let pinnedAgent: https.Agent | undefined;
+    const pinnedAgent = https.globalAgent;
     const hidePeerCertificate = (socket: Socket) => {
       if (socket.remotePort !== gatewayPort || hidPeerCertificate) {
         return;
@@ -262,19 +259,7 @@ describe("node worker transfer client", () => {
       hidPeerCertificate = true;
       (socket as TLSSocket).getPeerCertificate = (() => ({})) as TLSSocket["getPeerCertificate"];
     };
-    const request = https.request.bind(https);
-    const requestSpy = vi.spyOn(https, "request").mockImplementation(((
-      url: string | URL,
-      options: HttpsRequestOptions,
-    ) => {
-      const clientRequest = request(url, options);
-      const agent = options.agent;
-      if (!pinnedAgent && agent instanceof https.Agent) {
-        pinnedAgent = agent;
-        agent.on("free", hidePeerCertificate);
-      }
-      return clientRequest;
-    }) as typeof https.request);
+    pinnedAgent.on("free", hidePeerCertificate);
     try {
       await expect(
         runNodeWorkerWorkspaceTransfer({
@@ -311,8 +296,7 @@ describe("node worker transfer client", () => {
       expect(requestCount).toBe(3);
       expect(connectionCount).toBe(1);
     } finally {
-      pinnedAgent?.off("free", hidePeerCertificate);
-      requestSpy.mockRestore();
+      pinnedAgent.off("free", hidePeerCertificate);
       server.closeAllConnections();
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
@@ -388,6 +372,74 @@ describe("node worker transfer client", () => {
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
       });
+    }
+  });
+
+  it("preserves managed proxy routing for pinned transfers", async () => {
+    const root = tempDirs.make("node-worker-transfer-tls-proxy-");
+    const rawManifest = serializeWorkerWorkspaceManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [],
+    });
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    const target = createHttpsServer(
+      { cert: TEST_TLS_CERT_PEM, key: TEST_TLS_KEY_PEM },
+      (_req, res) => {
+        res.writeHead(200, { "content-length": String(Buffer.byteLength(rawManifest)) });
+        res.end(rawManifest);
+      },
+    );
+    const gatewayUrl = (await listen(target)).replace(/^ws/u, "wss");
+    const proxySockets = new Set<Socket>();
+    let connectCount = 0;
+    const proxy = createHttpServer();
+    proxy.on("connect", (req, clientSocket, head) => {
+      connectCount += 1;
+      const destination = new URL(`http://${req.url}`);
+      const upstream = connectNet(Number(destination.port), destination.hostname, () => {
+        clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (head.byteLength > 0) {
+          upstream.write(head);
+        }
+        upstream.pipe(clientSocket);
+        clientSocket.pipe(upstream);
+      });
+      proxySockets.add(clientSocket);
+      proxySockets.add(upstream);
+      clientSocket.once("close", () => proxySockets.delete(clientSocket));
+      upstream.once("close", () => proxySockets.delete(upstream));
+    });
+    const proxyUrl = (await listen(proxy)).replace(/^ws/u, "http");
+    const proxyHandle = installGlobalProxy({ mode: "managed", proxyUrl });
+    const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
+    try {
+      await expect(
+        runNodeWorkerWorkspaceTransfer({
+          gatewayUrl,
+          gatewayTlsFingerprint: fingerprint,
+          environmentId: "environment-tls-proxy",
+          workspaceDir: path.join(root, "workspace"),
+          manifestHome: root,
+          transfer: { direction: "download", token: "proxy-token", manifestRef },
+        }),
+      ).resolves.toBe(manifestRef);
+      expect(connectCount).toBe(1);
+    } finally {
+      proxyHandle.stop();
+      for (const socket of proxySockets) {
+        socket.destroy();
+      }
+      proxy.closeAllConnections();
+      target.closeAllConnections();
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          proxy.close(() => resolve());
+        }),
+        new Promise<void>((resolve) => {
+          target.close(() => resolve());
+        }),
+      ]);
     }
   });
 

--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -7,7 +7,11 @@ import http, {
   type RequestOptions,
   type Server as HttpServer,
 } from "node:http";
-import https, { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import https, {
+  createServer as createHttpsServer,
+  type RequestOptions as HttpsRequestOptions,
+  type Server as HttpsServer,
+} from "node:https";
 import type { Socket } from "node:net";
 import path from "node:path";
 import type { TLSSocket } from "node:tls";
@@ -259,11 +263,15 @@ describe("node worker transfer client", () => {
       (socket as TLSSocket).getPeerCertificate = (() => ({})) as TLSSocket["getPeerCertificate"];
     };
     const request = https.request.bind(https);
-    const requestSpy = vi.spyOn(https, "request").mockImplementation(((url, options) => {
+    const requestSpy = vi.spyOn(https, "request").mockImplementation(((
+      url: string | URL,
+      options: HttpsRequestOptions,
+    ) => {
       const clientRequest = request(url, options);
-      if (!pinnedAgent && options.agent instanceof https.Agent) {
-        pinnedAgent = options.agent;
-        pinnedAgent.on("free", hidePeerCertificate);
+      const agent = options.agent;
+      if (!pinnedAgent && agent instanceof https.Agent) {
+        pinnedAgent = agent;
+        agent.on("free", hidePeerCertificate);
       }
       return clientRequest;
     }) as typeof https.request);

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -30,6 +30,13 @@ import {
 const TRANSFER_TIMEOUT_MS = 10 * 60_000;
 const TRANSFER_RESULT_MAX_BYTES = 64 * 1024;
 const validatedTlsSocketPins = new WeakMap<TLSSocket, string>();
+// A resumed TLS session may omit the peer certificate, so replacement sockets cannot prove the pin.
+// Keep pooled pinned sockets, but require a full handshake whenever a new socket is created.
+const pinnedTransferAgent = new https.Agent({
+  keepAlive: true,
+  maxCachedSessions: 0,
+  timeout: 5_000,
+});
 const transferLog = createSubsystemLogger("node-host/worker-workspace");
 
 function transferUrl(gatewayUrl: string, routePath: string): URL {
@@ -137,7 +144,9 @@ async function openRequest(params: {
     method: params.method,
     headers: { authorization: `Bearer ${params.token}`, ...params.headers },
     signal: params.signal,
-    ...(url.protocol === "https:" && params.tlsFingerprint ? { rejectUnauthorized: false } : {}),
+    ...(url.protocol === "https:" && params.tlsFingerprint
+      ? { agent: pinnedTransferAgent, rejectUnauthorized: false }
+      : {}),
   });
   const response = once(request, "response").then(([message]) => message as IncomingMessage);
   const send = async () => {

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -30,14 +30,15 @@ import {
 const TRANSFER_TIMEOUT_MS = 10 * 60_000;
 const TRANSFER_RESULT_MAX_BYTES = 64 * 1024;
 const validatedTlsSocketPins = new WeakMap<TLSSocket, string>();
-// A resumed TLS session may omit the peer certificate, so replacement sockets cannot prove the pin.
-// Keep pooled pinned sockets, but require a full handshake whenever a new socket is created.
-const pinnedTransferAgent = new https.Agent({
-  keepAlive: true,
-  maxCachedSessions: 0,
-  timeout: 5_000,
-});
+// Replacement sockets must expose a full peer certificate for pin verification.
+const pinnedTransferAgent = new https.Agent({ keepAlive: true, maxCachedSessions: 0 });
 const transferLog = createSubsystemLogger("node-host/worker-workspace");
+
+function tlsPinMismatch(): NodeWorkerWorkspaceTransferError {
+  return new NodeWorkerWorkspaceTransferError(
+    "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+  );
+}
 
 function transferUrl(gatewayUrl: string, routePath: string): URL {
   const gateway = new URL(gatewayUrl);
@@ -94,23 +95,13 @@ function waitForTlsPin(request: ClientRequest, expectedRaw?: string): Promise<vo
       tlsSocket = socket as TLSSocket;
       const validated = validatedTlsSocketPins.get(tlsSocket);
       if (validated) {
-        finish(
-          validated === expected
-            ? undefined
-            : new NodeWorkerWorkspaceTransferError(
-                "workspace-transfer-failed: gateway TLS fingerprint mismatch",
-              ),
-        );
+        finish(validated === expected ? undefined : tlsPinMismatch());
         return;
       }
       verify = () => {
         const actual = normalizeFingerprint(tlsSocket!.getPeerCertificate().fingerprint256 ?? "");
         if (!actual || expected !== actual) {
-          finish(
-            new NodeWorkerWorkspaceTransferError(
-              "workspace-transfer-failed: gateway TLS fingerprint mismatch",
-            ),
-          );
+          finish(tlsPinMismatch());
           return;
         }
         validatedTlsSocketPins.set(tlsSocket!, actual);

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -30,8 +30,6 @@ import {
 const TRANSFER_TIMEOUT_MS = 10 * 60_000;
 const TRANSFER_RESULT_MAX_BYTES = 64 * 1024;
 const validatedTlsSocketPins = new WeakMap<TLSSocket, string>();
-// Replacement sockets must expose a full peer certificate for pin verification.
-const pinnedTransferAgent = new https.Agent({ keepAlive: true, maxCachedSessions: 0 });
 const transferLog = createSubsystemLogger("node-host/worker-workspace");
 
 function tlsPinMismatch(): NodeWorkerWorkspaceTransferError {
@@ -131,12 +129,13 @@ async function openRequest(params: {
 }): Promise<IncomingMessage> {
   const url = transferUrl(params.gatewayUrl, params.routePath);
   const transport = url.protocol === "https:" ? https : http;
+  // Keep the proxy-aware global transport, but require replacement sockets to expose a certificate.
   const request = transport.request(url, {
     method: params.method,
     headers: { authorization: `Bearer ${params.token}`, ...params.headers },
     signal: params.signal,
     ...(url.protocol === "https:" && params.tlsFingerprint
-      ? { agent: pinnedTransferAgent, rejectUnauthorized: false }
+      ? { rejectUnauthorized: false, session: Buffer.alloc(0) }
       : {}),
   });
   const response = once(request, "response").then(([message]) => message as IncomingMessage);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a correctly paired node host could complete an agent turn and make its assistant output visible, but then report a false `gateway TLS fingerprint mismatch` while reconciling the transferred workspace. Operators could see an error after successful side effects and retry the turn unsafely.

## Why This Change Was Made

Pinned workspace transfers keep the existing proxy-aware HTTP transport and pass an empty TLS session on each pinned request. Pooled sockets retain their verified pin, while every replacement socket performs a full handshake and exposes the peer certificate for pin verification. Wrong fingerprints remain rejected.

Regression provenance: the deterministic boundary is e44dde218f1629d87f585bf8bfeabda85e1a21f3 / #123696. Its device-revocation callbacks do not fire in this fresh pair → dispatch → turn flow; the commit exposed a pre-existing replacement-socket verifier defect from 8a3964f87cd2. #123696 was authored and merged by @steipete on August 14, 2026.

Production LOC: +12/-13 (net -1) | Tests: +144/-3. The implementation stays production-net-negative by deduplicating pin mismatch construction while preserving the existing transport owner.

## User Impact

Correctly pinned node-host turns now finish with a successful wait result after workspace reconciliation, including when the HTTPS connection needs a replacement socket. Operators no longer receive a false terminal failure after visible assistant output.

## Evidence

- Before, exact `origin/main` at e03d1a42f808e58028b285a4962fcc81cccccd64: the minimal harness produced the requested visible marker, then `agent.wait` returned `WORKSPACE_TRANSFER_FAILED` with two TLS fingerprint mismatch messages.
- Bisect: `e44dde218f1^` (`f8be386806d`) passed the same built harness; the preserved exact-`e44dde218f1` evidence failed three turns.
- Regression tests: the replacement-socket case failed before the production fix at `node-worker-transfer-client.ts:103` with `gateway TLS fingerprint mismatch`; a real local CONNECT-proxy case proves pinned transfers remain on Proxyline-managed routing. The focused file passes 8/8, including pooled-socket reuse and wrong-pin rejection.
- Repaired built source: three consecutive harness turns all returned `wait: ok`, all three unique markers were visible, and all launch rows completed without errors. Run: `/tmp/openclaw-p0-final-head-three-turns-20260814`.
- Source-blind behavior validation: 5/5 contract clauses passed with three distinct run IDs and markers.
- Format check and `git diff --check` passed.
- Autoreview of the full change and each follow-up: clean, no accepted/actionable findings.
- Changed gate is currently blocked by the pre-existing main baseline `OPENCLAW_* count 504 exceeds budget 502`; this patch adds no `OPENCLAW_*` names. The same first failure reproduced on the remote Daytona changed-gate run `run_27c8a637d3ae`.
- ClawSweeper proxy finding: the initial bare agent did not actually bypass managed routing because Proxyline patches `https.request` and replaces caller agents. The final implementation nonetheless removes that agent, preserves implicit proxy-aware routing, forwards the empty TLS session through Proxyline, and adds a concrete CONNECT-path regression. Exact-head CI: `31830737941`.
