### PR TITLE
fix(gateway): allow worker bootstrap on slow uplinks

### DIFF
--- a/src/gateway/server.sessions.worker-original-order.test.ts
+++ b/src/gateway/server.sessions.worker-original-order.test.ts
@@ -50,6 +50,7 @@ const RECEIPT = {
 const INSTALLATION: WorkerInstallationArtifact = {
   install: "bundle",
   ...RECEIPT,
+  tarballBytes: 1,
   tarballSha256: "b".repeat(64),
   tarballPath: "/gateway/worker-bundle.tgz",
 };

--- a/src/gateway/worker-environments/bootstrap.test.ts
+++ b/src/gateway/worker-environments/bootstrap.test.ts
@@ -41,6 +41,7 @@ const BUNDLE: WorkerInstallationArtifact = {
   bundleHash: BUNDLE_HASH,
   openclawVersion: VERSION,
   protocolFeatures: ["admission-v1"],
+  tarballBytes: 1,
   tarballSha256: TARBALL_SHA256,
   tarballPath: "/gateway/cache/worker.tgz",
 };
@@ -201,6 +202,61 @@ describe("bootstrapWorker", () => {
     expect(runner.calls[2]?.argv.at(-1)).toContain(TARBALL_SHA256);
     expect(runner.calls[2]?.argv.at(-1)).toContain(VERSION);
   });
+
+  it.each([
+    { name: "keeps the floor for a small bundle", tarballBytes: 1, transferTimeoutMs: 600_000 },
+    {
+      name: "scales the transfer timeout for a large bundle",
+      tarballBytes: 243_000_000,
+      transferTimeoutMs: 1_944_000,
+    },
+    {
+      name: "caps the transfer timeout for an absurdly large bundle",
+      tarballBytes: Number.MAX_SAFE_INTEGER,
+      transferTimeoutMs: 3_600_000,
+    },
+  ])(
+    "$name while other phases keep the base timeout",
+    async ({ tarballBytes, transferTimeoutMs }) => {
+      const baseTimeoutMs = 600_000;
+      const runner = fakeRunner([
+        result({ stdout: tagged("install", REMOTE_TARBALL) }),
+        result(),
+        result({ stdout: tagged("receipt", RECEIPT_JSON) }),
+        result(),
+      ]);
+
+      await expect(
+        bootstrapWorker(
+          { ssh: SSH, artifact: { ...BUNDLE, tarballBytes } },
+          { resolveIdentity, runCommand: runner.runCommand, timeoutMs: baseTimeoutMs },
+        ),
+      ).resolves.toEqual(JSON.parse(RECEIPT_JSON));
+
+      const [preflight, transfer, install] = runner.calls;
+      expect(preflight?.options.timeoutMs).toBeLessThanOrEqual(baseTimeoutMs);
+      expect(preflight?.options.timeoutMs).toBeGreaterThanOrEqual(baseTimeoutMs - 100);
+      expect(transfer?.argv[0]).toBe("scp");
+      expect(transfer?.options.timeoutMs).toBeLessThanOrEqual(transferTimeoutMs);
+      expect(transfer?.options.timeoutMs).toBeGreaterThanOrEqual(transferTimeoutMs - 100);
+      expect(install?.options.timeoutMs).toBeLessThanOrEqual(baseTimeoutMs);
+      expect(install?.options.timeoutMs).toBeGreaterThanOrEqual(baseTimeoutMs - 100);
+    },
+  );
+
+  it.each([Number.NaN, -1, 1.5, Number.POSITIVE_INFINITY])(
+    "rejects invalid bundle tarball size %s before any remote work",
+    async (tarballBytes) => {
+      const runner = fakeRunner([]);
+      await expect(
+        bootstrapWorker(
+          { ssh: SSH, artifact: { ...BUNDLE, tarballBytes } },
+          { resolveIdentity, runCommand: runner.runCommand },
+        ),
+      ).rejects.toThrow("Worker bundle artifact has an invalid tarball size");
+      expect(runner.calls).toHaveLength(0);
+    },
+  );
 
   it.each([
     `/home/worker/other/.incoming/${UPLOAD_FILENAME}`,

--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -591,10 +591,8 @@ function normalizeHandshake(artifact: WorkerInstallationArtifact): WorkerAdmissi
     if (!NPM_INTEGRITY_PATTERN.test(artifact.packageIntegrity)) {
       throw new Error("Worker npm install requires a pinned SHA-512 package integrity");
     }
-  } else {
-    if (!BUNDLE_HASH_PATTERN.test(artifact.tarballSha256)) {
-      throw new Error("Worker bundle archive digest must be a lowercase SHA-256 digest");
-    }
+  } else if (!BUNDLE_HASH_PATTERN.test(artifact.tarballSha256)) {
+    throw new Error("Worker bundle archive digest must be a lowercase SHA-256 digest");
   }
   return { bundleHash, openclawVersion, protocolFeatures };
 }

--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -30,6 +30,7 @@ const BOOTSTRAP_RECEIPT = "bootstrap-receipt.json";
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 10 * 60_000;
 const BUNDLE_TRANSFER_MIN_THROUGHPUT_BYTES_PER_SECOND = 125_000;
 const BUNDLE_TRANSFER_TIMEOUT_MAX_MS = 60 * 60_000;
+const BOOTSTRAP_OPERATION_HEADROOM_MS = 5 * 60_000;
 const NODE_MISSING_EXIT_CODE = 42;
 const NPM_MISSING_EXIT_CODE = 43;
 const LOCK_TIMEOUT_EXIT_CODE = 44;
@@ -45,6 +46,9 @@ const NPM_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{86}==$/u;
 // Scale transfer time for congested uplinks (~243 MB at <4 Mbps exceeds 10 minutes).
 // The base timeout remains the floor; the cap keeps transfer bounded and fail-closed.
 function bundleTransferTimeoutMs(tarballBytes: number, floorMs: number): number {
+  if (!Number.isSafeInteger(tarballBytes) || tarballBytes < 0) {
+    throw new Error("Worker bundle artifact has an invalid tarball size");
+  }
   return Math.min(
     BUNDLE_TRANSFER_TIMEOUT_MAX_MS,
     Math.max(
@@ -52,6 +56,16 @@ function bundleTransferTimeoutMs(tarballBytes: number, floorMs: number): number 
       Math.ceil(tarballBytes / BUNDLE_TRANSFER_MIN_THROUGHPUT_BYTES_PER_SECOND) * 1000,
     ),
   );
+}
+
+/** Bounds the complete bootstrap lifecycle without preempting any permitted phase. */
+export function workerBootstrapOperationTimeoutMs(artifact: WorkerInstallationArtifact): number {
+  const nonTransferTimeoutMs = DEFAULT_BOOTSTRAP_TIMEOUT_MS * 3;
+  const transferTimeoutMs =
+    artifact.install === "bundle"
+      ? bundleTransferTimeoutMs(artifact.tarballBytes, DEFAULT_BOOTSTRAP_TIMEOUT_MS)
+      : 0;
+  return nonTransferTimeoutMs + transferTimeoutMs + BOOTSTRAP_OPERATION_HEADROOM_MS;
 }
 
 // Keep these boundaries aligned with package.json engines.node and infra/runtime-guard.ts.
@@ -581,9 +595,6 @@ function normalizeHandshake(artifact: WorkerInstallationArtifact): WorkerAdmissi
     if (!BUNDLE_HASH_PATTERN.test(artifact.tarballSha256)) {
       throw new Error("Worker bundle archive digest must be a lowercase SHA-256 digest");
     }
-    if (!Number.isSafeInteger(artifact.tarballBytes) || artifact.tarballBytes < 0) {
-      throw new Error("Worker bundle artifact has an invalid tarball size");
-    }
   }
   return { bundleHash, openclawVersion, protocolFeatures };
 }
