### PR TITLE
fix: add ssrf protection to Beam fetches

### DIFF
--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -140,7 +140,7 @@ Beam can also act as the sender: an opt-in mirror that continuously publishes th
 }
 ```
 
-- `endpoint` (required): the final remote receiver URL. Redirect responses (301, 302, 303, 307, and 308) are not followed; configure the destination URL directly. HTTPS is enforced for non-loopback hosts; plaintext `http://` is accepted only for `localhost`/`127.0.0.1`/`::1` development.
+- `endpoint` (required): the final remote receiver URL. Redirect responses (301, 302, 303, 307, and 308) are not followed; configure the destination URL directly. After a redirect, repeated polls are suppressed for the current mirror service instance. A Gateway restart probes the configured endpoint once again so a receiver corrected at the same URL can recover. HTTPS is enforced for non-loopback hosts; plaintext `http://` is accepted only for `localhost`/`127.0.0.1`/`::1` development.
 - `token`: Gateway credential for the remote receiver, sent as `Authorization: Bearer`. Accepts a plain string or a secret reference; a configured-but-unresolved token pauses mirroring instead of sending unauthenticated requests. Deployments fronted by an identity-aware proxy need an ingress that accepts this bearer credential.
 - `catalogs` (required): the session catalog ids to mirror, as explicit per-catalog consent — an omitted or empty list mirrors nothing. The local `beam` receiver catalog is always excluded so two mirrored Gateways cannot re-mirror each other's rows.
 - `pollSeconds` (default 30, minimum 10): how often the mirror scans local catalogs.
@@ -172,7 +172,7 @@ The mirror applies the same redaction contract as the beam skill before anything
 
 `beam mirror upload blocked ... receiver returned redirect`
 
-: The configured mirror endpoint returned a redirect. Beam does not follow redirects; set `mirror.endpoint` to the final receiver URL.
+: The configured mirror endpoint returned a redirect. Beam does not follow redirects and suppresses repeated attempts for the current service instance; set `mirror.endpoint` to the final receiver URL. A Gateway restart probes the configured endpoint once again.
 
 ## Related
 

--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -140,7 +140,7 @@ Beam can also act as the sender: an opt-in mirror that continuously publishes th
 }
 ```
 
-- `endpoint` (required): the remote receiver URL. HTTPS is enforced for non-loopback hosts; plaintext `http://` is accepted only for `localhost`/`127.0.0.1`/`::1` development.
+- `endpoint` (required): the final remote receiver URL. Redirect responses (301, 302, 303, 307, and 308) are not followed; configure the destination URL directly. HTTPS is enforced for non-loopback hosts; plaintext `http://` is accepted only for `localhost`/`127.0.0.1`/`::1` development.
 - `token`: Gateway credential for the remote receiver, sent as `Authorization: Bearer`. Accepts a plain string or a secret reference; a configured-but-unresolved token pauses mirroring instead of sending unauthenticated requests. Deployments fronted by an identity-aware proxy need an ingress that accepts this bearer credential.
 - `catalogs` (required): the session catalog ids to mirror, as explicit per-catalog consent — an omitted or empty list mirrors nothing. The local `beam` receiver catalog is always excluded so two mirrored Gateways cannot re-mirror each other's rows.
 - `pollSeconds` (default 30, minimum 10): how often the mirror scans local catalogs.
@@ -169,6 +169,10 @@ The mirror applies the same redaction contract as the beam skill before anything
 `429 Too Many Requests`
 
 : The authenticated client exceeded the bounded request or concurrency limit. Retry after the current minute window.
