### PR TITLE
test(plugins): remove duplicate policy reevaluation case

### DIFF
--- a/src/plugins/install-security-scan.runtime.test.ts
+++ b/src/plugins/install-security-scan.runtime.test.ts
@@ -425,25 +425,6 @@ describe("legacy file install scan compatibility", () => {
     expect(runInstallPolicyMock).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps a block from policy re-evaluation terminal", async () => {
-    runInstallPolicyMock
-      .mockResolvedValueOnce({
-        warning: { reason: "review this plugin", fingerprint: "warning-a" },
-      })
-      .mockResolvedValueOnce({
-        blocked: { code: "security_scan_blocked", reason: "now blocked" },
-      });
-
-    const result = await scanFileInstallSourceRuntime({
-      filePath: "/tmp/payload.js",
-      logger: {},
-      onInstallPolicyWarning: vi.fn().mockResolvedValue({ status: "approved" }),
-      pluginId: "payload",
-    });
-
-    expect(result?.blocked).toEqual({ code: "security_scan_blocked", reason: "now blocked" });
-  });
-
   it("keeps the deprecated unsafe flag inert when policy warns", async () => {
     runInstallPolicyMock.mockResolvedValue({
       warning: { reason: "review this plugin", fingerprint: "warning-a" },


### PR DESCRIPTION
## What Problem This Solves

`install-security-scan.runtime.test.ts` contained two tests added in the same policy-acknowledgement change that configured the same warning, approved it, returned the same terminal block on re-evaluation, and asserted the same result.

The earlier case was a strict duplicate; the retained case additionally proves the policy owner ran exactly twice.

## Why This Change Was Made

Delete the weaker duplicate and keep the stronger re-evaluation case plus the changed-warning, repeated-approval, aggregate-limit, and terminal-block coverage around it.

Tests: -19 lines. No production or test-support changes.

## User Impact

No user-visible behavior change. Install policy warnings still require acknowledgement, and a block returned by fresh policy re-evaluation remains terminal.

## Evidence

- Focused install-policy owner proof: 1 file, 29 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- src/plugins/install-security-scan.runtime.test.ts` passed the coreTests gates locally, including test typecheck, lint, dead-export scans, formatting, environment budget, max-lines ratchet, and architecture guards.
- The changed-gate wrapper first attempted Crabbox/Testbox, but no remote provider was ready; trusted-source policy therefore used the documented local fallback.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Exact-head CI passed for `ce5158c3426a7d952b4c6029bdf0303d1353855b`: https://github.com/openclaw/openclaw/actions/runs/31841216840