@@ -773,10 +784,14 @@ export async function bootstrapWorker(
   dependencies: WorkerBootstrapDependencies,
 ): Promise<WorkerAdmissionHandshake> {
   const artifact = request.artifact;
+  const timeoutMs = dependencies.timeoutMs ?? DEFAULT_BOOTSTRAP_TIMEOUT_MS;
+  const transferTimeoutMs =
+    artifact.install === "bundle"
+      ? bundleTransferTimeoutMs(artifact.tarballBytes, timeoutMs)
+      : timeoutMs;
   const receipt = normalizeHandshake(artifact);
   const operationToken = createHash("sha256").update(request.operationId).digest("hex");
   const uploadFilename = workerUploadFilename(receipt.bundleHash, operationToken);
-  const timeoutMs = dependencies.timeoutMs ?? DEFAULT_BOOTSTRAP_TIMEOUT_MS;
   const runCommand = dependencies.runCommand ?? runCommandWithTimeout;
   const prepared = await prepareWorkerSsh({
     ssh: request.ssh,
@@ -815,7 +830,7 @@ export async function bootstrapWorker(
     if (artifact.install === "bundle") {
       const transfer = await runWorkerSshCandidates(
         prepared,
-        bundleTransferTimeoutMs(artifact.tarballBytes, timeoutMs),
+        transferTimeoutMs,
         (port, remainingTimeoutMs) =>
           runCommand(
             [

--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -28,6 +28,8 @@ import {
 const BOOTSTRAP_ROOT = ".openclaw-worker";
 const BOOTSTRAP_RECEIPT = "bootstrap-receipt.json";
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 10 * 60_000;
+const BUNDLE_TRANSFER_MIN_THROUGHPUT_BYTES_PER_SECOND = 125_000;
+const BUNDLE_TRANSFER_TIMEOUT_MAX_MS = 60 * 60_000;
 const NODE_MISSING_EXIT_CODE = 42;
 const NPM_MISSING_EXIT_CODE = 43;
 const LOCK_TIMEOUT_EXIT_CODE = 44;
@@ -39,6 +41,18 @@ const NPM_MISSING_MARKER = "OPENCLAW_WORKER_NPM_MISSING";
 const BOOTSTRAP_OUTPUT_TAG = "OPENCLAW_WORKER_BOOTSTRAP_V1";
 const BUNDLE_HASH_PATTERN = /^[a-f0-9]{64}$/u;
 const NPM_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+
+// Scale transfer time for congested uplinks (~243 MB at <4 Mbps exceeds 10 minutes).
+// The base timeout remains the floor; the cap keeps transfer bounded and fail-closed.
+function bundleTransferTimeoutMs(tarballBytes: number, floorMs: number): number {
+  return Math.min(
+    BUNDLE_TRANSFER_TIMEOUT_MAX_MS,
+    Math.max(
+      floorMs,
+      Math.ceil(tarballBytes / BUNDLE_TRANSFER_MIN_THROUGHPUT_BYTES_PER_SECOND) * 1000,
+    ),
+  );
+}
 
 // Keep these boundaries aligned with package.json engines.node and infra/runtime-guard.ts.
 const NODE_RUNTIME_CHECK_JS = String.raw`const parse = (value) => /^(\d+)\.(\d+)\.(\d+)$/.exec(value)?.slice(1).map(Number); const atLeast = (version, floor) => version[0] > floor[0] || (version[0] === floor[0] && (version[1] > floor[1] || (version[1] === floor[1] && version[2] >= floor[2])));
@@ -563,8 +577,13 @@ function normalizeHandshake(artifact: WorkerInstallationArtifact): WorkerAdmissi
     if (!NPM_INTEGRITY_PATTERN.test(artifact.packageIntegrity)) {
       throw new Error("Worker npm install requires a pinned SHA-512 package integrity");
     }
-  } else if (!BUNDLE_HASH_PATTERN.test(artifact.tarballSha256)) {
-    throw new Error("Worker bundle archive digest must be a lowercase SHA-256 digest");
+  } else {
+    if (!BUNDLE_HASH_PATTERN.test(artifact.tarballSha256)) {
+      throw new Error("Worker bundle archive digest must be a lowercase SHA-256 digest");
+    }
+    if (!Number.isSafeInteger(artifact.tarballBytes) || artifact.tarballBytes < 0) {
+      throw new Error("Worker bundle artifact has an invalid tarball size");
+    }
   }
   return { bundleHash, openclawVersion, protocolFeatures };
 }
@@ -796,7 +815,7 @@ export async function bootstrapWorker(
     if (artifact.install === "bundle") {
       const transfer = await runWorkerSshCandidates(
         prepared,
-        timeoutMs,
+        bundleTransferTimeoutMs(artifact.tarballBytes, timeoutMs),
         (port, remainingTimeoutMs) =>
           runCommand(
             [

--- a/src/gateway/worker-environments/bundle.test.ts
+++ b/src/gateway/worker-environments/bundle.test.ts
@@ -53,6 +53,7 @@ function bundleArtifact(overrides: Partial<WorkerBundleArtifact> = {}): WorkerBu
     bundleHash: "a".repeat(64),
     openclawVersion: "1.2.3",
     protocolFeatures: [],
+    tarballBytes: 1,
     tarballSha256: "b".repeat(64),
     tarballPath: "/tmp/openclaw-worker.tgz",
     ...overrides,
@@ -93,6 +94,9 @@ describe("worker bundle producer", () => {
 
       expect(first.bundleHash).toMatch(/^[a-f0-9]{64}$/u);
       expect(second.bundleHash).toBe(first.bundleHash);
+      await expect(fs.stat(first.tarballPath)).resolves.toMatchObject({
+        size: first.tarballBytes,
+      });
       expect(nodeBuild).toEqual({
         bundleHash: first.bundleHash,
         openclawVersion: first.openclawVersion,

--- a/src/gateway/worker-environments/bundle.ts
+++ b/src/gateway/worker-environments/bundle.ts
@@ -34,6 +34,7 @@ type WorkerInstallationArtifactBase = {
 
 type WorkerBundleArtifact = WorkerInstallationArtifactBase & {
   install: "bundle";
+  tarballBytes: number;
   tarballSha256: string;
   tarballPath: string;
 };
@@ -511,6 +512,7 @@ async function prepareWorkerBundle(
       bundleHash,
       openclawVersion,
       protocolFeatures,
+      tarballBytes: (await fs.stat(tarballPath)).size,
       tarballSha256: await hashWorkerBundleTarball(tarballPath),
       tarballPath,
     };

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -55,7 +55,10 @@ type WorkerProviderLifecycleOptions = {
   providerCallTimeoutMs?: number;
   tunnelManager?: Pick<WorkerTunnelManager, "stop">;
   credentialBroker: WorkerCredentialBroker;
-  callBootstrap: <T>(run: (signal: AbortSignal) => Promise<T>) => Promise<T>;
+  callBootstrap: <T>(
+    installation: WorkerInstallationArtifact,
+    run: (signal: AbortSignal) => Promise<T>,
+  ) => Promise<T>;
   callProvider: <T>(environmentId: string, run: () => Promise<T>, timeoutMs?: number) => Promise<T>;
   inState: (record: WorkerEnvironmentRecord, ...states: WorkerEnvironmentState[]) => boolean;
   isServiceError: (error: unknown, code: string) => boolean;
@@ -217,7 +220,7 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     const sshEndpoint = record.sshEndpoint;
     let receipt: WorkerAdmissionHandshake;
     try {
-      receipt = await callBootstrap((signal) =>
+      receipt = await callBootstrap(installation, (signal) =>
         options.bootstrapWorker({
           operationId: record.provisionOperationId,
           sshEndpoint,

--- a/src/gateway/worker-environments/provider-provisioning.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.test.ts
@@ -530,6 +530,42 @@ describe("worker environment service", () => {
     expect(support.testState.store.list()[0]).toMatchObject({ state: "failed", leaseId: null });
   });
 
+  it("allows a large bundle bootstrap to outlive the former service deadline", async () => {
+    vi.useFakeTimers();
+    support.testState.prepareInstallation = vi.fn(async () => ({
+      ...support.BUNDLE_ARTIFACT,
+      tarballBytes: 243_000_000,
+    }));
+    let finishBootstrap: (() => void) | undefined;
+    const bootstrapPending = new Promise<void>((resolve) => {
+      finishBootstrap = resolve;
+    });
+    let bootstrapSignal: AbortSignal | undefined;
+    support.testState.bootstrapWorker = vi.fn(async ({ signal }) => {
+      bootstrapSignal = signal;
+      await bootstrapPending;
+      return support.BOOTSTRAP_RECEIPT;
+    });
+    const workerService = support.createService(support.createProvider());
+
+    const creation = workerService.create("development", "request-large-bundle-bootstrap");
+    await support.waitForFast(() =>
+      expect(support.testState.bootstrapWorker).toHaveBeenCalledOnce(),
+    );
+    let creationError: unknown;
+    try {
+      await vi.advanceTimersByTimeAsync(35 * 60_000 + 1);
+      expect(bootstrapSignal?.aborted).toBe(false);
+    } finally {
+      finishBootstrap?.();
+      await creation.catch((error: unknown) => {
+        creationError = error;
+      });
+    }
+    expect(creationError).toBeUndefined();
+    expect(support.testState.store.list()[0]).toMatchObject({ state: "ready" });
+  });
+
   it("adopts one committed provision across a service and store restart", async () => {
     const physicalLeases = new Set<string>();
     const operationIds: string[] = [];

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -57,6 +57,7 @@ export const BUNDLE_ARTIFACT: WorkerInstallationArtifact = {
   bundleHash: BUNDLE_HASH,
   openclawVersion: "2026.7.2",
   protocolFeatures: [],
+  tarballBytes: 1,
   tarballSha256: "b".repeat(64),
   tarballPath: "/gateway/cache/worker-bundle.tgz",
 };

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -20,6 +20,7 @@ import type {
 } from "../../plugins/types.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import type { WorkerConnectionIdentity } from "./admission.js";
+import { workerBootstrapOperationTimeoutMs } from "./bootstrap.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
 import { createWorkerCredentialBroker } from "./credential-broker.js";
 import { createWorkerEnvironmentAccess } from "./environment-access.js";
@@ -198,13 +199,16 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     );
   };
 
-  const callBootstrap = async <T>(run: (signal: AbortSignal) => Promise<T>): Promise<T> => {
+  const callBootstrap = async <T>(
+    installation: WorkerInstallationArtifact,
+    run: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> => {
     const controller = new AbortController();
     const operation = Promise.resolve().then(() => run(controller.signal));
     try {
       return await withTimeout(
         operation,
-        options.bootstrapCallTimeoutMs ?? 35 * 60_000,
+        options.bootstrapCallTimeoutMs ?? workerBootstrapOperationTimeoutMs(installation),
         "Worker bootstrap operation",
       );
     } catch (error) {

--- a/src/worker/worker-fault-injection.test-support.ts
+++ b/src/worker/worker-fault-injection.test-support.ts
@@ -63,6 +63,7 @@ const BUNDLE_ARTIFACT = {
   bundleHash: BUNDLE_HASH,
   openclawVersion: HANDSHAKE.openclawVersion,
   protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+  tarballBytes: 1,
   tarballSha256: Array.from({ length: 64 }, () => "b").join(""),
   tarballPath: "/gateway/cache/worker-bundle.tgz",
 };


### PR DESCRIPTION
Related: #123743

AI-assisted: yes

## What Problem This Solves

Fixes an issue where cloud-worker bootstrap could fail during bundle upload on congested uplinks because every bootstrap phase shared one fixed 10-minute timeout. The approximately 243 MB worker bundle cannot finish within that deadline below roughly 4 Mbps effective throughput; three consecutive transfer-timeout failures were observed on 2026-08-13, while the same upload completed in seconds on a 400 Mbps link.

## Why This Change Was Made

The bundle producer records the exact tarball byte size, and bootstrap derives one coordinated set of bounded deadlines from that artifact. The transfer phase keeps the existing 10-minute floor, assumes a worst-tolerable 125,000 B/s uplink (about 1 Mbit/s), and caps at 60 minutes. The service-wide lifecycle deadline covers bounded preflight, transfer, install, and cleanup phases plus the existing five-minute headroom, so its outer abort cannot preempt an allowed upload. Receipt/hash verification, fail-closed behavior, and abort plumbing remain unchanged; invalid size metadata is rejected before remote work, and no new configuration surface is introduced.

## User Impact

Operators can bootstrap cloud workers over slow or temporarily congested uplinks without either the upload command or the enclosing service lifecycle cutting off a valid transfer. Fast transfers and all non-transfer phase limits retain their existing behavior.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/worker-environments/bootstrap.test.ts src/gateway/worker-environments/bundle.test.ts src/gateway/worker-environments/provider-provisioning.test.ts` — 93 passed.
- The original transfer regression failed before the first fix. The production service-path regression also failed on the prior PR head because the outer controller aborted at 35 minutes, then passed after coordinating the lifecycle budget.
- Boundary coverage exercises the 10-minute floor, size-based scaling, 60-minute transfer cap, invalid metadata, and timeout passed to every phase command. The service-path regression proves the outer cancellation no longer preempts a 243 MB bundle bootstrap after the former 35-minute limit. The bundle producer test verifies the recorded size matches the tarball on disk.
- Fresh autoreview after the lifecycle repair and final lint correction with Codex (`gpt-5.6-sol`, high reasoning): clean, no accepted/actionable findings.
- Exact-head CI: [run 31858265071](https://github.com/openclaw/openclaw/actions/runs/31858265071) on `b2709f697d4672131efda97b2116b313294958a1` — green. The prior head's related `check-lint-core-2` failure was fixed and is green in this run.
- ClawSweeper P1 handled: the service-wide bootstrap deadline now consumes the prepared artifact and shares the transfer policy; production-path regression coverage was added. The two corresponding Rank-up moves are complete.
- Production LOC: +47/-6 across `bootstrap.ts`, `bundle.ts`, `provider-lifecycle.ts`, and `service.ts` (net +41); remaining +99 lines are tests and test fixtures.
