### PR TITLE
fix: recover OpenAI sessions with backup auth profiles

### DIFF
--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -37,7 +37,7 @@ import { hasCodexAppServerRecoveryRetryBudget } from "./run/codex-app-server-rec
 import { createEmbeddedRunCompactionRuntime } from "./run/compaction-runtime.js";
 import { createEmbeddedRunContextRecoveryState } from "./run/context-recovery-state.js";
 import type { PreparedEmbeddedRunInput } from "./run/execution-context.js";
-import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./run/failover-policy.js";
+import { resolveRunFailoverDecision } from "./run/failover-policy.js";
 import { createEmbeddedRunFailoverRetryController } from "./run/failover-retry-controller.js";
 import { buildErrorAgentMeta, resolveMaxRunRetryIterations } from "./run/helpers.js";
 import { createIdleTimeoutBreakerState } from "./run/idle-timeout-breaker.js";
@@ -384,22 +384,12 @@ export async function runPreparedEmbeddedLoop(
           },
         });
       } catch (error) {
-        const retryReason = await failoverRetryController.retryThrownHarnessAuthFailure(error);
-        if (!retryReason) {
+        const retryTrace = await failoverRetryController.recoverThrownHarnessAuthFailure(error);
+        if (!retryTrace) {
           throw error;
         }
-        traceAttempts.push({
-          provider,
-          model: modelId,
-          result: "rotate_profile",
-          reason: retryReason,
-          stage: "prompt",
-        });
-        lastRetryFailoverReason = mergeRetryFailoverReason({
-          previous: lastRetryFailoverReason,
-          failoverReason: retryReason,
-          timedOut: false,
-        });
+        traceAttempts.push(retryTrace);
+        lastRetryFailoverReason = retryTrace.reason;
         continue;
       }
       startupStagesEmitted = dispatch.startupStagesEmitted;

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -37,7 +37,7 @@ import { hasCodexAppServerRecoveryRetryBudget } from "./run/codex-app-server-rec
 import { createEmbeddedRunCompactionRuntime } from "./run/compaction-runtime.js";
 import { createEmbeddedRunContextRecoveryState } from "./run/context-recovery-state.js";
 import type { PreparedEmbeddedRunInput } from "./run/execution-context.js";
-import { resolveRunFailoverDecision } from "./run/failover-policy.js";
+import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./run/failover-policy.js";
 import { createEmbeddedRunFailoverRetryController } from "./run/failover-retry-controller.js";
 import { buildErrorAgentMeta, resolveMaxRunRetryIterations } from "./run/helpers.js";
 import { createIdleTimeoutBreakerState } from "./run/idle-timeout-breaker.js";
@@ -356,31 +356,52 @@ export async function runPreparedEmbeddedLoop(
         runLoopIterations: runRetryBudget.attemptsCounted,
         maxRunLoopIterations: runRetryBudget.maxAttempts,
       });
-      const dispatch = await prepareAndDispatchEmbeddedRunAttempt({
-        runInput: admittedRunInput,
-        preparedRuntime,
-        contextEngine,
-        sessionPromptState,
-        terminalRetryState,
-        replayState: accumulatedReplayState,
-        provider,
-        modelId,
-        startupStagesEmitted,
-        bootstrapPromptWarningSignaturesSeen,
-        resolveRuntimeFallbackReason,
-        observeToolOutcome,
-        isTurnTainted: turnTaintState.isTainted,
-        allocateToolOutcomeOrdinal: terminalToolPresentation.allocateOrdinal,
-        getPostCompactionAbortError: () => postCompactionAbortError,
-        setPostCompactionAbortController: (controller) => {
-          postCompactionAbortController = controller;
-        },
-        clearPostCompactionAbortController: (controller) => {
-          if (postCompactionAbortController === controller) {
-            postCompactionAbortController = undefined;
-          }
-        },
-      });
+      let dispatch: Awaited<ReturnType<typeof prepareAndDispatchEmbeddedRunAttempt>>;
+      try {
+        dispatch = await prepareAndDispatchEmbeddedRunAttempt({
+          runInput: admittedRunInput,
+          preparedRuntime,
+          contextEngine,
+          sessionPromptState,
+          terminalRetryState,
+          replayState: accumulatedReplayState,
+          provider,
+          modelId,
+          startupStagesEmitted,
+          bootstrapPromptWarningSignaturesSeen,
+          resolveRuntimeFallbackReason,
+          observeToolOutcome,
+          isTurnTainted: turnTaintState.isTainted,
+          allocateToolOutcomeOrdinal: terminalToolPresentation.allocateOrdinal,
+          getPostCompactionAbortError: () => postCompactionAbortError,
+          setPostCompactionAbortController: (controller) => {
+            postCompactionAbortController = controller;
+          },
+          clearPostCompactionAbortController: (controller) => {
+            if (postCompactionAbortController === controller) {
+              postCompactionAbortController = undefined;
+            }
+          },
+        });
+      } catch (error) {
+        const retryReason = await failoverRetryController.retryThrownHarnessAuthFailure(error);
+        if (!retryReason) {
+          throw error;
+        }
+        traceAttempts.push({
+          provider,
+          model: modelId,
+          result: "rotate_profile",
+          reason: retryReason,
+          stage: "prompt",
+        });
+        lastRetryFailoverReason = mergeRetryFailoverReason({
+          previous: lastRetryFailoverReason,
+          failoverReason: retryReason,
+          timedOut: false,
+        });
+        continue;
+      }
       startupStagesEmitted = dispatch.startupStagesEmitted;
       const { dispatchedAttempt, runtimePlan } = dispatch;
       mcpAttemptCarryover.apply(dispatchedAttempt.rawAttempt);

--- a/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
+  mockedEnsureAuthProfileStore,
+  mockedGetApiKeyForModel,
+  mockedMarkAuthProfileFailure,
+  mockedResolveAuthProfileOrder,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+} from "./run.overflow-compaction.harness.js";
+
+const failedProfile = "openai:failed";
+const backupProfile = "openai:backup";
+
+function permanentAuthFailure(): Error {
+  return Object.assign(new Error("API key has been revoked"), {
+    name: "ProviderAuthError",
+    provider: "openai",
+    profileId: failedProfile,
+  });
+}
+
+async function prepareAuthFailoverRun() {
+  const { registerPreparedAgentHarness, runEmbeddedAgent } =
+    await loadRunOverflowCompactionHarness();
+  registerPreparedAgentHarness({
+    id: "codex",
+    label: "Codex",
+    authBootstrap: "harness",
+    supports: ({ provider }) =>
+      provider === "openai" ? { supported: true, priority: 100 } : { supported: false },
+    runAttempt: async (params) => await mockedRunEmbeddedAttempt(params),
+  });
+  mockedEnsureAuthProfileStore.mockReturnValue({
+    version: 1,
+    profiles: {
+      [failedProfile]: {
+        type: "api_key",
+        provider: "openai",
+        key: "failed-api-key",
+      },
+      [backupProfile]: {
+        type: "api_key",
+        provider: "openai",
+        key: "backup-api-key",
+      },
+    },
+    order: { openai: [failedProfile, backupProfile] },
+  });
+  mockedResolveAuthProfileOrder.mockReturnValue([failedProfile, backupProfile]);
+  mockedGetApiKeyForModel.mockImplementation(async ({ profileId } = {}) => ({
+    apiKey: profileId === backupProfile ? "backup-api-key" : "failed-api-key",
+    profileId: profileId ?? failedProfile,
+    source: "test",
+    mode: "api-key",
+  }));
+  return runEmbeddedAgent;
+}
+
+describe("native harness auth failover", () => {
+  it("retries a permanent harness auth failure with the next automatic profile", async () => {
+    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "OK" }]);
+    mockedRunEmbeddedAttempt
+      .mockRejectedValueOnce(permanentAuthFailure())
+      .mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["OK"] }));
+
+    await expect(
+      runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        modelId: "gpt-5.6-luna",
+        authProfileId: failedProfile,
+        authProfileIdSource: "auto",
+        runId: "run-native-harness-auth-failover",
+      }),
+    ).resolves.toMatchObject({ payloads: [{ text: "OK" }] });
+    expect(mockedRunEmbeddedAttempt.mock.calls.map(([params]) => params.authProfileId)).toEqual([
+      failedProfile,
+      backupProfile,
+    ]);
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ profileId: failedProfile, reason: "auth_permanent" }),
+    );
+  });
+
+  it("keeps an explicit user profile strict", async () => {
+    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    const failure = permanentAuthFailure();
+    mockedRunEmbeddedAttempt.mockRejectedValueOnce(failure);
+
+    await expect(
+      runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        modelId: "gpt-5.6-luna",
+        authProfileId: failedProfile,
+        authProfileIdSource: "user",
+        runId: "run-native-harness-user-auth-pin",
+      }),
+    ).rejects.toBe(failure);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ profileId: failedProfile, reason: "auth_permanent" }),
+    );
+  });
+
+  it("surfaces the original auth failure when automatic profiles are exhausted", async () => {
+    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    mockedResolveAuthProfileOrder.mockReturnValue([failedProfile]);
+    const failure = permanentAuthFailure();
+    mockedRunEmbeddedAttempt.mockRejectedValueOnce(failure);
+
+    await expect(
+      runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        modelId: "gpt-5.6-luna",
+        authProfileId: failedProfile,
+        authProfileIdSource: "auto",
+        runId: "run-native-harness-auth-exhausted",
+      }),
+    ).rejects.toBe(failure);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ profileId: failedProfile, reason: "auth_permanent" }),
+    );
+  });
+
+  it("does not rotate profiles for an unclassified harness failure", async () => {
+    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    const failure = new Error("native harness process exited");
+    mockedRunEmbeddedAttempt.mockRejectedValueOnce(failure);
+
+    await expect(
+      runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        modelId: "gpt-5.6-luna",
+        runId: "run-native-harness-non-auth-failure",
+      }),
+    ).rejects.toBe(failure);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+    expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
@@ -71,7 +71,7 @@ describe("native harness auth failover", () => {
       runEmbeddedAgent({
         ...overflowBaseRunParams,
         provider: "openai",
-        modelId: "gpt-5.6-luna",
+        model: "gpt-5.6-luna",
         authProfileId: failedProfile,
         authProfileIdSource: "auto",
         runId: "run-native-harness-auth-failover",
@@ -95,7 +95,7 @@ describe("native harness auth failover", () => {
       runEmbeddedAgent({
         ...overflowBaseRunParams,
         provider: "openai",
-        modelId: "gpt-5.6-luna",
+        model: "gpt-5.6-luna",
         authProfileId: failedProfile,
         authProfileIdSource: "user",
         runId: "run-native-harness-user-auth-pin",
@@ -117,7 +117,7 @@ describe("native harness auth failover", () => {
       runEmbeddedAgent({
         ...overflowBaseRunParams,
         provider: "openai",
-        modelId: "gpt-5.6-luna",
+        model: "gpt-5.6-luna",
         authProfileId: failedProfile,
         authProfileIdSource: "auto",
         runId: "run-native-harness-auth-exhausted",
@@ -138,7 +138,7 @@ describe("native harness auth failover", () => {
       runEmbeddedAgent({
         ...overflowBaseRunParams,
         provider: "openai",
-        modelId: "gpt-5.6-luna",
+        model: "gpt-5.6-luna",
         runId: "run-native-harness-non-auth-failure",
       }),
     ).rejects.toBe(failure);

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -14,6 +14,7 @@ import {
 } from "../../failover-error.js";
 import { isConfigBackedInlineProviderApiKey, type ResolvedProviderAuth } from "../../model-auth.js";
 import { log } from "../logger.js";
+import type { TraceAttempt } from "../types.js";
 import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
 import type { PreparedEmbeddedRunInput } from "./execution-context.js";
 import {
@@ -27,6 +28,7 @@ import {
 import type { prepareEmbeddedRunRuntime } from "./runtime-preparation.js";
 
 type PreparedRuntime = Awaited<ReturnType<typeof prepareEmbeddedRunRuntime>>;
+type AuthRetryTrace = TraceAttempt & { reason: FailoverReason };
 
 type RateLimitAuthProfileContext = {
   failoverProvider: string;
@@ -182,7 +184,7 @@ export function createEmbeddedRunFailoverRetryController(input: {
     },
     maybeMarkAuthProfileFailure,
     resolveAuthProfileFailureReason: resolveProfileFailureReason,
-    retryThrownHarnessAuthFailure: async (error: unknown): Promise<FailoverReason | null> => {
+    recoverThrownHarnessAuthFailure: async (error: unknown): Promise<AuthRetryTrace | null> => {
       // Native harnesses can throw before returning a terminal result. Recover only
       // provider-auth failures here; local harness faults must keep propagating.
       if (!input.harnessOwnsTransport()) {
@@ -206,7 +208,15 @@ export function createEmbeddedRunFailoverRetryController(input: {
       } catch (markError) {
         log.warn(`profile failure mark failed: ${String(markError)}`);
       }
-      return rotated ? failoverReason : null;
+      return rotated
+        ? {
+            provider,
+            model: modelId,
+            result: "rotate_profile",
+            reason: failoverReason,
+            stage: "prompt",
+          }
+        : null;
     },
     maybeBackoffBeforeOverloadFailover: async (reason: FailoverReason | null) => {
       if (reason !== "overloaded" || overloadFailoverBackoffMs <= 0) {

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -7,7 +7,11 @@ import {
 } from "../../auth-profiles.js";
 import { revokeRuntimeAuthMaterializations } from "../../auth-profiles/runtime-materializations.js";
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
-import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
+import {
+  FailoverError,
+  resolveFailoverReasonFromError,
+  resolveFailoverStatus,
+} from "../../failover-error.js";
 import { isConfigBackedInlineProviderApiKey, type ResolvedProviderAuth } from "../../model-auth.js";
 import { log } from "../logger.js";
 import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
@@ -73,6 +77,71 @@ export function createEmbeddedRunFailoverRetryController(input: {
     }
   };
 
+  const resolveProfileFailureReason = (
+    failoverReason: FailoverReason | null,
+    opts?: { providerStarted?: boolean; transientRateLimit?: boolean },
+  ) =>
+    resolveAuthProfileFailureReason({
+      failoverReason,
+      providerStarted: opts?.providerStarted,
+      transientRateLimit: opts?.transientRateLimit,
+      policy: params.authProfileFailurePolicy,
+    });
+
+  const maybeMarkAuthProfileFailure = async (failure: {
+    profileId?: string;
+    reason?: AuthProfileFailureReason | null;
+    modelId?: string;
+  }) => {
+    const { profileId, reason } = failure;
+    if (input.harnessOwnsTransport() && (reason === "auth" || reason === "auth_permanent")) {
+      revokeRuntimeAuthMaterializations({
+        agentDir,
+        provider,
+        runtimeOwnerId: input.getRuntimeAuthOwnerId(),
+      });
+    }
+    if (params.authProfileStateMode === "read-only" || !reason) {
+      return;
+    }
+    if (input.harnessOwnsTransport() && reason === "timeout") {
+      return;
+    }
+    if (profileId) {
+      await markAuthProfileFailure({
+        store: profileFailureStore,
+        profileId,
+        reason,
+        cfg: params.config,
+        agentDir,
+        runId: params.runId,
+        modelId: failure.modelId,
+      });
+      return;
+    }
+    const apiKeyInfo = input.getApiKeyInfo();
+    if (
+      apiKeyInfo?.mode !== "api-key" ||
+      !isConfigBackedInlineProviderApiKey({
+        cfg: params.config,
+        provider,
+        source: apiKeyInfo.source,
+        store: profileFailureStore,
+      })
+    ) {
+      return;
+    }
+    await markInlineProviderApiKeyFailure({
+      store: profileFailureStore,
+      provider,
+      reason,
+      cfg: params.config,
+      agentDir,
+      runId: params.runId,
+      modelId: failure.modelId,
+    });
+  };
+
   return {
     overloadProfileRotationLimit,
     get consecutiveSameModelRateLimitRetries() {
@@ -111,75 +180,33 @@ export function createEmbeddedRunFailoverRetryController(input: {
       }
       return rotated;
     },
-    maybeMarkAuthProfileFailure: async (failure: {
-      profileId?: string;
-      reason?: AuthProfileFailureReason | null;
-      modelId?: string;
-    }) => {
-      const { profileId, reason } = failure;
-      if (input.harnessOwnsTransport() && (reason === "auth" || reason === "auth_permanent")) {
-        revokeRuntimeAuthMaterializations({
-          agentDir,
-          provider,
-          runtimeOwnerId: input.getRuntimeAuthOwnerId(),
+    maybeMarkAuthProfileFailure,
+    resolveAuthProfileFailureReason: resolveProfileFailureReason,
+    retryThrownHarnessAuthFailure: async (error: unknown): Promise<FailoverReason | null> => {
+      // Native harnesses can throw before returning a terminal result. Recover only
+      // provider-auth failures here; local harness faults must keep propagating.
+      if (!input.harnessOwnsTransport()) {
+        return null;
+      }
+      const failoverReason = resolveFailoverReasonFromError(error, provider);
+      if (failoverReason !== "auth" && failoverReason !== "auth_permanent") {
+        return null;
+      }
+      const failedProfileId = input.getLastProfileId();
+      const profileFailureReason = resolveProfileFailureReason(failoverReason);
+      const userPinnedProfile =
+        params.authProfileIdSource === "user" && failedProfileId === params.authProfileId;
+      const rotated = userPinnedProfile ? false : await input.advanceAuthProfile();
+      try {
+        await maybeMarkAuthProfileFailure({
+          profileId: failedProfileId,
+          reason: profileFailureReason,
+          modelId,
         });
+      } catch (markError) {
+        log.warn(`profile failure mark failed: ${String(markError)}`);
       }
-      if (params.authProfileStateMode === "read-only") {
-        return;
-      }
-      if (!reason) {
-        return;
-      }
-      if (input.harnessOwnsTransport() && reason === "timeout") {
-        return;
-      }
-      if (profileId) {
-        await markAuthProfileFailure({
-          store: profileFailureStore,
-          profileId,
-          reason,
-          cfg: params.config,
-          agentDir,
-          runId: params.runId,
-          modelId: failure.modelId,
-        });
-        return;
-      }
-      // Inline provider API keys have no auth profile, so record their
-      // billing/auth failures under the provider-scoped inline cooldown so the
-      // resolver stops handing back the exhausted key on the next turn.
-      const apiKeyInfo = input.getApiKeyInfo();
-      if (
-        apiKeyInfo?.mode !== "api-key" ||
-        !isConfigBackedInlineProviderApiKey({
-          cfg: params.config,
-          provider,
-          source: apiKeyInfo.source,
-          store: profileFailureStore,
-        })
-      ) {
-        return;
-      }
-      await markInlineProviderApiKeyFailure({
-        store: profileFailureStore,
-        provider,
-        reason,
-        cfg: params.config,
-        agentDir,
-        runId: params.runId,
-        modelId: failure.modelId,
-      });
-    },
-    resolveAuthProfileFailureReason: (
-      failoverReason: FailoverReason | null,
-      opts?: { providerStarted?: boolean; transientRateLimit?: boolean },
-    ) => {
-      return resolveAuthProfileFailureReason({
-        failoverReason,
-        providerStarted: opts?.providerStarted,
-        transientRateLimit: opts?.transientRateLimit,
-        policy: params.authProfileFailurePolicy,
-      });
+      return rotated ? failoverReason : null;
     },
     maybeBackoffBeforeOverloadFailover: async (reason: FailoverReason | null) => {
       if (reason !== "overloaded" || overloadFailoverBackoffMs <= 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a stale automatically selected OAuth profile and a valid backup credential would see every OpenAI model fail instead of transparently continuing with the backup profile. This affected native agent harness runs because their authentication failure could be thrown before a terminal attempt result existed.

## Why This Change Was Made

The embedded run loop now classifies authentication errors thrown by native harness dispatch, records the failed automatic profile through the existing auth health machinery, and retries the same provider/model with the next eligible profile. Explicit user-selected profiles remain strict, candidate exhaustion rethrows the original error, and non-auth harness errors still propagate unchanged.

The production change is +48 net lines; the remaining +148 lines are focused regression coverage for the new owner-boundary behavior.

## User Impact

OpenAI sessions can recover in the same turn from a permanently failed automatic OAuth profile when another valid credential is available. Users no longer need to repair the session pin or manually re-authenticate merely to reach their configured API-key backup.

## Evidence

- Red on unmodified `e03d1a42f808e58028b285a4962fcc81cccccd64`: the native harness threw `OAuthRefreshFailureError` with `refresh_token_reused`; the run rejected without trying the backup profile.
- Green source-blind gateway proof on the proposed change: one public `openclaw agent` request returned `AUTH_FAILOVER_OK`; its execution trace recorded `rotate_profile` / `auth_permanent`, then `success` on the same `openai/gpt-5.6-sol` model. Persisted auth state recorded one permanent failure for the stale profile and the API-key profile as last-good.
- Regression coverage: 4 focused tests cover automatic recovery, strict explicit pins, exhausted candidates, and an unrelated harness-error negative control.
- Related embedded-runner suites: 194 tests passed across auth preparation, assistant failover, prompt failure, and failover classification.
- Autoreview: clean, with no accepted or actionable findings.
- Crabbox/Testbox was attempted with Crabbox `0.42.0` ([run](https://github.com/openclaw/openclaw/actions/runs/31826628184)); the delegated checkout had no reachable `origin/main`, so `check:changed` expanded to unrelated repository files and stopped on the global env-var budget before any patch-related failure.
