### PR TITLE
fix(channels): bound injected session context to the current session start

### DIFF
--- a/src/channels/inbound-event/session-transcript-context.runtime.test.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.test.ts
@@ -216,7 +216,7 @@ describe("session transcript inbound context", () => {
     expect(readRecent).not.toHaveBeenCalled();
   });
 
-  it("requests a session-start-bounded read so non-telegram channels don't leak pre-reset context", async () => {
+  it("requests a reset-boundary-bounded read so non-telegram channels don't leak pre-reset context", async () => {
     readRecent.mockResolvedValue([]);
     const ctx = context();
 
@@ -228,11 +228,11 @@ describe("session transcript inbound context", () => {
     });
 
     expect(readRecent).toHaveBeenCalledWith(
-      expect.objectContaining({ applySessionStartMinTimestamp: true }),
+      expect.objectContaining({ excludeResetCarryover: true }),
     );
   });
 
-  it("still forwards an explicit minTimestampMs (e.g. telegram's own wiring) alongside the default", async () => {
+  it("still forwards an explicit minTimestampMs (e.g. telegram's own wiring) alongside it", async () => {
     readRecent.mockResolvedValue([]);
     const ctx = context({
       SessionTranscriptContext: { historyLimit: 3, minTimestampMs: 1_500 },
@@ -246,7 +246,7 @@ describe("session transcript inbound context", () => {
     });
 
     expect(readRecent).toHaveBeenCalledWith(
-      expect.objectContaining({ minTimestampMs: 1_500, applySessionStartMinTimestamp: true }),
+      expect.objectContaining({ minTimestampMs: 1_500, excludeResetCarryover: true }),
     );
   });
 

--- a/src/channels/inbound-event/session-transcript-context.runtime.test.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.test.ts
@@ -216,6 +216,40 @@ describe("session transcript inbound context", () => {
     expect(readRecent).not.toHaveBeenCalled();
   });
 
+  it("requests a session-start-bounded read so non-telegram channels don't leak pre-reset context", async () => {
+    readRecent.mockResolvedValue([]);
+    const ctx = context();
+
+    await mergeSessionTranscriptContext({
+      agentId: "main",
+      ctx,
+      sessionKey: ctx.SessionKey!,
+      storePath: "/tmp/sessions.json",
+    });
+
+    expect(readRecent).toHaveBeenCalledWith(
+      expect.objectContaining({ applySessionStartMinTimestamp: true }),
+    );
+  });
+
+  it("still forwards an explicit minTimestampMs (e.g. telegram's own wiring) alongside the default", async () => {
+    readRecent.mockResolvedValue([]);
+    const ctx = context({
+      SessionTranscriptContext: { historyLimit: 3, minTimestampMs: 1_500 },
+    });
+
+    await mergeSessionTranscriptContext({
+      agentId: "main",
+      ctx,
+      sessionKey: ctx.SessionKey!,
+      storePath: "/tmp/sessions.json",
+    });
+
+    expect(readRecent).toHaveBeenCalledWith(
+      expect.objectContaining({ minTimestampMs: 1_500, applySessionStartMinTimestamp: true }),
+    );
+  });
+
   it("skips canonical history for session-boundary commands", async () => {
     const ctx = context({ CommandBody: "/new summarize this workspace" });
 

--- a/src/channels/inbound-event/session-transcript-context.runtime.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.ts
@@ -132,6 +132,11 @@ export async function mergeSessionTranscriptContext(params: {
       ? { beforeTimestampMs: options?.beforeTimestampMs ?? params.ctx.Timestamp }
       : {}),
     ...(options?.minTimestampMs !== undefined ? { minTimestampMs: options.minTimestampMs } : {}),
+    // Bound to the current session's start when the caller doesn't supply its own
+    // cutoff: a reset preserves sessionId but bumps sessionStartedAt, so without
+    // this a post-reset turn on non-telegram channels still surfaces pre-reset
+    // transcript content (session-transcript-boundary-cutoff).
+    applySessionStartMinTimestamp: true,
   });
   const labels = options?.senderLabels ?? { assistant: "Assistant", user: "User" };
   const transcript = turns.map((turn) => {

--- a/src/channels/inbound-event/session-transcript-context.runtime.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.ts
@@ -132,11 +132,10 @@ export async function mergeSessionTranscriptContext(params: {
       ? { beforeTimestampMs: options?.beforeTimestampMs ?? params.ctx.Timestamp }
       : {}),
     ...(options?.minTimestampMs !== undefined ? { minTimestampMs: options.minTimestampMs } : {}),
-    // Bound to the current session's start when the caller doesn't supply its own
-    // cutoff: a reset preserves sessionId but bumps sessionStartedAt, so without
-    // this a post-reset turn on non-telegram channels still surfaces pre-reset
-    // transcript content (session-transcript-boundary-cutoff).
-    applySessionStartMinTimestamp: true,
+    // Injected context is what the user believes the current session holds: a reset
+    // keeps sessionId, so without this the turn after it re-surfaces the replay tail
+    // the boundary retained for the runner.
+    excludeResetCarryover: true,
   });
   const labels = options?.senderLabels ?? { assistant: "Assistant", user: "User" };
   const transcript = turns.map((turn) => {

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -371,6 +371,17 @@ describe("SQLite active transcript event projection", () => {
     ]);
     expect(page.events.map((entry) => entry.seq)).toEqual([2, 4, 5]);
     expect(page.totalMessages).toBe(3);
+
+    const postBoundaryPage = readSessionTranscriptMessageEventPage(scope, {
+      excludeResetCarryover: true,
+      maxMessages: 10,
+      offset: 0,
+    });
+    expect(postBoundaryPage.events.map((entry) => (entry.event as { id?: unknown }).id)).toEqual([
+      "post-reset",
+    ]);
+    expect(postBoundaryPage.totalMessages).toBe(1);
+
     expect(readSessionTranscriptMessageEventCount(scope)).toBe(3);
     expect(readSessionTranscriptMessageEventById(scope, "old")).toBeUndefined();
     expect(readSessionTranscriptMessageEventById(scope, "kept-tool")).toBeUndefined();
@@ -406,6 +417,16 @@ describe("SQLite active transcript event projection", () => {
     expect(readSessionTranscriptActivePathEntryRelation(scope, "post-reset")).toBe("ancestor");
     expect(readSessionTranscriptMessageEventCount(scope)).toBe(3);
     expect(readSessionTranscriptMessageEventById(scope, "old")).toBeUndefined();
+
+    // The later compaction leaves the reset boundary closed (kept tail above), so
+    // excludeResetCarryover still narrows past that tail to genuinely-post-reset content.
+    expect(
+      readSessionTranscriptMessageEventPage(scope, {
+        excludeResetCarryover: true,
+        maxMessages: 10,
+        offset: 0,
+      }).events.map((entry) => (entry.event as { id?: unknown }).id),
+    ).toEqual(["post-reset"]);
   });
 
   it("fails closed when the latest indexed reset payload is malformed", async () => {

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -18,6 +18,7 @@ import {
   readTranscriptProjectionGeneration,
   readVisibleMessageRange,
   readVisibleTranscriptStats,
+  resolvePostResetVisibleStart,
   resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
@@ -407,11 +408,16 @@ export function readRecentSessionTranscriptMessageEvents(
 /** Reads one tail-relative message page with index range predicates, never OFFSET scanning. */
 export function readSessionTranscriptMessageEventPage(
   scope: SessionTranscriptReadScope,
-  options: { maxMessages: number; offset: number },
+  options: { excludeResetCarryover?: boolean; maxMessages: number; offset: number },
 ): SessionTranscriptMessageEventPage {
   return withCurrentProjectionSnapshot(scope, (projection) => {
     const visible = resolveVisibleMessagePositions(projection);
-    const totalMessages = visible.total;
+    // What the reset retained sits at the head of the visible window, so starting
+    // after it leaves exactly the messages that boundary admitted.
+    const firstVisible = options.excludeResetCarryover
+      ? resolvePostResetVisibleStart(projection)
+      : 0;
+    const totalMessages = Math.max(0, visible.total - firstVisible);
     const offset = Math.min(
       Math.max(0, Math.floor(Number.isFinite(options.offset) ? options.offset : 0)),
       totalMessages,
@@ -420,8 +426,8 @@ export function readSessionTranscriptMessageEventPage(
       0,
       Math.floor(Number.isFinite(options.maxMessages) ? options.maxMessages : 0),
     );
-    const endExclusive = Math.max(0, totalMessages - offset);
-    const start = Math.max(0, endExclusive - maxMessages);
+    const endExclusive = firstVisible + Math.max(0, totalMessages - offset);
+    const start = Math.max(firstVisible, endExclusive - maxMessages);
     return {
       activeLeafEntryId: projection.state.leafEventId,
       events: readVisibleMessageRange(projection, start, endExclusive),

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -345,6 +345,16 @@ export function resolveVisibleMessagePositions(
   };
 }
 
+/**
+ * Logical index of the first message the latest reset admitted, skipping the kept
+ * replay tail it retained. Readers that must not resurface any pre-reset content
+ * (even the tail a reset keeps for continuity) start from here instead of position 0.
+ */
+export function resolvePostResetVisibleStart(projection: ResetWindowProjection): number {
+  const window = resolveResetMessageWindow(projection);
+  return window ? window.keptMessagePositions.length : 0;
+}
+
 export function readVisibleMessageRange(
   projection: ResetWindowProjection,
   start: number,

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1062,6 +1062,112 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     ]);
   });
 
+  it("bounds recent context to the session's start when the caller opts in (post-reset boundary)", async () => {
+    await writeTranscriptStore({ sessionStartedAt: 5_000 });
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        { message: { role: "user", content: "before reset", timestamp: 4_000 } },
+        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
+      ],
+    });
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+        applySessionStartMinTimestamp: true,
+      }),
+    ).resolves.toEqual([
+      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
+    ]);
+  });
+
+  it("does not bound recent context to session start when the caller doesn't opt in (upstream-monitor parity)", async () => {
+    await writeTranscriptStore({ sessionStartedAt: 5_000 });
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        { message: { role: "user", content: "before reset", timestamp: 4_000 } },
+        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
+      ],
+    });
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+      }),
+    ).resolves.toEqual([
+      { id: expect.any(String), role: "user", text: "before reset", timestamp: 4_000 },
+      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
+    ]);
+  });
+
+  it("prefers an explicit minTimestampMs over the session-start default", async () => {
+    await writeTranscriptStore({ sessionStartedAt: 5_000 });
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        { message: { role: "user", content: "before reset", timestamp: 4_000 } },
+        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
+      ],
+    });
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+        minTimestampMs: 3_000,
+        applySessionStartMinTimestamp: true,
+      }),
+    ).resolves.toEqual([
+      { id: expect.any(String), role: "user", text: "before reset", timestamp: 4_000 },
+      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
+    ]);
+  });
+
+  it("fails closed on an unstamped row when the session-start default is active", async () => {
+    await writeTranscriptStore({ sessionStartedAt: 5_000 });
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        { message: { role: "user", content: "before reset, no timestamp" } },
+        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
+      ],
+    });
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+        applySessionStartMinTimestamp: true,
+      }),
+    ).resolves.toEqual([
+      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
+    ]);
+  });
+
+  it("still admits an unstamped row when the caller doesn't opt into the session-start default", async () => {
+    await writeTranscriptStore({ sessionStartedAt: 5_000 });
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [{ message: { role: "user", content: "no timestamp, no opt-in" } }],
+    });
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+      }),
+    ).resolves.toEqual([{ id: expect.any(String), role: "user", text: "no timestamp, no opt-in" }]);
+  });
+
   it("reads recent context only from the active transcript branch", async () => {
     await writeTranscriptStore();
     await persistSessionTranscriptTurn(

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1062,13 +1062,89 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     ]);
   });
 
