### PR TITLE
chore(gateway): verify legacy build identity absence

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -511,6 +511,34 @@ describe("gatherDaemonStatus", () => {
     }
   });
 
+  it("keeps deep JSON compatible when the Gateway omits build identity", async () => {
+    callGatewayStatusProbe.mockResolvedValueOnce({
+      ok: true,
+      url: "ws://127.0.0.1:19001",
+      error: null,
+      server: { version: "2026.5.6", connId: "conn-1" },
+    });
+
+    const status = await gatherStatus({ deep: true });
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+    try {
+      printDaemonStatus(status, { json: true, deep: true });
+      expect(writeJson).toHaveBeenCalledOnce();
+      const serialized = JSON.stringify(writeJson.mock.calls[0]?.[0]);
+      if (!serialized) {
+        throw new Error("expected terminal JSON output");
+      }
+      const parsed = JSON.parse(serialized) as {
+        rpc?: { server?: Record<string, unknown> };
+      };
+      const server = parsed.rpc?.server;
+      expect(server).toEqual({ version: "2026.5.6", connId: "conn-1" });
+      expect(server).not.toHaveProperty("buildId");
+    } finally {
+      writeJson.mockRestore();
+    }
+  });
+
   it("batches daemon and CLI port status inspection when ports differ", async () => {
     await gatherStatus();
 

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -18,7 +18,7 @@ const gatewayClientState = vi.hoisted(() => ({
     version: "2026.4.24",
     buildId: "build-test",
     connId: "conn-test",
-  },
+  } as { version: string; buildId?: string; connId: string },
   connectError: "scope upgrade pending approval (requestId: req-123)",
   connectErrorDetails: {
     code: "PAIRING_REQUIRED",
@@ -326,6 +326,11 @@ describe("probeGateway", () => {
       role: "operator",
       scopes: ["operator.read"],
     };
+    gatewayClientState.helloServer = {
+      version: "2026.4.24",
+      buildId: "build-test",
+      connId: "conn-test",
+    };
     gatewayClientState.connectError = "scope upgrade pending approval (requestId: req-123)";
     gatewayClientState.connectErrorDetails = {
       code: "PAIRING_REQUIRED",
@@ -418,6 +423,21 @@ describe("probeGateway", () => {
       buildId: "build-test",
       connId: "conn-test",
     });
+  });
+
+  it("keeps legacy server metadata compatible when build identity is absent", async () => {
+    gatewayClientState.helloServer = {
+      version: "2026.4.24",
+      connId: "conn-test",
+    };
+
+    const result = await runTokenLightweightProbe();
+
+    expect(result.server).toEqual({
+      version: "2026.4.24",
+      connId: "conn-test",
+    });
+    expect(result.server).not.toHaveProperty("buildId");
   });
 
   it("preserves structured missing-scope details from a post-connect request", async () => {


### PR DESCRIPTION
Related: #123917

## What Problem This Solves

Completes the regression proof for exact Gateway build identity by covering older Gateways that omit the optional `hello.server.buildId` field.

## Why This Change Was Made

#123917 proved that a reported immutable build ID reaches probe and status JSON output. These focused cases cover the other side of the additive contract: an absent build ID remains absent rather than becoming required, `null`, or a placeholder. The shared probe fixture is reset explicitly so present and absent cases cannot contaminate each other.

## User Impact

No production behavior changes. Maintainers now have direct regression proof that `gateway status --deep --json` remains compatible with older Gateways while exposing exact identity from newer ones.

## Evidence

- Blacksmith Testbox focused proof: [run 31858547300](https://github.com/openclaw/openclaw/actions/runs/31858547300) passed 33 Gateway probe tests and 44 CLI status tests, with one existing skip.
- Blacksmith Testbox changed gate: [run 31858653338](https://github.com/openclaw/openclaw/actions/runs/31858653338) passed core/test/extension typechecks, formatting, lint, dependency, boundary, dead-export, prompt-snapshot, import-cycle, and repository guards.
- Codex autoreview reported no accepted/actionable findings.

Production LOC: +0/-0 | Tests: +49/-1.
