### PR TITLE
fix(scripts): clean up tsgo process trees on timeout or signal

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -700,17 +700,17 @@ Native dependency policy:
       after 5 minutes with no stdout or stderr output. Set
       `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=0` to disable the watchdog for
       an intentionally silent investigation.
-    - `scripts/run-tsgo.mjs` terminates a tsgo run after 30 minutes, so a
-      wedged compiler fails loudly instead of blocking its caller forever.
-      Hosted tsgo lanes finish in 1-2 minutes; raise
-      `OPENCLAW_TSGO_TIMEOUT_MS` on a slower host. On expiry the whole tsgo
-      process tree is killed and the run fails. Values above Node's timer
+    - `scripts/run-tsgo.mjs` leaves tsgo unbounded by default, preserving the
+      behavior of existing local workflows. Set `OPENCLAW_TSGO_TIMEOUT_MS` to
+      a positive millisecond value to make a wedged compiler fail loudly
+      instead of blocking its caller forever. On expiry the whole tsgo process
+      tree is killed and the run fails. Values above Node's timer
       ceiling saturate at it instead of collapsing to a 1ms deadline; `0`, a
       negative, a fraction, or anything above `Number.MAX_SAFE_INTEGER` is
       rejected and fails the run. Surrounding whitespace is trimmed first;
       the remaining value must use plain decimal digits without leading zeros,
-      so values such as `1e5` or `007` are rejected. This watchdog cannot be
-      disabled.
+      so values such as `1e5` or `007` are rejected. Unset the variable to
+      disable the watchdog.
 
   </Accordion>
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -700,11 +700,12 @@ Native dependency policy:
       after 5 minutes with no stdout or stderr output. Set
       `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=0` to disable the watchdog for
       an intentionally silent investigation.
-    - `scripts/run-tsgo.mjs` waits indefinitely by default. Set
-      `OPENCLAW_TSGO_TIMEOUT_MS` to bound a run on hosts where a wedged
-      compiler would otherwise block its caller forever; on expiry the whole
-      tsgo process tree is killed and the run fails. Values above Node's
-      timer ceiling saturate instead of collapsing to a 1ms deadline.
+    - `scripts/run-tsgo.mjs` terminates a tsgo run after 30 minutes, so a
+      wedged compiler fails loudly instead of blocking its caller forever.
+      Hosted tsgo lanes finish in 1-2 minutes; raise
+      `OPENCLAW_TSGO_TIMEOUT_MS` on a slower host. On expiry the whole tsgo
+      process tree is killed and the run fails. Values above Node's timer
+      ceiling saturate instead of collapsing to a 1ms deadline.
 
   </Accordion>
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -700,6 +700,11 @@ Native dependency policy:
       after 5 minutes with no stdout or stderr output. Set
       `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=0` to disable the watchdog for
       an intentionally silent investigation.
+    - `scripts/run-tsgo.mjs` waits indefinitely by default. Set
+      `OPENCLAW_TSGO_TIMEOUT_MS` to bound a run on hosts where a wedged
+      compiler would otherwise block its caller forever; on expiry the whole
+      tsgo process tree is killed and the run fails. Values above Node's
+      timer ceiling saturate instead of collapsing to a 1ms deadline.
 
   </Accordion>
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -705,7 +705,12 @@ Native dependency policy:
       Hosted tsgo lanes finish in 1-2 minutes; raise
       `OPENCLAW_TSGO_TIMEOUT_MS` on a slower host. On expiry the whole tsgo
       process tree is killed and the run fails. Values above Node's timer
-      ceiling saturate instead of collapsing to a 1ms deadline.
+      ceiling saturate at it instead of collapsing to a 1ms deadline; `0`, a
+      negative, a fraction, or anything above `Number.MAX_SAFE_INTEGER` is
+      rejected and fails the run. Surrounding whitespace is trimmed first;
+      the remaining value must use plain decimal digits without leading zeros,
+      so values such as `1e5` or `007` are rejected. This watchdog cannot be
+      disabled.
 
   </Accordion>
 

