### PR TITLE
refactor(gateway): move host-origin tests to admission owner

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -4,22 +4,9 @@ import type { IncomingMessage } from "node:http";
 import { describe, expect, it } from "vitest";
 import {
   checkBrowserOrigin,
-  isGatewayHostBrowserOrigin,
   normalizeChromeExtensionOrigin,
   resolveAcceptedBrowserOrigin,
 } from "./origin-check.js";
-
-describe("isGatewayHostBrowserOrigin", () => {
-  it.each([
-    ["same host", "claw.example:18789", "https://claw.example:18789", true],
-    ["normalized host", "CLAW.EXAMPLE:18789", "https://claw.example:18789/", true],
-    ["separate host", "gateway.example:18789", "https://ui.example", false],
-    ["local dev port", "127.0.0.1:18789", "http://127.0.0.1:5173", false],
-    ["missing origin", "127.0.0.1:18789", undefined, false],
-  ])("classifies %s", (_name, requestHost, origin, expected) => {
-    expect(isGatewayHostBrowserOrigin({ requestHost, origin })).toBe(expected);
-  });
-});
 
 describe("checkBrowserOrigin", () => {
   it.each([

--- a/src/gateway/server/ws-connection/control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/control-ui-build-admission.test.ts
@@ -25,6 +25,26 @@ describe("resolveControlUiBuildMismatch", () => {
       mismatch,
     ],
     [
+      "matching explicit port",
+      {
+        ...bundled,
+        requestHost: "claw.example:18789",
+        requestOrigin: "https://claw.example:18789",
+        clientBuildId: "older-build",
+      },
+      mismatch,
+    ],
+    [
+      "same host with differing port",
+      {
+        ...bundled,
+        requestHost: "127.0.0.1:18789",
+        requestOrigin: "http://127.0.0.1:5173",
+        clientBuildId: "older-build",
+      },
+      null,
+    ],
+    [
       "missing origin",
       { ...bundled, requestOrigin: undefined, clientBuildId: "older-build" },
       null,

--- a/src/gateway/server/ws-connection/control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/control-ui-build-admission.test.ts
@@ -8,14 +8,26 @@ const bundled = {
   requestHost: "claw.example",
   requestOrigin: "https://claw.example",
 };
+const mismatch = { gatewayBuildId: "gateway-build", clientBuildId: "older-build" };
 
 describe("resolveControlUiBuildMismatch", () => {
   it.each([
     ["exact bundled build", { ...bundled, clientBuildId: "gateway-build" }, null],
+    ["stale bundled build", { ...bundled, clientBuildId: "older-build" }, mismatch],
     [
-      "stale bundled build",
-      { ...bundled, clientBuildId: "older-build" },
-      { gatewayBuildId: "gateway-build", clientBuildId: "older-build" },
+      "normalized same host",
+      {
+        ...bundled,
+        requestHost: "CLAW.EXAMPLE",
+        requestOrigin: "https://claw.example/",
+        clientBuildId: "older-build",
+      },
+      mismatch,
+    ],
+    [
+      "missing origin",
+      { ...bundled, requestOrigin: undefined, clientBuildId: "older-build" },
+      null,
     ],
     ["legacy bundled build", bundled, { gatewayBuildId: "gateway-build", clientBuildId: null }],
     ["configured root", { ...bundled, configuredControlUiRoot: "/srv/ui" }, null],


### PR DESCRIPTION
## What Problem This Solves

`isGatewayHostBrowserOrigin` has one production consumer, but its host-normalization cases were tested in a separate private-helper suite. The Control UI admission matrix already owned same-origin, separately hosted, local-development, client identity, configured-root, and build-identity policy.

## Why This Change Was Made

The meaningful origin inputs now run through the admission-policy owner, and the private-helper suite is removed. The matrix preserves normalized hosts, matching explicit ports, same-host differing ports, and missing origins under a stale non-development build so each case reaches the origin decision. The raw WebSocket admission test remains separate because it provides distinct transport-level rejection, close-code, pre-registration, presence, and RPC non-dispatch proof.

## User Impact

No behavior change. Same-origin bundled Control UI admission still normalizes host casing and trailing slashes, includes the explicit port in origin identity, and treats a missing origin as not Gateway-hosted.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/origin-check.test.ts src/gateway/server/ws-connection/control-ui-build-admission.test.ts src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts` — 3 files, 45 tests passed after rebasing onto current `main`.
- `node scripts/check-changed.mjs -- src/gateway/origin-check.test.ts src/gateway/server/ws-connection/control-ui-build-admission.test.ts` — coreTests changed gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready.
- `git diff --check` passed.
- Fresh structured autoreview after the final rebase reported no accepted/actionable findings.
- Production delta: 0. Tests: +35/-16, net +19. Test registrations decrease by one while all unique admission inputs remain covered at the owner boundary.

The earlier exact-head run exposed an unrelated new `main` coercion-helper guard regression. Its canonical shared-seam fix is now on `main`, so this final branch remains test-only.
