### PR TITLE
fix(plugins): uninstall fully removes isolated npm plugin files

### DIFF
--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -732,6 +732,11 @@ function assertPluginFileRemoved() {
 
 function assertNpmPluginRemoved() {
   const installPath = fs.readFileSync(scratchFile("plugins-npm-install-path.txt"), "utf8").trim();
+  const packageParent = path.dirname(installPath);
+  const nodeModulesPath = path.basename(packageParent).startsWith("@")
+    ? path.dirname(packageParent)
+    : packageParent;
+  const projectRoot = path.dirname(nodeModulesPath);
   const dependencyPackagePath = fs
     .readFileSync(scratchFile("plugins-npm-dependency-path.txt"), "utf8")
     .trim();
@@ -746,6 +751,9 @@ function assertNpmPluginRemoved() {
     throw new Error(
       `npm managed dependency still exists after uninstall: ${dependencyPackagePath}`,
     );
+  }
+  if (fs.existsSync(projectRoot)) {
+    throw new Error(`npm managed project still exists after uninstall: ${projectRoot}`);
   }
 }
 

--- a/src/plugins/install-record-commit.ts
+++ b/src/plugins/install-record-commit.ts
@@ -228,18 +228,13 @@ function resolveRetainedManagedNpmInstallMarkerTarget(params: {
       { runtimePluginIds: [] },
     ),
   );
-  if (
-    !plan.ok ||
-    !plan.directoryRemoval ||
-    plan.directoryRemoval.cleanup?.kind !== "npm" ||
-    path.resolve(plan.directoryRemoval.target) !== path.resolve(previousInstallPath)
-  ) {
+  if (!plan.ok || !plan.directoryRemoval || plan.directoryRemoval.cleanup?.kind !== "npm") {
     return null;
   }
-  if (nextInstallPath && installPathsOverlap(plan.directoryRemoval.target, nextInstallPath)) {
+  if (nextInstallPath && installPathsOverlap(previousInstallPath, nextInstallPath)) {
     return null;
   }
-  return plan.directoryRemoval.target;
+  return previousInstallPath;
 }
 
 function resolveNpmInstallRecordPackageName(record: PluginInstallRecord): string | null {

--- a/src/plugins/management-service.install-compensation.test.ts
+++ b/src/plugins/management-service.install-compensation.test.ts
@@ -1,9 +1,14 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectDir } from "./install-paths.js";
 
 const mocks = vi.hoisted(() => ({
   applyUninstall: vi.fn(),
   clawhubInstall: vi.fn(),
   installRecords: vi.fn(),
+  npmInstall: vi.fn(),
   pathInstall: vi.fn(),
   persistInstall: vi.fn(),
   planUninstall: vi.fn(),
@@ -15,6 +20,7 @@ vi.mock("./clawhub.js", () => ({
 
 vi.mock("./install.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./install.js")>()),
+  installPluginFromNpmSpec: (...args: unknown[]) => mocks.npmInstall(...args),
   installPluginFromPath: (...args: unknown[]) => mocks.pathInstall(...args),
 }));
 
@@ -35,6 +41,7 @@ vi.mock("./uninstall.js", async (importOriginal) => ({
 }));
 
 const { installManagedPluginSource } = await import("./management-service.js");
+const actualUninstall = await vi.importActual<typeof import("./uninstall.js")>("./uninstall.js");
 
 function installPersistSnapshot() {
   return {
@@ -95,6 +102,58 @@ describe("managed plugin install compensation", () => {
 
     expect(mocks.installRecords).toHaveBeenCalledWith({ env });
     expect(mocks.applyUninstall).toHaveBeenCalledWith({ target: targetDir });
+  });
+
+  it("removes a planner-validated isolated npm project after persistence conflicts", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-npm-conflict-"));
+    const env = { HOME: home };
+    const packageName = "@openclaw/demo";
+    const npmRoot = resolvePluginNpmProjectDir({
+      npmDir: resolveDefaultPluginNpmDir(env),
+      packageName,
+    });
+    const targetDir = path.join(npmRoot, "node_modules", "@openclaw", "demo");
+    const packArchive = path.join(npmRoot, "_openclaw-pack-archives", "demo.tgz");
+    const conflict = new Error("config changed during npm plugin install");
+
+    try {
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.mkdir(path.dirname(packArchive), { recursive: true });
+      await fs.writeFile(packArchive, "packed plugin");
+      mocks.npmInstall.mockResolvedValue({
+        ok: true,
+        pluginId: "demo",
+        targetDir,
+        extensions: ["index.js"],
+        manifestName: packageName,
+      });
+      mocks.persistInstall.mockRejectedValue(conflict);
+      mocks.planUninstall.mockImplementation((params) =>
+        actualUninstall.planPluginUninstall(
+          params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
+        ),
+      );
+      mocks.applyUninstall.mockImplementation(async (removal: { target: string }) => {
+        await fs.rm(removal.target, { recursive: true, force: true });
+        return { directoryRemoved: true, warnings: [] };
+      });
+
+      await expect(
+        installManagedPluginSource({
+          request: { source: "npm", spec: packageName, mode: "install" },
+          snapshot: installPersistSnapshot(),
+          env,
+        }),
+      ).rejects.toBe(conflict);
+
+      expect(mocks.applyUninstall).toHaveBeenCalledWith({
+        target: npmRoot,
+        cleanup: { kind: "npm", npmRoot, packageName },
+      });
+      await expect(fs.access(npmRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
   });
 
   it("never deletes an operator-owned source when link persistence fails", async () => {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -86,6 +86,7 @@ import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js"
 import { applySlotSelectionForPlugin } from "./slot-selection.js";
 import { setPluginEnabledInConfig } from "./toggle-config.js";
 import { collectClawPluginUninstallWarnings } from "./uninstall-claw-references.js";
+import { isUninstallPathInsideOrEqual } from "./uninstall-config.js";
 import {
   prepareConfigForPendingPluginDirectoryRemovalSet,
   recordPluginPackageUninstallPlan,
@@ -1084,7 +1085,13 @@ async function cleanupFailedManagedPluginInstall(params: {
       `Could not resolve a managed cleanup target for failed plugin install ${params.pluginId}.`,
     ];
   }
-  if (path.resolve(plan.directoryRemoval.target) !== path.resolve(params.targetDir)) {
+  const plannedTarget = path.resolve(plan.directoryRemoval.target);
+  const installedTarget = path.resolve(params.targetDir);
+  const removesIsolatedNpmProject =
+    plan.directoryRemoval.cleanup?.kind === "npm" &&
+    plannedTarget === path.resolve(plan.directoryRemoval.cleanup.npmRoot) &&
+    isUninstallPathInsideOrEqual(plannedTarget, installedTarget);
+  if (plannedTarget !== installedTarget && !removesIsolatedNpmProject) {
     return [
       `Refused cleanup for failed plugin install ${params.pluginId}: planned target does not match the newly installed target.`,
     ];

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1291,7 +1291,7 @@ describe("uninstallPlugin", () => {
       throw new Error(plan.error);
     }
     expect(plan.directoryRemoval).toEqual({
-      target: pluginDir,
+      target: npmRoot,
       cleanup: {
         kind: "npm",
         npmRoot,
@@ -1304,6 +1304,7 @@ describe("uninstallPlugin", () => {
     expect(applied).toEqual({ directoryRemoved: true, warnings: [] });
     expectNpmUninstallCommand({ packageName: "@openclaw/kitchen-sink", npmRoot });
     await expectPathAccessState(pluginDir, "missing");
+    await expectPathAccessState(npmRoot, "missing");
   });
 
   it("repairs remaining npm plugin openclaw peer links after npm uninstall prunes them", async () => {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -220,7 +220,14 @@ function resolveNpmManagedProjectInstall(params: {
     installPath: params.installPath,
     nodeModulesRoot,
   });
-  return packageName ? { installPath: params.installPath, npmRoot, packageName } : null;
+  if (
+    !packageName ||
+    resolveComparableUninstallPath(params.installPath) !==
+      resolveComparableUninstallPath(path.join(nodeModulesRoot, ...packageName.split("/")))
+  ) {
+    return null;
+  }
+  return { installPath: npmRoot, npmRoot, packageName };
 }
 
 function resolveNpmPackageNameFromInstallPath(params: {


### PR DESCRIPTION
Closes #123972

## What Problem This Solves

Fixes an issue where users who normally uninstalled an npm-managed plugin would still have its isolated OpenClaw npm project left on disk, including cached pack archives, package metadata, and transitive dependency debris.

## Why This Change Was Made

The uninstall owner now treats an exactly validated per-plugin npm project as the removal target, while shared legacy npm roots continue to remove only the selected package. The package-path equality check prevents ambiguous or nested records from widening deletion, and replaced npm generations continue to retain the original package path for running-process safety.

This is the canonical lifecycle-owner cleanup: no fallback, compatibility shim, config key, public API/Plugin SDK surface, protocol, dependency, security boundary, persistence contract, or schema changes.

Failed-install compensation consumes the same uninstall plan. When persistence fails after an npm install, it now accepts the wider project target only when the planner identifies npm cleanup, the target exactly equals that cleanup's npm root, and the newly installed package is contained within it. Shared or ambiguous targets remain refused.

## User Impact

Ordinary plugin uninstall now removes all OpenClaw-owned files for that isolated npm plugin project. Shared roots remain intact, and `--keep-files` plus retained update generations keep their existing behavior.

## Evidence

- Before the fix, the focused regression failed because the per-plugin project root still existed after uninstall.
- `node scripts/run-vitest.mjs src/plugins/management-service.test.ts src/plugins/management-service.install-compensation.test.ts src/plugins/uninstall.test.ts src/plugins/install-record-commit.test.ts src/plugins/install-record-commit.retention.test.ts` — 126 tests passed, including a real-planner persistence-conflict regression that removes the isolated project and cached pack archive.
- `node_modules/.bin/oxfmt --check --no-error-on-unmatched-pattern -- scripts/e2e/lib/plugins/assertions.mjs src/plugins/install-record-commit.ts src/plugins/management-service.install-compensation.test.ts src/plugins/management-service.ts src/plugins/uninstall.test.ts src/plugins/uninstall.ts` and `git diff --check origin/main...HEAD` — passed.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/plugins/assertions.mjs src/plugins/install-record-commit.ts src/plugins/management-service.install-compensation.test.ts src/plugins/management-service.ts src/plugins/uninstall.test.ts src/plugins/uninstall.ts` — full changed gate passed. The `ci-fast` remote route had no ready provider, so the wrapper used its explicit trusted local fallback.
- `OPENCLAW_PLUGINS_E2E_CLAWHUB=0 pnpm test:docker:plugins` — passed against the exact rebased commit. The lane built and validated the OpenClaw tarball, installed it source-absent in Docker with `npm install --omit=dev`, exercised plugin install/runtime/update/keep-files/reinstall, and proved ordinary uninstall removes the isolated project root and dependency debris.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — TruffleHog clean; one complete Codex pass over the final six-file branch; no accepted/actionable findings.

- ClawSweeper's P2 failed-install compensation finding was accepted and repaired. Its rank-up moves are applied: compensation recognizes only the validated isolated npm target, and the new regression uses the real planner and proves the project root is removed.

Production LOC: +19/-10 (net +9). The bounded growth is the exact package-path ownership guard plus the compensation check that preserves cleanup only for the planner-validated isolated npm root.

Tests and E2E support: +69/-1 (net +68).

No `CHANGELOG.md` edit. AI-assisted and maintainer-approved for landing.
