### PR TITLE
fix(matrix): accept Room v12 IDs without server suffix

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -308,7 +308,7 @@ Control how group/room messages are handled per channel:
     - DM pairing approvals (`*-allowFrom` store entries) apply to DM access only; group sender authorization stays explicit to group allowlists.
     - Discord: allowlist uses `channels.discord.guilds.<id>.channels`.
     - Slack: allowlist uses `channels.slack.channels`.
-    - Matrix: allowlist uses `channels.matrix.groups`. Use room IDs (`!room:server`) or aliases (`#alias:server`); room-name keys match only with `channels.matrix.dangerouslyAllowNameMatching: true`, and unresolved entries are ignored at runtime. Use `channels.matrix.groupAllowFrom` to restrict senders; per-room `users` allowlists are also supported.
+    - Matrix: allowlist uses `channels.matrix.groups`. Use room IDs (`!room:server`, or the suffixless `!room` form on room version 12+) or aliases (`#alias:server`); room-name keys match only with `channels.matrix.dangerouslyAllowNameMatching: true`, and unresolved entries are ignored at runtime. Use `channels.matrix.groupAllowFrom` to restrict senders; per-room `users` allowlists are also supported.
     - Group DMs are controlled separately (`channels.discord.dm.*`, `channels.slack.dm.*`: `groupEnabled`, `groupChannels`).
     - Telegram: sender allowlists accept numeric user IDs only (`"123456789"`; `telegram:`/`tg:` prefixes are stripped case-insensitively). `@username` entries do not match at runtime and log a warning; setup resolves `@username` to IDs. Negative chat IDs belong under `channels.telegram.groups`, not sender allowlists.
     - Default is `groupPolicy: "allowlist"`; if your group allowlist is empty, group messages are blocked.

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -74,7 +74,7 @@ Password-based (token is cached after first login):
 <Warning>
 Set `autoJoin: "allowlist"` plus `autoJoinAllowlist` to restrict accepted invites, or `autoJoin: "always"` to accept every invite.
 
-`autoJoinAllowlist` accepts only `!roomId:server`, `#alias:server`, or `*`. Plain room names are rejected; aliases resolve against the homeserver, not against state the invited room claims.
+`autoJoinAllowlist` accepts only a literal room ID (`!roomId:server`, or the suffixless `!roomId` form used by [room version 12](https://spec.matrix.org/latest/rooms/v12/) and later), `#alias:server`, or `*`. Plain room names are rejected; aliases resolve against the homeserver, not against state the invited room claims.
 </Warning>
 
 ```json5
@@ -97,8 +97,8 @@ Matrix user IDs are case-sensitive. Copy the exact `@user:server` value Matrix r
 
 - DMs (`dm.allowFrom`, `groupAllowFrom`, `groups.<room>.users`): use `@user:server`. Display names are ignored by default (mutable); set `dangerouslyAllowNameMatching: true` only for explicit display-name compatibility.
 - Approval forwarding (`approvals.exec.targets[].to` with `channel: "matrix"`): use `user:@user:server` with the exact Matrix casing.
-- Room allowlist keys (`groups`, legacy alias `rooms`): use `!room:server` or `#alias:server`. Plain names are ignored unless `dangerouslyAllowNameMatching: true`.
-- Invite allowlists (`autoJoinAllowlist`): use `!room:server`, `#alias:server`, or `*`. Plain names are always rejected.
+- Room allowlist keys (`groups`, legacy alias `rooms`): use `!room:server` (or the suffixless `!room` form on room version 12+) or `#alias:server`. Plain names are ignored unless `dangerouslyAllowNameMatching: true`.
+- Invite allowlists (`autoJoinAllowlist`): use `!room:server` (or suffixless `!room` on room version 12+), `#alias:server`, or `*`. Plain names are always rejected.
 
 ### Account ID normalization
 
@@ -823,7 +823,7 @@ Named accounts can override the top-level default with `channels.matrix.accounts
 Matrix accepts these target forms anywhere OpenClaw asks for a room or user target:
 
 - Users: `@user:server`, `user:@user:server`, or `matrix:user:@user:server`
-- Rooms: `!room:server`, `room:!room:server`, or `matrix:room:!room:server`
+- Rooms: `!room:server`, `room:!room:server`, or `matrix:room:!room:server` (room version 12+ room IDs have no `:server` suffix — `!room`, `room:!room`, `matrix:room:!room` — and are accepted the same way)
 - Aliases: `#alias:server`, `channel:#alias:server`, or `matrix:channel:#alias:server`
 
 Matrix room IDs are case-sensitive. Use the exact room ID casing from Matrix when configuring explicit delivery targets, cron jobs, bindings, or allowlists. OpenClaw keeps internal session keys canonical for storage, so those lowercase keys are not a reliable source for Matrix delivery IDs.

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -122,6 +122,35 @@ describe("resolveMatrixMonitorConfig", () => {
     });
   });
 
