### PR TITLE
fix(web-search): prevent cancelled results from reaching caches

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -384,6 +384,7 @@ export async function executeGeminiSearch(
   searchConfig?: SearchConfigRecord,
   context?: { signal?: AbortSignal },
 ): Promise<Record<string, unknown>> {
+  context?.signal?.throwIfAborted();
   const unsupportedResponse = buildUnsupportedSearchFilterResponse(
     {
       country: args.country,
@@ -458,6 +459,7 @@ export async function executeGeminiSearch(
     timeRangeFilter: timeRange.timeRangeFilter,
     headers,
   });
+  context?.signal?.throwIfAborted();
   const payload = {
     query,
     provider: "gemini",

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -422,10 +422,11 @@ describe("google web search provider", () => {
     );
   });
 
-  it("passes provider execution abort signals into the Gemini fetch", async () => {
+  it("does not contact Gemini for an already-cancelled search", async () => {
     const mockFetch = installGeminiFetch();
     const controller = new AbortController();
-    controller.abort();
+    const reason = new Error("Gemini search cancelled before billing");
+    controller.abort(reason);
     const provider = createGeminiWebSearchProvider();
     const tool = provider.createTool({
       config: {
@@ -444,10 +445,46 @@ describe("google web search provider", () => {
       searchConfig: { provider: "gemini" },
     });
 
-    await tool?.execute({ query: "OpenClaw docs" }, { signal: controller.signal });
+    await expect(
+      tool?.execute({ query: "OpenClaw cancelled docs" }, { signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 
-    const [, init] = requireFirstGeminiFetchCall(mockFetch);
-    expect(init?.signal?.aborted).toBe(true);
+  it("does not cache a Gemini result completed after caller cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Gemini search cancelled after response");
+    const mockFetch = installGeminiFetch();
+    mockFetch.mockImplementationOnce(async () => {
+      controller.abort(reason);
+      return new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: "Cancelled grounded answer" }] },
+              groundingMetadata: {},
+            },
+          ],
+        }),
+      );
+    });
+    const tool = createGeminiWebSearchProvider().createTool({
+      config: {
+        plugins: {
+          entries: {
+            google: { config: { webSearch: { apiKey: "AIza-plugin-test" } } },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini" },
+    });
+    const query = "OpenClaw late-cancel Gemini cache";
+
+    await expect(tool?.execute({ query }, { signal: controller.signal })).rejects.toBe(reason);
+    await tool?.execute({ query });
+
+    const postCalls = mockFetch.mock.calls.filter(([, init]) => typeof init?.body === "string");
+    expect(postCalls).toHaveLength(2);
   });
 
   it("reuses the Google model provider key when no web search key or env key is set", async () => {

--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -345,6 +345,7 @@ export async function executeKimiWebSearchProviderTool(
   args: Record<string, unknown>,
   opts?: { signal?: AbortSignal },
 ): Promise<Record<string, unknown>> {
+  opts?.signal?.throwIfAborted();
   const searchConfig = mergeScopedSearchConfig(
     ctx.searchConfig,
     "kimi",
@@ -397,6 +398,7 @@ export async function executeKimiWebSearchProviderTool(
     timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
     signal: opts?.signal,
   });
+  opts?.signal?.throwIfAborted();
   if (!result.grounded) {
     return {
       error: "kimi_web_search_ungrounded",

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -303,6 +303,36 @@ describe("kimi web search provider", () => {
     });
   });
 
+  it("does not cache a grounded Kimi result completed after caller cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Kimi search cancelled after response");
+    const grounded = {
+      search_results: [{ title: "OpenClaw", url: "https://github.com/openclaw/openclaw" }],
+      choices: [{ finish_reason: "stop", message: { content: "OpenClaw is on GitHub." } }],
+    };
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        controller.abort(reason);
+        return jsonResponse(grounded);
+      })
+      .mockResolvedValueOnce(jsonResponse(grounded));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await withEnvAsync({ KIMI_API_KEY: "kimi-test-key" }, async () => {
+      const tool = createKimiWebSearchProvider().createTool({ config: {}, searchConfig: {} });
+      if (!tool) {
+        throw new Error("Expected tool definition");
+      }
+      const query = "unique Kimi late-cancel cache regression";
+
+      await expect(tool.execute({ query }, { signal: controller.signal })).rejects.toBe(reason);
+      await tool.execute({ query });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("uses config apiKey when provided", () => {
     expect(testing.resolveKimiApiKey({ apiKey: "kimi-test-key" })).toBe("kimi-test-key");
   });

--- a/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
@@ -21,6 +21,7 @@ export async function executeParallelFreeWebSearchProviderTool(
   args: Record<string, unknown>,
   signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
+  signal?.throwIfAborted();
   const searchConfig = mergeScopedSearchConfig(
     ctx.searchConfig,
     "parallel-free",
@@ -59,6 +60,7 @@ export async function executeParallelFreeWebSearchProviderTool(
     timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
     signal,
   });
+  signal?.throwIfAborted();
   const payload = buildParallelSearchPayload({
     provider: "parallel-free",
     objective,

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -16,6 +16,7 @@ type ToolParameters = {
 };
 const endpointMockState = vi.hoisted(() => ({
   calls: [] as EndpointCall[],
+  effects: [] as Array<(() => void) | undefined>,
   responses: [] as Response[],
 }));
 vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
@@ -29,6 +30,7 @@ vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
         if (!response) {
           throw new Error("Missing mocked Parallel response.");
         }
+        endpointMockState.effects.shift()?.();
         return await run(response);
       },
     ),
@@ -120,6 +122,7 @@ const cacheKey = (overrides: Partial<CacheKeyParams> = {}) =>
   testing.buildParallelCacheKey({ ...CACHE_KEY_BASE, ...overrides });
 beforeEach(() => {
   endpointMockState.calls = [];
+  endpointMockState.effects = [];
   endpointMockState.responses = [];
 });
 describe("parallel web search provider", () => {
@@ -709,6 +712,24 @@ describe("parallel-free web search provider", () => {
 
     expect(endpointMockState.calls).toHaveLength(3);
     expect(endpointMockState.calls.every((call) => call.signal === controller.signal)).toBe(true);
+  });
+
+  it("does not cache a free MCP result completed after caller cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Parallel free search cancelled after response");
+    pushMcpHandshake({ search_id: "cancelled-free", results: [] });
+    pushMcpHandshake({ search_id: "recovered-free", results: [] });
+    endpointMockState.effects.push(undefined, undefined, () => controller.abort(reason));
+    const args = {
+      objective: "verify Parallel cancellation cache ownership",
+      search_queries: ["parallel cancellation cache"],
+    };
+
+    await expect(freeTool().execute(args, { signal: controller.signal })).rejects.toBe(reason);
+    const recovered = await freeTool().execute(args);
+
+    expect(endpointMockState.calls).toHaveLength(6);
+    expect(recovered.searchId).toBe("recovered-free");
   });
 
   it("exposes keyless metadata without claiming auto-detect fallback", () => {

--- a/extensions/tavily/src/tavily-client.test.ts
+++ b/extensions/tavily/src/tavily-client.test.ts
@@ -4,6 +4,7 @@ import { createStreamingResponse } from "../../test-support/streaming-error-resp
 
 // Capture every call to postTrustedWebToolsJson so we can assert on extraHeaders.
 const postTrustedWebToolsJson = vi.fn();
+const writeCache = vi.fn();
 
 vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>()),
@@ -12,7 +13,7 @@ vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => ({
   postTrustedWebToolsJson,
   readCache: () => undefined,
   resolveCacheTtlMs: () => 300_000,
-  writeCache: vi.fn(),
+  writeCache,
 }));
 
 vi.mock("./config.js", () => ({
@@ -33,6 +34,7 @@ describe("tavily client X-Client-Source header", () => {
 
   beforeEach(() => {
     postTrustedWebToolsJson.mockReset();
+    writeCache.mockReset();
     postTrustedWebToolsJson.mockImplementation(
       async (_params: unknown, parse: (r: Response) => Promise<unknown>) =>
         parse(Response.json({ results: [] })),
@@ -292,6 +294,29 @@ describe("tavily client X-Client-Source header", () => {
 
       await expect(operation).rejects.toBe(reason);
       expect(postTrustedWebToolsJson.mock.calls[0]?.[0]?.signal).toBe(controller.signal);
+    },
+  );
+
+  it.each(["search", "extract"] as const)(
+    "does not cache a %s result completed after caller cancellation",
+    async (kind) => {
+      const controller = new AbortController();
+      const reason = new Error(`${kind} cancelled after response`);
+      postTrustedWebToolsJson.mockImplementationOnce(async () => {
+        controller.abort(reason);
+        return { results: [] };
+      });
+
+      const operation =
+        kind === "search"
+          ? runTavilySearch({ query: "late cancel", signal: controller.signal })
+          : runTavilyExtract({
+              urls: ["https://example.com/late-cancel"],
+              signal: controller.signal,
+            });
+
+      await expect(operation).rejects.toBe(reason);
+      expect(writeCache).not.toHaveBeenCalled();
     },
   );
 });

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -203,6 +203,7 @@ export async function runTavilySearch(
     errorLabel: "Tavily Search",
     ...(params.signal ? { signal: params.signal } : {}),
   });
+  params.signal?.throwIfAborted();
 
   const rawResults = Array.isArray(payload.results) ? payload.results : [];
   let remainingSearchContentChars = TAVILY_SEARCH_MAX_CONTENT_CHARS;
@@ -321,6 +322,7 @@ export async function runTavilyExtract(
     responseMaxBytes: TAVILY_EXTRACT_RESPONSE_MAX_BYTES,
     ...(params.signal ? { signal: params.signal } : {}),
   });
+  params.signal?.throwIfAborted();
 
   const rawResults = Array.isArray(payload.results) ? payload.results : [];
   let remainingContentChars = TAVILY_EXTRACT_MAX_CONTENT_CHARS;

--- a/extensions/xai/src/web-search-provider.runtime.ts
+++ b/extensions/xai/src/web-search-provider.runtime.ts
@@ -153,6 +153,7 @@ function runXaiWebSearch(params: {
       inlineCitations: params.inlineCitations,
       ...(params.signal ? { signal: params.signal } : {}),
     });
+    params.signal?.throwIfAborted();
     const payload = buildXaiWebSearchPayload({
       query: params.query,
       provider: "grok",

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -840,6 +840,29 @@ describe("xai web search config resolution", () => {
     expect(transportSignal?.reason).toBe(reason);
   });
 
+  it("does not cache a Grok result completed after caller cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Grok search cancelled after response");
+    const mockFetch = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        controller.abort(reason);
+        return xaiAnswerResponse("Cancelled Grok answer");
+      })
+      .mockResolvedValueOnce(xaiAnswerResponse("Recovered Grok answer"));
+    global.fetch = withFetchPreconnect(mockFetch);
+    const tool = requireXaiWebSearchTool({
+      config: xaiPluginConfig({ webSearch: { apiKey: "xai-cancel-cache-key" } }),
+    });
+    const query = "unique Grok late-cancel cache regression";
+
+    await expect(tool.execute({ query }, { signal: controller.signal })).rejects.toBe(reason);
+    const recovered = await tool.execute({ query });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(recovered.content).toContain("Recovered Grok answer");
+  });
+
   it("does not contact the generic xAI provider when the caller is already cancelled", async () => {
     const mockFetch = installXaiWebSearchFetch();
     const controller = new AbortController();


### PR DESCRIPTION
Closes #123948

AI-assisted: yes (Codex)

## What Problem This Solves

Fixes an issue where canceled managed web searches could populate a provider success cache when cancellation arrived after the provider response but before result normalization and return. A later identical search could then receive data produced by work the caller explicitly canceled.

## Why This Change Was Made

Each affected provider now checks the caller's cancellation before starting work and immediately after the awaited provider result, before payload normalization, return, or cache insertion. The fences remain provider-owned for Gemini, Kimi, Parallel Free, Tavily search/extract, and Grok; the public provider API and shared SDK are unchanged.

The existing cache TTLs, authentication/configuration, normal successful results, timeout behavior, and error shapes remain unchanged. Moving the policy into the shared Plugin SDK was rejected because cancellation is already available at each provider execution boundary and a shared API change would needlessly expand the public contract.

Production LOC: +9/-0 (net +9) | Tests: +142/-6 (net +136)

## User Impact

Canceled web searches can no longer influence a later search through provider-local cached state. Successful searches and ordinary cache hits continue to behave as before.

## Evidence

- Pre-fix provider-boundary reproduction: 3 failures / 64 passes. Parallel Free, Tavily search, and Tavily extract returned successful payloads after caller cancellation.
- Post-fix focused provider suite: 171/171 tests passed across Gemini, Kimi, Parallel Free, Tavily, and Grok.
- Post-fix cancellation timing coverage: 41/41 core `web_search` runtime and agent-tool signal regressions passed.
- Read-only live Parallel Free search: returned two real results with `provider=parallel-free`, `cached=false`.
- Rebased changed gate: passed all extension production/test typechecks, lint, formatting, dead-code, dependency, plugin-boundary, database-first, sidecar, and import-cycle checks through the documented local fallback after no remote provider was ready.
- Targeted formatting: all ten changed files pass `oxfmt --check`; `git diff --check` is clean.
- Fresh branch autoreview on `01b7cf0ec6fac61c5c5c8886772b89211c3559a4`: clean, no actionable findings; best provider-owner-boundary fix verdict.
- Rebased patch identity matches approved commit `c733c00fcfe70e7cd3b4a0d8445000949e784c70` (`patch-id aa0c236da61557f33adc7b365443d3459580f1ea`).
- No public SDK, config, auth, security, dependency, schema, protocol, or changelog changes.

Current main commit `2276dca1d349c36bf3bdc4768e58301200fbde46` independently repaired the unrelated coercion-helper gate regression seen on the first PR head. This branch is rebased on that commit; the approved web-search patch remains byte-equivalent.
