### PR TITLE
fix(audit): keep supervisor ownership marker in audit writer worker env

### DIFF
--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -5,6 +5,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { claimOpenClawStateOwnership } from "../state/openclaw-state-ownership-operations.js";
 import { listAuditEvents, recordAuditEvent } from "./audit-event-store.js";
 import type { AuditEventInput } from "./audit-event-types.js";
 import { createAuditEventWriter } from "./audit-event-writer.js";
@@ -754,5 +755,68 @@ describe("audit event worker", () => {
     expect(
       inspectExecutionIdentityRun({ runId: "after-key-loss" }, database).identity,
     ).toMatchObject({ state: "unknown", reasonCode: "run_not_found" });
+  });
+
+  it("admits the audit worker under claimed external ownership and still refuses unmarked writers", async () => {
+    // Claim the documented durable external ownership on a fresh state dir,
+    // exactly like `OPENCLAW_SUPERVISOR_MODE=external openclaw database
+    // ownership claim --manager systemd-openclaw-gateway` does.
+    const externalEnv = {
+      OPENCLAW_STATE_DIR: tempDirs.make("openclaw-audit-writer-ownership-"),
+      OPENCLAW_SUPERVISOR_MODE: "external",
+    };
+    claimOpenClawStateOwnership("systemd-openclaw-gateway", { env: externalEnv });
+    closeOpenClawStateDatabaseForTest();
+
+    // Worker threads snapshot the parent environment at spawn; mark this
+    // process like the externally supervised Gateway systemd unit does.
+    const previousSupervisorMode = process.env.OPENCLAW_SUPERVISOR_MODE;
+    process.env.OPENCLAW_SUPERVISOR_MODE = "external";
+    try {
+      const errors: string[] = [];
+      const writer = createAuditEventWriter({
+        stateDir: externalEnv.OPENCLAW_STATE_DIR,
+        onError: (error) => errors.push(error),
+      });
+      await writer.ready;
+      expect(
+        writer.record({ ...input(), sourceId: "run-owned:1:started", runId: "run-owned" }),
+      ).toBe(true);
+      await writer.stop();
+      expect(errors).toEqual([]);
+      expect(listAuditEvents({ database: { env: externalEnv }, limit: 10 }).events).toHaveLength(1);
+    } finally {
+      if (previousSupervisorMode === undefined) {
+        delete process.env.OPENCLAW_SUPERVISOR_MODE;
+      } else {
+        process.env.OPENCLAW_SUPERVISOR_MODE = previousSupervisorMode;
+      }
+    }
+
+    // A worker spawned without the supervisor marker must still be fenced out
+    // of the claimed database: unmarked external writers stay refused.
+    const unmarkedEnv = {
+      OPENCLAW_STATE_DIR: tempDirs.make("openclaw-audit-writer-ownership-unmarked-"),
+      OPENCLAW_SUPERVISOR_MODE: "external",
+    };
+    claimOpenClawStateOwnership("systemd-openclaw-gateway", { env: unmarkedEnv });
+    closeOpenClawStateDatabaseForTest();
+    const unmarkedErrors: string[] = [];
+    const unmarkedWriter = createAuditEventWriter({
+      stateDir: unmarkedEnv.OPENCLAW_STATE_DIR,
+      onError: (error) => unmarkedErrors.push(error),
+    });
+    await unmarkedWriter.ready;
+    expect(
+      unmarkedWriter.record({
+        ...input(),
+        sourceId: "run-unmarked:1:started",
+        runId: "run-unmarked",
+      }),
+    ).toBe(true);
+    await unmarkedWriter.stop();
+    expect(unmarkedErrors.join("\n")).toContain(
+      "is externally supervised by systemd-openclaw-gateway",
+    );
   });
 });

--- a/src/audit/audit-event-writer.worker.ts
+++ b/src/audit/audit-event-writer.worker.ts
@@ -28,7 +28,9 @@ if (!parentPort || !stateDir) {
   throw new Error("audit event writer requires a parent port and state directory");
 }
 const port = parentPort;
