### PR TITLE
fix(ui): clear stale delivery warnings after confirmed sends

### DIFF
--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -590,6 +590,101 @@ suite.define(() => {
     }
   });
 
+  it("dismisses an ACK-lost banner after exact authoritative history proof", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "chat.history": {
+          messages: [],
+          sessionId: "control-ui-e2e-session",
+          sessionInfo: { hasActiveRun: false, status: "done" },
+          thinkingLevel: null,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.deferNext("chat.send");
+
+      const prompt = "already accepted after the reconnect";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const firstRequest = await gateway.waitForRequest("chat.send");
+      const runId = requireString(
+        requireRecord(firstRequest.params).idempotencyKey,
+        "first idempotency key",
+      );
+      await gateway.closeLatest(1006, "lost ack");
+
+      const queue = page.locator(".chat-queue");
+      await queue.getByText("Delivery uncertain").waitFor({ timeout: 10_000 });
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/01-delivery-uncertain.png`, fullPage: true });
+      }
+
+      await gateway.setHistoryMessages([
+        {
+          content: "different delivered turn",
+          idempotencyKey: "different-run:user",
+          role: "user",
+          timestamp: Date.now(),
+        },
+      ]);
+      await gateway.emitGatewayEvent("session.message", {
+        hasActiveRun: false,
+        messageId: "different-history-turn",
+        messageSeq: 1,
+        sessionKey: "main",
+        status: "done",
+      });
+      await queue.getByText("Delivery uncertain").waitFor({ timeout: 10_000 });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/02-different-key-still-uncertain.png`,
+          fullPage: true,
+        });
+      }
+
+      await gateway.setHistoryMessages([
+        {
+          content: prompt,
+          idempotencyKey: `${runId}:user`,
+          role: "user",
+          timestamp: Date.now(),
+        },
+      ]);
+      await gateway.emitGatewayEvent("session.message", {
+        clientRunId: runId,
+        hasActiveRun: true,
+        messageId: "accepted-history-turn",
+        messageSeq: 2,
+        sessionKey: "main",
+        status: "running",
+      });
+
+      await queue.waitFor({ state: "detached", timeout: 10_000 });
+      await page.locator(".chat-group.user").getByText(prompt).waitFor({ timeout: 10_000 });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/03-delivery-proven.png`, fullPage: true });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("stores new input while offline and sends it after reconnect", async () => {
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -232,8 +232,9 @@ async function reconcileStoredChatOutboxHead(
   }
   const historyArgs = [host, outbox, item, client, connectionEpoch, dependencies] as const;
   const history = await readCurrentStoredChatHistory(...historyArgs);
-  if (history === "blocked" || history === "continue") {
-    return history;
+  // Keyed unknown sends reach history only for exact proof; absence stays blocked.
+  if (history === "blocked" || history === "continue" || item.sendState === "unconfirmed") {
+    return history === "continue" ? "continue" : "blocked";
   }
   if (visibleSessionMatches(host, outbox.sessionKey, outbox.agentId) && isChatBusy(host)) {
     return "blocked";
@@ -285,7 +286,7 @@ async function drainStoredChatOutbox(
       return "empty";
     }
     if (
-      item.sendState === "unconfirmed" ||
+      (item.sendState === "unconfirmed" && (!item.sendRunId || item.localCommandName)) ||
       (item.sendState === "waiting-model" && !lane.pendingOptions.has(item.id)) ||
       // An open edit owns this row: sending the superseded text would deliver a
       // message the operator is visibly rewriting. The queue behind it waits,

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6934,40 +6934,43 @@ describe("handleSendChat", () => {
     );
   });
 
-  it("removes a reconnect send with history proof before stale local busy state blocks it", async () => {
-    const host = makeChatHost({
-      requestHandlers: {
-        "chat.history": () =>
-          Promise.resolve({
-            messages: [
-              {
-                role: "user",
-                __openclaw: { idempotencyKey: "ambiguous-run:user" },
-              },
-            ],
-            sessionInfo: row("agent:main", { hasActiveRun: false, status: "done" }),
-          }),
-      },
-      chatRunId: "ambiguous-run",
-      chatQueue: [
-        {
-          id: "ambiguous-delivered",
-          text: "already delivered",
-          createdAt: 1,
-          sendAttempts: 1,
-          sendRunId: "ambiguous-run",
-          sendState: "waiting-reconnect",
-          sessionKey: "agent:main",
+  it.each(["waiting-reconnect", "unconfirmed"] as const)(
+    "removes a %s send with history proof before stale local busy state blocks it",
+    async (sendState) => {
+      const host = makeChatHost({
+        requestHandlers: {
+          "chat.history": () =>
+            Promise.resolve({
+              messages: [
+                {
+                  role: "user",
+                  __openclaw: { idempotencyKey: "ambiguous-run:user" },
+                },
+              ],
+              sessionInfo: row("agent:main", { hasActiveRun: false, status: "done" }),
+            }),
         },
-      ],
-    });
-    admitHostQueueItems(host);
+        chatRunId: "ambiguous-run",
+        chatQueue: [
+          {
+            id: "ambiguous-delivered",
+            text: "already delivered",
+            createdAt: 1,
+            sendAttempts: 1,
+            sendRunId: "ambiguous-run",
+            sendState,
+            sessionKey: "agent:main",
+          },
+        ],
+      });
+      admitHostQueueItems(host);
 
-    await retryReconnectableQueuedChatSends(host);
+      await retryReconnectableQueuedChatSends(host);
 
-    expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
-    expect(host.chatQueue).toStrictEqual([]);
-  });
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+      expect(host.chatQueue).toStrictEqual([]);
+    },
+  );
 
   it("rechecks an idle history snapshot before parking a delivered send", async () => {
     let historyRequests = 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users could keep seeing a red **Delivery uncertain** banner after a reconnect even though the Gateway had already accepted the message and the agent run was active.

The banner remained indefinitely because a persisted `unconfirmed` outbox row was treated as terminal and never rechecked against authoritative chat history.

## Why This Change Was Made

Keyed, non-command `unconfirmed` sends now pass through the existing authoritative-history reconciliation path. An exact `sendRunId` / persisted idempotency-key match retires the outbox row; absent or different identity remains blocked for operator review and never triggers an automatic resend.

This keeps the change in the durable outbox owner. Unkeyed barriers, uncertain commands, already scoped rows, and explicit manual retry behavior are unchanged.

Best-fix verdict: this is the narrow owner-level fix. Dismissing from a generic session event would lack exact delivery identity, auto-retrying could duplicate an accepted turn, and changing only the banner copy would leave the stale state unresolved.

Production LOC: +4/-3 (net +1) | Tests: +129/-31

Provenance: the unconditional `unconfirmed` drain barrier was introduced by @steipete in #117387 / `6c9cb8e04d4d` on 2026-08-01; that PR was also authored and merged by @steipete.

## User Impact

After an acknowledgement is lost, the banner may appear while delivery is genuinely unknown. As soon as authoritative history proves the exact original send, the banner disappears automatically, the user turn remains visible, and the UI does not send the message again.

Release-note context: Control UI delivery warnings now self-heal after exact history proof instead of remaining visible after a successful send.

## Evidence

Red reproduction on unmodified `main` at `61bc6128a03e8bea5c89d396d31e5d993be39974`:

- `waiting-reconnect` exact-history case passed.
- Equivalent `unconfirmed` exact-history case failed because the durable row remained queued.
- The owner, unit-test, and browser-fixture blobs are byte-identical between that red base and the current PR base, so intervening `main` movement does not alter the reproduction.

Exact-head green proof:

- `ui/src/pages/chat/chat-send.test.ts`: 290/290 passed.
- `ui/src/e2e/chat-flow.history-recovery.e2e.test.ts`: 8/8 passed.
- Latest-base focused browser rerun: 1/1 passed on the final patch.
- `pnpm check:changed`: passed all selected formatting, dependency, generated-resource, typecheck, lint, and import-cycle gates.
- Autoreview: clean; no accepted/actionable findings, overall correctness 0.97.
- Source-blind contract validation: PASS with no evidence gaps.

Synthetic mocked-Gateway behavior verdict:

```json
{
  "initialChatSendRequests": 1,
  "differentRunKeyKeptBanner": true,
  "chatSendRequestsAfterDifferentRunKey": 1,
  "exactRunKeyRemovedBanner": true,
  "matchingUserTurnVisibleAfterRemoval": true,
  "chatSendRequestsAfterExactRunKey": 1
}
```

Testbox runs:

- Full unit/E2E and changed-gate run: https://github.com/openclaw/openclaw/actions/runs/31857198465
- Latest-base focused browser proof: https://github.com/openclaw/openclaw/actions/runs/31858391391

No Rosita transcript, account data, or live-session screenshot is included; all published fixtures are synthetic.
