### PR TITLE
fix(codex): keep the real answer when a trailing coda follows

### DIFF
--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -1,6 +1,6 @@
 import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
-import { isSilentReplyText } from "openclaw/plugin-sdk/reply-runtime";
+import { isSilentReplyPayloadText } from "openclaw/plugin-sdk/reply-chunking";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createAssistantCommentaryMessage as buildAssistantCommentaryMessage,
@@ -314,7 +314,7 @@ export class CodexAssistantProjection {
 
   collectAssistantTexts(): string[] {
     const afterHandoff = this.collectPersistableAssistantTexts(this.persistableAssistantBarrier);
-    const audibleAfterHandoff = afterHandoff.filter((text) => !isSilentReplyText(text));
+    const audibleAfterHandoff = afterHandoff.filter((text) => !isSilentReplyPayloadText(text));
     if (audibleAfterHandoff.length > 0) {
       return audibleAfterHandoff;
     }
@@ -324,7 +324,7 @@ export class CodexAssistantProjection {
       return afterHandoff.slice(-1);
     }
     const recoveredAudible = this.collectPersistableAssistantTexts(0).filter(
-      (text) => !isSilentReplyText(text),
+      (text) => !isSilentReplyPayloadText(text),
     );
     if (recoveredAudible.length > 0) {
       return recoveredAudible.slice(-1);

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -41,10 +41,11 @@ export class CodexAssistantProjection {
   private responseModel: string | undefined;
   private streamedPartialAssistantItemId: string | undefined;
   private streamedPartialAssistantItemReplaceable = false;
-  // turn/completed.items is a Summary of last_agent_message only. Native-tool
-  // invalidation has to be recorded from item notifications, or a later coda
-  // would revive every pre-tool final.
+  // turn/completed.items is a Summary of last_agent_message only. Tool
+  // invalidation has to be recorded from the first item notification for each
+  // native or dynamic handoff, or a later coda would revive every pre-tool final.
   private persistableAssistantBarrier = 0;
+  private readonly persistableAssistantBarrierItemIds = new Set<string>();
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
@@ -312,38 +313,16 @@ export class CodexAssistantProjection {
   }
 
   collectAssistantTexts(): string[] {
-    const texts: string[] = [];
-    let seenLaterPersistable = false;
-    let seenLaterUnphased = false;
-    // Phase-less agentMessages are replaceable coordination text. Explicit
-    // final_answer items stay unless later native work or a later unphased
-    // message supersedes them.
-    for (let index = this.assistantItemOrder.length - 1; index >= 0; index -= 1) {
-      const itemId = this.assistantItemOrder[index];
-      if (
-        !itemId ||
-        index < this.persistableAssistantBarrier ||
-        this.assistantPhaseByItem.get(itemId) === "commentary"
-      ) {
-        continue;
-      }
-      const text = this.assistantTextByItem.get(itemId)?.trim();
-      if (!text || this.isToolProgressEchoText(itemId, text)) {
-        continue;
-      }
-      const isTerminalFinal = this.assistantPhaseByItem.get(itemId) === "final_answer";
-      if (seenLaterUnphased || (!isTerminalFinal && seenLaterPersistable)) {
-        continue;
-      }
-      texts.push(text);
-      seenLaterPersistable = true;
-      if (!isTerminalFinal) {
-        seenLaterUnphased = true;
-      }
+    const afterHandoff = this.collectPersistableAssistantTexts(this.persistableAssistantBarrier);
+    if (afterHandoff.length > 0) {
+      return afterHandoff;
     }
-    texts.reverse();
-    const audible = texts.filter((text) => !isSilentReplyText(text));
-    return audible.length > 0 ? audible : texts;
+    const recoveredAudible = this.collectPersistableAssistantTexts(0);
+    if (recoveredAudible.length > 0) {
+      return recoveredAudible.slice(-1);
+    }
+    const recovered = this.resolveFinalAssistantTextItem()?.text;
+    return recovered ? [recovered] : [];
   }
 
   collectCommentaryMessages(): Array<{ itemId: string; message: AssistantMessage }> {
@@ -583,9 +562,45 @@ export class CodexAssistantProjection {
     return undefined;
   }
 
+  private collectPersistableAssistantTexts(minIndex: number): string[] {
+    const texts: string[] = [];
+    let seenLaterPersistable = false;
+    let seenLaterUnphased = false;
+    // Phase-less agentMessages are replaceable coordination text. Explicit
+    // final_answer items stay unless later native work or a later unphased
+    // message supersedes them.
+    for (let index = this.assistantItemOrder.length - 1; index >= minIndex; index -= 1) {
+      const itemId = this.assistantItemOrder[index];
+      if (!itemId || this.assistantPhaseByItem.get(itemId) === "commentary") {
+        continue;
+      }
+      const text = this.assistantTextByItem.get(itemId)?.trim();
+      if (!text || this.isToolProgressEchoText(itemId, text)) {
+        continue;
+      }
+      const isTerminalFinal = this.assistantPhaseByItem.get(itemId) === "final_answer";
+      if (seenLaterUnphased || (!isTerminalFinal && seenLaterPersistable)) {
+        continue;
+      }
+      texts.push(text);
+      seenLaterPersistable = true;
+      if (!isTerminalFinal) {
+        seenLaterUnphased = true;
+      }
+    }
+    texts.reverse();
+    return texts.filter((text) => !isSilentReplyText(text));
+  }
+
   private noteNativeWorkBarrier(item: CodexThreadItem | undefined): void {
-    if (!item || !shouldClearTerminalPresentationForNativeItem(item)) {
+    if (!item || !shouldAdvancePersistableAssistantBarrier(item)) {
       return;
+    }
+    if (item.id && this.persistableAssistantBarrierItemIds.has(item.id)) {
+      return;
+    }
+    if (item.id) {
+      this.persistableAssistantBarrierItemIds.add(item.id);
     }
     this.persistableAssistantBarrier = this.assistantItemOrder.length;
   }
@@ -601,4 +616,8 @@ export class CodexAssistantProjection {
   private isToolProgressEchoText(itemId: string, text: string): boolean {
     return this.rawPromotedAssistantItemIds.has(itemId) && this.matchesToolProgressEcho(text);
   }
+}
+
+function shouldAdvancePersistableAssistantBarrier(item: CodexThreadItem): boolean {
+  return shouldClearTerminalPresentationForNativeItem(item) || item.type === "dynamicToolCall";
 }

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -314,10 +314,18 @@ export class CodexAssistantProjection {
 
   collectAssistantTexts(): string[] {
     const afterHandoff = this.collectPersistableAssistantTexts(this.persistableAssistantBarrier);
-    if (afterHandoff.length > 0) {
-      return afterHandoff;
+    const audibleAfterHandoff = afterHandoff.filter((text) => !isSilentReplyText(text));
+    if (audibleAfterHandoff.length > 0) {
+      return audibleAfterHandoff;
     }
-    const recoveredAudible = this.collectPersistableAssistantTexts(0);
+    // A post-handoff silent token is the new terminal identity. Recover a
+    // pre-barrier answer only when that segment has no persistable text.
+    if (afterHandoff.length > 0) {
+      return afterHandoff.slice(-1);
+    }
+    const recoveredAudible = this.collectPersistableAssistantTexts(0).filter(
+      (text) => !isSilentReplyText(text),
+    );
     if (recoveredAudible.length > 0) {
       return recoveredAudible.slice(-1);
     }
@@ -589,7 +597,7 @@ export class CodexAssistantProjection {
       }
     }
     texts.reverse();
-    return texts.filter((text) => !isSilentReplyText(text));
+    return texts;
   }
 
   private noteNativeWorkBarrier(item: CodexThreadItem | undefined): void {

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -571,13 +571,12 @@ export class CodexAssistantProjection {
   }
 
   private collectPersistableAssistantTexts(minIndex: number): string[] {
-    const texts: string[] = [];
-    let seenLaterPersistable = false;
-    let seenLaterUnphased = false;
-    // Phase-less agentMessages are replaceable coordination text. Explicit
-    // final_answer items stay unless later native work or a later unphased
-    // message supersedes them.
-    for (let index = this.assistantItemOrder.length - 1; index >= minIndex; index -= 1) {
+    let texts: string[] = [];
+    let replaceable = false;
+    // Walk time order. Unphased text replaces the current segment. Explicit
+    // finals accumulate unless they follow a replacement. Silent payloads
+    // never replace; they only ride along for post-handoff identity.
+    for (let index = minIndex; index < this.assistantItemOrder.length; index += 1) {
       const itemId = this.assistantItemOrder[index];
       if (!itemId || this.assistantPhaseByItem.get(itemId) === "commentary") {
         continue;
@@ -586,17 +585,18 @@ export class CodexAssistantProjection {
       if (!text || this.isToolProgressEchoText(itemId, text)) {
         continue;
       }
+      if (isSilentReplyPayloadText(text)) {
+        texts.push(text);
+        continue;
+      }
       const isTerminalFinal = this.assistantPhaseByItem.get(itemId) === "final_answer";
-      if (seenLaterUnphased || (!isTerminalFinal && seenLaterPersistable)) {
+      if (!isTerminalFinal || replaceable) {
+        texts = [text];
+        replaceable = !isTerminalFinal;
         continue;
       }
       texts.push(text);
-      seenLaterPersistable = true;
-      if (!isTerminalFinal) {
-        seenLaterUnphased = true;
-      }
     }
-    texts.reverse();
     return texts;
   }
 
@@ -627,5 +627,11 @@ export class CodexAssistantProjection {
 }
 
 function shouldAdvancePersistableAssistantBarrier(item: CodexThreadItem): boolean {
-  return shouldClearTerminalPresentationForNativeItem(item) || item.type === "dynamicToolCall";
+  // Sleep is a Codex public Sleep handoff, not mutating presentation work.
+  // Record it here so a later final cannot join the pre-sleep answer.
+  return (
+    shouldClearTerminalPresentationForNativeItem(item) ||
+    item.type === "dynamicToolCall" ||
+    item.type === "sleep"
+  );
 }

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -304,9 +304,39 @@ export class CodexAssistantProjection {
     }
   }
 
-  collectAssistantTexts(): string[] {
-    const finalText = this.resolveFinalAssistantTextItem()?.text;
-    return finalText ? [finalText] : [];
+  collectAssistantTexts(turnItems?: readonly CodexThreadItem[]): string[] {
+    const lastNativeWorkIndex = lastNativeWorkItemIndex(turnItems);
+    const texts: string[] = [];
+    let seenLaterPersistable = false;
+    // Phase-less agentMessages are replaceable coordination text; a later
+    // persistable item supersedes them. Explicit final_answer items stay unless
+    // they sit before later native tool work.
+    for (let index = this.assistantItemOrder.length - 1; index >= 0; index -= 1) {
+      const itemId = this.assistantItemOrder[index];
+      if (!itemId || this.assistantPhaseByItem.get(itemId) === "commentary") {
+        continue;
+      }
+      if (turnItems && lastNativeWorkIndex >= 0) {
+        const itemIndex = turnItems.findIndex(
+          (item) => item?.type === "agentMessage" && item.id === itemId,
+        );
+        if (itemIndex >= 0 && itemIndex < lastNativeWorkIndex) {
+          continue;
+        }
+      }
+      const text = this.assistantTextByItem.get(itemId)?.trim();
+      if (!text || this.isToolProgressEchoText(itemId, text)) {
+        continue;
+      }
+      const isTerminalFinal = this.assistantPhaseByItem.get(itemId) === "final_answer";
+      if (!isTerminalFinal && seenLaterPersistable) {
+        continue;
+      }
+      texts.push(text);
+      seenLaterPersistable = true;
+    }
+    texts.reverse();
+    return texts;
   }
 
   collectCommentaryMessages(): Array<{ itemId: string; message: AssistantMessage }> {
@@ -557,4 +587,17 @@ export class CodexAssistantProjection {
   private isToolProgressEchoText(itemId: string, text: string): boolean {
     return this.rawPromotedAssistantItemIds.has(itemId) && this.matchesToolProgressEcho(text);
   }
+}
+
+function lastNativeWorkItemIndex(turnItems: readonly CodexThreadItem[] | undefined): number {
+  if (!turnItems) {
+    return -1;
+  }
+  for (let index = turnItems.length - 1; index >= 0; index -= 1) {
+    const item = turnItems[index];
+    if (item && shouldClearTerminalPresentationForNativeItem(item)) {
+      return index;
+    }
+  }
+  return -1;
 }

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -1,5 +1,6 @@
 import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { isSilentReplyText } from "openclaw/plugin-sdk/reply-runtime";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createAssistantCommentaryMessage as buildAssistantCommentaryMessage,
@@ -40,6 +41,10 @@ export class CodexAssistantProjection {
   private responseModel: string | undefined;
   private streamedPartialAssistantItemId: string | undefined;
   private streamedPartialAssistantItemReplaceable = false;
+  // turn/completed.items is a Summary of last_agent_message only. Native-tool
+  // invalidation has to be recorded from item notifications, or a later coda
+  // would revive every pre-tool final.
+  private persistableAssistantBarrier = 0;
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
@@ -155,6 +160,7 @@ export class CodexAssistantProjection {
   }
 
   recordItemStarted(item: CodexThreadItem | undefined, itemId: string | undefined): void {
+    this.noteNativeWorkBarrier(item);
     if (
       item?.type === "agentMessage" &&
       itemId &&
@@ -181,6 +187,7 @@ export class CodexAssistantProjection {
     itemId: string | undefined,
     activeItemIds: ReadonlySet<string>,
   ): void {
+    this.noteNativeWorkBarrier(item);
     if (
       item?.type === "agentMessage" &&
       itemId &&
@@ -304,39 +311,39 @@ export class CodexAssistantProjection {
     }
   }
 
-  collectAssistantTexts(turnItems?: readonly CodexThreadItem[]): string[] {
-    const lastNativeWorkIndex = lastNativeWorkItemIndex(turnItems);
+  collectAssistantTexts(): string[] {
     const texts: string[] = [];
     let seenLaterPersistable = false;
-    // Phase-less agentMessages are replaceable coordination text; a later
-    // persistable item supersedes them. Explicit final_answer items stay unless
-    // they sit before later native tool work.
+    let seenLaterUnphased = false;
+    // Phase-less agentMessages are replaceable coordination text. Explicit
+    // final_answer items stay unless later native work or a later unphased
+    // message supersedes them.
     for (let index = this.assistantItemOrder.length - 1; index >= 0; index -= 1) {
       const itemId = this.assistantItemOrder[index];
-      if (!itemId || this.assistantPhaseByItem.get(itemId) === "commentary") {
+      if (
+        !itemId ||
+        index < this.persistableAssistantBarrier ||
+        this.assistantPhaseByItem.get(itemId) === "commentary"
+      ) {
         continue;
-      }
-      if (turnItems && lastNativeWorkIndex >= 0) {
-        const itemIndex = turnItems.findIndex(
-          (item) => item?.type === "agentMessage" && item.id === itemId,
-        );
-        if (itemIndex >= 0 && itemIndex < lastNativeWorkIndex) {
-          continue;
-        }
       }
       const text = this.assistantTextByItem.get(itemId)?.trim();
       if (!text || this.isToolProgressEchoText(itemId, text)) {
         continue;
       }
       const isTerminalFinal = this.assistantPhaseByItem.get(itemId) === "final_answer";
-      if (!isTerminalFinal && seenLaterPersistable) {
+      if (seenLaterUnphased || (!isTerminalFinal && seenLaterPersistable)) {
         continue;
       }
       texts.push(text);
       seenLaterPersistable = true;
+      if (!isTerminalFinal) {
+        seenLaterUnphased = true;
+      }
     }
     texts.reverse();
-    return texts;
+    const audible = texts.filter((text) => !isSilentReplyText(text));
+    return audible.length > 0 ? audible : texts;
   }
 
   collectCommentaryMessages(): Array<{ itemId: string; message: AssistantMessage }> {
@@ -576,6 +583,13 @@ export class CodexAssistantProjection {
     return undefined;
   }
 
+  private noteNativeWorkBarrier(item: CodexThreadItem | undefined): void {
+    if (!item || !shouldClearTerminalPresentationForNativeItem(item)) {
+      return;
+    }
+    this.persistableAssistantBarrier = this.assistantItemOrder.length;
+  }
+
   private rememberAssistantItem(itemId: string): void {
     if (!itemId || this.assistantItemOrder.includes(itemId)) {
       return;
@@ -587,17 +601,4 @@ export class CodexAssistantProjection {
   private isToolProgressEchoText(itemId: string, text: string): boolean {
     return this.rawPromotedAssistantItemIds.has(itemId) && this.matchesToolProgressEcho(text);
   }
-}
-
-function lastNativeWorkItemIndex(turnItems: readonly CodexThreadItem[] | undefined): number {
-  if (!turnItems) {
-    return -1;
-  }
-  for (let index = turnItems.length - 1; index >= 0; index -= 1) {
-    const item = turnItems[index];
-    if (item && shouldClearTerminalPresentationForNativeItem(item)) {
-      return index;
-    }
-  }
-  return -1;
 }

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -83,7 +83,9 @@ export function buildCodexAttemptResult(
   // Result construction runs after the notification queue drains. Close any
   // tool lacking a terminal item so audit consumers never retain an open action.
   input.nativeToolLifecycleProjection.finalizeActive();
-  const assistantTexts = input.assistantProjection.collectAssistantTexts();
+  const assistantTexts = input.assistantProjection.collectAssistantTexts(
+    input.completedTurn?.items,
+  );
   const commentaryMessages = input.assistantProjection.collectCommentaryMessages();
   const reasoningText = input.reasoningProjection.reasoningText();
   const planText = input.reasoningProjection.planText();

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -83,9 +83,7 @@ export function buildCodexAttemptResult(
   // Result construction runs after the notification queue drains. Close any
   // tool lacking a terminal item so audit consumers never retain an open action.
   input.nativeToolLifecycleProjection.finalizeActive();
-  const assistantTexts = input.assistantProjection.collectAssistantTexts(
-    input.completedTurn?.items,
-  );
+  const assistantTexts = input.assistantProjection.collectAssistantTexts();
   const commentaryMessages = input.assistantProjection.collectCommentaryMessages();
   const reasoningText = input.reasoningProjection.reasoningText();
   const planText = input.reasoningProjection.planText();

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -308,6 +308,151 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
   });
 
+  it("drops a pre-unphased final when a later final follows the replacement", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("First candidate", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "First candidate",
+        },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Replacement draft", "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-3", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Later final", "answer-3"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-3",
+          phase: "final_answer",
+          text: "Later final",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-3", phase: "final_answer", text: "Later final" },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["Later final"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("Replacement draft");
+  });
+
+  it("keeps the unphased replacement when a later silent final follows", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("First candidate", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "First candidate",
+        },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Replacement draft", "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-3", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("NO_REPLY", "answer-3"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-3",
+          phase: "final_answer",
+          text: "NO_REPLY",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-3", phase: "final_answer", text: "NO_REPLY" },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["Replacement draft"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("NO_REPLY");
+  });
+
+  it("drops a pre-sleep final after a later sleep handoff", async () => {
+    const projector = await createProjector(await createParams());
+    const sleepItem = { type: "sleep", id: "sleep-1", durationMs: 250 };
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("First candidate", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "First candidate",
+        },
+      }),
+    );
+    await projector.handleNotification(forCurrentTurn("item/started", { item: sleepItem }));
+    await projector.handleNotification(forCurrentTurn("item/completed", { item: sleepItem }));
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("After sleep", "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: "After sleep",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "After sleep" },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["After sleep"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
+  });
+
   it("drops a trailing silent final when an earlier audible final remains", async () => {
     const projector = await createProjector(await createParams());
 

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -176,13 +176,6 @@ describe("CodexAppServerEventProjector assistant projection", () => {
       turnCompleted([
         {
           type: "agentMessage",
-          id: "answer-1",
-          phase: "final_answer",
-          text: "First candidate",
-        },
-        lateTool,
-        {
-          type: "agentMessage",
           id: "answer-2",
           phase: "final_answer",
           text: "Second candidate",
@@ -268,12 +261,6 @@ describe("CodexAppServerEventProjector assistant projection", () => {
       turnCompleted([
         {
           type: "agentMessage",
-          id: "answer-1",
-          phase: "final_answer",
-          text: summary,
-        },
-        {
-          type: "agentMessage",
           id: "answer-2",
           phase: "final_answer",
           text: coda,
@@ -290,6 +277,81 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     ]);
     expect(snapshot).toContain(summary);
     expect(snapshot).toContain(coda);
+  });
+
+  it("lets a later unphased message replace an earlier final answer", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("First candidate", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "First candidate",
+        },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Later unphased reply", "answer-2"));
+    await projector.handleNotification(
+      turnCompleted([{ type: "agentMessage", id: "answer-2", text: "Later unphased reply" }]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["Later unphased reply"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
+  });
+
+  it("drops a trailing silent final when an earlier audible final remains", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Keep this answer", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "Keep this answer",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("NO_REPLY", "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: "NO_REPLY",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "NO_REPLY" },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["Keep this answer"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("NO_REPLY");
   });
 
   it("does not reselect a final answer superseded by late tool work", async () => {

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -354,6 +354,115 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("NO_REPLY");
   });
 
+  it("keeps a final answer that arrives while an earlier native tool is still active", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "imageGeneration", id: "ig_1", status: "inProgress" },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Done.", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "Done.",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: { type: "imageGeneration", id: "ig_1", status: "completed" },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "Done." },
+      ]),
+    );
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).assistantTexts).toEqual(["Done."]);
+  });
+
+  it("drops a pre-handoff final after a later dynamic tool call", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("First candidate", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "First candidate",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "dynamicToolCall",
+          id: "call-search",
+          tool: "memory_search",
+          status: "inProgress",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "dynamicToolCall",
+          id: "call-search",
+          tool: "memory_search",
+          status: "completed",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Second candidate", "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: "Second candidate",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: "Second candidate",
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["Second candidate"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
+  });
+
   it("does not reselect a final answer superseded by late tool work", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -463,6 +463,71 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
   });
 
+  it("keeps a post-handoff silent final instead of recovering the pre-tool answer", async () => {
+    const projector = await createProjector(await createParams());
+    const lateTool = {
+      type: "commandExecution",
+      id: "late-tool",
+      command: "/bin/bash -lc 'printf late'",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      status: "completed",
+      commandActions: [],
+      aggregatedOutput: "late",
+      exitCode: 0,
+      durationMs: 1,
+    };
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("First candidate", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "First candidate",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { ...lateTool, status: "inProgress", aggregatedOutput: null, exitCode: null },
+      }),
+    );
+    await projector.handleNotification(forCurrentTurn("item/completed", { item: lateTool }));
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("NO_REPLY", "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: "NO_REPLY",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "NO_REPLY" },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["NO_REPLY"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
+  });
+
   it("does not reselect a final answer superseded by late tool work", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -354,6 +354,53 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("NO_REPLY");
   });
 
+  it("drops a trailing JSON silent payload when an earlier audible final remains", async () => {
+    const projector = await createProjector(await createParams());
+    const jsonSilent = '{"action":"NO_REPLY"}';
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Keep this answer", "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: "Keep this answer",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta(jsonSilent, "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: jsonSilent,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-2", phase: "final_answer", text: jsonSilent },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["Keep this answer"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain(jsonSilent);
+  });
+
   it("keeps a final answer that arrives while an earlier native tool is still active", async () => {
     const projector = await createProjector(await createParams());
 

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -227,6 +227,71 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("answer_candidate");
   });
 
+  it("keeps an earlier final answer when a later coda arrives with no tool work between them", async () => {
+    const projector = await createProjector(await createParams());
+    const summary = "Read-only; inspected actual diffs, no mutations: - #122457 — Copies";
+    const coda = "The summary above already incorporates the final review results.";
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta(summary, "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: summary,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta(coda, "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: coda,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "agentMessage",
+          id: "answer-1",
+          phase: "final_answer",
+          text: summary,
+        },
+        {
+          type: "agentMessage",
+          id: "answer-2",
+          phase: "final_answer",
+          text: coda,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const snapshot = JSON.stringify(result.messagesSnapshot);
+
+    expect(result.assistantTexts).toEqual([summary, coda]);
+    expect(result.lastAssistant?.content).toEqual([
+      { type: "text", text: `${summary}\n\n${coda}` },
+    ]);
+    expect(snapshot).toContain(summary);
+    expect(snapshot).toContain(coda);
+  });
+
   it("does not reselect a final answer superseded by late tool work", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({


### PR DESCRIPTION
Related: #116604

## What Problem This Solves

Fixes an issue where Codex users would lose the real reply in Control UI and session history when a later `final_answer` coda arrived with no tool work between the two texts. The visible transcript kept only the coda, for example “The summary above already incorporates the final review results.”

## Why This Change Was Made

Live persist used one `${turnId}:assistant` slot and last-won any non-commentary text. That is correct for phase-less coordination text and for a final that later native tool work reopens. It is wrong for two explicit `final_answer` items after the last tool: both are user-visible answers, and the first one disappeared.

Pinned dependency: `@openai/codex` 0.147.0 (`extensions/codex/package.json:11`). Inspected sibling `../codex` contract for that protocol: `codex-rs/app-server/src/bespoke_event_handling.rs:1276-1278` emits `turn/completed.items` as `TurnItemsView::Summary` of `last_agent_message` only; `codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs:274-278` defines that Summary; `codex-rs/protocol/src/models.rs:775-776` names `FinalAnswer` as terminal text for the current turn; `codex-rs/protocol/src/items.rs:60-63` and `codex-rs/app-server-protocol/src/protocol/v2/item.rs:378` model standalone sleep as an extension-owned public Sleep item. Result-time scans of the completion payload cannot see intervening tools or sleep.

The collector records a persistable-text barrier from the first native, dynamic, or sleep handoff notification. After that barrier it walks assistant items in time order: unphased text replaces the current segment, explicit finals accumulate unless they follow a replacement, and silent payloads never replace. The shared delivery silent-payload predicate keeps token, JSON, and reasoning-wrapped `NO_REPLY` envelopes out of an audible answer. A post-handoff silent final stays authoritative. Snapshot identity stays `${turnId}:assistant`. Activity candidate selection is unchanged.

Sibling #116604 still last-wins a silent trailing `NO_REPLY` on a distinct late-event race.

## User Impact

A Codex turn that emits a real answer and then a short coda without more tool work now keeps both texts in the transcript. Dashboard “Worked for” collapse is unchanged and is not the owner of the missing summary.

Already-written rows for old turns are not rewritten. An after-fix Control UI capture of the original session is not available on this head for that reason, and this change is not Telegram-visible.

## Evidence

Live Codex rollout on a dashboard session (2026-08-15) contained two `final_answer` items ~46ms apart: a 1394-character PR summary, then the coda above. OpenClaw SQLite kept only the coda. The rollout still had both items. No IPs, tokens, or private endpoints.

Pre-fix: `keeps an earlier final answer when a later coda arrives with no tool work between them` failed because `assistantTexts` kept only the coda. `final → unphased → later final` kept the stale first final. `final → unphased → silent final` revived the first final instead of the replacement. `final → sleep → later final` joined both texts. Activity and late-tool cases use a production summary-shaped `turn/completed` payload (`[second final]` only).

Post-fix focused:

```
node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/event-projector.assistant.test.ts \
  extensions/codex/src/app-server/event-projector.commentary.test.ts \
  extensions/codex/src/app-server/run-attempt.turn-watches.test.ts \
  extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts \
  extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts \
  extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
```

171 passed, including unphased replacement, silent-after-unphased, sleep handoff, JSON silent-payload join, post-handoff `NO_REPLY` authority, delayed image-generation, and timeout recovery.

`node scripts/check-changed.mjs -- <touched files>`: Crabbox `ci-fast` unavailable, local fallback exit 0.

`$autoreview --mode local`: clean on `64e276b4393`.