### PR TITLE
fix(compaction): preserve generated summaries when suffix context overflows

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test-support.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test-support.ts
@@ -31,6 +31,9 @@ type CompactionSafeguardTestApi = {
   MAX_FILE_OPS_SECTION_CHARS: number;
   MAX_FILE_OPS_LIST_CHARS: number;
   SUMMARY_TRUNCATED_MARKER: string;
+  CONTEXT_TRUNCATED_MARKER: string;
+  MAX_SPLIT_TURN_CONTEXT_CHARS: number;
+  SPLIT_TURN_TRUNCATED_MARKER: string;
 };
 
 function getTestApi(): CompactionSafeguardTestApi {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2973,6 +2973,50 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(compactionLogger.warn).not.toHaveBeenCalled();
   });
 
+  it("emits one redacted provider warning when the preserved-turn producer truncates", async () => {
+    const sensitiveSentinel = "preserved-secret-never-log";
+    const providerSummarize = vi.fn().mockResolvedValue("provider summary body");
+    registerCompactionProvider({
+      id: "preserved-overflow-provider",
+      label: "Preserved Overflow Provider",
+      summarize: providerSummarize,
+    });
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "preserved-overflow-provider",
+      recentTurnsPreserve: 12,
+    });
+    const messagesToSummarize = Array.from({ length: 24 }, (_, index) => ({
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `preserved-${index}-${sensitiveSentinel}-${"p".repeat(700)}`,
+      timestamp: index + 1,
+    })) as AgentMessage[];
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 20_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: null });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary).toContain("[Earlier preserved messages truncated]");
+    expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(compactionLogger.warn).toHaveBeenCalledOnce();
+    const warning = compactionLogger.warn.mock.calls[0]?.join(" ") ?? "";
+    expect(warning).toBe(
+      "Compaction safeguard: finalized artifact truncated; loss=preserved-turn-head",
+    );
+    expect(warning).not.toContain(sensitiveSentinel);
+  });
+
   it("retains provider body sentinels and emits one redacted warning when suffixes overflow", async () => {
     const sensitiveSentinel = "credential-sentinel-never-log";
     const providerBody = `BODY-START${"b".repeat(3_400)}BODY-MIDDLE${"b".repeat(3_400)}BODY-END`;
@@ -3022,7 +3066,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(compactionLogger.warn).toHaveBeenCalledOnce();
     const warning = compactionLogger.warn.mock.calls[0]?.join(" ") ?? "";
     expect(warning).toBe(
-      "Compaction safeguard: finalized artifact truncated; loss=split-turn-head,suffix-head",
+      "Compaction safeguard: finalized artifact truncated; " +
+        "loss=split-turn-head,preserved-turn-head,suffix-head",
     );
     expect(warning).not.toContain(sensitiveSentinel);
   });

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -82,6 +82,7 @@ const {
   formatToolFailuresSection,
   splitPreservedRecentTurns,
   formatPreservedTurnsSection,
+  formatSplitTurnContextSection,
   buildCompactionStructureInstructions,
   buildStructuredFallbackSummary,
   prependPreviousSummaryForRedistill,
@@ -102,6 +103,9 @@ const {
   MAX_COMPACTION_SUMMARY_CHARS,
   MAX_FILE_OPS_SECTION_CHARS,
   SUMMARY_TRUNCATED_MARKER,
+  CONTEXT_TRUNCATED_MARKER,
+  MAX_SPLIT_TURN_CONTEXT_CHARS,
+  SPLIT_TURN_TRUNCATED_MARKER,
 } = testing;
 
 function auditSummaryQuality(
@@ -494,6 +498,43 @@ describe("compaction-safeguard tool failures", () => {
 });
 
 describe("compaction-safeguard summary budgets", () => {
+  it.each([
+    { bodyLength: 60, suffixLength: 0, maxChars: 100, overflows: false },
+    { bodyLength: 60, suffixLength: 40, maxChars: 100, overflows: false },
+    { bodyLength: 80, suffixLength: 10, maxChars: 100, overflows: false },
+    { bodyLength: 80, suffixLength: 21, maxChars: 100, overflows: true },
+    { bodyLength: 20, suffixLength: 100, maxChars: 100, overflows: true },
+  ])(
+    "uses the slack-aware body allocation at body=$bodyLength suffix=$suffixLength cap=$maxChars",
+    ({ bodyLength, suffixLength, maxChars, overflows }) => {
+      const body = "b".repeat(bodyLength);
+      const suffix = "s".repeat(suffixLength);
+
+      const capped = capCompactionSummaryPreservingSuffix(body, suffix, maxChars);
+
+      expect(capped.length).toBeLessThanOrEqual(maxChars);
+      if (!overflows) {
+        expect(capped).toBe(`${body}${suffix}`);
+        return;
+      }
+      const bodyFloor = Math.min(bodyLength, Math.max(1, Math.ceil(maxChars / 2)));
+      const bodySlot = Math.min(
+        bodyLength,
+        Math.max(bodyFloor, maxChars - Math.min(suffixLength, maxChars)),
+      );
+      if (bodyLength > bodySlot && bodySlot >= SUMMARY_TRUNCATED_MARKER.length) {
+        expect(capped).toContain(SUMMARY_TRUNCATED_MARKER);
+      }
+      if (suffixLength > maxChars - Math.min(bodyLength, bodySlot)) {
+        expect(capped).toContain(
+          maxChars - Math.min(bodyLength, bodySlot) > CONTEXT_TRUNCATED_MARKER.length
+            ? CONTEXT_TRUNCATED_MARKER
+            : "s",
+        );
+      }
+    },
+  );
+
   it("caps file operations summary and reports omitted entries", () => {
     const readFiles = Array.from(
       { length: 200 },
@@ -584,6 +625,19 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped).not.toContain("[Compaction summary truncated");
   });
 
+  it("uses truncation markers when the budget exactly fits only the marker", () => {
+    expect(capCompactionSummary("oversized".repeat(10), SUMMARY_TRUNCATED_MARKER.length)).toBe(
+      SUMMARY_TRUNCATED_MARKER,
+    );
+    expect(
+      capCompactionSummaryPreservingSuffix(
+        "",
+        "oversized suffix".repeat(10),
+        CONTEXT_TRUNCATED_MARKER.length,
+      ),
+    ).toBe(CONTEXT_TRUNCATED_MARKER);
+  });
+
   it("preserves tail sections when suffix exceeds cap (workspace rules, diagnostics over preserved turns)", () => {
     const criticalTail =
       "\n\n## Tool Failures\n- exec: failed\n\n<read-files>\nfoo.ts\n</read-files>\n\n" +
@@ -602,8 +656,38 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped).toContain("## Session Startup");
   });
 
+  it("keeps generated summary content when an oversized suffix exhausts the artifact budget", () => {
+    const body = "BODY-START\nBODY-MIDDLE\nBODY-END";
+    const oversizedSuffix = `${"old context\n".repeat(MAX_COMPACTION_SUMMARY_CHARS)}CRITICAL-TAIL`;
+
+    const capped = capCompactionSummaryPreservingSuffix(body, oversizedSuffix);
+
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(capped).toContain("BODY-START");
+    expect(capped).toContain("BODY-MIDDLE");
+    expect(capped).toContain("BODY-END");
+    expect(capped).toContain("CRITICAL-TAIL");
+    expect(capped).toContain("truncated");
+  });
+
   it("keeps an oversized preserved suffix UTF-16 safe at its leading edge", () => {
-    expect(capCompactionSummaryPreservingSuffix("body", "A🚀tail", 5)).toBe("tail");
+    expect(capCompactionSummaryPreservingSuffix("body", "A🚀tail", 5)).toBe("bodil");
+  });
+
+  it("bounds raw split-turn context on whole-message boundaries and retains the newest end", () => {
+    const messages = Array.from({ length: 20 }, (_, index) => ({
+      role: "user" as const,
+      content: `message-${String(index).padStart(2, "0")}-${"x".repeat(700)}`,
+      timestamp: index,
+    }));
+
+    const section = formatSplitTurnContextSection(messages) as string;
+
+    expect(section.length).toBeLessThanOrEqual(MAX_SPLIT_TURN_CONTEXT_CHARS);
+    expect(section).toContain(SPLIT_TURN_TRUNCATED_MARKER.trim());
+    expect(section).not.toContain("message-00-");
+    expect(section).toContain("message-19-");
+    expect(section.split("\n").some((line) => line.startsWith("x"))).toBe(false);
   });
 });
 
@@ -1937,6 +2021,58 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves an above-half built-in body byte-for-byte when it fits the final artifact", async () => {
+    const body = `BUILTIN-START${"b".repeat(4_480)}BUILTIN-MIDDLE${"b".repeat(4_480)}BUILTIN-END`;
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(summaryResult(body));
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 0,
+    });
+    const event = createCompactionEvent({ messageText: "summarize me", tokensBefore: 1_500 });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4_000,
+    };
+
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event,
+      apiKey: "test-key",
+    });
+
+    expect(expectCompactionResult(result).summary).toBe(body);
+    expect(compactionLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("marks a trimmed built-in body and emits one redacted tail-loss warning", async () => {
+    const sensitiveSentinel = "body-secret-never-log";
+    const body = `${sensitiveSentinel}-${"b".repeat(MAX_COMPACTION_SUMMARY_CHARS)}`;
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(summaryResult(body));
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 0,
+    });
+    const event = createCompactionEvent({ messageText: "summarize me", tokensBefore: 1_500 });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4_000,
+    };
+
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event,
+      apiKey: "test-key",
+    });
+
+    expect(expectCompactionResult(result).summary).toContain(SUMMARY_TRUNCATED_MARKER.trim());
+    expect(compactionLogger.warn).toHaveBeenCalledOnce();
+    const warning = compactionLogger.warn.mock.calls[0]?.join(" ") ?? "";
+    expect(warning).toBe("Compaction safeguard: finalized artifact truncated; loss=summary-tail");
+    expect(warning).not.toContain(sensitiveSentinel);
+  });
+
   it("rejects a summary whose finalized bytes fail the quality audit", async () => {
     mockSummarizeInStages.mockReset();
     const latestAsk = "preserve the pending deployment status";
@@ -2757,6 +2893,99 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(compaction.summary).toContain("## Recent turns preserved verbatim");
     expect(compaction.summary).toContain("latest ask status");
     expect(compaction.summary).toContain("latest assistant reply");
+  });
+
+  it("preserves an above-half provider body byte-for-byte when the joined artifact fits", async () => {
+    const providerBody = `BODY-START${"b".repeat(4_480)}BODY-MIDDLE${"b".repeat(4_480)}BODY-END`;
+    const providerSummarize = vi.fn().mockResolvedValue(providerBody);
+    registerCompactionProvider({
+      id: "within-budget-provider",
+      label: "Within Budget Provider",
+      summarize: providerSummarize,
+    });
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "within-budget-provider",
+      recentTurnsPreserve: 0,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "summarize the active work", timestamp: 1 },
+        ] as AgentMessage[],
+        turnPrefixMessages: [
+          { role: "user", content: "small split-turn suffix", timestamp: 2 },
+        ] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: null });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary.startsWith(providerBody)).toBe(true);
+    expect(summary).toContain("small split-turn suffix");
+    expect(compactionLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("retains provider body sentinels and emits one redacted warning when suffixes overflow", async () => {
+    const sensitiveSentinel = "credential-sentinel-never-log";
+    const providerBody = `BODY-START${"b".repeat(3_400)}BODY-MIDDLE${"b".repeat(3_400)}BODY-END`;
+    const providerSummarize = vi.fn().mockResolvedValue(providerBody);
+    registerCompactionProvider({
+      id: "overflow-provider",
+      label: "Overflow Provider",
+      summarize: providerSummarize,
+    });
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "overflow-provider",
+      recentTurnsPreserve: 12,
+    });
+    const messagesToSummarize = Array.from({ length: 24 }, (_, index) => ({
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `preserved-${index}-${"p".repeat(700)}`,
+      timestamp: index + 1,
+    })) as AgentMessage[];
+    const turnPrefixMessages = Array.from({ length: 20 }, (_, index) => ({
+      role: "user" as const,
+      content: `raw-prefix-${index}-${sensitiveSentinel}-${"r".repeat(700)}`,
+      timestamp: index + 100,
+    }));
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages,
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 20_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: null });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(summary).toContain("BODY-START");
+    expect(summary).toContain("BODY-MIDDLE");
+    expect(summary).toContain("BODY-END");
+    expect(summary).toContain(CONTEXT_TRUNCATED_MARKER.trim());
+    expect(compactionLogger.warn).toHaveBeenCalledOnce();
+    const warning = compactionLogger.warn.mock.calls[0]?.join(" ") ?? "";
+    expect(warning).toBe(
+      "Compaction safeguard: finalized artifact truncated; loss=split-turn-head,suffix-head",
+    );
+    expect(warning).not.toContain(sensitiveSentinel);
   });
 });
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1040,7 +1040,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(section).toContain("- User: recent ask");
   });
 
