### PR TITLE
fix(gateway): prefer imported native blocks over cli-assistant aggregate

### DIFF
--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -119,32 +119,91 @@ function resolveCliAssistantAggregateText(message: unknown): string | undefined 
   return extractComparableText(message);
 }
 
-function collectImportedAssistantTexts(messages: unknown[]): string {
-  const parts: string[] = [];
+type ImportedAssistantTurn = {
+  text: string;
+  firstTimestamp?: number;
+  lastTimestamp?: number;
+  consumed: boolean;
+};
+
+// Groups imported native assistant blocks into turns (contiguous assistant
+// runs between user messages) so an aggregate can be matched only against the
+// exact native block sequence of its own CLI turn.
+function buildImportedAssistantTurns(messages: unknown[]): ImportedAssistantTurn[] {
+  const turns: ImportedAssistantTurn[] = [];
+  let current: { parts: string[]; firstTimestamp?: number; lastTimestamp?: number } | undefined;
+  const flush = () => {
+    if (current && current.parts.length > 0) {
+      turns.push({
+        text: current.parts.join(" "),
+        firstTimestamp: current.firstTimestamp,
+        lastTimestamp: current.lastTimestamp,
+        consumed: false,
+      });
+    }
+    current = undefined;
+  };
   for (const message of messages) {
     if (!message || typeof message !== "object") {
       continue;
     }
-    const record = message as { role?: unknown };
-    if (readStringValue(record.role) !== "assistant" || !resolveImportedExternalIdentity(message)) {
+    const role = readStringValue((message as { role?: unknown }).role);
+    if (role === "user") {
+      flush();
+      continue;
+    }
+    if (role !== "assistant" || !resolveImportedExternalIdentity(message)) {
       continue;
     }
     const text = extractComparableText(message);
-    if (text) {
-      parts.push(text);
+    if (!text) {
+      continue;
+    }
+    const timestamp = resolveComparableTimestamp(message);
+    if (!current) {
+      current = { parts: [], firstTimestamp: timestamp, lastTimestamp: timestamp };
+    }
+    current.parts.push(text);
+    if (timestamp !== undefined) {
+      current.firstTimestamp =
+        current.firstTimestamp === undefined
+          ? timestamp
+          : Math.min(current.firstTimestamp, timestamp);
+      current.lastTimestamp =
+        current.lastTimestamp === undefined
+          ? timestamp
+          : Math.max(current.lastTimestamp, timestamp);
     }
   }
-  return parts.join(" ");
+  flush();
+  return turns;
 }
 
-function countTextOccurrences(haystack: string, needle: string): number {
-  let count = 0;
-  let index = haystack.indexOf(needle);
-  while (index !== -1) {
-    count += 1;
-    index = haystack.indexOf(needle, index + needle.length);
+// A synthetic aggregate covers one CLI turn: its normalized text must equal
+// the concatenation of that turn's native blocks, and its write time must sit
+// near the turn's block timestamps. Exact turn-local matching keeps unrelated
+// imported turns (e.g. a later "not OK" reply) from consuming an "OK" fallback.
+function findMatchingImportedTurn(
+  turns: ImportedAssistantTurn[],
+  aggregateText: string,
+  aggregateTimestamp: number | undefined,
+): ImportedAssistantTurn | undefined {
+  for (const turn of turns) {
+    if (turn.consumed || turn.text !== aggregateText) {
+      continue;
+    }
+    if (
+      aggregateTimestamp !== undefined &&
+      turn.firstTimestamp !== undefined &&
+      turn.lastTimestamp !== undefined &&
+      (aggregateTimestamp < turn.firstTimestamp - DEDUPE_TIMESTAMP_WINDOW_MS ||
+        aggregateTimestamp > turn.lastTimestamp + DEDUPE_TIMESTAMP_WINDOW_MS)
+    ) {
+      continue;
+    }
+    return turn;
   }
-  return count;
+  return undefined;
 }
 
 function isEquivalentImportedMessage(existing: unknown, imported: unknown): boolean {
@@ -195,19 +254,22 @@ export function mergeImportedChatHistoryMessages(params: {
   if (params.importedMessages.length === 0) {
     return params.localMessages;
   }
-  const importedAssistantText = collectImportedAssistantTexts(params.importedMessages);
+  const importedAssistantTurns = buildImportedAssistantTurns(params.importedMessages);
   const merged: { message: unknown; order: number }[] = [];
-  const seenAggregateTexts = new Map<string, number>();
   params.localMessages.forEach((message, index) => {
     const aggregateText = resolveCliAssistantAggregateText(message);
     if (aggregateText) {
-      const seen = (seenAggregateTexts.get(aggregateText) ?? 0) + 1;
-      seenAggregateTexts.set(aggregateText, seen);
       // A cli-assistant aggregate is a synthetic single-text copy of one CLI
       // assistant turn. Prefer the proven overlapping imported native blocks:
-      // drop the aggregate only when the imported transcript covers this many
-      // copies of its text, and retain it as fallback history otherwise.
-      if (countTextOccurrences(importedAssistantText, aggregateText) >= seen) {
+      // drop the aggregate only when its own imported turn covers it exactly,
+      // and retain it as fallback history otherwise.
+      const match = findMatchingImportedTurn(
+        importedAssistantTurns,
+        aggregateText,
+        resolveComparableTimestamp(message),
+      );
+      if (match) {
+        match.consumed = true;
         return;
       }
     }

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -6,6 +6,7 @@ import {
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { CLAUDE_CLI_PROVIDER } from "./cli-session-history.claude.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
 // Synthetic single-text assistant aggregates persisted for CLI backends carry
@@ -108,8 +109,19 @@ function resolveCliAssistantAggregateText(message: unknown): string | undefined 
   if (!message || typeof message !== "object") {
     return undefined;
   }
-  const record = message as { role?: unknown; idempotencyKey?: unknown };
+  const record = message as {
+    role?: unknown;
+    idempotencyKey?: unknown;
+    provider?: unknown;
+  };
   if (readStringValue(record.role) !== "assistant") {
+    return undefined;
+  }
+  // The cli-assistant idempotency prefix is shared by every CLI backend, but
+  // this merger imports only Claude CLI history. Require the aggregate's
+  // provider to match the imported source so a same-text aggregate from
+  // another CLI backend is never deleted as if it were the imported turn.
+  if (readStringValue(record.provider) !== CLAUDE_CLI_PROVIDER) {
     return undefined;
   }
   const idempotencyKey = normalizeOptionalString(record.idempotencyKey);

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -8,6 +8,10 @@ import {
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
+// Synthetic single-text assistant aggregates persisted for CLI backends carry
+// this idempotency key prefix (see cli-run-transcript.ts). They duplicate the
+// per-block native transcript imported from the CLI session.
+const CLI_ASSISTANT_IDEMPOTENCY_PREFIX = "cli-assistant:";
 
 function extractComparableText(message: unknown): string | undefined {
   if (!message || typeof message !== "object") {
@@ -100,6 +104,49 @@ function hasSameExternalIdentity(existing: unknown, imported: unknown): boolean 
   );
 }
 
+function resolveCliAssistantAggregateText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const record = message as { role?: unknown; idempotencyKey?: unknown };
+  if (readStringValue(record.role) !== "assistant") {
+    return undefined;
+  }
+  const idempotencyKey = normalizeOptionalString(record.idempotencyKey);
+  if (!idempotencyKey?.startsWith(CLI_ASSISTANT_IDEMPOTENCY_PREFIX)) {
+    return undefined;
+  }
+  return extractComparableText(message);
+}
+
+function collectImportedAssistantTexts(messages: unknown[]): string {
+  const parts: string[] = [];
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as { role?: unknown };
+    if (readStringValue(record.role) !== "assistant" || !resolveImportedExternalIdentity(message)) {
+      continue;
+    }
+    const text = extractComparableText(message);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.join(" ");
+}
+
+function countTextOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
 function isEquivalentImportedMessage(existing: unknown, imported: unknown): boolean {
   // Text is a fallback only when either message lacks authoritative source identity.
   const sameExternalIdentity = hasSameExternalIdentity(existing, imported);
@@ -148,7 +195,24 @@ export function mergeImportedChatHistoryMessages(params: {
   if (params.importedMessages.length === 0) {
     return params.localMessages;
   }
-  const merged = params.localMessages.map((message, index) => ({ message, order: index }));
+  const importedAssistantText = collectImportedAssistantTexts(params.importedMessages);
+  const merged: { message: unknown; order: number }[] = [];
+  const seenAggregateTexts = new Map<string, number>();
+  params.localMessages.forEach((message, index) => {
+    const aggregateText = resolveCliAssistantAggregateText(message);
+    if (aggregateText) {
+      const seen = (seenAggregateTexts.get(aggregateText) ?? 0) + 1;
+      seenAggregateTexts.set(aggregateText, seen);
+      // A cli-assistant aggregate is a synthetic single-text copy of one CLI
+      // assistant turn. Prefer the proven overlapping imported native blocks:
+      // drop the aggregate only when the imported transcript covers this many
+      // copies of its text, and retain it as fallback history otherwise.
+      if (countTextOccurrences(importedAssistantText, aggregateText) >= seen) {
+        return;
+      }
+    }
+    merged.push({ message, order: index });
+  });
   let nextOrder = merged.length;
   for (const imported of params.importedMessages) {
     if (merged.some((existing) => isEquivalentImportedMessage(existing.message, imported))) {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -974,9 +974,10 @@ describe("cli session history", () => {
     // One aggregate is covered by the single imported block; the surplus copy
     // of the genuinely repeated turn survives as fallback history.
     expect(
-      merged.filter((message) =>
-        String(readRecord(message).idempotencyKey ?? "").startsWith("cli-assistant:"),
-      ),
+      merged.filter((message) => {
+        const key = readRecord(message).idempotencyKey;
+        return typeof key === "string" && key.startsWith("cli-assistant:");
+      }),
     ).toHaveLength(1);
   });
 
@@ -1096,9 +1097,10 @@ describe("cli session history", () => {
 
       expect(messages).toHaveLength(3);
       expect(
-        messages.some((message) =>
-          String(readRecord(message).idempotencyKey ?? "").startsWith("cli-assistant:"),
-        ),
+        messages.some((message) => {
+          const key = readRecord(message).idempotencyKey;
+          return typeof key === "string" && key.startsWith("cli-assistant:");
+        }),
       ).toBe(false);
       const importedAssistantBlocks = messages.filter((message) => {
         const record = readRecord(message);

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -975,6 +975,115 @@ describe("cli session history", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps a fallback aggregate when only an unrelated imported turn contains its text", () => {
+    const localMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "OK" }],
+        idempotencyKey: "cli-assistant:run-1",
+        timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+      },
+    ];
+    const importedMessages = [
+      {
+        role: "user",
+        content: "say not OK",
+        timestamp: Date.parse("2026-03-26T16:31:00.000Z"),
+        __openclaw: {
+          importedFrom: "claude-cli",
+          externalId: "user-2",
+          cliSessionId: "session-1",
+        },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "not OK" }],
+        timestamp: Date.parse("2026-03-26T16:31:01.000Z"),
+        __openclaw: {
+          importedFrom: "claude-cli",
+          externalId: "assistant-2",
+          cliSessionId: "session-1",
+        },
+      },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    // The unrelated later turn ("not OK") must not consume the "OK" fallback.
+    expect(
+      merged.filter((message) => readRecord(message).idempotencyKey === "cli-assistant:run-1"),
+    ).toHaveLength(1);
+    expect(merged.filter((message) => readRecord(message).role === "assistant")).toHaveLength(2);
+  });
+
+  it("replaces a cli-assistant aggregate with its own imported turn through the real file-backed import", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId }) => {
+      const filePath = path.join(
+        homeDir,
+        ".claude",
+        "projects",
+        "demo-workspace",
+        `${sessionId}.jsonl`,
+      );
+      await fs.writeFile(
+        filePath,
+        createClaudeTextHistoryLines([
+          { role: "user", uuid: "user-1", content: "hi" },
+          { role: "assistant", uuid: "assistant-1", content: "First block." },
+          { role: "assistant", uuid: "assistant-2", content: "Second block." },
+        ]),
+        "utf-8",
+      );
+      const localMessages = [
+        {
+          role: "user",
+          content: "hi",
+          timestamp: Date.parse("2026-03-26T16:29:54.900Z"),
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "First block.\n\nSecond block." }],
+          api: "cli",
+          provider: "claude-cli",
+          model: "gpt-5.6-sol",
+          idempotencyKey: "cli-assistant:run-1",
+          timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+        },
+      ];
+
+      const messages = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages,
+      });
+
+      expect(messages).toHaveLength(3);
+      expect(
+        messages.some((message) =>
+          readRecord(message).idempotencyKey?.startsWith("cli-assistant:"),
+        ),
+      ).toBe(false);
+      const importedAssistantBlocks = messages.filter((message) => {
+        const record = readRecord(message);
+        return (
+          record.role === "assistant" &&
+          (record["__openclaw"] as { importedFrom?: string } | undefined)?.importedFrom ===
+            "claude-cli"
+        );
+      });
+      expect(importedAssistantBlocks).toHaveLength(2);
+      expectFields(readRecord(importedAssistantBlocks[0]), {
+        role: "assistant",
+      });
+      expect(readRecord(importedAssistantBlocks[0])["__openclaw"]).toMatchObject({
+        externalId: "assistant-1",
+      });
+      expect(readRecord(importedAssistantBlocks[1])["__openclaw"]).toMatchObject({
+        externalId: "assistant-2",
+      });
+    });
+  });
+
   it.each([
     ["deduplicates a local redacted copy against an imported full copy", false],
     ["deduplicates when both local and imported copies are already redacted", true],

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -912,6 +912,7 @@ describe("cli session history", () => {
       {
         role: "assistant",
         content: [{ type: "text", text: "Only available locally." }],
+        provider: "claude-cli",
         idempotencyKey: "cli-assistant:run-1",
         timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
       },
@@ -942,12 +943,14 @@ describe("cli session history", () => {
       {
         role: "assistant",
         content: [{ type: "text", text: "Same answer." }],
+        provider: "claude-cli",
         idempotencyKey: "cli-assistant:run-1",
         timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
       },
       {
         role: "assistant",
         content: [{ type: "text", text: "Same answer." }],
+        provider: "claude-cli",
         idempotencyKey: "cli-assistant:run-2",
         // More than the 5-minute dedupe window apart: a genuinely repeated turn.
         timestamp: Date.parse("2026-03-26T16:36:56.000Z"),
@@ -971,7 +974,9 @@ describe("cli session history", () => {
     // One aggregate is covered by the single imported block; the surplus copy
     // of the genuinely repeated turn survives as fallback history.
     expect(
-      merged.filter((message) => readRecord(message).idempotencyKey?.startsWith("cli-assistant:")),
+      merged.filter((message) =>
+        String(readRecord(message).idempotencyKey ?? "").startsWith("cli-assistant:"),
+      ),
     ).toHaveLength(1);
   });
 
@@ -980,6 +985,7 @@ describe("cli session history", () => {
       {
         role: "assistant",
         content: [{ type: "text", text: "OK" }],
+        provider: "claude-cli",
         idempotencyKey: "cli-assistant:run-1",
         timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
       },
@@ -1013,6 +1019,37 @@ describe("cli session history", () => {
       merged.filter((message) => readRecord(message).idempotencyKey === "cli-assistant:run-1"),
     ).toHaveLength(1);
     expect(merged.filter((message) => readRecord(message).role === "assistant")).toHaveLength(2);
+  });
+
+  it("keeps a same-text cli-assistant aggregate from another CLI provider", () => {
+    const localMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Same answer." }],
+        provider: "openai",
+        idempotencyKey: "cli-assistant:run-1",
+        timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+      },
+    ];
+    const importedMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Same answer." }],
+        timestamp: Date.parse("2026-03-26T16:29:55.500Z"),
+        __openclaw: {
+          importedFrom: "claude-cli",
+          externalId: "assistant-1",
+          cliSessionId: "session-1",
+        },
+      },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    // The aggregate was written by a different CLI backend, so it is not a
+    // redundant copy of the imported Claude CLI turn and must survive.
+    expect(
+      merged.filter((message) => readRecord(message).idempotencyKey === "cli-assistant:run-1"),
+    ).toHaveLength(1);
   });
 
   it("replaces a cli-assistant aggregate with its own imported turn through the real file-backed import", async () => {
@@ -1060,7 +1097,7 @@ describe("cli session history", () => {
       expect(messages).toHaveLength(3);
       expect(
         messages.some((message) =>
-          readRecord(message).idempotencyKey?.startsWith("cli-assistant:"),
+          String(readRecord(message).idempotencyKey ?? "").startsWith("cli-assistant:"),
         ),
       ).toBe(false);
       const importedAssistantBlocks = messages.filter((message) => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -853,6 +853,128 @@ describe("cli session history", () => {
     });
   });
 
+  it("prefers overlapping imported native blocks over the synthetic cli-assistant aggregate", () => {
+    const localMessages = [
+      {
+        role: "user",
+        content: "hi",
+        timestamp: Date.parse("2026-03-26T16:29:54.900Z"),
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "First block.\n\nSecond block." }],
+        api: "cli",
+        provider: "claude-cli",
+        model: "gpt-5.6-sol",
+        idempotencyKey: "cli-assistant:run-1",
+        timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+      },
+    ];
+    const importedMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "First block." }],
+        timestamp: Date.parse("2026-03-26T16:29:55.500Z"),
+        __openclaw: {
+          importedFrom: "claude-cli",
+          externalId: "assistant-1",
+          cliSessionId: "session-1",
+        },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Second block." }],
+        timestamp: Date.parse("2026-03-26T16:29:55.700Z"),
+        __openclaw: {
+          importedFrom: "claude-cli",
+          externalId: "assistant-2",
+          cliSessionId: "session-1",
+        },
+      },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toHaveLength(3);
+    // The synthetic aggregate is replaced by the proven native blocks.
+    expect(
+      merged.some((message) => readRecord(message).idempotencyKey === "cli-assistant:run-1"),
+    ).toBe(false);
+    expect(merged.filter((message) => readRecord(message).role === "assistant")).toHaveLength(2);
+    expect(
+      merged
+        .filter((message) => readRecord(message).role === "assistant")
+        .every((message) => readRecord(message)["__openclaw"] !== undefined),
+    ).toBe(true);
+  });
+
+  it("retains the synthetic aggregate when imported history does not cover it", () => {
+    const localMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Only available locally." }],
+        idempotencyKey: "cli-assistant:run-1",
+        timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+      },
+    ];
+    const importedMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Unrelated imported turn." }],
+        timestamp: Date.parse("2026-03-26T16:29:55.500Z"),
+        __openclaw: {
+          importedFrom: "claude-cli",
+          externalId: "assistant-1",
+          cliSessionId: "session-1",
+        },
+      },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toHaveLength(2);
+    // The synthetic aggregate survives as fallback history.
+    expect(
+      merged.filter((message) => readRecord(message).idempotencyKey === "cli-assistant:run-1"),
+    ).toHaveLength(1);
+  });
+
+  it("preserves genuinely repeated assistant turns when imports cover only one copy", () => {
+    const localMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Same answer." }],
+        idempotencyKey: "cli-assistant:run-1",
+        timestamp: Date.parse("2026-03-26T16:29:56.000Z"),
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Same answer." }],
+        idempotencyKey: "cli-assistant:run-2",
+        // More than the 5-minute dedupe window apart: a genuinely repeated turn.
+        timestamp: Date.parse("2026-03-26T16:36:56.000Z"),
+      },
+    ];
+    const importedMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Same answer." }],
+        timestamp: Date.parse("2026-03-26T16:29:55.500Z"),
+        __openclaw: {
+          importedFrom: "claude-cli",
+          externalId: "assistant-1",
+          cliSessionId: "session-1",
+        },
+      },
+    ];
+
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+    expect(merged).toHaveLength(2);
+    // One aggregate is covered by the single imported block; the surplus copy
+    // of the genuinely repeated turn survives as fallback history.
+    expect(
+      merged.filter((message) => readRecord(message).idempotencyKey?.startsWith("cli-assistant:")),
+    ).toHaveLength(1);
+  });
+
   it.each([
     ["deduplicates a local redacted copy against an imported full copy", false],
     ["deduplicates when both local and imported copies are already redacted", true],


### PR DESCRIPTION
## What Problem This Solves

With a `claude-cli` (or other CLI) backend, every assistant turn is persisted **twice** through two independent writers, and clients that render the transcript show both copies: the live per-block view (imported native Claude CLI blocks) plus a concatenated aggregate as one plain block. The two copies are not byte-identical, so the Control UI duplicate-collapse rule never fires.

Root cause: `src/agents/cli-runner/cli-run-transcript.ts` persists a synthetic single-text assistant aggregate with idempotency key `cli-assistant:<runId>` whenever assistant persistence is enabled. The Gateway then merges that local history with the per-block transcript imported from the bound CLI session (`src/gateway/cli-session-history.ts`). `mergeImportedChatHistoryMessages` only skips imported messages that exactly match a local message (same external identity or identical normalized text), so a concatenated aggregate never matches its own imported blocks and both survive side by side (`src/gateway/cli-session-history.merge.ts`).

## Why

The merge owner is the correct fix boundary: the imported native blocks are the authoritative per-block record of the same turn, and the synthetic aggregate is a redundant local copy. Fixing it in the merge keeps every client (Control UI, Android app) correct at once, instead of masking the duplicate at render time — the report explicitly notes a render-time adoption would hide the duplicate rather than prevent it. Telegram is unaffected because it renders the delivered message, not the transcript.

## User Impact

Control UI and Android users on CLI backends see every assistant turn twice (full turn, then an immediate plain-block copy), with the duplicate-collapse rule unable to fire because the copies differ. After this fix each turn appears once, from the imported native blocks; the aggregate is retained as fallback whenever imported history does not cover that exact turn (missing/truncated imports, unrelated turns, or surplus copies of genuinely repeated identical answers).

## Evidence

[AI-assisted]

The merge now groups imported native assistant blocks into **turns** (contiguous assistant runs between user messages) and drops a `cli-assistant:` aggregate only when its exact normalized text equals the concatenation of its own turn's blocks within the 5-minute dedupe time window. Global substring matching was rejected in review because an unrelated later turn (e.g. "not OK") could consume a fallback aggregate ("OK") — the turn-local rule adds a regression for exactly that case.

Aggregate removal is additionally scoped to the imported CLI source: the recognizer now requires the aggregate's `provider` to match `claude-cli`, so a same-text aggregate written by another CLI backend (which shares the `cli-assistant:` idempotency prefix) is never deleted as if it were the imported Claude turn. A mixed-provider regression test covers that case.

Regression tests (fail on pre-fix code):

```text
$ git stash push -- src/gateway/cli-session-history.merge.ts   # pre-fix merge
$ node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts -t "prefers overlapping imported native blocks"
 × prefers overlapping imported native blocks over the synthetic cli-assistant aggregate
   AssertionError: expected [ { role: 'user', …(2) }, …(3) ] to have a length of 3 but got 4

$ node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts -t "unrelated imported turn"
 × keeps a fallback aggregate when only an unrelated imported turn contains its text
   (global substring matching wrongly consumed the "OK" fallback via a later "not OK" turn)
$ git stash pop   # fix restored
```

Post-fix suites (51 tests, including 6 new: covered aggregate replaced; uncovered aggregate retained; genuinely repeated identical turns preserved; unrelated later turn cannot consume a fallback; same-text aggregate from another CLI provider kept; real file-backed import through the gateway path):

```text
$ node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts
 ✓ gateway-core  ../../src/gateway/cli-session-history.test.ts (51 tests) 257ms
 Test Files  1 passed (1)
      Tests  51 passed (51)

$ node scripts/run-vitest.mjs src/gateway/server-methods/chat-history-pages.test.ts
 ✓ gateway-methods  ../../src/gateway/server-methods/chat-history-pages.test.ts (2 tests) 37ms
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ pnpm exec oxlint src/gateway/cli-session-history.merge.ts src/gateway/cli-session-history.test.ts
Found 0 warnings and 0 errors.

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.gateway-root.json
(no errors — check-test-types gate passes)
```

Real-setup proof: the new `replaces a cli-assistant aggregate with its own imported turn through the real file-backed import` test writes an actual Claude CLI `session.jsonl` on disk (user turn + two native assistant blocks) and runs the real `readClaudeCliSessionMessages` → `mergeImportedChatHistoryMessages` → `augmentChatHistoryWithCliSessionImports` composition, asserting the merged history keeps the two imported blocks (`externalId` preserved) and contains no `cli-assistant:` aggregate.

Fixes #123792
