### PR TITLE
fix(ci): route protocol-event coverage script through the shared record seam

### DIFF
--- a/scripts/check-protocol-event-coverage.mts
+++ b/scripts/check-protocol-event-coverage.mts
@@ -19,13 +19,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-
-// Local record guard by design: preflight runs this script without installed
-// dependencies (the dependency-free manifest contract), so the canonical
-// @openclaw/normalization-core/record-coerce import cannot resolve here.
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+// Preflight runs without installed dependencies, so the canonical
+// normalization-core import cannot resolve; the plain-Node shared seam can.
+import { isRecord } from "./lib/record-shared.mjs";
 
 const GATEWAY_EVENTS_FILE = "src/gateway/server-methods-list.ts";
 const GATEWAY_EVENT_CONSTANTS_FILE = "src/gateway/events.ts";


### PR DESCRIPTION
## What Problem This Solves

`checks-fast-coercion-helpers` is red on every PR's merge-ref CI: `scripts/check-protocol-event-coverage.mts:26` declares a local `isRecord`, which the coercion-helper guard bans. It arrived with the preflight dependency-free change (commit 7e54cc9d193), which needed a guard that works without installed dependencies — but declared it locally instead of using the existing carve-out seam.

## Why This Change Was Made

The guard's own error message prescribes the fix: "Dependency-free, copied, generated, or serialized code: use an existing dependency-light seam." That seam exists — `scripts/lib/record-shared.mjs` (plain-Node, carved out for exactly this reason, already imported by `changed-lanes.mts`, `check-built-plugin-control-plane-modules.mts`, `check-plugin-gateway-gauntlet.mts`). Import it; delete the local copy.

## User Impact

None (script-only). Unblocks merge-ref CI for all open PRs (observed failing on #123950).

## Evidence

- `node --import tsx scripts/check-coercion-helper-declarations.mts` → "guard passed (103 allowlisted declarations)" (was: "Banned local coercion-helper declarations").
- `node --import tsx scripts/check-protocol-event-coverage.mts` → "Protocol event coverage OK: 50 gateway events..." (script still works dependency-free via the .mjs seam).
- `pnpm tsgo` clean; oxfmt applied.

Production LOC delta: −4 (script-only).
