### PR TITLE
fix(gateway): name stale install on WS connect failures

### DIFF
--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from "node:url";
 import {
   ErrorCodes,
   errorShape,
@@ -9,9 +8,6 @@ import {
   gatewayStartupUnavailableDetails,
   GATEWAY_STARTUP_RETRY_AFTER_MS,
 } from "../../packages/gateway-protocol/src/startup-unavailable.js";
-import { formatCliCommand } from "../cli/command-format.js";
-import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
-import { hasNodeErrorCode, isPathInside } from "../infra/path-guards.js";
 import { getActivePluginHttpRouteRegistry, getActivePluginRegistry } from "../plugins/runtime.js";
 import {
   getPluginRuntimeGatewayRequestScope,
@@ -60,41 +56,9 @@ import {
   resolveSessionMutationAuthorization,
   SessionMutationAuthorizationChangedError,
 } from "./session-sharing.js";
+import { classifyGatewayStaleInstall } from "./stale-install.js";
 
 type CoreGatewayHandlerModuleLoader = () => Promise<GatewayRequestHandlers>;
-
-// The install root is process-stable; capture it before an upgrade can replace
-// package metadata, then consult it only after a dynamic import has failed.
-const gatewayInstallRoot = resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
-
-function staleInstallErrorShape(error: unknown): ErrorShape | null {
-  if (
-    !gatewayInstallRoot ||
-    !(error instanceof Error) ||
-    !hasNodeErrorCode(error, "ERR_MODULE_NOT_FOUND")
-  ) {
-    return null;
-  }
-  const url = (error as Error & { url?: unknown }).url;
-  if (typeof url !== "string") {
-    return null;
-  }
-  let missingPath: string;
-  try {
-    missingPath = fileURLToPath(url);
-  } catch {
-    return null;
-  }
-  if (!isPathInside(gatewayInstallRoot, missingPath)) {
-    return null;
-  }
-  const restartCommand = formatCliCommand("openclaw gateway restart");
-  return errorShape(
-    ErrorCodes.UNAVAILABLE,
-    `The running Gateway can no longer load part of its OpenClaw installation. The installation may have changed while the Gateway was running. Restart it with: ${restartCommand}`,
-    { details: { code: "STALE_INSTALL", restartCommand }, retryable: false },
-  );
-}
 
 const CORE_GATEWAY_HANDLER_MODULES = {
   agent: () => import("./server-methods/agent.js").then((module) => module.agentHandlers),
@@ -550,9 +514,9 @@ export async function runWithGatewayRequestEnvelope<T>(
       if (error instanceof SessionMutationAuthorizationChangedError) {
         return await options.reject(error.error);
       }
-      const staleInstallError = staleInstallErrorShape(error);
-      if (staleInstallError) {
-        return await options.reject(staleInstallError);
+      const staleInstall = classifyGatewayStaleInstall(error);
+      if (staleInstall) {
+        return await options.reject(staleInstall.error);
       }
       throw error;
     }

--- a/src/gateway/server/ws-connection.load-failure.test.ts
+++ b/src/gateway/server/ws-connection.load-failure.test.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  attachGatewayWsForTest,
+  createGatewayWsTestLogger,
+  createGatewayWsTestSocket,
+} from "./ws-connection.test-helpers.js";
+
+function moduleNotFoundError(filePath: string): Error {
+  return Object.assign(new Error(`Cannot find module '${filePath}'`), {
+    code: "ERR_MODULE_NOT_FOUND",
+    url: pathToFileURL(filePath).href,
+  });
+}
+
+async function connectWithMessageHandlerLoadError(error: Error) {
+  vi.resetModules();
+  vi.doMock("./ws-connection/message-handler.js", () => ({
+    get attachGatewayWsMessageHandler() {
+      throw error;
+    },
+  }));
+  const { attachGatewayWsConnectionHandler } = await import("./ws-connection.js");
+  const logWsControl = createGatewayWsTestLogger();
+  const socket = createGatewayWsTestSocket({ closeEmits: true });
+
+  attachGatewayWsForTest({
+    attach: attachGatewayWsConnectionHandler,
+    socket,
+    options: { logWsControl: logWsControl as never },
+  });
+  await vi.dynamicImportSettled();
+
+  return { logWsControl, socket };
+}
+
+describe("WebSocket message handler load failures", () => {
+  afterEach(() => {
+    vi.doUnmock("./ws-connection/message-handler.js");
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("names the restart remedy when the running install changed", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "r13");
+    const missingChunk = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "missing-message-handler-chunk.js",
+    );
+    const { logWsControl, socket } = await connectWithMessageHandlerLoadError(
+      moduleNotFoundError(missingChunk),
+    );
+
+    expect(socket.close).toHaveBeenCalledWith(
+      1011,
+      "gateway install changed; run: openclaw gateway restart",
+    );
+    expect(Buffer.byteLength(String(socket.close.mock.calls[0]?.[1]), "utf8")).toBeLessThanOrEqual(
+      123,
+    );
+    expect(logWsControl.error).toHaveBeenCalledWith(
+      expect.stringContaining("OpenClaw installation changed while the Gateway was running"),
+    );
+    expect(logWsControl.error).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw --profile r13 gateway restart"),
+    );
+    expect(logWsControl.warn).toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.objectContaining({
+        cause: "message-handler-load-failed",
+        staleInstall: true,
+        restartCommand: "openclaw --profile r13 gateway restart",
+      }),
+    );
+  });
+
+  it("keeps the generic 1011 behavior for an unclassified load failure", async () => {
+    const { logWsControl, socket } = await connectWithMessageHandlerLoadError(
+      new Error("loader exploded"),
+    );
+
+    expect(socket.close).toHaveBeenCalledWith(1011, "gateway message handler unavailable");
+    expect(logWsControl.warn).toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.not.objectContaining({ staleInstall: true }),
+    );
+  });
+});

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -27,6 +27,10 @@ import {
 } from "../server-constants.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
