### PR TITLE
fix(ui): clear stale companion state after session reset

### DIFF
--- a/ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts
@@ -1,0 +1,115 @@
+/* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-pane-companion-lifecycle.test/"} */
+
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
+import type { ChatSessionCompanionThreads } from "./chat-session-companion.ts";
+
+const companionThreads = (pane: TestChatPane) =>
+  (pane as TestChatPane & { sessionCompanionThreads: ChatSessionCompanionThreads })
+    .sessionCompanionThreads;
+
+describe("chat pane companion connection lifecycle", () => {
+  it("preserves threads while a same-client reconnect settles a pending answer", async () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    let rejectAnswer!: (error: Error) => void;
+    const threads = companionThreads(pane);
+    await threads.hydrate(
+      "agent:main:current",
+      async () => ({
+        exchanges: [{ question: "Earlier question", answer: "Earlier answer", ts: 1 }],
+      }),
+      "main",
+    );
+    const pending = threads.submit(
+      "agent:main:current",
+      "current question",
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectAnswer = reject;
+        }),
+      "main",
+    );
+    threads.setDraft("agent:main:other", "other draft", "main");
+
+    // GatewayProtocolClient flushes pending requests before publishing the
+    // reconnecting snapshot; Promise rejection settles on the next microtask.
+    rejectAnswer(new Error("gateway closed"));
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      phase: "reconnecting",
+      hello: null,
+    });
+
+    expect(threads.view("agent:main:current", "main").exchanges).toEqual([
+      { question: "Earlier question", answer: "Earlier answer", ts: 1 },
+    ]);
+    expect(threads.view("agent:main:other", "main").draft).toBe("other draft");
+    await pending;
+    expect(threads.view("agent:main:current", "main")).toMatchObject({
+      exchanges: [{ question: "Earlier question", answer: "Earlier answer", ts: 1 }],
+      failedQuestion: "current question",
+      pendingQuestion: null,
+    });
+
+    pane.connectedClient = client;
+    pane.applyGatewaySnapshot({ ...pane.context.gateway.snapshot, phase: "connected" });
+    expect(threads.view("agent:main:other", "main").draft).toBe("other draft");
+    await threads.hydrate(
+      "agent:main:current",
+      async () => ({
+        exchanges: [
+          { question: "Earlier question", answer: "Earlier answer", ts: 1 },
+          { question: "current question", answer: "Recovered answer", ts: 2 },
+        ],
+      }),
+      "main",
+    );
+    expect(threads.view("agent:main:current", "main")).toMatchObject({
+      exchanges: [
+        { question: "Earlier question", answer: "Earlier answer", ts: 1 },
+        { question: "current question", answer: "Recovered answer", ts: 2 },
+      ],
+      failedQuestion: null,
+      pendingQuestion: null,
+    });
+  });
+
+  it("retires every thread and late answer when the Gateway client is replaced", async () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const replacement = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const threads = companionThreads(pane);
+    let resolveAnswer!: (value: { answer: string; ts: number }) => void;
+    const pending = threads.submit(
+      "agent:main:current",
+      "replace this question",
+      () =>
+        new Promise((resolve) => {
+          resolveAnswer = resolve;
+        }),
+      "main",
+    );
+    threads.setDraft("agent:main:other", "replace this draft", "main");
+
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      client: replacement,
+      phase: "reconnecting",
+      hello: null,
+    });
+
+    expect(threads.view("agent:main:current", "main")).toMatchObject({
+      exchanges: [],
+      failedQuestion: null,
+      pendingQuestion: null,
+    });
+    expect(threads.view("agent:main:other", "main").draft).toBe("");
+    resolveAnswer({ answer: "late answer", ts: 3 });
+    await pending;
+    expect(threads.view("agent:main:current", "main").exchanges).toEqual([]);
+  });
+});

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -241,6 +241,9 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       this.sessionDiscussionOpenUrls.clear();
       this.sessionDiscussionPanels.clear();
       this.sessionParticipationTracker.reset();
+      if (state.client !== snapshot.client) {
+        this.sessionCompanionThreads.retire();
+      }
       // A new gateway/account owns its own membership + identity data; drop the
       // previous connection's sharing cache so a stale loading entry cannot
       // suppress the fresh load or leak the prior account's identities.

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -391,6 +391,8 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     };
     pageState.refreshSessionPullRequests = (options) => this.refreshSessionPullRequests(options);
     pageState.openSessionCompanion = (question) => this.submitSessionCompanionQuestion(question);
