### PR TITLE
fix(synology-chat): prevent duplicate sends after custody loss

### DIFF
--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -342,7 +342,10 @@ async function sendSynologyChatMedia(
     ctx.to,
     account.allowInsecureSsl,
     ...(dispatch ? [dispatch] : []),
-  );
+  ).catch(async (error: unknown) => {
+    await Promise.allSettled([prepared.cleanup()]);
+    throw error;
+  });
   if (sendResult.status === "not-dispatched") {
     await prepared.cleanup();
     throw new Error(

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -110,6 +110,7 @@ type SynologyChannelOutboundContext = {
   mediaAccess?: OutboundMediaLoadOptions["mediaAccess"];
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
+  onPlatformSendDispatch?: () => Promise<void>;
 };
 type SynologyChannelSendTextContext = SynologyChannelOutboundContext & { text: string };
 type SynologyChannelSendMediaContext = SynologyChannelOutboundContext & { mediaUrl: string };
@@ -305,7 +306,14 @@ async function sendSynologyChatText(
     }
     return `<${url.replace(/\\([()])/g, "$1")}|${label.replace(/\\([[\]])/g, "$1")}>`;
   });
-  const ok = await sendMessage(incomingUrl, text, ctx.to, account.allowInsecureSsl);
+  const dispatch = ctx.onPlatformSendDispatch;
+  const ok = await sendMessage(
+    incomingUrl,
+    text,
+    ctx.to,
+    account.allowInsecureSsl,
+    ...(dispatch ? [dispatch] : []),
+  );
   if (!ok) {
     throw new Error("Failed to send message to Synology Chat");
   }
@@ -327,11 +335,13 @@ async function sendSynologyChatMedia(
     mediaLocalRoots: ctx.mediaLocalRoots,
     mediaReadFile: ctx.mediaReadFile,
   });
