### PR TITLE
test(cli): remove duplicate daemon build-id assertions

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -491,54 +491,6 @@ describe("gatherDaemonStatus", () => {
     expect(inspectWindowsGatewayFirewall).not.toHaveBeenCalled();
   });
 
-  it("preserves probe build identity in deep JSON output", async () => {
-    const status = await gatherStatus({ deep: true });
-    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
-    try {
-      printDaemonStatus(status, { json: true, deep: true });
-      expect(writeJson).toHaveBeenCalledOnce();
-      expect(writeJson.mock.calls[0]?.[0]).toMatchObject({
-        rpc: {
-          server: {
-            version: "2026.5.6",
-            buildId: "build-2026.5.6",
-            connId: "conn-1",
-          },
-        },
-      });
-    } finally {
-      writeJson.mockRestore();
-    }
-  });
-
-  it("keeps deep JSON compatible when the Gateway omits build identity", async () => {
-    callGatewayStatusProbe.mockResolvedValueOnce({
-      ok: true,
-      url: "ws://127.0.0.1:19001",
-      error: null,
-      server: { version: "2026.5.6", connId: "conn-1" },
-    });
-
-    const status = await gatherStatus({ deep: true });
-    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
-    try {
-      printDaemonStatus(status, { json: true, deep: true });
-      expect(writeJson).toHaveBeenCalledOnce();
-      const serialized = JSON.stringify(writeJson.mock.calls[0]?.[0]);
-      if (!serialized) {
-        throw new Error("expected terminal JSON output");
-      }
-      const parsed = JSON.parse(serialized) as {
-        rpc?: { server?: Record<string, unknown> };
-      };
-      const server = parsed.rpc?.server;
-      expect(server).toEqual({ version: "2026.5.6", connId: "conn-1" });
-      expect(server).not.toHaveProperty("buildId");
-    } finally {
-      writeJson.mockRestore();
-    }
-  });
-
   it("batches daemon and CLI port status inspection when ports differ", async () => {
     await gatherStatus();
 

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -10,6 +10,7 @@ import { printDaemonStatus } from "./status.print.js";
 const runtime = vi.hoisted(() => ({
   log: vi.fn<(line: string) => void>(),
   error: vi.fn<(line: string) => void>(),
+  writeJson: vi.fn<(value: unknown) => void>(),
 }));
 const resolveControlUiLinksMock = vi.hoisted(() =>
   vi.fn((_opts?: unknown) => ({ httpUrl: "http://127.0.0.1:18789" })),
@@ -100,11 +101,41 @@ describe("printDaemonStatus", () => {
   beforeEach(() => {
     runtime.log.mockReset();
     runtime.error.mockReset();
+    runtime.writeJson.mockReset();
     renderGatewayServiceCleanupHintsMock.mockReset().mockReturnValue([]);
     resolveControlUiLinksMock.mockClear();
     isSystemdUnavailableDetailMock.mockReset().mockReturnValue(false);
     renderSystemdUnavailableHintsMock.mockReset().mockReturnValue([]);
     isWSLEnvMock.mockClear();
+  });
+
+  it("preserves Gateway server metadata while sanitizing JSON output", () => {
+    const servers = [
+      { version: "2026.5.6", buildId: "build-2026.5.6", connId: "conn-1" },
+      { version: "2026.5.6", connId: "conn-1" },
+    ];
+    for (const server of servers) {
+      printDaemonStatus(
+        {
+          service: {
+            label: "LaunchAgent",
+            loaded: true,
+            loadedText: "loaded",
+            notLoadedText: "not loaded",
+            command: { programArguments: ["node"], environment: { OPENCLAW_STATE_DIR: "/tmp" } },
+          },
+          rpc: { ok: true, server },
+          extraServices: [],
+        },
+        { json: true, deep: true },
+      );
+    }
+
+    expect(
+      runtime.writeJson.mock.calls.map(
+        ([payload]) => (payload as { rpc?: { server?: unknown } }).rpc?.server,
+      ),
+    ).toEqual(servers);
   });
 
   it("prints host desktop state and auth type", () => {


### PR DESCRIPTION
## What Problem This Solves

The daemon status suite re-tested build-ID presence and absence by passing a gathered object through shallow object spreads and generic JSON serialization. Those assertions duplicated stronger producer coverage and lived outside the JSON renderer that owns sanitization.

## Why This Change Was Made

The two gather-level deep-JSON cases are removed. One compact output-owner test now sends advertised and legacy server metadata through `printDaemonStatus` while forcing its sanitization clone, preserving the independently meaningful JSON boundary without replaying status gathering.

Gateway probe tests still own build-ID presence and absence, the existing gather test asserts the complete positive `rpc.server` object, gateway-status output verifies its own serialized server projection, and daemon JSON emission now has focused coverage in `status.print.test.ts`.

## User Impact

No behavior change. Gateway and daemon status JSON continue to include build identity when advertised and omit it for legacy Gateways.

AI-assisted: yes.

## Evidence

- `src/gateway/probe.test.ts` — 33 tests passed.
- `src/cli/daemon-cli/status.gather.test.ts` and `status.print.test.ts` — 76 tests passed, 1 skipped.
- `src/commands/gateway-status/output.test.ts` — 9 tests passed.
- `node scripts/check-changed.mjs -- src/cli/daemon-cli/status.gather.test.ts src/cli/daemon-cli/status.print.test.ts` — coreTests gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready.
- `git diff --check` passed.
- Fresh structured autoreview after the owner-boundary revision reported no accepted/actionable findings.
- ClawSweeper's P2 finding to retain a daemon JSON renderer boundary was accepted and addressed in `status.print.test.ts`.
- Production delta: 0. Tests: -17 lines.
