### PR TITLE
fix: visible sessions explain working-directory denials

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -200,7 +200,7 @@ Per-agent override: `agents.entries.*.subagents.delegationMode`.
   Spawn under another configured agent id when allowed by `subagents.allowAgents`.
 </ParamField>
 <ParamField path="cwd" type="string">
-  Optional task working directory for the child run. Native sub-agents still load bootstrap files from the target agent workspace; `cwd` only changes where runtime tools and CLI harnesses do the delegated work.
+  Optional task working directory for the child run. Native sub-agents still load bootstrap files from the target agent workspace; `cwd` only changes where runtime tools and CLI harnesses do the delegated work. For visible sessions, paths outside configured agent workspaces require `operator.admin`; omit `cwd` to use the target agent workspace.
 </ParamField>
 <ParamField path="runtime" type='"subagent" | "acp"' default="subagent">
   `acp` is only for external ACP harnesses (`claude`, `droid`, `gemini`, `opencode`, or explicitly requested Codex ACP/acpx) and for `agents.entries.*` entries whose `runtime.type` is `acp`.
@@ -257,7 +257,7 @@ their latest assistant turn back to the requester; external delivery stays with
 the parent/requester agent.
 </Warning>
 
-With `visible: true`, `model`, `cwd`, and a same-agent `context: "fork"` are supported. Use this mode when the user asks to create or open a thread that should appear in the sidebar. A sandboxed target restricts `cwd` to that agent's workspace. Thread binding, `mode`, thinking overrides, `lightContext`, `attachments`, and `attachAs` are unavailable on this path because visible sessions are persistent dashboard sessions created through `sessions.create`. The new dashboard child inherits the requester's effective tool-policy ceiling before its first turn. Session listing and addressing obey `tools.sessions.visibility`; the default `tree` scope covers the current session and its own spawn subtree. See [Managed worktrees](/concepts/managed-worktrees) for checkout naming, setup, cleanup, and restore behavior.
+With `visible: true`, `model`, `cwd`, and a same-agent `context: "fork"` are supported. Use this mode when the user asks to create or open a thread that should appear in the sidebar. A sandboxed target restricts `cwd` to that agent's workspace. Non-admin callers may use `cwd` only inside a configured agent workspace. Omit `cwd` to use the target agent workspace; for another repository, ask the operator to start the session from a registered project. Do not replace a rejected persistent spawn with the synchronous `openclaw agent` CLI, whose command deadline defaults to 600 seconds. Thread binding, `mode`, thinking overrides, `lightContext`, `attachments`, and `attachAs` are unavailable on this path because visible sessions are persistent dashboard sessions created through `sessions.create`. The new dashboard child inherits the requester's effective tool-policy ceiling before its first turn. Session listing and addressing obey `tools.sessions.visibility`; the default `tree` scope covers the current session and its own spawn subtree. See [Managed worktrees](/concepts/managed-worktrees) for checkout naming, setup, cleanup, and restore behavior.
 
 ### Task names and targeting
 

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -417,6 +417,9 @@ describe("sessions_spawn tool", () => {
     expect(schema.properties?.visible?.description).toBe(
       "Persistent sidebar UI session; use when the user asks to create or open a thread; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs.",
     );
+    expect(schema.properties?.cwd?.description).toContain(
+      "outside configured agent workspaces require operator.admin",
+    );
     expect(tool.description).toContain("`visible=true`: persistent sidebar dashboard session");
     expect(tool.description).toContain("when the user asks to create/open a thread");
     expect(tool.description).toContain('no `mode="run"`');
@@ -511,6 +514,54 @@ describe("sessions_spawn tool", () => {
         }),
       );
       expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("explains an out-of-workspace visible cwd denial without suggesting a CLI fallback", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("missing scope: operator.admin");
+    });
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      config: { agents: { list: [{ id: "main" }] } },
+      callGateway: callGateway as never,
+      countActiveRuns: () => 0,
+    });
+
+    const result = await tool.execute("visible-external-cwd", {
+      task: "inspect issue",
+      cwd: "/srv/external/repo",
+      visible: true,
+      worktree: true,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+      error:
+        'Visible session cwd "/srv/external/repo" is outside configured agent workspaces and requires operator.admin. Omit cwd to use the target agent workspace, or ask the operator to start the session from a registered project. Do not substitute the synchronous `openclaw agent` CLI for a persistent visible session.',
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+  });
+
+  it("preserves unrelated visible-session admin denials with an allowed cwd", async () => {
+    await withTestDir({ prefix: "openclaw-visible-spawn-allowed-cwd-" }, async (workspace) => {
+      const callGateway = vi.fn(async () => {
+        throw new Error("missing scope: operator.admin");
+      });
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+        config: { agents: { list: [{ id: "main", workspace }] } },
+        callGateway: callGateway as never,
+        countActiveRuns: () => 0,
+      });
+
+      await expect(
+        tool.execute("visible-admin-denial", {
+          task: "inspect issue",
+          cwd: workspace,
+          visible: true,
+        }),
+      ).rejects.toThrow("missing scope: operator.admin");
     });
   });
 

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
   SWARM_CODE_MODE_IDEMPOTENCY_KEY,
