### PR TITLE
fix(gateway): include build identity in status JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway status build identity:** preserve the Gateway's immutable build ID through connectivity probes and both deep and multi-target JSON status output.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway status build identity:** preserve the Gateway's immutable build ID through connectivity probes and both deep and multi-target JSON status output.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -23,14 +23,14 @@ const callGatewayStatusProbe = vi.fn<
     ok: boolean;
     url?: string;
     error?: string | null;
-    server?: { version?: string | null; connId?: string | null };
+    server?: { version?: string | null; buildId?: string | null; connId?: string | null };
     version?: string | null;
   }>
 >(async (_opts?: unknown) => ({
   ok: true,
   url: "ws://127.0.0.1:19001",
   error: null,
-  server: { version: "2026.5.6", connId: "conn-1" },
+  server: { version: "2026.5.6", buildId: "build-2026.5.6", connId: "conn-1" },
 }));
 const isDefaultInstallIdentity = vi.fn((_env?: NodeJS.ProcessEnv) => true);
 const isGatewayExternallySupervised = vi.fn((_env?: NodeJS.ProcessEnv) => false);
@@ -473,13 +473,37 @@ describe("gatherDaemonStatus", () => {
     expect(status.gateway?.version).toBe("2026.5.6");
     expect(status.rpc?.url).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.ok).toBe(true);
-    expect(status.rpc?.server).toEqual({ version: "2026.5.6", connId: "conn-1" });
+    expect(status.rpc?.server).toEqual({
+      version: "2026.5.6",
+      buildId: "build-2026.5.6",
+      connId: "conn-1",
+    });
     expect(status.cli?.version).toBe(VERSION);
     if (process.argv[1]) {
       expect(status.cli?.entrypoint).toBe(process.argv[1]);
     }
     expect(inspectGatewayRestart).not.toHaveBeenCalled();
     expect(inspectWindowsGatewayFirewall).not.toHaveBeenCalled();
+  });
+
+  it("preserves probe build identity in deep JSON output", async () => {
+    const status = await gatherStatus({ deep: true });
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+    try {
+      printDaemonStatus(status, { json: true, deep: true });
+      expect(writeJson).toHaveBeenCalledOnce();
+      expect(writeJson.mock.calls[0]?.[0]).toMatchObject({
+        rpc: {
+          server: {
+            version: "2026.5.6",
+            buildId: "build-2026.5.6",
+            connId: "conn-1",
+          },
+        },
+      });
+    } finally {
+      writeJson.mockRestore();
+    }
   });
 
   it("batches daemon and CLI port status inspection when ports differ", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -342,6 +342,7 @@ export type DaemonStatus = {
     };
     server?: {
       version?: string | null;
+      buildId?: string | null;
       connId?: string | null;
     };
     version?: string | null;

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -65,6 +65,7 @@ function createProbe(
     },
     server: {
       version: "2026.4.24",
+      buildId: "build-test",
       connId: "conn-test",
     },
     health: null,
@@ -448,6 +449,11 @@ describe("gateway status output", () => {
             role: "operator",
             scopes: ["operator.read"],
             capability: "read_only",
+          },
+          server: {
+            version: "2026.4.24",
+            buildId: "build-test",
+            connId: "conn-test",
           },
           self: null,
           config: null,

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -190,6 +190,7 @@ export function writeGatewayStatusJson(params: {
         close: entry.probe.close,
       },
       auth: entry.probe.auth,
+      server: entry.probe.server,
       self: entry.self,
       config: entry.configSummary,
       health: entry.probe.health,

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -16,6 +16,7 @@ const gatewayClientState = vi.hoisted(() => ({
   } as { role?: string; scopes?: string[] } | undefined,
   helloServer: {
     version: "2026.4.24",
+    buildId: "build-test",
     connId: "conn-test",
   },
   connectError: "scope upgrade pending approval (requestId: req-123)",
@@ -414,6 +415,7 @@ describe("probeGateway", () => {
     });
     expect(result.server).toEqual({
       version: "2026.4.24",
+      buildId: "build-test",
       connId: "conn-test",
     });
   });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -47,6 +47,7 @@ export type GatewayProbeAuthSummary = {
 
 export type GatewayProbeServerSummary = {
   version: string | null;
+  buildId?: string;
   connId: string | null;
 };
 
@@ -440,6 +441,9 @@ export async function probeGateway(opts: {
           authMetadataPresent = typeof hello?.auth === "object" && hello.auth !== null;
           server = {
             version: typeof hello?.server?.version === "string" ? hello.server.version : null,
+            ...(typeof hello?.server?.buildId === "string"
+              ? { buildId: hello.server.buildId }
+              : {}),
             connId: typeof hello?.server?.connId === "string" ? hello.server.connId : null,
           };
           auth = resolveProbeAuthSummary({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators consuming `openclaw gateway status --json` could not identify the exact running Gateway artifact after the Gateway began advertising `hello.server.buildId`.

The base connectivity probe projected only the server version and connection ID. The deep daemon status therefore had no build ID to serialize, and the multi-target JSON renderer separately omitted the complete server summary.

## Why This Change Was Made

The probe now preserves the existing optional hello build ID alongside version and connection ID. Both deep daemon JSON and multi-target gateway-status JSON expose that bounded server summary. This is an additive diagnostic projection of the already-shipped hello field; it does not change the Gateway protocol.

The sibling multi-target renderer is included because it consumes the same probe result and should not silently expose less server identity than the deep status path.

## User Impact

Operators and deployment managers can read the immutable Gateway build ID from status JSON instead of inferring artifact identity from a mutable version string.

Deployment order is deliberate: land this OpenClaw PR first, deploy its exact OpenClaw SHA with the currently installed old manager, verify production current exposes `rpc.server.buildId`, and only then land and install `steipete/manager#79`.

## Evidence

Pre-fix Blacksmith Testbox proof failed at both owner boundaries:

- `src/gateway/probe.test.ts`: expected `buildId: "build-test"`, received only version and connection ID.
- `src/commands/gateway-status/output.test.ts`: expected the target server summary, but JSON output omitted it.

Post-fix proof on Testbox `tbx_01m01h0nq32a00216g0fxv2xac` ([run](https://github.com/openclaw/openclaw/actions/runs/31856980713)):

- `pnpm test src/gateway/probe.test.ts src/cli/daemon-cli/probe.test.ts src/cli/daemon-cli/status.gather.test.ts src/commands/gateway-status/output.test.ts`: 104 passed, 1 skipped.
- `pnpm check:changed`: passed (`core`, `coreTests`, `docs`).
- Targeted `oxfmt --check`: passed.
- `git diff --check`: passed.
- Autoreview: clean, no accepted/actionable findings.

Production LOC: +7/-0. Tests: +34/-3. The positive production delta is the additive build-identity contract plus the multi-target JSON owner projection. Release-note context stays in this PR body for release automation.