-  it("bounds aggregate preserved tool results while retaining the newest complete messages", () => {
+  it("drops an oversized preserved tool interaction as one atomic group", () => {
     const toolCalls = Array.from({ length: 30 }, (_, index) => ({
       type: "toolCall",
       id: `call_${index}`,
@@ -1066,6 +1066,11 @@ describe("compaction-safeguard recent-turn preservation", () => {
               timestamp: index + 3,
             }) as unknown as AgentMessage,
         ),
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "terminal answer survives" }],
+          timestamp: 33,
+        } as unknown as AgentMessage,
       ],
       recentTurnsPreserve: 1,
     });
@@ -1075,7 +1080,9 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(section.length).toBeLessThanOrEqual(MAX_SPLIT_TURN_CONTEXT_CHARS);
     expect(section).toContain("[Earlier preserved messages truncated]");
     expect(section).not.toContain("paired-result-00-");
-    expect(section).toContain("paired-result-29-");
+    expect(section).not.toContain("paired-result-29-");
+    expect(section).not.toContain("- Tool result (read):");
+    expect(section).toContain("- Assistant: terminal answer survives");
     expect(section.split("\n").some((line) => line.startsWith("x"))).toBe(false);
   });
 
@@ -3116,6 +3123,81 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const firstRetainedLine = retainedSuffix.split("\n").find((line) => line.length > 0);
     expect(firstRetainedLine).toMatch(/^- User: raw-prefix-\d{2}-/);
     expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(summary).toContain("## Recent turns preserved verbatim");