-  it("bounds recent context to the session's start when the caller opts in (post-reset boundary)", async () => {
+  // Message timestamps deliberately contradict the reset order: the retained tail is
+  // stamped after the boundary and the post-reset turn before it, so a reader that
+  // used timestamps as a session-membership proxy would get both cases wrong.
+  async function writeResetBoundaryTranscript() {
     await writeTranscriptStore({ sessionStartedAt: 5_000 });
     await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
       updateMode: "none",
       messages: [
-        { message: { role: "user", content: "before reset", timestamp: 4_000 } },
-        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
+        {
+          eventId: "pre-reset-user",
+          parentId: null,
+          message: { role: "user", content: "pre-reset question", timestamp: 9_000 },
+        },
+        {
+          eventId: "pre-reset-assistant",
+          parentId: "pre-reset-user",
+          message: { role: "assistant", content: "pre-reset answer", timestamp: 9_100 },
+        },
+      ],
+    });
+    await appendTranscriptEvent(createFixtureTranscriptScope(), {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "pre-reset-assistant",
+      timestamp: "2026-08-15T00:00:00.000Z",
+      reason: "new",
+      firstKeptEntryId: "pre-reset-user",
+    });
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        {
+          eventId: "post-reset-user",
+          parentId: "reset-boundary",
+          message: { role: "user", content: "post-reset question", timestamp: 1_000 },
+        },
+      ],
+    });
+  }
+
+  it("reads only what the reset boundary admitted, ignoring message timestamp order", async () => {
+    await writeResetBoundaryTranscript();
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+        excludeResetCarryover: true,
+      }),
+    ).resolves.toEqual([
+      { id: "post-reset-user", role: "user", text: "post-reset question", timestamp: 1_000 },
+    ]);
+  });
+
+  it("keeps the retained replay tail for callers that read across resets (upstream-monitor parity)", async () => {
+    await writeResetBoundaryTranscript();
+
+    await expect(
+      readRecentUserAssistantTextForSession({
+        agentId: "main",
+        sessionKey,
+        storePath: fixture.storePath(),
+      }),
+    ).resolves.toEqual([
+      { id: "pre-reset-user", role: "user", text: "pre-reset question", timestamp: 9_000 },
+      {
+        id: "pre-reset-assistant",
+        role: "assistant",
+        text: "pre-reset answer",
+        timestamp: 9_100,
+      },
+      { id: "post-reset-user", role: "user", text: "post-reset question", timestamp: 1_000 },
+    ]);
+  });
+
+  it("leaves same-session history whole when no reset boundary exists", async () => {
+    await writeTranscriptStore();
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        { message: { role: "user", content: "first", timestamp: 1_000 } },
+        { message: { role: "assistant", content: "second", timestamp: 2_000 } },
       ],
     });
 
