### PR TITLE
perf(test): import package manifest helper directly

### DIFF
--- a/src/plugins/contracts/package-manifest.contract.test.ts
+++ b/src/plugins/contracts/package-manifest.contract.test.ts
@@ -1,5 +1,5 @@
-import { describePackageManifestContract } from "openclaw/plugin-sdk/plugin-test-contracts";
 import { describe, expect, it } from "vitest";
+import { describePackageManifestContract } from "../../plugin-sdk/test-helpers/package-manifest-contract.js";
 import { validatePackageExtensionEntriesForInstall } from "../package-entry-resolution.js";
 import {
   getPackageManifestMetadata,


### PR DESCRIPTION
## What Problem This Solves

The package-manifest contract test imported one helper through the aggregate `plugin-test-contracts` test barrel. That made this focused contract evaluate unrelated contract-testkit, registry/config, host-hook, and session-delivery modules before running its own assertions, adding avoidable time, CPU, and memory to a frequently selected test lane.

This is a bounded maintainer-requested test-performance change. It does not alter runtime behavior, the public Plugin SDK, package output, or production code.

## Why This Change Was Made

Import `describePackageManifestContract` directly from its internal test-helper module. This keeps the aggregate barrel and its independent registration/testing-harness coverage intact while giving the manifest contract the narrow dependency graph it actually needs.

The direct target is internal test support. `package.json` and `scripts/lib/plugin-sdk-entries.mts` continue to classify the aggregate barrel as test-only/excluded from the shipped package, so no public SDK export or build surface changes.

## User Impact

There is no user-visible or runtime behavior change. Maintainers get a materially cheaper package-manifest contract test with all 46 manifest cases, parameter rows, filesystem reads, parsers, and assertions unchanged.

Production LOC: +0/-0 (net 0). Tests: +1/-1 (net 0).

AI-assisted: yes. The patch and proof were inspected by the maintainer campaign lead and passed a fresh Codex autoreview.

## Evidence

Focused post-rebase proof:

- `node scripts/run-vitest.mjs src/plugins/contracts/package-manifest.contract.test.ts src/plugins/contracts/plugin-registration.contract.test.ts src/plugins/contracts/plugin-testing-harness.contract.test.ts --maxWorkers=1`
- 3 files passed, 137 tests passed, including all 46 package-manifest contract tests.
- `git diff --check origin/main...HEAD` passed.
- Changed-plan dry run selected `core`, `coreTests`, `extensions`, and `extensionTests`.
- Actual `node scripts/check-changed.mjs -- src/plugins/contracts/package-manifest.contract.test.ts` passed on Blacksmith Testbox `tbx_01m010yga64jen8fv6brxn6630`, backed by [Actions run 31840157168](https://github.com/openclaw/openclaw/actions/runs/31840157168). The environment-variable ratchet passed at 502/502.
- Fresh global Codex autoreview against `origin/main` with `gpt-5.6-sol`/high reasoning: clean, no accepted/actionable findings, overall 0.98.

Controlled local symmetric warm A/B, same machine and command shape, two warm samples per state, with state-specific module caches and Vitest import-duration reporting:

| Metric | Aggregate barrel | Direct helper | Change |
| --- | ---: | ---: | ---: |
| Wall | 1.73 s | 1.32 s | -23.7% |
| Vitest | 1.40 s | 0.197 s | -86.0% |
| Import | 1.29 s | 0.089 s | -93.1% |
| CPU user+sys | 2.175 s | 0.705 s | -67.6% |
| Peak RSS | 522.0 MiB | 223.8 MiB | -57.1% |

Test-body time stayed approximately flat (~9 ms before, ~12 ms after); the improvement comes from removing unrelated module evaluation. An earlier fresh Testbox (`tbx_01m00tq82j1k67r0sx5c9p5y08`) never received capacity and was stopped, so the performance measurements above are local, not remote. The later Testbox run proves the changed gate, not the performance delta.

No changelog entry is required for this internal test-only change. No agent transcript is attached.
