### PR TITLE
fix(gateway): stamp targeted event frames on the per-client sequence

### DIFF
--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -435,7 +435,27 @@ describe("gateway broadcaster", () => {
 
     expect(slowSocket.close).toHaveBeenCalledWith(1008, "slow consumer");
     expect(slowSocket.send).not.toHaveBeenCalled();
-    expect(healthySocket.sent).toEqual([{ type: "event", event: "session.message", payload }]);
+    expect(healthySocket.sent).toEqual([
+      { type: "event", event: "session.message", payload, seq: 1 },
+    ]);
+  });
+
+  it("stamps targeted frames on the per-client sequence so drops surface as gaps", () => {
+    const socket = makeRecordingSocket();
+    const client = makeOperatorWsClient("c-seq", socket, ["operator.read"]);
+    const clients = new Set<GatewayWsClient>([client]);
+    const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+
+    broadcastToConnIds("tick", { ts: 1 }, new Set(["c-seq"]));
+    broadcast("heartbeat", { ts: 2 });
+    // A slow-consumer drop between targeted sends must consume a sequence
+    // number: the next delivered frame exposes the loss to gap detection.
+    socket.bufferedAmount = MAX_BUFFERED_BYTES + 1;
+    broadcastToConnIds("tick", { ts: 3 }, new Set(["c-seq"]), { dropIfSlow: true });
+    socket.bufferedAmount = 0;
+    broadcastToConnIds("tick", { ts: 4 }, new Set(["c-seq"]));
+
+    expect(socket.sent.map((frame) => frame.seq)).toEqual([1, 2, 4]);
   });
 
   it("keeps workers outside all generic and targeted gateway broadcasts", () => {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -229,7 +229,7 @@ export function createGatewayBroadcaster(params: {
     if (shouldLogWs()) {
       const logMeta: Record<string, unknown> = {
         event,
-        seq: isTargeted ? "targeted" : "per-client",
+        seq: "per-client",
         clients: params.clients.size,
         targets: targetConnIds ? targetConnIds.size : undefined,
         dropIfSlow: opts?.dropIfSlow,
@@ -312,9 +312,9 @@ export function createGatewayBroadcaster(params: {
         });
       }
       if (slow && opts?.dropIfSlow) {
-        if (!isTargeted) {
-          clientSeq.set(c, nextSeq);
-        }
+        // Consume the seq for the dropped frame so the client's gap detector
+        // sees the loss instead of a silently thinner stream.
+        clientSeq.set(c, nextSeq);
         continue;
       }
       if (slow) {
@@ -326,13 +326,12 @@ export function createGatewayBroadcaster(params: {
         continue;
       }
       try {
-        const eventSeq = isTargeted ? undefined : nextSeq;
-        if (!isTargeted) {
-          clientSeq.set(c, nextSeq);
-        }
+        // Targeted frames ride the same per-client sequence as fanout frames:
+        // an unstamped frame is invisible to the client's gap detector, so a
+        // drop between two targeted sends would go unnoticed forever.
+        clientSeq.set(c, nextSeq);
         const base = getFrameBase();
-        const seqFragment = eventSeq === undefined ? "" : `,"seq":${eventSeq}`;
-        const frame = `{"type":"event","event":${base.eventJSON}${base.payloadFragment}${seqFragment}${base.stateVersionFragment}}`;
+        const frame = `{"type":"event","event":${base.eventJSON}${base.payloadFragment},"seq":${nextSeq}${base.stateVersionFragment}}`;
         c.socket.send(frame);
       } catch {
         /* ignore */


### PR DESCRIPTION
## What Problem This Solves

Found by the round-4 reconnect/outbox investigation lane. `broadcastToConnIds` (targeted gateway event frames: `session.message` durable deliveries, talk relay events, pairing completion, Control-UI PR-subscription updates, dashboard-tool pushes) sent frames with no `seq`. The client's gap detector (`protocol-client.ts` — `seq > lastSeq + 1` → gap-triggered recovery) never sees unstamped frames, so a slow-consumer `dropIfSlow` drop between targeted sends made the stream silently thinner: no gap, no recovery, the client simply never learns the frame existed. The `isTargeted ? undefined : nextSeq` special-casing dates to a Feb 2026 streaming fix (38e6da1fe0f) and predates the current gap-recovery machinery.

## Why This Change Was Made

Targeted frames now consume and carry the same per-client sequence as fanout frames, and a slow-consumer drop of a targeted frame also consumes a sequence number — that's what makes the loss visible: the next delivered frame exposes the hole. The protocol contract already treats `seq` as optional-but-monotonic (`frame-guards.ts` accepts `seq === undefined || nonNegativeInteger`), so older clients that ignore seq are unaffected, and current clients gain gap detection on the targeted paths they were blind to. This deletes the special case rather than adding one: the seq bookkeeping is now unconditional.

## User Impact

A Control UI (or iOS/node client) whose connection briefly backs up no longer silently misses a targeted durable message, talk event, or pairing completion — the seq gap triggers the client's existing recovery/resubscribe path instead of leaving the pane permanently out of sync until reload.

## Evidence

- New regression test "stamps targeted frames on the per-client sequence so drops surface as gaps" asserts seq [1, 2, 4] across a targeted send, fanout send, dropped slow send, and post-recovery send — fails pre-fix (seq undefined, drop invisible), passes post-fix. The updated slow-subscriber test locks the stamped frame shape.
- `gateway-misc.test.ts` 50/50; sibling suites green: `server-chat.agent-events`, `talk-transcription-relay`, `operator-approval-session-events`, `device-pair-setup-completion`, `protocol-client.sequence` (client-side gap contract).
- `pnpm tsgo` clean; oxlint/oxfmt clean.
- Autoreview (Codex, high): clean, no accepted findings, "patch is correct (0.99)".
- Production LOC: +9 −10 (net −1) — the fix is deleting the targeted special case.
