### PR TITLE
fix: reject multi-line exec allowlist patterns; match ~ and absolute spellings on remove

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -105,6 +105,7 @@ enum ExecApprovalDecision: String, Codable, Equatable {
 enum ExecAllowlistPatternValidationReason: String, Codable, Equatable, Sendable {
     case empty
     case missingPathComponent
+    case multiline
 
     var message: String {
         switch self {
@@ -112,6 +113,8 @@ enum ExecAllowlistPatternValidationReason: String, Codable, Equatable, Sendable 
             "Pattern cannot be empty."
         case .missingPathComponent:
             "Path patterns only. Include '/', '~', or '\\\\'."
+        case .multiline:
+            "One pattern per line."
         }
     }
 }
@@ -210,6 +213,9 @@ enum ExecApprovalHelpers {
     static func validateAllowlistPattern(_ pattern: String?) -> ExecAllowlistPatternValidation {
         let trimmed = pattern?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return .invalid(.empty) }
+        // One pattern is one first-token matcher. An embedded newline can never
+        // match an executable path, so it would persist as a silent no-op grant.
+        guard !trimmed.contains(where: \.isNewline) else { return .invalid(.multiline) }
         return .valid(trimmed)
     }
 

--- a/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
+++ b/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
@@ -797,9 +797,18 @@ final class ExecApprovalsSettingsModel {
     @discardableResult
     func addEntry(_ pattern: String) -> Bool {
         guard !self.isDefaultsScope else { return false }
-        let result = ExecApprovalsStore.addAllowlistEntry(
+        // A paste can carry several lines; each line is its own single-line
+        // pattern, so multi-line input never persists as one unmatchable entry.
+        let lines = pattern
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else {
+            return self.finishMutation(.failure(.invalidPattern(.empty)))
+        }
+        let result = ExecApprovalsStore.addAllowlistEntries(
             agentId: self.selectedAgentId,
-            pattern: pattern)
+            entries: lines.map { ExecAllowlistEntry(pattern: $0) })
         return self.finishMutation(result, showLoading: true)
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalHelpersTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalHelpersTests.swift
@@ -40,6 +40,15 @@ struct ExecApprovalHelpersTests {
         } else {
             Issue.record("Expected empty pattern rejection")
         }
+
+        // A multi-line paste must not persist as one unmatchable pattern.
+        let multiline = "/usr/bin/rg\n/usr/bin/rg"
+        if case let .invalid(reason) = ExecApprovalHelpers.validateAllowlistPattern(multiline) {
+            #expect(reason == .multiline)
+        } else {
+            Issue.record("Expected multi-line pattern rejection")
+        }
+        #expect(!ExecApprovalHelpers.isValidAllowlistPattern(multiline))
     }
 
     @Test func `requires ask matches policy`() {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { Command } from "commander";
@@ -909,6 +910,70 @@ describe("exec approvals CLI", () => {
     expect(updateExecApprovals).toHaveBeenCalledWith(
       expect.objectContaining({ baseHash: "hash-local" }),
     );
+    expectFields(saved, "saved approvals", {
+      version: 1,
+      agents: {},
+    });
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("rejects a multi-line allowlist add pattern instead of storing one unmatchable entry", async () => {
+    const updateExecApprovals = vi.mocked(execApprovals.updateExecApprovals);
+    updateExecApprovals.mockClear();
+
+    await expect(
+      runApprovalsCommand([
+        "approvals",
+        "allowlist",
+        "add",
+        "/usr/bin/uname\n/usr/bin/uname\n/usr/bin/uname",
+      ]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors.some((line) => line.includes("single line"))).toBe(true);
+    expect(updateExecApprovals).not.toHaveBeenCalled();
+  });
+
+  it("removes a stored absolute home path given its ~/ spelling", async () => {
+    const home = os.homedir();
+    localSnapshot.file = {
+      version: 1,
+      agents: {
+        "*": {
+          allowlist: [{ pattern: path.join(home, "bin", "ollama"), lastUsedAt: Date.now() }],
+        },
+      },
+    };
+
+    await runApprovalsCommand(["approvals", "allowlist", "remove", "~/bin/ollama"]);
+
+    const saved = requireRecord(localSnapshot.file, "saved approvals");
+    expectFields(saved, "saved approvals", {
+      version: 1,
+      agents: {},
+    });
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("removes a stored ~/ pattern given its absolute spelling", async () => {
+    const home = os.homedir();
+    localSnapshot.file = {
+      version: 1,
+      agents: {
+        "*": {
+          allowlist: [{ pattern: "~/bin/ollama", lastUsedAt: Date.now() }],
+        },
+      },
+    };
+
+    await runApprovalsCommand([
+      "approvals",
+      "allowlist",
+      "remove",
+      path.join(home, "bin", "ollama"),
+    ]);
+
+    const saved = requireRecord(localSnapshot.file, "saved approvals");
     expectFields(saved, "saved approvals", {
       version: 1,
       agents: {},

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,5 +1,7 @@
 // CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { expectDefined } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -1011,6 +1013,19 @@ function normalizeAllowlistEntry(entry: { pattern?: string } | null): string | n
   return pattern ? pattern : null;
 }
 
+// Stored patterns keep whatever spelling `add` received (absolute or `~/`), so
+// remove accepts either spelling; otherwise cleanup fails with "Pattern not found".
+function removePatternCandidates(pattern: string): Set<string> {
+  const home = os.homedir();
+  const candidates = new Set([pattern]);
+  if (pattern.startsWith("~/")) {
+    candidates.add(path.join(home, pattern.slice(2)));
+  } else if (home && pattern.startsWith(`${home}${path.sep}`)) {
+    candidates.add(`~/${pattern.slice(home.length + 1)}`);
+  }
+  return candidates;
+}
+
 function ensureAgent(file: ExecApprovalsFile, agentKey: string): ExecApprovalsAgent {
   const agents = file.agents ?? {};
   const entry = agents[agentKey] ?? {};
@@ -1268,6 +1283,11 @@ export function registerExecApprovalsCli(program: Command) {
     name: "add",
     description: "Add a glob pattern to an allowlist",
     mutate: ({ trimmedPattern, file, agent, agentKey, allowlistEntries }) => {
+      // One pattern is one first-token matcher; a multi-line value would persist
+      // as a single unmatchable entry (a silent no-op grant).
+      if (/[\r\n]/.test(trimmedPattern)) {
+        exitWithError("Pattern must be a single line. Run add once per pattern.");
+      }
       if (allowlistEntries.some((entry) => normalizeAllowlistEntry(entry) === trimmedPattern)) {
         defaultRuntime.log("Already allowlisted.");
         return false;
@@ -1284,8 +1304,9 @@ export function registerExecApprovalsCli(program: Command) {
     name: "remove",
     description: "Remove a glob pattern from an allowlist",
     mutate: ({ trimmedPattern, file, agent, agentKey, allowlistEntries }) => {
+      const candidates = removePatternCandidates(trimmedPattern);
       const nextEntries = allowlistEntries.filter(
-        (entry) => normalizeAllowlistEntry(entry) !== trimmedPattern,
+        (entry) => !candidates.has(normalizeAllowlistEntry(entry) ?? ""),
       );
       if (nextEntries.length === allowlistEntries.length) {
         defaultRuntime.log("Pattern not found.");

--- a/src/infra/exec-approvals-allow-always.ts
+++ b/src/infra/exec-approvals-allow-always.ts
@@ -206,7 +206,9 @@ function applyAllowlistEntryUpdate(params: {
   const existing = agents[target] ?? {};
   const allowlist = Array.isArray(existing.allowlist) ? existing.allowlist : [];
   const trimmed = params.pattern.trim();
-  if (!trimmed) {
+  // One pattern is one first-token matcher; an embedded newline can never match
+  // an executable path, so it would persist as a silent no-op grant.
+  if (!trimmed || /[\r\n]/.test(trimmed)) {
     return null;
   }
   const argPattern = params.options?.argPattern === "" ? undefined : params.options?.argPattern;


### PR DESCRIPTION
# fix: reject multi-line exec allowlist patterns; match `~` and absolute spellings on remove

## What Problem This Solves

A multi-line paste into the Mac app's System Run settings allowlist field persists as a **single** allowlist entry whose `pattern` contains embedded newlines. Such a pattern can never match the exec matcher's first-token comparison, so it is a silent no-op grant — the user believes they allowlisted something, and nothing happens. The same malformed entry can be created via `openclaw approvals allowlist add` with a multi-line argument, and the TS allow-always write seam had no guard either.

Observed in production (2026-08-13): a binary path pasted three times into the settings field became one entry with the path newline-joined ×3 — never matched, rendered as three confusing wrapped rows by `approvals get`, and required ANSI-C quoting (`$'…\n…'`) to remove.

Secondary paper cut fixed: stored allowlist patterns keep whatever spelling `add` received (absolute or `~/`), while table output can show the other form — so `allowlist remove <displayed-form>` failed with "Pattern not found". Remove now accepts either spelling of a home path.

## Why This Change Was Made

Validation belongs at the write seams so an unmatchable pattern can never persist:

- **macOS settings (`SystemRunSettingsView.addEntry`)**: a multi-line paste is split into one entry per non-empty line, each validated through the existing batch `addAllowlistEntries` path (friendly behavior — multi-line paste is a natural user action).
- **Swift validator (`ExecApprovalHelpers.validateAllowlistPattern`)**: rejects interior newlines with a new `.multiline` reason ("One pattern per line.") as the backstop for all store callers.
- **TS store (`applyAllowlistEntryUpdate` in `exec-approvals-allow-always.ts`)**: drops newline-containing patterns at the write seam (defense in depth for allow-always persistence).
- **TS CLI `allowlist add`**: errors with "Pattern must be a single line. Run add once per pattern." (explicit beats surprise multi-adds in scripts).
- **TS CLI `allowlist remove`**: matches the input against both its literal and `~`-expanded/abbreviated spellings. Remove deliberately does **not** reject newline input — that is the cleanup path for legacy malformed entries.

Deferred (with reasoning): escaping newlines in the `approvals get` table renderer — once the write seams are guarded the state can no longer be created, and the remove path handles legacy files; a display change would be dead code for a now-unrepresentable state.

## User Impact

- Pasting several paths into the Mac app's allowlist field now adds several working entries instead of one broken one.
- `approvals allowlist add` fails loudly on multi-line input instead of storing garbage.
- `approvals allowlist remove` works with the path spelling the table shows, not just the stored spelling.

## Evidence

- TS: `node scripts/run-vitest.mjs src/cli/exec-approvals-cli.test.ts` → 30/30 passed (3 new: multi-line add rejection, remove-by-`~/`-spelling, remove-by-absolute-spelling); `src/infra/exec-approvals-allow-always.test.ts` + `src/infra/exec-approvals.test.ts` → 129/129 passed. `scripts/run-oxlint.mjs` and `oxfmt --check` clean on touched files.
- Swift: new `.multiline` cases added to `ExecApprovalHelpersTests`. **Gap:** `swift test` could not run locally — the app's dependency macros (SwiftUI `@Entry` via KeyboardShortcuts) require full Xcode; this environment has CommandLineTools only. Files pass `swiftc -parse`; Swift tests need CI / a full-Xcode machine.
- Real-world repro of the original defect is documented above (entry removed from the affected machine with `$'…\n…'` quoting, which this PR's remove path preserves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
