### PR TITLE
fix(xai): prevent cancelled X searches from affecting retries

### DIFF
--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -276,6 +276,29 @@ describe("xai x_search tool", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("does not cache an X search result completed after caller cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("operator cancelled X search after response");
+    const mockFetch = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        controller.abort(reason);
+        return jsonResponse({ output_text: "Cancelled X answer", citations: [] });
+      })
+      .mockResolvedValueOnce(jsonResponse({ output_text: "Recovered X answer", citations: [] }));
+    global.fetch = withFetchPreconnect(mockFetch);
+    const tool = createConfiguredXSearchTool();
+    const query = "unique standalone x_search late-cancel cache regression";
+
+    await expect(tool.execute("xai-late-cancel", { query }, controller.signal)).rejects.toBe(
+      reason,
+    );
+    const recovered = await tool.execute("xai-late-cancel-retry", { query });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((recovered.details as { content?: string }).content).toContain("Recovered X answer");
+  });
+
   it("uses the xAI Responses x_search tool with structured filters", async () => {
     const mockFetch = installXSearchFetch();
     const tool = createConfiguredXSearchTool({ xSearch: { maxTurns: 2 } });

--- a/extensions/xai/x-search.ts
+++ b/extensions/xai/x-search.ts
@@ -242,6 +242,7 @@ export function createXSearchTool(options?: {
       options: xSearchOptions,
       ...(signal ? { signal } : {}),
     });
+    signal?.throwIfAborted();
     const payload = buildXaiXSearchPayload({
       query,
       model,


### PR DESCRIPTION
Closes #123964

## What Problem This Solves

Fixes an issue where a cancelled standalone `x_search` call could populate its process cache after the provider response completed, causing an identical later search to reuse work the caller had explicitly cancelled.

## Why This Change Was Made

The standalone tool now rechecks its caller signal immediately after `requestXaiXSearch` succeeds and before payload construction or cache insertion. This keeps cancellation ownership at the local state-commit boundary and preserves the exact caller abort reason.

This is intentionally distinct from the managed web-search provider repair in #123951. It does not change managed-provider behavior, cache TTL/keying, xAI request/auth/routing, tool schema/result shape, configuration, retry policy, or replay policy. Production growth is one lifecycle-fence line; the remaining 23 lines are regression coverage. No changelog edit is needed because release generation owns `CHANGELOG.md`.

## User Impact

Cancelling a standalone X search no longer affects an identical later retry. The cancelled call rejects with the caller's exact reason, and the retry performs a fresh request.

## Evidence

- Pre-fix focused regression: 22/23 passed; the new case failed because the cancelled call resolved with the provider answer.
- Pre-fix controlled local-server proof: first response completed, first call resolved, one upstream request, retry reported `cached: true`, and replayed the cancelled answer.
- Repaired standalone suite: 23/23 passed.
- Repaired xAI owner/sibling suites: 93/93 passed across standalone `x_search`, managed Grok web search, and shared Responses parsing.
- Repaired controlled local-server proof: exact caller reason preserved, first call rejected, retry was uncached, returned the distinct fresh response, and exactly two upstream requests were observed.
- `node scripts/check-changed.mjs -- extensions/xai/x-search.ts extensions/xai/x-search.test.ts`: passed, including extension production/test types, changed-file lint, formatting, boundary guards, and zero runtime import cycles. The remote route had no ready backend and the repository wrapper completed its documented local fallback.
- Fresh Codex autoreview on the rebased branch: clean; no accepted/actionable findings.
- Diff: production `+1/-0`; tests `+23/-0`; two files only.
