### PR TITLE
fix: prose containing braces hides the JSON that follows it

### DIFF
--- a/packages/normalization-core/src/balanced-json.test.ts
+++ b/packages/normalization-core/src/balanced-json.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { extractBalancedJsonFragments, extractBalancedJsonPrefix } from "./balanced-json.js";
+
+describe("extractBalancedJsonPrefix", () => {
+  it("skips an opener inside quoted prose", () => {
+    const raw = 'prefix "notjson{here}" middle {"a":[1,{"b":"c"}]} suffix';
+
+    expect(extractBalancedJsonPrefix(raw)?.json).toBe('{"a":[1,{"b":"c"}]}');
+  });
+
+  it("skips an escaped quote inside quoted prose", () => {
+    const raw = 'say "he said \\"{nope}\\" loudly" then {"ok":true}';
+
+    expect(extractBalancedJsonPrefix(raw)?.json).toBe('{"ok":true}');
+  });
+
+  it("keeps braces that appear inside a string of the value itself", () => {
+    const raw = '{"a":"}{","b":[1]}';
+
+    expect(extractBalancedJsonPrefix(raw)?.json).toBe(raw);
+  });
+
+  it("reports the index of the value it returns", () => {
+    const raw = 'noise "x{y}" {"a":1}';
+
+    expect(extractBalancedJsonPrefix(raw)).toEqual({
+      json: '{"a":1}',
+      startIndex: raw.indexOf('{"a":1}'),
+      endIndex: raw.length - 1,
+    });
+  });
+
+  it("honours the openers option", () => {
+    const raw = '[1,2] {"a":1}';
+
+    expect(extractBalancedJsonPrefix(raw, { openers: ["{"] })?.json).toBe('{"a":1}');
+  });
+
+  it("returns null when there is no balanced value", () => {
+    expect(extractBalancedJsonPrefix('prose "with {braces}" only')).toBeNull();
+    expect(extractBalancedJsonPrefix("no json here")).toBeNull();
+  });
+});
+
+describe("extractBalancedJsonFragments", () => {
+  it("does not report quoted prose as a fragment", () => {
+    const raw = '"{skip}" {"a":1} tail "{skip too}" [2]';
+
+    expect(extractBalancedJsonFragments(raw).map((fragment) => fragment.json)).toEqual([
+      '{"a":1}',
+      "[2]",
+    ]);
+  });
+});

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -19,14 +19,14 @@ export function extractBalancedJsonPrefix(
   opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
 ): BalancedJsonFragment | null {
   const openers = opts.openers ?? (["{", "["] as const);
-  let start = 0;
-  while (start < raw.length && !isJsonOpeningDelimiter(raw[start], openers)) {
-    start += 1;
-  }
   const stack: JsonOpeningDelimiter[] = [];
+  // The opener search has to track strings too: a brace inside quoted prose
+  // ("notjson{here}") is not the start of a JSON value, and anchoring on it
+  // hides the real value later in the text.
+  let start = -1;
   let inString = false;
   let escaped = false;
-  for (let index = start; index < raw.length; index += 1) {
+  for (let index = 0; index < raw.length; index += 1) {
     const char = raw[index];
     if (inString) {
       if (escaped) {
@@ -39,6 +39,9 @@ export function extractBalancedJsonPrefix(
     } else if (char === '"') {
       inString = true;
     } else if (isJsonOpeningDelimiter(char, openers)) {
+      if (stack.length === 0) {
+        start = index;
+      }
       stack.push(char);
     } else if (stack.length > 0 && char === (stack.at(-1) === "{" ? "}" : "]")) {
       stack.pop();


### PR DESCRIPTION
Closes #122353

## What Problem This Solves

Fixes an issue where text that mixes prose and JSON — CLI output, tool-call repair input, redacted diagnostics — is scanned for its embedded JSON and the wrong span is picked. A brace inside quoted prose (`"notjson{here}"`) is treated as the start of a JSON value, so `extractBalancedJsonPrefix` returns `{here}` and the real object later in the same string is never examined. Everything downstream that `JSON.parse`s the fragment (CLI record decoding, tool-call argument repair, credential redaction in diagnostics) silently loses that value.

## Why This Change Was Made

The function tracked string context in its balanced walk, but the loop that located the *opening* delimiter ran before any of that tracking started, so quotes were invisible to it. The two loops are now one: strings are tracked from index 0 and `start` is recorded at the transition from an empty stack to one opener. No new branch, no new state, and the returned shape is unchanged.

## User Impact

Prose containing braces no longer hides the JSON that follows it. Credential redaction in particular now sees the real object instead of a prose fragment, so structured payloads in diagnostics get projected and redacted rather than passed through as unparsed text.

## Evidence

Verified against the module directly with `node --experimental-strip-types`, before and after the change, same cases as the added test file.

Before (current `main`):

```
FAIL  input="prefix \"notjson{here}\" middle {\"a\":[1,{\"b\":\"c\"}]} suffix"   got="{here}"
FAIL  input="say \"he said \\\"{nope}\\\" loudly\" then {\"ok\":true}"           got="{nope}"
PASS  input="{\"a\":\"}{\",\"b\":[1]}"
FAIL  input="noise \"x{y}\" {\"a\":1}"                                          got="{y}"
FAIL  null cases -> [{"json":"{braces}","startIndex":12,"endIndex":19},null]
FAIL  fragments -> ["{skip}","{\"a\":1}","{skip too}","[2]"]
```

After:

```
PASS  input="prefix \"notjson{here}\" middle {\"a\":[1,{\"b\":\"c\"}]} suffix"   got="{\"a\":[1,{\"b\":\"c\"}]}"
PASS  input="say \"he said \\\"{nope}\\\" loudly\" then {\"ok\":true}"           got="{\"ok\":true}"
PASS  input="{\"a\":\"}{\",\"b\":[1]}"
PASS  input="noise \"x{y}\" {\"a\":1}"                                          got="{\"a\":1}"
PASS  openers option -> "{\"a\":1}"
PASS  null cases -> [null,null]
PASS  fragments -> ["{\"a\":1}","[2]"]
```

`packages/normalization-core/src/balanced-json.test.ts` carries the same cases as vitest tests, including the repro from the issue. Gap I should name: I could not run `node scripts/run-vitest.mjs` or `pnpm check` on this machine — there is not enough free disk for a workspace `pnpm install` — so the vitest run itself is CI's. The module is dependency-free, which is why the direct-import harness above is a faithful check of it.

Production LOC delta: +3 / -3 in `balanced-json.ts` (net 0); the rest is tests.
