### PR TITLE
refactor(gateway): remove setup GC test callback

### DIFF
--- a/src/gateway/server-maintenance.dedupe.test.ts
+++ b/src/gateway/server-maintenance.dedupe.test.ts
@@ -12,6 +12,11 @@ const cleanupManagedOutgoingMediaRecordsMock = vi.fn(async () => ({
   deletedFileCount: 0,
   retainedCount: 0,
 }));
+const pruneExpiredDevicePairSetupCompletionsMock = vi.fn(async () => 0);
+
+vi.mock("../infra/device-bootstrap.js", () => ({
+  pruneExpiredDevicePairSetupCompletions: pruneExpiredDevicePairSetupCompletionsMock,
+}));
 
 vi.mock("../infra/delivery-queue-sqlite.js", async () => {
   const actual = await vi.importActual<typeof import("../infra/delivery-queue-sqlite.js")>(
@@ -59,7 +64,6 @@ function createMaintenanceTimerDeps() {
     logHealth: { info: vi.fn(), error: vi.fn() },
     runWorktreeGc: vi.fn(async () => undefined),
     runDeliveryQueueMediaGc: vi.fn(async () => undefined),
-    runDevicePairSetupCompletionGc: vi.fn(async () => undefined),
     runManagedOutgoingMediaGc: cleanupManagedOutgoingMediaRecordsMock,
   };
 }
@@ -103,6 +107,7 @@ describe("gateway dedupe maintenance", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    pruneExpiredDevicePairSetupCompletionsMock.mockReset().mockResolvedValue(0);
   });
 
   it("keeps active exec approval dedupe aliases past the normal ttl", async () => {

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -18,7 +18,12 @@ const cleanupManagedOutgoingMediaRecordsMock = vi.fn(async () => ({
   retainedCount: 0,
 }));
 const pruneExpiredDeliveryQueueTombstonesMock = vi.fn();
+const pruneExpiredDevicePairSetupCompletionsMock = vi.fn(async () => 0);
 const pruneOrphanedDeliveryQueueMediaMock = vi.fn(async () => undefined);
+
+vi.mock("../infra/device-bootstrap.js", () => ({
+  pruneExpiredDevicePairSetupCompletions: pruneExpiredDevicePairSetupCompletionsMock,
+}));
 
 vi.mock("../infra/delivery-queue-sqlite.js", async () => {
   const actual = await vi.importActual<typeof import("../infra/delivery-queue-sqlite.js")>(
@@ -70,7 +75,6 @@ function createMaintenanceTimerDeps() {
     logHealth: { info: vi.fn(), error: vi.fn() },
     runWorktreeGc: vi.fn(async () => undefined),
     runDeliveryQueueMediaGc: vi.fn(async () => undefined),
-    runDevicePairSetupCompletionGc: vi.fn(async () => undefined),
     runManagedOutgoingMediaGc: cleanupManagedOutgoingMediaRecordsMock,
   };
 }
@@ -167,6 +171,7 @@ describe("startGatewayMaintenanceTimers", () => {
     vi.clearAllMocks();
     cleanOldMediaMock.mockReset().mockResolvedValue(undefined);
     prunePlaybackTranscodeCacheMock.mockReset().mockResolvedValue(undefined);
+    pruneExpiredDevicePairSetupCompletionsMock.mockReset().mockResolvedValue(0);
     cleanupManagedOutgoingMediaRecordsMock.mockReset().mockResolvedValue({
       deletedRecordCount: 0,
       deletedFileCount: 0,
@@ -232,7 +237,7 @@ describe("startGatewayMaintenanceTimers", () => {
     await stopMaintenanceTimers(timers);
   });
 
-  it("runs managed worktree and setup-outcome cleanup on their schedules", async () => {
+  it("runs managed worktree cleanup at startup and hourly", async () => {
     vi.useFakeTimers();
     const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
     const deps = createMaintenanceTimerDeps();
@@ -240,10 +245,38 @@ describe("startGatewayMaintenanceTimers", () => {
 
     await Promise.resolve();
     expect(deps.runWorktreeGc).toHaveBeenCalledTimes(1);
-    expect(deps.runDevicePairSetupCompletionGc).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(60 * 60_000);
     expect(deps.runWorktreeGc).toHaveBeenCalledTimes(2);
-    expect(deps.runDevicePairSetupCompletionGc).toHaveBeenCalledTimes(61);
+
+    await stopMaintenanceTimers(timers);
+  });
+
+  it("runs setup-outcome cleanup immediately without overlapping minute ticks", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    let resolvePrune = (_deletedCount: number) => {};
+    pruneExpiredDevicePairSetupCompletionsMock.mockImplementationOnce(
+      () =>
+        new Promise<number>((resolve) => {
+          resolvePrune = resolve;
+        }),
+    );
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const timers = startGatewayMaintenanceTimers(createMaintenanceTimerDeps());
+
+    expect(pruneExpiredDevicePairSetupCompletionsMock).toHaveBeenCalledWith({
+      nowMs: Date.now(),
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(pruneExpiredDevicePairSetupCompletionsMock).toHaveBeenCalledTimes(1);
+
+    resolvePrune(0);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(pruneExpiredDevicePairSetupCompletionsMock).toHaveBeenLastCalledWith({
+      nowMs: Date.now(),
+    });
+    expect(pruneExpiredDevicePairSetupCompletionsMock).toHaveBeenCalledTimes(2);
 
     await stopMaintenanceTimers(timers);
   });

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -94,7 +94,6 @@ export function startGatewayMaintenanceTimers(params: {
   runWorktreeGc?: () => Promise<unknown>;
   runDeliveryQueueMediaGc?: () => Promise<unknown>;
   runManagedOutgoingMediaGc?: () => Promise<unknown>;
-  runDevicePairSetupCompletionGc?: (nowMs: number) => unknown;
   enableSkillCurator?: boolean;
   runSkillCollectionReconcile?: () => Promise<unknown>;
 }): {
@@ -197,15 +196,12 @@ export function startGatewayMaintenanceTimers(params: {
   };
   void performDeliveryQueueMediaGc();
 
-  const runDevicePairSetupCompletionGc =
-    params.runDevicePairSetupCompletionGc ??
-    ((nowMs: number) => pruneExpiredDevicePairSetupCompletions({ nowMs }));
   let devicePairSetupCompletionGcInFlight: Promise<void> | null = null;
   const performDevicePairSetupCompletionGc = (nowMs: number) => {
     if (devicePairSetupCompletionGcInFlight) {
       return devicePairSetupCompletionGcInFlight;
     }
-    devicePairSetupCompletionGcInFlight = Promise.resolve(runDevicePairSetupCompletionGc(nowMs))
+    devicePairSetupCompletionGcInFlight = pruneExpiredDevicePairSetupCompletions({ nowMs })
       .then(() => undefined)
       .catch((error: unknown) => {
         params.logHealth.error(`device pair setup cleanup failed: ${formatError(error)}`);


### PR DESCRIPTION
## What Problem This Solves

Gateway maintenance exposed an optional `runDevicePairSetupCompletionGc` callback solely so tests could avoid the real prune owner. The scheduling test asserted that injected callback's call count, so it would stay green if the production prune import or argument mapping broke.

## Why This Change Was Made

Maintenance now always calls `pruneExpiredDevicePairSetupCompletions` directly. The Gateway tests mock that narrow owner module instead of a production parameter, and the retained scheduler proof now verifies immediate execution, current-time forwarding, single-flight suppression while a prune is pending, and recovery on a later minute tick. Dedupe tests keep the background owner mocked without carrying an unused callback through production.

## User Impact

No intended visible behavior change. Expired pairing outcomes are still pruned when post-ready maintenance starts and every minute thereafter, without accumulating overlapping queued prunes.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-maintenance.test.ts src/gateway/server-maintenance.dedupe.test.ts src/infra/device-bootstrap.test.ts` — 3 files, 76 tests passed across Gateway and infra projects.
- `node scripts/check-changed.mjs -- src/gateway/server-maintenance.ts src/gateway/server-maintenance.test.ts src/gateway/server-maintenance.dedupe.test.ts` — core/coreTests changed gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Production: +1/-5 (net -4). Tests: +43/-5 (net +38). The test growth replaces a callback-count proxy with direct cadence and single-flight owner proof.
