### PR TITLE
test(cli): remove duplicate skills verify error case

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -1297,24 +1297,6 @@ describe("skills cli commands", () => {
     expect(runtimeErrors).toStrictEqual([]);
   });
 
-  it("fails before fetching when verification target resolution fails", async () => {
-    resolveClawHubSkillVerificationTargetMock.mockResolvedValueOnce({
-      ok: false,
-      error: "Use either --version or --tag.",
-    });
-
-    await expect(
-      runCommand(["skills", "verify", "agentreceipt", "--version", "1.0.0", "--tag", "latest"]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(JSON.parse(runtimeStdout.at(-1) ?? "{}")).toEqual({
-      error: "Use either --version or --tag.",
-    });
-    expect(runtimeErrors).toStrictEqual([]);
-    expect(fetchClawHubSkillVerificationMock).not.toHaveBeenCalled();
-    expect(fetchClawHubSkillCardMock).not.toHaveBeenCalled();
-  });
-
   it("returns JSON when verify workspace selection fails", async () => {
     defaultRuntime.exit.mockImplementationOnce(() => undefined);
 


### PR DESCRIPTION
## What Problem This Solves

`skills-cli.commands.test.ts` mocked a verification-target failure and asserted two behaviors already owned elsewhere: target errors are written as machine-readable JSON, and `--version` plus `--tag` is rejected before verification.

The dedicated verify suite proves the CLI presentation through the real resolver for implicit and explicit JSON output, while the ClawHub lifecycle suite owns the exact selector-conflict error.

## Why This Change Was Made

Delete the mocked cross-owner replay and retain the stronger real-resolver CLI test, the exact lifecycle validation, and the unique workspace-selection JSON case beside it.

Tests: -18 lines. No production or test-support changes.

## User Impact

No user-visible behavior change. `openclaw skills verify` still returns target-resolution failures as JSON and rejects conflicting version/tag selectors before calling ClawHub.

## Evidence

- Skills verify owner proof: 3 files, 183 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- src/cli/skills-cli.commands.test.ts` passed the coreTests gates locally, including test typecheck, lint, dead-export scans, formatting, environment budget, max-lines ratchet, and architecture guards.
- The changed-gate wrapper first attempted Crabbox/Testbox, but no remote provider was ready; trusted-source policy therefore used the documented local fallback.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Exact-head CI passed for `4f4a7ea06c8ba4a3b842fda7d0d4898c1cb4555b`: https://github.com/openclaw/openclaw/actions/runs/31842103696
