### PR TITLE
improve(ui): offer persistent sidebar alert dismissal

### DIFF
--- a/ui/src/components/sidebar-attention-dismissals.ts
+++ b/ui/src/components/sidebar-attention-dismissals.ts
@@ -1,4 +1,4 @@
-// Per-gateway, per-browser snooze state for the sidebar attention chips.
+// Per-gateway, per-browser dismissal state for the sidebar attention chips.
 // Deliberately client-side chrome (like nav width / dock layout), not gateway
 // state: dismissing a nag on one device should not acknowledge it everywhere.
 import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
@@ -12,7 +12,7 @@ const SIDEBAR_ATTENTION_KINDS = [
 ] as const;
 export type SidebarAttentionKind = (typeof SIDEBAR_ATTENTION_KINDS)[number];
 
-export type SidebarAttentionDismissals = Partial<Record<SidebarAttentionKind, string>>;
+export type SidebarAttentionDismissals = Partial<Record<SidebarAttentionKind, string | true>>;
 
 // Minimal chip shape the snooze logic needs; keeps this module free of the
 // component's item type so the two files cannot form an import cycle.
@@ -37,7 +37,7 @@ export function loadDismissals(gatewayUrl: string): SidebarAttentionDismissals {
     const result: SidebarAttentionDismissals = {};
     for (const kind of SIDEBAR_ATTENTION_KINDS) {
       const value = (parsed as Record<string, unknown>)[kind];
-      if (typeof value === "string") {
+      if (typeof value === "string" || value === true) {
         result[kind] = value;
       }
     }
@@ -59,7 +59,7 @@ export function saveDismissals(gatewayUrl: string, dismissals: SidebarAttentionD
       storage.setItem(dismissalStoreKey(gatewayUrl), JSON.stringify(dismissals));
     }
   } catch {
-    // Quota/privacy-mode failures just lose the snooze; chips reappear.
+    // Quota/privacy-mode failures lose persistence; chips can reappear after reload.
   }
 }
 
@@ -78,6 +78,23 @@ export function addDismissal(
   return next;
 }
 
