### PR TITLE
fix: API-key sessions switch to OAuth after compaction

### DIFF
--- a/src/agents/auth-profiles/session-override.rotation.test.ts
+++ b/src/agents/auth-profiles/session-override.rotation.test.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import {
+  authStoreMocks,
+  configureProviderRoutes,
+  createAutomaticSessionEntry,
+  prepareCooldownAuthState,
+  resolveSession,
+  TEST_PRIMARY_PROFILE_ID,
+  TEST_SECONDARY_PROFILE_ID,
+  withAuthState,
+} from "./session-override.test-support.js";
+import type { AuthProfileStore } from "./types.js";
+
+const OPENAI_MODEL_ID = "gpt-5.6-sol";
+const API_PRIMARY_PROFILE_ID = "openai:api-primary";
+const API_BACKUP_PROFILE_ID = "openai:api-backup";
+const OAUTH_PROFILE_ID = "openai:subscription";
+const ANTHROPIC_API_PROFILE_ID = "anthropic:api";
+const CLAUDE_CLI_PROFILE_ID = "anthropic:claude-cli";
+
+type RotationTrigger = "compaction" | "cooldown";
+
+function configureMixedOpenAiAuthStore(): void {
+  authStoreMocks.state.hasSource = true;
+  authStoreMocks.state.store = {
+    version: 1,
+    profiles: {
+      [API_PRIMARY_PROFILE_ID]: {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-primary",
+      },
+      [API_BACKUP_PROFILE_ID]: {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-backup",
+      },
+      [OAUTH_PROFILE_ID]: {
+        type: "oauth",
+        provider: "openai",
+        access: "test-access",
+        refresh: "test-refresh",
+        expires: Date.now() + 60_000,
+      },
+    },
+    order: {
+      openai: [API_PRIMARY_PROFILE_ID, OAUTH_PROFILE_ID, API_BACKUP_PROFILE_ID],
+    },
+  };
+}
+
+function configureAnthropicFallbackStore(): void {
+  authStoreMocks.state.hasSource = true;
+  authStoreMocks.state.store = {
+    version: 1,
+    profiles: {
+      [ANTHROPIC_API_PROFILE_ID]: {
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-anthropic",
+      },
+      [CLAUDE_CLI_PROFILE_ID]: {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "test-access",
+        refresh: "test-refresh",
+        expires: Date.now() + 60_000,
+      },
+    },
+    order: {
+      anthropic: [ANTHROPIC_API_PROFILE_ID, CLAUDE_CLI_PROFILE_ID],
+    },
+  };
+}
+
+function createTriggeredSessionEntry(params: {
+  profileId: string;
+  model: string;
+  trigger: RotationTrigger;
+}): SessionEntry {
+  if (params.trigger === "cooldown") {
+    authStoreMocks.isProfileInCooldown.mockImplementation(
+      (_store: AuthProfileStore, profileId: string) => profileId === params.profileId,
+    );
+  }
+  return createAutomaticSessionEntry({
+    model: params.model,
+    authProfileOverride: params.profileId,
+    compactionCount: params.trigger === "compaction" ? 1 : 0,
+    authProfileOverrideCompactionCount: 0,
+  });
+}
+
+describe("session auth-profile rotation", () => {
+  it.each(["compaction", "cooldown"] as const)(
+    "keeps a multi-route OpenAI session on its physical route after %s",
+    async (trigger) => {
+      await withAuthState(async (state) => {
+        const agentDir = state.agentDir();
+        await fs.mkdir(agentDir, { recursive: true });
+        configureMixedOpenAiAuthStore();
+        configureProviderRoutes({
+          provider: "openai",
+          modelId: OPENAI_MODEL_ID,
+          requirements: ["api-key", "subscription"],
+        });
+        const sessionEntry = createTriggeredSessionEntry({
+          profileId: API_PRIMARY_PROFILE_ID,
+          model: OPENAI_MODEL_ID,
+          trigger,
+        });
+        const sessionStore = { "agent:main:main": sessionEntry };
+
+        const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
+
+        expect(resolved).toBe(API_BACKUP_PROFILE_ID);
+        expect(sessionEntry.authProfileOverride).toBe(API_BACKUP_PROFILE_ID);
+        expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+      });
+    },
+  );
+
+  it.each(["compaction", "cooldown"] as const)(
+    "retains Anthropic API-key to Claude CLI OAuth fallback after %s",
+    async (trigger) => {
+      await withAuthState(async (state) => {
+        const agentDir = state.agentDir();
+        await fs.mkdir(agentDir, { recursive: true });
+        configureAnthropicFallbackStore();
+        const sessionEntry = createTriggeredSessionEntry({
+          profileId: ANTHROPIC_API_PROFILE_ID,
+          model: "claude-sonnet-4-6",
+          trigger,
+        });
+        const sessionStore = { "agent:main:main": sessionEntry };
+
+        const resolved = await resolveSession({
+          provider: "anthropic",
+          agentDir,
+          sessionEntry,
+          sessionStore,
+        });
+
+        expect(resolved).toBe(CLAUDE_CLI_PROFILE_ID);
+        expect(sessionEntry.authProfileOverride).toBe(CLAUDE_CLI_PROFILE_ID);
+      });
+    },
+  );
+
+  it("retains mixed-mode rotation when the provider exposes only one route", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      configureMixedOpenAiAuthStore();
+      configureProviderRoutes({
+        provider: "openai",
+        modelId: OPENAI_MODEL_ID,
+        requirements: ["api-key"],
+      });
+      const sessionEntry = createTriggeredSessionEntry({
+        profileId: API_PRIMARY_PROFILE_ID,
+        model: OPENAI_MODEL_ID,
+        trigger: "compaction",
+      });
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
+
+      expect(resolved).toBe(OAUTH_PROFILE_ID);
+      expect(sessionEntry.authProfileOverride).toBe(OAUTH_PROFILE_ID);
+    });
+  });
+
+  it("rotates an automatic override to an auth profile that is not in cooldown", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = await prepareCooldownAuthState(state, {
+        profileIds: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
+      });
+      authStoreMocks.isProfileInCooldown.mockImplementation(
+        (_store: AuthProfileStore, profileId: string) => profileId === TEST_PRIMARY_PROFILE_ID,
+      );
+      const sessionEntry = createAutomaticSessionEntry();
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
+
+      expect(resolved).toBe(TEST_SECONDARY_PROFILE_ID);
+      expect(sessionEntry.authProfileOverride).toBe(TEST_SECONDARY_PROFILE_ID);
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
+
+  it("keeps an automatic override after its auth-profile cooldown expires", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = await prepareCooldownAuthState(state, {
+        usageStats: { [TEST_PRIMARY_PROFILE_ID]: { cooldownUntil: Date.now() - 1 } },
+      });
+      authStoreMocks.isProfileInCooldown.mockImplementation(
+        (store: AuthProfileStore, profileId: string) =>
+          (store.usageStats?.[profileId]?.cooldownUntil ?? 0) > Date.now(),
+      );
+      const sessionEntry = createAutomaticSessionEntry({ authProfileOverrideCompactionCount: 0 });
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
+
+      expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+      expect(sessionEntry.updatedAt).toBe(1);
+    });
+  });
+});

