### PR TITLE
fix(doctor): keep migrated agents on their existing workspace

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -238,7 +238,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   const includeOwnsRoster = configIncludeOwnsAgentRoster(snapshot);
   if (snapshot.exists && rosterMigrationNeeded && !includeOwnsRoster) {
     // Runtime roster normalization is read-only; doctor --fix owns persistence.
-    const migrated = migratePersistedImplicitMainRoster(state.candidate).config as OpenClawConfig;
+    // Persist the legacy owner's workspace in doctor's canonical candidate. The writer may run
+    // again after health repairs, when the retired owner marker is no longer available to recover it.
+    const migrated = migratePersistedImplicitMainRoster(state.candidate, {
+      materializeWorkspace: true,
+    }).config as OpenClawConfig;
     const migratedRoster = readAgentRosterProperty(migrated);
     const migratedEntries = migratedRoster?.kind === "entries" ? migratedRoster.value : undefined;
     const { list: _legacyList, ...candidateAgents } = migrated.agents ?? {};

--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import {
+  runInitialConfigWriteHealth,
+  runWriteConfigHealth,
+} from "../flows/doctor-health-contribution-runners.config.js";
+import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+
+describe("Doctor workspace persistence", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("keeps the legacy owner on the shared workspace across later health writes", async () => {
+    await withTempHome(async (home) => {
+      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        const workspace = path.join(home, "shared-workspace");
+        const configPath = await writeOpenClawConfig(home, {
+          agents: {
+            defaults: { workspace },
+            entries: {
+              main: { default: true },
+              cursor: { workspace },
+            },
+          },
+          gateway: { mode: "local" },
+        });
+        const runtime: RuntimeEnv = {
+          error: vi.fn(),
+          exit: vi.fn(),
+          log: vi.fn(),
+        };
+        const options: DoctorOptions = { nonInteractive: true, repair: true };
+        const prompter = createDoctorPrompter({ runtime, options });
+        const configResult = await loadAndMaybeMigrateDoctorConfig({
+          options,
+          confirm: (params) => prompter.confirm(params),
+          runtime,
+          prompter,
+        });
+        const ctx: DoctorHealthFlowContext = {
+          runtime,
+          options,
+          prompter,
+          configResult,
+          cfg: configResult.cfg,
+          cfgForPersistence: structuredClone(configResult.cfg),
+          sourceConfigValid: configResult.sourceConfigValid ?? true,
+          configPath,
+          stateDirExistedAtStart: true,
+          ...(configResult.runWithPluginMetadataSnapshot
+            ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
+            : {}),
+          ...(configResult.invalidatePluginMetadataSnapshot
+            ? { invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot }
+            : {}),
+        };
+
+        await runInitialConfigWriteHealth(ctx);
+        expect((await readConfigFileSnapshot()).config.agents?.entries?.main?.workspace).toBe(
+          workspace,
+        );
+
+        ctx.cfg = {
+          ...ctx.cfg,
+          gateway: { ...ctx.cfg.gateway, bind: "lan" },
+        };
+        await runWriteConfigHealth(ctx);
+
+        const snapshot = await readConfigFileSnapshot();
+        expect(snapshot.valid).toBe(true);
+        expect(snapshot.config.agents?.ownership).toBe("explicit");
+        expect(snapshot.config.agents?.entries?.main?.workspace).toBe(workspace);
+      });
+    });
+  });
+});

--- a/src/config/legacy.roster.ts
+++ b/src/config/legacy.roster.ts
@@ -15,7 +15,10 @@ type MigrationResult = {
   retainedLegacyDefaultAgentId?: string;
 };
 
