### PR TITLE
perf(test): move direct import smoke to test fixtures

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -353,14 +353,14 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/channel-test-helpers` | Repo-local channel-oriented test helpers for generic actions/setup/status contracts, directory assertions, account startup lifecycle, send-config threading, runtime mocks, status issues, outbound delivery, and hook registration |
     | `plugin-sdk/channel-target-testing` | Repo-local shared target-resolution error-case suite for channel tests |
     | `plugin-sdk/channel-contract-testing` | Repo-local narrow channel contract test helpers without the broad testing barrel |
-    | `plugin-sdk/plugin-test-contracts` | Repo-local plugin package, registration, public artifact, direct import, runtime API, and import side-effect contract helpers |
+    | `plugin-sdk/plugin-test-contracts` | Repo-local plugin package, registration, public artifact, runtime API, and import side-effect contract helpers |
     | `plugin-sdk/plugin-state-test-runtime` | Repo-local plugin state store, ingress queue, and state DB test helpers |
     | `plugin-sdk/provider-test-contracts` | Repo-local provider runtime, auth, discovery, onboard, catalog, wizard, media capability, replay policy, realtime STT live-audio, web-search/fetch, and stream contract helpers |
     | `plugin-sdk/provider-http-test-mocks` | Private-local after July 2026; Repo-local opt-in Vitest HTTP/auth mocks for provider tests that exercise `plugin-sdk/provider-http` |
     | `plugin-sdk/reply-payload-testing` | Repo-local helpers for attaching metadata to reply payload fixtures |
     | `plugin-sdk/sqlite-runtime-testing` | Repo-local SQLite lifecycle helpers for first-party tests |
     | `plugin-sdk/test-state` | Repo-local isolated OpenClaw state, config, workspace, environment, and auth-profile fixtures for plugin tests |
-    | `plugin-sdk/test-fixtures` | Repo-local generic CLI runtime capture, sandbox context, skill writer, agent-message, system-event, module reload, bundled plugin path, terminal-text, chunking, auth-token, and typed-case fixtures |
+    | `plugin-sdk/test-fixtures` | Repo-local generic CLI runtime capture, direct-import smoke, sandbox context, skill writer, agent-message, system-event, module reload, bundled plugin path, terminal-text, chunking, auth-token, and typed-case fixtures |
     | `plugin-sdk/test-node-mocks` | Repo-local focused Node builtin mock helpers for use inside Vitest `vi.mock("node:*")` factories |
   </Accordion>
 

--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -44,6 +44,7 @@ import { createRequestCaptureJsonFetch } from "openclaw/plugin-sdk/test-media-un
 import {
   bundledPluginRoot,
   createCliRuntimeCapture,
+  runDirectImportSmoke,
   typedCases,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { mockNodeBuiltinModule } from "openclaw/plugin-sdk/test-node-mocks";
@@ -118,6 +119,7 @@ the focused test subpaths above.
 | `createProviderUsageFetch`                                                | Build provider usage fetch fixtures. Import from `plugin-sdk/test-env`                                                                      |
 | `useFrozenTime` / `useRealTime`                                           | Freeze and restore timers for time-sensitive tests. Import from `plugin-sdk/test-env`                                                       |
 | `createCliRuntimeCapture`                                                 | Capture CLI runtime output in tests. Import from `plugin-sdk/test-fixtures`                                                                 |
+| `runDirectImportSmoke`                                                    | Run a plugin public-surface import in an isolated Node process. Import from `plugin-sdk/test-fixtures`                                      |
 | `importFreshModule`                                                       | Import an ESM module with a fresh query token to bypass module cache. Import from `plugin-sdk/test-fixtures`                                |
 | `bundledPluginRoot` / `bundledPluginFile`                                 | Resolve bundled plugin source or dist fixture paths. Import from `plugin-sdk/test-fixtures`                                                 |
 | `mockNodeBuiltinModule`                                                   | Install narrow Node builtin Vitest mocks. Import from `plugin-sdk/test-node-mocks`                                                          |

--- a/extensions/irc/runtime-api.test.ts
+++ b/extensions/irc/runtime-api.test.ts
@@ -1,5 +1,5 @@
 // Irc tests cover runtime api plugin behavior.
-import { runDirectImportSmoke } from "openclaw/plugin-sdk/plugin-test-contracts";
+import { runDirectImportSmoke } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, describe, expect, it } from "vitest";
 
 describe("irc bundled api seams", () => {

--- a/src/plugin-sdk/plugin-test-contracts.ts
+++ b/src/plugin-sdk/plugin-test-contracts.ts
@@ -15,7 +15,6 @@ export {
   registerVirtualTestPlugin,
   requireProvider,
 } from "./test-helpers/contracts-testkit.js";
-export { runDirectImportSmoke } from "./test-helpers/direct-smoke.js";
 export { describePackageManifestContract } from "./test-helpers/package-manifest-contract.js";
 export { pluginRegistrationContractCases } from "./test-helpers/plugin-registration-contract-cases.js";
 

--- a/src/plugin-sdk/test-fixtures.ts
+++ b/src/plugin-sdk/test-fixtures.ts
@@ -51,6 +51,7 @@ export {
   repoInstallSpec,
 } from "./test-helpers/bundled-plugin-paths.js";
 export { importFreshModule } from "./test-helpers/import-fresh.js";
+export { runDirectImportSmoke } from "./test-helpers/direct-smoke.js";
 export {
   createGrayscaleAlphaPngBuffer,
   createNoisyPngBuffer,


### PR DESCRIPTION
## What Problem This Solves

Resolves test overhead where the IRC direct-import smoke loaded its generic child-process helper through the plugin registration-contract barrel. After #123902, importing that barrel eagerly reached the runtime registry, bundled capability, config, and session graph before the isolated child probe began.

## Why This Change Was Made

Moves the existing `runDirectImportSmoke` export to the existing repo-local `plugin-sdk/test-fixtures` owner, removes the unrelated export from `plugin-sdk/plugin-test-contracts`, and updates the sole consumer and repo-local SDK testing docs. The helper implementation, IRC test name, child code, and assertion are unchanged. No new subpath, helper, duplicate path, or compatibility alias is added; these test subpaths are explicitly not published third-party exports.

Direct registry imports from the test were also measured and rejected: they improved wall time by only 0.6% and were reverted. Moving the generic helper to its existing generic fixture owner is the clean owner-boundary fix.

## User Impact

No user-visible runtime behavior changes. Maintainers get a materially faster and lighter IRC test shard while preserving the same direct-import contract coverage.

## Evidence

- Same warmed Testbox `tbx_01m01gp0hstzn53wk0h8xwtysb`, [Actions run 31856710396](https://github.com/openclaw/openclaw/actions/runs/31856710396): wall 5.40s -> 4.39s (-18.7%), Vitest 2.665s -> 1.640s (-38.5%), import 1.115s -> 0.023s (-97.9%), CPU user+sys 6.615s -> 5.235s (-20.9%), RSS 615.3 MiB -> 421.8 MiB (-31.4%). Test body time increased 4.2%, attributing the gain to the import graph.
- Post-rebase focused proof: IRC 141 tests, plugin contracts 1,045 tests, and extension boundary 11 tests; 1,197 tests passed.
- The accepted patch had already passed the actual remote changed gate; rebasing onto current `origin/main` preserved the exact stable patch ID.
- `node scripts/check-changed.mjs --dry-run -- <five changed paths>` selected the expected core, coreTests, extensions, extensionTests, and docs lanes.
- `pnpm docs:list` passed.
- `git diff --check origin/main...HEAD` passed.
- Fresh branch autoreview against `origin/main`: no findings, patch correct, confidence 0.99.
- LOC: production +0/-0; test +1/-1; test support +1/-1; docs +4/-2.
