### PR TITLE
fix(workers): bound Gateway bundle cache growth

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -13,22 +13,22 @@ Proposal, revision 2. Supersedes revision 1 in place (2026-08-11, operator
 decision). Implementation in progress; update this table in every PR that
 advances a milestone.
 
-| #   | Milestone                                                  | Status      | PRs                                                                                                                                                              |
-| --- | ---------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0   | This plan (revision 2)                                     | landed      | #122454                                                                                                                                                          |
-| 1a  | Naming: session copy revert                                | landed      | #120667                                                                                                                                                          |
-| 1b  | Naming: devices consolidation                              | landed      | #120689                                                                                                                                                          |
-| 1c  | Cleanup: node-pairing → device-pairing merge               | landed      | #120726                                                                                                                                                          |
-| 2   | `openclaw resume` + web Continue in terminal               | in progress | #120664, #122870                                                                                                                                                 |
-| 3   | `openclaw connect` one-paste onboarding + `/j/` join route | in progress | #120768, #122499                                                                                                                                                 |
-| 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635, #122774, #122923                                                                                                                      |
-| F   | Real-wire session boundary harness                         | landed      | #121212                                                                                                                                                          |
-| 5   | Public worker ingress path                                 | landed      | #122578, #122643                                                                                                                                                 |
-| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033, #122966, #123157, #123280, #123612, #123641, #123665, #123673, #123700, #123696, #123785, #123859, #123889 |
-| 7   | Bundle push consent + runner updates                       | not started | —                                                                                                                                                                |
-| 8   | Stop-and-continue moves                                    | not started | —                                                                                                                                                                |
-| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                                                                                                                                                |
-| 10  | Cloud convergence (provisioners run `openclaw connect`)    | not started | —                                                                                                                                                                |
+| #   | Milestone                                                  | Status      | PRs                                                                                                                                                                       |
+| --- | ---------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | This plan (revision 2)                                     | landed      | #122454                                                                                                                                                                   |
+| 1a  | Naming: session copy revert                                | landed      | #120667                                                                                                                                                                   |
+| 1b  | Naming: devices consolidation                              | landed      | #120689                                                                                                                                                                   |
+| 1c  | Cleanup: node-pairing → device-pairing merge               | landed      | #120726                                                                                                                                                                   |
+| 2   | `openclaw resume` + web Continue in terminal               | in progress | #120664, #122870                                                                                                                                                          |
+| 3   | `openclaw connect` one-paste onboarding + `/j/` join route | in progress | #120768, #122499                                                                                                                                                          |
+| 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635, #122774, #122923                                                                                                                               |
+| F   | Real-wire session boundary harness                         | landed      | #121212                                                                                                                                                                   |
+| 5   | Public worker ingress path                                 | landed      | #122578, #122643                                                                                                                                                          |
+| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033, #122966, #123157, #123280, #123612, #123641, #123665, #123673, #123700, #123696, #123785, #123859, #123889, #123901 |
+| 7   | Bundle push consent + runner updates                       | not started | —                                                                                                                                                                         |
+| 8   | Stop-and-continue moves                                    | not started | —                                                                                                                                                                         |
+| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                                                                                                                                                         |
+| 10  | Cloud convergence (provisioners run `openclaw connect`)    | not started | —                                                                                                                                                                         |
 
 Revision history: revision 1 (2026-08-08) established the session/runner
 vocabulary, the naming rulings, and the milestone skeleton after a
@@ -245,8 +245,10 @@ Device dormancy expiry and terminal launch/environment retention bound durable
 rows. Node workspace cleanup waits for a full reconnect-scoped Gateway retain
 snapshot, unions that authority with node-local launch and operation ownership,
 and then removes retired generations, transfer siblings, unreachable manifests,
