### PR TITLE
refactor(sessions): use archived projection for maintenance

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -1,5 +1,4 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { sql } from "kysely";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { getChildLogger } from "../../logging/logger.js";
 import {
@@ -78,14 +77,7 @@ function hasStaleSqliteSessionEntryCandidate(
       .selectFrom("session_nodes")
       .select(["entry_json", "session_key"])
       .where("updated_at", "<", cutoffMs)
-      .where(
-        /* kysely-allow-raw: archivedAt lives inside the canonical JSON entry, not a SQL column.
-         * The CASE guard keeps malformed legacy bytes from aborting unrelated session writes. */
-        sql<boolean>`CASE
-          WHEN json_valid(entry_json) THEN json_extract(entry_json, '$.archivedAt') IS NULL
-          ELSE 0
-        END`,
-      )
+      .where("archived_at", "is", null)
       .orderBy("updated_at", "asc"),
   ).rows;
   return rows.some((row) => {


### PR DESCRIPTION
Related: #123081

## What Problem This Solves

The SQLite stale-session probe added in #123081 queried `archivedAt` by parsing the canonical JSON payload with a raw SQLite `CASE` expression, even though the session schema already promotes and backfills that value into the typed `archived_at` query column. This left routine maintenance code harder to read and unnecessarily dependent on SQLite JSON1 behavior.

## Why This Change Was Made

Use the existing `session_nodes.archived_at` projection through Kysely's typed query builder. The projection is maintained by the canonical session write and migration paths; malformed entry payloads remain isolated by the existing row parser.

This is an AI-assisted, maintainer-requested cleanup follow-up to #123081.

## User Impact

No intended behavior change. Archived sessions remain protected from stale-session pruning, while the maintenance query becomes smaller and follows the schema's promoted-column contract.

## Evidence

- Focused Blacksmith Testbox proof passed: 2 tests covering malformed legacy JSON beside a valid write and archived-row preservation during write-triggered capping: https://github.com/openclaw/openclaw/actions/runs/31852864487
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh Codex autoreview reported no accepted/actionable findings.
- Production diff: 1 insertion, 9 deletions; no public API or schema change.
