### PR TITLE
perf(test): narrow plugin registration contract imports

### DIFF
--- a/src/plugin-sdk/plugin-test-contracts.ts
+++ b/src/plugin-sdk/plugin-test-contracts.ts
@@ -1,6 +1,12 @@
 /**
  * Test SDK subpath for plugin package, registration, and public surface contracts.
  */
+import { pluginRegistrationContractRegistry } from "../plugins/contracts/registry.js";
+import {
+  installPluginRegistrationContract,
+  type PluginRegistrationContractParams,
+} from "./test-helpers/plugin-registration-contract.js";
+
 export {
   assertNoImportTimeSideEffects,
   createPluginRegistryFixture,
@@ -12,7 +18,15 @@ export {
 export { runDirectImportSmoke } from "./test-helpers/direct-smoke.js";
 export { describePackageManifestContract } from "./test-helpers/package-manifest-contract.js";
 export { pluginRegistrationContractCases } from "./test-helpers/plugin-registration-contract-cases.js";
-export { describePluginRegistrationContract } from "./test-helpers/plugin-registration-contract.js";
+
+function resolvePluginRegistrationContract(pluginId: string) {
+  return pluginRegistrationContractRegistry.find((entry) => entry.pluginId === pluginId);
+}
+
+/** Installs tests against the runtime plugin registration contract registry. */
+export function describePluginRegistrationContract(params: PluginRegistrationContractParams) {
+  installPluginRegistrationContract(params, resolvePluginRegistrationContract);
+}
 export {
   GUARDED_EXTENSION_PUBLIC_SURFACE_BASENAMES,
   BUNDLED_RUNTIME_SIDECAR_BASENAMES,

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -1,9 +1,7 @@
 /**
  * Installs bundled plugin registration contract cases used across provider tests.
  */
-import { describePluginRegistrationContract } from "./plugin-registration-contract.js";
-
-type PluginRegistrationContractParams = Parameters<typeof describePluginRegistrationContract>[0];
+import type { PluginRegistrationContractParams } from "./plugin-registration-contract.js";
 
 export const pluginRegistrationContractCases = {
   alibaba: {

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract.ts
@@ -2,10 +2,9 @@
  * Contract suite for bundled plugin registration ownership and manifest auth metadata.
  */
 import { describe, expect, it } from "vitest";
-import { BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS } from "../../plugins/contracts/inventory/bundled-capability-metadata.js";
 import { loadPluginManifestRegistryCore } from "../../plugins/manifest-registry.js";
 
-type PluginRegistrationContractParams = {
+export type PluginRegistrationContractParams = {
   pluginId: string;
   cliBackendIds?: string[];
   providerIds?: string[];
@@ -30,18 +29,23 @@ type PluginRegistrationContractParams = {
   };
 };
 
-function findRegistration(pluginId: string) {
-  const entry = BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS.find(
-    (candidate) => candidate.pluginId === pluginId,
-  );
-  if (!entry) {
-    throw new Error(`plugin registration contract missing for ${pluginId}`);
-  }
-  return entry;
-}
+export type PluginRegistrationContractResolver = (
+  pluginId: string,
+) => Omit<PluginRegistrationContractParams, "manifestAuthChoice"> | undefined;
 
 /** Installs tests that pin a bundled plugin's registered provider/tool ownership. */
-export function describePluginRegistrationContract(params: PluginRegistrationContractParams) {
+export function installPluginRegistrationContract(
+  params: PluginRegistrationContractParams,
+  resolveRegistration: PluginRegistrationContractResolver,
+) {
+  const findRegistration = (pluginId: string) => {
+    const entry = resolveRegistration(pluginId);
+    if (!entry) {
+      throw new Error(`plugin registration contract missing for ${pluginId}`);
+    }
+    return entry;
+  };
+
   describe(`${params.pluginId} plugin registration contract`, () => {
     if (params.cliBackendIds) {
       it("keeps bundled cli-backend ownership explicit", () => {

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract.ts
@@ -2,7 +2,7 @@
  * Contract suite for bundled plugin registration ownership and manifest auth metadata.
  */
 import { describe, expect, it } from "vitest";
-import { pluginRegistrationContractRegistry } from "../../plugins/contracts/registry.js";
+import { BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS } from "../../plugins/contracts/inventory/bundled-capability-metadata.js";
 import { loadPluginManifestRegistryCore } from "../../plugins/manifest-registry.js";
 
 type PluginRegistrationContractParams = {
@@ -31,7 +31,7 @@ type PluginRegistrationContractParams = {
 };
 
 function findRegistration(pluginId: string) {
-  const entry = pluginRegistrationContractRegistry.find(
+  const entry = BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS.find(
     (candidate) => candidate.pluginId === pluginId,
   );
   if (!entry) {

--- a/src/plugins/contracts/plugin-registration.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.contract.test.ts
@@ -1,11 +1,18 @@
-// Plugin registration contract tests cover manifest registration cases exposed through the SDK.
 import { pluginRegistrationContractCases } from "../../plugin-sdk/test-helpers/plugin-registration-contract-cases.js";
-import { describePluginRegistrationContract } from "../../plugin-sdk/test-helpers/plugin-registration-contract.js";
+import {
+  installPluginRegistrationContract,
+  type PluginRegistrationContractResolver,
+} from "../../plugin-sdk/test-helpers/plugin-registration-contract.js";
+// Plugin registration contract tests cover manifest registration cases exposed through the SDK.
+import { BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS } from "./inventory/bundled-capability-metadata.js";
+
+const resolvePluginRegistrationContract: PluginRegistrationContractResolver = (pluginId) =>
+  BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS.find((entry) => entry.pluginId === pluginId);
 
 const pluginRegistrationContractCaseList = Object.values(pluginRegistrationContractCases).toSorted(
   (left, right) => left.pluginId.localeCompare(right.pluginId),
 );
 
 for (const contractCase of pluginRegistrationContractCaseList) {
-  describePluginRegistrationContract(contractCase);
+  installPluginRegistrationContract(contractCase, resolvePluginRegistrationContract);
 }

--- a/src/plugins/contracts/plugin-registration.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.contract.test.ts
@@ -1,6 +1,6 @@
 // Plugin registration contract tests cover manifest registration cases exposed through the SDK.
-import { pluginRegistrationContractCases } from "openclaw/plugin-sdk/plugin-test-contracts";
-import { describePluginRegistrationContract } from "openclaw/plugin-sdk/plugin-test-contracts";
+import { pluginRegistrationContractCases } from "../../plugin-sdk/test-helpers/plugin-registration-contract-cases.js";
+import { describePluginRegistrationContract } from "../../plugin-sdk/test-helpers/plugin-registration-contract.js";
 
 const pluginRegistrationContractCaseList = Object.values(pluginRegistrationContractCases).toSorted(
   (left, right) => left.pluginId.localeCompare(right.pluginId),

--- a/src/plugins/contracts/plugin-testing-harness.contract.test.ts
+++ b/src/plugins/contracts/plugin-testing-harness.contract.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   createPluginRegistryFixture,
+  describePluginRegistrationContract,
+  pluginRegistrationContractCases,
   registerVirtualTestPlugin,
 } from "openclaw/plugin-sdk/plugin-test-contracts";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
@@ -12,6 +14,8 @@ const echoCases = typedCases([
   { message: "alpha", expected: "scoped:alpha" },
   { message: "beta", expected: "scoped:beta" },
 ]);
+
+describePluginRegistrationContract(pluginRegistrationContractCases.brave);
 
 describe("plugin testing harness contracts", () => {
   it("executes declared tools and reports missing tool contracts", async () => {


### PR DESCRIPTION
## What Problem This Solves

The static plugin registration contract suite loaded the broad runtime registry and aggregate Plugin SDK test barrel even though its assertions only need the authoritative bundled contract data and focused test helpers. That incidental import graph made this focused contract suite substantially slower and more memory-intensive.

## Why This Change Was Made

The focused registration suite now installs its cases through a pure test-only resolver and keeps bundled inventory ownership in the core contract test. The documented one-argument `describePluginRegistrationContract` wrapper remains runtime-registry-backed in `plugin-test-contracts`, and the harness contract exercises that wrapper. The cases module has type-only coupling, while the independent registry/parity suite continues to prove runtime registry ownership and manifest coverage.

The first CI attempt correctly rejected a version that imported bundled inventory through the SDK helper. The final repair leaves the boundary invariant tests unchanged and moves the inventory resolver to the owning core contract test instead of weakening the boundary.

This is AI-assisted maintainer work. No production behavior, dependency, generated output, public runtime API, or release surface changes.

## User Impact

No user-visible or runtime behavior changes. The focused plugin registration contract suite starts faster and uses materially less memory, shortening test feedback and CI work while preserving the documented test wrapper contract.

Production LOC: +0/-0. Test and test-support LOC: +46/-19 across five files.

## Evidence

Final controlled warm measurement used the same Blacksmith Testbox (`tbx_01m01e9vgtbb7mtp6c5qhn3c7c`): https://github.com/openclaw/openclaw/actions/runs/31854755510

| Metric | Baseline | Final | Improvement |
| --- | ---: | ---: | ---: |
| Wall | 2.09s | 1.325s | 36.6% |
| Vitest | 1.595s | 0.697s | 56.3% |
| Import | 1.370s | 0.438s | 68.0% |
| CPU user | 2.380s | 1.490s | 37.4% |
| CPU system | 0.380s | 0.240s | 36.8% |
| Max RSS | 623.4 MiB | 370.2 MiB | 40.6% |

- Focused proof: 127/127 tests passed: 90 registration, 22 registry/parity, 13 boundary invariants, and 2 harness tests.
- The initial exact-head CI failure was the intended architecture guard catching the SDK-to-bundled-inventory import. The repaired head preserves those boundary tests unchanged.
- The remote changed gate passed on the repaired patch, including Plugin SDK/API surface, package and import boundaries, cycle checks, production/test types, lint, formatting, and repository guards.
- API preservation: `describePluginRegistrationContract(params)` remains runtime-registry-backed; the pure two-argument installer is test-only; contract cases import only its type; bundled inventory is confined to the owning `.contract.test.ts`; the harness covers the public wrapper.
- Resolved review concern: `registry.ts` under Vitest already returned snapshot clones, so routing the focused cases through the owning inventory resolver does not remove pre-existing runtime-registration coverage. Registry/parity and wrapper-harness coverage remain explicit.
- Fresh final Codex autoreview against the branch: clean, no accepted/actionable findings (overall confidence 0.96).
- Build omitted because the final diff changes only test and test-support ownership, with no production, package, public SDK runtime, generated, or lazy-loading surface.
