### PR TITLE
feat(slack): include observed away duration in presence events

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1922,6 +1922,8 @@ Slack does not send presence changes through the Events API or Socket Mode. Open
 
 OpenClaw polls at most 45 unique workspace-user pairs per minute per Slack account, seeds the first result without waking the agent, and only wakes on an observed `away` to `active` transition. A durable 8-hour cooldown applies per Slack account, workspace, and user, even if that person participates in several threads. The event routes only to that person's most recently active eligible conversation and tells the agent to consult memory/wiki and known timezone context before deciding whether to send one short greeting. The agent may stay silent.
 
+The event includes `observed_away_at_ms`, `observed_active_at_ms`, and `observed_away_duration_ms`. The duration is the elapsed time between the first sampled `away` state in the current monitor run and the later sampled `active` state. It is not exact time away because presence can change between polls, and the observation starts fresh after the monitor restarts or the target expires. The event records what Slack reported, not whether the person was at their keyboard; Slack can mark someone away automatically or manually, and `users.getPresence` does not distinguish those cases for another user.
+
 The bot token needs `users:read`, which is already included in the recommended manifest. Enterprise Grid org-wide installs create a workspace-scoped polling client only after an authorized event identifies that workspace; presence state, cooldowns, and delivery targets remain partitioned by workspace.
 
 ## Configuration reference

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -93,7 +93,7 @@ describe("Slack presence monitor", () => {
       .mockResolvedValueOnce({ presence: "active" })
       .mockResolvedValueOnce({ presence: "away" })
       .mockResolvedValueOnce({ presence: "active" });
-    const enqueue = vi.fn(() => true);
+    const enqueue = vi.fn((..._args: unknown[]) => true);
     const wake = vi.fn();
     const monitor = createSlackPresenceMonitor({
       accountId: "default",

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -131,9 +131,15 @@ describe("Slack presence monitor", () => {
         },
       }),
     );
-    expect(enqueue.mock.calls[0]?.[0]).toContain("retrieve relevant memory and wiki context");
-    expect(enqueue.mock.calls[0]?.[0]).toContain("not exact time away");
-    expect(enqueue.mock.calls[0]?.[0]).toContain("unobserved presence changes");
+    expect(enqueue.mock.calls[0]?.[0]).toBe(
+      [
+        "Slack presence event:",
+        'A human participant became active on Slack after being observed away: user_id="U123" channel_id="D123".',
+        "observed_away_at_ms=2000 observed_active_at_ms=7500 observed_away_duration_ms=5500",
+        "Before greeting, retrieve relevant memory and wiki context for this immutable user_id, including a known timezone when available. Use their local time; if their timezone is unknown, do not guess.",
+        "Send at most one short, natural greeting in this Slack conversation. Do not reveal private memory. If no greeting is appropriate, stay silent.",
+      ].join("\n"),
+    );
     expect(wake).toHaveBeenCalledOnce();
 
     now = 8_000;

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -84,9 +84,11 @@ describe("Slack presence monitor", () => {
   });
 
   it("seeds the first sample and wakes only on away-to-active", async () => {
+    let now = 1_000;
     const getPresence = vi
       .fn()
       .mockResolvedValueOnce({ presence: "active" })
+      .mockResolvedValueOnce({ presence: "away" })
       .mockResolvedValueOnce({ presence: "away" })
       .mockResolvedValueOnce({ presence: "active" })
       .mockResolvedValueOnce({ presence: "away" })
@@ -100,17 +102,26 @@ describe("Slack presence monitor", () => {
       cooldownStore: createCooldownStore(),
       enqueue,
       wake,
+      nowMs: () => now,
     });
     monitor.observe(createPrepared({ userId: "U123" }));
 
     await monitor.pollOnce();
+    now = 2_000;
     await monitor.pollOnce();
     expect(enqueue).not.toHaveBeenCalled();
 
+    now = 4_000;
+    await monitor.pollOnce();
+    expect(enqueue).not.toHaveBeenCalled();
+
+    now = 7_500;
     await monitor.pollOnce();
     expect(enqueue).toHaveBeenCalledOnce();
     expect(enqueue).toHaveBeenCalledWith(
-      expect.stringContaining("retrieve relevant memory and wiki context"),
+      expect.stringMatching(
+        /observed_away_at_ms=2000 observed_active_at_ms=7500 observed_away_duration_ms=5500/,
+      ),
       expect.objectContaining({ agentId: "main", sessionKey: "agent:main:slack:channel:D123" }),
       expect.objectContaining({
         deliveryContext: {
@@ -120,9 +131,14 @@ describe("Slack presence monitor", () => {
         },
       }),
     );
+    expect(enqueue.mock.calls[0]?.[0]).toContain("retrieve relevant memory and wiki context");
+    expect(enqueue.mock.calls[0]?.[0]).toContain("not exact time away");
+    expect(enqueue.mock.calls[0]?.[0]).toContain("unobserved presence changes");
     expect(wake).toHaveBeenCalledOnce();
 
+    now = 8_000;
     await monitor.pollOnce();
+    now = 9_000;
     await monitor.pollOnce();
     expect(enqueue).toHaveBeenCalledOnce();
   });

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -18,7 +18,9 @@ const SLACK_PRESENCE_MAX_TARGETS = 2_000;
 
 type SlackPresenceEventsConfig = NonNullable<SlackAccountConfig["presenceEvents"]>;
 type SlackPresenceEventsMode = NonNullable<SlackPresenceEventsConfig["mode"]>;
-type Presence = "active" | "away";
+type PresenceObservation =
+  | { presence: "active" }
+  | { presence: "away"; firstObservedAtMs: number };
 
 type PresenceTarget = {
   key: string;
@@ -73,10 +75,17 @@ function isTargetEligible(target: PresenceTarget): boolean {
   return target.participants.size <= SLACK_PRESENCE_AUTO_MAX_PARTICIPANTS;
 }
 
-function formatSlackPresenceEvent(target: PresenceTarget, userId: string): string {
+function formatSlackPresenceEvent(
+  target: PresenceTarget,
+  userId: string,
+  awayObservation: { observedAwayAtMs: number; observedActiveAtMs: number },
+): string {
+  const { observedAwayAtMs, observedActiveAtMs } = awayObservation;
+  const observedAwayDurationMs = Math.max(0, observedActiveAtMs - observedAwayAtMs);
   const lines = [
     "Slack presence event:",
-    `A human participant became active on Slack after being observed away: user_id=${JSON.stringify(userId)}${target.teamId ? ` team_id=${JSON.stringify(target.teamId)}` : ""} channel_id=${JSON.stringify(target.channelId)}${target.threadId ? ` thread_ts=${JSON.stringify(target.threadId)}` : ""}.`,
+    `Slack was first observed reporting away for a human participant and was later observed reporting active: user_id=${JSON.stringify(userId)}${target.teamId ? ` team_id=${JSON.stringify(target.teamId)}` : ""} channel_id=${JSON.stringify(target.channelId)}${target.threadId ? ` thread_ts=${JSON.stringify(target.threadId)}` : ""}.`,
+    `The elapsed time between these presence observations was: observed_away_at_ms=${observedAwayAtMs} observed_active_at_ms=${observedActiveAtMs} observed_away_duration_ms=${observedAwayDurationMs}. This is a polling-based observation interval, not exact time away; unobserved presence changes may have occurred between polls.`,
     "Before greeting, retrieve relevant memory and wiki context for this immutable user_id, including a known timezone when available. Use their local time; if their timezone is unknown, do not guess.",
     "Send at most one short, natural greeting in this Slack conversation. Do not reveal private memory. If no greeting is appropriate, stay silent.",
   ];
@@ -154,7 +163,7 @@ export function createSlackPresenceMonitor(params: {
     throw new Error("Slack presence monitor requires a client or client resolver");
   }
   const targets = new Map<string, PresenceTarget>();
-  const presenceByUser = new Map<string, Presence>();
+  const presenceByUser = new Map<string, PresenceObservation>();
   const nowMs = params.nowMs ?? Date.now;
   const enqueue = params.enqueue ?? enqueueRoutedSystemEvent;
   const wake = params.wake ?? requestHeartbeat;
@@ -223,7 +232,10 @@ export function createSlackPresenceMonitor(params: {
     pruneTargets(now);
   };
 
-  const emitTransition = (subject: PresenceSubject, now: number) => {
+  const emitTransition = (
+    subject: PresenceSubject,
+    awayObservation: { observedAwayAtMs: number; observedActiveAtMs: number },
+  ) => {
     const { teamId, userId } = subject;
     const target = Array.from(targets.values())
       .filter(
@@ -238,6 +250,7 @@ export function createSlackPresenceMonitor(params: {
     }
     const workspaceKey = teamId ?? "workspace";
     const cooldownKey = `${params.accountId}:${workspaceKey}:${userId}`;
+    const now = awayObservation.observedActiveAtMs;
     let reserved: boolean;
     try {
       reserved = params.cooldownStore.registerIfAbsent(cooldownKey, now, {
@@ -250,7 +263,7 @@ export function createSlackPresenceMonitor(params: {
     if (!reserved) {
       return;
     }
-    const queued = enqueue(formatSlackPresenceEvent(target, userId), target, {
+    const queued = enqueue(formatSlackPresenceEvent(target, userId, awayObservation), target, {
       contextKey: `slack:presence-active:${params.accountId}:${workspaceKey}:${userId}`,
       deliveryContext: {
         channel: "slack",
@@ -338,9 +351,19 @@ export function createSlackPresenceMonitor(params: {
         }
         const subjectKey = presenceSubjectKey(subject);
         const previous = presenceByUser.get(subjectKey);
-        presenceByUser.set(subjectKey, next);
-        if (previous === "away" && next === "active") {
-          emitTransition(subject, now);
+        const observedAtMs = nowMs();
+        const observation: PresenceObservation =
+          next === "away"
+            ? previous?.presence === "away"
+              ? previous
+              : { presence: "away", firstObservedAtMs: observedAtMs }
+            : { presence: "active" };
+        presenceByUser.set(subjectKey, observation);
+        if (previous?.presence === "away" && next === "active") {
+          emitTransition(subject, {
+            observedAwayAtMs: previous.firstObservedAtMs,
+            observedActiveAtMs: observedAtMs,
+          });
         }
       } catch (err) {
         if (stopped) {

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -82,8 +82,8 @@ function formatSlackPresenceEvent(
   const observedAwayDurationMs = Math.max(0, observedActiveAtMs - observedAwayAtMs);
   const lines = [
     "Slack presence event:",
-    `Slack was first observed reporting away for a human participant and was later observed reporting active: user_id=${JSON.stringify(userId)}${target.teamId ? ` team_id=${JSON.stringify(target.teamId)}` : ""} channel_id=${JSON.stringify(target.channelId)}${target.threadId ? ` thread_ts=${JSON.stringify(target.threadId)}` : ""}.`,
-    `The elapsed time between these presence observations was: observed_away_at_ms=${observedAwayAtMs} observed_active_at_ms=${observedActiveAtMs} observed_away_duration_ms=${observedAwayDurationMs}. This is a polling-based observation interval, not exact time away; unobserved presence changes may have occurred between polls.`,
+    `A human participant became active on Slack after being observed away: user_id=${JSON.stringify(userId)}${target.teamId ? ` team_id=${JSON.stringify(target.teamId)}` : ""} channel_id=${JSON.stringify(target.channelId)}${target.threadId ? ` thread_ts=${JSON.stringify(target.threadId)}` : ""}.`,
+    `observed_away_at_ms=${observedAwayAtMs} observed_active_at_ms=${observedActiveAtMs} observed_away_duration_ms=${observedAwayDurationMs}`,
     "Before greeting, retrieve relevant memory and wiki context for this immutable user_id, including a known timezone when available. Use their local time; if their timezone is unknown, do not guess.",
     "Send at most one short, natural greeting in this Slack conversation. Do not reveal private memory. If no greeting is appropriate, stay silent.",
   ];

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -18,9 +18,7 @@ const SLACK_PRESENCE_MAX_TARGETS = 2_000;
 
 type SlackPresenceEventsConfig = NonNullable<SlackAccountConfig["presenceEvents"]>;
 type SlackPresenceEventsMode = NonNullable<SlackPresenceEventsConfig["mode"]>;
-type PresenceObservation =
-  | { presence: "active" }
-  | { presence: "away"; firstObservedAtMs: number };
+type PresenceObservation = { presence: "active" } | { presence: "away"; firstObservedAtMs: number };
 
 type PresenceTarget = {
   key: string;


### PR DESCRIPTION
Closes #123804

## Summary

Adds timing metadata to the existing Slack `away → active` presence event:

- `observed_away_at_ms`
- `observed_active_at_ms`
- `observed_away_duration_ms`

The monitor preserves the first sampled `away` timestamp until the next sampled `active` state and reports the elapsed difference. No greeting instructions, routing, eligibility, cooldown, Slack scopes, or configuration changed; the existing event only gains the timing metadata line.

## Testing

- Added focused coverage for `active → away → away → active`, including preservation of the first `away` timestamp and duration calculation.
- Verified the existing presence prompt remains unchanged except for the timing metadata line.
- Focused Vitest, changed-file Oxlint, formatting, docs checks, and `git diff --check` passed.

AI-assisted by Codex. I reviewed the implementation and understand the timestamp calculation and monitor lifecycle.