@@ -1077,95 +1153,12 @@ describe("appendAssistantMessageToSessionTranscript", () => {
         agentId: "main",
         sessionKey,
         storePath: fixture.storePath(),
-        applySessionStartMinTimestamp: true,
+        excludeResetCarryover: true,
       }),
     ).resolves.toEqual([
-      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
+      { id: expect.any(String), role: "user", text: "first", timestamp: 1_000 },
+      { id: expect.any(String), role: "assistant", text: "second", timestamp: 2_000 },
     ]);
-  });
-
-  it("does not bound recent context to session start when the caller doesn't opt in (upstream-monitor parity)", async () => {
-    await writeTranscriptStore({ sessionStartedAt: 5_000 });
-    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
-      updateMode: "none",
-      messages: [
-        { message: { role: "user", content: "before reset", timestamp: 4_000 } },
-        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
-      ],
-    });
-
-    await expect(
-      readRecentUserAssistantTextForSession({
-        agentId: "main",
-        sessionKey,
-        storePath: fixture.storePath(),
-      }),
-    ).resolves.toEqual([
-      { id: expect.any(String), role: "user", text: "before reset", timestamp: 4_000 },
-      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
-    ]);
-  });
-
-  it("prefers an explicit minTimestampMs over the session-start default", async () => {
-    await writeTranscriptStore({ sessionStartedAt: 5_000 });
-    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
-      updateMode: "none",
-      messages: [
-        { message: { role: "user", content: "before reset", timestamp: 4_000 } },
-        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
-      ],
-    });
-
-    await expect(
-      readRecentUserAssistantTextForSession({
-        agentId: "main",
-        sessionKey,
-        storePath: fixture.storePath(),
-        minTimestampMs: 3_000,
-        applySessionStartMinTimestamp: true,
-      }),
-    ).resolves.toEqual([
-      { id: expect.any(String), role: "user", text: "before reset", timestamp: 4_000 },
-      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
-    ]);
-  });
-
-  it("fails closed on an unstamped row when the session-start default is active", async () => {
-    await writeTranscriptStore({ sessionStartedAt: 5_000 });
-    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
-      updateMode: "none",
-      messages: [
-        { message: { role: "user", content: "before reset, no timestamp" } },
-        { message: { role: "user", content: "after reset", timestamp: 6_000 } },
-      ],
-    });
-
-    await expect(
-      readRecentUserAssistantTextForSession({
-        agentId: "main",
-        sessionKey,
-        storePath: fixture.storePath(),
-        applySessionStartMinTimestamp: true,
-      }),
-    ).resolves.toEqual([
-      { id: expect.any(String), role: "user", text: "after reset", timestamp: 6_000 },
-    ]);
-  });
-
-  it("still admits an unstamped row when the caller doesn't opt into the session-start default", async () => {
-    await writeTranscriptStore({ sessionStartedAt: 5_000 });
-    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
-      updateMode: "none",
-      messages: [{ message: { role: "user", content: "no timestamp, no opt-in" } }],
-    });
-
-    await expect(
-      readRecentUserAssistantTextForSession({
-        agentId: "main",
-        sessionKey,
-        storePath: fixture.storePath(),
-      }),
-    ).resolves.toEqual([{ id: expect.any(String), role: "user", text: "no timestamp, no opt-in" }]);
   });
 
   it("reads recent context only from the active transcript branch", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -132,6 +132,20 @@ type ReadRecentSessionConversationTextOptions = {
   minTimestampMs?: number;
   role?: "user" | "assistant";
   preferUpstreamUserText?: boolean;
+  /**
+   * When set and the caller doesn't supply `minTimestampMs`, bound the read to the
+   * session's current `sessionStartedAt` — a reset preserves `sessionId` but bumps
+   * this field, so without it a post-reset read still sees pre-reset turns. Opt-in
+   * (not a blanket default) so callers like the upstream-activity monitor, which
+   * read across resets by design, are unaffected.
+   */
+  applySessionStartMinTimestamp?: boolean;
+  /**
+   * Internal: set by `readRecentUserAssistantTextForSession` (never by a caller)
+   * when it applied the `applySessionStartMinTimestamp` default, so the SQLite
+   * read path fails closed on rows with no timestamp instead of admitting them.
+   */
+  requireTimestampWithinMinBound?: boolean;
 };
 
 type ReadRecentSessionConversationTextParams = ReadRecentSessionConversationTextOptions & {
@@ -193,6 +207,7 @@ function parseAssistantTranscriptText(
 
 type SessionConversationTranscriptTarget = {
   sqliteScope?: SqliteSessionFileMarker;
+  sessionStartedAt?: number;
 };
 
 function parseRecentConversationText(
@@ -280,7 +295,7 @@ async function readRecentUserAssistantTextFromSqliteTranscript(
       storePath: scope.storePath,
     };
     const recent: SessionRecentConversationText[] = [];
-    for (let offset = 0; recent.length < limit; offset += pageSize) {
+    paging: for (let offset = 0; recent.length < limit; offset += pageSize) {
       const page = readSessionTranscriptMessageEventPage(readScope, {
         maxMessages: pageSize,
         offset,
@@ -290,10 +305,22 @@ async function readRecentUserAssistantTextFromSqliteTranscript(
       }
       for (const event of page.events.toReversed()) {
         const entry = parseRecentConversationText(JSON.stringify(event.event), options);
-        if (entry && isWithinTranscriptWindow(entry.timestamp, options)) {
+        if (!entry) {
+          continue;
+        }
+        if (
+          options.requireTimestampWithinMinBound &&
+          options.minTimestampMs !== undefined &&
+          entry.timestamp === undefined
+        ) {
+          // An unstamped row can't be shown to fall on either side of the bound;
+          // fail closed rather than risk re-surfacing pre-reset content.
+          continue;
+        }
+        if (isWithinTranscriptWindow(entry.timestamp, options)) {
           recent.push(entry);
           if (recent.length >= limit) {
-            break;
+            break paging;
           }
         }
       }
@@ -338,17 +365,29 @@ function resolveSessionConversationTranscriptTarget(params: {
       sessionId: entry.sessionId,
       storePath,
     },
+    sessionStartedAt: entry.sessionStartedAt,
   };
 }
 
 export async function readRecentUserAssistantTextForSession(
   params: ReadRecentSessionConversationTextParams,
 ): Promise<SessionRecentConversationText[]> {
+  const { applySessionStartMinTimestamp, ...options } = params;
   const target = resolveSessionConversationTranscriptTarget(params);
-  if (target.sqliteScope) {
-    return await readRecentUserAssistantTextFromSqliteTranscript(target.sqliteScope, params);
+  if (!target.sqliteScope) {
+    return [];
   }
-  return [];
+  const usingSessionStartDefault =
+    options.minTimestampMs === undefined &&
+    applySessionStartMinTimestamp === true &&
+    target.sessionStartedAt !== undefined;
+  const minTimestampMs =
+    options.minTimestampMs ?? (usingSessionStartDefault ? target.sessionStartedAt : undefined);
+  return await readRecentUserAssistantTextFromSqliteTranscript(target.sqliteScope, {
+    ...options,
+    ...(minTimestampMs !== undefined ? { minTimestampMs } : {}),
+    requireTimestampWithinMinBound: usingSessionStartDefault,
+  });
 }
 
 export async function readLatestAssistantTextFromSessionTranscript(

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -133,19 +133,11 @@ type ReadRecentSessionConversationTextOptions = {
   role?: "user" | "assistant";
   preferUpstreamUserText?: boolean;
   /**
-   * When set and the caller doesn't supply `minTimestampMs`, bound the read to the
-   * session's current `sessionStartedAt` — a reset preserves `sessionId` but bumps
-   * this field, so without it a post-reset read still sees pre-reset turns. Opt-in
-   * (not a blanket default) so callers like the upstream-activity monitor, which
-   * read across resets by design, are unaffected.
+   * Read only what the latest reset boundary admitted: a reset keeps `sessionId`, so
+   * an unbounded read re-surfaces the replay tail it retained. Opt-in — the
+   * upstream-activity monitor reads across resets by design.
    */
-  applySessionStartMinTimestamp?: boolean;
-  /**
-   * Internal: set by `readRecentUserAssistantTextForSession` (never by a caller)
-   * when it applied the `applySessionStartMinTimestamp` default, so the SQLite
-   * read path fails closed on rows with no timestamp instead of admitting them.
-   */
-  requireTimestampWithinMinBound?: boolean;
+  excludeResetCarryover?: boolean;
 };
 
 type ReadRecentSessionConversationTextParams = ReadRecentSessionConversationTextOptions & {
@@ -207,7 +199,6 @@ function parseAssistantTranscriptText(
 
 type SessionConversationTranscriptTarget = {
   sqliteScope?: SqliteSessionFileMarker;
-  sessionStartedAt?: number;
 };
 
 function parseRecentConversationText(
@@ -295,8 +286,9 @@ async function readRecentUserAssistantTextFromSqliteTranscript(
       storePath: scope.storePath,
     };
     const recent: SessionRecentConversationText[] = [];
-    paging: for (let offset = 0; recent.length < limit; offset += pageSize) {
+    for (let offset = 0; recent.length < limit; offset += pageSize) {
       const page = readSessionTranscriptMessageEventPage(readScope, {
+        ...(options.excludeResetCarryover ? { excludeResetCarryover: true } : {}),
         maxMessages: pageSize,
         offset,
       });
@@ -305,22 +297,10 @@ async function readRecentUserAssistantTextFromSqliteTranscript(
       }
       for (const event of page.events.toReversed()) {
         const entry = parseRecentConversationText(JSON.stringify(event.event), options);
-        if (!entry) {
-          continue;
-        }
-        if (
-          options.requireTimestampWithinMinBound &&
-          options.minTimestampMs !== undefined &&
-          entry.timestamp === undefined
-        ) {
-          // An unstamped row can't be shown to fall on either side of the bound;
-          // fail closed rather than risk re-surfacing pre-reset content.
-          continue;
-        }
-        if (isWithinTranscriptWindow(entry.timestamp, options)) {
+        if (entry && isWithinTranscriptWindow(entry.timestamp, options)) {
           recent.push(entry);
           if (recent.length >= limit) {
-            break paging;
+            break;
           }
         }
       }
@@ -365,29 +345,17 @@ function resolveSessionConversationTranscriptTarget(params: {
       sessionId: entry.sessionId,
       storePath,
     },
-    sessionStartedAt: entry.sessionStartedAt,
   };
 }
 
 export async function readRecentUserAssistantTextForSession(
   params: ReadRecentSessionConversationTextParams,
 ): Promise<SessionRecentConversationText[]> {
-  const { applySessionStartMinTimestamp, ...options } = params;
   const target = resolveSessionConversationTranscriptTarget(params);
-  if (!target.sqliteScope) {
-    return [];
+  if (target.sqliteScope) {
+    return await readRecentUserAssistantTextFromSqliteTranscript(target.sqliteScope, params);
   }
-  const usingSessionStartDefault =
-    options.minTimestampMs === undefined &&
-    applySessionStartMinTimestamp === true &&
-    target.sessionStartedAt !== undefined;
-  const minTimestampMs =
-    options.minTimestampMs ?? (usingSessionStartDefault ? target.sessionStartedAt : undefined);
-  return await readRecentUserAssistantTextFromSqliteTranscript(target.sqliteScope, {
-    ...options,
-    ...(minTimestampMs !== undefined ? { minTimestampMs } : {}),
-    requireTimestampWithinMinBound: usingSessionStartDefault,
-  });
+  return [];
 }
 
 export async function readLatestAssistantTextFromSessionTranscript(


### PR DESCRIPTION
## Summary

**Prompt request:** Make the shared post-reset prompt-context injector stop surfacing pre-reset transcript content on the built-in channels that don't already exclude it, matching the one channel that does, while leaving unrelated cross-reset readers of the same underlying function unaffected.

**Proof target:** Show that a channel's first turn after a session reset no longer includes a pre-reset message that the production reset-persistence path actually persisted — including when the message clocks contradict the reset order — while an ordinary same-session turn with no reset still includes its own recent history.

## What changed since the first review

The first version of this PR bounded the read with the session's `sessionStartedAt`. Automated review rejected that, correctly: `sessionStartedAt` is a session-lifecycle clock, while the timestamps stored on transcript messages come from the channel — the same function already compares them against a channel-supplied `ctx.Timestamp`. Measured against the superseded implementation, a pre-reset turn stamped after the reset still passed the filter and a post-reset turn stamped before it was dropped, so the cutoff was wrong in both directions. This revision selects by persisted position instead and deletes the timestamp policy entirely. The branch has since been rebased onto `upstream/main`; the current head applies cleanly against merge base `be5e79ca4713` (`upstream/main` at review time). Those rebases only moved the base the diff applies against — the seven changed files and their content are exactly what this PR's own diff shows, which is the description below.

A follow-up review asked for stronger real-behavior proof: the original capture drove the shared injector directly with a hand-built `ctx`, skipping the channel-turn wrapper every real channel goes through. The proof harness now drives `runPreparedChannelTurn` (`src/channels/turn/execution.ts`) instead — the same channel-agnostic entry point every built-in channel calls before dispatch, which internally invokes the injector inside its prepared-turn dispatch (`execution.ts:259`), before recording and dispatching the turn. No production code changed for this; see the updated "Real behavior proof" section below, which also re-captures this proof at the current head after the rebases above.

## What Problem This Solves

Resolves a problem where a user who resets a conversation (`/new` or `/reset`) on any built-in channel except Telegram could still see prior-session content injected into the prompt on their very next message, even though the reset was supposed to start a fresh conversation.

## Why This Change Was Made

`mergeSessionTranscriptContext` (`src/channels/inbound-event/session-transcript-context.runtime.ts`) is the single, channel-agnostic function that builds the "Conversation context" prompt block for every built-in channel — it has exactly one call site, in the shared channel-turn pipeline (`src/channels/turn/execution.ts`), with no per-channel branching. It reads recent same-session transcript turns via `readRecentUserAssistantTextForSession`.

Terms used below, once: the *active path* is the chain of transcript events the session currently projects; a reset writes a boundary event into it and marks a short tail of preceding user/assistant messages as *kept*, so that tail stays visible after the boundary; the *position the reset admitted* is the first message that follows the boundary.

A reset preserves `sessionId` (`resetReplyRunSession`, `src/auto-reply/reply/agent-runner-session-reset.ts`), so the read stays in scope across the boundary. What it *should* stop at is already persisted: `persistSessionResetLifecycle` appends a real reset boundary event, and the SQLite projection in `src/config/sessions/session-accessor.sqlite-reset-window.ts` already separates the replay tail that boundary retained (`kept` — `DEFAULT_REPLAY_MAX_MESSAGES`, kept so DM continuity survives silent session rotations) from the first post-boundary message position. The prompt-context read simply never asked for that distinction, so the retained tail — the pre-reset content — sat at the head of the window it reads.

This change adds an opt-in (`excludeResetCarryover`) that `mergeSessionTranscriptContext` sets, threading down to `readSessionTranscriptMessageEventPage`, which starts its logical range after what the reset retained. Selection is by persisted position, not by time: message timestamps come from the channel, and the same function already compares them against a channel-supplied `ctx.Timestamp`, so they are not an ordering key for a session-lifecycle boundary. A pre-reset turn stamped after the reset, or a delayed post-reset turn stamped before it, both land correctly (`reads only what the reset boundary admitted, ignoring message timestamp order` in `src/config/sessions/transcript.test.ts`).

The lower bound stays anchored to the reset even after a later compaction, because the resolver it reuses already is anchored that way: `resolveResetMessageWindow`'s default scope (`"history"`, pre-existing and unmodified by this PR) looks specifically for the latest *reset*-type boundary, so a compaction landing after the reset leaves which reset is found, and how long its kept tail is, exactly as they were before the compaction (`src/config/sessions/session-accessor.sqlite-reset-window.ts`; the one caller in this codebase that wants the more-recent-of-either-type boundary passes the other scope, `"context"`, explicitly, and is unrelated to this injector's path). `resolvePostResetVisibleStart`, the one function this PR adds, is a second call into that same resolver with its default scope. The resolver is keyed by database path, session ID, and scope (`resetMessageWindowCacheKey`, `session-accessor.sqlite-reset-window.ts:118-120,303-308`); cached entries additionally carry two freshness markers checked on lookup rather than being part of the key (`:309-328`). The second call in one page read therefore reuses the same history-scope window rather than recomputing it, and the kept-tail length it returns is identical to what `resolveVisibleMessagePositions` computed from that same cached window for the non-excluding read just above it. The separate function exists to give the page reader's lower bound a name — "the position the reset admitted" — instead of an inline reach into `visible.kept.length`. The regression added in `src/config/sessions/session-accessor.sqlite-active-events.test.ts` appends a compaction after the reset and re-asserts `excludeResetCarryover` still narrows to the same post-reset content, pinning the invariant against a future change to the resolver's scope semantics.

The read function's own default is unchanged: `excludeResetCarryover` is opt-in, off unless a caller passes it. What changes for the user is that the shared prompt-context injector — the one caller every built-in channel goes through — now always passes it, so the default *user-visible* prompt-context behavior does change, on every channel that routes through that injector; that is exactly where this PR's user-visible effect comes from. For everything else the claim is narrow rather than categorical: `resolveVisibleMessagePositions` (unmodified by this diff) returns `{ kept: [], postStart: 0, total: activeMessageCount }` when a session has no reset boundary at all — the only case this PR's `resolvePostResetVisibleStart` shares, returning `0` for the same reason. A reset that already happened keeps its kept-tail length regardless of a later compaction, for both functions, because both resolve it the same, pre-existing, reset-scoped way described above. The reset payload is read whenever a reset boundary exists in the session, so the existing fail-closed behavior on a malformed reset payload is untouched (covered by the unmodified `fails closed when the latest indexed reset payload is malformed` in `src/config/sessions/session-accessor.sqlite-active-events.test.ts`, still green).

Concretely, there are three caller classes and each is stated separately: the prompt-context injector opts in and is the only behavior change; the upstream-activity monitor does not opt in and reads across resets exactly as before; every other consumer of the projection never passes the new option, so its reads are unchanged — `resolveVisibleMessagePositions` itself is not modified by this diff and returns exactly what it returned before in every state.

The unrelated second caller of the same read function (`src/sessions/session-upstream-monitor.ts`, which polls for direct upstream human activity across session resets by design) never sets the flag, so nothing changes for it (`keeps the retained replay tail for callers that read across resets (upstream-monitor parity)`). Telegram goes through the same injector and so also receives the new bound; because it already supplied its own `minTimestampMs`, it was the one channel not exhibiting the leak, and the added bound does not reintroduce it. See User Impact for the exact interaction.

## User Impact

After resetting a conversation, the prompt sent for the assistant's next reply no longer includes transcript content from before the reset. The change is made at the shared injector rather than per channel, so by construction it reaches every channel that routes through it — that reach is an architectural inference from the single call site, not something this proof exercises channel by channel; the proof exercises that shared injector through the real channel-turn entry point, not each channel's own inbound handling, and the per-channel wiring above that shared entry point is unchanged by this diff. Telegram routes through the same shared injector, so it receives the new position-based bound as well; its own `minTimestampMs` continues to apply on top of it, as an additional filter, not a replacement (`readRecentUserAssistantTextFromSqliteTranscript` selects the post-reset page by position first, then applies `minTimestampMs` to what that page already contains — see `src/config/sessions/transcript.ts`). Because position excludes pre-reset content before the timestamp check ever runs, Telegram cannot leak pre-reset content through this path even under the clock-skew shape this PR's `reordered-timestamps-must-follow-the-persisted-boundary` proof case exercises — that gap is closed for Telegram too, not just the other 8 channels. This PR leaves alone the opposite, pre-existing direction of Telegram's own filter: a genuinely post-reset message stamped before the reset can still be dropped by its `minTimestampMs`, exactly as before this PR — over-filtering, not leaking, unfixed and unworsened here. Telegram is not measured in this capture; its suite is untouched and not re-run. The upstream-activity monitor does not go through this injector and reads across resets exactly as before.
## Real behavior proof

Scope of this proof: it drives the shared prompt-context injector through the real channel-turn entry point (`runPreparedChannelTurn`, `src/channels/turn/execution.ts`) that every built-in channel actually calls before dispatch, plus the real reset persistence, against a live SQLite session store. It does not drive a specific channel's own inbound message-parsing (native payload decoding, webhook verification, etc.) upstream of that shared entry point. See "What was not tested" at the end of this section.

Behavior addressed: a post-reset turn on a non-Telegram channel injecting pre-reset transcript content into the prompt, including when the message timestamps contradict the reset order — proven through the real channel-turn call every built-in channel makes (`runPreparedChannelTurn`), not the injector called in isolation.
Real environment tested: Linux x86_64, node v24.18.0. Baseline `be5e79ca4713` is this PR's merge base (current `upstream/main` at review time); candidate `e5e5c5242805` is this PR's head. Both runs are driven by a single before/after harness that lives in my own tooling and is deliberately not part of this diff. It imports the production modules named in the capture below and drives them directly through the real channel-turn entry point; it resolves every module from `process.cwd()` and takes no branch on which side it is running, so the side appears in the resolved import path echoed to stderr but never in a decision the harness makes. Captured as proof run `20260830t073850z-proof-5c82546d`; the manifest records a sha256 for each evidence file. The harness reaches the reset through the production `persistSessionResetLifecycle`, which is what appends the real boundary event — it does not hand-write the boundary row. The capture shows it importing `src/channels/turn/execution.ts` (the real channel-turn entry point, `runPreparedChannelTurn`, which internally calls the injector under test) and `src/config/sessions/session-accessor.ts` (real reset persistence).

Exact steps or command run after this patch (local before/after tooling, recorded for completeness — these commands are not runnable from this repository):

```sh
# The harness drives these production modules directly, which is what the
# capture's stderr shows it importing on each side, and what the capture's
# stdout names as "moduleUnderTest":
#   src/channels/turn/execution.ts                              (real channel-turn entry point: runPreparedChannelTurn)
#   src/config/sessions/session-accessor.ts                     (real reset persistence)
#   src/channels/inbound-event/session-transcript-context.runtime.ts  (module under test: mergeSessionTranscriptContext)
clawproof work start session-transcript-boundary-cutoff --baseline be5e79ca4713c33a11ccd56b2d728c19f0779f3d
git -C ~/.clawproof/work-items/session-transcript-boundary-cutoff/after reset --hard e5e5c524280579c32fcd0466f127c9ddda89b1e2
clawproof build plan session-transcript-boundary-cutoff --worktree before --apply
clawproof build plan session-transcript-boundary-cutoff --worktree after --apply
clawproof prove session-transcript-boundary-cutoff --scenario default --final --problem-file docs/work-items/session-transcript-boundary-cutoff/proof/problem.md
ocw proof import session-transcript-boundary-cutoff
```

Before (pre-fix):

```text
===== BEFORE (baseline be5e79ca4713, unfixed source) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/before/src/channels/turn/execution.ts]
[harness: importing [REDACTED:path]/before/src/config/sessions/session-accessor.ts]
[harness: running post-reset-turn-must-not-leak-pre-reset-transcript]
[harness: reset persisted: sessionId unchanged (boundary-proof-session), sessionStartedAt -> 1005000]
[turn/execution] visible channel turn dispatched with no queued reply payloads: channel=discord messageId=[REDACTED] sessionKey=agent:main:boundary-proof-channel cause=unknown
[harness: running no-reset-ordinary-turn-must-remain-visible]
[turn/execution] visible channel turn dispatched with no queued reply payloads: channel=discord messageId=[REDACTED] sessionKey=agent:main:boundary-proof-channel-control cause=unknown
[harness: running reordered-timestamps-must-follow-the-persisted-boundary]
[turn/execution] visible channel turn dispatched with no queued reply payloads: channel=discord messageId=[REDACTED] sessionKey=agent:main:boundary-proof-channel-reordered cause=unknown
--- harness.stdout ---
{
  "moduleUnderTest": "src/channels/inbound-event/session-transcript-context.runtime.ts",
  "results": [
    {
      "case": "post-reset-turn-must-not-leak-pre-reset-transcript",
      "sessionId": "boundary-proof-session",
      "sessionStartedAtBeforeReset": 1000000,
      "sessionStartedAtAfterReset": 1005000,
      "injectedBodies": [
        "secret vacation plans discussed pre-reset",
        "what's on my schedule now"
      ],
      "leakedPreResetMessage": true,
      "includesPostResetMessage": true,
      "error": null
    },
    {
      "case": "no-reset-ordinary-turn-must-remain-visible",
      "sessionId": "boundary-proof-session-control",
      "sessionStartedAt": 2000000,
      "injectedBodies": [
        "ordinary same-session turn, no reset happened"
      ],
      "includesOrdinaryTurn": true,
      "error": null
    },
    {
      "case": "reordered-timestamps-must-follow-the-persisted-boundary",
      "sessionId": "boundary-proof-session-reordered",
      "resetAt": 3005000,
      "preResetMessageTimestamp": 3090000,
      "postResetMessageTimestamp": 3001000,
      "readAt": 3100000,
      "injectedBodies": [
        "post-reset turn stamped before the reset",
        "pre-reset turn stamped after the reset"
      ],
      "leakedPreResetMessage": true,
      "includesPostResetMessage": true,
      "error": null
    }
  ]
}

```

Evidence after fix:

```text
===== AFTER (candidate e5e5c5242805, fix applied) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/after/src/channels/turn/execution.ts]
[harness: importing [REDACTED:path]/after/src/config/sessions/session-accessor.ts]
[harness: running post-reset-turn-must-not-leak-pre-reset-transcript]
[harness: reset persisted: sessionId unchanged (boundary-proof-session), sessionStartedAt -> 1005000]
[turn/execution] visible channel turn dispatched with no queued reply payloads: channel=discord messageId=[REDACTED] sessionKey=agent:main:boundary-proof-channel cause=unknown
[harness: running no-reset-ordinary-turn-must-remain-visible]
[turn/execution] visible channel turn dispatched with no queued reply payloads: channel=discord messageId=[REDACTED] sessionKey=agent:main:boundary-proof-channel-control cause=unknown
[harness: running reordered-timestamps-must-follow-the-persisted-boundary]
[turn/execution] visible channel turn dispatched with no queued reply payloads: channel=discord messageId=[REDACTED] sessionKey=agent:main:boundary-proof-channel-reordered cause=unknown
--- harness.stdout ---
{
  "moduleUnderTest": "src/channels/inbound-event/session-transcript-context.runtime.ts",
  "results": [
    {
      "case": "post-reset-turn-must-not-leak-pre-reset-transcript",
      "sessionId": "boundary-proof-session",
      "sessionStartedAtBeforeReset": 1000000,
      "sessionStartedAtAfterReset": 1005000,
      "injectedBodies": [
        "what's on my schedule now"
      ],
      "leakedPreResetMessage": false,
      "includesPostResetMessage": true,
      "error": null
    },
    {
      "case": "no-reset-ordinary-turn-must-remain-visible",
      "sessionId": "boundary-proof-session-control",
      "sessionStartedAt": 2000000,
      "injectedBodies": [
        "ordinary same-session turn, no reset happened"
      ],
      "includesOrdinaryTurn": true,
      "error": null
    },
    {
      "case": "reordered-timestamps-must-follow-the-persisted-boundary",
      "sessionId": "boundary-proof-session-reordered",
      "resetAt": 3005000,
      "preResetMessageTimestamp": 3090000,
      "postResetMessageTimestamp": 3001000,
      "readAt": 3100000,
      "injectedBodies": [
        "post-reset turn stamped before the reset"
      ],
      "leakedPreResetMessage": false,
      "includesPostResetMessage": true,
      "error": null
    }
  ]
}
```

Observed result after fix: both runs exited 0 on the same harness bytes — the harness process itself completing without crashing on either side, not a pass/fail verdict by itself; the baseline run is expected to complete and still report the defect, which it does. `post-reset-turn-must-not-leak-pre-reset-transcript` goes `leakedPreResetMessage` true -> false while going through the real channel-turn entry point (`runPreparedChannelTurn`) rather than the injector called in isolation, confirming the fix holds at the boundary every built-in channel actually calls. `reordered-timestamps-must-follow-the-persisted-boundary` — where the pre-reset turn is stamped at 3090000 (after the 3005000 reset) and the post-reset turn at 3001000 (before it), with the read clock at 3100000 so the pre-existing `beforeTimestampMs` upper bound excludes nothing — also goes true -> false while still returning the post-reset turn. The no-reset control is identical in both runs. The `visible channel turn dispatched with no queued reply payloads` stderr line on both sides is the channel-turn wrapper's own diagnostic for the harness's stubbed no-op `runDispatch`; it fires identically before and after and is not part of the behavior under test.
What was not tested: the harness drives the shared channel-turn entry point (`runPreparedChannelTurn`) with a hand-built `ctx` and stubbed `recordInboundSession`/`runDispatch`, not a specific channel's own inbound message-handling pipeline upstream of that shared entry point, so per-channel wiring above the shared boundary is still not individually exercised. Telegram receives the new bound through the same shared injector, but its own suite is untouched and not re-run here, so its behavior is argued from the code path rather than measured in this capture. A compaction landing after the reset is covered by unit regression in `src/config/sessions/session-accessor.sqlite-active-events.test.ts`, not by this harness.

Focused tests, exact commands and totals:

- `node scripts/run-vitest.mjs src/config/sessions` — 100 files, 1126 tests passed. Includes the new reset-boundary cases in `src/config/sessions/transcript.test.ts` and `src/config/sessions/session-accessor.sqlite-active-events.test.ts`.
- `node scripts/run-vitest.mjs src/channels/inbound-event/session-transcript-context.runtime.test.ts` — 1 file, 9 tests passed.
- `node scripts/run-vitest.mjs src/gateway/session-transcript-readers.test.ts src/gateway/session-transcript-readers.markers.test.ts src/gateway/session-transcript-title-reader.test.ts` — 3 files, 49 tests passed. These files are unmodified; they cover other consumers of the projection whose returned value is unchanged.
- `pnpm tsgo:core` — clean.

CI failure on this head that I could not reproduce: the `checks-node-compact-small-44` shard fails 4
tests across two files — `test/scripts/run-additional-boundary-checks.test.ts > run-additional-boundary-checks
> waits for timed-out process groups after the wrapper exits` and three parameterized cases of
`test/scripts/watch-pr-ci.test.ts > watch-pr-ci > queued placeholder CLI evidence > rejects changed run
evidence after collecting jobs` (missing ID / missing workflow / missing attempt) — and `openclaw/ci-gate` fails with it
([job log](https://github.com/openclaw/openclaw/actions/runs/33300072698/job/99226507226)). What I can
state: neither file is in this diff — the seven changed files are `src/channels/inbound-event/session-transcript-context.runtime.ts`,
`src/channels/inbound-event/session-transcript-context.runtime.test.ts`, `src/config/sessions/transcript.ts`,
`src/config/sessions/transcript.test.ts`, `src/config/sessions/session-accessor.sqlite-active-events.ts`,
`src/config/sessions/session-accessor.sqlite-active-events.test.ts`, and
`src/config/sessions/session-accessor.sqlite-reset-window.ts`, while the two failing files are
process-wrapper and CI-watcher tooling tests under `test/scripts/`; both files
pass together locally on this exact head (147 of 147 tests). What I have not established is a baseline
showing the same shard failing without this diff — I cannot re-run upstream CI as a contributor. So I am
reporting this as an unexplained failure I could not attribute to this change, not asserting it is a
known flake.

Regression teeth: forcing the new lower bound to 0 in `readSessionTranscriptMessageEventPage` and re-running `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts src/config/sessions/session-accessor.sqlite-active-events.test.ts` fails 2 of 83 — `reads only what the reset boundary admitted, ignoring message timestamp order` (`expected [ Array(3) ] to deeply equal [ { id: 'post-reset-user', … } ]`) and `projects reset kept-tail and post-boundary messages without rewriting raw positions` (`expected [ 'kept-user', 'kept-assistant', … ] to deeply equal [ 'post-reset' ]`). Both fail by the retained pre-reset tail reappearing, which is the defect this PR removes.

Boundary cases covered by unit regression rather than by the harness: a compaction landing after the reset, an ordinary session with no reset boundary at all, and a caller that does not opt in (upstream-monitor parity).

## Non-Scope

Selection by persisted position is confined to the shared transcript read path plus the one flag that activates it from the shared prompt-context injector. Telegram's own `minTimestampMs` wiring — threaded through its inbound buffering and media-group batching — is left alone; it is pre-existing behavior and removing it is plugin-side work, not this fix. The replay tail a reset retains is not removed either: it exists so DM continuity survives silent session rotations (`DEFAULT_REPLAY_MAX_MESSAGES`) and remains in the projection for readers that want it, including the runner. This change only stops the channel-injected "Conversation context" block from reaching across the boundary.

This PR does not close an issue.
