### PR TITLE
fix(agents): expose Skill Workshop evaluation results immediately

### DIFF
--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -1,8 +1,13 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
+  SkillProposalEvaluation,
   SkillProposalManifestEntry,
   SkillProposalReadResult,
   SkillProposalStatus,
 } from "../../skills/workshop/types.js";
+
+const EVALUATION_TRUNCATION_MARKER =
+  "\n[truncated: evaluator details exceed the model projection limit]";
 
 export function listProposalEntries(params: {
   proposals: readonly SkillProposalManifestEntry[];
@@ -68,6 +73,26 @@ export function formatProposalList(proposals: readonly SkillProposalManifestEntr
     .join("\n");
 }
 
+export function formatProposalEvaluationSummary(evaluation: SkillProposalEvaluation): string {
+  const counts = { pass: 0, revise: 0, block: 0, none: 0, error: 0, skipped: 0 };
+  for (const outcome of evaluation.outcomes) {
+    counts[outcome.status === "completed" ? (outcome.result.decision ?? "none") : outcome.status]++;
+  }
+  return `Decisions: pass=${counts.pass}, revise=${counts.revise}, block=${counts.block}, none=${counts.none}; errors=${counts.error}; skipped=${counts.skipped}.\nRun skill_workshop action=inspect for persisted evaluator summaries, reasons, findings, metrics, and errors.`;
+}
+
+function formatProposalEvaluationDetails(evaluation: SkillProposalEvaluation): string {
+  const text = JSON.stringify(
+    evaluation.outcomes.map(({ pluginId, evaluatorId, ...outcome }) => ({
+      by: `${pluginId}/${evaluatorId}`,
+      ...outcome,
+    })),
+  );
+  return text.length > 620
+    ? `${truncateUtf16Safe(text, 620 - EVALUATION_TRUNCATION_MARKER.length)}${EVALUATION_TRUNCATION_MARKER}`
+    : text;
+}
+
 export function formatProposalInspect(proposal: SkillProposalReadResult): string {
   const supportFiles =
     proposal.supportFiles && proposal.supportFiles.length > 0
@@ -82,18 +107,7 @@ export function formatProposalInspect(proposal: SkillProposalReadResult): string
     ? [
         "",
         `Evaluation: ${evaluation.outcomes.length} result(s), ${evaluation.trigger}, ${evaluation.completedAt}`,
-        ...evaluation.outcomes.map((outcome) => {
-          const label = `${outcome.pluginId}/${outcome.evaluatorId}`;
-          if (outcome.status === "error") {
-            return `- ${label}: error - ${outcome.error}`;
-          }
-          if (outcome.status === "skipped") {
-            return `- ${label}: skipped`;
-          }
-          const decision = outcome.result.decision ? `, ${outcome.result.decision}` : "";
-          const summary = outcome.result.summary ? ` - ${outcome.result.summary}` : "";
-          return `- ${label}: completed${decision}${summary}`;
-        }),
+        formatProposalEvaluationDetails(evaluation),
       ]
     : [];
   return [

--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -1,4 +1,4 @@
-import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
+import { stableStringify } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   SkillProposalEvaluation,

--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -6,6 +6,7 @@ import type {
   SkillProposalStatus,
 } from "../../skills/workshop/types.js";
 
+const SKILL_PROPOSAL_EVALUATION_MAX_CHARS = 999;
 const EVALUATION_TRUNCATION_MARKER =
   "\n[truncated: evaluator details exceed the model projection limit]";
 
@@ -73,23 +74,21 @@ export function formatProposalList(proposals: readonly SkillProposalManifestEntr
     .join("\n");
 }
 
-export function formatProposalEvaluationSummary(evaluation: SkillProposalEvaluation): string {
+export function formatProposalEvaluation(
+  evaluation: SkillProposalEvaluation,
+  proposalId?: string,
+): string {
+  const heading = proposalId
+    ? `Evaluated skill proposal ${proposalId} with ${evaluation.outcomes.length} evaluator result(s).`
+    : `Evaluation: ${evaluation.outcomes.length} result(s), ${evaluation.trigger}, ${evaluation.completedAt}`;
   const counts = { pass: 0, revise: 0, block: 0, none: 0, error: 0, skipped: 0 };
   for (const outcome of evaluation.outcomes) {
     counts[outcome.status === "completed" ? (outcome.result.decision ?? "none") : outcome.status]++;
   }
-  return `Decisions: pass=${counts.pass}, revise=${counts.revise}, block=${counts.block}, none=${counts.none}; errors=${counts.error}; skipped=${counts.skipped}.\nRun skill_workshop action=inspect for persisted evaluator summaries, reasons, findings, metrics, and errors.`;
-}
-
-function formatProposalEvaluationDetails(evaluation: SkillProposalEvaluation): string {
-  const text = JSON.stringify(
-    evaluation.outcomes.map(({ pluginId, evaluatorId, ...outcome }) => ({
-      by: `${pluginId}/${evaluatorId}`,
-      ...outcome,
-    })),
-  );
-  return text.length > 620
-    ? `${truncateUtf16Safe(text, 620 - EVALUATION_TRUNCATION_MARKER.length)}${EVALUATION_TRUNCATION_MARKER}`
+  const outcomes = JSON.stringify(evaluation.outcomes);
+  const text = `${heading}\nDecisions: pass=${counts.pass}, revise=${counts.revise}, block=${counts.block}, none=${counts.none}; errors=${counts.error}; skipped=${counts.skipped}.\nOutcomes: ${outcomes}`;
+  return text.length > SKILL_PROPOSAL_EVALUATION_MAX_CHARS
+    ? `${truncateUtf16Safe(text, SKILL_PROPOSAL_EVALUATION_MAX_CHARS - EVALUATION_TRUNCATION_MARKER.length)}${EVALUATION_TRUNCATION_MARKER}`
     : text;
 }
 
@@ -103,13 +102,7 @@ export function formatProposalInspect(proposal: SkillProposalReadResult): string
         ]
       : [];
   const evaluation = proposal.record.evaluation;
-  const evaluationLines = evaluation
-    ? [
-        "",
-        `Evaluation: ${evaluation.outcomes.length} result(s), ${evaluation.trigger}, ${evaluation.completedAt}`,
-        formatProposalEvaluationDetails(evaluation),
-      ]
-    : [];
+  const evaluationLines = evaluation ? [formatProposalEvaluation(evaluation)] : [];
   return [
     `Proposal: ${proposal.record.id}`,
     `Status: ${proposal.record.status}`,

--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -1,3 +1,4 @@
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   SkillProposalEvaluation,
@@ -85,7 +86,7 @@ export function formatProposalEvaluation(
   for (const outcome of evaluation.outcomes) {
     counts[outcome.status === "completed" ? (outcome.result.decision ?? "none") : outcome.status]++;
   }
-  const outcomes = JSON.stringify(evaluation.outcomes);
+  const outcomes = stableStringify(evaluation.outcomes);
   const text = `${heading}\nDecisions: pass=${counts.pass}, revise=${counts.revise}, block=${counts.block}, none=${counts.none}; errors=${counts.error}; skipped=${counts.skipped}.\nOutcomes: ${outcomes}`;
   return text.length > SKILL_PROPOSAL_EVALUATION_MAX_CHARS
     ? `${truncateUtf16Safe(text, SKILL_PROPOSAL_EVALUATION_MAX_CHARS - EVALUATION_TRUNCATION_MARKER.length)}${EVALUATION_TRUNCATION_MARKER}`

--- a/src/agents/tools/skill-workshop-tool.evaluation.test.ts
+++ b/src/agents/tools/skill-workshop-tool.evaluation.test.ts
@@ -64,33 +64,41 @@ describe("skill_workshop evaluation", () => {
     const { tool, proposal } = await createEvaluationFixture("Evaluated Skill");
 
     evaluatorMocks.enabled = true;
-    evaluatorMocks.evaluate.mockResolvedValue([
-      { evaluatorId: "offline", pluginId: "quality", status: "error", error: "private error" },
-      {
-        evaluatorId: "pass-rules",
-        pluginId: "quality",
-        pluginVersion: "1.2.3",
-        status: "completed",
-        result: {
-          decision: "pass",
-          decisionReason: "private pass reason",
-          summary: "private pass summary",
-          evaluatorVersion: "rules-7",
-          mode: "static",
-          metrics: { score: 0.8 },
-          findings: [
-            {
-              ruleId: "critical-rule",
-              severity: "critical",
-              message: "critical finding",
-              file: "SKILL.md",
-              line: 12,
-            },
-          ],
-        },
+    const completedOutcome = {
+      evaluatorId: "pass-rules",
+      pluginId: "quality",
+      pluginVersion: "1.2.3",
+      status: "completed",
+      result: {
+        decision: "pass",
+        decisionReason: "private pass reason",
+        summary: "private pass summary",
+        evaluatorVersion: "rules-7",
+        mode: "static",
+        metrics: { score: 0.8, coverage: 0.75 },
+        findings: [
+          {
+            ruleId: "critical-rule",
+            severity: "critical",
+            message: "critical finding",
+            file: "SKILL.md",
+            line: 12,
+          },
+        ],
       },
-      { evaluatorId: "optional", pluginId: "quality", status: "skipped" },
-    ]);
+    } as const;
+    const errorOutcome = {
+      evaluatorId: "offline",
+      pluginId: "quality",
+      status: "error",
+      error: "private error",
+    } as const;
+    const skippedOutcome = {
+      evaluatorId: "optional",
+      pluginId: "quality",
+      status: "skipped",
+    } as const;
+    evaluatorMocks.evaluate.mockResolvedValue([errorOutcome, completedOutcome, skippedOutcome]);
 
     const evaluated = await tool.execute("evaluate", {
       action: "evaluate",
@@ -107,10 +115,11 @@ describe("skill_workshop evaluation", () => {
     expect(visible).toContain('"decision":"pass"');
     expect(visible).toContain("private pass reason");
     expect(visible).toContain("private pass summary");
-    expect(visible).toContain(
-      '"severity":"critical","message":"critical finding","file":"SKILL.md","line":12',
-    );
-    expect(visible).toContain('"metrics":{"score":0.8}');
+    expect(visible).toContain('"file":"SKILL.md"');
+    expect(visible).toContain('"line":12');
+    expect(visible).toContain('"message":"critical finding"');
+    expect(visible).toContain('"severity":"critical"');
+    expect(visible).toContain('"metrics":{"coverage":0.75,"score":0.8}');
     expect(visible).toContain('"evaluatorVersion":"rules-7"');
     expect(visible).toContain('"mode":"static"');
     expect(visible).toContain('"error":"private error"');
@@ -136,6 +145,21 @@ describe("skill_workshop evaluation", () => {
     });
     const inspectVisible = toolText(inspected);
     expect(inspectVisible).toContain(visible.slice(visible.indexOf("Decisions:")));
+
+    evaluatorMocks.evaluate.mockResolvedValue([
+      errorOutcome,
+      {
+        ...completedOutcome,
+        result: { ...completedOutcome.result, metrics: { coverage: 0.75, score: 0.8 } },
+      },
+      skippedOutcome,
+    ]);
+    const reevaluated = await tool.execute("evaluate", {
+      action: "evaluate",
+      proposal_id: proposal.id,
+      expected_revision_hash: proposal.revisionHash,
+    });
+    expect(toolText(reevaluated)).toBe(visible);
   });
 
   it("bounds adversarial evaluator details with an explicit truncation marker", async () => {

--- a/src/agents/tools/skill-workshop-tool.evaluation.test.ts
+++ b/src/agents/tools/skill-workshop-tool.evaluation.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
+
+const evaluatorMocks = vi.hoisted(() => ({ enabled: false, evaluate: vi.fn() }));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({
+    hasHooks: (hookName: string) =>
+      hookName === "skill_proposal_evaluate" && evaluatorMocks.enabled,
+    runSkillProposalEvaluate: evaluatorMocks.evaluate,
+  }),
+}));
+
+const tempDirs = createTrackedTempDirs();
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  evaluatorMocks.enabled = false;
+  evaluatorMocks.evaluate.mockReset();
+  await Promise.all(cleanups.splice(0).map(async (cleanup) => await cleanup()));
+  await tempDirs.cleanup();
+});
+
+describe("skill_workshop evaluation", () => {
+  it("returns bounded decision counts without exposing private evaluator details", async () => {
+    const testState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-skill-workshop-evaluation-state-",
+    });
+    cleanups.push(async () => await testState.cleanup());
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-evaluation-");
+    const tool = createSkillWorkshopTool({ workspaceDir, agentId: "main", env: testState.env });
+    const created = await tool.execute("create", {
+      action: "create",
+      name: "Evaluated Skill",
+      description: "Exercise model-visible evaluation results",
+      proposal_content: "# Evaluated Skill\n",
+    });
+    const proposal = created.details as { id: string; revisionHash: string };
+
+    evaluatorMocks.enabled = true;
+    const completed = (evaluatorId: string, decision?: "pass" | "revise" | "block") => ({
+      evaluatorId,
+      pluginId: "quality",
+      status: "completed",
+      result: decision ? { decision, summary: `private ${decision} summary` } : { metrics: {} },
+    });
+    evaluatorMocks.evaluate.mockResolvedValue([
+      {
+        evaluatorId: "pass-rules",
+        pluginId: "quality",
+        status: "completed",
+        result: {
+          decision: "pass",
+          decisionReason: "private pass reason",
+          summary: "private pass summary",
+          metrics: { score: 0.8 },
+          findings: [
+            { ruleId: "critical-rule", severity: "critical", message: "critical finding" },
+            { ruleId: "warn-rule", severity: "warn", message: "warn finding" },
+            { ruleId: "info-rule", severity: "info", message: "info finding" },
+          ],
+        },
+      },
+      {
+        evaluatorId: "metrics-only",
+        pluginId: "quality",
+        status: "completed",
+        result: { metrics: { coverage: 0.75 } },
+      },
+      { evaluatorId: "offline", pluginId: "quality", status: "error", error: "private error" },
+      completed("revise-rules", "revise"),
+      completed("block-rules", "block"),
+      { evaluatorId: "optional", pluginId: "quality", status: "skipped" },
+    ]);
+
+    const evaluated = await tool.execute("evaluate", {
+      action: "evaluate",
+      proposal_id: proposal.id,
+      expected_revision_hash: proposal.revisionHash,
+    });
+    const visible = evaluated.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+
+    expect(visible).toContain("Decisions: pass=1, revise=1, block=1, none=1; errors=1; skipped=1.");
+    expect(visible).toContain("skill_workshop action=inspect");
+    expect(visible.length).toBeLessThan(1_000);
+    expect(visible).not.toContain("private");
+    const details = evaluated.details as { evaluation: { outcomes: unknown[] } };
+    expect(details.evaluation.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ result: expect.objectContaining({ decision: "pass" }) }),
+      ]),
+    );
+
+    const inspected = await tool.execute("inspect", {
+      action: "inspect",
+      proposal_id: proposal.id,
+    });
+    const inspectVisible = inspected.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    expect(inspectVisible).toContain("private pass reason");
+    expect(inspectVisible).toContain("critical finding");
+    expect(inspectVisible).toContain("warn finding");
+    expect(inspectVisible).toContain("info finding");
+    expect(inspectVisible).toContain('"score":0.8');
+    expect(inspectVisible).toContain('"coverage":0.75');
+    expect(inspectVisible).toContain("private error");
+  });
+
+  it("bounds adversarial evaluator details with an explicit truncation marker", async () => {
+    const testState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-skill-workshop-evaluation-bound-state-",
+    });
+    cleanups.push(async () => await testState.cleanup());
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-evaluation-bound-");
+    const tool = createSkillWorkshopTool({ workspaceDir, agentId: "main", env: testState.env });
+    const created = await tool.execute("create", {
+      action: "create",
+      name: "Bounded Evaluation",
+      description: "Exercise evaluator projection bounds",
+      proposal_content: "# Bounded Evaluation\n",
+    });
+    const proposal = created.details as { id: string; revisionHash: string };
+
+    evaluatorMocks.enabled = true;
+    evaluatorMocks.evaluate.mockResolvedValue([
+      {
+        evaluatorId: "adversarial",
+        pluginId: "quality",
+        status: "completed",
+        result: {
+          decision: "revise",
+          decisionReason: "r".repeat(2_000),
+          summary: "s".repeat(4_000),
+          findings: Array.from({ length: 64 }, (_, index) => ({
+            ruleId: `rule-${index}`,
+            severity: index % 2 === 0 ? "critical" : "warn",
+            message: "f".repeat(2_000),
+          })),
+        },
+      },
+    ]);
+    await tool.execute("evaluate", {
+      action: "evaluate",
+      proposal_id: proposal.id,
+      expected_revision_hash: proposal.revisionHash,
+    });
+    const inspected = await tool.execute("inspect", {
+      action: "inspect",
+      proposal_id: proposal.id,
+    });
+    const visible = inspected.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    const projectionStart = visible.indexOf("[{");
+    const projectionEnd = visible.indexOf("\n\n---", projectionStart);
+    const evaluationProjection = visible.slice(projectionStart, projectionEnd);
+    expect(evaluationProjection.length).toBeLessThanOrEqual(620);
+    expect(evaluationProjection).toContain("[truncated:");
+  });
+});

