### PR TITLE
fix(workboard): prevent board summaries from stalling Gateway tools

### DIFF
--- a/extensions/workboard/src/persistence-types.ts
+++ b/extensions/workboard/src/persistence-types.ts
@@ -33,3 +33,19 @@ export type WorkboardKeyedStore<T = PersistedWorkboardCard> = {
   delete(key: string): Promise<boolean>;
   entries(): Promise<Array<{ key: string; value: T }>>;
 };
+
+export type WorkboardBoardCardAggregate = {
+  boardId: string;
+  status: WorkboardCard["status"];
+  total: number;
+  archived: number;
+  updatedAt: number;
+};
+
+export type WorkboardCardStore = WorkboardKeyedStore & {
+  listBoardAggregates(): Promise<WorkboardBoardCardAggregate[]>;
+};
+
+export function isWorkboardCardStore(store: WorkboardKeyedStore): store is WorkboardCardStore {
+  return "listBoardAggregates" in store && typeof store.listBoardAggregates === "function";
+}

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -27,6 +27,7 @@ import type {
   PersistedWorkboardBoard,
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
+  WorkboardCardStore,
   WorkboardKeyedStore,
 } from "./persistence-types.js";
 const WORKBOARD_DB_RELATIVE_PATH = ["plugins", "workboard", "workboard.sqlite"] as const;
@@ -36,7 +37,7 @@ const WORKBOARD_SQLITE_DIR_MODE = 0o700;
 const WORKBOARD_SQLITE_FILE_MODE = 0o600;
 type Row = Record<string, unknown>;
 type WorkboardSqliteStores = {
-  cards: WorkboardKeyedStore;
+  cards: WorkboardCardStore;
   boards: WorkboardKeyedStore<PersistedWorkboardBoard>;
   subscriptions: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
   attachments: WorkboardKeyedStore<PersistedWorkboardAttachment>;
@@ -1195,7 +1196,7 @@ function insertCard(db: DatabaseSync, card: WorkboardCard): void {
   }
 }
 
-class WorkboardSqliteCardStore implements WorkboardKeyedStore {
+class WorkboardSqliteCardStore implements WorkboardCardStore {
   constructor(private readonly db: DatabaseSync) {}
 
   async register(key: string, value: PersistedWorkboardCard): Promise<void> {
@@ -1239,6 +1240,31 @@ class WorkboardSqliteCardStore implements WorkboardKeyedStore {
     return rows.map((row) => ({
       key: requiredString(row, "id"),
       value: { version: 1, card: readCard(this.db, row, preloaded) },
+    }));
+  }
+
+  async listBoardAggregates() {
+    const rows = this.db
+      .prepare(
+        `
+          SELECT
+            board_id,
+            status,
+            COUNT(*) AS total,
+            SUM(CASE WHEN archived_at IS NOT NULL AND archived_at <> 0 THEN 1 ELSE 0 END) AS archived,
+            MAX(updated_at) AS updated_at
+          FROM workboard_cards
+          GROUP BY board_id, status
+          ORDER BY board_id ASC, status ASC
+        `,
+      )
+      .all() as Row[];
+    return rows.map((row) => ({
+      boardId: requiredString(row, "board_id"),
+      status: requiredString(row, "status") as WorkboardCard["status"],
+      total: requiredNumber(row, "total"),
+      archived: requiredNumber(row, "archived"),
+      updatedAt: requiredNumber(row, "updated_at"),
     }));
   }
 }

--- a/extensions/workboard/src/store-change-tracker.ts
+++ b/extensions/workboard/src/store-change-tracker.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WorkboardChange } from "@openclaw/workboard-contract";
-import type { WorkboardKeyedStore } from "./persistence-types.js";
+import type { WorkboardCardStore, WorkboardKeyedStore } from "./persistence-types.js";
 
 export class WorkboardChangeTracker {
   private readonly epoch = randomUUID();
@@ -28,6 +28,13 @@ export class WorkboardChangeTracker {
         return deleted;
       },
       entries: async () => await store.entries(),
+    };
+  }
+
+  trackCardStore(store: WorkboardCardStore): WorkboardCardStore {
+    return {
+      ...this.track(store),
+      listBoardAggregates: async () => await store.listBoardAggregates(),
     };
   }
 

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -8,11 +8,14 @@ import type {
   WorkboardStatus,
 } from "@openclaw/workboard-contract";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isWorkboardCardStore } from "./persistence-types.js";
 import type {
   PersistedWorkboardAttachment,
   PersistedWorkboardBoard,
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
+  WorkboardBoardCardAggregate,
+  WorkboardCardStore,
   WorkboardKeyedStore,
 } from "./persistence-types.js";
 import { normalizeAutomationPatch, normalizeCardAutomation } from "./store-automation.js";
@@ -71,6 +74,7 @@ export class WorkboardCoreStore {
   private mutationQueue: Promise<unknown> = Promise.resolve();
   private lastNotificationSequence = 0;
   private readonly changes: WorkboardChangeTracker;
+  private readonly cardStore?: WorkboardCardStore;
   protected readonly store: WorkboardKeyedStore;
   protected readonly boardStore: WorkboardKeyedStore<PersistedWorkboardBoard>;
   protected readonly subscriptionStore: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
@@ -86,7 +90,12 @@ export class WorkboardCoreStore {
     } = {},
   ) {
     this.changes = new WorkboardChangeTracker(stores.dataVersion);
-    this.store = this.changes.track(store);
+    if (isWorkboardCardStore(store)) {
+      this.cardStore = this.changes.trackCardStore(store);
+      this.store = this.cardStore;
+    } else {
+      this.store = this.changes.track(store);
+    }
     this.boardStore = this.changes.track(
       stores.boards ?? (store as unknown as WorkboardKeyedStore<PersistedWorkboardBoard>),
     );
@@ -196,8 +205,17 @@ export class WorkboardCoreStore {
         byStatus: {},
       });
     }