--- a/src/agents/auth-profiles/session-override.test-support.ts
+++ b/src/agents/auth-profiles/session-override.test-support.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs/promises";
+import { afterEach, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type {
+  ProviderModelRouteAuthRequirement,
+  ProviderModelRouteCandidate,
+  ProviderModelRouteResolution,
+} from "../../plugin-sdk/provider-model-types.js";
+import {
+  type OpenClawTestState,
+  withOpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import type { AuthProfileStore } from "./types.js";
+
+export const TEST_PRIMARY_PROFILE_ID = "openai:primary@example.test";
+export const TEST_SECONDARY_PROFILE_ID = "openai:secondary@example.test";
+
+const authStoreMocks = vi.hoisted(() => {
+  const state: {
+    hasSource: boolean;
+    routeResolutions: Map<string, ProviderModelRouteResolution>;
+    store: AuthProfileStore;
+  } = {
+    hasSource: false,
+    routeResolutions: new Map(),
+    store: { version: 1, profiles: {} },
+  };
+  return {
+    state,
+    ensureAuthProfileStore: vi.fn(() => state.store),
+    hasAnyAuthProfileStoreSource: vi.fn(() => state.hasSource),
+    isProfileInCooldown: vi.fn((_store: AuthProfileStore, _profileId: string) => false),
+    resolveProviderModelRoutes: vi.fn(
+      ({ provider, modelId }: { provider: string; modelId?: string }) =>
+        state.routeResolutions.get(`${provider}\0${modelId ?? ""}`) ?? null,
+    ),
+    resolveProviderIdForAuth: vi.fn((provider: string) => {
+      const normalized = provider.trim().toLowerCase();
+      return (
+        {
+          "claude-cli": "anthropic",
+          "codex-cli": "openai",
+          "z.ai": "zai",
+        }[normalized] ?? normalized
+      );
+    }),
+    reset() {
+      state.hasSource = false;
+      state.routeResolutions.clear();
+      state.store = { version: 1, profiles: {} };
+    },
+  };
+});
+
+vi.mock("./store.js", () => ({
+  ensureAuthProfileStore: authStoreMocks.ensureAuthProfileStore,
+  hasAnyAuthProfileStoreSource: authStoreMocks.hasAnyAuthProfileStoreSource,
+}));
+
+vi.mock("../provider-auth-aliases.js", () => ({
+  resolveProviderIdForAuth: authStoreMocks.resolveProviderIdForAuth,
+}));
+
+vi.mock("./usage.js", () => ({
+  isProfileInCooldown: authStoreMocks.isProfileInCooldown,
+}));
+
+vi.mock("../../plugins/provider-model-routes.js", () => ({
+  resolveProviderModelRoutes: authStoreMocks.resolveProviderModelRoutes,
+}));
+
+export const { clearSessionAuthProfileOverride, resolveSessionAuthProfileOverride } =
+  await import("./session-override.js");
+export { authStoreMocks };
+
+afterEach(() => {
+  authStoreMocks.reset();
+  vi.clearAllMocks();
+});
+
+export async function withAuthState<T>(run: (state: OpenClawTestState) => Promise<T>): Promise<T> {
+  return await withOpenClawTestState(
+    {
+      layout: "state-only",
+      prefix: "openclaw-auth-",
+    },
+    run,
+  );
+}
+
+export function createAuthStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
+    },
+    order: {
+      zai: ["zai:work"],
+    },
+  };
+}
+
+export function createAuthStoreWithProfiles(params: {
+  profiles: AuthProfileStore["profiles"];
+  order?: Record<string, string[]>;
+}): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: params.profiles,
+    ...(params.order ? { order: params.order } : {}),
+  };
+}
+
+export function configureProviderRoutes(params: {
+  provider: string;
+  modelId: string;
+  requirements: ProviderModelRouteAuthRequirement[];
+}): void {
+  const routes = params.requirements.map<ProviderModelRouteCandidate>((authRequirement, index) => ({
+    api: authRequirement === "api-key" ? "openai-responses" : "openai-chatgpt-responses",
+    baseUrl: `https://route-${index}.example.test`,
+    authRequirement,
+    requestTransportOverrides: "none",
+  }));
+  const first = routes[0];
+  if (!first) {
+    return;
+  }
+  authStoreMocks.state.routeResolutions.set(`${params.provider}\0${params.modelId}`, {
+    kind: "routes",
+    routes: [first, ...routes.slice(1)],
+  });
+}
+
+export async function prepareCooldownAuthState(
+  state: OpenClawTestState,
+  options: {
+    profileIds?: string[];
+    usageStats?: AuthProfileStore["usageStats"];
+  } = {},
+): Promise<string> {
+  const agentDir = state.agentDir();
+  await fs.mkdir(agentDir, { recursive: true });
+  authStoreMocks.state.hasSource = true;
+  const profileIds = options.profileIds ?? [TEST_PRIMARY_PROFILE_ID];
+  authStoreMocks.state.store = {
+    ...createAuthStoreWithProfiles({
+      profiles: Object.fromEntries(
+        profileIds.map((profileId) => [
+          profileId,
+          { type: "api_key" as const, provider: "openai", key: "sk-test" },
+        ]),
+      ),
+      order: { openai: profileIds },
+    }),
+    ...(options.usageStats ? { usageStats: options.usageStats } : {}),
+  };
+  authStoreMocks.isProfileInCooldown.mockReturnValue(true);
+  return agentDir;
+}
+
+export async function resolveSession(params: {
+  agentDir: string;
+  sessionEntry: SessionEntry;
+  sessionStore: Record<string, SessionEntry>;
+  cfg?: OpenClawConfig;
+  provider?: string;
+  sessionKey?: string;
+  storePath?: string;
+  isNewSession?: boolean;
+}): Promise<string | undefined> {
+  return await resolveSessionAuthProfileOverride({
+    cfg: params.cfg ?? ({} as OpenClawConfig),
+    provider: params.provider ?? "openai",
+    agentDir: params.agentDir,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+    sessionKey: params.sessionKey ?? "agent:main:main",
+    storePath: params.storePath,
+    isNewSession: params.isNewSession ?? false,
+  });
+}
+
+export function createAutomaticSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "s1",
+    updatedAt: 1,
+    authProfileOverride: TEST_PRIMARY_PROFILE_ID,
+    authProfileOverrideSource: "auto",
+    ...overrides,
+  };
+}

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -1,11 +1,6 @@
-/**
- * Session auth-profile override rotation tests.
- * Exercises provider compatibility, cooldown handling, and persisted override
- * updates without loading the real auth store implementation.
- */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   deleteSessionEntryLifecycle,
   loadSessionEntry,
