### PR TITLE
fix(agents): continue timeout recovery from compacted transcript

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -115,6 +115,7 @@ describe("compactEmbeddedRunForRecovery", () => {
         runOwnsCompactionAfterHook: vi.fn(async () => {}),
         adoptCompactionTranscript: vi.fn(async () => undefined),
         getActiveSession: () => ({ id: "session-1", file: baseRunParams.sessionFile }),
+        prepareCompactedTranscriptRetry: vi.fn(async () => {}),
         armPostCompactionGuard: vi.fn(),
       },
       {

--- a/src/agents/embedded-agent-runner/run.timeout-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-context-recovery.test.ts
@@ -99,6 +99,7 @@ function makeInput(overrides: RecoveryOverrides = {}): RecoveryInput {
     runOwnsCompactionAfterHook: vi.fn(async () => {}),
     adoptCompactionTranscript: vi.fn(async () => undefined),
     getActiveSession: () => ({ id: "session-1", file: "/tmp/session-1.jsonl" }),
+    prepareCompactedTranscriptRetry: vi.fn(async () => {}),
     armPostCompactionGuard: vi.fn(),
     ...inputOverrides,
   } as unknown as RecoveryInput;
@@ -189,6 +190,7 @@ describe("recoverEmbeddedRunTimeout", () => {
       lastCompactionTokensAfter: 80_000,
     });
     expect(input.armPostCompactionGuard).toHaveBeenCalledOnce();
+    expect(input.prepareCompactedTranscriptRetry).toHaveBeenCalledOnce();
   });
 
   it("counts compacted-false results against the shared retry cap", async () => {

--- a/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentHarness } from "../harness/types.js";
 import { makeAttemptResult, makeCompactionSuccess } from "./run.overflow-compaction.fixture.js";
 import {
+  mockedBuildEmbeddedRunPayloads,
   mockedCompactDirect,
   mockedGetApiKeyForModel,
   mockedResolveAuthProfileOrder,
@@ -37,14 +38,20 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
     resetSharedRunIntegrationHarnessMocks();
   });
 
-  it("adopts a compacted transcript and retries with the complete runtime context", async () => {
+  it("adopts a compacted transcript and retries with a continuation prompt", async () => {
+    mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "timeout recovery complete" }]);
     mockedRunEmbeddedAttempt
-      .mockResolvedValueOnce(
-        makeAttemptResult({
+      .mockImplementationOnce(async (params) => {
+        params.onUserMessagePersisted?.({
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        });
+        return makeAttemptResult({
           timedOut: true,
           lastAssistant: { usage: { input: 160_000 } } as never,
-        }),
-      )
+        });
+      })
       .mockResolvedValueOnce(
         makeAttemptResult({
           promptError: null,
@@ -73,6 +80,12 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
       sessionId: "timeout-rotated-session",
       sessionFile: "/tmp/timeout-rotated-session.json",
     });
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]?.prompt).toContain(
+      "Continue from the current transcript",
+    );
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]?.prompt).not.toBe(
+      overflowBaseRunParams.prompt,
+    );
     const compactParams = mockedCompactDirect.mock.calls[0]?.[0] as CompactParams | undefined;
     expect(compactParams).toMatchObject({
       sessionId: "test-session",
@@ -88,6 +101,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
       },
     });
     expect(result.meta.agentMeta?.compactionTokensAfter).toBe(60_000);