+  });
+
+  it("finally trims a raw tool interaction only at its atomic boundary", async () => {
+    const providerSummarize = vi.fn().mockResolvedValue(`BODY-START${"b".repeat(9_000)}BODY-END`);
+    registerCompactionProvider({
+      id: "tool-boundary-provider",
+      label: "Tool Boundary Provider",
+      summarize: providerSummarize,
+    });
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "tool-boundary-provider",
+      recentTurnsPreserve: 3,
+    });
+    const messagesToSummarize = Array.from({ length: 6 }, (_, index) => ({
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `preserved-${index}-${"p".repeat(600)}`,
+      timestamp: index + 1,
+    })) as AgentMessage[];
+    const toolCalls = Array.from({ length: 12 }, (_, index) => ({
+      type: "toolCall",
+      id: `finalizer_call_${index}`,
+      name: "read",
+      arguments: {},
+    }));
+    const turnPrefixMessages = [
+      { role: "user" as const, content: "raw tool request", timestamp: 100 },
+      {
+        role: "assistant" as const,
+        content: toolCalls,
+        timestamp: 101,
+      } as unknown as AgentMessage,
+      ...toolCalls.map(
+        (toolCall, index) =>
+          ({
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: "read",
+            content: [
+              {
+                type: "text",
+                text: `finalizer-tool-output-${index}-${"r".repeat(600)}`,
+              },
+            ],
+            timestamp: index + 102,
+          }) as unknown as AgentMessage,
+      ),
+      {
+        role: "assistant" as const,
+        content: [{ type: "text", text: "raw terminal answer survives" }],
+        timestamp: 114,
+      } as unknown as AgentMessage,
+    ];
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages,
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 20_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: null });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(summary).toContain("raw terminal answer survives");
+    expect(summary).not.toContain("finalizer-tool-output-");
+    expect(summary).not.toContain("- Tool result (read):");
     expect(summary).toContain("## Recent turns preserved verbatim");
   });
 });

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1040,6 +1040,45 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(section).toContain("- User: recent ask");
   });
 
