### PR TITLE
fix(release): restore llama-cpp plugin security scan

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -34,6 +34,7 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
   ["@openclaw/google-meet:dangerous-exec:src/node-host.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
+  ["@openclaw/llama-cpp-provider:dangerous-exec:src/llama-server-install.ts", 1],
   ["@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts", 2],
   ["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts", 1],
   ["@openclaw/raft:dangerous-exec:src/gateway.ts", 1],

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -32,7 +32,6 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
-  ["@openclaw/google-meet:dangerous-exec:src/node-host.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
   ["@openclaw/llama-cpp-provider:dangerous-exec:src/llama-server-install.ts", 1],
   ["@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts", 2],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the prerelease publishable-plugin security scan rejected the llama-cpp plugin after its managed server installer added a reviewed version probe.

## Why This Change Was Made

The release baseline now records the exact `@openclaw/llama-cpp-provider` source finding and requires exactly one occurrence. It also removes the obsolete Google Meet source baseline left behind when PR #118451 replaced that plugin's direct `child_process.spawnSync` use with the shared meeting runtime. Unknown execution sites and count drift still fail the scan; scanner and runtime behavior are unchanged.

## User Impact

Release validation can accept the audited llama-cpp `--version` probe while continuing to block new or changed critical execution findings.

## Evidence

- Pre-fix direct AWS Crabbox run: `src/plugins/npm-install-security-scan.release.test.ts` reported the llama-cpp `execFile(command, ["--version"])` site as an unexpected critical finding.
- Full exact-head release-scan proof: `node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts` — 94 passed.
- `/home/openclaw/openclaw/node_modules/.bin/oxfmt --check src/plugins/npm-install-security-scan.release.test.ts` — passed.
- `git diff --check` — passed.
- Autoreview: clean, no accepted/actionable findings.

Production LOC: +0/-0 (net 0) | Tests: +1/-1 (net 0)
