### PR TITLE
refactor(system-agent): remove plugin install test seam

### DIFF
--- a/src/system-agent/operations-parse.ts
+++ b/src/system-agent/operations-parse.ts
@@ -57,11 +57,6 @@ export type SystemAgentCommandDeps = {
   runGatewayRestart?: () => Promise<void | boolean>;
   runGatewayStart?: () => Promise<void>;
   runGatewayStop?: () => Promise<void>;
-  runPluginInstall?: (
-    spec: string,
-    runtime: RuntimeEnv,
-    options: { allowInstallPolicyWarningPrompt: false },
-  ) => Promise<void>;
   runPluginUninstall?: (pluginId: string, runtime: RuntimeEnv) => Promise<void>;
   runPluginsList?: (runtime: RuntimeEnv) => Promise<void>;
   runPluginsSearch?: (query: string, runtime: RuntimeEnv) => Promise<void>;

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -165,6 +165,7 @@ const mockConfig = vi.hoisted(() => {
   };
 });
 const mockDaemonRestart = vi.hoisted(() => vi.fn(async () => true));
+const runPluginInstallCommandMock = vi.hoisted(() => vi.fn(async () => undefined));
 const mockScheduleGatewayRestart = vi.hoisted(() =>
   vi.fn(() => ({
     ok: true,
@@ -181,6 +182,9 @@ vi.mock("../cli/daemon-cli/lifecycle.js", () => ({
   runDaemonStart: vi.fn(async () => {}),
   runDaemonStop: vi.fn(async () => {}),
   runDaemonRestart: mockDaemonRestart,
+}));
+vi.mock("../cli/plugins-install-command.js", () => ({
+  runPluginInstallCommand: runPluginInstallCommandMock,
 }));
 vi.mock("../infra/restart.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/restart.js")>()),
@@ -237,6 +241,7 @@ describe("system agent operations", () => {
   beforeEach(() => {
     mockConfig.reset();
     mockDaemonRestart.mockClear();
+    runPluginInstallCommandMock.mockClear();
     mockScheduleGatewayRestart.mockClear();
     stateDirSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
@@ -957,36 +962,38 @@ describe("system agent operations", () => {
     const tempDir = opTempDirs.make("openclaw-plugin-install-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createSystemAgentTestRuntime();
-    const runPluginInstall = vi.fn(async (spec: string, pluginRuntime: RuntimeEnv) => {
-      pluginRuntime.log(`installed ${spec}`);
-    });
 
     const plan = await executeSystemAgentOperation(
       { kind: "plugin-install", spec: "clawhub:openclaw-demo" },
       runtime,
-      { deps: { runPluginInstall } },
     );
     expectRecordFields(plan as unknown as Record<string, unknown>, {
       applied: false,
       message: "Plan: install plugin clawhub:openclaw-demo. Say yes to apply.",
     });
-    expect(runPluginInstall).not.toHaveBeenCalled();
+    expect(runPluginInstallCommandMock).not.toHaveBeenCalled();
 
     const result = await executeSystemAgentOperation(
       { kind: "plugin-install", spec: "clawhub:openclaw-demo" },
       runtime,
       {
         approved: true,
-        deps: { runPluginInstall },
         auditDetails: { rescue: true },
       },
     );
     expect(result.applied).toBe(true);
 
-    const installCall = requireFirstMockCall(runPluginInstall, "runPluginInstall");
-    expect(installCall[0]).toBe("clawhub:openclaw-demo");
-    expectRuntimeArg(installCall[1]);
-    expect(installCall[2]).toEqual({ allowInstallPolicyWarningPrompt: false });
+    const [installParams] = requireFirstMockCall(
+      runPluginInstallCommandMock,
+      "runPluginInstallCommand",
+    );
+    const installRequest = requireRecord(installParams, "plugin install request");
+    expectRecordFields(installRequest, {
+      raw: "clawhub:openclaw-demo",
+      opts: {},
+      allowInstallPolicyWarningPrompt: false,
+    });
+    expectRuntimeArg(installRequest.runtime);
     expect(lines.join("\n")).toContain("[openclaw] done: plugin.install");
     const audit = readLastAuditEntry();
     expectAuditRecord(
@@ -1000,7 +1007,6 @@ describe("system agent operations", () => {
   });
 
   it("rejects an invalid approved plugin spec without exiting inside the executor", async () => {
-    const runPluginInstall = vi.fn();
     mockConfig.readConfigFileSnapshot.mockClear();
     const runtime: RuntimeEnv = {
       log: vi.fn(),
@@ -1012,30 +1018,25 @@ describe("system agent operations", () => {
       executeSystemAgentOperation(
         { kind: "plugin-install", spec: "https://example.test/plugin.tgz" },
         runtime,
-        { approved: true, deps: { runPluginInstall } },
+        { approved: true },
       ),
     ).rejects.toThrow("accepts npm or ClawHub package specs only");
 
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
-    expect(runPluginInstall).not.toHaveBeenCalled();
+    expect(runPluginInstallCommandMock).not.toHaveBeenCalled();
     expect(mockConfig.readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 
   it("rejects arbitrary plugin sources before proposing or installing them", async () => {
     const { runtime } = createSystemAgentTestRuntime();
-    const runPluginInstall = vi.fn();
 
     // Untrusted spec must be rejected on the unapproved path too, so a
     // formatted "plan" never surfaces an arbitrary source for approval.
     await expect(
-      executeSystemAgentOperation(
-        { kind: "plugin-install", spec: "npm:@example/plugin" },
-        runtime,
-        { deps: { runPluginInstall } },
-      ),
+      executeSystemAgentOperation({ kind: "plugin-install", spec: "npm:@example/plugin" }, runtime),
     ).rejects.toThrow("trusted shell");
-    expect(runPluginInstall).not.toHaveBeenCalled();
+    expect(runPluginInstallCommandMock).not.toHaveBeenCalled();
   });
 
   it("uninstalls a non-route plugin only after approval and audits the write", async () => {

--- a/src/system-agent/plugin-install.ts
+++ b/src/system-agent/plugin-install.ts
@@ -25,23 +25,12 @@ export async function executePluginInstall(
     runtime,
     opts,
     run: async (ctx) => {
-      const runPluginInstall =
-        ctx.deps?.runPluginInstall ??
-        (async (
-          spec: string,
-          pluginRuntime: RuntimeEnv,
-          installOptions: { allowInstallPolicyWarningPrompt: false },
-        ) => {
-          const { runPluginInstallCommand } = await import("../cli/plugins-install-command.js");
-          await runPluginInstallCommand({
-            raw: spec,
-            opts: {},
-            runtime: pluginRuntime,
-            ...installOptions,
-          });
-        });
       await ctx.commit(async () => {
-        await runPluginInstall(operation.spec, createNoExitRuntime(ctx.runtime), {
+        const { runPluginInstallCommand } = await import("../cli/plugins-install-command.js");
+        await runPluginInstallCommand({
+          raw: operation.spec,
+          opts: {},
+          runtime: createNoExitRuntime(ctx.runtime),
           allowInstallPolicyWarningPrompt: false,
         });
       });

--- a/src/system-agent/rescue-message.test.ts
+++ b/src/system-agent/rescue-message.test.ts
@@ -23,6 +23,8 @@ function readLastAuditEntry(): Record<string, unknown> {
   return (listSystemAgentAuditEntriesForTests().at(-1)?.value ?? {}) as Record<string, unknown>;
 }
 
+const runPluginInstallCommandMock = vi.hoisted(() => vi.fn(async () => undefined));
+
 const mockConfig = vi.hoisted(() => {
   const state = {
     path: "/tmp/openclaw.json",
@@ -82,6 +84,10 @@ const mockConfig = vi.hoisted(() => {
     ),
   };
 });
+
+vi.mock("../cli/plugins-install-command.js", () => ({
+  runPluginInstallCommand: runPluginInstallCommandMock,
+}));
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
@@ -203,6 +209,7 @@ describe("OpenClaw rescue message", () => {
 
   beforeEach(() => {
     mockConfig.reset();
+    runPluginInstallCommandMock.mockClear();
   });
 
   afterAll(async () => {
@@ -496,16 +503,11 @@ describe("OpenClaw rescue message", () => {
 
   it("refuses plugin install from remote rescue", async () => {
     const cfg: OpenClawConfig = {};
-    const deps = {
-      runPluginInstall: vi.fn(async () => {
-        throw new Error("remote rescue must not install plugins");
-      }),
-    };
 
     await expect(
-      runRescue("/openclaw plugin install clawhub:openclaw-demo", cfg, commandContext(), deps),
+      runRescue("/openclaw plugin install clawhub:openclaw-demo", cfg),
     ).resolves.toContain("cannot install plugins from a message channel");
-    expect(deps.runPluginInstall).not.toHaveBeenCalled();
+    expect(runPluginInstallCommandMock).not.toHaveBeenCalled();
   });
 
   it("allows plugin list and search from remote rescue", async () => {


### PR DESCRIPTION
## What Problem This Solves

The system-agent plugin-install tests injected a `runPluginInstall` callback through production dependencies. That bypassed the real adapter, so the suite could stay green if the dynamic CLI import disappeared or if the Gateway-backed install stopped forcing `allowInstallPolicyWarningPrompt: false`.

## Why This Change Was Made

The system agent now calls the canonical plugin-install command directly inside the guarded commit. Tests mock that narrow command module, preserving approval and audit coverage while also proving the real adapter maps the trusted spec, no-exit runtime, empty CLI options, and noninteractive warning policy correctly. The unused production dependency member is removed.

## User Impact

No intended visible behavior change. System-agent installs retain the same approval, trusted-source, audit, and restart-guidance behavior, while tests now protect the actual execution boundary and noninteractive security policy.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs src/system-agent/operations.test.ts src/system-agent/rescue-message.test.ts src/system-agent/operations-parse.test.ts src/agents/tools/system-agent-tool.test.ts src/cli/install-policy-warning-acknowledgement.test.ts src/claws/packages.test.ts` — 6 files, 134 tests passed across 5 Vitest projects.
- `node scripts/check-changed.mjs -- src/system-agent/plugin-install.ts src/system-agent/operations-parse.ts src/system-agent/operations.test.ts src/system-agent/rescue-message.test.ts` — core/coreTests changed gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Production: +5/-21 (net -16). Tests: +30/-27 (net +3). Total: net -13.
