### PR TITLE
fix(acp): deliver thread-bound ACP child replies instead of suppressing them

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -479,6 +479,7 @@ export async function gatherDispatchRequest(
     markIdle,
     markInboundDedupeReplayUnsafe,
     acpDispatchSessionKey,
+    boundAcpDispatchSessionKey,
     markProgress,
     sessionStoreEntry,
     notePreparedSession,

--- a/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
@@ -27,6 +27,7 @@ import { resolveReplyRoutingDecision } from "./routing-policy.js";
 
 export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyState) {
   const {
+    boundAcpDispatchSessionKey,
     cfg,
     ctx,
     groupId,
@@ -49,7 +50,8 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
     sessionAcpMeta && sessionStoreEntry.entry
       ? { ...sessionStoreEntry.entry, acp: sessionAcpMeta }
       : sessionStoreEntry.entry;
-  const suppressAcpChildUserDelivery = isParentOwnedBackgroundAcpSession(sessionEntryWithAcp);
+  const suppressAcpChildUserDelivery =
+    isParentOwnedBackgroundAcpSession(sessionEntryWithAcp) && !boundAcpDispatchSessionKey;
   const normalizedRouteReplyChannel = normalizeMessageChannel(replyRoute.channel);
   const normalizedProviderChannel = normalizeMessageChannel(ctx.Provider);
   const normalizedSurfaceChannel = normalizeMessageChannel(ctx.Surface);


### PR DESCRIPTION
Closes #123933

> AI-assisted: authored with an AI coding agent.

## What Problem This Solves

Fixes an issue where a persistent ACP session spawned into its own thread (via `sessions_spawn({ thread: true })`, e.g. an OpenCode coding thread) never delivers its replies back to that thread. A user sends a message in the thread and the session runs, but nothing appears on the channel; the gateway logs `visible channel turn dispatched with no queued reply payloads`. Only the operator slash-command spawn path delivers replies, so persistent ACP coding threads are effectively unusable for in-thread conversation.

## Why This Change Was Made

Delivery suppression was keyed only on session lineage: `resolveAcpSessionInteractionMode` classifies any ACP session carrying `spawnedBy`/`parentSessionKey` as `parent-owned-background`, and `prepareDispatchDelivery` suppresses user-channel delivery for that whole class — dropping a thread-bound child's replies even though it is the user-facing owner of its own thread.

The distinguishing fact is the conversation binding, already resolved in the gather phase as `boundAcpDispatchSessionKey` (set only when the current conversation is bound to an ACP session). This PR forwards that prepared fact to the delivery gate and gates suppression on it inline at the delivery owner: `isParentOwnedBackgroundAcpSession(session) && !boundAcpDispatchSessionKey`. No new exported API is added; the classifier and the parent/child A2A check are untouched, so `sessions_send` ping-pong gating is unchanged and unbound background children remain silent.

## User Impact

- Persistent ACP sessions spawned into a thread now reply in that thread; multi-turn conversations work.
- Genuine background delegations stay silent on the user channel (they have no visible conversation binding), so no new channel noise.

## Evidence

Before (current `main`) — the reply is suppressed and nothing reaches the thread:

```
[gateway] visible channel turn dispatched with no queued reply payloads:
          channel=discord sessionKey=agent:opencode:acp:<redacted>
```

After (delivery gate consults the conversation binding, i.e. this change) — the same flow delivers in-thread:

```
[thread] user:    remember the word <codeword>
[thread] session: acknowledged; will remember "<codeword>" for this conversation
[thread] user:    <follow-up>
[thread] session: <reply delivered>          # multi-turn, in-thread
[gateway] (no "no queued reply payloads" warning for this session)
```

Reproduced by spawning a persistent ACP session with `sessions_spawn({ runtime: "acp", agentId: "opencode", thread: true, mode: "session", cwd: <abs> })`: before the change the thread stayed silent (zero-payload warning above), after it the replies landed across multiple turns and no other channel received stray output.

Review notes: the one-caller predicate is now inlined at the delivery owner (no new `acp-core` export), addressing the LOC/API finding. A `dispatch-from-config` harness regression covering bound→delivered / unbound→suppressed would be a welcome follow-up; I could not run that harness in my environment, and the live before/after above is the boundary proof. Full local gate runs (`pnpm build && pnpm check && pnpm test`) were likewise not executed here, so CI should validate.
