### PR TITLE
refactor(agents): trim compaction duplicate tests

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test-support.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test-support.ts
@@ -7,7 +7,6 @@ type CompactionSafeguardTestApi = {
   formatToolFailuresSection: CallableFunction;
   splitPreservedRecentTurns: CallableFunction;
   formatPreservedTurnsSection: CallableFunction;
-  formatSplitTurnContextSection: CallableFunction;
   buildCompactionStructureInstructions: CallableFunction;
   buildStructuredFallbackSummary: CallableFunction;
   prependPreviousSummaryForRedistill: CallableFunction;
@@ -33,7 +32,6 @@ type CompactionSafeguardTestApi = {
   SUMMARY_TRUNCATED_MARKER: string;
   CONTEXT_TRUNCATED_MARKER: string;
   MAX_SPLIT_TURN_CONTEXT_CHARS: number;
-  SPLIT_TURN_TRUNCATED_MARKER: string;
 };
 
 function getTestApi(): CompactionSafeguardTestApi {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -82,7 +82,6 @@ const {
   formatToolFailuresSection,
   splitPreservedRecentTurns,
   formatPreservedTurnsSection,
-  formatSplitTurnContextSection,
   buildCompactionStructureInstructions,
   buildStructuredFallbackSummary,
   prependPreviousSummaryForRedistill,
@@ -105,7 +104,6 @@ const {
   SUMMARY_TRUNCATED_MARKER,
   CONTEXT_TRUNCATED_MARKER,
   MAX_SPLIT_TURN_CONTEXT_CHARS,
-  SPLIT_TURN_TRUNCATED_MARKER,
 } = testing;
 
 function auditSummaryQuality(
@@ -498,43 +496,6 @@ describe("compaction-safeguard tool failures", () => {
 });
 
 describe("compaction-safeguard summary budgets", () => {
-  it.each([
-    { bodyLength: 60, suffixLength: 0, maxChars: 100, overflows: false },
-    { bodyLength: 60, suffixLength: 40, maxChars: 100, overflows: false },
-    { bodyLength: 80, suffixLength: 10, maxChars: 100, overflows: false },
-    { bodyLength: 80, suffixLength: 21, maxChars: 100, overflows: true },
-    { bodyLength: 20, suffixLength: 100, maxChars: 100, overflows: true },
-  ])(
-    "uses the slack-aware body allocation at body=$bodyLength suffix=$suffixLength cap=$maxChars",
-    ({ bodyLength, suffixLength, maxChars, overflows }) => {
-      const body = "b".repeat(bodyLength);
-      const suffix = "s".repeat(suffixLength);
-
-      const capped = capCompactionSummaryPreservingSuffix(body, suffix, maxChars);
-
-      expect(capped.length).toBeLessThanOrEqual(maxChars);
-      if (!overflows) {
-        expect(capped).toBe(`${body}${suffix}`);
-        return;
-      }
-      const bodyFloor = Math.min(bodyLength, Math.max(1, Math.ceil(maxChars / 2)));
-      const bodySlot = Math.min(
-        bodyLength,
-        Math.max(bodyFloor, maxChars - Math.min(suffixLength, maxChars)),
-      );
-      if (bodyLength > bodySlot && bodySlot >= SUMMARY_TRUNCATED_MARKER.length) {
-        expect(capped).toContain(SUMMARY_TRUNCATED_MARKER);
-      }
-      if (suffixLength > maxChars - Math.min(bodyLength, bodySlot)) {
-        expect(capped).toContain(
-          maxChars - Math.min(bodyLength, bodySlot) > CONTEXT_TRUNCATED_MARKER.length
-            ? CONTEXT_TRUNCATED_MARKER
-            : "s",
-        );
-      }
-    },
-  );
-
   it("caps file operations summary and reports omitted entries", () => {
     const readFiles = Array.from(
       { length: 200 },
@@ -654,40 +615,6 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped).toContain("## Tool Failures");
     expect(capped).toContain("<read-files>");
     expect(capped).toContain("## Session Startup");
-  });
-
-  it("keeps generated summary content when an oversized suffix exhausts the artifact budget", () => {
-    const body = "BODY-START\nBODY-MIDDLE\nBODY-END";
-    const oversizedSuffix = `${"old context\n".repeat(MAX_COMPACTION_SUMMARY_CHARS)}CRITICAL-TAIL`;
-
-    const capped = capCompactionSummaryPreservingSuffix(body, oversizedSuffix);
-
-    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
-    expect(capped).toContain("BODY-START");
-    expect(capped).toContain("BODY-MIDDLE");
-    expect(capped).toContain("BODY-END");
-    expect(capped).toContain("CRITICAL-TAIL");
-    expect(capped).toContain("truncated");
-  });
-
-  it("keeps an oversized preserved suffix UTF-16 safe at its leading edge", () => {
-    expect(capCompactionSummaryPreservingSuffix("body", "A🚀tail", 5)).toBe("bodil");
-  });
-
-  it("bounds raw split-turn context on whole-message boundaries and retains the newest end", () => {
-    const messages = Array.from({ length: 20 }, (_, index) => ({
-      role: "user" as const,
-      content: `message-${String(index).padStart(2, "0")}-${"x".repeat(700)}`,
-      timestamp: index,
-    }));
-
-    const section = formatSplitTurnContextSection(messages) as string;
-
-    expect(section.length).toBeLessThanOrEqual(MAX_SPLIT_TURN_CONTEXT_CHARS);
-    expect(section).toContain(SPLIT_TURN_TRUNCATED_MARKER.trim());
-    expect(section).not.toContain("message-00-");
-    expect(section).toContain("message-19-");
-    expect(section.split("\n").some((line) => line.startsWith("x"))).toBe(false);
   });
 });
 
@@ -3123,6 +3050,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const retainedSuffix = summary.split(CONTEXT_TRUNCATED_MARKER)[1] ?? "";
     const firstRetainedLine = retainedSuffix.split("\n").find((line) => line.length > 0);
     expect(firstRetainedLine).toMatch(/^- User: raw-prefix-\d{2}-/);
+    expect(summary).toContain("raw-prefix-19-");
     expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
     expect(summary).toContain("## Recent turns preserved verbatim");
   });

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -965,10 +965,6 @@ function buildSplitTurnContextSection(
   });
 }
 
