### PR TITLE
fix(security): skip unused default workspace in explicit fleets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Security audit workspace ownership:** keep ownerless explicit fleets from scanning a fabricated legacy/default workspace while still auditing every configured agent workspace and preserving rosterless compatibility.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Security audit workspace ownership:** keep ownerless explicit fleets from scanning a fabricated legacy/default workspace while still auditing every configured agent workspace and preserving rosterless compatibility.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/security/audit-rosterless.test.ts
+++ b/src/security/audit-rosterless.test.ts
@@ -19,6 +19,19 @@ describe("security audit rosterless configs", () => {
     return { stateDir, workspaceDir };
   }
 
+  function makeEscapingWorkspace(rootDir: string, workspaceDir: string) {
+    const externalSkillDir = path.join(rootDir, `external-${path.basename(workspaceDir)}`);
+    const skillsDir = path.join(workspaceDir, "skills");
+    fs.mkdirSync(externalSkillDir, { recursive: true });
+    fs.mkdirSync(skillsDir, { recursive: true });
+    fs.writeFileSync(path.join(externalSkillDir, "SKILL.md"), "# external\n");
+    fs.symlinkSync(
+      externalSkillDir,
+      path.join(skillsDir, "escape"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+  }
+
   it("uses the explicit audit workspace without resolving a missing roster default", async () => {
     const { stateDir, workspaceDir } = makeAuditPaths("rosterless");
 
@@ -33,6 +46,30 @@ describe("security audit rosterless configs", () => {
         includeChannelSecurity: false,
       }),
     ).resolves.toEqual(expect.objectContaining({ findings: expect.any(Array) }));
+  });
+
+  it("keeps the implicit main workspace for a rosterless compatibility config", async () => {
+    const rootDir = tempDirs.make("openclaw-audit-rosterless-default-");
+    const stateDir = path.join(rootDir, "state");
+    const workspaceDir = path.join(rootDir, ".openclaw", "workspace");
+    fs.mkdirSync(stateDir, { recursive: true });
+    makeEscapingWorkspace(rootDir, workspaceDir);
+
+    const report = await runSecurityAuditCore({
+      config: {},
+      stateDir,
+      configPath: path.join(stateDir, "openclaw.json"),
+      env: { HOME: rootDir },
+      includeFilesystem: true,
+      includeChannelSecurity: false,
+    });
+
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        checkId: "skills.workspace.symlink_escape",
+        detail: expect.stringContaining(`workspace=${workspaceDir}`),
+      }),
+    );
   });
 
   it("distinguishes an authored empty roster from an absent pre-roster source", async () => {
@@ -150,5 +187,43 @@ describe("security audit rosterless configs", () => {
         detail: expect.stringContaining("Expected no"),
       }),
     );
+  });
+
+  it("scans every explicit fleet workspace without fabricating a legacy default workspace", async () => {
+    const rootDir = tempDirs.make("openclaw-audit-explicit-workspaces-");
+    const stateDir = path.join(rootDir, "state");
+    const unusedDefaultsWorkspace = path.join(rootDir, "unused-defaults");
+    const alphaWorkspace = path.join(rootDir, "alpha");
+    const betaWorkspace = path.join(rootDir, "beta");
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    for (const workspaceDir of [unusedDefaultsWorkspace, alphaWorkspace, betaWorkspace]) {
+      makeEscapingWorkspace(rootDir, workspaceDir);
+    }
+
+    const report = await runSecurityAuditCore({
+      config: {
+        agents: {
+          ownership: "explicit",
+          defaults: { workspace: unusedDefaultsWorkspace },
+          entries: {
+            alpha: { workspace: alphaWorkspace },
+            beta: { workspace: betaWorkspace },
+          },
+        },
+      } as never,
+      stateDir,
+      configPath: path.join(stateDir, "openclaw.json"),
+      env: { HOME: rootDir },
+      includeFilesystem: true,
+      includeChannelSecurity: false,
+    });
+
+    const finding = report.findings.find(
+      (candidate) => candidate.checkId === "skills.workspace.symlink_escape",
+    );
+    expect(finding?.detail).toContain(`workspace=${alphaWorkspace}`);
+    expect(finding?.detail).toContain(`workspace=${betaWorkspace}`);
+    expect(finding?.detail).not.toContain(`workspace=${unusedDefaultsWorkspace}`);
   });
 });

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -5,10 +5,9 @@ import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { hasAgentRosterProperty, listAgentEntries } from "../agents/agent-scope-config.js";
-import { resolveAgentWorkspaceDir, tryResolveDefaultAgentId } from "../agents/agent-scope.js";
+import { tryResolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveExecDefaults } from "../agents/exec-defaults.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
-import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/config.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
@@ -34,9 +33,9 @@ import {
   resolveMergedSafeBinProfileFixtures,
 } from "../infra/exec-safe-bin-runtime-policy.js";
 import { listRiskyConfiguredSafeBins } from "../infra/exec-safe-bin-semantics.js";