+
+`beam mirror upload blocked ... receiver returned redirect`
+
+: The configured mirror endpoint returned a redirect. Beam does not follow redirects; set `mirror.endpoint` to the final receiver URL.
 
 ## Related
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -201,7 +201,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/security-runtime` | Deprecated broad barrel for trust, DM gating, root-bounded file/path helpers including create-only writes, sync/async atomic file replacement, sibling temp writes, cross-device move fallback, private file-store helpers, symlink-parent guards, external-content, sensitive text redaction, constant-time secret comparison, and secret-collection helpers; prefer focused security/SSRF/secret subpaths |
     | `plugin-sdk/ssrf-policy` | Host allowlist and private-network SSRF policy helpers |
     | `plugin-sdk/ssrf-dispatcher` | Private-local after July 2026; Narrow pinned-dispatcher helpers without the broad infra runtime surface |
-    | `plugin-sdk/ssrf-runtime` | Pinned-dispatcher, SSRF-guarded fetch, SSRF error, SSRF policy helpers, and loopback/private host classification |
+    | `plugin-sdk/ssrf-runtime` | Pinned-dispatcher, SSRF-guarded fetch, `SsrFBlockedError` and `GuardedFetchRedirectError`, SSRF policy helpers, and loopback/private host classification |
     | `plugin-sdk/secret-input` | Secret input parsing helpers |
     | `plugin-sdk/secret-ref-readonly` | Closed available/missing/blocked resolution and provider-policy checks for read-only env SecretRefs |
     | `plugin-sdk/webhook-ingress` | Webhook request/target helpers and raw websocket/body coercion |

--- a/extensions/beam/openclaw.plugin.json
+++ b/extensions/beam/openclaw.plugin.json
@@ -7,7 +7,7 @@
   "uiHints": {
     "mirror.endpoint": {
       "label": "Mirror Endpoint",
-      "help": "Remote Beam receiver URL, e.g. https://team.example.com/api/v1/beam/sessions."
+      "help": "Final Beam receiver URL, e.g. https://team.example.com/api/v1/beam/sessions. Redirects are not followed."
     },
     "mirror.token": {
       "label": "Mirror Token",

--- a/extensions/beam/openclaw.plugin.json
+++ b/extensions/beam/openclaw.plugin.json
@@ -7,7 +7,7 @@
   "uiHints": {
     "mirror.endpoint": {
       "label": "Mirror Endpoint",
-      "help": "Final Beam receiver URL, e.g. https://team.example.com/api/v1/beam/sessions. Redirects are not followed."
+      "help": "Final Beam receiver URL, e.g. https://team.example.com/api/v1/beam/sessions. Redirects are not followed; retries pause until the service restarts or the endpoint changes."
     },
     "mirror.token": {
       "label": "Mirror Token",

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -368,6 +368,46 @@ describe("createBeamMirrorRunner", () => {
     },
   );
 
+  it("logs a terminal redirect block after a recent transient warning", async () => {
+    const warnings: string[] = [];
+    let requestCount = 0;
+    const server = createServer((req, res) => {
+      void readRequestBody(req).then(
+        () => {
+          requestCount += 1;
+          res.statusCode = requestCount === 1 ? 503 : 307;
+          res.end();
+        },
+        (error: unknown) => {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        },
+      );
+    });
+    try {
+      const origin = await listenOnLoopback(server);
+      const runner = createBeamMirrorRunner({
+        runtime: fakeRuntime(mirrorConfig({ endpoint: `${origin}/beam` })),
+        logger: { warn: (message) => warnings.push(message), info: () => {} },
+        now: () => NOW,
+        listCatalogs: () => [
+          fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+        ],
+      });
+
+      await runner.tick();
+      await runner.tick();
+      await runner.tick();
+
+      expect(requestCount).toBe(2);
+      expect(warnings).toEqual([
+        "beam mirror upload failed (503) for claude",
+        "beam mirror upload blocked for claude: receiver returned redirect (307); redirects are not followed; configure the final endpoint",
+      ]);
+    } finally {
+      await closeTestServer(server);
+    }
+  });
+
   it("rechecks once after runner restart and resumes after the endpoint changes", async () => {
     const requests: string[] = [];
     const server = createServer((req, res) => {

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -308,6 +308,49 @@ describe("createBeamMirrorRunner", () => {
     }
   });
 
+  it("retries when the configured receiver redirects to a successful response", async () => {
+    const receiverBodies: string[] = [];
+    const redirectedBodies: string[] = [];
+    const server = createServer((req, res) => {
+      void readRequestBody(req).then(
+        (body) => {
+          if (req.url === "/redirected") {
+            redirectedBodies.push(body);
+            res.statusCode = 200;
+            res.end("ok");
+            return;
+          }
+          receiverBodies.push(body);
+          res.statusCode = 307;
+          res.setHeader("Location", "/redirected");
+          res.end();
+        },
+        (error: unknown) => {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        },
+      );
+    });
+    try {
+      const origin = await listenOnLoopback(server);
+      const runner = createBeamMirrorRunner({
+        runtime: fakeRuntime(mirrorConfig({ endpoint: `${origin}/beam` })),
+        logger: silentLogger,
+        now: () => NOW,
+        listCatalogs: () => [
+          fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+        ],
+      });
+
+      await runner.tick();
+      await runner.tick();
+
+      expect(receiverBodies).toHaveLength(2);
+      expect(redirectedBodies).toEqual([]);
+    } finally {
+      await closeTestServer(server);
+    }
+  });
+
   it("uploads active local sessions and skips unchanged ones", async () => {
     const sent: SentRequest[] = [];
     const reads: string[] = [];
@@ -414,6 +457,7 @@ describe("createBeamMirrorRunner", () => {
         expect.objectContaining({
           url: "https://team.example/api/v1/beam/sessions",
           timeoutMs: 15_000,
+          maxRedirects: 0,
           policy: { allowedOrigins: ["https://team.example"] },
         }),
       );

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -368,7 +368,7 @@ describe("createBeamMirrorRunner", () => {
     },
   );
 
-  it("resumes delivery after the blocked endpoint changes", async () => {
+  it("rechecks once after runner restart and resumes after the endpoint changes", async () => {
     const requests: string[] = [];
     const server = createServer((req, res) => {
       void readRequestBody(req).then(
@@ -393,21 +393,25 @@ describe("createBeamMirrorRunner", () => {
       const runtime = {
         config: { current: () => mirrorConfig({ endpoint }) },
       } as unknown as PluginRuntime;
-      const runner = createBeamMirrorRunner({
-        runtime,
-        logger: silentLogger,
-        now: () => NOW,
-        listCatalogs: () => [
-          fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
-        ],
-      });
+      const createRunner = () =>
+        createBeamMirrorRunner({
+          runtime,
+          logger: silentLogger,
+          now: () => NOW,
+          listCatalogs: () => [
+            fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+          ],
+        });
+      const runner = createRunner();
 
       await runner.tick();
       await runner.tick();
+      const restartedRunner = createRunner();
+      await restartedRunner.tick();
       endpoint = `${origin}/direct`;
-      await runner.tick();
+      await restartedRunner.tick();
 
-      expect(requests).toEqual(["/redirecting", "/direct"]);
+      expect(requests).toEqual(["/redirecting", "/redirecting", "/direct"]);
     } finally {
       await closeTestServer(server);
     }

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -1,3 +1,4 @@
+import { createServer, type IncomingMessage, type Server } from "node:http";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type {
   SessionCatalogHost,
@@ -5,6 +6,7 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import type { ActiveSessionCatalog } from "openclaw/plugin-sdk/session-catalog-runtime";
+import * as ssrfRuntime from "openclaw/plugin-sdk/ssrf-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
   beamMirrorId,
@@ -92,7 +94,7 @@ function captureFetch(
   status = 200,
   onCancel?: () => void | Promise<void>,
 ): typeof fetch {
-  return (async (url: unknown, init?: RequestInit) => {
+  return vi.fn(async (url: unknown, init?: RequestInit) => {
     const headers = (init?.headers ?? {}) as Record<string, string>;
     sent.push({
       url: String(url),
@@ -105,10 +107,43 @@ function captureFetch(
         })
       : "{}";
     return new Response(body, { status });
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
 }
 
 const silentLogger = { warn: () => {}, info: () => {} };
+
+async function listenOnLoopback(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not expose a TCP address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeTestServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
 
 describe("parseBeamMirrorConfig", () => {
   it("returns undefined without mirror config", () => {
@@ -223,6 +258,56 @@ describe("fitBeamMirrorUpload", () => {
 });
 
 describe("createBeamMirrorRunner", () => {
+  it("does not replay mirror uploads across redirects to another private origin", async () => {
+    const redirectedBodies: string[] = [];
+    const internalServer = createServer((req, res) => {
+      void readRequestBody(req).then(
+        (body) => {
+          redirectedBodies.push(body);
+          res.statusCode = 200;
+          res.end("ok");
+        },
+        (error: unknown) => {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        },
+      );
+    });
+    const internalOrigin = await listenOnLoopback(internalServer);
+    const receiverBodies: string[] = [];
+    const receiverServer = createServer((req, res) => {
+      void readRequestBody(req).then(
+        (body) => {
+          receiverBodies.push(body);
+          res.statusCode = 307;
+          res.setHeader("Location", `${internalOrigin}/internal-action`);
+          res.end();
+        },
+        (error: unknown) => {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        },
+      );
+    });
+    try {
+      const receiverOrigin = await listenOnLoopback(receiverServer);
+      const runner = createBeamMirrorRunner({
+        runtime: fakeRuntime(mirrorConfig({ endpoint: `${receiverOrigin}/beam` })),
+        logger: silentLogger,
+        now: () => NOW,
+        listCatalogs: () => [
+          fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+        ],
+      });
+
+      await runner.tick();
+
+      expect(receiverBodies).toHaveLength(1);
+      expect(receiverBodies[0]).toContain("Fix the flow.");
+      expect(redirectedBodies).toEqual([]);
+    } finally {
+      await Promise.all([closeTestServer(receiverServer), closeTestServer(internalServer)]);
+    }
+  });
+
   it("uploads active local sessions and skips unchanged ones", async () => {
     const sent: SentRequest[] = [];
     const reads: string[] = [];
@@ -297,6 +382,46 @@ describe("createBeamMirrorRunner", () => {
     expect(sent).toHaveLength(1);
     expect(cancel).toHaveBeenCalledOnce();
     expect(warnings).toEqual([]);
+  });
+
+  it("bounds guarded uploads and releases their response resources", async () => {
+    const cancel = vi.fn();
+    const release = vi.fn();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel,
+      }),
+      { status: 200 },
+    );
+    const guardedFetch = vi.spyOn(ssrfRuntime, "fetchWithSsrFGuard").mockResolvedValue({
+      response,
+      finalUrl: "https://team.example/api/v1/beam/sessions",
+      release,
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: silentLogger,
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+      ],
+    });
+
+    try {
+      await runner.tick();
+
+      expect(guardedFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://team.example/api/v1/beam/sessions",
+          timeoutMs: 15_000,
+          policy: { allowedOrigins: ["https://team.example"] },
+        }),
+      );
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      guardedFetch.mockRestore();
+    }
   });
 
   it("ignores idle sessions, node hosts, the beam catalog, and unlisted catalogs", async () => {

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -308,21 +308,78 @@ describe("createBeamMirrorRunner", () => {
     }
   });
 
-  it("retries when the configured receiver redirects to a successful response", async () => {
-    const receiverBodies: string[] = [];
-    const redirectedBodies: string[] = [];
+  it.each([
+    { label: "301", status: 301, location: "/redirected?private=do-not-log" },
+    { label: "302", status: 302, location: "/redirected?private=do-not-log" },
+    { label: "303", status: 303, location: "/redirected?private=do-not-log" },
+    { label: "307", status: 307, location: "/redirected?private=do-not-log" },
+    { label: "308", status: 308, location: "/redirected?private=do-not-log" },
+    { label: "307 without Location", status: 307, location: undefined },
+  ])(
+    "blocks a $label redirect without retrying the configured endpoint",
+    async ({ status, location }) => {
+      const warnings: string[] = [];
+      const receiverBodies: string[] = [];
+      const redirectedBodies: string[] = [];
+      const server = createServer((req, res) => {
+        void readRequestBody(req).then(
+          (body) => {
+            if (req.url === "/redirected") {
+              redirectedBodies.push(body);
+              res.statusCode = 200;
+              res.end("ok");
+              return;
+            }
+            receiverBodies.push(body);
+            res.statusCode = status;
+            if (location) {
+              res.setHeader("Location", location);
+            }
+            res.end();
+          },
+          (error: unknown) => {
+            res.destroy(error instanceof Error ? error : new Error(String(error)));
+          },
+        );
+      });
+      try {
+        const origin = await listenOnLoopback(server);
+        const runner = createBeamMirrorRunner({
+          runtime: fakeRuntime(mirrorConfig({ endpoint: `${origin}/beam` })),
+          logger: { warn: (message) => warnings.push(message), info: () => {} },
+          now: () => NOW,
+          listCatalogs: () => [
+            fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+          ],
+        });
+
+        await runner.tick();
+        await runner.tick();
+
+        expect(receiverBodies).toHaveLength(1);
+        expect(redirectedBodies).toEqual([]);
+        expect(warnings).toEqual([
+          `beam mirror upload blocked for claude: receiver returned redirect (${status}); redirects are not followed; configure the final endpoint`,
+        ]);
+        expect(warnings.join(" ")).not.toContain("do-not-log");
+      } finally {
+        await closeTestServer(server);
+      }
+    },
+  );
+
+  it("resumes delivery after the blocked endpoint changes", async () => {
+    const requests: string[] = [];
     const server = createServer((req, res) => {
       void readRequestBody(req).then(
-        (body) => {
-          if (req.url === "/redirected") {
-            redirectedBodies.push(body);
+        () => {
+          requests.push(req.url ?? "");
+          if (req.url === "/redirecting") {
+            res.statusCode = 307;
+            res.setHeader("Location", "/redirected");
+          } else {
             res.statusCode = 200;
-            res.end("ok");
-            return;
           }
-          receiverBodies.push(body);
-          res.statusCode = 307;
-          res.setHeader("Location", "/redirected");
           res.end();
         },
         (error: unknown) => {
@@ -332,8 +389,12 @@ describe("createBeamMirrorRunner", () => {
     });
     try {
       const origin = await listenOnLoopback(server);
+      let endpoint = `${origin}/redirecting`;
+      const runtime = {
+        config: { current: () => mirrorConfig({ endpoint }) },
+      } as unknown as PluginRuntime;
       const runner = createBeamMirrorRunner({
-        runtime: fakeRuntime(mirrorConfig({ endpoint: `${origin}/beam` })),
+        runtime,
         logger: silentLogger,
         now: () => NOW,
         listCatalogs: () => [
@@ -343,9 +404,10 @@ describe("createBeamMirrorRunner", () => {
 
       await runner.tick();
       await runner.tick();
+      endpoint = `${origin}/direct`;
+      await runner.tick();
 
-      expect(receiverBodies).toHaveLength(2);
-      expect(redirectedBodies).toEqual([]);
+      expect(requests).toEqual(["/redirecting", "/direct"]);
     } finally {
       await closeTestServer(server);
     }

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/session-catalog-runtime";
 import {
   fetchWithSsrFGuard,
+  GuardedFetchRedirectError,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -277,6 +278,7 @@ export function createBeamMirrorRunner(params: {
   const listCatalogs = params.listCatalogs ?? listActiveSessionCatalogs;
   const tracked = new Map<string, TrackedMirrorSession>();
   let lastWarnAt = 0;
+  let redirectBlockedEndpoint: string | undefined;
   let running = false;
 
   const warnThrottled = (message: string) => {
@@ -291,24 +293,45 @@ export function createBeamMirrorRunner(params: {
     token: string | undefined,
     payload: BeamMirrorUpload,
   ): Promise<boolean> => {
-    const { response, release } = await fetchWithSsrFGuard({
-      url: endpoint,
-      fetchImpl: params.fetchFn,
-      timeoutMs: MIRROR_UPLOAD_TIMEOUT_MS,
-      policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(endpoint),
-      auditContext: "beam.mirror_upload",
-      // Only the configured receiver can acknowledge delivery. Following a redirect
-      // could fingerprint a payload that the receiver never accepted.
-      maxRedirects: 0,
-      init: {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    if (redirectBlockedEndpoint === endpoint) {
+      return false;
+    }
+    redirectBlockedEndpoint = undefined;
+
+    let guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>>;
+    try {
+      guarded = await fetchWithSsrFGuard({
+        url: endpoint,
+        fetchImpl: params.fetchFn,
+        timeoutMs: MIRROR_UPLOAD_TIMEOUT_MS,
+        policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(endpoint),
+        auditContext: "beam.mirror_upload",
+        // Only the configured receiver can acknowledge delivery. Following a redirect
+        // could fingerprint a payload that the receiver never accepted.
+        maxRedirects: 0,
+        init: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify(payload),
         },
-        body: JSON.stringify(payload),
-      },
-    });
+      });
+    } catch (error) {
+      if (error instanceof GuardedFetchRedirectError) {
+        // Redirect policy cannot recover on a later poll. Hold this exact endpoint
+        // until config changes instead of repeatedly sending the same sensitive POST.
+        redirectBlockedEndpoint = endpoint;
+        warnThrottled(
+          `beam mirror upload blocked for ${payload.source}: receiver returned redirect (${error.status}); redirects are not followed; configure the final endpoint`,
+        );
+        return false;
+      }
+      throw error;
+    }
+
+    const { response, release } = guarded;
     try {
       if (!response.ok) {
         warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -320,8 +320,9 @@ export function createBeamMirrorRunner(params: {
       });
     } catch (error) {
       if (error instanceof GuardedFetchRedirectError) {
-        // Redirect policy cannot recover on a later poll. Hold this exact endpoint
-        // until config changes instead of repeatedly sending the same sensitive POST.
+        // Repeating the same poll cannot satisfy direct-only delivery. Hold this exact
+        // endpoint for this service instance; a fresh instance probes once so a receiver
+        // fixed in place can recover without a meaningless config change.
         redirectBlockedEndpoint = endpoint;
         warnThrottled(
           `beam mirror upload blocked for ${payload.source}: receiver returned redirect (${error.status}); redirects are not followed; configure the final endpoint`,

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -297,6 +297,9 @@ export function createBeamMirrorRunner(params: {
       timeoutMs: MIRROR_UPLOAD_TIMEOUT_MS,
       policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(endpoint),
       auditContext: "beam.mirror_upload",
+      // Only the configured receiver can acknowledge delivery. Following a redirect
+      // could fingerprint a payload that the receiver never accepted.
+      maxRedirects: 0,
       init: {
         method: "POST",
         headers: {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -11,6 +11,10 @@ import {
   listActiveSessionCatalogs,
   type ActiveSessionCatalog,
 } from "openclaw/plugin-sdk/session-catalog-runtime";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { BEAM_MAX_BODY_BYTES, BEAM_MAX_ITEM_CHARS, BEAM_MAX_ITEMS } from "./types.js";
@@ -30,6 +34,7 @@ const MIRROR_MAX_SESSIONS = 32;
 const MIRROR_BODY_BUDGET_BYTES = BEAM_MAX_BODY_BYTES - 2_048;
 // One warning per source per interval keeps a broken endpoint from flooding logs.
 const MIRROR_WARN_INTERVAL_MS = 5 * 60_000;
+const MIRROR_UPLOAD_TIMEOUT_MS = 15_000;
 
 type BeamMirrorConfig = {
   endpoint: string;
@@ -268,7 +273,6 @@ export function createBeamMirrorRunner(params: {
   listCatalogs?: () => ActiveSessionCatalog[];
 }): BeamMirrorRunner {
   const env = params.env ?? process.env;
-  const fetchFn = params.fetchFn ?? fetch;
   const now = params.now ?? Date.now;
   const listCatalogs = params.listCatalogs ?? listActiveSessionCatalogs;
   const tracked = new Map<string, TrackedMirrorSession>();
@@ -287,13 +291,20 @@ export function createBeamMirrorRunner(params: {
     token: string | undefined,
     payload: BeamMirrorUpload,
   ): Promise<boolean> => {
-    const response = await fetchFn(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    const { response, release } = await fetchWithSsrFGuard({
+      url: endpoint,
+      fetchImpl: params.fetchFn,
+      timeoutMs: MIRROR_UPLOAD_TIMEOUT_MS,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(endpoint),
+      auditContext: "beam.mirror_upload",
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(payload),
       },
-      body: JSON.stringify(payload),
     });
     try {
       if (!response.ok) {
@@ -305,6 +316,7 @@ export function createBeamMirrorRunner(params: {
       // The mirror uses only the status; cancel the ignored payload so slow
       // receiver responses cannot retain connection slots across poll retries.
       await response.body?.cancel().catch(() => undefined);
+      await release();
     }
   };
 

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -324,7 +324,7 @@ export function createBeamMirrorRunner(params: {
         // endpoint for this service instance; a fresh instance probes once so a receiver
         // fixed in place can recover without a meaningless config change.
         redirectBlockedEndpoint = endpoint;
-        warnThrottled(
+        params.logger.warn(
           `beam mirror upload blocked for ${payload.source}: receiver returned redirect (${error.status}); redirects are not followed; configure the final endpoint`,
         );
         return false;

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -301,7 +301,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: shared delegation policy (mode resolver + section builder) so harness
       //     runtimes render the same guidance instead of diverging prompt copies.
       // +1: shared harness visible-source-reply guidance.
-      4335,
+      // +1: typed guarded-fetch redirect error for direct-only plugin delivery.
+      4336,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -110,6 +110,18 @@ export type GuardedFetchResult = {
   dispatcherReused?: boolean;
 };
 
+export class GuardedFetchRedirectError extends Error {
+  readonly status: number;
+  readonly maxRedirects: number;
+
+  constructor(params: { status: number; maxRedirects: number }) {
+    super(`Too many redirects (limit: ${params.maxRedirects})`);
+    this.name = "GuardedFetchRedirectError";
+    this.status = params.status;
+    this.maxRedirects = params.maxRedirects;
+  }
+}
+
 type GuardedFetchInternalOptions = GuardedFetchOptions & {
   managedProxyBypass?: ConfiguredLocalOriginManagedProxyBypass;
   resolveDispatcherPolicy?: (url: URL) => PinnedDispatcherPolicy | undefined;
@@ -721,13 +733,13 @@ async function fetchWithSsrFGuardInternal(
       });
 
       if (isRedirectStatus(response.status)) {
+        redirectCount += 1;
+        if (redirectCount > maxRedirects) {
+          throw new GuardedFetchRedirectError({ status: response.status, maxRedirects });
+        }
         const location = response.headers.get("location");
         if (!location) {
           throw new Error(`Redirect missing location header (${response.status})`);
-        }
-        redirectCount += 1;
-        if (redirectCount > maxRedirects) {
-          throw new Error(`Too many redirects (limit: ${maxRedirects})`);
         }
         const nextParsedUrl = new URL(location, parsedUrl);
         const nextUrl = nextParsedUrl.toString();

--- a/src/plugin-sdk/ssrf-runtime.ts
+++ b/src/plugin-sdk/ssrf-runtime.ts
@@ -16,7 +16,7 @@ export {
   type SsrFPolicy,
 } from "../infra/net/ssrf.js";
 export { formatErrorMessage } from "../infra/errors.js";
-export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export { fetchWithSsrFGuard, GuardedFetchRedirectError } from "../infra/net/fetch-guard.js";
 export {
   assertHttpUrlTargetsPrivateNetwork,
   buildHostnameAllowlistPolicyFromSuffixAllowlist,


### PR DESCRIPTION
## What Problem This Solves

Beam mirror uploads carry session content and an optional bearer token. Before this change, the configured receiver could redirect that POST and cause the request body to be replayed to another origin.

## Product Decision

Maintainer product decision (accepted): land the direct-only upgrade contract and require redirecting deployments to configure the final receiver URL.

Beam mirror delivery is direct-only. The configured `mirror.endpoint` must be the final receiver URL.

- Redirect responses (301, 302, 303, 307, and 308) are never followed.
- Within one mirror service instance, a redirect blocks later polls from resending the same sensitive POST.
- Delivery resumes when the operator changes `mirror.endpoint`. A fresh service also probes the configured endpoint once so a receiver corrected in place can recover without a meaningless config change.
- The warning identifies the redirect status and tells the operator to configure the final endpoint, but does not log `Location`.
- Transient network and non-redirect HTTP failures remain retryable.

This intentionally changes the valid flow for deployments whose receiver currently redirects. Those operators must configure the final destination directly; there is no redirect compatibility switch because it would reopen the payload-forwarding boundary.

SDK-owner decision (approved): keep `GuardedFetchRedirectError` in the public SSRF runtime subpath. It types an existing generic terminal condition of the already-public guarded-fetch primitive, lets plugins classify redirect-limit failures without matching error text, and exposes no new authority or Beam-specific policy. The scoped SDK restriction on single-consumer provider-local wrappers does not apply to this shared transport contract.

## Implementation

- Routes Beam uploads through `fetchWithSsrFGuard` with the configured endpoint's exact-origin policy, DNS pinning, a 15-second timeout, and `maxRedirects: 0`.
- Adds the typed `GuardedFetchRedirectError` at the shared guarded-fetch owner boundary and exports it through `openclaw/plugin-sdk/ssrf-runtime`.
- Blocks repeated sends only for the redirecting endpoint while preserving retry behavior for transient failures.
- Cancels ignored response bodies and releases dispatcher resources.
- Documents the final-URL requirement in Beam configuration help and operator troubleshooting.

Relevant boundaries:

- `extensions/beam/src/mirror.ts` owns upload policy, endpoint blocking, operator feedback, and delivery acknowledgement.
- `src/infra/net/fetch-guard.ts` owns redirect classification and cleanup.
- `src/plugin-sdk/ssrf-runtime.ts` exposes the typed failure without a Beam-specific network implementation.

## Evidence

### Real Behavior Proof

ClawSweeper exercised the pre-rebase patch head (`5d7bb3e86dd`) in its isolated runner with the production Beam runner and real loopback HTTP servers; `fetch` was not mocked. After a conflict-free rebase onto current main, the current head (`3ff9a350c50`) passed the same 27-test file locally:

```text
$ node scripts/run-vitest.mjs extensions/beam/src/mirror.test.ts
Test Files  1 passed (1)
Tests       27 passed (27)
```

Coverage proves:

- Cross-origin private redirect: one configured receiver request, zero redirected-target requests, and no POST replay.
- All recognized redirect statuses: 301, 302, 303, 307, and 308, including a redirect without `Location`.
- Two unchanged ticks after a redirect: one configured endpoint request total, one actionable warning, no leaked `Location` value.
- Service restart: a fresh runner probes the configured endpoint once, while still refusing its redirect.
- Endpoint correction: delivery resumes after `mirror.endpoint` changes to a direct URL.
- Existing transient failure behavior: a 503 response is retried on the next tick.
- Terminal recovery signal ordering: after a 503 warning, a 307 still emits the final-endpoint warning before the endpoint is blocked; a third tick sends no request.

Autoreview also completed cleanly with no accepted or actionable findings.

## Review Surface

- Production: +65/-14 (net +51). The growth establishes the shared typed redirect boundary, terminal endpoint state, cleanup, and operator-visible recovery path.
- Tests: +277/-2 (net +275).
- Docs, metadata, and SDK tooling: +9/-4 (net +5).

Trail of Bits developed this fix as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified and fixed primarily by the Codex coding agent, and manually reviewed before submission.