### PR TITLE
fix(agents): reject non-allowlisted explicit sessions_spawn models

### DIFF
--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -4,7 +4,7 @@ import { isIncognitoSessionKey } from "../../../routing/session-key.js";
 import { resolveUserPath } from "../../../utils.js";
 import { resolveAgentDir } from "../../agent-scope-config.js";
 import { findModelCatalogEntry } from "../../model-catalog-lookup.js";
-import { resolveDefaultModelForAgent } from "../../model-selection.js";
+import { resolveAllowedModelRef, resolveDefaultModelForAgent } from "../../model-selection.js";
 import { supportsModelTools } from "../../model-tool-support.js";
 import { summarizeSpawnError } from "../../spawn-pipeline.js";
 import { resolveSpawnSandboxError, mintSpawnSessionKey } from "../../spawn-plan.js";
@@ -82,6 +82,54 @@ async function resolveCollectorOutputModelError(params: {
     return undefined;
   }
   return `sessions_spawn outputSchema requires a tool-capable target model; "${provider}/${model}" declares compat.supportsTools=false.`;
+}
+
+/**
+ * Validates an explicit caller-supplied sessions_spawn model ref against the
+ * prepared catalog and modelPolicy.allow before any child state is created.
+ * Implicit default selection is intentionally left unchanged.
+ */
+async function resolveExplicitSpawnModelAllowError(params: {
+  cfg: OpenClawConfig;
+  targetAgentId: string;
+  targetAgentDir: string;
+  workspaceDir?: string;
+  resolvedModel: string;
+}): Promise<string | undefined> {
+  const fallback = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.targetAgentId,
+  });
+  const { provider, model } = splitModelRef(params.resolvedModel);
+  const providerId = provider ?? fallback.provider;
+  if (!providerId || !model) {
+    return undefined;
+  }
+  let catalog: Awaited<ReturnType<typeof loadPreparedModelCatalog>>;
+  try {
+    catalog = await getSubagentSpawnDeps().loadPreparedModelCatalog({
+      config: params.cfg,
+      agentDir: params.targetAgentDir,
+      workspaceDir: params.workspaceDir,
+      readOnly: true,
+      providerDiscoveryProviderIds: [providerId],
+      scopedLiveProviderDiscovery: true,
+    });
+  } catch (error) {
+    return `sessions_spawn could not verify the requested model: ${summarizeSpawnError(error)}`;
+  }
+  const resolved = resolveAllowedModelRef({
+    cfg: params.cfg,
+    catalog,
+    raw: params.resolvedModel,
+    defaultProvider: fallback.provider,
+    defaultModel: fallback.model,
+    agentId: params.targetAgentId,
+  });
+  if ("error" in resolved) {
+    return `sessions_spawn model "${params.resolvedModel}" is not usable: ${resolved.error}`;
+  }
+  return undefined;
 }
 
 type ResolvedSubagentChildPlan = {
@@ -221,6 +269,22 @@ export async function resolveSubagentChildPlan(params: {
     };
   }
   const { resolvedModel } = modelPlan;
+  // Explicit model refs must pass catalog/policy before any child state exists.
+  if (params.request.model?.trim()) {
+    const modelAllowError = await resolveExplicitSpawnModelAllowError({
+      cfg: params.cfg,
+      targetAgentId: params.targetAgentId,
+      targetAgentDir,
+      workspaceDir: spawnedWorkspaceDir,
+      resolvedModel,
+    });
+    if (modelAllowError) {
+      return {
+        ok: false,
+        result: { status: "error", error: modelAllowError },
+      };
+    }
+  }
   const resolvedLaunchModel = splitModelRef(resolvedModel);
   const launchAuthorization: SubagentLaunchAuthorization | undefined =
     params.request.model?.trim() && resolvedLaunchModel.model

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1074,6 +1074,84 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
   });
 
