### PR TITLE
fix: compaction accepts slash-delimited prose

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -146,11 +146,11 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 
 /** Extracts likely exact identifiers that summaries should preserve literally. */
 export function extractOpaqueIdentifiers(text: string): string[] {
-  // Host/port candidates start at token boundaries so a long non-identifier
-  // does not retry the greedy branch at every character.
+  // Path and host/port candidates start at token boundaries so prose such as
+  // "typecheck/lint/format" is not mistaken for an absolute path.
   const matches =
     text.match(
-      /([A-Fa-f0-9]{8,}|https?:\/\/\S+|\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|\b\d{6,}\b)/g,
+      /([A-Fa-f0-9]{8,}|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|\b\d{6,}\b)/g,
     ) ?? [];
   return uniqueStrings(
     matches

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1170,7 +1170,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("filters ordinary short numbers and trims wrapped punctuation", () => {
     const identifiers = extractOpaqueIdentifiers(
-      "Year 2026 count 42 port 18789 ticket 123456 URL https://example.com/a, path /tmp/x.log, and tiny /a with prose on/off.",
+      "Year 2026 count 42 port 18789 ticket 123456 URL https://example.com/a, path /tmp/x.log, and tiny /a with prose on/off plus typecheck/lint/format.",
     );
 
     expect(identifiers).not.toContain("2026");
@@ -1178,6 +1178,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiers).not.toContain("18789");
     expect(identifiers).not.toContain("/a");
     expect(identifiers).not.toContain("/off");
+    expect(identifiers).not.toContain("/lint/format");
     expect(identifiers).toContain("123456");
     expect(identifiers).toContain("https://example.com/a");
     expect(identifiers).toContain("/tmp/x.log");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users compacting a conversation could have every summary rejected as missing an identifier when recent prose contained slash-delimited terms such as `typecheck/lint/format`.

## Why This Change Was Made

The compaction safeguard now requires absolute POSIX path candidates to start at a token boundary. This prevents path matching from restarting inside ordinary words while preserving genuine paths such as `/tmp/x.log`.

The false positive was carried forward by the identifier-regex hardening in #118422; this change applies the same token-boundary discipline already used by host/port candidates.

## User Impact

Conversations containing slash-delimited prose can compact normally without weakening identifier preservation for real paths, URLs, numeric IDs, or opaque identifiers.

## Evidence

- Live local Gateway proof: the previously failing conversation compacted successfully with this worktree loaded.
- Regression test reproduced `"/lint/format"` on the pre-fix code and excludes it after the fix.
- Full focused safeguard run: 250 tests passed.
- Scoped formatting, lint, and `git diff --check` passed.
- Production LOC: +3/-3 (net 0); tests: +2/-1.
- `autoreview --mode branch --base origin/main`: clean with Codex `gpt-5.6-sol`, high reasoning; no accepted/actionable findings.