+  it("keeps a room version 12 room ID (no :server suffix) as already resolved", async () => {
+    // Room version 12 (MSC4291) dropped the trailing ":server" from room IDs — they're
+    // now a hash of the create event — so this must not be sent through name/alias
+    // resolution the way an unresolved query would be.
+    const runtime = createRuntime();
+    const resolveTargets = vi.fn(async ({ inputs }: { inputs: string[] }) =>
+      inputs.map((input) => ({ input, resolved: false })),
+    );
+
+    const roomsConfig: MatrixRoomsConfig = {
+      "!UIZ0YzC99dC1AyEM6mGl0_XNP8u8xeCCt_Zk8Uhkp70": { enabled: true },
+    };
+
+    const result = await resolveMatrixMonitorConfig({
+      cfg: createConfig(),
+      accountId: "ops",
+      allowFrom: [],
+      groupAllowFrom: [],
+      roomsConfig,
+      runtime,
+      resolveTargets,
+    });
+
+    expect(result.roomsConfig).toEqual({
+      "!UIZ0YzC99dC1AyEM6mGl0_XNP8u8xeCCt_Zk8Uhkp70": { enabled: true },
+    });
+    expect(resolveTargets).not.toHaveBeenCalled();
+  });
+
   it("strips config prefixes before lookups and logs unresolved guidance once per section", async () => {
     const runtime = createRuntime();
     const resolveTargets = vi.fn(

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -168,6 +168,7 @@ describe("resolveMatrixMonitorConfig", () => {
       allowFrom: ["user:Ghost"],
       groupAllowFrom: ["matrix:@known:example.org"],
       roomsConfig: {
+        "!": { enabled: true },
         "channel:Project X": {
           enabled: true,
           users: ["matrix:Ghost"],
@@ -188,14 +189,14 @@ describe("resolveMatrixMonitorConfig", () => {
     expectResolveTargetCall(resolveTargets, 1, {
       accountId: "ops",
       kind: "group",
-      inputs: ["Project X"],
+      inputs: ["!", "Project X"],
     });
     expect(resolveTargets).toHaveBeenCalledTimes(2);
     expect(runtime.log).toHaveBeenCalledWith("matrix dm allowlist unresolved: user:Ghost");
     expect(runtime.log).toHaveBeenCalledWith(
       "matrix dm allowlist entries must be full Matrix IDs (example: @user:server). Unresolved entries will not match any sender.",
     );
-    expect(runtime.log).toHaveBeenCalledWith("matrix rooms unresolved: channel:Project X");
+    expect(runtime.log).toHaveBeenCalledWith("matrix rooms unresolved: !, channel:Project X");
     expect(runtime.log).toHaveBeenCalledWith(
       "matrix rooms must be room IDs or aliases (example: !room:server, the suffixless !room form on room version 12+, or #alias:server). Unresolved entries are ignored.",
     );

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -197,7 +197,7 @@ describe("resolveMatrixMonitorConfig", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith("matrix rooms unresolved: channel:Project X");
     expect(runtime.log).toHaveBeenCalledWith(
-      "matrix rooms must be room IDs or aliases (example: !room:server or #alias:server). Unresolved entries are ignored.",
+      "matrix rooms must be room IDs or aliases (example: !room:server, the suffixless !room form on room version 12+, or #alias:server). Unresolved entries are ignored.",
     );
   });
 

--- a/extensions/matrix/src/matrix/monitor/config.ts
+++ b/extensions/matrix/src/matrix/monitor/config.ts
@@ -3,7 +3,7 @@ import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-na
 import { resolveMatrixTargets } from "../../resolve-targets.js";
 import type { CoreConfig, MatrixRoomConfig } from "../../types.js";
 import { resolveMatrixAccountConfig } from "../account-config.js";
-import { isMatrixQualifiedUserId } from "../target-ids.js";
+import { isMatrixQualifiedUserId, isMatrixRoomId } from "../target-ids.js";
 import { normalizeMatrixUserId } from "./allowlist.js";
 import {
   addAllowlistUserEntriesFromConfigEntry,
@@ -427,7 +427,7 @@ async function resolveMatrixMonitorRoomsConfig(params: {
       unresolved.push(entry);
       continue;
     }
-    if (cleaned.startsWith("!") && cleaned.includes(":")) {
+    if (isMatrixRoomId(cleaned)) {
       if (!nextRooms[cleaned]) {
         nextRooms[cleaned] = roomConfig;
       }

--- a/extensions/matrix/src/matrix/monitor/config.ts
+++ b/extensions/matrix/src/matrix/monitor/config.ts
@@ -471,7 +471,7 @@ async function resolveMatrixMonitorRoomsConfig(params: {
   summarizeMapping("matrix rooms", mapping, unresolved, params.runtime);
   if (unresolved.length > 0) {
     params.runtime.log?.(
-      "matrix rooms must be room IDs or aliases (example: !room:server or #alias:server). Unresolved entries are ignored.",
+      "matrix rooms must be room IDs or aliases (example: !room:server, the suffixless !room form on room version 12+, or #alias:server). Unresolved entries are ignored.",
     );
   }
 

--- a/extensions/matrix/src/matrix/target-ids.test.ts
+++ b/extensions/matrix/src/matrix/target-ids.test.ts
@@ -22,4 +22,8 @@ describe("isMatrixRoomId", () => {
   it("rejects an unresolved name query", () => {
     expect(isMatrixRoomId("General")).toBe(false);
   });
+
+  it.each(["!", " !  "])("rejects an empty room identifier: %j", (roomId) => {
+    expect(isMatrixRoomId(roomId)).toBe(false);
+  });
 });

--- a/extensions/matrix/src/matrix/target-ids.test.ts
+++ b/extensions/matrix/src/matrix/target-ids.test.ts
@@ -1,0 +1,25 @@
+// Matrix tests cover target-id shape predicates.
+import { describe, expect, it } from "vitest";
+import { isMatrixRoomId } from "./target-ids.js";
+
+describe("isMatrixRoomId", () => {
+  it("accepts a room version 12 room ID with no :server suffix", () => {
+    expect(isMatrixRoomId("!UIZ0YzC99dC1AyEM6mGl0_XNP8u8xeCCt_Zk8Uhkp70")).toBe(true);
+  });
+
+  it("accepts a pre-v12 room ID that still has a :server suffix", () => {
+    expect(isMatrixRoomId("!ops:example.org")).toBe(true);
+  });
+
+  it("rejects a user ID", () => {
+    expect(isMatrixRoomId("@bob:example.org")).toBe(false);
+  });
+
+  it("rejects an alias", () => {
+    expect(isMatrixRoomId("#general:example.org")).toBe(false);
+  });
+
+  it("rejects an unresolved name query", () => {
+    expect(isMatrixRoomId("General")).toBe(false);
+  });
+});

--- a/extensions/matrix/src/matrix/target-ids.ts
+++ b/extensions/matrix/src/matrix/target-ids.ts
@@ -49,6 +49,16 @@ export function isMatrixQualifiedUserId(raw: string): boolean {
   return trimmed.startsWith("@") && trimmed.includes(":");
 }
 
+/**
+ * Whether `raw` is already a literal room ID rather than a name/query to resolve.
+ * Room version 12 (MSC4291) dropped the trailing ":server" from room IDs — they're
+ * now a hash of the create event — so this must not require a colon the way user
+ * IDs and aliases still do.
+ */
+export function isMatrixRoomId(raw: string): boolean {
+  return raw.trim().startsWith("!");
+}
+
 export function normalizeMatrixResolvableTarget(raw: string): string {
   return stripKnownPrefixes(raw, [MATRIX_PREFIX, ROOM_PREFIX, CHANNEL_PREFIX]);
 }

--- a/extensions/matrix/src/matrix/target-ids.ts
+++ b/extensions/matrix/src/matrix/target-ids.ts
@@ -56,7 +56,8 @@ export function isMatrixQualifiedUserId(raw: string): boolean {
  * IDs and aliases still do.
  */
 export function isMatrixRoomId(raw: string): boolean {
-  return raw.trim().startsWith("!");
+  const trimmed = raw.trim();
+  return trimmed.startsWith("!") && trimmed.length > 1;
 }
 
 export function normalizeMatrixResolvableTarget(raw: string): string {

--- a/extensions/matrix/src/onboarding.test-harness.ts
+++ b/extensions/matrix/src/onboarding.test-harness.ts
@@ -265,6 +265,8 @@ export function createMatrixUpdateKeepCredentialsPrompter(params?: {
   updateAutoJoin?: boolean;
   homeserver?: string;
   deviceName?: string;
+  configureRoomsAccess?: boolean;
+  roomsAllowlist?: string;
   onText?: PromptHandler<string | Promise<string>>;
 }) {
   return createMatrixWizardPrompter({
@@ -272,15 +274,19 @@ export function createMatrixUpdateKeepCredentialsPrompter(params?: {
     select: {
       "Matrix already configured. What do you want to do?": "update",
       ...(params?.inviteAutoJoin ? { "Matrix invite auto-join": params.inviteAutoJoin } : {}),
+      ...(params?.configureRoomsAccess ? { "Matrix rooms access": "allowlist" } : {}),
     },
     text: {
       "Matrix homeserver URL": params?.homeserver ?? "https://matrix.example.org",
       "Matrix device name (optional)": params?.deviceName ?? "OpenClaw Gateway",
+      ...(params?.roomsAllowlist
+        ? { "Matrix rooms allowlist (comma-separated)": params.roomsAllowlist }
+        : {}),
     },
     confirm: {
       "Matrix credentials already configured. Keep them?": true,
       "Enable end-to-end encryption (E2EE)?": false,
-      "Configure Matrix rooms access?": false,
+      "Configure Matrix rooms access?": params?.configureRoomsAccess ?? false,
       "Configure Matrix invite auto-join?": params?.inviteAutoJoin !== undefined,
       ...(params?.inviteAutoJoin !== undefined
         ? { "Update Matrix invite auto-join?": params?.updateAutoJoin ?? true }

--- a/extensions/matrix/src/onboarding.test-harness.ts
+++ b/extensions/matrix/src/onboarding.test-harness.ts
@@ -38,7 +38,9 @@ function createNonExitingTypedRuntimeEnv<TRuntime>(): TRuntime {
 
 export function installMatrixOnboardingEnvRestoreHooks() {
   afterEach(() => {
-    for (const [key, value] of Object.entries(previousMatrixEnv)) {
+    // Restore only the fixed Matrix allowlist; never replay arbitrary keys into host env.
+    for (const key of MATRIX_ENV_KEYS) {
+      const value = previousMatrixEnv[key];
       if (value === undefined) {
         delete process.env[key];
       } else {

--- a/extensions/matrix/src/onboarding.test.ts
+++ b/extensions/matrix/src/onboarding.test.ts
@@ -511,6 +511,51 @@ describe("matrix onboarding", () => {
     ]);
   });
 
+  it("advertises the suffixless Room v12 form in the invite auto-join placeholder", async () => {
+    installMatrixTestRuntime();
+    const prompter = createMatrixUpdateKeepCredentialsPrompter({
+      inviteAutoJoin: "allowlist",
+      onText: async (message) =>
+        message === "Matrix invite auto-join allowlist (comma-separated)" ? "#ops:example.org" : "",
+    });
+
+    await runMatrixInteractiveConfigure({
+      cfg: createConfiguredMatrixTopLevelConfig(),
+      prompter,
+      configured: true,
+    });
+
+    const invitePromptCall = vi
+      .mocked(prompter.text)
+      .mock.calls.find(
+        ([options]) => options.message === "Matrix invite auto-join allowlist (comma-separated)",
+      );
+    expect(invitePromptCall?.[0].placeholder).toBe("!roomId:server, !roomId, #alias:server, *");
+  });
+
+  it("advertises the suffixless Room v12 form in the group room setup placeholder", async () => {
+    installMatrixTestRuntime();
+    const prompter = createMatrixUpdateKeepCredentialsPrompter({
+      configureRoomsAccess: true,
+      roomsAllowlist: "!ops-room:example.org",
+    });
+
+    await runMatrixInteractiveConfigure({
+      cfg: createConfiguredMatrixTopLevelConfig(),
+      prompter,
+      configured: true,
+    });
+
+    const roomsPromptCall = vi
+      .mocked(prompter.text)
+      .mock.calls.find(
+        ([options]) => options.message === "Matrix rooms allowlist (comma-separated)",
+      );
+    expect(roomsPromptCall?.[0].placeholder).toBe(
+      "!roomId:server, !roomId, #alias:server, Project Room",
+    );
+  });
+
   it("reports account-scoped DM config keys for named accounts", () => {
     const resolveConfigKeys = matrixOnboardingAdapter.dmPolicy?.resolveConfigKeys;
     if (resolveConfigKeys === undefined) {

--- a/extensions/matrix/src/onboarding.test.ts
+++ b/extensions/matrix/src/onboarding.test.ts
@@ -449,7 +449,7 @@ describe("matrix onboarding", () => {
       onText: async (message) => {
         if (message === "Matrix invite auto-join allowlist (comma-separated)") {
           inviteAllowlistPrompts += 1;
-          return inviteAllowlistPrompts === 1 ? "Project Room" : "#ops:example.org";
+          return inviteAllowlistPrompts === 1 ? "!, Project Room" : "#ops:example.org";
         }
         throw new Error(`unexpected text prompt: ${message}`);
       },
@@ -472,7 +472,7 @@ describe("matrix onboarding", () => {
     expect(notes.join("\n")).toContain(
       "Use only stable Matrix invite targets for auto-join: !roomId:server (or the suffixless !roomId form on room version 12+), #alias:server, or *.",
     );
-    expect(notes.join("\n")).toContain("Invalid: Project Room");
+    expect(notes.join("\n")).toContain("Invalid: !, Project Room");
   });
 
   it("accepts a room version 12 auto-join target (no :server suffix) on the first entry", async () => {

--- a/extensions/matrix/src/onboarding.test.ts
+++ b/extensions/matrix/src/onboarding.test.ts
@@ -470,7 +470,7 @@ describe("matrix onboarding", () => {
     expect(result.cfg.channels?.matrix?.autoJoin).toBe("allowlist");
     expect(result.cfg.channels?.matrix?.autoJoinAllowlist).toEqual(["#ops:example.org"]);
     expect(notes.join("\n")).toContain(
-      "Use only stable Matrix invite targets for auto-join: !roomId:server, #alias:server, or *.",
+      "Use only stable Matrix invite targets for auto-join: !roomId:server (or the suffixless !roomId form on room version 12+), #alias:server, or *.",
     );
     expect(notes.join("\n")).toContain("Invalid: Project Room");
   });

--- a/extensions/matrix/src/onboarding.test.ts
+++ b/extensions/matrix/src/onboarding.test.ts
@@ -475,6 +475,42 @@ describe("matrix onboarding", () => {
     expect(notes.join("\n")).toContain("Invalid: Project Room");
   });
 
+  it("accepts a room version 12 auto-join target (no :server suffix) on the first entry", async () => {
+    // Room version 12 (MSC4291) dropped the trailing ":server" from room IDs.
+    installMatrixTestRuntime();
+    const notes: string[] = [];
+    let inviteAllowlistPrompts = 0;
+
+    const prompter = createMatrixUpdateKeepCredentialsPrompter({
+      notes,
+      inviteAutoJoin: "allowlist",
+      onText: async (message) => {
+        if (message === "Matrix invite auto-join allowlist (comma-separated)") {
+          inviteAllowlistPrompts += 1;
+          return "!UIZ0YzC99dC1AyEM6mGl0_XNP8u8xeCCt_Zk8Uhkp70";
+        }
+        throw new Error(`unexpected text prompt: ${message}`);
+      },
+    });
+
+    const result = await runMatrixInteractiveConfigure({
+      cfg: createConfiguredMatrixTopLevelConfig(),
+      prompter,
+      configured: true,
+    });
+
+    expect(result).not.toBe("skip");
+    if (result === "skip") {
+      return;
+    }
+
+    expect(inviteAllowlistPrompts).toBe(1);
+    expect(result.cfg.channels?.matrix?.autoJoin).toBe("allowlist");
+    expect(result.cfg.channels?.matrix?.autoJoinAllowlist).toEqual([
+      "!UIZ0YzC99dC1AyEM6mGl0_XNP8u8xeCCt_Zk8Uhkp70",
+    ]);
+  });
+
   it("reports account-scoped DM config keys for named accounts", () => {
     const resolveConfigKeys = matrixOnboardingAdapter.dmPolicy?.resolveConfigKeys;
     if (resolveConfigKeys === undefined) {

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -250,7 +250,7 @@ async function configureMatrixInviteAutoJoin(params: {
     if (allowlist.length === 0 || invalidEntries.length > 0) {
       await params.prompter.note(
         [
-          "Use only stable Matrix invite targets for auto-join: !roomId:server, #alias:server, or *.",
+          "Use only stable Matrix invite targets for auto-join: !roomId:server (or the suffixless !roomId form on room version 12+), #alias:server, or *.",
           invalidEntries.length > 0 ? `Invalid: ${invalidEntries.join(", ")}` : undefined,
         ]
           .filter(Boolean)

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -238,7 +238,7 @@ async function configureMatrixInviteAutoJoin(params: {
   while (true) {
     const rawAllowlist = await params.prompter.text({
       message: "Matrix invite auto-join allowlist (comma-separated)",
-      placeholder: "!roomId:server, #alias:server, *",
+      placeholder: "!roomId:server, !roomId, #alias:server, *",
       initialValue: currentAllowlist[0] ? currentAllowlist.join(", ") : undefined,
       validate: (value) => {
         const entries = splitSetupEntries(value);
@@ -289,7 +289,7 @@ async function configureMatrixAccessPrompts(params: {
     label: "Matrix rooms",
     currentPolicy: existingAccountConfig.groupPolicy ?? "allowlist",
     currentEntries: Object.keys(existingGroups ?? {}),
-    placeholder: "!roomId:server, #alias:server, Project Room",
+    placeholder: "!roomId:server, !roomId, #alias:server, Project Room",
     updatePrompt: Boolean(existingGroups),
   });
   if (accessConfig) {

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -32,6 +32,7 @@ import {
 } from "./matrix/client/url-validation.js";
 import { updateMatrixAccountConfig } from "./matrix/config-update.js";
 import { ensureMatrixSdkInstalled, isMatrixSdkAvailable } from "./matrix/deps.js";
+import { isMatrixRoomId } from "./matrix/target-ids.js";
 import type { RuntimeEnv, WizardPrompter } from "./runtime-api.js";
 import { moveSingleMatrixAccountConfigToNamedAccount } from "./setup-config.js";
 import { createMatrixSetupDmPolicy } from "./setup-dm-policy.js";
@@ -54,11 +55,7 @@ function isMatrixInviteAutoJoinPolicy(value: string): value is MatrixInviteAutoJ
 }
 
 function isMatrixInviteAutoJoinTarget(entry: string): boolean {
-  return (
-    entry === "*" ||
-    (entry.startsWith("!") && entry.includes(":")) ||
-    (entry.startsWith("#") && entry.includes(":"))
-  );
+  return entry === "*" || isMatrixRoomId(entry) || (entry.startsWith("#") && entry.includes(":"));
 }
 
 function resolveMatrixOnboardingAccountId(cfg: CoreConfig, accountId?: string): string {
@@ -312,7 +309,7 @@ async function configureMatrixAccessPrompts(params: {
               continue;
             }
             const cleaned = trimmed.replace(/^(room|channel):/i, "").trim();
-            if (cleaned.startsWith("!") && cleaned.includes(":")) {
+            if (isMatrixRoomId(cleaned)) {
               resolvedIds.push(cleaned);
               continue;
             }

--- a/extensions/matrix/src/session-route.test.ts
+++ b/extensions/matrix/src/session-route.test.ts
@@ -346,6 +346,27 @@ describe("resolveMatrixOutboundSessionRoute", () => {
     expect(route?.recipientSessionExact).toBe(false);
   });
 
+  it("claims a room id as canonical when DMs are room-scoped", () => {
+    const route = resolveMatrixOutboundSessionRoute({
+      cfg: { channels: { matrix: perRoomDmMatrixConfig } },
+      agentId: "main",
+      target: "room:!ops:example.org",
+    });
+
+    expect(route?.recipientSessionExact).toBe(true);
+  });
+
+  it("claims a room version 12 room id (no :server suffix) as canonical when DMs are room-scoped", () => {
+    // Room version 12 (MSC4291) dropped the trailing ":server" from room IDs.
+    const route = resolveMatrixOutboundSessionRoute({
+      cfg: { channels: { matrix: perRoomDmMatrixConfig } },
+      agentId: "main",
+      target: "room:!UIZ0YzC99dC1AyEM6mGl0_XNP8u8xeCCt_Zk8Uhkp70",
+    });
+
+    expect(route?.recipientSessionExact).toBe(true);
+  });
+
   it("resolves per-room DM metadata from the base key when currentSessionKey has a thread suffix", async () => {
     const storedSession = createStoredDirectDmSession();
     const route = resolveUserRoute({

--- a/extensions/matrix/src/session-route.ts
+++ b/extensions/matrix/src/session-route.ts
@@ -10,7 +10,11 @@ import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-s
 import { resolveMatrixAccountConfig } from "./matrix/account-config.js";
 import { resolveDefaultMatrixAccountId } from "./matrix/accounts.js";
 import { resolveMatrixStoredSessionMeta } from "./matrix/session-store-metadata.js";
-import { isMatrixQualifiedUserId, resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
+import {
+  isMatrixQualifiedUserId,
+  isMatrixRoomId,
+  resolveMatrixTargetIdentity,
+} from "./matrix/target-ids.js";
 
 function resolveEffectiveMatrixAccountId(
   params: Pick<ChannelOutboundSessionRouteParams, "cfg" | "accountId">,
@@ -107,7 +111,7 @@ export function resolveMatrixOutboundSessionRoute(params: ChannelOutboundSession
     accountId: effectiveAccountId,
     recipientSessionExact:
       target.kind === "room"
-        ? dmSessionScope === "per-room" && target.id.startsWith("!") && target.id.includes(":")
+        ? dmSessionScope === "per-room" && isMatrixRoomId(target.id)
         : dmSessionScope === "per-user"
           ? isMatrixQualifiedUserId(target.id)
           : roomScopedDmId !== undefined,


### PR DESCRIPTION
## What Problem This Solves

Matrix room version 12 changed room IDs from the legacy `!opaque:server` form to a suffixless `!opaque` form. OpenClaw still required `:` at several “already resolved room ID” boundaries, so a valid Room v12 ID could be treated as unresolved and silently omitted from room policy.

This PR now covers only Room v12 IDs. The separate sync-quiescence problem encountered while gathering the original live proof was fixed more broadly by #125362 and has been removed from this branch.

## Why This Change Was Made

The Matrix plugin had four stale checks for `!` plus `:`:

- configured room resolution
- invite auto-join validation
- interactive room setup
- per-room DM session routing

The change adds one shared `isMatrixRoomId` predicate beside the existing user-ID predicate and uses it at those boundaries. It requires a nonempty identifier after `!`; user IDs and aliases still require their domain-qualified forms.

## User Impact

Operators can use the suffixless Room v12 IDs returned by their homeserver in Matrix room allowlists, invite auto-join allowlists, interactive setup, and per-room DM session routing. Guidance and placeholders now show both legacy and Room v12 forms.

## Evidence

- Matrix specification: [Room version 12](https://spec.matrix.org/v1.16/rooms/v12/) and [room ID grammar](https://spec.matrix.org/v1.16/appendices/#room-ids) allow suffixless room IDs.
- The author’s isolated Conduit proof created a real v12 room, configured its suffixless ID, sent a Matrix message through OpenClaw, and observed the deterministic bot reply in the same room. The rewrite retains that Room v12 behavior while removing the unrelated sync patch.
- The sync failure found during that exercise was rerun against current `main` and confirmed resolved by #125362: https://github.com/openclaw/openclaw/issues/125679#issuecomment-5348573657
- This rewritten branch has no diff in `client-sync-quiesce.ts` or `sdk.test.ts`; current `main` remains the sole owner of the broader lifecycle repair.
- Exact-head CI is green for `c06eea86bf7a51cfbd11c3ccedfd9f01c28984e5`: https://github.com/openclaw/openclaw/actions/runs/32311018098
- Exact-head OpenGrep is green: https://github.com/openclaw/openclaw/actions/runs/32311018134

Focused tests:

```bash
node scripts/run-vitest.mjs \
  extensions/matrix/src/matrix/target-ids.test.ts \
  extensions/matrix/src/matrix/monitor/config.test.ts \
  extensions/matrix/src/session-route.test.ts \
  extensions/matrix/src/onboarding.test.ts
```

These paths ran in the exact-head changed-extension CI lanes above. Contributor code was not executed in a credentialed local checkout.

## Production LOC

Matrix production code: `+26/-14` (net `+12`). The added helper centralizes one room-ID invariant used at four existing boundaries; each caller replaces its prior inline shape check. Tests and test support are `+177/-8`; docs are `+5/-5`.
