### PR TITLE
fix(cli): preserve explicit read-only agent targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Read-only CLI agent targeting:** honor explicit agents in `models list`, `sandbox explain`, and `hooks list|info|check`, including hooks' unavailable/older-Gateway fallback, instead of resolving or guessing an ambient default first.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Read-only CLI agent targeting:** honor explicit agents in `models list`, `sandbox explain`, and `hooks list|info|check`, including hooks' unavailable/older-Gateway fallback, instead of resolving or guessing an ambient default first.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -15,8 +15,8 @@ Related: [Hooks](/automation/hooks) - [Plugin hooks](/plugins/hooks)
 ## List hooks
 
 ```bash
-openclaw hooks --json
-openclaw hooks list [--eligible] [--json] [-v|--verbose]
+openclaw hooks --agent <id> --json
+openclaw hooks list [--agent <id>] [--eligible] [--json] [-v|--verbose]
 ```
 
 Bare `openclaw hooks` and `openclaw hooks --json` use the same list operation as
@@ -24,6 +24,7 @@ Bare `openclaw hooks` and `openclaw hooks --json` use the same list operation as
 extra, and bundled directories.
 
 - `--eligible`: only hooks whose requirements are met.
+- `--agent <id>`: inspect hooks for that agent's workspace. Required when multiple agents are configured without an implicit owner.
 - `--json`: structured output.
 - `-v, --verbose`: include a Missing column with unmet requirements.
 
@@ -40,7 +41,7 @@ Ready:
 ## Get hook info
 
 ```bash
-openclaw hooks info <name> [--json]
+openclaw hooks info <name> [--agent <id>] [--json]
 ```
 
 `<name>` is the hook name or hook key (for example `session-memory`). Shows source, file/handler paths, homepage, events, and per-requirement status (binaries, env, config, OS).
@@ -48,7 +49,7 @@ openclaw hooks info <name> [--json]
 ## Check eligibility
 
 ```bash
-openclaw hooks check [--json]
+openclaw hooks check [--agent <id>] [--json]
 ```
 
 Prints a ready/not-ready count summary; with hooks not ready, lists each with its blocking reason.
@@ -120,6 +121,7 @@ grep '"action":"new"' ~/.openclaw/logs/commands.log | jq .   # filter by action
 ## Notes
 
 - `hooks list --json`, `info --json`, and `check --json` write structured JSON directly to stdout.
+- `hooks list`, `info`, and `check` pass `--agent` to a running Gateway and preserve it when falling back to local read-only discovery against an older or unavailable Gateway.
 
 ## Related
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -28,7 +28,7 @@ openclaw models set-image <model-or-alias>
 openclaw models scan
 ```
 
-`status` and `auth` subcommands accept `--agent <id>` to target a configured agent; `list`, `scan`, `aliases`, and `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`/`set-image` reject `--agent` outright. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `scan`, `aliases`, and `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`/`set-image` reject `--agent` outright. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
 
 ### Status
 
@@ -78,7 +78,7 @@ The catalog's public change history lives in
 [`openclaw/catalog`](https://github.com/openclaw/catalog), where each content
 update is committed by the scheduled publisher.
 
-Options: `--all` (full catalog), `--local` (filter to local models), `--provider <id>`, `--json`, `--plain`.
+Options: `--all` (full catalog), `--local` (filter to local models), `--provider <id>`, `--agent <id>`, `--json`, `--plain`. `--agent` selects that agent's auth store, workspace, and provider catalog context; explicit multi-agent fleets do not need a default owner when it is present.
 
 Notes:
 

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -59,6 +59,7 @@ openclaw sandbox explain --json
 ```
 
 Unlike `recreate --session`, this accepts short session names (for example `main`) and expands them against the resolved agent.
+An explicit `--agent` is sufficient for multi-agent fleets with no implicit owner; sandbox explanation does not require or guess a default first.
 
 ## Why recreate is needed
 

--- a/src/cli/hooks-cli.toggle.test.ts
+++ b/src/cli/hooks-cli.toggle.test.ts
@@ -14,6 +14,10 @@ const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
   replaceConfigFile: vi.fn(),
   requestExitAfterOneShotOutput: vi.fn(),
+  listAgentIds: vi.fn(),
+  resolveAgentWorkspaceDir: vi.fn(),
+  resolveDefaultAgentId: vi.fn(),
+  tryResolveLegacyCompatibilityAgentId: vi.fn(),
 }));
 
 const capture = createCliRuntimeCapture();