+  it("rejects an explicit non-allowlisted model before creating child state", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          modelPolicy: { allow: ["openai/gpt-5.6-sol"] },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+
+    const rejected = await spawnSubagentDirect(
+      {
+        task: "explicit disallowed model",
+        model: "openai/gpt-5.4",
+      },
+      { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
+    );
+
+    expect(rejected.status).toBe("error");
+    expect(rejected.error).toContain("is not usable");
+    expect(rejected.error).toContain("model not allowed");
+    expect(hoisted.loadPreparedModelCatalogMock).toHaveBeenCalledWith({
+      config: hoisted.configOverride,
+      agentDir: expect.any(String),
+      workspaceDir: "/tmp/workspace-main",
+      readOnly: true,
+      providerDiscoveryProviderIds: ["openai"],
+      scopedLiveProviderDiscovery: true,
+    });
+    expect(hoisted.updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts an explicit model that is on the configured allowlist", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          modelPolicy: { allow: ["openai/gpt-5.4"] },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+
+    const accepted = await spawnSubagentDirect(
+      {
+        task: "explicit allowed model",
+        model: "openai/gpt-5.4",
+      },
+      { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
+    );
+
+    expect(accepted.status).toBe("accepted");
+    expect(hoisted.updateSessionStoreMock).toHaveBeenCalled();
+  });
+
+  it("leaves implicit default model selection unchanged under a configured allowlist", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          modelPolicy: { allow: ["openai/gpt-5.6-sol"] },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+
+    const accepted = await spawnSubagentDirect(
+      { task: "implicit default model" },
+      { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
+    );
+
+    expect(accepted.status).toBe("accepted");
+    expect(hoisted.loadPreparedModelCatalogMock).not.toHaveBeenCalled();
+    expect(hoisted.updateSessionStoreMock).toHaveBeenCalled();
+  });
+
   it("rejects a group id outside collector mode", async () => {
     hoisted.configOverride = createConfigOverride({ tools: { swarm: true } });
 


### PR DESCRIPTION
## What Problem This Solves

`sessions_spawn` accepts an explicit `model` ref without any catalog or `modelPolicy.allow` validation, persists it into the child session, and reports `modelApplied: true` — then the child run silently executes on the default model when the requested ref is unusable:

- **Repro 1:** `sessions_spawn` with `model="anthropic/claude-nonexistent-model-test"` → response reports `resolvedModel` + `modelApplied: true`, child silently runs the default model, no warning logged.
- **Repro 2:** a configured provider whose model is intentionally absent from the `agents.defaults.models` allowlist → `resolvedProvider` reported, child runs the default model, the target server receives zero requests.

The child planner (`resolveSubagentModelAndThinkingPlan` in `src/agents/subagents/spawn/subagent-spawn-plan.ts`) resolves the model through aliases only; the spawned session is persisted and acknowledged before any sibling-path validation (like `resolveSessionPatchModelSelection` in `src/gateway/sessions-patch.ts`, which uses `resolveAllowedModelRef`) is applied.

## Why

The issue's request #2 asks for explicit user-supplied refs to hard-fail (or surface a classified error) instead of silently substituting, and request #3 asks that `modelApplied` reflect reality. The maintainer-accepted fix direction: validate explicit `sessions_spawn` model refs at the single child-planning boundary against the prepared catalog and `modelPolicy.allow`, reusing the existing allowed-model resolver — no new allowlist, no change to implicit default selection.

## User Impact

A config/CLI typo or an allowlist miss in `sessions_spawn` now returns a classified error (`sessions_spawn model "<ref>" is not usable: model not allowed: <key>`) before any child session is created, instead of silently running a different model with `modelApplied: true`. Evaluation harnesses and test rigs can no longer be silently bypassed. Implicit default selection and allowlisted explicit models behave exactly as before.

## Evidence

[AI-assisted]

New regression test (fails on pre-fix code — spawn returns `accepted` for a non-allowlisted explicit model — passes with the fix):

```text
$ git stash push -- src/agents/subagents/spawn/subagent-spawn-child-plan.ts   # pre-fix planner
$ node scripts/run-vitest.mjs src/agents/subagents/spawn/subagent-spawn.test.ts -t "rejects an explicit non-allowlisted model"
 × rejects an explicit non-allowlisted model before creating child state
   AssertionError: expected 'accepted' to be 'error' // Object.is equality
$ git stash pop   # fix restored
```

Post-fix suites:

```text
$ node scripts/run-vitest.mjs src/agents/subagents/spawn/subagent-spawn.test.ts
 ✓ agents-support  src/agents/subagents/spawn/subagent-spawn.test.ts (57 tests) 20304ms
   ✓ rejects an explicit non-allowlisted model before creating child state  442ms
   ✓ accepts an explicit model that is on the configured allowlist  429ms
 Test Files  1 passed (1)
      Tests  57 passed (57)

$ node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts src/gateway/http-utils.model-override.test.ts
 Test Files  2 passed (2)
      Tests  86 passed (86)

$ pnpm exec oxlint src/agents/subagents/spawn/subagent-spawn-child-plan.ts src/agents/subagents/spawn/subagent-spawn.test.ts
 Found 0 warnings and 0 errors.
```

The fix (`resolveExplicitSpawnModelAllowError` in `src/agents/subagents/spawn/subagent-spawn-child-plan.ts`): when `request.model` is explicitly set, load the prepared catalog (same scoped read-only call the outputSchema path uses) and run `resolveAllowedModelRef` with the target agent's default provider/model; on the resolver's classified error, abort the plan before any child state is persisted or launched. Three new tests cover: non-allowlisted explicit ref rejected with no session-store write; allowlisted explicit ref accepted; implicit default selection unchanged (catalog not even loaded).

Fixes #123601