-export function migratePersistedImplicitMainRoster(raw: unknown): MigrationResult {
+export function migratePersistedImplicitMainRoster(
+  raw: unknown,
+  options: { materializeWorkspace?: boolean } = {},
+): MigrationResult {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return { config: raw, changed: false, diagnostics: [] };
   }
@@ -124,6 +127,7 @@ export function migratePersistedImplicitMainRoster(raw: unknown): MigrationResul
     const materialized = materializeLegacyDefaultAgentRoles(
       nextRoot as OpenClawConfig,
       legacyDefaultAgentId,
+      options,
     );
     nextRoot = materialized.config as Record<string, unknown>;
     insertedPaths = materialized.insertedPaths;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading a legacy multi-agent configuration and running `openclaw doctor --fix` could have the previous owner agent silently moved from the shared `agents.defaults.workspace` to a new `<workspace>/<agentId>` directory after a later Doctor health write.

## Why This Change Was Made

Doctor now materializes the legacy owner's workspace in its canonical roster migration candidate before retiring the old default marker. Every later Doctor write therefore persists the same authoritative workspace. This keeps explicit multi-agent ownership intact and does not introduce a global default agent or a resolver fallback.

The repair reuses the existing legacy-role materializer at the Doctor persistence boundary. Production delta: +8 net lines; test delta: +83 lines.

## User Impact

Existing multi-agent installations keep the owner's current workspace, memory, and workspace files after an upgrade/Doctor repair instead of appearing to start from an empty agent-specific directory.

## Evidence

### Exact-head real Doctor upgrade proof

- Product head: `2777d6425c730cf7bcbe5e6939e4ee8c317554b3`.
- Boundary: real source-checkout CLI built and run from that head against an isolated temporary `HOME`, state directory, and config. Bundled plugins were disabled; no provider or channel was exercised.
- `--generate-gateway-token` supplied a deterministic post-migration health mutation, forcing Doctor's final config writer to run after the initial migration write. The token value was never printed; evidence records only whether it exists.

Representative legacy input (paths redacted):

```json
{
  "agents": {
    "defaults": { "workspace": "<proof-root>/shared-workspace" },
    "entries": {
      "main": { "default": true },
      "cursor": { "workspace": "<proof-root>/shared-workspace" }
    }
  },
  "gateway": { "mode": "local" }
}
```

`MEMORY.md` and `AGENTS.md` canaries existed in the shared workspace before the run.

Command:

```bash
HOME=<proof-root>/home \
OPENCLAW_STATE_DIR=<proof-root>/state \
OPENCLAW_CONFIG_PATH=<proof-root>/openclaw.json \
OPENCLAW_DISABLE_UPDATE_CHECK=1 \
OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 \
pnpm openclaw doctor --fix --non-interactive --yes --generate-gateway-token
```

Selected redacted terminal output (unrelated isolated-environment diagnostics omitted):

```text
[openclaw] Building TypeScript (dist is stale: git_head_changed - git head changed).
OpenClaw 2026.8.1 (2777d64)

Config warnings
- Materialized legacy per-surface agent ownership.
- Removed retired agents.entries.*.default markers.

Doctor changes
- Prepared the canonical agent roster without retired default markers for persistence.
- Stamped the multi-agent roster for explicit per-surface ownership.

Updated config: <proof-root>/openclaw.json
Backup: <proof-root>/openclaw.json.bak

Gateway auth
- Gateway token configured.

Updated config: <proof-root>/openclaw.json
Backup: <proof-root>/openclaw.json.bak

Doctor complete.
exit=0
```

Sanitized persisted state immediately before the second write (`openclaw.json.bak`):

```json
{
  "ownership": "explicit",
  "defaults_workspace": "<proof-root>/shared-workspace",
  "main_workspace": "<proof-root>/shared-workspace",
  "cursor_workspace": "<proof-root>/shared-workspace",
  "retired_default_marker_present": false,
  "gateway_auth_mode": null,
  "gateway_token_present": false
}
```

Sanitized final state after the second write:

```json
{
  "ownership": "explicit",
  "defaults_workspace": "<proof-root>/shared-workspace",
  "main_workspace": "<proof-root>/shared-workspace",
  "cursor_workspace": "<proof-root>/shared-workspace",
  "retired_default_marker_present": false,
  "gateway_auth_mode": "token",
  "gateway_token_present": true
}
```

Post-run workspace checks:

```text
MEMORY.md sha256=4954482e0ad1c68678b417cc88777f840e569d275dd4f33162babb8f1a2bc250
AGENTS.md sha256=852b4ec232664cff55016cf68a263933d87c59eb88ec81283e5120b62388b620
unexpected_nested_workspace_exists=false
```

This proves the real two-write lifecycle at the exact PR head: the later health mutation was persisted, while both agent workspaces and the existing workspace canaries remained in place.

### Automated and static verification

- `node scripts/run-vitest.mjs src/commands/doctor-config-flow.workspace-persistence.test.ts src/config/legacy.roster.test.ts src/commands/doctor/shared/default-agent-role-materialization.write.test.ts` — 43 tests passed.
- `pnpm tsgo:core` — passed.
- `pnpm tsgo:core:test` — passed.
- Targeted Oxfmt and Oxlint — passed.
- Autoreview and TruffleHog — clean; no actionable findings.

Proof status: real behavior passed at the exact PR head. Merge-CI status is tracked independently. Full changed-gate delegation could not start because the local Crabbox binary failed its own version/help sanity check; the required local fallback then stopped on an existing `main` ratchet mismatch (`OPENCLAW_*` count 504 vs budget 502). This patch adds no environment variables.