### PR TITLE
fix(logging): stop duplicate root file log records

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 // Provides root logger helpers and themed terminal output.
 import { theme } from "../packages/terminal-core/src/theme.js";
 import { isVerbose } from "./global-state.js";
+import { writeRootConsoleLine } from "./logging/console.js";
 import { getLogger } from "./logging/logger.js";
 import { createSubsystemLogger } from "./logging/subsystem.js";
 import { defaultRuntime, type RuntimeEnv } from "./runtime.js";
@@ -41,7 +42,10 @@ function logWithSubsystem(params: {
     method(parsed.rest);
     return;
   }
-  params.runtime[params.runtimeMethod](params.runtimeFormatter(params.message));
+  const formatted = params.runtimeFormatter(params.message);
+  if (params.runtime !== defaultRuntime || !writeRootConsoleLine(params.runtimeMethod, formatted)) {
+    params.runtime[params.runtimeMethod](formatted);
+  }
   getLogger()[params.loggerMethod](params.message);
 }
 

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { setVerbose } from "../global-state.js";
-import { logError, logWarn } from "../logger.js";
+import { logError, logInfo, logWarn } from "../logger.js";
 import {
   createSubsystemLogger,
   enableConsoleCapture,
@@ -49,6 +49,7 @@ afterEach(() => {
   resetLogger();
   setLoggerOverride(null);
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 afterAll(async () => {
@@ -386,6 +387,32 @@ describe("enableConsoleCapture", () => {
     const content = fs.readFileSync(logPath, "utf-8");
     expect(countMatchingLines(content, "conflicting schema definitions")).toBe(1);
   });
+
+  it.each([
+    { name: "info", log: logInfo, consoleMethod: "log" as const },
+    { name: "error", log: logError, consoleMethod: "error" as const },
+  ])(
+    "routes non-subsystem $name logs through one file and console sink",
+    async ({ log, consoleMethod }) => {
+      vi.stubEnv("OPENCLAW_TEST_RUNTIME_LOG", "1");
+      const logPath = tempLogPath();
+      setLoggerOverride({ level: "info", file: logPath });
+      const consoleSpy = vi.fn();
+      console[consoleMethod] = consoleSpy;
+      enableConsoleCapture();
+
+      log(`[tools] operation failed: Authorization: Bearer ${secret}`);
+      await testApi.flushFileLogQueueForTests();
+
+      expect(
+        countMatchingLines(fs.readFileSync(logPath, "utf-8"), "[tools] operation failed"),
+      ).toBe(1);
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      const consoleLine = firstMockArgAsString(consoleSpy);
+      expect(consoleLine).toContain("[tools] operation failed");
+      expect(consoleLine).not.toContain(secret);
+    },
+  );
 
   it("redacts credentials before forwarding console output", () => {
     setLoggerOverride({ level: "info", file: tempLogPath() });

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -1,6 +1,7 @@
 // Console logging helpers format and write messages to console streams.
 import util from "node:util";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { clearActiveProgressLine } from "../../packages/terminal-core/src/progress-line.js";
 import { isVerbose } from "../global-state.js";
 import { readLoggingConfig } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
@@ -183,6 +184,75 @@ function hasTimestampPrefix(value: string): boolean {
   );
 }
 
+function writeFormattedConsoleOutput(params: {
+  level: LogLevel;
+  args: unknown[];
+  formatted: string;
+  write: (...args: unknown[]) => void;
+  traceWrite: (...args: unknown[]) => void;
+  caller?: (...args: unknown[]) => void;
+}) {
+  const trimmed = stripAnsi(params.formatted).trimStart();
+  const consoleStyle = getConsoleSettings().style;
+  const shouldPrefixTimestamp =
+    consoleStyle !== "json" &&
+    loggingState.consoleTimestampPrefix &&
+    trimmed.length > 0 &&
+    !hasTimestampPrefix(trimmed);
+  const timestamp = shouldPrefixTimestamp ? formatConsoleTimestamp(consoleStyle) : "";
+  const jsonMessage = consoleStyle === "json" ? stripAnsi(params.formatted) : "";
+  const jsonMeta =
+    consoleStyle === "json" && params.level === "trace" && params.caller
+      ? { stack: stripAnsi(captureConsoleTraceStack(params.formatted, params.caller)) }
+      : undefined;
+  try {
+    const redacted = redactSensitiveText(params.formatted);
+    const line =
+      consoleStyle === "json"
+        ? formatJsonConsoleLine({ level: params.level, message: jsonMessage, meta: jsonMeta })
+        : timestamp
+          ? `${timestamp} ${redacted}`
+          : redacted;
+    if (loggingState.forceConsoleToStderr) {
+      process.stderr.write(`${line}\n`);
+    } else if (consoleStyle === "json") {
+      // Node and Bun implement console.trace() through this.error(). Use the raw error
+      // sink so the structured trace does not re-enter as an error.
+      (params.level === "trace" ? params.traceWrite : params.write).call(console, line);
+    } else if (!timestamp && params.args.length === 0) {
+      params.write.apply(console, params.args as []);
+    } else {
+      params.write.call(console, line);
+    }
+  } catch (err) {
+    if (isEpipeError(err)) {
+      return;
+    }
+    throw err;
+  }
+}
+
+/** Writes a root logger line to the pre-capture console sink without re-entering file capture. */
+export function writeRootConsoleLine(method: "log" | "error", line: string): boolean {
+  const rawConsole = loggingState.rawConsole;
+  if (!rawConsole) {
+    return false;
+  }
+  clearActiveProgressLine();
+  if (shouldSuppressConsoleMessage(line)) {
+    return true;
+  }
+  const level = method === "error" ? "error" : "info";
+  writeFormattedConsoleOutput({
+    level,
+    args: [line],
+    formatted: line,
+    write: rawConsole[method],
+    traceWrite: rawConsole.error,
+  });
+  return true;
+}
+
 /**
  * Route console.* calls through file logging while still emitting to stdout/stderr.
  * This keeps user-facing output unchanged but guarantees every console call is captured in log files.
@@ -245,14 +315,6 @@ export function enableConsoleCapture(): void {
       if (shouldSuppressConsoleMessage(formatted)) {
         return;
       }
-      const trimmed = stripAnsi(formatted).trimStart();
-      const consoleStyle = getConsoleSettings().style;
-      const shouldPrefixTimestamp =
-        consoleStyle !== "json" &&
-        loggingState.consoleTimestampPrefix &&
-        trimmed.length > 0 &&
-        !hasTimestampPrefix(trimmed);
-      const timestamp = shouldPrefixTimestamp ? formatConsoleTimestamp(consoleStyle) : "";
       try {
         const resolvedLogger = getLoggerLazy();
         // Map console levels to file logger
@@ -272,58 +334,14 @@ export function enableConsoleCapture(): void {
       } catch {
         // never block console output on logging failures
       }
-      const jsonMessage = consoleStyle === "json" ? stripAnsi(formatted) : "";
-      const jsonMeta =
-        consoleStyle === "json" && level === "trace"
-          ? { stack: stripAnsi(captureConsoleTraceStack(formatted, forwardedConsoleCall)) }
-          : undefined;
-      if (loggingState.forceConsoleToStderr) {
-        // In --json mode, all console.* writes are diagnostics and should stay off stdout.
-        try {
-          const redacted = redactSensitiveText(formatted);
-          const line =
-            consoleStyle === "json"
-              ? formatJsonConsoleLine({ level, message: jsonMessage, meta: jsonMeta })
-              : timestamp
-                ? `${timestamp} ${redacted}`
-                : redacted;
-          process.stderr.write(`${line}\n`);
-        } catch (err) {
-          if (isEpipeError(err)) {
-            return;
-          }
-          throw err;
-        }
-      } else {
-        try {
-          const redacted = redactSensitiveText(formatted);
-          if (consoleStyle === "json") {
-            const line = formatJsonConsoleLine({ level, message: jsonMessage, meta: jsonMeta });
-            // Node and Bun implement console.trace() through this.error(). Use the raw error
-            // sink so the structured trace does not re-enter as an error.
-            if (level === "trace") {
-              original.error(line);
-            } else {
-              orig.call(console, line);
-            }
-            return;
-          }
-          if (!timestamp) {
-            if (args.length === 0) {
-              orig.apply(console, args as []);
-              return;
-            }
-            orig.call(console, redacted);
-            return;
-          }
-          orig.call(console, redacted ? `${timestamp} ${redacted}` : timestamp);
-        } catch (err) {
-          if (isEpipeError(err)) {
-            return;
-          }
-          throw err;
-        }
-      }
+      writeFormattedConsoleOutput({
+        level,
+        args,
+        formatted,
+        write: orig,
+        traceWrite: original.error,
+        caller: forwardedConsoleCall,
+      });
     };
     return forwardedConsoleCall;
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reading `openclaw logs` saw every non-subsystem `logInfo`, `logWarn`, and `logError` message twice in the profile file log. The default 200-line tail therefore held roughly half as much useful history, and support bundles inherited the duplicate error-heavy stream.

Live evidence from the reported gateway log showed adjacent error records for the same `[tools] read failed` message: one from `dist/console-*.js:161`, followed 1 ms later by one from `dist/logger-*.js:28`. The supplied whole-log count was 44 adjacent duplicate pairs among 572 records.

## Why This Change Was Made

Root helpers now keep their explicit, correctly leveled file-logger write and send terminal output through a console-only seam that targets the pre-capture sink. The seam is extracted from console capture's existing output formatter, so JSON/pretty/compact formatting, timestamping, forced-stderr routing, EPIPE handling, redaction, and progress-line clearing stay on one canonical path.

This is safer than dropping the explicit file write: root helpers are also used without console capture, and existing library/no-capture coverage requires those calls to keep reaching the file logger. Routing unprefixed messages through a subsystem logger was also rejected because it would add visible subsystem presentation to roughly 150 existing call sites.

## User Impact

`openclaw logs` and diagnostic bundles now contain one file record per non-subsystem root log call while the console still prints one redacted line with its existing presentation.

Production LOC: +83/-61 (net +22). Tests: +28/-1 (net +27). The production growth is the console-only owner seam; the larger console diff is the existing formatter moved behind that shared seam, not a second formatting implementation.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/logging/console-capture.test.ts` failed both new info/error cases with 2 matching file records instead of 1.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/logging/console-capture.test.ts src/logger.test.ts src/logging/subsystem.test.ts` — 68 tests passed across 2 shards. This covers one file record and one console line for info/error, subsystem routing remaining single-write, and console redaction.
- Changed gate: `node scripts/check-changed.mjs` — passed formatting, production/test typechecks, core lint, import cycles, and repository guards on Blacksmith Testbox (`tbx_01m01hvfejm3hyycw1j1me8tz2`; run https://github.com/openclaw/openclaw/actions/runs/31857630521).
- Built scratch-profile proof: `pnpm build`, isolated `OPENCLAW_STATE_DIR`, derived loopback port, `OPENCLAW_SKIP_CHANNELS=1`, and a healthy live gateway. Two built-runtime non-subsystem probes produced exactly 2 file records and 2 redacted console lines. Whole-log adjacent-pair count was 1/20 versus the supplied 44/572 baseline (`tbx_01m01kdmpj335p2ytawnf91fn5`; run https://github.com/openclaw/openclaw/actions/runs/31858853119).
- The one remaining whole-log pair was `cron: job added`, emitted independently by the cron mutation and gateway audit owners; neither probe message duplicated. That is a separate producer-level follow-up, not root logger recursion.
- Autoreview: clean; no accepted or actionable findings.

AI-assisted: yes. The implementation, tests, and live proof were reviewed and understood.