--- a/scripts/lib/tsx-cli-shim.mjs
+++ b/scripts/lib/tsx-cli-shim.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
-const FORCE_KILL_DELAY_MS = 5_000;
+const DEFAULT_FORCE_KILL_DELAY_MS = 5_000;
 const SHIM_CHECKOUT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 function resolvePrimaryRoot(checkoutRoot) {
@@ -78,6 +78,7 @@ function signalChild(child, signal, detached) {
 
 async function runTsxCliShimInner(moduleUrl, options) {
   const detached = options.detached ?? (process.platform !== "win32" && !process.stdin.isTTY);
+  const forceKillDelayMs = options.forceKillDelayMs ?? DEFAULT_FORCE_KILL_DELAY_MS;
   let child = null;
   let forceKillTimer = null;
   const signalHandlers = new Map();
@@ -98,7 +99,7 @@ async function runTsxCliShimInner(moduleUrl, options) {
       signalChild(child, signal, detached);
       forceKillTimer ??= setTimeout(
         () => signalChild(child, "SIGKILL", detached),
-        FORCE_KILL_DELAY_MS,
+        forceKillDelayMs,
       );
       forceKillTimer.unref();
     };

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -3,4 +3,7 @@ import { runTsxCliShim } from "./lib/tsx-cli-shim.mjs";
 await runTsxCliShim(import.meta.url, {
   implementation: "./run-tsgo.mts",
   failureTool: "tsgo",
+  // The implementation owns a detached compiler group and escalates after 5s.
+  // Its outer shim must stay alive long enough to finish that cleanup.
+  forceKillDelayMs: 10_000,
 });

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -16,17 +16,21 @@ import {
   shouldSkipSparseTsgoGuardError,
 } from "./lib/tsgo-sparse-guard.mts";
 
-/**
- * Hosted tsgo lanes finish in 1-2 minutes and their CI jobs cap at 15-20, so 30
- * leaves headroom for a far slower local host while still bounding a wedge that
- * would otherwise never report. Raise OPENCLAW_TSGO_TIMEOUT_MS for slower hosts.
- */
-const DEFAULT_TSGO_TIMEOUT_MS = 30 * 60 * 1000;
 // Declared locally, as sibling scripts do, rather than imported from packages/:
 // a static import there resolves before the sparse-checkout guard can report a
 // missing project, turning a clean skip into ERR_MODULE_NOT_FOUND. Mirrors
 // normalization-core's MAX_TIMER_TIMEOUT_MS.
 const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
+
+export function resolveTsgoTimeoutMs(env: NodeJS.ProcessEnv): number | undefined {
+  if (!env.OPENCLAW_TSGO_TIMEOUT_MS?.trim()) {
+    return undefined;
+  }
+  return Math.min(
+    readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, MAX_TIMER_TIMEOUT_MS),
+    MAX_TIMER_TIMEOUT_MS,
+  );
+}
 
 async function main(): Promise<void> {
   const hostResources = {
@@ -58,17 +62,14 @@ async function main(): Promise<void> {
   }
 
   ensureRepoToolNodeModulesLink(tsgoPath);
-  let timeoutMs: number;
+  let timeoutMs: number | undefined;
   try {
-    timeoutMs = Math.min(
-      readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS),
-      MAX_TIMER_TIMEOUT_MS,
-    );
+    timeoutMs = resolveTsgoTimeoutMs(env);
   } catch {
     // main() is top-level awaited, so an escaping parse error would surface as a raw
     // module rejection with no guidance about the variable that caused it.
     console.error(
-      `[tsgo] OPENCLAW_TSGO_TIMEOUT_MS must be plain decimal digits with no leading zero, sign, exponent, or decimal point, between 1 and ${Number.MAX_SAFE_INTEGER}; got ${env.OPENCLAW_TSGO_TIMEOUT_MS}. The watchdog cannot be disabled; raise the value instead.`,
+      `[tsgo] OPENCLAW_TSGO_TIMEOUT_MS must be plain decimal digits with no leading zero, sign, exponent, or decimal point, between 1 and ${Number.MAX_SAFE_INTEGER}; got ${env.OPENCLAW_TSGO_TIMEOUT_MS}. Unset it to disable the watchdog.`,
     );
     process.exitCode = 1;
     return;
@@ -88,7 +89,7 @@ async function main(): Promise<void> {
       throw error;
     }
     console.error(
-      `[tsgo] no completion after ${timeoutMs}ms; killed the tsgo process tree. Raise OPENCLAW_TSGO_TIMEOUT_MS for intentionally longer builds.`,
+      `[tsgo] no completion after ${timeoutMs}ms; killed the tsgo process tree. Raise OPENCLAW_TSGO_TIMEOUT_MS for intentionally longer builds, or unset it to disable the watchdog.`,
     );
     process.exitCode = 1;
   }

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -18,6 +18,8 @@ import {
 
 /** Watchdog bound for one tsgo run; sized well above a healthy whole-program check. */
 const DEFAULT_TSGO_TIMEOUT_MS = 45 * 60 * 1000;
+/** Node's timer ceiling: a longer delay silently becomes 1ms, so a raised override must saturate. */
+const MAX_TSGO_TIMEOUT_MS = 2_147_483_647;
 
 async function main(): Promise<void> {
   const hostResources = {
@@ -49,7 +51,10 @@ async function main(): Promise<void> {
   }
 
   ensureRepoToolNodeModulesLink(tsgoPath);
-  const timeoutMs = readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS);
+  const timeoutMs = Math.min(
+    readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS),
+    MAX_TSGO_TIMEOUT_MS,
+  );
   try {
     // Managed run owns the whole tsgo process tree: on timeout it SIGKILLs the
     // process group, because a wedged checker ignores SIGTERM and would otherwise

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -1,5 +1,4 @@
 // Runs tsgo through local resource policy and sparse-checkout guards.
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -10,13 +9,17 @@ import {
   resolveLocalCheckEnv,
   resolveRepoToolBinPath,
 } from "./lib/local-check-runtime.mts";
-import { createManagedCommandInvocation } from "./lib/managed-child-process.mts";
+import { runManagedCommand } from "./lib/managed-child-process.mts";
+import { readPositiveEnvInt } from "./lib/numeric-options.mjs";
 import {
   getSparseTsgoGuardError,
   shouldSkipSparseTsgoGuardError,
 } from "./lib/tsgo-sparse-guard.mts";
 
-function main(): void {
+/** Watchdog bound for one tsgo run; sized well above a healthy whole-program check. */
+const DEFAULT_TSGO_TIMEOUT_MS = 45 * 60 * 1000;
+
+async function main(): Promise<void> {
   const hostResources = {
     logicalCpuCount:
       typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length,
@@ -46,25 +49,28 @@ function main(): void {
   }
 
   ensureRepoToolNodeModulesLink(tsgoPath);
-  const tsgo = createManagedCommandInvocation({
-    args: finalArgs,
-    bin: tsgoPath,
-    env,
-  });
-  const result = spawnSync(tsgo.command, tsgo.args, {
-    stdio: "inherit",
-    env,
-    shell: tsgo.shell,
-    windowsVerbatimArguments: tsgo.windowsVerbatimArguments,
-  });
-
-  if (result.error) {
-    throw result.error;
+  const timeoutMs = readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS);
+  try {
+    // Managed run owns the whole tsgo process tree: on timeout it SIGKILLs the
+    // process group, because a wedged checker ignores SIGTERM and would otherwise
+    // block the caller forever on a compiler that will never report.
+    process.exitCode = await runManagedCommand({
+      bin: tsgoPath,
+      args: finalArgs,
+      env,
+      timeoutMs,
+    });
+  } catch (error) {
+    if ((error as { code?: string } | undefined)?.code !== "ETIMEDOUT") {
+      throw error;
+    }
+    console.error(
+      `[tsgo] no completion after ${timeoutMs}ms; killed the tsgo process tree. Raise OPENCLAW_TSGO_TIMEOUT_MS for intentionally longer builds.`,
+    );
+    process.exitCode = 1;
   }
-
-  process.exitCode = result.status ?? 1;
 }
 
 if (import.meta.main) {
-  main();
+  await main();
 }

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -16,6 +16,12 @@ import {
   shouldSkipSparseTsgoGuardError,
 } from "./lib/tsgo-sparse-guard.mts";
 
+/**
+ * Hosted tsgo lanes finish in 1-2 minutes and their CI jobs cap at 15-20, so 30
+ * leaves headroom for a far slower local host while still bounding a wedge that
+ * would otherwise never report. Raise OPENCLAW_TSGO_TIMEOUT_MS for slower hosts.
+ */
+const DEFAULT_TSGO_TIMEOUT_MS = 30 * 60 * 1000;
 /** Node's timer ceiling: a longer delay silently becomes 1ms, so a raised override must saturate. */
 const MAX_TSGO_TIMEOUT_MS = 2_147_483_647;
 
@@ -49,14 +55,10 @@ async function main(): Promise<void> {
   }
 
   ensureRepoToolNodeModulesLink(tsgoPath);
-  // Opt-in deadline: no supported duration contract covers every host and project,
-  // so an unset value keeps the pre-existing unbounded wait rather than guessing one.
-  const timeoutMs = env.OPENCLAW_TSGO_TIMEOUT_MS?.trim()
-    ? Math.min(
-        readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, MAX_TSGO_TIMEOUT_MS),
-        MAX_TSGO_TIMEOUT_MS,
-      )
-    : undefined;
+  const timeoutMs = Math.min(
+    readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS),
+    MAX_TSGO_TIMEOUT_MS,
+  );
   try {
     // Managed run owns the whole tsgo process tree: on timeout it SIGKILLs the
     // process group, because a wedged checker ignores SIGTERM and would otherwise

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -22,8 +22,11 @@ import {
  * would otherwise never report. Raise OPENCLAW_TSGO_TIMEOUT_MS for slower hosts.
  */
 const DEFAULT_TSGO_TIMEOUT_MS = 30 * 60 * 1000;
-/** Node's timer ceiling: a longer delay silently becomes 1ms, so a raised override must saturate. */
-const MAX_TSGO_TIMEOUT_MS = 2_147_483_647;
+// Declared locally, as sibling scripts do, rather than imported from packages/:
+// a static import there resolves before the sparse-checkout guard can report a
+// missing project, turning a clean skip into ERR_MODULE_NOT_FOUND. Mirrors
+// normalization-core's MAX_TIMER_TIMEOUT_MS.
+const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
 
 async function main(): Promise<void> {
   const hostResources = {
@@ -55,10 +58,21 @@ async function main(): Promise<void> {
   }
 
   ensureRepoToolNodeModulesLink(tsgoPath);
-  const timeoutMs = Math.min(
-    readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS),
-    MAX_TSGO_TIMEOUT_MS,
-  );
+  let timeoutMs: number;
+  try {
+    timeoutMs = Math.min(
+      readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS),
+      MAX_TIMER_TIMEOUT_MS,
+    );
+  } catch {
+    // main() is top-level awaited, so an escaping parse error would surface as a raw
+    // module rejection with no guidance about the variable that caused it.
+    console.error(
+      `[tsgo] OPENCLAW_TSGO_TIMEOUT_MS must be plain decimal digits with no leading zero, sign, exponent, or decimal point, between 1 and ${Number.MAX_SAFE_INTEGER}; got ${env.OPENCLAW_TSGO_TIMEOUT_MS}. The watchdog cannot be disabled; raise the value instead.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
   try {
     // Managed run owns the whole tsgo process tree: on timeout it SIGKILLs the
     // process group, because a wedged checker ignores SIGTERM and would otherwise

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -16,8 +16,6 @@ import {
   shouldSkipSparseTsgoGuardError,
 } from "./lib/tsgo-sparse-guard.mts";
 
-/** Watchdog bound for one tsgo run; sized well above a healthy whole-program check. */
-const DEFAULT_TSGO_TIMEOUT_MS = 45 * 60 * 1000;
 /** Node's timer ceiling: a longer delay silently becomes 1ms, so a raised override must saturate. */
 const MAX_TSGO_TIMEOUT_MS = 2_147_483_647;
 
@@ -51,10 +49,14 @@ async function main(): Promise<void> {
   }
 
   ensureRepoToolNodeModulesLink(tsgoPath);
-  const timeoutMs = Math.min(
-    readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, DEFAULT_TSGO_TIMEOUT_MS),
-    MAX_TSGO_TIMEOUT_MS,
-  );
+  // Opt-in deadline: no supported duration contract covers every host and project,
+  // so an unset value keeps the pre-existing unbounded wait rather than guessing one.
+  const timeoutMs = env.OPENCLAW_TSGO_TIMEOUT_MS?.trim()
+    ? Math.min(
+        readPositiveEnvInt("OPENCLAW_TSGO_TIMEOUT_MS", env, MAX_TSGO_TIMEOUT_MS),
+        MAX_TSGO_TIMEOUT_MS,
+      )
+    : undefined;
   try {
     // Managed run owns the whole tsgo process tree: on timeout it SIGKILLs the
     // process group, because a wedged checker ignores SIGTERM and would otherwise

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -8,6 +8,7 @@ import {
   getSparseTsgoGuardError,
   shouldSkipSparseTsgoGuardError,
 } from "../../scripts/lib/tsgo-sparse-guard.mts";
+import { resolveTsgoTimeoutMs } from "../../scripts/run-tsgo.mts";
 import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
@@ -235,6 +236,12 @@ describe("run-tsgo sparse guard", () => {
 });
 
 describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
+  it("keeps the watchdog opt-in", () => {
+    expect(resolveTsgoTimeoutMs({})).toBeUndefined();
+    expect(resolveTsgoTimeoutMs({ OPENCLAW_TSGO_TIMEOUT_MS: "  " })).toBeUndefined();
+    expect(resolveTsgoTimeoutMs({ OPENCLAW_TSGO_TIMEOUT_MS: "30000" })).toBe(30_000);
+  });
+
   function writeFakeTsgo(cwd: string, body: string) {
     const binDir = path.join(cwd, "node_modules", ".bin");
     fs.mkdirSync(binDir, { recursive: true });
@@ -306,7 +313,7 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("must be plain decimal digits");
-      expect(result.stderr).toContain("cannot be disabled");
+      expect(result.stderr).toContain("Unset it to disable the watchdog");
       expect(result.stderr).not.toContain("at readPositiveEnvInt");
       expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
     },
@@ -382,7 +389,7 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
   // regression that matters: without saturation Node collapses the delay to 1ms and
   // would kill this sleeping child immediately.
   it.each([
-    { bound: undefined, name: "the default deadline", body: "#!/bin/sh\nsleep 2\nexit 0\n" },
+    { bound: undefined, name: "the disabled watchdog", body: "#!/bin/sh\nsleep 2\nexit 0\n" },
     { bound: "30000", name: "an explicit bound", body: "#!/bin/sh\nexit 0\n" },
     {
       bound: "2147483648",

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -242,17 +242,16 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
     fs.chmodSync(fakeTsgo, 0o755);
   }
 
-  function runFakeTsgo(cwd: string, timeoutMs: string) {
+  function runFakeTsgo(cwd: string, timeoutMs: string | undefined) {
+    const { OPENCLAW_TSGO_TIMEOUT_MS: _unset, ...baseEnv } = process.env;
     return spawnSync(
       process.execPath,
       [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
       {
         cwd,
         encoding: "utf8",
-        env: {
-          ...process.env,
-          OPENCLAW_TSGO_TIMEOUT_MS: timeoutMs,
-        },
+        env:
+          timeoutMs === undefined ? baseEnv : { ...baseEnv, OPENCLAW_TSGO_TIMEOUT_MS: timeoutMs },
         // spawnSync blocks this thread, so vitest's own per-test budget can never
         // fire; a regression here would hang the worker instead of failing.
         timeout: 25_000,
@@ -264,14 +263,28 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
   it("kills a wedged tsgo that ignores SIGTERM instead of blocking its caller forever", () => {
     const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
     // Mirrors the observed wedge: the checker refuses SIGTERM and never reports,
-    // so only a process-group SIGKILL frees the caller.
-    writeFakeTsgo(cwd, "#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 1; done\n");
+    // so only a process-group SIGKILL frees the caller. The bounded loop is the
+    // harness backstop: a pre-fix or failing run must not leak this tree.
+    writeFakeTsgo(
+      cwd,
+      "#!/bin/sh\ntrap '' TERM\ni=0\nwhile [ $i -lt 60 ]; do sleep 1; i=$((i+1)); done\n",
+    );
 
     const result = runFakeTsgo(cwd, "2000");
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("killed the tsgo process tree");
     expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
+  }, 30_000);
+
+  it("arms no watchdog until an operator opts in", () => {
+    const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
+    writeFakeTsgo(cwd, "#!/bin/sh\nsleep 2\nexit 0\n");
+
+    const result = runFakeTsgo(cwd, undefined);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("killed the tsgo process tree");
   }, 30_000);
 
   it("leaves a tsgo that finishes inside the watchdog bound alone", () => {

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -242,32 +242,57 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
     fs.chmodSync(fakeTsgo, 0o755);
   }
 
+  // The fake compiler is a grandchild in its own process group, so spawnSync's
+  // killSignal never reaches it. Its recorded pid is the only handle the harness
+  // has to tear the tree down when the outer timeout fires on a pre-fix run.
+  function reapFakeTsgo(cwd: string) {
+    const pidFile = path.join(cwd, "fake-tsgo.pid");
+    if (!fs.existsSync(pidFile)) {
+      return;
+    }
+    const pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+    if (!Number.isInteger(pid) || pid <= 1) {
+      return;
+    }
+    for (const target of [-pid, pid]) {
+      try {
+        process.kill(target, "SIGKILL");
+      } catch {
+        // Already reaped by the watchdog under test.
+      }
+    }
+  }
+
   function runFakeTsgo(cwd: string, timeoutMs: string | undefined) {
     const { OPENCLAW_TSGO_TIMEOUT_MS: _unset, ...baseEnv } = process.env;
-    return spawnSync(
-      process.execPath,
-      [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
-      {
-        cwd,
-        encoding: "utf8",
-        env:
-          timeoutMs === undefined ? baseEnv : { ...baseEnv, OPENCLAW_TSGO_TIMEOUT_MS: timeoutMs },
-        // spawnSync blocks this thread, so vitest's own per-test budget can never
-        // fire; a regression here would hang the worker instead of failing.
-        timeout: 25_000,
-        killSignal: "SIGKILL",
-      },
-    );
+    try {
+      return spawnSync(
+        process.execPath,
+        [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
+        {
+          cwd,
+          encoding: "utf8",
+          env:
+            timeoutMs === undefined ? baseEnv : { ...baseEnv, OPENCLAW_TSGO_TIMEOUT_MS: timeoutMs },
+          // spawnSync blocks this thread, so vitest's own per-test budget can never
+          // fire; a regression here would hang the worker instead of failing.
+          timeout: 25_000,
+          killSignal: "SIGKILL",
+        },
+      );
+    } finally {
+      reapFakeTsgo(cwd);
+    }
   }
 
   it("kills a wedged tsgo that ignores SIGTERM instead of blocking its caller forever", () => {
     const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
     // Mirrors the observed wedge: the checker refuses SIGTERM and never reports,
-    // so only a process-group SIGKILL frees the caller. The bounded loop is the
-    // harness backstop: a pre-fix or failing run must not leak this tree.
+    // so only a process-group SIGKILL frees the caller. It records its pid so the
+    // harness can reap the tree, and self-exits as a last-resort backstop.
     writeFakeTsgo(
       cwd,
-      "#!/bin/sh\ntrap '' TERM\ni=0\nwhile [ $i -lt 60 ]; do sleep 1; i=$((i+1)); done\n",
+      '#!/bin/sh\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\ntrap \'\' TERM\ni=0\nwhile [ $i -lt 60 ]; do sleep 1; i=$((i+1)); done\n',
     );
 
     const result = runFakeTsgo(cwd, "2000");

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -277,7 +277,7 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
     expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
   }, 30_000);
 
-  it("arms no watchdog until an operator opts in", () => {
+  it("leaves a healthy run alone under the default deadline", () => {
     const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
     writeFakeTsgo(cwd, "#!/bin/sh\nsleep 2\nexit 0\n");
 

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -232,3 +232,55 @@ describe("run-tsgo sparse guard", () => {
     });
   });
 });
+
+describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
+  function writeFakeTsgo(cwd: string, body: string) {
+    const binDir = path.join(cwd, "node_modules", ".bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const fakeTsgo = path.join(binDir, "tsgo");
+    fs.writeFileSync(fakeTsgo, body, "utf8");
+    fs.chmodSync(fakeTsgo, 0o755);
+  }
+
+  function runFakeTsgo(cwd: string, timeoutMs: string) {
+    return spawnSync(
+      process.execPath,
+      [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
+      {
+        cwd,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_TSGO_TIMEOUT_MS: timeoutMs,
+        },
+        // spawnSync blocks this thread, so vitest's own per-test budget can never
+        // fire; a regression here would hang the worker instead of failing.
+        timeout: 25_000,
+        killSignal: "SIGKILL",
+      },
+    );
+  }
+
+  it("kills a wedged tsgo that ignores SIGTERM instead of blocking its caller forever", () => {
+    const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
+    // Mirrors the observed wedge: the checker refuses SIGTERM and never reports,
+    // so only a process-group SIGKILL frees the caller.
+    writeFakeTsgo(cwd, "#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 1; done\n");
+
+    const result = runFakeTsgo(cwd, "2000");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("killed the tsgo process tree");
+    expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
+  }, 30_000);
+
+  it("leaves a tsgo that finishes inside the watchdog bound alone", () => {
+    const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
+    writeFakeTsgo(cwd, "#!/bin/sh\nexit 0\n");
+
+    const result = runFakeTsgo(cwd, "30000");
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("killed the tsgo process tree");
+  }, 30_000);
+});

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -1,5 +1,5 @@
 // Run Tsgo tests cover run tsgo script behavior.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import {
   getSparseTsgoGuardError,
   shouldSkipSparseTsgoGuardError,
 } from "../../scripts/lib/tsgo-sparse-guard.mts";
+import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
@@ -322,20 +323,60 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
       '#!/bin/sh\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\ntrap \'\' TERM\ni=0\nwhile [ $i -lt 60 ]; do sleep 1; i=$((i+1)); done\n',
     );
 
-    const pidBeforeReap = { value: undefined as number | undefined };
-    const result = runFakeTsgo(cwd, "2000", (running) => {
-      pidBeforeReap.value = running;
+    const observedBeforeReap = {
+      error: undefined as unknown,
+      pid: undefined as number | undefined,
+    };
+    const result = runFakeTsgo(cwd, "2000", (pid) => {
+      observedBeforeReap.pid = pid;
+      if (pid === undefined) {
+        return;
+      }
+      try {
+        process.kill(pid, 0);
+      } catch (error) {
+        observedBeforeReap.error = error;
+      }
     });
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("killed the tsgo process tree");
     // Printing the message is not the contract; the tree actually being gone is.
-    expect(pidBeforeReap.value).toBeDefined();
-    expect(() => process.kill(pidBeforeReap.value as number, 0)).toThrow(
-      expect.objectContaining({ code: "ESRCH" }),
-    );
+    expect(observedBeforeReap.pid).toBeDefined();
+    expect(observedBeforeReap.error).toMatchObject({ code: "ESRCH" });
     expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
   }, 30_000);
+
+  it("lets the inner supervisor reap a wedged compiler before the wrapper exits on SIGTERM", async () => {
+    const cwd = createTempDir("openclaw-run-tsgo-signal-");
+    const pidFile = path.join(cwd, "fake-tsgo.pid");
+    fs.writeFileSync(path.join(cwd, "tsconfig.extensions.json"), "{}\n");
+    writeFakeTsgo(
+      cwd,
+      '#!/bin/sh\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\ntrap \'\' TERM HUP INT\nwhile true; do sleep 1; done\n',
+    );
+    const wrapper = spawn(
+      process.execPath,
+      [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
+      { cwd, stdio: "ignore" },
+    );
+
+    try {
+      const compilerPid = await waitForPidFile(pidFile, 10_000);
+      wrapper.kill("SIGTERM");
+
+      await expect(waitForChildClose(wrapper, 15_000)).resolves.toEqual({
+        code: 143,
+        signal: null,
+      });
+      await expect(waitForDead(compilerPid, 2_000)).resolves.toBeUndefined();
+    } finally {
+      if (wrapper.exitCode === null && wrapper.signalCode === null) {
+        wrapper.kill("SIGKILL");
+      }
+      reapFakeTsgo(cwd);
+    }
+  }, 20_000);
 
   // Every bound that must leave a completing compiler alone. The ceiling case is the
   // regression that matters: without saturation Node collapses the delay to 1ms and

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -245,13 +245,18 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
   // The fake compiler is a grandchild in its own process group, so spawnSync's
   // killSignal never reaches it. Its recorded pid is the only handle the harness
   // has to tear the tree down when the outer timeout fires on a pre-fix run.
-  function reapFakeTsgo(cwd: string) {
+  function readFakeTsgoPid(cwd: string) {
     const pidFile = path.join(cwd, "fake-tsgo.pid");
     if (!fs.existsSync(pidFile)) {
-      return;
+      return undefined;
     }
     const pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
-    if (!Number.isInteger(pid) || pid <= 1) {
+    return Number.isInteger(pid) && pid > 1 ? pid : undefined;
+  }
+
+  function reapFakeTsgo(cwd: string) {
+    const pid = readFakeTsgoPid(cwd);
+    if (pid === undefined) {
       return;
     }
     for (const target of [-pid, pid]) {
@@ -263,7 +268,11 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
     }
   }
 
-  function runFakeTsgo(cwd: string, timeoutMs: string | undefined) {
+  function runFakeTsgo(
+    cwd: string,
+    timeoutMs: string | undefined,
+    onBeforeReap?: (pid: number | undefined) => void,
+  ) {
     const { OPENCLAW_TSGO_TIMEOUT_MS: _unset, ...baseEnv } = process.env;
     try {
       return spawnSync(
@@ -281,9 +290,27 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
         },
       );
     } finally {
+      onBeforeReap?.(readFakeTsgoPid(cwd));
       reapFakeTsgo(cwd);
     }
   }
+
+  it.each([{ bound: "0" }, { bound: "abc" }])(
+    "explains a rejected OPENCLAW_TSGO_TIMEOUT_MS of $bound instead of crashing",
+    ({ bound }) => {
+      const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
+      writeFakeTsgo(cwd, "#!/bin/sh\nexit 0\n");
+
+      const result = runFakeTsgo(cwd, bound);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("must be plain decimal digits");
+      expect(result.stderr).toContain("cannot be disabled");
+      expect(result.stderr).not.toContain("at readPositiveEnvInt");
+      expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
+    },
+    30_000,
+  );
 
   it("kills a wedged tsgo that ignores SIGTERM instead of blocking its caller forever", () => {
     const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
@@ -295,40 +322,43 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
       '#!/bin/sh\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\ntrap \'\' TERM\ni=0\nwhile [ $i -lt 60 ]; do sleep 1; i=$((i+1)); done\n',
     );
 
-    const result = runFakeTsgo(cwd, "2000");
+    const pidBeforeReap = { value: undefined as number | undefined };
+    const result = runFakeTsgo(cwd, "2000", (running) => {
+      pidBeforeReap.value = running;
+    });
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("killed the tsgo process tree");
+    // Printing the message is not the contract; the tree actually being gone is.
+    expect(pidBeforeReap.value).toBeDefined();
+    expect(() => process.kill(pidBeforeReap.value as number, 0)).toThrow(
+      expect.objectContaining({ code: "ESRCH" }),
+    );
     expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
   }, 30_000);
 
-  it("leaves a healthy run alone under the default deadline", () => {
-    const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
-    writeFakeTsgo(cwd, "#!/bin/sh\nsleep 2\nexit 0\n");
+  // Every bound that must leave a completing compiler alone. The ceiling case is the
+  // regression that matters: without saturation Node collapses the delay to 1ms and
+  // would kill this sleeping child immediately.
+  it.each([
+    { bound: undefined, name: "the default deadline", body: "#!/bin/sh\nsleep 2\nexit 0\n" },
+    { bound: "30000", name: "an explicit bound", body: "#!/bin/sh\nexit 0\n" },
+    {
+      bound: "2147483648",
+      name: "an override past Node's timer ceiling",
+      body: "#!/bin/sh\nsleep 1\nexit 0\n",
+    },
+  ])(
+    "leaves a completing tsgo alone under $name",
+    ({ bound, body }) => {
+      const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
+      writeFakeTsgo(cwd, body);
 
-    const result = runFakeTsgo(cwd, undefined);
+      const result = runFakeTsgo(cwd, bound);
 
-    expect(result.status).toBe(0);
-    expect(result.stderr).not.toContain("killed the tsgo process tree");
-  }, 30_000);
-
-  it("leaves a tsgo that finishes inside the watchdog bound alone", () => {
-    const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
-    writeFakeTsgo(cwd, "#!/bin/sh\nexit 0\n");
-
-    const result = runFakeTsgo(cwd, "30000");
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).not.toContain("killed the tsgo process tree");
-  }, 30_000);
-
-  it("saturates an override past Node's timer ceiling instead of arming a 1ms watchdog", () => {
-    const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
-    writeFakeTsgo(cwd, "#!/bin/sh\nsleep 1\nexit 0\n");
-
-    const result = runFakeTsgo(cwd, "2147483648");
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).not.toContain("killed the tsgo process tree");
-  }, 30_000);
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain("killed the tsgo process tree");
+    },
+    30_000,
+  );
 });

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -283,4 +283,14 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).not.toContain("killed the tsgo process tree");
   }, 30_000);
+
+  it("saturates an override past Node's timer ceiling instead of arming a 1ms watchdog", () => {
+    const cwd = createTempDir("openclaw-run-tsgo-watchdog-");
+    writeFakeTsgo(cwd, "#!/bin/sh\nsleep 1\nexit 0\n");
+
+    const result = runFakeTsgo(cwd, "2147483648");
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("killed the tsgo process tree");
+  }, 30_000);
 });


### PR DESCRIPTION
The `tsgo` wrapper could leave a wedged compiler process tree behind when the
wrapper received a signal, and operators had no bounded opt-in execution path.
This PR routes `tsgo` through the existing managed-process owner, adds an
optional `OPENCLAW_TSGO_TIMEOUT_MS` watchdog, and keeps the wrapper alive until
signal cleanup finishes. Existing invocations remain unbounded when the
variable is unset; when a deadline is configured, expiry fails visibly only
after the compiler process tree is gone.

Layer 1 of 3. Base: `main`. #123976 depends on this PR.

## Change breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Process supervision | 3 | +56 | -22 |
| Tests and fixtures | 1 | +179 | -1 |
| Documentation | 1 | +11 | -0 |
| **Total** | **5** | **+246** | **-23** |

## Proof

Same TERM-ignoring fake compiler in both runs:

**Before: direct base**

```text
completion: none after a 120s outer cap
compiler: still alive after SIGTERM
side effect: orphaned compiler process remained
```

**After: PR with `OPENCLAW_TSGO_TIMEOUT_MS=2000`**

```text
watchdog: fired after 2000ms
exit: 1
compiler process group alive: false
last stderr: [tsgo] FAILED (exit 1)
```

A four-run SIGTERM stress check also left 0 of 4 compiler process groups alive
after wrapper exit.

## How to verify

```bash
node scripts/run-vitest.mjs run test/scripts/run-tsgo.test.ts --reporter=verbose
```

Exact head `7d13625ec6c14d3684e6187f0be9b3bf435ccf42`: 20/20 tests passed.

## Implementation notes

The watchdog is deliberately opt-in to preserve the existing unlimited default.
Set `OPENCLAW_TSGO_TIMEOUT_MS` to a positive millisecond value to bound a run;
invalid values fail with an actionable message, and unsetting the variable
disables the watchdog.