@@ -518,6 +519,42 @@ describe("sessions_spawn tool", () => {
   });
 
   it("explains an out-of-workspace visible cwd denial without suggesting a CLI fallback", async () => {
+    await withTestDir({ prefix: "openclaw-visible-spawn-external-cwd-" }, async (workspace) => {
+      const outside = path.dirname(workspace);
+      const callGateway = vi.fn(async () => {
+        throw new GatewayClientRequestError({
+          code: "FORBIDDEN",
+          message: "permission denied",
+          details: {
+            code: "MISSING_SCOPE",
+            missingScope: "operator.admin",
+            requiredScopes: ["operator.admin"],
+          },
+        });
+      });
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+        config: { agents: { list: [{ id: "main", workspace }] } },
+        callGateway: callGateway as never,
+        countActiveRuns: () => 0,
+      });
+
+      const result = await tool.execute("visible-external-cwd", {
+        task: "inspect issue",
+        cwd: outside,
+        visible: true,
+        worktree: true,
+      });
+
+      expect(result.details).toMatchObject({
+        status: "forbidden",
+        error: `Visible session cwd "${outside}" is outside configured agent workspaces and requires operator.admin. Omit cwd to use the target agent workspace, or ask the operator to start the session from a registered project. Do not substitute the synchronous \`openclaw agent\` CLI for a persistent visible session.`,
+      });
+      expect(callGateway).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("preserves matching error text without structured missing-scope details", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("missing scope: operator.admin");
     });
@@ -528,25 +565,55 @@ describe("sessions_spawn tool", () => {
       countActiveRuns: () => 0,
     });
 
-    const result = await tool.execute("visible-external-cwd", {
-      task: "inspect issue",
-      cwd: "/srv/external/repo",
-      visible: true,
-      worktree: true,
+    await expect(
+      tool.execute("visible-message-only-denial", {
+        task: "inspect issue",
+        cwd: "/srv/external/repo",
+        visible: true,
+      }),
+    ).rejects.toThrow("missing scope: operator.admin");
+  });
+
+  it("preserves inconsistent structured missing-scope details", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new GatewayClientRequestError({
+        code: "FORBIDDEN",
+        message: "permission denied",
+        details: {
+          code: "MISSING_SCOPE",
+          missingScope: "operator.admin",
+          requiredScopes: ["operator.write"],
+        },
+      });
+    });
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      config: { agents: { list: [{ id: "main" }] } },
+      callGateway: callGateway as never,
+      countActiveRuns: () => 0,
     });
 
