### PR TITLE
chore: verify Linux installer failures and user paths

### DIFF
--- a/.github/workflows/website-installer-sync.yml
+++ b/.github/workflows/website-installer-sync.yml
@@ -87,6 +87,150 @@ jobs:
             node:24-bookworm-slim \
             bash -lc 'apt-get update -y && apt-get install -y curl && bash /tmp/install-cli.sh --prefix /tmp/openclaw --no-onboard --version latest && /tmp/openclaw/bin/openclaw --version'
 
+  linux-build-tools-failure:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: install.sh reports build-tool failures honestly
+        run: |
+          timeout --kill-after=10s 5m docker run --rm -i \
+            -v "$PWD/scripts/install.sh:/tmp/install.sh:ro" \
+            debian:bookworm \
+            bash -s <<'CONTAINER'
+          set -euo pipefail
+          export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+          cat > /usr/local/sbin/apt-get <<'STUB'
+          #!/bin/bash
+          for arg in "$@"; do
+            if [[ "$arg" == "build-essential" ]]; then
+              : > /tmp/build-tools-stub-triggered
+              echo "E: simulated package manager failure" >&2
+              exit 100
+            fi
+          done
+          for arg in "$@"; do
+            if [[ "$arg" == "update" ]]; then
+              exit 0
+            fi
+          done
+          echo "unexpected apt-get call: $*" >&2
+          exit 99
+          STUB
+
+          cat > /usr/local/bin/curl <<'STUB'
+          #!/bin/sh
+          echo "network blocked by failure-propagation lane" >&2
+          exit 97
+          STUB
+          chmod +x /usr/local/sbin/apt-get /usr/local/bin/curl
+
+          installer_status=0
+          bash /tmp/install.sh --no-onboard --no-prompt </dev/null > /tmp/out.log 2>&1 || installer_status=$?
+          cat /tmp/out.log
+
+          if [[ ! -f /tmp/build-tools-stub-triggered ]]; then
+            echo "stub did not trigger" >&2
+            exit 2
+          fi
+          if ! grep -aFq "Installing build tools failed" /tmp/out.log; then
+            echo "installer did not report the simulated build-tools failure" >&2
+            exit 2
+          fi
+          if grep -aFq "Build tools installed" /tmp/out.log; then
+            echo "REGRESSION: installer claimed success after failure" >&2
+            exit 1
+          fi
+          if (( installer_status == 0 )); then
+            echo "installer unexpectedly completed despite blocked package and network access" >&2
+            exit 3
+          fi
+          echo "ok: failure reported honestly"
+          CONTAINER
+
+  linux-non-root:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: install.sh as a non-root user
+        run: |
+          timeout --kill-after=30s 20m docker run --rm -i \
+            -v "$PWD/scripts/install.sh:/tmp/install.sh:ro" \
+            node:24-bookworm-slim \
+            bash -s <<'CONTAINER'
+          set -euo pipefail
+          apt-get update -qq
+          apt-get install -y -qq sudo
+          useradd --create-home --shell /bin/bash installer
+          printf '%s\n' 'installer ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/installer
+          chmod 0440 /etc/sudoers.d/installer
+
+          sudo -u installer -H bash <<'USER'
+          set -euo pipefail
+          test "$(id -u)" -ne 0
+          sudo -n true
+          initial_prefix="$(npm config get prefix)"
+          if [[ -w "$initial_prefix" || -w "$initial_prefix/lib" ]]; then
+            echo "initial npm prefix is writable; relocation path would not run" >&2
+            exit 1
+          fi
+          bash /tmp/install.sh --install-method npm --no-onboard --no-prompt --version latest
+          test "$(npm config get prefix)" = "$HOME/.npm-global"
+          "$HOME/.npm-global/bin/openclaw" --version
+          grep -Fxq 'export PATH="$HOME/.npm-global/bin:$PATH"' "$HOME/.bashrc"
+          echo "ok: non-root prefix relocation and bash PATH persistence verified"
+          USER
+          CONTAINER
+
+  fedora-installer:
+    name: Fedora installer (${{ matrix.user }})
+    strategy:
+      fail-fast: false
+      matrix:
+        user: [root, non-root]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: install.sh on Fedora
+        env:
+          INSTALL_USER: ${{ matrix.user }}
+        run: |
+          if [[ "$INSTALL_USER" == "root" ]]; then
+            timeout --kill-after=30s 20m docker run --rm -i \
+              -v "$PWD/scripts/install.sh:/tmp/install.sh:ro" \
+              fedora:44 \
+              bash -s <<'CONTAINER'
+          set -euo pipefail
+          bash /tmp/install.sh --install-method npm --no-onboard --no-prompt --version latest
+          openclaw --version
+          CONTAINER
+          else
+            timeout --kill-after=30s 20m docker run --rm -i \
+              -v "$PWD/scripts/install.sh:/tmp/install.sh:ro" \
+              fedora:44 \
+              bash -s <<'CONTAINER'
+          set -euo pipefail
+          dnf install -y -q sudo shadow-utils
+          useradd --create-home --shell /bin/bash installer
+          printf '%s\n' 'installer ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/installer
+          chmod 0440 /etc/sudoers.d/installer
+
+          sudo -u installer -H bash <<'USER'
+          set -euo pipefail
+          test "$(id -u)" -ne 0
+          sudo -n true
+          bash /tmp/install.sh --install-method npm --no-onboard --no-prompt --version latest
+          test "$(npm config get prefix)" = "$HOME/.npm-global"
+          "$HOME/.npm-global/bin/openclaw" --version
+          grep -Fxq 'export PATH="$HOME/.npm-global/bin:$PATH"' "$HOME/.bashrc"
+          echo "ok: Fedora non-root install and PATH persistence verified"
+          USER
+          CONTAINER
+          fi
+
   macos-installer:
     runs-on: macos-15
     steps:
