### PR TITLE
fix: Linux installer reports success after build tools fail to install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -821,50 +821,33 @@ apt_get_install() {
 install_build_tools_linux() {
     require_sudo
 
+    # apt_get already escalates privileges itself, so it stays separate from the
+    # sudo-prefixed command list below.
     if command -v apt-get &> /dev/null; then
         run_quiet_step "Updating package index" apt_get_update
         run_quiet_step "Installing build tools" apt_get_install build-essential python3 make g++ cmake
-        return 0
+        return
     fi
 
+    local -a build_tools_cmd=()
     if command -v pacman &> /dev/null && is_arch_linux; then
-        if is_root; then
-            run_quiet_step "Installing build tools" pacman -Sy --noconfirm base-devel python make cmake gcc
-        else
-            run_quiet_step "Installing build tools" sudo pacman -Sy --noconfirm base-devel python make cmake gcc
-        fi
-        return 0
+        build_tools_cmd=(pacman -Sy --noconfirm base-devel python make cmake gcc)
+    elif command -v dnf &> /dev/null; then
+        build_tools_cmd=(dnf install -y -q gcc gcc-c++ make cmake python3)
+    elif command -v yum &> /dev/null; then
+        build_tools_cmd=(yum install -y -q gcc gcc-c++ make cmake python3)
+    elif command -v apk &> /dev/null && is_alpine_linux; then
+        build_tools_cmd=(apk add --no-cache build-base python3 cmake)
+    else
+        ui_warn "Could not detect package manager for auto-installing build tools"
+        return 1
     fi
 
-    if command -v dnf &> /dev/null; then
-        if is_root; then
-            run_quiet_step "Installing build tools" dnf install -y -q gcc gcc-c++ make cmake python3
-        else
-            run_quiet_step "Installing build tools" sudo dnf install -y -q gcc gcc-c++ make cmake python3
-        fi
-        return 0
-    fi
-
-    if command -v yum &> /dev/null; then
-        if is_root; then
-            run_quiet_step "Installing build tools" yum install -y -q gcc gcc-c++ make cmake python3
-        else
-            run_quiet_step "Installing build tools" sudo yum install -y -q gcc gcc-c++ make cmake python3
-        fi
-        return 0
-    fi
-
-    if command -v apk &> /dev/null && is_alpine_linux; then
-        if is_root; then
-            run_quiet_step "Installing build tools" apk add --no-cache build-base python3 cmake
-        else
-            run_quiet_step "Installing build tools" sudo apk add --no-cache build-base python3 cmake
-        fi
-        return 0
-    fi
-
-    ui_warn "Could not detect package manager for auto-installing build tools"
-    return 1
+    is_root || build_tools_cmd=(sudo "${build_tools_cmd[@]}")
+    # Return the package manager's status: callers choose between "Build tools
+    # installed" and the continue-without-build-tools warning based on it, so
+    # swallowing a failure here makes the installer claim success after an error.
+    run_quiet_step "Installing build tools" "${build_tools_cmd[@]}"
 }
 
 install_build_tools_macos() {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -408,6 +408,33 @@ NODE
     expect(nodeSourceIndex).toBeGreaterThan(apkIndex);
   });
 