+  const dispatch = ctx.onPlatformSendDispatch;
   const sendResult = await sendHostedFileUrl(
     incomingUrl,
     prepared.url,
     ctx.to,
     account.allowInsecureSsl,
+    ...(dispatch ? [dispatch] : []),
   );
   if (sendResult.status === "not-dispatched") {
     await prepared.cleanup();

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import * as http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -139,6 +140,76 @@ describe("Synology Chat client loopback", () => {
     console.log(
       `[synology webhook retry proof] server_received=${requestCount} disconnect_after_upload=true replayed=${requestCount > 1} outcome=not_sent`,
     );
+  });
+
+  it("acquires durable send custody before webhook bytes cross the loopback boundary", async () => {
+    const receivedPayloads: Array<Record<string, unknown>> = [];
+    const port = await listenLoopback((req, res) => {
+      let formBody = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk: string) => {
+        formBody += chunk;
+      });
+      req.on("end", () => {
+        const payload = new URLSearchParams(formBody).get("payload");
+        if (payload) {
+          receivedPayloads.push(JSON.parse(payload) as Record<string, unknown>);
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ success: true }));
+      });
+    });
+    const incomingUrl = `http://127.0.0.1:${port}/webapi/entry.cgi`;
+    const cfg = {
+      channels: {
+        "synology-chat": {
+          enabled: true,
+          token: "synology-custody-proof",
+          incomingUrl,
+        },
+      },
+    };
+    const marker = `autoqa-synology-custody-${randomUUID()}`;
+    const custodyFailure = new Error(`fault-injected custody failure: ${marker}`);
+    const rejectedDispatch = vi.fn(async () => {
+      throw custodyFailure;
+    });
+
+    await expect(
+      synologyChatPlugin.message.send?.text?.({
+        cfg,
+        text: marker,
+        to: "42",
+        onPlatformSendDispatch: rejectedDispatch,
+      }),
+    ).rejects.toThrow(custodyFailure.message);
+    expect(rejectedDispatch).toHaveBeenCalledOnce();
+    expect(receivedPayloads).toEqual([]);
+
+    const acceptedDispatch = vi.fn(async () => undefined);
+    await synologyChatPlugin.message.send?.text?.({
+      cfg,
+      text: marker,
+      to: "42",
+      onPlatformSendDispatch: acceptedDispatch,
+    });
+    expect(acceptedDispatch).toHaveBeenCalledOnce();
+    expect(receivedPayloads).toEqual([{ text: marker, user_ids: [42] }]);
+
+    const rejectedMediaDispatch = vi.fn(async () => {
+      throw custodyFailure;
+    });
+    await expect(
+      synologyChatPlugin.message.send?.media?.({
+        cfg,
+        text: marker,
+        mediaUrl: "https://example.com/custody-proof.png",
+        to: "42",
+        onPlatformSendDispatch: rejectedMediaDispatch,
+      }),
+    ).rejects.toThrow(custodyFailure.message);
+    expect(rejectedMediaDispatch).toHaveBeenCalledOnce();
+    expect(receivedPayloads).toHaveLength(1);
   });
 
   it("delivers authenticated text and media without inventing platform message ids", async () => {

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -5,14 +5,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { synologyChatPlugin } from "./channel.js";
 import { resolveLegacyWebhookNameToChatUserId, sendMessage } from "./client.js";
 
-const { hostedCapabilityUrl } = vi.hoisted(() => ({
+const { hostedCapabilityUrl, hostedCapabilityCleanup } = vi.hoisted(() => ({
   hostedCapabilityUrl:
     "https://gateway.example.com/webhook/synology?__openclaw_synology_media_token_aaaaaaaaaaaaaaaaaaaaaaaa=secret",
+  hostedCapabilityCleanup: vi.fn(async () => undefined),
 }));
 vi.mock("./outbound-media.js", () => ({
   prepareSynologyHostedMedia: vi.fn(async () => ({
     url: hostedCapabilityUrl,
-    cleanup: vi.fn(async () => undefined),
+    cleanup: hostedCapabilityCleanup,
   })),
   resolveSynologyHostedMediaRoute: vi.fn(),
 }));
@@ -199,6 +200,7 @@ describe("Synology Chat client loopback", () => {
     const rejectedMediaDispatch = vi.fn(async () => {
       throw custodyFailure;
     });
+    hostedCapabilityCleanup.mockClear();
     await expect(
       synologyChatPlugin.message.send?.media?.({
         cfg,
@@ -209,6 +211,7 @@ describe("Synology Chat client loopback", () => {
       }),
     ).rejects.toThrow(custodyFailure.message);
     expect(rejectedMediaDispatch).toHaveBeenCalledOnce();
+    expect(hostedCapabilityCleanup).toHaveBeenCalledOnce();
     expect(receivedPayloads).toHaveLength(1);
   });
 

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -142,53 +142,34 @@ export async function sendMessage(
   text: string,
   userId?: string | number,
   allowInsecureSsl = false,
+  onPlatformSendDispatch?: () => Promise<void>,
 ): Promise<boolean> {
   const chunks = chunkTextForOutbound(text, SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
   for (const chunk of chunks.length > 0 ? chunks : [text]) {
-    if (!(await sendMessageChunk(incomingUrl, chunk, userId, allowInsecureSsl))) {
-      return false;
+    // Synology Chat API requires numeric user_ids to specify the recipient.
+    const body = buildWebhookBody({ text: chunk }, userId);
+    // Retry only proven pre-connect failures; ambiguous webhook replays can duplicate messages.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await waitForSendSlot();
+      await onPlatformSendDispatch?.();
+      try {
+        const result = await doPost(incomingUrl, body, allowInsecureSsl);
+        if (result === "accepted") {
+          break;
+        }
+        return false;
+      } catch (error) {
+        if (!isProvenPreConnectFailure(error)) {
+          return false;
+        }
+      }
+      if (attempt === 2) {
+        return false;
+      }
+      await sleep(300 * 2 ** attempt);
     }
   }
   return true;
-}
-
-async function sendMessageChunk(
-  incomingUrl: string,
-  text: string,
-  userId?: string | number,
-  allowInsecureSsl = false,
-): Promise<boolean> {
-  // Synology Chat API requires user_ids (numeric) to specify the recipient
-  // The @mention is optional but user_ids is mandatory
-  const body = buildWebhookBody({ text }, userId);
-
-  // A webhook POST is non-idempotent. Retry only when the transport proves the
-  // request never connected; replaying an ambiguous failure can duplicate a message.
-  const maxRetries = 3;
-  const baseDelay = 300;
-
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      await waitForSendSlot();
-      const result = await doPost(incomingUrl, body, allowInsecureSsl);
-      if (result === "accepted") {
-        return true;
-      }
-      // An explicit rejection is final, while a server-side/ambiguous outcome
-      // cannot be replayed safely after a non-idempotent webhook POST.
-      return false;
-    } catch (error) {
-      if (!isProvenPreConnectFailure(error)) {
-        return false;
-      }
-    }
-
-    if (attempt < maxRetries - 1) {
-      await sleep(baseDelay * 2 ** attempt);
-    }
-  }
-
-  return false;
 }
 
 /**
@@ -199,6 +180,7 @@ export async function sendHostedFileUrl(
   fileUrl: SynologyHostedMediaUrl,
   userId?: string | number,
   allowInsecureSsl = false,
+  onPlatformSendDispatch?: () => Promise<void>,
 ): Promise<SynologyHostedFileSendResult> {
   let body: string;
   try {
@@ -208,6 +190,7 @@ export async function sendHostedFileUrl(
   }
 
   await waitForSendSlot();
+  await onPlatformSendDispatch?.();
 
   try {
     return { status: await doPost(incomingUrl, body, allowInsecureSsl) };


### PR DESCRIPTION
Closes #123952

## What Problem This Solves

Fixes an issue where Synology Chat durable text and hosted-media sends could cross the non-idempotent webhook boundary without first acquiring dispatch custody. If local ownership was lost after the POST began, recovery could incorrectly replay an already-started send and produce a duplicate message.

## Why This Change Was Made

The Synology Chat plugin now forwards and awaits the existing `onPlatformSendDispatch` callback immediately before every webhook POST, including every text chunk, proven pre-connect retry, and hosted-media send. The text retry loop is kept in its single owner so custody, pacing, request classification, and replay policy cannot drift.

This remains plugin-local. It does not change account configuration, URL preparation, pacing, cleanup, response classification, result shapes, public SDK, protocol, dependencies, or the honest empty platform-message IDs returned by Synology webhooks.

## User Impact

Synology Chat operators no longer risk duplicate recipient-visible messages when a durable send loses local ownership around webhook I/O. Custody rejection prevents the request entirely, while safe pre-connect retries still work.

## Evidence

- Before: the loopback regression expected the injected custody rejection, but the adapter resolved and the server received the text POST.
- After: a UUID-tagged text marker is accepted exactly once; rejected custody produces zero text requests and zero hosted-media requests. Rejected media custody also cleans the staged capability exactly once while preserving the original error.
- Focused proof: `node scripts/run-vitest.mjs extensions/synology-chat/src/client.loopback.test.ts extensions/synology-chat/src/client.test.ts extensions/synology-chat/src/channel.test.ts` — 110 passed.
- Format: `pnpm format extensions/synology-chat/src/channel.ts extensions/synology-chat/src/client.ts extensions/synology-chat/src/client.loopback.test.ts` — clean.
- Diff: `git diff --check origin/main...HEAD` — clean.
- Fresh Codex autoreview after the final ClawSweeper cleanup repair — clean, no accepted/actionable findings.
- Changed gate: Testbox reported no ready `ci-fast` provider, so the trusted-source fallback ran locally and passed. The branch includes canonical main fix `2276dca1d349c36bf3bdc4768e58301200fbde46` for the earlier unrelated coercion-guard break.
- ClawSweeper’s P2 finding was addressed in the same owner: staged hosted media is cleaned when custody rejects before I/O, and the original custody error is rethrown.
- Production LOC: +36/-40 across `channel.ts` and `client.ts` (net -4). Tests: +76/-2 (net +74).

AI-assisted: yes. The implementation and proof were reviewed and understood by the submitting maintainer.