+import { resolvePluginControlPlaneWorkspace } from "../plugins/control-plane-workspace.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { readControlUiDeviceAuthMigrationState } from "../state/control-ui-device-auth-migration.js";
-import { resolveUserPath } from "../utils.js";
 import { collectDeepCodeSafetyFindings } from "./audit-deep-code-safety.js";
 import { collectDeepProbeFindings } from "./audit-deep-probe-findings.js";
 import {
@@ -1301,15 +1300,11 @@ async function createAuditExecutionContext(
   const deepTimeoutMs = Math.max(250, opts.deepTimeoutMs ?? 5000);
   const stateDir = opts.stateDir ?? resolveStateDir(env);
   const configPath = opts.configPath ?? resolveConfigPath(env, stateDir);
-  const defaultAgentId = tryResolveDefaultAgentId(cfg);
-  const configuredDefaultWorkspace = cfg.agents?.defaults?.workspace?.trim();
-  const workspaceDir =
-    opts.workspaceDir ??
-    (defaultAgentId
-      ? resolveAgentWorkspaceDir(cfg, defaultAgentId)
-      : configuredDefaultWorkspace
-        ? resolveUserPath(configuredDefaultWorkspace, env)
-        : resolveDefaultAgentWorkspaceDir(env));
+  const workspaceDir = resolvePluginControlPlaneWorkspace({
+    config: cfg,
+    workspaceDir: opts.workspaceDir,
+    env,
+  }).workspaceDir;
   const { readConfigSnapshotForAudit } = await loadAuditNonDeepModule();
   const configSnapshot = includeFilesystem
     ? opts.configSnapshot !== undefined


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw security audit` and the security section of `openclaw status --all` inspected an unused legacy/default workspace when an explicit multi-agent fleet intentionally had no ambient owner. That could report findings from a workspace no configured agent used.

## Why This Change Was Made

The audit now uses the same control-plane workspace resolver as status and plugin diagnostics. Ownerless explicit fleets omit single-workspace enrichment, an explicitly configured system-agent owner remains selectable, rosterless installs retain their legacy workspace, and all configured agent workspaces continue to be audited by the existing aggregate scanners.

Production LOC: +7/-12 (net -5). Tests: +75/-0.

## User Impact

Security and status diagnostics no longer attribute an unused default workspace to explicit fleets, while still reporting findings from every real agent workspace and from compatible rosterless installations.

## Evidence

- Reproduced on the pre-fix tree: the focused regression found the unused defaults workspace alongside both configured agent workspaces ([Testbox run 31846969815](https://github.com/openclaw/openclaw/actions/runs/31846969815)).
- Focused post-fix Testbox proof: 11/11 tests passed across `audit-rosterless` and the shared control-plane resolver ([run 31847218589](https://github.com/openclaw/openclaw/actions/runs/31847218589)).
- Changed gate passed on Blacksmith Testbox, including formatting, core/type-test typechecks, lint, boundary guards, dead-code checks, and import-cycle checks ([run 31847412683](https://github.com/openclaw/openclaw/actions/runs/31847412683)).
- Autoreview: clean, no accepted/actionable findings (0.98 confidence).
