### PR TITLE
fix: skipped gateway install no longer fails onboarding

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -296,7 +296,8 @@ openclaw onboard --non-interactive --accept-risk --skip-health \
 ### Local gateway health
 
 - Unless you pass `--skip-health`, onboarding waits for a reachable local gateway before exiting successfully.
-- `--install-daemon` starts the managed gateway install path first. Without it, a local gateway must already be running (for example `openclaw gateway run`).
+- `--install-daemon` starts the managed gateway install path first. With no daemon flag, a local gateway must already be running (for example `openclaw gateway run`).
+- Explicit `--skip-daemon` or `--no-install-daemon` still probes for an existing gateway. If none is listening, setup reports that the gateway was not started and exits successfully; a reachable but unhealthy gateway still fails the health check.
 - `--skip-health` skips the wait if you only want config/workspace/bootstrap writes in automation.
 - `--skip-bootstrap` sets `agents.defaults.skipBootstrap: true` and skips creating `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, and `BOOTSTRAP.md`.
 - On native Windows, `--install-daemon` tries Scheduled Tasks first and falls back to a per-user Startup-folder login item if task creation is denied.

--- a/docs/start/wizard-cli-automation.md
+++ b/docs/start/wizard-cli-automation.md
@@ -9,7 +9,7 @@ sidebarTitle: "CLI automation"
 
 Use `openclaw onboard --non-interactive` to script setup. It requires `--accept-risk`: non-interactive setup can write credentials and daemon config without a confirmation prompt, so the flag is the explicit risk acknowledgement.
 
-Each command must install a managed Gateway with `--install-daemon`, use `--skip-health` for config-only setup, or run with an already-running compatible Gateway.
+Each command can install a managed Gateway with `--install-daemon`, require an already-running compatible Gateway by omitting daemon flags, explicitly leave the Gateway stopped with `--skip-daemon`, or use `--skip-health` for config-only setup. The explicit skip still probes for an existing Gateway and reports whether one is reachable, but an absent listener is informational rather than a setup failure.
 
 <Note>
 `--json` does not imply non-interactive mode. Pass `--non-interactive --accept-risk` explicitly for scripts.

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -846,29 +846,39 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     });
   }, 60_000);
 
-  it("explains local health failure when no daemon was requested", async () => {
+  it("completes explicit no-daemon setup when no gateway is listening", async () => {
     await withStateDir("state-local-health-hint-", async (stateDir) => {
       waitForGatewayReachableMock = vi.fn(async () => ({
         ok: false,
-        detail: "socket closed: 1006 abnormal closure",
+        detail: "connect ECONNREFUSED 127.0.0.1:18789",
+      }));
+      const log = vi.fn();
+
+      await runNonInteractiveSetup(
+        { ...createLocalDaemonSetupOptions(stateDir), installDaemon: false },
+        { ...runtime, log },
+      );
+
+      expect(log.mock.calls.flat().join("\n")).toMatch(
+        /Setup complete; gateway was not installed or started because daemon installation was explicitly skipped\.[\s\S]*Gateway did not become reachable[\s\S]*Classification: not-listening[\s\S]*only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`[\s\S]*openclaw onboard --install-daemon[\s\S]*openclaw onboard --skip-health/,
+      );
+    });
+  }, 60_000);
+
+  it("still fails when an existing gateway is expected but unreachable", async () => {
+    await withStateDir("state-local-health-required-", async (stateDir) => {
+      waitForGatewayReachableMock = vi.fn(async () => ({
+        ok: false,
+        detail: "connect ECONNREFUSED 127.0.0.1:18789",
       }));
 
       await expect(
         runNonInteractiveSetup(
-          {
-            nonInteractive: true,
-            mode: "local",
-            workspace: path.join(stateDir, "openclaw"),
-            authChoice: "skip",
-            skipSkills: true,
-            skipHealth: false,
-            installDaemon: false,
-            gatewayBind: "loopback",
-          },
+          { ...createLocalDaemonSetupOptions(stateDir), installDaemon: undefined },
           runtime,
         ),
       ).rejects.toThrow(
-        /only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`[\s\S]*openclaw onboard --install-daemon[\s\S]*openclaw onboard --skip-health/,
+        /Gateway did not become reachable[\s\S]*Classification: not-listening[\s\S]*openclaw onboard --install-daemon[\s\S]*openclaw onboard --skip-health/,
       );
     });
   }, 60_000);

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -32,6 +32,7 @@ import type { OnboardOptions } from "../onboard-types.js";
 import { commitNonInteractiveOnboardConfig } from "./config-write.js";
 import { applyNonInteractiveGatewayConfig } from "./local/gateway-config.js";
 import {
+  classifyGatewayHealthFailure,
   type GatewayHealthFailureDiagnostics,
   logNonInteractiveOnboardingFailure,
   logNonInteractiveOnboardingJson,
@@ -302,6 +303,7 @@ export async function runNonInteractiveLocalSetup(params: {
         skippedReason?: "systemd-user-unavailable";
       }
     | undefined;
+  let gatewayNotRunning = false;
   if (opts.installDaemon) {
     const { installGatewayDaemonNonInteractive } = await import("./local/daemon-install.js");
     const daemonInstall = await installGatewayDaemonNonInteractive({
@@ -384,46 +386,61 @@ export async function runNonInteractiveLocalSetup(params: {
       const diagnostics = opts.installDaemon
         ? await collectGatewayHealthFailureDiagnostics()
         : undefined;
-      logNonInteractiveOnboardingFailure({
-        opts,
-        runtime,
-        mode,
-        phase: "gateway-health",
-        message: `Gateway did not become reachable at ${links.wsUrl}.`,
-        detail,
-        gateway: {
-          wsUrl: links.wsUrl,
-          httpUrl: links.httpUrl,
+      const explicitlySkippedAbsentGateway =
+        opts.installDaemon === false &&
+        classifyGatewayHealthFailure({ detail, diagnostics }) === "not-listening";
+      if (explicitlySkippedAbsentGateway && !opts.json) {
+        runtime.log(
+          "Setup complete; gateway was not installed or started because daemon installation was explicitly skipped.",
+        );
+      }
+      if (!explicitlySkippedAbsentGateway || !opts.json) {
+        logNonInteractiveOnboardingFailure({
+          opts,
+          runtime,
+          mode,
+          phase: "gateway-health",
+          message: `Gateway did not become reachable at ${links.wsUrl}.`,
+          detail,
+          gateway: {
+            wsUrl: links.wsUrl,
+            httpUrl: links.httpUrl,
+          },
+          installDaemon: Boolean(opts.installDaemon),
+          daemonInstall: daemonInstallStatus,
+          daemonRuntime: opts.installDaemon ? daemonRuntimeRaw : undefined,
+          diagnostics,
+          hints: !opts.installDaemon
+            ? [
+                "Non-interactive local setup only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`.",
+                `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run \`${formatCliCommand("openclaw onboard --install-daemon")}\`, or use \`${formatCliCommand("openclaw onboard --skip-health")}\`.`,
+                process.platform === "win32"
+                  ? "Native Windows managed gateway install tries Scheduled Tasks first and falls back to a per-user Startup-folder login item when task creation is denied."
+                  : undefined,
+              ].filter((value): value is string => Boolean(value))
+            : [`Run \`${formatCliCommand("openclaw gateway status --deep")}\` for more detail.`],
+          informational: explicitlySkippedAbsentGateway,
+        });
+      }
+      if (!explicitlySkippedAbsentGateway) {
+        runtime.exit(1);
+        return;
+      }
+      gatewayNotRunning = true;
+    } else {
+      await healthCommand(
+        {
+          json: false,
+          timeoutMs: opts.installDaemon
+            ? installDaemonGatewayHealthTiming.healthCommandTimeoutMs
+            : 10_000,
+          config: nextConfig,
+          token: probeAuth.token,
+          password: probeAuth.password,
         },
-        installDaemon: Boolean(opts.installDaemon),
-        daemonInstall: daemonInstallStatus,
-        daemonRuntime: opts.installDaemon ? daemonRuntimeRaw : undefined,
-        diagnostics,
-        hints: !opts.installDaemon
-          ? [
-              "Non-interactive local setup only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`.",
-              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run \`${formatCliCommand("openclaw onboard --install-daemon")}\`, or use \`${formatCliCommand("openclaw onboard --skip-health")}\`.`,
-              process.platform === "win32"
-                ? "Native Windows managed gateway install tries Scheduled Tasks first and falls back to a per-user Startup-folder login item when task creation is denied."
-                : undefined,
-            ].filter((value): value is string => Boolean(value))
-          : [`Run \`${formatCliCommand("openclaw gateway status --deep")}\` for more detail.`],
-      });
-      runtime.exit(1);
-      return;
+        runtime,
+      );
     }
