### PR TITLE
test: trim compact command leftovers

### DIFF
--- a/src/auto-reply/reply/commands-compact-context-budget.test.ts
+++ b/src/auto-reply/reply/commands-compact-context-budget.test.ts
@@ -17,7 +17,6 @@ vi.mock("./commands-compact.runtime.js", () => ({
   isCurrentSessionEntry: vi.fn(() => true),
   isEmbeddedAgentRunAbortableForCompaction: vi.fn().mockReturnValue(false),
   resolveFreshSessionTotalTokens: vi.fn(() => 12_345),
-  resolveSessionFilePathOptions: vi.fn(() => ({})),
   waitForEmbeddedAgentRunEnd: vi.fn().mockResolvedValue(true),
 }));
 

--- a/src/auto-reply/reply/commands-compact.lifecycle.test.ts
+++ b/src/auto-reply/reply/commands-compact.lifecycle.test.ts
@@ -17,34 +17,6 @@ import type { HandleCommandsParams } from "./commands-types.js";
 describe("handleCompactCommand lifecycle authority", () => {
   beforeEach(resetCompactCommandMocks);
 
-  it("does not abort the command reply run before compacting", async () => {
-    vi.mocked(isEmbeddedAgentRunAbortableForCompaction).mockReturnValueOnce(false);
-    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
-      ok: true,
-      compacted: false,
-    });
-
-    const result = await handleCompactCommand(
-      {
-        ...buildCompactParams("/compact", {
-          commands: { text: true },
-          channels: { whatsapp: { allowFrom: ["*"] } },
-        } as OpenClawConfig),
-        sessionEntry: {
-          sessionId: "session-1",
-          updatedAt: Date.now(),
-        },
-      } as HandleCommandsParams,
-      true,
-    );
-
-    expect(result?.shouldContinue).toBe(false);
-    expect(vi.mocked(isEmbeddedAgentRunAbortableForCompaction)).toHaveBeenCalledWith("session-1");
-    expect(vi.mocked(abortEmbeddedAgentRun)).not.toHaveBeenCalled();
-    expect(vi.mocked(waitForEmbeddedAgentRunEnd)).not.toHaveBeenCalled();
-    expect(vi.mocked(compactEmbeddedAgentSession)).toHaveBeenCalledOnce();
-  });
-
   it("does not abort a run after the bound session changes", async () => {
     vi.mocked(isCurrentSessionEntry).mockReturnValueOnce(false);
     vi.mocked(isEmbeddedAgentRunAbortableForCompaction).mockReturnValueOnce(true);

--- a/src/auto-reply/reply/commands-compact.runtime.ts
+++ b/src/auto-reply/reply/commands-compact.runtime.ts
@@ -21,10 +21,7 @@ export {
   isEmbeddedAgentRunAbortableForCompaction,
   waitForEmbeddedAgentRunEnd,
 } from "../../agents/embedded-agent.js";
-export {
-  resolveFreshSessionTotalTokens,
-  resolveSessionFilePathOptions,
-} from "../../config/sessions.js";
+export { resolveFreshSessionTotalTokens } from "../../config/sessions.js";
 export { enqueueSystemEvent } from "../../infra/system-events.js";
 export { formatContextUsageShort, formatTokenCount } from "../status.js";
 export { incrementCompactionCount } from "./session-updates.js";

--- a/src/auto-reply/reply/commands-compact.test-support.ts
+++ b/src/auto-reply/reply/commands-compact.test-support.ts
@@ -17,7 +17,6 @@ vi.mock("./commands-compact.runtime.js", () => ({
   isCurrentSessionEntry: vi.fn(() => true),
   isEmbeddedAgentRunAbortableForCompaction: vi.fn().mockReturnValue(false),
   resolveFreshSessionTotalTokens: vi.fn(() => 12_345),
-  resolveSessionFilePathOptions: vi.fn(() => ({})),
   waitForEmbeddedAgentRunEnd: vi.fn().mockResolvedValue(true),
 }));
 

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -669,20 +669,9 @@ describe("handleCompactCommand", () => {
 
   it.each([
     {
-      owner: "Codex",
+      owner: "native harness",
       compactionKind: "native-harness" as const,
-      details: {
-        backend: "codex-app-server",
-        threadId: "thread-1",
-        signal: "thread/compact/start",
-        pending: false,
-        completed: true,
-      },
-    },
-    {
-      owner: "Copilot",
-      compactionKind: "native-harness" as const,
-      details: { success: true, tokensRemoved: 45, messagesRemoved: 2 },
+      details: { completed: true },
     },
     {
       owner: "context engine",


### PR DESCRIPTION
## What Problem This Solves

The compact-command tests retained a strict subset of existing lifecycle behavior, duplicated native-harness fixtures by provider name, and kept a session-path runtime re-export plus mock entries that no compact-command production or test caller used.

Those assertions made behavior-preserving refactors touch tests and preserved a production-facing seam solely for mocks.

## Why This Change Was Made

The redundant no-abort lifecycle case is removed while the stronger command-boundary and stale-session lifecycle coverage remains. The Codex and Copilot rows are collapsed into one generic native-harness contract while the behaviorally distinct context-engine successor remains. The unused `resolveSessionFilePathOptions` re-export and mock entries are deleted instead of preserved as compatibility surface.

Production/tooling: +1/-4 (net -3). Tests/test support: +2/-43 (net -41). Total: +3/-47 (net -44).

## User Impact

No intended user-visible behavior change. Compact command behavior and compaction ownership remain unchanged; the tests now protect the canonical behavior without provider-local fixture duplication or a test-only runtime export.

## Evidence

- Focused compact-command owner proof: 4 files, 52 tests passed after the final rebase.
- `pnpm build` passed.
- `node scripts/check-changed.mjs -- <five changed files>` passed the core/coreTests gates locally, including typecheck, test types, lint, dead-export scans, import cycles, formatting, environment budget, max-lines ratchet, and architecture guards.
- The changed-gate wrapper first attempted Crabbox/Testbox, but no remote provider was ready; trusted-source policy therefore used the documented local fallback.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Exact-head CI passed for `f7d5b361b412fde91efb7ecc134c80a6e249b3cd`: https://github.com/openclaw/openclaw/actions/runs/31835907235
