### PR TITLE
fix(dns): preserve valid zones when writes fail

### DIFF
--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -20,6 +20,7 @@ vi.mock("../infra/widearea-dns.js", async () => {
   return {
     getWideAreaZonePath: () => testState.zonePath,
     normalizeWideAreaDomain: (d: string) => d,
+    replaceWideAreaZoneFile: vi.fn(),
     resolveWideAreaDiscoveryDomain: () => "openclaw.internal.",
   };
 });

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -11,6 +11,7 @@ import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet
 import {
   getWideAreaZonePath,
   normalizeWideAreaDomain,
+  replaceWideAreaZoneFile,
   resolveWideAreaDiscoveryDomain,
 } from "../infra/widearea-dns.js";
 import { defaultRuntime } from "../runtime.js";
@@ -238,7 +239,6 @@ export function registerDnsCli(program: Command) {
       writeFileSudoIfNeeded(serverPath, server);
 
       // Ensure the gateway can write its zone file path.
-      await fs.promises.mkdir(path.dirname(zonePath), { recursive: true });
       if (zoneFileNeedsBootstrap(zonePath)) {
         const y = new Date().getUTCFullYear();
         const m = String(new Date().getUTCMonth() + 1).padStart(2, "0");
@@ -256,7 +256,7 @@ export function registerDnsCli(program: Command) {
           ``,
         ].filter((line): line is string => Boolean(line));
 
-        fs.writeFileSync(zonePath, zoneLines.join("\n"), "utf-8");
+        replaceWideAreaZoneFile(zonePath, zoneLines.join("\n"));
       }
 
       defaultRuntime.log("");

--- a/src/infra/widearea-dns.test.ts
+++ b/src/infra/widearea-dns.test.ts
@@ -1,6 +1,9 @@
 // Tests wide-area DNS discovery parsing and timeout behavior.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as utils from "../utils.js";
 import {
@@ -11,6 +14,13 @@ import {
   type WideAreaGatewayZoneOpts,
   writeWideAreaGatewayZone,
 } from "./widearea-dns.js";
+
+const replaceFileAtomicSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./replace-file.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./replace-file.js")>()),
+  replaceFileAtomicSync: replaceFileAtomicSyncMock,
+}));
 
 const baseZoneOpts: WideAreaGatewayZoneOpts = {
   domain: "openclaw.internal.",
@@ -41,6 +51,7 @@ function expectZoneRecords(text: string, records: string[]): void {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  replaceFileAtomicSyncMock.mockReset();
 });
 
 describe("wide-area DNS discovery domain helpers", () => {
@@ -184,23 +195,17 @@ describe("wide-area DNS zone writes", () => {
   it.each(["../../x", "foo/bar", "foo\\bar", "evil\nrecords", "openclaw..internal"])(
     "rejects invalid domain %j before writing",
     async (domain) => {
-      const ensureDirSpy = vi.spyOn(utils, "ensureDir").mockResolvedValue(undefined);
-      const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
-
       await expect(writeWideAreaGatewayZone(makeZoneOpts({ domain }))).rejects.toThrow(
         "wide-area discovery domain must be a valid DNS name",
       );
 
-      expect(ensureDirSpy).not.toHaveBeenCalled();
-      expect(writeSpy).not.toHaveBeenCalled();
+      expect(replaceFileAtomicSyncMock).not.toHaveBeenCalled();
     },
   );
 
   it("skips rewriting unchanged content", async () => {
-    vi.spyOn(utils, "ensureDir").mockResolvedValue(undefined);
     const existing = renderWideAreaGatewayZoneText({ ...makeZoneOpts(), serial: 2026031301 });
     vi.spyOn(fs, "readFileSync").mockReturnValue(existing);
-    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
 
     const result = await writeWideAreaGatewayZone(makeZoneOpts());
 
@@ -208,17 +213,15 @@ describe("wide-area DNS zone writes", () => {
       zonePath: getWideAreaZonePath("openclaw.internal."),
       changed: false,
     });
-    expect(writeSpy).not.toHaveBeenCalled();
+    expect(replaceFileAtomicSyncMock).not.toHaveBeenCalled();
   });
 
   it("increments same-day serials when content changes", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-13T12:00:00.000Z"));
-    vi.spyOn(utils, "ensureDir").mockResolvedValue(undefined);
     vi.spyOn(fs, "readFileSync").mockReturnValue(
       renderWideAreaGatewayZoneText({ ...makeZoneOpts(), serial: 2026031304 }),
     );
-    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
 
     const result = await writeWideAreaGatewayZone(
       makeZoneOpts({ gatewayTlsEnabled: true, gatewayTlsFingerprintSha256: "abc123" }),
@@ -232,10 +235,74 @@ describe("wide-area DNS zone writes", () => {
       ...makeZoneOpts({ gatewayTlsEnabled: true, gatewayTlsFingerprintSha256: "abc123" }),
       serial: 2026031305,
     });
-    expect(writeSpy).toHaveBeenCalledWith(
-      getWideAreaZonePath("openclaw.internal."),
-      expectedZoneText,
-      "utf-8",
-    );
+    expect(replaceFileAtomicSyncMock).toHaveBeenCalledWith({
+      filePath: getWideAreaZonePath("openclaw.internal."),
+      content: expectedZoneText,
+      dirMode: 0o700,
+      mode: 0o644,
+      preserveExistingMode: true,
+      syncTempFile: true,
+      syncParentDir: true,
+      tempPrefix: ".openclaw-dns-zone",
+    });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves the previous zone when the replacement exceeds the OS file-size limit",
+    () => {
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-widearea-dns-fault-"));
+      const dnsDir = path.join(stateDir, "dns");
+      const zonePath = path.join(dnsDir, "openclaw.internal.db");
+      const previous = "; previous valid zone\n$ORIGIN openclaw.internal.\n";
+      fs.mkdirSync(dnsDir);
+      fs.writeFileSync(zonePath, previous, { mode: 0o640 });
+
+      try {
+        const moduleUrl = pathToFileURL(path.resolve("src/infra/widearea-dns.ts")).href;
+        const script = `
+          const { writeWideAreaGatewayZone } = await import(${JSON.stringify(moduleUrl)});
+          try {
+            await writeWideAreaGatewayZone({
+              domain: "openclaw.internal",
+              gatewayPort: 18789,
+              displayName: "X".repeat(8192),
+              tailnetIPv4: "100.64.0.1",
+            });
+            process.exitCode = 24;
+          } catch (error) {
+            if (error?.code !== "EFBIG") {
+              console.error(error);
+              process.exitCode = 25;
+            }
+          }
+        `;
+        const child = spawnSync(
+          "/bin/sh",
+          [
+            "-c",
+            'ulimit -f 1; exec "$@"',
+            "openclaw-widearea-dns-fault",
+            process.execPath,
+            "--import",
+            "tsx",
+            "--input-type=module",
+            "-e",
+            script,
+          ],
+          {
+            cwd: process.cwd(),
+            encoding: "utf8",
+            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+          },
+        );
+
+        expect(child.status, child.stderr).toBe(0);
+        expect(fs.readFileSync(zonePath, "utf8")).toBe(previous);
+        expect(fs.statSync(zonePath).mode & 0o777).toBe(0o640);
+        expect(fs.readdirSync(dnsDir)).toEqual(["openclaw.internal.db"]);
+      } finally {
+        fs.rmSync(stateDir, { force: true, recursive: true });
+      }
+    },
+  );
 });

--- a/src/infra/widearea-dns.ts
+++ b/src/infra/widearea-dns.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { CONFIG_DIR, ensureDir } from "../utils.js";
+import { CONFIG_DIR } from "../utils.js";
+import { replaceFileAtomicSync } from "./replace-file.js";
 
 const DNS_LABEL_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
 const MAX_DNS_NAME_LENGTH = 253;
@@ -62,6 +63,20 @@ export function getWideAreaZonePath(domain: string): string {
   const zonePath = path.resolve(dnsDir, zoneFilenameForDomain(domain));
   assertZonePathUnderDnsDir(zonePath, dnsDir);
   return zonePath;
+}
+
+/** Durably replace the CoreDNS zone only after its complete sibling write succeeds. */
+export function replaceWideAreaZoneFile(zonePath: string, content: string): void {
+  replaceFileAtomicSync({
+    filePath: zonePath,
+    content,
+    dirMode: 0o700,
+    mode: 0o644,
+    preserveExistingMode: true,
+    syncTempFile: true,
+    syncParentDir: true,
+    tempPrefix: ".openclaw-dns-zone",
+  });
 }
 
 function dnsLabel(raw: string, fallback: string): string {
@@ -212,7 +227,6 @@ export async function writeWideAreaGatewayZone(
   }
   const normalizedOpts = { ...opts, domain };
   const zonePath = getWideAreaZonePath(domain);
-  await ensureDir(path.dirname(zonePath));
 
   const existing = (() => {
     try {
@@ -233,6 +247,6 @@ export async function writeWideAreaGatewayZone(
   const existingSerial = existing ? extractSerial(existing) : null;
   const serial = nextSerial(existingSerial, new Date());
   const next = renderWideAreaGatewayZoneText({ ...normalizedOpts, serial });
-  fs.writeFileSync(zonePath, next, "utf-8");
+  replaceWideAreaZoneFile(zonePath, next);
   return { zonePath, changed: true };
 }


### PR DESCRIPTION
Closes #123926

## What Problem This Solves

Fixes an issue where operators using wide-area DNS discovery could lose the last valid CoreDNS zone when a Gateway refresh or `openclaw dns setup --apply` write failed after truncating the final file.

## Why This Change Was Made

Both zone producers now call one `replaceWideAreaZoneFile` owner backed by the existing `replaceFileAtomicSync` primitive. The owner stages a sibling file, preserves an existing mode, keeps the DNS directory private, syncs staged bytes and the parent directory, propagates failures, and removes failed staging files before the final rename.

The +14 production-line delta is the accepted shared ownership contract for the two production callers; it adds no dependency, configuration, schema, protocol, or public package API.

## User Impact

Failed wide-area DNS zone updates now leave the previous valid zone available to CoreDNS instead of publishing partial bytes. Successful Gateway refresh and DNS bootstrap behavior is unchanged.

## Evidence

- Current-main red proof (`RLIMIT_FSIZE`, `EFBIG`): a 117-byte mode-0640 valid zone became a 512-byte partial zone at the final path.
- Candidate green proof under the same authentic OS fault: `EFBIG` propagated; final zone remained 117 bytes, mode 0640, one final file, and no staging residue.
- Focused Vitest: 43/43 passed across `src/infra/widearea-dns.test.ts`, `src/cli/dns-cli.test.ts`, and `src/gateway/server-discovery-runtime.test.ts`.
- Environment ratchet: `OPENCLAW_* count 503/503`.
- Full changed gate: passed, including core/core-test typechecks, lint, dead exports, database-first, import-cycle, and auth guards. The remote fast-CI route was unavailable, so the repository wrapper completed via its trusted local fallback.
- Targeted `oxfmt` and `git diff --check`: passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings (0.98 confidence).
- LOC: production +19/-5 (net +14); tests +83/-15 (net +68).

AI-assisted: yes. The change was source-audited, fault-injected, tested, and independently reviewed before publication.