@@ -123,7 +267,14 @@ jobs:
         run: .\scripts\install.ps1 -DryRun -NoOnboard -InstallMethod npm
 
   sync-website:
-    needs: [static, linux-docker, macos-installer, windows-installer]
+    needs:
+      - static
+      - linux-docker
+      - linux-build-tools-failure
+      - linux-non-root
+      - fedora-installer
+      - macos-installer
+      - windows-installer
     if: >
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && inputs.sync_website)

--- a/test/scripts/website-installer-sync-workflow.test.ts
+++ b/test/scripts/website-installer-sync-workflow.test.ts
@@ -16,9 +16,22 @@ describe("website installer sync workflow", () => {
     }
   });
 
-  it("verifies installers on Linux Docker plus native macOS and Windows runners", () => {
+  it("verifies installers across Linux privilege and package-manager paths", () => {
     expect(workflow).toContain("linux-docker:");
-    expect(workflow.match(/timeout --kill-after=30s 20m docker run --rm/g)?.length).toBe(2);
+    expect(workflow.match(/timeout --kill-after=30s 20m docker run --rm/g)?.length).toBe(5);
+    expect(workflow).toContain("linux-build-tools-failure:");
+    expect(workflow).toContain("/tmp/build-tools-stub-triggered");
+    expect(workflow).toContain('grep -aFq "Installing build tools failed"');
+    expect(workflow).toContain('grep -aFq "Build tools installed"');
+    expect(workflow).toContain("linux-non-root:");
+    expect(workflow).toContain("sudo -u installer -H bash");
+    expect(workflow).toContain('test "$(npm config get prefix)" = "$HOME/.npm-global"');
+    expect(workflow).toContain(
+      `grep -Fxq 'export PATH="$HOME/.npm-global/bin:$PATH"' "$HOME/.bashrc"`,
+    );
+    expect(workflow).toContain("fedora-installer:");
+    expect(workflow).toContain("user: [root, non-root]");
+    expect(workflow.match(/fedora:44/g)?.length).toBe(2);
     expect(workflow).not.toContain("timeout 20m docker run --rm");
     expect(workflow).not.toMatch(/(^|\n)\s+docker run --rm/u);
     expect(workflow).toContain("bash /tmp/install.sh --version latest && openclaw --version");
@@ -39,7 +52,20 @@ describe("website installer sync workflow", () => {
   });
 
   it("syncs verified scripts to openclaw.ai only after all installer checks pass", () => {
-    expect(workflow).toContain("needs: [static, linux-docker, macos-installer, windows-installer]");
+    const syncNeeds = workflow.match(/  sync-website:\n    needs:\n((?:      - [^\n]+\n)+)/u);
+    expect(syncNeeds?.[1]).toBe(
+      [
+        "static",
+        "linux-docker",
+        "linux-build-tools-failure",
+        "linux-non-root",
+        "fedora-installer",
+        "macos-installer",
+        "windows-installer",
+      ]
+        .map((job) => `      - ${job}\n`)
+        .join(""),
+    );
     expect(workflow).toContain("repository: openclaw/openclaw.ai");
     expect(workflow).toContain("OPENCLAW_GH_TOKEN: ${{ secrets.OPENCLAW_GH_TOKEN }}");
     expect(workflow).toContain("OPENCLAW_GH_TOKEN is not configured");


### PR DESCRIPTION
Closes #123822

## What Problem This Solves

Fixes an issue where installer changes could pass website publication checks despite breaking non-root Linux users, Fedora users, or failure reporting. The existing workflow exercised only Debian-as-root happy paths, so it did not catch the false-success regression fixed in #123817.

## Why This Change Was Made

This adds three focused verification jobs: a deterministic build-tools failure lane, a Debian non-root npm-prefix lane, and a Fedora 44 root/non-root matrix. All three are required by `sync-website`, and the installer scripts themselves remain unchanged.

## User Impact

There is no runtime behavior change. Operators get stronger protection against publishing an installer that hides package-manager failures or breaks common non-root and dnf-based installations.

## Evidence

- The failure lane passes against the fixed installer:
  ```text
  Installing build tools failed — re-run with --verbose for details
  Continuing without auto-installing build tools
  installer exit status: 1
  ok: failure reported honestly
  ```
- The identical lane fails against a scratch copy with the original `return 0` regression restored:
  ```text
  Installing build tools failed — re-run with --verbose for details
  Build tools installed
  REGRESSION: installer claimed success after failure
  exit 1
  ```
- Debian non-root Docker install passed and verified the `~/.npm-global` CLI plus the exact `.bashrc` PATH entry.
- Fedora 44 root and non-root Docker installs passed on arm64; the image also publishes amd64 for GitHub runners.
- `actionlint .github/workflows/website-installer-sync.yml`
- Ruby YAML parse: passed
- `node scripts/run-vitest.mjs test/scripts/website-installer-sync-workflow.test.ts`: 3 passed
- `git diff --check`: passed
- Autoreview: clean, no accepted/actionable findings
- Exact-head [`Website Installer Sync`](https://github.com/openclaw/openclaw/actions/runs/31842713615): static, Debian root, failure propagation, Debian non-root, Fedora root, Fedora non-root, macOS, and Windows all passed; publication correctly skipped for the PR event.
- Exact-head PR watcher: `SUCCESS` with zero pending checks.

AI-assisted: yes; the resulting workflow and proof outputs were reviewed directly.
