### PR TITLE
feat(sessions): preserve recent session history during maintenance

### DIFF
--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -185,6 +185,7 @@ shown:
       mode: "enforce", // "enforce" applies cleanup; "warn" only reports
       pruneAfter: "30d",
       maxEntries: 500,
+      preserveRecent: "7d", // optional; false or omitted disables
     },
   },
 }
@@ -215,6 +216,18 @@ ACP, and sub-agent sessions do not inherit this 24h retention.
 Maintenance preserves durable external conversation pointers, including group
 sessions and thread-scoped chat sessions, while still allowing synthetic cron,
 hook, heartbeat, ACP, and sub-agent entries to age out.
+
+Shared or high-volume installations can set `preserveRecent` to protect
+recently active interactive sessions and every SQLite history generation owned
+by those sessions. The option is disabled when omitted or set to `false`, so
+personal installations keep the normal oldest-first policy. Synthetic
+model-run, cron, hook, heartbeat, ACP, and sub-agent sessions remain eligible
+for bounded cleanup. Protection can temporarily keep the store above its entry
+or disk target; it expires after the configured inactivity window.
+
+Recent-session protection does not archive sessions or change managed-worktree
+garbage collection. Archiving remains an explicit user action for sessions that
+should stay on the permanent shelf.
 
 Archived and pinned sessions are user-protected and exempt from every automatic
 maintenance path, including age pruning, entry caps, model-run cleanup, and

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1221,6 +1221,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
       mode: "enforce", // enforce (default) | warn
       pruneAfter: "30d",
       maxEntries: 500,
+      preserveRecent: "7d", // optional duration or false
       resetArchiveRetention: "30d", // duration or false
       maxDiskBytes: "500mb", // optional hard budget
       highWaterBytes: "400mb", // optional cleanup target
@@ -1264,6 +1265,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
   - `mode`: `enforce` applies cleanup and is the default; `warn` emits warnings only.
   - `pruneAfter`: age cutoff for stale entries (default `30d`).
   - `maxEntries`: maximum total number of live SQLite session entries (default `500`). Every row counts toward the cap, but archived or pinned sessions, active or admitted work, model-locked sessions, and durable external conversation pointers are never automatic eviction targets. Cleanup removes the oldest unprotected rows; if protection prevents reaching the cap, the store remains above it. Runtime writes batch cleanup with a small high-water buffer for production-sized caps; `openclaw sessions cleanup --enforce` applies the cap immediately but does not unprotect rows. Unarchive, unpin, wait for active work to finish, or explicitly delete protected sessions to reduce the total.
+  - `preserveRecent`: optional inactivity window that protects recently active interactive sessions and all of their SQLite history generations from automatic age, count, and disk-budget history eviction (for example `"7d"`). Unset or `false` disables this protection. Synthetic model-run, cron, hook, heartbeat, ACP, and sub-agent sessions remain eligible for bounded cleanup. Protection can temporarily keep the store above configured entry or disk targets and does not archive sessions.
   - Short-lived gateway model-run probe sessions use fixed `24h` retention, but cleanup is pressure-gated: it only removes stale strict model-run probe rows when session-entry maintenance/cap pressure is reached. Only strict explicit probe keys matching `agent:*:explicit:model-run-<uuid>` are eligible; normal direct, group, thread, cron, hook, heartbeat, ACP, and sub-agent sessions do not inherit this 24h retention. When model-run cleanup runs, it runs before the broader `pruneAfter` stale-entry cleanup and `maxEntries` cap.
   - Legacy `rotateBytes` is rejected by the current schema; `openclaw doctor --fix` removes it from older configs.
   - `resetArchiveRetention`: age-based retention for reset/deleted transcript archives. By default, archives remain until disk-budget eviction; set a duration to opt into wall-clock deletion, or `false` to disable it explicitly.