+    expect(result.payloads).toEqual([{ text: "timeout recovery complete" }]);
   });
 
   it("leaves timeout recovery to a forced unlocked Codex compaction owner", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -236,6 +236,7 @@ export async function recoverEmbeddedRunAttempt(input: {
       file: sessionPromptState.sessionFile,
       target: sessionPromptState.sessionTarget,
     }),
+    prepareCompactedTranscriptRetry: sessionPromptState.prepareCompactedTranscriptRetry,
     armPostCompactionGuard: input.armPostCompactionGuard,
   };
   if (
@@ -260,7 +261,6 @@ export async function recoverEmbeddedRunAttempt(input: {
     assistantOverflowCandidate,
     attemptCompactionCount,
     prepareCurrentTranscriptRetry: sessionPromptState.continueFromCurrentTranscript,
-    prepareCompactedTranscriptRetry: sessionPromptState.prepareCompactedTranscriptRetry,
   });
   if (overflowRecovery.action === "retry") {
     return retry();

--- a/src/agents/embedded-agent-runner/run/compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-runtime.ts
@@ -63,6 +63,7 @@ export type EmbeddedRunCompactionRecoveryInput = {
     file: string;
     target?: ContextEngineSessionTarget;
   };
+  prepareCompactedTranscriptRetry: () => Promise<void>;
   armPostCompactionGuard: () => void;
 };
 

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -54,7 +54,6 @@ export async function recoverEmbeddedRunOverflow(
     toolResultPromptProjectionState: ToolResultPromptProjectionState;
     attemptCompactionCount: number;
     prepareCurrentTranscriptRetry: () => void;
-    prepareCompactedTranscriptRetry: () => Promise<void>;
   },
 ): Promise<EmbeddedRunOverflowRecoveryOutcome> {
   const contextOverflowError =
@@ -216,7 +215,6 @@ export async function recoverEmbeddedRunOverflow(
     }
 
     if (compactResult.compacted) {
-      await input.adoptCompactionTranscript(compactResult);
       const tokensAfter = compactResult.result?.tokensAfter;
       if (typeof tokensAfter === "number" && Number.isFinite(tokensAfter) && tokensAfter >= 0) {
         input.state.lastCompactionTokensAfter = Math.floor(tokensAfter);

--- a/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
@@ -111,5 +111,6 @@ export async function recoverEmbeddedRunTimeout(
     `[timeout-compaction] compaction succeeded for ${input.provider}/${input.modelId}; retrying prompt`,
   );
   input.armPostCompactionGuard();
+  await input.prepareCompactedTranscriptRetry();
   return true;
 }


### PR DESCRIPTION
Closes #123989

AI-assisted change; the patch and proof were reviewed end to end.

## What Problem This Solves

Fixes an issue where an embedded agent turn that timed out under high context pressure could successfully compact its session and then receive the original persisted user request again. The model could restart completed work, repeat expensive tools, or duplicate side effects instead of continuing from the compacted transcript.

## Why This Change Was Made

Timeout recovery now uses the session prompt-state owner's existing compacted-transcript continuation transition, which overflow recovery already uses. The shared recovery input carries that owner once, and overflow recovery no longer adopts the same compacted successor a second time.

The repair is internal and deliberately leaves timeout/cancel/tool-execution/run-budget exclusions, hooks, token accounting, retry caps, final payload projection, provider routing, protocols, configuration, persistence shape/schema, public APIs, and security boundaries unchanged.

Sibling Codex source was inspected at `57f42a81131ccf5933e7ec5dc659c381eeb5d72b`:

- Mid-turn compaction retains the last real user message and places the summary last: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/core/src/compact.rs#L59-L65
- Codex continues the same turn after mid-turn compaction: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/core/src/session/turn.rs#L435-L460
- Remote compaction follows the same last-user placement: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/core/src/compact_remote.rs#L304-L320
- Every app-server `turn/start` submits supplied input as a fresh user operation: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server/src/request_processors/turn_processor.rs#L512-L565

This confirms the host must send a continuation after adopting the compacted transcript; resending the original prompt would create another user instruction.

Production LOC: `+3/-3` (net `0`) | Tests: `+22/-5` (net `+17`)

## User Impact

Agents recovering from a high-context prompt timeout now continue the work already represented in the compacted transcript. Users should no longer see the original request replayed or completed work repeated by this recovery path.

## Evidence

Baseline: `origin/main` at `295f2c0212fd759fabd5e80cecfd00fc324bb441`  
PR head: `5c8f9defc84ba6df6ffdc6795eec762c160bddfc`

Before fix, retaining the new boundary regression while removing only the four production hunks produced:

```text
runEmbeddedAgent timeout recovery composition
× adopts a compacted transcript and retries with a continuation prompt
AssertionError: expected 'hello' to contain 'Continue from the current transcript'
Tests: 1 failed | 64 passed (65)
```

Red Testbox: https://github.com/openclaw/openclaw/actions/runs/31862701555

After fix:

- 82/82 focused tests pass across timeout recovery, the complete run-loop integration, and overflow/compaction composition.
- The boundary test persists the first user turn, injects high-pressure timeout recovery, adopts the rotated compacted transcript, verifies the retry prompt is a continuation rather than `hello`, and verifies one visible final payload.
- Timeout/cancel, compaction-timeout, tool-execution-timeout, and aggregate-run-budget exclusions remain green.
- Hooks, retry caps, token accounting, auth-profile rotation, visible final payload preservation, and overflow single-adoption siblings remain green.
- Source-blind isolated validation passed the named scenario and all 82 tests with zero failures or skips.
- Targeted `oxfmt` passed all seven files.
- Path-scoped `check:changed` passed core/core-test types, changed-file lint (0 findings), dependency/plugin/storage/webhook/pairing guards, dead-code, and runtime import cycles (0 cycles).
- Fresh Codex autoreview on the rebased branch: clean, no accepted/actionable findings; patch correctness confidence `0.97`.

Green Testbox / changed gate: https://github.com/openclaw/openclaw/actions/runs/31862811933

No changelog edit: release generation owns `CHANGELOG.md`.