+    pageState.retireSessionCompanion = (key, agentId) =>
+      this.sessionCompanionThreads.retire(key, agentId);
     this.state = pageState;
     if (this.sessionKey) {
       const initialSessionKey = this.setPaneSessionKey(this.sessionKey);
@@ -613,7 +615,6 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     this.connectionGeneration += 1;
     this.deferredSessionHydrationRequestVersion += 1;
     this.sessionDiscussionPanels.clear();
-    this.sessionCompanionHydrationKey = "";
     this.taskSuggestionsRequestVersion += 1;
     this.taskSuggestions = [];
     this.taskSuggestionBusyIds.clear();

--- a/ui/src/pages/chat/chat-session-companion.ts
+++ b/ui/src/pages/chat/chat-session-companion.ts
@@ -229,11 +229,15 @@ export class ChatSessionCompanionThreads {
     if (!targetSessionKey) {
       return;
     }
-    const key = companionThreadKey(targetSessionKey, agentId);
     await clear(targetSessionKey);
-    this.hydrationTokens.delete(key);
-    this.submissionTokens.delete(key);
-    this.threads.set(key, createThread());
+    this.retire(targetSessionKey, agentId);
+  }
+
+  retire(sessionKey?: string, agentId?: string | null): void {
+    const key = sessionKey ? companionThreadKey(sessionKey, agentId) : null;
+    for (const store of [this.threads, this.hydrationTokens, this.submissionTokens]) {
+      void (key ? store.delete(key) : store.clear());
+    }
     this.notify();
   }
 

--- a/ui/src/pages/chat/chat-session-rail.test.ts
+++ b/ui/src/pages/chat/chat-session-rail.test.ts
@@ -401,6 +401,32 @@ describe("ChatSessionCompanionThreads", () => {
     expect(threads.view("one").exchanges).toEqual([]);
   });
 
+  it("retires one session without clearing unrelated companion state", () => {
+    const threads = new ChatSessionCompanionThreads();
+    threads.setDraft("one", "retire me", "main");
+    threads.setDraft("two", "keep me", "main");
+
+    threads.retire("one", "main");
+
+    expect(threads.view("one", "main").draft).toBe("");
+    expect(threads.view("two", "main").draft).toBe("keep me");
+  });
+
+  it("adopts an empty restarted-Gateway thread without discarding its local draft", async () => {
+    const threads = new ChatSessionCompanionThreads();
+    await threads.hydrate("one", async () => ({
+      exchanges: [{ question: "Before restart", answer: "Old answer", ts: 1 }],
+    }));
+    threads.setDraft("one", "unsent local draft");
+
+    await threads.hydrate("one", async () => ({ exchanges: [] }));
+
+    expect(threads.view("one")).toMatchObject({
+      draft: "unsent local draft",
+      exchanges: [],
+    });
+  });
+
   it.each(["resolve", "reject"] as const)(
     "does not resurrect a reset request after a late $outcome",
     async (outcome) => {

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -269,8 +269,11 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
     event && globalSessionEventMatchesChat(state, event) && sessionMessageMatchesChat(state, event),
   );
   const source = asNullableRecord(payload);
-  const resetsSelectedSession =
-    matchesChat && (source?.reason === "reset" || source?.phase === "reset");
+  const resetsSession = source?.reason === "reset" || source?.phase === "reset";
+  if (event && (resetsSession || source?.reason === "new")) {
+    state.retireSessionCompanion?.(event.key, event.agentId);
+  }
+  const resetsSelectedSession = matchesChat && resetsSession;
   if (resetsSelectedSession) {
     const scope = readChatSessionProjectionScope(state, { agentId: resolveChatAgentId(state) });
     // Reset keeps the public session ID; the explicit reducer event is the

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -150,4 +150,5 @@ export type ChatPageHost = ChatHost &
     refreshCurrentSessionTools?: () => Promise<void>;
     refreshCurrentChat?: () => Promise<void>;
     refreshSessionPullRequests?: (options?: { refresh?: boolean }) => Promise<void>;
+    retireSessionCompanion?: (sessionKey: string, agentId?: string | null) => void;
   };

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -265,6 +265,7 @@ describe("canonical session message recovery", () => {
   });
 
   it("drops pre-reset live and pending messages before accepting a new session turn", () => {
+    const retireSessionCompanion = vi.fn();
     const pendingUser = {
       role: "user",
       content: [{ type: "text", text: "Pending before reset" }],
@@ -274,6 +275,9 @@ describe("canonical session message recovery", () => {
       connected: false,
       chatMessages: [pendingUser],
     });
+    (
+      state as ChatPageHost & { retireSessionCompanion: typeof retireSessionCompanion }
+    ).retireSessionCompanion = retireSessionCompanion;
     const deliverUser = (id: string, text: string) =>
       handlePageGatewayEvent(state, {
         type: "event",
@@ -301,6 +305,7 @@ describe("canonical session message recovery", () => {
       },
     });
     expect(state.chatMessages).toEqual([]);
+    expect(retireSessionCompanion).toHaveBeenCalledExactlyOnceWith(state.sessionKey, "main");
 
     deliverUser("post-reset-live", "Live after reset");
     expect(state.chatMessages).toHaveLength(1);
@@ -310,6 +315,7 @@ describe("canonical session message recovery", () => {
   });
 
   it("does not clear the selected transcript when another agent resets", () => {
+    const retireSessionCompanion = vi.fn();
     const selectedUser = {
       role: "user",
       content: [{ type: "text", text: "Keep this agent's conversation" }],
@@ -319,6 +325,9 @@ describe("canonical session message recovery", () => {
       connected: false,
       chatMessages: [selectedUser],
     });
+    (
+      state as ChatPageHost & { retireSessionCompanion: typeof retireSessionCompanion }
+    ).retireSessionCompanion = retireSessionCompanion;
 
     handlePageGatewayEvent(state, {
       type: "event",
@@ -331,6 +340,7 @@ describe("canonical session message recovery", () => {
     });
 
     expect(state.chatMessages).toEqual([selectedUser]);
+    expect(retireSessionCompanion).toHaveBeenCalledExactlyOnceWith("agent:other:main", "other");
   });
 
   it("keeps the routed row when a hidden pane observes its archive first", () => {


### PR DESCRIPTION
Closes #123940

## What Problem This Solves

Fixes an issue where Control UI users resetting a session could continue seeing stale Session companion questions, answers, and drafts after the Gateway had deleted that companion thread. It also prevents ordinary same-client reconnects from silently discarding safe local companion state.

## Why This Change Was Made

The pane-owned companion store now owns one scoped/all retirement path for threads plus hydration/submission tokens. Exact `sessions.changed` reset/new events retire only their session, browser Gateway-client replacement retires all state, and transient reconnects preserve local exchanges/drafts while the connection generation triggers fresh hydration.

This keeps policy at the lifecycle owners: the session event producer chooses scoped retirement, the connection owner chooses all-state retirement, and the store performs the actual token/thread cleanup.

Production LOC: +19/-7 (net +12) | Tests: +151/-0

The remaining production growth buys the typed page-state callback (+1), scoped reset/new routing (+3), browser-client replacement retirement (+3), lifecycle wiring while deleting duplicate hydration invalidation (+1), and the canonical scoped/all store cleanup (+4). The simplification pass reused the existing connection generation and reset predicate instead of adding a parallel cache, retry path, or compatibility layer.

## User Impact

Session reset/new immediately clears only that companion thread. Transient reconnects retain safe local companion exchanges and drafts, while reconnect hydration reconciles server state. Switching to a replacement Gateway browser client/account clears all prior companion state.

## Evidence

Negative controls on latest `origin/main` base `7160c4de0bf3c38ab390c19d7a7ad725a81749e9`:

- Removing reset/new retirement: `chat-state.test.ts` failed 2/53 because the retirement callback had 0 calls.
- Retiring all state on same-client reconnect: `chat-pane-companion-lifecycle.test.ts` failed 1/2 because the prior exchange became `[]`.

Focused regression command:

```text
node scripts/run-vitest.mjs run ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts ui/src/pages/chat/chat-pane-lifecycle.test.ts ui/src/pages/chat/chat-session-rail.test.ts ui/src/pages/chat/chat-state.test.ts
```

Result: 125/125 passed across two UI shards.

Built isolated Gateway + Control UI Chromium proof on Blacksmith Testbox `tbx_01m01k968zdq9j26cbacb7p5vx` ([run 31858526307](https://github.com/openclaw/openclaw/actions/runs/31858526307)):

- same-client TCP transport drop preserved the companion exchange and draft;
- scoped `/clear` removed the selected companion while an unrelated session retained its exchange;
- Gateway process restart removed server-backed exchanges while retaining the safe unsent draft;
- final UI contained no offline, reconnecting, or Gateway error state;
- built asset: `assets/index-D47JfoSu.js`, SHA-256 `07c8ccdea4cf0ef64aad0ea4322da8ccfed8c43a841fa6697e7b28e130a1f02d`.

Before transient reconnect:

![Companion before transient reconnect](https://github.com/user-attachments/assets/73cdfeb3-29ca-4f82-bfc1-1113c1e60b20)

After transient reconnect:

![Companion preserved after transient reconnect](https://github.com/user-attachments/assets/02f33b52-0041-458c-9aca-a117d2e8da52)

After scoped reset:

![Selected companion cleared after reset](https://github.com/user-attachments/assets/61ae409a-e826-4bd5-8a49-f86c87e3dce9)

After Gateway restart:

![Companion after Gateway restart](https://github.com/user-attachments/assets/72bb2d9c-845e-48ea-add5-20d003e6259b)

Also passed targeted oxfmt, type-aware Oxlint, `git diff --check`, and the exact eight-file changed-gate classification (`coreTests`, `ui`).
