### PR TITLE
fix(ui): keep newly created sessions above Show more

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { GatewaySessionRow } from "../api/types.ts";
 import { fetchSessionLineage } from "./app-sidebar-child-session-data.ts";
-import { buildSidebarSessionNavigationState } from "./app-sidebar-session-navigation-logic.ts";
+import {
+  buildSidebarSessionNavigationState,
+  compareSidebarSessionRowsByMode,
+} from "./app-sidebar-session-navigation-logic.ts";
 import { projectSessionTree } from "./app-sidebar-session-tree.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 
@@ -56,6 +59,97 @@ function projectDraftOwnership(
 ): boolean | undefined {
   return projectSidebarSession(row, selfUserId).draftOwnedBySelf;
 }
+
+function sortSidebarRows(
+  rows: GatewaySessionRow[],
+  sortMode: "created" | "updated" | "people",
+  createdOrder: ReadonlyMap<string, number>,
+  creators?: Array<{ id: string; label: string }>,
+) {
+  return rows.toSorted((a, b) =>
+    compareSidebarSessionRowsByMode({ a, b, sortMode, createdOrder, creators }),
+  );
+}
+
+describe("sidebar session sort modes", () => {
+  const row = (
+    key: string,
+    createdAt?: number,
+    updatedAt = 1,
+    creatorId?: string,
+  ): GatewaySessionRow => ({
+    key,
+    kind: "direct",
+    updatedAt,
+    createdAt,
+    createdActor: creatorId ? { type: "human", id: creatorId } : undefined,
+  });
+
+  it("sorts timestamped sessions newest-first ahead of legacy sessions", () => {
+    const rows = [
+      row("old-stamped", 100),
+      row("legacy"),
+      row("new-stamped", 200),
+      row("invalid", Number.NaN),
+    ];
+    const observed = new Map(rows.map((entry, index) => [entry.key, index]));
+
+    expect(sortSidebarRows(rows, "created", observed).map((entry) => entry.key)).toEqual([
+      "new-stamped",
+      "old-stamped",
+      "legacy",
+      "invalid",
+    ]);
+  });
+
+  it("falls back to stable observation order for equal or missing timestamps", () => {
+    const rows = [
+      row("missing-later"),
+      row("equal-later", 100),
+      row("equal-earlier", 100),
+      row("missing-earlier"),
+    ];
+    const observed = new Map([
+      ["equal-earlier", 0],
+      ["equal-later", 1],
+      ["missing-earlier", 2],
+      ["missing-later", 3],
+    ]);
+
+    expect(sortSidebarRows(rows, "created", observed).map((entry) => entry.key)).toEqual([
+      "equal-earlier",
+      "equal-later",
+      "missing-earlier",
+      "missing-later",
+    ]);
+  });
+
+  it("keeps creator ordering primary and creation time secondary in People mode", () => {
+    const rows = [
+      row("alex-old", 100, 1, "alex"),
+      row("sam-new", 300, 1, "sam"),
+      row("alex-new", 200, 1, "alex"),
+    ];
+    const observed = new Map(rows.map((entry, index) => [entry.key, index]));
+
+    expect(
+      sortSidebarRows(rows, "people", observed, [
+        { id: "alex", label: "Alex" },
+        { id: "sam", label: "Sam" },
+      ]).map((entry) => entry.key),
+    ).toEqual(["alex-new", "alex-old", "sam-new"]);
+  });
+
+  it("leaves Updated mode ordered by activity", () => {
+    const rows = [row("created-new", 300, 100), row("updated-new", 100, 300)];
+    const observed = new Map(rows.map((entry, index) => [entry.key, index]));
+
+    expect(sortSidebarRows(rows, "updated", observed).map((entry) => entry.key)).toEqual([
+      "updated-new",
+      "created-new",
+    ]);
+  });
+});
 
 describe("sidebar session live-run projection", () => {
   it("projects the durable last-message preview", () => {

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -82,8 +82,7 @@ export function compareSidebarSessionRowsByMode(input: {
   if (input.sortMode !== "people") {
     return input.sortMode === "updated"
       ? compareSessionRowsByUpdatedAt(a, b)
-      : (input.createdOrder.get(a.key) ?? Number.MAX_SAFE_INTEGER) -
-          (input.createdOrder.get(b.key) ?? Number.MAX_SAFE_INTEGER);
+      : compareSidebarSessionRowsByCreatedAt(a, b, input.createdOrder);
   }
   const creators = input.creators ?? [];
   const idA = a.createdActor?.id?.trim() ?? "";
@@ -98,10 +97,38 @@ export function compareSidebarSessionRowsByMode(input: {
       return byCreator;
     }
   }
-  const byCreated =
-    (input.createdOrder.get(a.key) ?? Number.MAX_SAFE_INTEGER) -
-    (input.createdOrder.get(b.key) ?? Number.MAX_SAFE_INTEGER);
-  return byCreated || a.key.localeCompare(b.key);
+  return compareSidebarSessionRowsByCreatedAt(a, b, input.createdOrder);
+}
+
+function compareSidebarSessionRowsByCreatedAt(
+  a: SessionRow,
+  b: SessionRow,
+  createdOrder: ReadonlyMap<string, number>,
+): number {
+  const createdAtA =
+    typeof a.createdAt === "number" && Number.isFinite(a.createdAt) && a.createdAt >= 0
+      ? a.createdAt
+      : null;
+  const createdAtB =
+    typeof b.createdAt === "number" && Number.isFinite(b.createdAt) && b.createdAt >= 0
+      ? b.createdAt
+      : null;
+  if (createdAtA !== null || createdAtB !== null) {
+    if (createdAtA === null) {
+      return 1;
+    }
+    if (createdAtB === null) {
+      return -1;
+    }
+    const byCreatedAt = createdAtB - createdAtA;
+    if (byCreatedAt !== 0) {
+      return byCreatedAt;
+    }
+  }
+  const byObservedOrder =
+    (createdOrder.get(a.key) ?? Number.MAX_SAFE_INTEGER) -
+    (createdOrder.get(b.key) ?? Number.MAX_SAFE_INTEGER);
+  return byObservedOrder || a.key.localeCompare(b.key);
 }
 
 function isSidebarDraftOwnedBySelf(

--- a/ui/src/e2e/session-management.created-sort.e2e.test.ts
+++ b/ui/src/e2e/session-management.created-sort.e2e.test.ts
@@ -1,0 +1,94 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  captureUiProofEnabled,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+  uiProofArtifactDir,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  it("keeps externally discovered newest sessions above Show more", async () => {
+    const baseTime = Date.parse("2026-08-14T18:00:00.000Z");
+    const olderRows = Array.from({ length: 10 }, (_, index) => ({
+      ...sessionRow(
+        `agent:main:older-${index}`,
+        `Older session ${index}`,
+        baseTime - index * 1_000,
+      ),
+      createdAt: baseTime - index * 1_000,
+    }));
+    const newestKey = "agent:main:external-new";
+    const newestRow = {
+      ...sessionRow(newestKey, "External newest", baseTime + 1_000),
+      createdAt: baseTime + 1_000,
+    };
+    const expectedVisibleKeys = [newestKey, ...olderRows.slice(0, 9).map((row) => row.key)];
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      recordVideo: captureUiProofEnabled
+        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        : undefined,
+    });
+    const page = await context.newPage();
+    const proofVideo = page.video();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse(olderRows),
+      },
+      sessionKey: olderRows[0]?.key,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const rows = page.locator(".sidebar-recent-session");
+      await expect.poll(() => rows.count(), { timeout: 10_000 }).toBe(10);
+      await captureUiProof(page, "sidebar-created-sort-before-refresh.png");
+      const initialListCount = (await gateway.getRequests("sessions.list")).length;
+
+      await gateway.setMethodResponse(
+        "sessions.list",
+        sessionsListResponse([...olderRows, newestRow]),
+      );
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: newestKey,
+        kind: "direct",
+        reason: "create",
+        sessionKey: newestKey,
+        updatedAt: newestRow.updatedAt,
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length)
+        .toBeGreaterThan(initialListCount);
+      await expect
+        .poll(() =>
+          rows.evaluateAll((elements) =>
+            elements.map((element) => element.getAttribute("data-session-key")),
+          ),
+        )
+        .toEqual(expectedVisibleKeys);
+      await captureUiProof(page, "sidebar-created-sort-after-refresh.png");
+
+      expect(await rows.count()).toBe(10);
+      expect(
+        await rows.evaluateAll((elements) =>
+          elements.map((element) => element.getAttribute("data-session-key")),
+        ),
+      ).toEqual(expectedVisibleKeys);
+    } finally {
+      await context.close();
+      if (proofVideo) {
+        await proofVideo.saveAs(
+          path.join(uiProofArtifactDir, "sidebar-created-sort-external-session.webm"),
+        );
+      }
+    }
+  });
+});

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -28,6 +28,35 @@ describe("AppSidebar session pagination", () => {
     expect(sidebar.querySelector(".sidebar-session-pagination")).toBeNull();
   });
 
