### PR TITLE
fix(cua): keep driver endpoint env private

### DIFF
--- a/apps/macos/Sources/OpenClaw/ComputerControlProvider.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerControlProvider.swift
@@ -29,8 +29,8 @@ struct CuaDriverWorkerEndpoint: Equatable, Sendable {
 }
 
 enum CuaDriverWorkerEnvironment {
-    static let socketPath = "OPENCLAW_CUA_DRIVER_SOCKET_PATH"
-    static let binaryPath = "OPENCLAW_CUA_DRIVER_BINARY_PATH"
+    static let socketPath = "CUA_DRIVER_SOCKET_PATH"
+    static let binaryPath = "CUA_DRIVER_BINARY_PATH"
 }
 
 enum CuaDriverArtifact {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -329,8 +329,8 @@ struct MacNodeHostWorkerTests {
     @Test func `worker receives only the app-provided CUA endpoint`() async throws {
         let worker = MacNodeHostWorker(session: GatewayNodeSession())
         let script = """
-        test "$OPENCLAW_CUA_DRIVER_SOCKET_PATH" = "/private/test/cua.sock" || exit 41
-        test "$OPENCLAW_CUA_DRIVER_BINARY_PATH" = "/Applications/OpenClaw.app/Contents/Resources/cua-driver" || exit 42
+        test "$CUA_DRIVER_SOCKET_PATH" = "/private/test/cua.sock" || exit 41
+        test "$CUA_DRIVER_BINARY_PATH" = "/Applications/OpenClaw.app/Contents/Resources/cua-driver" || exit 42
         printf '%s\\n' '{"type":"ready","version":"test","manifest":{"caps":[],"commands":[],"pathEnv":"/usr/bin:/bin"},"inventory":{"skills":null,"pluginTools":[]}}'
         while IFS= read -r line; do :; done
         """

--- a/extensions/cua-computer/src/commands.test.ts
+++ b/extensions/cua-computer/src/commands.test.ts
@@ -174,8 +174,8 @@ describe("cua-computer provider", () => {
   it("advertises the macOS mapping only with a complete app-provided endpoint", () => {
     const { session } = driver();
     const endpoint = {
-      OPENCLAW_CUA_DRIVER_SOCKET_PATH: "/tmp/openclaw-cua-test/driver.sock",
-      OPENCLAW_CUA_DRIVER_BINARY_PATH: process.execPath,
+      CUA_DRIVER_SOCKET_PATH: "/tmp/openclaw-cua-test/driver.sock",
+      CUA_DRIVER_BINARY_PATH: process.execPath,
     };
     const provider = createCuaComputerProvider({
       platform: "darwin",
@@ -204,10 +204,10 @@ describe("cua-computer provider", () => {
 
     for (const env of [
       {},
-      { OPENCLAW_CUA_DRIVER_SOCKET_PATH: endpoint.OPENCLAW_CUA_DRIVER_SOCKET_PATH },
-      { OPENCLAW_CUA_DRIVER_BINARY_PATH: endpoint.OPENCLAW_CUA_DRIVER_BINARY_PATH },
-      { ...endpoint, OPENCLAW_CUA_DRIVER_SOCKET_PATH: "relative.sock" },
-      { ...endpoint, OPENCLAW_CUA_DRIVER_BINARY_PATH: "/missing/cua-driver" },
+      { CUA_DRIVER_SOCKET_PATH: endpoint.CUA_DRIVER_SOCKET_PATH },
+      { CUA_DRIVER_BINARY_PATH: endpoint.CUA_DRIVER_BINARY_PATH },
+      { ...endpoint, CUA_DRIVER_SOCKET_PATH: "relative.sock" },
+      { ...endpoint, CUA_DRIVER_BINARY_PATH: "/missing/cua-driver" },
     ]) {
       expect(
         createCuaComputerProvider({ platform: "darwin", env, driver: session }).isAvailable(),
@@ -231,8 +231,8 @@ describe("cua-computer provider", () => {
     const computer = await createCuaComputerProvider({
       platform: "darwin",
       env: {
-        OPENCLAW_CUA_DRIVER_SOCKET_PATH: "/tmp/openclaw-cua-test/driver.sock",
-        OPENCLAW_CUA_DRIVER_BINARY_PATH: process.execPath,
+        CUA_DRIVER_SOCKET_PATH: "/tmp/openclaw-cua-test/driver.sock",
+        CUA_DRIVER_BINARY_PATH: process.execPath,
       },
       driver: retina.session,
       imageProcessor: {

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -39,8 +39,8 @@ const CUA_WIRE_ACTION_NAMES = COMPUTER_USE_V2_ACTION_NAMES.slice(1, 14);
 // capture, not the delivered frame. 8K (7680x4320 = ~33.2M) is a valid primary
 // display; budget above it so full-resolution snapshots reach the downscaler.
 const MAX_IMAGE_PIXELS = 40_000_000;
-const CUA_DRIVER_SOCKET_PATH_ENV = "OPENCLAW_CUA_DRIVER_SOCKET_PATH";
-const CUA_DRIVER_BINARY_PATH_ENV = "OPENCLAW_CUA_DRIVER_BINARY_PATH";
+const CUA_DRIVER_SOCKET_PATH_ENV = "CUA_DRIVER_SOCKET_PATH";
+const CUA_DRIVER_BINARY_PATH_ENV = "CUA_DRIVER_BINARY_PATH";
 
 const DesktopStateSchema = z.object({
   platform: z.string().min(1),


### PR DESCRIPTION
## What Problem This Solves

The embedded macOS CUA endpoint handoff added two private app-to-plugin facts to the global `OPENCLAW_*` environment namespace. That made internal worker plumbing look like operator configuration and caused current main to exceed the repository's environment-name ratchet.

## Why This Change Was Made

The socket and binary paths are produced by the signed macOS app and consumed only by the bundled CUA plugin inside the app-owned node worker. They are not documented configuration or a public compatibility surface. The handoff now uses plugin-owned `CUA_DRIVER_SOCKET_PATH` and `CUA_DRIVER_BINARY_PATH` names consistently across Swift and TypeScript.

The app still removes ambient endpoint values before merging the explicit launch environment, the plugin still requires both absolute paths and an executable binary, and all failure behavior remains unchanged. This PR is AI-assisted.

## User Impact

No intended user-visible behavior change. The CUA provider keeps the same app-owned endpoint and validation semantics, while the global OpenClaw environment surface returns to its committed budget.

Production: +4/-4. Tests: +10/-10. Total: +14/-14.

## Evidence

- CUA command owner: 17 tests passed.
- macOS `MacNodeHostWorkerTests`: 22 tests passed.
- `pnpm build` passed.
- `pnpm tsgo:extensions` passed after refreshing the existing lockfile install.
- `pnpm lint:extensions` passed.
- SwiftFormat passed for both touched Swift files.
- Environment ratchet passed at 502/502 without raising the budget.
- Repository formatting and `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Exact-head CI passed for `02fd708e5ace1eebd5a2c4f67a34ff663a516bcc`: https://github.com/openclaw/openclaw/actions/runs/31831751572