-    expect(result.details).toMatchObject({
-      status: "forbidden",
-      error:
-        'Visible session cwd "/srv/external/repo" is outside configured agent workspaces and requires operator.admin. Omit cwd to use the target agent workspace, or ask the operator to start the session from a registered project. Do not substitute the synchronous `openclaw agent` CLI for a persistent visible session.',
-    });
-    expect(callGateway).toHaveBeenCalledOnce();
+    await expect(
+      tool.execute("visible-inconsistent-scope-denial", {
+        task: "inspect issue",
+        cwd: "/srv/external/repo",
+        visible: true,
+      }),
+    ).rejects.toThrow("permission denied");
   });
 
   it("preserves unrelated visible-session admin denials with an allowed cwd", async () => {
     await withTestDir({ prefix: "openclaw-visible-spawn-allowed-cwd-" }, async (workspace) => {
       const callGateway = vi.fn(async () => {
-        throw new Error("missing scope: operator.admin");
+        throw new GatewayClientRequestError({
+          code: "FORBIDDEN",
+          message: "permission denied",
+          details: {
+            code: "MISSING_SCOPE",
+            missingScope: "operator.admin",
+            requiredScopes: ["operator.admin"],
+          },
+        });
       });
       const tool = createSessionsSpawnTool({
         agentSessionKey: "agent:main:main",
@@ -561,7 +628,7 @@ describe("sessions_spawn tool", () => {
           cwd: workspace,
           visible: true,
         }),
-      ).rejects.toThrow("missing scope: operator.admin");
+      ).rejects.toThrow("permission denied");
     });
   });
 

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -162,7 +162,12 @@ function createSessionsSpawnToolSchema(params: {
     thinking: Type.Optional(
       Type.String({ description: "Thinking override; unavailable with visible=true." }),
     ),
-    cwd: Type.Optional(Type.String()),
+    cwd: Type.Optional(
+      Type.String({
+        description:
+          "Working directory for the child. With visible=true, paths outside configured agent workspaces require operator.admin; omit to use the target agent workspace.",
+      }),
+    ),
     ...(params.threadAvailable
       ? {
           thread: Type.Optional(

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -5,6 +5,7 @@ import {
 } from "../../config/agent-limits.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveWorkspacePathContainment } from "../../gateway/server-methods/workspace-path-containment.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
@@ -292,26 +293,41 @@ export async function maybeSpawnVisibleSession(params: {
             deny: [...(params.options?.inheritedToolDenylist ?? [])],
           },
         }));
-    const response = await createGatewayCall<{
+    let response: {
       key?: string;
       runStarted?: boolean;
       runId?: string;
       runError?: unknown;
-    }>("sessions.create", {
-      agentId: targetAgentId,
-      ...(params.label ? { label: params.label } : {}),
-      model: resolvedModel,
-      task: params.task,
-      parentSessionKey: requesterKey,
-      // Declared spawn lineage: without it the child persists as a depth-0 root
-      // and could spawn past maxSpawnDepth.
-      spawnDepth: callerDepth + 1,
-      ...(params.raw.context === "fork" ? { fork: true } : {}),
-      ...(spawnedCwd ? { cwd: spawnedCwd } : {}),
-      ...(worktree ? { worktree: true } : {}),
-      ...(worktreeName ? { worktreeName } : {}),
-      ...(worktreeBaseRef ? { worktreeBaseRef } : {}),
-    });
+    };
+    try {
+      response = await createGatewayCall("sessions.create", {
+        agentId: targetAgentId,
+        ...(params.label ? { label: params.label } : {}),
+        model: resolvedModel,
+        task: params.task,
+        parentSessionKey: requesterKey,
+        // Declared spawn lineage: without it the child persists as a depth-0 root
+        // and could spawn past maxSpawnDepth.
+        spawnDepth: callerDepth + 1,
+        ...(params.raw.context === "fork" ? { fork: true } : {}),
+        ...(spawnedCwd ? { cwd: spawnedCwd } : {}),
+        ...(worktree ? { worktree: true } : {}),
+        ...(worktreeName ? { worktreeName } : {}),
+        ...(worktreeBaseRef ? { worktreeBaseRef } : {}),
+      });
+    } catch (error) {
+      if (
+        spawnedCwd &&
+        summarizeSessionsSpawnError(error).includes("missing scope: operator.admin") &&
+        !(await resolveWorkspacePathContainment(spawnedCwd, cfg))
+      ) {
+        return {
+          status: "forbidden",
+          error: `Visible session cwd "${spawnedCwd}" is outside configured agent workspaces and requires operator.admin. Omit cwd to use the target agent workspace, or ask the operator to start the session from a registered project. Do not substitute the synchronous \`openclaw agent\` CLI for a persistent visible session.`,
+        };
+      }
+      throw error;
+    }
     const childSessionKey = response.key?.trim();
     const runId = response.runId?.trim();
     const runError = response.runError

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -1,10 +1,12 @@
 import { Type } from "typebox";
+import { readMissingScopeErrorDetails } from "../../../packages/gateway-protocol/src/gateway-error-details.js";
 import {
   DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
   DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
 } from "../../config/agent-limits.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { ADMIN_SCOPE } from "../../gateway/method-scopes.js";
 import { resolveWorkspacePathContainment } from "../../gateway/server-methods/workspace-path-containment.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
@@ -316,9 +318,13 @@ export async function maybeSpawnVisibleSession(params: {
         ...(worktreeBaseRef ? { worktreeBaseRef } : {}),
       });
     } catch (error) {
+      const missingScope = readMissingScopeErrorDetails(
+        error && typeof error === "object" && "details" in error ? error.details : undefined,
+      );
       if (
         spawnedCwd &&
-        summarizeSessionsSpawnError(error).includes("missing scope: operator.admin") &&
+        missingScope?.missingScope === ADMIN_SCOPE &&
+        missingScope.requiredScopes.includes(ADMIN_SCOPE) &&
         !(await resolveWorkspacePathContainment(spawnedCwd, cfg))
       ) {
         return {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -52,6 +52,7 @@
             "type": "string"
           },
           "cwd": {
+            "description": "Working directory for the child. With visible=true, paths outside configured agent workspaces require operator.admin; omit to use the target agent workspace.",
             "type": "string"
           },
           "label": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -188,6 +188,7 @@
           "type": "string"
         },
         "cwd": {
+          "description": "Working directory for the child. With visible=true, paths outside configured agent workspaces require operator.admin; omit to use the target agent workspace.",
           "type": "string"
         },
         "label": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 49173,
-    "roughTokens": 12294
+    "chars": 49359,
+    "roughTokens": 12340
   },
   "openClawDeveloperInstructions": {
     "chars": 4479,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7216
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78037,
-    "roughTokens": 19510
+    "chars": 78223,
+    "roughTokens": 19556
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 48865,
-    "roughTokens": 12217
+    "chars": 49051,
+    "roughTokens": 12263
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6846
   },
   "totalWithDynamicToolsJson": {
-    "chars": 76249,
-    "roughTokens": 19063
+    "chars": 76435,
+    "roughTokens": 19109
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 50399,
-    "roughTokens": 12600
+    "chars": 50585,
+    "roughTokens": 12647
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78199,
-    "roughTokens": 19550
+    "chars": 78385,
+    "roughTokens": 19597
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

Users asking an agent to open a persistent visible session for a repository outside its configured workspace could see the work stop roughly ten minutes later. The Gateway correctly denied the external `cwd` without `operator.admin`, but `sessions_spawn` exposed only an opaque scope error. That left the agent free to substitute the synchronous `openclaw agent` CLI, whose finite deadline then terminated still-active work.

## Root Cause And Fix

The authorization boundary was correct; the broken contract was the visible-session tool result.

`sessions_spawn` now translates only a validated structured `MISSING_SCOPE` denial when:

- `missingScope` is `operator.admin`;
- `requiredScopes` also contains `operator.admin`; and
- canonical workspace containment confirms the requested `cwd` is external.

That case remains fail-closed but returns actionable persistent-session guidance: omit `cwd`, use a registered project, and do not substitute the synchronous CLI. Message-only, inconsistent, allowed-workspace, and unrelated admin errors remain unchanged.

The tool schema, docs, and prompt snapshots also expose the visible-session `cwd` contract to the model.

## Why This Is The Canonical Fix

- Changing the Gateway message globally would not own the tool-specific recovery contract.
- Preflighting authorization in the tool would duplicate and race the Gateway security decision.
- Changing the synchronous CLI timeout is complementary global behavior, not the owner of a persistent visible-session denial.

The patch consumes the Gateway protocol's typed error details and reuses the canonical workspace-containment helper at the visible-session boundary.

## Evidence

- Canonical-base red regression (`054354e099c4952af5152c974253b99af5cfb676`): the structured external-`cwd` scenario propagated `GatewayClientRequestError: missing scope: operator.admin`.
- Gateway producer proof: the real `sessions.create` boundary emitted validated `MISSING_SCOPE` / `operator.admin` details.
- Source-blind behavior validation: positive structured external denial plus message-only, allowed-workspace, and inconsistent-scope negative controls all passed.
- Blacksmith Testbox: [run 31857218082](https://github.com/openclaw/openclaw/actions/runs/31857218082) passed 99 tool tests, the real Gateway producer test, 10 protocol tests, and `corepack pnpm check:changed` (types, lint, guards, snapshots).
- Final push rebased the identical patch over unrelated Gateway-status/worker-environment movement; that range did not touch the visible-session, session-create, containment, or missing-scope surfaces. Exact-head GitHub CI is the final merge gate.
- Fresh branch autoreview: clean, no accepted/actionable findings.

Production delta is +27 net lines; tests add 118 net lines, with docs and generated prompt snapshots classified separately. The runtime growth is the visible-`cwd` capability, typed security-boundary classification, and actionable recovery contract.

## User Impact

Persistent visible-session requests no longer fail opaquely and drift into a finite CLI fallback. Operators retain the same host-path authorization boundary, while agents get a precise safe recovery path.