@@ -15,210 +10,21 @@ import {
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
-  type OpenClawTestState,
-  withOpenClawTestState,
-} from "../../test-utils/openclaw-test-state.js";
-import {
+  authStoreMocks,
   clearSessionAuthProfileOverride,
+  createAuthStore,
+  createAuthStoreWithProfiles,
+  createAutomaticSessionEntry,
+  prepareCooldownAuthState,
+  resolveSession,
   resolveSessionAuthProfileOverride,
-} from "./session-override.js";
+  TEST_PRIMARY_PROFILE_ID,
+  TEST_SECONDARY_PROFILE_ID,
+  withAuthState,
+} from "./session-override.test-support.js";
 import type { AuthProfileStore } from "./types.js";
 
-const authStoreMocks = vi.hoisted(() => {
-  const normalizeProvider = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "");
-  const state: { hasSource: boolean; store: AuthProfileStore } = {
-    hasSource: false,
-    store: { version: 1, profiles: {} },
-  };
-  return {
-    state,
-    ensureAuthProfileStore: vi.fn(() => state.store),
-    hasAnyAuthProfileStoreSource: vi.fn(() => state.hasSource),
-    isProfileInCooldown: vi.fn((_store: AuthProfileStore, _profileId: string) => false),
-    reset() {
-      state.hasSource = false;
-      state.store = { version: 1, profiles: {} };
-    },
-    resolveAuthProfileOrder: vi.fn(
-      ({
-        cfg,
-        store,
-        provider,
-      }: {
-        cfg?: OpenClawConfig;
-        store: AuthProfileStore;
-        provider: string;
-      }) => {
-        const providerKey = normalizeProvider(provider);
-        const ordered = Object.entries(store.order ?? {}).find(
-          ([key]) => normalizeProvider(key) === providerKey,
-        )?.[1];
-        if (ordered) {
-          return ordered;
-        }
-        const configured = Object.entries(cfg?.auth?.profiles ?? {})
-          .filter(([profileId, profile]) => {
-            if (normalizeProvider(profile.provider) !== providerKey) {
-              return false;
-            }
-            const stored = store.profiles[profileId];
-            return !stored || normalizeProvider(stored.provider) === providerKey;
-          })
-          .map(([profileId]) => profileId);
-        if (configured.length > 0) {
-          return configured;
-        }
-        return Object.entries(store.profiles)
-          .filter(([, profile]) => normalizeProvider(profile.provider) === providerKey)
-          .map(([profileId]) => profileId);
-      },
-    ),
-  };
-});
-
-vi.mock("./store.js", () => ({
-  ensureAuthProfileStore: authStoreMocks.ensureAuthProfileStore,
-  hasAnyAuthProfileStoreSource: authStoreMocks.hasAnyAuthProfileStoreSource,
-}));
-
-vi.mock("./order.js", () => ({
-  isStoredCredentialCompatibleWithAuthProvider: ({
-    cfg: _cfg,
-    provider,
-    credential,
-  }: {
-    cfg?: OpenClawConfig;
-    provider: string;
-    credential: { type: string; provider: string };
-  }) => {
-    const normalizeProvider = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "");
-    const providerKey = normalizeProvider(provider);
-    const credentialProviderKey = normalizeProvider(credential.provider);
-    return (
-      credentialProviderKey === providerKey ||
-      (providerKey === "openaicodex" &&
-        credentialProviderKey === "openai" &&
-        credential.type === "api_key")
-    );
-  },
-  isConfiguredAwsSdkAuthProfileForProvider: ({
-    cfg,
-    provider,
-    profileId,
-  }: {
-    cfg?: OpenClawConfig;
-    provider: string;
-    profileId: string;
-  }) => {
-    const normalizeProvider = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "");
-    const profile = cfg?.auth?.profiles?.[profileId];
-    return (
-      profile?.mode === "aws-sdk" &&
-      normalizeProvider(profile.provider) === normalizeProvider(provider)
-    );
-  },
-  resolveAuthProfileOrder: authStoreMocks.resolveAuthProfileOrder,
-}));
-
-vi.mock("./usage.js", () => ({
-  isProfileInCooldown: authStoreMocks.isProfileInCooldown,
-}));
-
-async function withAuthState<T>(run: (state: OpenClawTestState) => Promise<T>): Promise<T> {
-  return await withOpenClawTestState(
-    {
-      layout: "state-only",
-      prefix: "openclaw-auth-",
-    },
-    run,
-  );
-}
-
-function createAuthStore(): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: {
-      "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
-    },
-    order: {
-      zai: ["zai:work"],
-    },
-  };
-}
-
-function createAuthStoreWithProfiles(params: {
-  profiles: Record<string, { type: "api_key"; provider: string; key: string }>;
-  order?: Record<string, string[]>;
-}): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: params.profiles,
-    ...(params.order ? { order: params.order } : {}),
-  };
-}
-
-const TEST_PRIMARY_PROFILE_ID = "openai:primary@example.test";
-const TEST_SECONDARY_PROFILE_ID = "openai:secondary@example.test";
-
-async function prepareCooldownAuthState(
-  state: OpenClawTestState,
-  options: {
-    profileIds?: string[];
-    usageStats?: AuthProfileStore["usageStats"];
-  } = {},
-): Promise<string> {
-  const agentDir = state.agentDir();
-  await fs.mkdir(agentDir, { recursive: true });
-  authStoreMocks.state.hasSource = true;
-  const profileIds = options.profileIds ?? [TEST_PRIMARY_PROFILE_ID];
-  authStoreMocks.state.store = {
-    ...createAuthStoreWithProfiles({
-      profiles: Object.fromEntries(
-        profileIds.map((profileId) => [
-          profileId,
-          { type: "api_key" as const, provider: "openai", key: "sk-test" },
-        ]),
-      ),
-      order: { openai: profileIds },
-    }),
-    ...(options.usageStats ? { usageStats: options.usageStats } : {}),
-  };
-  authStoreMocks.isProfileInCooldown.mockReturnValue(true);
-  return agentDir;
-}
-
-async function resolveOpenAiSession(params: {
-  agentDir: string;
-  sessionEntry: SessionEntry;
-  sessionStore: Record<string, SessionEntry>;
-  sessionKey?: string;
-  storePath?: string;
-}): Promise<string | undefined> {
-  return await resolveSessionAuthProfileOverride({
-    cfg: {} as OpenClawConfig,
-    provider: "openai",
-    ...params,
-    sessionKey: params.sessionKey ?? "agent:main:main",
-    isNewSession: false,
-  });
-}
-
-function createAutomaticSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
-  return {
-    sessionId: "s1",
-    updatedAt: 1,
-    authProfileOverride: TEST_PRIMARY_PROFILE_ID,
-    authProfileOverrideSource: "auto",
-    ...overrides,
-  };
-}
-
 describe("resolveSessionAuthProfileOverride", () => {
-  afterEach(() => {
-    authStoreMocks.reset();
-    vi.clearAllMocks();
-  });
-
   it("returns early when no auth sources exist", async () => {
     await withAuthState(async (state) => {
       const agentDir = state.agentDir();
@@ -701,7 +507,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       const sessionStore = { [sessionKey]: sessionEntry! };
 
       await patchSessionEntryCore(scope, () => ({ label: "renamed", pinnedAt: undefined }));
-      const resolved = await resolveOpenAiSession({
+      const resolved = await resolveSession({
         agentDir,
         sessionEntry: sessionEntry!,
         sessionStore,
@@ -742,7 +548,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       const sessionStore = { [sessionKey]: sessionEntry! };
       await patchSessionEntryCore(scope, () => ({ label: "renamed", pinnedAt: undefined }));
 
-      const resolved = await resolveOpenAiSession({
+      const resolved = await resolveSession({
         agentDir,
         sessionEntry: sessionEntry!,
         sessionStore,
@@ -811,7 +617,7 @@ describe("resolveSessionAuthProfileOverride", () => {
           }));
         }
         const sessionStore = { [sessionKey]: persisted ? sessionEntry : latestEntry };
-        const resolved = await resolveOpenAiSession({
+        const resolved = await resolveSession({
           agentDir,
           sessionEntry,
           sessionStore,
@@ -843,7 +649,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       const latestEntry = createAutomaticSessionEntry({ label: "latest", pinnedAt: 2 });
       const sessionStore = { "agent:main:main": latestEntry };
 
-      const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
+      const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
 
       expect(resolved).toBeUndefined();
       expect(sessionStore["agent:main:main"]).toBe(latestEntry);
@@ -862,7 +668,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       const sessionEntry = createAutomaticSessionEntry();
       const sessionStore: Record<string, SessionEntry> = {};
 
-      expect(await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore })).toBeUndefined();
+      expect(await resolveSession({ agentDir, sessionEntry, sessionStore })).toBeUndefined();
       expect(Object.hasOwn(sessionStore, "agent:main:main")).toBe(false);
       expect(sessionEntry.authProfileOverride).toBe(TEST_PRIMARY_PROFILE_ID);
     });
@@ -886,7 +692,7 @@ describe("resolveSessionAuthProfileOverride", () => {
         target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
       });
 
-      const resolved = await resolveOpenAiSession({
+      const resolved = await resolveSession({
         agentDir,
         sessionEntry,
         sessionStore,
@@ -945,7 +751,7 @@ describe("resolveSessionAuthProfileOverride", () => {
           authProfileOverrideCompactionCount: 0,
         });
         const sessionStore = { "agent:main:main": sessionEntry };
-        const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
+        const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
         expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
         expect(authStoreMocks.isProfileInCooldown).toHaveBeenCalledWith(
           expect.anything(),
@@ -977,7 +783,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       });
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
+      const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
 
       expect(resolved).toBeUndefined();
       expect(sessionEntry.authProfileOverride).toBeUndefined();
@@ -991,7 +797,7 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       const sessionEntry: SessionEntry = { sessionId: "s1", updatedAt: 1 };
       const sessionStore = { "agent:main:main": sessionEntry };
-      const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
+      const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
 
       expect(resolved).toBeUndefined();
       expect(sessionEntry).toEqual({ sessionId: "s1", updatedAt: 1 });
@@ -1022,7 +828,7 @@ describe("resolveSessionAuthProfileOverride", () => {
           authProfileOverrideCompactionCount: 2,
         };
         const sessionStore = { "agent:main:main": sessionEntry };
-        const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
+        const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
 
         expect(resolved).toBeUndefined();
         expect(sessionEntry.authProfileOverride).toBeUndefined();
@@ -1043,50 +849,11 @@ describe("resolveSessionAuthProfileOverride", () => {
         authProfileOverrideSource: "user",
       };
       const sessionStore = { "agent:main:main": sessionEntry };
-      const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
+      const resolved = await resolveSession({ agentDir, sessionEntry, sessionStore });
 
       expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
       expect(sessionEntry.authProfileOverride).toBe(TEST_PRIMARY_PROFILE_ID);
       expect(sessionEntry.authProfileOverrideSource).toBe("user");
-      expect(sessionEntry.updatedAt).toBe(1);
-    });
-  });
-
-  it("rotates an automatic override to an auth profile that is not in cooldown", async () => {
-    await withAuthState(async (state) => {
-      const agentDir = await prepareCooldownAuthState(state, {
-        profileIds: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
-      });
-      authStoreMocks.isProfileInCooldown.mockImplementation(
-        (_store: AuthProfileStore, profileId: string) => profileId === TEST_PRIMARY_PROFILE_ID,
-      );
-
-      const sessionEntry = createAutomaticSessionEntry();
-      const sessionStore = { "agent:main:main": sessionEntry };
-      const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
-
-      expect(resolved).toBe(TEST_SECONDARY_PROFILE_ID);
-      expect(sessionEntry.authProfileOverride).toBe(TEST_SECONDARY_PROFILE_ID);
-      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
-    });
-  });
-
-  it("keeps an automatic override after its auth-profile cooldown expires", async () => {
-    await withAuthState(async (state) => {
-      const agentDir = await prepareCooldownAuthState(state, {
-        usageStats: { [TEST_PRIMARY_PROFILE_ID]: { cooldownUntil: Date.now() - 1 } },
-      });
-      authStoreMocks.isProfileInCooldown.mockImplementation(
-        (store: AuthProfileStore, profileId: string) =>
-          (store.usageStats?.[profileId]?.cooldownUntil ?? 0) > Date.now(),
-      );
-
-      const sessionEntry = createAutomaticSessionEntry({ authProfileOverrideCompactionCount: 0 });
-      const sessionStore = { "agent:main:main": sessionEntry };
-      const resolved = await resolveOpenAiSession({ agentDir, sessionEntry, sessionStore });
-
-      expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
-      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
       expect(sessionEntry.updatedAt).toBe(1);
     });
   });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -1,11 +1,8 @@
-/**
- * Session-level auth profile override rotation.
- * Keeps automatic profile choice stable within a session while still rotating
- * across new sessions, compactions, provider changes, and cooldowns.
- */
+/** Keeps automatic auth profiles stable within sessions while rotating at lifecycle boundaries. */
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveProviderModelRoutes } from "../../plugins/provider-model-routes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
   isConfiguredAwsSdkAuthProfileForProvider,
@@ -18,6 +15,7 @@ import {
   isModelScopedCooldownReason,
 } from "../auth-profiles/usage-state.js";
 import { isProfileInCooldown } from "../auth-profiles/usage.js";
+import { resolveProviderModelRouteAuthRequirement } from "../provider-model-route-auth.js";
 
 const sessionAccessorLoader = createLazyImportLoader(
   () => import("../../config/sessions/session-accessor.js"),
@@ -344,46 +342,46 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   const isProfileUnavailableForSessionModel = (profileId: string) =>
     isProfileInCooldown(store, profileId, undefined, sessionEntry.model);
-  const pickFirstAvailable = () =>
-    order.find((profileId) => !isProfileUnavailableForSessionModel(profileId)) ?? order[0];
-  const pickNextAvailable = (active: string) => {
-    const startIndex = order.indexOf(active);
-    if (startIndex < 0) {
-      return pickFirstAvailable();
-    }
-    for (let offset = 1; offset <= order.length; offset += 1) {
-      const candidate = order[(startIndex + offset) % order.length];
-      if (candidate && !isProfileUnavailableForSessionModel(candidate)) {
-        return candidate;
-      }
-    }
-    return order[startIndex] ?? order[0];
-  };
-
+  const currentUnavailable = current ? isProfileUnavailableForSessionModel(current) : false;
   const compactionCount = sessionEntry.compactionCount ?? 0;
   const storedCompaction =
     typeof sessionEntry.authProfileOverrideCompactionCount === "number"
       ? sessionEntry.authProfileOverrideCompactionCount
       : compactionCount;
-  const replacementForUnusableCurrent =
-    current && isProfileUnavailableForSessionModel(current)
-      ? order.find(
-          (profileId) => profileId !== current && !isProfileUnavailableForSessionModel(profileId),
-        )
+  const shouldRotateCurrent =
+    Boolean(current) && !isNewSession && (currentUnavailable || compactionCount > storedCompaction);
+
+  // Provider artifacts own persisted route stickiness; runtime planning owns cross-route failover.
+  const profileAuthRequirement = (profileId: string) =>
+    resolveProviderModelRouteAuthRequirement(
+      store.profiles[profileId]?.type ?? cfg.auth?.profiles?.[profileId]?.mode,
+    );
+  const routeResolution = shouldRotateCurrent
+    ? resolveProviderModelRoutes({ provider, modelId: sessionEntry.model, config: cfg })
+    : null;
+  const currentAuthRequirement =
+    current && routeResolution?.kind === "routes" && routeResolution.routes.length > 1
+      ? profileAuthRequirement(current)
       : undefined;
-  if (replacementForUnusableCurrent) {
-    current = undefined;
-  }
+  const rotationOrder = currentAuthRequirement
+    ? order.filter((profileId) => profileAuthRequirement(profileId) === currentAuthRequirement)
+    : order;
+  const pickAvailable = (active?: string) => {
+    const startIndex = active ? rotationOrder.indexOf(active) : -1;
+    for (let offset = 1; offset <= rotationOrder.length; offset += 1) {
+      const candidate = rotationOrder[(startIndex + offset) % rotationOrder.length];
+      if (candidate && !isProfileUnavailableForSessionModel(candidate)) {
+        return candidate;
+      }
+    }
+    return rotationOrder[startIndex] ?? rotationOrder[0];
+  };
 
   let next = current;
-  if (replacementForUnusableCurrent) {
-    next = replacementForUnusableCurrent;
-  } else if (isNewSession) {
-    next = current ? pickNextAvailable(current) : pickFirstAvailable();
-  } else if (current && compactionCount > storedCompaction) {
-    next = pickNextAvailable(current);
-  } else if (!current || isProfileUnavailableForSessionModel(current)) {
-    next = pickFirstAvailable();
+  if (isNewSession || shouldRotateCurrent) {
+    next = pickAvailable(currentUnavailable ? undefined : current);
+  } else if (!current) {
+    next = pickAvailable();
   }
 
   if (!next) {

--- a/src/agents/auth-profiles/session-override.user-pin.test.ts
+++ b/src/agents/auth-profiles/session-override.user-pin.test.ts
@@ -1,84 +1,48 @@
 // Focused lifecycle coverage for explicit auth-profile pins.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveSessionAuthProfileOverride } from "./session-override.js";
-import type { AuthProfileStore } from "./types.js";
+import {
+  authStoreMocks,
+  createAuthStoreWithProfiles,
+  resolveSession,
+  TEST_PRIMARY_PROFILE_ID,
+  TEST_SECONDARY_PROFILE_ID,
+} from "./session-override.test-support.js";
 
-const PRIMARY_PROFILE_ID = "openai:primary@example.test";
-const SECONDARY_PROFILE_ID = "openai:secondary@example.test";
-
-const authStoreMocks = vi.hoisted(() => {
-  const state: { store: AuthProfileStore } = {
-    store: { version: 1, profiles: {} },
-  };
-  return {
-    state,
-    isProfileInCooldown: vi.fn(() => false),
-  };
-});
-
-vi.mock("./store.js", () => ({
-  ensureAuthProfileStore: () => authStoreMocks.state.store,
-  hasAnyAuthProfileStoreSource: () => true,
-}));
-
-vi.mock("./order.js", () => ({
-  isStoredCredentialCompatibleWithAuthProvider: ({
-    provider,
-    credential,
-  }: {
-    provider: string;
-    credential: { provider: string };
-  }) => credential.provider === provider,
-  isConfiguredAwsSdkAuthProfileForProvider: () => false,
-  resolveAuthProfileOrder: ({ store, provider }: { store: AuthProfileStore; provider: string }) =>
-    store.order?.[provider] ?? [],
-}));
-
-vi.mock("./usage.js", () => ({
-  isProfileInCooldown: authStoreMocks.isProfileInCooldown,
-}));
-
-function createStore(order: string[]): AuthProfileStore {
-  return {
-    version: 1,
+function createStore(order: string[]) {
+  return createAuthStoreWithProfiles({
     profiles: {
-      [PRIMARY_PROFILE_ID]: {
+      [TEST_PRIMARY_PROFILE_ID]: {
         type: "api_key",
         provider: "openai",
         key: "sk-primary",
       },
-      [SECONDARY_PROFILE_ID]: {
+      [TEST_SECONDARY_PROFILE_ID]: {
         type: "api_key",
         provider: "openai",
         key: "sk-secondary",
       },
     },
     order: { openai: order },
-  };
+  });
 }
 
-async function resolveSession(params: {
-  sessionEntry: SessionEntry;
-  isNewSession: boolean;
-}): Promise<string | undefined> {
-  return await resolveSessionAuthProfileOverride({
-    cfg: {} as OpenClawConfig,
-    provider: "openai",
+async function resolvePinnedSession(
+  sessionEntry: SessionEntry,
+  isNewSession: boolean,
+): Promise<string | undefined> {
+  return await resolveSession({
     agentDir: "/tmp/agent",
-    sessionEntry: params.sessionEntry,
-    sessionStore: { "agent:main:main": params.sessionEntry },
-    sessionKey: "agent:main:main",
-    storePath: undefined,
-    isNewSession: params.isNewSession,
+    sessionEntry,
+    sessionStore: { "agent:main:main": sessionEntry },
+    isNewSession,
   });
 }
 
 describe("explicit auth-profile pin lifecycle", () => {
   beforeEach(() => {
-    authStoreMocks.state.store = createStore([PRIMARY_PROFILE_ID, SECONDARY_PROFILE_ID]);
-    authStoreMocks.isProfileInCooldown.mockReset();
+    authStoreMocks.state.hasSource = true;
+    authStoreMocks.state.store = createStore([TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID]);
     authStoreMocks.isProfileInCooldown.mockReturnValue(false);
   });
 
@@ -92,14 +56,14 @@ describe("explicit auth-profile pin lifecycle", () => {
     },
     {
       name: "new session",
-      order: [PRIMARY_PROFILE_ID, SECONDARY_PROFILE_ID],
+      order: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
       isNewSession: true,
       compactionCount: 0,
       authProfileOverrideCompactionCount: 0,
     },
     {
       name: "compaction advance",
-      order: [PRIMARY_PROFILE_ID, SECONDARY_PROFILE_ID],
+      order: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
       isNewSession: false,
       compactionCount: 2,
       authProfileOverrideCompactionCount: 1,
@@ -112,17 +76,17 @@ describe("explicit auth-profile pin lifecycle", () => {
         sessionId: "s1",
         updatedAt: 1,
         compactionCount,
-        authProfileOverride: PRIMARY_PROFILE_ID,
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
         authProfileOverrideSource: "user",
         authProfileOverrideCompactionCount,
       };
 
-      const resolved = await resolveSession({ sessionEntry, isNewSession });
+      const resolved = await resolvePinnedSession(sessionEntry, isNewSession);
 
-      expect(resolved).toBe(PRIMARY_PROFILE_ID);
+      expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
       expect(sessionEntry).toMatchObject({
         updatedAt: 1,
-        authProfileOverride: PRIMARY_PROFILE_ID,
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
         authProfileOverrideSource: "user",
         authProfileOverrideCompactionCount,
       });
@@ -134,13 +98,13 @@ describe("explicit auth-profile pin lifecycle", () => {
       sessionId: "s1",
       updatedAt: 1,
       compactionCount: 0,
-      authProfileOverride: PRIMARY_PROFILE_ID,
+      authProfileOverride: TEST_PRIMARY_PROFILE_ID,
     };
 
-    const resolved = await resolveSession({ sessionEntry, isNewSession: true });
+    const resolved = await resolvePinnedSession(sessionEntry, true);
 
-    expect(resolved).toBe(PRIMARY_PROFILE_ID);
-    expect(sessionEntry.authProfileOverride).toBe(PRIMARY_PROFILE_ID);
+    expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
+    expect(sessionEntry.authProfileOverride).toBe(TEST_PRIMARY_PROFILE_ID);
   });
 
   it("still rotates a legacy source-less automatic pin on a new session", async () => {
@@ -148,14 +112,14 @@ describe("explicit auth-profile pin lifecycle", () => {
       sessionId: "s1",
       updatedAt: 1,
       compactionCount: 0,
-      authProfileOverride: PRIMARY_PROFILE_ID,
+      authProfileOverride: TEST_PRIMARY_PROFILE_ID,
       authProfileOverrideCompactionCount: 0,
     };
 
-    const resolved = await resolveSession({ sessionEntry, isNewSession: true });
+    const resolved = await resolvePinnedSession(sessionEntry, true);
 
-    expect(resolved).toBe(SECONDARY_PROFILE_ID);
-    expect(sessionEntry.authProfileOverride).toBe(SECONDARY_PROFILE_ID);
+    expect(resolved).toBe(TEST_SECONDARY_PROFILE_ID);
+    expect(sessionEntry.authProfileOverride).toBe(TEST_SECONDARY_PROFILE_ID);
     expect(sessionEntry.authProfileOverrideSource).toBe("auto");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

OpenAI sessions pinned automatically to an API-key profile could cross into a subscription/OAuth profile after compaction or cooldown. Session rotation walked the provider's mixed credential order without preserving the physical provider route, so the next turn could unexpectedly leave the direct API route and enter ChatGPT OAuth refresh handling.

## Why This Change Was Made

Automatic session rotation now consults the provider-owned model-route seam and, when a provider exposes multiple physical routes, rotates only among profiles with the current route's auth requirement. The route-aware runtime planner remains the owner of intentional cross-route failover. Providers with one route, explicit user pins, and the existing Anthropic API-to-external-CLI fallback retain their current behavior.

## User Impact

API-key sessions stay on direct API authentication across compaction and cooldown rotation, selecting an API-key backup when available instead of silently switching to subscription credentials. Subscription sessions continue to rotate among compatible subscription credentials, and explicit user-selected profiles remain pinned.

## Evidence

- Exact scope: five files under `src/agents/auth-profiles/`. Production LOC is `+35/-37` (net `-2`); tests and test support are `+467/-329` (net `+138`). There are no config, schema, protocol, dependency, or changelog changes.
- Pre-fix regression: the focused rotation suite failed both multi-route OpenAI cases (compaction and cooldown), selecting `openai:subscription` instead of `openai:api-backup`.
- Post-fix focused tests: `pnpm test src/agents/auth-profiles/session-override.rotation.test.ts src/agents/auth-profiles/session-override.test.ts src/agents/auth-profiles/session-override.user-pin.test.ts` passed rotation `7/7`, session override `28/28`, and user pin `5/5`. `pnpm test src/agents/provider-model-route-auth.test.ts src/agents/auth-profiles/external-cli-auth-selection.test.ts` passed provider route auth `33/33` and external CLI fallback `7/7`.
- Keyless real Gateway proof passed on an isolated state directory and port `61509`, using canonical SQLite auth profiles and the real first hook turn -> semantic `sessions compact` -> second-turn flow. The first turn and compaction used `api.openai.com/v1/responses` with `api-primary`; the second turn used the same direct endpoint with `api-backup`. Persisted compaction advanced `0 -> 1`, the override marker advanced `0 -> 1`, and there were zero `chatgpt.com` or OAuth-material requests. The operator Gateway on `18789` was untouched. Inspected artifacts: `.artifacts/qa-e2e/pr-123894-auth-route/{verdict.json,summary.json,requests.ndjson,session-rows.json,gateway.log}`.
- `git diff --check`, formatting, and all changed-file guards through deadcode passed. The final local `pnpm check:changed` attempt then reached only a pnpm dlx/knip cache failure after the coordinator pruned a corrupted local pnpm cache; full `check:changed` green is not claimed, and exact-head CI is authoritative for that infrastructure-only gap.
- Fresh Codex autoreview found no actionable issues (`0.95` correctness confidence).
- Direct Codex contract inspection confirms the route boundary: `../codex/codex-rs/protocol/src/auth.rs:6-55`, `../codex/codex-rs/login/src/token_data.rs:10-24`, and `../codex/codex-rs/login/src/auth/manager.rs:249-349,420-460,1478-1545` distinguish direct API-key backend use from ChatGPT OAuth/Codex-backend auth and its refresh lifecycle.
- Contributor credit is preserved in the commit trailer for `@fuller-stack-dev`.

AI-assisted: yes. I reviewed and understand the code and its behavior.
