### PR TITLE
fix(gateway): expose exact build identity in status JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway status build identity:** preserve the running Gateway's exact immutable build ID in probe results and `gateway status --deep --json` while remaining compatible with Gateways that do not advertise one.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -23,7 +23,7 @@ const callGatewayStatusProbe = vi.fn<
     ok: boolean;
     url?: string;
     error?: string | null;
-    server?: { version?: string | null; connId?: string | null };
+    server?: { version?: string | null; buildId?: string; connId?: string | null };
     version?: string | null;
   }>
 >(async (_opts?: unknown) => ({
@@ -789,6 +789,51 @@ describe("gatherDaemonStatus", () => {
       error.mockRestore();
     }
   }, 1_000);
+
+  it("preserves optional exact Gateway build identity in deep JSON status", async () => {
+    callGatewayStatusProbe.mockResolvedValueOnce({
+      ok: true,
+      url: "ws://127.0.0.1:19001",
+      error: null,
+      server: {
+        version: "2026.5.6",
+        buildId: "1efe57b78b85d6d19ab30cc4f282969b6752989d",
+        connId: "conn-1",
+      },
+    });
+
+    const withBuildId = await gatherStatus({ rpc: { json: true }, deep: true });
+    expect(withBuildId.rpc?.server).toEqual({
+      version: "2026.5.6",
+      buildId: "1efe57b78b85d6d19ab30cc4f282969b6752989d",
+      connId: "conn-1",
+    });
+
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+    try {
+      printDaemonStatus(withBuildId, { json: true, deep: true });
+      expect(writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rpc: expect.objectContaining({
+            server: {
+              version: "2026.5.6",
+              buildId: "1efe57b78b85d6d19ab30cc4f282969b6752989d",
+              connId: "conn-1",
+            },
+          }),
+        }),
+      );
+    } finally {
+      writeJson.mockRestore();
+    }
+
+    const withoutBuildId = await gatherStatus({ rpc: { json: true }, deep: true });
+    expect(withoutBuildId.rpc?.server).toEqual({
+      version: "2026.5.6",
+      connId: "conn-1",
+    });
+    expect(withoutBuildId.rpc?.server).not.toHaveProperty("buildId");
+  });
 
   it("keeps gateway status read-only when service management is unsupported", async () => {
     serviceReadCommand.mockResolvedValueOnce(null);

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -33,6 +33,7 @@ import { trimToUndefined } from "../../gateway/credentials.js";
 import type { HostDesktopStatus } from "../../gateway/desktop/host-source.js";
 import { resolveGatewayRequiredListenHosts } from "../../gateway/net.js";
 import { resolveGatewayProbeCredentialConfig } from "../../gateway/probe-auth.js";
+import type { GatewayProbeServerSummary } from "../../gateway/probe.js";
 import {
   ALL_GATEWAY_SECRET_INPUT_PATHS,
   readGatewaySecretInputValue,
@@ -340,10 +341,7 @@ export type DaemonStatus = {
       scopes?: string[];
       capability?: string;
     };
-    server?: {
-      version?: string | null;
-      connId?: string | null;
-    };
+    server?: Partial<GatewayProbeServerSummary>;
     version?: string | null;
     error?: string;
     connectFailure?: {

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -17,7 +17,7 @@ const gatewayClientState = vi.hoisted(() => ({
   helloServer: {
     version: "2026.4.24",
     connId: "conn-test",
-  },
+  } as { version: string; connId: string; buildId?: string },
   connectError: "scope upgrade pending approval (requestId: req-123)",
   connectErrorDetails: {
     code: "PAIRING_REQUIRED",
@@ -325,6 +325,10 @@ describe("probeGateway", () => {
       role: "operator",
       scopes: ["operator.read"],
     };
+    gatewayClientState.helloServer = {
+      version: "2026.4.24",
+      connId: "conn-test",
+    };
     gatewayClientState.connectError = "scope upgrade pending approval (requestId: req-123)";
     gatewayClientState.connectErrorDetails = {
       code: "PAIRING_REQUIRED",
@@ -414,6 +418,22 @@ describe("probeGateway", () => {
     });
     expect(result.server).toEqual({
       version: "2026.4.24",
+      connId: "conn-test",
+    });
+  });
+
+  it("preserves the optional exact server build identity", async () => {
+    gatewayClientState.helloServer = {
+      version: "2026.4.24",
+      buildId: "1efe57b78b85d6d19ab30cc4f282969b6752989d",
+      connId: "conn-test",
+    };
+
+    const result = await runTokenLightweightProbe();
+
+    expect(result.server).toEqual({
+      version: "2026.4.24",
+      buildId: "1efe57b78b85d6d19ab30cc4f282969b6752989d",
       connId: "conn-test",
     });
   });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -47,6 +47,7 @@ export type GatewayProbeAuthSummary = {
 
 export type GatewayProbeServerSummary = {
   version: string | null;
+  buildId?: string;
   connId: string | null;
 };
 
@@ -440,6 +441,9 @@ export async function probeGateway(opts: {
           authMetadataPresent = typeof hello?.auth === "object" && hello.auth !== null;
           server = {
             version: typeof hello?.server?.version === "string" ? hello.server.version : null,
+            ...(typeof hello?.server?.buildId === "string"
+              ? { buildId: hello.server.buildId }
+              : {}),
             connId: typeof hello?.server?.connId === "string" ? hello.server.connId : null,
           };
           auth = resolveProbeAuthSummary({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using immutable Gateway deployments could not distinguish two builds with the same package version through `openclaw gateway status --deep --json`, even though the Gateway already advertises its exact build ID during the hello handshake.

## Why This Change Was Made

The existing probe reconstructed server metadata with only `version` and `connId`, dropping the optional protocol-owned `buildId`. Preserve that field at the probe owner, reuse the probe summary contract in daemon status, and continue omitting it when an older Gateway does not advertise one. This is an additive diagnostic projection only; it does not change the Gateway protocol.

## User Impact

Operators and deployment managers can compare the running Gateway's exact immutable build identity from deep JSON status. Older Gateways retain their existing output shape without a `buildId` field.

## Evidence

- Pre-fix Blacksmith Testbox regression: [run 31856886908](https://github.com/openclaw/openclaw/actions/runs/31856886908) failed because the hello `buildId` disappeared from the probe result.
- Fixed focused proof: [run 31856951003](https://github.com/openclaw/openclaw/actions/runs/31856951003) passed 33 Gateway probe tests plus 43 CLI status tests (one existing skip), including exact-ID visibility and absence compatibility.
- Full changed-surface gate: [run 31857475465](https://github.com/openclaw/openclaw/actions/runs/31857475465) passed formatting, production/test typechecks, lint, dependency, boundary, dead-export, import-cycle, and repository guards.
- Codex autoreview reported no accepted/actionable findings.

Production LOC: +6/-4 (net +2) | Tests: +67/-2. The small production increase exposes the existing immutable build-identity contract at the diagnostic boundary; status type duplication is reduced by reusing the canonical probe summary.