-    for (const card of await this.list()) {
-      const boardId = cardBoardId(card);
+    const cardAggregates: WorkboardBoardCardAggregate[] = this.cardStore
+      ? await this.cardStore.listBoardAggregates()
+      : (await this.list()).map((card) => ({
+          boardId: cardBoardId(card),
+          status: card.status,
+          total: 1,
+          archived: card.metadata?.archivedAt ? 1 : 0,
+          updatedAt: card.updatedAt,
+        }));
+    for (const aggregate of cardAggregates) {
+      const boardId = aggregate.boardId;
       const summary =
         boards.get(boardId) ??
         ({
@@ -207,14 +225,12 @@ export class WorkboardCoreStore {
           archived: 0,
           byStatus: {},
         } satisfies WorkboardBoardSummary);
-      summary.total += 1;
-      if (card.metadata?.archivedAt) {
-        summary.archived += 1;
-      } else {
-        summary.active += 1;
-      }
-      summary.byStatus[card.status] = (summary.byStatus[card.status] ?? 0) + 1;
-      summary.updatedAt = Math.max(summary.updatedAt ?? 0, card.updatedAt);
+      summary.total += aggregate.total;
+      summary.archived += aggregate.archived;
+      summary.active += aggregate.total - aggregate.archived;
+      summary.byStatus[aggregate.status] =
+        (summary.byStatus[aggregate.status] ?? 0) + aggregate.total;
+      summary.updatedAt = Math.max(summary.updatedAt ?? 0, aggregate.updatedAt);
       boards.set(boardId, summary);
     }
     return {

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -277,6 +277,67 @@ describe("WorkboardStore", () => {
     }
   });
 
+  it("lists sqlite board summaries without hydrating card child rows", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-summary-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    try {
+      let cardId = "";
+      const initialStores = createWorkboardSqliteStores({ dbPath });
+      try {
+        const initial = new WorkboardStore(initialStores.cards, {
+          boards: initialStores.boards,
+          subscriptions: initialStores.subscriptions,
+          attachments: initialStores.attachments,
+        });
+        await initial.upsertBoard({ id: "ops", name: "Ops" });
+        const card = await initial.create({ title: "Summarize me", boardId: "ops" });
+        cardId = card.id;
+        await initial.addComment(card.id, { body: "valid before corruption" });
+        const archived = await initial.create({
+          title: "Summarize archived card",
+          boardId: "ops",
+          status: "ready",
+        });
+        await initial.archive(archived.id, true);
+      } finally {
+        initialStores.close();
+      }
+
+      const rawDb = new DatabaseSync(dbPath);
+      try {
+        rawDb.prepare("UPDATE workboard_card_comments SET body = '' WHERE card_id = ?").run(cardId);
+      } finally {
+        rawDb.close();
+      }
+
+      const reopenedStores = createWorkboardSqliteStores({ dbPath });
+      try {
+        const reopened = new WorkboardStore(reopenedStores.cards, {
+          boards: reopenedStores.boards,
+          subscriptions: reopenedStores.subscriptions,
+          attachments: reopenedStores.attachments,
+        });
+        await expect(reopened.get(cardId)).rejects.toThrow(/missing body/);
+        await expect(reopened.listBoards()).resolves.toMatchObject({
+          boards: expect.arrayContaining([
+            expect.objectContaining({
+              id: "ops",
+              name: "Ops",
+              total: 2,
+              active: 1,
+              archived: 1,
+              byStatus: { ready: 1, todo: 1 },
+            }),
+          ]),
+        });
+      } finally {
+        reopenedStores.close();
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("migrates a version 2 workboard table to STRICT without losing rows", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-strict-migration-"));
     const dbPath = path.join(dir, "workboard.sqlite");


### PR DESCRIPTION
Closes #123289

## What Problem This Solves

Fixes an issue where refreshing board summaries on a large Workboard could block agent work and unrelated Gateway requests.

## Why This Change Was Made

The SQLite store now calculates board counts from card rows instead of loading every card and its comments, proof, artifacts, labels, events, and attachments. Board metadata and default-board behavior remain in the Workboard store. Non-SQLite stores keep the existing fallback, and the SQLite schema is unchanged.

## User Impact

Large Workboard summary refreshes no longer hydrate card details, so multiple Control UI clients can refresh without stalling agents or other Gateway tools.

## Evidence

- Added a SQLite regression test that proves board summaries succeed without hydrating an intentionally unreadable child row. The same row still makes card detail lookup fail, confirming the summary path does not load it.
- Focused Workboard tests: 123 passed.
- Extension typecheck, lint, formatting, and diff checks passed.
- [Inspectable live Gateway trace](https://github.com/openclaw/openclaw/pull/123922#issuecomment-5300328793): an isolated Gateway used a 19.43 MiB fixture with the row counts from the issue. Nine clients completed `workboard.boards.list` in 2.19 to 13.99 ms while a concurrent `sessions.list` completed in 30.99 ms. All requests stayed below the 10-second timeout.
