### PR TITLE
fix: terminal embedded replies missing from transcripts

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -17,6 +17,7 @@ import {
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
 import { clearSessionStoreCacheForTest } from "../../config/sessions/store-writer-state.js";
+import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
@@ -2199,6 +2200,54 @@ describe("CLI attempt execution", () => {
     });
   });
 
+  it("does not reuse a disposed embedded-attempt lock for post-run gap-fill", async () => {
+    const sessionKey = "agent:main:direct:disposed-gap-fill-owner";
+    const sessionEntry = makeSessionEntry("session-disposed-gap-fill-owner");
+    await writeSessionStoreSeed({ [sessionKey]: sessionEntry });
+    const disposedOwnerWrite = vi.fn(async () => {
+      throw new Error("attempt disposed before transcript write");
+    });
+
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionKey,
+        sessionTarget: {
+          agentId: "main",
+          sessionId: sessionEntry.sessionId,
+          sessionKey,
+          storePath,
+        },
+        withSessionWriteLock: disposedOwnerWrite,
+      },
+      () =>
+        persistCliTurnTranscript({
+          body: "ignored prompt",
+          result: makeCliResult("terminal review result"),
+          sessionId: sessionEntry.sessionId,
+          sessionKey,
+          sessionEntry,
+          storePath,
+          sessionAgentId: "main",
+          sessionCwd: tmpDir,
+          config: {},
+          embeddedAssistantGapFill: true,
+        }),
+    );
+
+    expect(disposedOwnerWrite).not.toHaveBeenCalled();
+    const messages = await readSessionMessages({
+      agentId: "main",
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      storePath,
+    });
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: "terminal review result" }],
+      }),
+    );
+  });
   it("persists a media-only ACP user turn when the reply is empty", async () => {
     const sessionKey = "agent:main:direct:acp-media-only";
     const sessionFile = path.join(tmpDir, "session-acp-media-only.jsonl");

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -25,6 +25,7 @@ import {
   persistSessionTranscriptTurn,
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
+import { runWithoutOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import { readTailAssistantTextFromSessionTranscript } from "../../config/sessions/transcript.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -487,22 +488,32 @@ export async function persistCliTurnTranscript(params: {
   const gapFill = params.embeddedAssistantGapFill ?? false;
   const skipUserTurn = gapFill || requestedSkipUserTurn === true;
 
-  return await persistTextTurnTranscript({
-    ...transcript,
-    body: skipUserTurn ? "" : transcript.body,
-    transcriptBody: skipUserTurn ? undefined : transcript.transcriptBody,
-    userMessage: skipUserTurn ? undefined : transcript.userMessage,
-    finalText: replyText,
-    embeddedAssistantGapFill: gapFill,
-    assistant: {
-      api: "cli",
-      provider,
-      model,
-      // The marker is terminal for fallback scans: without it, readers could
-      // skip this turn and revive an older cumulative usage record as fresh.
-      usage: resolveCliTranscriptUsage(result.meta.agentMeta?.lastCallUsage),
-    },
-  });
+  const persist = async () =>
+    await persistTextTurnTranscript({
+      ...transcript,
+      body: skipUserTurn ? "" : transcript.body,
+      transcriptBody: skipUserTurn ? undefined : transcript.transcriptBody,
+      userMessage: skipUserTurn ? undefined : transcript.userMessage,
+      finalText: replyText,
+      embeddedAssistantGapFill: gapFill,
+      assistant: {
+        api: "cli",
+        provider,
+        model,
+        // The marker is terminal for fallback scans: without it, readers could
+        // skip this turn and revive an older cumulative usage record as fresh.
+        usage: resolveCliTranscriptUsage(result.meta.agentMeta?.lastCallUsage),
+      },
+    });
+  if (!gapFill) {
+    return await persist();
+  }
+
+  // Embedded gap-fill runs after the embedded attempt has completed and
+  // released its controller. A promise continuation can still inherit that
+  // controller's AsyncLocalStorage context, so explicitly leave it before
+  // the transcript accessor acquires the post-run session lock.
+  return await runWithoutOwnedSessionTranscriptWrites(persist);
 }
 
 export function runAgentAttempt(params: {


### PR DESCRIPTION
Closes #123809

## What Problem This Solves

Fixes an issue where embedded and ACP child turns could finish successfully but lose their terminal assistant transcript when post-run gap-fill inherited a session-write owner that the completed attempt had already disposed. The gateway logged `attempt disposed before transcript write`, and subsequent conversation history omitted that terminal result.

## Why This Change Was Made

Post-run embedded gap-fill now explicitly exits the completed attempt's AsyncLocalStorage transcript owner before calling the existing transcript accessor. The accessor then acquires its normal session-key lock and retains its existing idempotent assistant-tail check. In-attempt and CLI transcript writes keep their existing owner behavior.

## User Impact

Terminal embedded child responses remain in conversation history instead of being dropped during rapid attempt teardown. This does not rerun agent work or duplicate an assistant turn.

## Evidence

- Production before: 13 `Turn transcript persistence failed ...: attempt disposed before transcript write` events in a 54-minute review window.
- Regression recreates an exact matching disposed owner context and verifies the gap-fill bypasses it and persists the terminal assistant message.
- `node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts` on current `main`: 120 passed.
- The same focused suite on the deployed beta.7 base: 75 passed.
- `oxfmt --check` and `oxlint --deny-warnings` pass for both changed files.

AI-assisted: yes. I traced the attempt cleanup, AsyncLocalStorage owner matching, post-run caller, and transcript accessor paths and understand the ownership boundary changed here.