### PR TITLE
fix: recognize xAI in empty-config startup validation

### DIFF
--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -79,6 +79,7 @@ const EXPECTED_EMPTY_CONFIG_GATEWAY_STARTUP_PLUGIN_IDS = [
   "opencode",
   "talk-voice",
   "teams-meetings",
+  "xai",
   "zoom-meetings",
 ] as const;
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the empty-config Gateway startup baseline omitted the enabled-by-default xAI plugin even though startup planning correctly includes it.

## Why This Change Was Made

Updates the existing startup-plan contract baseline to match the canonical manifest-driven resolver. No runtime behavior or plugin policy changes.

## User Impact

No runtime behavior changes. Release validation now accepts the intended xAI startup plan instead of reporting stale baseline drift.

## Evidence

- Before fix: `bundled plugin metadata > keeps empty-config Gateway startup narrower than declared startup sidecars` failed because the received list contained `xai` and the expected list did not.
- After fix: `node scripts/run-vitest.mjs src/plugins/bundled-plugin-metadata.test.ts` — 36 tests passed.
- `git diff --check` passed.
- `check:changed` passed all guards through plugin boundaries; the remote dead-export scan could not run because the leased workspace lacked dependencies, and the required install retry stopped on the current lockfile missing `@oxc-parser/binding-android-arm-eabi@0.128.0`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs src/plugins/bundled-plugin-metadata.test.ts" --stream-engine-output` — clean, no accepted/actionable findings.

Production LOC: +0/-0 | Tests: +1/-0
