### PR TITLE
fix(anthropic): non-interactive onboarding reads Claude CLI Keychain auth

### DIFF
--- a/extensions/anthropic/cli-auth-seam.test.ts
+++ b/extensions/anthropic/cli-auth-seam.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const { readClaudeCliCredentialsCached } = vi.hoisted(() => ({
+  readClaudeCliCredentialsCached: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  readClaudeCliCredentialsCached,
+}));
+
+const { readClaudeCliCredentialsForRuntime, readClaudeCliCredentialsForSetupNonInteractive } =
+  await import("./cli-auth-seam.js");
+
+beforeEach(() => {
+  readClaudeCliCredentialsCached.mockReset();
+});
+
+it("keeps runtime Claude credential reads on the non-prompting path", () => {
+  readClaudeCliCredentialsForRuntime();
+
+  expect(readClaudeCliCredentialsCached).toHaveBeenCalledWith({ allowKeychainPrompt: false });
+});
+
+it("uses the bounded credential inspector only for non-interactive setup", () => {
+  readClaudeCliCredentialsForSetupNonInteractive();
+
+  expect(readClaudeCliCredentialsCached).toHaveBeenCalledWith(
+    expect.objectContaining({
+      allowKeychainPrompt: false,
+      tryKeychainWithoutPrompt: true,
+      ttlMs: 0,
+      onStoredCredentialUnreadable: expect.any(Function),
+    }),
+  );
+});

