### PR TITLE
fix(ui): stage every gateway-honored agent model shape instead of silently dropping input

### DIFF
--- a/ui/src/pages/agents/model-config.test.ts
+++ b/ui/src/pages/agents/model-config.test.ts
@@ -60,4 +60,67 @@ describe("agent model config", () => {
     expect(runtimeConfig.state.configForm?.agents).not.toHaveProperty("list");
     runtimeConfig.dispose();
   });
+
+  it("stages fallbacks without a primary when no model is authored anywhere", async () => {
+    // Fully implicit default model: typing a fallback chip must stage the
+    // { fallbacks }-only shape the gateway honors, not silently no-op.
+    const runtimeConfig = createRuntimeConfig({
+      agents: { entries: { main: { default: true } } },
+    });
+    await runtimeConfig.ensureLoaded();
+
+    stageAgentModelFallbacks(runtimeConfig, "main", ["openai/gpt-5.4"]);
+
+    expect(runtimeConfig.state.configForm).toEqual({
+      agents: {
+        entries: {
+          main: { default: true, model: { fallbacks: ["openai/gpt-5.4"] } },
+        },
+      },
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("keeps authored fallbacks when the primary model is cleared", async () => {
+    const runtimeConfig = createRuntimeConfig({
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.4" } },
+        entries: {
+          main: {
+            default: true,
+            model: { primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5.4"] },
+          },
+        },
+      },
+    });
+    await runtimeConfig.ensureLoaded();
+
+    stageAgentPrimaryModel(runtimeConfig, "main", null);
+
+    expect(runtimeConfig.state.configForm).toEqual({
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.4" } },
+        entries: {
+          main: { default: true, model: { fallbacks: ["openai/gpt-5.4"] } },
+        },
+      },
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("still removes the model node when clearing a primary with no fallbacks", async () => {
+    const runtimeConfig = createRuntimeConfig({
+      agents: {
+        entries: { main: { default: true, model: "anthropic/claude-sonnet-4-6" } },
+      },
+    });
+    await runtimeConfig.ensureLoaded();
+
+    stageAgentPrimaryModel(runtimeConfig, "main", null);
+
+    expect(runtimeConfig.state.configForm).toEqual({
+      agents: { entries: { main: { default: true } } },
+    });
+    runtimeConfig.dispose();
+  });
 });

--- a/ui/src/pages/agents/model-config.ts
+++ b/ui/src/pages/agents/model-config.ts
@@ -21,6 +21,44 @@ function modelEntry(target: AgentConfigEntryTarget) {
   };
 }
 
+// Stage the smallest config shape that expresses the selection. The gateway
+// resolver honors a bare string, { primary, fallbacks }, and { fallbacks }
+// with no primary (agent-scope.ts); staging must write all three or an
+// authored piece of the selection silently disappears.
+function stageModelShape(
+  runtimeConfig: RuntimeConfig,
+  path: Array<string | number>,
+  primary: string | null,
+  fallbacks: string[] | null,
+) {
+  if (primary && fallbacks) {
+    runtimeConfig.patchForm(path, { primary, fallbacks });
+  } else if (primary) {
+    runtimeConfig.patchForm(path, primary);
+  } else if (fallbacks) {
+    runtimeConfig.patchForm(path, { fallbacks });
+  } else {
+    runtimeConfig.removeFormValue(path);
+  }
+}
+
+function existingModelParts(existing: unknown): {
+  primary: string | null;
+  fallbacks: string[] | null;
+} {
+  if (typeof existing === "string") {
+    return { primary: existing.trim() || null, fallbacks: null };
+  }
+  if (existing && typeof existing === "object") {
+    const record = existing as { primary?: unknown; fallbacks?: unknown };
+    return {
+      primary: typeof record.primary === "string" ? record.primary.trim() || null : null,
+      fallbacks: Array.isArray(record.fallbacks) ? (record.fallbacks as string[]) : null,
+    };
+  }
+  return { primary: null, fallbacks: null };
+}
+
 /** Stage a primary-model change; clearing falls back to the inherited default. */
 export function stageAgentPrimaryModel(
   runtimeConfig: RuntimeConfig,
@@ -32,17 +70,9 @@ export function stageAgentPrimaryModel(
     return;
   }
   const entry = modelEntry(target);
-  if (!modelId) {
-    runtimeConfig.removeFormValue(entry.path);
-  } else if (entry.existing && typeof entry.existing === "object") {
-    const fallbacks = (entry.existing as { fallbacks?: unknown }).fallbacks;
-    runtimeConfig.patchForm(entry.path, {
-      primary: modelId,
-      ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-    });
-  } else {
-    runtimeConfig.patchForm(entry.path, modelId);
-  }
+  // Clearing the primary must not delete authored agent fallbacks: the
+  // { fallbacks }-only shape stays representable.
+  stageModelShape(runtimeConfig, entry.path, modelId, existingModelParts(entry.existing).fallbacks);
 }
 
 /** Stage fallback-list edits, preserving the effective primary model shape. */
@@ -54,40 +84,20 @@ export function stageAgentModelFallbacks(
   const config = currentConfigObject(runtimeConfig.state);
   const normalized = normalizeStringEntries(fallbacks);
   const resolved = resolveAgentConfig(config, agentId);
-  const primary =
-    resolveModelPrimary(resolved.entry?.model) ?? resolveModelPrimary(resolved.defaults?.model);
   const effective = resolveEffectiveModelFallbacks(resolved.entry?.model, resolved.defaults?.model);
   const existingTarget = runtimeConfig.agentEntry(agentId);
-  const target =
-    normalized.length > 0
-      ? primary
-        ? (existingTarget ?? runtimeConfig.agentEntry(agentId, { ensure: true }))
-        : null
-      : (effective?.length ?? 0) > 0 || existingTarget
-        ? (existingTarget ?? runtimeConfig.agentEntry(agentId, { ensure: true }))
-        : null;
+  const mustWrite = normalized.length > 0 || (effective?.length ?? 0) > 0 || existingTarget;
+  const target = mustWrite
+    ? (existingTarget ?? runtimeConfig.agentEntry(agentId, { ensure: true }))
+    : null;
   if (!target) {
     return;
   }
   const entry = modelEntry(target);
-  const currentPrimary =
-    typeof entry.existing === "string"
-      ? entry.existing.trim()
-      : entry.existing &&
-          typeof entry.existing === "object" &&
-          typeof (entry.existing as { primary?: unknown }).primary === "string"
-        ? (entry.existing as { primary: string }).primary.trim()
-        : "";
-  if (normalized.length === 0) {
-    if (currentPrimary || primary) {
-      runtimeConfig.patchForm(entry.path, currentPrimary || primary);
-    } else {
-      runtimeConfig.removeFormValue(entry.path);
-    }
-  } else if (currentPrimary || primary) {
-    runtimeConfig.patchForm(entry.path, {
-      primary: currentPrimary || primary,
-      fallbacks: normalized,
-    });
-  }
+  const primary =
+    existingModelParts(entry.existing).primary ??
+    resolveModelPrimary(resolved.entry?.model) ??
+    resolveModelPrimary(resolved.defaults?.model) ??
+    null;
+  stageModelShape(runtimeConfig, entry.path, primary, normalized.length > 0 ? normalized : null);
 }


### PR DESCRIPTION
## What Problem This Solves

Found by the round-4 agents-page/model-switching investigation lane, verified against live code. The agents-page fallback editor (`stageAgentModelFallbacks`) gated staging on a resolvable primary model. But the gateway resolver explicitly honors a model object with `fallbacks` and no `primary` (`src/agents/agent-scope.ts` — including the documented "explicit empty array disables global fallbacks" contract). With a fully implicit default model (no `agents.defaults.model`, no per-agent model — a supported config-light setup), typing a fallback ref and pressing Enter cleared the input, staged nothing, showed no chip and no error. Doctrine-worst class: a user action with no visible outcome and no recorded reason.

`stageAgentPrimaryModel` had the sibling bug: clearing the primary called `removeFormValue` on the whole `model` node, deleting authored agent `fallbacks` along with it — "inherit the default primary, keep my fallbacks" was silently unexpressible.

## Why This Change Was Made

Both bugs come from staging code that could not represent every config shape the gateway honors. One `stageModelShape` owner now writes the smallest representable form — bare string, `{ primary, fallbacks }`, `{ fallbacks }`, or node removal — and both entry points share one `existingModelParts` probe instead of duplicating existing-shape inspection. This deletes the duplicated primary-probing branches and the artificial `primary ? … : null` gate rather than patching around them.

## User Impact

Typing a fallback model on an agent with no authored primary now stages and saves it (the gateway already honored the shape; only the UI refused to write it). Clearing an agent's primary model keeps its authored fallbacks. Clearing a primary with no fallbacks still removes the model node cleanly.

## Evidence

- 2 new regression tests fail pre-fix: "stages fallbacks without a primary when no model is authored anywhere" (form stayed empty) and "keeps authored fallbacks when the primary model is cleared" (fallbacks deleted). Both pass post-fix; a third new test locks the still-correct removal path, and the existing keyed-entry write test passes unchanged (4/4).
- Full `ui/src/pages/agents` suite: 171 passed | 1 skipped. `pnpm tsgo:ui` clean; oxlint/oxfmt clean.
- Autoreview (Codex, high): clean, no accepted findings, "patch is correct (0.98)".
- Production LOC: +51 −41 in `model-config.ts` (net +10, of which 7 are the two invariant comments and the shared-shape doc). Justified: replaces two divergent partial-shape writers with one owner that can express the full gateway contract; the silent-drop gate and duplicated probing are deleted.
