### PR TITLE
improve: replace ingress test delays with quiescence barriers

### DIFF
--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -518,9 +518,7 @@ describe("LINE webhook spool", () => {
         await waitForVerdict(queue, "message:message-event-duplicate", "completed");
 
         await spool.accept(callback(event));
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 600);
-        });
+        await spool.stop();
 
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {
@@ -550,9 +548,7 @@ describe("LINE webhook spool", () => {
         await spool.accept(
           callback(createEvent({ webhookEventId: "delivery-b", messageId: "shared-message" })),
         );
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 600);
-        });
+        await spool.stop();
 
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {

--- a/extensions/msteams/src/msteams-ingress.test.ts
+++ b/extensions/msteams/src/msteams-ingress.test.ts
@@ -176,9 +176,7 @@ describe("Microsoft Teams durable ingress", () => {
         await ingress.accept(incoming);
         await waitForVerdict(queue, "activity-duplicate", "completed");
         await ingress.accept(incoming);
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 600);
-        });
+        await ingress.stop();
         expect(dispatch).toHaveBeenCalledTimes(1);
       } finally {
         await ingress.stop();
@@ -199,9 +197,7 @@ describe("Microsoft Teams durable ingress", () => {
         await ingress.accept(first);
         await waitForVerdict(queue, "bot-framework-redelivery", "completed");
         await ingress.accept(redelivery);
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 600);
-        });
+        await ingress.stop();
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0]?.[0]).toMatchObject({ text: "original" });
       } finally {

--- a/extensions/zalo/src/webhook-spool.test.ts
+++ b/extensions/zalo/src/webhook-spool.test.ts
@@ -134,9 +134,7 @@ describe("Zalo durable webhook ingress", () => {
         await ingress.accept(raw);
         await waitForZaloWebhookVerdict(queue, "duplicate", "completed");
         await ingress.accept(raw);
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 600);
-        });
+        await ingress.stop();
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {
         await ingress.stop();
@@ -162,9 +160,7 @@ describe("Zalo durable webhook ingress", () => {
         await ingress.accept(
           rawEvent({ messageId: "redelivery", text: "transport redelivery", date: 2 }),
         );
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 600);
-        });
+        await ingress.stop();
         expect(deliver).toHaveBeenCalledTimes(1);
         expect(deliver.mock.calls[0]?.[0].message?.text).toBe("original");
       } finally {


### PR DESCRIPTION
## What Problem This Solves

The LINE, Microsoft Teams, and Zalo durable-ingress tests each waited an arbitrary 600 ms after duplicate or redelivery input. Those fixed sleeps made the retained 40-test coverage slower without proving any additional behavior.

## Why This Change Was Made

The tests now await the ingress `stop()` quiescence barrier that already owns completion of accepted work. This keeps synchronization at the ingress lifecycle boundary instead of approximating it with wall-clock delays. The change is test-only: +6/-18 lines (net -12), with no production-code or assertion changes.

## User Impact

There is no user-visible runtime change. Maintainers get faster, deterministic coverage for LINE, Microsoft Teams, and Zalo webhook duplicate/redelivery behavior.

## Evidence

- Same-Testbox warm A/B, three files and 40 retained tests:
  - mean wall: 23.365s -> 19.400s (-17.0%)
  - test body: 16.345s -> 12.675s (-22.5%)
  - CPU user: 10.070s -> 9.685s
  - CPU sys: 1.065s -> 1.000s
  - RSS was effectively flat: 612844 KiB -> 616142 KiB; no RSS improvement is claimed.
- Rebased focused proof: `node scripts/run-vitest.mjs extensions/line/src/webhook-spool.test.ts extensions/msteams/src/msteams-ingress.test.ts extensions/zalo/src/webhook-spool.test.ts --maxWorkers=1` -> 3 files, 40/40 tests passed.
- Targeted format check and `git diff --check origin/main...HEAD` passed.
- Path-scoped changed gate passed through Blacksmith Testbox: lease `tbx_01m01rb0dpwe0f740h4kfnxhx5`, Actions run https://github.com/openclaw/openclaw/actions/runs/31862613863, wrapper exit 0. The one-shot lease was stopped after success.
- Fresh committed-branch autoreview against `origin/main` found no actionable findings (overall confidence 0.99).