--- a/extensions/anthropic/cli-auth-seam.ts
+++ b/extensions/anthropic/cli-auth-seam.ts
@@ -11,7 +11,18 @@ export function readClaudeCliCredentialsForSetup() {
 
 /** Read Claude CLI credentials for setup checks that must not prompt. */
 export function readClaudeCliCredentialsForSetupNonInteractive() {
-  return readClaudeCliCredentialsCached({ allowKeychainPrompt: false });
+  let unreadable = false;
+  const credential = readClaudeCliCredentialsCached({
+    allowKeychainPrompt: false,
+    tryKeychainWithoutPrompt: true,
+    ttlMs: 0,
+    onStoredCredentialUnreadable: () => {
+      unreadable = true;
+    },
+  });
+  return credential
+    ? ({ status: "available", credential } as const)
+    : ({ status: unreadable ? "unreadable" : "missing" } as const);
 }
 
 /** Read Claude CLI credentials for runtime without keychain prompts. */

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -583,11 +583,14 @@ describe("anthropic cli migration", () => {
 
   it("registered non-interactive cli auth keeps anthropic fallbacks and selects claude-cli runtime", async () => {
     readClaudeCliCredentialsForSetupNonInteractive.mockReturnValue({
-      type: "oauth",
-      provider: "anthropic",
-      access: "access-token",
-      refresh: "refresh-token",
-      expires: Date.now() + 60_000,
+      status: "available",
+      credential: {
+        type: "oauth",
+        provider: "anthropic",
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      },
     });
     const method = await resolveAnthropicCliAuthMethod();
     const config = {
@@ -635,7 +638,7 @@ describe("anthropic cli migration", () => {
   });
 
   it("registered non-interactive cli auth reports missing local auth and exits cleanly", async () => {
-    readClaudeCliCredentialsForSetupNonInteractive.mockReturnValue(null);
+    readClaudeCliCredentialsForSetupNonInteractive.mockReturnValue({ status: "missing" });
     const method = await resolveAnthropicCliAuthMethod();
     const ctx = createProviderAuthMethodNonInteractiveContext();
 
@@ -644,6 +647,21 @@ describe("anthropic cli migration", () => {
       [
         'Auth choice "anthropic-cli" requires Claude CLI auth on this host.',
         "Run claude auth login first.",
+      ].join("\n"),
+    );
+    expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("registered non-interactive cli auth reports stored credentials that need interaction", async () => {
+    readClaudeCliCredentialsForSetupNonInteractive.mockReturnValue({ status: "unreadable" });
+    const method = await resolveAnthropicCliAuthMethod();
+    const ctx = createProviderAuthMethodNonInteractiveContext();
+
+    await expect(method.runNonInteractive?.(ctx)).resolves.toBeNull();
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      [
+        'Auth choice "anthropic-cli" found Claude CLI credentials on this host, but they could not be read non-interactively.',
+        "Re-run this command without --non-interactive, or use --auth-choice setup-token / --anthropic-api-key <key>.",
       ].join("\n"),
     );
     expect(ctx.runtime.exit).toHaveBeenCalledWith(1);

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -984,19 +984,24 @@ async function runAnthropicCliMigrationNonInteractive(ctx: {
   runtime: ProviderAuthContext["runtime"];
   agentDir?: string;
 }): Promise<ProviderAuthContext["config"] | null> {
-  const credential = claudeCliAuth.readClaudeCliCredentialsForSetupNonInteractive();
-  if (!credential) {
-    ctx.runtime.error(
-      [
-        'Auth choice "anthropic-cli" requires Claude CLI auth on this host.',
-        `Run ${formatCliCommand("claude auth login")} first.`,
-      ].join("\n"),
-    );
+  const credentialResult = claudeCliAuth.readClaudeCliCredentialsForSetupNonInteractive();
+  if (credentialResult.status !== "available") {
+    const error =
+      credentialResult.status === "unreadable"
+        ? [
+            'Auth choice "anthropic-cli" found Claude CLI credentials on this host, but they could not be read non-interactively.',
+            "Re-run this command without --non-interactive, or use --auth-choice setup-token / --anthropic-api-key <key>.",
+          ]
+        : [
+            'Auth choice "anthropic-cli" requires Claude CLI auth on this host.',
+            `Run ${formatCliCommand("claude auth login")} first.`,
+          ];
+    ctx.runtime.error(error.join("\n"));
     ctx.runtime.exit(1);
     return null;
   }
 
-  const result = buildAnthropicCliMigrationResult(ctx.config, credential);
+  const result = buildAnthropicCliMigrationResult(ctx.config, credentialResult.credential);
   const currentDefaults = ctx.config.agents?.defaults;
   const currentModel = currentDefaults?.model;
   const currentFallbacks =

--- a/src/agents/cli-credentials.claude-keychain.test.ts
+++ b/src/agents/cli-credentials.claude-keychain.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readClaudeCliCredentialsCached } from "./cli-credentials.js";
+
+const execSyncMock = vi.fn();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  execSyncMock.mockReset();
+});
+
+function readNonInteractiveClaudeCredential(platform: NodeJS.Platform) {
+  let unreadable = false;
+  const credential = readClaudeCliCredentialsCached({
+    platform,
+    homeDir: tempDirs.make("openclaw-claude-non-interactive-"),
+    execSync: execSyncMock,
+    allowKeychainPrompt: false,
+    tryKeychainWithoutPrompt: true,
+    ttlMs: 0,
+    onStoredCredentialUnreadable: () => {
+      unreadable = true;
+    },
+  });
+  return { credential, unreadable };
+}
+
+function mockReadableKeychainCredential() {
+  execSyncMock.mockReturnValue(
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "test-access",
+        refreshToken: "test-refresh",
+        expiresAt: Date.now() + 60_000,
+      },
+    }),
+  );
+}
+
+it("reads an already-authorized Claude keychain credential during non-interactive setup", () => {
+  mockReadableKeychainCredential();
+
+  expect(readNonInteractiveClaudeCredential("darwin")).toEqual({
+    credential: expect.objectContaining({
+      type: "oauth",
+      provider: "anthropic",
+      refresh: "test-refresh",
+    }),
+    unreadable: false,
+  });
+  expect(execSyncMock).toHaveBeenCalledWith(
+    expect.stringContaining(" -w"),
+    expect.objectContaining({ timeout: 2_000 }),
+  );
+});
+
+it("reports a present but unreadable Claude keychain credential", () => {
+  execSyncMock.mockImplementation((command: string) => {
+    if (command.includes(" -w")) {
+      throw new Error("User interaction is not allowed");
+    }
+    return "keychain metadata";
+  });
+
+  expect(readNonInteractiveClaudeCredential("darwin")).toEqual({
+    credential: null,
+    unreadable: true,
+  });
+  expect(execSyncMock).toHaveBeenNthCalledWith(
+    2,
+    expect.not.stringContaining(" -w"),
+    expect.objectContaining({ timeout: 2_000 }),
+  );
+});
+
+it("reports missing Claude CLI auth when neither keychain nor file credentials exist", () => {
+  execSyncMock.mockImplementation(() => {
+    throw new Error("item not found");
+  });
+
+  expect(readNonInteractiveClaudeCredential("darwin")).toEqual({
+    credential: null,
+    unreadable: false,
+  });
+  expect(execSyncMock).toHaveBeenCalledTimes(2);
+});
+
+it("keeps non-darwin non-interactive Claude auth on the file path", () => {
+  mockReadableKeychainCredential();
+
+  expect(readNonInteractiveClaudeCredential("linux")).toEqual({
+    credential: null,
+    unreadable: false,
+  });
+  expect(execSyncMock).not.toHaveBeenCalled();
+});

--- a/src/agents/cli-credentials.claude-keychain.ts
+++ b/src/agents/cli-credentials.claude-keychain.ts
@@ -1,0 +1,35 @@
+import { execSync } from "node:child_process";
+
+const CLAUDE_CLI_KEYCHAIN_SERVICE = "Claude Code-credentials";
+export const CLAUDE_CLI_KEYCHAIN_TIMEOUT_MS = 2_000;
+
+type ExecSyncFn = typeof execSync;
+
+export function readClaudeCliKeychainPayload(
+  execSyncImpl: ExecSyncFn = execSync,
+  timeout = 5000,
+): Record<string, unknown> | null {
+  try {
+    const result = execSyncImpl(
+      `security find-generic-password -s "${CLAUDE_CLI_KEYCHAIN_SERVICE}" -w`,
+      { encoding: "utf8", timeout, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const parsed = JSON.parse(result.trim());
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasClaudeCliKeychainItem(execSyncImpl: ExecSyncFn = execSync): boolean {
+  try {
+    execSyncImpl(`security find-generic-password -s "${CLAUDE_CLI_KEYCHAIN_SERVICE}"`, {
+      encoding: "utf8",
+      timeout: CLAUDE_CLI_KEYCHAIN_TIMEOUT_MS,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -363,7 +363,7 @@ describe("cli credentials", () => {
     expect(cliLogin && "email" in cliLogin ? cliLogin.email : undefined).toBeUndefined();
   });
 
-  it("keeps no-prompt Claude reads on the file credential path after a keychain read", () => {
+  it("keeps runtime-style no-prompt Claude reads on the file credential path", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-cache-"));
     vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
     mockClaudeCliCredentialRead();

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -14,6 +14,11 @@ import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { loadJsonFileThroughSymlink } from "../infra/json-file.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { OAuthProvider } from "./auth-profiles/types.js";
+import {
+  CLAUDE_CLI_KEYCHAIN_TIMEOUT_MS,
+  hasClaudeCliKeychainItem,
+  readClaudeCliKeychainPayload,
+} from "./cli-credentials.claude-keychain.js";
 
 const log = createSubsystemLogger("agents/auth-profiles");
 
@@ -24,7 +29,6 @@ const MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH = ".minimax/oauth_creds.json";
 const GEMINI_CLI_CREDENTIALS_RELATIVE_PATH = ".gemini/oauth_creds.json";
 const CODEX_CLI_FALLBACK_EXPIRY_MS = 60 * 60 * 1000;
 
-const CLAUDE_CLI_KEYCHAIN_SERVICE = "Claude Code-credentials";
 type CachedValue<T> = {
   value: T | null;
   readAt: number;
@@ -460,22 +464,6 @@ function readGeminiCliCredentials(options?: { homeDir?: string }): GeminiCliCred
   };
 }
 
-function readClaudeCliKeychainCredentials(
-  execSyncImpl: ExecSyncFn = execSync,
-): ClaudeCliCredential | null {
-  try {
-    const result = execSyncImpl(
-      `security find-generic-password -s "${CLAUDE_CLI_KEYCHAIN_SERVICE}" -w`,
-      { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
-    );
-
-    const data = JSON.parse(result.trim());
-    return parseClaudeCliOauthCredential(data?.claudeAiOauth);
-  } catch {
-    return null;
-  }
-}
-
 function readClaudeCliUserApiKeyHelperCredential(homeDir?: string): ClaudeCliCredential | null {
   const raw = loadJsonFileThroughSymlink(resolveClaudeCliUserSettingsPath(homeDir));
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
@@ -526,6 +514,8 @@ function withClaudeAccountEmail(
 /** Reads Claude CLI credentials in Claude Code's credential precedence order. */
 function readClaudeCliCredentials(options?: {
   allowKeychainPrompt?: boolean;
+  tryKeychainWithoutPrompt?: boolean;
+  onStoredCredentialUnreadable?: () => void;
   platform?: NodeJS.Platform;
   homeDir?: string;
   execSync?: ExecSyncFn;
@@ -536,8 +526,15 @@ function readClaudeCliCredentials(options?: {
   }
 
   const platform = options?.platform ?? process.platform;
-  if (platform === "darwin" && options?.allowKeychainPrompt !== false) {
-    const keychainCreds = readClaudeCliKeychainCredentials(options?.execSync);
+  const tryKeychain =
+    platform === "darwin" &&
+    (options?.allowKeychainPrompt !== false || options?.tryKeychainWithoutPrompt === true);
+  if (tryKeychain) {
+    const keychainPayload = readClaudeCliKeychainPayload(
+      options?.execSync,
+      options?.tryKeychainWithoutPrompt ? CLAUDE_CLI_KEYCHAIN_TIMEOUT_MS : undefined,
+    );
+    const keychainCreds = parseClaudeCliOauthCredential(keychainPayload?.claudeAiOauth);
     if (keychainCreds) {
       log.info("read anthropic credentials from claude cli keychain", {
         type: keychainCreds.type,
@@ -548,31 +545,52 @@ function readClaudeCliCredentials(options?: {
 
   const credPath = resolveClaudeCliCredentialsPath(options?.homeDir);
   const raw = loadJsonFileThroughSymlink(credPath);
-  if (!raw || typeof raw !== "object") {
-    return null;
+  const fileCredential =
+    raw && typeof raw === "object"
+      ? withClaudeAccountEmail(
+          parseClaudeCliOauthCredential((raw as Record<string, unknown>).claudeAiOauth),
+          options?.homeDir,
+        )
+      : null;
+  if (fileCredential) {
+    return fileCredential;
   }
-
-  const data = raw as Record<string, unknown>;
-  return withClaudeAccountEmail(
-    parseClaudeCliOauthCredential(data.claudeAiOauth),
-    options?.homeDir,
-  );
+  if (
+    options?.tryKeychainWithoutPrompt &&
+    (fs.existsSync(credPath) ||
+      (platform === "darwin" && hasClaudeCliKeychainItem(options.execSync)))
+  ) {
+    options.onStoredCredentialUnreadable?.();
+  }
+  return null;
 }
 
-/** @deprecated Anthropic provider-owned CLI credential helper; do not use from third-party plugins. */
-export function readClaudeCliCredentialsCached(options?: {
+type ClaudeCliCredentialReadOptions = {
   allowKeychainPrompt?: boolean;
+  tryKeychainWithoutPrompt?: boolean;
+  onStoredCredentialUnreadable?: () => void;
   ttlMs?: number;
   platform?: NodeJS.Platform;
   homeDir?: string;
   execSync?: ExecSyncFn;
-}): ClaudeCliCredential | null {
+};
+
+/** @deprecated Anthropic provider-owned CLI credential helper; do not use from third-party plugins. */
+export function readClaudeCliCredentialsCached(
+  options?: ClaudeCliCredentialReadOptions,
+): ClaudeCliCredential | null {
   const platform = options?.platform ?? process.platform;
   const ttlMs = options?.ttlMs ?? 0;
   const credentialsPath = resolveClaudeCliCredentialsPath(options?.homeDir);
   const settingsPath = resolveClaudeCliUserSettingsPath(options?.homeDir);
   const keychainIntent =
-    platform === "darwin" && options?.allowKeychainPrompt !== false ? "keychain" : "file";
+    platform !== "darwin"
+      ? "file"
+      : options?.tryKeychainWithoutPrompt
+        ? "keychain-bounded"
+        : options?.allowKeychainPrompt !== false
+          ? "keychain"
+          : "file";
   return readCachedCliCredential({
     ttlMs,
     cache: claudeCliCache,
@@ -580,6 +598,8 @@ export function readClaudeCliCredentialsCached(options?: {
     read: () =>
       readClaudeCliCredentials({
         allowKeychainPrompt: options?.allowKeychainPrompt,
+        tryKeychainWithoutPrompt: options?.tryKeychainWithoutPrompt,
+        onStoredCredentialUnreadable: options?.onStoredCredentialUnreadable,
         platform,
         homeDir: options?.homeDir,
         execSync: options?.execSync,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users running non-interactive onboarding with `--auth-choice anthropic-cli` were told that Claude CLI was not authenticated even when Claude Code was logged in and its credential existed in the login Keychain.

At the reported base (`15bf43fe193`), `extensions/anthropic/cli-auth-seam.ts:13-14` passed `allowKeychainPrompt: false`; `src/agents/cli-credentials.ts:539-553` interpreted that as skipping Keychain entirely, fell through to the absent `~/.claude/.credentials.json`, and returned `null`. The resulting `claude auth login` remedy could not change this already-authenticated state.

## Why This Change Was Made

Non-interactive setup now uses a setup-only, two-second-bounded Keychain read. When ACL access is already granted, onboarding imports the credential immediately. If secret access fails, a metadata-only query distinguishes a present Keychain item (or present unreadable file) from genuinely missing auth, so the Anthropic provider can give a truthful remedy.

The existing `allowKeychainPrompt: false` contract remains file-only for runtime and status paths. Interactive setup retains its existing Keychain behavior. The macOS command details remain in the Claude credential owner (`src/agents/cli-credentials.claude-keychain.ts`), and the generic onboarding layer remains provider-agnostic.

## User Impact

Already-authorized macOS installs can complete scripted Claude CLI onboarding. If macOS will not release the stored secret non-interactively, users are told to rerun without `--non-interactive` or choose `--auth-choice setup-token` / `--anthropic-api-key <key>`. Hosts with no credential keep the existing `claude auth login` message.

## Evidence

Before, with an isolated `OPENCLAW_STATE_DIR`, profile `co2`, and a Keychain-backed Claude Code login:

```text
claude auth status -> loggedIn=true, authMethod=claude.ai, apiProvider=firstParty
~/.claude/.credentials.json -> absent
Claude Code-credentials metadata -> present
openclaw ... --auth-choice anthropic-cli -> exit 1
Auth choice "anthropic-cli" requires Claude CLI auth on this host.
Run claude auth login first.
config_written=no
```

The bounded output-suppressed ACL probe returned status 0 without a GUI dialog. After the fix, the same isolated source onboarding path reached the Keychain branch and wrote the Claude CLI runtime config:

```text
[agents/auth-profiles] read anthropic credentials from claude cli keychain
onboard_exit=0
config_written=yes
primary=anthropic/claude-opus-5
claudeCliRuntimeModelCount=7
```

The isolated no-daemon proof added `--skip-health` because no Gateway was intentionally listening on the derived scratch port. Without that flag, auth still succeeded and config was written; the command then exited only on the expected not-listening health check. All scratch state was removed afterward. No credential value was printed.

Validation:

- `node scripts/run-vitest.mjs src/agents/cli-credentials.test.ts src/agents/cli-credentials.claude-keychain.test.ts extensions/anthropic/cli-auth-seam.test.ts extensions/anthropic/cli-migration.test.ts` — 56 tests passed
- `node scripts/check-changed.mjs` — passed on exact rebased head via Testbox (run 31839913612)
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings
