### PR TITLE
fix(terminal): keep table identifiers intact when wide columns can shrink

### DIFF
--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -22,6 +22,43 @@ function expectIntroducersToStartCompleteSequences(
   }
 }
 
+const pluginListColumns = [
+  { key: "Name", header: "Name", minWidth: 14, flex: true },
+  { key: "ID", header: "ID", minWidth: 10, flex: true },
+  { key: "Format", header: "Format", minWidth: 9 },
+  { key: "Status", header: "Status", minWidth: 10 },
+  { key: "Source", header: "Source", minWidth: 26, flex: true },
+  { key: "Version", header: "Version", minWidth: 8 },
+];
+
+const pluginListRows = [
+  {
+    Name: "Amazon Bedrock",
+    ID: "amazon-bedrock",
+    Format: "openclaw",
+    Status: "enabled",
+    Source: "~/Projects/openclaw/extensions/amazon-bedrock/index.ts",
+    Version: "2026.8.1",
+  },
+  {
+    Name: "N".repeat(40),
+    ID: "i".repeat(22),
+    Format: "openclaw",
+    Status: "disabled",
+    Source: `/${"s".repeat(80)}`,
+    Version: "2026.8.1",
+  },
+];
+
+function renderPluginListTable(width: number): string {
+  return renderTable({
+    width,
+    border: "unicode",
+    columns: pluginListColumns,
+    rows: pluginListRows,
+  });
+}
+
 describe("renderTable", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -59,6 +96,30 @@ describe("renderTable", () => {
     expect(out).toContain("Dashboard");
     expect(out).toMatch(/[│|] Dashboard\s+[│|]/);
   });
+
+  it("keeps identifier columns intact when wider flex columns can absorb the shrink", () => {
+    const out = renderPluginListTable(120);
+
+    expect(out).toMatch(/│ Amazon Bedrock\s+│ amazon-bedrock\s+│/);
+  });
+
+  it.each([60, 80, 120, 160, 200])(
+    "keeps the plugin-list shape deterministic and within %i columns",
+    (width) => {
+      const out = renderPluginListTable(width);
+      const lines = out.trimEnd().split("\n");
+      const headerCells = (lines[1] ?? "").split("│").slice(1, -1);
+
+      expect(out).toBe(renderPluginListTable(width));
+      expect(Math.max(...lines.map(visibleWidth))).toBeLessThanOrEqual(width);
+      expect(headerCells).toHaveLength(pluginListColumns.length);
+      for (const [index, column] of pluginListColumns.entries()) {
+        expect(visibleWidth(headerCells[index] ?? "")).toBeGreaterThanOrEqual(
+          visibleWidth(column.header) + 2,
+        );
+      }
+    },
+  );
 
   it("expands flex columns to fill available width", () => {
     const width = 60;
@@ -532,18 +593,19 @@ describe("renderTable", () => {
     }
   });
 
-  it("keeps borders aligned when a narrow flex column receives wide content", () => {
+  it("terminates with aligned borders when a flex column starts at its floor", () => {
     const out = renderTable({
       width: 10,
       border: "ascii",
       columns: [
         { key: "A", header: "long header here" },
-        { key: "B", header: "", flex: true },
+        { key: "B", header: "", flex: true, maxWidth: 3 },
       ],
       rows: [{ A: "data", B: "📸" }],
     });
     const lines = out.trimEnd().split("\n");
     const headerWidth = visibleWidth(lines[0] ?? "");
+    expect(headerWidth).toBeGreaterThan(10);
     for (const line of lines) {
       expect(visibleWidth(line)).toBe(headerWidth);
     }

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -601,45 +601,37 @@ export function renderTable(opts: RenderTableOptions): string {
   if (maxWidth && total > maxWidth) {
     let over = total - maxWidth;
 
-    const flexOrder = columns
-      .map((_c, i) => ({ i, w: widths[i] ?? 0 }))
-      .filter(({ i }) => Boolean(columns[i]?.flex))
-      .toSorted((a, b) => b.w - a.w)
-      .map((x) => x.i);
+    const flexColumns = columns.flatMap((column, i) => (column.flex ? [i] : []));
+    const nonFlexColumns = columns.flatMap((column, i) => (column.flex ? [] : [i]));
 
-    const nonFlexOrder = columns
-      .map((_c, i) => ({ i, w: widths[i] ?? 0 }))
-      .filter(({ i }) => !columns[i]?.flex)
-      .toSorted((a, b) => b.w - a.w)
-      .map((x) => x.i);
-
-    const shrink = (order: number[], minWidths: number[]) => {
+    const shrink = (indices: number[], minWidths: number[]) => {
       while (over > 0) {
-        let progressed = false;
-        for (const i of order) {
+        let widest: number | undefined;
+        for (const i of indices) {
           if ((widths[i] ?? 0) <= (minWidths[i] ?? 0)) {
             continue;
           }
-          widths[i] = (widths[i] ?? 0) - 1;
-          over -= 1;
-          progressed = true;
-          if (over <= 0) {
-            break;
+          // Water-fill from the widest eligible column. Strict comparison makes
+          // equal-width ties deterministic: the leftmost column shrinks first.
+          if (widest === undefined || (widths[i] ?? 0) > (widths[widest] ?? 0)) {
+            widest = i;
           }
         }
-        if (!progressed) {
+        if (widest === undefined) {
           break;
         }
+        widths[widest] = (widths[widest] ?? 0) - 1;
+        over -= 1;
       }
     };
 
     // Prefer shrinking flex columns; only shrink non-flex if necessary.
     // If required to fit, allow flex columns to shrink below user minWidth
     // down to their absolute minimum (header + padding).
-    shrink(flexOrder, preferredMinWidths);
-    shrink(flexOrder, absoluteMinWidths);
-    shrink(nonFlexOrder, preferredMinWidths);
-    shrink(nonFlexOrder, absoluteMinWidths);
+    shrink(flexColumns, preferredMinWidths);
+    shrink(flexColumns, absoluteMinWidths);
+    shrink(nonFlexColumns, preferredMinWidths);
+    shrink(nonFlexColumns, absoluteMinWidths);
   }
 
   // If we have room and any flex columns, expand them to fill the available width.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using CLI tables with several flexible columns could see short, copy-sensitive identifiers wrap even while a much wider path or description column retained substantial slack. In `openclaw plugins list`, `amazon-bedrock` was split at 120 and 160 columns, making the token required by `openclaw plugins enable <id>` harder to copy correctly.

## Why This Change Was Made

The shared table allocator sorted flexible columns widest-first but then removed one column from every eligible flex column per pass, so the sort only affected the final partial pass. This change implements deterministic integer water-filling: each step shrinks the currently widest eligible column, with left-to-right order breaking equal-width ties. The existing flex/non-flex and preferred/absolute minimum phases remain unchanged.

Water-filling is preferable to proportional slack for this shape. With outer widths `Name=42`, `ID=24`, and `Source=83` at a 120-column terminal, proportional shrink would produce `23/15/45`; after padding, the ID would have only 13 content columns and `amazon-bedrock` would still wrap. Water-filling produces `29/24/30`, preserving the ID and moving wrapping into Source.

## User Impact

Identifiers remain copyable on normal and wide terminals when a larger flexible column can absorb the shrink. Narrow terminals still honor header and absolute-width floors, and genuinely unsatisfiable widths terminate without shrinking columns below those floors.

AI-assisted: yes. I understand and reviewed the allocator, caller blast radius, tests, and live output.

## Evidence

### Reproduction and allocation

The new renderer regression uses the measured plugin-list shape: 40-character Name, 22-character ID, 81-character Source, and the real fixed columns. It failed before the production change because the 120-column row rendered `amazon-` / `bedrock` on separate lines.

Measured outer flex widths:

| Terminal | Previous | Water-fill |
| --- | --- | --- |
| 80 | `12/8/23` | `14/10/19` |
| 120 | `16/10/57` | `29/24/30` |
| 160 | `33/16/74` | `42/24/57` |

### PTY before/after

All commands used isolated scratch `OPENCLAW_STATE_DIR` directories and `OPENCLAW_SKIP_CHANNELS=1`; no live profile or Gateway port was touched.

Before, the installed pre-fix macOS CLI (`2026.7.2`, 148 plugins) split the ID:

```text
80:  │ Amazon │ amazon │ ... │ ~/Projects/openclaw-  │
     │ Bedrock│ -      │ ... │ main/extensions/...  │
     │        │ bedroc │ ... │ amazon-bedrock/...   │
     │        │ k      │ ... │                      │
120: │ Amazon │ amazon-│ ... │ ~/Projects/openclaw-main/extensions/... │
     │ Bedrock│ bedrock│ ... │                                       │
160: │ Amazon │ amazon-│ ... │ ~/Projects/openclaw-main/extensions/... │
     │ Bedrock│ bedrock│ ... │                                       │
```

After a full build of this head, the fixed CLI (`2026.8.1`, 149 plugins) rendered:

```text
80:  │ Amazon       │ amazon-        │ ... │ ~/_work/openclaw/... │
     │ Bedrock      │ bedrock        │ ... │ extensions/...       │
120: │ Amazon Bedrock              │ amazon-bedrock        │ ... │ ~/_work/openclaw/openclaw/ │
     │                             │                       │ ... │ extensions/amazon-bedrock/ │
160: │ Amazon Bedrock                           │ amazon-bedrock        │ ... │ ~/_work/openclaw/.../amazon-bedrock/ │
     │                                          │                       │ ... │ index.ts                              │
```

At 80 columns the hard floors still require wrapping, but the identifier improves from four fragments to two. At 120 and 160 it remains intact while Source absorbs the wrapping.

### Tests and gates

- Pre-fix regression: failed for the intended split-ID reason; passes after the allocator change.
- `node scripts/run-vitest.mjs packages/terminal-core/src`: 23 files passed, 342 tests passed, 3 skipped.
- Existing table-output CLI/status coverage: 17 files passed, 445 tests passed.
- `node scripts/check-changed.mjs`: Testbox exit 0; format, prod/test types, lint, dead exports, dependency, architecture, and boundary guards passed ([run](https://github.com/openclaw/openclaw/actions/runs/31857899453)).
- Full build plus PTY proof: exit 0 ([run](https://github.com/openclaw/openclaw/actions/runs/31858514531)).
- Source-blind behavior validation: all clauses passed at 60/80/120/160/200; tables were aligned and exactly bounded, IDs stayed intact at 120/160 while Source wrapped, and repeat output was deterministic after excluding the randomized banner.
- Autoreview: clean, no accepted/actionable findings.

### Blast-radius and snapshot review

Audited all 32 direct production invocations across 19 files plus the injected status-report path. This covers plugins, nodes, devices, worktrees, exec approvals/policy, hooks, directory, DNS, pairing, skills, update status, fleet, message formatting, model probes, and status reports.

No relevant `toMatchSnapshot` or `toMatchInlineSnapshot` assertions exist. Existing rendered-output tests are containment/shape-based, and all of them passed; `plugins-list-command.test.ts` mocks the renderer, so the new terminal-core regression is the canonical allocation proof.

Production LOC: `+16/-24` (net `-8`) | Tests: `+64/-2` (net `+62`).
