### PR TITLE
fix(doctor): surface telemetry exporter probe failures

### DIFF
--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -165,6 +165,30 @@ describe("checkGatewayHealth", () => {
     expect(message.split("\n")).toHaveLength(2);
   });
 
+  it("reports sanitized exporter diagnostic failures with a retry command", async () => {
+    const token = "sk-abcdefghijklmnopqrstuv";
+    callGateway
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(
+        new Error(`\u001B[31mexporter probe failed\nAuthorization: Bearer ${token}`),
+      );
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await expect(
+      checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
+    ).resolves.toEqual({ authenticated: true, healthOk: true, status: { ok: true } });
+
+    const [message, title] = note.mock.calls.at(-1) ?? [];
+    expect(title).toBe("Telemetry exporters");
+    expect(message).toContain("Exporter diagnostics failed: exporter probe failed");
+    expect(message).toContain("Retry: openclaw gateway stability --type telemetry.exporter");
+    expect(message).not.toContain(token);
+    expect(message).not.toContain("\u001B");
+    expect(message.split("\n")).toHaveLength(2);
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
   it("notes CLI and gateway version mismatch when the gateway reports another runtime version", async () => {
     callGateway.mockResolvedValueOnce({ runtimeVersion: "2026.4.23" }).mockResolvedValueOnce({});
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -160,6 +160,14 @@ export async function checkGatewayHealth(params: {
       if (exporterSummary) {
         note(exporterSummary.lines.join("\n"), exporterSummary.title);
       }
+    } else {
+      note(
+        [
+          `Exporter diagnostics failed: ${sanitizeTerminalText(formatErrorMessage(exporterResult.reason))}`,
+          `Retry: ${formatCliCommand("openclaw gateway stability --type telemetry.exporter")}`,
+        ].join("\n"),
+        "Telemetry exporters",
+      );
     }
     return { healthOk, authenticated: true, status };
   } catch (err) {


### PR DESCRIPTION
Closes #123968

AI-assisted: yes. The maintainer reviewed the complete owner path, regression, source-blind proof, and final diff.

## What Problem This Solves

Fixes an issue where operators running interactive Doctor could receive an unexplained successful completion when the Gateway was reachable but its auxiliary telemetry-exporter diagnostics probe failed. The failure was silently omitted, so the operator saw neither the rejected diagnostic nor the command needed to investigate it.

## Why This Change Was Made

The exporter and channel probes intentionally run as independent `Promise.allSettled` siblings after Gateway liveness succeeds. The channel rejection branch already rendered a sanitized warning and retry command, but the exporter path handled only fulfillment. This change adds the matching rejected-state projection in the Doctor health owner while preserving the reachable Gateway result and healthy sibling diagnostics.

A shared probe-failure helper was considered and rejected: parameterizing the two short branches adds another concept and does not reduce production LOC or improve the owner boundary. The direct sibling branch is the clearer bounded fix.

Scope remains two files. There are no config, protocol, public CLI shape, persistence, schema, dependency, or security-policy changes.

Production LOC: +8/-0 (net +8) | Tests: +24/-0

## User Impact

Doctor now explains telemetry-exporter probe failures with a sanitized reason and the exact recovery command:

`openclaw gateway stability --type telemetry.exporter`

The warning does not mark a reachable Gateway unhealthy, suppress healthy sibling output, or expose the exact injected credential/control bytes.

## Evidence

- Pre-fix regression: with only the exporter rejection branch removed, `reports sanitized exporter diagnostic failures with a retry command` failed because no `Telemetry exporters` note was emitted.
- Focused tests: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/commands/doctor-gateway-health.test.ts src/commands/telemetry-exporter-summary.test.ts` — 25/25 passed.
- Source-blind isolated Gateway/Doctor proof: the process requested `status`, `channels.status`, and `diagnostics.stability`; independent sibling output remained visible; the exporter rejection and exact recovery command were visible; `healthOk` and `authenticated` remained true; runtime errors were empty; ANSI bytes and the exact injected token were absent.
- Changed gate: `node scripts/check-changed.mjs -- src/commands/doctor-gateway-health.ts src/commands/doctor-gateway-health.test.ts` — passed all selected core/core-test type, lint, formatting, dependency, dead-export, database-first, import-cycle, and architecture checks. The wrapper fell back locally because no remote `ci-fast` provider was ready.
- Targeted format/lint: `oxfmt --check` and `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` passed for both files.
- Diff check: `git diff --check origin/main...HEAD` passed.
- Fresh Codex autoreview on exact final head `817dd2990d788253a0b31f4eba21fb5ea5a1ff33`: clean; no accepted/actionable findings; patch rated correct at 0.99.
