### PR TITLE
refactor(gateway): consolidate pairing completion tests

### DIFF
--- a/src/gateway/device-pair-setup-completion.test.ts
+++ b/src/gateway/device-pair-setup-completion.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readDevicePairSetupCompletion } from "../infra/device-bootstrap.js";
 import {
-  loadDeviceBootstrapTokenRecords,
   persistDeviceBootstrapTokenRecords,
   persistDevicePairingStoreState,
 } from "../infra/device-pairing-store.js";
@@ -145,41 +144,6 @@ describe("device pair setup completion", () => {
     });
   });
 
-  it("records the completion even when the broadcast itself fails", async () => {
-    const baseDir = await tempDirs.make("openclaw-setup-completion-broadcast-fail-");
-    const broadcast = vi.fn(() => {
-      throw new Error("socket fanout failed");
-    });
-
-    persistDeviceBootstrapTokenRecords(
-      {
-        "bootstrap-secret": {
-          token: "bootstrap-secret",
-          setupId: "setup-broadcast-fail",
-          ts: Date.now(),
-          deviceId: "device-123",
-          profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
-          issuedAtMs: Date.now(),
-        },
-      },
-      baseDir,
-    );
-    const handoff = await consumeSetupHandoff({
-      token: "bootstrap-secret",
-      deviceId: "device-123",
-      baseDir,
-      ts: 4,
-    });
-    const confirmed = await confirmSetupHandoffDelivery({ handoff: handoff!, baseDir });
-    expect(confirmed).not.toBeNull();
-    expect(() => broadcastSetupHandoffCompletion({ handoff: confirmed!, broadcast })).toThrow(
-      "socket fanout failed",
-    );
-    await expect(
-      readDevicePairSetupCompletion({ baseDir, setupId: "setup-broadcast-fail" }),
-    ).resolves.toMatchObject({ setupId: "setup-broadcast-fail", access: "limited" });
-  });
-
   it("ignores generic bootstrap records without setup correlation", async () => {
     const baseDir = await tempDirs.make("openclaw-setup-completion-generic-");
     persistDeviceBootstrapTokenRecords(
@@ -202,50 +166,5 @@ describe("device pair setup completion", () => {
     expect(handoff).toMatchObject({ record: { token: "generic" } });
     broadcastSetupHandoffCompletion({ handoff: handoff!, broadcast });
     expect(broadcast).not.toHaveBeenCalled();
-  });
-
-  it("does not consume a setup credential after its paired binding changed", async () => {
-    const baseDir = await tempDirs.make("openclaw-setup-completion-stale-binding-");
-    persistDeviceBootstrapTokenRecords(
-      {
-        "bootstrap-secret": {
-          token: "bootstrap-secret",
-          setupId: "setup-stale-binding",
-          ts: Date.now(),
-          deviceId: "device-123",
-          profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
-          issuedAtMs: Date.now(),
-        },
-      },
-      baseDir,
-    );
-    persistDevicePairingStoreState(
-      {
-        pendingById: {},
-        pairedByDeviceId: {
-          "device-123": {
-            deviceId: "device-123",
-            publicKey: "replacement-key",
-            createdAtMs: 1,
-            approvedAtMs: 2,
-          },
-        },
-      },
-      baseDir,
-      "paired",
-    );
-
-    await expect(
-      consumeSetupHandoff({
-        token: "bootstrap-secret",
-        deviceId: "device-123",
-        pairedDeviceMatches: (device) => device?.publicKey === "original-key",
-        baseDir,
-      }),
-    ).resolves.toBeNull();
-    expect(loadDeviceBootstrapTokenRecords(baseDir)).toHaveProperty("bootstrap-secret");
-    await expect(
-      readDevicePairSetupCompletion({ baseDir, setupId: "setup-stale-binding" }),
-    ).resolves.toBeNull();
   });
 });

--- a/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
@@ -162,6 +162,106 @@ describe("sendGatewayHello setup completion ordering", () => {
     );
   });
 
