### PR TITLE
fix(workers): clean transfer scratch across gateway restarts

### DIFF
--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -21,6 +23,35 @@ afterEach(() => {
 });
 
 describe("gateway worker environment startup", () => {
+  it("cleans transfer scratch before serving and removes it on shutdown", async () => {
+    const stateDir = tempDirs.make("openclaw-worker-transfer-startup-");
+    const transferRoot = path.join(stateDir, "tmp", "node-workspace-transfer");
+    const staleRoot = path.join(transferRoot, "context-stale");
+    await fs.mkdir(staleRoot, { recursive: true });
+    await fs.writeFile(path.join(staleRoot, "base.pack"), "stale");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const startup = await loadGatewayWorkerEnvironmentStartupState();
+      const runtime = await createGatewayWorkerEnvironmentRuntime({
+        getPluginRegistry: () => ({ workerProviders: new Map() }),
+        resolveWorkerGateway: () => undefined,
+        desktopSessionRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
+        startup,
+        log: { child: () => ({ warn: () => {} }) },
+      });
+      const service = runtime.workerEnvironmentService;
+      if (!service) {
+        throw new Error("worker environment service was not created");
+      }
+      try {
+        await expect(fs.readdir(transferRoot)).resolves.toEqual([]);
+      } finally {
+        await service.stop();
+      }
+      await expect(fs.stat(transferRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
   it("binds device revocation to the persisted profile settings", async () => {
     const stateDir = tempDirs.make("openclaw-worker-startup-");
     try {

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -181,6 +181,7 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
   const nodeWorkspaceTransfer = createNodeWorkspaceTransferService({
     getOwner: (environmentId) => params.startup.store.getTransferOwner(environmentId),
   });
+  await nodeWorkspaceTransfer.initialize();
   const nodeWorkerTunnelManager = createNodeWorkerTunnelManager({
     gatewayDeviceId: loadOrCreateProcessDeviceIdentity().deviceId,
     getEnvironment: (environmentId) => params.startup.store.get(environmentId),

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -713,6 +713,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
         pending.cancelled = true;
       }
       await Promise.all([...entries.values()].map(stopEntry));
+      await options.workspaceTransfer.closeAll();
     },
     status(environmentId: string): WorkerTunnelStatus {
       const entry = entries.get(environmentId);

--- a/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
-import type { Server } from "node:http";
+import type { IncomingMessage, Server } from "node:http";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { NODE_WORKER_WORKSPACE_EXEC_COMMAND } from "../../infra/node-commands.js";
@@ -367,6 +368,132 @@ describe("node workspace transfer service", () => {
 
     expect(signal.aborted).toBe(true);
     expect(service.isAuthorizationCurrent(authorization!)).toBe(false);
+  });
+
+  it("clears crash scratch eagerly and removes the transfer root on shutdown", async () => {
+    const root = tempDirs.make("node-workspace-transfer-lifecycle-");
+    const temporaryRoot = path.join(root, "transfer-tmp");
+    const staleRoot = path.join(temporaryRoot, "context-stale");
+    await fs.mkdir(staleRoot, { recursive: true });
+    await fs.writeFile(path.join(staleRoot, "base.pack"), "stale");
+    const service = createNodeWorkspaceTransferService({
+      getOwner: () => undefined,
+      temporaryRoot,
+    });
+
+    await service.initialize();
+
+    await expect(fs.readdir(temporaryRoot)).resolves.toEqual([]);
+    await service.closeAll();
+    await expect(fs.stat(temporaryRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serializes transfer context replacement for one environment", async () => {
+    const root = tempDirs.make("node-workspace-transfer-serialization-");
+    const localPath = path.join(root, "workspace");
+    const temporaryRoot = path.join(root, "transfer-tmp");
+    await fs.mkdir(localPath);
+    await fs.writeFile(path.join(localPath, "input.txt"), "input\n");
+    const service = createNodeWorkspaceTransferService({
+      getOwner: () => ({
+        credential: {
+          ownerEpoch: 1,
+          expiresAtMs: Date.now() + 60_000,
+          sessionId: "session-serialize",
+        },
+        environment: {
+          ownerEpoch: 1,
+          attachedSessionIds: ["session-serialize"],
+          destroyRequestedAtMs: null,
+          state: "attached",
+        },
+      }),
+      temporaryRoot,
+    });
+
+    await Promise.all([
+      service.prepareSync({
+        environmentId: "environment-serialize",
+        ownerEpoch: 1,
+        sessionId: "session-serialize",
+        generation: 1,
+        localPath,
+        isAuthorized: () => true,
+      }),
+      service.prepareSync({
+        environmentId: "environment-serialize",
+        ownerEpoch: 1,
+        sessionId: "session-serialize",
+        generation: 2,
+        localPath,
+        isAuthorized: () => true,
+      }),
+    ]);
+
+    const contexts = (await fs.readdir(temporaryRoot)).filter((name) =>
+      name.startsWith("context-"),
+    );
+    expect(contexts).toHaveLength(1);
+    await service.closeAll();
+  });
+
+  it("releases an upload owner after validation fails before staging", async () => {
+    const root = tempDirs.make("node-workspace-transfer-upload-release-");
+    const localPath = path.join(root, "workspace");
+    await fs.mkdir(localPath);
+    await fs.writeFile(path.join(localPath, "input.txt"), "input\n");
+    const service = createNodeWorkspaceTransferService({
+      getOwner: () => ({
+        credential: {
+          ownerEpoch: 1,
+          expiresAtMs: Date.now() + 60_000,
+          sessionId: "session-upload-release",
+        },
+        environment: {
+          ownerEpoch: 1,
+          attachedSessionIds: ["session-upload-release"],
+          destroyRequestedAtMs: null,
+          state: "attached",
+        },
+      }),
+      temporaryRoot: path.join(root, "transfer-tmp"),
+    });
+    const prepared = await service.prepareSync({
+      environmentId: "environment-upload-release",
+      ownerEpoch: 1,
+      sessionId: "session-upload-release",
+      generation: 1,
+      localPath,
+      isAuthorized: () => true,
+    });
+    const token = service.prepareUpload(
+      "environment-upload-release",
+      prepared.snapshot.manifestRef,
+    );
+    const route = {
+      kind: "reconcile",
+      direction: "upload",
+      environmentId: "environment-upload-release",
+      baseManifestRef: prepared.snapshot.manifestRef,
+    } as const;
+    const authorization = service.authorize({ route, token });
+    if (!authorization) {
+      throw new Error("upload authorization was not created");
+    }
+    const request = Readable.from([]) as unknown as IncomingMessage;
+    request.headers = { "content-length": "0" };
+
+    await expect(
+      service.receiveUpload({
+        authorization,
+        request,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow("byte limit");
+    expect(() =>
+      service.prepareUpload("environment-upload-release", prepared.snapshot.manifestRef),
+    ).not.toThrow();
+    await service.closeAll();
   });
 
   it("rejects a retained tunnel callback after durable transfer ownership changes", async () => {

--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
 import { isPathInside } from "../../infra/fs-safe.js";
+import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type { NodeWorkspaceTransferHttpRoute } from "./node-workspace-transfer-http-contract.js";
 import {
   prepareNodeWorkspaceTransferSnapshot,
@@ -269,6 +270,7 @@ export function createNodeWorkspaceTransferService(options: {
   temporaryRoot?: string;
 }) {
   const contexts = new Map<string, TransferContext>();
+  const contextOperations = new KeyedAsyncQueue();
   const now = options.now ?? Date.now;
   const temporaryBaseRoot =
     options.temporaryRoot ?? path.join(resolveStateDir(), "tmp", "node-workspace-transfer");
@@ -303,6 +305,14 @@ export function createNodeWorkspaceTransferService(options: {
     }
     await fsp.rm(context.temporaryRoot, { recursive: true, force: true });
   };
+
+  const closeEnvironment = (environmentId: string) =>
+    contextOperations.enqueue(environmentId, async () => {
+      const context = contexts.get(environmentId);
+      if (context) {
+        await closeContext(context);
+      }
+    });
 
   const mintDownload = (context: TransferContext, manifestRef: string): string => {
     const credential = currentOwner(context)?.credential;
@@ -383,6 +393,8 @@ export function createNodeWorkspaceTransferService(options: {
   };
 
   return {
+    initialize: ensureTemporaryRoot,
+
     async prepareSync(params: {
       environmentId: string;
       ownerEpoch: number;
@@ -392,47 +404,49 @@ export function createNodeWorkspaceTransferService(options: {
       isAuthorized: () => boolean;
       signal?: AbortSignal;
     }) {
-      const previous = contexts.get(params.environmentId);
-      if (previous) {
-        await closeContext(previous);
-      }
-      await ensureTemporaryRoot();
-      const abortController = new AbortController();
-      const context: TransferContext = {
-        ...params,
-        localPath: await fsp.realpath(params.localPath),
-        temporaryRoot: await fsp.mkdtemp(path.join(temporaryBaseRoot, "context-")),
-        currentManifestRef: "",
-        snapshots: new Map(),
-        downloads: new Map(),
-        abortController,
-      };
-      if (params.signal) {
-        const abortFromOwner = () => abortController.abort(params.signal!.reason);
-        params.signal.addEventListener("abort", abortFromOwner, { once: true });
-        context.stopWatchingOwnerSignal = () =>
-          params.signal?.removeEventListener("abort", abortFromOwner);
-        if (params.signal.aborted) {
-          abortFromOwner();
+      return await contextOperations.enqueue(params.environmentId, async () => {
+        const previous = contexts.get(params.environmentId);
+        if (previous) {
+          await closeContext(previous);
         }
-      }
-      try {
-        const snapshot = await prepareNodeWorkspaceTransferSnapshot({
-          localPath: context.localPath,
-          temporaryRoot: context.temporaryRoot,
-          signal: AbortSignal.any([
-            context.abortController.signal,
-            AbortSignal.timeout(TRANSFER_TIMEOUT_MS),
-          ]),
-        });
-        context.snapshots.set(snapshot.manifestRef, snapshot);
-        context.currentManifestRef = snapshot.manifestRef;
-        contexts.set(context.environmentId, context);
-        return { snapshot, token: mintDownload(context, snapshot.manifestRef) };
-      } catch (error) {
-        await closeContext(context);
-        throw error;
-      }
+        await ensureTemporaryRoot();
+        const abortController = new AbortController();
+        const context: TransferContext = {
+          ...params,
+          localPath: await fsp.realpath(params.localPath),
+          temporaryRoot: await fsp.mkdtemp(path.join(temporaryBaseRoot, "context-")),
+          currentManifestRef: "",
+          snapshots: new Map(),
+          downloads: new Map(),
+          abortController,
+        };
+        if (params.signal) {
+          const abortFromOwner = () => abortController.abort(params.signal!.reason);
+          params.signal.addEventListener("abort", abortFromOwner, { once: true });
+          context.stopWatchingOwnerSignal = () =>
+            params.signal?.removeEventListener("abort", abortFromOwner);
+          if (params.signal.aborted) {
+            abortFromOwner();
+          }
+        }
+        try {
+          const snapshot = await prepareNodeWorkspaceTransferSnapshot({
+            localPath: context.localPath,
+            temporaryRoot: context.temporaryRoot,
+            signal: AbortSignal.any([
+              context.abortController.signal,
+              AbortSignal.timeout(TRANSFER_TIMEOUT_MS),
+            ]),
+          });
+          context.snapshots.set(snapshot.manifestRef, snapshot);
+          context.currentManifestRef = snapshot.manifestRef;
+          contexts.set(context.environmentId, context);
+          return { snapshot, token: mintDownload(context, snapshot.manifestRef) };
+        } catch (error) {
+          await closeContext(context);
+          throw error;
+        }
+      });
     },
 
     prepareUpload(environmentId: string, baseManifestRef: string): string {
@@ -602,39 +616,38 @@ export function createNodeWorkspaceTransferService(options: {
         params.signal.throwIfAborted();
         assertAuthorizationCurrent(authorization);
       };
-      assertCurrent();
-      const contentLength = Number(params.request.headers["content-length"]);
-      if (
-        !Number.isSafeInteger(contentLength) ||
-        contentLength < 8 ||
-        contentLength > MAX_UPLOAD_BYTES
-      ) {
-        throw new NodeWorkspaceTransferLimitError(
-          "Workspace transfer upload exceeds its byte limit",
-        );
-      }
-      const reader = new RequestByteReader(params.request, params.signal, assertCurrent);
-      const readManifest = async (expectedRef?: string) => {
-        const bytes = (await reader.readExactly(4)).readUInt32BE();
-        if (bytes < 2 || bytes > MAX_WORKSPACE_MANIFEST_BYTES) {
+      let stagingRoot: string | undefined;
+      try {
+        assertCurrent();
+        const contentLength = Number(params.request.headers["content-length"]);
+        if (
+          !Number.isSafeInteger(contentLength) ||
+          contentLength < 8 ||
+          contentLength > MAX_UPLOAD_BYTES
+        ) {
           throw new NodeWorkspaceTransferLimitError(
-            "Workspace transfer manifest exceeds its byte limit",
+            "Workspace transfer upload exceeds its byte limit",
           );
         }
-        const raw = (await reader.readExactly(bytes)).toString("utf8");
-        const ref = expectedRef ?? `sha256:${createHash("sha256").update(raw).digest("hex")}`;
-        return { raw, ref, manifest: parseWorkerWorkspaceManifest(raw, ref) };
-      };
-      const base = await readManifest(operation.baseManifestRef);
-      assertCurrent();
-      const current = await readManifest();
-      assertCurrent();
-      const transferPaths = workerWorkspaceTransferPaths(current.manifest, base.manifest);
-      const transferPathSet = new Set(transferPaths);
-      const stagingRoot = await fsp.mkdtemp(
-        path.join(authorization.context.temporaryRoot, "upload-"),
-      );
-      try {
+        const reader = new RequestByteReader(params.request, params.signal, assertCurrent);
+        const readManifest = async (expectedRef?: string) => {
+          const bytes = (await reader.readExactly(4)).readUInt32BE();
+          if (bytes < 2 || bytes > MAX_WORKSPACE_MANIFEST_BYTES) {
+            throw new NodeWorkspaceTransferLimitError(
+              "Workspace transfer manifest exceeds its byte limit",
+            );
+          }
+          const raw = (await reader.readExactly(bytes)).toString("utf8");
+          const ref = expectedRef ?? `sha256:${createHash("sha256").update(raw).digest("hex")}`;
+          return { raw, ref, manifest: parseWorkerWorkspaceManifest(raw, ref) };
+        };
+        const base = await readManifest(operation.baseManifestRef);
+        assertCurrent();
+        const current = await readManifest();
+        assertCurrent();
+        const transferPaths = workerWorkspaceTransferPaths(current.manifest, base.manifest);
+        const transferPathSet = new Set(transferPaths);
+        stagingRoot = await fsp.mkdtemp(path.join(authorization.context.temporaryRoot, "upload-"));
         const currentByPath = new Map(current.manifest.entries.map((entry) => [entry.path, entry]));
         for (const relative of transferPaths) {
           const entry = currentByPath.get(relative);
@@ -680,7 +693,9 @@ export function createNodeWorkspaceTransferService(options: {
         operation.state = "completed";
         return { manifestRef: current.ref };
       } catch (error) {
-        await fsp.rm(stagingRoot, { recursive: true, force: true });
+        if (stagingRoot) {
+          await fsp.rm(stagingRoot, { recursive: true, force: true });
+        }
         if (authorization.context.upload === operation) {
           authorization.context.upload = undefined;
         }
@@ -700,15 +715,11 @@ export function createNodeWorkspaceTransferService(options: {
       );
     },
 
-    async close(environmentId: string): Promise<void> {
-      const context = contexts.get(environmentId);
-      if (context) {
-        await closeContext(context);
-      }
-    },
+    close: closeEnvironment,
 
     async closeAll(): Promise<void> {
-      await Promise.all([...contexts.values()].map(closeContext));
+      await temporaryRootReady;
+      await Promise.all([...contexts.keys()].map(closeEnvironment));
       await fsp.rm(temporaryBaseRoot, { recursive: true, force: true });
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway node-workspace transfer scratch could survive a crashed process, concurrent sync preparation could leave a losing context directory behind, and an upload rejected before staging could permanently retain the active upload slot.

## Why This Change Was Made

The Gateway now owns the complete transfer-scratch lifecycle: it clears the private scratch root before exposing worker transfer paths, serializes context replacement per environment, releases upload ownership for every failed receive stage, and removes the root after node tunnels drain on shutdown. The change is AI-assisted and keeps the existing transfer authority and storage contracts unchanged.

## User Impact

Node-hosted session workspaces recover cleanly across Gateway restarts and failed transfers without accumulating stale scratch data or wedging later reconciliation attempts. There is no new configuration, protocol, or SQLite schema surface.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-worker-environment-startup.test.ts src/gateway/worker-environments/node-workspace-transfer-service.test.ts src/gateway/worker-environments/node-worker-tunnel.test.ts` — 3 files, 15 tests passed on the rebased head.
- The four new lifecycle regressions were run against the pre-fix production code and failed for the intended reasons: stale startup scratch remained, concurrent preparation left two contexts, early upload rejection retained the active slot, and the service had no eager initialization hook.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- <five changed paths>` — passed all core/core-test changed gates, including format, dead exports, type checks, lint, schema-version guard, and import cycles. The first delegated attempt was discarded because the remote checkout lacked its hydrated workspace modules.
- Structured autoreview on the final rebased branch reported no accepted/actionable findings.
