### PR TITLE
fix(gateway,ui): discard prepared attachment media on pre-persist exits and release catalog-open payloads

### DIFF
--- a/src/gateway/server-methods/chat-send-attachments.ts
+++ b/src/gateway/server-methods/chat-send-attachments.ts
@@ -61,6 +61,13 @@ function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolea
   return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
 }
 
+// Prepared inbound media has no transcript reference until the user turn
+// persists; abort/routing exits before that point must delete it here or the
+// files are orphaned forever (the inbound sweep is off unless attachments.ttlHours is set).
+export async function discardPreparedChatSendAttachments(refs: OffloadedRef[]): Promise<void> {
+  await Promise.allSettled(refs.map((ref) => deleteMediaBuffer(ref.id, "inbound")));
+}
+
 // Stage media before ACK so permanent client errors stay 4xx and retryable
 // staging failures stay 5xx. Managed PDFs retain their host-readable fallback.
 async function prestageMediaPathOffloads(params: {

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -6,7 +6,10 @@ import { emitDiagnosticsTimelineEvent } from "../../infra/diagnostics-timeline.j
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
 import { startChatDispatch } from "./chat-send-agent-dispatch.js";
-import { prepareChatSendAttachments } from "./chat-send-attachments.js";
+import {
+  discardPreparedChatSendAttachments,
+  prepareChatSendAttachments,
+} from "./chat-send-attachments.js";
 import { handleChatSendSetupError } from "./chat-send-dispatch-errors.js";
 import type { ChatSendExternalAuthorityAdmission } from "./chat-send-external-authority-contract.js";
 import {
@@ -71,12 +74,14 @@ async function handleChatSendWithOptions(
     return;
   }
   if (activeRunAbort.controller.signal.aborted) {
+    void discardPreparedChatSendAttachments(preparedAttachments.value.offloadedRefs);
     finishAbortedChatSend();
     return;
   }
   // Attachment preparation can suspend. Recheck immediately before the
   // synchronous ACK path so aborts and hot routing reloads cannot cross it.
   if (sessionRoutingChanged(context.getRuntimeConfig())) {
+    void discardPreparedChatSendAttachments(preparedAttachments.value.offloadedRefs);
     admitted.value.rejectSessionRoutingChanged();
     return;
   }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -30,6 +30,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/diagnostic-events.js";
 import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
+import { getMediaDir } from "../media/store.js";
 import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { rebasePluginMetadataSnapshotManifestRegistry } from "../plugins/plugin-metadata-snapshot.js";
@@ -2043,6 +2044,8 @@ describe("gateway server chat", () => {
       });
       dispatchInboundMessageMock.mockImplementation(async () => dispatchRelease.promise);
 
+      const inboundDir = path.join(getMediaDir(), "inbound");
+      const inboundBaseline = new Set(await fs.readdir(inboundDir).catch(() => []));
       const pngB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
       const params = makeChatSendParams({
@@ -2137,6 +2140,8 @@ describe("gateway server chat", () => {
         getRuntimeConfig: () => ({}),
       });
 
+      const inboundDir = path.join(getMediaDir(), "inbound");
+      const inboundBaseline = new Set(await fs.readdir(inboundDir).catch(() => []));
       const pngB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
       const params = makeChatSendParams({
@@ -2148,6 +2153,14 @@ describe("gateway server chat", () => {
             mimeType: "image/png",
             fileName: "dot.png",
             content: pngB64,
+          },
+          {
+            // Non-image attachments always offload into the inbound media
+            // store during preparation; the aborted send must discard them.
+            type: "file",
+            mimeType: "text/plain",
+            fileName: "notes.txt",
+            content: Buffer.from("offloaded inbound media").toString("base64"),
           },
         ],
       });
@@ -2246,6 +2259,13 @@ describe("gateway server chat", () => {
       expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
       expect(context.addChatRun).not.toHaveBeenCalled();
       expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      // Prepared inbound media has no transcript reference on this exit; the
+      // handler must discard it or the file is orphaned forever (the inbound
+      // sweep is disabled unless attachments.ttlHours is set).
+      await waitForFast(async () => {
+        const remaining = await fs.readdir(inboundDir).catch(() => []);
+        expect(remaining.filter((name) => !inboundBaseline.has(name))).toEqual([]);
+      }, FAST_WAIT_OPTS);
     } finally {
       firstCatalogSnapshot.resolve(createChatVisionModelCatalogSnapshot());
       resetDirectChatSession();

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2044,8 +2044,6 @@ describe("gateway server chat", () => {
       });
       dispatchInboundMessageMock.mockImplementation(async () => dispatchRelease.promise);
 
-      const inboundDir = path.join(getMediaDir(), "inbound");
-      const inboundBaseline = new Set(await fs.readdir(inboundDir).catch(() => []));
       const pngB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
       const params = makeChatSendParams({

--- a/ui/src/pages/chat/chat-pane-session.catalog-attachments.test.ts
+++ b/ui/src/pages/chat/chat-pane-session.catalog-attachments.test.ts
@@ -1,0 +1,36 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import {
+  getChatAttachmentDataUrl,
+  registerChatAttachmentPayload,
+} from "./attachment-payload-store.ts";
+import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
+
+describe("catalog session open", () => {
+  it("releases staged attachment payloads instead of stranding them for the tab", () => {
+    const { pane, state } = createTestChatPane({
+      client: { request: () => new Promise(() => {}) } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const attachment = registerChatAttachmentPayload({
+      attachment: { id: "catalog-staged", mimeType: "image/png" },
+      dataUrl: "data:image/png;base64,c3RhZ2Vk",
+      file: new File(["staged"], "staged.png", { type: "image/png" }),
+    });
+    state.chatAttachments = [attachment];
+
+    (
+      pane as TestChatPane & {
+        openCatalogSession: (key: unknown, state: unknown) => void;
+      }
+    ).openCatalogSession({ catalogId: "cat-1", hostId: "host-1", threadId: "thread-1" }, state);
+
+    expect(state.chatAttachments).toEqual([]);
+    // The payload-store entry must be gone: a retained entry keeps the File
+    // and its object URL resident for the whole tab lifetime.
+    expect(getChatAttachmentDataUrl(attachment)).toBeNull();
+  });
+});

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -22,6 +22,7 @@ import {
 } from "../../lib/sessions/catalog-key.ts";
 import { resolveSessionKey, scopedAgentParamsForSession } from "../../lib/sessions/index.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
+import { releaseChatAttachmentPayloads } from "./attachment-payload-store.ts";
 import { catalogMessageId } from "./catalog-message-id.ts";
 import { loadChatBranches } from "./chat-history.ts";
 import {
@@ -286,6 +287,9 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
     this.catalogCursor = undefined;
     this.catalogSession = null;
     this.catalogHost = null;
+    // Payload-store entries and their object URLs are reclaimed only by
+    // explicit release; clearing the array alone strands them for the tab.
+    releaseChatAttachmentPayloads(state.chatAttachments);
     state.chatAttachments = [];
     state.chatLoading = true;
     state.requestUpdate();


### PR DESCRIPTION
## What Problem This Solves

Two attachment-lifecycle leaks found by the round-4 attachments/media investigation lane. Both share one shape: an owner dropped its reference to a resource without reclaiming it.

1. **Gateway inbound-media orphans on abort/routing-change.** `chat.send` stages inbound media into `~/.openclaw/media/inbound/` during attachment preparation. The two exits between preparation success and user-turn persistence — active-run abort (`finishAbortedChatSend`) and hot session-routing change (`rejectSessionRoutingChanged`) — returned without deleting the staged files. Nothing ever references them afterward (the transcript entry that would carry the `media://inbound/<id>` URI never persists), and the inbound sweep (`cleanOldMedia`) is disabled unless `attachments.ttlHours` is set, so on default installs every aborted send with an offloaded attachment leaks its files permanently. The error exits already clean up; these two success-then-bail exits did not.
2. **UI catalog-open payload strand.** Opening a terminal-catalog session cleared `state.chatAttachments = []` without `releaseChatAttachmentPayloads`, stranding payload-store `File` entries and their object URLs for the tab lifetime. Every sibling discard path (pane handoff, queue removal) releases first.

## Why This Change Was Made

Repair leaked state at its producer: the chat-send handler owns the prepared-attachments lifetime until the turn persists, so the two pre-persist exits now discard through a small `discardPreparedChatSendAttachments` helper using the same `deleteMediaBuffer` path the preparation error exits already use. The UI fix adds the one missing release call before the array clear, matching the established pattern.

## User Impact

Aborting a send that carried attachments (or racing a config routing change) no longer permanently leaks files into the media directory on default installs. Opening a catalog session with staged attachments no longer pins their memory and blob URLs for the rest of the tab.

## Evidence

- Extended the existing `chat.abort cancels chat.send during attachment preparation before ACK` e2e test with an offloaded non-image attachment and an inbound-directory baseline assertion: fails pre-fix (2 orphaned files remain), passes post-fix. Full `server.chat.gateway-server-chat-b.test.ts` suite green (100 tests).
- New `chat-pane-session.catalog-attachments.test.ts` proves the payload-store entry is released on catalog open: fails pre-fix (dataUrl still resolvable), passes post-fix.
- `src/gateway/chat-attachments.test.ts` green; `pnpm tsgo`, `pnpm tsgo:ui`, `pnpm check:test-types` clean; oxlint/oxfmt clean.
- Autoreview (Codex, high): clean, no accepted findings, "patch is correct (0.95)".
- Production LOC: +14 −1 (helper with invariant comment + two discard calls + one release call). Justified: closes a permanent disk leak at its lifecycle owner; the alternative — enabling the sweep by default — changes a shipped retention contract.
