### PR TITLE
fix(gateway): explain stale install chunks after upgrades

### DIFF
--- a/src/gateway/server-methods.stale-install.test.ts
+++ b/src/gateway/server-methods.stale-install.test.ts
@@ -1,0 +1,69 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleGatewayRequest } from "./server-methods.js";
+
+function moduleNotFoundError(filePath: string): Error {
+  return Object.assign(new Error(`Cannot find module '${filePath}'`), {
+    code: "ERR_MODULE_NOT_FOUND",
+    url: pathToFileURL(filePath).href,
+  });
+}
+
+async function dispatchThrowingHandler(error: Error, respond = vi.fn()) {
+  await handleGatewayRequest({
+    req: { type: "req", id: "stale-install", method: "test.stale-install" },
+    respond,
+    client: null,
+    isWebchatConnect: () => false,
+    context: {} as never,
+    extraHandlers: {
+      "test.stale-install": async () => {
+        throw error;
+      },
+    },
+  });
+  return respond;
+}
+
+describe("gateway stale install errors", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("turns a missing module from the OpenClaw install into restart guidance", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "sd1");
+    const missingChunk = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "missing-own-chunk.js",
+    );
+    const respond = await dispatchThrowingHandler(moduleNotFoundError(missingChunk));
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        retryable: false,
+        message: expect.stringContaining("openclaw --profile sd1 gateway restart"),
+        details: {
+          code: "STALE_INSTALL",
+          restartCommand: "openclaw --profile sd1 gateway restart",
+        },
+      }),
+    );
+  });
+
+  it("does not rewrite a missing module outside the OpenClaw install", async () => {
+    const outsideInstall = path.join(
+      path.parse(process.cwd()).root,
+      "outside-openclaw",
+      "missing.js",
+    );
+    const error = moduleNotFoundError(outsideInstall);
+    const respond = vi.fn();
+
+    await expect(dispatchThrowingHandler(error, respond)).rejects.toBe(error);
+    expect(respond).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import {
   ErrorCodes,
   errorShape,
@@ -8,6 +9,9 @@ import {
   gatewayStartupUnavailableDetails,
   GATEWAY_STARTUP_RETRY_AFTER_MS,
 } from "../../packages/gateway-protocol/src/startup-unavailable.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { hasNodeErrorCode, isPathInside } from "../infra/path-guards.js";
 import { getActivePluginHttpRouteRegistry, getActivePluginRegistry } from "../plugins/runtime.js";
 import {
   getPluginRuntimeGatewayRequestScope,
@@ -58,6 +62,39 @@ import {
 } from "./session-sharing.js";
 
 type CoreGatewayHandlerModuleLoader = () => Promise<GatewayRequestHandlers>;
+
+// The install root is process-stable; capture it before an upgrade can replace
+// package metadata, then consult it only after a dynamic import has failed.
+const gatewayInstallRoot = resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
+
+function staleInstallErrorShape(error: unknown): ErrorShape | null {
+  if (
+    !gatewayInstallRoot ||
+    !(error instanceof Error) ||
+    !hasNodeErrorCode(error, "ERR_MODULE_NOT_FOUND")
+  ) {
+    return null;
+  }
+  const url = (error as Error & { url?: unknown }).url;
+  if (typeof url !== "string") {
+    return null;
+  }
+  let missingPath: string;
+  try {
+    missingPath = fileURLToPath(url);
+  } catch {
+    return null;
+  }
+  if (!isPathInside(gatewayInstallRoot, missingPath)) {
+    return null;
+  }
+  const restartCommand = formatCliCommand("openclaw gateway restart");
+  return errorShape(
+    ErrorCodes.UNAVAILABLE,
+    `The running Gateway can no longer load part of its OpenClaw installation. The installation may have changed while the Gateway was running. Restart it with: ${restartCommand}`,
+    { details: { code: "STALE_INSTALL", restartCommand }, retryable: false },
+  );
+}
 
 const CORE_GATEWAY_HANDLER_MODULES = {
   agent: () => import("./server-methods/agent.js").then((module) => module.agentHandlers),
@@ -512,6 +549,10 @@ export async function runWithGatewayRequestEnvelope<T>(
     } catch (error) {
       if (error instanceof SessionMutationAuthorizationChangedError) {
         return await options.reject(error.error);
+      }
+      const staleInstallError = staleInstallErrorShape(error);
+      if (staleInstallError) {
+        return await options.reject(staleInstallError);
       }
       throw error;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators upgrading or replacing an OpenClaw installation while its Gateway was still running would see arbitrary later commands fail with a raw `ERR_MODULE_NOT_FOUND`. The error did not explain that the live process still referenced content-hashed chunks from the previous installation or that restarting the Gateway repairs the state.

## Why This Change Was Made

The Gateway now captures its package root once and translates only `ERR_MODULE_NOT_FOUND` failures whose missing file is inside that root. Translation happens at the shared request envelope, so lazy core handlers, plugin Gateway methods, and nested request-time imports receive the same treatment without request-path filesystem polling or scattered catches. External module failures are preserved unchanged; automatic restart and proactive freshness polling remain out of scope.

AI-assisted: yes (Codex). The resulting code and behavior were reviewed and validated.

## User Impact

Instead of a raw Node module-resolution error, operators now get a typed unavailable response explaining that the installation may have changed and showing the exact restart command. Named profiles are preserved, for example `openclaw --profile sd1 gateway restart`.

## Evidence

Live scratch reproduction used profile `sd1`, an isolated temporary `OPENCLAW_STATE_DIR`, a derived loopback port, `OPENCLAW_SKIP_CHANNELS=1`, and a Gateway-owned test token. No default state or port was touched.

Before, moving the not-yet-loaded built cron handler chunk and invoking `cron list` produced:

```text
GatewayClientRequestError: Error: Cannot find module '.../dist/cron-Bsfnc0XQ.js' imported from .../dist/server-methods-BIE_Qu6-.js: code=ERR_MODULE_NOT_FOUND
```

After the fix, the same built-dist scenario produced:

```text
GatewayClientRequestError: The running Gateway can no longer load part of its OpenClaw installation. The installation may have changed while the Gateway was running. Restart it with: openclaw --profile sd1 gateway restart
```

The unchanged-build control returned `{"ok":true,"status":"live"}` from `/healthz`, and `cron list` succeeded without a stale-install warning. Scratch Gateways were stopped, temporary state was removed, and the moved chunk was restored. Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/31839670708

Validation:

- Pre-fix regression run: intended own-install case failed with the raw module error; outside-install control passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods.stale-install.test.ts src/gateway/server-methods.plugin-gateway-dispatch.test.ts src/gateway/server-methods/lazy-core-handlers.test.ts` — 7 passed.
- `node scripts/check-changed.mjs` — green, including core/core-test typechecks, lint, import cycles, and architecture guards.
- `pnpm build` — green; no ineffective dynamic-import warning.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