+import {
+  classifyGatewayStaleInstall,
+  GATEWAY_STALE_INSTALL_CLOSE_REASON,
+} from "../stale-install.js";
 import { cleanupTalkConnection } from "../talk-session-registry.js";
 import { formatForLog, logWs } from "../ws-log.js";
 import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
@@ -144,11 +148,25 @@ function attachGatewayWsMessageHandlerOnDemand(
     })
     .catch((error: unknown) => {
       params.socket.off("message", queueMessage);
+      const formattedError = formatError(error);
+      const staleInstall = classifyGatewayStaleInstall(error);
+      if (staleInstall) {
+        params.setCloseCause("message-handler-load-failed", {
+          error: formattedError,
+          staleInstall: true,
+          restartCommand: staleInstall.restartCommand,
+        });
+        params.logWsControl.error(
+          `failed to load ws message handler because the OpenClaw installation changed while the Gateway was running conn=${params.connId}; run: ${staleInstall.restartCommand}; error: ${formattedError}`,
+        );
+        params.close(1011, GATEWAY_STALE_INSTALL_CLOSE_REASON);
+        return;
+      }
       params.setCloseCause("message-handler-load-failed", {
-        error: formatError(error),
+        error: formattedError,
       });
-      params.logWsControl.warn(
-        `failed to load ws message handler conn=${params.connId}: ${formatError(error)}`,
+      params.logWsControl.error(
+        `failed to load ws message handler conn=${params.connId}: ${formattedError}`,
       );
       params.close(1011, "gateway message handler unavailable");
     });

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.load-failure.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.load-failure.test.ts
@@ -1,0 +1,86 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayWsClient } from "../ws-types.js";
+import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+
+function moduleNotFoundError(filePath: string): Error {
+  return Object.assign(new Error(`Cannot find module '${filePath}'`), {
+    code: "ERR_MODULE_NOT_FOUND",
+    url: pathToFileURL(filePath).href,
+  });
+}
+
+describe("authenticated request dispatcher load failures", () => {
+  afterEach(() => {
+    vi.doUnmock("./authenticated-request-dispatch.server-methods.runtime.js");
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns typed restart guidance when the running install changed", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "r13");
+    const missingChunk = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "missing-request-dispatch-chunk.js",
+    );
+    const error = moduleNotFoundError(missingChunk);
+    vi.resetModules();
+    vi.doMock("./authenticated-request-dispatch.server-methods.runtime.js", () => ({
+      get handleGatewayRequest() {
+        throw error;
+      },
+    }));
+    const { createGatewayAuthenticatedRequestDispatcher } =
+      await import("./authenticated-request-dispatch.js");
+    const send = vi.fn();
+    const dispatcher = createGatewayAuthenticatedRequestDispatcher({
+      handler: {
+        connId: "stale-install-dispatch",
+        extraHandlers: {},
+        buildRequestContext: () => ({}) as never,
+        send,
+        close: vi.fn(),
+        isClosed: () => false,
+        setCloseCause: vi.fn(),
+        logGateway: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      } as unknown as GatewayWsMessageHandlerParams,
+      isWebchatConnect: () => false,
+    });
+    const client = {
+      socket: {},
+      connId: "stale-install-dispatch",
+      usesSharedGatewayAuth: false,
+      connect: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: { id: "gateway-client", version: "dev", platform: "test", mode: "backend" },
+        role: "operator",
+        scopes: ["operator.admin"],
+      },
+    } as GatewayWsClient;
+
+    await dispatcher.dispatch(
+      { type: "req", id: "stale-install", method: "status", params: {} },
+      client,
+    );
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "stale-install",
+          ok: false,
+          error: expect.objectContaining({
+            code: "UNAVAILABLE",
+            retryable: false,
+            message: expect.stringContaining("openclaw --profile r13 gateway restart"),
+            details: {
+              code: "STALE_INSTALL",
+              restartCommand: "openclaw --profile r13 gateway restart",
+            },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -15,6 +15,7 @@ import {
   runWithDiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
 import { createLazyPromise } from "../../../shared/lazy-runtime.js";
+import { classifyGatewayStaleInstall } from "../../stale-install.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
@@ -211,10 +212,11 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       } catch (err) {
         // Failure diagnostics and responses belong to the same request trace as the handler.
         logGateway.error(`request handler failed: ${formatForLog(err)}`);
+        const staleInstall = classifyGatewayStaleInstall(err);
         respondWithAuthority(
           false,
           undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)),
+          staleInstall?.error ?? errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)),
         );
       } finally {
         if (requestController) {

--- a/src/gateway/stale-install.ts
+++ b/src/gateway/stale-install.ts
@@ -1,0 +1,53 @@
+import { fileURLToPath } from "node:url";
+import {
+  ErrorCodes,
+  errorShape,
+  type ErrorShape,
+} from "../../packages/gateway-protocol/src/index.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { hasNodeErrorCode, isPathInside } from "../infra/path-guards.js";
+
+export const GATEWAY_STALE_INSTALL_CLOSE_REASON =
+  "gateway install changed; run: openclaw gateway restart";
+
+// The install root is process-stable; capture it before an upgrade can replace
+// package metadata, then consult it only after a dynamic import has failed.
+const gatewayInstallRoot = resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
+
+type GatewayStaleInstall = {
+  error: ErrorShape;
+  restartCommand: string;
+};
+
+export function classifyGatewayStaleInstall(error: unknown): GatewayStaleInstall | null {
+  if (
+    !gatewayInstallRoot ||
+    !(error instanceof Error) ||
+    !hasNodeErrorCode(error, "ERR_MODULE_NOT_FOUND")
+  ) {
+    return null;
+  }
+  const url = (error as Error & { url?: unknown }).url;
+  if (typeof url !== "string") {
+    return null;
+  }
+  let missingPath: string;
+  try {
+    missingPath = fileURLToPath(url);
+  } catch {
+    return null;
+  }
+  if (!isPathInside(gatewayInstallRoot, missingPath)) {
+    return null;
+  }
+  const restartCommand = formatCliCommand("openclaw gateway restart");
+  return {
+    error: errorShape(
+      ErrorCodes.UNAVAILABLE,
+      `The running Gateway can no longer load part of its OpenClaw installation. The installation may have changed while the Gateway was running. Restart it with: ${restartCommand}`,
+      { details: { code: "STALE_INSTALL", restartCommand }, retryable: false },
+    ),
+    restartCommand,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators connecting to a running Gateway would receive only `gateway closed (1011): gateway message handler unavailable` after an update or source rebuild replaced a not-yet-loaded dist chunk. The Gateway knew that its installation had changed underneath the process, but the WebSocket connection boundary discarded that fact and gave no recovery step.

Related: #123842

## Why This Change Was Made

The process-stable install-root capture and `ERR_MODULE_NOT_FOUND` containment check from #123842 now live in one shared Gateway classifier. Both method dispatch and the two connection-time lazy-load boundaries consume that owner: a cold WS message-handler load closes with a short RFC 6455-safe restart instruction, while an already-connected socket whose request dispatcher is still cold receives the existing typed `STALE_INSTALL` error. Unknown loader failures retain the generic 1011 reason.

The close cause remains `message-handler-load-failed` for diagnostic compatibility and gains `staleInstall: true` plus the profile-aware restart command. Handler-load failures are logged at ERROR because they leave every affected connection unusable. The Gateway does not auto-restart.

## User Impact

After an in-place update or rebuild invalidates lazy dist chunks, the CLI, `gateway status`, and doctor now identify that the Gateway install changed and tell the operator to run `openclaw gateway restart` instead of dead-ending at a generic internal error.

The close reason is 54 UTF-8 bytes:

```text
gateway install changed; run: openclaw gateway restart
```

## Evidence

Live macOS proof used a copied dist package, isolated temporary state, `OPENCLAW_SKIP_CHANNELS=1`, and a derived loopback port. No installed Gateway or default state was touched.

Before removing the cold message-handler chunk:

```text
Checking channel status…
Gateway reachable.
```

After restarting that scratch Gateway, removing only its copied handler chunk, and connecting for the first time:

```text
gateway connect failed: Error: gateway closed (1011): gateway install changed; run: openclaw gateway restart
Gateway not reachable: gateway closed (1011): gateway install changed; run: openclaw gateway restart
```

The Gateway emitted the detailed outage cause at ERROR:

```text
failed to load ws message handler because the OpenClaw installation changed while the Gateway was running; run: openclaw gateway restart; error: Cannot find module '<scratch-dist>/<hashed-message-handler-chunk>.js'
```

Validation:

- `node scripts/run-vitest.mjs src/gateway/server/ws-connection.load-failure.test.ts src/gateway/server/ws-connection/authenticated-request-dispatch.load-failure.test.ts src/gateway/server-methods.stale-install.test.ts src/gateway/server-import-boundary.test.ts` — 4 files, 11 tests passed on rebased head.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01m01qhrf5dk2b1s6dz9f1hpps` (exit 0).
- `node --import tsx scripts/build-all.mts gatewayWatch` — passed on rebased head; verifies the changed lazy-import/built-Gateway boundary.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no findings.
- Full `pnpm build` built the Gateway/runtime and plugin SDK successfully, then hit an unrelated Control UI startup gzip ratchet (325.5 KiB observed vs 325.3 KiB limit). Exact-head PR CI remains the authoritative full-build result.

Sibling sweep: the authenticated-request dispatcher cold-load gap is fixed here. Core/plugin HTTP lazy loads and plugin WebSocket-upgrade loads have different response ownership and remain explicit follow-up surfaces rather than broadening this WS-connect repair.

Production LOC: +81/-44 (net +37), consisting of the shared process-stable classifier plus both pre-envelope consumers; tests: +175/-0.
