### PR TITLE
refactor(claws): remove test-only lifecycle bypasses

### DIFF
--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -187,30 +187,6 @@ describe("installClawCronJobs", () => {
     expect(add).not.toHaveBeenCalled();
   });
 
-  it("rejects a drifted complete job beyond the first gateway page", async () => {
-    const current = await fixture();
-    await installClawCronJobs(current.plan, {
-      env: current.env,
-      gateway: { add: vi.fn().mockResolvedValue({ id: "scheduler-123" }) },
-    });
-    const [ref] = readClawCronRefs("worker-two", { env: current.env });
-    const drifted = listedCronJob("worker-two", ref!, "scheduler-123");
-    drifted.payload = { kind: "agentTurn", message: "Different declaration" };
-    const fillers = Array.from({ length: 200 }, (_, index) => ({ id: `filler-${index}` }));
-    const add = vi.fn();
-
-    await expect(
-      installClawCronJobs(current.plan, {
-        env: current.env,
-        gateway: {
-          add,
-          list: vi.fn().mockResolvedValue({ jobs: [...fillers, drifted] }),
-        },
-      }),
-    ).rejects.toMatchObject({ code: "cron_reconcile_conflict" });
-    expect(add).not.toHaveBeenCalled();
-  });
-
   it("preserves an ambiguous pending reference when cron.add fails", async () => {
     const current = await fixture();
 

--- a/src/claws/lifecycle-mcp-removal.ts
+++ b/src/claws/lifecycle-mcp-removal.ts
@@ -22,7 +22,6 @@ type RemoveMcpServerOptions = OpenClawStateDatabaseOptions & {
   listMcpServers?: typeof listConfiguredMcpServers;
   referencedCleanup?: ClawReferencedCleanup;
   unsetMcpServer?: typeof unsetConfiguredMcpServer;
-  withMcpLifecycleLease?: typeof withClawMcpLifecycleLease;
 };
 
 export async function removeClawMcpServers(params: {
@@ -46,11 +45,10 @@ export async function removeClawMcpServers(params: {
         params.options.sourceMcpServers ?? params.options.config?.mcp?.servers,
       );
   const unsetMcpServer = params.options.unsetMcpServer ?? unsetConfiguredMcpServer;
-  const withMcpLifecycleLease = params.options.withMcpLifecycleLease ?? withClawMcpLifecycleLease;
   const mcpServers: RemovedMcpServer[] = [];
   for (const server of params.servers) {
     let removalError: string | undefined;
-    await withMcpLifecycleLease(server.name, params.options, async () => {
+    await withClawMcpLifecycleLease(server.name, params.options, async () => {
       const currentRef = readClawMcpServerRefsByName(server.name, params.options).find(
         (candidate) => candidate.agentId === params.agentId,
       );

--- a/src/claws/mcp-update.test.ts
+++ b/src/claws/mcp-update.test.ts
@@ -1,9 +1,9 @@
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { applyClawMcpUpdate } from "./mcp-update.js";
+import { applyClawMcpUpdate as applyClawMcpUpdateRaw } from "./mcp-update.js";
 import {
   CLAW_MCP_REF_SCHEMA_VERSION,
   digestClawMcpServer,
@@ -24,7 +24,17 @@ const remote: ClawMcpServer = {
 };
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let leaseEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  leaseEnv = { OPENCLAW_STATE_DIR: join(tempDirs.make("openclaw-mcp-update-"), "state") };
+});
 afterEach(() => closeOpenClawStateDatabaseForTest());
+
+function applyClawMcpUpdate(...args: Parameters<typeof applyClawMcpUpdateRaw>) {
+  const [updatePlan, targetManifest, options] = args;
+  return applyClawMcpUpdateRaw(updatePlan, targetManifest, { env: leaseEnv, ...options });
+}
 
 function ref(name: string, server: ClawMcpServer): PersistedClawMcpServerRef {
   return {
@@ -81,14 +91,6 @@ function manifest(): ClawManifest {
     mcpServers: { docs: newDocs, remote },
     cronJobs: [],
   };
-}
-
-async function runWithoutMcpLease<T>(
-  _name: string,
-  _options: unknown,
-  run: () => Promise<T>,
-): Promise<T> {
-  return await run();
 }
 
 describe("applyClawMcpUpdate", () => {
@@ -149,7 +151,6 @@ describe("applyClawMcpUpdate", () => {
         unsetServer,
         upsertRef,
         deleteRef,
-        withMcpLifecycleLease: runWithoutMcpLease,
       },
     );
 
@@ -225,7 +226,6 @@ describe("applyClawMcpUpdate", () => {
         unsetServer,
         upsertRef,
         deleteRef,
-        withMcpLifecycleLease: runWithoutMcpLease,
       },
     );
 
@@ -257,7 +257,6 @@ describe("applyClawMcpUpdate", () => {
           readRefs: () => [previous],
           planRemoval: () => ({ action: "remove" }),
           deleteRef,
-          withMcpLifecycleLease: runWithoutMcpLease,
         },
       ),
     ).rejects.toThrow("no longer safely releasable");
@@ -428,7 +427,6 @@ describe("applyClawMcpUpdate", () => {
           readRefs: () => [previous],
           setServer: vi.fn().mockResolvedValue({ ok: false, path: "config", error: "changed" }),
           upsertRef,
-          withMcpLifecycleLease: runWithoutMcpLease,
         },
       ),
     ).rejects.toMatchObject({ partial: true });
@@ -461,7 +459,6 @@ describe("applyClawMcpUpdate", () => {
         }),
         unsetServer,
         upsertRef: vi.fn(),
-        withMcpLifecycleLease: runWithoutMcpLease,
       },
     );
 
@@ -496,7 +493,6 @@ describe("applyClawMcpUpdate", () => {
         }),
         unsetServer,
         upsertRef: vi.fn(),
-        withMcpLifecycleLease: runWithoutMcpLease,
       },
     );
 
@@ -524,7 +520,6 @@ describe("applyClawMcpUpdate", () => {
           sourceMcpServers: { remote },
           readRefs: () => [],
           setServer,
-          withMcpLifecycleLease: runWithoutMcpLease,
         },
       ),
     ).rejects.toThrow("was not claimed");

--- a/src/claws/mcp-update.ts
+++ b/src/claws/mcp-update.ts
@@ -49,7 +49,6 @@ export async function applyClawMcpUpdate(
     ) => { action: "remove" | "release" };
     upsertRef?: typeof upsertClawMcpServerRef;
     deleteRef?: typeof deleteClawMcpServerRef;
-    withMcpLifecycleLease?: typeof withClawMcpLifecycleLease;
   },
 ): Promise<ClawMcpUpdateExecution> {
   const actions = updatePlan.actions.filter(
@@ -65,7 +64,6 @@ export async function applyClawMcpUpdate(
   const planRemoval = options.planRemoval ?? planClawMcpServerRemoval;
   const upsertRef = options.upsertRef ?? upsertClawMcpServerRef;
   const deleteRef = options.deleteRef ?? deleteClawMcpServerRef;
-  const withMcpLifecycleLease = options.withMcpLifecycleLease ?? withClawMcpLifecycleLease;
   const currentServers = normalizeConfiguredMcpServers(options.sourceMcpServers);
   const undo: Array<() => Promise<void>> = [];
   const appliedNames: string[] = [];
@@ -88,7 +86,7 @@ export async function applyClawMcpUpdate(
 
   try {
     for (const action of actions) {
-      await withMcpLifecycleLease(action.id, options, async () => {
+      await withClawMcpLifecycleLease(action.id, options, async () => {
         const name = action.id;
         const previousRef = readRefs(updatePlan.agentId, options).find(
           (candidate) => candidate.name === name,
@@ -119,7 +117,7 @@ export async function applyClawMcpUpdate(
           deleteRef(updatePlan.agentId, name, options);
           undo.push(
             async () =>
-              await withMcpLifecycleLease(name, options, async () => {
+              await withClawMcpLifecycleLease(name, options, async () => {
                 upsertRef(previousRef, options);
               }),
           );
@@ -151,7 +149,7 @@ export async function applyClawMcpUpdate(
           }
           undo.push(
             async () =>
-              await withMcpLifecycleLease(name, options, async () => {
+              await withClawMcpLifecycleLease(name, options, async () => {
                 const restored = await setServer({
                   name,
                   server: previousServer,
@@ -208,7 +206,7 @@ export async function applyClawMcpUpdate(
         }
         undo.push(
           async () =>
-            await withMcpLifecycleLease(name, options, async () => {
+            await withClawMcpLifecycleLease(name, options, async () => {
               const currentRefs = readRefsByName(name, options);
               const currentOwnRef = currentRefs.find(
                 (candidate) => candidate.agentId === updatePlan.agentId,

--- a/src/claws/mcp.ts
+++ b/src/claws/mcp.ts
@@ -182,15 +182,13 @@ export async function installClawMcpServers(
     }) => ReturnType<typeof setConfiguredMcpServer>;
     listMcpServers?: typeof listConfiguredMcpServers;
     nowMs?: number;
-    withMcpLifecycleLease?: typeof withClawMcpLifecycleLease;
   } = {},
 ): Promise<PersistedClawMcpServerRef[]> {
   const setMcpServer = options.setMcpServer ?? setConfiguredMcpServer;
   const listMcpServers = options.listMcpServers ?? listConfiguredMcpServers;
-  const withMcpLifecycleLease = options.withMcpLifecycleLease ?? withClawMcpLifecycleLease;
   const refs: PersistedClawMcpServerRef[] = [];
   for (const action of plan.actions.filter((candidate) => candidate.kind === "mcpServer")) {
-    await withMcpLifecycleLease(action.id, options, async () => {
+    await withClawMcpLifecycleLease(action.id, options, async () => {
       const server = action.details ? mcpServerFromActionDetails(action.details) : undefined;
       if (!server) {
         throw new ClawMcpInstallError(


### PR DESCRIPTION
## What Problem This Solves

Claw MCP install, update, and removal exposed optional lifecycle-lease callbacks that production never supplied. Update tests used those hooks to bypass the serialization boundary the feature was intended to enforce. Separately, a cron test claimed second-page coverage while passing one preassembled array and never exercising pagination.

## Why This Change Was Made

The MCP lifecycle owners now call the canonical Claw lease directly. Update tests use a per-test isolated state directory and therefore exercise real lease acquisition while retaining CAS, ownership, rollback, adoption, and partial-failure assertions. The fake beyond-first-page cron case is deleted; real two-page Gateway pagination and declaration-drift rejection remain covered independently.

## User Impact

No user-visible behavior change. Tests now execute the same lifecycle serialization boundary as production, and Claw MCP APIs no longer expose test-only lock bypasses.

AI-assisted: yes.

## Evidence

- Claws cron/MCP/update/removal owners: 6 files, 55 tests passed.
- Cron/Claws CLI owners: 3 files, 213 tests passed.
- MCP config mutation lease owner: 6 tests passed.
- `node scripts/check-changed.mjs -- <changed paths>` — core/coreTests gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready. This included production/test typecheck, core lint, import cycles, architecture guards, native schema guard, and dead-export scans.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Production delta: -6 lines. Tests: -29 lines. Total: -35 lines.
