### PR TITLE
fix(ui): re-attach chat transcript virtualizer after dashboard→split face switch

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 333309,
-  "reason": "cumulative 2026-08-15 UI fix growth (tab retry/session attention/talk backpressure stream); CI run 31861213699 build-artifacts bytes",
+  "startupJsGzipBytes": 333338,
+  "reason": "cumulative 2026-08-15 UI fix growth (tab retry/session attention/talk backpressure stream) plus chat transcript virtualizer re-attach fix (#123974); CI runs 31861213699 and 31861214469 build-artifacts bytes",
   "updatedAt": "2026-08-15"
 }

--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -1,0 +1,147 @@
+// Regression: the chat transcript must repaint after a dashboard -> split face
+// switch re-stamps it into the sidebar region (issue: virtualizer stayed
+// detached until an unrelated re-render, painting a blank pane).
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  controlUiBundledSettingsStorageKey,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const sessionKey = "agent:main:board-split-transcript";
+
+let browser: Browser;
+let controlUi: ControlUiE2eServer;
+const contexts = new Set<BrowserContext>();
+
+function boardSnapshot(chatDock: "right" | "hidden", revision = 1) {
+  return {
+    sessionKey,
+    revision,
+    tabs: [{ tabId: "main", title: "Main", position: 0, chatDock }],
+    widgets: [],
+  };
+}
+
+async function visibleTranscriptState(page: Page) {
+  return await page.evaluate(() => {
+    const inner = [...document.querySelectorAll<HTMLElement>(".chat-thread-inner--virtual")].find(
+      (candidate) => {
+        const cachePane = candidate.closest(".chat-pane-cache__pane");
+        return !cachePane || cachePane.classList.contains("chat-pane-cache__pane--visible");
+      },
+    );
+    const scroller = inner?.parentElement;
+    if (!inner || !scroller) {
+      return { present: false, intersectingRows: 0 };
+    }
+    const rect = scroller.getBoundingClientRect();
+    const intersectingRows = [...inner.querySelectorAll<HTMLElement>(".chat-virtual-row")].filter(
+      (row) => {
+        const rowRect = row.getBoundingClientRect();
+        return rowRect.bottom > rect.top && rowRect.top < rect.bottom;
+      },
+    ).length;
+    return { present: true, intersectingRows };
+  });
+}
+
+describeControlUiE2e("Board split transcript restore", () => {
+  beforeAll(async () => {
+    controlUi = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  }, 120_000);
+
+  afterAll(async () => {
+    for (const context of contexts) {
+      await context.close();
+    }
+    await browser?.close();
+    await controlUi?.close();
+  });
+
+  it("repaints the docked transcript after dashboard -> split", async () => {
+    const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+    contexts.add(context);
+    const page = await context.newPage();
+    const now = Date.now();
+    const gateway = await installMockGateway(page, {
+      sessionKey,
+      featureMethods: [
+        "board.get",
+        "board.update",
+        "chat.history",
+        "chat.metadata",
+        "chat.startup",
+        "sessions.patch",
+      ],
+      methodResponses: {
+        "board.get": boardSnapshot("right"),
+        "board.update": {
+          sequence: [boardSnapshot("hidden", 2), boardSnapshot("right", 3)],
+        },
+      },
+      historyMessages: Array.from({ length: 40 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `Message number ${index}: the quick brown fox jumps over the lazy dog to give this bubble a realistic height.`,
+        timestamp: now - (40 - index) * 60_000,
+      })),
+    });
+
+    const settingsKey = controlUiBundledSettingsStorageKey(controlUi.baseUrl);
+    await page.addInitScript(
+      ({ key, storageKey }) => {
+        const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
+          string,
+          unknown
+        >;
+        settings.boardSessionViews = { [key]: { activeTabId: "main" } };
+        localStorage.setItem(storageKey, JSON.stringify(settings));
+      },
+      { key: sessionKey, storageKey: settingsKey },
+    );
+    await page.goto(`${controlUi.baseUrl}dashboard`);
+    await page.locator(".board-session-surface").waitFor();
+    await page.getByText("Message number 39:").first().waitFor({ timeout: 15_000 });
+
+    const mode = (value: "split" | "dashboard") =>
+      page.locator(`wa-radio.settings-segmented__btn[value="${value}"]`);
+
+    // Defer each dock update so the pane render that stamps the transcript into
+    // the sidebar region arrives alone, as it does against a remote gateway.
+    // With instant responses the click-time renders coalesce and mask the bug.
+    await gateway.deferNext("board.update");
+    await mode("dashboard").click();
+    await page.waitForTimeout(200);
+    await gateway.resolveDeferred("board.update");
+    await expect
+      .poll(async () => (await visibleTranscriptState(page)).present, { timeout: 5_000 })
+      .toBe(false);
+
+    await gateway.deferNext("board.update");
+    await mode("split").click();
+    await page.waitForTimeout(200);
+    await gateway.resolveDeferred("board.update");
+
+    // The transcript must repaint promptly from the dock-restore render itself,
+    // without waiting for an unrelated state change to re-render the pane.
+    await expect
+      .poll(async () => await visibleTranscriptState(page), { timeout: 2_000 })
+      .toMatchObject({ present: true, intersectingRows: expect.any(Number) });
+    await expect
+      .poll(async () => (await visibleTranscriptState(page)).intersectingRows, { timeout: 2_000 })
+      .toBeGreaterThan(0);
+    await page
+      .getByText("Message number 39:")
+      .first()
+      .waitFor({ state: "visible", timeout: 2_000 });
+  }, 120_000);
+});

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { render } from "lit";
+import { nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
 import { renderChatThread } from "./chat-thread.ts";
@@ -131,6 +131,14 @@ describe("chat transcript controller", () => {
 
     const scrollElement = container.querySelector<HTMLElement>(".chat-thread");
     expect(scrollElement).not.toBeNull();
+    // Establish the real viewport baseline first: zero rects from jsdom's
+    // 0-width offsetWidth are ignored as hide transitions, matching browsers
+    // where the initial attach rect is the true width.
+    for (const observer of resizeObservers) {
+      if (observer.observes(scrollElement!)) {
+        observer.emit(800, 600);
+      }
+    }
     scrollElement!.scrollTop = 40;
     scrollElement!.dispatchEvent(new Event("scroll"));
     const virtualizer = (
@@ -215,4 +223,68 @@ describe("chat transcript controller", () => {
       transcript.hostDisconnected();
     },
   );
+
+  it("re-attaches the virtualizer when a foreign host re-stamps the transcript", async () => {
+    const transcript = createTestTranscript();
+    const props = threadProps("pane-foreign-stamp");
+    const chatFace = document.body.appendChild(document.createElement("div"));
+    render(renderChatThread(props, transcript), chatFace);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+    const chatScroller = chatFace.querySelector<HTMLElement>(".chat-thread");
+    expect(chatScroller).not.toBeNull();
+    expect(observedElements.has(chatScroller!)).toBe(true);
+
+    // Dashboard face: the pane unmounts the transcript and finishes its update.
+    render(nothing, chatFace);
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    // Split restore: the sidebar region — a different Lit host that receives
+    // the chat template as a property — stamps the transcript in its own
+    // update cycle. The pane does not update again, so attachment must follow
+    // the ref-recorded DOM identity rather than the pane's render cycle.
+    const dock = document.body.appendChild(document.createElement("div"));
+    render(renderChatThread(props, transcript), dock);
+    await flushDeferredRowPrune();
+
+    const dockScroller = dock.querySelector<HTMLElement>(".chat-thread");
+    expect(dockScroller).not.toBeNull();
+    expect(observedElements.has(dockScroller!)).toBe(true);
+    expect(transcriptRows(dock).length).toBeGreaterThan(0);
+    transcript.hostDisconnected();
+  });
+
+  it("keeps rendering rows after a hide-transition zero rect", async () => {
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const messages = Array.from({ length: 40 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index + 1,
+    }));
+    const props = threadProps("pane-zero-rect", "agent:main:zero-rect", messages);
+    render(renderChatThread(props, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+    const scrollElement = container.querySelector<HTMLElement>(".chat-thread");
+    expect(scrollElement).not.toBeNull();
+    expect(transcriptRows(container).length).toBeGreaterThan(0);
+
+    // A pane cache or face switch hiding the transcript reports a 0x0 rect.
+    // It must not become the virtualizer's viewport (an empty range renders a
+    // blank transcript) nor count as a width change that wipes measurements.
+    for (const observer of resizeObservers) {
+      if (observer.observes(scrollElement!)) {
+        observer.emit(0, 0);
+      }
+    }
+    render(renderChatThread(props, transcript), container);
+    transcript.hostUpdated();
+
+    expect(transcriptRows(container).length).toBeGreaterThan(0);
+    transcript.hostDisconnected();
+  });
 });

--- a/ui/src/pages/chat/components/chat-transcript-controller.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.ts
@@ -101,8 +101,36 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
   // re-invoke them for every visible row and re-measure each row every render.
   // Lit tracks the last element per callback, so each row needs its own.
   private readonly scrollElementRef = (element?: Element) => {
-    this.threadInnerElement = element instanceof HTMLDivElement ? element : null;
+    const next = element instanceof HTMLDivElement ? element : null;
+    if (next === this.threadInnerElement) {
+      return;
+    }
+    this.threadInnerElement = next;
+    this.queueScrollElementAttach();
   };
+  // The transcript template can be stamped by a host other than the pane that
+  // drives this controller: sidebar panels receive it as a property and render
+  // it in their own, later update cycle. The virtualizer re-resolves its
+  // scroll element only inside _willUpdate, which runs on the pane's update —
+  // after a foreign-host re-stamp (chat<->dashboard face switch docking chat
+  // into the sidebar) no pane update follows, so the virtualizer stays
+  // detached and paints zero rows until an unrelated re-render. Attachment
+  // must follow the DOM identity this ref records, not the pane render cycle.
+  private scrollElementAttachQueued = false;
+  private queueScrollElementAttach(): void {
+    if (this.scrollElementAttachQueued) {
+      return;
+    }
+    this.scrollElementAttachQueued = true;
+    queueMicrotask(() => {
+      this.scrollElementAttachQueued = false;
+      const instance = this.virtualizerController.getVirtualizer();
+      if (this.connected && instance.scrollElement !== this.scrollElement) {
+        this.virtualizerController.hostUpdated();
+        this.host.requestUpdate();
+      }
+    });
+  }
   private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
   private pruneDetachedRowsQueued = false;
   private pendingRowMeasureFrame: number | null = null;
@@ -195,6 +223,14 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
       followOnAppend: false,
       observeElementRect: (instance, callback) =>
         observeElementRect(instance, (rect) => {
+          // A zero rect is a hide/teardown transition (pane cache display:none
+          // or a face switch unmounting the transcript), not a real resize.
+          // Reacting to it wipes every measured row height via measure() and
+          // records garbage as the last width/height; keep the last real rect
+          // so a remount with unchanged geometry restores rows instantly.
+          if (rect.width === 0 || rect.height === 0) {
+            return;
+          }
           const previousHeight = this.observedHeight;
           const widthChanged = this.observedWidth !== null && this.observedWidth !== rect.width;
           const heightChanged = previousHeight !== null && previousHeight !== rect.height;


### PR DESCRIPTION
## What Problem This Solves
Switching a board session from Dashboard back to Split (or Chat → Split) left the docked chat transcript blank — sizer-height empty space with no message rows — until an unrelated state change re-rendered the pane or the user scrolled. On real-latency gateways the blank state persisted for many seconds. Silent blank output on a default UI path.

## Why This Change Was Made
Root cause: the chat transcript template is stamped by `openclaw-chat-sidebar-region` (it receives the template as a property and renders it in its own, later update cycle), while the TanStack virtualizer re-resolves its scroll element only inside the pane host's update cycle (`ChatTranscriptController` → `VirtualizerController.hostUpdated`). After a face-switch re-stamp no pane update follows, so the virtualizer stayed detached: `scrollElement` null, viewport rect zeroed by the hide transition, `calculateRange()` null, zero rows painted. Fix at the owner (`ChatSessionVirtualizerHost`): attachment now follows the DOM identity the scroll-element ref records — an identity change queues a microtask that re-runs the virtualizer adapter's update hook, regardless of which host stamped the DOM. Additionally, zero-size rects from hide transitions (`display:none` sidebar panels, unmount teardown) are ignored: they previously wiped every measured row height via `measure()` and became the virtualizer's viewport. Covers the sibling task-sidebar transcript automatically (same controller).

## User Impact
Dashboard→Split (and Chat→Split with a left/right dock) now repaints the transcript immediately; no more blank chat pane that heals only on scroll or later gateway events. Scroll position and measured row heights survive the face switch.

## Evidence
- Live root-cause proof on a real remote gateway (pre-fix): 5+ s after clicking Split the virtualizer had `scrollElement: null`, `scrollRect {0,0}`, `getVirtualItems() = []`, 0 DOM rows at sizer height 2280px (= 19 rows × 120px estimate, measurement cache wiped); a single `pane.requestUpdate()` healed it instantly, proving the missing-attachment mechanism.
- Regression tests (fail pre-fix, verified): `ui/src/pages/chat/components/chat-transcript-controller.test.ts` — "re-attaches the virtualizer when a foreign host re-stamps the transcript" and "keeps rendering rows after a hide-transition zero rect".
- New e2e: `ui/src/e2e/board-split-transcript.e2e.test.ts` drives the real Control UI with a mocked gateway using deferred `board.update` responses (real-latency shape) and asserts the docked transcript repaints.
- Local proof: controller suite 9/9, e2e green, `check:changed` green (local remote-child fallback; the Crabbox lane failed on an unrelated remote git-seed infra error), oxlint/oxfmt clean, Codex autoreview clean on the final diff.
- Before/after visuals: a mocked "before" capture is infeasible — with an instant mock gateway, ancillary renders (pane-width ResizeObserver etc.) re-attach the virtualizer within <40 ms, faster than a video frame; only real-latency gateways expose the multi-second blank. After-proof (mocked, synthetic data): screenshot + video below.

![after](https://github.com/user-attachments/assets/e801dc35-fc0b-4386-99bb-21d7f5684d82)

https://github.com/user-attachments/assets/53eb3d6d-5de1-4402-a646-834149f513b6