-const database = { env: { OPENCLAW_STATE_DIR: stateDir } };
+// Preserve inherited env so ownership markers like OPENCLAW_SUPERVISOR_MODE
+// still admit the externally supervised Gateway's own audit worker.
+const database = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
 
 function executionIdentityFailureMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## What Problem

On a Gateway whose `state/openclaw.sqlite` is under the documented durable external ownership (`OPENCLAW_SUPERVISOR_MODE=external openclaw database ownership claim --manager systemd-openclaw-gateway`), the Gateway's own audit-event worker fails **every** state write with `OpenClawStateExternalOwnershipError`. Audit persistence silently stops even though the Gateway process itself carries the supervisor marker.

Root cause: `src/audit/audit-event-writer.worker.ts` constructs its state database options with a **replacement** environment that only carries `OPENCLAW_STATE_DIR`:

```ts
const database = { env: { OPENCLAW_STATE_DIR: stateDir } };
```

The state ownership admission (`assertOwnershipAllowsWrite` → `isGatewayExternallySupervised(env)`, see `src/state/openclaw-state-ownership.ts:229-237`) reads `OPENCLAW_SUPERVISOR_MODE` from that supplied env. Worker threads do inherit the parent env, but the reduced `database.env` masks the marker, so the durable ownership feature fences out the very worker it is meant to protect.

## Why

The external-ownership contract (issues #101290 / #119583) requires: Gateway-owned workers admitted under the Gateway's durable ownership identity; unmarked external writers still refused. The audit worker is the only Gateway-owned worker that rebuilds its database env this way (production sweep confirmed no other reduced-environment worker pattern), so the defect is narrow and has a single owner-boundary fix: preserve the inherited environment and override only the state directory.

## User Impact

Operators who follow the documented external-ownership hardening can no longer use it without losing all audit persistence (agent run events, execution identity contexts, execution decision facts). Every startup maintenance pass and every event write fails with `OpenClawStateExternalOwnershipError`. This PR restores audit persistence under claimed external ownership while keeping unmarked writers fenced out.

## Evidence

[AI-assisted]

Regression test (fails on pre-fix code with the exact reported error, passes with the fix):

```text
$ git stash push -- src/audit/audit-event-writer.worker.ts   # pre-fix worker
$ node scripts/run-vitest.mjs src/audit/audit-event-writer.test.ts -t "admits the audit worker under claimed external ownership"
 × admits the audit worker under claimed external ownership and still refuses unmarked writers
   AssertionError: expected [ …(7) ] to deeply equal []
   + "OpenClawStateExternalOwnershipError: OpenClaw shared state database /tmp/.../state/openclaw.sqlite
     is externally supervised by systemd-openclaw-gateway. Use that external supervisor with
     OPENCLAW_SUPERVISOR_MODE=external for writable operations."
$ git stash pop   # fix restored
```

Post-fix full suite:

```text
$ node scripts/run-vitest.mjs src/audit/audit-event-writer.test.ts
 ✓ unit  src/audit/audit-event-writer.test.ts (8 tests) 25481ms
   ✓ admits the audit worker under claimed external ownership and still refuses unmarked writers  4179ms
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ node scripts/run-vitest.mjs src/audit/ src/state/openclaw-state-ownership.test.ts
 Test Files  10 passed (10)
      Tests  184 passed (184)

$ pnpm exec oxlint src/audit/audit-event-writer.worker.ts src/audit/audit-event-writer.test.ts
 Found 0 warnings and 0 errors.
```

The new test: claims external ownership on a fresh state dir (same command shape as the documented systemd flow), spawns the real worker thread with the supervisor marker in the parent env, asserts the event persists with zero errors, then spawns a second worker **without** the marker and asserts it is still refused with `is externally supervised by systemd-openclaw-gateway`.

Fixes #123691