### PR TITLE
refactor(cli): test marketplace shorthand at command boundary

### DIFF
--- a/src/cli/plugins-install-preflight.test.ts
+++ b/src/cli/plugins-install-preflight.test.ts
@@ -18,7 +18,6 @@ import {
   runtimeErrors,
   configWriteMock,
 } from "./plugins-cli-test-helpers.js";
-import { resolvePluginInstallPreflight } from "./plugins-install-preflight.js";
 
 const { withPluginLifecycleLeaseMock } = vi.hoisted(() => ({
   withPluginLifecycleLeaseMock: vi.fn(),
@@ -62,19 +61,16 @@ describe("plugin install mutation-free preflight", () => {
     });
 
     await expect(
-      resolvePluginInstallPreflight({
-        raw: "superpowers@claude-plugins-official",
-        allowInstallPolicyWarningPrompt: false,
-        opts: { force: true },
-      }),
-    ).resolves.toMatchObject({
-      ok: true,
-      raw: "superpowers",
-      marketplace: "claude-plugins-official",
-      sourcePlan: null,
-    });
+      runPluginsCommand(["plugins", "install", "superpowers@claude-plugins-official", "--force"]),
+    ).rejects.toThrow("__exit__:1");
 
-    expectNoPluginInstallSideEffects();
+    expect(installPluginFromMarketplaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketplace: "claude-plugins-official",
+        plugin: "superpowers",
+      }),
+    );
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

The marketplace-shorthand regression test asserted the private `PluginInstallPreflight` result shape directly. A behavior-preserving refactor of the preflight object would require updating the test even though the real contract is that `plugin@marketplace` routes to the marketplace installer before ordinary npm/git source classification.

## Why This Change Was Made

The retained regression now enters through the real `openclaw plugins install` command and proves that registered shorthand reaches the marketplace installer with the normalized plugin and marketplace while the npm installer remains untouched. This protects the same precedence invariant without coupling the test to private planning fields.

## User Impact

No user-visible behavior change. The existing marketplace shorthand contract has stronger boundary-level regression coverage.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs src/cli/plugins-install-preflight.test.ts src/plugins/marketplace.test.ts` — 2 files, 62 tests passed.
- `node scripts/check-changed.mjs -- src/cli/plugins-install-preflight.test.ts` — core-test changed gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Test delta: +9/-13, net -4. Production delta: 0.
