### PR TITLE
fix(cli): drop orphaned ClawHub workspace-dir helper (repairs red main)

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -221,13 +221,6 @@ function resolveSkillsWorkspaceForCommand(
   return resolveSkillsWorkspace({ agentId: resolveAgentOption(command ?? undefined, opts) });
 }
 
-function resolveClawHubTargetWorkspaceDir(
-  command: Command | undefined,
-  opts: { agent?: string; global?: boolean },
-): string | undefined {
-  return resolveClawHubTargetWorkspace(command, opts)?.workspaceDir;
-}
-
 function resolveClawHubTargetWorkspace(
   command: Command | undefined,
   opts: { agent?: string; global?: boolean },


### PR DESCRIPTION
## What Problem This Solves

`main` is red: `check-lint-core-2` and `check-prod-types` both fail, blocking the merge gate for every open PR.

```
src/cli/skills-cli.ts(224,10): error TS6133: 'resolveClawHubTargetWorkspaceDir' is declared but its value is never read.
  224:10  error  Function 'resolveClawHubTargetWorkspaceDir' is declared but never used.  eslint(no-unused-vars)
  1233:4  error  File has too many lines (1007).  eslint(max-lines)
```

#116489 removed the last call site of `resolveClawHubTargetWorkspaceDir` (`const workspaceDir = resolveClawHubTargetWorkspaceDir(command, opts);`) but left the function behind. That orphaned it (TS6133 + no-unused-vars) and kept `skills-cli.ts` at 1007 counted lines against the 1000 limit for its glob group.

## Why This Change Was Made

Deleting the dead function is the smallest correct fix and resolves all three errors at once: it removes the unused symbol and drops the file back under the `max-lines` limit, so no suppression or baseline edit is needed. The sibling `resolveClawHubTargetWorkspace` (which returns the full workspace, not just `workspaceDir`) remains the single caller-facing helper.

## User Impact

None — the deleted function had no callers. This restores a green merge gate.

## Evidence

- `oxlint src/cli/skills-cli.ts` → exit 0 (both the `no-unused-vars` and `max-lines` errors clear with the deletion alone).
- `grep -rn resolveClawHubTargetWorkspaceDir src/` → 0 matches repo-wide, confirming no remaining references.
- 97 tests pass across the skills-cli unit suites: `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/cli/skills-cli.curator.test.ts src/cli/skills-cli.formatting.test.ts src/cli/skills-cli.verify.test.ts src/cli/skills-cli.workshop.test.ts src/cli/skills-cli.workshop-cache.test.ts`
- `oxfmt` clean.

Unblocks #123680 and #123797, whose merge refs inherit this failure.
