### PR TITLE
perf(test): reuse Quicksilver peer module graph

### DIFF
--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -25,6 +25,26 @@ import {
   parseSent,
 } from "./realtime-quicksilver.test-helpers.js";
 
+type LibopusModule = typeof import("libopus-wasm");
+type LibopusDecoder = Awaited<ReturnType<LibopusModule["createDecoder"]>>;
+type LibopusEncoder = Awaited<ReturnType<LibopusModule["createEncoder"]>>;
+
+const libopusFactoryOverrides = vi.hoisted(() => ({
+  createDecoder: undefined as LibopusModule["createDecoder"] | undefined,
+  createEncoder: undefined as LibopusModule["createEncoder"] | undefined,
+}));
+
+vi.mock("libopus-wasm", async (importOriginal) => {
+  const actual = await importOriginal<LibopusModule>();
+  return {
+    ...actual,
+    createDecoder: (...args: Parameters<LibopusModule["createDecoder"]>) =>
+      (libopusFactoryOverrides.createDecoder ?? actual.createDecoder)(...args),
+    createEncoder: (...args: Parameters<LibopusModule["createEncoder"]>) =>
+      (libopusFactoryOverrides.createEncoder ?? actual.createEncoder)(...args),
+  };
+});
+
 function createRelayTone(): Buffer {
   const pcm = Buffer.alloc(480 * 2);
   for (let index = 0; index < 480; index += 1) {
@@ -503,24 +523,15 @@ describe("GPT-Live werift audio peer", () => {
 
   it("releases the encoder and peer when decoder initialization fails", async () => {
     const encoder = { free: vi.fn() };
-    vi.doMock("libopus-wasm", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("libopus-wasm")>();
-      return {
-        ...actual,
-        createEncoder: vi.fn(async () => encoder),
-        createDecoder: vi.fn(async () => {
-          throw new Error("decoder init failed");
-        }),
-      };
-    });
-    vi.resetModules();
+    libopusFactoryOverrides.createEncoder = async () => encoder as unknown as LibopusEncoder;
+    libopusFactoryOverrides.createDecoder = async () => {
+      throw new Error("decoder init failed");
+    };
     const { RTCPeerConnection } = await import("werift");
     const closePeer = vi.spyOn(RTCPeerConnection.prototype, "close");
     try {
-      const { OpenAIQuicksilverAudioPeer: ReloadedPeer } =
-        await import("./realtime-quicksilver-peer.runtime.js");
       await expect(
-        ReloadedPeer.create({
+        OpenAIQuicksilverAudioPeer.create({
           callbacks: { onAudio: vi.fn(), onError: vi.fn() },
           iceServers: [],
         }),
@@ -529,8 +540,8 @@ describe("GPT-Live werift audio peer", () => {
       expect(closePeer).toHaveBeenCalled();
     } finally {
       closePeer.mockRestore();
-      vi.doUnmock("libopus-wasm");
-      vi.resetModules();
+      libopusFactoryOverrides.createEncoder = undefined;
+      libopusFactoryOverrides.createDecoder = undefined;
     }
   });
 
@@ -544,22 +555,14 @@ describe("GPT-Live werift audio peer", () => {
           resolveDecoder = resolve;
         }),
     );
-    vi.doMock("libopus-wasm", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("libopus-wasm")>();
-      return {
-        ...actual,
-        createEncoder: vi.fn(async () => encoder),
-        createDecoder,
-      };
-    });
-    vi.resetModules();
+    libopusFactoryOverrides.createEncoder = async () => encoder as unknown as LibopusEncoder;
+    libopusFactoryOverrides.createDecoder = async () =>
+      (await createDecoder()) as unknown as LibopusDecoder;
     const { RTCPeerConnection } = await import("werift");
     const closePeer = vi.spyOn(RTCPeerConnection.prototype, "close");
     const controller = new AbortController();
     try {
-      const { OpenAIQuicksilverAudioPeer: ReloadedPeer } =
-        await import("./realtime-quicksilver-peer.runtime.js");
-      const creation = ReloadedPeer.create({
+      const creation = OpenAIQuicksilverAudioPeer.create({
         callbacks: { onAudio: vi.fn(), onError: vi.fn() },
         iceServers: [],
         signal: controller.signal,
@@ -574,8 +577,8 @@ describe("GPT-Live werift audio peer", () => {
       expect(encoder.free).toHaveBeenCalledOnce();
     } finally {
       closePeer.mockRestore();
-      vi.doUnmock("libopus-wasm");
-      vi.resetModules();
+      libopusFactoryOverrides.createEncoder = undefined;
+      libopusFactoryOverrides.createDecoder = undefined;
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Two Quicksilver peer-cleanup tests each replaced `libopus-wasm`, reset Vitest's complete evaluated module registry, and re-imported the peer and its broad realtime/session graph. The retained cleanup behavior was correct, but the global invalidation added avoidable wall time, CPU, and memory to this extension test shard.

## Why This Change Was Made

The test file now owns one hoisted partial `libopus-wasm` mock whose factories delegate to the real module by default. Only the two partial-allocation cleanup cases temporarily override `createEncoder` and `createDecoder`, clear those overrides in `finally`, and reuse the same production peer class. Normal audio, RTP, round-trip, and bridge tests still exercise the real dependency.

This is AI-assisted, test-only maintenance. Production/runtime bytes, package surfaces, and live-provider behavior are unchanged.

## User Impact

No user-visible behavior changes. Maintainers get a faster, lower-memory Quicksilver test shard without reducing collected tests or weakening encoder, decoder, peer, audio, routing, or architecture coverage.

## Evidence

Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31858694506 (`tbx_01m01k6zdnc820gwr5kwf663qe`). Baseline and changed samples ran on the same lease with isolated per-side Vitest caches; the cache-fill sample on each side was excluded.

| Warm average | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Wall | 5.405 s | 4.965 s | -8.1% |
| Vitest duration | 2.430 s | 2.095 s | -13.8% |
| Test body | 724.5 ms | 460.0 ms | -36.5% |
| Import | 1.420 s | 1.365 s | -3.9% |
| CPU (user + sys) | 6.465 s | 5.770 s | -10.8% |
| Max RSS | 815,092 KiB | 754,960 KiB | -7.4% |

Validation:

- Selected Linux Testbox file: 30 collected, 29 passed, 1 Bun skip.
- Four Quicksilver/voice sibling files: 76 collected, 75 passed, 1 Bun skip.
- Current rebased head `52384dee5a73019071591b135db6c7cb9941f363`, six focused/sibling/boundary paths: 6 files and 128 tests passed via `node scripts/run-vitest.mjs`.
- Architecture/import boundaries: 52 passed.
- Fresh Blacksmith Testbox changed gate: https://github.com/openclaw/openclaw/actions/runs/31860423733 (`tbx_01m01nfs2ar2jkke6r2yqbc9v2`), exit 0. The precise plan remained `extensionTests`; extension test typecheck, lint with zero warnings/errors, targeted formatting, dependency/boundary guards, and dead-export scans all passed.
- The earlier exact-head guard failure was a pre-existing `main` issue in `scripts/check-protocol-event-coverage.mts`; current `main` resolves it in `2276dca1d34` by using `scripts/lib/record-shared.mjs`. The protocol coverage script and coercion-helper declaration guard both pass on this rebased head.
- `git diff --check` passed. Production LOC: +0/-0. Test LOC: +33/-30 (net +3).
- Fresh branch autoreview passed with no accepted/actionable findings (patch correctness 0.99).

Dependency contracts inspected directly:

- Vitest 4.1.10: `vi.hoisted` runs before imports; the `vi.mock` factory's `importOriginal` delegates through `importActual`; `resetModules` invalidates the evaluated module map while retaining the mock registry.
- `libopus-wasm` 0.2.0: `createEncoder` and `createDecoder` are async factories returning handles with `free()`, and both use the package's cached module promise.

No live call was run because production code is byte-identical and the existing live Gateway relay suite is untouched. No docs or changelog change is required for this internal test-only optimization.
