### PR TITLE
fix(ui): dismiss landed steer notices

### DIFF
--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -761,6 +761,96 @@ suite.define(() => {
     }
   });
 
+  it("dismisses an informational steer notice when the steer request lands", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
+      await page.locator("[data-settings-follow-up-mode]").selectOption("queue");
+      await page.goto(`${suite.server.baseUrl}chat?session=main`);
+
+      await page.locator(".agent-chat__composer-combobox textarea").fill("keep this run active");
+      await page.getByRole("button", { name: "Send message" }).click();
+      const activeRequest = await gateway.waitForRequest("chat.send");
+      const activeRunId = requireString(
+        requireRecord(activeRequest.params).idempotencyKey,
+        "active run idempotency key",
+      );
+      await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
+
+      const steerText = "route this into the active run";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(steerText);
+      await page.getByRole("button", { name: "Queue message" }).click();
+      const queue = page.locator(".chat-queue");
+      await queue.getByText(steerText).waitFor({ timeout: 10_000 });
+      await queue.getByRole("button", { name: "Steer" }).click();
+
+      const sends = await waitForRequests(gateway, "chat.send", 2);
+      const steerParams = requireRecord(sends[1]?.params);
+      expect(steerParams).toMatchObject({
+        expectedRunId: activeRunId,
+        message: steerText,
+        queueMode: "steer",
+      });
+      const steerRunId = requireString(steerParams.idempotencyKey, "steer idempotency key");
+      const row = queue.locator(".chat-queue__item--steered", { hasText: steerText });
+      await row.waitFor({ timeout: 10_000 });
+      const pendingPresentation = await row.evaluate((element) => {
+        const badge = element.querySelector<HTMLElement>(".chat-queue__badge--steered");
+        const icon = element.querySelector(".chat-queue__icon");
+        const probe = document.createElement("span");
+        probe.style.color = "var(--info)";
+        probe.style.background = "var(--info-subtle)";
+        document.body.append(probe);
+        const probeStyle = getComputedStyle(probe);
+        const infoColor = probeStyle.color;
+        const infoSubtle = probeStyle.backgroundColor;
+        probe.remove();
+        return {
+          badgeColor: badge ? getComputedStyle(badge).color : "",
+          backgroundColor: getComputedStyle(element).backgroundColor,
+          iconPoints: icon?.querySelector("polyline")?.getAttribute("points") ?? "",
+          infoColor,
+          infoSubtle,
+        };
+      });
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/steer-pending.png`, fullPage: true });
+      }
+
+      await gateway.emitGatewayEvent("chat", {
+        runId: steerRunId,
+        sessionKey: "main",
+        state: "final",
+      });
+      await page.waitForTimeout(250);
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/steer-landed.png`, fullPage: true });
+      }
+
+      expect(pendingPresentation).toMatchObject({
+        badgeColor: pendingPresentation.infoColor,
+        backgroundColor: pendingPresentation.infoSubtle,
+        iconPoints: "15 10 20 15 15 20",
+      });
+      expect(await row.count()).toBe(0);
+      await page.getByText(steerText, { exact: true }).waitFor({ timeout: 10_000 });
+      await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("steers a restored queued message when only the session row reports the active run", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -845,6 +845,19 @@ suite.define(() => {
       });
       expect(await row.count()).toBe(0);
       await page.getByText(steerText, { exact: true }).waitFor({ timeout: 10_000 });
+      await expect
+        .poll(() =>
+          page.locator(".chat-thread-inner").evaluate(
+            (thread, texts) => {
+              const bubbles = Array.from(thread.querySelectorAll(".chat-bubble"));
+              return texts.map((text) =>
+                bubbles.findIndex((bubble) => bubble.textContent?.includes(text)),
+              );
+            },
+            ["keep this run active", steerText],
+          ),
+        )
+        .toEqual([0, 1]);
       await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/pages/chat/chat-composer-queue.test.ts
+++ b/ui/src/pages/chat/chat-composer-queue.test.ts
@@ -37,6 +37,38 @@ describe("chat composer steering queue", () => {
     const badges = container.querySelectorAll(".chat-queue__badge");
     expect(badges).toHaveLength(1);
     expect(badges[0]?.textContent?.trim()).toBe(t("chat.queue.states.steering"));
+    const icon = container.querySelector(".chat-queue__icon");
+    expect(icon?.querySelector('polyline[points="15 10 20 15 15 20"]')).not.toBeNull();
+    expect(icon?.querySelector("circle")).toBeNull();
+  });
+
+  it("keeps a failed steer visually classified as an error", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderChatQueue({
+        queue: [
+          {
+            id: "failed-steer",
+            text: "change course",
+            createdAt: 1,
+            kind: "steered",
+            sendState: "failed",
+            sendError: "steer rejected",
+          },
+        ],
+        onQueueRemove: vi.fn(),
+      }),
+      container,
+    );
+
+    const row = container.querySelector(".chat-queue__item");
+    expect(row?.classList.contains("chat-queue__item--failed")).toBe(true);
+    expect(row?.classList.contains("chat-queue__item--steered")).toBe(false);
+    const icon = row?.querySelector(".chat-queue__icon");
+    expect(icon?.querySelector('path[d^="m21.73 18"]')).not.toBeNull();
+    expect(icon?.querySelector('polyline[points="15 10 20 15 15 20"]')).toBeNull();
+    expect(container.querySelector(".chat-queue__badge--steered")).toBeNull();
   });
 });
 

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -920,6 +920,80 @@ describe("handleChatGatewayEvent", () => {
     });
   });
 
