### PR TITLE
fix(ui): stale tabs keep dispatching after gateway updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI stale-build admission:** reject outdated bundled same-origin documents before they register or dispatch RPCs, return exact reload guidance, and retain a one-shot compatibility retry for older Gateways.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI stale-build admission:** reject outdated bundled same-origin documents before they register or dispatch RPCs, return exact reload guidance, and retain a one-shot compatibility retry for older Gateways.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/packages/gateway-client/src/reconnect-policy.test.ts
+++ b/packages/gateway-client/src/reconnect-policy.test.ts
@@ -18,6 +18,7 @@ describe("shouldPauseGatewayReconnect", () => {
     ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
     ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
     ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH,
+    ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
     ConnectErrorDetailCodes.PAIRING_REQUIRED,
     ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
   ])("pauses reconnect for %s", (code) => {

--- a/packages/gateway-client/src/reconnect-policy.ts
+++ b/packages/gateway-client/src/reconnect-policy.ts
@@ -12,6 +12,7 @@ const NON_RECOVERABLE_AUTH_ERRORS = new Set<string>([
   ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
   ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
   ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH,
+  ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
   ConnectErrorDetailCodes.PAIRING_REQUIRED,
   ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED,
   ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED,

--- a/packages/gateway-protocol/src/connect-error-details.test.ts
+++ b/packages/gateway-protocol/src/connect-error-details.test.ts
@@ -5,11 +5,13 @@ import {
   buildPairingConnectErrorDetails,
   buildPairingConnectErrorMessage,
   classifyGatewayConnectFailure,
+  ConnectErrorDetailCodes,
   describePairingConnectRequirement,
   formatConnectErrorMessage,
   formatConnectPairingRequiredMessage,
   normalizePairingConnectRequestId,
   readConnectErrorDetailCode,
+  readControlUiBuildMismatchDetails,
   readConnectErrorRecoveryAdvice,
   readConnectPairingRequiredMessage,
   readPairingConnectErrorDetails,
@@ -39,6 +41,39 @@ describe("readConnectErrorDetailCode", () => {
   it("returns null for invalid detail payloads", () => {
     expect(readConnectErrorDetailCode(null)).toBeNull();
     expect(readConnectErrorDetailCode("AUTH_TOKEN_MISMATCH")).toBeNull();
+  });
+});
+
+describe("readControlUiBuildMismatchDetails", () => {
+  it("returns a bounded reload target", () => {
+    expect(
+      readControlUiBuildMismatchDetails({
+        code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+        gatewayBuildId: "gateway-build",
+        reloadRequired: true,
+      }),
+    ).toEqual({
+      code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+      gatewayBuildId: "gateway-build",
+      reloadRequired: true,
+    });
+  });
+
+  it.each([
+    {},
+    { code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH },
+    {
+      code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+      gatewayBuildId: "x".repeat(97),
+      reloadRequired: true,
+    },
+    {
+      code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+      gatewayBuildId: "gateway-build",
+      reloadRequired: false,
+    },
+  ])("rejects malformed details", (details) => {
+    expect(readControlUiBuildMismatchDetails(details)).toBeNull();
   });
 });
 

--- a/packages/gateway-protocol/src/connect-error-details.ts
+++ b/packages/gateway-protocol/src/connect-error-details.ts
@@ -36,6 +36,7 @@ export const ConnectErrorDetailCodes = {
   AUTH_TAILSCALE_PROXY_MISSING: "AUTH_TAILSCALE_PROXY_MISSING",
   AUTH_TAILSCALE_WHOIS_FAILED: "AUTH_TAILSCALE_WHOIS_FAILED",
   AUTH_TAILSCALE_IDENTITY_MISMATCH: "AUTH_TAILSCALE_IDENTITY_MISMATCH",
+  CONTROL_UI_BUILD_MISMATCH: "CONTROL_UI_BUILD_MISMATCH",
   CONTROL_UI_ORIGIN_NOT_ALLOWED: "CONTROL_UI_ORIGIN_NOT_ALLOWED",
   PROTOCOL_MISMATCH: "PROTOCOL_MISMATCH",
   CONTROL_UI_DEVICE_IDENTITY_REQUIRED: "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
@@ -53,6 +54,12 @@ export const ConnectErrorDetailCodes = {
 
 type ConnectErrorDetailCode =
   (typeof ConnectErrorDetailCodes)[keyof typeof ConnectErrorDetailCodes];
+
+export type ControlUiBuildMismatchDetails = {
+  code: typeof ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH;
+  gatewayBuildId: string;
+  reloadRequired: true;
+};
 
 /** Pairing-specific reasons clients can display and use for reconnect policy. */
 const ConnectPairingRequiredReasons = {
@@ -227,6 +234,30 @@ export function readConnectErrorDetailCode(details: unknown): string | null {
   }
   const code = (details as { code?: unknown }).code;
   return typeof code === "string" && code.trim().length > 0 ? code.trim() : null;
+}
+
+/** Read the exact target artifact from an untrusted reload-required rejection. */
+export function readControlUiBuildMismatchDetails(
+  details: unknown,
+): ControlUiBuildMismatchDetails | null {
+  if (
+    readConnectErrorDetailCode(details) !== ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH ||
+    !details ||
+    typeof details !== "object" ||
+    Array.isArray(details)
+  ) {
+    return null;
+  }
+  const raw = details as { gatewayBuildId?: unknown; reloadRequired?: unknown };
+  const gatewayBuildId = normalizeOptionalProtocolString(raw.gatewayBuildId);
+  if (!gatewayBuildId || gatewayBuildId.length > 96 || raw.reloadRequired !== true) {
+    return null;
+  }
+  return {
+    code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+    gatewayBuildId,
+    reloadRequired: true,
+  };
 }
 
 /** Extracts normalized retry advice from untrusted connect-error details. */

--- a/scripts/ui.mts
+++ b/scripts/ui.mts
@@ -5,6 +5,8 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { normalizeControlUiBuildInfo } from "../ui/src/build-info-normalizers.ts";
+import { resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
 import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
 import { resolvePnpmRunner } from "./pnpm-runner.mts";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "./windows-cmd-helpers.mjs";
@@ -15,6 +17,78 @@ const uiDir = path.join(repoRoot, "ui");
 
 const WINDOWS_CMD_EXE_EXTENSIONS = new Set([".cmd", ".bat"]);
 const FORWARDED_SIGNAL_KILL_GRACE_MS = 250;
+
+type UiBuildEnvironmentSources = {
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+  readBuildInfo?: () => unknown;
+  readGitCommit?: () => string | null;
+  readPackageVersion?: () => string | null;
+};
+
+function readCurrentGitCommit(): string | null {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function readCurrentPackageVersion(): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")) as {
+      version?: unknown;
+    };
+    return typeof parsed.version === "string" && parsed.version.trim()
+      ? parsed.version.trim()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readExistingBuildInfo(): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(repoRoot, "dist/build-info.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Reuse a matching runtime identity for a standalone rebuild of the bundled UI. */
+export function resolveUiBuildEnvironment(
+  sources: UiBuildEnvironmentSources = {},
+): NodeJS.ProcessEnv {
+  const env = sources.env ?? process.env;
+  const buildEnv = resolveBuildIdentityEnvironment({
+    commitLabel: "Control UI build commit",
+    env,
+    now: sources.now,
+    readGitCommit: sources.readGitCommit ?? readCurrentGitCommit,
+  });
+  if (env.OPENCLAW_BUILD_TIMESTAMP?.trim() || env.OPENCLAW_CONTROL_UI_BUILD_ID?.trim()) {
+    return buildEnv;
+  }
+
+  const existing = normalizeControlUiBuildInfo((sources.readBuildInfo ?? readExistingBuildInfo)());
+  const version = (sources.readPackageVersion ?? readCurrentPackageVersion)();
+  const release = env.OPENCLAW_CONTROL_UI_RELEASE_BUILD?.trim() === "1";
+  if (
+    existing.buildId === "dev" ||
+    !existing.builtAt ||
+    existing.commit !== buildEnv.GIT_COMMIT ||
+    existing.version !== version ||
+    existing.release !== release
+  ) {
+    return buildEnv;
+  }
+  return {
+    ...buildEnv,
+    OPENCLAW_BUILD_TIMESTAMP: existing.builtAt,
+    OPENCLAW_CONTROL_UI_BUILD_ID: existing.buildId,
+  };
+}
 
 type UiSpawnCall = {
   args: string[];
@@ -367,13 +441,14 @@ function main(argv: string[] = process.argv.slice(2)): void {
   }
 
   if (action === "build") {
+    const buildEnv = resolveUiBuildEnvironment();
     const buildCall = noPnpmBuild
-      ? resolveSpawnCall(process.execPath, [
-          path.join(repoRoot, "node_modules/vite/bin/vite.js"),
-          "build",
-          ...rest,
-        ])
-      : resolvePnpmSpawnCall(["run", "build", ...rest]);
+      ? resolveSpawnCall(
+          process.execPath,
+          [path.join(repoRoot, "node_modules/vite/bin/vite.js"), "build", ...rest],
+          buildEnv,
+        )
+      : resolvePnpmSpawnCall(["run", "build", ...rest], buildEnv);
     runSpawnCallSync(buildCall, "Control UI build");
     if (rest.some((arg) => arg === "--help" || arg === "-h")) {
       return;
@@ -386,7 +461,7 @@ function main(argv: string[] = process.argv.slice(2)): void {
         resolveSpawnCall(
           process.execPath,
           ["--import", "tsx", path.join(repoRoot, "scripts", validator)],
-          process.env,
+          buildEnv,
           { cwd: repoRoot },
         ),
         validator,

--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -4,9 +4,22 @@ import type { IncomingMessage } from "node:http";
 import { describe, expect, it } from "vitest";
 import {
   checkBrowserOrigin,
+  isGatewayHostBrowserOrigin,
   normalizeChromeExtensionOrigin,
   resolveAcceptedBrowserOrigin,
 } from "./origin-check.js";
+
+describe("isGatewayHostBrowserOrigin", () => {
+  it.each([
+    ["same host", "claw.example:18789", "https://claw.example:18789", true],
+    ["normalized host", "CLAW.EXAMPLE:18789", "https://claw.example:18789/", true],
+    ["separate host", "gateway.example:18789", "https://ui.example", false],
+    ["local dev port", "127.0.0.1:18789", "http://127.0.0.1:5173", false],
+    ["missing origin", "127.0.0.1:18789", undefined, false],
+  ])("classifies %s", (_name, requestHost, origin, expected) => {
+    expect(isGatewayHostBrowserOrigin({ requestHost, origin })).toBe(expected);
+  });
+});
 
 describe("checkBrowserOrigin", () => {
   it.each([

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -78,6 +78,16 @@ function parseOrigin(
   }
 }
 
+/** Whether a browser document was loaded from the Gateway's advertised HTTP host. */
+export function isGatewayHostBrowserOrigin(params: {
+  requestHost?: string;
+  origin?: string;
+}): boolean {
+  const parsedOrigin = parseOrigin(params.origin);
+  const requestHost = normalizeHostHeader(params.requestHost);
+  return Boolean(parsedOrigin && requestHost && parsedOrigin.host === requestHost);
+}
+
 /** Return a canonical Chrome extension origin for pairing-bound authorization. */
 export function normalizeChromeExtensionOrigin(originRaw?: string): string | undefined {
   const parsed = parseOrigin(originRaw);

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -57,6 +57,7 @@ import type { GatewayWsClient } from "../ws-types.js";
 import { resolveEffectiveConnectionScopes } from "./connect-admission.js";
 import { sendGatewayHello } from "./connect-hello.js";
 import { prepareGatewayNodeConnect } from "./connect-node-session.js";
+import { resolveControlUiBuildMismatch } from "./control-ui-build-admission.js";
 import type {
   DeviceAuthorizedGatewayConnect,
   GatewayConnectPhaseContext,
@@ -102,6 +103,8 @@ export async function attachAuthenticatedGatewayConnect(
     setCloseCause,
     logGateway,
     logWsControl,
+    requestHost,
+    requestOrigin,
   } = context.handler;
   const {
     connectParams,
@@ -311,6 +314,35 @@ export async function attachAuthenticatedGatewayConnect(
       return;
     }
   }
+  const controlUiBuildMismatch = resolveControlUiBuildMismatch({
+    clientId: connectParams.client.id,
+    clientBuildId: connectParams.client.buildId,
+    gatewayBuildId: resolveRuntimeServiceBuildId(),
+    configuredControlUiRoot: context.configSnapshot.gateway?.controlUi?.root,
+    requestHost,
+    requestOrigin,
+  });
+  if (controlUiBuildMismatch) {
+    const message = "Control UI updated; reload this page to continue";
+    markHandshakeFailure("control-ui-build-mismatch", {
+      clientBuildId: controlUiBuildMismatch.clientBuildId ?? "legacy",
+      gatewayBuildId: controlUiBuildMismatch.gatewayBuildId,
+    });
+    sendHandshakeErrorResponse(ErrorCodes.UNAVAILABLE, message, {
+      retryable: false,
+      details: {
+        code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+        gatewayBuildId: controlUiBuildMismatch.gatewayBuildId,
+        reloadRequired: true,
+      },
+    });
+    logWsControl.warn(
+      `control ui build rejected conn=${connId} clientBuild=${formatForLog(controlUiBuildMismatch.clientBuildId ?? "legacy")} gatewayBuild=${formatForLog(controlUiBuildMismatch.gatewayBuildId)}; reload required`,
+    );
+    await releasePendingNodePairingCleanup();
+    close(1008, truncateCloseReason(message));
+    return;
+  }
   const internal =
     isLocalClient || isTrustedApprovalRuntime || trustedAgentRuntimeIdentity
       ? {
@@ -490,18 +522,7 @@ export async function attachAuthenticatedGatewayConnect(
   }
 
   if (isWebchatConnect(connectParams)) {
-    const gatewayBuildId = resolveRuntimeServiceBuildId();
     const clientBuildId = connectParams.client.buildId?.trim();
-    if (
-      connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI &&
-      !context.configSnapshot.gateway?.controlUi?.root &&
-      gatewayBuildId &&
-      clientBuildId !== gatewayBuildId
-    ) {
-      logWsControl.warn(
-        `control ui build mismatch conn=${connId} clientBuild=${formatForLog(clientBuildId ?? "legacy")} gatewayBuild=${formatForLog(gatewayBuildId)}; reload required`,
-      );
-    }
     logWsControl.info(
       `webchat connected conn=${connId} remote=${remoteAddr ?? "?"} client=${clientLabel} ${connectParams.client.mode} v${connectParams.client.version} build=${formatForLog(clientBuildId ?? "legacy")}`,
     );

--- a/src/gateway/server/ws-connection/control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/control-ui-build-admission.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { GATEWAY_CLIENT_IDS } from "../../../../packages/gateway-protocol/src/client-info.js";
+import { resolveControlUiBuildMismatch } from "./control-ui-build-admission.js";
+
+const bundled = {
+  clientId: GATEWAY_CLIENT_IDS.CONTROL_UI,
+  gatewayBuildId: "gateway-build",
+  requestHost: "claw.example",
+  requestOrigin: "https://claw.example",
+};
+
+describe("resolveControlUiBuildMismatch", () => {
+  it.each([
+    ["exact bundled build", { ...bundled, clientBuildId: "gateway-build" }, null],
+    [
+      "stale bundled build",
+      { ...bundled, clientBuildId: "older-build" },
+      { gatewayBuildId: "gateway-build", clientBuildId: "older-build" },
+    ],
+    ["legacy bundled build", bundled, { gatewayBuildId: "gateway-build", clientBuildId: null }],
+    ["configured root", { ...bundled, configuredControlUiRoot: "/srv/ui" }, null],
+    ["separately hosted UI", { ...bundled, requestOrigin: "https://ui.example" }, null],
+    ["local dev UI", { ...bundled, clientBuildId: "dev" }, null],
+    ["absent Gateway build", { ...bundled, gatewayBuildId: null }, null],
+    ["non-Control UI", { ...bundled, clientId: "test-client" }, null],
+  ])("classifies $0", (_name, input, expected) => {
+    expect(resolveControlUiBuildMismatch(input)).toEqual(expected);
+  });
+});

--- a/src/gateway/server/ws-connection/control-ui-build-admission.ts
+++ b/src/gateway/server/ws-connection/control-ui-build-admission.ts
@@ -1,0 +1,37 @@
+import { GATEWAY_CLIENT_IDS } from "../../../../packages/gateway-protocol/src/client-info.js";
+import { isGatewayHostBrowserOrigin } from "../../origin-check.js";
+
+export type ControlUiBuildMismatch = {
+  gatewayBuildId: string;
+  clientBuildId: string | null;
+};
+
+/**
+ * The Gateway owns bundled same-origin UI admission. Browser code still owns
+ * reload, but an older document must never become an RPC-capable session.
+ */
+export function resolveControlUiBuildMismatch(params: {
+  clientId: string;
+  clientBuildId?: string;
+  gatewayBuildId?: string | null;
+  configuredControlUiRoot?: string;
+  requestHost?: string;
+  requestOrigin?: string;
+}): ControlUiBuildMismatch | null {
+  const gatewayBuildId = params.gatewayBuildId?.trim();
+  const clientBuildId = params.clientBuildId?.trim();
+  if (
+    params.clientId !== GATEWAY_CLIENT_IDS.CONTROL_UI ||
+    params.configuredControlUiRoot ||
+    !gatewayBuildId ||
+    clientBuildId === "dev" ||
+    !isGatewayHostBrowserOrigin({
+      requestHost: params.requestHost,
+      origin: params.requestOrigin,
+    }) ||
+    clientBuildId === gatewayBuildId
+  ) {
+    return null;
+  }
+  return { gatewayBuildId, clientBuildId: clientBuildId || null };
+}

--- a/src/gateway/server/ws-connection/control-ui-build-admission.ts
+++ b/src/gateway/server/ws-connection/control-ui-build-admission.ts
@@ -1,7 +1,7 @@
 import { GATEWAY_CLIENT_IDS } from "../../../../packages/gateway-protocol/src/client-info.js";
 import { isGatewayHostBrowserOrigin } from "../../origin-check.js";
 
-export type ControlUiBuildMismatch = {
+type ControlUiBuildMismatch = {
   gatewayBuildId: string;
   clientBuildId: string | null;
 };

--- a/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { ConnectErrorDetailCodes } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
 import { ErrorCodes, PROTOCOL_VERSION } from "../../../../packages/gateway-protocol/src/index.js";
+import { rawDataToString } from "../../../infra/ws.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
 import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
@@ -99,7 +100,12 @@ afterEach(() => {
 describe("Control UI build admission over WebSocket", () => {
   it("rejects a legacy same-origin document before registration or RPC dispatch", async () => {
     const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
-    await withDeadline(new Promise<void>((resolve) => wss.once("listening", resolve)), "listen");
+    await withDeadline(
+      new Promise<void>((resolve) => {
+        wss.once("listening", resolve);
+      }),
+      "listen",
+    );
     const address = wss.address();
     if (!address || typeof address === "string") {
       throw new Error("WebSocket test server did not expose a port");
@@ -157,17 +163,24 @@ describe("Control UI build admission over WebSocket", () => {
       },
     });
     try {
-      await withDeadline(new Promise<void>((resolve) => ws.once("open", resolve)), "open");
+      await withDeadline(
+        new Promise<void>((resolve) => {
+          ws.once("open", resolve);
+        }),
+        "open",
+      );
       const response = withDeadline(
         new Promise<Record<string, unknown>>((resolve) => {
-          ws.once("message", (data) =>
-            resolve(JSON.parse(String(data)) as Record<string, unknown>),
-          );
+          ws.once("message", (data) => {
+            resolve(JSON.parse(rawDataToString(data)) as Record<string, unknown>);
+          });
         }),
         "connect rejection",
       );
       const closed = withDeadline(
-        new Promise<number>((resolve) => ws.once("close", (code) => resolve(code))),
+        new Promise<number>((resolve) => {
+          ws.once("close", (code) => resolve(code));
+        }),
         "socket close",
       );
       ws.send(
@@ -209,7 +222,12 @@ describe("Control UI build admission over WebSocket", () => {
       expect(handleGatewayRequestMock).not.toHaveBeenCalled();
     } finally {
       ws.terminate();
-      await withDeadline(new Promise<void>((resolve) => wss.close(() => resolve())), "cleanup");
+      await withDeadline(
+        new Promise<void>((resolve) => {
+          wss.close(() => resolve());
+        }),
+        "cleanup",
+      );
     }
   });
 });

--- a/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
@@ -1,0 +1,215 @@
+// Raw WebSocket proof for the pre-registration Control UI build admission boundary.
+import type { IncomingMessage } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { ConnectErrorDetailCodes } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
+import { ErrorCodes, PROTOCOL_VERSION } from "../../../../packages/gateway-protocol/src/index.js";
+import type { GatewayRequestContext } from "../../server-methods/types.js";
+import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
+
+const {
+  handleGatewayRequestMock,
+  incrementPresenceVersionMock,
+  resolveRuntimeServiceBuildIdMock,
+  upsertPresenceMock,
+} = vi.hoisted(() => ({
+  handleGatewayRequestMock: vi.fn(),
+  incrementPresenceVersionMock: vi.fn(() => 2),
+  resolveRuntimeServiceBuildIdMock: vi.fn<() => string | null>(() => "gateway-build"),
+  upsertPresenceMock: vi.fn(),
+}));
+
+const gatewayConfig = {
+  gateway: {
+    auth: { mode: "token" as const, token: "test-token" },
+    controlUi: { allowedOrigins: ["*"] },
+  },
+};
+
+vi.mock("../../../config/config.js", () => ({
+  getRuntimeConfig: () => gatewayConfig,
+  loadConfig: () => gatewayConfig,
+}));
+vi.mock("../../../config/io.js", () => ({ getRuntimeConfig: () => gatewayConfig }));
+vi.mock("../../../infra/system-presence.js", () => ({ upsertPresence: upsertPresenceMock }));
+vi.mock("../../../state/user-profiles.js", () => ({
+  adoptTailscaleProfileAvatar: vi.fn(),
+  ensureProfileForEmail: vi.fn(async () => ({
+    id: "profile-1",
+    displayName: null,
+    avatarRevision: "0",
+    hasAvatar: false,
+    updatedAt: 1,
+  })),
+  ensureProfileForTailscaleIdentity: vi.fn(),
+  getUserProfileDisplay: vi.fn(() => ({
+    id: "profile-1",
+    displayName: null,
+    avatarRevision: "0",
+    hasAvatar: false,
+    updatedAt: 1,
+  })),
+}));
+vi.mock("../../server-methods.js", () => ({
+  handleGatewayRequest: handleGatewayRequestMock,
+}));
+vi.mock("../health-state.js", () => ({
+  buildGatewaySnapshot: vi.fn(() => ({
+    presence: [],
+    health: {},
+    stateVersion: { presence: 1, health: 1 },
+    uptimeMs: 1,
+    sessionDefaults: {
+      defaultAgentId: "main",
+      mainKey: "main",
+      mainSessionKey: "main",
+      scope: "per-sender",
+    },
+  })),
+  getHealthCache: vi.fn(() => null),
+  getHealthVersion: vi.fn(() => 1),
+  incrementPresenceVersion: incrementPresenceVersionMock,
+}));
+vi.mock("../../../version.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../version.js")>();
+  return { ...actual, resolveRuntimeServiceBuildId: resolveRuntimeServiceBuildIdMock };
+});
+
+import { attachGatewayWsMessageHandler } from "./message-handler.js";
+
+function createLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function withDeadline<T>(promise: Promise<T>, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timeout waiting for ${label}`)), 5_000);
+      timer.unref?.();
+    }),
+  ]);
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  resolveRuntimeServiceBuildIdMock.mockReturnValue("gateway-build");
+});
+
+describe("Control UI build admission over WebSocket", () => {
+  it("rejects a legacy same-origin document before registration or RPC dispatch", async () => {
+    const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await withDeadline(new Promise<void>((resolve) => wss.once("listening", resolve)), "listen");
+    const address = wss.address();
+    if (!address || typeof address === "string") {
+      throw new Error("WebSocket test server did not expose a port");
+    }
+    const origin = `http://127.0.0.1:${address.port}`;
+    let connectedClient: unknown = null;
+
+    wss.on("connection", (socket, request) => {
+      const send = (value: unknown) => socket.send(JSON.stringify(value));
+      attachGatewayWsMessageHandler({
+        socket,
+        upgradeReq: request as IncomingMessage,
+        connId: "legacy-build-connection",
+        remoteAddr: "127.0.0.1",
+        localAddr: "127.0.0.1",
+        requestHost: request.headers.host,
+        requestOrigin:
+          typeof request.headers.origin === "string" ? request.headers.origin : undefined,
+        connectNonce: "legacy-build-nonce",
+        isControlUiDeviceAuthMigrationPending: () => true,
+        getResolvedAuth: () => ({
+          mode: "token",
+          token: "test-token",
+          allowTailscale: false,
+        }),
+        gatewayMethods: [],
+        events: [],
+        extraHandlers: {},
+        buildRequestContext: () => ({}) as GatewayRequestContext,
+        nodeLifecycleDispatch: new GatewayNodeLifecycleDispatchTracker(),
+        refreshHealthSnapshot: vi.fn(),
+        send,
+        close: (code, reason) => socket.close(code, reason),
+        isClosed: () => socket.readyState >= WebSocket.CLOSING,
+        clearHandshakeTimer: vi.fn(),
+        getClient: () => connectedClient as never,
+        setClient: (next) => {
+          connectedClient = next;
+          return true;
+        },
+        setHandshakeState: vi.fn(),
+        advanceHandshakePhase: vi.fn(),
+        setCloseCause: vi.fn(),
+        setLastFrameMeta: vi.fn(),
+        originCheckMetrics: { hostHeaderFallbackAccepted: 0 },
+        logGateway: createLogger() as never,
+        logHealth: createLogger() as never,
+        logWsControl: createLogger() as never,
+      });
+    });
+
+    const ws = new WebSocket(`ws://127.0.0.1:${address.port}`, {
+      headers: {
+        origin,
+      },
+    });
+    try {
+      await withDeadline(new Promise<void>((resolve) => ws.once("open", resolve)), "open");
+      const response = withDeadline(
+        new Promise<Record<string, unknown>>((resolve) => {
+          ws.once("message", (data) =>
+            resolve(JSON.parse(String(data)) as Record<string, unknown>),
+          );
+        }),
+        "connect rejection",
+      );
+      const closed = withDeadline(
+        new Promise<number>((resolve) => ws.once("close", (code) => resolve(code))),
+        "socket close",
+      );
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "connect-legacy-build",
+          method: "connect",
+          params: {
+            minProtocol: PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+            client: {
+              id: "openclaw-control-ui",
+              version: "2026.8.1",
+              platform: "web",
+              mode: "webchat",
+            },
+            role: "operator",
+            caps: [],
+            auth: { token: "test-token" },
+          },
+        }),
+      );
+
+      expect(await response).toMatchObject({
+        ok: false,
+        error: {
+          code: ErrorCodes.UNAVAILABLE,
+          retryable: false,
+          details: {
+            code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+            gatewayBuildId: "gateway-build",
+            reloadRequired: true,
+          },
+        },
+      });
+      expect(await closed).toBe(1008);
+      expect(connectedClient).toBeNull();
+      expect(upsertPresenceMock).not.toHaveBeenCalled();
+      expect(handleGatewayRequestMock).not.toHaveBeenCalled();
+    } finally {
+      ws.terminate();
+      await withDeadline(new Promise<void>((resolve) => wss.close(() => resolve())), "cleanup");
+    }
+  });
+});

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -6,10 +6,12 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   isDirectScriptExecution,
+  resolveUiBuildEnvironment,
   resolvePnpmSpawnCall,
   resolveSpawnCall,
   shouldUseCmdExeForCommand,
 } from "../../scripts/ui.mts";
+import { normalizeControlUiBuildInfo } from "../../ui/src/build-info-normalizers.ts";
 // writeFileSync creates the file before its content lands, so an existence
 // poll can observe an empty file on loaded runners; wait for bytes instead.
 function readNonEmpty(file: string): string | null {
@@ -54,6 +56,78 @@ async function waitForExit(
 }
 
 describe("scripts/ui windows spawn behavior", () => {
+  it("reuses the runtime identity for the documented standalone UI rebuild", () => {
+    const commit = "0123456789abcdef0123456789abcdef01234567";
+    const firstBuild = normalizeControlUiBuildInfo({
+      version: "2026.8.1",
+      commit,
+      builtAt: "2026-08-14T23:00:00.000Z",
+    });
+
+    const env = resolveUiBuildEnvironment({
+      env: {},
+      now: () => new Date("2026-08-14T23:05:00.000Z"),
+      readBuildInfo: () => firstBuild,
+      readGitCommit: () => commit,
+      readPackageVersion: () => "2026.8.1",
+    });
+    const rebuiltUi = normalizeControlUiBuildInfo({
+      version: "2026.8.1",
+      commit: env.GIT_COMMIT,
+      builtAt: env.OPENCLAW_BUILD_TIMESTAMP,
+      buildId: env.OPENCLAW_CONTROL_UI_BUILD_ID,
+    });
+
+    expect(rebuiltUi).toMatchObject({
+      builtAt: firstBuild.builtAt,
+      buildId: firstBuild.buildId,
+      commit: firstBuild.commit,
+      version: firstBuild.version,
+    });
+  });
+
+  it("does not reuse build info from a different source revision", () => {
+    const env = resolveUiBuildEnvironment({
+      env: {},
+      now: () => new Date("2026-08-14T23:05:00.000Z"),
+      readBuildInfo: () => ({
+        version: "2026.8.1",
+        commit: "a".repeat(40),
+        builtAt: "2026-08-14T23:00:00.000Z",
+      }),
+      readGitCommit: () => "b".repeat(40),
+      readPackageVersion: () => "2026.8.1",
+    });
+
+    expect(env).toMatchObject({
+      GIT_COMMIT: "b".repeat(40),
+      OPENCLAW_BUILD_TIMESTAMP: "2026-08-14T23:05:00.000Z",
+    });
+    expect(env.OPENCLAW_CONTROL_UI_BUILD_ID).toBeUndefined();
+  });
+
+  it("does not reuse non-release build info for a release UI build", () => {
+    const commit = "a".repeat(40);
+    const env = resolveUiBuildEnvironment({
+      env: { OPENCLAW_CONTROL_UI_RELEASE_BUILD: "1" },
+      now: () => new Date("2026-08-14T23:05:00.000Z"),
+      readBuildInfo: () => ({
+        version: "2026.8.1",
+        commit,
+        builtAt: "2026-08-14T23:00:00.000Z",
+        release: false,
+      }),
+      readGitCommit: () => commit,
+      readPackageVersion: () => "2026.8.1",
+    });
+
+    expect(env).toMatchObject({
+      GIT_COMMIT: commit,
+      OPENCLAW_BUILD_TIMESTAMP: "2026-08-14T23:05:00.000Z",
+    });
+    expect(env.OPENCLAW_CONTROL_UI_BUILD_ID).toBeUndefined();
+  });
+
   it("wraps Windows command launchers with cmd.exe without enabling shell mode", () => {
     expect(
       shouldUseCmdExeForCommand("C:\\Users\\dev\\AppData\\Local\\pnpm\\pnpm.CMD", "win32"),

--- a/ui/src/api/gateway-connect-errors.ts
+++ b/ui/src/api/gateway-connect-errors.ts
@@ -1,0 +1,51 @@
+import {
+  ConnectErrorDetailCodes,
+  GatewayProtocolRequestError,
+  MIN_CLIENT_PROTOCOL_VERSION,
+  PROTOCOL_VERSION,
+  readConnectErrorDetailCode,
+  shouldPauseGatewayReconnect,
+} from "@openclaw/gateway-client/browser";
+
+export function enrichProtocolMismatchDetails(
+  message: string | undefined,
+  details: unknown,
+): unknown {
+  if (readConnectErrorDetailCode(details) === ConnectErrorDetailCodes.PROTOCOL_MISMATCH) {
+    return details;
+  }
+  if (!message?.toLowerCase().includes("protocol mismatch")) {
+    return details;
+  }
+  return {
+    code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+    clientMinProtocol: MIN_CLIENT_PROTOCOL_VERSION,
+    clientMaxProtocol: PROTOCOL_VERSION,
+    ...(details && typeof details === "object" && !Array.isArray(details) ? details : {}),
+  };
+}
+
+export function resolveGatewayErrorDetailCode(
+  error: { details?: unknown } | null | undefined,
+): string | null {
+  return readConnectErrorDetailCode(error?.details);
+}
+
+export function isLegacyGatewayBuildIdSchemaError(
+  error: GatewayProtocolRequestError,
+  clientBuildId: string | undefined,
+): boolean {
+  return Boolean(
+    clientBuildId && /invalid connect params.*unexpected property.*buildid/iu.test(error.message),
+  );
+}
+
+/** Token mismatch stays with its bounded retry owner; static failures pause. */
+export function isNonRecoverableConnectError(error: { details?: unknown } | undefined): boolean {
+  return error
+    ? shouldPauseGatewayReconnect({
+        details: error.details,
+        protocolMismatchIsTerminal: true,
+      })
+    : false;
+}

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -461,6 +461,47 @@ describe("GatewayBrowserClient", () => {
     expect(connectFrame.params?.scopes).toEqual([...CONTROL_UI_OPERATOR_SCOPES]);
   });
 
+  it("retries an old closed-schema Gateway once without client build identity", async () => {
+    useNodeFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+      clientBuildId: "build-a",
+    });
+
+    const first = await startConnect(client);
+    expect(first.connectFrame.params?.client.buildId).toBe("build-a");
+    first.ws.emitMessage({
+      type: "res",
+      id: first.connectFrame.id,
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "invalid connect params: at /client: unexpected property 'buildId'",
+      },
+    });
+    await expectSocketClosed(first.ws);
+    first.ws.emitClose(4008, "connect retry");
+
+    await vi.advanceTimersByTimeAsync(250);
+    const second = await continueConnect(getLatestWebSocket(), "nonce-2");
+    expect(second.connectFrame.params?.client.buildId).toBeUndefined();
+    second.ws.emitMessage({
+      type: "res",
+      id: second.connectFrame.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+      },
+    });
+    expect(wsInstances).toHaveLength(2);
+
+    client.stop();
+    vi.useRealTimers();
+  });
+
   it("signs device proof with Gateway time instead of browser wall-clock time", async () => {
     useNodeFakeTimers();
     vi.setSystemTime(new Date("2040-01-01T00:00:00.000Z"));

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -88,6 +88,19 @@ export function resolveGatewayErrorDetailCode(
   return readConnectErrorDetailCode(error?.details);
 }
 
+function isLegacyGatewayBuildIdSchemaError(
+  error: GatewayProtocolRequestError,
+  clientBuildId: string | undefined,
+): boolean {
+  const message = error.message.toLowerCase();
+  return Boolean(
+    clientBuildId &&
+    message.includes("invalid connect params") &&
+    message.includes("unexpected property") &&
+    message.includes("buildid"),
+  );
+}
+
 /**
  * Connect failures that cannot recover while client and server state stay unchanged.
  * AUTH_TOKEN_MISMATCH stays out: the close handler owns its bounded cached-token retry.
@@ -314,6 +327,10 @@ export class GatewayBrowserClient {
   private tickWatchTimer: ReturnType<typeof setInterval> | null = null;
   private pendingDeviceTokenRetry = false;
   private deviceTokenRetryBudgetUsed = false;
+  // Older shipped Gateways used a closed client schema. Downgrade once per
+  // browser client; a document reload creates a fresh exact-identity attempt.
+  private clientBuildIdCompatibilityDisabled = false;
+  private clientBuildIdRetryBudgetUsed = false;
   // Close/stop advances this generation before another socket can make stale hello work look active.
   private recovery = { value: "", resolved: false, generation: 0 };
   private scopeUpgradeBinding: ScopeUpgradeBinding | null = null;
@@ -404,6 +421,8 @@ export class GatewayBrowserClient {
     this.scopeUpgradeBinding = null;
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
+    this.clientBuildIdCompatibilityDisabled = false;
+    this.clientBuildIdRetryBudgetUsed = false;
   }
 
   get connected() {
@@ -446,7 +465,7 @@ export class GatewayBrowserClient {
     const client: ConnectParams["client"] = {
       id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
       version: this.opts.clientVersion ?? "control-ui",
-      buildId: this.opts.clientBuildId,
+      buildId: this.clientBuildIdCompatibilityDisabled ? undefined : this.opts.clientBuildId,
       platform: this.opts.platform ?? navigator.platform ?? "web",
       mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT,
       instanceId: this.opts.instanceId,
@@ -609,6 +628,15 @@ export class GatewayBrowserClient {
   private handleConnectFailure(err: GatewayProtocolRequestError, plan: ConnectPlan) {
     const connectErrorCode =
       err instanceof GatewayRequestError ? resolveGatewayErrorDetailCode(err) : null;
+    if (
+      !this.clientBuildIdRetryBudgetUsed &&
+      isLegacyGatewayBuildIdSchemaError(err, plan.params.client.buildId)
+    ) {
+      this.clientBuildIdCompatibilityDisabled = true;
+      this.clientBuildIdRetryBudgetUsed = true;
+      this.client.resetReconnectBackoff(250);
+      return { closeCode: CONNECT_FAILED_CLOSE_CODE, closeReason: "connect retry" };
+    }
     if (
       shouldRetryGatewayWithDeviceToken({
         retryBudgetUsed: this.deviceTokenRetryBudgetUsed,

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -1,10 +1,10 @@
 import {
   buildGatewayConnectAuth,
   buildDeviceAuthPayload,
+  ConnectErrorDetailCodes,
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
-  ConnectErrorDetailCodes,
   formatConnectErrorMessage,
   GatewayProtocolClient,
   GatewayProtocolRequestError,
@@ -19,16 +19,14 @@ import {
   type ErrorShape,
   type EventFrame,
   type HelloOk,
-  shouldPauseGatewayReconnect,
   resolveGatewayConnectScopes,
-  readConnectErrorDetailCode,
   selectGatewayConnectAuth,
   shouldRetryGatewayWithDeviceToken,
   isRetryableGatewayStartupUnavailableError,
-  resolveGatewayStartupRetryAfterMs,
-  resolveSafeTimeoutDelayMs,
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
+  resolveGatewayStartupRetryAfterMs,
+  resolveSafeTimeoutDelayMs,
 } from "@openclaw/gateway-client/browser";
 export type { EventFrame as GatewayEventFrame } from "@openclaw/gateway-client/browser";
 import type {
@@ -54,6 +52,14 @@ import {
 } from "../lib/nodes/index.ts";
 import { generateUUID } from "../lib/uuid.ts";
 import { createBrowserGatewaySocket } from "./gateway-browser-socket.ts";
+import {
+  enrichProtocolMismatchDetails,
+  isLegacyGatewayBuildIdSchemaError,
+  isNonRecoverableConnectError,
+  resolveGatewayErrorDetailCode,
+} from "./gateway-connect-errors.ts";
+
+export { resolveGatewayErrorDetailCode };
 
 export class GatewayRequestError extends GatewayProtocolRequestError {
   constructor(error: ErrorShape) {
@@ -65,54 +71,6 @@ export class GatewayRequestError extends GatewayProtocolRequestError {
     });
     this.name = "GatewayRequestError";
   }
-}
-
-function enrichProtocolMismatchDetails(message: string | undefined, details: unknown): unknown {
-  if (readConnectErrorDetailCode(details) === ConnectErrorDetailCodes.PROTOCOL_MISMATCH) {
-    return details;
-  }
-  if (!message?.toLowerCase().includes("protocol mismatch")) {
-    return details;
-  }
-  return {
-    code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
-    clientMinProtocol: MIN_CLIENT_PROTOCOL_VERSION,
-    clientMaxProtocol: PROTOCOL_VERSION,
-    ...(details && typeof details === "object" && !Array.isArray(details) ? details : {}),
-  };
-}
-
-export function resolveGatewayErrorDetailCode(
-  error: { details?: unknown } | null | undefined,
-): string | null {
-  return readConnectErrorDetailCode(error?.details);
-}
-
-function isLegacyGatewayBuildIdSchemaError(
-  error: GatewayProtocolRequestError,
-  clientBuildId: string | undefined,
-): boolean {
-  const message = error.message.toLowerCase();
-  return Boolean(
-    clientBuildId &&
-    message.includes("invalid connect params") &&
-    message.includes("unexpected property") &&
-    message.includes("buildid"),
-  );
-}
-
-/**
- * Connect failures that cannot recover while client and server state stay unchanged.
- * AUTH_TOKEN_MISMATCH stays out: the close handler owns its bounded cached-token retry.
- */
-function isNonRecoverableConnectError(error: { details?: unknown } | undefined): boolean {
-  if (!error) {
-    return false;
-  }
-  return shouldPauseGatewayReconnect({
-    details: error.details,
-    protocolMismatchIsTerminal: true,
-  });
 }
 
 function isLoopbackIPv4Host(host: string): boolean {

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -12,6 +12,14 @@ import { createStorageMock } from "../test-helpers/storage.ts";
 import { createApplicationGateway } from "./gateway-store.ts";
 import { loadSettings } from "./settings.ts";
 
+const { scheduleStaleChunkReloadMock } = vi.hoisted(() => ({
+  scheduleStaleChunkReloadMock: vi.fn(async () => true),
+}));
+
+vi.mock("./stale-chunk-reload.ts", () => ({
+  scheduleStaleChunkReload: scheduleStaleChunkReloadMock,
+}));
+
 vi.mock("../build-info.ts", () => ({
   CONTROL_UI_BUILD_INFO: {
     version: "2026.7.19",
@@ -112,6 +120,7 @@ function createStore(
 
 describe("createApplicationGateway connection phase", () => {
   beforeEach(() => {
+    scheduleStaleChunkReloadMock.mockClear();
     vi.stubGlobal("localStorage", createStorageMock());
     vi.stubGlobal("sessionStorage", createStorageMock());
     vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
@@ -193,6 +202,32 @@ describe("createApplicationGateway connection phase", () => {
     current().opts.onClose?.({ code: 1006, reason: "restarting", willRetry: true });
     current().opts.onHello?.(legacyHello);
     expect(gateway.snapshot.phase).toBe("reconnecting");
+  });
+
+  it("turns a structured build rejection into one guarded reload", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 1008,
+      reason: "connect failed",
+      willRetry: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: "Control UI updated; reload this page to continue",
+        details: {
+          code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+          gatewayBuildId: "replacement-build",
+          reloadRequired: true,
+        },
+      },
+    });
+
+    expect(gateway.snapshot.phase).toBe("stopped");
+    expect(gateway.snapshot.lastErrorCode).toBe(ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH);
+    expect(scheduleStaleChunkReloadMock).toHaveBeenCalledWith({
+      buildId: "replacement-build",
+    });
   });
 
   it("does not compare a separately hosted Control UI with a remote gateway build", () => {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -1,3 +1,4 @@
+import { readControlUiBuildMismatchDetails } from "@openclaw/gateway-client/browser";
 import type { ControlUiBootstrapProfileHint } from "../../../src/gateway/control-ui-contract.js";
 // Control UI module owns the application gateway store: the reactive
 // snapshot around GatewayBrowserClient consumed by the app shell.
@@ -430,6 +431,10 @@ export function createApplicationGateway(
           return;
         }
         stopCanvasSurfaceLease();
+        const buildMismatch = readControlUiBuildMismatchDetails(error?.details);
+        if (buildMismatch) {
+          void scheduleStaleChunkReload({ buildId: buildMismatch.gatewayBuildId });
+        }
         setSnapshot({
           ...snapshot,
           client: nextClient,

--- a/ui/src/app/overlays.build-mismatch.test.ts
+++ b/ui/src/app/overlays.build-mismatch.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { client, createGatewayHarness } from "./overlays-access.test-support.ts";
+import { createApplicationOverlays } from "./overlays.ts";
+
+vi.mock("../build-info.ts", () => ({
+  controlUiBuildDiffersFrom: (identity: {
+    version?: string | null;
+    buildId?: string | null;
+    controlUiBuildSource?: "bundled" | "configured";
+  }) =>
+    identity.controlUiBuildSource === "configured"
+      ? false
+      : Boolean(
+          identity.buildId?.trim()
+            ? identity.buildId.trim() !== "test"
+            : identity.version?.trim() && identity.version.trim() !== "1.0.0",
+        ),
+  reloadControlUiIfStale: vi.fn(),
+}));
+vi.mock("../lib/toast.ts", () => ({ showToast: vi.fn() }));
+const { peekStoredDeviceIdentityIdMock } = vi.hoisted(() => ({
+  peekStoredDeviceIdentityIdMock: vi.fn((): string | null => "browser-1"),
+}));
+vi.mock("../lib/nodes/index.ts", () => ({
+  peekStoredDeviceIdentityId: peekStoredDeviceIdentityIdMock,
+}));
+
+it("keeps reload guidance visible after pre-hello build rejection", () => {
+  const gatewayClient = client(async () => []);
+  const harness = createGatewayHarness(null, false);
+  const overlays = createApplicationOverlays(harness.gateway);
+
+  harness.update({
+    client: gatewayClient,
+    phase: "stopped",
+    hello: null,
+    lastErrorCode: "CONTROL_UI_BUILD_MISMATCH",
+  });
+
+  expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
+  overlays.dispose();
+});

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -251,22 +251,6 @@ describe("device-auth upgrade migration", () => {
 });
 
 describe("Control UI refresh nudge", () => {
-  it("keeps reload guidance visible after pre-hello build rejection", () => {
-    const gatewayClient = client(async () => []);
-    const harness = createGatewayHarness(null, false);
-    const overlays = createApplicationOverlays(harness.gateway);
-
-    harness.update({
-      client: gatewayClient,
-      phase: "stopped",
-      hello: null,
-      lastErrorCode: "CONTROL_UI_BUILD_MISMATCH",
-    });
-
-    expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
-    overlays.dispose();
-  });
-
   it("flags an exact build mismatch on the first connection", () => {
     const gatewayClient = client(async () => []);
     const harness = createGatewayHarness(null, false);

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -251,6 +251,22 @@ describe("device-auth upgrade migration", () => {
 });
 
 describe("Control UI refresh nudge", () => {
+  it("keeps reload guidance visible after pre-hello build rejection", () => {
+    const gatewayClient = client(async () => []);
+    const harness = createGatewayHarness(null, false);
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.update({
+      client: gatewayClient,
+      phase: "stopped",
+      hello: null,
+      lastErrorCode: "CONTROL_UI_BUILD_MISMATCH",
+    });
+
+    expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
+    overlays.dispose();
+  });
+
   it("flags an exact build mismatch on the first connection", () => {
     const gatewayClient = client(async () => []);
     const harness = createGatewayHarness(null, false);

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -1,3 +1,4 @@
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
@@ -312,7 +313,10 @@ export function createApplicationOverlays(
       if (!next.client) {
         connectedEpoch = 0;
         snapshot = { ...snapshot, controlUiRefreshRequired: false };
-      } else if (next.hello) {
+      } else if (
+        next.hello ||
+        next.lastErrorCode === ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH
+      ) {
         snapshot = { ...snapshot, controlUiRefreshRequired: true };
       }
       clearExecApprovalTimers(promptState);

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -43,6 +43,23 @@ afterEach(() => {
 });
 
 describe("login gate failure recovery", () => {
+  it("offers explicit reload guidance for a rejected stale build", async () => {
+    const element = await mountFailure(
+      "Control UI updated; reload this page to continue",
+      ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+    );
+
+    const failure = element.querySelector<HTMLElement>(
+      '.login-gate__failure[data-kind="build-mismatch"]',
+    );
+    expect(failure?.querySelector(".login-gate__failure-title")?.textContent?.trim()).toBe(
+      "Server updated",
+    );
+    expect(
+      failure?.querySelector<HTMLButtonElement>(".login-gate__failure-refresh"),
+    ).not.toBeNull();
+  });
+
   it("offers page refresh for a protocol mismatch and reloads when selected", async () => {
     const element = await mountFailure(
       "protocol mismatch",

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -23,6 +23,7 @@ type LoginFailureKind =
   | "pairing-required"
   | "insecure-context"
   | "origin-not-allowed"
+  | "build-mismatch"
   | "protocol-mismatch"
   | "network";
 
@@ -122,6 +123,19 @@ function resolveLoginFailureFeedback(
   const rawError = params.lastError;
   const lastErrorCode = params.lastErrorCode ?? null;
   const lower = normalizeLowercaseStringOrEmpty(rawError);
+
+  if (lastErrorCode === ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH) {
+    return {
+      kind: "build-mismatch",
+      title: t("chat.sidebar.serverUpdatedTitle"),
+      summary: t("chat.sidebar.serverUpdatedRefresh"),
+      refreshAction: { label: t("login.failure.protocol.refresh") },
+      steps: [],
+      docsHref: "https://docs.openclaw.ai/web/control-ui",
+      docsLabel: t("login.failure.docsAuth"),
+      rawError: redactLoginFailureError(rawError),
+    };
+  }
 
   const pairing = resolvePairingHint(false, rawError, lastErrorCode);
   if (pairing) {

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -125,16 +125,15 @@ function resolveLoginFailureFeedback(
   const lower = normalizeLowercaseStringOrEmpty(rawError);
 
   if (lastErrorCode === ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH) {
-    return {
+    return buildFeedback({
       kind: "build-mismatch",
-      title: t("chat.sidebar.serverUpdatedTitle"),
-      summary: t("chat.sidebar.serverUpdatedRefresh"),
+      rawError,
+      titleKey: "chat.sidebar.serverUpdatedTitle",
+      summaryKey: "chat.sidebar.serverUpdatedRefresh",
       refreshAction: { label: t("login.failure.protocol.refresh") },
-      steps: [],
+      stepKeys: [],
       docsHref: "https://docs.openclaw.ai/web/control-ui",
-      docsLabel: t("login.failure.docsAuth"),
-      rawError: redactLoginFailureError(rawError),
-    };
+    });
   }
 
   const pairing = resolvePairingHint(false, rawError, lastErrorCode);

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -59,6 +59,56 @@ async function closeContext(context: BrowserContext): Promise<void> {
 }
 
 suite.define(() => {
+  it("reloads once for a build rejection, then keeps visible recovery guidance", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      const key = "openclaw.control-ui-e2e.build-rejection-loads";
+      const count = Number.parseInt(sessionStorage.getItem(key) ?? "0", 10);
+      sessionStorage.setItem(key, String(count + 1));
+    });
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+    const mismatch = {
+      code: "UNAVAILABLE",
+      message: "Control UI updated; reload this page to continue",
+      details: {
+        code: ConnectErrorDetailCodes.CONTROL_UI_BUILD_MISMATCH,
+        gatewayBuildId: "replacement-build",
+        reloadRequired: true,
+      },
+      retryable: false,
+    };
+
+    try {
+      await page.goto(suite.server.baseUrl);
+      await gateway.waitForRequest("connect");
+      await gateway.rejectDeferred("connect", mismatch);
+      await page.waitForFunction(
+        () =>
+          sessionStorage.getItem("openclaw.controlUi.staleChunkReloadBuildId") ===
+            "replacement-build" &&
+          sessionStorage.getItem("openclaw.control-ui-e2e.build-rejection-loads") === "2",
+      );
+
+      await gateway.waitForRequest("connect");
+      await gateway.rejectDeferred("connect", mismatch);
+      const failure = page.locator('.login-gate__failure[data-kind="build-mismatch"]');
+      await failure.waitFor({ timeout: 10_000 });
+      expect(await failure.locator(".login-gate__failure-title").textContent()).toBe(
+        "Server updated",
+      );
+      expect(await failure.locator(".login-gate__failure-refresh").isVisible()).toBe(true);
+      expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
+      expect(
+        await page.evaluate(() =>
+          sessionStorage.getItem("openclaw.control-ui-e2e.build-rejection-loads"),
+        ),
+      ).toBe("2");
+    } finally {
+      await closeContext(context);
+    }
+  });
+
   it("shows a protocol mismatch without reconnecting", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where already-open bundled Control UI tabs could reconnect after a same-version Gateway deployment and continue dispatching connected-state RPCs before stale JavaScript reloaded. Documents predating exact build identity were fully admitted because the Gateway only logged `clientBuild=legacy`; on `claw.steipete.dev`, three such sessions persisted through the next deployment and each restored an ownerless terminal.

## Why This Change Was Made

The Gateway now owns bundled same-origin Control UI build admission. A missing or mismatched immutable build ID receives a structured reload-required rejection carrying the exact Gateway build before client registration, presence, hello, or RPC dispatch. Configured roots, separately hosted/remote UIs, local development, non-Control-UI clients, and runtimes without an exact build remain exempt.

Build-aware browsers reload once per target build and retain the existing visible **Server updated / Refresh page** recovery action when automatic recovery has already run. To preserve the shipped upgrade contract in the opposite direction, a current UI retries an older closed-schema Gateway exactly once without the additive client build field. The documented standalone `pnpm ui:build` path also reuses a matching runtime identity, so rebuilding the bundled UI cannot make it reject itself.

Production delta: +294/-60 lines (net +234), justified by the server-owned admission boundary, structured recovery contract, bounded old-Gateway compatibility path, and canonical build-identity ownership. Tests: +571 lines.

## User Impact

Stale bundled documents can no longer start terminal sessions, subscriptions, or other RPC work after a Gateway update. Current browsers recover automatically; older documents fail closed until reloaded; custom and development Control UIs continue to connect independently.

## Evidence

- Live pre-fix evidence on `9f125bcee01709288e1bf91f890cda8f1f6cf374`: three `clientBuild=legacy` sockets remained connected for more than 16 minutes, drained normal startup RPCs, and each emitted an ownerless `terminal.open`; the previous legacy cohort persisted about 24 minutes until deployment disconnect.
- Blacksmith Testbox `tbx_01m018rnh7z70dvqg8z4g63m12` ([run](https://github.com/openclaw/openclaw/actions/runs/31849523520)): 293 focused protocol/Gateway/browser-client/UI/build-wrapper assertions passed, including a real raw WebSocket rejection with zero registration, presence, or RPC dispatch.
- Chromium Control UI E2E: 8/8 passed on source head `b6a902558fcfcd6bcdc26c3ecb6b80ee49352baa`. The stale browser reloads exactly once, persists the target-build guard, shows visible recovery guidance after the guarded retry, and emits zero `terminal.open` calls.
- Independent source-blind behavior validation passed all four admission/reload/guidance/no-dispatch clauses on the behavior-equivalent Testbox build; no blockers remain.
- Fixed-identity Control UI production build passed its startup budget at 333036/333064 bytes gzip. Production types: core + UI passed. Test types: package + core source + UI passed. Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Exact source head `b6a902558fcfcd6bcdc26c3ecb6b80ee49352baa`: focused Testbox and Chromium proof passed; final dirty-bundle autoreview was clean with no accepted/actionable findings (0.98 confidence).
