### PR TITLE
fix(gateway): allow workspace retry after rejected upload

### DIFF
--- a/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
@@ -250,13 +250,11 @@ describe("node workspace transfer service", () => {
         persistenceRetry.release();
       }
       await upload;
-      const replay = await fetch(
-        `${httpOrigin}/__openclaw__/worker-transfer/v1/environments/environment-1/reconciliations/${prepared.snapshot.manifestRef.slice(7)}`,
-        {
-          method: "POST",
-          headers: { authorization: `Bearer ${uploadToken}`, "content-length": "0" },
-        },
-      );
+      const reconciliationUrl = `${httpOrigin}/__openclaw__/worker-transfer/v1/environments/environment-1/reconciliations/${prepared.snapshot.manifestRef.slice(7)}`;
+      const replay = await fetch(reconciliationUrl, {
+        method: "POST",
+        headers: { authorization: `Bearer ${uploadToken}`, "content-length": "0" },
+      });
       expect(replay.status).toBe(404);
       const uploaded = service.takeUpload("environment-1", prepared.snapshot.manifestRef);
       expect(uploaded.current.entries).toContainEqual(
@@ -265,6 +263,23 @@ describe("node workspace transfer service", () => {
       await expect(
         fs.readFile(path.join(uploaded.stagingRoot, "result.txt"), "utf8"),
       ).resolves.toBe("node result\n");
+      const invalidUploadToken = service.prepareUpload(
+        "environment-1",
+        prepared.snapshot.manifestRef,
+      );
+      const invalidUpload = await fetch(reconciliationUrl, {
+        method: "POST",
+        headers: { authorization: `Bearer ${invalidUploadToken}`, "content-length": "0" },
+      });
+      expect(invalidUpload.status).toBe(413);
+      await expect(invalidUpload.json()).resolves.toEqual({
+        error: "workspace_transfer_limit",
+      });
+      const replacementUploadToken = service.prepareUpload(
+        "environment-1",
+        prepared.snapshot.manifestRef,
+      );
+      service.revoke("environment-1", replacementUploadToken);
       writeFaults.failNextWrite(new Error("injected terminal upload write failure"));
       const failedUploadToken = service.prepareUpload(
         "environment-1",

--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -602,39 +602,38 @@ export function createNodeWorkspaceTransferService(options: {
         params.signal.throwIfAborted();
         assertAuthorizationCurrent(authorization);
       };
-      assertCurrent();
-      const contentLength = Number(params.request.headers["content-length"]);
-      if (
-        !Number.isSafeInteger(contentLength) ||
-        contentLength < 8 ||
-        contentLength > MAX_UPLOAD_BYTES
-      ) {
-        throw new NodeWorkspaceTransferLimitError(
-          "Workspace transfer upload exceeds its byte limit",
-        );
-      }
-      const reader = new RequestByteReader(params.request, params.signal, assertCurrent);
-      const readManifest = async (expectedRef?: string) => {
-        const bytes = (await reader.readExactly(4)).readUInt32BE();
-        if (bytes < 2 || bytes > MAX_WORKSPACE_MANIFEST_BYTES) {
+      let stagingRoot: string | undefined;
+      try {
+        assertCurrent();
+        const contentLength = Number(params.request.headers["content-length"]);
+        if (
+          !Number.isSafeInteger(contentLength) ||
+          contentLength < 8 ||
+          contentLength > MAX_UPLOAD_BYTES
+        ) {
           throw new NodeWorkspaceTransferLimitError(
-            "Workspace transfer manifest exceeds its byte limit",
+            "Workspace transfer upload exceeds its byte limit",
           );
         }
-        const raw = (await reader.readExactly(bytes)).toString("utf8");
-        const ref = expectedRef ?? `sha256:${createHash("sha256").update(raw).digest("hex")}`;
-        return { raw, ref, manifest: parseWorkerWorkspaceManifest(raw, ref) };
-      };
-      const base = await readManifest(operation.baseManifestRef);
-      assertCurrent();
-      const current = await readManifest();
-      assertCurrent();
-      const transferPaths = workerWorkspaceTransferPaths(current.manifest, base.manifest);
-      const transferPathSet = new Set(transferPaths);
-      const stagingRoot = await fsp.mkdtemp(
-        path.join(authorization.context.temporaryRoot, "upload-"),
-      );
-      try {
+        const reader = new RequestByteReader(params.request, params.signal, assertCurrent);
+        const readManifest = async (expectedRef?: string) => {
+          const bytes = (await reader.readExactly(4)).readUInt32BE();
+          if (bytes < 2 || bytes > MAX_WORKSPACE_MANIFEST_BYTES) {
+            throw new NodeWorkspaceTransferLimitError(
+              "Workspace transfer manifest exceeds its byte limit",
+            );
+          }
+          const raw = (await reader.readExactly(bytes)).toString("utf8");
+          const ref = expectedRef ?? `sha256:${createHash("sha256").update(raw).digest("hex")}`;
+          return { raw, ref, manifest: parseWorkerWorkspaceManifest(raw, ref) };
+        };
+        const base = await readManifest(operation.baseManifestRef);
+        assertCurrent();
+        const current = await readManifest();
+        assertCurrent();
+        const transferPaths = workerWorkspaceTransferPaths(current.manifest, base.manifest);
+        const transferPathSet = new Set(transferPaths);
+        stagingRoot = await fsp.mkdtemp(path.join(authorization.context.temporaryRoot, "upload-"));
         const currentByPath = new Map(current.manifest.entries.map((entry) => [entry.path, entry]));
         for (const relative of transferPaths) {
           const entry = currentByPath.get(relative);
@@ -680,7 +679,9 @@ export function createNodeWorkspaceTransferService(options: {
         operation.state = "completed";
         return { manifestRef: current.ref };
       } catch (error) {
-        await fsp.rm(stagingRoot, { recursive: true, force: true });
+        if (stagingRoot) {
+          await fsp.rm(stagingRoot, { recursive: true, force: true });
+        }
         if (authorization.context.upload === operation) {
           authorization.context.upload = undefined;
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a node workspace reconciliation upload that was rejected before staging began could leave the upload permanently marked active. A later reconciliation for the same workspace then failed with “Node workspace transfer upload is already active” instead of receiving a fresh upload token.

## Why This Change Was Made

The transfer service now owns cleanup for the complete post-authorization receive lifecycle, including content-length validation and manifest parsing before a staging directory exists. Failed operations release the exact claimed upload while preserving delegated-authority checks, transfer limits, staging cleanup, and completed-upload publication.

This is intentionally separate from #123739, which fixed positive short writes. No short-write behavior is changed here.

## User Impact

Node workspace reconciliation can recover from rejected or malformed upload requests by minting a fresh upload operation instead of leaving the workspace stuck until its transfer context is replaced.

## Evidence

- Pre-fix HTTP-boundary regression: `node scripts/run-vitest.mjs src/gateway/worker-environments/node-workspace-transfer-service.test.ts` failed 1 of 3 tests with `Node workspace transfer upload is already active`.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/gateway/worker-environments/node-workspace-transfer-service.test.ts src/gateway/worker-environments/node-worker-tunnel.test.ts src/gateway/server-http.node-workspace-transfer.test.ts` — 13 tests passed.
- `node scripts/check-changed.mjs -- src/gateway/worker-environments/node-workspace-transfer-service.ts src/gateway/worker-environments/node-workspace-transfer-service.test.ts` — passed on Blacksmith Testbox `tbx_01m0109bkrjxxjy9x370gcr5yc`: https://github.com/openclaw/openclaw/actions/runs/31839270350
- Targeted `oxfmt --check`, oxlint, and `git diff --check` passed.
- Fresh Codex-backed branch autoreview reported no accepted/actionable findings.
- Production LOC: +32/-31 (net +1). Tests: +22/-7 (net +15).

AI-assisted; the lifecycle owner, authority behavior, regression, and final rebased diff were independently reviewed.
