### PR TITLE
fix(policy): require --agent for explicit workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Policy CLI agent ownership:** add explicit agent selection for policy check, watch, and relative compare paths so multi-agent fleets never inspect an arbitrary workspace.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Policy CLI agent ownership:** add explicit agent selection for policy check, watch, and relative compare paths so multi-agent fleets never inspect an arbitrary workspace.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -528,6 +528,7 @@ Run policy-only checks during authoring:
 
 ```bash
 openclaw policy check
+openclaw policy check --agent ops
 openclaw policy check --json
 openclaw policy check --severity-min error
 ```
@@ -535,11 +536,16 @@ openclaw policy check --severity-min error
 `policy check` runs only the policy check set and emits evidence, findings,
 and attestation hashes. The same findings also appear in
 `openclaw doctor --lint` when the Policy plugin is enabled.
+In a multi-agent fleet with explicit ownership, pass `--agent <id>` so the
+command reads governed declarations and `policy.jsonc` from that agent's
+workspace. A sole-agent or retained legacy-owner configuration still resolves
+without the flag; OpenClaw never selects an arbitrary first agent.
 
 Compare an operator policy file against an authored baseline:
 
 ```bash
 openclaw policy compare --baseline official.policy.jsonc
+openclaw policy compare --baseline official.policy.jsonc --agent ops
 openclaw policy compare --baseline official.policy.jsonc --policy policy.jsonc --json
 ```
 
@@ -557,6 +563,9 @@ For routing probes, every baseline probe id must remain with the same route
 and expected agent. A checked policy may add probes or narrow `matchedBy`, but
 removing a probe, changing its route or agent, or widening its accepted match
 kinds is weaker.
+When the checked policy path comes from the plugin configuration and is
+relative, `--agent <id>` selects the workspace used to resolve it. Absolute
+policy paths do not depend on an agent workspace.
 
 Clean compare (`--json`):
 
@@ -796,6 +805,7 @@ longer matches `expectedAttestationHash`:
 
 ```bash
 openclaw policy watch --json
+openclaw policy watch --agent ops --json
 ```
 
 Use `--once` in CI or scripts that need a single drift evaluation. Without

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -36,6 +36,10 @@ through `openclaw policy check` and `openclaw doctor --lint`. A clean policy
 check emits policy, evidence, findings, and attestation hashes that operators
 can record for audit.
 
+`openclaw policy check`, `watch`, and workspace-relative `compare` accept
+`--agent <id>`. Explicit multi-agent fleets must select the workspace owner;
+the plugin does not infer one from roster order.
+
 `openclaw policy compare --baseline <file>` compares one policy file to another
 policy file. It is config-level conformance only: it uses policy rule metadata
 to verify that the checked policy is not missing or weaker than the authored

--- a/extensions/policy/openclaw.plugin.json
+++ b/extensions/policy/openclaw.plugin.json
@@ -34,7 +34,7 @@
       },
       "path": {
         "type": "string",
-        "description": "Optional policy.jsonc path. Relative paths resolve from the active workspace."
+        "description": "Optional policy.jsonc path. Relative paths resolve from the selected agent workspace."
       }
     }
   }

