### PR TITLE
fix(macos): keep replacement node worker active after stale exit

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -37,15 +37,18 @@ struct MacNodeHostWorkerLaunch: Equatable, Sendable {
     let command: [String]
     let currentDirectoryURL: URL?
     let environment: [String: String]
+    let configurationGeneration: UInt64
 
     init(
         command: [String],
         currentDirectoryURL: URL? = nil,
-        environment: [String: String] = [:])
+        environment: [String: String] = [:],
+        configurationGeneration: UInt64 = 0)
     {
         self.command = command
         self.currentDirectoryURL = currentDirectoryURL
         self.environment = environment
+        self.configurationGeneration = configurationGeneration
     }
 }
 
@@ -88,7 +91,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private let writerQueue = DispatchQueue(label: "ai.openclaw.node-host-worker.writer")
     private let session: GatewayNodeSession
     private let startupTimeout: TimeInterval
-    private let onUnexpectedExit: @Sendable () -> Void
+    private let onUnexpectedExit: @Sendable (UInt64) -> Void
     private var process: ManagedProcess?
     private var processCleanupTask: Task<Void, Never>?
     private var stdinPipe: Pipe?
@@ -115,7 +118,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     init(
         session: GatewayNodeSession,
         startupTimeout: TimeInterval = MacNodeHostWorker.defaultStartupTimeout,
-        onUnexpectedExit: @escaping @Sendable () -> Void = {})
+        onUnexpectedExit: @escaping @Sendable (UInt64) -> Void = { _ in })
     {
         self.session = session
         self.startupTimeout = startupTimeout
@@ -709,6 +712,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         notifyUnexpectedExit: Bool = false) -> Task<Void, Never>?
     {
         let wasReady = self.manifest != nil
+        let stoppedWorker = self.launchedWorker
         self.startTimer?.cancel()
         self.startTimer = nil
         self.launchedWorker = nil
@@ -727,8 +731,8 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         for (id, continuation) in pending {
             continuation.resume(returning: Self.unavailableResponse(id, "UNAVAILABLE: node-host worker stopped"))
         }
-        if notifyUnexpectedExit, wasReady {
-            self.onUnexpectedExit()
+        if notifyUnexpectedExit, wasReady, let stoppedWorker {
+            self.onUnexpectedExit(stoppedWorker.configurationGeneration)
         }
         guard let process = self.process else {
             return nil

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorkerRetryPolicy.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorkerRetryPolicy.swift
@@ -3,7 +3,6 @@ import Foundation
 struct MacNodeHostWorkerRetryPolicy: Sendable {
     struct Input: Equatable, Sendable {
         let launch: MacNodeHostWorkerLaunch
-        let configurationGeneration: UInt64
     }
 
     enum UnexpectedExitDisposition: Equatable, Sendable {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -849,8 +849,9 @@ final class MacNodeModeCoordinator: NSObject {
         self.activeNodeHostWorkerInput = input
     }
 
-    func handleNodeHostWorkerFailureForTesting() {
-        self.handleNodeHostWorkerFailure(configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
+    func handleNodeHostWorkerFailureForTesting(configurationGeneration: UInt64? = nil) {
+        self.handleNodeHostWorkerFailure(
+            configurationGeneration: configurationGeneration ?? self.nodeHostWorkerConfigurationGeneration)
     }
 
     func waitForNodeHostWorkerRetryForTesting() async {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -843,8 +843,9 @@ final class MacNodeModeCoordinator: NSObject {
             throw MacNodeHostWorkerRetryPolicy.RetryBackoffPending()
         }
         let input = MacNodeHostWorkerRetryPolicy.Input(
-            launch: MacNodeHostWorkerLaunch(command: command),
-            configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
+            launch: MacNodeHostWorkerLaunch(
+                command: command,
+                configurationGeneration: self.nodeHostWorkerConfigurationGeneration))
         try self.nodeHostWorkerRetryPolicy.prepareForStart(input)
         self.activeNodeHostWorkerInput = input
     }
@@ -960,9 +961,7 @@ extension MacNodeModeCoordinator {
             currentDirectoryURL: launch.currentDirectoryURL,
             environment: workerEnvironment,
             configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
-        let input = MacNodeHostWorkerRetryPolicy.Input(
-            launch: effectiveLaunch,
-            configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
+        let input = MacNodeHostWorkerRetryPolicy.Input(launch: effectiveLaunch)
         try self.nodeHostWorkerRetryPolicy.prepareForStart(input)
         self.activeNodeHostWorkerInput = input
         return try await nodeHostWorker.start(launch: effectiveLaunch)

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -130,8 +130,8 @@ final class MacNodeModeCoordinator: NSObject {
 
     override private convenience init() {
         let session = GatewayNodeSession()
-        let nodeHostWorker = MacNodeHostWorker(session: session) {
-            NotificationCenter.default.post(name: .openclawNodeHostWorkerFailed, object: nil)
+        let nodeHostWorker = MacNodeHostWorker(session: session) { generation in
+            NotificationCenter.default.post(name: .openclawNodeHostWorkerFailed, object: NSNumber(value: generation))
         }
         self.init(
             session: session,
@@ -259,7 +259,6 @@ final class MacNodeModeCoordinator: NSObject {
     }
 
     func prepareForCuaDaemonStop() async {
-        self.resetNodeHostWorkerRetryState()
         await self.enqueueRouteInvalidation(mode: .workerRestart).value
     }
 
@@ -279,7 +278,6 @@ final class MacNodeModeCoordinator: NSObject {
         self.endpointRefreshTask = nil
         self.reconnectProbeTask?.cancel()
         self.reconnectProbeTask = nil
-        self.resetNodeHostWorkerRetryState()
     }
 
     func setPreferredGatewayStableID(
@@ -380,6 +378,15 @@ final class MacNodeModeCoordinator: NSObject {
     private func enqueueRouteInvalidation(
         mode: RouteInvalidationMode) -> Task<Void, Never>
     {
+        // Worker replacement advances synchronously so a queued exit from the
+        // old process cannot revoke or consume retry budget from its successor.
+        switch mode {
+        case .workerRestart, .terminalStop:
+            self.nodeHostWorkerConfigurationGeneration &+= 1
+            self.resetNodeHostWorkerRetryState()
+        case .ordinaryDisconnect, .reconnectRefresh:
+            break
+        }
         self.revokeRouteAuthority()
         let invalidationGeneration = self.endpointAttemptGeneration
         let invalidatedRouteAuthorityGeneration = self.routeAuthorityGeneration
@@ -843,7 +850,7 @@ final class MacNodeModeCoordinator: NSObject {
     }
 
     func handleNodeHostWorkerFailureForTesting() {
-        self.handleNodeHostWorkerFailure()
+        self.handleNodeHostWorkerFailure(configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
     }
 
     func waitForNodeHostWorkerRetryForTesting() async {
@@ -866,9 +873,10 @@ final class MacNodeModeCoordinator: NSObject {
         }
     }
 
-    @objc private nonisolated func nodeHostWorkerFailed(_: Notification) {
+    @objc private nonisolated func nodeHostWorkerFailed(_ notification: Notification) {
+        guard let generation = (notification.object as? NSNumber)?.uint64Value else { return }
         Task { @MainActor [weak self] in
-            self?.handleNodeHostWorkerFailure()
+            self?.handleNodeHostWorkerFailure(configurationGeneration: generation)
         }
     }
 
@@ -880,11 +888,9 @@ final class MacNodeModeCoordinator: NSObject {
 
     @discardableResult
     private func handleNodeHostConfigurationChange() -> Task<Void, Never> {
-        self.nodeHostWorkerConfigurationGeneration &+= 1
-        self.resetNodeHostWorkerRetryState()
         // Worker code, plugin availability, and its manifest are startup-scoped.
         // Replace the process before reconnecting so updates cannot leave a stale route.
-        return self.enqueueRouteInvalidation(mode: .workerRestart)
+        self.enqueueRouteInvalidation(mode: .workerRestart)
     }
 }
 
@@ -951,7 +957,8 @@ extension MacNodeModeCoordinator {
         let effectiveLaunch = MacNodeHostWorkerLaunch(
             command: launch.command,
             currentDirectoryURL: launch.currentDirectoryURL,
-            environment: workerEnvironment)
+            environment: workerEnvironment,
+            configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
         let input = MacNodeHostWorkerRetryPolicy.Input(
             launch: effectiveLaunch,
             configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
@@ -960,7 +967,8 @@ extension MacNodeModeCoordinator {
         return try await nodeHostWorker.start(launch: effectiveLaunch)
     }
 
-    private func handleNodeHostWorkerFailure() {
+    private func handleNodeHostWorkerFailure(configurationGeneration: UInt64) {
+        guard configurationGeneration == self.nodeHostWorkerConfigurationGeneration else { return }
         guard let input = self.activeNodeHostWorkerInput else {
             self.logger.error("node-host worker exited without an active startup input")
             self.enqueueRouteInvalidation(mode: .ordinaryDisconnect)

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -51,8 +51,8 @@ struct MacNodeHostWorkerTests {
     @Test func `worker crash retry budget is bounded and exponentially delayed`() throws {
         let input = MacNodeHostWorkerRetryPolicy.Input(
             launch: MacNodeHostWorkerLaunch(
-                command: ["/usr/local/bin/openclaw", "node", "worker"]),
-            configurationGeneration: 4)
+                command: ["/usr/local/bin/openclaw", "node", "worker"],
+                configurationGeneration: 4))
         var policy = MacNodeHostWorkerRetryPolicy(maximumRetryCount: 5)
 
         try policy.prepareForStart(input)
@@ -76,11 +76,12 @@ struct MacNodeHostWorkerTests {
     @Test func `new worker input resets an exhausted crash retry budget`() throws {
         let original = MacNodeHostWorkerRetryPolicy.Input(
             launch: MacNodeHostWorkerLaunch(
-                command: ["/usr/local/bin/openclaw", "node", "worker"]),
-            configurationGeneration: 4)
+                command: ["/usr/local/bin/openclaw", "node", "worker"],
+                configurationGeneration: 4))
         let updated = MacNodeHostWorkerRetryPolicy.Input(
-            launch: original.launch,
-            configurationGeneration: 5)
+            launch: MacNodeHostWorkerLaunch(
+                command: original.launch.command,
+                configurationGeneration: 5))
         var policy = MacNodeHostWorkerRetryPolicy(maximumRetryCount: 1)
 
         try policy.prepareForStart(original)

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -429,7 +429,9 @@ struct MacNodeHostWorkerTests {
     @Test func `ready worker exit notifies its route owner`() async throws {
         try await confirmation("unexpected worker exit") { confirmed in
             let exitGate = AsyncTestGate()
-            let worker = MacNodeHostWorker(session: GatewayNodeSession()) { _ in
+            let expectedGeneration: UInt64 = 42
+            let worker = MacNodeHostWorker(session: GatewayNodeSession()) { generation in
+                #expect(generation == expectedGeneration)
                 confirmed()
                 exitGate.open()
             }
@@ -440,7 +442,8 @@ struct MacNodeHostWorkerTests {
             """
 
             _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
-                command: ["/bin/sh", "-c", script]))
+                command: ["/bin/sh", "-c", script],
+                configurationGeneration: expectedGeneration))
             await exitGate.wait()
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -429,7 +429,7 @@ struct MacNodeHostWorkerTests {
     @Test func `ready worker exit notifies its route owner`() async throws {
         try await confirmation("unexpected worker exit") { confirmed in
             let exitGate = AsyncTestGate()
-            let worker = MacNodeHostWorker(session: GatewayNodeSession()) {
+            let worker = MacNodeHostWorker(session: GatewayNodeSession()) { _ in
                 confirmed()
                 exitGate.open()
             }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -304,6 +304,33 @@ struct MacNodeModeCoordinatorTests {
         await coordinator.stopAndWait()
     }
 
+    @Test @MainActor func `queued failure from replaced worker does not penalize replacement`() async throws {
+        let worker = CoordinatorNodeHostWorkerProbe()
+        let session = GatewayNodeSession()
+        let notificationCenter = NotificationCenter()
+        let coordinator = MacNodeModeCoordinator(
+            session: session,
+            runtime: MacNodeRuntime(nodeHostWorker: worker),
+            nodeHostWorker: worker,
+            notificationCenter: notificationCenter,
+            observeNotifications: true)
+        let command = ["/usr/local/bin/openclaw", "node", "worker"]
+
+        try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
+        await coordinator.handleNodeHostConfigurationChangeForTesting()
+        try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
+
+        // This models the old process's notification reaching MainActor after
+        // configuration replacement has installed the successor input.
+        notificationCenter.post(
+            name: .openclawNodeHostWorkerFailed,
+            object: NSNumber(value: UInt64.zero))
+        try await Task.sleep(for: .milliseconds(10))
+
+        try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
+        await coordinator.stopAndWait()
+    }
+
     @Test func `paused node state requires route disconnect`() {
         #expect(MacNodeModeCoordinator.pausedStateRequiresDisconnect(true))
         #expect(!MacNodeModeCoordinator.pausedStateRequiresDisconnect(false))

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -307,25 +307,19 @@ struct MacNodeModeCoordinatorTests {
     @Test @MainActor func `queued failure from replaced worker does not penalize replacement`() async throws {
         let worker = CoordinatorNodeHostWorkerProbe()
         let session = GatewayNodeSession()
-        let notificationCenter = NotificationCenter()
         let coordinator = MacNodeModeCoordinator(
             session: session,
             runtime: MacNodeRuntime(nodeHostWorker: worker),
-            nodeHostWorker: worker,
-            notificationCenter: notificationCenter,
-            observeNotifications: true)
+            nodeHostWorker: worker)
         let command = ["/usr/local/bin/openclaw", "node", "worker"]
 
         try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
         await coordinator.handleNodeHostConfigurationChangeForTesting()
         try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
 
-        // This models the old process's notification reaching MainActor after
-        // configuration replacement has installed the successor input.
-        notificationCenter.post(
-            name: .openclawNodeHostWorkerFailed,
-            object: NSNumber(value: UInt64.zero))
-        try await Task.sleep(for: .milliseconds(10))
+        // Generation zero belongs to the replaced process. Handle it only after
+        // the successor input is installed so the ordering is deterministic.
+        coordinator.handleNodeHostWorkerFailureForTesting(configurationGeneration: .zero)
 
         try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
         await coordinator.stopAndWait()


### PR DESCRIPTION
Closes #123967

## What Problem This Solves

Fixes an issue where macOS users could lose native node capabilities when a startup-scoped worker was replaced while the old process's crash notification was still queued. The delayed notification could consume the successor's retry budget and revoke its current route even though the successor had not crashed.

## Why This Change Was Made

The app-owned worker launch now carries the coordinator's authoritative configuration generation, and unexpected-exit notifications return that exact generation to the lifecycle owner. Worker replacement advances the generation synchronously; the coordinator ignores obsolete exits while preserving the existing bounded recovery path for current-generation crashes.

This is the canonical owner-boundary fix: filtering downstream by current command, process liveness, or route state would still misattribute same-command replacements after an await. The change does not alter Gateway protocol, configuration, public API, security boundaries, persistence, schemas, or product policy.

## User Impact

macOS node capabilities remain attached to the current replacement worker during provider/configuration changes. Real crashes of the current worker continue to retry and reconnect as before.

## Evidence

- Pre-fix reproduction: `swift test --package-path apps/macos --filter 'queued failure from replaced worker'` failed with `RetryBackoffPending()` at the regression boundary.
- Final focused proof on `34806347c8ca65b9dbf3da99594e0859dd10c4cf`: `swift test --package-path apps/macos --filter 'MacNode(HostWorker|ModeCoordinator)Tests'` passed 60 tests. The stale-generation test invokes the owner deterministically with no fixed delay, and the worker test asserts that the stopped launch generation is forwarded.
- Build: `swift build --package-path apps/macos --configuration release` passed.
- Changed gate: `node scripts/check-changed.mjs -- <five changed native files>` passed locally after the repository wrapper found no ready remote provider; SwiftLint covered 721 native files and six Vitest shards passed 354 tests.
- Formatting/diff: `./scripts/format-swift.sh macos`, `git diff --check origin/main...HEAD`, and the native state schema v8 guard passed.
- Exact-head review: `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` reported no accepted/actionable findings on `34806347c8ca65b9dbf3da99594e0859dd10c4cf`.
- Exact-head CI: run `31862818396` passed, including `macos-node`, `macos-swift`, OpenGrep, macOS/shared-kit dead-code scans, and `openclaw/ci-gate`.
- ClawSweeper rank-up moves: the 10 ms sleep was replaced by deterministic owner handling, stopped-launch generation propagation is asserted, duplicate retry identity was removed, and all remaining exact-head native checks completed successfully.
- Repeated signed lifecycle proof on final bytes: a Foundation Developer ID-signed app (`TeamIdentifier=FWJYW4S8P8`) ran from a stable isolated path with separate task state and loopback Gateway port 39873. Killing only its current app-owned node worker logged retry attempt 1 after one second; a new exact-worktree worker generation started and both app-owned loopback routes were restored within 21 seconds without exhausting retry state or losing Gateway availability. Killing the task app reaped the complete successor worker chain immediately; the task Gateway then shut down cleanly on SIGINT.
- Proof gap recorded: an earlier first launch of the identical final signed bytes stayed silent beyond the existing 300-second worker startup bound. During this repeated run, one initial task-only launch was restarted before that bound, then the clean restart completed the lifecycle proof. No timeout, config, code, operator service, state, or TCC setting changed to obtain either pass; investigate the debug source-runner first-launch readiness stall separately if it recurs.
- Cleanup: port 39873 is free, task processes are gone, the task profile defaults were removed, and the exact temporary signed bundle/state/lock were moved to Trash.
- LOC: production +34/-23 (net +11); tests +33/-8 (net +25). Raw diff +67/-31 across five files. No changelog edit.
