### PR TITLE
fix(ui): keep the lobster dismiss menu from scrolling its own items

### DIFF
--- a/ui/src/components/lobster-pet-dismiss-menu.ts
+++ b/ui/src/components/lobster-pet-dismiss-menu.ts
@@ -14,6 +14,16 @@ export function renderLobsterPetDismissMenu(params: {
   if (!position) {
     return nothing;
   }
+  // Web Awesome caps `#menu` to `--auto-size-available-height` and its `size`
+  // middleware runs after `flip`, so a popup anchored near a viewport edge is
+  // shrunk in place instead of flipping and silently scrolls its own items.
+  // The pet lives on the footer ledge, i.e. always at the bottom edge, so the
+  // anchor is clamped like every other pointer-anchored menu (session-menu.ts,
+  // catalog-session-menu.ts, native-link-menu.ts, sidebar-menus-controller.ts).
+  const menuWidth = 264;
+  const menuHeight = 80;
+  const x = Math.max(8, Math.min(position.x, window.innerWidth - menuWidth - 8));
+  const y = Math.max(8, Math.min(position.y, window.innerHeight - menuHeight - 8));
   return html`
     <openclaw-menu-surface>
       <wa-dropdown
@@ -38,7 +48,7 @@ export function renderLobsterPetDismissMenu(params: {
           tabindex="-1"
           aria-hidden="true"
           aria-label=${t("quickSettings.appearance.lobsterVisits")}
-          style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+          style="position: fixed; left: ${x}px; top: ${y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
         ></button>
         <wa-dropdown-item class="session-menu__item" value="dismiss"
           >${t("common.dismiss")}</wa-dropdown-item

--- a/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
@@ -1,0 +1,148 @@
+// Measures the lobster dismiss menu's internal overflow in the real sidebar
+// footer context, with classic (space-taking) scrollbars forced on so the
+// Linux run matches what a macOS "Always show scrollbars" operator sees.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { BrowserContext, Page } from "playwright";
+import { beforeEach, expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI lobster dismiss menu overflow",
+  startServerBeforeBrowser: true,
+  browserLaunchOptions: {
+    args: ["--disable-features=OverlayScrollbar,FluentOverlayScrollbar,FluentScrollbar"],
+  },
+  unavailableMessage: (executablePath) => `Playwright Chromium cannot start at ${executablePath}`,
+});
+
+type BrowserLobsterPet = HTMLElement & {
+  mode: "idle" | "busy" | "offline";
+  runOutcome: "ok" | "error" | "aborted";
+  seed: number;
+  visitsEnabled: boolean;
+  updateComplete: Promise<unknown>;
+};
+
+const artifactDir = path.resolve(
+  process.cwd(),
+  ".artifacts/control-ui-e2e/lobster-dismiss-menu-overflow",
+);
+
+let context: BrowserContext;
+let page: Page;
+
+/** Mounts the pet inside the real sidebar footer ledge so production CSS
+ *  (`openclaw-lobster-pet { height: 52px; overflow: hidden }`) applies. */
+async function mountPetInRealFooter(seed: number) {
+  await page.evaluate(async (petSeed) => {
+    const footer = document.querySelector(".sidebar-shell__footer");
+    if (!footer) {
+      throw new Error("sidebar footer ledge not found");
+    }
+    footer.querySelector("openclaw-lobster-pet")?.remove();
+    const pet = document.createElement("openclaw-lobster-pet") as BrowserLobsterPet;
+    pet.seed = petSeed;
+    pet.mode = "offline";
+    pet.runOutcome = "ok";
+    pet.visitsEnabled = true;
+    footer.append(pet);
+    await pet.updateComplete;
+  }, seed);
+}
+
+/** Reads the geometry that decides whether the popup scrolls. */
+async function measureDismissMenu() {
+  return await page.evaluate(() => {
+    const dropdown = document.querySelector("wa-dropdown.lobster-pet-dismiss-menu");
+    if (!dropdown?.shadowRoot) {
+      throw new Error("dismiss menu dropdown not found");
+    }
+    const menu = dropdown.shadowRoot.querySelector<HTMLElement>("#menu");
+    const popup = dropdown.shadowRoot.querySelector("wa-popup");
+    const popupBox = popup?.shadowRoot?.querySelector<HTMLElement>(".popup") ?? null;
+    if (!menu) {
+      throw new Error("dismiss menu #menu part not found");
+    }
+    const menuStyle = getComputedStyle(menu);
+    const host = document.querySelector<HTMLElement>("openclaw-lobster-pet");
+    const hostStyle = host ? getComputedStyle(host) : null;
+    return {
+      scrollHeight: menu.scrollHeight,
+      clientHeight: menu.clientHeight,
+      offsetHeight: menu.offsetHeight,
+      overflowPx: menu.scrollHeight - menu.clientHeight,
+      scrollbarWidthPx: menu.offsetWidth - menu.clientWidth,
+      computedMaxHeight: menuStyle.maxHeight,
+      computedOverflowY: menuStyle.overflowY,
+      autoSizeAvailableHeight: popup
+        ? getComputedStyle(popup).getPropertyValue("--auto-size-available-height").trim()
+        : "(no wa-popup)",
+      resolvedPlacement: popup?.getAttribute("data-current-placement") ?? "(none)",
+      anchorTop: dropdown.querySelector<HTMLElement>('[slot="trigger"]')?.style.top ?? "(none)",
+      viewportHeight: window.innerHeight,
+      popupIsTopLayer: popupBox ? popupBox.matches(":popover-open") : null,
+      menuSurfaceIsTopLayer:
+        document.querySelector("openclaw-menu-surface")?.matches(":popover-open") ?? null,
+      hostHeight: hostStyle?.height ?? null,
+      hostOverflow: hostStyle?.overflow ?? null,
+      itemHeights: [...dropdown.querySelectorAll("wa-dropdown-item")].map(
+        (item) => (item as HTMLElement).offsetHeight,
+      ),
+    };
+  });
+}
+
+suite.define(() => {
+  beforeEach(async () => {
+    context = await suite.newBrowserContext({ viewport: { width: 1280, height: 900 } });
+    page = await context.newPage();
+    await page.clock.install({ time: new Date("2026-07-09T12:00:00") });
+    await installMockGateway(page);
+    await page.goto(suite.server.baseUrl);
+    await page.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
+    const loadedAt = await page.evaluate(() => Date.now());
+    await page.clock.pauseAt(loadedAt + 1_000);
+    await mkdir(artifactDir, { recursive: true });
+  });
+
+  it("does not scroll its two dismissal items in the real sidebar footer", async () => {
+    await mountPetInRealFooter(42);
+    const sprite = page.locator(".lobster-pet");
+    await sprite.waitFor();
+
+    await sprite.click({ button: "right" });
+    await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+    await page.getByText("Dismiss and don't show again", { exact: true }).waitFor();
+
+    const measurement = await measureDismissMenu();
+    await page.screenshot({ path: path.join(artifactDir, "real-footer-context.png") });
+
+    // Asserting on the whole measurement so a regression prints the anchor
+    // position and resolved max-height that explain it.
+    expect(measurement).toMatchObject({ overflowPx: 0 });
+  });
+
+  // Control: the identical menu content, anchored away from the bottom edge.
+  // Isolates the anchor position as the cause rather than the menu's content.
+  it("has room for the same two items when the ledge is not at the viewport edge", async () => {
+    await mountPetInRealFooter(42);
+    await page.evaluate(() => {
+      const footer = document.querySelector<HTMLElement>(".sidebar-shell__footer");
+      if (footer) {
+        footer.style.transform = "translateY(-400px)";
+      }
+    });
+    const sprite = page.locator(".lobster-pet");
+    await sprite.waitFor();
+
+    await sprite.click({ button: "right" });
+    await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+
+    const measurement = await measureDismissMenu();
+    await page.screenshot({ path: path.join(artifactDir, "control-away-from-edge.png") });
+
+    expect(measurement).toMatchObject({ overflowPx: 0 });
+  });
+});


### PR DESCRIPTION
Related: #123789

## What Problem This Solves

Fixes an issue where users who right-click the lobster in the sidebar would see the dismissal menu render its two items inside a scrollable box, with the first item clipped at the top, instead of showing both options in full. On systems set to always render scrollbars, the menu shows a visible scrollbar for two short items.

The menu itself is new on this branch, so the symptom exists only here and not on `main`.

## Why This Change Was Made

The dismiss menu positions a synthetic trigger at the raw pointer coordinates, and the pet is pinned to the sidebar footer ledge (`ui/src/styles/lobster-pet.css`), so that pointer is always a few dozen pixels from the bottom of the viewport. Web Awesome caps its dropdown to `--auto-size-available-height`, and its `size` middleware runs after `flip`, so instead of flipping upward into the free space the popup is shrunk in place to whatever room is left below the pointer.

The rest of the sidebar already solves this by clamping the anchor so the popup keeps the room it needs — `session-menu.ts:264-265`, `catalog-session-menu.ts:55-56`, `native-link-menu.ts:36-37`, and five call sites in `sidebar-menus-controller.ts` (`:270`, `:296`, `:400`, `:426`, `:448`). This change applies that same clamp to the dismiss menu, so the behavior matches every other pointer-anchored menu in the sidebar rather than introducing a second positioning rule.

Non-goal: consolidating those nine copies of the clamp into one shared helper. That is worth doing, but it touches every sidebar menu and does not belong in a fix for this symptom.

## User Impact

Right-clicking the lobster now shows "Dismiss" and "Dismiss and don't show again" in full, with no internal scrolling and no scrollbar, regardless of the operator's scrollbar setting. Menu contents, keyboard behavior, and dismissal semantics are unchanged.

## Evidence

Measured in the Control UI against a mock gateway, with the pet mounted in the real sidebar footer and scrollbars forced to their space-taking mode. Same menu, same two items; only the anchor position differs:

| | before | after | control (anchor moved 400px up) |
| --- | --- | --- | --- |
| anchor `top` | 824px | 812px | 424px |
| `--auto-size-available-height` | 60px | 72px | 460px |
| menu `scrollHeight` / `clientHeight` | 64 / 58 | 64 / 64 | 64 / 64 |
| internal overflow | **6px** | 0 | 0 |
| resolved placement | `bottom-start` | `bottom-start` | `bottom-start` |

The control column is the point: with identical content, moving the anchor away from the viewport edge removes the overflow entirely, which is what identifies the anchor position as the cause rather than the menu's contents or a fixed height being a few pixels short.

Before — menu squeezed to 60px against the viewport edge, first item clipped:

![before](https://github.com/user-attachments/assets/59db77e4-84fb-46fd-87d9-39a6acd7aa3e)

After — both items rendered in full:

![after](https://github.com/user-attachments/assets/7a0b3591-9917-4523-8876-aec5d337b088)

Tests, run on Linux:

- `node scripts/run-vitest.mjs ui/src/components/lobster-pet.test.ts` — 52 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/lobster-pet.e2e.test.ts ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts` — 5 passed

`ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts` is added here as the regression guard. It fails on the pre-fix commit for the intended reason (`expected 6 to be +0`) and carries the control case alongside it, so a future change that re-anchors this menu at a viewport edge fails instead of silently scrolling.

Production delta is +11/-1; the remaining +150 lines are the regression test.