--- a/extensions/policy/src/cli.agent-owner.test.ts
+++ b/extensions/policy/src/cli.agent-owner.test.ts
@@ -1,0 +1,178 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { clearConfigCache } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerPolicyCli } from "./cli.js";
+
+let workspaceDir: string;
+
+async function writeFixture(path: string, value: unknown): Promise<void> {
+  await fs.writeFile(path, typeof value === "string" ? value : JSON.stringify(value), "utf-8");
+}
+
+async function runPolicyCli(args: readonly string[]) {
+  const output: string[] = [];
+  const stdout = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    output.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+  const stderr = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    output.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  const consoleError = vi.spyOn(console, "error").mockImplementation((...values: unknown[]) => {
+    output.push(`${values.map(String).join(" ")}\n`);
+  });
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  try {
+    const program = new Command().name("openclaw");
+    registerPolicyCli(program);
+    await program.parseAsync(["policy", ...args], { from: "user" });
+    const lastOutput = output.at(-1) ?? "";
+    const parsed = /^[{[]/.test(lastOutput.trimStart()) ? JSON.parse(lastOutput) : {};
+    return { exitCode: process.exitCode ?? 0, parsed, output };
+  } finally {
+    process.exitCode = previousExitCode;
+    stdout.mockRestore();
+    stderr.mockRestore();
+    consoleError.mockRestore();
+  }
+}
+
+async function writeExplicitFleetConfig(): Promise<{
+  readonly alphaWorkspace: string;
+  readonly betaWorkspace: string;
+}> {
+  const alphaWorkspace = join(workspaceDir, "alpha-workspace");
+  const betaWorkspace = join(workspaceDir, "beta-workspace");
+  await Promise.all([
+    fs.mkdir(alphaWorkspace, { recursive: true }),
+    fs.mkdir(betaWorkspace, { recursive: true }),
+  ]);
+  const configPath = join(workspaceDir, "openclaw.jsonc");
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+  await writeFixture(configPath, {
+    agents: {
+      ownership: "explicit",
+      entries: {
+        alpha: { workspace: alphaWorkspace },
+        beta: { workspace: betaWorkspace },
+      },
+    },
+    plugins: {
+      entries: {
+        policy: { enabled: true, config: { enabled: true, path: "policy.jsonc" } },
+      },
+    },
+  });
+  clearConfigCache();
+  return { alphaWorkspace, betaWorkspace };
+}
+
+describe("policy CLI agent ownership", () => {
+  beforeEach(async () => {
+    workspaceDir = await fs.mkdtemp(join(tmpdir(), "policy-cli-owner-"));
+    vi.stubEnv("OPENCLAW_WORKSPACE_DIR", workspaceDir);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    clearConfigCache();
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("checks the explicitly selected workspace without inspecting the first agent", async () => {
+    const { alphaWorkspace, betaWorkspace } = await writeExplicitFleetConfig();
+    await writeFixture(join(alphaWorkspace, "policy.jsonc"), "{");
+    await writeFixture(join(betaWorkspace, "policy.jsonc"), {});
+
+    const { exitCode, parsed } = await runPolicyCli(["check", "--agent", "beta", "--json"]);
+
+    expect(exitCode).toBe(0);
+    expect(parsed).toMatchObject({
+      ok: true,
+      attestation: { policy: { path: "policy.jsonc" } },
+      findings: [],
+    });
+  });
+
+  it("watches the explicitly selected workspace without inspecting the first agent", async () => {
+    const { alphaWorkspace, betaWorkspace } = await writeExplicitFleetConfig();
+    await writeFixture(join(alphaWorkspace, "policy.jsonc"), "{");
+    await writeFixture(join(betaWorkspace, "policy.jsonc"), {});
+
+    const { exitCode, parsed } = await runPolicyCli([
+      "watch",
+      "--agent",
+      "beta",
+      "--json",
+      "--once",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(parsed).toMatchObject({
+      status: "clean",
+      ok: true,
+      attestation: { policy: { path: "policy.jsonc" } },
+      findings: [],
+    });
+  });
+
+  it("resolves a relative compare policy from the explicitly selected workspace", async () => {
+    const { alphaWorkspace, betaWorkspace } = await writeExplicitFleetConfig();
+    const baselinePath = join(workspaceDir, "baseline.policy.jsonc");
+    await writeFixture(baselinePath, { network: { privateNetwork: { allow: false } } });
+    await writeFixture(join(alphaWorkspace, "policy.jsonc"), {
+      network: { privateNetwork: { allow: true } },
+    });
+    await writeFixture(join(betaWorkspace, "policy.jsonc"), {
+      network: { privateNetwork: { allow: false } },
+    });
+
+    const { exitCode, parsed } = await runPolicyCli([
+      "compare",
+      "--agent",
+      "beta",
+      "--baseline",
+      baselinePath,
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(parsed).toMatchObject({ ok: true, policyPath: "policy.jsonc", findings: [] });
+  });
+
+  it.each([
+    {
+      name: "check",
+      args: ["check", "--json"],
+      expected: "policy check has no explicit owner",
+    },
+    {
+      name: "relative compare",
+      args: ["compare", "--baseline", "baseline.policy.jsonc", "--json"],
+      expected: "policy compare has no explicit owner",
+    },
+  ])("requires an owner for $name", async ({ args, expected }) => {
+    await writeExplicitFleetConfig();
+    await writeFixture(join(workspaceDir, "baseline.policy.jsonc"), {});
+
+    const { exitCode, output } = await runPolicyCli(args);
+
+    expect(exitCode).toBe(2);
+    expect(output.join("\n")).toContain(expected);
+    expect(output.join("\n")).toContain("Pass --agent <id>.");
+  });
+
+  it("rejects an unknown explicit owner", async () => {
+    await writeExplicitFleetConfig();
+
+    const { exitCode, output } = await runPolicyCli(["check", "--agent", "ghost", "--json"]);
+
+    expect(exitCode).toBe(2);
+    expect(output.join("\n")).toContain('Unknown agent id "ghost"');
+  });
+});

--- a/extensions/policy/src/cli.ts
+++ b/extensions/policy/src/cli.ts
@@ -2,6 +2,7 @@
 import { isAbsolute, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { Command } from "commander";
+import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import {
   exitCodeFromFindings,
   healthFindingMeetsSeverity,
@@ -12,6 +13,7 @@ import {
   type HealthCheckContext,
   type HealthFinding,
 } from "openclaw/plugin-sdk/health";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { defaultRuntime as cliRuntime } from "openclaw/plugin-sdk/runtime";
 import { POLICY_FIX_METADATA_BY_CHECK_ID } from "./doctor/fix-metadata.js";
 import { POLICY_CHECK_IDS, evaluatePolicy } from "./doctor/register.js";
@@ -28,6 +30,7 @@ type PolicyCommandRuntime = {
 };
 
 interface PolicyCheckOptions {
+  readonly agent?: string;
   readonly json?: boolean;
   readonly severityMin?: string;
   readonly cwd?: string;
@@ -39,6 +42,7 @@ interface PolicyWatchOptions extends PolicyCheckOptions {
 }
 
 interface PolicyCompareOptions {
+  readonly agent?: string;
   readonly baseline?: string;
   readonly policy?: string;
   readonly json?: boolean;
@@ -76,6 +80,7 @@ export function registerPolicyCli(program: Command): void {
     .description("Compare policy.jsonc against an authored baseline policy file")
     .requiredOption("--baseline <path>", "Baseline policy file to compare against")
     .option("--policy <path>", "Policy file to check; defaults to configured policy path")
+    .option("--agent <id>", "Agent id for relative policy workspace paths")
     .option("--json", "Emit JSON output")
     .action(async (options: PolicyCompareOptions) => {
       process.exitCode = await policyCompareCommand(options);
@@ -84,6 +89,7 @@ export function registerPolicyCli(program: Command): void {
   policy
     .command("check")
     .description("Check policy requirements and emit an audit attestation")
+    .option("--agent <id>", "Agent id (required when multiple agents are configured)")
     .option("--json", "Emit JSON output")
     .option("--severity-min <severity>", "Minimum severity: info, warning, or error")
     .action(async (options: PolicyCheckOptions) => {
@@ -93,6 +99,7 @@ export function registerPolicyCli(program: Command): void {
   policy
     .command("watch")
     .description("Watch policy evidence and report accepted-attestation drift")
+    .option("--agent <id>", "Agent id (required when multiple agents are configured)")
     .option("--json", "Emit JSON output")
     .option("--severity-min <severity>", "Minimum severity: info, warning, or error")
     .option("--interval-ms <ms>", "Polling interval in milliseconds")
@@ -129,7 +136,7 @@ async function policyCheckCommand(
   runtime: PolicyCommandRuntime = defaultRuntime,
 ): Promise<number> {
   try {
-    const report = await buildPolicyCheckReport(options, runtime);
+    const report = await buildPolicyCheckReport(options, runtime, "policy check");
     writePolicyCheckReport(report, options, runtime);
     return report.exitCode;
   } catch (err) {
@@ -146,7 +153,7 @@ async function policyWatchCommand(
     const intervalMs = normalizeWatchIntervalMs(options.intervalMs);
     let previousKey: string | undefined;
     for (;;) {
-      const report = await buildPolicyCheckReport(options, runtime);
+      const report = await buildPolicyCheckReport(options, runtime, "policy watch");
       const status = policyWatchStatus(report);
       const key = `${status}:${report.attestation?.attestationHash ?? ""}:${report.exitCode}`;
       if (previousKey === undefined || previousKey !== key || options.once === true) {
@@ -171,6 +178,7 @@ async function policyWatchCommand(
 async function buildPolicyCheckReport(
   options: PolicyCheckOptions,
   runtime: PolicyCommandRuntime,
+  ownerSurface: "policy check" | "policy watch",
 ): Promise<PolicyCheckReport> {
   const severityMin =
     options.severityMin === undefined ? "info" : parseHealthFindingSeverity(options.severityMin);
@@ -199,7 +207,9 @@ async function buildPolicyCheckReport(
     };
   }
   const cfg = snapshot.valid ? policyCommandConfig(snapshot.config) : {};
-  const cwd = options.cwd ?? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const cwd =
+    options.cwd ??
+    resolveAgentWorkspaceDir(cfg, resolvePolicyCommandAgentId(cfg, options.agent, ownerSurface));
   const ctx: HealthCheckContext = {
     mode: "lint",
     runtime: {
@@ -267,6 +277,30 @@ function policyCommandConfig(cfg: HealthCheckContext["cfg"]): HealthCheckContext
   };
 }
 
+function resolvePolicyCommandAgentId(
+  cfg: HealthCheckContext["cfg"],
+  rawAgentId: string | undefined,
+  surface: "policy check" | "policy watch" | "policy compare",
+): string {
+  const requestedAgentId = rawAgentId?.trim();
+  if (rawAgentId !== undefined && !requestedAgentId) {
+    throw new Error("--agent must not be blank");
+  }
+  if (requestedAgentId) {
+    const agentId = normalizeAgentId(requestedAgentId);
+    if (!listAgentIds(cfg).includes(agentId)) {
+      throw new Error(
+        `Unknown agent id "${requestedAgentId}". Run \`openclaw agents list\` to see configured agents.`,
+      );
+    }
+    return agentId;
+  }
+  return resolveDefaultAgentId(cfg, {
+    surface,
+    hint: "Pass --agent <id>.",
+  });
+}
+
 async function policyCompareCandidatePath(options: PolicyCompareOptions): Promise<string> {
   if (options.policy !== undefined && options.policy.trim() !== "") {
     return options.policy.trim();
@@ -287,7 +321,10 @@ async function policyCompareCandidatePath(options: PolicyCompareOptions): Promis
   }
   const cwd =
     options.cwd ??
-    resolveAgentWorkspaceDir(snapshot.config, resolveDefaultAgentId(snapshot.config));
+    resolveAgentWorkspaceDir(
+      snapshot.config,
+      resolvePolicyCommandAgentId(snapshot.config, options.agent, "policy compare"),
+    );
   return resolve(cwd, policyPath);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `openclaw policy check`, `policy watch`, or a configured relative `policy compare` path could not select the owning workspace in an explicit multi-agent fleet. The commands exposed no `--agent` option while their workspace lookup still required an implicit default owner.

## Why This Change Was Made

The Policy plugin now accepts and validates `--agent <id>` at the CLI boundary, then carries that owner into workspace and configured-relative-path resolution. Omission remains selection-required when several explicit agents are configured; unknown ids fail before a typo-scoped workspace can be inspected. No roster-order or `main` fallback was added.

The fix stays at the policy CLI ownership boundary shared by check, watch, and compare. Absolute compare paths remain independent of a workspace. Production LOC is +42/-5 (net +37) for the explicit ownership capability and validation; focused tests are +178/-0 and docs are +14/-0. Release-note context is carried here for the release-owned changelog flow.

## User Impact

Operators can now run policy checks and drift watches against a named agent workspace, and can resolve configured relative policy files for that same agent during comparison. Explicit fleets without an owner get actionable `--agent` guidance instead of an arbitrary workspace choice.

## Evidence

- Before the production fix, the six focused ownership regressions failed on the trusted Testbox: `--agent` was rejected as unknown, and ownerless errors had only generic guidance.
- Focused Testbox proof after the fix: 43/43 policy CLI tests passed (`extensions/policy/src/cli.test.ts` plus `cli.agent-owner.test.ts`).
- Source-blind CLI proof exercised `pnpm openclaw policy` with contrasting alpha/beta workspaces: beta check/watch/relative compare passed; alpha compare returned `policy/policy-conformance-weaker`; invalid beta returned `policy/policy-jsonc-invalid`; ownerless and unknown-owner requests exited 2 with actionable guidance.
- `pnpm check:changed` passed on Blacksmith Testbox, including extension production/test types, full extension lint (8,092 files), docs formatting, plugin metadata, import cycles, and repository guards.
- Structured autoreview completed clean with no accepted/actionable findings.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31847158251
