### PR TITLE
fix(gateway): separate concurrent worker runtime dispatches

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -63,9 +63,13 @@ describe("worker placement dispatch coordinator", () => {
         },
       }),
     ).rejects.toThrow(`Session ${REQUEST.sessionKey} is already dispatching another request`);
+    const modeConflict = expect(
+      coordinated.dispatch({ ...REQUEST, executionMode: "remote-exec" }),
+    ).rejects.toThrow(`Session ${REQUEST.sessionKey} is already dispatching another request`);
     const retry = coordinated.dispatch(REQUEST);
     releaseDispatch.resolve();
 
+    await modeConflict;
     const [firstResult, retryResult] = await Promise.all([first, retry]);
     expect(retryResult).toBe(firstResult);
     expect(dispatch).toHaveBeenCalledOnce();

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -91,6 +91,7 @@ export function coordinateWorkerPlacementDispatch(
           inFlight.request.sessionKey !== request.sessionKey ||
           inFlight.request.agentId !== request.agentId ||
           inFlight.request.profileId !== request.profileId ||
+          inFlight.request.executionMode !== request.executionMode ||
           inFlight.request.deviceId !== request.deviceId ||
           !isDeepStrictEqual(inFlight.request.inheritedProfile, request.inheritedProfile)
         ) {


### PR DESCRIPTION
Closes #123945

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where overlapping cloud-worker dispatches for one session could share an in-flight operation even when the session runtime changed between `worker-turn` and `remote-exec`.

Those modes use different placement and turn-claim authority. Returning the first mode's placement to the second caller obscures the runtime change instead of producing a conflict and retry outcome.

## Why This Change Was Made

The placement dispatch coordinator already defines exact-request identity using session key, agent, profile, device, and inherited provider profile. This change adds the missing prepared `executionMode` fact to that same owner boundary, preserving coalescing for identical retries while rejecting authority-mode mismatches.

The repair is intentionally limited to the coordinator comparison and its existing ordered coalescing regression. It changes no protocol, security policy, persistence, config, public API, worker bundle, tunnel, terminal outcome, or session-observer behavior.

Production LOC is +1 because the newly introduced request field must participate directly in the existing identity predicate; moving or abstracting the predicate would add more surface without removing policy. Tests are +4.

ClawSweeper rank-up decisions:

- **Resolve merge risk (P1): accepted.** The +1 production comparison is the minimal canonical representation of the missing authority-bearing fact. A net-neutral extraction is not available: moving the check to callers or persistence leaves the coalescing race outside its owner, while introducing a key/fingerprint helper adds more production surface.
- **Complete next step (P2): in progress through the native maintainer flow.** No repair lane is needed because the exact maintainer-owned head has no review findings; merge remains gated on green exact-head CI and `scripts/pr` prepare/merge.

## User Impact

Operators changing a cloud session's runtime while a placement dispatch is in flight now receive an explicit conflicting-request outcome and can retry, rather than observing a placement created under the other runtime authority mode.

## Evidence

- Pre-fix regression: the conflicting `remote-exec` promise resolved with `{ state: "active" }` instead of rejecting.
- Focused post-fix proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch-coordinator.test.ts src/gateway/server.sessions.worker-original-order.test.ts` — 2 files, 5 tests passed, including all 4 coordinator cases and the isolated Gateway/worker restart/workspace/retirement lifecycle.
- Formatter: both changed files pass `oxfmt --check`.
- Changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` passed the `core, coreTests` lanes on Blacksmith Testbox `tbx_01m01mzm4kxnh30ynpj4b27dc8` ([run](https://github.com/openclaw/openclaw/actions/runs/31860041226)).
- Fresh Codex autoreview on `origin/main...7372bba47bd432041bd8b288581eed387aa586a1`: clean, no accepted/actionable findings; patch-correct assessment 0.99.
- Duplicate search: current `origin/main`, Gitcrawl archive, and live GitHub issue/PR searches contain no equivalent execution-mode identity fix.
- Diff: production +1/-0; tests +4/-0; exactly two files.