-and empty workspace parents in bounded passes. Milestone 7 upgrades this to
-Gateway-pinned, namespaced bundle bytes. Isolation, checkout ownership, and
+and empty workspace parents in bounded passes. The Gateway bundle producer
+also prunes unreferenced local tarballs only after a successful current build,
+while preserving hashes named by durable environments and placements. Milestone
+7 upgrades this to Gateway-pinned, namespaced bundle bytes. Isolation, checkout ownership, and
 durable offline recovery actions remain milestone 6 work.
 
 ### Trust model (operator-decided, v1)

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -137,6 +137,16 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
   // A crashed gateway can leak local turn claims; drop them before workers re-admit turns.
   params.startup.placementStore.clearLocalTurnClaimsAfterRestart();
   const placementGate = createWorkerSessionPlacementGate(params.startup.placementStore);
+  const workerEnvironmentLog = params.log.child("worker-environments");
+  const listRetainedBundleHashes = () =>
+    uniqueStrings([
+      ...params.startup.store
+        .list()
+        .flatMap((record) => (record.bootstrapReceipt ? [record.bootstrapReceipt.bundleHash] : [])),
+      ...params.startup.placementStore
+        .list()
+        .flatMap((placement) => (placement.workerBundleHash ? [placement.workerBundleHash] : [])),
+    ]);
   let workerBundleProducer: WorkerBundleProducer | undefined;
   let workerNpmArtifact: Promise<WorkerNpmArtifact> | undefined;
   const prepareInstallation = async (install: "bundle" | "npm") => {
@@ -144,10 +154,15 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
       loadWorkerEnvironmentRuntimeModule(),
       import("../../packages/gateway-protocol/src/schema/worker-admission.js"),
     ]);
-    workerBundleProducer ??= workerRuntime.createWorkerBundleProducer({
+    const producer = (workerBundleProducer ??= workerRuntime.createWorkerBundleProducer({
       protocolFeatures: WORKER_PROTOCOL_FEATURES,
-    });
-    const bundle = await workerBundleProducer.prepare();
+      cacheOwnership: "exclusive",
+      onCacheCleanupError: (error) => {
+        workerEnvironmentLog.warn(`Worker bundle cache cleanup failed: ${String(error)}`);
+      },
+    }));
+    const bundle = await producer.prepare();
+    await producer.prune(listRetainedBundleHashes());
     if (install === "bundle") {
       return bundle;
     }
@@ -200,7 +215,6 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
   let dispatchChild: WorkerPlacementDispatchContract["dispatch"] = async () => {
     throw new Error("Worker session dispatch is unavailable");
   };
