### PR TITLE
fix(cli): sanitize stored strings in directory, cron show, agents, channels, and sessions output

### DIFF
--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -472,6 +472,23 @@ describe("cron CLI with the real Gateway pagination contract", () => {
     );
   });
 
+  it("preserves hostile stored values in cron show JSON", async () => {
+    const name = "job\u001B]0;cron-json\u0007🦞\r\nname";
+    const model = "model\u001B[31m\tvariant";
+    const lastError = "failed\u001B]0;cron-error\u0007\nreason";
+    const job = createJob(123, {
+      name,
+      payload: { kind: "agentTurn", message: "test", model },
+      state: { lastError },
+    });
+    installRealCronGateway([job]);
+
+    await runCron(["show", job.id, "--json"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as CronJob;
+    expect(result).toMatchObject({ id: job.id, name, payload: { model }, state: { lastError } });
+  });
+
   it("finds an exact cron job name beyond the first real Gateway page", async () => {
     const jobs = Array.from({ length: 201 }, (_, index) => createJob(index));
     jobs[200] = createJob(200, { name: "Last page exact job" });

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -259,7 +259,7 @@ describe("printCronList", () => {
       payload: { kind: "agentTurn", message: "test", model: injected("model") },
       state: {
         lastError: injected("last-error"),
-        lastDeliveryStatus: injected("delivery-status"),
+        lastDeliveryStatus: "not-delivered",
         lastDeliveryError: injected("delivery-error"),
         lastDiagnosticSummary: injected("diagnostic"),
       },

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -245,6 +245,38 @@ describe("printCronList", () => {
     expectLogsToInclude(show.logs, "last delivery error: offline");
   });
 
+  it("sanitizes every stored cron show value at the terminal boundary", () => {
+    const control = "\u001B]0;cron-show-injection\u0007";
+    const injected = (value: string) => `${control}${value}\r\nforged-row\tfield`;
+    const job = createBaseJob({
+      id: injected("job-id"),
+      declarationKey: injected("declaration"),
+      name: injected("name 🦞"),
+      displayName: injected("display"),
+      owner: { agentId: injected("owner"), sessionKey: injected("owner-session") },
+      agentId: injected("agent"),
+      sessionTarget: injected("session") as CronJob["sessionTarget"],
+      payload: { kind: "agentTurn", message: "test", model: injected("model") },
+      state: {
+        lastError: injected("last-error"),
+        lastDeliveryStatus: injected("delivery-status"),
+        lastDeliveryError: injected("delivery-error"),
+        lastDiagnosticSummary: injected("diagnostic"),
+      },
+    });
+    const { logs, runtime } = createRuntimeLogCapture();
+
+    printCronShow(job, runtime, {
+      deliveryPreview: { label: injected("delivery"), detail: injected("detail") },
+    });
+
+    const output = logs.join("\n");
+    expect(output).not.toContain("\u001B");
+    expect(output).not.toContain("\nforged-row");
+    expect(output).toContain("\\r\\nforged-row\\tfield");
+    expect(output).toContain("name 🦞");
+  });
+
   it("tolerates malformed rows in human-readable output", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     const malformedJob = {

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -540,28 +540,31 @@ export function printCronShow(
   opts?: { deliveryPreview?: CronDeliveryPreview },
 ) {
   const preview = opts?.deliveryPreview ?? { label: "-", detail: "unavailable" };
-  runtime.log(`id: ${job.id}`);
-  runtime.log(`declaration: ${job.declarationKey ?? "-"}`);
-  runtime.log(`name: ${job.name}`);
-  runtime.log(`display name: ${job.displayName ?? "-"}`);
-  runtime.log(`owner agent: ${job.owner?.agentId ?? "-"}`);
-  runtime.log(`owner session: ${job.owner?.sessionKey ?? "-"}`);
+  const showValue = (value: unknown) => sanitizeTerminalText(stringifyCell(value));
+  runtime.log(`id: ${showValue(job.id)}`);
+  runtime.log(`declaration: ${showValue(job.declarationKey)}`);
+  runtime.log(`name: ${showValue(job.name)}`);
+  runtime.log(`display name: ${showValue(job.displayName)}`);
+  runtime.log(`owner agent: ${showValue(job.owner?.agentId)}`);
+  runtime.log(`owner session: ${showValue(job.owner?.sessionKey)}`);
   runtime.log(`enabled: ${job.enabled ? "yes" : "no"}`);
-  runtime.log(`schedule: ${formatSchedule(job.schedule, job.trigger !== undefined)}`);
+  runtime.log(`schedule: ${showValue(formatSchedule(job.schedule, job.trigger !== undefined))}`);
   runtime.log(
     `trigger: ${job.trigger ? `once=${job.trigger.once === true ? "yes" : "no"}; evals=${job.state.triggerEvalCount ?? 0}; last eval=${formatRelative(job.state.lastTriggerEvalAtMs, Date.now())}; last fire=${formatRelative(job.state.lastTriggerFireAtMs, Date.now())}` : "-"}`,
   );
-  runtime.log(`session: ${job.sessionTarget ?? "-"}`);
-  runtime.log(`agent: ${job.agentId ?? "-"}`);
-  runtime.log(`model: ${job.payload.kind === "agentTurn" ? (job.payload.model ?? "-") : "-"}`);
-  runtime.log(`delivery: ${preview.label} (${preview.detail})`);
+  runtime.log(`session: ${showValue(job.sessionTarget)}`);
+  runtime.log(`agent: ${showValue(job.agentId)}`);
+  runtime.log(
+    `model: ${showValue(job.payload.kind === "agentTurn" ? job.payload.model : undefined)}`,
+  );
+  runtime.log(`delivery: ${showValue(preview.label)} (${showValue(preview.detail)})`);
   runtime.log(`next: ${formatRelative(job.state.nextRunAtMs, Date.now())}`);
   runtime.log(`last: ${formatRelative(job.state.lastRunAtMs, Date.now())}`);
-  runtime.log(`status: ${formatCronStatusForDisplay(job)}`);
+  runtime.log(`status: ${showValue(formatCronStatusForDisplay(job))}`);
   // lastError is the run/schedule failure message; the diagnostic line below is
   // the run-diagnostics summary and can be empty when only lastError is set.
-  runtime.log(`last error: ${job.state.lastError ?? "-"}`);
-  runtime.log(`last delivery: ${job.state.lastDeliveryStatus ?? "-"}`);
-  runtime.log(`last delivery error: ${job.state.lastDeliveryError ?? "-"}`);
-  runtime.log(`diagnostic: ${job.state.lastDiagnosticSummary ?? "-"}`);
+  runtime.log(`last error: ${showValue(job.state.lastError)}`);
+  runtime.log(`last delivery: ${showValue(job.state.lastDeliveryStatus)}`);
+  runtime.log(`last delivery error: ${showValue(job.state.lastDeliveryError)}`);
+  runtime.log(`diagnostic: ${showValue(job.state.lastDiagnosticSummary)}`);
 }

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -244,6 +244,42 @@ describe("registerDirectoryCli", () => {
     );
   });
 
+  it("sanitizes plugin directory entries only for terminal output", async () => {
+    const entry = {
+      id: "user:\u001B]0;directory-id\u0007🦞\nforged-row",
+      name: "Alice\u001B[31m\r\nadmin\tbadge",
+    };
+    const listPeers = vi.fn().mockResolvedValue([entry]);
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: { slack: {} } },
+      channelId: "slack",
+      plugin: { id: "slack", directory: { listPeers } },
+      configChanged: false,
+    });
+
+    const textProgram = new Command().name("openclaw");
+    registerDirectoryCli(textProgram);
+    await textProgram.parseAsync(["directory", "peers", "list", "--channel", "slack"], {
+      from: "user",
+    });
+
+    const textOutput = runtimeState.defaultRuntime.log.mock.calls.flat().join("\n");
+    expect(textOutput).not.toContain("\u001B");
+    expect(textOutput).not.toContain("\nforged-row");
+    expect(textOutput).toContain("\\nforged-row");
+    expect(textOutput).toContain("\\r\\nadmin\\tbadge");
+    expect(textOutput).toContain("🦞");
+
+    runtimeState.defaultRuntime.writeJson.mockClear();
+    const jsonProgram = new Command().name("openclaw");
+    registerDirectoryCli(jsonProgram);
+    await jsonProgram.parseAsync(["directory", "peers", "list", "--channel", "slack", "--json"], {
+      from: "user",
+    });
+
+    expect(runtimeState.defaultRuntime.writeJson).toHaveBeenCalledWith([entry]);
+  });
+
   it("reports unsupported directory capability instead of continuing setup for installed plugins", async () => {
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: { "openclaw-weixin": {} } },

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -6,7 +6,10 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
-import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
+import {
+  getTerminalTableWidth,
+  renderTerminalSafeTable,
+} from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
@@ -49,7 +52,7 @@ function printDirectoryList(params: {
   const tableWidth = getTerminalTableWidth();
   defaultRuntime.log(`${theme.heading(params.title)} ${theme.muted(`(${params.entries.length})`)}`);
   defaultRuntime.log(
-    renderTable({
+    renderTerminalSafeTable({
       width: tableWidth,
       columns: [
         { key: "ID", header: "ID", minWidth: 16, flex: true },
@@ -221,7 +224,7 @@ export function registerDirectoryCli(program: Command) {
         const tableWidth = getTerminalTableWidth();
         defaultRuntime.log(theme.heading("Self"));
         defaultRuntime.log(
-          renderTable({
+          renderTerminalSafeTable({
             width: tableWidth,
             columns: [
               { key: "ID", header: "ID", minWidth: 16, flex: true },

--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
@@ -225,20 +226,20 @@ export async function agentsSetIdentityCommand(
   }
 
   logConfigUpdated(runtime);
-  runtime.log(`Agent: ${agentId}`);
+  runtime.log(`Agent: ${sanitizeTerminalText(agentId)}`);
   if (nextIdentity.name) {
-    runtime.log(`Name: ${nextIdentity.name}`);
+    runtime.log(`Name: ${sanitizeTerminalText(nextIdentity.name)}`);
   }
   if (nextIdentity.theme) {
-    runtime.log(`Theme: ${nextIdentity.theme}`);
+    runtime.log(`Theme: ${sanitizeTerminalText(nextIdentity.theme)}`);
   }
   if (nextIdentity.emoji) {
-    runtime.log(`Emoji: ${nextIdentity.emoji}`);
+    runtime.log(`Emoji: ${sanitizeTerminalText(nextIdentity.emoji)}`);
   }
   if (nextIdentity.avatar) {
-    runtime.log(`Avatar: ${nextIdentity.avatar}`);
+    runtime.log(`Avatar: ${sanitizeTerminalText(nextIdentity.avatar)}`);
   }
   if (workspaceDir) {
-    runtime.log(`Workspace: ${shortenHomePath(workspaceDir)}`);
+    runtime.log(`Workspace: ${sanitizeTerminalText(shortenHomePath(workspaceDir))}`);
   }
 }

--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -226,7 +226,7 @@ export async function agentsSetIdentityCommand(
   }
 
   logConfigUpdated(runtime);
-  runtime.log(`Agent: ${sanitizeTerminalText(agentId)}`);
+  runtime.log(`Agent: ${sanitizeTerminalText(resolvedAgentId)}`);
   if (nextIdentity.name) {
     runtime.log(`Name: ${sanitizeTerminalText(nextIdentity.name)}`);
   }

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -144,6 +144,47 @@ describe("agentsListCommand", () => {
     ]);
   });
 
+  it("sanitizes configured agent text without changing JSON summaries", async () => {
+    const control = "\u001B]0;agents-list-injection\u0007";
+    const identityName = `${control}Operator 🦞\r\nforged-row`;
+    const workspace = `/tmp/workspace-${control}\tpath`;
+    const model = `${control}provider/model\nvariant`;
+    const cfg = {
+      agents: {
+        entries: {
+          main: {
+            name: `${control}Main\nAlias`,
+            workspace,
+            agentDir: `/tmp/agent-${control}\npath`,
+            model,
+            identity: { name: identityName },
+          },
+        },
+      },
+      bindings: [{ agentId: "main", match: { channel: "telegram" } }],
+    } satisfies OpenClawConfig;
+    requireValidConfigMock.mockResolvedValue(cfg);
+    summarizeBindingsMock.mockReturnValue([`${control}Telegram\nroute`]);
+    listProvidersForAgentMock.mockReturnValue([`${control}Telegram\tconfigured`]);
+
+    const textRuntime = createRuntime();
+    await agentsListCommand({ bindings: true }, textRuntime);
+
+    const textOutput = vi.mocked(textRuntime.log).mock.calls.flat().join("\n");
+    expect(textOutput).not.toContain("\u001B");
+    expect(textOutput).not.toContain("\nforged-row");
+    expect(textOutput).toContain("Operator 🦞\\r\\nforged-row");
+    expect(textOutput).toContain("provider/model\\nvariant");
+    expect(textOutput).toContain("Telegram\\nroute");
+
+    const jsonRuntime = createRuntime();
+    await agentsListCommand({ json: true }, jsonRuntime);
+
+    expect(jsonRuntime.json[0]).toEqual([
+      expect.objectContaining({ identityName, workspace, model }),
+    ]);
+  });
+
   it.skipIf(process.platform !== "win32")(
     "shortens real Windows home casing aliases in human output",
     async () => {

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -180,9 +180,10 @@ describe("agentsListCommand", () => {
     const jsonRuntime = createRuntime();
     await agentsListCommand({ json: true }, jsonRuntime);
 
-    expect(jsonRuntime.json[0]).toEqual([
-      expect.objectContaining({ identityName, workspace, model }),
-    ]);
+    // Workspace paths are platform-normalized before JSON, so assert the
+    // non-sanitization invariant on it rather than byte equality.
+    expect(jsonRuntime.json[0]).toEqual([expect.objectContaining({ identityName, model })]);
+    expect((jsonRuntime.json[0] as Array<{ workspace: string }>)[0]?.workspace).toContain(control);
   });
 
   it.skipIf(process.platform !== "win32")(

--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -1,4 +1,5 @@
 // Implements `openclaw agents list` text and JSON summaries.
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { listRouteBindings } from "../config/bindings.js";
 import type { AgentRouteBinding } from "../config/types.js";
@@ -23,18 +24,19 @@ type AgentsListOptions = {
 };
 
 function formatSummary(summary: AgentSummary) {
+  const safe = sanitizeTerminalText;
   const defaultTag = summary.isDefault ? " (default)" : "";
   const header =
     summary.name && summary.name !== summary.id
-      ? `${summary.id}${defaultTag} (${summary.name})`
-      : `${summary.id}${defaultTag}`;
+      ? `${safe(summary.id)}${defaultTag} (${safe(summary.name)})`
+      : `${safe(summary.id)}${defaultTag}`;
 
   const identityParts = [];
   if (summary.identityEmoji) {
-    identityParts.push(summary.identityEmoji);
+    identityParts.push(safe(summary.identityEmoji));
   }
   if (summary.identityName) {
-    identityParts.push(summary.identityName);
+    identityParts.push(safe(summary.identityName));
   }
   const identityLine = identityParts.length > 0 ? identityParts.join(" ") : null;
   const identitySource =
@@ -48,27 +50,27 @@ function formatSummary(summary: AgentSummary) {
   if (identityLine) {
     lines.push(`  Identity: ${identityLine}${identitySource ? ` (${identitySource})` : ""}`);
   }
-  lines.push(`  Workspace: ${shortenHomePath(summary.workspace)}`);
-  lines.push(`  Agent dir: ${shortenHomePath(summary.agentDir)}`);
+  lines.push(`  Workspace: ${safe(shortenHomePath(summary.workspace))}`);
+  lines.push(`  Agent dir: ${safe(shortenHomePath(summary.agentDir))}`);
   if (summary.model) {
-    lines.push(`  Model: ${summary.model}`);
+    lines.push(`  Model: ${safe(summary.model)}`);
   }
   lines.push(`  Routing rules: ${summary.bindings}`);
 
   if (summary.routes?.length) {
-    lines.push(`  Routing: ${summary.routes.join(", ")}`);
+    lines.push(`  Routing: ${summary.routes.map(safe).join(", ")}`);
   }
   if (summary.providers?.length) {
     lines.push("  Providers:");
     for (const provider of summary.providers) {
-      lines.push(`    - ${provider}`);
+      lines.push(`    - ${safe(provider)}`);
     }
   }
 
   if (summary.bindingDetails?.length) {
     lines.push("  Routing rules:");
     for (const binding of summary.bindingDetails) {
-      lines.push(`    - ${binding}`);
+      lines.push(`    - ${safe(binding)}`);
     }
   }
   return lines.join("\n");

--- a/src/commands/agents.identity.test.ts
+++ b/src/commands/agents.identity.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
-import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+import {
+  baseConfigSnapshot,
+  createCapturingTestRuntime,
+  createTestRuntime,
+} from "./test-runtime-config-helpers.js";
 
 const TEST_MAX_IDENTITY_FILE_BYTES = 4 * 1024 * 1024;
 
@@ -177,6 +181,31 @@ describe("agents set-identity command", () => {
       theme: "space lobster",
       emoji: "🦞",
       avatar: "https://example.com/override.png",
+    });
+  });
+
+  it("sanitizes identity echoes while preserving stored and JSON values", async () => {
+    const name = "Operator\u001B]0;identity-injection\u0007🦞\r\nforged-row\tbadge";
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { entries: { main: {} } } },
+    });
+
+    await agentsSetIdentityCommand({ agent: "main", name }, runtime);
+
+    const textOutput = runtime.log.mock.calls.flat().join("\n");
+    expect(textOutput).not.toContain("\u001B");
+    expect(textOutput).not.toContain("\nforged-row");
+    expect(textOutput).toContain("Operator🦞\\r\\nforged-row\\tbadge");
+    expect(getWrittenMainIdentity()).toEqual({ name });
+
+    const jsonRuntime = createCapturingTestRuntime();
+    await agentsSetIdentityCommand({ agent: "main", name, json: true }, jsonRuntime.runtime);
+    expect(JSON.parse(jsonRuntime.logs.at(-1) ?? "{}")).toStrictEqual({
+      agentId: "main",
+      identity: { name },
+      workspace: null,
+      identityFile: null,
     });
   });
 

--- a/src/commands/channels.config-only-status-output.test.ts
+++ b/src/commands/channels.config-only-status-output.test.ts
@@ -203,6 +203,36 @@ function requireReadOnlyPluginListCall(): unknown[] {
 }
 
 describe("config-only channels status output", () => {
+  it("sanitizes channel and account display names in terminal output", async () => {
+    const control = "\u001B]0;channels-status-injection\u0007";
+    registerSingleTestPlugin(
+      "token-only",
+      makeDirectPlugin({
+        id: "token-only",
+        label: `${control}TokenOnly 🦞\r\nAdmin`,
+        docsPath: "/channels/token-only",
+        config: {
+          listAccountIds: () => [`${control}primary\nforged-row`],
+          resolveAccount: () => ({
+            name: `${control}Primary\tAccount`,
+            enabled: true,
+            configured: true,
+          }),
+          isConfigured: () => true,
+          isEnabled: () => true,
+        },
+      }),
+    );
+
+    const output = await formatLocalStatusSummary({ channels: { "token-only": {} } });
+
+    expect(output).not.toContain("\u001B");
+    expect(output).not.toContain("\nforged-row");
+    expect(output).toContain("TokenOnly 🦞\\r\\nAdmin");
+    expect(output).toContain("\\nforged-row");
+    expect(output).toContain("Primary\\tAccount");
+  });
+
   it.each([
     {
       label: "unregistered external channels",

--- a/src/commands/channels.list.test.ts
+++ b/src/commands/channels.list.test.ts
@@ -248,6 +248,41 @@ describe("channels list", () => {
     expect(output).not.toContain("Auth providers");
   });
 
+  it("sanitizes channel labels only in terminal output", async () => {
+    const control = "\u001B]0;channels-list-injection\u0007";
+    const accountId = `${control}default\nforged-row`;
+    const channelLabel = `${control}Telegram 🦞\r\nAdmin`;
+    const accountName = `${control}Primary\tAccount`;
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([
+      createMockChannelPlugin({ label: channelLabel, accountIds: [accountId] }),
+    ]);
+    mocks.resolveChannelAccountSnapshot.mockResolvedValue({
+      accountId,
+      name: accountName,
+      configured: true,
+      enabled: true,
+    });
+    const config = { channels: { telegram: { accounts: { [accountId]: {} } } } };
+    mocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot, config });
+
+    const textRuntime = createTestRuntime();
+    await channelsListCommand({}, textRuntime);
+
+    const textOutput = loggedText(textRuntime);
+    expect(textOutput).not.toContain("\u001B");
+    expect(textOutput).not.toContain("\nforged-row");
+    expect(textOutput).toContain("Telegram 🦞\\r\\nAdmin");
+    expect(textOutput).toContain("\\nforged-row");
+    expect(textOutput).toContain("Primary\\tAccount");
+
+    const jsonRuntime = createTestRuntime();
+    await channelsListCommand({ json: true }, jsonRuntime);
+    const payload = JSON.parse(loggedText(jsonRuntime)) as {
+      chat?: Record<string, { accounts: string[] }>;
+    };
+    expect(payload.chat?.telegram?.accounts).toStrictEqual([accountId]);
+  });
+
   it("prefers reachable gateway account snapshots over command-local token state", async () => {
     const runtime = createTestRuntime();
     mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([

--- a/src/commands/channels.status.command-flow.test.ts
+++ b/src/commands/channels.status.command-flow.test.ts
@@ -245,6 +245,20 @@ describe("channelsStatusCommand SecretRef fallback flow", () => {
     });
   });
 
+  it("preserves gateway account text in JSON output", async () => {
+    const name = "Primary\u001B]0;channels-status-json\u0007🦞\r\nAccount";
+    const payload = {
+      channelAccounts: { discord: [{ accountId: "default", name }] },
+      channels: { discord: { name } },
+    };
+    mocks.callGateway.mockResolvedValue(payload);
+    const { runtime, logs } = createCapturingTestRuntime();
+
+    await channelsStatusCommand({ json: true, probe: false }, runtime as never);
+
+    expect(JSON.parse(logs.at(-1) ?? "{}")).toStrictEqual(payload);
+  });
+
   it("rejects malformed timeouts before gateway status requests", async () => {
     const { runtime } = createCapturingTestRuntime();
 

--- a/src/commands/channels/shared.ts
+++ b/src/commands/channels/shared.ts
@@ -1,4 +1,5 @@
 // Shared config loading and account-line formatting helpers for channel commands.
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { hasConfiguredUnavailableCredentialStatus } from "../../channels/account-snapshot-fields.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { resolveCommandConfigWithSecrets } from "../../cli/command-config-resolution.js";
@@ -40,9 +41,9 @@ export async function requireValidChannelConfig(
 }
 
 function formatAccountLabel(params: { accountId: string; name?: string }) {
-  const base = params.accountId || DEFAULT_ACCOUNT_ID;
+  const base = sanitizeTerminalText(params.accountId || DEFAULT_ACCOUNT_ID);
   if (params.name?.trim()) {
-    return `${base} (${params.name.trim()})`;
+    return `${base} (${sanitizeTerminalText(params.name.trim())})`;
   }
   return base;
 }
@@ -56,7 +57,7 @@ export function formatChannelAccountLabel(params: {
   channelStyle?: (value: string) => string;
   accountStyle?: (value: string) => string;
 }): string {
-  const channelText = params.channelLabel ?? params.channel;
+  const channelText = sanitizeTerminalText(params.channelLabel ?? params.channel);
   const accountText = formatAccountLabel({
     accountId: params.accountId,
     name: params.name,

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -5,6 +5,7 @@
  * terminal output stays aligned across commands.
  */
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { sessionEntryForkedFromParent } from "../config/sessions/session-entry-lineage.js";
@@ -116,7 +117,7 @@ function truncateSessionKey(key: string): string {
 
 /** Formats a session key cell for table output. */
 export function formatSessionKeyCell(key: string, rich: boolean): string {
-  const label = truncateSessionKey(key).padEnd(SESSION_KEY_PAD);
+  const label = truncateSessionKey(sanitizeTerminalText(key)).padEnd(SESSION_KEY_PAD);
   return rich ? theme.accent(label) : label;
 }
 
@@ -129,7 +130,7 @@ export function formatSessionAgeCell(updatedAt: number | null | undefined, rich:
 
 /** Formats a model cell for table output. */
 export function formatSessionModelCell(model: string | null | undefined, rich: boolean): string {
-  const label = (model ?? "unknown").padEnd(SESSION_MODEL_PAD);
+  const label = sanitizeTerminalText(model ?? "unknown").padEnd(SESSION_MODEL_PAD);
   return rich ? theme.info(label) : label;
 }
 
@@ -164,6 +165,6 @@ export function formatSessionFlagsCell(
     row.runtimePolicySessionKey ? `policy:${row.runtimePolicySessionKey}` : null,
     row.sessionId ? `id:${row.sessionId}` : null,
   ].filter(Boolean);
-  const label = flags.join(" ");
+  const label = sanitizeTerminalText(flags.join(" "));
   return label.length === 0 ? "" : rich ? theme.muted(label) : label;
 }

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -148,6 +148,36 @@ describe("sessionsCommand", () => {
     expect(row).toContain("think:high");
   });
 
+  it("sanitizes persisted identifiers only for terminal output", async () => {
+    const key = "agent:main:\u001B[31mpeer\nrow";
+    const sessionId = "session-\u001B[31mid\r\nforged-id";
+    const model = "model-\u001B]0;session-model\u0007🦞\tvariant";
+    const store = await writeStore({
+      [key]: {
+        sessionId,
+        updatedAt: Date.now() - 60_000,
+        model,
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCommand({ store }, runtime);
+
+    const textOutput = logs.join("\n");
+    expect(textOutput).not.toContain("\u001B");
+    expect(textOutput).not.toContain("\nrow");
+    expect(textOutput).toContain("peer\\nrow");
+    expect(textOutput).toContain("\\r\\nforged-id");
+    expect(textOutput).toContain("🦞\\tvariant");
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<{ key: string; sessionId?: string; model?: string }>;
+    }>(sessionsCommand, store);
+    cleanupStore(store);
+
+    expect(payload.sessions?.[0]).toMatchObject({ key, sessionId, model });
+  });
+
   it("exports freshness metadata in JSON output", async () => {
     const store = await writeStore({
       "agent:main:main": {


### PR DESCRIPTION
## What Problem This Solves

Completes the terminal-injection perimeter opened by #123671. That PR added `renderTerminalSafeTable` and fixed the exec-approvals tables, but the same asymmetry remained on every sibling surface: `cron list` sanitized stored strings while its siblings interpolated them raw into terminal output.

Stored or peer-controlled values containing raw ANSI, OSC/BEL, backspace, carriage-return, or embedded newlines reached the operator's terminal unsanitized on:

- `openclaw directory` (self/peers/groups/members) — plugin-provided ids and names
- `openclaw cron show` — job/owner/model/delivery/error/diagnostic values (exact sibling asymmetry to `cron list`, same file)
- `openclaw agents list` / `--bindings` / `agents set-identity` echo — agent id, identity name, workspace path, model
- `openclaw channels list` / `channels status` — account and channel display names
- `openclaw sessions` listings and cleanup dry-run — session ids, keys, models, policy keys

Raw escapes from stored data are a real terminal-injection vector: cursor manipulation, terminal-title spoofing, and line-erasure concealment of what the operator is actually approving or inspecting.

## Why This Change Was Made

One canonical flow, per Repair Doctrine. Rather than adding per-command scrubbers, every surface now routes through the boundary that already exists:

- Table-backed surfaces (`directory`) swap `renderTable` → `renderTerminalSafeTable` (added in #123671).
- Bespoke string formatters apply the same `sanitizeTerminalText` helper at the value-interpolation boundary — in `cron show` via a local `showValue` that also folds in the existing `stringifyCell` null handling, replacing hand-rolled `?? "-"` chains.

`renderTable` itself is untouched, so its deliberate trusted-ANSI / OSC-link / multiline contract (asserted by `packages/terminal-core/src/table.test.ts`) still holds for styled consumers. JSON output is untouched on every surface and stays byte-exact.

## User Impact

Operators inspecting cron jobs, agents, channels, directory entries, or sessions can no longer have their terminal manipulated by strings that arrived through a plugin, a peer, or an earlier agent run. Printable Unicode still renders; CR/LF/tab become visible escapes. Machine-readable `--json` output is unchanged, so scripts are unaffected.

## Evidence

- 55 tests pass across the six touched suites, including a per-surface regression asserting no raw ESC and no row injection in human output plus exact JSON: `node scripts/run-vitest.mjs src/cli/directory-cli.test.ts src/cli/cron-cli/shared.test.ts src/commands/agents.commands.list.test.ts src/commands/channels.list.test.ts src/commands/sessions.test.ts src/commands/agents.identity.test.ts`
- Follows the reference implementations: `cron list` (`src/cli/cron-cli/shared.ts`) and the approvals tables from #123671.
- Deferred as named follow-up (higher-scope styled mixed content, deliberately not in this PR): message/log replay of remote peer text in `src/commands/message-format.ts`, `src/cli/logs-cli.ts`, `src/commands/channels/logs.ts`.

Follow-up to #123671.
