### PR TITLE
fix(status): keep explicit fleets ownerless in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Multi-agent status ownership:** keep status, health, channel inventory, memory, workspace skills, usage auth, and security-audit projections from treating the first explicit-fleet agent as an implicit default; use the configured system agent where appropriate and require `status --usage --agent <id>` when no owner exists.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Multi-agent status ownership:** keep status, health, channel inventory, memory, workspace skills, usage auth, and security-audit projections from treating the first explicit-fleet agent as an implicit default; use the configured system agent where appropriate and require `status --usage --agent <id>` when no owner exists.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -13,6 +13,7 @@ openclaw status
 openclaw status --all
 openclaw status --deep
 openclaw status --usage
+openclaw status --usage --agent work
 ```
 
 | Flag                    | Description                                                                                                     |
@@ -20,6 +21,7 @@ openclaw status --usage
 | `--all`                 | Full diagnosis (read-only, pasteable). Includes security audit, plugin compatibility, and memory-vector probes. |
 | `--deep`                | Runs live probes (WhatsApp Web + Telegram + Discord + Slack + Signal). Also enables the security audit.         |
 | `--usage`               | Prints normalized provider usage windows as `X% left`.                                                          |
+| `--agent <id>`          | Selects the agent auth/profile scope for `--usage`. Required when an explicit multi-agent fleet has no default. |
 | `--json`                | Machine-readable output.                                                                                        |
 | `--timeout <ms>`        | Probe timeout in milliseconds (default: `10000`).                                                               |
 | `--verbose` / `--debug` | Also print the raw Gateway target resolution before the report.                                                 |
@@ -60,8 +62,9 @@ and `openclaw memory status --deep`.
 
 - `--usage` prints normalized provider usage windows as `X% left`.
 - In an explicit multi-agent setup, `--usage` reads the auth profiles owned by
-  `agents.defaults.systemAgent.agentId`. Set that owner before using `--usage`;
-  OpenClaw does not guess one agent's credentials from an ambiguous roster.
+  `agents.defaults.systemAgent.agentId` by default. Pass `--agent <id>` to
+  inspect another agent; without either owner, OpenClaw does not guess one
+  agent's credentials from an ambiguous roster.
 - MiniMax's raw `usage_percent` / `usagePercent` fields are remaining quota,
   so OpenClaw inverts them before display; count-based fields win when
   present. `model_remains` responses prefer the chat-model entry, derive the

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -166,6 +166,8 @@ describe("registerStatusHealthSessionsCommands", () => {
       "--all",
       "--deep",
       "--usage",
+      "--agent",
+      "beta",
       "--debug",
       "--timeout",
       "5000",
@@ -177,6 +179,7 @@ describe("registerStatusHealthSessionsCommands", () => {
       all: true,
       deep: true,
       usage: true,
+      agent: "beta",
       timeoutMs: 5000,
       verbose: true,
     });

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -250,6 +250,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--json", "Output JSON instead of text", false)
     .option("--all", "Full diagnosis (read-only, pasteable)", false)
     .option("--usage", "Show model provider usage/quota snapshots", false)
+    .option("--agent <id>", "Agent id for --usage auth scope")
     .option("--deep", "Probe channels (WhatsApp Web + Telegram + Discord + Slack + Signal)", false)
     .option("--timeout <ms>", "Probe timeout in milliseconds", "10000")
     .option("--verbose", "Verbose logging", false)
@@ -283,6 +284,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             all: Boolean(opts.all),
             deep: Boolean(opts.deep),
             usage: Boolean(opts.usage),
+            ...(opts.agent !== undefined ? { agent: opts.agent } : {}),
             timeoutMs,
             verbose,
           },

--- a/src/cli/program/route-args.test.ts
+++ b/src/cli/program/route-args.test.ts
@@ -33,6 +33,8 @@ describe("route-args", () => {
         "--deep",
         "--all",
         "--usage",
+        "--agent",
+        "beta",
         "--timeout",
         "5000",
       ]),
@@ -41,10 +43,12 @@ describe("route-args", () => {
       deep: true,
       all: true,
       usage: true,
+      agent: "beta",
       verbose: false,
       timeoutMs: 5000,
     });
     expect(parseStatusRouteArgs(["node", "openclaw", "status", "--timeout"])).toBeNull();
+    expect(parseStatusRouteArgs(["node", "openclaw", "status", "--agent"])).toBeNull();
   });
 
   it("defers status/health --timeout with a present-but-invalid value to Commander", () => {

--- a/src/cli/program/route-args.ts
+++ b/src/cli/program/route-args.ts
@@ -109,7 +109,7 @@ export function parseStatusRouteArgs(argv: string[]) {
   const positionals = getRoutedCommandPositionals(argv, {
     commandPath: ["status"],
     booleanFlags: ["--json", "--deep", "--all", "--usage", "--verbose", "--debug"],
-    valueFlags: ["--timeout"],
+    valueFlags: ["--timeout", "--agent"],
   });
   if (!positionals || positionals.length !== 0) {
     return null;
@@ -118,11 +118,16 @@ export function parseStatusRouteArgs(argv: string[]) {
   if (timeoutMs === null) {
     return null;
   }
+  const agent = parseOptionalFlagValue(argv, "--agent");
+  if (!agent.ok) {
+    return null;
+  }
   return {
     json: hasFlag(argv, "--json"),
     deep: hasFlag(argv, "--deep"),
     all: hasFlag(argv, "--all"),
     usage: hasFlag(argv, "--usage"),
+    ...(agent.value !== undefined ? { agent: agent.value } : {}),
     verbose: getVerboseFlag(argv, { includeDebug: true }),
     timeoutMs,
   };

--- a/src/cli/program/routed-command-definitions.ts
+++ b/src/cli/program/routed-command-definitions.ts
@@ -99,6 +99,7 @@ export const routedCommandDefinitions = {
             deep: args.deep,
             all: args.all,
             usage: args.usage,
+            ...(args.agent !== undefined ? { agent: args.agent } : {}),
             timeoutMs: args.timeoutMs,
           },
           defaultRuntime,

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -296,11 +296,11 @@ describe("program routes", () => {
 
   it("routes status --json through the lean JSON command", async () => {
     const route = expectRoute(["status"]);
-    await expect(route.run(routeArgv("status --json --deep --usage --timeout 5000"))).resolves.toBe(
-      true,
-    );
+    await expect(
+      route.run(routeArgv("status --json --deep --usage --agent beta --timeout 5000")),
+    ).resolves.toBe(true);
     expect(statusJsonCommandMock).toHaveBeenCalledWith(
-      { deep: true, all: false, usage: true, timeoutMs: 5000 },
+      { deep: true, all: false, usage: true, agent: "beta", timeoutMs: 5000 },
       defaultRuntime,
     );
   });

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -214,6 +214,42 @@ describe("healthCommand", () => {
     expect(output).toContain("Gateway probe duration: 5ms");
   });
 
+  it("shows every agent when an explicit fleet has no default owner", async () => {
+    const sessions = (agentId: string) => ({
+      path: `/tmp/${agentId}/sessions.json`,
+      count: 0,
+      recent: [],
+    });
+    const snapshot = {
+      ...createHealthSummary({ channels: {}, channelOrder: [], channelLabels: {} }),
+      defaultAgentId: undefined,
+      agents: [
+        { ...createMainAgentSummary(sessions("alpha")), agentId: "alpha", isDefault: false },
+        { ...createMainAgentSummary(sessions("beta")), agentId: "beta", isDefault: false },
+      ],
+    };
+    callGatewayMock.mockResolvedValueOnce(snapshot);
+
+    await healthCommand(
+      {
+        json: false,
+        timeoutMs: 1000,
+        config: {
+          agents: {
+            ownership: "explicit",
+            entries: { alpha: {}, beta: {} },
+          },
+        },
+      },
+      runtime as never,
+    );
+
+    const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
+    expect(output).toContain("Session store (alpha): /tmp/alpha/sessions.json");
+    expect(output).toContain("Session store (beta): /tmp/beta/sessions.json");
+    expect(output).not.toContain("(default)");
+  });
+
   it("prints persistent event-loop degradation duration in text output", async () => {
     const snapshot = {
       ...createHealthSummary({ channels: {}, channelOrder: [], channelLabels: {} }),

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -337,9 +337,10 @@ export async function healthCommand(
               } satisfies AgentHealthSummary;
             }),
           );
-    const displayAgents = opts.verbose
-      ? resolvedAgents
-      : resolvedAgents.filter((agent) => agent.agentId === defaultAgentId);
+    const displayAgents =
+      opts.verbose || !defaultAgentId
+        ? resolvedAgents
+        : resolvedAgents.filter((agent) => agent.agentId === defaultAgentId);
     const channelBindings = buildChannelAccountBindings(cfg);
     const displayPlugins = listReadOnlyChannelPluginsForConfig(cfg, {
       includeSetupFallbackPlugins: false,

--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -7,10 +7,12 @@ const mocks = vi.hoisted(() => ({
   resolveGatewayBindHost: vi.fn(async () => "127.0.0.1"),
   resolveStatusGatewayDiagnosticsSafe: vi.fn(async () => null),
   resolveStatusGatewayHealthSafe: vi.fn(async () => undefined),
+  resolveNodeExecEligibility: vi.fn(() => ({ canExec: false })),
+  buildWorkspaceSkillStatus: vi.fn(() => null),
 }));
 
 vi.mock("../../agents/exec-defaults.js", () => ({
-  resolveNodeExecEligibility: () => ({ canExec: false }),
+  resolveNodeExecEligibility: mocks.resolveNodeExecEligibility,
 }));
 vi.mock("../../config/config.js", () => ({
   readConfigFileSnapshot: mocks.readConfigFileSnapshot,
@@ -27,7 +29,9 @@ vi.mock("../../gateway/net.js", () => ({
 vi.mock("../../infra/ports-inspect.js", () => ({ inspectPortUsage: mocks.inspectPortUsage }));
 vi.mock("../../infra/restart-sentinel.js", () => ({ readRestartSentinel: async () => null }));
 vi.mock("../../plugins/status.js", () => ({ buildPluginCompatibilityNotices: () => [] }));
-vi.mock("../../skills/discovery/status.js", () => ({ buildWorkspaceSkillStatus: () => null }));
+vi.mock("../../skills/discovery/status.js", () => ({
+  buildWorkspaceSkillStatus: mocks.buildWorkspaceSkillStatus,
+}));
 vi.mock("../../skills/runtime/remote.js", () => ({ getRemoteSkillEligibility: () => ({}) }));
 vi.mock("../status-overview-rows.ts", () => ({ buildStatusAllOverviewRows: () => [] }));
 vi.mock("../status-overview-surface.ts", () => ({
@@ -124,5 +128,95 @@ describe("buildStatusAllReportData", () => {
         }),
       ],
     ]);
+  });
+
+  it("uses the configured system agent for workspace skill diagnosis", async () => {
+    await buildStatusAllReportData({
+      overview: {
+        cfg: {
+          agents: {
+            ownership: "explicit",
+            defaults: { systemAgent: { agentId: "beta" } },
+            entries: {
+              alpha: { workspace: "/tmp/alpha" },
+              beta: { workspace: "/tmp/beta" },
+            },
+          },
+        },
+        gatewaySnapshot: {
+          gatewayReachable: false,
+          gatewayProbe: null,
+          gatewayCallOverrides: undefined,
+          gatewayConnection: {},
+          remoteUrlMissing: false,
+        },
+        secretDiagnostics: [],
+        tailscaleMode: "off",
+        tailscaleDns: null,
+        agentStatus: {
+          agents: [
+            { id: "alpha", workspaceDir: "/tmp/alpha" },
+            { id: "beta", workspaceDir: "/tmp/beta" },
+          ],
+          defaultId: null,
+        },
+        channels: { rows: [], details: [] },
+        channelIssues: [],
+        osSummary: { label: "test" },
+      } as never,
+      daemon: {} as never,
+      nodeService: {} as never,
+      nodeOnlyGateway: {} as never,
+      progress: { setLabel: vi.fn(), tick: vi.fn() },
+    });
+
+    expect(mocks.resolveNodeExecEligibility).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      agentId: "beta",
+    });
+    expect(mocks.buildWorkspaceSkillStatus).toHaveBeenCalledWith("/tmp/beta", expect.any(Object));
+  });
+
+  it("does not inspect the first workspace when an explicit fleet has no owner", async () => {
+    await buildStatusAllReportData({
+      overview: {
+        cfg: {
+          agents: {
+            ownership: "explicit",
+            entries: {
+              alpha: { workspace: "/tmp/alpha" },
+              beta: { workspace: "/tmp/beta" },
+            },
+          },
+        },
+        gatewaySnapshot: {
+          gatewayReachable: false,
+          gatewayProbe: null,
+          gatewayCallOverrides: undefined,
+          gatewayConnection: {},
+          remoteUrlMissing: false,
+        },
+        secretDiagnostics: [],
+        tailscaleMode: "off",
+        tailscaleDns: null,
+        agentStatus: {
+          agents: [
+            { id: "alpha", workspaceDir: "/tmp/alpha" },
+            { id: "beta", workspaceDir: "/tmp/beta" },
+          ],
+          defaultId: null,
+        },
+        channels: { rows: [], details: [] },
+        channelIssues: [],
+        osSummary: { label: "test" },
+      } as never,
+      daemon: {} as never,
+      nodeService: {} as never,
+      nodeOnlyGateway: {} as never,
+      progress: { setLabel: vi.fn(), tick: vi.fn() },
+    });
+
+    expect(mocks.resolveNodeExecEligibility).not.toHaveBeenCalled();
+    expect(mocks.buildWorkspaceSkillStatus).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -7,6 +7,7 @@ import { readLastGatewayErrorLine } from "../../daemon/diagnostics.js";
 import { resolveGatewayBindHost, resolveGatewayRequiredListenHosts } from "../../gateway/net.js";
 import { inspectPortUsage } from "../../infra/ports-inspect.js";
 import { readRestartSentinel } from "../../infra/restart-sentinel.js";
+import { resolvePluginControlPlaneWorkspace } from "../../plugins/control-plane-workspace.js";
 import { buildPluginCompatibilityNotices } from "../../plugins/status.js";
 import { buildWorkspaceSkillStatus } from "../../skills/discovery/status.js";
 import { getRemoteSkillEligibility } from "../../skills/runtime/remote.js";
@@ -122,11 +123,11 @@ async function resolveStatusAllLocalDiagnosis(params: {
   }).catch(() => null);
   params.progress.tick();
 
-  const defaultWorkspace =
-    overview.agentStatus.agents.find((a) => a.id === overview.agentStatus.defaultId)
-      ?.workspaceDir ??
-    overview.agentStatus.agents[0]?.workspaceDir ??
-    null;
+  const controlPlaneWorkspace = resolvePluginControlPlaneWorkspace({
+    config: overview.cfg,
+    env: process.env,
+  });
+  const defaultWorkspace = controlPlaneWorkspace.workspaceDir ?? null;
   const skillStatus =
     defaultWorkspace != null
       ? (() => {
@@ -134,7 +135,7 @@ async function resolveStatusAllLocalDiagnosis(params: {
             // Skill eligibility depends on whether the default agent may request node exec.
             const nodeSkills = resolveNodeExecEligibility({
               cfg: overview.cfg,
-              agentId: overview.agentStatus.defaultId,
+              agentId: controlPlaneWorkspace.agentId,
             });
             return buildWorkspaceSkillStatus(defaultWorkspace, {
               config: overview.cfg,

--- a/src/commands/status-json-command.test.ts
+++ b/src/commands/status-json-command.test.ts
@@ -55,7 +55,7 @@ describe("runStatusJsonCommand", () => {
     const scanStatusJsonFast = vi.fn(async () => scan);
 
     await runStatusJsonCommand({
-      opts: { deep: true, usage: true, timeoutMs: 1234, all: true },
+      opts: { deep: true, usage: true, agent: "beta", timeoutMs: 1234, all: true },
       runtime,
       scanStatusJsonFast,
       includeSecurityAudit: true,
@@ -66,7 +66,7 @@ describe("runStatusJsonCommand", () => {
     expect(scanStatusJsonFast).toHaveBeenCalledWith({ timeoutMs: 1234, all: true }, runtime);
     expect(mocks.resolveStatusJsonOutput).toHaveBeenCalledWith({
       scan,
-      opts: { deep: true, usage: true, timeoutMs: 1234, all: true },
+      opts: { deep: true, usage: true, agent: "beta", timeoutMs: 1234, all: true },
       includeSecurityAudit: true,
       includePluginCompatibility: true,
       suppressHealthErrors: true,
@@ -75,11 +75,30 @@ describe("runStatusJsonCommand", () => {
       built: true,
       input: {
         scan,
-        opts: { deep: true, usage: true, timeoutMs: 1234, all: true },
+        opts: { deep: true, usage: true, agent: "beta", timeoutMs: 1234, all: true },
         includeSecurityAudit: true,
         includePluginCompatibility: true,
         suppressHealthErrors: true,
       },
     });
+  });
+
+  it("rejects --agent when usage is not requested", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as never;
+    const scanStatusJsonFast = vi.fn();
+
+    await expect(
+      runStatusJsonCommand({
+        opts: { agent: "beta" },
+        runtime,
+        scanStatusJsonFast,
+        includeSecurityAudit: false,
+      }),
+    ).rejects.toThrow("--agent is only valid with --usage");
+    expect(scanStatusJsonFast).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/status-json-command.ts
+++ b/src/commands/status-json-command.ts
@@ -7,9 +7,17 @@ import { resolveStatusJsonOutput } from "./status-json-runtime.ts";
 type StatusJsonCommandOptions = {
   deep?: boolean;
   usage?: boolean;
+  agent?: string;
   timeoutMs?: number;
   all?: boolean;
 };
+
+/** Prevents --agent from implying that the aggregate status report itself is agent-scoped. */
+export function assertStatusUsageAgentScope(opts: StatusJsonCommandOptions): void {
+  if (opts.agent !== undefined && opts.usage !== true) {
+    throw new Error("--agent is only valid with --usage");
+  }
+}
 
 /** Runs the fast status scan, resolves optional deep fields, and writes JSON through the runtime. */
 export async function runStatusJsonCommand(params: {
@@ -23,6 +31,7 @@ export async function runStatusJsonCommand(params: {
     runtime: RuntimeEnv,
   ) => Promise<Parameters<typeof resolveStatusJsonOutput>[0]["scan"]>;
 }) {
+  assertStatusUsageAgentScope(params.opts);
   const scan = await params.scanStatusJsonFast(
     { timeoutMs: params.opts.timeoutMs, all: params.opts.all },
     params.runtime,

--- a/src/commands/status-json-runtime.test.ts
+++ b/src/commands/status-json-runtime.test.ts
@@ -89,7 +89,7 @@ describe("status-json-runtime", () => {
     const scan = createScan();
     const result = await resolveStatusJsonOutput({
       scan,
-      opts: { deep: true, usage: true, timeoutMs: 1234 },
+      opts: { deep: true, usage: true, agent: "beta", timeoutMs: 1234 },
       includeSecurityAudit: true,
       includePluginCompatibility: true,
     });
@@ -98,6 +98,7 @@ describe("status-json-runtime", () => {
       config: { update: { channel: "stable" }, gateway: {} },
       sourceConfig: { gateway: {} },
       timeoutMs: 1234,
+      agentId: "beta",
       usage: true,
       deep: true,
       gatewayReachable: true,

--- a/src/commands/status-json-runtime.ts
+++ b/src/commands/status-json-runtime.ts
@@ -59,6 +59,7 @@ export async function resolveStatusJsonOutput(params: {
   opts: {
     deep?: boolean;
     usage?: boolean;
+    agent?: string;
     timeoutMs?: number;
   };
   includeSecurityAudit: boolean;
@@ -71,6 +72,7 @@ export async function resolveStatusJsonOutput(params: {
       config: scan.cfg,
       sourceConfig: scan.sourceConfig,
       timeoutMs: opts.timeoutMs,
+      ...(opts.agent ? { agentId: opts.agent } : {}),
       usage: opts.usage,
       deep: opts.deep,
       gatewayReachable: scan.gatewayReachable,

--- a/src/commands/status-json.ts
+++ b/src/commands/status-json.ts
@@ -10,6 +10,7 @@ export async function statusJsonCommand(
   opts: {
     deep?: boolean;
     usage?: boolean;
+    agent?: string;
     timeoutMs?: number;
     all?: boolean;
   },

--- a/src/commands/status-runtime-shared.test.ts
+++ b/src/commands/status-runtime-shared.test.ts
@@ -362,6 +362,45 @@ describe("status-runtime-shared", () => {
     });
   });
 
+  it("resolves usage auth from an explicitly selected agent", async () => {
+    const config = {
+      agents: {
+        ownership: "explicit" as const,
+        entries: {
+          alpha: { agentDir: "/tmp/alpha-agent" },
+          beta: { agentDir: "/tmp/beta-agent" },
+        },
+      },
+    };
+
+    await resolveStatusUsageSummary({
+      timeoutMs: 2345,
+      config,
+      agentId: "beta",
+    });
+
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledWith({
+      timeoutMs: 2345,
+      config,
+      agentDir: "/tmp/beta-agent",
+    });
+  });
+
+  it("rejects an unknown explicit usage owner", async () => {
+    await expect(
+      resolveStatusUsageSummary({
+        config: {
+          agents: {
+            ownership: "explicit",
+            entries: { alpha: {}, beta: {} },
+          },
+        },
+        agentId: "ghost",
+      }),
+    ).rejects.toThrow('Unknown agent id "ghost"');
+    expect(mocks.loadProviderUsageSummary).not.toHaveBeenCalled();
+  });
+
   it("resolves gateway health with the shared probe call shape", async () => {
     await resolveStatusGatewayHealth({
       config: { gateway: {} },
@@ -459,6 +498,25 @@ describe("status-runtime-shared", () => {
       includeChannelSecurity: true,
       loadPluginSecurityCollectors: false,
       plugins: [{ id: "telegram" }],
+    });
+  });
+
+  it("threads the selected agent into usage resolution", async () => {
+    const resolveUsage = vi.fn(async () => ({ updatedAt: 1, providers: [] }));
+
+    await resolveStatusRuntimeSnapshot({
+      config: { gateway: {} },
+      sourceConfig: { gateway: {} },
+      agentId: "beta",
+      usage: true,
+      gatewayReachable: false,
+      resolveUsage,
+    });
+
+    expect(resolveUsage).toHaveBeenCalledWith({
+      config: { gateway: {} },
+      agentId: "beta",
+      timeoutMs: undefined,
     });
   });
 

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -1,7 +1,10 @@
 // Shared runtime probes used by status text and JSON commands.
 // Heavy modules stay lazily loaded so fast status output avoids security/provider/gateway costs.
 
-import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
+import {
+  listAgentIds,
+  resolveSystemAgentTargetAgentId,
+} from "../agents/agent-scope-config.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
@@ -9,6 +12,7 @@ import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../agents/openai-routing.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import {
   buildCodexSyntheticUsageAuth,
@@ -56,9 +60,9 @@ function shouldUseConfiguredCodexSyntheticUsage(params: {
   });
   const policy = resolveAgentHarnessPolicy({
     config: params.config,
+    agentId: params.agentId,
     provider: configuredDefault.provider,
     modelId: configuredDefault.model,
-    agentId: params.agentId,
   });
   if (
     !shouldUseCodexSyntheticUsageForRuntime({
@@ -119,20 +123,34 @@ type StatusUsageSummaryOptions = {
 /** Loads provider usage for status output from an explicit or ambient system-agent scope. */
 export async function resolveStatusUsageSummary(params: StatusUsageSummaryOptions) {
   const { loadProviderUsageSummary } = await loadProviderUsage();
-  let agentId = params.agentId
-    ? resolveSystemAgentTargetAgentId(params.config, params.agentId)
-    : undefined;
+  const rawAgentId = params.agentId?.trim();
+  if (params.agentId !== undefined && !rawAgentId) {
+    throw new Error("--agent must not be blank");
+  }
+  const agentId = rawAgentId ? normalizeAgentId(rawAgentId) : undefined;
+  if (agentId && !listAgentIds(params.config).includes(agentId)) {
+    throw new Error(
+      `Unknown agent id "${agentId}". Run \`openclaw agents list\` to see configured agents.`,
+    );
+  }
+  let resolvedAgentId = agentId;
   let agentDir = params.agentDir;
   if (!agentDir) {
-    agentId ??= resolveSystemAgentTargetAgentId(params.config);
-    agentDir = resolveAgentDir(params.config, agentId);
+    resolvedAgentId ??= resolveSystemAgentTargetAgentId(params.config);
+    agentDir = resolveAgentDir(params.config, resolvedAgentId);
   }
   const usage = await loadProviderUsageSummary({
     timeoutMs: params.timeoutMs,
     config: params.config,
     agentDir,
   });