--- a/src/config/schema.help.automation.ts
+++ b/src/config/schema.help.automation.ts
@@ -78,6 +78,8 @@ export const AUTOMATION_FIELD_HELP: Record<string, string> = {
     "Removes entries older than this duration (for example `30d` or `12h`) during maintenance passes. Use this as the primary age-retention control and align it with data retention policy.",
   "session.maintenance.maxEntries":
     "Caps total session entry count retained in the store to prevent unbounded growth over time. Protected entries count toward the limit but are never automatically removed, so the store can remain above the cap when protection alone exceeds it. Use lower limits for constrained environments, or higher limits when longer history is required.",
+  "session.maintenance.preserveRecent":
+    "Protects interactive sessions active within this duration (for example `7d`) from automatic age, count, and disk-budget history eviction. Unset or `false` keeps the normal oldest-first policy. Synthetic model-run, cron, hook, heartbeat, ACP, and sub-agent rows remain eligible for bounded cleanup.",
   "session.maintenance.resetArchiveRetention":
     "Age-based retention for archived transcripts (`*.reset.<timestamp>` and `*.deleted.<timestamp>`). Defaults to keeping archives until the disk budget evicts them oldest-first; set a duration (for example `30d`) to opt into wall-clock deletion, or `false` to disable it explicitly.",
   "session.maintenance.maxDiskBytes":

--- a/src/config/schema.help.quality.test-fixtures.ts
+++ b/src/config/schema.help.quality.test-fixtures.ts
@@ -112,6 +112,7 @@ export const TARGET_KEYS = [
   "session.maintenance.mode",
   "session.maintenance.pruneAfter",
   "session.maintenance.maxEntries",
+  "session.maintenance.preserveRecent",
   "session.maintenance.resetArchiveRetention",
   "session.maintenance.maxDiskBytes",
   "session.maintenance.highWaterBytes",

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -244,6 +244,7 @@ describe("config help copy quality", () => {
       name: "documents session maintenance duration/size examples and deprecations",
       fields: [
         ["session.maintenance.pruneAfter", ["30d", "12h"]],
+        ["session.maintenance.preserveRecent", ["7d", /false/i]],
         ["session.maintenance.resetArchiveRetention", [".reset.", /false/i]],
         ["session.maintenance.maxDiskBytes", ["500mb"]],
         ["session.maintenance.highWaterBytes", ["80%"]],

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -753,6 +753,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.maintenance.mode": "Session Maintenance Mode",
   "session.maintenance.pruneAfter": "Session Prune After",
   "session.maintenance.maxEntries": "Session Max Entries",
+  "session.maintenance.preserveRecent": "Preserve Recent Sessions",
   "session.maintenance.resetArchiveRetention": "Session Reset Archive Retention",
   "session.maintenance.maxDiskBytes": "Session Max Disk Budget",
   "session.maintenance.highWaterBytes": "Session Disk High-water Target",

--- a/src/config/schema.tiers.ts
+++ b/src/config/schema.tiers.ts
@@ -166,7 +166,10 @@ wizard.accessMode wizard.appRecommendations
   .trim()
   .split(/\s+/);
 
-const ADVANCED_TUNING_PATHS = new Set(["agents.defaults.heartbeat.every"]);
+const ADVANCED_TUNING_PATHS = new Set([
+  "agents.defaults.heartbeat.every",
+  "session.maintenance.preserveRecent",
+]);
 const CHANNEL_KERNEL_TIER_PREFIXES = ["channels.defaults", "channels.modelByChannel"] as const;
 
 function isPluginOwnedChannelTierPath(path: string): boolean {

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -414,6 +414,7 @@ async function previewStoreCleanup(params: {
     ? pruneStaleModelRunEntries(previewStore, params.maintenance.modelRunPruneAfterMs, {
         log: false,
         preserveKeys: preserveSessionKeys,
+        preserveRecentMs: params.maintenance.preserveRecentMs,
         onPruned: ({ key }) => {
           modelRunPrunedKeys.add(key);
         },
@@ -422,6 +423,7 @@ async function previewStoreCleanup(params: {
   const pruned = pruneStaleEntries(previewStore, params.maintenance.pruneAfterMs, {
     log: false,
     preserveKeys: preserveSessionKeys,
+    preserveRecentMs: params.maintenance.preserveRecentMs,
     onPruned: ({ key }) => {
       staleKeys.add(key);
     },
@@ -429,6 +431,7 @@ async function previewStoreCleanup(params: {
   const capped = capEntryCount(previewStore, params.maintenance.maxEntries, {
     log: false,
     preserveKeys: preserveSessionKeys,
+    preserveRecentMs: params.maintenance.preserveRecentMs,
     onCapped: ({ key }) => {
       cappedKeys.add(key);
     },

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -29,6 +29,7 @@ import type { SessionEntry } from "./types.js";
 type SessionDiskBudgetConfig = {
   maxDiskBytes: number | null;
   highWaterBytes: number | null;
+  preserveRecentMs?: number | null;
 };
 
 export type SessionDiskBudgetSweepResult = {
@@ -846,7 +847,14 @@ export async function enforceSessionDiskBudget(params: {
       if (!entry) {
         continue;
       }
-      if (shouldPreserveMaintenanceEntry({ key, entry, preserveKeys: params.preserveKeys })) {
+      if (
+        shouldPreserveMaintenanceEntry({
+          key,
+          entry,
+          preserveKeys: params.preserveKeys,
+          preserveRecentMs: params.maintenance.preserveRecentMs,
+        })
+      ) {
         continue;
       }
       const previousProjectedBytes = projectedStoreBytes;

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1656,13 +1656,14 @@ describe("sqlite session normalization", () => {
     ).toEqual(["agent:main:newer", "agent:main:newest"]);
   });
 
-  it("counts protected SQLite rows while preserving them during write-triggered capping", async () => {
+  it("preserves recent SQLite entries and transcripts during write-triggered capping", async () => {
     vi.mocked(getRuntimeConfig).mockReturnValue({
       session: {
         maintenance: {
           mode: "enforce",
           pruneAfter: "365d",
           maxEntries: 2,
+          preserveRecent: "7d",
         },
       },
     });
@@ -1732,7 +1733,12 @@ describe("sqlite session normalization", () => {
         env,
         storePath: paths.sqlitePath,
       }).map((summary) => summary.sessionKey),
-    ).toEqual(["agent:main:archived-1", "agent:main:maintenance-trigger"]);
+    ).toEqual([
+      "agent:main:archived-1",
+      "agent:main:maintenance-trigger",
+      "agent:main:recent-dashboard-1",
+      "agent:main:recent-dashboard-2",
+    ]);
     await expect(
       loadTranscriptEvents({
         agentId: "main",
@@ -1740,7 +1746,7 @@ describe("sqlite session normalization", () => {
         sessionId: recentSessionId,
         storePath: paths.sqlitePath,
       }),
-    ).resolves.toEqual([]);
+    ).resolves.toEqual([recentTranscriptEvent]);
   });
 
   it("preserves pinned SQLite entries and transcripts during write-triggered capping", async () => {

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -69,6 +69,7 @@ function hasStaleSqliteSessionEntryCandidate(
   database: OpenClawAgentDatabase,
   pruneAfterMs: number,
   preserveKeys: ReadonlySet<string> | undefined,
+  preserveRecentMs: number | null,
 ): boolean {
   const cutoffMs = Date.now() - pruneAfterMs;
   const db = getSessionKysely(database.db);
@@ -90,6 +91,7 @@ function hasStaleSqliteSessionEntryCandidate(
       key: normalizeStoreSessionKey(row.session_key),
       entry,
       preserveKeys,
+      preserveRecentMs,
     });
   });
 }
@@ -139,6 +141,7 @@ export function applySessionEntryMaintenance(
     database,
     maintenance.pruneAfterMs,
     preserveCandidateKeys,
+    maintenance.preserveRecentMs ?? null,
   );
   const shouldMaintainStore =
     params.forceMaintenance === true ||
@@ -187,6 +190,7 @@ export function applySessionEntryMaintenance(
       log: false,
       onPruned: rememberRemovedEntry,
       preserveKeys,
+      preserveRecentMs: maintenance.preserveRecentMs,
     });
   }
   if (
@@ -198,6 +202,7 @@ export function applySessionEntryMaintenance(
       log: false,
       onPruned: rememberRemovedEntry,
       preserveKeys,
+      preserveRecentMs: maintenance.preserveRecentMs,
     });
   }
   if (
@@ -211,6 +216,7 @@ export function applySessionEntryMaintenance(
       log: false,
       onCapped: rememberRemovedEntry,
       preserveKeys,
+      preserveRecentMs: maintenance.preserveRecentMs,
     });
   }
   for (const sessionId of readSessionGenerationIdsForKeys(database, removedKeys)) {

--- a/src/config/sessions/session-history-eviction.test.ts
+++ b/src/config/sessions/session-history-eviction.test.ts
@@ -301,6 +301,49 @@ describe("SQLite historical session disk budget", () => {
     }
   });
 
+  it("preserves every generation of a recently active session under physical pressure", async () => {
+    const now = Date.now();
+    const dayMs = 24 * 60 * 60 * 1000;
+    const recentKey = "agent:main:recent-history";
+    const staleKey = "agent:main:stale-history";
+    await createHistoricalTranscript({
+      content: "recent history " + "r".repeat(64 * 1024),
+      nextSessionId: "recent-live",
+      sessionId: "recent-old",
+      sessionKey: recentKey,
+      updatedAt: now - 8 * dayMs,
+    });
+    await replaceSessionEntry(
+      { sessionKey: recentKey, storePath },
+      { sessionId: "recent-live", updatedAt: now },
+    );
+    await createHistoricalTranscript({
+      content: "stale history " + "s".repeat(64 * 1024),
+      nextSessionId: "stale-live",
+      sessionId: "stale-old",
+      sessionKey: staleKey,
+      updatedAt: now - 8 * dayMs,
+    });
+    settlePhysicalUsage();
+    const before = await measureSessionPhysicalDiskUsage(storePath);
+
+    const result = await enforceSqliteSessionHistoryDiskBudget({
+      storePath,
+      mode: "enforce",
+      maintenance: {
+        maxDiskBytes: before.totalBytes - 1,
+        highWaterBytes: 0,
+        preserveRecentMs: 7 * dayMs,
+      },
+    });
+
+    expect(result?.removedEntries).toBe(1);
+    expect(sessionExists("recent-old")).toBe(true);
+    expect(sessionExists("recent-live")).toBe(true);
+    expect(sessionExists("stale-old")).toBe(false);
+    expect(sessionExists("stale-live")).toBe(true);
+  });
+
   it("warn mode reports physical overage without extracting or deleting history", async () => {
     await createHistoricalTranscript({
       content: "warn history",

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -38,13 +38,17 @@ import {
 import { parseSessionEntryJson } from "./session-accessor.sqlite-status.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
-import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
+import {
+  isRecentSessionMaintenanceEntry,
+  type ResolvedSessionMaintenanceConfig,
+} from "./store-maintenance.js";
 
 type SessionHistoryDiskBudgetParams = {
   agentId?: string;
   mode: ResolvedSessionMaintenanceConfig["mode"];
   storePath: string;
-  maintenance: Pick<ResolvedSessionMaintenanceConfig, "highWaterBytes" | "maxDiskBytes">;
+  maintenance: Pick<ResolvedSessionMaintenanceConfig, "highWaterBytes" | "maxDiskBytes"> &
+    Partial<Pick<ResolvedSessionMaintenanceConfig, "preserveRecentMs">>;
 };
 
 function createPhysicalBudgetResult(params: {
@@ -102,8 +106,9 @@ export async function inspectSqliteSessionHistoryDiskBudget(
   }
   const candidates = readHistoricalSessionIds({
     database,
-    protectedSessionIds: collectProtectedHistoricalSessionIds({
+    protectedSessionIds: collectInitialProtectedHistoricalSessionIds({
       database,
+      preserveRecentMs: params.maintenance.preserveRecentMs,
       storePath: params.storePath,
     }),
   });
@@ -117,6 +122,103 @@ function collectProtectedHistoricalSessionIds(params: {
   const protectedSessionIds = readReferencedSessionIds(params.database);
   for (const sessionId of collectAdmissionProtectedSessionIds(params)) {
     protectedSessionIds.add(sessionId);
+  }
+  return protectedSessionIds;
+}
+
+function collectInitialProtectedHistoricalSessionIds(params: {
+  database: OpenClawAgentDatabase;
+  preserveRecentMs?: number | null;
+  storePath: string;
+}): Set<string> {
+  const protectedSessionIds = collectProtectedHistoricalSessionIds(params);
+  for (const sessionId of collectRecentSessionHistoryIds(params)) {
+    protectedSessionIds.add(sessionId);
+  }
+  return protectedSessionIds;
+}
+
+function collectRecentSessionHistoryIds(params: {
+  database: OpenClawAgentDatabase;
+  preserveRecentMs?: number | null;
+}): Set<string> {
+  if (params.preserveRecentMs == null) {
+    return new Set();
+  }
+  const db = getSessionKysely(params.database.db);
+  const rows = executeSqliteQuerySync(
+    params.database.db,
+    db
+      .selectFrom("session_windows")
+      .innerJoin("session_nodes", "session_nodes.session_key", "session_windows.session_key")
+      .select([
+        "session_nodes.current_session_id",
+        "session_nodes.entry_json",
+        "session_nodes.session_key",
+        "session_nodes.updated_at",
+        "session_windows.session_id",
+      ]),
+  ).rows;
+  return new Set(
+    rows.flatMap((row) => {
+      const entry = parseSessionEntryJson(row);
+      return entry &&
+        isRecentSessionMaintenanceEntry({
+          key: row.session_key,
+          entry,
+          preserveRecentMs: params.preserveRecentMs,
+        })
+        ? [row.session_id]
+        : [];
+    }),
+  );
+}
+
+function isRecentHistoricalSessionId(params: {
+  database: OpenClawAgentDatabase;
+  preserveRecentMs?: number | null;
+  sessionId: string;
+}): boolean {
+  if (params.preserveRecentMs == null) {
+    return false;
+  }
+  const db = getSessionKysely(params.database.db);
+  const row = executeSqliteQuerySync(
+    params.database.db,
+    db
+      .selectFrom("session_windows")
+      .innerJoin("session_nodes", "session_nodes.session_key", "session_windows.session_key")
+      .select([
+        "session_nodes.current_session_id",
+        "session_nodes.entry_json",
+        "session_nodes.session_key",
+        "session_nodes.updated_at",
+      ])
+      .where("session_windows.session_id", "=", params.sessionId),
+  ).rows[0];
+  if (!row) {
+    return false;
+  }
+  const entry = parseSessionEntryJson(row);
+  return Boolean(
+    entry &&
+    isRecentSessionMaintenanceEntry({
+      key: row.session_key,
+      entry,
+      preserveRecentMs: params.preserveRecentMs,
+    }),
+  );
+}
+
+function collectCandidateProtectedHistoricalSessionIds(params: {
+  database: OpenClawAgentDatabase;
+  preserveRecentMs?: number | null;
+  sessionId: string;
+  storePath: string;
+}): Set<string> {
+  const protectedSessionIds = collectProtectedHistoricalSessionIds(params);
+  if (isRecentHistoricalSessionId(params)) {
+    protectedSessionIds.add(params.sessionId);
   }
   return protectedSessionIds;
 }
@@ -479,8 +581,9 @@ async function enforceSessionHistoryMaintenanceSerialized(
   }
   const candidates = readHistoricalSessionIds({
     database,
-    protectedSessionIds: collectProtectedHistoricalSessionIds({
+    protectedSessionIds: collectInitialProtectedHistoricalSessionIds({
       database,
+      preserveRecentMs: params.maintenance.preserveRecentMs,
       storePath: params.storePath,
     }),
   });
@@ -494,8 +597,10 @@ async function enforceSessionHistoryMaintenanceSerialized(
       identities: [sessionId],
       run: async () => {
         const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
-          const protectedBeforeArchive = collectProtectedHistoricalSessionIds({
+          const protectedBeforeArchive = collectCandidateProtectedHistoricalSessionIds({
             database,
+            preserveRecentMs: params.maintenance.preserveRecentMs,
+            sessionId,
             storePath: params.storePath,
           });
           const candidate = planSessionStateDeleteIfUnreferenced({
@@ -521,8 +626,10 @@ async function enforceSessionHistoryMaintenanceSerialized(
           let deleted = false;
           let archivedTranscripts: ReturnType<typeof deleteMaterializedSessionStatePlans> = [];
           runOpenClawAgentWriteTransaction((transactionDb) => {
-            const protectedAtDelete = collectProtectedHistoricalSessionIds({
+            const protectedAtDelete = collectCandidateProtectedHistoricalSessionIds({
               database: transactionDb,
+              preserveRecentMs: params.maintenance.preserveRecentMs,
+              sessionId,
               storePath: params.storePath,
             });
             archivedTranscripts = deleteMaterializedSessionStatePlans(

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -112,6 +112,7 @@ async function applyWarnOnlyMaintenance(params: {
       pruneAfterMs: params.maintenance.pruneAfterMs,
       maxEntries: params.maintenance.maxEntries,
       preserveKeys: params.preserveSessionKeys,
+      preserveRecentMs: params.maintenance.preserveRecentMs,
     });
     if (warning) {
       params.operation.log.warn(
@@ -214,6 +215,7 @@ async function applyEnforcedMaintenance(params: {
           rememberRemovedSessionFile(removedSessionFiles, entry);
         },
         preserveKeys: params.preserveSessionKeys,
+        preserveRecentMs: params.maintenance.preserveRecentMs,
       })
     : 0;
   const pruned = pruneStaleEntries(params.operation.store, params.maintenance.pruneAfterMs, {
@@ -221,6 +223,7 @@ async function applyEnforcedMaintenance(params: {
       rememberRemovedSessionFile(removedSessionFiles, entry);
     },
     preserveKeys: params.preserveSessionKeys,
+    preserveRecentMs: params.maintenance.preserveRecentMs,
   });
   const countAfterPrune = Object.keys(params.operation.store).length;
   const shouldRunCapMaintenance =
@@ -235,6 +238,7 @@ async function applyEnforcedMaintenance(params: {
           rememberRemovedSessionFile(removedSessionFiles, entry);
         },
         preserveKeys: params.preserveSessionKeys,
+        preserveRecentMs: params.maintenance.preserveRecentMs,
       })
     : 0;
   const referencedSessionIds = collectReferencedSessionIds(params.operation.store);

--- a/src/config/sessions/store-maintenance-recent-preservation.test.ts
+++ b/src/config/sessions/store-maintenance-recent-preservation.test.ts
@@ -1,0 +1,85 @@
+// Recent-session preservation tests cover the operator-configured retention shield.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { enforceSessionDiskBudget } from "./disk-budget.js";
+import {
+  capEntryCount,
+  pruneStaleEntries,
+  resolveMaintenanceConfigFromInput,
+} from "./store-maintenance.js";
+import type { SessionEntry } from "./types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("recent session maintenance preservation", () => {
+  it("is opt-in and keeps recent interactive sessions through prune and cap pressure", () => {
+    const now = Date.now();
+    const recentKey = "agent:main:dashboard:recent";
+    const staleKey = "agent:main:dashboard:stale";
+    const syntheticKey = "agent:main:subagent:recent-worker";
+    const store: Record<string, SessionEntry> = {
+      [recentKey]: { sessionId: "recent", updatedAt: now - DAY_MS },
+      [staleKey]: { sessionId: "stale", updatedAt: now - 8 * DAY_MS },
+      [syntheticKey]: { sessionId: "synthetic", updatedAt: now - DAY_MS },
+    };
+    const preserveRecentMs = 7 * DAY_MS;
+
+    expect(resolveMaintenanceConfigFromInput().preserveRecentMs).toBeNull();
+    expect(
+      resolveMaintenanceConfigFromInput({ preserveRecent: false }).preserveRecentMs,
+    ).toBeNull();
+    expect(resolveMaintenanceConfigFromInput({ preserveRecent: "7d" }).preserveRecentMs).toBe(
+      preserveRecentMs,
+    );
+
+    expect(
+      pruneStaleEntries(store, 12 * 60 * 60 * 1000, {
+        preserveRecentMs,
+      }),
+    ).toBe(2);
+    expect(store).toHaveProperty(recentKey);
+    expect(store).not.toHaveProperty(staleKey);
+    expect(store).not.toHaveProperty(syntheticKey);
+
+    store[staleKey] = { sessionId: "stale-2", updatedAt: now - 8 * DAY_MS };
+    expect(capEntryCount(store, 1, { preserveRecentMs })).toBe(1);
+    expect(store).toHaveProperty(recentKey);
+    expect(store).not.toHaveProperty(staleKey);
+  });
+
+  it("keeps recent interactive sessions under file-store disk pressure", async () => {
+    await withTestDir({ prefix: "openclaw-preserve-recent-budget-" }, async (dir) => {
+      const now = Date.now();
+      const recentKey = "agent:main:dashboard:recent";
+      const staleKey = "agent:main:dashboard:stale";
+      const store: Record<string, SessionEntry> = {
+        [recentKey]: {
+          sessionId: "recent",
+          updatedAt: now,
+          displayName: "r".repeat(4_000),
+        },
+        [staleKey]: {
+          sessionId: "stale",
+          updatedAt: now - 8 * DAY_MS,
+          displayName: "s".repeat(4_000),
+        },
+      };
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath: path.join(dir, "sessions.json"),
+        maintenance: {
+          highWaterBytes: 1,
+          maxDiskBytes: 1,
+          preserveRecentMs: 7 * DAY_MS,
+        },
+        warnOnly: false,
+      });
+
+      expect(result?.removedEntries).toBe(1);
+      expect(store).toHaveProperty(recentKey);
+      expect(store).not.toHaveProperty(staleKey);
+    });
+  });
+});

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -46,6 +46,7 @@ export type ResolvedSessionMaintenanceConfig = {
   pruneAfterMs: number;
   maxEntries: number;
   modelRunPruneAfterMs: number;
+  preserveRecentMs?: number | null;
   resetArchiveRetentionMs: number | null;
   maxDiskBytes: number | null;
   highWaterBytes: number | null;
@@ -87,6 +88,18 @@ function resolveResetArchiveRetentionMs(
   }
   try {
     return parseDurationMs(normalized, { defaultUnit: "d" });
+  } catch {
+    return null;
+  }
+}
+
+function resolvePreserveRecentMs(maintenance?: SessionMaintenanceConfig): number | null {
+  const raw = maintenance?.preserveRecent;
+  if (raw === false || raw === undefined) {
+    return null;
+  }
+  try {
+    return parseDurationMs(normalizeStringifiedOptionalString(raw) ?? "", { defaultUnit: "d" });
   } catch {
     return null;
   }
@@ -156,6 +169,7 @@ export function resolveMaintenanceConfigFromInput(
     pruneAfterMs,
     maxEntries: maintenance?.maxEntries ?? DEFAULT_SESSION_MAX_ENTRIES,
     modelRunPruneAfterMs: DEFAULT_MODEL_RUN_PRUNE_AFTER_MS,
+    preserveRecentMs: resolvePreserveRecentMs(maintenance),
     resetArchiveRetentionMs: resolveResetArchiveRetentionMs(maintenance),
     maxDiskBytes,
     highWaterBytes: resolveHighWaterBytes(maintenance, maxDiskBytes),
@@ -168,6 +182,7 @@ export function normalizeResolvedMaintenanceConfigInput(
   return {
     ...maintenance,
     modelRunPruneAfterMs: maintenance.modelRunPruneAfterMs ?? DEFAULT_MODEL_RUN_PRUNE_AFTER_MS,
+    preserveRecentMs: maintenance.preserveRecentMs ?? null,
   };
 }
 
@@ -253,13 +268,21 @@ export function pruneStaleEntries(
     log?: boolean;
     onPruned?: (params: { key: string; entry: SessionEntry }) => void;
     preserveKeys?: ReadonlySet<string>;
+    preserveRecentMs?: number | null;
   } = {},
 ): number {
   const maxAgeMs = overrideMaxAgeMs ?? resolveMaintenanceConfigFromInput().pruneAfterMs;
   const cutoffMs = Date.now() - maxAgeMs;
   let pruned = 0;
   for (const [key, entry] of Object.entries(store)) {
-    if (shouldPreserveMaintenanceEntry({ key, entry, preserveKeys: opts.preserveKeys })) {
+    if (
+      shouldPreserveMaintenanceEntry({
+        key,
+        entry,
+        preserveKeys: opts.preserveKeys,
+        preserveRecentMs: opts.preserveRecentMs,
+      })
+    ) {
       continue;
     }
     if (entry?.updatedAt != null && entry.updatedAt < cutoffMs) {
@@ -286,6 +309,7 @@ export function pruneStaleModelRunEntries(
     log?: boolean;
     onPruned?: (params: { key: string; entry: SessionEntry }) => void;
     preserveKeys?: ReadonlySet<string>;
+    preserveRecentMs?: number | null;
   } = {},
 ): number {
   if (overrideMaxAgeMs == null) {
@@ -294,7 +318,14 @@ export function pruneStaleModelRunEntries(
   const cutoffMs = Date.now() - overrideMaxAgeMs;
   let pruned = 0;
   for (const [key, entry] of Object.entries(store)) {
-    if (shouldPreserveMaintenanceEntry({ key, entry, preserveKeys: opts.preserveKeys })) {
+    if (
+      shouldPreserveMaintenanceEntry({
+        key,
+        entry,
+        preserveKeys: opts.preserveKeys,
+        preserveRecentMs: opts.preserveRecentMs,
+      })
+    ) {
       continue;
     }
     if (!isGatewayModelRunSessionKey(key)) {
@@ -364,6 +395,7 @@ function isSyntheticSessionMaintenanceKey(sessionKey: string): boolean {
   const rest = normalizeLowercaseStringOrEmpty(parsed?.rest ?? sessionKey);
   // ACP bridge sessions use normal model dispatch, but remain synthetic and disposable.
   return (
+    isGatewayModelRunSessionKey(sessionKey) ||
     isSubagentSessionKey(sessionKey) ||
     isAcpSessionKey(sessionKey) ||
     isCronSessionKey(sessionKey) ||
@@ -374,6 +406,25 @@ function isSyntheticSessionMaintenanceKey(sessionKey: string): boolean {
     rest.endsWith(":heartbeat") ||
     rest.includes(":heartbeat:")
   );
+}
+
+export function isRecentSessionMaintenanceEntry(params: {
+  key: string;
+  entry: SessionEntry | undefined;
+  preserveRecentMs?: number | null;
+  nowMs?: number;
+}): boolean {
+  if (params.preserveRecentMs == null || isSyntheticSessionMaintenanceKey(params.key)) {
+    return false;
+  }
+  const activityAt = Math.max(
+    params.entry?.lastInteractionAt ?? 0,
+    params.entry?.lastActivityAt ?? 0,
+    params.entry?.sessionStartedAt ?? 0,
+    params.entry?.updatedAt ?? 0,
+  );
+  const now = params.nowMs ?? Date.now();
+  return activityAt > 0 && now - activityAt <= params.preserveRecentMs;
 }
 
 function isTelegramTopicSessionKey(sessionKey: string): boolean {
@@ -427,6 +478,7 @@ export function shouldPreserveMaintenanceEntry(params: {
   key: string;
   entry: SessionEntry | undefined;
   preserveKeys?: ReadonlySet<string>;
+  preserveRecentMs?: number | null;
 }): boolean {
   // Archived and pinned sessions are user-retained; only an explicit user action may release them.
   if (params.entry?.archivedAt !== undefined || params.entry?.pinnedAt !== undefined) {
@@ -439,6 +491,7 @@ export function shouldPreserveMaintenanceEntry(params: {
   return (
     params.entry?.modelSelectionLocked === true ||
     params.preserveKeys?.has(params.key) === true ||
+    isRecentSessionMaintenanceEntry(params) ||
     isProtectedSessionMaintenanceEntry(params.key, params.entry)
   );
 }
@@ -447,6 +500,7 @@ function selectSessionEntryCapVictims(
   store: Record<string, SessionEntry>,
   maxEntries: number,
   preserveKeys?: ReadonlySet<string>,
+  preserveRecentMs?: number | null,
 ): string[] {
   const keys = Object.keys(store);
   const overflow = keys.length - Math.max(0, maxEntries);
@@ -457,7 +511,13 @@ function selectSessionEntryCapVictims(
   // All persisted rows consume the cap, but protected rows are never victims. If protected rows
   // alone exceed the cap, maintenance removes every eligible row and leaves the excess intact.
   const eligibleKeys = keys.filter(
-    (key) => !shouldPreserveMaintenanceEntry({ key, entry: store[key], preserveKeys }),
+    (key) =>
+      !shouldPreserveMaintenanceEntry({
+        key,
+        entry: store[key],
+        preserveKeys,
+        preserveRecentMs,
+      }),
   );
   const victimCount = Math.min(overflow, eligibleKeys.length);
   if (victimCount === 0) {
@@ -477,6 +537,7 @@ export function getActiveSessionMaintenanceWarning(params: {
   maxEntries: number;
   nowMs?: number;
   preserveKeys?: ReadonlySet<string>;
+  preserveRecentMs?: number | null;
 }): SessionMaintenanceWarning | null {
   const activeSessionKey = params.activeSessionKey.trim();
   if (!activeSessionKey) {
@@ -491,6 +552,7 @@ export function getActiveSessionMaintenanceWarning(params: {
       key: activeSessionKey,
       entry: activeEntry,
       preserveKeys: params.preserveKeys,
+      preserveRecentMs: params.preserveRecentMs,
     })
   ) {
     return null;
@@ -503,6 +565,7 @@ export function getActiveSessionMaintenanceWarning(params: {
     params.store,
     params.maxEntries,
     params.preserveKeys,
+    params.preserveRecentMs,
   ).includes(activeSessionKey);
 
   if (!wouldPrune && !wouldCap) {
@@ -533,9 +596,15 @@ export function capEntryCount(
     log?: boolean;
     onCapped?: (params: { key: string; entry: SessionEntry }) => void;
     preserveKeys?: ReadonlySet<string>;
+    preserveRecentMs?: number | null;
   } = {},
 ): number {
-  const toRemove = selectSessionEntryCapVictims(store, maxEntries, opts.preserveKeys);
+  const toRemove = selectSessionEntryCapVictims(
+    store,
+    maxEntries,
+    opts.preserveKeys,
+    opts.preserveRecentMs,
+  );
   if (toRemove.length === 0) {
     return 0;
   }

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -251,6 +251,8 @@ export type SessionMaintenanceConfig = {
   pruneAfter?: string | number;
   /** Maximum total session entries to keep when protection permits. Default: 500. */
   maxEntries?: number;
+  /** Protect interactive sessions active within this duration. Default and false: disabled. */
+  preserveRecent?: string | number | false;
   /**
    * Age-based retention for archived transcripts (`*.reset.<timestamp>` and
    * `*.deleted.<timestamp>`). Default and `false`: keep archives until the

--- a/src/config/zod-schema.session-maintenance-extensions.test.ts
+++ b/src/config/zod-schema.session-maintenance-extensions.test.ts
@@ -6,12 +6,23 @@ describe("SessionSchema maintenance extensions", () => {
   it("accepts valid maintenance extensions", () => {
     const result = SessionSchema.safeParse({
       maintenance: {
+        preserveRecent: "7d",
         resetArchiveRetention: "14d",
         maxDiskBytes: "500mb",
         highWaterBytes: "350mb",
       },
     });
     expect(result.success).toBe(true);
+  });
+
+  it("accepts disabling recent-session preservation", () => {
+    expect(SessionSchema.safeParse({ maintenance: { preserveRecent: false } }).success).toBe(true);
+  });
+
+  it("rejects an invalid recent-session preservation duration", () => {
+    const result = SessionSchema.safeParse({ maintenance: { preserveRecent: "forever" } });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toContain("preserveRecent");
   });
 
   it("accepts disabling reset archive cleanup", () => {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -91,6 +91,7 @@ export const SessionSchema = z
         mode: z.enum(["enforce", "warn"]).optional(),
         pruneAfter: PositiveDurationSchema.optional(),
         maxEntries: z.number().int().positive().optional(),
+        preserveRecent: z.union([PositiveDurationSchema, z.literal(false)]).optional(),
         resetArchiveRetention: z.union([PositiveDurationSchema, z.literal(false)]).optional(),
         maxDiskBytes: z.union([z.string(), z.number(), z.literal(false)]).optional(),
         highWaterBytes: z.union([z.string(), z.number()]).optional(),

--- a/src/infra/state-migrations.legacy-session-store.ts
+++ b/src/infra/state-migrations.legacy-session-store.ts
@@ -278,12 +278,14 @@ export function loadLegacySessionStore(
         pruneStaleModelRunEntries(sessionStore, maintenance.modelRunPruneAfterMs, {
           log: false,
           preserveKeys: preserveSessionKeys,
+          preserveRecentMs: maintenance.preserveRecentMs,
         });
       }
       if (Object.keys(sessionStore).length > maintenance.maxEntries) {
         pruneStaleEntries(sessionStore, maintenance.pruneAfterMs, {
           log: false,
           preserveKeys: preserveSessionKeys,
+          preserveRecentMs: maintenance.preserveRecentMs,
         });
         if (
           shouldRunSessionEntryMaintenance({
@@ -294,6 +296,7 @@ export function loadLegacySessionStore(
           capEntryCount(sessionStore, maintenance.maxEntries, {
             log: false,
             preserveKeys: preserveSessionKeys,
+            preserveRecentMs: maintenance.preserveRecentMs,
           });
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Busy shared Gateways can evict recently active sessions when protected rows already consume the configured entry or disk budget. Archiving sessions during updates is not an appropriate clutter policy because archived sessions are a permanent user shelf.

## Why This Change Was Made

Adds one opt-in `session.maintenance.preserveRecent` duration. When configured, automatic maintenance protects recently active interactive session rows and every SQLite history generation owned by those sessions. Synthetic model-run, cron, hook, heartbeat, ACP, and sub-agent sessions remain eligible for bounded cleanup.

The option is disabled when omitted or set to `false`, preserving existing personal-Claw behavior. This revision intentionally drops `preserveActiveWorktrees`: managed worktrees already have separate session-aware seven-day garbage collection, so session maintenance does not need an indefinite worktree-derived protection path or shared-state reads inside agent write transactions.

SQLite physical-budget cleanup computes recent history protection once before candidate selection and rechecks only the candidate generation at archive/delete boundaries. That preserves the policy without rescanning the full history table for every eviction.

## User Impact

Shared installations can use:

```json5
session: {
  maintenance: {
    preserveRecent: "7d",
  },
}
```

Protection expires after the configured inactivity window and can temporarily keep the store above its entry or disk target. It does not archive sessions or change managed-worktree garbage collection.

## Evidence

- Red regression on current `main`: 5 failures / 32 passes. The schema rejected `preserveRecent`, cap maintenance removed the recent row, and SQLite physical-budget cleanup deleted both recent and stale historical generations.
- Green post-rebase focused proof: 196 tests across policy, file disk budget, SQLite accessor conformance, SQLite history eviction, cleanup preview/application, schema/help, and legacy migration.
- `tsgo:core` and sharded core test types pass.
- Focused oxlint passes for every changed TypeScript file.
- Runtime import-cycle check reports 0 cycles.
- Docs MDX and all configuration examples pass.
- Final P1 autoreview: clean, no accepted/actionable findings. The accepted quadratic-history-scan finding was fixed with one bulk prefilter plus indexed candidate-only rechecks.
- No live Gateway video was captured; the storage behavior is covered through real SQLite accessor and physical-budget boundary tests.

AI-assisted: yes. I reviewed the implementation, tests, and final diff.