-    await healthCommand(
-      {
-        json: false,
-        timeoutMs: opts.installDaemon
-          ? installDaemonGatewayHealthTiming.healthCommandTimeoutMs
-          : 10_000,
-        config: nextConfig,
-        token: probeAuth.token,
-        password: probeAuth.password,
-      },
-      runtime,
-    );
   }
 
   logNonInteractiveOnboardingJson({
@@ -437,6 +454,7 @@ export async function runNonInteractiveLocalSetup(params: {
       bind: gatewayResult.bind,
       authMode: gatewayResult.authMode,
       tailscaleMode: gatewayResult.tailscaleMode,
+      ...(gatewayNotRunning ? { reachable: false } : {}),
     },
     installDaemon: Boolean(opts.installDaemon),
     daemonInstall: daemonInstallStatus,

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -44,6 +44,7 @@ export function logNonInteractiveOnboardingJson(params: {
     bind: string;
     authMode: string;
     tailscaleMode: string;
+    reachable?: boolean;
   };
   installDaemon?: boolean;
   daemonInstall?: {
@@ -99,7 +100,7 @@ function hasConnectionRefusedDetail(detail: string): boolean {
   return /\b(?:econnrefused|connection refused|connect refused)\b/i.test(detail);
 }
 
-function classifyGatewayHealthFailure(params: {
+export function classifyGatewayHealthFailure(params: {
   detail?: string;
   diagnostics?: GatewayHealthFailureDiagnostics;
 }): GatewayHealthFailureClassification | undefined {
@@ -183,6 +184,7 @@ export function logNonInteractiveOnboardingFailure(params: {
   };
   daemonRuntime?: string;
   diagnostics?: GatewayHealthFailureDiagnostics;
+  informational?: boolean;
 }) {
   const classification = classifyGatewayHealthFailure({
     detail: params.detail,
@@ -229,5 +231,9 @@ export function logNonInteractiveOnboardingFailure(params: {
     .filter(Boolean)
     .join("\n");
 
-  params.runtime.error(lines);
+  if (params.informational) {
+    params.runtime.log(lines);
+  } else {
+    params.runtime.error(lines);
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw onboard --non-interactive --skip-daemon` completed all setup writes, then exited 1 because the post-setup health gate required the gateway that the operator had explicitly declined to install or start.

## Why This Change Was Made

The non-interactive local health owner now distinguishes Commander's three daemon intents: install (`true`), explicitly skip (`false`), and unspecified (`undefined`). Only an explicit skip combined with a concrete `not-listening` probe is informational. Requested installs, implicit attachment to an expected existing gateway, auth mismatches, and other health failures remain fatal.

The existing diagnostic and remedy text is preserved. Human output adds an explicit setup-complete line, while JSON success output records `gateway.reachable: false`. No flags, config keys, or generated config shapes changed.

## User Impact

Automation can use `--skip-daemon` or `--no-install-daemon` for a fresh local profile and receive exit 0 after successful config/workspace/session setup, while still seeing that the gateway is not running and how to start it.

Exit-code contract:

| Input / observed state | Before | After | Change |
| --- | ---: | ---: | --- |
| Explicit `--skip-daemon`, no listener | 1 | 0 | Intentional |
| No daemon flag, no listener (existing gateway expected) | 1 | 1 | None |
| `--install-daemon`, install or health failure | 1 | 1 | None |
| Explicit daemon skip, reachable compatible gateway | 0 | 0 | None |
| `--skip-health` | 0 | 0 | None |
| `--mode remote` | 0 | 0 | None; remote onboarding remains config-only |

## Evidence

- Before/after built-CLI proof used the same Blacksmith Testbox (`tbx_01m010mehz4btpg6e7ba4hknmq`, [run](https://github.com/openclaw/openclaw/actions/runs/31839740418)), isolated `OPENCLAW_STATE_DIR` values, `OPENCLAW_SKIP_CHANNELS=1`, and distinct derived ports. Scratch state was removed by an exit trap.
  - Before: explicit `--skip-daemon` exited 1; no daemon flag exited 1.
  - After: explicit `--skip-daemon` exited 0 and printed `Setup complete; gateway was not installed or started because daemon installation was explicitly skipped.` plus the unchanged classification and three remedies; no daemon flag still exited 1.
  - The successful scratch profile contained `openclaw.json`, `workspace/`, and `agents/main/sessions/`.
- Regression was red before the production edit: the explicit-skip test failed at the existing `runtime.exit(1)` health-gate branch.
- `node scripts/run-vitest.mjs src/commands/onboard-non-interactive.gateway.test.ts src/commands/onboard-non-interactive/remote.test.ts src/commands/configure.wizard.test.ts` — 3 files, 46 tests passed.
- `node scripts/check-changed.mjs` — green on Blacksmith Testbox `tbx_01m012qg7b60853g910n36tsgr` ([run](https://github.com/openclaw/openclaw/actions/runs/31842469009)); formatting, max-lines, dead exports, production/test types, changed-file lint, architecture guards, and import cycles passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
- `node scripts/check-docs-mdx.mjs docs/cli/onboard.md docs/start/wizard-cli-automation.md` — passed.
- Production LOC: +64/-40 (net +24). Tests: +23/-13 (net +10). Docs: +3/-2 (net +1). Production growth records the explicit outcome at the health owner, reuses the existing failure classifier/remedy formatter, and adds the machine-readable reachability fact.
- A full docs anchor audit also found one unrelated pre-existing broken link in `plugins/codex-computer-use.md`; no onboarding-doc link failed.

AI-assisted: yes. I understand and verified the owner boundary, changed exit-code combination, preserved failure cases, and live behavior.
