### PR TITLE
fix(ci): invalidate plugin SDK declarations on auth changes

### DIFF
--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -161,6 +161,8 @@ function listSourceDtsOutputs(sourceDir: string, outputPrefix: string) {
 const PLUGIN_SDK_TYPE_INPUTS = [
   "tsconfig.json",
   "src/plugin-sdk",
+  // provider-auth re-exports these signatures into generated SDK declarations.
+  "src/agents/cli-credentials.ts",
   "src/plugins/provider-runtime-model.types.ts",
   "src/plugins/types.ts",
   "src/auto-reply",

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -76,6 +76,14 @@ describe("device-auth upgrade migration", () => {
     const request = vi.fn<RequestFn>(() => Promise.resolve({}));
     const harness = createGatewayHarness(null, false);
     const overlays = createApplicationOverlays(harness.gateway);
+    const migrationError = new Promise<string>((resolve) => {
+      const unsubscribe = overlays.subscribe((snapshot) => {
+        if (snapshot.deviceAuthMigration.error) {
+          unsubscribe();
+          resolve(snapshot.deviceAuthMigration.error);
+        }
+      });
+    });
     harness.update({
       client: client(request),
       phase: "connected",
@@ -85,9 +93,7 @@ describe("device-auth upgrade migration", () => {
       } as ApplicationGatewaySnapshot["hello"],
     });
 
-    await vi.waitFor(() => {
-      expect(overlays.snapshot.deviceAuthMigration.error).toContain("HTTPS or localhost");
-    });
+    await expect(migrationError).resolves.toContain("HTTPS or localhost");
     expect(overlays.snapshot.deviceAuthMigration.requestId).toBeNull();
     expect(request).not.toHaveBeenCalledWith("device.pair.list", expect.anything());
     overlays.dispose();


### PR DESCRIPTION
## What Problem This Solves

Repairs repeated `main` failures in `check-additional-extension-package-boundary`. The Anthropic plugin correctly used the newly added non-interactive keychain options, but cached Plugin SDK declarations still exposed the older option type.

## Root Cause

The boundary artifact digest covered `src/plugin-sdk/**` but not `src/agents/cli-credentials.ts`, even though `provider-auth` re-exports the credential reader signature from that file. A restored declaration cache therefore remained "fresh" after the public signature changed and compiled plugins against stale declarations.

## Fix

Include the credential reader source in the canonical Plugin SDK declaration inputs. Any future signature change now invalidates both root and package declaration stamps before plugin package compilation.

Runtime production delta: 0. CI tooling: +2 lines. Tests: +9/-3 lines (net +6).

## Evidence

- Reproduced on four consecutive `main` runs, including [31843294122](https://github.com/openclaw/openclaw/actions/runs/31843294122) and [31843824451](https://github.com/openclaw/openclaw/actions/runs/31843824451): Anthropic failed because cached declarations omitted `tryKeychainWithoutPrompt`.
- Focused artifact-preparation tests: 19/19 passed.
- Exact-head restored-cache package-boundary job passed on [31844479447](https://github.com/openclaw/openclaw/actions/runs/31844479447).
- That run exposed an unrelated loaded-shard timing defect in `overlays.test.ts`: its lazy migration import could complete after the polling assertion expired. The test now waits on the overlay's published snapshot event; focused UI proof passed 54/54.
- Targeted formatting, scripts lint, and `git diff --check` passed.
- Autoreview: no accepted/actionable findings.
- Final exact-head CI passed at `0bbf9f593def2936da8bc71600be41d0e0790f86`: [31845597239](https://github.com/openclaw/openclaw/actions/runs/31845597239).
