### PR TITLE
refactor(ai): remove Responses replay test seams

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
@@ -6,7 +6,7 @@ import {
   buildOpenAIResponsesReasoningReplayMetadata,
   captureOpenAIResponsesCompaction,
 } from "../transports/openai-responses-compaction-replay.js";
-import { tagOpenAIResponsesReasoningReplayItem } from "../transports/openai-responses-replay-internal.js";
+import { OPENAI_RESPONSES_REASONING_REPLAY_META_KEY } from "../transports/openai-responses-contracts.js";
 import type { AssistantMessage, Context, Model } from "../types.js";
 import {
   closeOpenAICodexWebSocketSessions,
@@ -45,18 +45,16 @@ function createReplayContext(kind: "compaction" | "mixed"): Context {
     content.push({
       type: "thinking",
       thinking: "prior reasoning",
-      thinkingSignature: JSON.stringify(
-        tagOpenAIResponsesReasoningReplayItem(
-          {
-            type: "reasoning",
-            id: "rs_retry",
-            encrypted_content: REASONING_CIPHERTEXT,
-            summary: [],
-          },
+      thinkingSignature: JSON.stringify({
+        type: "reasoning",
+        id: "rs_retry",
+        encrypted_content: REASONING_CIPHERTEXT,
+        summary: [],
+        [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: buildOpenAIResponsesReasoningReplayMetadata(
           model,
           REPLAY_IDENTITY,
         ),
-      ),
+      }),
     });
   }
   const prior: AssistantMessage = {

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
@@ -14,7 +14,7 @@ import {
   buildOpenAIResponsesReasoningReplayMetadata,
   captureOpenAIResponsesCompaction,
 } from "./openai-responses-compaction-replay.js";
-import { tagOpenAIResponsesReasoningReplayItem } from "./openai-responses-replay-internal.js";
+import { OPENAI_RESPONSES_REASONING_REPLAY_META_KEY } from "./openai-responses-contracts.js";
 
 type SdkResponse = { data: AsyncIterable<unknown>; response: Response };
 const SDK_FULL_HISTORY_PREFIX = "full history before compaction";
@@ -135,18 +135,14 @@ function createCompactionContext(
           {
             type: "thinking",
             thinking: "prior reasoning",
-            thinkingSignature: JSON.stringify(
-              tagOpenAIResponsesReasoningReplayItem(
-                {
-                  type: "reasoning",
-                  id: "rs_sdk_retry",
-                  encrypted_content: SDK_REASONING_CIPHERTEXT,
-                  summary: [],
-                },
-                model,
-                identity,
-              ),
-            ),
+            thinkingSignature: JSON.stringify({
+              type: "reasoning",
+              id: "rs_sdk_retry",
+              encrypted_content: SDK_REASONING_CIPHERTEXT,
+              summary: [],
+              [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]:
+                buildOpenAIResponsesReasoningReplayMetadata(model, identity),
+            }),
           },
         ]
       : [],

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -249,6 +249,4 @@ export {
   convertResponsesMessages,
   createOpenAIResponsesAssistantOutput,
   encodeTextSignatureV1,
-  prepareOpenAIResponsesReasoningItemForReplay,
-  tagOpenAIResponsesReasoningReplayItem,
 } from "./openai-responses-replay-messages-internal.js";

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -5,7 +5,6 @@ import type {
   ResponseInputItem,
   ResponseInputMessageContentList,
 } from "openai/resources/responses/responses.js";
-import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import { transformProviderMessages } from "../provider-transcript-transform.js";
 import {
   describeToolResultMediaPlaceholder,
@@ -16,7 +15,6 @@ import { shortHash } from "../utils/hash.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { transformTransportMessages } from "./host-policy.js";
 import {
-  buildOpenAIResponsesReasoningReplayMetadata,
   buildOpenAIResponsesReplayContext,
   buildOpenAIResponsesCompactionReplayPlan,
   isOpenAIResponsesReplayContext,
@@ -74,23 +72,6 @@ export function stripEncryptedReasoningContentFields(value: unknown): {
   return changed ? { value: next, changed: true } : { value, changed: false };
 }
 
-export function tagOpenAIResponsesReasoningReplayItem(
-  item: Record<string, unknown>,
-  model: Model,
-  options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId">,
-): Record<string, unknown> {
-  if (!("encrypted_content" in item)) {
-    return item;
-  }
-  return {
-    ...item,
-    [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: buildOpenAIResponsesReasoningReplayMetadata(
-      model,
-      options,
-    ),
-  };
-}
-
 function isOpenAIResponsesReasoningReplayMetadata(
   value: unknown,
 ): value is OpenAIResponsesReasoningReplayMetadata {
@@ -121,7 +102,7 @@ function normalizeOpenAIResponsesReasoningReplayItem(
   return { ...record, summary: [] } as ReplayableResponseReasoningItem;
 }
 
-export function prepareOpenAIResponsesReasoningItemForReplay(
+function prepareOpenAIResponsesReasoningItemForReplay(
   item: ReplayableResponseReasoningItem,
   context: OpenAIResponsesReplayContext,
   blockMetadata?: OpenAIResponsesReasoningReplayMetadata | null,

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -23,9 +23,7 @@ import {
 import {
   createResponsesStreamWithEncryptedContentRetry,
   isInvalidEncryptedContentError,
-  prepareOpenAIResponsesReasoningItemForReplay,
   resolveAzureOpenAIApiVersion,
-  tagOpenAIResponsesReasoningReplayItem,
 } from "./openai-responses-replay-internal.js";
 import { processResponsesStream } from "./openai-responses-stream-internal.js";
 import {
@@ -58,10 +56,8 @@ const responsesTesting = {
   buildOpenAIResponsesReasoningReplayMetadata,
   isInvalidEncryptedContentError,
   normalizeResponsesFailedEvent,
-  prepareOpenAIResponsesReasoningItemForReplay,
   createResponsesStreamWithEncryptedContentRetry,
   resolveAzureOpenAIApiVersion,
-  tagOpenAIResponsesReasoningReplayItem,
   summarizeResponsesFailedNoDetailsObservation,
   summarizeResponsesPayload,
   summarizeResponsesTools,

--- a/src/agents/openai-transport-stream.replay-and-tools.test.ts
+++ b/src/agents/openai-transport-stream.replay-and-tools.test.ts
@@ -497,11 +497,15 @@ describe("openai transport stream", () => {
       replayContext({
         source: model,
         thinking: {
-          signature: testing.tagOpenAIResponsesReasoningReplayItem(
-            { type: "reasoning", id: "rs_prior", encrypted_content: "ciphertext" },
-            model,
-            { authProfileId: "openai:oauth", sessionId: "session-123" },
-          ) as Record<string, unknown>,
+          signature: {
+            type: "reasoning",
+            id: "rs_prior",
+            encrypted_content: "ciphertext",
+            __openclaw_replay: testing.buildOpenAIResponsesReasoningReplayMetadata(model, {
+              authProfileId: "openai:oauth",
+              sessionId: "session-123",
+            }),
+          },
         },
       }),
       { authProfileId: "openai:oauth", sessionId: "session-123" },


### PR DESCRIPTION
## What Problem This Solves

The OpenAI Responses transport exposed two replay-preparation helpers through an internal barrel and the global transport test API even though production had no caller for the tag builder and the preparation function had only one local production caller.

Tests then depended on those production exports to manufacture replay fixtures, preserving a broader runtime/test-support surface than the behavior requires.

## Why This Change Was Made

The replay preparation function is now private to its owning conversion module. The unused tag builder, its barrel exports, and both global test-API properties are deleted. Tests construct the legacy embedded-provenance fixture directly with the canonical replay metadata builder, so the real compatibility behavior remains covered without a test-only production helper.

Production: +1/-26 (net -25). Tests: +26/-28 (net -2). Total: +27/-54 (net -27).

## User Impact

No intended user-visible behavior change. Route-bound encrypted reasoning replay, compaction recovery, retry behavior, and the legacy embedded-provenance compatibility fallback remain covered at their transport boundaries.

## Evidence

- Responses replay owner proof: 4 files, 116 tests passed after the final rebase.
- `pnpm build` passed, including the AI package and published transport surfaces.
- `node scripts/check-changed.mjs -- <six changed files>` passed the core/coreTests gates locally, including production/test typecheck, lint, dead-export scans, formatting, import cycles, environment budget, max-lines ratchet, and architecture guards.
- The changed-gate wrapper first attempted Crabbox/Testbox, but no remote provider was ready; trusted-source policy therefore used the documented local fallback.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Exact-head CI passed for `db86c68b6f0f7f7946943ca803aeb0d600d95d00`: https://github.com/openclaw/openclaw/actions/runs/31839942825
