### PR TITLE
fix(ui): keep desktop notifications clear of topbar controls

### DIFF
--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -435,7 +435,7 @@ suite.define(() => {
   });
 
   it.each(["dark", "light"] as const)(
-    "keeps the toast above the mobile drawer in %s mode",
+    "positions the drawer toast responsively in %s mode",
     async (colorScheme) => {
       const page = await openPage({
         colorScheme,
@@ -462,12 +462,21 @@ suite.define(() => {
       await expect.poll(() => toast.textContent()).toContain("Codex hidden");
       const dismiss = toast.getByRole("button", { name: "Dismiss" });
       await dismiss.click({ trial: true });
+      const drawerToastBounds = await toast.boundingBox();
+      if (!drawerToastBounds) {
+        throw new Error("expected the drawer toast to have a layout box");
+      }
+      expect(Math.round(drawerToastBounds.y)).toBe(20);
 
       await page.screenshot({
         animations: "disabled",
         path: path.join(TOAST_PROOF_DIR, `mobile-drawer-toast-${colorScheme}.png`),
       });
-      if (colorScheme === "dark") {
+      // The two runs split the modal-to-shell handoff routes: dismissing the drawer
+      // keeps phone width, while growing the viewport unmounts it. Only the dismissal
+      // route still sits at phone width afterwards, so it owns the narrow assertions.
+      const handsOffAtPhoneWidth = colorScheme === "dark";
+      if (handsOffAtPhoneWidth) {
         await page.keyboard.press("Escape");
         await expect.poll(() => dialog.isVisible()).toBe(false);
       } else {
@@ -476,15 +485,29 @@ suite.define(() => {
       }
       const handedOffToast = page.locator(".shell > openclaw-toast-host .app-toast");
       await expect.poll(() => handedOffToast.textContent()).toContain("Codex hidden");
-      const [toastBounds, composerBounds] = await Promise.all([
-        handedOffToast.boundingBox(),
-        page.locator(".agent-chat__composer-shell").boundingBox(),
-      ]);
-      if (!toastBounds || !composerBounds) {
-        throw new Error("expected the handed-off toast and chat composer to have layout boxes");
+      if (handsOffAtPhoneWidth) {
+        const [mobileToastBounds, composerBounds] = await Promise.all([
+          handedOffToast.boundingBox(),
+          page.locator(".agent-chat__composer-shell").boundingBox(),
+        ]);
+        if (!mobileToastBounds || !composerBounds) {
+          throw new Error("expected the handed-off toast and chat composer to have layout boxes");
+        }
+        expect(Math.round(mobileToastBounds.y)).toBe(20);
+        expect(mobileToastBounds.y + mobileToastBounds.height).toBeLessThan(composerBounds.y);
+        await page.setViewportSize({ width: 1280, height: 900 });
+        await expect.poll(() => drawer.count()).toBe(0);
       }
-      expect(Math.round(toastBounds.y)).toBe(20);
-      expect(toastBounds.y + toastBounds.height).toBeLessThan(composerBounds.y);
+      const desktopToastBounds = await handedOffToast.boundingBox();
+      if (!desktopToastBounds) {
+        throw new Error("expected the desktop toast to have a layout box");
+      }
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(TOAST_PROOF_DIR, `desktop-toast-${colorScheme}.png`),
+      });
+      expect(Math.round(1280 - desktopToastBounds.x - desktopToastBounds.width)).toBe(20);
+      expect(Math.round(900 - desktopToastBounds.y - desktopToastBounds.height)).toBe(20);
       await handedOffToast.getByRole("button", { name: "Dismiss" }).click();
       await expect.poll(() => handedOffToast.isVisible()).toBe(false);
     },

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -635,13 +635,13 @@ openclaw-session-owner-chip {
   line-height: 1;
 }
 
-/* Passive notifications stay in the trailing top corner, away from the chat
- * composer and other bottom-docked controls. The host shows one toast at a time
- * (`show()` replaces the active one), so there is no stack to offset against. */
+/* Wide layouts keep passive notifications in the peripheral bottom corner, clear
+ * of the topbar controls. The host shows one toast at a time (`show()` replaces
+ * the active one), so there is no stack to offset against. */
 .app-toast {
   position: fixed;
   right: calc(20px + var(--safe-area-right));
-  top: calc(20px + var(--safe-area-top));
+  bottom: calc(20px + var(--safe-area-bottom));
   z-index: var(--z-toast);
   display: flex;
   align-items: center;
@@ -655,12 +655,15 @@ openclaw-session-owner-chip {
   box-shadow: var(--shadow-lg);
 }
 
-/* A corner toast degenerates at phone widths, where it would span nearly the
- * whole viewport anyway. Use the full-width top idiom instead. */
+/* Phone layouts move the toast to the top, clear of the composer, keyboard, and
+ * home gesture, and go full-width because a corner toast would span nearly the
+ * whole viewport anyway. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .app-toast {
+    top: calc(20px + var(--safe-area-top));
     left: max(12px, var(--safe-area-left));
     right: max(12px, var(--safe-area-right));
+    bottom: auto;
     max-width: none;
   }
 }


### PR DESCRIPTION
Closes #123939

## What Problem This Solves

Fixes an issue where desktop Control UI users would see passive notifications cover or compete with interactive topbar controls, including the notification bell, because the narrow-screen top placement also applied to wide layouts.

#123423 correctly moved narrow-screen notifications away from the composer. This follow-up preserves that mobile behavior and scopes it to the existing narrow-layout breakpoint.

## Why This Change Was Made

Toast position is responsive rather than fixed. On desktop, bottom-right is the established peripheral status zone used by Windows notifications, VS Code, and IntelliJ: the eye can treat it as ambient and ignorable until needed. Top-right instead collides with interactive chrome and competes with the page's attention hierarchy.

On narrow screens, top remains the correct position because the bottom edge is occupied by the keyboard, composer, and home gesture. A top banner also follows the familiar system push-notification pattern.

The shared toast therefore defaults to bottom-right and switches to top only inside the app's existing phone breakpoint: `768px`, plus the existing `932×500` landscape-phone exception. Safe-area insets, horizontal fit, wrapping, dismissal, and modal handoff remain unchanged.

## User Impact

Desktop notifications return to the bottom-right status area and no longer cover topbar actions. Phone and narrow-landscape notifications remain full-width at the top, clear of bottom-docked interaction surfaces.

## Evidence

### Desktop: restored peripheral placement

| Theme | Before | In this PR |
| --- | --- | --- |
| Light | ![Before, desktop light: notification overlaps the topbar action region](https://github.com/user-attachments/assets/20eab2ca-ee54-4801-87f3-9a98fd637fca) | ![In this PR, desktop light: notification is in the bottom-right status area](https://github.com/user-attachments/assets/a5c73359-677d-4c96-80a7-a0c64b17557e) |
| Dark | ![Before, desktop dark: notification overlaps the topbar action region](https://github.com/user-attachments/assets/00be23c2-4a36-4eaf-9c9b-205a7919af04) | ![In this PR, desktop dark: notification is in the bottom-right status area](https://github.com/user-attachments/assets/609bc67f-23bd-4a1b-85ce-8a154e278093) |

### Narrow: #123423 behavior preserved

| Theme | Before | In this PR |
| --- | --- | --- |
| Light | ![Before, narrow light: notification is full-width at the top of the drawer](https://github.com/user-attachments/assets/a0259901-2865-4a89-bb97-0aa15efaacfb) | ![In this PR, narrow light: notification remains full-width at the top of the drawer](https://github.com/user-attachments/assets/6d4929f3-f34e-4bcf-9e51-67d270a2fbe4) |
| Dark | ![Before, narrow dark: notification is full-width at the top of the drawer](https://github.com/user-attachments/assets/c6517eef-5ed1-4419-ba8a-c9408b6267e4) | ![In this PR, narrow dark: notification remains full-width at the top of the drawer](https://github.com/user-attachments/assets/460a9a18-465b-46ae-80b8-776d1bd413a6) |

- Pre-fix regression proof: both desktop theme cases failed with an 815 px bottom gap while both narrow cases retained their 20 px top inset.
- Exact-head Control UI E2E: 12/12 passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31859445962).
- Path-scoped checks: formatting, repository guards, i18n, dead exports, dependency pins, core/UI typechecks, and lint passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31858917587).
- All eight before/after frames were captured in headed Chromium and inspected individually.