+  it("retires a landed steer chip when its request run finishes inside the active run", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "active-run",
+      chatQueue: [
+        {
+          id: "landed-steer-chip",
+          text: "Use the deployment plan",
+          createdAt: 3,
+          kind: "steered",
+          pendingRunId: "active-run",
+          sendRunId: "steer-request-run",
+          sessionKey: "main",
+        },
+      ],
+    });
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "steer-request-run",
+        sessionKey: "main",
+        state: "final",
+      }),
+    ).toBe("final");
+
+    expect(state.chatQueue).toEqual([]);
+    expect(state.chatRunId).toBe("active-run");
+    expect(state.chatMessages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        __openclaw: { idempotencyKey: "steer-request-run:user" },
+      }),
+    ]);
+  });
+
+  it("keeps a pending steer chip when an unrelated request run finishes", () => {
+    const chip = {
+      id: "pending-steer-chip",
+      text: "Keep waiting for this steer",
+      createdAt: 3,
+      kind: "steered" as const,
+      pendingRunId: "active-run",
+      sendRunId: "steer-request-run",
+      sessionKey: "main",
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "active-run",
+      chatQueue: [
+        chip,
+        {
+          id: "unrelated-pending-row",
+          text: "Keep unrelated pending work",
+          createdAt: 4,
+          pendingRunId: "unrelated-run",
+          sessionKey: "main",
+        },
+      ],
+    });
+
+    handleChatGatewayEvent(state, {
+      runId: "unrelated-run",
+      sessionKey: "main",
+      state: "final",
+    });
+
+    expect(state.chatQueue).toEqual([
+      chip,
+      expect.objectContaining({ id: "unrelated-pending-row" }),
+    ]);
+    expect(state.chatRunId).toBe("active-run");
+    expect(state.chatMessages).toEqual([]);
+  });
+
   it("uses an already-persisted steer to recover the active stream boundary", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -921,10 +921,19 @@ describe("handleChatGatewayEvent", () => {
   });
 
   it("retires a landed steer chip when its request run finishes inside the active run", () => {
+    const activePrompt = {
+      id: "active-prompt",
+      text: "Keep this run active",
+      createdAt: 1,
+      sendRunId: "active-run",
+      sendState: "waiting-model" as const,
+      sessionKey: "main",
+    };
     const state = createState({
       sessionKey: "main",
       chatRunId: "active-run",
       chatQueue: [
+        activePrompt,
         {
           id: "landed-steer-chip",
           text: "Use the deployment plan",
@@ -945,9 +954,13 @@ describe("handleChatGatewayEvent", () => {
       }),
     ).toBe("final");
 
-    expect(state.chatQueue).toEqual([]);
+    expect(state.chatQueue).toEqual([activePrompt]);
     expect(state.chatRunId).toBe("active-run");
     expect(state.chatMessages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        __openclaw: { idempotencyKey: "active-run:user" },
+      }),
       expect.objectContaining({
         role: "user",
         __openclaw: { idempotencyKey: "steer-request-run:user" },

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -24,7 +24,10 @@ import {
 } from "./history-merge.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import { appendChatMessageToCache } from "./session-message-cache.ts";
-import { retireSteeredChipsForTerminalRun } from "./steer-lifecycle.ts";
+import {
+  retireSteeredChipsForRequestRun,
+  retireSteeredChipsForTerminalRun,
+} from "./steer-lifecycle.ts";
 import {
   appendTerminalAssistantMessage,
   clearToolStreamSegments,
@@ -494,22 +497,37 @@ function handleChatEvent(
 export function handleChatGatewayEvent(state: ChatState, payload?: ChatEventPayload) {
   const activeRunIdBeforeEvent = state.chatRunId;
   let terminalKeyedStreamStartIndex: number | undefined;
-  if (
+  const terminalEventMatchesChat =
     isTerminalChatState(payload?.state) &&
     payload !== undefined &&
     // Unkeyed events must also carry a real run id: with no active run,
     // `undefined === undefined` would let sessionless internal-run terminals
     // (e.g. companion answers) materialize into the open main thread.
     (chatEventSessionMatches(state, payload) ||
-      (typeof payload.runId === "string" && payload.runId === activeRunIdBeforeEvent)) &&
-    !isEventForDifferentActiveRun(payload, activeRunIdBeforeEvent)
+      (typeof payload.runId === "string" && payload.runId === activeRunIdBeforeEvent));
+  const terminalOwnsActiveRun =
+    terminalEventMatchesChat && !isEventForDifferentActiveRun(payload, activeRunIdBeforeEvent);
+  const localOnlySteerBoundary = terminalOwnsActiveRun
+    ? streamReconciliationStartIndex(state.chatMessages)
+    : undefined;
+  // An accepted steer terminal is keyed by the steer request while the chip
+  // also tracks the active target run. Reconcile either identity before the
+  // generic different-run path ignores the terminal and leaves stale status.
+  let firstPersistedSteerIndex = terminalOwnsActiveRun
+    ? retireSteeredChipsForTerminalRun(state, payload?.runId)
+    : undefined;
+  const requestRunSteerIndex = terminalEventMatchesChat
+    ? retireSteeredChipsForRequestRun(state, payload?.runId)
+    : undefined;
+  if (
+    requestRunSteerIndex !== undefined &&
+    (firstPersistedSteerIndex === undefined || requestRunSteerIndex < firstPersistedSteerIndex)
   ) {
+    firstPersistedSteerIndex = requestRunSteerIndex;
+  }
+  if (terminalOwnsActiveRun) {
     // The active stream belongs to the user boundary that preceded any steer
     // chip retired below. Preserve that boundary through terminal materialization.
-    const localOnlySteerBoundary = streamReconciliationStartIndex(state.chatMessages);
-    // A steered chip can be the only local copy while transcript persistence lags.
-    // Materialize it before the terminal assistant so user/assistant order stays stable.
-    const firstPersistedSteerIndex = retireSteeredChipsForTerminalRun(state, payload?.runId);
     terminalKeyedStreamStartIndex =
       firstPersistedSteerIndex === undefined
         ? localOnlySteerBoundary

--- a/ui/src/pages/chat/components/chat-composer-queue.ts
+++ b/ui/src/pages/chat/components/chat-composer-queue.ts
@@ -198,7 +198,7 @@ function renderChatQueueItem(
       ${reconnecting
         ? html`<span class="chat-queue__dot" aria-hidden="true"></span>`
         : html`<span class="chat-queue__icon" aria-hidden="true">
-            ${failed ? icons.alertTriangle : icons.clock}
+            ${failed ? icons.alertTriangle : steered ? icons.cornerDownRight : icons.clock}
           </span>`}
       ${renderChatAuthorAvatar(item.sender)}
       ${steered

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -251,6 +251,41 @@ export function retireSteeredChipsForTerminalRun(
   return firstPersistedSteerIndex;
 }
 
+export function retireSteeredChipsForRequestRun(
+  state: SteerLifecycleHost,
+  runId: string | undefined,
+): number | undefined {
+  if (!runId) {
+    return undefined;
+  }
+  const landed = state.chatQueue.filter(
+    (item) => isAckedSteeredChip(item) && item.sendRunId === runId,
+  );
+  let firstPersistedSteerIndex: number | undefined;
+  for (const item of landed) {
+    const persistedIndex = findQueuedSendMessageIndex(state.chatMessages, item, true);
+    if (
+      persistedIndex >= 0 &&
+      (firstPersistedSteerIndex === undefined || persistedIndex < firstPersistedSteerIndex)
+    ) {
+      firstPersistedSteerIndex = persistedIndex;
+    }
+    preserveQueuedUserTurn(state, item);
+  }
+  if (landed.length > 0) {
+    const landedIds = new Set(landed.map((item) => item.id));
+    writeChatQueueForScope(
+      state,
+      state.sessionKey,
+      state.chatQueue.filter((item) => !landedIds.has(item.id)),
+    );
+    for (const item of landed) {
+      releaseChatAttachmentPayloads(excludeComposerAttachments(state, item.attachments));
+    }
+  }
+  return firstPersistedSteerIndex;
+}
+
 export function retirePersistedSteeredChips(state: SteerLifecycleHost): void {
   const retired = state.chatQueue.filter(
     (item) =>

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -263,6 +263,15 @@ export function retireSteeredChipsForRequestRun(
   );
   let firstPersistedSteerIndex: number | undefined;
   for (const item of landed) {
+    // A started active turn can still exist only as an optimistic queue row.
+    // Promote that target before its landed steer so stable transcript history
+    // cannot render the newer steer ahead of the original prompt.
+    const target = state.chatQueue.find(
+      (candidate) => candidate.id !== item.id && candidate.sendRunId === item.pendingRunId,
+    );
+    if (target) {
+      preserveQueuedUserTurn(state, target);
+    }
     const persistedIndex = findQueuedSendMessageIndex(state.chatMessages, item, true);
     if (
       persistedIndex >= 0 &&

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2835,7 +2835,7 @@ td.data-table-key-col {
 }
 
 .chat-queue__item--steered {
-  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  background: var(--info-subtle);
 }
 
 /* The edited row keeps its slot so the operator can see where the corrected
@@ -2920,6 +2920,10 @@ td.data-table-key-col {
   color: var(--danger);
 }
 
+.chat-queue__item--steered .chat-queue__icon {
+  color: var(--info);
+}
+
 /* Reconnect rows mirror the connection pill's amber status dot so the queue
    reads as quiet auto-retry status, not a failure needing action. */
 .chat-queue__dot {
@@ -2951,8 +2955,8 @@ td.data-table-key-col {
 }
 
 .chat-queue__badge--steered {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--info) 16%, transparent);
+  color: var(--info);
 }
 
 .chat-queue__item--failed .chat-queue__badge {


### PR DESCRIPTION
Related: #123744

AI-assisted with Codex; the implementation and evidence were inspected by the maintainer agent.

## What Problem This Solves

Fixes an issue where users steering an active Control UI WebChat run would keep seeing an error-like red `Steering` notice with a clock icon after the steer request had already landed.

## Why This Change Was Made

The request-run terminal now retires only its matching acknowledged steer notice, materializes the original active prompt before its accepted steer when that prompt is still optimistic, and leaves the target run active. Pending steers use an informational blue treatment and directional route icon; failed steers remain red errors.

## User Impact

Steer status now communicates routing rather than failure and disappears automatically once the steer lands. The transcript remains chronological (`original prompt`, then `steer`), unrelated terminal events cannot clear pending work, and rejected steers still surface as errors.

## Evidence

- Base failure and initial presentation evidence: [original evidence comment](https://github.com/openclaw/openclaw/pull/123908#issuecomment-5299623777).
- Corrected landed-state screenshot: [chronological-order evidence](https://github.com/openclaw/openclaw/pull/123908#issuecomment-5299904928).
- Base `ad508a51c285`: red clock notice remains after the authoritative steer-request final.
- Head `77d1514aed9e`: blue directional notice while pending; on landing, the notice dismisses, the original prompt remains above the accepted steer, and the target run stays active.
- Adjacent unit proof: 524 tests passed.
- Browser proof: all 12 follow-up scenarios passed; exact post-rebase regression passed with visible order `[0, 1]`.
- Full repository preflight and TypeScript checks passed; changed-file format and lint checks passed.
- Exact-commit autoreview found no actionable issues.