-  const workerEnvironmentLog = params.log.child("worker-environments");
   const workerEnvironmentServiceBase = createWorkerEnvironmentService({
     store: params.startup.store,
     getConfig: getRuntimeConfig,

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -26,6 +26,7 @@ import type { WorkerSessionPlacementStore } from "./worker-environments/placemen
 import type { WorkerPlacementDispatchContract } from "./worker-environments/service-contract.js";
 import type { WorkerEnvironmentService } from "./worker-environments/service.js";
 import type { WorkerTunnelManager } from "./worker-environments/tunnel.js";
+import { listRetainedWorkerBundleHashes } from "./worker-environments/worker-bundle-retention.js";
 
 type WorkerEnvironmentStore = ReturnType<
   typeof import("./worker-environments/store.js").createWorkerEnvironmentStore
@@ -139,14 +140,10 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
   const placementGate = createWorkerSessionPlacementGate(params.startup.placementStore);
   const workerEnvironmentLog = params.log.child("worker-environments");
   const listRetainedBundleHashes = () =>
-    uniqueStrings([
-      ...params.startup.store
-        .list()
-        .flatMap((record) => (record.bootstrapReceipt ? [record.bootstrapReceipt.bundleHash] : [])),
-      ...params.startup.placementStore
-        .list()
-        .flatMap((placement) => (placement.workerBundleHash ? [placement.workerBundleHash] : [])),
-    ]);
+    listRetainedWorkerBundleHashes({
+      environments: params.startup.store.list(),
+      placements: params.startup.placementStore.list(),
+    });
   let workerBundleProducer: WorkerBundleProducer | undefined;
   let workerNpmArtifact: Promise<WorkerNpmArtifact> | undefined;
   const prepareInstallation = async (install: "bundle" | "npm") => {

--- a/src/gateway/worker-environments/bundle.test.ts
+++ b/src/gateway/worker-environments/bundle.test.ts
@@ -378,6 +378,104 @@ describe("worker bundle producer", () => {
     });
   });
 
+  it("prunes unreferenced bundles only for an exclusive cache owner", async () => {
+    await withTestDir({ prefix: "openclaw-worker-bundle-prune-" }, async (root) => {
+      const packageRoot = path.join(root, "package");
+      const cacheDir = path.join(root, "cache");
+      await writeFixture(packageRoot, [["dist/entry.js", "export const value = 1;\n"]]);
+      const previous = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
+      await fs.writeFile(
+        path.join(packageRoot, "dist/entry.js"),
+        "export const value = 2;\n",
+        "utf8",
+      );
+      const owner = createWorkerBundleProducer({
+        packageRoot,
+        cacheDir,
+        cacheOwnership: "exclusive",
+      });
+      const current = await owner.prepare();
+
+      await owner.prune([]);
+
+      await expect(fs.stat(previous.tarballPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(current.tarballPath)).resolves.toBeDefined();
+    });
+  });
+
+  it("retains durable hashes while pruning an exclusive cache", async () => {
+    await withTestDir({ prefix: "openclaw-worker-bundle-retain-" }, async (root) => {
+      const packageRoot = path.join(root, "package");
+      const cacheDir = path.join(root, "cache");
+      await writeFixture(packageRoot, [["dist/entry.js", "export const value = 1;\n"]]);
+      const previous = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
+      await fs.writeFile(
+        path.join(packageRoot, "dist/entry.js"),
+        "export const value = 2;\n",
+        "utf8",
+      );
+      const owner = createWorkerBundleProducer({
+        packageRoot,
+        cacheDir,
+        cacheOwnership: "exclusive",
+      });
+      const current = await owner.prepare();
+
+      await owner.prune([previous.bundleHash]);
+
+      await expect(fs.stat(previous.tarballPath)).resolves.toBeDefined();
+      await expect(fs.stat(current.tarballPath)).resolves.toBeDefined();
+    });
+  });
+
+  it("reclaims recognized crash artifacts but preserves unknown cache entries", async () => {
+    await withTestDir({ prefix: "openclaw-worker-bundle-crash-cleanup-" }, async (root) => {
+      const packageRoot = path.join(root, "package");
+      const cacheDir = path.join(root, "cache");
+      await writeFixture(packageRoot, [["dist/entry.js", "export {};\n"]]);
+      const owner = createWorkerBundleProducer({
+        packageRoot,
+        cacheDir,
+        cacheOwnership: "exclusive",
+      });
+      const current = await owner.prepare();
+      const staging = path.join(cacheDir, ".staging-stale");
+      const temporary = path.join(
+        cacheDir,
+        `${"b".repeat(64)}.tgz.123.123e4567-e89b-12d3-a456-426614174000.tmp`,
+      );
+      const unknown = path.join(cacheDir, "keep-me.txt");
+      await fs.mkdir(staging);
+      await fs.writeFile(temporary, "partial", "utf8");
+      await fs.writeFile(unknown, "operator-owned", "utf8");
+
+      await owner.prune([]);
+
+      await expect(fs.stat(staging)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(temporary)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(unknown, "utf8")).resolves.toBe("operator-owned");
+      await expect(fs.stat(current.tarballPath)).resolves.toBeDefined();
+    });
+  });
+
+  it("keeps custom caches non-destructive and failed preparations non-destructive", async () => {
+    await withTestDir({ prefix: "openclaw-worker-bundle-shared-cache-" }, async (root) => {
+      const cacheDir = path.join(root, "cache");
+      await fs.mkdir(cacheDir);
+      const historical = path.join(cacheDir, `${"c".repeat(64)}.tgz`);
+      await fs.writeFile(historical, "historical", "utf8");
+      const shared = createWorkerBundleProducer({
+        packageRoot: path.join(root, "missing-package"),
+        cacheDir,
+      });
+
+      await expect(shared.prepare()).rejects.toBeDefined();
+      await shared.prune([]);
+
+      await expect(fs.readFile(historical, "utf8")).resolves.toBe("historical");
+    });
+  });
+
   it("archives the staged bytes when the source changes during packaging", async () => {
     await withTestDir({ prefix: "openclaw-worker-bundle-mutation-" }, async (root) => {
       const baselineRoot = path.join(root, "baseline");

--- a/src/gateway/worker-environments/bundle.ts
+++ b/src/gateway/worker-environments/bundle.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { createReadStream, type Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -23,6 +23,9 @@ export { WORKER_BUNDLE_MANIFEST_VERSION };
 const OPENCLAW_NPM_REGISTRY = "https://registry.npmjs.org/";
 const NPM_RELEASE_PROOF_TIMEOUT_MS = 60_000;
 const NPM_SHA512_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+const BUNDLE_TARBALL_NAME_PATTERN = /^([a-f0-9]{64})\.tgz$/u;
+const BUNDLE_STAGING_NAME_PATTERN = /^\.staging-[A-Za-z0-9_-]+$/u;
+const BUNDLE_TEMP_NAME_PATTERN = /^[a-f0-9]{64}\.tgz\.[0-9]+\.[0-9a-f-]{36}\.tmp$/u;
 type WorkerInstallationArtifactBase = {
   bundleHash: string;
   openclawVersion: string;
@@ -45,6 +48,7 @@ export type WorkerInstallationArtifact = WorkerBundleArtifact | WorkerNpmArtifac
 
 export type WorkerBundleProducer = {
   prepare: () => Promise<WorkerBundleArtifact>;
+  prune: (retainedBundleHashes: readonly string[]) => Promise<void>;
 };
 
 type WorkerBundleProducerOptions = {
@@ -52,6 +56,8 @@ type WorkerBundleProducerOptions = {
   cacheDir?: string;
   openclawVersion?: string;
   protocolFeatures?: readonly string[];
+  cacheOwnership?: "exclusive";
+  onCacheCleanupError?: (error: unknown) => void;
 };
 
 type WorkerNpmPackageInstallCheck = (packageRoot: string) => Promise<boolean>;
@@ -67,6 +73,12 @@ function normalizeProtocolFeatures(features: readonly string[]): string[] {
     throw new Error("Worker protocol features must be non-empty strings");
   }
   return [...new Set(normalized)].toSorted(comparePaths);
+}
+
+function resolveBundleCacheDir(cacheDir: string | undefined): string {
+  return cacheDir
+    ? path.resolve(cacheDir)
+    : path.join(resolveStateDir(), "cache", "worker-bundles");
 }
 
 function resolvePackageRoot(packageRoot: string | undefined): string {
@@ -427,13 +439,57 @@ async function writeTarball(params: {
   }
 }
 
+async function pruneWorkerBundleCache(params: {
+  cacheDir: string;
+  currentBundleHash: string;
+  retainedBundleHashes: readonly string[];
+  onError?: (error: unknown) => void;
+}): Promise<void> {
+  const retained = new Set(
+    [params.currentBundleHash, ...params.retainedBundleHashes].filter((hash) =>
+      /^[a-f0-9]{64}$/u.test(hash),
+    ),
+  );
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(params.cacheDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      params.onError?.(error);
+    }
+    return;
+  }
+  for (const entry of entries.toSorted((left, right) => comparePaths(left.name, right.name))) {
+    const tarball = BUNDLE_TARBALL_NAME_PATTERN.exec(entry.name);
+    const removableTarball = tarball && !retained.has(tarball[1]!);
+    const removableStaging = BUNDLE_STAGING_NAME_PATTERN.test(entry.name);
+    const removableTemp = BUNDLE_TEMP_NAME_PATTERN.test(entry.name);
+    if (!removableTarball && !removableStaging && !removableTemp) {
+      continue;
+    }
+    const target = path.join(params.cacheDir, entry.name);
+    try {
+      const stats = await fs.lstat(target);
+      if (stats.isSymbolicLink()) {
+        continue;
+      }
+      if (removableStaging ? !stats.isDirectory() : !stats.isFile()) {
+        continue;
+      }
+      await fs.rm(target, { recursive: removableStaging, force: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        params.onError?.(error);
+      }
+    }
+  }
+}
+
 async function prepareWorkerBundle(
   options: WorkerBundleProducerOptions,
 ): Promise<WorkerBundleArtifact> {
   const packageRoot = resolvePackageRoot(options.packageRoot);
-  const cacheDir = options.cacheDir
-    ? path.resolve(options.cacheDir)
-    : path.join(resolveStateDir(), "cache", "worker-bundles");
+  const cacheDir = resolveBundleCacheDir(options.cacheDir);
   const openclawVersion = (options.openclawVersion ?? VERSION).trim();
   if (!openclawVersion) {
     throw new Error("Worker bundle requires a non-empty OpenClaw version");
@@ -468,18 +524,41 @@ export function createWorkerBundleProducer(
   options: WorkerBundleProducerOptions = {},
 ): WorkerBundleProducer {
   let prepared: Promise<WorkerBundleArtifact> | undefined;
+  let currentArtifact: WorkerBundleArtifact | undefined;
+  let pruning = Promise.resolve();
   return {
     prepare() {
       if (!prepared) {
-        const pending = prepareWorkerBundle(options).catch((error: unknown) => {
-          if (prepared === pending) {
-            prepared = undefined;
-          }
-          throw error;
-        });
+        const pending = prepareWorkerBundle(options)
+          .then((artifact) => {
+            currentArtifact = artifact;
+            return artifact;
+          })
+          .catch((error: unknown) => {
+            if (prepared === pending) {
+              prepared = undefined;
+            }
+            throw error;
+          });
         prepared = pending;
       }
       return prepared;
+    },
+    async prune(retainedBundleHashes) {
+      const artifact = currentArtifact;
+      if (options.cacheOwnership !== "exclusive" || !artifact) {
+        return;
+      }
+      const operation = pruning.then(async () => {
+        await pruneWorkerBundleCache({
+          cacheDir: resolveBundleCacheDir(options.cacheDir),
+          currentBundleHash: artifact.bundleHash,
+          retainedBundleHashes,
+          onError: options.onCacheCleanupError,
+        });
+      });
+      pruning = operation.catch(() => undefined);
+      await operation;
     },
   };
 }

--- a/src/gateway/worker-environments/worker-bundle-retention.test.ts
+++ b/src/gateway/worker-environments/worker-bundle-retention.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { WorkerSessionPlacementRecord } from "./placement-store.js";
+import type { WorkerEnvironmentRecord } from "./store.js";
+import { listRetainedWorkerBundleHashes } from "./worker-bundle-retention.js";
+
+const hash = (value: string) => value.repeat(64);
+
+function environment(state: WorkerEnvironmentRecord["state"], bundleHash: string) {
+  return {
+    state,
+    bootstrapReceipt: {
+      bundleHash,
+      openclawVersion: "1.2.3",
+      protocolFeatures: [],
+    },
+  } as Pick<WorkerEnvironmentRecord, "bootstrapReceipt" | "state">;
+}
+
+function placement(state: WorkerSessionPlacementRecord["state"], bundleHash: string | null) {
+  return { state, workerBundleHash: bundleHash } as WorkerSessionPlacementRecord;
+}
+
+describe("worker bundle retention", () => {
+  it("retains only operational environment and placement bundle hashes", () => {
+    expect(
+      listRetainedWorkerBundleHashes({
+        environments: [
+          environment("attached", hash("0")),
+          environment("destroyed", hash("1")),
+          environment("failed", hash("2")),
+          environment("orphaned", hash("3")),
+        ],
+        placements: [
+          placement("syncing", hash("4")),
+          placement("starting", hash("5")),
+          placement("active", hash("6")),
+          placement("draining", hash("7")),
+          placement("reconciling", hash("8")),
+          placement("reclaimed", hash("9")),
+          placement("failed", hash("a")),
+          placement("local", null),
+        ],
+      }),
+    ).toEqual([hash("0"), hash("4"), hash("5"), hash("6"), hash("7"), hash("8")]);
+  });
+});

--- a/src/gateway/worker-environments/worker-bundle-retention.ts
+++ b/src/gateway/worker-environments/worker-bundle-retention.ts
@@ -1,0 +1,30 @@
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { WorkerSessionPlacementRecord } from "./placement-store.js";
+import type { WorkerEnvironmentRecord } from "./store.js";
+
+const TERMINAL_ENVIRONMENT_STATES = new Set(["destroyed", "failed", "orphaned"]);
+const RECOVERY_BUNDLE_PLACEMENT_STATES = new Set([
+  "syncing",
+  "starting",
+  "active",
+  "draining",
+  "reconciling",
+]);
+
+export function listRetainedWorkerBundleHashes(params: {
+  environments: Pick<WorkerEnvironmentRecord, "bootstrapReceipt" | "state">[];
+  placements: WorkerSessionPlacementRecord[];
+}): string[] {
+  return uniqueStrings([
+    ...params.environments.flatMap((record) =>
+      record.bootstrapReceipt && !TERMINAL_ENVIRONMENT_STATES.has(record.state)
+        ? [record.bootstrapReceipt.bundleHash]
+        : [],
+    ),
+    ...params.placements.flatMap((placement) =>
+      placement.workerBundleHash && RECOVERY_BUNDLE_PLACEMENT_STATES.has(placement.state)
+        ? [placement.workerBundleHash]
+        : [],
+    ),
+  ]);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where every distinct Gateway worker build permanently left a content-addressed tarball under `state/cache/worker-bundles`. Long-running development and upgrade cycles therefore grew the Gateway cache without a lifecycle owner, even after environments and placements stopped referencing older builds.

## Why This Change Was Made

The process-scoped bundle producer now exposes best-effort pruning only when its caller explicitly owns the cache exclusively. Gateway worker startup supplies that ownership after the state-directory lock, retains the successfully prepared current hash plus every durable environment and placement hash, and prunes after successful publication. Cleanup only recognizes complete 64-hex tarballs and producer-shaped crash staging/temp artifacts. Shared custom caches remain non-destructive, and remote per-hash worker installations are intentionally out of scope because their shared-host ownership is not strong enough for safe deletion. This AI-assisted change adds no configuration, protocol, or persistent schema surface.

Production delta is +134/-14 (net +120); tests are +144. The growth is the bounded cache ownership capability and recovery-only durable-reference projection; terminal diagnostic records do not pin historical archives. Existing hash, archive integrity, bootstrap, and admission contracts are unchanged.

## User Impact

Gateways no longer accumulate an unbounded local tarball for every historical worker build. Current, active, recovered, and terminal-diagnostic bundle hashes remain available while referenced. Cleanup failure only leaves extra cache bytes and logs a warning; it never blocks a successful bundle preparation.

## Evidence

- Pre-fix proof: the exclusive-cache cleanup regression failed because the bundle producer had no pruning owner.
- Focused bundle, retention-policy, bootstrap, lazy import-boundary, and worker-startup suites passed; terminal environments and reclaimed/failed placements are explicitly excluded while syncing through reconciling placements remain protected.
- Full changed gate passed, including formatting, dead exports, core and core-test type checks, lint, schema-version guard, import cycles, and architecture checks.
- `pnpm build` passed for the lazy bundle/package boundary.
- Fresh structured autoreview on the final rebased branch reported no accepted/actionable findings.
