### PR TITLE
fix(ui): keep the open session's incognito identity through a Gateway disconnect

### DIFF
--- a/ui/src/e2e/chat-incognito-offline.e2e.test.ts
+++ b/ui/src/e2e/chat-incognito-offline.e2e.test.ts
@@ -1,0 +1,71 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  chatSessionListResponse,
+  controlUiSessionUrl,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const SESSION_KEY = "agent:main:dashboard:incognito-offline-proof";
+
+suite.define(() => {
+  it("keeps the incognito indicator while the Gateway is offline", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    if (artifactDir) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    const shot = async (name: string) => {
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, `${name}.png`) });
+      }
+    };
+
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey: SESSION_KEY,
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([
+          {
+            incognito: true,
+            key: SESSION_KEY,
+            kind: "direct",
+            label: "Incognito",
+            updatedAt: 2,
+          },
+        ]),
+      },
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, SESSION_KEY));
+      const incognito = page.locator(".chat-pane__incognito");
+      const offlineHint = page.locator(".agent-chat__offline-hint");
+      await page.locator(".agent-chat__composer-combobox textarea").waitFor({ timeout: 10_000 });
+      await incognito.waitFor({ timeout: 10_000 });
+      await shot("01-incognito-connected");
+
+      // Losing the Gateway clears the roster the pane used to describe this
+      // session. The session did not stop being incognito, so the indicator has
+      // to outlive the roster, and it has to coexist with the offline warning.
+      await gateway.setOnline(false);
+      await offlineHint.waitFor({ timeout: 10_000 });
+      expect(await incognito.count()).toBe(1);
+      await shot("02-incognito-and-offline");
+
+      await gateway.setOnline(true);
+      await offlineHint.waitFor({ state: "detached", timeout: 15_000 });
+      expect(await incognito.count()).toBe(1);
+      await shot("03-incognito-reconnected");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-composer-context.test.ts
+++ b/ui/src/pages/chat/chat-composer-context.test.ts
@@ -9,6 +9,11 @@ type ComposerProps = Parameters<typeof renderChatComposer>[0];
 
 function renderComposer(overrides: Partial<ComposerProps> = {}) {
   const container = document.createElement("div");
+  // The pane resolves the open session and hands it down; mirror that here so
+  // fixtures keep describing the roster instead of restating the active row.
+  const activeSession =
+    overrides.activeSession ??
+    overrides.sessions?.sessions?.find((row) => row.key === (overrides.sessionKey ?? "main"));
   render(
     renderChatComposer({
       paneId: crypto.randomUUID(),
@@ -29,6 +34,7 @@ function renderComposer(overrides: Partial<ComposerProps> = {}) {
       onQueueRemove: vi.fn(),
       onNewSession: vi.fn(),
       ...overrides,
+      activeSession,
     }),
     container,
   );

--- a/ui/src/pages/chat/chat-composer-disabled-banner.test.ts
+++ b/ui/src/pages/chat/chat-composer-disabled-banner.test.ts
@@ -22,6 +22,7 @@ function renderComposer(overrides: Partial<ComposerProps>) {
       queue: [],
       draft: "",
       sessions: null,
+      activeSession: undefined,
       assistantName: "OpenClaw",
       onDraftChange: vi.fn(),
       onSend: vi.fn(),

--- a/ui/src/pages/chat/chat-composer-pointer-activation.test.ts
+++ b/ui/src/pages/chat/chat-composer-pointer-activation.test.ts
@@ -21,6 +21,7 @@ function props(overrides: Partial<ComposerProps> = {}): ComposerProps {
     queue: [],
     draft: "",
     sessions: null,
+    activeSession: undefined,
     assistantName: "OpenClaw",
     onDraftChange: vi.fn(),
     onSend: vi.fn(),

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -35,6 +35,7 @@ function props(overrides: Partial<ComposerProps> = {}): ComposerProps {
     queue: [],
     draft: "",
     sessions: null,
+    activeSession: undefined,
     assistantName: "OpenClaw",
     onDraftChange: vi.fn(),
     onSend: vi.fn(),

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -130,6 +130,7 @@ export function makeChatHost(
     sessionsLoading: false,
     sessionsResult: null,
     sessionsResultAgentId: null,
+    retainedSelectedSession: null,
     sessionsError: null,
     sessionsArchivedFilter: "active" as const,
     chatModelsLoading: false,

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -3,7 +3,7 @@ import type { UiSettings } from "../../app/settings.ts";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
-import type { ChatComposerMemoryFallback } from "./chat-state-host.ts";
+import type { ChatComposerMemoryFallback, ChatPageHost } from "./chat-state-host.ts";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 
 type RequestHandlers = Record<string, unknown>;
@@ -40,6 +40,10 @@ type TestChatHost = Omit<ChatHost, "settings"> & {
   chatComposerFallbackByScope: Record<string, ChatComposerMemoryFallback>;
   sessionsError?: string | null;
   sessionsResultAgentId?: string | null;
+  // The route distinguishes a cleared roster (null) from a live one, so the
+  // test host mirrors the page host here instead of also allowing undefined.
+  sessionsResult: ChatPageHost["sessionsResult"];
+  retainedSelectedSession: ChatPageHost["retainedSelectedSession"];
   sessionsArchivedFilter?: "active" | "archived" | "all";
   password?: string;
   pendingSettingsPatches?: Record<string, Promise<boolean>>;

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -411,6 +411,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
             }
           : undefined,
       sessions: state.sessionsResult,
+      activeSession: selectedSession,
       toolOverrides: selectedSession?.toolOverrides,
       capabilityMenu: catalogKey
         ? undefined

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -1,6 +1,7 @@
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type {
   AgentsListResult,
+  GatewaySessionRow,
   ModelAuthStatusResult,
   ModelCatalogEntry,
   SessionsListResult,
@@ -68,6 +69,8 @@ export type ChatPageHost = ChatHost &
     modelAuthStatusError: string | null;
     sessionsResult: SessionsListResult | null;
     sessionsResultAgentId: string | null;
+    /** Identity of the open session, kept while the roster is unavailable. */
+    retainedSelectedSession: { sessionKey: string; row: GatewaySessionRow } | null;
     sessionsError: string | null;
     sessionsArchivedFilter: "active" | "archived" | "all";
     selectedChatSessionArchived: boolean;

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -206,6 +206,7 @@ export function createPageState(
     modelAuthStatusError: null,
     sessionsResult: null,
     sessionsResultAgentId: null,
+    retainedSelectedSession: null,
     sessionsLoading: false,
     sessionsError: null,
     sessionsArchivedFilter: "active",

--- a/ui/src/pages/chat/chat-state-route.test.ts
+++ b/ui/src/pages/chat/chat-state-route.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
+import { selectedChatSessionRow } from "./chat-state-route.ts";
+
+const SESSION_KEY = "agent:main:dashboard:incognito-9f2c";
+
+function roster(rows: GatewaySessionRow[]): SessionsListResult {
+  return { sessions: rows } as unknown as SessionsListResult;
+}
+
+function incognitoRow(): GatewaySessionRow {
+  return { key: SESSION_KEY, kind: "direct", incognito: true } as unknown as GatewaySessionRow;
+}
+
+describe("selectedChatSessionRow across a gateway disconnect", () => {
+  it("keeps the open session's incognito identity when the roster clears", () => {
+    const state = makeChatHost({
+      sessionKey: SESSION_KEY,
+      sessionsResult: roster([incognitoRow()]),
+    });
+
+    expect(selectedChatSessionRow(state)?.incognito).toBe(true);
+
+    // A disconnect makes the sessions store publish result: null. The session the
+    // user still has open did not stop being incognito because it cannot be listed.
+    state.sessionsResult = null;
+
+    expect(selectedChatSessionRow(state)?.incognito).toBe(true);
+  });
+
+  it("does not resurrect a session that a live roster no longer lists", () => {
+    const state = makeChatHost({
+      sessionKey: SESSION_KEY,
+      sessionsResult: roster([incognitoRow()]),
+    });
+    selectedChatSessionRow(state);
+
+    // Still connected, but the row is gone: archived or deleted, never retained.
+    state.sessionsResult = roster([]);
+
+    expect(selectedChatSessionRow(state)).toBeUndefined();
+  });
+
+  it("does not lend a retained identity to a different session", () => {
+    const state = makeChatHost({
+      sessionKey: SESSION_KEY,
+      sessionsResult: roster([incognitoRow()]),
+    });
+    selectedChatSessionRow(state);
+
+    state.sessionsResult = null;
+    state.sessionKey = "agent:main:dashboard:ordinary-1";
+
+    expect(selectedChatSessionRow(state)).toBeUndefined();
+  });
+});

--- a/ui/src/pages/chat/chat-state-route.ts
+++ b/ui/src/pages/chat/chat-state-route.ts
@@ -24,6 +24,25 @@ export function canCreateChatSession(state: ChatPageHost) {
 }
 
 export function selectedChatSessionRow(state: ChatPageHost) {
+  const live = resolveLiveChatSessionRow(state);
+  if (live) {
+    state.retainedSelectedSession = { sessionKey: state.sessionKey, row: live };
+    return live;
+  }
+  // Disconnecting clears the roster (the sessions store publishes result: null),
+  // but the open session's identity — incognito above all — is not in doubt just
+  // because it cannot be re-listed. Only an absent roster may fall back: a roster
+  // that is present and lacks the row means archived or deleted, never retained.
+  if (state.sessionsResult !== null) {
+    return undefined;
+  }
+  const retained = state.retainedSelectedSession;
+  return retained && areUiSessionKeysEquivalent(retained.sessionKey, state.sessionKey)
+    ? retained.row
+    : undefined;
+}
+
+function resolveLiveChatSessionRow(state: ChatPageHost) {
   const rows = state.sessionsResult?.sessions ?? [];
   const exact = rows.find((candidate) =>
     areUiSessionKeysEquivalent(candidate.key, state.sessionKey),

--- a/ui/src/pages/chat/chat-state-route.ts
+++ b/ui/src/pages/chat/chat-state-route.ts
@@ -13,6 +13,20 @@ import {
 } from "../../lib/sessions/session-key.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 
+/** Only the session-identity slice of the page host: the roster, the open key,
+ *  the retained row, and the agent scope the global-key rules read. Kept narrow
+ *  so selecting a row never depends on transcript, realtime or composer state. */
+type ChatSessionRowHost = Pick<
+  ChatPageHost,
+  | "sessionKey"
+  | "sessionsResult"
+  | "sessionsResultAgentId"
+  | "retainedSelectedSession"
+  | "assistantAgentId"
+  | "agentsList"
+  | "hello"
+>;
+
 export function canCreateChatSession(state: ChatPageHost) {
   return (
     !state.chatLoading &&
@@ -23,7 +37,7 @@ export function canCreateChatSession(state: ChatPageHost) {
   );
 }
 
-export function selectedChatSessionRow(state: ChatPageHost) {
+export function selectedChatSessionRow(state: ChatSessionRowHost) {
   const live = resolveLiveChatSessionRow(state);
   if (live) {
     state.retainedSelectedSession = { sessionKey: state.sessionKey, row: live };
@@ -42,7 +56,7 @@ export function selectedChatSessionRow(state: ChatPageHost) {
     : undefined;
 }
 
-function resolveLiveChatSessionRow(state: ChatPageHost) {
+function resolveLiveChatSessionRow(state: ChatSessionRowHost) {
   const rows = state.sessionsResult?.sessions ?? [];
   const exact = rows.find((candidate) =>
     areUiSessionKeysEquivalent(candidate.key, state.sessionKey),

--- a/ui/src/pages/chat/chat-state-route.ts
+++ b/ui/src/pages/chat/chat-state-route.ts
@@ -9,6 +9,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
   resolveUiSelectedGlobalAgentId,
+  type UiSessionDefaultsHost,
   uiSessionRowMatchesSelectedChat,
 } from "../../lib/sessions/session-key.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -18,14 +19,9 @@ import type { ChatPageHost } from "./chat-state-host.ts";
  *  so selecting a row never depends on transcript, realtime or composer state. */
 type ChatSessionRowHost = Pick<
   ChatPageHost,
-  | "sessionKey"
-  | "sessionsResult"
-  | "sessionsResultAgentId"
-  | "retainedSelectedSession"
-  | "assistantAgentId"
-  | "agentsList"
-  | "hello"
->;
+  "sessionKey" | "sessionsResult" | "retainedSelectedSession"
+> &
+  UiSessionDefaultsHost & { sessionsResultAgentId?: string | null };
 
 export function canCreateChatSession(state: ChatPageHost) {
   return (

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -174,6 +174,8 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     workspaceConflict?: WorkspaceResultConflict;
     onDismissWorkspaceConflict?: () => void;
     sessions: SessionsListResult | null;
+    /** Open session resolved by the pane; survives a disconnect, unlike `sessions`. */
+    activeSession: GatewaySessionRow | undefined;
     toolOverrides?: SessionToolOverrides;
     capabilityMenu?: CapabilityMenuProps;
     swarmSessions?: readonly GatewaySessionRow[];
@@ -395,6 +397,7 @@ export function renderChat(props: ChatProps) {
     paneId: props.paneId,
     sessionKey: props.sessionKey,
     currentAgentId: props.currentAgentId,
+    activeSession: props.activeSession,
     connected: props.connected,
     offline: props.offline,
     queuedOutboxCount: props.queuedOutboxCount,

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -1,6 +1,6 @@
 import type { TemplateResult, nothing } from "lit";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
-import type { SessionsListResult } from "../../../api/types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../../api/types.ts";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import type { ChatSendShortcut } from "../../../app/settings.ts";
 import type { ChatQueueItem } from "../../../lib/chat/chat-types.ts";
@@ -86,6 +86,8 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   queue: ChatQueueItem[];
   draft: string;
   sessions: SessionsListResult | null;
+  /** Open session resolved by the pane; survives a disconnect, unlike `sessions`. */
+  activeSession: GatewaySessionRow | undefined;
   toolOverrides?: SessionToolOverrides;
   capabilityMenu?: CapabilityMenuProps;
   providerUsage?: ProviderUsageDisplayProps;

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -130,7 +130,7 @@ export function renderChatComposer(props: ChatComposerProps) {
       : props.runStatus;
   const compactBusy =
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
-  const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
+  const activeSession = props.activeSession;
   const draftKey = composerDraftKey(props);
   if (state.dictationDraftKey !== null && state.dictationDraftKey !== draftKey) {
     state.dictation?.dispose();


### PR DESCRIPTION
Fixes #123852

## What Problem This Solves

While the Gateway is disconnected or restarting, the chat pane loses the open session's identity. Incognito is the case that matters most: the lock in the pane header disappears exactly when the user can least verify where their words are going. The session's goal, model, workspace and title vanish with it.

The **sidebar** keeps its incognito badge through the same disconnect. The two surfaces therefore contradict each other in one viewport, for the same session, at the same instant.

## Why This Change Was Made

The sessions store publishes `result: null` whenever the gateway is not connected (`ui/src/lib/sessions/index.ts:367-378`). That is correct for a roster — a list that cannot be refreshed must not be shown as live truth, and `ui/src/lib/sessions/connection-hydration.test.ts:276` locks it in.

The defect is downstream: the identity of the session the user *currently has open* was re-derived by scanning that roster, so clearing the roster erased it. The sidebar already guards against exactly this, with a comment about the reconnect-flash hazard (`ui/src/components/session-data-controller.ts:409-425`); the chat pane took the cleared value blindly.

So the fix goes to the owner, not to the indicator:

- `selectedChatSessionRow()` resolves the open session once and retains that identity while the roster is absent.
- The prepared row is handed down to the composer instead of the composer repeating the lookup, removing a duplicate re-derivation.

**Identity is retained; authority is not.** Only the selected row is retained, so mutation paths (sharing, patch, archive) still resolve from the live roster and still get nothing while offline. And only an *absent* roster falls back — a roster that is present but lacks the row still means archived or deleted, so a deleted session is never resurrected.

An alternative was considered and rejected: deriving incognito from the session key via the existing `isIncognitoSessionKey()`. It fixes only incognito, and recovers a privacy-critical fact by regex-parsing a server-minted key shape that the gateway treats as a storage-routing detail (`src/config/sessions/combined-store-gateway.ts:138`). If key minting ever changed, incognito would silently under-report — fail-open on a privacy signal. Full reasoning in the issue.

## User Impact

An operator composing in an incognito session keeps seeing that it is incognito while the Gateway restarts, alongside the existing offline warning — both facts at once, which is what the moment requires. Goal, model, workspace and title likewise stop flickering out on every reconnect.

Liveness is still announced once, globally, by the existing offline layer (connection pill, warn composer border and hint, "Waiting for reconnect" queue rows). Retained identity fields are not individually decorated.

## Evidence

Remote proof on Blacksmith Testbox (`tbx_01m0139y28gx13py7zw802xs9g`, and `tbx_01m0126ac02wm8kytmqf6aq4f4` for the pre-fix run):

**Regression fails pre-fix, for the intended reason.** With only `ui/src/pages/chat/chat-state-route.ts` reverted to `origin/main`:

```
× keeps the open session's incognito identity when the roster clears
✓ does not resurrect a session that a live roster no longer lists
✓ does not lend a retained identity to a different session
Tests  1 failed | 2 passed (3)
```

The two guard assertions pass pre-fix by design — they protect behavior that already held, so the fix cannot trade one bug for another.

**Post-fix, same box:**

```
pnpm tsgo:ui            -> clean
pnpm format:check       -> All matched files use the correct format.
pnpm test <7 chat files> -> 105 passed (6 files) + 38 passed (1 file)
```

Covering `chat-state-route.test.ts`, `chat-composer.test.ts`, `chat-composer-context.test.ts`, `chat-composer-disabled-banner.test.ts`, `chat-composer-pointer-activation.test.ts`, `chat-state.test.ts`, `chat-pane.test.ts`.

**Production vs test LOC:** +26 production, +72 test/test-support. The production delta buys a privacy invariant and deletes one duplicate lookup; the composer now consumes a prepared fact rather than rediscovering it.

## Note for #123573

PR #123573 adds the composer's dashed incognito frame and retention note. It reads the same re-derived row, so it inherits this bug today. Two follow-ups belong there, not here:

1. Once identity is retained, `agent-chat__input--offline` and `agent-chat__input--incognito` co-occur **for the first time**. Both set `border-color` at equal specificity, with the incognito block later in `ui/src/styles/chat/layout.css` — so the muted incognito border would override the warn offline border. It needs an explicit precedence rule (a compound selector; `ui/AGENTS.md` rules out `@layer` and flags duplicate selectors).
2. That PR's e2e has no offline coverage at all.
