### PR TITLE
fix(gateway): resolve cron owner for explicit agent rosters

### DIFF
--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -435,6 +435,30 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("uses the configured system agent for explicit rosters", () => {
+    const cfg = {
+      ...createCronConfig("server-cron-explicit-owner"),
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, worker: {} },
+        defaults: { systemAgent: { agentId: "main" } },
+      },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+
+    try {
+      expect(state.cron.getDefaultAgentId()).toBe("main");
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("passes the persisted payload tool cap to trigger evaluation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-14T12:00:00.000Z"));

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -459,6 +459,30 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("does not use a retired session-store owner for an explicit roster", () => {
+    const cfg = {
+      ...createCronConfig("server-cron-retired-session-store-owner"),
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, worker: {} },
+        defaults: { sessionStore: { agentId: "retired-ops" } },
+      },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+
+    try {
+      expect(state.cron.getDefaultAgentId()).toBeUndefined();
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("passes the persisted payload tool cap to trigger evaluation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-14T12:00:00.000Z"));

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -10,6 +10,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import {
   resolveSessionStoreCompatibilityAgentId,
   tryGetLegacyDefaultAgentId,
+  tryResolveLegacyCompatibilityAgentId,
 } from "../config/legacy.default-agent-owner.js";
 import {
   canonicalizeMainSessionAlias,
@@ -372,18 +373,23 @@ export function buildGatewayCronService(params: {
   const findAgentEntry = (cfg: OpenClawConfig, agentId: string) =>
     listAgentEntries(cfg).find((entry) => normalizeAgentId(entry.id) === agentId);
 
-  // Explicit agent rosters do not have a legacy default owner. Cron still
-  // needs a concrete owner for jobs and session reaping, so prefer the
-  // configured system agent and fall back to the compatibility session-store
-  // owner used by the rest of the Gateway.
-  const resolveCronDefaultAgentId = (cfg: OpenClawConfig) =>
-    normalizeAgentId(
-      cfg.agents?.defaults?.systemAgent?.agentId?.trim() ??
-        resolveSessionStoreCompatibilityAgentId(cfg),
-    );
-
   const hasConfiguredAgent = (cfg: OpenClawConfig, agentId: string) =>
     Boolean(findAgentEntry(cfg, agentId));
+
+  // Explicit agent rosters do not have a legacy default owner. Cron still
+  // needs a concrete owner when one is configured, so prefer the configured
+  // system agent and fall back only to an active legacy owner. The session
+  // store owner is upgrade metadata and may outlive the active roster.
+  const resolveCronDefaultAgentId = (cfg: OpenClawConfig) => {
+    const systemAgentId = cfg.agents?.defaults?.systemAgent?.agentId?.trim();
+    if (systemAgentId) {
+      const normalizedSystemAgentId = normalizeAgentId(systemAgentId);
+      if (hasConfiguredAgent(cfg, normalizedSystemAgentId)) {
+        return normalizedSystemAgentId;
+      }
+    }
+    return tryResolveLegacyCompatibilityAgentId(cfg);
+  };
 
   const resolveCronAgent = (requested?: string | null) => {
     const runtimeConfig = getRuntimeConfig();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -10,7 +10,6 @@ import { getRuntimeConfig } from "../config/io.js";
 import {
   resolveSessionStoreCompatibilityAgentId,
   tryGetLegacyDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
 } from "../config/legacy.default-agent-owner.js";
 import {
   canonicalizeMainSessionAlias,
@@ -373,6 +372,16 @@ export function buildGatewayCronService(params: {
   const findAgentEntry = (cfg: OpenClawConfig, agentId: string) =>
     listAgentEntries(cfg).find((entry) => normalizeAgentId(entry.id) === agentId);
 
+  // Explicit agent rosters do not have a legacy default owner. Cron still
+  // needs a concrete owner for jobs and session reaping, so prefer the
+  // configured system agent and fall back to the compatibility session-store
+  // owner used by the rest of the Gateway.
+  const resolveCronDefaultAgentId = (cfg: OpenClawConfig) =>
+    normalizeAgentId(
+      cfg.agents?.defaults?.systemAgent?.agentId?.trim() ??
+        resolveSessionStoreCompatibilityAgentId(cfg),
+    );
+
   const hasConfiguredAgent = (cfg: OpenClawConfig, agentId: string) =>
     Boolean(findAgentEntry(cfg, agentId));
 
@@ -380,7 +389,7 @@ export function buildGatewayCronService(params: {
     const runtimeConfig = getRuntimeConfig();
     const normalized =
       typeof requested === "string" && requested.trim() ? normalizeAgentId(requested) : undefined;
-    const defaultAgentId = tryResolveLegacyCompatibilityAgentId(runtimeConfig);
+    const defaultAgentId = resolveCronDefaultAgentId(runtimeConfig);
     if (
       normalized !== undefined &&
       normalized !== defaultAgentId &&
@@ -507,7 +516,7 @@ export function buildGatewayCronService(params: {
     return sanitizeCronHeartbeatOverride(heartbeatOverride);
   };
 
-  const defaultAgentId = tryResolveLegacyCompatibilityAgentId(params.cfg);
+  const defaultAgentId = resolveCronDefaultAgentId(params.cfg);
   const legacyDefaultAgentId = tryGetLegacyDefaultAgentId(params.cfg);
   const resolveSessionStorePath = (agentId?: string) =>
     resolveSessionStorePathCore(params.cfg.session?.store, {
@@ -728,7 +737,7 @@ export function buildGatewayCronService(params: {
       : {}),
     ...(defaultAgentId ? { defaultAgentId } : {}),
     ...(legacyDefaultAgentId ? { legacyDefaultAgentId } : {}),
-    resolveDefaultAgentId: () => tryResolveLegacyCompatibilityAgentId(getRuntimeConfig()),
+    resolveDefaultAgentId: () => resolveCronDefaultAgentId(getRuntimeConfig()),
     resolveSessionStoreAgentIds: () => {
       const cfg = getRuntimeConfig();
       try {


### PR DESCRIPTION
AI-assisted contribution prepared with Codex. I understand the implementation and validation described below.

## What Problem This Solves

Fixes Gateway Cron ownership when the configuration uses an explicit agent roster. The legacy compatibility resolver can return no active owner, while persisted session-store metadata may name a retired agent that is no longer in the roster. Cron must not promote that migration metadata into a runnable agent.

## Why This Change Was Made

Cron now prefers the configured system agent when it is present in the active roster and otherwise falls back only to the active legacy compatibility owner. It no longer uses `sessionStore.agentId` as a runnable Cron default. Session-store compatibility metadata remains available for store-path discovery.

The regression coverage preserves the explicit system-agent case and verifies that an explicit roster retaining `retired-ops` as its session-store owner receives no Cron default.

## User Impact

Explicit multi-agent Gateways no longer route scheduled jobs or session-reaper callbacks to retired agents retained only for migration compatibility. Valid configured system owners and active legacy owners continue to work. No configuration migration is required.

## Evidence

- ClawSweeper finding fixed at exact PR head `574b4fa9827f82ee869074581f9ea66041b04ca5`.
- The PR remains based on `origin/main` `628056b0ba99dcb4b725edb70702a05a6672c47b`.
- Exact-head focused validation: `pnpm exec vitest run src/cron/service.session-reaper-in-finally.test.ts src/gateway/server-cron.test.ts --reporter=dot` — 2 files, 76 tests passed.
- Exact-head formatting: `pnpm exec oxfmt --check src/gateway/server-cron.ts src/gateway/server-cron.test.ts` passed.
- Exact-head `git diff --check` passed.
- Direct source-level Cron lifecycle proof with an explicit `main`/`worker` roster retaining `retired-ops` only as `sessionStore.agentId`:

  ```text
  {"started":true,"defaultAgentId":null}
  {"stopped":true}
  ```

  The real `buildGatewayCronService` started and stopped cleanly without selecting the retired owner.
- Stronger after-fix runtime proof exercised the real `buildGatewayCronService` owner resolver and real `onTimer`/session-reaper path in a fresh temporary state. The redacted trace was:

  ```json
  {
    "explicitRoster": ["main", "worker"],
    "configuredSystemAgent": "main",
    "upgradeOnlySessionStoreOwner": "retired-ops",
    "cronDefaultAgentId": "main",
    "sessionReaperTargets": ["main", "worker"],
    "expiredSessionRowsRemaining": {"main": 0, "worker": 0},
    "retiredOwnerUsedAsCronDefault": false
  }
  ```

  The proof harness supplied the isolated active-roster target list to avoid unrelated host registry entries; the production owner resolver, Cron state, timer path, and session sweep ran unchanged. This is not a full daemon/socket/account-delivery proof.
- The PR diff is limited to `src/gateway/server-cron.ts` and `src/gateway/server-cron.test.ts`.

AI-assisted: Yes. The patch was prepared with Codex, and the author reviewed the behavior, scope, and validation results.
