### PR TITLE
perf(test): reuse LAN node pairing gateways

### DIFF
--- a/src/gateway/server.node-pairing-auto-approve.test.ts
+++ b/src/gateway/server.node-pairing-auto-approve.test.ts
@@ -1,18 +1,18 @@
 // Node pairing auto-approve tests cover LAN self-connect detection, token auth,
 // node identity persistence, and auto-approved pairing state.
-import { describe, expect, test } from "vitest";
+import { expect, test } from "vitest";
 import { writeConfigFile } from "../config/config.js";
 import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
 import { installGatewayTestHooks } from "./test-helpers.js";
-import { withLanNodePairingAttempt } from "./test-helpers.lan-pairing.js";
+import { describeWithLanNodePairingServer } from "./test-helpers.lan-pairing.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
-describe("gateway trusted CIDR node pairing auto-approve", () => {
+describeWithLanNodePairingServer("gateway trusted CIDR node pairing auto-approve", (attempt) => {
   test("stays disabled by default for a direct non-loopback node", async () => {
-    await withLanNodePairingAttempt({
+    await attempt({
       identityName: "trusted-cidr-default-off",
-      beforeStart: async () => {
+      configure: async () => {
         // Pin SSH verification off so this case exercises the CIDR default
         // without spawning a real ssh probe to the runner's own LAN IP.
         await writeConfigFile({
@@ -34,9 +34,9 @@ describe("gateway trusted CIDR node pairing auto-approve", () => {
   });
 
   test("auto-approves first-time node pairing from a matching direct non-loopback CIDR", async () => {
-    await withLanNodePairingAttempt({
+    await attempt({
       identityName: "trusted-cidr-direct-lan-auto-approve",
-      beforeStart: async (lanIp) => {
+      configure: async (lanIp) => {
         await writeConfigFile({
           gateway: {
             nodes: {

--- a/src/gateway/server.node-pairing-ssh-verify.test.ts
+++ b/src/gateway/server.node-pairing-ssh-verify.test.ts
@@ -1,6 +1,6 @@
 // SSH-verified node pairing e2e: real gateway server on the LAN self-connect
 // harness, with the SSH probe runtime mocked at the module boundary.
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 import { writeConfigFile } from "../config/config.js";
 import {
   getPairedDevice,
@@ -12,7 +12,7 @@ import type {
   NodeIdentityProbeResult,
 } from "./node-pairing-ssh-verify.runtime.js";
 import { installGatewayTestHooks } from "./test-helpers.js";
-import { withLanNodePairingAttempt } from "./test-helpers.lan-pairing.js";
+import { describeWithLanNodePairingServer } from "./test-helpers.lan-pairing.js";
 
 const probeMock = vi.hoisted(() =>
   vi.fn<(params: NodeIdentityProbeParams) => Promise<NodeIdentityProbeResult>>(),
@@ -54,14 +54,14 @@ type PairingRequiredDetails = {
   pauseReconnect?: boolean;
 };
 
-describe("gateway ssh-verified node pairing auto-approve", () => {
+describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve", (attempt) => {
   beforeEach(() => {
     // Each case uses a distinct identityName, matching the host+device cooldown key.
     probeMock.mockReset();
   });
 
   test("approves device pairing and the first capability surface on a key match", async () => {
-    await withLanNodePairingAttempt({
+    await attempt({
       identityName: "ssh-verify-key-match",
       run: async ({ lanIp, loaded, connectNode }) => {
         probeMock.mockImplementation(async () => ({
@@ -100,7 +100,7 @@ describe("gateway ssh-verified node pairing auto-approve", () => {
   });
 
   test("does not ssh-approve a pending request that carries scopes from an earlier attempt", async () => {
-    await withLanNodePairingAttempt({
+    await attempt({
       identityName: "ssh-verify-scoped-refresh",
       run: async ({ loaded, connectNode }) => {
         // Seed a scoped pending request (as an earlier interactive attempt
@@ -134,7 +134,7 @@ describe("gateway ssh-verified node pairing auto-approve", () => {
   });
 
   test("leaves the pairing pending when the remote identity does not match", async () => {
-    await withLanNodePairingAttempt({
+    await attempt({
       identityName: "ssh-verify-key-mismatch",
       run: async ({ loaded, connectNode }) => {
         // A different key than the pending request: assembled from words so the
@@ -167,9 +167,9 @@ describe("gateway ssh-verified node pairing auto-approve", () => {
   });
 
   test("sshVerify: false disables the probe and keeps default reconnect pause behavior", async () => {
-    await withLanNodePairingAttempt({
+    await attempt({
       identityName: "ssh-verify-disabled",
-      beforeStart: async () => {
+      configure: async () => {
         await writeConfigFile({
           gateway: { nodes: { pairing: { sshVerify: false } } },
         });

--- a/src/gateway/test-helpers.lan-pairing.ts
+++ b/src/gateway/test-helpers.lan-pairing.ts
@@ -3,6 +3,7 @@
 // address so the server observes a direct non-loopback client IP. Skips
 // silently on hosts without a usable LAN interface.
 import net from "node:net";
+import { afterAll, beforeAll, describe } from "vitest";
 import { WebSocket } from "ws";
 import { getPairedDevice, removePairedDevice } from "../infra/device-pairing.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -88,52 +89,76 @@ type LanNodePairingContext = {
   connectNode: () => Promise<Awaited<ReturnType<typeof connectReq>>>;
 };
 
-export async function withLanNodePairingAttempt(params: {
+type LanNodePairingAttempt = (params: {
   identityName: string;
-  beforeStart?: (lanIp: string) => Promise<void>;
+  configure?: (lanIp: string) => Promise<void>;
   run: (ctx: LanNodePairingContext) => Promise<void>;
-}): Promise<void> {
-  const lanIp = pickPrimaryLanIPv4();
-  if (!lanIp || !(await canUseLanSelfConnect(lanIp))) {
-    return;
-  }
-  await params.beforeStart?.(lanIp);
-  const started = await startServer(LAN_NODE_PAIRING_TOKEN, {
-    bind: "lan",
-    controlUiEnabled: false,
-  });
-  const openSockets: WebSocket[] = [];
-  try {
-    const loaded = loadDeviceIdentity(params.identityName);
-    // The suite shares one state home under --isolate=false; drop any paired
-    // record for this identity so a sibling suite's row cannot mask a fresh
-    // pairing (a stale approvedVia would survive a re-approve by design).
-    if (await getPairedDevice(loaded.identity.deviceId)) {
-      await removePairedDevice(loaded.identity.deviceId);
-    }
-    const connectNode = async () => {
-      const ws = await openLanGatewayWs({ host: lanIp, port: started.port });
-      openSockets.push(ws);
-      try {
-        return await connectReq(ws, {
-          token: LAN_NODE_PAIRING_TOKEN,
-          role: "node",
-          scopes: [],
-          client: NODE_CLIENT,
-          deviceIdentityPath: loaded.identityPath,
-        });
-      } finally {
-        // These tests cover pairing, not the WebSocket close handshake. Terminate so
-        // gateway cleanup never waits on a client that has already returned its result.
+}) => Promise<void>;
+
+// Pairing config is read when each WebSocket handler attaches. Reuse the real
+// Gateway while suite-scoped hooks reset mutable runtime state between cases.
+export function describeWithLanNodePairingServer(
+  name: string,
+  defineTests: (attempt: LanNodePairingAttempt) => void,
+): void {
+  describe(name, () => {
+    let lanIp: string | undefined;
+    let started: Awaited<ReturnType<typeof startServer>> | undefined;
+    const openSockets = new Set<WebSocket>();
+
+    beforeAll(async () => {
+      const candidate = pickPrimaryLanIPv4();
+      if (!candidate || !(await canUseLanSelfConnect(candidate))) {
+        return;
+      }
+      lanIp = candidate;
+      started = await startServer(LAN_NODE_PAIRING_TOKEN, {
+        bind: "lan",
+        controlUiEnabled: false,
+      });
+    });
+
+    afterAll(async () => {
+      for (const ws of openSockets) {
         ws.terminate();
       }
-    };
-    await params.run({ lanIp, loaded, connectNode });
-  } finally {
-    for (const ws of openSockets) {
-      ws.terminate();
-    }
-    await started.server.close();
-    started.envSnapshot.restore();
-  }
+      await started?.server.close();
+      started?.envSnapshot.restore();
+    });
+
+    defineTests(async (params) => {
+      const activeServer = started;
+      const host = lanIp;
+      if (!activeServer || !host) {
+        return;
+      }
+      await params.configure?.(host);
+      const loaded = loadDeviceIdentity(params.identityName);
+      // The suite shares one state home under --isolate=false; drop any paired
+      // record for this identity so a sibling suite's row cannot mask a fresh
+      // pairing (a stale approvedVia would survive a re-approve by design).
+      if (await getPairedDevice(loaded.identity.deviceId)) {
+        await removePairedDevice(loaded.identity.deviceId);
+      }
+      const connectNode = async () => {
+        const ws = await openLanGatewayWs({ host, port: activeServer.port });
+        openSockets.add(ws);
+        try {
+          return await connectReq(ws, {
+            token: LAN_NODE_PAIRING_TOKEN,
+            role: "node",
+            scopes: [],
+            client: NODE_CLIENT,
+            deviceIdentityPath: loaded.identityPath,
+          });
+        } finally {
+          // These tests cover pairing, not the WebSocket close handshake. Terminate so
+          // gateway cleanup never waits on a client that has already returned its result.
+          openSockets.delete(ws);
+          ws.terminate();
+        }
+      };
+      await params.run({ lanIp: host, loaded, connectNode });
+    });
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

The two real-Gateway LAN node-pairing suites started and closed a complete Gateway for every test even though each case varies only configuration, identity, socket, and the SSH probe delegate. That repeated lifecycle work made this focused boundary unnecessarily expensive.

## Why This Change Was Made

The shared LAN-pairing fixture now owns one real LAN-bound Gateway per test file through suite hooks. Each case still configures the Gateway after the per-test reset, uses a distinct identity, clears only its exact paired row, opens fresh WebSockets, exercises the real connect/pairing path, and terminates sockets deterministically. This is test-only/internal and AI-assisted; it does not change production behavior.

## User Impact

There is no user-visible behavior change. Maintainers get faster node-pairing test feedback while all six real-Gateway tests and 40 policy/probe siblings retain their existing names and assertions.

Production LOC: +0/-0. Test files: +15/-15. Test support: +69/-44.

## Evidence

Post-rebase focused proof:

```text
node scripts/run-vitest.mjs \
  src/gateway/node-pairing-auto-approve.test.ts \
  src/gateway/node-pairing-ssh-verify.test.ts \
  src/gateway/server.node-pairing-auto-approve.test.ts \
  src/gateway/server.node-pairing-ssh-verify.test.ts

Test Files  4 passed (4)
Tests       46 passed (46)
Duration    7.80s
```

The post-rebase changed gate passed on Blacksmith Testbox `tbx_01m00z36jm5617eteerpnqa8wz` using `OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs`: core and core-test typechecks, focused oxlint, formatting, dead-code, import-cycle, storage, pairing, and repository guards all passed. The repaired environment-variable ratchet passed at `502/502`. Hydration: https://github.com/openclaw/openclaw/actions/runs/31837680906

`git diff --check origin/main..HEAD` passed. Fresh Codex autoreview on the rebased diff passed with no accepted/actionable findings:

```text
/Users/steipete/.claude/skills/autoreview/scripts/autoreview \
  --mode branch --base origin/main \
  --engine codex --model gpt-5.6-sol --thinking high
```

Controlled same-Testbox A/B used the identical two-file command with `maxWorkers=1` and two warm samples (`tbx_01m00prm3mvew0v50j1m5ns2bq`, hydration https://github.com/openclaw/openclaw/actions/runs/31826426239):

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall | 12.75s | 11.74s | -1.01s (-7.9%) |
| Vitest | 9.30s | 8.18s | -12.0% |
| Test body | 6.74s | 5.07s | -24.9% |
| CPU user+sys | 19.02s | 16.28s | -14.4% |
| Peak RSS | 1498.3 MiB | 1533.1 MiB | +2.3% |
| Import | 2.18s | 2.70s | +24.1% |

This change does not claim a memory or import-time improvement; both measured slightly worse in this sample.