@@ -24,8 +28,10 @@ vi.mock("../state/config-machine-state.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
-  resolveAgentWorkspaceDir: () => "/tmp/openclaw-hook-workspace",
-  resolveDefaultAgentId: () => "main",
+  listAgentIds: mocks.listAgentIds,
+  resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+  tryResolveLegacyCompatibilityAgentId: mocks.tryResolveLegacyCompatibilityAgentId,
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -133,6 +139,10 @@ describe("hooks CLI metadata config keys", () => {
     mocks.callGateway.mockRejectedValue(new Error("gateway unavailable"));
     mocks.buildWorkspaceHookStatus.mockReturnValue(report);
     mocks.getRuntimeConfig.mockReturnValue(sourceConfig);
+    mocks.listAgentIds.mockReturnValue(["main"]);
+    mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-hook-workspace");
+    mocks.resolveDefaultAgentId.mockReturnValue("main");
+    mocks.tryResolveLegacyCompatibilityAgentId.mockReturnValue("main");
     mocks.readConfigFileSnapshot.mockResolvedValue({ sourceConfig, hash: "config-hash" });
     mocks.replaceConfigFile.mockResolvedValue(undefined);
     readConfigMachineStateMock.mockReturnValue(undefined);
@@ -287,11 +297,121 @@ describe("hooks CLI metadata config keys", () => {
     expect(mocks.callGateway).toHaveBeenCalledWith({
       config: sourceConfig,
       method: "hooks.status",
-      params: {},
+      params: { agentId: "main" },
       timeoutMs: 1_500,
       clientName: "cli",
       mode: "cli",
     });
     expect(mocks.buildWorkspaceHookStatus).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["list", ["hooks", "list", "--agent", "research", "--json"]],
+    ["info", ["hooks", "info", "display-name", "--agent", "research", "--json"]],
+    ["check", ["hooks", "check", "--agent", "research", "--json"]],
+  ])("passes the explicit agent to hooks.status for %s", async (_label, argv) => {
+    mocks.listAgentIds.mockReturnValue(["main", "research"]);
+    mocks.callGateway.mockResolvedValue({ ...report, workspaceDir: "/gateway/research" });
+
+    await createHooksProgram().parseAsync(argv, { from: "user" });
+
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { agentId: "research" } }),
+    );
+  });
+
+  it("passes a parent --agent to the default and list read forms", async () => {
+    mocks.listAgentIds.mockReturnValue(["main", "research"]);
+    mocks.callGateway.mockResolvedValue({ ...report, workspaceDir: "/gateway/research" });
+
+    await createHooksProgram().parseAsync(["hooks", "--agent", "research", "--json"], {
+      from: "user",
+    });
+    await createHooksProgram().parseAsync(["hooks", "--agent", "research", "list", "--json"], {
+      from: "user",
+    });
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(2);
+    for (const [call] of mocks.callGateway.mock.calls) {
+      expect(call).toEqual(expect.objectContaining({ params: { agentId: "research" } }));
+    }
+  });
+
+  it("rejects a parent --agent for hook writes", async () => {
+    await expect(
+      createHooksProgram().parseAsync(["hooks", "--agent", "research", "enable", "display-name"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("does not support --agent");
+
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps the explicit owner in the offline hooks fallback", async () => {
+    const explicitFleet = {
+      agents: {
+        ownership: "explicit",
+        list: [
+          { id: "ops", workspace: "/tmp/openclaw-ops-workspace" },
+          { id: "research", workspace: "/tmp/openclaw-research-workspace" },
+        ],
+      },
+    };
+    mocks.getRuntimeConfig.mockReturnValue(explicitFleet);
+    mocks.listAgentIds.mockReturnValue(["ops", "research"]);
+    mocks.tryResolveLegacyCompatibilityAgentId.mockReturnValue(undefined);
+    mocks.resolveDefaultAgentId.mockImplementation(() => {
+      throw new Error("selection required");
+    });
+    mocks.resolveAgentWorkspaceDir.mockImplementation(
+      (_config: unknown, agentId: string) => `/tmp/openclaw-${agentId}-workspace`,
+    );
+
+    await createHooksProgram().parseAsync(["hooks", "list", "--agent", "research", "--json"], {
+      from: "user",
+    });
+
+    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledWith(explicitFleet, "research");
+    expect(mocks.buildWorkspaceHookStatus).toHaveBeenCalledWith(
+      "/tmp/openclaw-research-workspace",
+      expect.anything(),
+    );
+  });
+
+  it("does not replace an authoritative Gateway ownership error with a local report", async () => {
+    const error = Object.assign(new Error('unknown agent id "retired"'), {
+      name: "GatewayClientRequestError",
+      gatewayCode: "INVALID_REQUEST",
+    });
+    mocks.callGateway.mockRejectedValue(error);
+
+    await expect(
+      createHooksProgram().parseAsync(["hooks", "list", "--json"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(capture.runtimeErrors.at(-1)).toContain('unknown agent id "retired"');
+    expect(mocks.buildWorkspaceHookStatus).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "unknown method: hooks.status",
+    "invalid hooks.status params: unexpected property agentId",
+  ])("uses the selected local fallback for an older Gateway: %s", async (message) => {
+    mocks.callGateway.mockRejectedValue(
+      Object.assign(new Error(message), {
+        name: "GatewayClientRequestError",
+        gatewayCode: "INVALID_REQUEST",
+      }),
+    );
+
+    await createHooksProgram().parseAsync(["hooks", "list", "--agent", "main", "--json"], {
+      from: "user",
+    });
+
+    expect(mocks.buildWorkspaceHookStatus).toHaveBeenCalledWith(
+      "/tmp/openclaw-hook-workspace",
+      expect.anything(),
+    );
   });
 });

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -10,7 +10,12 @@ import {
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+  tryResolveLegacyCompatibilityAgentId,
+} from "../agents/agent-scope.js";
 import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -23,8 +28,10 @@ import { loadWorkspaceHookEntries } from "../hooks/workspace.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { loadGatewayStartupPluginPlanWithMetadata } from "../plugins/channel-plugin-ids.js";
 import { buildPluginDiagnosticsReport } from "../plugins/status.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
+import { resolveOptionFromCommand } from "./cli-utils.js";
 import { formatCliCommand } from "./command-format.js";
 import { runNativeHookRelayCli, type NativeHookRelayCliOptions } from "./native-hook-relay-cli.js";
 import { requestExitAfterOneShotOutput } from "./one-shot-exit.js";
@@ -32,16 +39,19 @@ import { runPluginInstallCommand } from "./plugins-install-command.js";
 import { runPluginUpdateCommand } from "./plugins-update-command.js";
 
 export type HooksListOptions = {
+  agent?: string;
   json?: boolean;
   eligible?: boolean;
   verbose?: boolean;
 };
 
 export type HookInfoOptions = {
+  agent?: string;
   json?: boolean;
 };
 
 export type HooksCheckOptions = {
+  agent?: string;
   json?: boolean;
 };
 
@@ -60,9 +70,32 @@ type HooksInstallOptions = {
 
 const GATEWAY_HOOKS_STATUS_TIMEOUT_MS = 1_500;
 
-function buildHooksReport(config: OpenClawConfig): HookStatusReport {
+type HooksReportTarget = {
+  agentId: string;
+  workspaceDir: string;
+};
+
+function resolveHooksReportTarget(config: OpenClawConfig, rawAgentId?: string): HooksReportTarget {
+  const requested = rawAgentId?.trim();
+  const requestedAgentId = requested ? normalizeAgentId(requested) : undefined;
+  if (requestedAgentId && !listAgentIds(config).includes(requestedAgentId)) {
+    throw new Error(
+      `Unknown agent id "${requested}". Run ${formatCliCommand("openclaw agents list")} to see configured agents.`,
+    );
+  }
+  const agentId =
+    requestedAgentId ??
+    tryResolveLegacyCompatibilityAgentId(config) ??
+    resolveDefaultAgentId(config, {
+      surface: "hooks status reporting",
+      hint: "Pass --agent <id> to select a configured agent.",
+    });
+  return { agentId, workspaceDir: resolveAgentWorkspaceDir(config, agentId) };
+}
+
+function buildHooksReport(config: OpenClawConfig, target: HooksReportTarget): HookStatusReport {
   // Plugin-managed and workspace hooks share one resolved policy view for status/actions.
-  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const workspaceDir = target.workspaceDir;
   const workspaceEntries = loadWorkspaceHookEntries(workspaceDir, { config });
   // Native plugin hooks only exist after registration. Match the Gateway's startup
   // plan so active hooks remain visible without executing unrelated installed plugins.
@@ -82,22 +115,45 @@ function buildHooksReport(config: OpenClawConfig): HookStatusReport {
   return buildWorkspaceHookStatus(workspaceDir, { config, entries });
 }
 
-async function loadHooksReport(): Promise<HookStatusReport> {
+async function loadHooksReport(agentId?: string): Promise<HookStatusReport> {
   const config = getRuntimeConfig({ skipPluginValidation: true });
+  const target = resolveHooksReportTarget(config, agentId);
   try {
     const { callGateway } = await import("../gateway/call.js");
     return await callGateway<HookStatusReport>({
       config,
       method: "hooks.status",
-      params: {},
+      params: { agentId: target.agentId },
       timeoutMs: GATEWAY_HOOKS_STATUS_TIMEOUT_MS,
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       mode: GATEWAY_CLIENT_MODES.CLI,
     });
-  } catch {
-    // Transport, auth, and older-Gateway failures all retain the existing local report path.
-    return buildHooksReport(config);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.name === "GatewayClientRequestError" &&
+      !(
+        (error as Error & { gatewayCode?: unknown }).gatewayCode === "INVALID_REQUEST" &&
+        /^(?:unknown method: hooks\.status|invalid hooks\.status params(?::|$))/iu.test(
+          error.message,
+        )
+      )
+    ) {
+      throw error;
+    }
+    // Unavailable and older Gateways retain the selected owner for local read-only discovery.
+    return buildHooksReport(config, target);
   }
+}
+
+function resolveHooksAgentOption(
+  command: Command | undefined,
+  opts?: { agent?: unknown },
+): string | undefined {
+  return (
+    resolveOptionFromCommand<string>(command, "agent") ??
+    (typeof opts?.agent === "string" ? opts.agent : undefined)
+  );
 }
 
 function resolveHookForToggle(
@@ -507,7 +563,11 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
 async function enableHook(hookName: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const hook = resolveHookForToggle(buildHooksReport(config), hookName, { requireEligible: true });
+  const hook = resolveHookForToggle(
+    buildHooksReport(config, resolveHooksReportTarget(config)),
+    hookName,
+    { requireEligible: true },
+  );
   const nextConfig = buildConfigWithHookEnabled({
     config,
     hookName: hook.hookKey,
@@ -527,7 +587,10 @@ async function enableHook(hookName: string): Promise<void> {
 async function disableHook(hookName: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const hook = resolveHookForToggle(buildHooksReport(config), hookName);
+  const hook = resolveHookForToggle(
+    buildHooksReport(config, resolveHooksReportTarget(config)),
+    hookName,
+  );
   const nextConfig = buildConfigWithHookEnabled({
     config,
     hookName: hook.hookKey,
@@ -547,6 +610,7 @@ export function registerHooksCli(program: Command): void {
   const hooks = program
     .command("hooks")
     .description("Manage internal agent hooks")
+    .option("--agent <id>", "Agent id to inspect")
     .option("--json", "Output as JSON", false)
     .addHelpText(
       "after",
@@ -555,16 +619,29 @@ export function registerHooksCli(program: Command): void {
     );
   const hasJsonOutput = (opts: { json?: boolean } | undefined): boolean =>
     Boolean(opts?.json || hooks.opts<{ json?: boolean }>().json);
+  hooks.hook("preAction", (_thisCommand, actionCommand) => {
+    const parentAgent = hooks.opts<{ agent?: string }>().agent;
+    if (
+      parentAgent &&
+      actionCommand !== hooks &&
+      !new Set(["list", "info", "check"]).has(actionCommand.name())
+    ) {
+      throw new Error(
+        `openclaw hooks ${actionCommand.name()} does not support --agent; the option only selects an owner for read-only hook reports.`,
+      );
+    }
+  });
 
   hooks
     .command("list")
     .description("List all hooks")
+    .option("--agent <id>", "Agent id to inspect")
     .option("--eligible", "Show only eligible hooks", false)
     .option("--json", "Output as JSON", false)
     .option("-v, --verbose", "Show more details including missing requirements", false)
-    .action(async (opts: HooksListOptions) =>
+    .action(async (opts: HooksListOptions, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        const report = await loadHooksReport();
+        const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
         const json = hasJsonOutput(opts);
         writeHooksOutput(formatHooksList(report, { ...opts, json }), json);
       }),
@@ -573,10 +650,11 @@ export function registerHooksCli(program: Command): void {
   hooks
     .command("info <name>")
     .description("Show detailed information about a hook")
+    .option("--agent <id>", "Agent id to inspect")
     .option("--json", "Output as JSON", false)
-    .action(async (name, opts: HookInfoOptions) =>
+    .action(async (name, opts: HookInfoOptions, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        const report = await loadHooksReport();
+        const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
         const json = hasJsonOutput(opts);
         writeHooksOutput(formatHookInfo(report, name, { ...opts, json }), json);
         return report.hooks.some((hook) => hook.name === name || hook.hookKey === name) ? 0 : 1;
@@ -586,10 +664,11 @@ export function registerHooksCli(program: Command): void {
   hooks
     .command("check")
     .description("Check hooks eligibility status")
+    .option("--agent <id>", "Agent id to inspect")
     .option("--json", "Output as JSON", false)
-    .action(async (opts: HooksCheckOptions) =>
+    .action(async (opts: HooksCheckOptions, command: Command) =>
       runOneShotHooksCliAction(async () => {
-        const report = await loadHooksReport();
+        const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
         const json = hasJsonOutput(opts);
         writeHooksOutput(formatHooksCheck(report, { ...opts, json }), json);
       }),
@@ -672,9 +751,9 @@ export function registerHooksCli(program: Command): void {
       await runPluginUpdateCommand({ id, opts });
     });
 
-  hooks.action(async (opts: HooksListOptions) =>
+  hooks.action(async (opts: HooksListOptions, command: Command) =>
     runOneShotHooksCliAction(async () => {
-      const report = await loadHooksReport();
+      const report = await loadHooksReport(resolveHooksAgentOption(command, opts));
       const json = hasJsonOutput(opts);
       writeHooksOutput(formatHooksList(report, { ...opts, json }), json);
     }),

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -6,6 +6,7 @@ import { registerModelsCli } from "./models-cli.js";
 import { isCommandJsonOutputMode } from "./program/json-mode.js";
 
 const mocks = vi.hoisted(() => ({
+  modelsListCommand: vi.fn().mockResolvedValue(undefined),
   modelsStatusCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
@@ -33,7 +34,7 @@ const {
 } = mocks;
 
 vi.mock("../commands/models/list.list-command.js", () => ({
-  modelsListCommand: mocks.noopAsync,
+  modelsListCommand: mocks.modelsListCommand,
 }));
 vi.mock("../commands/models/list.status-command.js", () => ({
   modelsStatusCommand: mocks.modelsStatusCommand,
@@ -85,6 +86,7 @@ vi.mock("../commands/models/set-image.js", () => ({
 
 describe("models cli", () => {
   beforeEach(() => {
+    mocks.modelsListCommand.mockClear();
     modelsAuthAddCommand.mockClear();
     modelsAuthListCommand.mockClear();
     modelsAuthLoginCommand.mockClear();
@@ -201,6 +203,14 @@ describe("models cli", () => {
   ])("passes --agent to models status ($label)", async ({ args }) => {
     await runModelsCommand(args);
     expectCommandOptions(modelsStatusCommand, { agent: "poe" });
+  });
+
+  it.each([
+    { label: "list flag", args: ["models", "list", "--agent", "poe"] },
+    { label: "parent flag", args: ["models", "--agent", "poe", "list"] },
+  ])("passes --agent to models list ($label)", async ({ args }) => {
+    await runModelsCommand(args);
+    expectCommandOptions(mocks.modelsListCommand, { agent: "poe" });
   });
 
   it.each([

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -61,12 +61,20 @@ export function registerModelsCli(program: Command) {
     .option("--all", "Show full model catalog", false)
     .option("--local", "Filter to local models", false)
     .option("--provider <id>", "Filter by provider id")
+    .option("--agent <id>", "Agent id to inspect (overrides OPENCLAW_AGENT_DIR)")
     .option("--json", "Output JSON", false)
     .option("--plain", "Plain line output", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command) => {
+      await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
         const { modelsListCommand } = await import("../commands/models/list.list-command.js");
-        await modelsListCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsListCommand(
+          {
+            ...opts,
+            json: hasJsonOutput(opts),
+            agent: resolveModelAgentOption(command, opts),
+          },
+          defaultRuntime,
+        );
       });
     });
 

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -89,6 +89,7 @@ const mocks = vi.hoisted(() => {
     ensureOpenClawModelsJson: vi.fn(),
     ensureAuthProfileStore: vi.fn(),
     resolveDefaultAgentDir: vi.fn(),
+    resolveModelsTargetAgent: vi.fn(),
     loadModelRegistry: vi.fn(),
     loadModelCatalog: vi.fn(),
     resolveConfiguredEntries: vi.fn(),
@@ -112,6 +113,10 @@ function resetMocks() {
   mocks.ensureOpenClawModelsJson.mockResolvedValue({ wrote: false });
   mocks.ensureAuthProfileStore.mockReturnValue({ version: 1, profiles: {}, order: {} });
   mocks.resolveDefaultAgentDir.mockReturnValue("/tmp/openclaw-agent");
+  mocks.resolveModelsTargetAgent.mockReturnValue({
+    agentId: "main",
+    agentDir: "/tmp/openclaw-agent",
+  });
   mocks.loadModelRegistry.mockResolvedValue({
     models: [],
     availableKeys: new Set(),
@@ -230,6 +235,11 @@ function installModelsListCommandForwardCompatMocks() {
 
   vi.doMock("./list.configured.js", () => ({
     resolveConfiguredEntries: mocks.resolveConfiguredEntries,
+  }));
+
+  vi.doMock("./shared.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./shared.js")>()),
+    resolveModelsTargetAgent: mocks.resolveModelsTargetAgent,
   }));
 
   vi.doMock("./list.table.js", () => ({
@@ -394,6 +404,18 @@ beforeEach(() => {
 });
 
 describe("modelsListCommand forward-compat", () => {
+  it("uses the explicitly selected agent for auth and catalog discovery", async () => {
+    mocks.resolveModelsTargetAgent.mockReturnValueOnce({
+      agentId: "research",
+      agentDir: "/tmp/openclaw-agent-research",
+    });
+
+    await modelsListCommand({ agent: "research", json: true }, createRuntime() as never);
+
+    expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(mocks.resolvedConfig, "research");
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-agent-research");
+  });
+
   describe("empty model lists", () => {
     it.each([
       { name: "JSON", options: { json: true } },

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -16,6 +16,7 @@ import { printModelTable } from "./list.table.js";
 import type { ModelRow } from "./list.types.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
 import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
+import { resolveModelsTargetAgent } from "./shared.js";
 
 const DISPLAY_MODEL_PARSE_OPTIONS = { allowPluginNormalization: false } as const;
 
@@ -47,6 +48,7 @@ export async function modelsListCommand(
     all?: boolean;
     local?: boolean;
     provider?: string;
+    agent?: string;
     json?: boolean;
     plain?: boolean;
   },
@@ -74,7 +76,7 @@ export async function modelsListCommand(
   const humanReadable = !opts.json && !opts.plain;
   const [
     { loadAuthProfileStoreWithoutExternalProfiles },
-    { resolveAgentWorkspaceDir, resolveDefaultAgentDir, resolveDefaultAgentId },
+    { resolveAgentWorkspaceDir },
     { resolveDefaultAgentWorkspaceDir },
   ] = await Promise.all([
     import("../../agents/auth-profiles/store.js"),
@@ -85,8 +87,7 @@ export async function modelsListCommand(
     commandName: "models list",
     runtime,
   });
-  const agentId = resolveDefaultAgentId(cfg);
-  const agentDir = resolveDefaultAgentDir(cfg);
+  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
   const authStore = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId) ?? resolveDefaultAgentWorkspaceDir();
   const metadataSnapshot = loadManifestMetadataSnapshot({

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -23,6 +23,32 @@ vi.mock("../config/config.js", async () => {
 });
 
 describe("sandbox explain command", () => {
+  it("honors an explicit agent in an ownerless multi-agent fleet", async () => {
+    mockCfg = {
+      agents: {
+        ownership: "explicit",
+        defaults: { sandbox: { mode: "off" } },
+        list: [
+          { id: "ops", workspace: "/tmp/openclaw-ops-workspace" },
+          { id: "research", workspace: "/tmp/openclaw-research-workspace" },
+        ],
+      },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand({ json: true, agent: "research" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.agentId).toBe("research");
+    expect(parsed.sandbox.effectiveHostWorkspaceRoot).toBe(
+      path.resolve("/tmp/openclaw-research-workspace"),
+    );
+  });
+
   it("reads a missing session without creating or registering an agent database", async () => {
     await withOpenClawTestState({ label: "sandbox-explain-readonly" }, async (state) => {
       const agentDatabasePath = state.statePath(

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -13,8 +13,8 @@ import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import {
   resolveAgentConfig,
+  resolveSessionAgentId,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
 import { getSandboxBackendWorkdirResolver } from "../agents/sandbox/backend.js";
@@ -143,22 +143,22 @@ export async function sandboxExplainCommand(
 ): Promise<void> {
   const cfg = getRuntimeConfig();
 
-  const defaultAgentId = resolveDefaultAgentId(cfg);
   const requestedSession = opts.session?.trim();
   const requestedAgentId = opts.agent?.trim() ? normalizeAgentId(opts.agent) : undefined;
-  const sessionAgentId = requestedSession
-    ? requestedSession === "global"
-      ? defaultAgentId
-      : requestedSession.includes(":")
-        ? normalizeAgentId(resolveAgentIdFromSessionKey(requestedSession))
-        : undefined
-    : undefined;
+  const sessionAgentId =
+    requestedSession && requestedSession !== "global" && requestedSession.includes(":")
+      ? normalizeAgentId(resolveAgentIdFromSessionKey(requestedSession))
+      : undefined;
   if (requestedAgentId && sessionAgentId && requestedAgentId !== sessionAgentId) {
     throw new Error(
       `Sandbox explain agent "${requestedAgentId}" does not match session agent "${sessionAgentId}".`,
     );
   }
-  const resolvedAgentId = sessionAgentId ?? requestedAgentId ?? defaultAgentId;
+  const resolvedAgentId = resolveSessionAgentId({
+    sessionKey: requestedSession,
+    config: cfg,
+    agentId: requestedAgentId,
+  });
 
   const sessionKey = normalizeExplainSessionKey({
     cfg,
@@ -171,6 +171,8 @@ export async function sandboxExplainCommand(
   const sandboxRuntime = resolveSandboxRuntimeStatus({
     cfg,
     sessionKey,
+    agentId: resolvedAgentId,
+    classificationAgentId: resolvedAgentId,
   });
   const mainSessionKey = sandboxRuntime.mainSessionKey;
   const sessionIsSandboxed = sandboxRuntime.sandboxed;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where read-only CLI commands could ignore an explicit agent or require an ambient default before reading it in multi-agent configurations. This affected `models list`, `sandbox explain`, and hook status reads, especially when no implicit fleet owner existed or the Gateway was unavailable/older.

## Why This Change Was Made

Each command now resolves one explicit owner before any compatibility/default fallback and carries that owner through its workspace, auth, catalog, sandbox, or hook-status read. Hooks pass the selected agent to modern Gateways, retain it for local compatibility fallback, and no longer replace authoritative Gateway ownership errors with a local report.

The hook `--agent` option is intentionally read-only. Parent-scoped use with mutation subcommands is rejected rather than silently implying an agent-scoped config write.

## User Impact

Operators can safely inspect a named agent in an explicit multi-agent fleet:

- `openclaw models list --agent <id>`
- `openclaw sandbox explain --agent <id>`
- `openclaw hooks list|info|check --agent <id>`

No protocol, config, storage, or migration surface changes.

## Evidence

- Before-fix Testbox: six focused regressions failed because models dropped `--agent` and hooks did not accept it: https://github.com/openclaw/openclaw/actions/runs/31845069265
- After-fix Testbox: 103 focused tests passed across CLI, models list, sandbox explain, and hooks owner/fallback coverage on lease `tbx_01m014t8w8j5gwnwmqm5cb5te0`.
- Path formatting: all 12 changed code/docs files matched `oxfmt`.
- `git diff --check`: clean.
- Autoreview: clean, no accepted/actionable findings; overall confidence 0.99.

Production LOC: +124/-34 (net +90) | Tests: +182/-4. The production growth establishes the missing explicit-owner boundary and narrows compatibility fallback so semantic Gateway errors remain authoritative.

The broader changed gate was attempted on the reused Testbox, but its stale base classified unrelated main drift and lacked the base `pnpm-lock.yaml`; exact-head native PR prepare/CI remains the authoritative broad gate.
