### PR TITLE
improve: make git installs use a blobless clone

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2874,7 +2874,7 @@ install_openclaw_from_git() {
     validate_git_checkout_head "$repo_dir" || return 1
     if [[ ! -d "$repo_dir" ]]; then
         mkdir -p "$(dirname "$repo_dir")"
-        run_quiet_step "Cloning OpenClaw" git clone "$repo_url" "$repo_dir"
+        run_quiet_step "Cloning OpenClaw" git clone --filter=blob:none "$repo_url" "$repo_dir" # Git warns and falls back if filtering is unsupported.
     fi
 
     local git_ref

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2874,7 +2874,11 @@ install_openclaw_from_git() {
     validate_git_checkout_head "$repo_dir" || return 1
     if [[ ! -d "$repo_dir" ]]; then
         mkdir -p "$(dirname "$repo_dir")"
-        run_quiet_step "Cloning OpenClaw" git clone --filter=blob:none "$repo_url" "$repo_dir" # Git warns and falls back if filtering is unsupported.
+        # Blobless clone: the installer checks out one release tag, so full blob
+        # history is downloaded and then discarded. blob:none keeps ref metadata
+        # (unlike --depth 1) so ref switching and later updates still work, and
+        # git warns and falls back to a full clone if the server cannot filter.
+        run_quiet_step "Cloning OpenClaw" git clone --filter=blob:none "$repo_url" "$repo_dir"
     fi
 
     local git_ref

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1017,9 +1017,9 @@ NODE
     const output = result?.stdout ?? "";
     expect(output).toContain(`git=${join(openclawHome, "openclaw")}`);
     const mkdirParentIndex = script.indexOf('mkdir -p "$(dirname "$repo_dir")"');
-    const cloneIndex = script.indexOf(
-      'run_quiet_step "Cloning OpenClaw" git clone --filter=blob:none "$repo_url" "$repo_dir"',
-    );
+    // Ordering only. The clone flags are asserted behaviorally below, so this
+    // needle stays short enough to survive future changes to them.
+    const cloneIndex = script.indexOf('run_quiet_step "Cloning OpenClaw" git clone');
     expect(mkdirParentIndex).toBeGreaterThan(-1);
     expect(cloneIndex).toBeGreaterThan(-1);
     expect(mkdirParentIndex).toBeLessThan(cloneIndex);

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1018,11 +1018,44 @@ NODE
     expect(output).toContain(`git=${join(openclawHome, "openclaw")}`);
     const mkdirParentIndex = script.indexOf('mkdir -p "$(dirname "$repo_dir")"');
     const cloneIndex = script.indexOf(
-      'run_quiet_step "Cloning OpenClaw" git clone "$repo_url" "$repo_dir"',
+      'run_quiet_step "Cloning OpenClaw" git clone --filter=blob:none "$repo_url" "$repo_dir"',
     );
     expect(mkdirParentIndex).toBeGreaterThan(-1);
     expect(cloneIndex).toBeGreaterThan(-1);
     expect(mkdirParentIndex).toBeLessThan(cloneIndex);
+  });
+
+  it("uses a blobless partial clone for new git installs", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      repo="$HOME/openclaw"
+      check_git() { return 0; }
+      ensure_pnpm() { :; }
+      ensure_pnpm_binary_for_scripts() { :; }
+      resolve_git_openclaw_ref() { printf 'main\\n'; }
+      checkout_git_openclaw_ref() { :; }
+      cleanup_legacy_submodules() { :; }
+      activate_repo_pnpm_version() { :; }
+      git_install_lockfile_flag() { printf '%s\\n' '--frozen-lockfile'; }
+      run_quiet_step() {
+        printf 'step:%s|%s\\n' "$1" "\${*:2}"
+        [[ "$1" == "Cloning OpenClaw" ]] && mkdir -p "$repo"
+        return 0
+      }
+      ensure_user_local_bin_on_path() { mkdir -p "$HOME/.local/bin"; }
+      ui_info() { :; }
+      ui_success() { :; }
+      ui_error() { printf 'error:%s\\n' "$*"; }
+      git() { return 0; }
+
+      install_openclaw_from_git "$repo"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "step:Cloning OpenClaw|git clone --filter=blob:none https://github.com/openclaw/openclaw.git",
+    );
   });
 
   it("does not treat OS HOME config as active when OPENCLAW_HOME is set", () => {


### PR DESCRIPTION
Closes #123823

## What Problem This Solves

Fixes an issue where users choosing the homepage-advertised Git install method downloaded the repository's complete blob history before checking out one release tag. In a clean Ubuntu 24.04 container, the clone took 689.08 seconds and occupied 2.8 GB after checking out `v2026.7.1-2`, before dependency installation or builds began.

## Why This Change Was Made

New Git installs now clone with `--filter=blob:none`, retaining refs and commit metadata while deferring historical file blobs. This preserves tag switching, `--version main`, version derivation, and normal fetch/pull updates; unlike `--depth 1`, it does not make the repository shallow. Git itself warns and continues with a full clone when a server does not support filtering, so the installer does not add a duplicate retry path.

## User Impact

Git-method installs use substantially less bandwidth, disk, and wall-clock time while remaining ordinary updatable Git checkouts. In the same clean Ubuntu 24.04 measurement, the blobless clone took 77.87 seconds and occupied 641 MB after checking out the same tag and commit—a 9x faster clone and roughly 77% less disk.

## Evidence

- Clean `ubuntu:24.04`, Git 2.43.0, direct clone-step comparison using the installer's exact old/new clone flags:
  - Before: `git clone ...` — 689.08s, 2.8G after checkout; `v2026.7.1-2` at `0790d9f593ad`.
  - After: `git clone --filter=blob:none ...` — 77.87s, 641M after checkout; the same tag and commit; `remote.origin.promisor=true`.
- Actual installer run, stopped intentionally when a stubbed dependency command failed after checkout:
  - Tag: `Using git ref: v2026.7.1-2` → `Fetching requested version` → `Checking out v2026.7.1-2`.
  - Subsequent update on the same partial clone: `Using git ref: main` → `Fetching requested version` → `Checking out main` → `Updating repository`; final branch `main`, with `remote.origin.promisor=true`.
- Unsupported-server contract: Git v2.43.0 documents `--filter=blob:none` in [`Documentation/git-clone.txt` lines 180–188](https://github.com/git/git/blob/v2.43.0/Documentation/git-clone.txt#L180-L188), and [`fetch-pack.c` lines 1179–1184](https://github.com/git/git/blob/v2.43.0/fetch-pack.c#L1179-L1184) warns `filtering not recognized by server, ignoring` rather than failing. A local non-filter-capable upload-pack probe exited 0 with that warning.
- `node scripts/run-vitest.mjs test/scripts/install-sh.test.ts` — 90/90 passed.
- `bash -n scripts/install.sh` — passed.
- `shellcheck -e SC1091 scripts/install.sh scripts/install-cli.sh` — passed.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.

AI-assisted implementation; the behavior and dependency contract were independently exercised with the commands above.
