### PR TITLE
fix(ui): prevent stale session header errors after navigation

### DIFF
--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -62,17 +62,6 @@ suite.define(() => {
             .evaluate((pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey),
         )
         .toBe(sessionB);
-      await gateway.resolveDeferred("sessions.files.reveal", {
-        ok: false,
-        error: "Stale reveal failure must stay retired.",
-      });
-      await page.evaluate(
-        () =>
-          new Promise<void>((resolve) => {
-            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-          }),
-      );
-
       await page
         .locator(
           `.sidebar-recent-session[data-session-key="${sessionA}"] a.sidebar-recent-session__link`,
@@ -86,6 +75,16 @@ suite.define(() => {
             .evaluate((pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey),
         )
         .toBe(sessionA);
+      await gateway.resolveDeferred("sessions.files.reveal", {
+        ok: false,
+        error: "Stale reveal failure must stay retired.",
+      });
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
       await expect
         .poll(() => page.getByText("Stale reveal failure must stay retired.").count())
         .toBe(0);

--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -55,6 +55,13 @@ suite.define(() => {
         )
         .click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionB));
+      await expect
+        .poll(() =>
+          page
+            .locator(".chat-pane-cache__pane--visible")
+            .evaluate((pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey),
+        )
+        .toBe(sessionB);
       await gateway.resolveDeferred("sessions.files.reveal", {
         ok: false,
         error: "Stale reveal failure must stay retired.",
@@ -72,6 +79,13 @@ suite.define(() => {
         )
         .click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionA));
+      await expect
+        .poll(() =>
+          page
+            .locator(".chat-pane-cache__pane--visible")
+            .evaluate((pane) => (pane as HTMLElement & { sessionKey?: string }).sessionKey),
+        )
+        .toBe(sessionA);
       await expect
         .poll(() => page.getByText("Stale reveal failure must stay retired.").count())
         .toBe(0);

--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -1,0 +1,90 @@
+import { expect, it } from "vitest";
+import {
+  chatSessionListResponse,
+  controlUiSessionPath,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("does not resurrect a reveal failure after navigating away", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionA = "agent:main:session-a";
+    const sessionB = "agent:main:session-b";
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.startup", "sessions.files.reveal"],
+      historyMessages: [{ role: "assistant", content: "Session outcome proof." }],
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([
+          {
+            key: sessionA,
+            kind: "direct",
+            label: "Session A",
+            spawnedCwd: "/workspace/session-a",
+            updatedAt: 2,
+          },
+          {
+            key: sessionB,
+            kind: "direct",
+            label: "Session B",
+            spawnedCwd: "/workspace/session-b",
+            updatedAt: 1,
+          },
+        ]),
+      },
+      sessionKey: sessionA,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.deferNext("sessions.files.reveal");
+      await page.getByRole("button", { name: "Workspace actions for session-a" }).click();
+      await page.getByRole("menuitem", { name: "Open in file manager" }).click();
+      await gateway.waitForRequest("sessions.files.reveal");
+
+      await page
+        .locator(
+          `.sidebar-recent-session[data-session-key="${sessionB}"] a.sidebar-recent-session__link`,
+        )
+        .click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionB));
+      await gateway.resolveDeferred("sessions.files.reveal", {
+        ok: false,
+        error: "Stale reveal failure must stay retired.",
+      });
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+      await page
+        .locator(
+          `.sidebar-recent-session[data-session-key="${sessionA}"] a.sidebar-recent-session__link`,
+        )
+        .click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionA));
+      await expect
+        .poll(() => page.getByText("Stale reveal failure must stay retired.").count())
+        .toBe(0);
+      await expect
+        .poll(() =>
+          page.locator(".chat-pane-cache__pane--visible").evaluate((pane) => {
+            return (pane as HTMLElement & { state?: { chatError?: string | null } }).state
+              ?.chatError;
+          }),
+        )
+        .not.toBe("Stale reveal failure must stay retired.");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -223,6 +223,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
 
   private isHeaderSessionActionScopeCurrent(scope: SidebarSessionMutationScope): boolean {
     return (
+      this.presented &&
       this.isConnected &&
       this.connectionGeneration === scope.epoch &&
       this.context === scope.context &&
@@ -284,8 +285,9 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       this.publishHeaderError(access.reason);
       return;
     }
+    const generation = this.connectionGeneration;
     void patchChatSessionLabel(state, this.context.sessions, key, label).catch((error: unknown) =>
-      this.publishHeaderError(error),
+      this.publishHeaderError(error, generation),
     );
   }
 
@@ -387,11 +389,12 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     const copiedValue =
       action === "copy-path" ? workspaceRoot : action === "copy-branch" ? branch : null;
     if (copiedValue) {
+      const generation = this.connectionGeneration;
       void copy(copiedValue).then((copied) => {
         if (copied) {
           this.showHeaderCopied(action);
         } else {
-          this.publishHeaderError(t("common.copyFailed"));
+          this.publishHeaderError(t("common.copyFailed"), generation);
         }
       });
       return;
@@ -401,8 +404,8 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     }
   }
 
-  protected publishHeaderError(error: unknown): void {
-    if (!this.state) {
+  protected publishHeaderError(error: unknown, generation = this.connectionGeneration): void {
+    if (!this.state || !this.presented || generation !== this.connectionGeneration) {
       return;
     }
     this.state.lastError = error instanceof Error ? error.message : String(error);
@@ -415,6 +418,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     if (!client) {
       return;
     }
+    const generation = this.connectionGeneration;
     const agentId = parseAgentSessionKey(row.key)?.agentId;
     try {
       const result = await client.request<SessionsFilesRevealResult>("sessions.files.reveal", {
@@ -422,10 +426,10 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
         ...(agentId ? { agentId } : {}),
       });
       if (!result.ok) {
-        this.publishHeaderError(result.error ?? "Failed to reveal session workspace.");
+        this.publishHeaderError(result.error ?? "Failed to reveal session workspace.", generation);
       }
     } catch (error) {
-      this.publishHeaderError(error);
+      this.publishHeaderError(error, generation);
     }
   }
 }

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -28,7 +28,14 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
   private headerSessionOperationsLoad: Promise<
     typeof import("../../components/session-organizer-operations.runtime.ts")
   > | null = null;
-
+  private headerPresentationGeneration = 0;
+  protected override presentedChanged(presented: boolean): void {
+    this.headerPresentationGeneration += 1;
+    super.presentedChanged(presented);
+  }
+  private get headerOutcomeOwner() {
+    return `${this.connectionGeneration}:${this.headerPresentationGeneration}`;
+  }
   protected async loadHeaderPlatform(
     client: GatewayBrowserClient,
     generation: number,
@@ -72,6 +79,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       this.publishHeaderError(t("sessionsView.actionRequiresConnection"));
       return;
     }
+    const owner = this.headerOutcomeOwner;
     const session = {
       key: row.key,
       sessionId: row.sessionId,
@@ -89,10 +97,10 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       const host: SessionActionHost = {
         sessionData: {
           isSessionMutationScopeCurrent: (candidate) =>
-            this.isHeaderSessionActionScopeCurrent(candidate),
+            this.isHeaderSessionActionCurrent(candidate, owner),
           publishSessionMutationError: (candidate, error) => {
-            if (this.isHeaderSessionActionScopeCurrent(candidate)) {
-              this.publishHeaderError(error);
+            if (this.isHeaderSessionActionCurrent(candidate, owner)) {
+              this.publishHeaderError(error, owner);
             }
           },
           refreshSidebarSessions: async (agentId) => {
@@ -126,8 +134,8 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
           break;
       }
     } catch (error) {
-      if (this.isHeaderSessionActionScopeCurrent(scope)) {
-        this.publishHeaderError(error);
+      if (this.isHeaderSessionActionCurrent(scope, owner)) {
+        this.publishHeaderError(error, owner);
       }
     }
   }
@@ -221,11 +229,10 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     };
   }
 
-  private isHeaderSessionActionScopeCurrent(scope: SidebarSessionMutationScope): boolean {
+  private isHeaderSessionActionCurrent(scope: SidebarSessionMutationScope, owner: string): boolean {
     return (
-      this.presented &&
+      owner === this.headerOutcomeOwner &&
       this.isConnected &&
-      this.connectionGeneration === scope.epoch &&
       this.context === scope.context &&
       this.context.gateway === scope.gateway &&
       this.context.sessions === scope.sessions &&
@@ -285,9 +292,9 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       this.publishHeaderError(access.reason);
       return;
     }
-    const generation = this.connectionGeneration;
+    const owner = this.headerOutcomeOwner;
     void patchChatSessionLabel(state, this.context.sessions, key, label).catch((error: unknown) =>
-      this.publishHeaderError(error, generation),
+      this.publishHeaderError(error, owner),
     );
   }
 
@@ -389,12 +396,15 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     const copiedValue =
       action === "copy-path" ? workspaceRoot : action === "copy-branch" ? branch : null;
     if (copiedValue) {
-      const generation = this.connectionGeneration;
+      const owner = this.headerOutcomeOwner;
       void copy(copiedValue).then((copied) => {
+        if (!this.presented || owner !== this.headerOutcomeOwner) {
+          return;
+        }
         if (copied) {
           this.showHeaderCopied(action);
         } else {
-          this.publishHeaderError(t("common.copyFailed"), generation);
+          this.publishHeaderError(t("common.copyFailed"), owner);
         }
       });
       return;
@@ -404,12 +414,12 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     }
   }
 
-  protected publishHeaderError(error: unknown, generation = this.connectionGeneration): void {
-    if (!this.state || !this.presented || generation !== this.connectionGeneration) {
+  protected publishHeaderError(error: unknown, owner = this.headerOutcomeOwner): void {
+    if (!this.state || !this.presented || owner !== this.headerOutcomeOwner) {
       return;
     }
-    this.state.lastError = error instanceof Error ? error.message : String(error);
-    this.state.chatError = this.state.lastError;
+    this.state.chatError = this.state.lastError =
+      error instanceof Error ? error.message : String(error);
     this.state.requestUpdate?.();
   }
 
@@ -418,7 +428,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     if (!client) {
       return;
     }
-    const generation = this.connectionGeneration;
+    const owner = this.headerOutcomeOwner;
     const agentId = parseAgentSessionKey(row.key)?.agentId;
     try {
       const result = await client.request<SessionsFilesRevealResult>("sessions.files.reveal", {
@@ -426,10 +436,11 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
         ...(agentId ? { agentId } : {}),
       });
       if (!result.ok) {
-        this.publishHeaderError(result.error ?? "Failed to reveal session workspace.", generation);
+        const error = result.error ?? "Failed to reveal session workspace.";
+        this.publishHeaderError(error, owner);
       }
     } catch (error) {
-      this.publishHeaderError(error, generation);
+      this.publishHeaderError(error, owner);
     }
   }
 }

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -401,6 +401,42 @@ describe("chat pane header state", () => {
     await vi.waitFor(() => expect(state.chatError).toBe("No desktop available."));
     expect(state.lastError).toBe(state.chatError);
   });
+
+  it.each([
+    {
+      name: "navigating away",
+      retire: (pane: TestChatPane) => {
+        pane.presented = false;
+      },
+    },
+    {
+      name: "replacing the Gateway generation",
+      retire: (pane: TestChatPane) => {
+        pane.connectionGeneration += 1;
+      },
+    },
+  ])("does not resurrect a reveal failure after $name", async ({ retire }) => {
+    const revealed = createDeferred<{ ok: false; error: string }>();
+    const request = vi.fn(() => revealed.promise);
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const session = {
+      key: "agent:main:current",
+      kind: "direct",
+      updatedAt: 0,
+    } satisfies GatewaySessionRow;
+
+    pane.handleHeaderMenuAction("reveal", session, "/src/openclaw", null);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    retire(pane);
+    revealed.resolve({ ok: false, error: "No desktop available." });
+    await vi.waitFor(() => expect(request).toHaveResolved());
+
+    expect(state.chatError).toBeNull();
+    expect(state.lastError).toBeNull();
+  });
 });
 
 describe("chat pane initialization", () => {

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -404,9 +404,10 @@ describe("chat pane header state", () => {
 
   it.each([
     {
-      name: "navigating away",
+      name: "leaving and returning before settlement",
       retire: (pane: TestChatPane) => {
         pane.presented = false;
+        pane.presented = true;
       },
     },
     {


### PR DESCRIPTION
Closes #123955

AI-assisted: yes. The change was source-audited, browser-tested, independently reviewed, and approved for landing by the maintainer.

## What Problem This Solves

Fixes an issue where users who navigate away from a Control UI chat session—or reconnect the Gateway—while a header action is pending can see that delayed failure resurrect when they later return to the retained session pane.

The affected actions include rename, copy path/branch, reveal workspace, and the shared fork/archive/delete session flows.

## Why This Change Was Made

Chat-header outcome publication now belongs to the presentation lifetime that launched it. A monotonic presentation generation is composed with the existing Gateway generation and captured when each asynchronous action starts. Any hide/show cycle or reconnect changes that token; shared session actions use the same owner. Navigation or reconnect therefore retires old outcomes—even after A → B → A—while failures from the current presentation remain visible.

This is the canonical lifecycle-owner repair. Consumer-side clearing on navigation was rejected because it would allow stale asynchronous writers to repopulate state later. The change does not modify public API, configuration, protocol, persistence, security, or release surfaces.

Production LOC: +31/-16 (net +15) | Tests: +140/-0

## User Impact

Returning to a retained chat session no longer shows an old header-action error from a different navigation or Gateway generation. Current-action failures still appear normally.

## Evidence

Exact head: `9ba96bb9d8eb63e4c5b6aef126c3c4a6b01548b0`

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane.test.ts --reporter=dot` — 40/40 passed, including hidden-pane and Gateway-generation retirement.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-header-session-outcomes.e2e.test.ts` — real Chromium + mocked Gateway WebSocket, 1/1 passed.
- Source-blind A → B → A-before-settlement behavior contract — `revealRequestCount=1`, `staleTextCount=0`, `visibleError=null`.
- `node scripts/check-changed.mjs ...` — passed all selected `coreTests, ui` gates after rebasing onto repaired current main.
- `oxfmt --check ...` and `git diff --check` — passed.
- Codex autoreview — clean, no actionable findings (0.99 confidence).
- ClawSweeper's presentation-lifetime finding is addressed: the proof now returns to Session A before settling the deferred failure, and the launch token remains retired.

Initial session:

![Session A before the delayed action](https://github.com/user-attachments/assets/a0577c1e-7324-4d11-8313-bc4c020bdb9b)

Pending workspace action:

![Open in file manager action](https://github.com/user-attachments/assets/35922cb4-2828-441a-a767-48d318c55587)

Navigation retires the old outcome:

![Session B active](https://github.com/user-attachments/assets/edef69c3-74d4-414f-901c-58b594cd87b8)

Returning to Session A stays clean:

![Session A restored before settlement without resurrecting the failure](https://github.com/user-attachments/assets/3e714461-2535-4679-9deb-23ef8092db12)

https://github.com/user-attachments/assets/38b6b631-70d8-4bd5-a548-7b76d8171060
