### PR TITLE
fix(cron): keep agent-less schedules running after adding an agent

### DIFF
--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -13,6 +13,7 @@ import {
   resolveSystemAgentTargetAgentId,
   tryResolveDefaultAgentId,
   tryResolveSoleAgentId,
+  tryResolveSystemAgentTargetAgentId,
 } from "./agent-scope-config.js";
 
 vi.unmock("./agent-scope-config.js");
@@ -65,6 +66,18 @@ describe("agent roster resolution", () => {
       }),
     ).toBe("ops");
     expect(resolveSystemAgentTargetAgentId({ agents: { entries: { ops: {} } } })).toBe("ops");
+    expect(
+      tryResolveSystemAgentTargetAgentId({
+        agents: {
+          defaults: { systemAgent: { agentId: "ops" } },
+          entries: { main: {}, ops: {} },
+        },
+      }),
+    ).toBe("ops");
+    expect(tryResolveSystemAgentTargetAgentId({ agents: { entries: { ops: {} } } })).toBe("ops");
+    expect(
+      tryResolveSystemAgentTargetAgentId({ agents: { entries: { main: {}, ops: {} } } }),
+    ).toBeUndefined();
     expect(() =>
       resolveSystemAgentTargetAgentId({
         agents: { entries: { main: { default: true }, ops: {} } },

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -220,16 +220,24 @@ export function tryResolveLegacyCompatibilityAgentId(cfg: OpenClawConfig): strin
 }
 
 /** Resolves the configured owner for ambient system work and explicit consults. */
+export function tryResolveSystemAgentTargetAgentId(
+  cfg: OpenClawConfig,
+  requestedAgentId?: string,
+): string | undefined {
+  const configuredAgentId =
+    normalizeOptionalString(requestedAgentId) ??
+    normalizeOptionalString(cfg.agents?.defaults?.systemAgent?.agentId);
+  return configuredAgentId ? normalizeAgentId(configuredAgentId) : tryResolveSoleAgentId(cfg);
+}
+
 export function resolveSystemAgentTargetAgentId(
   cfg: OpenClawConfig,
   requestedAgentId?: string,
   context?: AgentSelectionContext,
 ): string {
-  const configuredAgentId =
-    normalizeOptionalString(requestedAgentId) ??
-    normalizeOptionalString(cfg.agents?.defaults?.systemAgent?.agentId);
-  if (configuredAgentId) {
-    return normalizeAgentId(configuredAgentId);
+  const resolvedAgentId = tryResolveSystemAgentTargetAgentId(cfg, requestedAgentId);
+  if (resolvedAgentId) {
+    return resolvedAgentId;
   }
   return normalizeAgentId(
     resolveSoleAgentId(

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -50,6 +50,7 @@ export {
   resolveDefaultAgentId,
   resolveSoleAgentId,
   tryResolveLegacyCompatibilityAgentId,
+  tryResolveSystemAgentTargetAgentId,
   tryResolveSoleAgentId,
   tryResolveDefaultAgentId,
   AgentSelectionRequiredError,

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -481,7 +481,7 @@ export function registerCronAddCommand(cron: Command) {
               defaultRuntime.error(
                 theme.warn(
                   "No --agent specified; the job will run with the configured default agent. " +
-                    "Specify --agent to choose a specific agent.",
+                    "Specify --agent to choose a specific agent, or set agents.defaults.systemAgent.agentId.",
                 ),
               );
             }

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -171,9 +171,25 @@ export function applyAgentConfig(
       entries: toAgentEntriesRecord(nextList),
     },
   };
-  return list.length === 1 && nextList.length > 1
-    ? pinLegacyInheritedAuthOwnerForRosterTransition(cfg, nextConfig)
-    : nextConfig;
+  if (list.length !== 1 || nextList.length <= 1) {
+    return nextConfig;
+  }
+  const priorSystemAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
+  const transitionedConfig =
+    priorSystemAgentId &&
+    !normalizeOptionalString(nextConfig.agents?.defaults?.systemAgent?.agentId)
+      ? {
+          ...nextConfig,
+          agents: {
+            ...nextConfig.agents,
+            defaults: {
+              ...nextConfig.agents?.defaults,
+              systemAgent: { agentId: priorSystemAgentId },
+            },
+          },
+        }
+      : nextConfig;
+  return pinLegacyInheritedAuthOwnerForRosterTransition(cfg, transitionedConfig);
 }
 
 /** Remove an agent and any config references that route or allow traffic to it. */

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -113,6 +113,18 @@ describe("agents helpers", () => {
     expect(requireAgentSummary(buildAgentSummaries(next), "work").isDefault).toBe(true);
   });
 
+  it("preserves the sole agent as the ambient system owner when adding a second agent", () => {
+    const cfg: OpenClawConfig = { agents: { entries: { main: {} } } };
+
+    const next = applyAgentConfig(cfg, { agentId: "helper", name: "Helper" });
+
+    expect(next.agents).toMatchObject({
+      ownership: "explicit",
+      defaults: { systemAgent: { agentId: "main" } },
+      entries: { main: {}, helper: { name: "Helper" } },
+    });
+  });
+
   it("applyAgentConfig clears a model override", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/cron/agent-id.ts
+++ b/src/cron/agent-id.ts
@@ -1,9 +1,22 @@
+import {
+  tryResolveLegacyCompatibilityAgentId,
+  tryResolveSystemAgentTargetAgentId,
+} from "../agents/agent-scope-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 
 type CronAgentScope = {
-  agentId?: string;
-  sessionKey?: string;
+  agentId?: string | null;
+  sessionKey?: string | null;
 };
+
+export const CRON_AGENT_SELECTION_REQUIRED_MESSAGE =
+  "Agent-less cron job has no resolvable owner. Pass --agent <id> when creating or editing the job, or set agents.defaults.systemAgent.agentId.";
+
+/** Keeps shipped legacy defaults while routing modern ambient jobs through the system owner. */
+export function tryResolveCronDefaultAgentId(cfg: OpenClawConfig): string | undefined {
+  return tryResolveLegacyCompatibilityAgentId(cfg) ?? tryResolveSystemAgentTargetAgentId(cfg);
+}
 
 /** Resolves cron ownership: explicit non-blank id, scoped session key, then configured default. */
 export function resolveCronJobEffectiveAgentId(
@@ -15,7 +28,7 @@ export function resolveCronJobEffectiveAgentId(
     parseAgentSessionKey(job.sessionKey)?.agentId ||
     configuredDefaultAgentId?.trim();
   if (!agentId) {
-    throw new Error("Cron job has no agent id and no configured default was provided.");
+    throw new Error(CRON_AGENT_SELECTION_REQUIRED_MESSAGE);
   }
   return normalizeAgentId(agentId);
 }

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -24,7 +24,7 @@ import {
 } from "../../sessions/session-lifecycle-admission.js";
 import { resolveCronSkillsSnapshot } from "../../skills/runtime/cron-snapshot.js";
 import type { SkillSnapshot } from "../../skills/types.js";
-import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
+import { resolveCronJobEffectiveAgentId, tryResolveCronDefaultAgentId } from "../agent-id.js";
 import type { CronDeliveryPlan } from "../delivery-plan.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { resolveCronScheduledToolPolicy } from "../scheduled-tool-policy.js";
@@ -80,7 +80,6 @@ import {
   resolveAgentTimeoutMs,
   resolveAgentWorkspaceDir,
   resolveCronStyleNow,
-  tryResolveLegacyCompatibilityAgentId,
   resolveHookExternalContentSource,
   isThinkingLevelSupported,
   resolveSupportedThinkingLevel,
@@ -151,7 +150,7 @@ export async function prepareCronRunContext(params: {
     normalizedRequested ?? parseAgentSessionKey(input.job.sessionKey ?? input.sessionKey)?.agentId;
   const initialAgentId = resolveCronJobEffectiveAgentId(
     { agentId: requiredAgentId },
-    tryResolveLegacyCompatibilityAgentId(requestedRuntimeCfg),
+    tryResolveCronDefaultAgentId(requestedRuntimeCfg),
   );
   const modelOwner = await resolveCronModelSelectionOwner({
     cfg: requestedRuntimeCfg,

--- a/src/cron/isolated-agent/run.runtime.ts
+++ b/src/cron/isolated-agent/run.runtime.ts
@@ -3,7 +3,6 @@ export {
   resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  tryResolveLegacyCompatibilityAgentId,
 } from "../../agents/agent-scope-config.js";
 export { resolveCronStyleNow } from "../../agents/current-time.js";
 export { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -137,11 +137,6 @@ vi.mock("./run.runtime.js", async () => ({
   resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
   resolveAgentModelFallbacksOverride: resolveAgentModelFallbacksOverrideMock,
   resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock,
-  tryResolveLegacyCompatibilityAgentId: (
-    await vi.importActual<typeof import("../../agents/agent-scope-config.js")>(
-      "../../agents/agent-scope-config.js",
-    )
-  ).tryResolveLegacyCompatibilityAgentId,
   resolveCronStyleNow: resolveCronStyleNowMock,
   DEFAULT_CONTEXT_TOKENS: 128000,
   isCliProvider: isCliProviderMock,

--- a/src/cron/service/ops-shared.ts
+++ b/src/cron/service/ops-shared.ts
@@ -1,9 +1,8 @@
 /** Shared cron operation invariants used across lifecycle, CRUD, and manual runs. */
-import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { clearCronJobActive, markCronJobActive, type CronActiveJobMarker } from "../active-jobs.js";
+import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
 import { cronStreamScheduleKey } from "../stream-schedule.js";
 import type { CronJob } from "../types.js";
-import { normalizeOptionalAgentId } from "./normalize.js";
 import { recomputeUnownedCronSchedules } from "./run-recovery.js";
 import { applyCronRuntimeRowsToState } from "./runtime-store.js";
 import type { CronServiceState } from "./state.js";
@@ -19,14 +18,7 @@ export function resolveEffectiveJobAgentId(
   job: { agentId?: string | null; sessionKey?: string | null },
   defaultAgentId: string | undefined,
 ): string {
-  const agentId =
-    normalizeOptionalAgentId(job.agentId) ??
-    normalizeOptionalAgentId(parseAgentSessionKey(job.sessionKey)?.agentId) ??
-    normalizeOptionalAgentId(defaultAgentId);
-  if (!agentId) {
-    throw new Error("Cron job requires an agent id or prepared configured default.");
-  }
-  return agentId;
+  return resolveCronJobEffectiveAgentId(job, defaultAgentId);
 }
 
 export function markManualCronJobActive(

--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -50,7 +50,7 @@ describe("cron task run terminal records", () => {
       "agent:ops:cron:default-owner:run:1500",
     );
     expect(() => resolveMainSessionCronRunSessionKey(job, 1_500, undefined)).toThrow(
-      "Cron job has no agent id and no configured default was provided.",
+      "Pass --agent <id>",
     );
   });
 

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -4,11 +4,14 @@ import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
+import {
+  CRON_AGENT_SELECTION_REQUIRED_MESSAGE,
+  resolveCronJobEffectiveAgentId,
+} from "../agent-id.js";
 
 function requireCronAgentId(agentId: string | undefined): string {
   if (!agentId?.trim()) {
-    throw new Error("Cron task run requires an agent id or prepared configured default.");
+    throw new Error(CRON_AGENT_SELECTION_REQUIRED_MESSAGE);
   }
   return normalizeAgentId(agentId);
 }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -390,6 +390,52 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("fires scheduled ownerless jobs as the configured system agent", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-14T12:00:00.000Z"));
+    const cfg = createCronConfig("server-cron-system-agent-owner");
+    cfg.agents = { entries: { main: {} } };
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+
+    try {
+      await state.cron.start();
+      const job = await state.cron.add({
+        name: "scheduled system owner",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "run on schedule" },
+      });
+      expect(job.agentId).toBeUndefined();
+      loadConfigMock.mockReturnValue({
+        ...cfg,
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { main: {}, helper: {} },
+        },
+      } satisfies OpenClawConfig);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(state.cron.getJob(job.id)?.state).toMatchObject({
+        lastStatus: "ok",
+        consecutiveErrors: 0,
+        lastError: undefined,
+      });
+      expectIsolatedRunFields({ agentId: "main" });
+    } finally {
+      state.cron.stop();
+      vi.useRealTimers();
+    }
+  });
+
   it("pins ownerless jobs only when a retained legacy owner is present", async () => {
     const tmpDir = path.join(os.tmpdir(), `server-cron-retained-owner-${Date.now()}`);
     const cfg = retainLegacyDefaultAgentId(

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -10,7 +10,6 @@ import { getRuntimeConfig } from "../config/io.js";
 import {
   resolveSessionStoreCompatibilityAgentId,
   tryGetLegacyDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
 } from "../config/legacy.default-agent-owner.js";
 import {
   canonicalizeMainSessionAlias,
@@ -25,7 +24,7 @@ import {
 } from "../config/sessions/targets.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveCronJobEffectiveAgentId } from "../cron/agent-id.js";
+import { resolveCronJobEffectiveAgentId, tryResolveCronDefaultAgentId } from "../cron/agent-id.js";
 import {
   buildCronCommandSummary,
   redactCronCommandSummaryForExternalDelivery,
@@ -380,7 +379,7 @@ export function buildGatewayCronService(params: {
     const runtimeConfig = getRuntimeConfig();
     const normalized =
       typeof requested === "string" && requested.trim() ? normalizeAgentId(requested) : undefined;
-    const defaultAgentId = tryResolveLegacyCompatibilityAgentId(runtimeConfig);
+    const defaultAgentId = tryResolveCronDefaultAgentId(runtimeConfig);
     if (
       normalized !== undefined &&
       normalized !== defaultAgentId &&
@@ -507,7 +506,7 @@ export function buildGatewayCronService(params: {
     return sanitizeCronHeartbeatOverride(heartbeatOverride);
   };
 
-  const defaultAgentId = tryResolveLegacyCompatibilityAgentId(params.cfg);
+  const defaultAgentId = tryResolveCronDefaultAgentId(params.cfg);
   const legacyDefaultAgentId = tryGetLegacyDefaultAgentId(params.cfg);
   const resolveSessionStorePath = (agentId?: string) =>
     resolveSessionStorePathCore(params.cfg.session?.store, {
@@ -728,7 +727,7 @@ export function buildGatewayCronService(params: {
       : {}),
     ...(defaultAgentId ? { defaultAgentId } : {}),
     ...(legacyDefaultAgentId ? { legacyDefaultAgentId } : {}),
-    resolveDefaultAgentId: () => tryResolveLegacyCompatibilityAgentId(getRuntimeConfig()),
+    resolveDefaultAgentId: () => tryResolveCronDefaultAgentId(getRuntimeConfig()),
     resolveSessionStoreAgentIds: () => {
       const cfg = getRuntimeConfig();
       try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who created an agent-less scheduled cron job would see every firing fail after adding a second agent. This also affected bundled agent-less schedules such as Memory Dreaming Promotion, while a manual `cron run` misleadingly succeeded because it supplied caller scope.

## Why This Change Was Made

Scheduled agent-less work now follows the existing ambient system-agent owner: retained shipped defaults remain first for compatibility, then `agents.defaults.systemAgent.agentId`, then the sole-agent fallback. When `agents add` changes a sole roster into an explicit multi-agent roster, it preserves the former sole agent in that existing system-owner field. Cron rows remain agent-less and continue following the runtime owner across reloads and restarts; no owners are stamped onto jobs.

Genuinely ambiguous multi-agent rosters still fail closed, but the mutation is rejected before persistence with instructions to pass `--agent <id>` or configure `agents.defaults.systemAgent.agentId`.

## User Impact

Adding a normal second agent no longer silently breaks recurring agent-less schedules. Existing explicit owners and sole-agent behavior are unchanged, and operators get an actionable error instead of an internal-sounding recurring failure when no owner can be resolved.

## Evidence

- Before: macOS live reproduction on `054354e099c` recorded four consecutive scheduled errors: `Cron job has no agent id and no configured default was provided.` Manual execution was not used as proof.
- Regression: the timer-driven Gateway test creates an agent-less recurring job under a sole roster, changes the runtime to a two-agent explicit roster with the canonical system owner, advances the scheduler, and verifies an `ok` run under `main`. The test failed before the fix with `lastStatus: error` and `consecutiveErrors: 1`.
- Dynamic ownership contracts remain unchanged and green: `src/gateway/server-cron.test.ts` and `src/cron/service.every-jobs-fire.test.ts`.
- Focused validation: 66 Gateway cron tests, 31 cron owner/session tests, 155 cron CLI tests, 16 agent mutation tests, 15 agent-add tests, and 11 agent-scope tests passed.
- `node scripts/check-changed.mjs` passed after the hosted test-type worker stalled and the repository-approved trusted-source local fallback completed all formatting, dead-export, typecheck, lint, database-first, and import-cycle gates.
- Live after: fresh isolated Ollama profile on a derived non-default port; created an agent-less `--every 1m` job, added `helper`, and observed two timer-fired `ok` runs with `agent:main:cron:...` session keys. SQLite retained `agent_id=NULL`, `owner_agent_id=NULL`, and `owner_session_key=NULL`, with `consecutive_errors=0`.
- Ambiguity probe: after deliberately removing the system owner from a copied two-agent profile, `cron add` exited 1 before persistence and named both remedies. A follow-up list confirmed zero matching jobs.
- Structured autoreview reported no accepted/actionable findings.
- `pnpm build` completed the runtime/CLI bundles used for live proof; the later Control UI startup-size guard failed independently by 9 gzip bytes (`333073` vs `333064`).

AI-assisted; the implementation and evidence were reviewed and understood.