--- a/src/agents/tools/skill-workshop-tool.evaluation.test.ts
+++ b/src/agents/tools/skill-workshop-tool.evaluation.test.ts
@@ -16,6 +16,42 @@ vi.mock("../../plugins/hook-runner-global.js", () => ({
 const tempDirs = createTrackedTempDirs();
 const cleanups: Array<() => Promise<void>> = [];
 
+async function createEvaluationFixture(name: string) {
+  const testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-evaluation-state-",
+  });
+  cleanups.push(async () => await testState.cleanup());
+  const workspaceDir = await tempDirs.make("openclaw-skill-workshop-evaluation-");
+  const tool = createSkillWorkshopTool({ workspaceDir, agentId: "main", env: testState.env });
+  const created = await tool.execute("create", {
+    action: "create",
+    name,
+    description: "Exercise model-visible evaluation results",
+    proposal_content: `# ${name}\n`,
+  });
+  return { tool, proposal: created.details as { id: string; revisionHash: string } };
+}
+
+function toolText(result: { content: Array<{ type: string; text?: string }> }): string {
+  return result.content
+    .flatMap((block) => (block.type === "text" ? [block.text ?? ""] : []))
+    .join("\n");
+}
+
+function expectUtf16WellFormed(value: string): void {
+  for (let index = 0; index < value.length; index++) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(++index);
+      expect(next).toBeGreaterThanOrEqual(0xdc00);
+      expect(next).toBeLessThanOrEqual(0xdfff);
+    } else {
+      expect(unit < 0xdc00 || unit > 0xdfff).toBe(true);
+    }
+  }
+}
+
 afterEach(async () => {
   evaluatorMocks.enabled = false;
   evaluatorMocks.evaluate.mockReset();
@@ -24,55 +60,35 @@ afterEach(async () => {
 });
 
 describe("skill_workshop evaluation", () => {
-  it("returns bounded decision counts without exposing private evaluator details", async () => {
-    const testState = await createOpenClawTestState({
-      layout: "state-only",
-      prefix: "openclaw-skill-workshop-evaluation-state-",
-    });
-    cleanups.push(async () => await testState.cleanup());
-    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-evaluation-");
-    const tool = createSkillWorkshopTool({ workspaceDir, agentId: "main", env: testState.env });
-    const created = await tool.execute("create", {
-      action: "create",
-      name: "Evaluated Skill",
-      description: "Exercise model-visible evaluation results",
-      proposal_content: "# Evaluated Skill\n",
-    });
-    const proposal = created.details as { id: string; revisionHash: string };
+  it("returns the bounded evaluator outcome directly and keeps inspect in parity", async () => {
+    const { tool, proposal } = await createEvaluationFixture("Evaluated Skill");
 
     evaluatorMocks.enabled = true;
-    const completed = (evaluatorId: string, decision?: "pass" | "revise" | "block") => ({
-      evaluatorId,
-      pluginId: "quality",
-      status: "completed",
-      result: decision ? { decision, summary: `private ${decision} summary` } : { metrics: {} },
-    });
     evaluatorMocks.evaluate.mockResolvedValue([
+      { evaluatorId: "offline", pluginId: "quality", status: "error", error: "private error" },
       {
         evaluatorId: "pass-rules",
         pluginId: "quality",
+        pluginVersion: "1.2.3",
         status: "completed",
         result: {
           decision: "pass",
           decisionReason: "private pass reason",
           summary: "private pass summary",
+          evaluatorVersion: "rules-7",
+          mode: "static",
           metrics: { score: 0.8 },
           findings: [
-            { ruleId: "critical-rule", severity: "critical", message: "critical finding" },
-            { ruleId: "warn-rule", severity: "warn", message: "warn finding" },
-            { ruleId: "info-rule", severity: "info", message: "info finding" },
+            {
+              ruleId: "critical-rule",
+              severity: "critical",
+              message: "critical finding",
+              file: "SKILL.md",
+              line: 12,
+            },
           ],
         },
       },
-      {
-        evaluatorId: "metrics-only",
-        pluginId: "quality",
-        status: "completed",
-        result: { metrics: { coverage: 0.75 } },
-      },
-      { evaluatorId: "offline", pluginId: "quality", status: "error", error: "private error" },
-      completed("revise-rules", "revise"),
-      completed("block-rules", "block"),
       { evaluatorId: "optional", pluginId: "quality", status: "skipped" },
     ]);
 
@@ -81,15 +97,32 @@ describe("skill_workshop evaluation", () => {
       proposal_id: proposal.id,
       expected_revision_hash: proposal.revisionHash,
     });
-    const visible = evaluated.content
-      .filter((block): block is { type: "text"; text: string } => block.type === "text")
-      .map((block) => block.text)
-      .join("\n");
+    const visible = toolText(evaluated);
 
-    expect(visible).toContain("Decisions: pass=1, revise=1, block=1, none=1; errors=1; skipped=1.");
-    expect(visible).toContain("skill_workshop action=inspect");
+    expect(visible).toContain("Decisions: pass=1, revise=0, block=0, none=0; errors=1; skipped=1.");
+    expect(visible).toContain('"evaluatorId":"offline","pluginId":"quality","status":"error"');
+    expect(visible).toContain('"evaluatorId":"pass-rules","pluginId":"quality"');
+    expect(visible).toContain('"pluginVersion":"1.2.3"');
+    expect(visible).toContain('"status":"completed"');
+    expect(visible).toContain('"decision":"pass"');
+    expect(visible).toContain("private pass reason");
+    expect(visible).toContain("private pass summary");
+    expect(visible).toContain(
+      '"severity":"critical","message":"critical finding","file":"SKILL.md","line":12',
+    );
+    expect(visible).toContain('"metrics":{"score":0.8}');
+    expect(visible).toContain('"evaluatorVersion":"rules-7"');
+    expect(visible).toContain('"mode":"static"');
+    expect(visible).toContain('"error":"private error"');
+    expect(visible).toContain('"evaluatorId":"optional","pluginId":"quality","status":"skipped"');
+    expect(visible.indexOf('"evaluatorId":"offline"')).toBeLessThan(
+      visible.indexOf('"evaluatorId":"pass-rules"'),
+    );
+    expect(visible.indexOf('"evaluatorId":"pass-rules"')).toBeLessThan(
+      visible.indexOf('"evaluatorId":"optional"'),
+    );
     expect(visible.length).toBeLessThan(1_000);
-    expect(visible).not.toContain("private");
+    expect(visible).not.toContain("[truncated:");
     const details = evaluated.details as { evaluation: { outcomes: unknown[] } };
     expect(details.evaluation.outcomes).toEqual(
       expect.arrayContaining([
@@ -101,34 +134,12 @@ describe("skill_workshop evaluation", () => {
       action: "inspect",
       proposal_id: proposal.id,
     });
-    const inspectVisible = inspected.content
-      .filter((block): block is { type: "text"; text: string } => block.type === "text")
-      .map((block) => block.text)
-      .join("\n");
-    expect(inspectVisible).toContain("private pass reason");
-    expect(inspectVisible).toContain("critical finding");
-    expect(inspectVisible).toContain("warn finding");
-    expect(inspectVisible).toContain("info finding");
-    expect(inspectVisible).toContain('"score":0.8');
-    expect(inspectVisible).toContain('"coverage":0.75');
-    expect(inspectVisible).toContain("private error");
+    const inspectVisible = toolText(inspected);
+    expect(inspectVisible).toContain(visible.slice(visible.indexOf("Decisions:")));
   });
 
   it("bounds adversarial evaluator details with an explicit truncation marker", async () => {
-    const testState = await createOpenClawTestState({
-      layout: "state-only",
-      prefix: "openclaw-skill-workshop-evaluation-bound-state-",
-    });
-    cleanups.push(async () => await testState.cleanup());
-    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-evaluation-bound-");
-    const tool = createSkillWorkshopTool({ workspaceDir, agentId: "main", env: testState.env });
-    const created = await tool.execute("create", {
-      action: "create",
-      name: "Bounded Evaluation",
-      description: "Exercise evaluator projection bounds",
-      proposal_content: "# Bounded Evaluation\n",
-    });
-    const proposal = created.details as { id: string; revisionHash: string };
+    const { tool, proposal } = await createEvaluationFixture("Bounded Evaluation");
 
     evaluatorMocks.enabled = true;
     evaluatorMocks.evaluate.mockResolvedValue([
@@ -138,8 +149,8 @@ describe("skill_workshop evaluation", () => {
         status: "completed",
         result: {
           decision: "revise",
-          decisionReason: "r".repeat(2_000),
-          summary: "s".repeat(4_000),
+          decisionReason: "SENSITIVE".repeat(1_000),
+          summary: "😀".repeat(4_000),
           findings: Array.from({ length: 64 }, (_, index) => ({
             ruleId: `rule-${index}`,
             severity: index % 2 === 0 ? "critical" : "warn",
@@ -148,23 +159,23 @@ describe("skill_workshop evaluation", () => {
         },
       },
     ]);
-    await tool.execute("evaluate", {
+    const evaluated = await tool.execute("evaluate", {
       action: "evaluate",
       proposal_id: proposal.id,
       expected_revision_hash: proposal.revisionHash,
     });
-    const inspected = await tool.execute("inspect", {
-      action: "inspect",
-      proposal_id: proposal.id,
-    });
-    const visible = inspected.content
-      .filter((block): block is { type: "text"; text: string } => block.type === "text")
-      .map((block) => block.text)
-      .join("\n");
-    const projectionStart = visible.indexOf("[{");
-    const projectionEnd = visible.indexOf("\n\n---", projectionStart);
-    const evaluationProjection = visible.slice(projectionStart, projectionEnd);
-    expect(evaluationProjection.length).toBeLessThanOrEqual(620);
-    expect(evaluationProjection).toContain("[truncated:");
+    const evaluateVisible = toolText(evaluated);
+    expect(evaluateVisible.length).toBeLessThan(1_000);
+    expect(evaluateVisible).toContain(
+      "[truncated: evaluator details exceed the model projection limit]",
+    );
+    expect(evaluateVisible).not.toContain("😀".repeat(1_000));
+    expect(evaluateVisible).not.toContain("SENSITIVE".repeat(200));
+    expectUtf16WellFormed(evaluateVisible);
+    const details = evaluated.details as {
+      evaluation: { outcomes: Array<{ result?: { decisionReason?: string; summary?: string } }> };
+    };
+    expect(details.evaluation.outcomes[0]?.result?.decisionReason).toHaveLength(2_000);
+    expect(details.evaluation.outcomes[0]?.result?.summary).toHaveLength(8_000);
   });
 });

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -65,7 +65,7 @@ import {
   skillWorkshopAgentEventActor,
 } from "./skill-workshop-tool-helpers.js";
 import {
-  formatProposalEvaluationSummary,
+  formatProposalEvaluation,
   formatProposalInspect,
   formatProposalList,
   listProposalEntries,
@@ -446,7 +446,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
           content: [
             {
               type: "text",
-              text: `Evaluated skill proposal ${evaluated.record.id} with ${evaluated.evaluation.outcomes.length} evaluator result(s).\n${formatProposalEvaluationSummary(evaluated.evaluation)}`,
+              text: formatProposalEvaluation(evaluated.evaluation, evaluated.record.id),
             },
           ],
           details: {

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -65,6 +65,7 @@ import {
   skillWorkshopAgentEventActor,
 } from "./skill-workshop-tool-helpers.js";
 import {
+  formatProposalEvaluationSummary,
   formatProposalInspect,
   formatProposalList,
   listProposalEntries,
@@ -445,7 +446,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
           content: [
             {
               type: "text",
-              text: `Evaluated skill proposal ${evaluated.record.id} with ${evaluated.evaluation.outcomes.length} evaluator result(s).`,
+              text: `Evaluated skill proposal ${evaluated.record.id} with ${evaluated.evaluation.outcomes.length} evaluator result(s).\n${formatProposalEvaluationSummary(evaluated.evaluation)}`,
             },
           ],
           details: {


### PR DESCRIPTION
Closes #123992

## What Problem This Solves

Fixes an issue where agents evaluating a Skill Workshop proposal received only the evaluator-result count, even though decisions, reasons, summaries, findings, metrics, modes/versions, skips, and errors were already available. The model had to spend another `inspect` round trip—or act without the authoritative outcome.

## Why This Change Was Made

The model-visible projection now belongs to one deterministic formatter shared by `evaluate` and `inspect`. The initiating evaluate result includes decision counts plus ordered evaluator outcomes, while the full persisted evaluation remains authoritative in private details. The formatter uses canonical recursive key ordering, enforces a named 999-character cap, truncates on UTF-16 boundaries, and appends an explicit marker.

This is the owner-boundary fix: changing the global detail-stripping boundary would expose unrelated private payloads, while an evaluate-only formatter would duplicate policy and drift from inspect. There are no config, protocol, Plugin SDK, persistence-shape, security, provider, or public CLI changes, and no changelog edit.

Provenance: the count-only projection was introduced by @vincentkoc in #115606 and merged by @vincentkoc as `14940edf15f6f5844d09aeff985843948e0716c2` on July 29, 2026.

## User Impact

Agents can immediately decide whether to apply, revise, or block a proposal from the result of the evaluate action itself. Normal evaluator output costs no extra model/tool round trip, and oversized output remains explicit and bounded instead of silently consuming context.

Production LOC: +28/−19 (net +9) | Tests: +205/−0

## Evidence

- Pre-fix on exact main `295f2c0212fd759fabd5e80cecfd00fc324bb441`: 2/2 regressions fail because direct evaluate omits decisions/outcomes and has no truncation marker.
- Final focused and owner tests: 27/27 pass.
- Source-blind real-tool validation: 7/7 clauses pass.
- Direct evaluate measurements: 356, 539, 669, and 999 characters; all below 1,000.
- Adversarial proof: explicit truncation marker, intact UTF-16, full sensitive fixture omitted.
- Complete mixed evaluate/inspect projections are byte-identical after their action-specific headings.
- Reversed metric insertion order produces byte-identical model-visible output through the canonical stable serializer.
- LLM boundary proof: full authoritative `details` never enter model-visible content.
- Changed gate: `core, coreTests`, exit 0; typecheck, lint, max-lines, dead exports, import cycles, architecture, formatting, and selected guards pass.
- `git diff --check`: pass.
- ClawSweeper determinism finding addressed with stable nested-record serialization and regression coverage.
- Fresh Codex autoreview on final head `78b7ae9914284d912b70e6dd50c3c7ce6125be40`: clean, no accepted findings.