+export function addPermanentDismissal(
+  gatewayUrl: string,
+  kind: SidebarAttentionKind,
+): SidebarAttentionDismissals {
+  const next = { ...loadDismissals(gatewayUrl), [kind]: true };
+  saveDismissals(gatewayUrl, next);
+  return next;
+}
+
+export function isDismissed(
+  dismissals: SidebarAttentionDismissals,
+  item: DismissableChip,
+): boolean {
+  const dismissal = dismissals[item.kind];
+  return dismissal === true || dismissal === item.signature;
+}
+
 /**
  * Drop dismissals whose chip is gone or whose entity set changed, so a state
  * that clears and later recurs surfaces again instead of staying hidden by a
@@ -94,7 +111,7 @@ export function pruneDismissals(
     if (stored === undefined) {
       continue;
     }
-    if (items.some((item) => item.kind === kind && item.signature === stored)) {
+    if (stored === true || items.some((item) => item.kind === kind && item.signature === stored)) {
       next[kind] = stored;
     } else {
       changed = true;

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -18,7 +18,9 @@ import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { icons } from "./icons.ts";
 import {
   addDismissal,
+  addPermanentDismissal,
   dismissalStoreKey,
+  isDismissed,
   loadDismissals,
   pruneDismissals,
   saveDismissals,
@@ -29,6 +31,7 @@ import {
   type SidebarAttentionItem,
 } from "./sidebar-attention-items.ts";
 import "./tooltip.ts";
+import "./web-awesome.ts";
 
 // Reloads are connection-scoped; a visibility change only refetches after the
 // snapshot is older than this, so tab switches stay free of request bursts.
@@ -227,14 +230,14 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     ]);
   }
 
-  // Re-arm stale snoozes only right after this tab's own data refresh: fresh
+  // Re-arm stale incident snoozes only right after this tab's own data refresh: fresh
   // data is the only safe basis for deciding a chip is gone. Pruning from
   // render/update hooks would let a hidden tab with stale data clobber a
   // dismissal another tab just wrote (its storage event triggers an update
   // here). Against the persisted map, not the in-memory snapshot, for the
   // same lost-update reason as addDismissal. A failed fetch (empty cron list,
-  // null auth status) prunes those kinds, which fails safe — re-nag, never
-  // stay hidden.
+  // null auth status) prunes incident snoozes, which fails safe — re-nag,
+  // never stay hidden. Explicit permanent dismissals survive refreshes.
   private pruneAfterRefresh() {
     if (!this.dismissedScope) {
       return;
@@ -261,6 +264,13 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     this.dismissed = addDismissal(this.dismissedScope, item.kind, item.signature);
   }
 
+  private dismissPermanently(item: SidebarAttentionItem) {
+    if (!this.dismissedScope) {
+      return;
+    }
+    this.dismissed = addPermanentDismissal(this.dismissedScope, item.kind);
+  }
+
   private open(item: SidebarAttentionItem) {
     if (item.action.kind === "openApprovals") {
       this.onOpenApprovals?.();
@@ -279,7 +289,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
       modelAuthAgentId: this.modelAuthAgentId,
       approvalQueue: this.context.overlays.snapshot.approvalQueue,
       now: Date.now(),
-    }).filter((item) => this.dismissed[item.kind] !== item.signature);
+    }).filter((item) => !isDismissed(this.dismissed, item));
     if (items.length === 0) {
       return nothing;
     }
@@ -300,15 +310,37 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
                   <span class="sidebar-attention__label">${item.label}</span>
                 </button>
               </openclaw-tooltip>
-              <openclaw-tooltip .content=${t("common.dismiss")}>
-                <button
-                  type="button"
-                  class="sidebar-attention__dismiss"
-                  aria-label=${t("common.dismiss")}
-                  @click=${() => this.dismiss(item)}
+              <openclaw-tooltip .content=${t("attention.dismissOptions")}>
+                <wa-dropdown
+                  class="sidebar-attention__dismiss-menu"
+                  placement="top-end"
+                  size="s"
+                  aria-label=${t("attention.dismissOptions")}
+                  @wa-select=${(
+                    event: CustomEvent<{ item: { value?: "dismiss" | "dismiss-permanently" } }>,
+                  ) => {
+                    if (event.detail.item.value === "dismiss") {
+                      this.dismiss(item);
+                    } else if (event.detail.item.value === "dismiss-permanently") {
+                      this.dismissPermanently(item);
+                    }
+                  }}
                 >
-                  ${icons.x}
-                </button>
+                  <button
+                    slot="trigger"
+                    type="button"
+                    class="sidebar-attention__dismiss"
+                    aria-label=${t("attention.dismissOptions")}
+                  >
+                    ${icons.x}
+                  </button>
+                  <wa-dropdown-item class="session-menu__item" value="dismiss">
+                    ${t("common.dismiss")}
+                  </wa-dropdown-item>
+                  <wa-dropdown-item class="session-menu__item" value="dismiss-permanently">
+                    ${t("common.dismissAndDontShowAgain")}
+                  </wa-dropdown-item>
+                </wa-dropdown>
               </openclaw-tooltip>
             </div>
           `,

--- a/ui/src/e2e/sidebar-attention.e2e.test.ts
+++ b/ui/src/e2e/sidebar-attention.e2e.test.ts
@@ -1,0 +1,134 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI sidebar attention dismissal E2E",
+  trackBrowserContexts: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}.`,
+});
+
+const artifactDir = path.resolve(".artifacts/control-ui-e2e/sidebar-attention");
+const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+
+function failedCron(id: string) {
+  return {
+    id,
+    name: `Failed automation ${id}`,
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "test" },
+    state: { lastRunStatus: "error", lastError: `Failure ${id}` },
+  };
+}
+
+function cronListResponse(id: string) {
+  return {
+    jobs: [failedCron(id)],
+    snapshotRevision: `sidebar-attention-${id}`,
+    total: 1,
+    offset: 0,
+    limit: 50,
+    hasMore: false,
+    nextOffset: null,
+  };
+}
+
+suite.define(() => {
+  it("offers incident and permanent dismissal choices", async () => {
+    if (captureProof) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      recordVideo: captureProof
+        ? { dir: artifactDir, size: { width: 1_280, height: 900 } }
+        : undefined,
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": cronListResponse("first"),
+        "models.authStatus": { ts: 1, providers: [] },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const chip = page.locator(".sidebar-attention__item", {
+        hasText: "1 automation(s) failed",
+      });
+      await chip.waitFor({ state: "visible" });
+      if (captureProof) {
+        await page.screenshot({ path: path.join(artifactDir, "01-failed-alert.png") });
+      }
+
+      await chip.locator(".sidebar-attention__dismiss").click();
+      await expect.poll(() => chip.count()).toBe(1);
+      const menu = page.locator("wa-dropdown.sidebar-attention__dismiss-menu");
+      await expect.poll(() => menu.getAttribute("open")).not.toBeNull();
+      await expect
+        .poll(async () =>
+          (await menu.locator("wa-dropdown-item").allTextContents()).map((text) => text.trim()),
+        )
+        .toEqual(["Dismiss", "Dismiss and don't show again"]);
+      if (captureProof) {
+        await page.screenshot({ path: path.join(artifactDir, "02-dismiss-menu.png") });
+      }
+
+      await menu.locator('wa-dropdown-item[value="dismiss"]').click();
+      await expect.poll(() => chip.count()).toBe(0);
+
+      await gateway.setMethodResponse("cron.list", cronListResponse("second"));
+      await gateway.emitGatewayEvent("cron", {});
+      await chip.waitFor({ state: "visible" });
+      if (captureProof) {
+        await page.screenshot({ path: path.join(artifactDir, "03-new-incident.png") });
+      }
+
+      await chip.locator(".sidebar-attention__dismiss").click();
+      await menu.locator('wa-dropdown-item[value="dismiss-permanently"]').click();
+      await expect.poll(() => chip.count()).toBe(0);
+      expect(
+        await page.evaluate(() => {
+          const key = Object.keys(localStorage).find((candidate) =>
+            candidate.startsWith("openclaw.control.sidebarAttention.v1:"),
+          );
+          return key ? JSON.parse(localStorage.getItem(key) ?? "null").cronFailed : null;
+        }),
+      ).toBe(true);
+
+      await gateway.setMethodResponse("cron.list", cronListResponse("third"));
+      const requestCount = (await gateway.getRequests("cron.list")).length;
+      await gateway.emitGatewayEvent("cron", {});
+      await expect
+        .poll(async () => (await gateway.getRequests("cron.list")).length)
+        .toBeGreaterThan(requestCount);
+      await expect.poll(() => chip.count()).toBe(0);
+
+      await page.reload();
+      await gateway.waitForRequest("cron.list");
+      await page.waitForFunction(() => {
+        const element = document.querySelector("openclaw-sidebar-attention") as HTMLElement & {
+          cronJobs?: Array<{ id?: string }>;
+        };
+        return element?.cronJobs?.some((job) => job.id === "third") === true;
+      });
+      await expect.poll(() => chip.count()).toBe(0);
+      if (captureProof) {
+        await page.screenshot({ path: path.join(artifactDir, "04-hidden-after-reload.png") });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3753,6 +3753,7 @@ export const en: TranslationMap = {
     cronErrorUnknown: "Unknown error",
     cronFailed: "{count} automation(s) failed",
     cronOverdue: "{count} automation(s) overdue",
+    dismissOptions: "Dismiss options",
     modelAuthExpired: "Model auth expired: {providers}",
     pendingApproval: "{count} pending approval",
     pendingApprovals: "{count} pending approvals",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1082,7 +1082,6 @@ openclaw-settings-save-indicator {
 
 .sidebar-attention__dismiss {
   display: inline-flex;
-  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   padding: 6px 8px 6px 6px;
@@ -1091,6 +1090,20 @@ openclaw-settings-save-indicator {
   color: var(--muted);
   cursor: var(--cursor-action);
   opacity: 0.6;
+}
+
+wa-dropdown.sidebar-attention__dismiss-menu {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+wa-dropdown.sidebar-attention__dismiss-menu::part(menu) {
+  min-width: max-content;
+  padding: var(--menu-padding);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--menu-radius);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-md);
 }
 
 .sidebar-attention__dismiss:hover {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the sidebar attention dismiss control immediately hid an alert without letting users choose whether to silence only the current incident or stop seeing that alert kind in the current browser.

## Why This Change Was Made

The dismiss control now opens the Control UI's existing accessible dropdown pattern. **Dismiss** keeps the existing incident-signature behavior, while **Dismiss and don't show again** stores a per-Gateway, browser-local permanent dismissal in the existing localStorage-backed attention store.

## User Impact

Users can dismiss one occurrence of a sidebar attention alert or permanently hide that alert kind for the current Gateway in that browser. Permanent dismissals survive new incidents and page reloads.

## Evidence

- Chromium mock-Gateway E2E: menu opens with both choices; ordinary dismissal reappears for a new incident; permanent dismissal survives a new incident and reload.
- `sidebar-attention.test.ts`: 14 tests passed.
- Focused E2E: 1 test passed.
- Formatting, Stylelint, Control UI i18n verification, and latest-main UI typecheck passed.
- `pnpm check:changed` passed through its documented local fallback; configured remote Crabbox/Testbox providers were unavailable.
- Autoreview: clean, no accepted/actionable findings.

Production LOC: +81/-18 (net +63) for the menu and persistent dismissal capability. Tests: +134/-0.
