### PR TITLE
fix(gateway): keep node worker outcomes consistent under load

### DIFF
--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -639,11 +639,28 @@ export function createAgentTurnService({
     // same owner snapshot that selected the chat-vs-agent observation source.
     const activeChatEntry = context.chatAbortControllers.get(runId);
     const hasActiveChatRun = activeChatEntry !== undefined && activeChatEntry.kind !== "agent";
+    const queuedResult = () =>
+      context.chatQueuedTurns.has(runId)
+        ? {
+            runId,
+            status: "pending" as const,
+            timeoutPhase: "queue" as const,
+            providerStarted: false,
+          }
+        : undefined;
+    const queuedBeforeWait = queuedResult();
+    if (queuedBeforeWait) {
+      return queuedBeforeWait;
+    }
     const snapshot = await waitForAgentJob({
       runId,
       timeoutMs,
       ...(hasActiveChatRun ? { source: "chat" } : {}),
     });
+    const queuedAfterWait = queuedResult();
+    if (queuedAfterWait) {
+      return queuedAfterWait;
+    }
     if (!snapshot) {
       const activeRunRegistered = activeChatEntry !== undefined;
       return {

--- a/src/gateway/agent-turn/agent-wait-dedupe.test.ts
+++ b/src/gateway/agent-turn/agent-wait-dedupe.test.ts
@@ -22,6 +22,7 @@ function waitThroughGateway(
         chatAbortControllers: activeKind
           ? new Map([[params.runId, { kind: activeKind }]])
           : new Map(),
+        chatQueuedTurns: new Map(),
       },
     } as unknown as Parameters<typeof handler>[0]),
   );

--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -6,6 +6,7 @@ import type { WorkerAdmissionHandshake } from "../../packages/gateway-protocol/s
 import {
   isPrivateNodeInvokeCommand,
   NODE_WORKER_PRIVATE_COMMANDS,
+  NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
 } from "../infra/node-commands.js";
 import {
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
@@ -237,6 +238,7 @@ function resolveWorkerSupervisorProof(
 function isWorkerSupervisorProofCurrent(
   state: NodeRegistryPrivateState,
   proof: NodeWorkerSupervisorNodeProof,
+  requireLaunchEligibility: boolean,
 ): boolean {
   const node = state.context.getNode(proof.nodeId);
   if (!node || node.client.invalidated === true || node.connId !== proof.connId) {
@@ -250,7 +252,7 @@ function isWorkerSupervisorProofCurrent(
     current.clientMode === proof.clientMode &&
     current.protocolFeature === proof.protocolFeature &&
     sameOptionalWorkerBuild(current.workerBuild, proof.workerBuild) &&
-    sameOptionalWorkerBuild(current.workerRuns, proof.workerRuns)
+    (!requireLaunchEligibility || sameOptionalWorkerBuild(current.workerRuns, proof.workerRuns))
   );
 }
 
@@ -493,7 +495,12 @@ export function registerNodeRegistryPrivateRuntime(
         };
       }
       const isProofCurrent = () =>
-        params.isDispatchAuthorized() && isWorkerSupervisorProofCurrent(state, params.node);
+        params.isDispatchAuthorized() &&
+        isWorkerSupervisorProofCurrent(
+          state,
+          params.node,
+          params.command === NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
+        );
       if (!isProofCurrent()) {
         return {
           ok: false,

--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -71,6 +71,9 @@ export type NodeWorkerSupervisorNodeProof = {
   clientId: typeof GATEWAY_CLIENT_IDS.NODE_HOST;
   clientMode: "node";
   protocolFeature: typeof NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE;
+  /** Immutable build ceiling from the authenticated connection handshake. */
+  workerBuild?: WorkerAdmissionHandshake;
+  /** Transient new-launch eligibility; omitted while the node is at capacity. */
   workerRuns?: WorkerAdmissionHandshake;
   commands: readonly string[];
 };
@@ -91,7 +94,7 @@ export type NodeWorkerSupervisorTransport = {
 
 type NodeRunnerInventoryRecord = Omit<
   NodeWorkerSupervisorNodeProof,
-  "commands" | "pairingGeneration" | "workerRuns"
+  "commands" | "pairingGeneration" | "workerBuild" | "workerRuns"
 > & {
   protocolFeatures: readonly string[];
   workerRuns?: WorkerAdmissionHandshake;
@@ -225,6 +228,7 @@ function resolveWorkerSupervisorProof(
     clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
     clientMode: "node",
     protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+    ...(node.workerRuns ? { workerBuild: structuredClone(node.workerRuns) } : {}),
     ...(declaration.workerRuns ? { workerRuns: structuredClone(declaration.workerRuns) } : {}),
     commands: [...node.commands],
   };
@@ -245,6 +249,7 @@ function isWorkerSupervisorProofCurrent(
     current.clientId === proof.clientId &&
     current.clientMode === proof.clientMode &&
     current.protocolFeature === proof.protocolFeature &&
+    sameOptionalWorkerBuild(current.workerBuild, proof.workerBuild) &&
     sameOptionalWorkerBuild(current.workerRuns, proof.workerRuns)
   );
 }

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -402,6 +402,7 @@ describe("gateway/node-registry", () => {
         pairingIdentity: "identity-a",
         pairingGeneration: "generation-a",
         protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+        workerBuild: WORKER_RUNS,
         workerRuns: WORKER_RUNS,
         commands: ["system.run"],
       }),

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -16,8 +16,10 @@ import {
 import { getCurrentActiveNodeContext, setActiveNodeContext } from "../infra/active-node-context.js";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import {
+  NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
   NODE_WORKER_PRIVATE_COMMANDS,
   NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
+  NODE_WORKER_WORKSPACE_EXEC_COMMAND,
 } from "../infra/node-commands.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../infra/node-runner-inventory.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -598,6 +600,72 @@ describe("gateway/node-registry", () => {
       },
     });
     expect(frames).toEqual([]);
+  });
+
+  it("keeps workspace proof current across capacity withdrawal while fencing launches", async () => {
+    const frames: string[] = [];
+    const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime();
+    registerNodeSession(
+      nodeRegistry,
+      makeClient("conn-1", "node-1", frames, {
+        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+        commands: ["system.run"],
+        workerRuns: WORKER_RUNS,
+      }),
+      { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
+    );
+    expect(
+      updateNodeRunnerInventory({
+        registry: nodeRegistry,
+        nodeId: "node-1",
+        connId: "conn-1",
+        declaration: {
+          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+          workerRuns: WORKER_RUNS,
+        },
+      }),
+    ).toEqual({ changed: true });
+    const [proof] = await nodeWorkerSupervisorTransport.listCurrentNodes();
+    if (!proof) {
+      throw new Error("expected current supervisor proof");
+    }
+    expect(
+      updateNodeRunnerInventory({
+        registry: nodeRegistry,
+        nodeId: "node-1",
+        connId: "conn-1",
+        declaration: { protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE] },
+      }),
+    ).toEqual({ changed: true });
+
+    const workspaceInvoke = nodeWorkerSupervisorTransport.invoke({
+      node: proof,
+      command: NODE_WORKER_WORKSPACE_EXEC_COMMAND,
+      isDispatchAuthorized: () => true,
+    });
+    await vi.waitFor(() => expect(frames).toHaveLength(1));
+    const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+    expect(
+      nodeRegistry.handleInvokeResult({
+        id: request.payload?.id ?? "",
+        nodeId: "node-1",
+        connId: "conn-1",
+        ok: true,
+        payloadJSON: "null",
+      }),
+    ).toBe(true);
+    await expect(workspaceInvoke).resolves.toMatchObject({ ok: true, payloadJSON: "null" });
+
+    await expect(
+      nodeWorkerSupervisorTransport.invoke({
+        node: proof,
+        command: NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
+        isDispatchAuthorized: () => true,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: "PRIVATE_DIALECT_UNAVAILABLE" },
+    });
   });
 
   it("keeps a private proof current across equivalent worker feature ordering", async () => {

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -28,6 +28,7 @@ function createContext(): GatewayRequestContext {
       error: vi.fn(),
     },
     chatAbortControllers: new Map(),
+    chatQueuedTurns: new Map(),
     dedupe: new Map(),
   } as unknown as GatewayRequestContext;
 }

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -412,6 +412,8 @@ export function createGatewayWorkerPlacementRuntime(params: GatewayWorkerPlaceme
     placements: params.placements,
     admitNewPlacements: params.admitNewPlacements,
     resolveWorkspacePath,
+    recoverPendingWorkspaceResult: async (environmentId) =>
+      await dispatchService.reconcileActive(environmentId),
     redispatchReclaimed: createReclaimedPlacementRedispatch({
       environments: params.environments,
       dispatch: dispatchService.dispatch,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -43,6 +43,7 @@ import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { createAgentTurnService } from "./agent-turn/agent-turn-service.js";
 import { assertPluginMetadataSnapshotConsistency } from "./plugin-metadata.test-helpers.js";
 import {
   createDirectChatContext,
@@ -4211,6 +4212,17 @@ describe("gateway server chat", () => {
       expect(finalEvents).toHaveLength(1);
       expect(context.chatQueuedTurns.has("idem-queued-followup")).toBe(true);
       expect(isSessionWorkAdmissionActive(storePath, ["agent:main:main", "sess-main"])).toBe(true);
+      await expect(
+        createAgentTurnService({ context, isWebchatConnect: () => true }).waitForTurn({
+          runId: "idem-queued-followup",
+          timeoutMs: 10,
+        }),
+      ).resolves.toMatchObject({
+        runId: "idem-queued-followup",
+        status: "pending",
+        timeoutPhase: "queue",
+        providerStarted: false,
+      });
 
       onQueueDisposition?.("queue-cap-old");
       expect(context.logGateway.info).toHaveBeenCalledWith(

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -43,7 +43,6 @@ import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
-import { createAgentTurnService } from "./agent-turn/agent-turn-service.js";
 import { assertPluginMetadataSnapshotConsistency } from "./plugin-metadata.test-helpers.js";
 import {
   createDirectChatContext,
@@ -4212,6 +4211,7 @@ describe("gateway server chat", () => {
       expect(finalEvents).toHaveLength(1);
       expect(context.chatQueuedTurns.has("idem-queued-followup")).toBe(true);
       expect(isSessionWorkAdmissionActive(storePath, ["agent:main:main", "sess-main"])).toBe(true);
+      const { createAgentTurnService } = await import("./agent-turn/agent-turn-service.js");
       await expect(
         createAgentTurnService({ context, isWebchatConnect: () => true }).waitForTurn({
           runId: "idem-queued-followup",

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -117,6 +117,7 @@ function transport(): NodeWorkerSupervisorTransport {
         clientMode: GATEWAY_CLIENT_MODES.NODE,
         protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
         commands: ["system.run"],
+        workerBuild: BUILD,
         workerRuns: BUILD,
       },
     ],
@@ -193,12 +194,13 @@ describe("node worker tunnel manager", () => {
     );
   });
 
-  it("restores workspace command authority from the durable owner epoch", async () => {
+  it("keeps concurrent workspace commands on the admitted build while launch capacity is full", async () => {
     const record = environment();
     const manifest = { version: 1 as const, baseCommit: null, entries: [] };
     const rawManifest = serializeWorkerWorkspaceManifest(manifest);
     const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
-    const outputs = [`quiesced ${"c".repeat(32)}`, manifestRef, "", "restored"];
+    const outputs = [`quiesced ${"c".repeat(32)}`, manifestRef, ""];
+    let launchEligible = true;
     const invoke = vi.fn(
       async (request: Parameters<NodeWorkerSupervisorTransport["invoke"]>[0]) => {
         expect(request.params).toMatchObject({
@@ -237,7 +239,26 @@ describe("node worker tunnel manager", () => {
     const manager = createNodeWorkerTunnelManager({
       gatewayDeviceId: "gateway-device-1",
       getEnvironment: () => record,
-      getTransport: () => ({ ...transport(), invoke }),
+      getTransport: () => {
+        const nodeTransport = transport();
+        return {
+          ...nodeTransport,
+          listCurrentNodes: async () => {
+            const [proof] = await nodeTransport.listCurrentNodes();
+            if (!proof) {
+              return [];
+            }
+            return [
+              {
+                ...proof,
+                workerBuild: BUILD,
+                ...(launchEligible ? {} : { workerRuns: undefined }),
+              } as typeof proof & { workerBuild: typeof BUILD },
+            ];
+          },
+          invoke,
+        };
+      },
       launchNodeWorker: vi.fn(),
       validateWorkerTurn: () => true,
       workspaceTransfer: transfer,
@@ -250,12 +271,23 @@ describe("node worker tunnel manager", () => {
     manager.bindWorkspaceBindingResolver(resolveWorkspaceBinding);
 
     const handle = await manager.start(startRequest());
-    await expect(
-      handle.runWorkspaceCommand({
-        argv: ["printf", "restored"],
-        transportRetry: "idempotent",
-      }),
-    ).resolves.toMatchObject({ stdout: "restored", workspaceDir: "/node/workspace" });
+    launchEligible = false;
+    const reconciled = await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        handle.runWorkspaceCommand({
+          argv: ["printf", `reconciled-${index}`],
+          transportRetry: "never",
+        }),
+      ),
+    );
+    expect(reconciled).toHaveLength(12);
+    expect(reconciled).toEqual(
+      expect.arrayContaining(
+        Array.from({ length: 12 }, () =>
+          expect.objectContaining({ stdout: "", workspaceDir: "/node/workspace" }),
+        ),
+      ),
+    );
     expect(resolveWorkspaceBinding).toHaveBeenCalledWith({
       environmentId: "environment-1",
       ownerEpoch: record.ownerEpoch,
@@ -499,5 +531,75 @@ describe("node worker tunnel manager", () => {
         journal: { load: () => undefined, begin: vi.fn(), commit: vi.fn(), abort: vi.fn() },
       }),
     ).rejects.toThrow("changed during final reconciliation");
+  });
+
+  it("does not republish an accepted manifest already current on the node", async () => {
+    const record = environment();
+    const localPath = tempDirs.make("node-worker-accepted-current-");
+    const remoteWorkspaceDir = tempDirs.make("node-worker-accepted-current-remote-");
+    const manifest = { version: 1 as const, baseCommit: null, entries: [] };
+    const raw = serializeWorkerWorkspaceManifest(manifest);
+    const baseManifestRef = `sha256:${createHash("sha256").update(raw).digest("hex")}`;
+    const spawnResult = (stdout: string) =>
+      JSON.stringify({
+        workspaceDir: remoteWorkspaceDir,
+        stdout,
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      });
+    const transferDirections: string[] = [];
+    const nodeTransport = transport();
+    nodeTransport.invoke = vi.fn(async ({ params }) => {
+      const input = params as { transfer?: { direction?: string } };
+      if (input.transfer?.direction) {
+        transferDirections.push(input.transfer.direction);
+      }
+      return { ok: true, payloadJSON: spawnResult(`${baseManifestRef}\n`) };
+    });
+    const publishSnapshot = vi.fn(() => "accepted-download-token");
+    const transfer = {
+      prepareSync: vi.fn(async () => ({
+        snapshot: { manifest, manifestRef: baseManifestRef, rawManifest: raw, root: localPath },
+        token: "download-token",
+      })),
+      prepareUpload: vi.fn(() => "upload-token"),
+      takeUpload: vi.fn(() => ({
+        base: manifest,
+        baseManifestRef,
+        baseRaw: raw,
+        current: manifest,
+        currentManifestRef: baseManifestRef,
+        currentRaw: raw,
+        stagingRoot: localPath,
+      })),
+      getSnapshot: vi.fn(() => ({ manifest, manifestRef: baseManifestRef, rawManifest: raw })),
+      publishSnapshot,
+      close: vi.fn(async () => {}),
+      revoke: vi.fn(),
+    } as unknown as NodeWorkspaceTransferService;
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: () => record,
+      getTransport: () => nodeTransport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: transfer,
+    });
+    const handle = await manager.start(startRequest());
+    await handle.syncWorkspace({ localPath, sessionId: "session-1", generation: 1 });
+
+    const reconciliation = await handle.reconcileWorkspace({
+      localPath,
+      remoteWorkspaceDir,
+      baseManifestRef,
+      journal: { load: () => undefined, begin: vi.fn(), commit: vi.fn(), abort: vi.fn() },
+    });
+
+    expect(reconciliation.manifestRef).toBe(baseManifestRef);
+    expect(transferDirections).toEqual(["download", "upload"]);
+    expect(publishSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -14,6 +14,7 @@ import {
   NODE_WORKSPACE_TRANSFER_ERROR_CODE,
   NodeWorkerWorkspaceTransferError,
 } from "../../worker/node-workspace-transfer-protocol.js";
+import { sameWorkerBuild } from "../../worker/worker-build-identity.js";
 import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
@@ -116,20 +117,6 @@ type NodeTunnelEntry = NodeWorkerTunnelStartRequest & {
   stopPromise?: Promise<void>;
 };
 
-function exactBuild(
-  actual: WorkerAdmissionHandshake | undefined,
-  expected: WorkerAdmissionHandshake,
-): boolean {
-  return (
-    actual?.bundleHash === expected.bundleHash &&
-    actual.openclawVersion === expected.openclawVersion &&
-    actual.protocolFeatures.length === expected.protocolFeatures.length &&
-    actual.protocolFeatures
-      .toSorted()
-      .every((feature, index) => feature === expected.protocolFeatures.toSorted()[index])
-  );
-}
-
 function spawnResultFromReceipt(receipt: NodeWorkerSupervisorReceipt): SpawnResult {
   if (receipt.state === "completed") {
     return {
@@ -207,7 +194,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       current &&
       current.ownerEpoch === entry.ownerEpoch &&
       current.bootstrapReceipt?.installKind === "local" &&
-      exactBuild(current.bootstrapReceipt, entry.expectedBuild) &&
+      sameWorkerBuild(current.bootstrapReceipt, entry.expectedBuild) &&
       current.attachedSessionIds.length <= 1 &&
       (current.attachedSessionIds.length === 0 ||
         current.attachedSessionIds[0] === entry.sessionId),
@@ -234,7 +221,8 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
     const node = (await raceWithSignal(transport.listCurrentNodes(), signal)).find(
       (candidate) =>
         candidate.nodeId === entry.deviceId &&
-        exactBuild(candidate.workerRuns, entry.expectedBuild),
+        candidate.workerBuild &&
+        sameWorkerBuild(candidate.workerBuild, entry.expectedBuild),
     );
     if (!node) {
       throw new Error("device worker node is not connected with the expected build");
@@ -442,6 +430,9 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           manifest: typeof uploaded.current;
           conflictPaths: string[];
         }) => {
+          if (accepted.manifestRef === expectedRemoteRef) {
+            return;
+          }
           const baseSnapshot = options.workspaceTransfer.getSnapshot(
             entry.environmentId,
             request.baseManifestRef,
@@ -653,7 +644,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
               current.abortController.signal.aborted ||
               current.deviceId !== request.deviceId ||
               current.sessionId !== request.sessionId ||
-              !exactBuild(current.expectedBuild, request.expectedBuild)
+              !sameWorkerBuild(current.expectedBuild, request.expectedBuild)
             ) {
               throw new Error("node worker tunnel owner binding changed within one epoch");
             }

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -91,6 +91,7 @@ function pendingWorkerLossError(
 export async function recoverPendingWorkspaceResults(
   deps: PlacementRecoveryDeps,
   cleanupOrphans: boolean,
+  environmentId?: string,
 ): Promise<Set<string>> {
   const { environments, failure, placements } = deps;
   const stagedResultOwners = new Set<string>();
@@ -104,6 +105,9 @@ export async function recoverPendingWorkspaceResults(
       continue;
     }
     const placement = placements.get(pending.sessionId);
+    if (environmentId !== undefined && placement?.environmentId !== environmentId) {
+      continue;
+    }
     try {
       const claim = placement?.turnClaim;
       if (

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -255,7 +255,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   // durable active ownership and retry teardown already fenced by a previous failure.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
     await environments.reconcileOnce();
-    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, false);
+    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, false, environmentId);
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
       if (journalOwners.has(placement.sessionId) || pendingResultOwners.has(placement.sessionId)) {

--- a/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
@@ -28,7 +28,7 @@ describe("worker turn launcher terminal results", () => {
   beforeEach(setupWorkerTurnLauncherTest);
   afterEach(cleanupWorkerTurnLauncherTest);
 
-  it("retains a cloud result when reconciliation fails after worker finishing", async () => {
+  it("requests immediate recovery when reconciliation fails after worker finishing", async () => {
     seedActivePlacement();
     const destroy = vi.fn(async () => attachedEnvironment());
     const tunnelFailure = new NodeWorkerWorkspaceTransferError(
@@ -88,7 +88,18 @@ describe("worker turn launcher terminal results", () => {
       startTunnel: vi.fn(async () => tunnel),
       destroy,
     };
-    const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+    const recoverPendingWorkspaceResult = vi.fn(async () => {
+      const [pending] = placements.listPendingWorkspaceResults();
+      if (!pending) {
+        throw new Error("expected pending workspace result");
+      }
+      placements.failWorkspaceResultAndReleaseTurn(pending, tunnelFailure);
+    });
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments,
+      placements,
+      recoverPendingWorkspaceResult,
+    });
 
     await expect(
       provider.executeTurn(
@@ -106,11 +117,9 @@ describe("worker turn launcher terminal results", () => {
         "Cloud worker finished, but its workspace result could not be reconciled: workspace-transfer-failed: gateway TLS fingerprint mismatch",
     });
 
-    expect(placements.get(SESSION_ID)).toMatchObject({
-      state: "active",
-      turnClaim: { runId: "run-reconcile-tunnel-loss" },
-    });
-    expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(recoverPendingWorkspaceResult).toHaveBeenCalledWith(ENVIRONMENT_ID);
+    expect(placements.get(SESSION_ID)).toMatchObject({ state: "failed", turnClaim: null });
+    expect(placements.listPendingWorkspaceResults()).toHaveLength(0);
     expect(destroy).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -71,6 +71,7 @@ type WorkerTurnLauncherOptions = {
   environments: WorkerTurnEnvironmentService;
   placements: WorkerSessionPlacementStore;
   resolveWorkspacePath: (identity: ReturnType<typeof resolvePlacementIdentity>) => Promise<string>;
+  recoverPendingWorkspaceResult?: (environmentId: string) => Promise<void>;
   workspaceOperations?: WorkerWorkspaceOperationCoordinator;
   redispatchReclaimed?: (placement: ReclaimedWorkerPlacement) => Promise<ActiveWorkerPlacement>;
 };
@@ -624,6 +625,7 @@ export function createWorkerSessionTurnPlacementProvider(
           // A recovery sweep owns the still-live worker claim. Teardown here
           // could discard the terminal event's durably fenced file results.
           options.placements.handoffWorkspaceResultRecovery(turnClaim);
+          await options.recoverPendingWorkspaceResult?.(placement.environmentId);
           throw error;
         }
         if (error instanceof WorkerRunnerUnavailableError && !handedOff) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent turns on paired node workers could finish and visibly apply their assistant result, then incorrectly fail workspace reconciliation because the node was temporarily at launch capacity. It also prevents queued chat turns from reporting a terminal successful wait before their queued work has settled.

## Why This Change Was Made

The private node proof now separates the immutable build advertised by the authenticated connection from transient new-launch eligibility, so post-turn workspace work remains fenced to the correct build without treating a full node as disconnected. Reconcile failures request immediate targeted recovery instead of waiting for the periodic sweep, unchanged accepted manifests are not redundantly copied back to a node that already has them, and `agent.wait` reports `pending` while its chat turn still exists in the queued-turn owner.

TLS behavior is unchanged.

## User Impact

Operators can run concurrent turns on shared paired nodes without false post-outcome build errors. Large-session follow-ups no longer produce misleading green waits while queued: callers see queue truth until settlement, and terminal success corresponds to an eventual visible outcome.

## Evidence

- Pre-fix regression replay: four focused tests failed with the reported expected-build error, a redundant `download, upload, download` transfer sequence, no immediate recovery callback, and queued `agent.wait` returning `ok`.
- Post-fix focused proof: 171 node registry, tunnel, placement recovery, and launcher tests passed; the queued chat wait boundary test passed separately.
- CI follow-up proof: the complete affected registry/tunnel/wait/chat suites passed 221 tests after addressing command-specific proof revalidation and test import ordering.
- Sustained real node-host rig, three repetitions: 108/108 visible markers, 108/108 successful waits, zero TLS/listener failures, all placements active.
- Large-sync real node-host rig, three repetitions: 18/18 launches and visible markers; every terminal successful wait had its visible marker, queued intervals reported `pending/queue`, zero TLS/listener failures, all placements active.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed on the exact PR head.
- `check:changed` passed for the final core/core-tests path set. Remote changed-gate allocation was unavailable, so the repository wrapper recorded and used its supported local fallback.
- Structured autoreview passed twice with no accepted/actionable findings, including the final rebased branch review.

Production LOC: +49/-21 (net +28) | Tests: +209/-16