+  it("bounds aggregate preserved tool results while retaining the newest complete messages", () => {
+    const toolCalls = Array.from({ length: 30 }, (_, index) => ({
+      type: "toolCall",
+      id: `call_${index}`,
+      name: "read",
+      arguments: {},
+    }));
+    const split = splitPreservedRecentTurns({
+      messages: [
+        { role: "user", content: "recent ask", timestamp: 1 },
+        { role: "assistant", content: toolCalls, timestamp: 2 } as unknown as AgentMessage,
+        ...toolCalls.map(
+          (toolCall, index) =>
+            ({
+              role: "toolResult",
+              toolCallId: toolCall.id,
+              toolName: "read",
+              content: [
+                {
+                  type: "text",
+                  text: `paired-result-${String(index).padStart(2, "0")}-${"x".repeat(700)}`,
+                },
+              ],
+              timestamp: index + 3,
+            }) as unknown as AgentMessage,
+        ),
+      ],
+      recentTurnsPreserve: 1,
+    });
+
+    const section = formatPreservedTurnsSection(split.preservedMessages) as string;
+
+    expect(section.length).toBeLessThanOrEqual(MAX_SPLIT_TURN_CONTEXT_CHARS);
+    expect(section).toContain("[Earlier preserved messages truncated]");
+    expect(section).not.toContain("paired-result-00-");
+    expect(section).toContain("paired-result-29-");
+    expect(section.split("\n").some((line) => line.startsWith("x"))).toBe(false);
+  });
+
   it("formats preserved non-text messages with placeholders", () => {
     const section = formatPreservedTurnsSection([
       {
@@ -2986,6 +3025,53 @@ describe("compaction-safeguard recent-turn preservation", () => {
       "Compaction safeguard: finalized artifact truncated; loss=split-turn-head,suffix-head",
     );
     expect(warning).not.toContain(sensitiveSentinel);
+  });
+
+  it("starts a finally trimmed raw split-turn suffix at a complete message boundary", async () => {
+    const providerBody = `BODY-START${"b".repeat(6_760)}BODY-END`;
+    const providerSummarize = vi.fn().mockResolvedValue(providerBody);
+    registerCompactionProvider({
+      id: "boundary-provider",
+      label: "Boundary Provider",
+      summarize: providerSummarize,
+    });
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "boundary-provider",
+      recentTurnsPreserve: 3,
+    });
+    const messagesToSummarize = Array.from({ length: 6 }, (_, index) => ({
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `preserved-${index}-${"p".repeat(700)}`,
+      timestamp: index + 1,
+    })) as AgentMessage[];
+    const turnPrefixMessages = Array.from({ length: 20 }, (_, index) => ({
+      role: "user" as const,
+      content: `raw-prefix-${String(index).padStart(2, "0")}-${"r".repeat(700)}`,
+      timestamp: index + 100,
+    }));
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages,
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 20_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: null });
+
+    const summary = expectCompactionResult(result).summary;
+    const retainedSuffix = summary.split(CONTEXT_TRUNCATED_MARKER)[1] ?? "";
+    const firstRetainedLine = retainedSuffix.split("\n").find((line) => line.length > 0);
+    expect(firstRetainedLine).toMatch(/^- User: raw-prefix-\d{2}-/);
+    expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(summary).toContain("## Recent turns preserved verbatim");
   });
 });
 

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { classifyToolUseResultPairing } from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
@@ -318,7 +319,7 @@ async function summarizeViaLLM(params: Parameters<typeof summarizeInStages>[0]):
  */
 type ContextSection = {
   text: string;
-  messageStarts: number[];
+  segmentStarts: number[];
   // Keep producer loss attached to the bounded artifact so every finalizer path
   // emits the same redacted diagnostic when the section already dropped context.
   truncatedLoss?: CompactionLoss;
@@ -326,9 +327,9 @@ type ContextSection = {
 
 type CompactionSuffix = {
   text: string;
-  // Keep producer message boundaries after later suffix sections are appended;
-  // otherwise the final tail cap can expose a raw mid-message fragment.
-  contextRanges: Array<{ start: number; end: number; messageStarts: number[] }>;
+  // Keep producer segment boundaries after later suffix sections are appended;
+  // otherwise the final tail cap can split an assistant tool-call/result group.
+  contextRanges: Array<{ start: number; end: number; segmentStarts: number[] }>;
 };
 
 function assembleSuffix(parts: {
@@ -353,9 +354,9 @@ function assembleSuffix(parts: {
       contextRanges.push({
         start,
         end: start + appended.length,
-        messageStarts: part.messageStarts
-          .filter((messageStart) => messageStart >= leadingTrim)
-          .map((messageStart) => start + messageStart - leadingTrim),
+        segmentStarts: part.segmentStarts
+          .filter((segmentStart) => segmentStart >= leadingTrim)
+          .map((segmentStart) => start + segmentStart - leadingTrim),
       });
     }
   }
@@ -366,7 +367,7 @@ function assembleSuffix(parts: {
     for (const range of contextRanges) {
       range.start += 2;
       range.end += 2;
-      range.messageStarts = range.messageStarts.map((messageStart) => messageStart + 2);
+      range.segmentStarts = range.segmentStarts.map((segmentStart) => segmentStart + 2);
     }
   }
   return { text, contextRanges };
@@ -643,7 +644,7 @@ function resolveSuffixTailStart(suffix: CompactionSuffix, tailBudget: number): n
     return desiredStart;
   }
   return (
-    containingRange.messageStarts.find((messageStart) => messageStart >= desiredStart) ??
+    containingRange.segmentStarts.find((segmentStart) => segmentStart >= desiredStart) ??
     containingRange.end
   );
 }
@@ -828,37 +829,61 @@ function splitPreservedRecentTurns(params: {
   };
 }
 
-function formatContextMessages(messages: AgentMessage[]): string[] {
-  return messages
-    .map((message) => {
-      let roleLabel: string;
-      if (message.role === "assistant") {
-        roleLabel = "Assistant";
-      } else if (message.role === "user") {
-        roleLabel = "User";
-      } else if (message.role === "toolResult") {
-        const toolName = (message as { toolName?: unknown }).toolName;
-        const safeToolName = typeof toolName === "string" && toolName.trim() ? toolName : "tool";
-        roleLabel = `Tool result (${safeToolName})`;
-      } else {
-        return null;
-      }
-      const rendered = [
-        extractMessageText(message),
-        formatNonTextPlaceholder((message as { content?: unknown }).content),
-      ]
-        .filter(Boolean)
-        .join("\n");
-      if (!rendered) {
-        return null;
-      }
-      const trimmed =
-        rendered.length > MAX_RECENT_TURN_TEXT_CHARS
-          ? `${truncateUtf16Safe(rendered, MAX_RECENT_TURN_TEXT_CHARS)}...`
-          : rendered;
-      return `- ${roleLabel}: ${trimmed}`;
-    })
-    .filter((line): line is string => Boolean(line));
+function formatContextMessage(message: AgentMessage): string | null {
+  let roleLabel: string;
+  if (message.role === "assistant") {
+    roleLabel = "Assistant";
+  } else if (message.role === "user") {
+    roleLabel = "User";
+  } else if (message.role === "toolResult") {
+    const toolName = (message as { toolName?: unknown }).toolName;
+    const safeToolName = typeof toolName === "string" && toolName.trim() ? toolName : "tool";
+    roleLabel = `Tool result (${safeToolName})`;
+  } else {
+    return null;
+  }
+  const rendered = [
+    extractMessageText(message),
+    formatNonTextPlaceholder((message as { content?: unknown }).content),
+  ]
+    .filter(Boolean)
+    .join("\n");
+  if (!rendered) {
+    return null;
+  }
+  const trimmed =
+    rendered.length > MAX_RECENT_TURN_TEXT_CHARS
+      ? `${truncateUtf16Safe(rendered, MAX_RECENT_TURN_TEXT_CHARS)}...`
+      : rendered;
+  return `- ${roleLabel}: ${trimmed}`;
+}
+
+function formatContextSegments(messages: AgentMessage[]): string[] {
+  const pairing = classifyToolUseResultPairing(messages);
+  // A call-bearing assistant and all occurrence-matched results are one context
+  // atom; keeping remainder messages separate lets later terminal text survive.
+  const toolSegments = new Map<AgentMessage, AgentMessage[]>(
+    pairing.frames.map((frame) => [
+      frame.assistant,
+      [
+        frame.assistant,
+        ...frame.occurrences.flatMap((occurrence) =>
+          occurrence.sourceResult ? [occurrence.sourceResult] : [],
+        ),
+      ],
+    ]),
+  );
+  return messages.flatMap((message) => {
+    if (message.role === "toolResult") {
+      // Paired results render with their assistant message; unclaimed results
+      // are unsafe context because their owning call is absent or ambiguous.
+      return [];
+    }
+    const lines = (toolSegments.get(message) ?? [message])
+      .map(formatContextMessage)
+      .filter((line): line is string => Boolean(line));
+    return lines.length > 0 ? [lines.join("\n")] : [];
+  });
 }
 
 function formatBoundedContextSection(params: {
@@ -869,20 +894,20 @@ function formatBoundedContextSection(params: {
   truncatedLoss: CompactionLoss;
   onTruncated?: () => void;
 }): ContextSection {
-  const lines = formatContextMessages(params.messages);
-  if (lines.length === 0) {
-    return { text: "", messageStarts: [] };
+  const segments = formatContextSegments(params.messages);
+  if (segments.length === 0) {
+    return { text: "", segmentStarts: [] };
   }
 
   const completePrefix = `${params.heading}\n`;
-  const complete = `${completePrefix}${lines.join("\n")}`;
+  const complete = `${completePrefix}${segments.join("\n")}`;
   if (complete.length <= params.maxChars) {
     let offset = completePrefix.length;
     return {
       text: complete,
-      messageStarts: lines.map((line) => {
+      segmentStarts: segments.map((segment) => {
         const start = offset;
-        offset += line.length + 1;
+        offset += segment.length + 1;
         return start;
       }),
     };
@@ -891,21 +916,21 @@ function formatBoundedContextSection(params: {
   const prefix = `${completePrefix}${params.truncatedMarker}`;
   const retained: string[] = [];
   let usedChars = prefix.length;
-  for (const line of lines.toReversed()) {
-    const lineChars = line.length + (retained.length > 0 ? 1 : 0);
-    if (usedChars + lineChars > params.maxChars) {
+  for (const segment of segments.toReversed()) {
+    const segmentChars = segment.length + (retained.length > 0 ? 1 : 0);
+    if (usedChars + segmentChars > params.maxChars) {
       break;
     }
-    retained.unshift(line);
-    usedChars += lineChars;
+    retained.unshift(segment);
+    usedChars += segmentChars;
   }
   params.onTruncated?.();
   let offset = prefix.length;
   return {
     text: `${prefix}${retained.join("\n")}`,
-    messageStarts: retained.map((line) => {
+    segmentStarts: retained.map((segment) => {
       const start = offset;
-      offset += line.length + 1;
+      offset += segment.length + 1;
       return start;
     }),
     truncatedLoss: params.truncatedLoss,

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -75,6 +75,7 @@ const CONTEXT_TRUNCATED_MARKER = "\n\n[Earlier compaction context truncated to f
 // guaranteed half of the final artifact before common finalization runs.
 const MAX_SPLIT_TURN_CONTEXT_CHARS = Math.floor(MAX_COMPACTION_SUMMARY_CHARS / 2);
 const SPLIT_TURN_TRUNCATED_MARKER = "[Earlier split-turn messages truncated]\n";
+const PRESERVED_TURNS_TRUNCATED_MARKER = "[Earlier preserved messages truncated]\n";
 const DEFAULT_RECENT_TURNS_PRESERVE = 3;
 const DEFAULT_QUALITY_GUARD_MAX_RETRIES = 1;
 const MAX_RECENT_TURNS_PRESERVE = 12;
@@ -310,20 +311,57 @@ async function summarizeViaLLM(params: Parameters<typeof summarizeInStages>[0]):
  * Build the reserved suffix that follows the summary body. Both the provider
  * and LLM paths use this so diagnostic sections survive truncation.
  */
+type ContextSection = {
+  text: string;
+  messageStarts: number[];
+};
+
+type CompactionSuffix = {
+  text: string;
+  // Keep producer message boundaries after later suffix sections are appended;
+  // otherwise the final tail cap can expose a raw mid-message fragment.
+  contextRanges: Array<{ start: number; end: number; messageStarts: number[] }>;
+};
+
 function assembleSuffix(parts: {
-  splitTurnSection?: string;
-  preservedTurnsSection?: string;
+  splitTurnSection?: ContextSection;
+  preservedTurnsSection?: ContextSection;
   toolFailureSection?: string;
   fileOpsSummary?: string;
   workspaceContext?: string;
-}): string {
-  const suffix = Object.values(parts).reduce(
-    (summary, section) => appendSummarySection(summary, section ?? ""),
-    "",
-  );
+}): CompactionSuffix {
+  let text = "";
+  const contextRanges: CompactionSuffix["contextRanges"] = [];
+  for (const part of Object.values(parts)) {
+    const section = typeof part === "string" ? part : part?.text;
+    if (!section) {
+      continue;
+    }
+    const leadingTrim = text ? 0 : section.length - section.trimStart().length;
+    const appended = leadingTrim > 0 ? section.slice(leadingTrim) : section;
+    const start = text.length;
+    text = appendSummarySection(text, section);
+    if (typeof part !== "string") {
+      contextRanges.push({
+        start,
+        end: start + appended.length,
+        messageStarts: part.messageStarts
+          .filter((messageStart) => messageStart >= leadingTrim)
+          .map((messageStart) => start + messageStart - leadingTrim),
+      });
+    }
+  }
   // Ensure leading separator so suffix does not merge with body (e.g. when body
   // ends without newline: "...## Exact identifiers## Tool Failures").
-  return suffix && !/^\s/.test(suffix) ? `\n\n${suffix}` : suffix;
+  if (text && !/^\s/.test(text)) {
+    text = `\n\n${text}`;
+    for (const range of contextRanges) {
+      range.start += 2;
+      range.end += 2;
+      range.messageStarts = range.messageStarts.map((messageStart) => messageStart + 2);
+    }
+  }
+  return { text, contextRanges };
 }
 
 type ToolFailure = {
@@ -584,24 +622,50 @@ function capCompactionSummaryPreservingSuffix(
   return budgetCompactionSummary(summaryBody, suffix, maxChars).summary;
 }
 
-function capCompactionSuffix(suffix: string, maxChars: number): string {
-  if (suffix.length <= maxChars) {
-    return suffix;
+function normalizeCompactionSuffix(suffix: string | CompactionSuffix): CompactionSuffix {
+  return typeof suffix === "string" ? { text: suffix, contextRanges: [] } : suffix;
+}
+
+function resolveSuffixTailStart(suffix: CompactionSuffix, tailBudget: number): number {
+  const desiredStart = Math.max(0, suffix.text.length - tailBudget);
+  const containingRange = suffix.contextRanges.find(
+    (range) => desiredStart > range.start && desiredStart < range.end,
+  );
+  if (!containingRange) {
+    return desiredStart;
+  }
+  return (
+    containingRange.messageStarts.find((messageStart) => messageStart >= desiredStart) ??
+    containingRange.end
+  );
+}
+
+function capCompactionSuffix(suffixInput: string | CompactionSuffix, maxChars: number): string {
+  const suffix = normalizeCompactionSuffix(suffixInput);
+  if (suffix.text.length <= maxChars) {
+    return suffix.text;
   }
   if (maxChars <= 0) {
     return "";
   }
   if (maxChars < CONTEXT_TRUNCATED_MARKER.length) {
-    return sliceUtf16Safe(suffix, -maxChars);
+    const start = resolveSuffixTailStart(suffix, maxChars);
+    return sliceUtf16Safe(suffix.text, start);
   }
   const tailBudget = maxChars - CONTEXT_TRUNCATED_MARKER.length;
+  const start = resolveSuffixTailStart(suffix, tailBudget);
   return tailBudget > 0
-    ? `${CONTEXT_TRUNCATED_MARKER}${sliceUtf16Safe(suffix, -tailBudget)}`
+    ? `${CONTEXT_TRUNCATED_MARKER}${sliceUtf16Safe(suffix.text, start)}`
     : CONTEXT_TRUNCATED_MARKER;
 }
 
-function budgetCompactionSummary(summaryBody: string, suffix: string, maxChars: number) {
-  const joined = `${summaryBody}${suffix}`;
+function budgetCompactionSummary(
+  summaryBody: string,
+  suffixInput: string | CompactionSuffix,
+  maxChars: number,
+) {
+  const suffix = normalizeCompactionSuffix(suffixInput);
+  const joined = `${summaryBody}${suffix.text}`;
   if (maxChars <= 0 || joined.length <= maxChars) {
     return {
       summary: joined,
@@ -613,7 +677,7 @@ function budgetCompactionSummary(summaryBody: string, suffix: string, maxChars: 
   }
 
   const bodyFloor = Math.min(summaryBody.length, Math.max(1, Math.ceil(maxChars / 2)));
-  const suffixReservation = Math.min(suffix.length, maxChars);
+  const suffixReservation = Math.min(suffix.text.length, maxChars);
   const bodySlot = Math.min(summaryBody.length, Math.max(bodyFloor, maxChars - suffixReservation));
   const cappedBody = capCompactionSummary(summaryBody, bodySlot);
   const suffixBudget = Math.max(0, maxChars - cappedBody.length);
@@ -623,7 +687,7 @@ function budgetCompactionSummary(summaryBody: string, suffix: string, maxChars: 
     structuralSummary: cappedBody,
     bodyBudget: bodySlot,
     bodyTrimmed: cappedBody.length < summaryBody.length,
-    suffixTrimmed: cappedSuffix.length < suffix.length,
+    suffixTrimmed: cappedSuffix.length < suffix.text.length,
   };
 }
 
@@ -789,35 +853,83 @@ function formatContextMessages(messages: AgentMessage[]): string[] {
     .filter((line): line is string => Boolean(line));
 }
 
-function formatContextSection(messages: AgentMessage[], heading: string): string {
-  const lines = formatContextMessages(messages);
-  return lines.length > 0 ? `${heading}\n${lines.join("\n")}` : "";
-}
-
-function formatPreservedTurnsSection(messages: AgentMessage[]): string {
-  return formatContextSection(messages, "\n\n## Recent turns preserved verbatim");
-}
-
-function formatSplitTurnContextSection(messages: AgentMessage[], onTruncated?: () => void): string {
-  const heading = "**Turn Context (split turn):**\n";
-  const lines = formatContextMessages(messages);
-  const complete = lines.length > 0 ? `${heading}\n${lines.join("\n")}` : "";
-  if (complete.length <= MAX_SPLIT_TURN_CONTEXT_CHARS) {
-    return complete;
+function formatBoundedContextSection(params: {
+  messages: AgentMessage[];
+  heading: string;
+  maxChars: number;
+  truncatedMarker: string;
+  onTruncated?: () => void;
+}): ContextSection {
+  const lines = formatContextMessages(params.messages);
+  if (lines.length === 0) {
+    return { text: "", messageStarts: [] };
   }
 
+  const completePrefix = `${params.heading}\n`;
+  const complete = `${completePrefix}${lines.join("\n")}`;
+  if (complete.length <= params.maxChars) {
+    let offset = completePrefix.length;
+    return {
+      text: complete,
+      messageStarts: lines.map((line) => {
+        const start = offset;
+        offset += line.length + 1;
+        return start;
+      }),
+    };
+  }
+
+  const prefix = `${completePrefix}${params.truncatedMarker}`;
   const retained: string[] = [];
-  let usedChars = heading.length + 1 + SPLIT_TURN_TRUNCATED_MARKER.length;
+  let usedChars = prefix.length;
   for (const line of lines.toReversed()) {
     const lineChars = line.length + (retained.length > 0 ? 1 : 0);
-    if (usedChars + lineChars > MAX_SPLIT_TURN_CONTEXT_CHARS) {
+    if (usedChars + lineChars > params.maxChars) {
       break;
     }
     retained.unshift(line);
     usedChars += lineChars;
   }
-  onTruncated?.();
-  return `${heading}\n${SPLIT_TURN_TRUNCATED_MARKER}${retained.join("\n")}`;
+  params.onTruncated?.();
+  let offset = prefix.length;
+  return {
+    text: `${prefix}${retained.join("\n")}`,
+    messageStarts: retained.map((line) => {
+      const start = offset;
+      offset += line.length + 1;
+      return start;
+    }),
+  };
+}
+
+function buildPreservedTurnsSection(messages: AgentMessage[]): ContextSection {
+  return formatBoundedContextSection({
+    messages,
+    heading: "\n\n## Recent turns preserved verbatim",
+    maxChars: MAX_SPLIT_TURN_CONTEXT_CHARS,
+    truncatedMarker: PRESERVED_TURNS_TRUNCATED_MARKER,
+  });
+}
+
+function formatPreservedTurnsSection(messages: AgentMessage[]): string {
+  return buildPreservedTurnsSection(messages).text;
+}
+
+function buildSplitTurnContextSection(
+  messages: AgentMessage[],
+  onTruncated?: () => void,
+): ContextSection {
+  return formatBoundedContextSection({
+    messages,
+    heading: "**Turn Context (split turn):**\n",
+    maxChars: MAX_SPLIT_TURN_CONTEXT_CHARS,
+    truncatedMarker: SPLIT_TURN_TRUNCATED_MARKER,
+    onTruncated,
+  });
+}
+
+function formatSplitTurnContextSection(messages: AgentMessage[], onTruncated?: () => void): string {
+  return buildSplitTurnContextSection(messages, onTruncated).text;
 }
 
 function formatGeneratedSplitTurnSection(summary: string, onTruncated?: () => void): string {
@@ -997,7 +1109,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     let workspaceContextPromise: Promise<string> | undefined;
     const finalizeSummaryText = async (
       body: string,
-      sections: { splitTurnSection?: string; preservedTurnsSection?: string },
+      sections: { splitTurnSection?: ContextSection; preservedTurnsSection?: ContextSection },
       producerLosses: ReadonlySet<CompactionLoss> = new Set(),
     ) => {
       workspaceContextPromise ??= readWorkspaceContextForSummary(
@@ -1055,11 +1167,11 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               providerResult,
               {
                 splitTurnSection: preparation.isSplitTurn
-                  ? formatSplitTurnContextSection(turnPrefixMessages, () => {
+                  ? buildSplitTurnContextSection(turnPrefixMessages, () => {
                       producerLosses.add("split-turn-head");
                     })
-                  : "",
-                preservedTurnsSection: formatPreservedTurnsSection(preservedMessages),
+                  : undefined,
+                preservedTurnsSection: buildPreservedTurnsSection(preservedMessages),
               },
               producerLosses,
             );
@@ -1206,7 +1318,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         recentTurnsPreserve,
       });
       messagesToSummarize = summaryTargetMessages;
-      const preservedTurnsSectionLocal = formatPreservedTurnsSection(preservedRecentMessages);
+      const preservedTurnsSectionLocal = buildPreservedTurnsSection(preservedRecentMessages);
       const allMessages = [...messagesToSummarize, ...turnPrefixMessages];
 
       // Use adaptive chunk ratio based on message sizes, reserving headroom for

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -88,7 +88,12 @@ const PREVIOUS_SUMMARY_REDISTILL_PREFIX =
 const compactionSafeguardDeps = {
   summarizeInStages,
 };
-type CompactionLoss = "summary-tail" | "suffix-head" | "split-turn-head" | "split-turn-tail";
+type CompactionLoss =
+  | "summary-tail"
+  | "suffix-head"
+  | "split-turn-head"
+  | "split-turn-tail"
+  | "preserved-turn-head";
 
 function prependPreviousSummaryForRedistill(params: {
   messages: AgentMessage[];
@@ -314,6 +319,9 @@ async function summarizeViaLLM(params: Parameters<typeof summarizeInStages>[0]):
 type ContextSection = {
   text: string;
   messageStarts: number[];
+  // Keep producer loss attached to the bounded artifact so every finalizer path
+  // emits the same redacted diagnostic when the section already dropped context.
+  truncatedLoss?: CompactionLoss;
 };
 
 type CompactionSuffix = {
@@ -858,6 +866,7 @@ function formatBoundedContextSection(params: {
   heading: string;
   maxChars: number;
   truncatedMarker: string;
+  truncatedLoss: CompactionLoss;
   onTruncated?: () => void;
 }): ContextSection {
   const lines = formatContextMessages(params.messages);
@@ -899,6 +908,7 @@ function formatBoundedContextSection(params: {
       offset += line.length + 1;
       return start;
     }),
+    truncatedLoss: params.truncatedLoss,
   };
 }
 
@@ -908,6 +918,7 @@ function buildPreservedTurnsSection(messages: AgentMessage[]): ContextSection {
     heading: "\n\n## Recent turns preserved verbatim",
     maxChars: MAX_SPLIT_TURN_CONTEXT_CHARS,
     truncatedMarker: PRESERVED_TURNS_TRUNCATED_MARKER,
+    truncatedLoss: "preserved-turn-head",
   });
 }
 
@@ -924,6 +935,7 @@ function buildSplitTurnContextSection(
     heading: "**Turn Context (split turn):**\n",
     maxChars: MAX_SPLIT_TURN_CONTEXT_CHARS,
     truncatedMarker: SPLIT_TURN_TRUNCATED_MARKER,
+    truncatedLoss: "split-turn-head",
     onTruncated,
   });
 }
@@ -1124,6 +1136,11 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       });
       const finalized = budgetCompactionSummary(body, suffix, MAX_COMPACTION_SUMMARY_CHARS);
       const losses = new Set(producerLosses);
+      for (const section of Object.values(sections)) {
+        if (section?.truncatedLoss) {
+          losses.add(section.truncatedLoss);
+        }
+      }
       if (finalized.bodyTrimmed) {
         losses.add("summary-tail");
       }

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -70,6 +70,11 @@ const MAX_COMPACTION_SUMMARY_CHARS = 16_000;
 const MAX_FILE_OPS_SECTION_CHARS = 2_000;
 const MAX_FILE_OPS_LIST_CHARS = 900;
 const SUMMARY_TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
+const CONTEXT_TRUNCATED_MARKER = "\n\n[Earlier compaction context truncated to fit budget]\n\n";
+// Split-turn context supplements the generated summary and must not claim its
+// guaranteed half of the final artifact before common finalization runs.
+const MAX_SPLIT_TURN_CONTEXT_CHARS = Math.floor(MAX_COMPACTION_SUMMARY_CHARS / 2);
+const SPLIT_TURN_TRUNCATED_MARKER = "[Earlier split-turn messages truncated]\n";
 const DEFAULT_RECENT_TURNS_PRESERVE = 3;
 const DEFAULT_QUALITY_GUARD_MAX_RETRIES = 1;
 const MAX_RECENT_TURNS_PRESERVE = 12;
@@ -82,6 +87,7 @@ const PREVIOUS_SUMMARY_REDISTILL_PREFIX =
 const compactionSafeguardDeps = {
   summarizeInStages,
 };
+type CompactionLoss = "summary-tail" | "suffix-head" | "split-turn-head" | "split-turn-tail";
 
 function prependPreviousSummaryForRedistill(params: {
   messages: AgentMessage[];
@@ -562,11 +568,11 @@ function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY
     return summary;
   }
   const marker = SUMMARY_TRUNCATED_MARKER;
-  const budget = Math.max(0, maxChars - marker.length);
-  if (budget <= 0) {
+  if (maxChars < marker.length) {
     // Marker cannot fit; keep body prefix instead of a partial marker fragment.
     return truncateUtf16Safe(summary, maxChars);
   }
+  const budget = maxChars - marker.length;
   return `${truncateUtf16Safe(summary, budget)}${marker}`;
 }
 
@@ -575,19 +581,50 @@ function capCompactionSummaryPreservingSuffix(
   suffix: string,
   maxChars = MAX_COMPACTION_SUMMARY_CHARS,
 ): string {
-  if (!suffix) {
-    return capCompactionSummary(summaryBody, maxChars);
+  return budgetCompactionSummary(summaryBody, suffix, maxChars).summary;
+}
+
+function capCompactionSuffix(suffix: string, maxChars: number): string {
+  if (suffix.length <= maxChars) {
+    return suffix;
   }
   if (maxChars <= 0) {
-    return capCompactionSummary(`${summaryBody}${suffix}`, maxChars);
+    return "";
   }
-  if (suffix.length >= maxChars) {
-    // Preserve tail (workspace rules, diagnostics) over head (preserved turns).
+  if (maxChars < CONTEXT_TRUNCATED_MARKER.length) {
     return sliceUtf16Safe(suffix, -maxChars);
   }
-  const bodyBudget = Math.max(0, maxChars - suffix.length);
-  const cappedBody = capCompactionSummary(summaryBody, bodyBudget);
-  return `${cappedBody}${suffix}`;
+  const tailBudget = maxChars - CONTEXT_TRUNCATED_MARKER.length;
+  return tailBudget > 0
+    ? `${CONTEXT_TRUNCATED_MARKER}${sliceUtf16Safe(suffix, -tailBudget)}`
+    : CONTEXT_TRUNCATED_MARKER;
+}
+
+function budgetCompactionSummary(summaryBody: string, suffix: string, maxChars: number) {
+  const joined = `${summaryBody}${suffix}`;
+  if (maxChars <= 0 || joined.length <= maxChars) {
+    return {
+      summary: joined,
+      structuralSummary: summaryBody,
+      bodyBudget: maxChars,
+      bodyTrimmed: false,
+      suffixTrimmed: false,
+    };
+  }
+
+  const bodyFloor = Math.min(summaryBody.length, Math.max(1, Math.ceil(maxChars / 2)));
+  const suffixReservation = Math.min(suffix.length, maxChars);
+  const bodySlot = Math.min(summaryBody.length, Math.max(bodyFloor, maxChars - suffixReservation));
+  const cappedBody = capCompactionSummary(summaryBody, bodySlot);
+  const suffixBudget = Math.max(0, maxChars - cappedBody.length);
+  const cappedSuffix = capCompactionSuffix(suffix, suffixBudget);
+  return {
+    summary: `${cappedBody}${cappedSuffix}`,
+    structuralSummary: cappedBody,
+    bodyBudget: bodySlot,
+    bodyTrimmed: cappedBody.length < summaryBody.length,
+    suffixTrimmed: cappedSuffix.length < suffix.length,
+  };
 }
 
 function resolveSummaryReserveTokens(
@@ -761,8 +798,36 @@ function formatPreservedTurnsSection(messages: AgentMessage[]): string {
   return formatContextSection(messages, "\n\n## Recent turns preserved verbatim");
 }
 
-function formatSplitTurnContextSection(messages: AgentMessage[]): string {
-  return formatContextSection(messages, "**Turn Context (split turn):**\n");
+function formatSplitTurnContextSection(messages: AgentMessage[], onTruncated?: () => void): string {
+  const heading = "**Turn Context (split turn):**\n";
+  const lines = formatContextMessages(messages);
+  const complete = lines.length > 0 ? `${heading}\n${lines.join("\n")}` : "";
+  if (complete.length <= MAX_SPLIT_TURN_CONTEXT_CHARS) {
+    return complete;
+  }
+
+  const retained: string[] = [];
+  let usedChars = heading.length + 1 + SPLIT_TURN_TRUNCATED_MARKER.length;
+  for (const line of lines.toReversed()) {
+    const lineChars = line.length + (retained.length > 0 ? 1 : 0);
+    if (usedChars + lineChars > MAX_SPLIT_TURN_CONTEXT_CHARS) {
+      break;
+    }
+    retained.unshift(line);
+    usedChars += lineChars;
+  }
+  onTruncated?.();
+  return `${heading}\n${SPLIT_TURN_TRUNCATED_MARKER}${retained.join("\n")}`;
+}
+
+function formatGeneratedSplitTurnSection(summary: string, onTruncated?: () => void): string {
+  const heading = "**Turn Context (split turn):**\n\n";
+  const summaryBudget = MAX_SPLIT_TURN_CONTEXT_CHARS - heading.length;
+  const cappedSummary = capCompactionSummary(summary, summaryBudget);
+  if (cappedSummary.length < summary.length) {
+    onTruncated?.();
+  }
+  return `${heading}${cappedSummary}`;
 }
 
 function extractLatestUserAsk(messages: AgentMessage[]): string | null {
@@ -933,6 +998,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const finalizeSummaryText = async (
       body: string,
       sections: { splitTurnSection?: string; preservedTurnsSection?: string },
+      producerLosses: ReadonlySet<CompactionLoss> = new Set(),
     ) => {
       workspaceContextPromise ??= readWorkspaceContextForSummary(
         runtime?.postCompactionSections,
@@ -944,15 +1010,20 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         fileOpsSummary,
         workspaceContext: await workspaceContextPromise,
       });
-      const bodyBudget = Math.max(0, MAX_COMPACTION_SUMMARY_CHARS - suffix.length);
-      return {
-        summary: capCompactionSummaryPreservingSuffix(body, suffix),
-        structuralSummary:
-          suffix.length >= MAX_COMPACTION_SUMMARY_CHARS
-            ? ""
-            : capCompactionSummary(body, bodyBudget),
-        bodyBudget,
-      };
+      const finalized = budgetCompactionSummary(body, suffix, MAX_COMPACTION_SUMMARY_CHARS);
+      const losses = new Set(producerLosses);
+      if (finalized.bodyTrimmed) {
+        losses.add("summary-tail");
+      }
+      if (finalized.suffixTrimmed) {
+        losses.add("suffix-head");
+      }
+      if (losses.size > 0) {
+        log.warn(
+          `Compaction safeguard: finalized artifact truncated; loss=${[...losses].join(",")}`,
+        );
+      }
+      return finalized;
     };
     const compactionResult = (summary: string) => ({
       compaction: {
@@ -979,12 +1050,19 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               messages: baseMessagesToSummarize,
               recentTurnsPreserve,
             });
-            const finalized = await finalizeSummaryText(providerResult, {
-              splitTurnSection: preparation.isSplitTurn
-                ? formatSplitTurnContextSection(turnPrefixMessages)
-                : "",
-              preservedTurnsSection: formatPreservedTurnsSection(preservedMessages),
-            });
+            const producerLosses = new Set<CompactionLoss>();
+            const finalized = await finalizeSummaryText(
+              providerResult,
+              {
+                splitTurnSection: preparation.isSplitTurn
+                  ? formatSplitTurnContextSection(turnPrefixMessages, () => {
+                      producerLosses.add("split-turn-head");
+                    })
+                  : "",
+                preservedTurnsSection: formatPreservedTurnsSection(preservedMessages),
+              },
+              producerLosses,
+            );
             return compactionResult(finalized.summary);
           }
           log.warn(
@@ -1153,6 +1231,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
         let splitTurnSectionLocal = "";
         let historySummary = "";
+        const producerLosses = new Set<CompactionLoss>();
         try {
           historySummary =
             messagesToSummarize.length > 0
@@ -1173,7 +1252,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               customInstructions: `${TURN_PREFIX_INSTRUCTIONS}\n\nAdditional requirements:\n\n${currentInstructions}`,
               previousSummary: undefined,
             });
-            splitTurnSectionLocal = `**Turn Context (split turn):**\n\n${prefixSummary}`;
+            splitTurnSectionLocal = formatGeneratedSplitTurnSection(prefixSummary, () => {
+              producerLosses.add("split-turn-tail");
+            });
           }
         } catch (attemptError) {
           if (signal?.aborted) {
@@ -1196,9 +1277,13 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           historySummary,
           splitTurnSectionLocal ? `\n\n${splitTurnSectionLocal}` : "",
         );
-        const finalized = await finalizeSummaryText(structuralSummary, {
-          preservedTurnsSection: preservedTurnsSectionLocal,
-        });
+        const finalized = await finalizeSummaryText(
+          structuralSummary,
+          {
+            preservedTurnsSection: preservedTurnsSectionLocal,
+          },
+          producerLosses,
+        );
 
         const canRegenerate =
           messagesToSummarize.length > 0 ||
@@ -1297,6 +1382,9 @@ const testing = {
   MAX_FILE_OPS_SECTION_CHARS,
   MAX_FILE_OPS_LIST_CHARS,
   SUMMARY_TRUNCATED_MARKER,
+  CONTEXT_TRUNCATED_MARKER,
+  MAX_SPLIT_TURN_CONTEXT_CHARS,
+  SPLIT_TURN_TRUNCATED_MARKER,
 } as const;
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -1,6 +1,15 @@
+import path from "node:path";
 import type { AssistantMessage, Context, Model } from "openclaw/plugin-sdk/llm";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  appendTranscriptMessage,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import { closeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
+import { testing as compactionSafeguardTesting } from "../agent-hooks/compaction-safeguard.test-support.js";
 import {
   createAssistant,
   createAssistantResultStream,
@@ -20,6 +29,7 @@ import { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 
 registerAgentSessionLoopTestLifecycle();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createStaleThinkingContent(): AssistantMessage["content"] {
   return [
@@ -32,6 +42,70 @@ function createStaleThinkingContent(): AssistantMessage["content"] {
 }
 
 describe("AgentSession compaction", () => {
+  it("persists and replays a body-preserving oversized-suffix artifact after reopen", async () => {
+    const dir = tempDirs.make("openclaw-body-preserving-compaction-");
+    const target = {
+      agentId: "main",
+      sessionId: "body-preserving-compaction",
+      sessionKey: "agent:main:body-preserving-compaction",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
+    await appendTranscriptMessage(target, {
+      cwd: dir,
+      message: { role: "user", content: "authoritative question", timestamp: 1 },
+    });
+    const sessionManager = SessionManager.open(target, dir);
+    const retainedAssistantId = sessionManager.appendMessage(
+      createAssistant(testModel, [{ type: "text", text: "authoritative answer" }]),
+    );
+    const body = "BODY-MARKER\n## Decisions\nKeep the generated summary.";
+    const suffix = `${"older split-turn context\n".repeat(2_000)}SELECTED-SUFFIX-CONTEXT`;
+    const finalized = compactionSafeguardTesting.capCompactionSummaryPreservingSuffix(
+      body,
+      suffix,
+    ) as string;
+    expect(finalized).toContain("BODY-MARKER");
+    expect(finalized).toContain("Earlier compaction context truncated");
+    expect(finalized).toContain("SELECTED-SUFFIX-CONTEXT");
+    const handlers = createCompactionHandlers();
+    handlers.set("session_before_compact", [
+      async (event: unknown) => ({
+        compaction: {
+          summary: finalized,
+          firstKeptEntryId: retainedAssistantId,
+          tokensBefore: (event as { preparation: { tokensBefore: number } }).preparation
+            .tokensBefore,
+        },
+      }),
+    ]);
+    const { session } = await createTestSession({
+      sessionManager,
+      resourceLoader: createResourceLoader(handlers),
+    });
+
+    const result = await session.compact();
+
+    expect(result.summary).toBe(finalized);
+    expect(sessionManager.getBranch().filter((entry) => entry.type === "compaction")).toHaveLength(
+      1,
+    );
+    expect(JSON.stringify(sessionManager.buildSessionContext())).toContain("BODY-MARKER");
+    sessionManager.flushPendingPersistence();
+    const databasePath = resolveSqliteTargetFromSessionStorePath(target.storePath).path;
+    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+    const reopened = SessionManager.open(target, dir);
+    try {
+      expect(reopened.getBranch().findLast((entry) => entry.type === "compaction")).toMatchObject({
+        summary: finalized,
+      });
+      expect(JSON.stringify(reopened.buildSessionContext())).toContain("BODY-MARKER");
+      expect(JSON.stringify(reopened.buildSessionContext())).toContain("SELECTED-SUFFIX-CONTEXT");
+    } finally {
+      closeOpenClawAgentDatabaseByPath(databasePath);
+    }
+  });
+
   it.each(Array.from({ length: MAX_OVERFLOW_COMPACTION_ATTEMPTS }, (_, index) => index + 1))(
     "recovers when the provider accepts overflow compaction attempt %i",
     async (overflowCount) => {


### PR DESCRIPTION
Closes #119272

## What Problem This Solves

An oversized compaction suffix could consume the complete 16,000-character artifact budget. The finalizer then returned an unmarked suffix tail, discarding the generated summary body even though provider and built-in summarization had succeeded.

## Why This Change Was Made

Make safeguard finalization the canonical budget owner. Exact-fit body and suffix bytes pass through unchanged. Actual overflow assigns the generated body a slack-aware minimum share, marks any body or suffix loss, retains suffix tail context safely, carries producer-recorded message boundaries through final suffix assembly, and bounds raw split-turn and paired preserved-tool-result producers. Bounded context artifacts carry their closed producer-loss direction into common finalization, which emits one redacted diagnostic. Provider and built-in paths share the same policy; persistence, reset, deletion, schema, configuration, and fallback ownership remain unchanged.

## User Impact

Compaction no longer turns a valid generated summary into an unexplained mid-context fragment when diagnostic, preserved-turn, workspace, or split-turn suffixes are large. Operators retain useful generated decisions and pending work, see deterministic truncation markers in the artifact, and receive a content-free warning when loss occurs.

## Evidence

The exact-base regression failed because BODY-START was absent from the suffix-only result. After a clean patch-equivalent rebase onto integration base `15bf43fe1931819aab0172ad714561cf3c4f23ad`, exact head `0ee739578da8b8fd281ecc6aca1999f45913b330` passed 330 locked-matrix tests (all 327 accepted tests plus three upstream lifecycle additions) across finalizer boundaries, provider and built-in siblings, single-warning redaction, preserved-turn producer loss, aggregate paired-tool-result bounds, final suffix whole-message alignment, SQLite append/reopen/replay, rejection/reset, local and Gateway deletion, and deleted-agent live guards. Another 194 upstream-adjacent native/manual/Gateway compaction tests passed. The integration-base-bound changed gate and branch-history secret scan also passed.