### PR TITLE
fix(ui): prevent mobile image viewer cutoff

### DIFF
--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -146,10 +146,10 @@ class OpenClawImageLightbox extends OpenClawLitElement {
 
     .image {
       display: block;
-      max-width: 100%;
-      max-height: 100%;
-      width: auto;
-      height: auto;
+      min-width: 0;
+      min-height: 0;
+      width: 100%;
+      height: 100%;
       border-radius: var(--radius-md);
       background: rgba(255, 255, 255, 0.04);
       object-fit: contain;

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -55,8 +55,14 @@ describeControlUiE2e("Control UI image lightbox", () => {
     const banner = await readFile(path.join(process.cwd(), "docs/assets/openclaw-banner-dark.png"));
     const bannerBase64 = banner.toString("base64");
     const dataUrl = `data:image/png;base64,${bannerBase64}`;
+    if (captureUiProofEnabled) {
+      await mkdir(proofDir, { recursive: true });
+    }
     const context = await newContext({
       locale: "en-US",
+      recordVideo: captureUiProofEnabled
+        ? { dir: proofDir, size: { height: 900, width: 1440 } }
+        : undefined,
       serviceWorkers: "block",
       viewport: { height: 900, width: 1440 },
     });
@@ -180,7 +186,6 @@ describeControlUiE2e("Control UI image lightbox", () => {
       await sidebarTrigger.waitFor({ state: "visible", timeout: 10_000 });
 
       if (captureUiProofEnabled) {
-        await mkdir(proofDir, { recursive: true });
         await page.screenshot({
           fullPage: true,
           path: path.join(proofDir, "01-sidebar-image.png"),
@@ -207,13 +212,56 @@ describeControlUiE2e("Control UI image lightbox", () => {
       await page.setViewportSize({ height: 844, width: 390 });
       await sidebarTrigger.click();
       await sidebarDialog.waitFor({ state: "visible" });
+      await page.locator("openclaw-image-lightbox wa-dialog").evaluate(async (dialogAdapter) => {
+        const nativeDialog = dialogAdapter.shadowRoot?.querySelector("dialog");
+        await Promise.all(
+          (nativeDialog?.getAnimations({ subtree: true }) ?? []).map(
+            (animation) => animation.finished,
+          ),
+        );
+      });
       const mobileBox = await page.locator("openclaw-image-lightbox .lightbox").boundingBox();
+      const mobileImageLayout = await page
+        .locator("openclaw-image-lightbox .stage")
+        .evaluate((stage) => {
+          const image = stage.querySelector("img");
+          if (!image) {
+            throw new Error("missing lightbox image");
+          }
+          const stageBox = stage.getBoundingClientRect();
+          const imageBox = image.getBoundingClientRect();
+          const style = getComputedStyle(stage);
+          return {
+            image: {
+              bottom: imageBox.bottom,
+              left: imageBox.left,
+              right: imageBox.right,
+              top: imageBox.top,
+            },
+            stage: {
+              bottom: stageBox.bottom - Number.parseFloat(style.paddingBottom),
+              left: stageBox.left + Number.parseFloat(style.paddingLeft),
+              right: stageBox.right - Number.parseFloat(style.paddingRight),
+              top: stageBox.top + Number.parseFloat(style.paddingTop),
+            },
+          };
+        });
       const mobileViewport = await page.evaluate(() => ({
         height: window.innerHeight,
         width: window.innerWidth,
       }));
       expect((mobileBox?.width ?? 0) / mobileViewport.width).toBeGreaterThanOrEqual(0.75);
       expect((mobileBox?.height ?? 0) / mobileViewport.height).toBeGreaterThanOrEqual(0.65);
+      expect(mobileImageLayout.image.left).toBeCloseTo(mobileImageLayout.stage.left, 0);
+      expect(mobileImageLayout.image.right).toBeCloseTo(mobileImageLayout.stage.right, 0);
+      expect(mobileImageLayout.image.top).toBeCloseTo(mobileImageLayout.stage.top, 0);
+      expect(mobileImageLayout.image.bottom).toBeCloseTo(mobileImageLayout.stage.bottom, 0);
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "03-mobile-lightbox.png"),
+        });
+      }
       await page.keyboard.press("Escape");
       await expect.poll(() => sidebarDialog.count()).toBe(0);
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening wide images in the Control UI lightbox on mobile could see the image and modal content cut off outside the visible viewport.

## Why This Change Was Made

The lightbox image now fills the stage's bounded content box and lets `object-fit: contain` preserve its aspect ratio. This keeps sizing ownership in the lightbox image rather than adding viewport-specific compensating rules to the modal shell.

The mobile E2E regression waits for the dialog transition, then verifies all four image edges stay inside the stage content bounds at a 390×844 viewport.

## User Impact

Mobile users can view the complete image, filename, and lightbox actions without horizontal or vertical cutoff.

## Evidence

- Pre-fix regression: the image exceeded the stage content bounds by 278px vertically.
- [390×844 after-fix screenshot](https://gist.githubusercontent.com/clawsweeper/6a15e8b0568d0940f0f9c719f6aeeef9/raw/6200c51185afd3cccf14cfef970f4ff9e93a2aca/mobile-lightbox-after.svg) from the mocked Control UI on exact head `f3043ac75e9e21ecb39e39dc3ab1c34b8fd892c6`.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-image-lightbox.e2e.test.ts` — passed; screenshot and video captured locally.
- `node scripts/run-vitest.mjs ui/src/components/image-lightbox.test.ts` — 8/8 passed.
- Targeted oxfmt, stylelint, and `git diff --check` — passed.
- Structured Codex autoreview (`gpt-5.6-sol`, high) — clean; no actionable findings.

Production LOC: +4/-4 (net 0) | Tests: +49/-1

Root cause: replaced-element auto sizing with independent `max-width` and `max-height` constraints did not make the image box itself obey both dimensions of the bounded grid stage.

Best-fix verdict: best. The stage is the sizing owner, and a stage-sized image box plus `object-fit: contain` directly enforces that invariant. Modal-shell overflow guards or mobile-only width/height calculations would be downstream, duplicated policy.

Provenance: clearly introduced in #112442 on 2026-07-22; code and PR author @steipete, merged by @steipete.
