### PR TITLE
Restore current-main validation

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -221,13 +221,6 @@ function resolveSkillsWorkspaceForCommand(
   return resolveSkillsWorkspace({ agentId: resolveAgentOption(command ?? undefined, opts) });
 }
 
-function resolveClawHubTargetWorkspaceDir(
-  command: Command | undefined,
-  opts: { agent?: string; global?: boolean },
-): string | undefined {
-  return resolveClawHubTargetWorkspace(command, opts)?.workspaceDir;
-}
-
 function resolveClawHubTargetWorkspace(
   command: Command | undefined,
   opts: { agent?: string; global?: boolean },

--- a/src/gateway/server-maintenance.device-pairing.test.ts
+++ b/src/gateway/server-maintenance.device-pairing.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGatewayMaintenanceStateForTest } from "./test-helpers.maintenance-state.js";
+
+describe("device pairing maintenance", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prunes retained setup outcomes at startup and every maintenance minute", async () => {
+    vi.useFakeTimers();
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const runDevicePairSetupCompletionGc = vi.fn(async () => undefined);
+    const timers = startGatewayMaintenanceTimers({
+      ...createGatewayMaintenanceStateForTest(),
+      logHealth: { info: vi.fn(), error: vi.fn() },
+      runWorktreeGc: vi.fn(async () => undefined),
+      runDeliveryQueueMediaGc: vi.fn(async () => undefined),
+      runDevicePairSetupCompletionGc,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runDevicePairSetupCompletionGc).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(runDevicePairSetupCompletionGc).toHaveBeenCalledTimes(2);
+
+    clearInterval(timers.tickInterval);
+    clearInterval(timers.healthInterval);
+    clearInterval(timers.dedupeCleanup);
+    clearInterval(timers.worktreeCleanup);
+    await timers.stopMediaCleanup();
+    timers.skillCuratorCleanup();
+  });
+});

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -70,7 +70,6 @@ function createMaintenanceTimerDeps() {
     logHealth: { info: vi.fn(), error: vi.fn() },
     runWorktreeGc: vi.fn(async () => undefined),
     runDeliveryQueueMediaGc: vi.fn(async () => undefined),
-    runDevicePairSetupCompletionGc: vi.fn(async () => undefined),
     runManagedOutgoingMediaGc: cleanupManagedOutgoingMediaRecordsMock,
   };
 }
@@ -274,20 +273,6 @@ describe("startGatewayMaintenanceTimers", () => {
     await vi.advanceTimersByTimeAsync(60 * 60_000);
     expect(pruneExpiredDeliveryQueueTombstonesMock).toHaveBeenCalledTimes(2);
     expect(pruneOrphanedDeliveryQueueMediaMock).toHaveBeenCalledTimes(2);
-
-    await stopMaintenanceTimers(timers);
-  });
-
-  it("prunes retained setup outcomes at startup and every maintenance minute", async () => {
-    vi.useFakeTimers();
-    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
-    const deps = createMaintenanceTimerDeps();
-    const timers = startGatewayMaintenanceTimers(deps);
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(deps.runDevicePairSetupCompletionGc).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(deps.runDevicePairSetupCompletionGc).toHaveBeenCalledTimes(2);
 
     await stopMaintenanceTimers(timers);
   });

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -70,6 +70,7 @@ function createMaintenanceTimerDeps() {
     logHealth: { info: vi.fn(), error: vi.fn() },
     runWorktreeGc: vi.fn(async () => undefined),
     runDeliveryQueueMediaGc: vi.fn(async () => undefined),
+    runDevicePairSetupCompletionGc: vi.fn(async () => undefined),
     runManagedOutgoingMediaGc: cleanupManagedOutgoingMediaRecordsMock,
   };
 }


### PR DESCRIPTION
## New behavior

Current-main validation is restored without changing runtime behavior.

- Gateway device-pair setup cleanup remains covered at startup and every maintenance minute, but its scheduler test now lives in a focused file so the shared maintenance suite stays under the enforced line limit.
- The skills CLI no longer carries an unused workspace helper; existing commands continue through the canonical resolver.

No production behavior, public API, or max-lines exemption is added.

## Visual proof

<img width="1225" height="768" alt="Gateway maintenance calls device-pair cleanup at startup and after one minute" src="https://github.com/user-attachments/assets/668686b7-e5fa-4778-9284-7aefcd6bba89" />

**What this shows:** A real `startGatewayMaintenanceTimers` instance calls the device-pair setup cleanup owner at startup, calls it again after one maintenance minute, and shuts down cleanly after the test split.

**State:** Maintenance behavior captured from this branch with Node 24.15.0 using the real 61-second timer interval. The final follow-up only completed a test fixture and removed an unused helper; neither changes the captured runtime behavior.

## How to verify

1. Start `startGatewayMaintenanceTimers` with a visible `runDevicePairSetupCompletionGc` callback.
2. Observe one callback immediately and a second callback after 60 seconds.
3. Run the focused Gateway maintenance and skills CLI suites; confirm the shared test stays within the 1,000-line budget and production validation no longer reports the unused helper.