-  if (!shouldUseConfiguredCodexSyntheticUsage({ config: params.config, agentDir, agentId })) {
+  if (
+    !shouldUseConfiguredCodexSyntheticUsage({
+      config: params.config,
+      agentDir,
+      agentId: resolvedAgentId,
+    })
+  ) {
     return usage;
   }
   const codexUsage = await loadProviderUsageSummary({
@@ -258,6 +276,7 @@ type StatusSecurityAudit = Awaited<ReturnType<typeof resolveStatusSecurityAudit>
 async function resolveStatusRuntimeDetails(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
+  agentId?: string;
   usage?: boolean;
   deep?: boolean;
   gatewayReachable: boolean;
@@ -274,6 +293,7 @@ async function resolveStatusRuntimeDetails(params: {
     ? await resolveUsageSummary({
         timeoutMs: params.timeoutMs,
         config: params.config,
+        ...(params.agentId ? { agentId: params.agentId } : {}),
       })
     : undefined;
   // JSON status remains nonthrowing, but requested probe failures must stay visible.
@@ -318,6 +338,7 @@ export async function resolveStatusRuntimeSnapshot(params: {
   config: OpenClawConfig;
   sourceConfig: OpenClawConfig;
   timeoutMs?: number;
+  agentId?: string;
   usage?: boolean;
   deep?: boolean;
   gatewayReachable: boolean;
@@ -344,6 +365,7 @@ export async function resolveStatusRuntimeSnapshot(params: {
   const runtimeDetails = await resolveStatusRuntimeDetails({
     config: params.config,
     timeoutMs: params.timeoutMs,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     usage: params.usage,
     deep: params.deep,
     gatewayReachable: params.gatewayReachable,

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -1,10 +1,7 @@
 // Shared runtime probes used by status text and JSON commands.
 // Heavy modules stay lazily loaded so fast status output avoids security/provider/gateway costs.
 
-import {
-  listAgentIds,
-  resolveSystemAgentTargetAgentId,
-} from "../agents/agent-scope-config.js";
+import { listAgentIds, resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";

--- a/src/commands/status.agent-local.test.ts
+++ b/src/commands/status.agent-local.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAgentLocalStatuses } from "./status.agent-local.js";
+
+const mocks = vi.hoisted(() => ({
+  listGatewayAgentsBasic: vi.fn(),
+}));
+
+vi.mock("../gateway/agent-list.js", () => ({
+  listGatewayAgentsBasic: mocks.listGatewayAgentsBasic,
+}));
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) => `/tmp/${agentId}`,
+}));
+vi.mock("../config/sessions/paths.js", () => ({
+  resolveSessionStorePathCore: (_store: unknown, scope: { agentId: string }) =>
+    `/tmp/${scope.agentId}/sessions.json`,
+}));
+vi.mock("../config/sessions/session-accessor.js", () => ({
+  listSessionEntriesReadOnly: () => [],
+}));
+vi.mock("../infra/fs-safe.js", () => ({ pathExists: async () => false }));
+
+describe("getAgentLocalStatuses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not project the gateway's compatibility id as an explicit fleet default", async () => {
+    mocks.listGatewayAgentsBasic.mockReturnValue({
+      defaultId: "alpha",
+      ownership: "explicit",
+      selectionRequired: true,
+      agents: [{ id: "alpha" }, { id: "beta" }],
+    });
+
+    await expect(getAgentLocalStatuses({})).resolves.toMatchObject({
+      defaultId: null,
+      ownership: "explicit",
+      selectionRequired: true,
+      agents: [{ id: "alpha" }, { id: "beta" }],
+    });
+  });
+
+  it("preserves a resolved sole owner", async () => {
+    mocks.listGatewayAgentsBasic.mockReturnValue({
+      defaultId: "alpha",
+      ownership: "sole",
+      selectionRequired: false,
+      agents: [{ id: "alpha" }],
+    });
+
+    await expect(getAgentLocalStatuses({})).resolves.toMatchObject({
+      defaultId: "alpha",
+      ownership: "sole",
+      selectionRequired: false,
+    });
+  });
+});

--- a/src/commands/status.agent-local.ts
+++ b/src/commands/status.agent-local.ts
@@ -6,7 +6,7 @@ import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
+import { listGatewayAgentsBasic, type GatewayAgentOwnership } from "../gateway/agent-list.js";
 import { pathExists } from "../infra/fs-safe.js";
 
 export type AgentLocalStatus = {
@@ -21,7 +21,9 @@ export type AgentLocalStatus = {
 };
 
 type AgentLocalStatusesResult = {
-  defaultId: string;
+  defaultId: string | null;
+  ownership: GatewayAgentOwnership;
+  selectionRequired: boolean;
   agents: AgentLocalStatus[];
   totalSessions: number;
   bootstrapPendingCount: number;
@@ -74,7 +76,11 @@ export async function getAgentLocalStatuses(
   const totalSessions = statuses.reduce((sum, s) => sum + s.sessionsCount, 0);
   const bootstrapPendingCount = statuses.reduce((sum, s) => sum + (s.bootstrapPending ? 1 : 0), 0);
   return {
-    defaultId: agentList.defaultId,
+    // The gateway keeps a projected first id for wire compatibility. Local status must
+    // preserve the selection state so read-only consumers never treat that id as an owner.
+    defaultId: agentList.selectionRequired ? null : agentList.defaultId,
+    ownership: agentList.ownership ?? (agentList.selectionRequired === true ? "explicit" : "sole"),
+    selectionRequired: agentList.selectionRequired === true,
     agents: statuses,
     totalSessions,
     bootstrapPendingCount,

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { HealthSummary } from "./health.js";
 import {
   buildStatusFooterLines,
+  buildStatusAgentsValue,
   buildStatusHealthRows,
   buildStatusHeartbeatValue,
   buildStatusModelSelectionLines,
@@ -16,6 +17,39 @@ import {
 } from "./status.command-sections.ts";
 
 describe("status.command-sections", () => {
+  it("does not label an arbitrary agent as the default in an explicit fleet", () => {
+    expect(
+      buildStatusAgentsValue({
+        agentStatus: {
+          defaultId: null,
+          bootstrapPendingCount: 0,
+          totalSessions: 0,
+          agents: [
+            {
+              id: "alpha",
+              workspaceDir: "/tmp/alpha",
+              bootstrapPending: false,
+              sessionsPath: "/tmp/alpha/sessions.json",
+              sessionsCount: 0,
+              lastUpdatedAt: null,
+              lastActiveAgeMs: null,
+            },
+            {
+              id: "beta",
+              workspaceDir: "/tmp/beta",
+              bootstrapPending: false,
+              sessionsPath: "/tmp/beta/sessions.json",
+              sessionsCount: 0,
+              lastUpdatedAt: null,
+              lastActiveAgeMs: null,
+            },
+          ],
+        },
+        formatTimeAgo: () => "now",
+      }),
+    ).toBe("2 · no workspaces bootstrapping · sessions 0");
+  });
+
   it("shows when heartbeat is waiting for a delivery route", () => {
     expect(
       buildStatusHeartbeatValue({

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -13,7 +13,7 @@ import { OPENCLAW_WRAPPER_ENV_KEY } from "../daemon/program-args.js";
 import { readRestartSentinel } from "../infra/restart-sentinel.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
-import { runStatusJsonCommand } from "./status-json-command.ts";
+import { assertStatusUsageAgentScope, runStatusJsonCommand } from "./status-json-command.ts";
 import { buildStatusOverviewSurfaceFromScan } from "./status-overview-surface.ts";
 import {
   loadStatusProviderUsageModule,
@@ -103,12 +103,14 @@ export async function statusCommand(
     json?: boolean;
     deep?: boolean;
     usage?: boolean;
+    agent?: string;
     timeoutMs?: number;
     verbose?: boolean;
     all?: boolean;
   },
   runtime: RuntimeEnv,
 ) {
+  assertStatusUsageAgentScope(opts);
   if (opts.all && !opts.json) {
     // Human `--all` has a dedicated report path; JSON `--all` stays on the JSON schema.
     await statusAllModuleLoader
@@ -179,6 +181,7 @@ export async function statusCommand(
     config: scan.cfg,
     sourceConfig: scan.sourceConfig,
     timeoutMs: opts.timeoutMs,
+    ...(opts.agent ? { agentId: opts.agent } : {}),
     usage: opts.usage,
     deep: opts.deep,
     gatewayReachable,

--- a/src/commands/status.scan-memory.test.ts
+++ b/src/commands/status.scan-memory.test.ts
@@ -22,6 +22,8 @@ vi.mock("./status.scan.shared.js", () => ({
 function createMainAgentStatus() {
   return {
     defaultId: "main",
+    ownership: "sole" as const,
+    selectionRequired: false,
     totalSessions: 0,
     bootstrapPendingCount: 0,
     agents: [

--- a/src/commands/status.scan-result.test.ts
+++ b/src/commands/status.scan-result.test.ts
@@ -66,6 +66,8 @@ describe("buildStatusScanResult", () => {
     ];
     const agentStatus = {
       defaultId: "main",
+      ownership: "sole" as const,
+      selectionRequired: false,
       totalSessions: 0,
       bootstrapPendingCount: 0,
       agents: [

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -551,6 +551,29 @@ describe("buildTailscaleHttpsUrl", () => {
 });
 
 describe("resolveSharedMemoryStatusSnapshot", () => {
+  it("skips agent-scoped memory when an explicit fleet has no selected owner", async () => {
+    const resolveMemoryConfig = vi.fn();
+    const getMemorySearchManager = vi.fn();
+
+    await expect(
+      resolveSharedMemoryStatusSnapshot({
+        cfg: {
+          agents: {
+            ownership: "explicit",
+            entries: { alpha: {}, beta: {} },
+          },
+        },
+        agentStatus: { defaultId: null },
+        memoryPlugin: { enabled: true, slot: "memory-core" },
+        resolveMemoryConfig,
+        getMemorySearchManager,
+      }),
+    ).resolves.toBeNull();
+
+    expect(resolveMemoryConfig).not.toHaveBeenCalled();
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "top-level defaults",

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -396,7 +396,12 @@ export async function resolveSharedMemoryStatusSnapshot(params: {
   if (!memoryPlugin.enabled || !memoryPlugin.slot) {
     return null;
   }
-  const agentId = agentStatus.defaultId ?? "main";
+  const agentId = agentStatus.defaultId;
+  if (!agentId) {
+    // Memory is agent-scoped. An explicit fleet has no default owner, so status must not
+    // inspect an arbitrary first agent's database merely to populate a read-only summary.
+    return null;
+  }
 
   if (memoryPlugin.slot !== defaultSlotIdForKey("memory")) {
     // Non-default memory slots are plugin-owned; ask the manager directly instead of checking built-in files.

--- a/src/plugins/control-plane-workspace.test.ts
+++ b/src/plugins/control-plane-workspace.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolvePluginControlPlaneWorkspace } from "./control-plane-workspace.js";
+
+describe("resolvePluginControlPlaneWorkspace", () => {
+  it("omits workspace scope for an ownerless explicit fleet", () => {
+    expect(
+      resolvePluginControlPlaneWorkspace({
+        config: {
+          agents: {
+            ownership: "explicit",
+            entries: { alpha: {}, beta: {} },
+          },
+        },
+        env: { OPENCLAW_STATE_DIR: "/tmp/openclaw-control-plane" },
+      }),
+    ).toMatchObject({
+      workspaceScope: "omitted",
+      diagnostic: { code: "workspace-scope-omitted" },
+    });
+  });
+
+  it("uses the configured system agent for control-plane workspace enrichment", () => {
+    expect(
+      resolvePluginControlPlaneWorkspace({
+        config: {
+          agents: {
+            ownership: "explicit",
+            defaults: { systemAgent: { agentId: "beta" } },
+            entries: {
+              alpha: { workspace: "/tmp/alpha" },
+              beta: { workspace: "/tmp/beta" },
+            },
+          },
+        },
+        env: {},
+      }),
+    ).toEqual({
+      agentId: "beta",
+      workspaceDir: "/tmp/beta",
+      workspaceScope: "selected",
+    });
+  });
+});

--- a/src/plugins/control-plane-workspace.ts
+++ b/src/plugins/control-plane-workspace.ts
@@ -10,6 +10,7 @@ import type { PluginDiagnostic } from "./manifest-types.js";
 const PLUGIN_WORKSPACE_SCOPE_OMITTED_DIAGNOSTIC_CODE = "workspace-scope-omitted" as const;
 
 type PluginControlPlaneWorkspaceResolution = {
+  agentId?: string;
   workspaceDir?: string;
   workspaceScope: "selected" | "omitted";
   diagnostic?: PluginDiagnostic;
@@ -35,6 +36,7 @@ export function resolvePluginControlPlaneWorkspace(params: {
     : undefined;
   if (workspaceDir) {
     return {
+      agentId,
       workspaceDir,
       workspaceScope: "selected",
     };

--- a/src/security/audit-rosterless.test.ts
+++ b/src/security/audit-rosterless.test.ts
@@ -104,4 +104,51 @@ describe("security audit rosterless configs", () => {
       );
     },
   );
+
+  it("accepts an explicit multi-agent roster without a legacy default marker", async () => {
+    const { stateDir, workspaceDir } = makeAuditPaths("explicit-roster");
+    const report = await runSecurityAuditCore({
+      config: {
+        agents: {
+          ownership: "explicit",
+          entries: { alpha: {}, beta: {} },
+        },
+      } as never,
+      stateDir,
+      configPath: path.join(stateDir, "openclaw.json"),
+      workspaceDir,
+      env: {},
+      includeFilesystem: true,
+      includeChannelSecurity: false,
+    });
+
+    expect(report.findings).not.toContainEqual(
+      expect.objectContaining({ checkId: "config.agent_roster.invalid_default_count" }),
+    );
+  });
+
+  it("still reports a legacy default marker on an explicit roster", async () => {
+    const { stateDir, workspaceDir } = makeAuditPaths("explicit-roster-with-default");
+    const report = await runSecurityAuditCore({
+      config: {
+        agents: {
+          ownership: "explicit",
+          entries: { alpha: { default: true }, beta: {} },
+        },
+      } as never,
+      stateDir,
+      configPath: path.join(stateDir, "openclaw.json"),
+      workspaceDir,
+      env: {},
+      includeFilesystem: true,
+      includeChannelSecurity: false,
+    });
+
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        checkId: "config.agent_roster.invalid_default_count",
+        detail: expect.stringContaining("Expected no"),
+      }),
+    );
+  });
 });

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -956,7 +956,8 @@ function collectAgentRosterFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
     return [];
   }
   const defaultCount = agents.filter((agent) => agent?.default === true).length;
-  if (defaultCount === 1) {
+  const expectedDefaultCount = cfg.agents?.ownership === "explicit" ? 0 : 1;
+  if (defaultCount === expectedDefaultCount) {
     return [];
   }
   return [
@@ -964,7 +965,10 @@ function collectAgentRosterFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
       checkId: "config.agent_roster.invalid_default_count",
       severity: "warn",
       title: "Agent roster has an invalid default selection",
-      detail: `Expected exactly one agents.entries default=true entry, found ${defaultCount}.`,
+      detail:
+        expectedDefaultCount === 0
+          ? `Expected no agents.entries default=true entries with agents.ownership=explicit, found ${defaultCount}.`
+          : `Expected exactly one agents.entries default=true entry, found ${defaultCount}.`,
       remediation: "Run `openclaw doctor --fix` to repair the authored agent roster.",
     },
   ];


### PR DESCRIPTION
## What Problem This Solves

Fixes the remaining explicit multi-agent status ownership leaks after #123826 repaired channel inventory and the ambient usage owner. Local status still published the Gateway's compatibility first-agent `defaultId` as authority, so human status mislabeled it as default, JSON/full status inspected that agent's memory, and `status --all` read the first workspace's skills. Plain health hid every agent when the fleet had no default, while the security audit incorrectly warned that an explicit roster needed a legacy `default=true` marker.

`openclaw status --usage` could use the configured system agent after #123826, but operators still had no command-line selector for inspecting another agent's auth profiles and runtime policy.

## Why This Change Was Made

The repair preserves `ownership` and `selectionRequired` in local status instead of treating the Gateway compatibility projection as authority. Agent-scoped memory and workspace-skill probes skip an ownerless fleet; workspace skills use the configured system agent when present. Plain health shows every configured agent when no default exists, and the security audit correctly expects zero legacy markers under `agents.ownership: "explicit"`.

Usage now accepts and validates `--agent <id>` while preserving #123826's ambient `agents.defaults.systemAgent.agentId` behavior when the flag is omitted. The already-landed channel inventory implementation from #123826 is retained unchanged.

## User Impact

Operators can run status, deep status, full diagnosis, and health on explicit fleets without silently inspecting or labeling the first agent. Usage snapshots can target a specific agent with `openclaw status --usage --agent <id>`, and healthy explicit rosters no longer produce a stale default-marker warning.

## Evidence

- Exact reconciled code head `c67a88401f879cf3881d083b011f134c8cdece97` passed 279 focused tests across unit-fast, unit, CLI, commands-light, and commands lanes in [Blacksmith Testbox run 31842103287](https://github.com/openclaw/openclaw/actions/runs/31842103287). Current head `f0601a59a85d6be4d6175b466a871c4ae5758545` only applies the formatter's one-line import layout.
- Full repository formatting and core typecheck passed on the reconciled tree; `git diff --check` is clean.
- The final post-reconciliation structured Codex autoreview reported no accepted/actionable findings with confidence 0.98.
- Production LOC: +86/-25 (net +61), justified by the explicit usage selector and carrying canonical ownership facts through status consumers. Tests: +434/-10. Docs: +5/-2. Release-note context stays in this PR body because `CHANGELOG.md` is release-owned.

Provenance: #114388 made multi-agent ownership explicit and exposed older read-only consumers that treated projected first/default ids as authority. #123826 landed the channel and ambient-usage subset while this PR was in flight; this branch was rebased onto that fix and deliberately drops its duplicate channel implementation.

Separate follow-ups remain for `models --agent list`, `sandbox explain --agent`, and `hooks list|info|check`, which use different command-specific owner-selection paths.
