### PR TITLE
fix(google-meet): preserve --output files when writes fail

### DIFF
--- a/extensions/google-meet/src/cli-artifacts.test.ts
+++ b/extensions/google-meet/src/cli-artifacts.test.ts
@@ -1,4 +1,14 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import JSZip from "jszip";
@@ -315,6 +325,49 @@ describe("google-meet CLI", () => {
       attendanceStdout.restore();
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves an existing output when the OS rejects a full write",
+    () => {
+      const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-output-failure-"));
+      const outputPath = path.join(tempDir, "artifacts.md");
+      const prior = "prior export\n";
+      writeFileSync(outputPath, prior);
+      chmodSync(outputPath, 0o640);
+
+      try {
+        const source = path.join(process.cwd(), "extensions/google-meet/src/cli-shared.ts");
+        const script = `import { writeCliOutput } from ${JSON.stringify(source)}; await writeCliOutput({ output: process.env.OPENCLAW_TEST_OUTPUT }, "x".repeat(8192));`;
+        const result = spawnSync(
+          "/bin/sh",
+          [
+            "-c",
+            'ulimit -f 1\nexec "$@"',
+            "--",
+            process.execPath,
+            "--import",
+            "tsx",
+            "--input-type=module",
+            "-e",
+            script,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, OPENCLAW_TEST_OUTPUT: outputPath },
+            encoding: "utf8",
+          },
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.signal === "SIGXFSZ" || result.stderr.includes("EFBIG")).toBe(true);
+        expect(readFileSync(outputPath, "utf8")).toBe(prior);
+        expect(statSync(outputPath).mode & 0o777).toBe(0o640);
+        expect(readdirSync(tempDir)).toEqual(["artifacts.md"]);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("prints CSV attendance output", async () => {
     stubMeetArtifactsApi();

--- a/extensions/google-meet/src/cli-shared.ts
+++ b/extensions/google-meet/src/cli-shared.ts
@@ -1,4 +1,5 @@
-import { writeFile } from "node:fs/promises";
+import { stat } from "node:fs/promises";
+import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { format } from "node:util";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -7,6 +8,7 @@ import {
   clampTimerTimeoutMs,
   parseStrictPositiveInteger,
 } from "openclaw/plugin-sdk/number-runtime";
+import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import prettyMilliseconds from "pretty-ms";
 import type { GoogleMeetCalendarLookupResult } from "./calendar.js";
 import {
@@ -236,7 +238,18 @@ export function writeStdoutLine(...values: unknown[]): void {
 
 export async function writeCliOutput(options: { output?: string }, text: string): Promise<void> {
   if (options.output?.trim()) {
-    await writeFile(options.output, text.endsWith("\n") ? text : `${text}\n`, "utf8");
+    const dirMode = (await stat(path.dirname(options.output))).mode & 0o7777;
+    await replaceFileAtomic({
+      filePath: options.output,
+      content: text.endsWith("\n") ? text : `${text}\n`,
+      dirMode,
+      mode: 0o666 & ~process.umask(),
+      preserveExistingMode: true,
+      tempPrefix: ".google-meet-output",
+      syncTempFile: true,
+      syncParentDir: true,
+      throwOnCleanupError: true,
+    });
     writeStdoutLine("wrote: %s", options.output);
     return;
   }


### PR DESCRIPTION
Closes #123957

## What Problem This Solves

Fixes an issue where operators using Google Meet command-level `--output` files could lose a previous valid export when the replacement write failed. Under a real process file-size limit, the CLI returned `EFBIG` after replacing the prior file with 512 bytes of the new payload.

This is distinct from #122306. That PR covers the six multi-file export-bundle artifacts and optional ZIP in `cli-export.ts`; this repair covers the shared `writeCliOutput` path used by generic command output in `cli-shared.ts`.

## Why This Change Was Made

The shared Google Meet CLI output owner now uses the existing public Plugin SDK `replaceFileAtomic` seam. It preserves an existing file's mode, uses the actual parent mode and the normal umask-derived mode for a new file, syncs the staged file and parent directory, surfaces cleanup errors, and removes failed staging files.

Maintainer decision: the supplied `--output` path is the atomic publication boundary. If that path is an existing symlink, successful publication replaces the symlink instead of mutating its indirectly referenced target. This is intentional: Google Meet does not document link-following as an output contract, and preserving it would weaken the approved complete-file publication boundary.

Stdout-only behavior and the existing export-bundle atomic publication path remain unchanged. No dependency, configuration, storage, or public SDK surface changes.

## User Impact

Google Meet `artifacts` and `attendance` commands using `--output` now publish complete files atomically. A failed write or sync leaves the previous output untouched instead of replacing it with partial bytes.

## Evidence

- Before: an 8 KiB replacement under `ulimit -f 1` failed with `EFBIG` and replaced the prior 19-byte file with 512 bytes of the new payload.
- After: the authentic OS-fault regression propagates `EFBIG`, preserves the prior bytes and `0640` mode, and finds only the final file in the parent directory.
- `node scripts/run-vitest.mjs extensions/google-meet/src/cli-artifacts.test.ts` — 18 passed on exact head `b90f134e861b3c8d8ba79b2e1b3e443089b5d2fc`.
- Targeted `oxfmt --check` and `git diff --check` — passed.
- Exact changed gate — passed on Blacksmith Testbox `tbx_01m01n37qrnte66gf356g4gm1g`, run https://github.com/openclaw/openclaw/actions/runs/31860126653 (`exitCode=0`; one-shot Testbox stopped).
- Fresh exact-head Codex autoreview and TruffleHog — clean, no accepted/actionable findings.

Production LOC: +15/-2 (net +13). Tests: +54/-1 (net +53).
