### PR TITLE
fix(agent): avoid false orphan warning for background shell work

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -2928,6 +2928,31 @@ describe("createCodexDynamicToolBridge", () => {
     expect(Object.keys(result)).not.toContain("terminate");
   });
 
+  it.each(["exec", "process"])(
+    "preserves a running %s session as asynchronous work",
+    async (toolName) => {
+      const bridge = createBridgeWithToolResult(
+        toolName,
+        textToolResult("Process still running.", {
+          status: "running",
+          sessionId: "quiet-dune",
+        }),
+      );
+
+      const result = await bridge.handleToolCall({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: `call-${toolName}-running`,
+        namespace: null,
+        tool: toolName,
+        arguments: toolName === "exec" ? { command: "sleep 30" } : { action: "poll" },
+      });
+
+      expect(result.asyncStarted).toBe(true);
+      expect(result.sideEffectEvidence).toBe(true);
+    },
+  );
+
   it("marks executed dynamic tool results as side-effect evidence", async () => {
     const bridge = createBridgeWithToolResult("exec", textToolResult("done"));
 

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -809,7 +809,8 @@ export function createCodexDynamicToolBridge(params: {
             (confirmedSourceReply && sourceReplyFinal === true),
         );
         const asyncStarted =
-          isAsyncStartedToolResult(rawResult) || isAsyncStartedToolResult(result);
+          isAsyncStartedToolResult(toolName, rawResult) ||
+          isAsyncStartedToolResult(toolName, result);
         withDynamicToolAsyncStarted(response, asyncStarted);
         const replaySafe =
           executionPrevented ||
@@ -1396,9 +1397,22 @@ function isToolResultYield(result: AgentToolResult<unknown>): boolean {
   }
   return details.status.trim().toLowerCase() === "yielded";
 }
-function isAsyncStartedToolResult(result: AgentToolResult<unknown>): boolean {
+function isAsyncStartedToolResult(toolName: string, result: AgentToolResult<unknown>): boolean {
   const details = result.details;
-  return isRecord(details) && details.async === true && details.status === "started";
+  if (!isRecord(details)) {
+    return false;
+  }
+  if (details.async === true && details.status === "started") {
+    return true;
+  }
+  if (toolName !== "exec" && toolName !== "bash" && toolName !== "process") {
+    return false;
+  }
+  return (
+    details.status === "running" &&
+    typeof details.sessionId === "string" &&
+    details.sessionId.trim().length > 0
+  );
 }
 function withDiagnosticTerminalType<T extends CodexDynamicToolCallResponse>(
   response: T,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -176,7 +176,7 @@ export async function handleToolExecutionEnd(
     (trackedExecutionStarted ?? evt.executionStarted ?? true) && !executionPrevented;
   const attemptedPotentialSideEffect = !callSummary.replaySafe && executionStarted;
   const meta = callSummary.meta;
-  const asyncStarted = !isToolError && isAsyncStartedToolResult(sanitizedResult);
+  const asyncStarted = !isToolError && isAsyncStartedToolResult(toolName, sanitizedResult);
   const asyncTaskIds = asyncStarted ? readAsyncStartedTaskIds(sanitizedResult) : {};
   ctx.state.toolMetas.push({
     toolName,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -213,9 +213,15 @@ export function applyToolSendReceiptForExtraction(
   };
 }
 
-export function isAsyncStartedToolResult(result: unknown): boolean {
+export function isAsyncStartedToolResult(toolName: string, result: unknown): boolean {
   const details = readToolResultDetails(result);
-  return details?.async === true && details.status === "started";
+  if (details?.async === true && details.status === "started") {
+    return true;
+  }
+  if (toolName !== "exec" && toolName !== "bash" && toolName !== "process") {
+    return false;
+  }
+  return details?.status === "running" && Boolean(readStringValue(details.sessionId));
 }
 
 export function readAsyncStartedTaskIds(result: unknown): {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2096,6 +2096,43 @@ describe("handleToolExecutionEnd timeout metadata", () => {
     expect(ctx.state.toolMetas[2]?.asyncStarted).toBe(true);
   });
 
+  it.each(["exec", "bash", "process"])(
+    "treats a running %s session as async continuation evidence",
+    async (toolName) => {
+      const { ctx } = createTestContext();
+      const normalizedToolName = toolName === "bash" ? "exec" : toolName;
+
+      await endTool(ctx, {
+        toolName,
+        toolCallId: `tool-${toolName}-running`,
+        isError: false,
+        result: {
+          details: {
+            status: "running",
+            sessionId: "quiet-dune",
+          },
+        },
+      });
+
+      expect(ctx.state.toolMetas).toEqual([
+        expect.objectContaining({ toolName: normalizedToolName, asyncStarted: true }),
+      ]);
+    },
+  );
+
+  it("does not treat an unscoped running result as continuation evidence", async () => {
+    const { ctx } = createTestContext();
+
+    await endTool(ctx, {
+      toolName: "process",
+      toolCallId: "tool-process-running-unscoped",
+      isError: false,
+      result: { details: { status: "running" } },
+    });
+
+    expect(ctx.state.toolMetas).toEqual([expect.not.objectContaining({ asyncStarted: true })]);
+  });
+
   it("retains every failed call after later successes change the last-error slot", async () => {
     const { ctx } = createTestContext();
 


### PR DESCRIPTION
Related: #123028

## What Problem This Solves

Fixes an issue where users who start a background shell command and then call `sessions_yield` receive `Turn yielded without a continuation source` even though OpenClaw has a live background process session that can continue the workflow.

This was reproduced twice on OpenClaw 2026.7.2-beta.5. In both runs, `exec` returned a durable running process result shaped as `{ status: "running", sessionId: "..." }`, but terminal resolution did not recognize it as continuation evidence.

## Why This Change Was Made

Treat a running result from the built-in `exec`, `bash`, or `process` tools as asynchronous work only when it includes a nonempty process `sessionId`. Apply the same boundary in both the embedded-agent subscriber and the Codex app-server dynamic-tool bridge.

The existing generic `{ async: true, status: "started" }` contract remains unchanged. Arbitrary plugin tools and running results without a session ID do not gain continuation status, so a genuine source-less yield still emits the diagnostic.

## User Impact

Agents can yield while durable background shell work is running without telling users to manually resume a workflow that already has a continuation source.

## Evidence

Live reproduction:

- macOS, OpenClaw 2026.7.2-beta.5, Codex-backed agent
- two independent turns started background `exec` work and received `status: "running"` with a process `sessionId`
- both turns then called `sessions_yield` and incorrectly emitted the no-continuation warning

Focused validation on current `main`:

- `node scripts/run-vitest.mjs run src/agents/embedded-agent-subscribe.handlers.tools.test.ts --config vitest.config.ts --pool forks --testTimeout 20000`: 336 passed
- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/dynamic-tools.test.ts --config vitest.config.ts --pool forks --testTimeout 20000`: 127 passed
- focused `oxlint`: passed
- focused `oxfmt --check`: passed
- `git diff --check`: passed

`pnpm check:changed` could not start locally because the selected Blacksmith Testbox `crabbox` binary failed its own version/help sanity check before examining changed files.