+  it("propagates package manager failure out of install_build_tools_linux", () => {
+    // PATH="" hides real package managers so only the stubbed function below is
+    // discoverable, keeping the selected branch identical on macOS and Linux.
+    for (const packageManager of ["apt-get", "dnf", "yum", "apk", "pacman"]) {
+      const result = runInstallShell(`
+        set -uo pipefail
+        source "${SCRIPT_PATH}"
+        PATH=""
+        require_sudo() { :; }
+        is_root() { return 0; }
+        is_arch_linux() { [[ "${packageManager}" == "pacman" ]]; }
+        is_alpine_linux() { [[ "${packageManager}" == "apk" ]]; }
+        ui_warn() { printf 'warn:%s\\n' "$*"; }
+        ${packageManager}() { :; }
+        run_quiet_step() { return 1; }
+        if install_build_tools_linux; then
+          printf 'result:success\\n'
+        else
+          printf 'result:failure\\n'
+        fi
+      `);
+
+      expect(result.stdout, packageManager).toContain("result:failure");
+      expect(result.stdout, packageManager).not.toContain("result:success");
+    }
+  });
+
   it("uses the apk Node.js installer path on Alpine", () => {
     const result = runInstallShell(`
       set -euo pipefail


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators installing OpenClaw on Linux would be told the
install succeeded when it had actually failed. When the distribution's package
manager could not install the native build tools, `install.sh` printed the
failure and then immediately contradicted it:

```
✗ Installing build tools failed — re-run with --verbose for details
✓ Build tools installed
```

The installer then continued as if the toolchain were present, so the real
failure surfaced later as a confusing native-module build error with no
connection to its cause. The npm-failure recovery path had the same problem:
it reported `Build tools setup complete` and retried an install that could not
succeed.

## Why This Change Was Made

`install_build_tools_linux` ran `run_quiet_step` — which correctly returns
non-zero — and then hit an unconditional `return 0` in every package-manager
branch, discarding the status. That made the caller's
"Continuing without auto-installing build tools" warning unreachable dead code.
`install_build_tools_macos` already propagated its status correctly through
`[[ "$ok" == "true" ]]`; only the Linux sibling swallowed it.

Rather than patch one branch, this returns the package manager's exit status and
collapses the five duplicated `is_root`/`sudo` branches into a single command
list, which removes the bug class from the whole function. `apt` stays separate
because `apt_get` already handles its own privilege escalation.

Production LOC is net **-17** (+19/-36); the +27 added lines are tests.

## User Impact

Linux operators now get an honest outcome. A package-manager failure reports
"Continuing without auto-installing build tools" instead of a false success, so
the problem is visible at the step that caused it rather than as an unexplained
build error later. No change to successful installs, and no change on macOS.

## Evidence

**Reproduction against the live `openclaw.ai/install.sh`** (Debian container,
`apt-get` stubbed to fail only on `build-essential`):

Before — step failed but installer claimed success:
```
· Installing build tools
✗ Installing build tools failed — re-run with --verbose for details
✓ Build tools installed
FAIL: step failed but installer claimed success
```

After — failure reported honestly:
```
· Installing build tools
✗ Installing build tools failed — re-run with --verbose for details
! Continuing without auto-installing build tools
PASS: failure reported honestly
```

**Regression test** (`test/scripts/install-sh.test.ts`) covers all five package
managers and fails on pre-fix code for the intended reason:
```
- result:failure
+ result:success
  Tests  1 failed | 88 skipped (89)
```
Post-fix: `Tests  89 passed (89)`.

**Live install proof** — the documented one-liner run against the live URL in
clean containers, all reaching a working `openclaw --version` (2026.7.1-2):

| Scenario | Result |
| --- | --- |
| `curl \| bash`, bare Ubuntu 24.04, no Node (bootstraps Node 26 + build tools + git) | pass |
| `curl \| bash`, non-root user (relocates npm prefix, patches `.bashrc` PATH) | pass |
| `curl \| bash` with TTY (reattaches `/dev/tty`, enters onboarding) | pass |
| Fedora 41, root and non-root (dnf path + new sudo-prefix line) | pass |
| `install-cli.sh` from live URL | pass |
| Upgrade path, pinned `2026.6.34` → latest | pass |
| `--install-method git` (resolves and checks out `v2026.7.1-2`) | pass |

**Static checks:** `bash -n`, `shellcheck -e SC1091`, `oxfmt --check`, oxlint,
`install.sh --help`, and `install.sh --dry-run --no-onboard --no-prompt` all clean —
matching the gates in `website-installer-sync.yml`.

**Autoreview:** Codex `gpt-5.6-sol` / high — clean, no accepted or actionable findings.

## Follow-ups (not in this PR)

- `website-installer-sync.yml` only exercises Debian-as-root on happy paths, which
  is why this survived. Non-root, failure-propagation, and dnf/pacman/apk lanes
  would have caught it.
- `scripts/install.sh:2877` does a full `git clone` for `--install-method git`
  (~4.9 GB working directory). Since the installer pins a release tag rather than
  tracking a branch, a `--filter=blob:none` or tag-scoped fetch looks viable, but
  it touches version derivation and branch switching so it deserves its own change.
