### PR TITLE
fix(cli): exit non-zero when skills info cannot find a skill

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -167,7 +167,10 @@ function primeSkillVerification(overrides: Record<string, unknown> = {}) {
   });
 }
 
-afterEach(() => restoreTty());
+afterEach(() => {
+  restoreTty();
+  vi.unstubAllEnvs();
+});
 
 function mockCall(mock: unknown, index = 0): Array<unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
@@ -1374,6 +1377,39 @@ describe("skills cli commands", () => {
 
     const payload = JSON.parse(runtimeStdout.at(-1) ?? "{}") as Record<string, unknown>;
     assert(payload);
+  });
+
+  it.each([
+    {
+      label: "human",
+      argv: ["skills", "info", "missing-skill"],
+      expected:
+        'Skill "missing-skill" not found. Run `openclaw skills list` to see available skills.\n\nTip: use `openclaw skills search`, `openclaw skills install`, and `openclaw skills update` for ClawHub-backed skills.',
+    },
+    {
+      label: "JSON",
+      argv: ["skills", "info", "missing-skill", "--json"],
+      expected: JSON.stringify({ error: "not found", skill: "missing-skill" }, null, 2),
+    },
+  ])("exits nonzero for missing skill info in $label mode", async ({ argv, expected }) => {
+    vi.stubEnv("OPENCLAW_PROFILE", "");
+    vi.stubEnv("OPENCLAW_CONTAINER_HINT", "");
+
+    await expect(runCommand(argv)).rejects.toThrow("__exit__:1");
+
+    expect(runtimeStdout).toEqual([expected]);
+    expect(runtimeErrors).toStrictEqual([]);
+    expect(defaultRuntime.exit).toHaveBeenCalledOnce();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps successful human skill info output at exit zero", async () => {
+    await runCommand(["skills", "info", "calendar"]);
+
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
+    expect(runtimeStdout).toHaveLength(1);
+    expect(runtimeStdout.at(-1)).toContain("📅 calendar ✓ Ready");
+    expect(runtimeStdout.at(-1)).toContain("Calendar helpers");
   });
 
   it.each([

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -25,6 +25,7 @@ import {
 } from "../infra/clawhub-skills.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
+import { resolveSkillStatusEntry, type SkillStatusReport } from "../skills/discovery/status.js";
 import {
   installSkillFromClawHub,
   readVerifiedClawHubSkillSourceUrl,
@@ -80,9 +81,6 @@ export type {
 } from "./skills-cli.format.js";
 export { formatSkillInfo, formatSkillsCheck, formatSkillsList } from "./skills-cli.format.js";
 
-type SkillStatusReport = Awaited<
-  ReturnType<(typeof import("../skills/discovery/status.js"))["buildWorkspaceSkillStatus"]>
->;
 type ResolvedClawHubSkillVerificationTarget = Extract<
   Awaited<ReturnType<typeof resolveClawHubSkillVerificationTarget>>,
   { ok: true }
@@ -1236,16 +1234,22 @@ export function registerSkillsCli(program: Command) {
     .option("--json", "Output as JSON", false)
     .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
     .action(async (name: string, opts: { json?: boolean; agent?: string }, command: Command) => {
+      let skillFound = false;
       await runSkillsAction(
-        (report) =>
-          formatSkillInfo(report, name, {
+        (report) => {
+          skillFound = resolveSkillStatusEntry(report.skills, name) !== null;
+          return formatSkillInfo(report, name, {
             ...opts,
             json: hasJsonOutput(opts),
-          }),
+          });
+        },
         {
           agentId: resolveAgentOption(command, opts),
         },
       );
+      if (!skillFound) {
+        defaultRuntime.exit(1);
+      }
     });
 
   skills


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw skills info <missing>` printed a clear not-found result but exited `0`, so shell conditionals and machine consumers treated a missing skill as present.

The human and JSON payloads were already correct; only the process status contradicted them.

## Why This Change Was Made

The command action now resolves the requested skill with the same canonical resolver used by the formatter, writes the existing formatter output unchanged, and exits `1` when resolution fails. This keeps the exported `formatSkillInfo` string contract intact instead of widening it with command-status metadata.

The direct structural sibling, `hooks info`, follows the same separation: format output first, then derive the command status independently from the report.

## User Impact

Scripts can safely use `openclaw skills info NAME && ...`, and machine consumers can trust a non-zero status for missing skills. Existing skills still exit `0`. Human text and JSON keys are unchanged.

## Evidence

### Before

Reproduced with the packaged CLI before the patch:

```text
$ openclaw skills info nope-not-real --agent main
Skill "nope-not-real" not found. Run `openclaw skills list` to see available skills.

Tip: use `openclaw skills search`, `openclaw skills install`, and `openclaw skills update` for ClawHub-backed skills.
$ echo $?
0

$ openclaw skills info nope-not-real --agent main --json
{
  "error": "not found",
  "skill": "nope-not-real"
}
$ echo $?
0
```

Sibling behavior at the same boundary:

| Command | Missing-result exit |
| --- | ---: |
| `cron show <bogus>` | 1 |
| `approvals resolve <bogus>` | 1 |
| `config get <missing path>` | 1 |
| `agents delete <bogus>` | 1 |
| `hooks info <bogus>` | 1 |
| `skills info <bogus>` before this patch | 0 |

`hooks info --json` returns `{ "error": "not found", "hook": NAME }` and exits `1`; `skills info --json` keeps its parallel `{ "error": "not found", "skill": NAME }` shape and now also exits `1`.

### After: built CLI, isolated state

Built the exact branch, then ran with a fresh `OPENCLAW_STATE_DIR` and `OPENCLAW_SKIP_CHANNELS=1`:

| Command | Exit |
| --- | ---: |
| `skills info nope-not-real --agent main` | 1 |
| `skills info nope-not-real --agent main --json` | 1 |
| `skills info skill-creator --agent main` | 0 |
| `skills info skill-creator --agent main --json` | 0 |
| `hooks info nope-not-real --agent main` | 1 |
| `hooks info nope-not-real --agent main --json` | 1 |
| `config get nope.not.real --json` | 1 |
| `agents delete nope-not-real --force` | 1 |

The missing human text and pretty-printed JSON were byte-identical to the baseline payloads. The existing JSON still reported `"name": "skill-creator"`.

### Skills surface sweep

| Surface | Checked exit behavior |
| --- | --- |
| default / `list` | Valid empty or populated report: 0; load error: 1 |
| `info` | Existing: 0; missing: 1 after this patch |
| `check` | Diagnostic report, including missing requirements: 0; load error: 1 |
| `search` | Empty results: 0; invalid input or registry failure: 1 |
| `install` | Invalid input and install failures: 1 |
| `update` | Missing/conflicting selection or failed update: 1; empty `--all`: intentional no-op 0 |
| `verify` | Resolution, card, verification, malformed-envelope, and transport failures: 1 |
| curator `status` | Successful current report: 0; current read failure: 1 |
| curator `pin` / `unpin` / `restore` | Missing skill and mutation failures: 1 |
| workshop parent / `list` | Help or empty proposal list: 0 |
| workshop `inspect` and mutations | Missing proposal/input and service failures: 1 |

Repo-wide `src/cli/**` search found only two formatter-returned top-level `{ error: "not found" }` payloads: skills and hooks. Hooks was already correct. Other direct JSON error writers checked (config, directory, system, webhooks, node/gateway status, doctor, and database) already exit non-zero.

Named follow-up: define `plugins doctor` exit semantics when its report has `ok: false`. Its report mixes hard load errors with warnings, so changing that broader diagnostic contract needs a separate product-policy decision rather than riding this focused not-found fix.

### Validation

- Pre-fix regression proof: both new missing-skill cases failed because the command resolved instead of exiting.
- `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/cli/skills-cli.test.ts src/cli/skills-cli.formatting.test.ts src/cli/hooks-cli.test.ts` — 123 passed.
- `node scripts/check-changed.mjs -- src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts` — passed on Blacksmith Testbox (types, lint, formatting, dead-code and boundary guards).
- `pnpm build` on Blacksmith Testbox — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.
- Post-rebase focused command test — 3 passed.

AI-assisted: implementation, sweep, and validation were performed with Codex; the behavior and diff were reviewed directly.