+  it("shows a newly discovered session above the created-sort pagination boundary", async () => {
+    const olderKeys = Array.from({ length: 10 }, (_, index) => `agent:main:older-${index}`);
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const sessions = createSessionsHarness("main", olderKeys);
+    const { sidebar } = await mountSidebar(gateway, sessions.sessions);
+    const refreshed = createSessionState("main", [...olderKeys, "agent:main:external-new"]);
+    const rows = refreshed.result?.sessions;
+    if (!rows) {
+      throw new Error("expected refreshed session rows");
+    }
+    const newestRow = rows.at(-1);
+    if (!newestRow) {
+      throw new Error("expected newest session row");
+    }
+    newestRow.createdAt = 2_000;
+
+    sessions.publishList({ result: refreshed.result, agentId: refreshed.agentId });
+    await sidebar.updateComplete;
+
+    expect(
+      Array.from(
+        sidebar.querySelectorAll<HTMLElement>("[data-session-key]"),
+        (row) => row.dataset.sessionKey,
+      ),
+    ).toEqual(["agent:main:external-new", ...olderKeys.slice(0, 9)]);
+    expect(sidebar.querySelectorAll(".sidebar-recent-session")).toHaveLength(10);
+    expect(sidebar.querySelector('button[aria-label="Show more"]')).not.toBeNull();
+  });
+
   it("reveals sessions ten at a time and offers Collapse after thirty", async () => {
     const keys = [
       "agent:main:session-0",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sorting the Control UI sidebar by Created could have a newly created session hidden below **Show more** when that session was discovered through a refresh or another client.

## Why This Change Was Made

The Created and People sort paths now use the gateway's authoritative creation timestamp. Timestamped sessions sort newest-first, while legacy rows without a timestamp retain their stable first-observed fallback order. Updated sorting and pinned-zone priority are unchanged.

## User Impact

New sessions consistently appear at the top of their unpinned sidebar section, including sessions created from another client or process.

## Evidence

- Red browser reproduction on the unmodified base: the external session was absent from the first ten rows and hidden below **Show more**.
- Green browser proof on the fix: the external session is first, the visible row count remains ten, and the oldest row moves below **Show more**.
- `node scripts/run-vitest.mjs run ui/src/components/app-sidebar-session-navigation-logic.test.ts ui/src/components/app-sidebar.test.ts` — 278 passed.
- `OPENCLAW_E2E_WORKERS=1 pnpm test:ui:e2e -- ui/src/e2e/session-management.created-sort.e2e.test.ts` — passed.
- `pnpm tsgo:ui` — passed.
- Focused Oxlint and format checks — passed.
- Source-blind behavior validation: 6 relevant clauses passed, 0 failed; refresh/local-event convergence remained an evidence-only gap.
- Commit-level autoreview: clean, no accepted/actionable findings.

AI-assisted: implementation, tests, proof capture, and review were performed with Codex/OpenClaw tooling.