-function formatSplitTurnContextSection(messages: AgentMessage[], onTruncated?: () => void): string {
-  return buildSplitTurnContextSection(messages, onTruncated).text;
-}
-
 function formatGeneratedSplitTurnSection(summary: string, onTruncated?: () => void): string {
   const heading = "**Turn Context (split turn):**\n\n";
   const summaryBudget = MAX_SPLIT_TURN_CONTEXT_CHARS - heading.length;
@@ -1512,7 +1508,6 @@ const testing = {
   formatToolFailuresSection,
   splitPreservedRecentTurns,
   formatPreservedTurnsSection,
-  formatSplitTurnContextSection,
   buildCompactionStructureInstructions,
   buildStructuredFallbackSummary,
   prependPreviousSummaryForRedistill,
@@ -1538,7 +1533,6 @@ const testing = {
   SUMMARY_TRUNCATED_MARKER,
   CONTEXT_TRUNCATED_MARKER,
   MAX_SPLIT_TURN_CONTEXT_CHARS,
-  SPLIT_TURN_TRUNCATED_MARKER,
 } as const;
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -1,15 +1,6 @@
-import path from "node:path";
 import type { AssistantMessage, Context, Model } from "openclaw/plugin-sdk/llm";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import {
-  appendTranscriptMessage,
-  upsertSessionEntryCore,
-} from "../../config/sessions/session-accessor.js";
-import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
-import { closeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
+import { describe, expect, it } from "vitest";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
-import { testing as compactionSafeguardTesting } from "../agent-hooks/compaction-safeguard.test-support.js";
 import {
   createAssistant,
   createAssistantResultStream,
@@ -29,7 +20,6 @@ import { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 
 registerAgentSessionLoopTestLifecycle();
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createStaleThinkingContent(): AssistantMessage["content"] {
   return [
@@ -42,70 +32,6 @@ function createStaleThinkingContent(): AssistantMessage["content"] {
 }
 
 describe("AgentSession compaction", () => {
-  it("persists and replays a body-preserving oversized-suffix artifact after reopen", async () => {
-    const dir = tempDirs.make("openclaw-body-preserving-compaction-");
-    const target = {
-      agentId: "main",
-      sessionId: "body-preserving-compaction",
-      sessionKey: "agent:main:body-preserving-compaction",
-      storePath: path.join(dir, "sessions.json"),
-    };
-    await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
-    await appendTranscriptMessage(target, {
-      cwd: dir,
-      message: { role: "user", content: "authoritative question", timestamp: 1 },
-    });
-    const sessionManager = SessionManager.open(target, dir);
-    const retainedAssistantId = sessionManager.appendMessage(
-      createAssistant(testModel, [{ type: "text", text: "authoritative answer" }]),
-    );
-    const body = "BODY-MARKER\n## Decisions\nKeep the generated summary.";
-    const suffix = `${"older split-turn context\n".repeat(2_000)}SELECTED-SUFFIX-CONTEXT`;
-    const finalized = compactionSafeguardTesting.capCompactionSummaryPreservingSuffix(
-      body,
-      suffix,
-    ) as string;
-    expect(finalized).toContain("BODY-MARKER");
-    expect(finalized).toContain("Earlier compaction context truncated");
-    expect(finalized).toContain("SELECTED-SUFFIX-CONTEXT");
-    const handlers = createCompactionHandlers();
-    handlers.set("session_before_compact", [
-      async (event: unknown) => ({
-        compaction: {
-          summary: finalized,
-          firstKeptEntryId: retainedAssistantId,
-          tokensBefore: (event as { preparation: { tokensBefore: number } }).preparation
-            .tokensBefore,
-        },
-      }),
-    ]);
-    const { session } = await createTestSession({
-      sessionManager,
-      resourceLoader: createResourceLoader(handlers),
-    });
-
-    const result = await session.compact();
-
-    expect(result.summary).toBe(finalized);
-    expect(sessionManager.getBranch().filter((entry) => entry.type === "compaction")).toHaveLength(
-      1,
-    );
-    expect(JSON.stringify(sessionManager.buildSessionContext())).toContain("BODY-MARKER");
-    sessionManager.flushPendingPersistence();
-    const databasePath = resolveSqliteTargetFromSessionStorePath(target.storePath).path;
-    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
-    const reopened = SessionManager.open(target, dir);
-    try {
-      expect(reopened.getBranch().findLast((entry) => entry.type === "compaction")).toMatchObject({
-        summary: finalized,
-      });
-      expect(JSON.stringify(reopened.buildSessionContext())).toContain("BODY-MARKER");
-      expect(JSON.stringify(reopened.buildSessionContext())).toContain("SELECTED-SUFFIX-CONTEXT");
-    } finally {
-      closeOpenClawAgentDatabaseByPath(databasePath);
-    }
-  });
-
   it.each(Array.from({ length: MAX_OVERFLOW_COMPACTION_ATTEMPTS }, (_, index) => index + 1))(
     "recovers when the provider accepts overflow compaction attempt %i",
     async (overflowCount) => {


### PR DESCRIPTION
## What Problem This Solves

The new compaction regression suite included a copied body-budget algorithm, a cross-owner persistence/reopen composition that injected an already-finalized string, a tiny-budget UTF-16 expectation that no longer crossed a surrogate boundary, and a direct split-turn wrapper test duplicated by the real provider finalizer. Those tests would churn under behavior-preserving refactors and kept a production test wrapper plus global test API fields alive.

## Why This Change Was Made

The duplicated/private-shape tests are removed. The one unique split-turn invariant—retaining the newest raw message—is added to the existing provider-boundary test that already proves final trimming starts at a complete message. The now-test-only string wrapper and its test API declarations are deleted. Strong owner regressions for provider and built-in bodies, exact marker fits, redacted loss warnings, atomic tool interactions, persistence, and replay remain.

## User Impact

No intended visible behavior change. Compaction still preserves generated summary bodies, bounds suffix context, reports loss, and keeps message/tool boundaries intact, with less implementation-coupled coverage and less production test surface.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/sessions/agent-session-compaction.test.ts src/agents/sessions/agent-session-loop-correctness.test.ts src/agents/sessions/session-manager.test.ts packages/agent-core/src/harness/session/session-context.test.ts packages/normalization-core/src/utf16-slice.test.ts` — 6 files, 225 tests passed across 3 Vitest projects.
- `node scripts/check-changed.mjs -- src/agents/agent-hooks/compaction-safeguard.ts src/agents/agent-hooks/compaction-safeguard.test-support.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/sessions/agent-session-compaction.test.ts` — core/coreTests changed gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Production/test API: +0/-6 (net -6). Tests/test support: +2/-150 (net -148). Total: net -154.
