### PR TITLE
fix(ui): keep session titles neutral under attention states

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4030,12 +4030,14 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   stroke-linejoin: round;
 }
 
-.sidebar-recent-session.sidebar-recent-session--attention-amber .sidebar-recent-session__name,
+/* Attention tints the subtitle and the icons, never the title: the title is the
+   session's identity, and recolouring it makes the same session read as a
+   different one each time its state changes. The subtitle is what reports
+   state, so it carries the tone alone. */
 .sidebar-recent-session.sidebar-recent-session--attention-amber .sidebar-recent-session__subtitle {
   color: color-mix(in srgb, var(--warn) 82%, var(--text));
 }
 
-.sidebar-recent-session.sidebar-recent-session--attention-danger .sidebar-recent-session__name,
 .sidebar-recent-session.sidebar-recent-session--attention-danger .sidebar-recent-session__subtitle {
   color: color-mix(in srgb, var(--danger) 86%, var(--text));
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a session's title in the Control UI sidebar changed colour whenever that session needed attention. A session waiting for approval had its title rendered amber, and a session whose run failed had its title rendered red, so the same session looked like a different entry each time its state changed.

Affected surface: the session rows in the Control UI sidebar (`Waiting for approval`, `Run failed: ...` and any other attention state).

## Why This Change Was Made

Attention is a state report, and the row already reports it in the places that exist for that purpose: the subtitle text, the attention glyph, and the row's status dot. The title is the session's identity and should stay stable so the row remains recognisable while its state moves. This drops the title from the two attention colour rules and leaves the tone on the subtitle alone; the amber and danger tones themselves, the glyphs, and the subtitle treatment are all unchanged.

Non-goal: this does not touch which sessions enter an attention state, the attention glyphs, or the approval subtitle's own treatment.

## User Impact

Session titles in the sidebar keep one consistent colour. A session that starts waiting for approval, fails, or recovers no longer appears to change identity — only its subtitle and indicators change, which is where the state belongs. Active and selected rows keep their existing emphasis.

## Evidence

Provenance: the two rules date from #111035 (`6c2973dee41`), which introduced automatic sidebar attention states and applied the tone to `.sidebar-recent-session__name` alongside `.sidebar-recent-session__subtitle`.

Nothing else depends on the removed selectors — the only other references to `--attention-amber` / `--attention-danger` in the tree are the two lines in `app-sidebar-session-row-render.ts` that emit the classes, and no test asserts a title colour.

Measured live in the mock (`scripts/control-ui-mock-dev.ts --fixture=approval`), computed `color` of `.sidebar-recent-session__name`, same scene before and after:

| Row | Theme | Title before | Title after | Subtitle after |
| --- | --- | --- | --- | --- |
| Production export (amber) | light | `srgb 0.515 0.248 0.082` | `rgb(33,30,26)` | `srgb 0.515 0.248 0.082` |
| Model budget review (danger) | light | `srgb 0.659 0.127 0.124` | `rgb(64,60,53)` | `srgb 0.659 0.127 0.124` |
| Production export (amber) | dark | `srgb 0.921 0.641 0.171` | `rgb(244,244,245)` | `srgb 0.921 0.641 0.171` |
| Model budget review (danger) | dark | `srgb 0.940 0.484 0.487` | `rgb(188,188,192)` | `srgb 0.940 0.484 0.487` |

After the change both titles resolve to the ordinary title colours (`--text`, and `--text-strong` on the active row) while the subtitles keep the exact tone they had before.

**Before — light**

<img width="600" alt="Sidebar before, light theme: session titles tinted amber and red" src="https://github.com/user-attachments/assets/78fdf78d-ea68-4b4a-bc0a-fad9c5251aad" />

**After — light**

<img width="600" alt="Sidebar after, light theme: session titles neutral, subtitles tinted" src="https://github.com/user-attachments/assets/25192489-fedc-4d3f-b18b-00389191d868" />

**Before — dark**

<img width="600" alt="Sidebar before, dark theme: session titles tinted amber and red" src="https://github.com/user-attachments/assets/369d44ba-b043-465d-8c4b-6d9d26d659f7" />

**After — dark**

<img width="600" alt="Sidebar after, dark theme: session titles neutral, subtitles tinted" src="https://github.com/user-attachments/assets/3b89f7fc-c8c8-4ad5-85c5-ac0a74cb83dc" />

Capture note: the demo approval in `--fixture=approval` currently expires on the first tick, so the amber row is not observable from a stock checkout. Its expiry was extended locally for these captures only; that tweak is not part of this branch, and the before and after shots use the identical mock state so the only difference between them is this diff.