+  it("keeps correlated setup completion uncertain when hello delivery fails", async () => {
+    await withOpenClawTestState(
+      { label: "ws-setup-completion-send-failure", layout: "state-only" },
+      async () => {
+        const paired: PairedDevice = {
+          deviceId: "device-setup-send-failure",
+          publicKey: "public-key-setup-send-failure",
+          displayName: "Test phone",
+          createdAtMs: 1,
+          approvedAtMs: 2,
+        };
+        persistDevicePairingStoreState(
+          { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
+          undefined,
+          "paired",
+        );
+        const issued = await issueDevicePairSetupBootstrapToken({
+          profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+        });
+        const verifyParams = {
+          token: issued.token,
+          deviceId: paired.deviceId,
+          publicKey: paired.publicKey,
+          role: "operator" as const,
+          scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
+        };
+        await expect(verifyDeviceBootstrapToken(verifyParams)).resolves.toEqual({ ok: true });
+
+        const broadcast = vi.fn();
+        const close = vi.fn();
+        const context = {
+          handler: {
+            connId: "conn-setup-send-failure",
+            gatewayMethods: [],
+            events: [],
+            buildRequestContext: () => ({ broadcast, nodeRegistry: { get: vi.fn() } }),
+            refreshHealthSnapshot: vi.fn(async () => ({})),
+            close,
+            advanceHandshakePhase: vi.fn(),
+            setCloseCause: vi.fn(),
+            logGateway: { warn: vi.fn() },
+            logHealth: { error: vi.fn() },
+          },
+          frame: { id: "hello-setup-send-failure" },
+          connectParams: {
+            client: { id: "openclaw-ios", version: "dev", platform: "test", mode: "backend" },
+            role: "operator",
+            scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
+          },
+          configSnapshot: {},
+          sendFrame: vi.fn(async () => {
+            throw new Error("socket closed");
+          }),
+          pendingNodePairingCleanup: {},
+          releasePendingNodePairingCleanup: vi.fn(async () => undefined),
+        };
+        const state = {
+          resolvedAuth: { mode: "none" },
+          role: "operator",
+          scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
+          device: { id: paired.deviceId },
+          devicePublicKey: paired.publicKey,
+          hasTokenAuth: false,
+          hasPasswordAuth: false,
+          bootstrapTokenCandidate: issued.token,
+          authResult: { ok: true, method: "bootstrap-token" },
+          authMethod: "bootstrap-token",
+          issuedBootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+          handoffBootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+          deviceToken: null,
+          bootstrapDeviceTokens: [],
+          controlUiDeviceAuthMigrationPending: false,
+        };
+
+        await sendGatewayHello(context as never, state as never, {});
+
+        expect(close).toHaveBeenCalled();
+        expect(broadcast).toHaveBeenCalledWith(
+          "device.pair.setup.deliveryUncertain",
+          expect.objectContaining({ setupId: issued.setupId, deviceId: paired.deviceId }),
+          { dropIfSlow: true },
+        );
+        expect(
+          broadcast.mock.calls.some(([event]) => event === "device.pair.setup.completed"),
+        ).toBe(false);
+        await expect(
+          readDevicePairSetupCompletion({ setupId: issued.setupId }),
+        ).resolves.toMatchObject({
+          setupId: issued.setupId,
+          deviceId: paired.deviceId,
+          deliveryState: "uncertain",
+        });
+        await expect(verifyDeviceBootstrapToken(verifyParams)).resolves.toEqual({
+          ok: false,
+          reason: "bootstrap_token_invalid",
+        });
+      },
+    );
+  });
+
   it("does not consume a setup bearer after the paired public key is replaced", async () => {
     await withOpenClawTestState(
       { label: "ws-setup-completion-replaced-key", layout: "state-only" },

--- a/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
@@ -8,40 +8,10 @@ const {
   emitGatewayAuthSecurityEventMock,
   listControlUiPluginTabsMock,
   listControlUiPluginWidgetKindsMock,
-  redeemDeviceBootstrapTokenProfileMock,
-  restoreGenericDeviceBootstrapTokenMock,
-  broadcastSetupHandoffCompletionMock,
-  broadcastSetupHandoffDeliveryUncertainMock,
-  confirmSetupHandoffDeliveryMock,
-  consumeSetupHandoffMock,
 } = vi.hoisted(() => ({
   emitGatewayAuthSecurityEventMock: vi.fn(),
   listControlUiPluginTabsMock: vi.fn((_scopes: readonly string[]) => []),
   listControlUiPluginWidgetKindsMock: vi.fn((_scopes: readonly string[]) => []),
-  broadcastSetupHandoffCompletionMock: vi.fn(),
-  broadcastSetupHandoffDeliveryUncertainMock: vi.fn(),
-  confirmSetupHandoffDeliveryMock: vi.fn(async ({ handoff }) => handoff),
-  redeemDeviceBootstrapTokenProfileMock: vi.fn(async () => ({
-    recorded: true,
-    fullyRedeemed: true,
-  })),
-  restoreGenericDeviceBootstrapTokenMock: vi.fn(async () => true),
-  consumeSetupHandoffMock: vi.fn(async () => ({
-    record: {
-      token: "bootstrap-secret",
-      setupId: "setup-failed-send",
-      ts: 1,
-      issuedAtMs: 1,
-    },
-    completion: {
-      setupId: "setup-failed-send",
-      deviceId: "device-123",
-      access: "node",
-      completedAtMs: 1,
-      deliveryState: "uncertain",
-      retainUntilMs: 2,
-    },
-  })),
   buildGatewaySnapshotMock: vi.fn((opts?: { includeUpdateDetails?: boolean }) => {
     const updateAvailable = {
       currentVersion: "2026.8.7",
@@ -80,18 +50,6 @@ const {
         : {}),
     };
   }),
-}));
-
-vi.mock("../../../infra/device-bootstrap.js", () => ({
-  redeemDeviceBootstrapTokenProfile: redeemDeviceBootstrapTokenProfileMock,
-  restoreGenericDeviceBootstrapToken: restoreGenericDeviceBootstrapTokenMock,
-}));
-
-vi.mock("../../device-pair-setup-completion.js", () => ({
-  broadcastSetupHandoffCompletion: broadcastSetupHandoffCompletionMock,
-  broadcastSetupHandoffDeliveryUncertain: broadcastSetupHandoffDeliveryUncertainMock,
-  confirmSetupHandoffDelivery: confirmSetupHandoffDeliveryMock,
-  consumeSetupHandoff: consumeSetupHandoffMock,
 }));
 
 vi.mock("../health-state.js", () => ({
@@ -310,30 +268,5 @@ describe("sendGatewayHello update detail scope", () => {
       expect(scope).not.toContain("profile-");
       expect(scope).not.toContain("device-token-");
     }
-  });
-
-  it("keeps setup completion committed when hello delivery fails", async () => {
-    const context = makeContext("node", []);
-    context.sendFrame.mockRejectedValueOnce(new Error("socket closed"));
-    const state = {
-      ...makeState("node", []),
-      device: { id: "device-123" },
-      devicePublicKey: "public-key-123",
-      authMethod: "bootstrap-token",
-      bootstrapTokenCandidate: "bootstrap-secret",
-      issuedBootstrapProfile: { roles: ["node"], scopes: [] },
-    };
-
-    await sendGatewayHello(context as never, state as never, {});
-
-    expect(consumeSetupHandoffMock).toHaveBeenCalledWith({
-      token: "bootstrap-secret",
-      deviceId: "device-123",
-      pairedDeviceMatches: expect.any(Function),
-    });
-    expect(broadcastSetupHandoffCompletionMock).not.toHaveBeenCalled();
-    expect(broadcastSetupHandoffDeliveryUncertainMock).toHaveBeenCalled();
-    expect(restoreGenericDeviceBootstrapTokenMock).not.toHaveBeenCalled();
-    expect(context.handler.close).toHaveBeenCalled();
   });
 });

--- a/src/gateway/watch-node-http.test.ts
+++ b/src/gateway/watch-node-http.test.ts
@@ -767,23 +767,6 @@ describe("watch node HTTP transport", () => {
       expect(connectResponse.status).toBe(200);
       await readJson(connectResponse);
       await completedRuntime.connectHandled;
-      expect(
-        completedRuntime.broadcasts.find((entry) => entry.event === "device.pair.setup.completed")
-          ?.payload,
-      ).toEqual({
-        setupId: completedBootstrap.setupId,
-        deviceId: completedIdentity.deviceId,
-        deviceName: "Test Watch",
-        access: "node",
-        ts: expect.any(Number),
-      });
-      expect(
-        loadDevicePairSetupCompletionRecord(
-          completedBootstrap.setupId,
-          Date.now(),
-          completedBaseDir,
-        ),
-      ).toMatchObject({ deliveryState: "confirmed" });
       await waitForLastConnectedMetadata(completedBaseDir, completedIdentity.deviceId);
       const resetAfterCompletion = await fetch(`${completedRuntime.baseUrl}/challenge`);
       expect(resetAfterCompletion.status).toBe(200);
@@ -853,6 +836,11 @@ describe("watch node HTTP transport", () => {
     expect(response.status).toBe(200);
     await readJson(response);
     await fixture.connectHandled;
+    const completionAfterHandoff = loadDevicePairSetupCompletionRecord(
+      fixture.issued.setupId,
+      Date.now(),
+      fixture.baseDir,
+    );
 
     expect(completionAtHandoff).toMatchObject({
       setupId: fixture.issued.setupId,
@@ -860,6 +848,16 @@ describe("watch node HTTP transport", () => {
       deviceName: "Test Watch",
       access: "node",
       deliveryState: "uncertain",
+    });
+    expect(completionAfterHandoff).toMatchObject({ deliveryState: "confirmed" });
+    expect(
+      fixture.broadcasts.find((entry) => entry.event === "device.pair.setup.completed")?.payload,
+    ).toEqual({
+      setupId: fixture.issued.setupId,
+      deviceId: fixture.identity.deviceId,
+      deviceName: "Test Watch",
+      access: "node",
+      ts: expect.any(Number),
     });
     fixture.runtime.close();
   });
@@ -895,15 +893,6 @@ describe("watch node HTTP transport", () => {
     ]);
     expect(broadcasts.map((entry) => entry.event)).toContain("device.pair.resolved");
     expect(broadcasts.map((entry) => entry.event)).toContain("node.pair.resolved");
-    expect(
-      broadcasts.find((entry) => entry.event === "device.pair.setup.completed")?.payload,
-    ).toEqual({
-      setupId: issued.setupId,
-      deviceId: identity.deviceId,
-      deviceName: "Test Watch",
-      access: "node",
-      ts: expect.any(Number),
-    });
     expect(connectedNodes).toEqual([identity.deviceId]);
 
     const reconnectResponse = await connectWatchNode({


### PR DESCRIPTION
## What Problem This Solves

Pairing completion coverage was spread across helper-level replays, a mocked update-scope test that never created durable state, and duplicate Watch success assertions appended to unrelated scenarios. The mocked WebSocket failure test claimed the completion remained committed even though it did not touch the completion store.

## Why This Change Was Made

The WebSocket send-failure regression now uses the real setup token, pairing store, handoff helper, and completion database. It proves the correlated bearer stays retired, the durable row remains uncertain, false success is not emitted, and the uncertainty event is broadcast. Redundant helper tests and update-scope mocks are removed. Watch success state and event assertions now live with the existing response-ordering test instead of the rate-limiter and broad transport smoke.

## User Impact

No intended visible behavior change. The recovery contract for a paired device whose credential response cannot be delivered now has stronger boundary-level regression proof with less duplicate maintenance.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/device-pair-setup-completion.test.ts src/gateway/watch-node-http.test.ts src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts src/gateway/server/ws-connection/connect-hello.update-scope.test.ts` — 4 files, 30 tests passed.
- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts src/gateway/server-methods/device-pair-setup.test.ts src/infra/device-bootstrap.test.ts` — 3 sibling owner files, 93 tests passed.
- `node scripts/check-changed.mjs -- src/gateway/device-pair-setup-completion.test.ts src/gateway/watch-node-http.test.ts src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts src/gateway/server/ws-connection/connect-hello.update-scope.test.ts` — coreTests changed gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Production delta: 0. Tests: +115/-174, net -59.
