### PR TITLE
Add Planning Knowledge retrieval plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,8 @@
+"plugin: planning-knowledge":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/planning-knowledge/**"
+
 "plugin: azure-speech":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/planning-knowledge/README.md
+++ b/extensions/planning-knowledge/README.md
@@ -1,18 +1,25 @@
 # Planning Knowledge plugin
 
-This optional OpenClaw tool plugin provides read-only retrieval from the
-Planning-owned personal Knowledge corpus through OneLibrary's existing CLI.
+This optional OpenClaw tool plugin provides private retrieval from, and
+explicit capture into, the Planning-owned personal Knowledge corpus. Retrieval
+uses OneLibrary's existing CLI; capture uses Planning's narrow
+`knowledge_notes.py create` writer and then refreshes the derived index.
 
 Configure explicit paths for:
 
 - OneLibrary's `planning_knowledge_index.py`;
 - the canonical `notes/knowledge/` root; and
-- the derived `planning_personal` index.
+- the derived `planning_personal` index; and
+- optionally Planning's `knowledge_notes.py` writer to enable capture.
 
-The plugin never crawls the Goal_Agent repository, reads `config/secrets/`,
-or writes Planning files. Retrieval results retain the portable canonical
+The plugin never accepts a caller-controlled filesystem path, crawls
+`config/secrets/`, or writes outside the Planning writer's canonical
+`notes/knowledge/` boundary. Retrieval results retain the portable canonical
 citation `note:notes/knowledge/<slug>`.
 
-In PLN-500A, the capture tool only recognizes an explicit save-as-Knowledge
-request and returns `capture_not_enabled_in_pln_500a`; it performs no write
-and does not turn the request into a task.
+Without `writerScriptPath`, the capture tool remains recognition-only and
+returns `capture_not_enabled_in_pln_500a`. With the Planning writer configured,
+an explicit capture creates or retries one canonical note, refreshes only the
+derived OneLibrary index, and returns the canonical `note:` ref. Mixed request
+follow-ups are reported as `route_separately`; this plugin never creates tasks
+or calendar events.

--- a/extensions/planning-knowledge/README.md
+++ b/extensions/planning-knowledge/README.md
@@ -1,0 +1,18 @@
+# Planning Knowledge plugin
+
+This optional OpenClaw tool plugin provides read-only retrieval from the
+Planning-owned personal Knowledge corpus through OneLibrary's existing CLI.
+
+Configure explicit paths for:
+
+- OneLibrary's `planning_knowledge_index.py`;
+- the canonical `notes/knowledge/` root; and
+- the derived `planning_personal` index.
+
+The plugin never crawls the Goal_Agent repository, reads `config/secrets/`,
+or writes Planning files. Retrieval results retain the portable canonical
+citation `note:notes/knowledge/<slug>`.
+
+In PLN-500A, the capture tool only recognizes an explicit save-as-Knowledge
+request and returns `capture_not_enabled_in_pln_500a`; it performs no write
+and does not turn the request into a task.

--- a/extensions/planning-knowledge/index.ts
+++ b/extensions/planning-knowledge/index.ts
@@ -1,9 +1,11 @@
 import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
 import {
   createPlanningKnowledgeCaptureTool,
+  createPlanningKnowledgeMaintenanceTool,
   createPlanningKnowledgeSearchTool,
   planningKnowledgeConfigSchema,
   planningKnowledgeCaptureParameters,
+  planningKnowledgeMaintenanceParameters,
   planningKnowledgeSearchParameters,
   resolvePlanningKnowledgeConfig,
 } from "./src/planning-knowledge-tool.js";
@@ -43,6 +45,23 @@ export default defineToolPlugin({
         }
         const resolved = resolvePlanningKnowledgeConfig(config, api.resolvePath);
         return createPlanningKnowledgeCaptureTool(resolved ?? undefined);
+      },
+    }),
+    tool({
+      name: "planning_knowledge_maintenance",
+      label: "Planning Knowledge Maintenance",
+      description:
+        "Run bounded read-only Planning Knowledge validation, health, quality review and OneLibrary audit. Canonical mutation, derived repair, candidate acceptance, migration and restore are not available through this tool.",
+      parameters: planningKnowledgeMaintenanceParameters,
+      optional: true,
+      factory: ({ api, config, toolContext }) => {
+        if (toolContext.senderIsOwner === false) {
+          return null;
+        }
+        const resolved = resolvePlanningKnowledgeConfig(config, api.resolvePath);
+        return resolved?.maintenanceScriptPath
+          ? createPlanningKnowledgeMaintenanceTool(resolved)
+          : null;
       },
     }),
   ],

--- a/extensions/planning-knowledge/index.ts
+++ b/extensions/planning-knowledge/index.ts
@@ -1,0 +1,44 @@
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+import {
+  createPlanningKnowledgeCaptureTool,
+  createPlanningKnowledgeSearchTool,
+  planningKnowledgeConfigSchema,
+  planningKnowledgeCaptureParameters,
+  planningKnowledgeSearchParameters,
+  resolvePlanningKnowledgeConfig,
+} from "./src/planning-knowledge-tool.js";
+
+export default defineToolPlugin({
+  id: "planning-knowledge",
+  name: "Planning Knowledge",
+  description:
+    "Read-only access to Oliver's Planning-owned personal Knowledge Notes. Canonical refs remain note:notes/knowledge/<slug>.",
+  configSchema: planningKnowledgeConfigSchema,
+  tools: (tool) => [
+    tool({
+      name: "planning_knowledge_search",
+      label: "Planning Knowledge Search",
+      description:
+        "Search Oliver's saved personal Planning Knowledge Notes through the configured OneLibrary derived index. Use for questions about what Oliver has saved. Results are private, current-truth eligible, and carry canonical note:notes/knowledge/<slug> citations. Do not use for generic knowledge, tasks, or books/media.",
+      parameters: planningKnowledgeSearchParameters,
+      optional: true,
+      factory: ({ api, config, toolContext }) => {
+        if (toolContext.senderIsOwner === false) {
+          return null;
+        }
+        const resolved = resolvePlanningKnowledgeConfig(config, api.resolvePath);
+        return resolved ? createPlanningKnowledgeSearchTool(resolved) : null;
+      },
+    }),
+    tool({
+      name: "planning_knowledge_capture",
+      label: "Planning Knowledge Capture (disabled)",
+      description:
+        "Recognize an explicit request to save content as a personal Planning Knowledge Note. PLN-500A is retrieval-only: never write, edit, archive, or create a task from this tool. For mixed requests, route any operational reminder separately.",
+      parameters: planningKnowledgeCaptureParameters,
+      optional: true,
+      factory: ({ toolContext }) =>
+        toolContext.senderIsOwner === false ? null : createPlanningKnowledgeCaptureTool(),
+    }),
+  ],
+});

--- a/extensions/planning-knowledge/index.ts
+++ b/extensions/planning-knowledge/index.ts
@@ -12,7 +12,7 @@ export default defineToolPlugin({
   id: "planning-knowledge",
   name: "Planning Knowledge",
   description:
-    "Read-only access to Oliver's Planning-owned personal Knowledge Notes. Canonical refs remain note:notes/knowledge/<slug>.",
+    "Private retrieval and explicit Planning-owned capture for personal Knowledge Notes. Canonical refs remain note:notes/knowledge/<slug>.",
   configSchema: planningKnowledgeConfigSchema,
   tools: (tool) => [
     tool({
@@ -32,13 +32,18 @@ export default defineToolPlugin({
     }),
     tool({
       name: "planning_knowledge_capture",
-      label: "Planning Knowledge Capture (disabled)",
+      label: "Planning Knowledge Capture",
       description:
-        "Recognize an explicit request to save content as a personal Planning Knowledge Note. PLN-500A is retrieval-only: never write, edit, archive, or create a task from this tool. For mixed requests, route any operational reminder separately.",
+        "Create an explicit personal Knowledge Note through the Planning-owned writer and refresh the derived OneLibrary index. Never edit arbitrary Planning files or create tasks/calendar events; route mixed operational follow-ups separately.",
       parameters: planningKnowledgeCaptureParameters,
       optional: true,
-      factory: ({ toolContext }) =>
-        toolContext.senderIsOwner === false ? null : createPlanningKnowledgeCaptureTool(),
+      factory: ({ api, config, toolContext }) => {
+        if (toolContext.senderIsOwner === false) {
+          return null;
+        }
+        const resolved = resolvePlanningKnowledgeConfig(config, api.resolvePath);
+        return createPlanningKnowledgeCaptureTool(resolved ?? undefined);
+      },
     }),
   ],
 });

--- a/extensions/planning-knowledge/openclaw.plugin.json
+++ b/extensions/planning-knowledge/openclaw.plugin.json
@@ -28,6 +28,11 @@
         "minLength": 1,
         "description": "Explicit Planning-owned knowledge_notes.py writer path."
       },
+      "maintenanceScriptPath": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Explicit read-only Planning knowledge_maintenance.py path."
+      },
       "pythonExecutable": {
         "type": "string",
         "minLength": 1,
@@ -61,7 +66,8 @@
   "contracts": {
     "tools": [
       "planning_knowledge_search",
-      "planning_knowledge_capture"
+      "planning_knowledge_capture",
+      "planning_knowledge_maintenance"
     ]
   },
   "toolMetadata": {
@@ -69,6 +75,9 @@
       "optional": true
     },
     "planning_knowledge_capture": {
+      "optional": true
+    },
+    "planning_knowledge_maintenance": {
       "optional": true
     }
   }

--- a/extensions/planning-knowledge/openclaw.plugin.json
+++ b/extensions/planning-knowledge/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "planning-knowledge",
   "name": "Planning Knowledge",
-  "description": "Read-only access to Oliver's Planning-owned personal Knowledge Notes. Canonical refs remain note:notes/knowledge/<slug>.",
+  "description": "Private retrieval and explicit Planning-owned capture for personal Knowledge Notes. Canonical refs remain note:notes/knowledge/<slug>.",
   "activation": {
     "onStartup": true
   },
@@ -22,6 +22,11 @@
         "type": "string",
         "minLength": 1,
         "description": "Explicit derived planning_personal index path."
+      },
+      "writerScriptPath": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Explicit Planning-owned knowledge_notes.py writer path."
       },
       "pythonExecutable": {
         "type": "string",

--- a/extensions/planning-knowledge/openclaw.plugin.json
+++ b/extensions/planning-knowledge/openclaw.plugin.json
@@ -1,12 +1,63 @@
 {
   "id": "planning-knowledge",
   "name": "Planning Knowledge",
-  "description": "Read-only retrieval from the Planning-owned personal Knowledge corpus.",
+  "description": "Read-only access to Oliver's Planning-owned personal Knowledge Notes. Canonical refs remain note:notes/knowledge/<slug>.",
   "activation": {
     "onStartup": true
   },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "scriptPath": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Explicit OneLibrary planning_knowledge_index.py path."
+      },
+      "sourceRoot": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Explicit notes/knowledge source root."
+      },
+      "indexPath": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Explicit derived planning_personal index path."
+      },
+      "pythonExecutable": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Python executable for the OneLibrary CLI."
+      },
+      "mode": {
+        "anyOf": [
+          {
+            "type": "string",
+            "const": "text"
+          },
+          {
+            "type": "string",
+            "const": "semantic"
+          },
+          {
+            "type": "string",
+            "const": "hybrid"
+          }
+        ]
+      },
+      "timeoutMs": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 120000
+      }
+    },
+    "additionalProperties": false
+  },
+  "version": "2026.8.1",
   "contracts": {
-    "tools": ["planning_knowledge_search", "planning_knowledge_capture"]
+    "tools": [
+      "planning_knowledge_search",
+      "planning_knowledge_capture"
+    ]
   },
   "toolMetadata": {
     "planning_knowledge_search": {
@@ -15,40 +66,5 @@
     "planning_knowledge_capture": {
       "optional": true
     }
-  },
-  "configSchema": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-      "scriptPath": {
-        "type": "string",
-        "description": "Explicit path to OneLibrary's planning_knowledge_index.py CLI."
-      },
-      "sourceRoot": {
-        "type": "string",
-        "description": "Explicit notes/knowledge/ source root; no repository crawl is performed."
-      },
-      "indexPath": {
-        "type": "string",
-        "description": "OneLibrary derived planning_personal SQLite index path."
-      },
-      "pythonExecutable": {
-        "type": "string",
-        "description": "Python executable used for the OneLibrary CLI.",
-        "default": "python3"
-      },
-      "mode": {
-        "type": "string",
-        "enum": ["text", "semantic", "hybrid"],
-        "default": "text"
-      },
-      "timeoutMs": {
-        "type": "integer",
-        "minimum": 100,
-        "maximum": 120000,
-        "default": 10000
-      }
-    }
-  },
-  "version": "2026.8.1"
+  }
 }

--- a/extensions/planning-knowledge/openclaw.plugin.json
+++ b/extensions/planning-knowledge/openclaw.plugin.json
@@ -1,0 +1,54 @@
+{
+  "id": "planning-knowledge",
+  "name": "Planning Knowledge",
+  "description": "Read-only retrieval from the Planning-owned personal Knowledge corpus.",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": ["planning_knowledge_search", "planning_knowledge_capture"]
+  },
+  "toolMetadata": {
+    "planning_knowledge_search": {
+      "optional": true
+    },
+    "planning_knowledge_capture": {
+      "optional": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "scriptPath": {
+        "type": "string",
+        "description": "Explicit path to OneLibrary's planning_knowledge_index.py CLI."
+      },
+      "sourceRoot": {
+        "type": "string",
+        "description": "Explicit notes/knowledge/ source root; no repository crawl is performed."
+      },
+      "indexPath": {
+        "type": "string",
+        "description": "OneLibrary derived planning_personal SQLite index path."
+      },
+      "pythonExecutable": {
+        "type": "string",
+        "description": "Python executable used for the OneLibrary CLI.",
+        "default": "python3"
+      },
+      "mode": {
+        "type": "string",
+        "enum": ["text", "semantic", "hybrid"],
+        "default": "text"
+      },
+      "timeoutMs": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 120000,
+        "default": 10000
+      }
+    }
+  },
+  "version": "2026.8.1"
+}

--- a/extensions/planning-knowledge/package.json
+++ b/extensions/planning-knowledge/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openclaw/planning-knowledge",
+  "version": "2026.8.1",
+  "private": true,
+  "description": "Read-only OpenClaw access to the Planning-owned personal Knowledge corpus",
+  "type": "module",
+  "dependencies": {
+    "typebox": "1.3.6"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.8.1"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
@@ -6,9 +6,11 @@ import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import {
   createPlanningKnowledgeCaptureTool,
+  createPlanningKnowledgeMaintenanceTool,
   createPlanningKnowledgeSearchTool,
   planningKnowledgeCaptureParameters,
   planningKnowledgeConfigSchema,
+  planningKnowledgeMaintenanceParameters,
   resolvePlanningKnowledgeConfig,
 } from "./planning-knowledge-tool.js";
 
@@ -29,6 +31,11 @@ const config = {
 const writerConfig = {
   ...config,
   writerScriptPath: "/opt/Goal_Agent/tools/planning/knowledge_notes.py",
+};
+
+const maintenanceConfig = {
+  ...config,
+  maintenanceScriptPath: "/opt/Goal_Agent/tools/planning/knowledge_maintenance.py",
 };
 
 const validHit = {
@@ -78,6 +85,7 @@ describe("planning-knowledge config", () => {
   it("declares a strict configuration schema", () => {
     expect(planningKnowledgeConfigSchema).toMatchObject({ additionalProperties: false });
     expect(planningKnowledgeCaptureParameters).toMatchObject({ additionalProperties: false });
+    expect(planningKnowledgeMaintenanceParameters).toMatchObject({ additionalProperties: false });
   });
 
   it("resolves absolute external paths without the plugin-local path resolver", () => {
@@ -95,6 +103,13 @@ describe("planning-knowledge config", () => {
   it("accepts an explicit Planning-owned writer path", () => {
     const resolved = resolvePlanningKnowledgeConfig(writerConfig, () => undefined);
     expect(resolved).toMatchObject({ writerScriptPath: writerConfig.writerScriptPath });
+  });
+
+  it("accepts an explicit read-only maintenance path", () => {
+    const resolved = resolvePlanningKnowledgeConfig(maintenanceConfig, () => undefined);
+    expect(resolved).toMatchObject({
+      maintenanceScriptPath: maintenanceConfig.maintenanceScriptPath,
+    });
   });
 
   it("fails closed when a relative path is outside the plugin resolver boundary", () => {
@@ -430,5 +445,74 @@ describe("planning-knowledge capture in PLN-500C", () => {
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
+  });
+});
+
+describe("planning-knowledge bounded maintenance", () => {
+  it("runs only the fixed Level-A read-only command and returns its portable contract", async () => {
+    const runner = runnerReturning({
+      schema: "planning_knowledge_maintenance",
+      schema_version: 1,
+      read_only: true,
+      result: "completed",
+      writes: { canonical_knowledge: 0, derived_index: 0 },
+    });
+    const tool = createPlanningKnowledgeMaintenanceTool(maintenanceConfig, runner);
+
+    const result = await tool.execute("call-1", { trigger: "scheduled" });
+
+    expect(result.details).toMatchObject({
+      schema: "planning_knowledge_maintenance",
+      schema_version: 1,
+      read_only: true,
+      result: "completed",
+    });
+    const request = vi.mocked(runner).mock.calls[0]?.[0];
+    expect(request?.args).toEqual([
+      maintenanceConfig.maintenanceScriptPath,
+      "run",
+      "--root",
+      "/tmp/goal-agent",
+      "--onelibrary-script",
+      config.scriptPath,
+      "--index",
+      config.indexPath,
+      "--python",
+      config.pythonExecutable,
+      "--trigger",
+      "scheduled",
+      "--runtime-tool-visible",
+    ]);
+    expect(request?.args).not.toContain("--repair");
+  });
+
+  it("fails closed when the maintenance capability is not authorized", async () => {
+    const tool = createPlanningKnowledgeMaintenanceTool(maintenanceConfig, runnerReturning({}), {
+      authorized: false,
+    });
+    await expect(tool.execute("call-1", {})).rejects.toThrow(/access denied/);
+  });
+
+  it("rejects a non-read-only or path-bearing maintenance result", async () => {
+    const writable = createPlanningKnowledgeMaintenanceTool(
+      maintenanceConfig,
+      runnerReturning({
+        schema: "planning_knowledge_maintenance",
+        schema_version: 1,
+        read_only: false,
+      }),
+    );
+    await expect(writable.execute("call-1", {})).rejects.toThrow(/invalid contract/);
+
+    const pathBearing = createPlanningKnowledgeMaintenanceTool(
+      maintenanceConfig,
+      runnerReturning({
+        schema: "planning_knowledge_maintenance",
+        schema_version: 1,
+        read_only: true,
+        output: "/Users/private/secret",
+      }),
+    );
+    await expect(pathBearing.execute("call-1", {})).rejects.toThrow(/local path/);
   });
 });

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -22,6 +22,11 @@ const config = {
   pythonExecutable: "python3",
   mode: "text" as const,
   timeoutMs: 5000,
+};
+
+const writerConfig = {
+  ...config,
+  writerScriptPath: "/opt/Goal_Agent/tools/planning/knowledge_notes.py",
 };
 
 const validHit = {
@@ -83,6 +88,11 @@ describe("planning-knowledge config", () => {
       indexPath: config.indexPath,
     });
     expect(resolvePath).not.toHaveBeenCalled();
+  });
+
+  it("accepts an explicit Planning-owned writer path", () => {
+    const resolved = resolvePlanningKnowledgeConfig(writerConfig, () => undefined);
+    expect(resolved).toMatchObject({ writerScriptPath: writerConfig.writerScriptPath });
   });
 
   it("fails closed when a relative path is outside the plugin resolver boundary", () => {
@@ -163,6 +173,7 @@ describe("planning-knowledge search", () => {
     "canary-runs the configured OneLibrary CLI against a synthetic note",
     async () => {
       const cliPath = process.env.OPENCLAW_PLANNING_KNOWLEDGE_CLI;
+      const pythonExecutable = process.env.OPENCLAW_PLANNING_KNOWLEDGE_PYTHON ?? "python3";
       if (!cliPath) {
         throw new Error("OneLibrary CLI canary requires OPENCLAW_PLANNING_KNOWLEDGE_CLI");
       }
@@ -210,12 +221,13 @@ Output after learning improves retention.
             scriptPath: cliPath,
             sourceRoot,
             indexPath,
+            pythonExecutable,
           },
           (value) => value,
         );
         expect(configured).not.toBeNull();
         await execFileAsync(
-          "python3",
+          pythonExecutable,
           [cliPath, "sync", "--root", sourceRoot, "--index", indexPath, "--mode", "text"],
           { env: process.env },
         );
@@ -257,5 +269,164 @@ describe("planning-knowledge capture in PLN-500A", () => {
       operational_follow_up: "route_separately",
       write_performed: false,
     });
+  });
+});
+
+describe("planning-knowledge capture in PLN-500C", () => {
+  it("calls only the Planning writer and derived sync, returning the canonical ref", async () => {
+    const responses = [
+      {
+        stdout: JSON.stringify({
+          status: "created",
+          title: "Input Output Balance",
+          canonical_ref: "note:notes/knowledge/input_output_balance",
+        }),
+        exitCode: 0,
+      },
+      {
+        stdout: JSON.stringify({
+          inserted_records: 1,
+          updated_records: 0,
+          unchanged_records: 0,
+        }),
+        exitCode: 0,
+      },
+    ];
+    const calls: Array<Parameters<PlanningKnowledgeCommandRunner>[0]> = [];
+    const runner: PlanningKnowledgeCommandRunner = vi.fn(async (request) => {
+      calls.push(request);
+      return responses.shift() ?? { stdout: "{}", exitCode: 0 };
+    });
+    const tool = createPlanningKnowledgeCaptureTool(writerConfig, runner);
+
+    const result = await tool.execute("call-1", {
+      title: "Input Output Balance",
+      knowledgeType: "principle",
+      sourceType: "human",
+      verificationStatus: "reviewed",
+      content: "Output after learning improves retention.",
+      essence: "Input should be followed by active output.",
+      knowledge: "Output after learning improves retention.",
+      operationalFollowUp: "Remind me tomorrow",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "created",
+      write_performed: true,
+      canonical_ref: "note:notes/knowledge/input_output_balance",
+      corpus: "planning_personal",
+      derived_sync: "completed",
+      operational_follow_up: "route_separately",
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.args).toEqual([
+      writerConfig.writerScriptPath,
+      "create",
+      "--root",
+      "/tmp/goal-agent",
+      "--input",
+      "-",
+    ]);
+    expect(JSON.parse(calls[0]?.stdin ?? "{}")).toMatchObject({
+      title: "Input Output Balance",
+      knowledge_type: "principle",
+      source_type: "human",
+      verification_status: "reviewed",
+    });
+    expect(calls[1]?.args).toEqual([
+      writerConfig.scriptPath,
+      "sync",
+      "--root",
+      writerConfig.sourceRoot,
+      "--index",
+      writerConfig.indexPath,
+      "--mode",
+      "text",
+    ]);
+  });
+
+  it("fails closed on a writer collision and does not sync", async () => {
+    const runner: PlanningKnowledgeCommandRunner = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        status: "error",
+        error_code: "collision",
+        message: "Knowledge target already contains different content",
+      }),
+      exitCode: 2,
+    }));
+    const tool = createPlanningKnowledgeCaptureTool(writerConfig, runner);
+
+    await expect(
+      tool.execute("call-1", {
+        title: "Input Output Balance",
+        knowledgeType: "principle",
+        sourceType: "human",
+        verificationStatus: "reviewed",
+        content: "A conflicting proposition.",
+      }),
+    ).rejects.toThrow(/different content/);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it.skipIf(
+    !process.env.OPENCLAW_PLANNING_KNOWLEDGE_CLI || !process.env.OPENCLAW_PLANNING_KNOWLEDGE_WRITER,
+  )("runs the real writer → sync → retrieval cycle in an isolated fixture", async () => {
+    const cliPath = process.env.OPENCLAW_PLANNING_KNOWLEDGE_CLI;
+    const writerPath = process.env.OPENCLAW_PLANNING_KNOWLEDGE_WRITER;
+    const pythonExecutable = process.env.OPENCLAW_PLANNING_KNOWLEDGE_PYTHON ?? "python3";
+    if (!cliPath || !writerPath) {
+      throw new Error("PLN-500C canary requires both Planning and OneLibrary CLIs");
+    }
+    const tempRoot = await mkdtemp(join(tmpdir(), "openclaw-pln-500c-"));
+    const sourceRoot = join(tempRoot, "notes", "knowledge");
+    const indexPath = join(tempRoot, "planning-personal.sqlite3");
+    try {
+      await mkdir(sourceRoot, { recursive: true });
+      const configured = resolvePlanningKnowledgeConfig(
+        {
+          ...config,
+          scriptPath: cliPath,
+          writerScriptPath: writerPath,
+          sourceRoot,
+          indexPath,
+          pythonExecutable,
+        },
+        (value) => value,
+      );
+      expect(configured).not.toBeNull();
+      const capture = createPlanningKnowledgeCaptureTool(configured!);
+      const payload = {
+        title: "Input Output Balance",
+        knowledgeType: "principle" as const,
+        sourceType: "human" as const,
+        verificationStatus: "reviewed" as const,
+        content: "Output after learning improves retention.",
+        essence: "Input should be followed by active output.",
+        knowledge: "Output after learning improves retention.",
+      };
+
+      const created = await capture.execute("call-1", payload);
+      expect(created.details).toMatchObject({
+        status: "created",
+        canonical_ref: "note:notes/knowledge/input_output_balance",
+        derived_sync: "completed",
+      });
+      await execFileAsync(pythonExecutable, [writerPath, "validate-all", "--root", tempRoot]);
+
+      const search = createPlanningKnowledgeSearchTool(configured!);
+      const retrieved = await search.execute("call-2", {
+        query: "Input Output Balance",
+      });
+      expect(retrieved.details).toMatchObject({
+        corpus: "planning_personal",
+        results: [{ canonical_ref: "note:notes/knowledge/input_output_balance" }],
+      });
+
+      const retry = await capture.execute("call-3", payload);
+      expect(retry.details).toMatchObject({ status: "already_exists", write_performed: false });
+      expect(await readdir(sourceRoot)).toHaveLength(1);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
@@ -1,0 +1,240 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPlanningKnowledgeCaptureTool,
+  createPlanningKnowledgeSearchTool,
+  planningKnowledgeCaptureParameters,
+  planningKnowledgeConfigSchema,
+  resolvePlanningKnowledgeConfig,
+  type PlanningKnowledgeCommandRunner,
+} from "./planning-knowledge-tool.js";
+
+const execFileAsync = promisify(execFile);
+
+const config = {
+  scriptPath: "/opt/OneLibrary/Browser-Tracker/scripts/planning_knowledge_index.py",
+  sourceRoot: "/tmp/goal-agent/notes/knowledge",
+  indexPath: "/tmp/planning-personal.sqlite3",
+  pythonExecutable: "python3",
+  mode: "text" as const,
+  timeoutMs: 5000,
+};
+
+const validHit = {
+  canonical_ref: "note:notes/knowledge/input_output_balance",
+  title: "Input Output Balance",
+  snippet: "Learning should be followed by a concrete output.",
+  score: 1.2,
+  knowledge_type: "principle",
+  status: "active",
+  verification_status: "reviewed",
+  domains: ["lernen"],
+  topics: ["learning"],
+  project_refs: [],
+  goal_refs: [],
+  source_type: "human",
+  created_at: "2026-08-01",
+  updated_at: "2026-08-01",
+};
+
+function runnerReturning(payload: unknown): PlanningKnowledgeCommandRunner {
+  return vi.fn(async () => ({
+    stdout: JSON.stringify(payload),
+    exitCode: 0,
+  }));
+}
+
+describe("planning-knowledge config", () => {
+  it("requires an explicit notes/knowledge root before enabling search", () => {
+    expect(resolvePlanningKnowledgeConfig({}, (value) => value)).toBeNull();
+    expect(() =>
+      resolvePlanningKnowledgeConfig(
+        { ...config, sourceRoot: "/tmp/goal-agent/notes" },
+        (value) => value,
+      ),
+    ).toThrow(/notes\/knowledge/);
+  });
+
+  it("keeps the derived index outside the canonical source", () => {
+    expect(() =>
+      resolvePlanningKnowledgeConfig(
+        { ...config, indexPath: "/tmp/goal-agent/notes/knowledge/index.sqlite3" },
+        (value) => value,
+      ),
+    ).toThrow(/outside/);
+  });
+
+  it("declares a strict configuration schema", () => {
+    expect(planningKnowledgeConfigSchema).toMatchObject({ additionalProperties: false });
+    expect(planningKnowledgeCaptureParameters).toMatchObject({ additionalProperties: false });
+  });
+});
+
+describe("planning-knowledge search", () => {
+  it("delegates to OneLibrary and returns only portable canonical citations", async () => {
+    const runner = runnerReturning({ results: [validHit] });
+    const tool = createPlanningKnowledgeSearchTool(config, runner);
+
+    const result = await tool.execute("call-1", { query: "input output balance" });
+    expect(result.details).toMatchObject({
+      source_system: "planning",
+      record_type: "knowledge",
+      corpus: "planning_personal",
+      security_scope: "personal",
+      results: [{ canonical_ref: validHit.canonical_ref }],
+    });
+    expect(JSON.stringify(result)).not.toMatch(/vector|chunk_id|sqlite|\/tmp\//i);
+    expect(runner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executable: "python3",
+        args: expect.arrayContaining([
+          "search",
+          "--root",
+          config.sourceRoot,
+          "--index",
+          config.indexPath,
+          "--query",
+          "input output balance",
+        ]),
+      }),
+    );
+  });
+
+  it("fails closed for no matches", async () => {
+    const tool = createPlanningKnowledgeSearchTool(config, runnerReturning({ results: [] }));
+    const result = await tool.execute("call-1", { query: "not stored" });
+    expect(result.details).toMatchObject({
+      count: 0,
+      message: "No stored Planning Knowledge Note found for this query.",
+    });
+  });
+
+  it("rejects invalid citations and ineligible results", async () => {
+    const invalidRef = createPlanningKnowledgeSearchTool(
+      config,
+      runnerReturning({ results: [{ ...validHit, canonical_ref: "vector-123" }] }),
+    );
+    await expect(invalidRef.execute("call-1", { query: "x" })).rejects.toThrow(
+      /canonical note ref/,
+    );
+
+    const archived = createPlanningKnowledgeSearchTool(
+      config,
+      runnerReturning({ results: [{ ...validHit, status: "archived" }] }),
+    );
+    await expect(archived.execute("call-1", { query: "x" })).rejects.toThrow(/ineligible/);
+  });
+
+  it("does not use a shell and propagates the caller signal", async () => {
+    const runner = runnerReturning({ results: [] });
+    const tool = createPlanningKnowledgeSearchTool(config, runner);
+    const signal = new AbortController().signal;
+    await tool.execute("call-1", { query: "x" }, signal);
+    expect(runner).toHaveBeenCalledWith(expect.objectContaining({ signal }));
+    expect(vi.mocked(runner).mock.calls[0]?.[0].args).not.toContain("/bin/sh");
+  });
+
+  it.skipIf(!process.env.OPENCLAW_PLANNING_KNOWLEDGE_CLI)(
+    "canary-runs the configured OneLibrary CLI against a synthetic note",
+    async () => {
+      const cliPath = process.env.OPENCLAW_PLANNING_KNOWLEDGE_CLI;
+      if (!cliPath) {
+        throw new Error("OneLibrary CLI canary requires OPENCLAW_PLANNING_KNOWLEDGE_CLI");
+      }
+      const tempRoot = await mkdtemp(join(tmpdir(), "openclaw-planning-knowledge-"));
+      const sourceRoot = join(tempRoot, "notes", "knowledge");
+      const notePath = join(sourceRoot, "input_output_balance.md");
+      const indexPath = join(tempRoot, "planning-personal.sqlite3");
+      try {
+        await mkdir(sourceRoot, { recursive: true });
+        await writeFile(
+          notePath,
+          `---
+schema: planning_knowledge_note
+schema_version: 1
+id: "note:notes/knowledge/input_output_balance"
+title: "Input Output Balance"
+knowledge_type: principle
+status: active
+created_at: "2026-08-01"
+updated_at: "2026-08-01"
+source_type: human
+verification_status: reviewed
+domains: ["lernen"]
+topics: ["learning"]
+goal_refs: []
+project_refs: []
+related_note_refs: []
+source_refs: []
+supersedes: []
+---
+
+## Essence
+
+No major input without a concrete output.
+
+## Knowledge
+
+Output after learning improves retention.
+`,
+          "utf8",
+        );
+        const configured = resolvePlanningKnowledgeConfig(
+          {
+            ...config,
+            scriptPath: cliPath,
+            sourceRoot,
+            indexPath,
+          },
+          (value) => value,
+        );
+        expect(configured).not.toBeNull();
+        await execFileAsync(
+          "python3",
+          [cliPath, "sync", "--root", sourceRoot, "--index", indexPath, "--mode", "text"],
+          { env: process.env },
+        );
+        const tool = createPlanningKnowledgeSearchTool(configured!);
+        const result = await tool.execute("call-1", { query: "input output balance" });
+        expect(result.details).toMatchObject({
+          corpus: "planning_personal",
+          results: [{ canonical_ref: "note:notes/knowledge/input_output_balance" }],
+        });
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+describe("planning-knowledge capture in PLN-500A", () => {
+  it("recognizes explicit capture without writing or creating a task", async () => {
+    const result = await createPlanningKnowledgeCaptureTool().execute("call-1", {
+      content: "No major input without an output.",
+    });
+    expect(result.details).toEqual({
+      intent: "knowledge_capture",
+      status: "capture_not_enabled_in_pln_500a",
+      write_performed: false,
+      canonical_owner: "planning",
+      operational_follow_up: "none",
+    });
+  });
+
+  it("keeps a mixed operational follow-up separate", async () => {
+    const result = await createPlanningKnowledgeCaptureTool().execute("call-1", {
+      content: "No major input without an output.",
+      operationalFollowUp: "Remind me tomorrow",
+    });
+    expect(result.details).toMatchObject({
+      intent: "knowledge_capture",
+      status: "capture_not_enabled_in_pln_500a",
+      operational_follow_up: "route_separately",
+      write_performed: false,
+    });
+  });
+});

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
@@ -10,10 +10,12 @@ import {
   planningKnowledgeCaptureParameters,
   planningKnowledgeConfigSchema,
   resolvePlanningKnowledgeConfig,
-  type PlanningKnowledgeCommandRunner,
 } from "./planning-knowledge-tool.js";
 
 const execFileAsync = promisify(execFile);
+type PlanningKnowledgeCommandRunner = NonNullable<
+  Parameters<typeof createPlanningKnowledgeSearchTool>[1]
+>;
 
 const config = {
   scriptPath: "/opt/OneLibrary/Browser-Tracker/scripts/planning_knowledge_index.py",

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.test.ts
@@ -72,6 +72,27 @@ describe("planning-knowledge config", () => {
     expect(planningKnowledgeConfigSchema).toMatchObject({ additionalProperties: false });
     expect(planningKnowledgeCaptureParameters).toMatchObject({ additionalProperties: false });
   });
+
+  it("resolves absolute external paths without the plugin-local path resolver", () => {
+    const resolvePath = vi.fn(() => undefined);
+    const resolved = resolvePlanningKnowledgeConfig(config, resolvePath);
+
+    expect(resolved).toMatchObject({
+      scriptPath: config.scriptPath,
+      sourceRoot: config.sourceRoot,
+      indexPath: config.indexPath,
+    });
+    expect(resolvePath).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a relative path is outside the plugin resolver boundary", () => {
+    expect(() =>
+      resolvePlanningKnowledgeConfig(
+        { ...config, sourceRoot: "../../../Goal_Agent_latest/notes/knowledge" },
+        () => undefined,
+      ),
+    ).toThrow(/sourceRoot must be an absolute path/);
+  });
 });
 
 describe("planning-knowledge search", () => {

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.ts
@@ -35,6 +35,12 @@ export const planningKnowledgeConfigSchema = Type.Object(
         description: "Explicit Planning-owned knowledge_notes.py writer path.",
       }),
     ),
+    maintenanceScriptPath: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Explicit read-only Planning knowledge_maintenance.py path.",
+      }),
+    ),
     pythonExecutable: Type.Optional(
       Type.String({ minLength: 1, description: "Python executable for the OneLibrary CLI." }),
     ),
@@ -126,6 +132,7 @@ type ResolvedPlanningKnowledgeConfig = {
   sourceRoot: string;
   indexPath: string;
   writerScriptPath?: string;
+  maintenanceScriptPath?: string;
   pythonExecutable: string;
   mode: "text" | "semantic" | "hybrid";
   timeoutMs: number;
@@ -201,6 +208,9 @@ export function resolvePlanningKnowledgeConfig(
   const normalizedWriterScriptPath = config.writerScriptPath
     ? resolveConfiguredPath(config.writerScriptPath, "writerScriptPath", resolvePath)
     : undefined;
+  const normalizedMaintenanceScriptPath = config.maintenanceScriptPath
+    ? resolveConfiguredPath(config.maintenanceScriptPath, "maintenanceScriptPath", resolvePath)
+    : undefined;
 
   if (!isKnowledgeRoot(normalizedSourceRoot)) {
     throw new Error("Planning Knowledge sourceRoot must end in notes/knowledge");
@@ -210,6 +220,14 @@ export function resolvePlanningKnowledgeConfig(
   }
   if (normalizedWriterScriptPath && basename(normalizedWriterScriptPath) !== "knowledge_notes.py") {
     throw new Error("Planning Knowledge writerScriptPath must be Planning knowledge_notes.py");
+  }
+  if (
+    normalizedMaintenanceScriptPath &&
+    basename(normalizedMaintenanceScriptPath) !== "knowledge_maintenance.py"
+  ) {
+    throw new Error(
+      "Planning Knowledge maintenanceScriptPath must be Planning knowledge_maintenance.py",
+    );
   }
   if (isPathInside(normalizedIndexPath, normalizedSourceRoot)) {
     throw new Error("Planning Knowledge indexPath must be outside the canonical source root");
@@ -225,6 +243,9 @@ export function resolvePlanningKnowledgeConfig(
     sourceRoot: normalizedSourceRoot,
     indexPath: normalizedIndexPath,
     ...(normalizedWriterScriptPath ? { writerScriptPath: normalizedWriterScriptPath } : {}),
+    ...(normalizedMaintenanceScriptPath
+      ? { maintenanceScriptPath: normalizedMaintenanceScriptPath }
+      : {}),
     pythonExecutable: config.pythonExecutable?.trim() || "python3",
     mode: config.mode ?? "text",
     timeoutMs,
@@ -627,6 +648,75 @@ export function createPlanningKnowledgeCaptureTool(
         },
         operational_follow_up: params.operationalFollowUp?.trim() ? "route_separately" : "none",
       });
+    },
+  };
+}
+
+export const planningKnowledgeMaintenanceParameters = Type.Object(
+  {
+    trigger: Type.Optional(
+      Type.Union([Type.Literal("manual"), Type.Literal("scheduled"), Type.Literal("openclaw")]),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createPlanningKnowledgeMaintenanceTool(
+  config: ResolvedPlanningKnowledgeConfig,
+  runner: PlanningKnowledgeCommandRunner = runCommand,
+  options: { authorized?: boolean } = {},
+) {
+  return {
+    name: "planning_knowledge_maintenance",
+    label: "Planning Knowledge Maintenance",
+    description:
+      "Run bounded Level-A Planning Knowledge validation, health, quality and read-only OneLibrary audit. It cannot write canonical Notes, repair derived state, accept Candidates, migrate schemas or restore backups.",
+    parameters: planningKnowledgeMaintenanceParameters,
+    optional: true,
+    async execute(
+      _toolCallId: string,
+      params: Static<typeof planningKnowledgeMaintenanceParameters>,
+      signal?: AbortSignal,
+    ) {
+      if (options.authorized === false) {
+        throw new Error("Planning Knowledge maintenance access denied");
+      }
+      if (!config.maintenanceScriptPath) {
+        throw new Error("Planning Knowledge maintenance is not configured");
+      }
+      const result = await runner({
+        executable: config.pythonExecutable,
+        args: [
+          config.maintenanceScriptPath,
+          "run",
+          "--root",
+          dirname(dirname(config.sourceRoot)),
+          "--onelibrary-script",
+          config.scriptPath,
+          "--index",
+          config.indexPath,
+          "--python",
+          config.pythonExecutable,
+          "--trigger",
+          params.trigger ?? "openclaw",
+          "--runtime-tool-visible",
+        ],
+        timeoutMs: config.timeoutMs,
+        signal,
+      });
+      if (result.exitCode !== 0) {
+        throw new Error("Planning Knowledge maintenance failed closed");
+      }
+      const parsed = parseCommandObject(result.stdout, "maintenance");
+      if (
+        parsed.schema !== "planning_knowledge_maintenance" ||
+        parsed.schema_version !== 1 ||
+        parsed.read_only !== true
+      ) {
+        throw new Error("Planning Knowledge maintenance returned an invalid contract");
+      }
+      assertPortableCommandObject(parsed);
+      return jsonResult(parsed);
     },
   };
 }

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.ts
@@ -1,0 +1,376 @@
+import { spawn } from "node:child_process";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { jsonResult } from "openclaw/plugin-sdk/tool-results";
+import { Type, type Static } from "typebox";
+
+const NOTE_REF_PATTERN = /^note:notes\/knowledge\/[a-z0-9]+(?:_[a-z0-9]+)*$/;
+const ABSOLUTE_PATH_PATTERN =
+  /(?:file:\/\/|~\/|(?:^|[\s'"`])\/(?:Users|private|tmp|var|home)(?:\/|$)|(?:^|[\s'"`])[A-Za-z]:[\\/])/i;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export const planningKnowledgeConfigSchema = Type.Object(
+  {
+    scriptPath: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Explicit OneLibrary planning_knowledge_index.py path.",
+      }),
+    ),
+    sourceRoot: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Explicit notes/knowledge source root.",
+      }),
+    ),
+    indexPath: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Explicit derived planning_personal index path.",
+      }),
+    ),
+    pythonExecutable: Type.Optional(
+      Type.String({ minLength: 1, description: "Python executable for the OneLibrary CLI." }),
+    ),
+    mode: Type.Optional(
+      Type.Union([Type.Literal("text"), Type.Literal("semantic"), Type.Literal("hybrid")]),
+    ),
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 100, maximum: 120_000 })),
+  },
+  { additionalProperties: false },
+);
+
+export type PlanningKnowledgeConfig = Static<typeof planningKnowledgeConfigSchema>;
+
+export const planningKnowledgeSearchParameters = Type.Object(
+  {
+    query: Type.String({
+      minLength: 1,
+      description: "Question or terms to find in saved Knowledge.",
+    }),
+    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 20, default: 5 })),
+  },
+  { additionalProperties: false },
+);
+
+export type PlanningKnowledgeSearchParams = Static<typeof planningKnowledgeSearchParameters>;
+
+export const planningKnowledgeCaptureParameters = Type.Object(
+  {
+    content: Type.String({
+      minLength: 1,
+      description: "Content the user explicitly asked to save as personal Knowledge.",
+    }),
+    operationalFollowUp: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Separate reminder/action text, if the request is mixed.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export type PlanningKnowledgeCaptureParams = Static<typeof planningKnowledgeCaptureParameters>;
+
+type ResolvedPlanningKnowledgeConfig = {
+  scriptPath: string;
+  sourceRoot: string;
+  indexPath: string;
+  pythonExecutable: string;
+  mode: "text" | "semantic" | "hybrid";
+  timeoutMs: number;
+};
+
+type CommandResult = {
+  stdout: string;
+  exitCode: number | null;
+};
+
+export type PlanningKnowledgeCommandRunner = (request: {
+  executable: string;
+  args: string[];
+  timeoutMs: number;
+  signal?: AbortSignal;
+}) => Promise<CommandResult>;
+
+function isPathInside(candidate: string, parent: string): boolean {
+  const rel = relative(parent, candidate);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+function isKnowledgeRoot(value: string): boolean {
+  const normalized = resolve(value);
+  return basename(normalized) === "knowledge" && basename(dirname(normalized)) === "notes";
+}
+
+function requireConfiguredString(value: string | undefined, name: string): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`Planning Knowledge ${name} is not configured`);
+  }
+  return normalized;
+}
+
+export function resolvePlanningKnowledgeConfig(
+  config: PlanningKnowledgeConfig,
+  resolvePath: (input: string) => string,
+): ResolvedPlanningKnowledgeConfig | null {
+  if (!config.scriptPath || !config.sourceRoot || !config.indexPath) {
+    return null;
+  }
+
+  const scriptPath = resolvePath(requireConfiguredString(config.scriptPath, "scriptPath"));
+  const sourceRoot = resolvePath(requireConfiguredString(config.sourceRoot, "sourceRoot"));
+  const indexPath = resolvePath(requireConfiguredString(config.indexPath, "indexPath"));
+  const normalizedSourceRoot = resolve(sourceRoot);
+  const normalizedScriptPath = resolve(scriptPath);
+  const normalizedIndexPath = resolve(indexPath);
+
+  if (!isKnowledgeRoot(normalizedSourceRoot)) {
+    throw new Error("Planning Knowledge sourceRoot must end in notes/knowledge");
+  }
+  if (basename(normalizedScriptPath) !== "planning_knowledge_index.py") {
+    throw new Error("Planning Knowledge scriptPath must be OneLibrary planning_knowledge_index.py");
+  }
+  if (isPathInside(normalizedIndexPath, normalizedSourceRoot)) {
+    throw new Error("Planning Knowledge indexPath must be outside the canonical source root");
+  }
+
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 100 || timeoutMs > 120_000) {
+    throw new Error("Planning Knowledge timeoutMs is outside the allowed range");
+  }
+
+  return {
+    scriptPath: normalizedScriptPath,
+    sourceRoot: normalizedSourceRoot,
+    indexPath: normalizedIndexPath,
+    pythonExecutable: config.pythonExecutable?.trim() || "python3",
+    mode: config.mode ?? "text",
+    timeoutMs,
+  };
+}
+
+function runCommand(request: {
+  executable: string;
+  args: string[];
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<CommandResult> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(request.executable, request.args, {
+      shell: false,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    let stdout = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(new Error("Planning Knowledge retrieval timed out"));
+    }, request.timeoutMs);
+
+    const abort = () => {
+      child.kill("SIGTERM");
+      finish(new Error("Planning Knowledge retrieval was cancelled"));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      request.signal?.removeEventListener("abort", abort);
+    };
+
+    const finish = (error?: Error, result?: CommandResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (error) {
+        reject(error);
+      } else if (result) {
+        resolveResult(result);
+      }
+    };
+
+    request.signal?.addEventListener("abort", abort, { once: true });
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.once("error", () => finish(new Error("Planning Knowledge adapter is unavailable")));
+    child.once("close", (exitCode) => finish(undefined, { stdout, exitCode }));
+  });
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function safeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value) || !value.every(isString)) {
+    throw new Error("Planning Knowledge returned invalid metadata");
+  }
+  return value.slice();
+}
+
+function assertNoAbsolutePath(value: unknown): void {
+  if (isString(value) && ABSOLUTE_PATH_PATTERN.test(value)) {
+    throw new Error("Planning Knowledge result contained a local path");
+  }
+}
+
+function safeSearchResult(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Planning Knowledge returned an invalid result");
+  }
+  const record = value as Record<string, unknown>;
+  const canonicalRef = record.canonical_ref;
+  const status = record.status;
+  const verificationStatus = record.verification_status;
+  if (!isString(canonicalRef) || !NOTE_REF_PATTERN.test(canonicalRef)) {
+    throw new Error("Planning Knowledge result is missing a valid canonical note ref");
+  }
+  if (status !== "active" || verificationStatus === "rejected") {
+    throw new Error("Planning Knowledge returned an ineligible result");
+  }
+  if (!isString(record.title) || !isString(record.snippet)) {
+    throw new Error("Planning Knowledge returned incomplete result metadata");
+  }
+  const domains = safeStringArray(record.domains);
+  const topics = safeStringArray(record.topics);
+  const projectRefs = safeStringArray(record.project_refs);
+  const goalRefs = safeStringArray(record.goal_refs);
+  if (!isString(record.knowledge_type) || !isString(record.source_type)) {
+    throw new Error("Planning Knowledge returned incomplete result metadata");
+  }
+  for (const candidate of [
+    canonicalRef,
+    record.title,
+    record.snippet,
+    ...domains,
+    ...topics,
+    ...projectRefs,
+    ...goalRefs,
+  ]) {
+    assertNoAbsolutePath(candidate);
+  }
+  return {
+    canonical_ref: canonicalRef,
+    title: record.title,
+    snippet: record.snippet,
+    ...(typeof record.score === "number" && Number.isFinite(record.score)
+      ? { score: record.score }
+      : {}),
+    knowledge_type: record.knowledge_type,
+    status,
+    verification_status: verificationStatus,
+    domains,
+    topics,
+    project_refs: projectRefs,
+    goal_refs: goalRefs,
+    source_type: record.source_type,
+    ...(isString(record.created_at) ? { created_at: record.created_at } : {}),
+    ...(isString(record.updated_at) ? { updated_at: record.updated_at } : {}),
+  };
+}
+
+function parseSearchOutput(stdout: string): Record<string, unknown>[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error("Planning Knowledge adapter returned invalid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Planning Knowledge adapter returned an invalid response");
+  }
+  const results = (parsed as Record<string, unknown>).results;
+  if (!Array.isArray(results)) {
+    throw new Error("Planning Knowledge adapter returned no result list");
+  }
+  return results.map(safeSearchResult);
+}
+
+export function createPlanningKnowledgeSearchTool(
+  config: ResolvedPlanningKnowledgeConfig,
+  runner: PlanningKnowledgeCommandRunner = runCommand,
+  options: { authorized?: boolean } = {},
+) {
+  return {
+    name: "planning_knowledge_search",
+    label: "Planning Knowledge Search",
+    description:
+      "Search private Planning-owned personal Knowledge Notes through OneLibrary. Results are derived and must be cited with canonical note:notes/knowledge/<slug> refs.",
+    parameters: planningKnowledgeSearchParameters,
+    optional: true,
+    async execute(
+      _toolCallId: string,
+      params: PlanningKnowledgeSearchParams,
+      signal?: AbortSignal,
+    ) {
+      if (options.authorized === false) {
+        throw new Error("Planning Knowledge access denied");
+      }
+      const query = params.query.trim();
+      if (!query) {
+        throw new Error("query required");
+      }
+      const limit = params.limit ?? 5;
+      const result = await runner({
+        executable: config.pythonExecutable,
+        args: [
+          config.scriptPath,
+          "search",
+          "--root",
+          config.sourceRoot,
+          "--index",
+          config.indexPath,
+          "--query",
+          query,
+          "--limit",
+          String(limit),
+          "--mode",
+          config.mode,
+        ],
+        timeoutMs: config.timeoutMs,
+        signal,
+      });
+      if (result.exitCode !== 0) {
+        throw new Error("Planning Knowledge retrieval is unavailable");
+      }
+      const results = parseSearchOutput(result.stdout);
+      return jsonResult({
+        source_system: "planning",
+        record_type: "knowledge",
+        corpus: "planning_personal",
+        security_scope: "personal",
+        query,
+        results,
+        count: results.length,
+        ...(results.length === 0
+          ? { message: "No stored Planning Knowledge Note found for this query." }
+          : {}),
+      });
+    },
+  };
+}
+
+export function createPlanningKnowledgeCaptureTool() {
+  return {
+    name: "planning_knowledge_capture",
+    label: "Planning Knowledge Capture (disabled)",
+    description:
+      "Recognize explicit requests to save personal Knowledge without writing in PLN-500A.",
+    parameters: planningKnowledgeCaptureParameters,
+    optional: true,
+    async execute(_toolCallId: string, params: PlanningKnowledgeCaptureParams) {
+      return jsonResult({
+        intent: "knowledge_capture",
+        status: "capture_not_enabled_in_pln_500a",
+        write_performed: false,
+        canonical_owner: "planning",
+        operational_follow_up: params.operationalFollowUp?.trim() ? "route_separately" : "none",
+      });
+    },
+  };
+}

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.ts
@@ -29,6 +29,12 @@ export const planningKnowledgeConfigSchema = Type.Object(
         description: "Explicit derived planning_personal index path.",
       }),
     ),
+    writerScriptPath: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Explicit Planning-owned knowledge_notes.py writer path.",
+      }),
+    ),
     pythonExecutable: Type.Optional(
       Type.String({ minLength: 1, description: "Python executable for the OneLibrary CLI." }),
     ),
@@ -61,6 +67,48 @@ export const planningKnowledgeCaptureParameters = Type.Object(
       minLength: 1,
       description: "Content the user explicitly asked to save as personal Knowledge.",
     }),
+    title: Type.Optional(Type.String({ minLength: 1 })),
+    knowledgeType: Type.Optional(
+      Type.Union([
+        Type.Literal("principle"),
+        Type.Literal("learning"),
+        Type.Literal("framework"),
+        Type.Literal("concept"),
+        Type.Literal("reference"),
+        Type.Literal("reflection"),
+      ]),
+    ),
+    sourceType: Type.Optional(
+      Type.Union([
+        Type.Literal("human"),
+        Type.Literal("ai_chat"),
+        Type.Literal("meeting"),
+        Type.Literal("book"),
+        Type.Literal("paper"),
+        Type.Literal("article"),
+        Type.Literal("web"),
+        Type.Literal("document"),
+        Type.Literal("other"),
+      ]),
+    ),
+    verificationStatus: Type.Optional(
+      Type.Union([
+        Type.Literal("unverified"),
+        Type.Literal("reviewed"),
+        Type.Literal("confirmed"),
+        Type.Literal("corrected"),
+        Type.Literal("rejected"),
+      ]),
+    ),
+    essence: Type.Optional(Type.String({ minLength: 1 })),
+    knowledge: Type.Optional(Type.String({ minLength: 1 })),
+    domains: Type.Optional(Type.Array(Type.String())),
+    topics: Type.Optional(Type.Array(Type.String())),
+    goalRefs: Type.Optional(Type.Array(Type.String())),
+    projectRefs: Type.Optional(Type.Array(Type.String())),
+    relatedNoteRefs: Type.Optional(Type.Array(Type.String())),
+    sourceRefs: Type.Optional(Type.Array(Type.String())),
+    supersedes: Type.Optional(Type.Array(Type.String())),
     operationalFollowUp: Type.Optional(
       Type.String({
         minLength: 1,
@@ -77,6 +125,7 @@ type ResolvedPlanningKnowledgeConfig = {
   scriptPath: string;
   sourceRoot: string;
   indexPath: string;
+  writerScriptPath?: string;
   pythonExecutable: string;
   mode: "text" | "semantic" | "hybrid";
   timeoutMs: number;
@@ -90,6 +139,7 @@ type CommandResult = {
 export type PlanningKnowledgeCommandRunner = (request: {
   executable: string;
   args: string[];
+  stdin?: string;
   timeoutMs: number;
   signal?: AbortSignal;
 }) => Promise<CommandResult>;
@@ -148,12 +198,18 @@ export function resolvePlanningKnowledgeConfig(
   const normalizedSourceRoot = resolveConfiguredPath(config.sourceRoot, "sourceRoot", resolvePath);
   const normalizedScriptPath = resolveConfiguredPath(config.scriptPath, "scriptPath", resolvePath);
   const normalizedIndexPath = resolveConfiguredPath(config.indexPath, "indexPath", resolvePath);
+  const normalizedWriterScriptPath = config.writerScriptPath
+    ? resolveConfiguredPath(config.writerScriptPath, "writerScriptPath", resolvePath)
+    : undefined;
 
   if (!isKnowledgeRoot(normalizedSourceRoot)) {
     throw new Error("Planning Knowledge sourceRoot must end in notes/knowledge");
   }
   if (basename(normalizedScriptPath) !== "planning_knowledge_index.py") {
     throw new Error("Planning Knowledge scriptPath must be OneLibrary planning_knowledge_index.py");
+  }
+  if (normalizedWriterScriptPath && basename(normalizedWriterScriptPath) !== "knowledge_notes.py") {
+    throw new Error("Planning Knowledge writerScriptPath must be Planning knowledge_notes.py");
   }
   if (isPathInside(normalizedIndexPath, normalizedSourceRoot)) {
     throw new Error("Planning Knowledge indexPath must be outside the canonical source root");
@@ -168,6 +224,7 @@ export function resolvePlanningKnowledgeConfig(
     scriptPath: normalizedScriptPath,
     sourceRoot: normalizedSourceRoot,
     indexPath: normalizedIndexPath,
+    ...(normalizedWriterScriptPath ? { writerScriptPath: normalizedWriterScriptPath } : {}),
     pythonExecutable: config.pythonExecutable?.trim() || "python3",
     mode: config.mode ?? "text",
     timeoutMs,
@@ -177,13 +234,14 @@ export function resolvePlanningKnowledgeConfig(
 function runCommand(request: {
   executable: string;
   args: string[];
+  stdin?: string;
   timeoutMs: number;
   signal?: AbortSignal;
 }): Promise<CommandResult> {
   return new Promise((resolveResult, reject) => {
     const child = spawn(request.executable, request.args, {
       shell: false,
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: [request.stdin === undefined ? "ignore" : "pipe", "pipe", "ignore"],
     });
     let stdout = "";
     let settled = false;
@@ -216,8 +274,16 @@ function runCommand(request: {
     };
 
     request.signal?.addEventListener("abort", abort, { once: true });
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
+    if (request.stdin !== undefined) {
+      child.stdin?.end(request.stdin);
+    }
+    const stdoutStream = child.stdout;
+    if (!stdoutStream) {
+      finish(new Error("Planning Knowledge command returned no stdout"));
+      return;
+    }
+    stdoutStream.setEncoding("utf8");
+    stdoutStream.on("data", (chunk: string) => {
       stdout += chunk;
     });
     child.once("error", () => finish(new Error("Planning Knowledge adapter is unavailable")));
@@ -314,6 +380,65 @@ function parseSearchOutput(stdout: string): Record<string, unknown>[] {
   return results.map(safeSearchResult);
 }
 
+function parseCommandObject(stdout: string, label: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error(`Planning Knowledge ${label} returned invalid JSON`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Planning Knowledge ${label} returned an invalid response`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function assertPortableCommandObject(value: unknown): void {
+  if (isString(value)) {
+    assertNoAbsolutePath(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertPortableCommandObject(item);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) {
+      assertPortableCommandObject(item);
+    }
+  }
+}
+
+function parseCaptureResult(stdout: string): {
+  status: "created" | "already_exists";
+  title: string;
+  canonical_ref: string;
+} {
+  const result = parseCommandObject(stdout, "Planning writer");
+  const status = result.status;
+  const title = result.title;
+  const canonicalRef = result.canonical_ref;
+  if (status !== "created" && status !== "already_exists") {
+    throw new Error("Planning writer returned an unexpected status");
+  }
+  if (!isString(title) || !title.trim()) {
+    throw new Error("Planning writer returned no title");
+  }
+  if (!isString(canonicalRef) || !NOTE_REF_PATTERN.test(canonicalRef)) {
+    throw new Error("Planning writer returned an invalid canonical note ref");
+  }
+  assertPortableCommandObject({ title, canonical_ref: canonicalRef });
+  return { status, title, canonical_ref: canonicalRef };
+}
+
+function parseSyncResult(stdout: string): Record<string, unknown> {
+  const result = parseCommandObject(stdout, "OneLibrary sync");
+  assertPortableCommandObject(result);
+  return result;
+}
+
 export function createPlanningKnowledgeSearchTool(
   config: ResolvedPlanningKnowledgeConfig,
   runner: PlanningKnowledgeCommandRunner = runCommand,
@@ -378,20 +503,128 @@ export function createPlanningKnowledgeSearchTool(
   };
 }
 
-export function createPlanningKnowledgeCaptureTool() {
+export function createPlanningKnowledgeCaptureTool(
+  config?: ResolvedPlanningKnowledgeConfig,
+  runner: PlanningKnowledgeCommandRunner = runCommand,
+) {
   return {
     name: "planning_knowledge_capture",
-    label: "Planning Knowledge Capture (disabled)",
-    description:
-      "Recognize explicit requests to save personal Knowledge without writing in PLN-500A.",
+    label: config?.writerScriptPath
+      ? "Planning Knowledge Capture"
+      : "Planning Knowledge Capture (disabled)",
+    description: config?.writerScriptPath
+      ? "Create an explicitly requested Planning Knowledge Note through the Planning-owned writer, then refresh the derived OneLibrary index. Never create tasks or calendar events."
+      : "Recognize explicit requests to save personal Knowledge without writing in PLN-500A.",
     parameters: planningKnowledgeCaptureParameters,
     optional: true,
-    async execute(_toolCallId: string, params: PlanningKnowledgeCaptureParams) {
+    async execute(
+      _toolCallId: string,
+      params: PlanningKnowledgeCaptureParams,
+      signal?: AbortSignal,
+    ) {
+      if (!config?.writerScriptPath) {
+        return jsonResult({
+          intent: "knowledge_capture",
+          status: "capture_not_enabled_in_pln_500a",
+          write_performed: false,
+          canonical_owner: "planning",
+          operational_follow_up: params.operationalFollowUp?.trim() ? "route_separately" : "none",
+        });
+      }
+
+      const title = params.title?.trim();
+      const knowledgeType = params.knowledgeType;
+      const sourceType = params.sourceType;
+      const verificationStatus = params.verificationStatus;
+      if (!title || !knowledgeType || !sourceType || !verificationStatus) {
+        throw new Error(
+          "Planning Knowledge capture requires title, knowledgeType, sourceType, and verificationStatus",
+        );
+      }
+      const content = params.content.trim();
+      if (!content) {
+        throw new Error("Planning Knowledge capture content required");
+      }
+      const writerPayload: Record<string, unknown> = {
+        title,
+        knowledge_type: knowledgeType,
+        source_type: sourceType,
+        verification_status: verificationStatus,
+        content: {
+          essence: params.essence?.trim() || content,
+          knowledge: params.knowledge?.trim() || content,
+        },
+      };
+      for (const [input, output] of [
+        ["domains", "domains"],
+        ["topics", "topics"],
+        ["goalRefs", "goal_refs"],
+        ["projectRefs", "project_refs"],
+        ["relatedNoteRefs", "related_note_refs"],
+        ["sourceRefs", "source_refs"],
+        ["supersedes", "supersedes"],
+      ] as const) {
+        const value = params[input];
+        if (value !== undefined) {
+          writerPayload[output] = value;
+        }
+      }
+
+      const writerResult = await runner({
+        executable: config.pythonExecutable,
+        args: [
+          config.writerScriptPath,
+          "create",
+          "--root",
+          dirname(dirname(config.sourceRoot)),
+          "--input",
+          "-",
+        ],
+        stdin: JSON.stringify(writerPayload),
+        timeoutMs: config.timeoutMs,
+        signal,
+      });
+      if (writerResult.exitCode !== 0) {
+        const error = parseCommandObject(writerResult.stdout, "Planning writer");
+        throw new Error(
+          isString(error.message) ? error.message : "Planning Knowledge capture failed",
+        );
+      }
+      const created = parseCaptureResult(writerResult.stdout);
+
+      const syncResult = await runner({
+        executable: config.pythonExecutable,
+        args: [
+          config.scriptPath,
+          "sync",
+          "--root",
+          config.sourceRoot,
+          "--index",
+          config.indexPath,
+          "--mode",
+          config.mode,
+        ],
+        timeoutMs: config.timeoutMs,
+        signal,
+      });
+      if (syncResult.exitCode !== 0) {
+        throw new Error("Planning Knowledge derived index sync failed");
+      }
+      const synced = parseSyncResult(syncResult.stdout);
       return jsonResult({
         intent: "knowledge_capture",
-        status: "capture_not_enabled_in_pln_500a",
-        write_performed: false,
+        status: created.status,
+        write_performed: created.status === "created",
         canonical_owner: "planning",
+        canonical_ref: created.canonical_ref,
+        title: created.title,
+        corpus: "planning_personal",
+        derived_sync: "completed",
+        sync_summary: {
+          inserted_records: synced.inserted_records,
+          updated_records: synced.updated_records,
+          unchanged_records: synced.unchanged_records,
+        },
         operational_follow_up: params.operationalFollowUp?.trim() ? "route_separately" : "none",
       });
     },

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import { Type, type Static } from "typebox";
@@ -111,20 +112,42 @@ function requireConfiguredString(value: string | undefined, name: string): strin
   return normalized;
 }
 
+function resolveConfiguredPath(
+  value: string | undefined,
+  name: string,
+  resolvePath: (input: string) => string | undefined,
+): string {
+  const configured = requireConfiguredString(value, name);
+  if (isAbsolute(configured)) {
+    return resolve(configured);
+  }
+  if (configured === "~" || configured.startsWith("~/") || configured.startsWith("~\\")) {
+    return resolve(homedir(), configured.slice(2));
+  }
+
+  let resolvedByPlugin: string | undefined;
+  try {
+    resolvedByPlugin = resolvePath(configured);
+  } catch {
+    resolvedByPlugin = undefined;
+  }
+  if (!resolvedByPlugin) {
+    throw new Error(`Planning Knowledge ${name} must be an absolute path or a plugin-local path`);
+  }
+  return resolve(resolvedByPlugin);
+}
+
 export function resolvePlanningKnowledgeConfig(
   config: PlanningKnowledgeConfig,
-  resolvePath: (input: string) => string,
+  resolvePath: (input: string) => string | undefined,
 ): ResolvedPlanningKnowledgeConfig | null {
   if (!config.scriptPath || !config.sourceRoot || !config.indexPath) {
     return null;
   }
 
-  const scriptPath = resolvePath(requireConfiguredString(config.scriptPath, "scriptPath"));
-  const sourceRoot = resolvePath(requireConfiguredString(config.sourceRoot, "sourceRoot"));
-  const indexPath = resolvePath(requireConfiguredString(config.indexPath, "indexPath"));
-  const normalizedSourceRoot = resolve(sourceRoot);
-  const normalizedScriptPath = resolve(scriptPath);
-  const normalizedIndexPath = resolve(indexPath);
+  const normalizedSourceRoot = resolveConfiguredPath(config.sourceRoot, "sourceRoot", resolvePath);
+  const normalizedScriptPath = resolveConfiguredPath(config.scriptPath, "scriptPath", resolvePath);
+  const normalizedIndexPath = resolveConfiguredPath(config.indexPath, "indexPath", resolvePath);
 
   if (!isKnowledgeRoot(normalizedSourceRoot)) {
     throw new Error("Planning Knowledge sourceRoot must end in notes/knowledge");

--- a/extensions/planning-knowledge/src/planning-knowledge-tool.ts
+++ b/extensions/planning-knowledge/src/planning-knowledge-tool.ts
@@ -46,7 +46,7 @@ export const planningKnowledgeConfigSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export type PlanningKnowledgeConfig = Static<typeof planningKnowledgeConfigSchema>;
+type PlanningKnowledgeConfig = Static<typeof planningKnowledgeConfigSchema>;
 
 export const planningKnowledgeSearchParameters = Type.Object(
   {
@@ -59,7 +59,7 @@ export const planningKnowledgeSearchParameters = Type.Object(
   { additionalProperties: false },
 );
 
-export type PlanningKnowledgeSearchParams = Static<typeof planningKnowledgeSearchParameters>;
+type PlanningKnowledgeSearchParams = Static<typeof planningKnowledgeSearchParameters>;
 
 export const planningKnowledgeCaptureParameters = Type.Object(
   {
@@ -119,7 +119,7 @@ export const planningKnowledgeCaptureParameters = Type.Object(
   { additionalProperties: false },
 );
 
-export type PlanningKnowledgeCaptureParams = Static<typeof planningKnowledgeCaptureParameters>;
+type PlanningKnowledgeCaptureParams = Static<typeof planningKnowledgeCaptureParameters>;
 
 type ResolvedPlanningKnowledgeConfig = {
   scriptPath: string;
@@ -136,7 +136,7 @@ type CommandResult = {
   exitCode: number | null;
 };
 
-export type PlanningKnowledgeCommandRunner = (request: {
+type PlanningKnowledgeCommandRunner = (request: {
   executable: string;
   args: string[];
   stdin?: string;

--- a/extensions/planning-knowledge/tsconfig.json
+++ b/extensions/planning-knowledge/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1572,6 +1572,19 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/planning-knowledge:
+    dependencies:
+      typebox:
+        specifier: 1.3.6
+        version: 1.3.6
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/policy:
     dependencies:
       json5:


### PR DESCRIPTION
## What Problem This Solves
OpenClaw main lacks the verified read-only Planning Knowledge retrieval extension. This change restores a current-main-compatible plugin so OpenClaw can query the private `planning_personal` corpus through the explicit OneLibrary CLI boundary, preserve canonical `note:notes/knowledge/<slug>` citations, and detect capture intent without performing writes.

## What Changed
- add the Planning Knowledge plugin and its manifest/configuration
- enforce planning_personal scope, eligible statuses, portable canonical refs, and fail-closed malformed results
- recognize explicit capture intent with `write_performed: false`; PLN-500B owns the future writer
- update the workspace lockfile only for this extension

## Evidence
- production TypeScript check: passed
- extension test TypeScript check: passed
- focused tests: 9 passed, 1 skipped
- real OneLibrary synthetic CLI canary: 10 passed
- extension boundary tests: 28 passed
- direct Oxlint, Oxfmt, and `git diff --check`: passed
- no Planning, OneLibrary, OneAgent, or `~/.openclaw` runtime files changed

## Scope
Exactly these eight files are changed:
- `pnpm-lock.yaml`
- `extensions/planning-knowledge/package.json`
- `extensions/planning-knowledge/openclaw.plugin.json`
- `extensions/planning-knowledge/index.ts`
- `extensions/planning-knowledge/tsconfig.json`
- `extensions/planning-knowledge/README.md`
- `extensions/planning-knowledge/src/planning-knowledge-tool.ts`
- `extensions/planning-knowledge/src/planning-knowledge-tool.test.ts`

No Planning writer, OneLibrary implementation, or runtime deployment is included.