### PR TITLE
[BACKPORT] feat(slack): include observed away duration in presence events

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1937,6 +1937,8 @@ Slack does not send presence changes through the Events API or Socket Mode. Open
 
 OpenClaw polls at most 45 unique workspace-user pairs per minute per Slack account, seeds the first result without waking the agent, and only wakes on an observed `away` to `active` transition. A durable 8-hour cooldown applies per Slack account, workspace, and user, even if that person participates in several threads. The event routes only to that person's most recently active eligible conversation and tells the agent to consult memory/wiki and known timezone context before deciding whether to send one short greeting. The agent may stay silent.
 
+The event includes `observed_away_at_ms`, `observed_active_at_ms`, and `observed_away_duration_ms`. The duration is the elapsed time between the first sampled `away` state in the current monitor run and the later sampled `active` state. It is not exact time away because presence can change between polls, and the observation starts fresh after the monitor restarts or the target expires. The event records what Slack reported, not whether the person was at their keyboard; Slack can mark someone away automatically or manually, and `users.getPresence` does not distinguish those cases for another user.
+
 The bot token needs `users:read`, which is already included in the recommended manifest. Enterprise Grid org-wide installs create a workspace-scoped polling client only after an authorized event identifies that workspace; presence state, cooldowns, and delivery targets remain partitioned by workspace.
 
 ## Configuration reference

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -79,14 +79,16 @@ describe("Slack presence monitor", () => {
   });
 
   it("seeds the first sample and wakes only on away-to-active", async () => {
+    let now = 1_000;
     const getPresence = vi
       .fn()
       .mockResolvedValueOnce({ presence: "active" })
       .mockResolvedValueOnce({ presence: "away" })
+      .mockResolvedValueOnce({ presence: "away" })
       .mockResolvedValueOnce({ presence: "active" })
       .mockResolvedValueOnce({ presence: "away" })
       .mockResolvedValueOnce({ presence: "active" });
-    const enqueue = vi.fn(() => true);
+    const enqueue = vi.fn((..._args: unknown[]) => true);
     const wake = vi.fn();
     const monitor = createSlackPresenceMonitor({
       accountId: "default",
@@ -95,18 +97,28 @@ describe("Slack presence monitor", () => {
       cooldownStore: createCooldownStore(),
       enqueue,
       wake,
+      nowMs: () => now,
     });
     monitor.observe(createPrepared({ userId: "U123" }));
 
     await monitor.pollOnce();
+    now = 2_000;
     await monitor.pollOnce();
     expect(enqueue).not.toHaveBeenCalled();
 
+    now = 4_000;
+    await monitor.pollOnce();
+    expect(enqueue).not.toHaveBeenCalled();
+
+    now = 7_500;
     await monitor.pollOnce();
     expect(enqueue).toHaveBeenCalledOnce();
     expect(enqueue).toHaveBeenCalledWith(
-      expect.stringContaining("retrieve relevant memory and wiki context"),
+      expect.stringMatching(
+        /observed_away_at_ms=2000 observed_active_at_ms=7500 observed_away_duration_ms=5500/,
+      ),
       expect.objectContaining({
+        sessionKey: "agent:main:slack:channel:D123",
         deliveryContext: {
           channel: "slack",
           to: "user:U123",
@@ -114,9 +126,20 @@ describe("Slack presence monitor", () => {
         },
       }),
     );
+    expect(enqueue.mock.calls[0]?.[0]).toBe(
+      [
+        "Slack presence event:",
+        'A human participant became active on Slack after being observed away: user_id="U123" channel_id="D123".',
+        "observed_away_at_ms=2000 observed_active_at_ms=7500 observed_away_duration_ms=5500",
+        "Before greeting, retrieve relevant memory and wiki context for this immutable user_id, including a known timezone when available. Use their local time; if their timezone is unknown, do not guess.",
+        "Send at most one short, natural greeting in this Slack conversation. Do not reveal private memory. If no greeting is appropriate, stay silent.",
+      ].join("\n"),
+    );
     expect(wake).toHaveBeenCalledOnce();
 
+    now = 8_000;
     await monitor.pollOnce();
+    now = 9_000;
     await monitor.pollOnce();
     expect(enqueue).toHaveBeenCalledOnce();
   });

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -16,7 +16,7 @@ const SLACK_PRESENCE_MAX_TARGETS = 2_000;
 
 type SlackPresenceEventsConfig = NonNullable<SlackAccountConfig["presenceEvents"]>;
 type SlackPresenceEventsMode = NonNullable<SlackPresenceEventsConfig["mode"]>;
-type Presence = "active" | "away";
+type PresenceObservation = { presence: "active" } | { presence: "away"; firstObservedAtMs: number };
 
 type PresenceTarget = {
   key: string;
@@ -71,10 +71,17 @@ function isTargetEligible(target: PresenceTarget): boolean {
   return target.participants.size <= SLACK_PRESENCE_AUTO_MAX_PARTICIPANTS;
 }
 
-function formatSlackPresenceEvent(target: PresenceTarget, userId: string): string {
+function formatSlackPresenceEvent(
+  target: PresenceTarget,
+  userId: string,
+  awayObservation: { observedAwayAtMs: number; observedActiveAtMs: number },
+): string {
+  const { observedAwayAtMs, observedActiveAtMs } = awayObservation;
+  const observedAwayDurationMs = Math.max(0, observedActiveAtMs - observedAwayAtMs);
   const lines = [
     "Slack presence event:",
     `A human participant became active on Slack after being observed away: user_id=${JSON.stringify(userId)}${target.teamId ? ` team_id=${JSON.stringify(target.teamId)}` : ""} channel_id=${JSON.stringify(target.channelId)}${target.threadId ? ` thread_ts=${JSON.stringify(target.threadId)}` : ""}.`,
+    `observed_away_at_ms=${observedAwayAtMs} observed_active_at_ms=${observedActiveAtMs} observed_away_duration_ms=${observedAwayDurationMs}`,
     "Before greeting, retrieve relevant memory and wiki context for this immutable user_id, including a known timezone when available. Use their local time; if their timezone is unknown, do not guess.",
     "Send at most one short, natural greeting in this Slack conversation. Do not reveal private memory. If no greeting is appropriate, stay silent.",
   ];
@@ -152,7 +159,7 @@ export function createSlackPresenceMonitor(params: {
     throw new Error("Slack presence monitor requires a client or client resolver");
   }
   const targets = new Map<string, PresenceTarget>();
-  const presenceByUser = new Map<string, Presence>();
+  const presenceByUser = new Map<string, PresenceObservation>();
   const nowMs = params.nowMs ?? Date.now;
   const enqueue = params.enqueue ?? enqueueSystemEvent;
   const wake = params.wake ?? requestHeartbeat;
@@ -220,7 +227,10 @@ export function createSlackPresenceMonitor(params: {
     pruneTargets(now);
   };
 
-  const emitTransition = (subject: PresenceSubject, now: number) => {
+  const emitTransition = (
+    subject: PresenceSubject,
+    awayObservation: { observedAwayAtMs: number; observedActiveAtMs: number },
+  ) => {
     const { teamId, userId } = subject;
     const target = Array.from(targets.values())
       .filter(
@@ -235,6 +245,7 @@ export function createSlackPresenceMonitor(params: {
     }
     const workspaceKey = teamId ?? "workspace";
     const cooldownKey = `${params.accountId}:${workspaceKey}:${userId}`;
+    const now = awayObservation.observedActiveAtMs;
     let reserved: boolean;
     try {
       reserved = params.cooldownStore.registerIfAbsent(cooldownKey, now, {
@@ -247,7 +258,7 @@ export function createSlackPresenceMonitor(params: {
     if (!reserved) {
       return;
     }
-    const queued = enqueue(formatSlackPresenceEvent(target, userId), {
+    const queued = enqueue(formatSlackPresenceEvent(target, userId, awayObservation), {
       sessionKey: target.sessionKey,
       contextKey: `slack:presence-active:${params.accountId}:${workspaceKey}:${userId}`,
       deliveryContext: {
@@ -323,9 +334,19 @@ export function createSlackPresenceMonitor(params: {
         }
         const subjectKey = presenceSubjectKey(subject);
         const previous = presenceByUser.get(subjectKey);
-        presenceByUser.set(subjectKey, next);
-        if (previous === "away" && next === "active") {
-          emitTransition(subject, now);
+        const observedAtMs = nowMs();
+        const observation: PresenceObservation =
+          next === "away"
+            ? previous?.presence === "away"
+              ? previous
+              : { presence: "away", firstObservedAtMs: observedAtMs }
+            : { presence: "active" };
+        presenceByUser.set(subjectKey, observation);
+        if (previous?.presence === "away" && next === "active") {
+          emitTransition(subject, {
+            observedAwayAtMs: previous.firstObservedAtMs,
+            observedActiveAtMs: observedAtMs,
+          });
         }
       } catch (err) {
         if (stopped) {


### PR DESCRIPTION
## What Problem This Solves

Carries the merged Slack presence-event duration change into the canonical release branch.

Backport-Of: #123805
Release-Target: sjf_openclaw_2026-07-31

## Why This Change Was Made

The release branch needs the same observed-away timestamps and duration emitted by the merged source change. The application preserves the release branch's existing system-event enqueue API.

## User Impact

Slack presence events include sampled away and active timestamps plus the observed away duration, with documentation clarifying the sampling limits.

## Evidence

- Applied the authoritative merged change from #123805 as one commit.
- Resolved the release-branch enqueue overlap while preserving its existing system-event routing contract.
- `oxfmt --check` passed on all three changed files.
- The focused Slack presence monitor test passed (1 file, 9 tests).

AI-assisted backport; the resulting change and release-branch conflict resolution were reviewed before publication.
