### PR TITLE
docs: fix stale cua-computer section link on the Codex Computer Use page

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -327,7 +327,7 @@ tools when available, and the specific message for the failing setup step.
 This Codex-owned Computer Use path runs on macOS, where the MCP server may need
 local OS permissions before it can inspect or control apps. (For cross-platform
 desktop control on Windows and Linux node hosts, see the
-[cua-computer fulfiller](/nodes/computer-use#windows-and-linux-experimental%2C-via-cua-driver-sdk).)
+[cua-computer fulfiller](/nodes/computer-use#windows-and-linux-experimental%2C-direct-sdk).)
 If OpenClaw says Computer Use is installed but the MCP server is unavailable,
 verify the Codex-side Computer Use setup first:
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Codex Computer Use](https://docs.openclaw.ai/plugins/codex-computer-use) who followed the "cua-computer fulfiller" cross-reference in the **macOS permissions** section landed at the top of the [node Computer Use](https://docs.openclaw.ai/nodes/computer-use) page instead of the Windows/Linux fulfiller section they were sent to find.

The link targeted `#windows-and-linux-experimental%2C-via-cua-driver-sdk`. That anchor no longer exists: the heading was renamed to `### Windows and Linux (experimental, direct SDK)` in 19ace6830b1 (`feat(macos): add embedded CUA computer provider`, #123635), and the pointer added in c1a313676b3 was never updated.

## Why This Change Was Made

One-line retarget to the current anchor, `#windows-and-linux-experimental%2C-direct-sdk`. The intent of the cross-reference is unchanged and the section it points at still exists, so the link moves rather than the heading — renaming the heading back would break the anchor the node page's own structure now advertises.

Found incidentally during a full docs anchor audit while working on an unrelated PR; both pages that PR touched were clean, so this was split out as its own change.

## User Impact

Readers on the Codex Computer Use page who need cross-platform desktop control now land directly on the Windows/Linux `cua-computer` fulfiller instructions. Docs-only; no runtime, config, or API behavior changes.

## Evidence

Docs-only change, so `git diff --check` plus the docs checks are the proof. The default `docs:check-links` lane audits routes, not anchors, so the anchor lane is the one that matters here — and it reproduces the failure before the fix:

Before (anchor lane on pre-fix content):

```
$ pnpm docs:check-links:anchors
found 1 broken links in 1 files

plugins/codex-computer-use.md
 ⎿  /nodes/computer-use#windows-and-linux-experimental%2C-via-cua-driver-sdk
```

After:

```
$ pnpm docs:check-links:anchors
success no broken links found

$ pnpm docs:check-links
checked_internal_links=6495
broken_links=0

$ pnpm docs:check-mdx
Docs MDX check passed (774 files, 2934ms).

$ pnpm format:docs:check
Docs formatting clean (758 files).

$ git diff --check
(clean)
```

Production LOC delta: 0 (docs-only, 1 line changed).
