### PR TITLE
feat(lint): reject widen-then-assert type laundering

### DIFF
--- a/config/oxlint/boundary-guards.json
+++ b/config/oxlint/boundary-guards.json
@@ -5,6 +5,7 @@
   "categories": { "correctness": "off" },
   "rules": {
     "openclaw-boundaries/no-raw-window-open-call": "error",
-    "openclaw-boundaries/no-register-http-handler-call": "error"
+    "openclaw-boundaries/no-register-http-handler-call": "error",
+    "openclaw-boundaries/no-widen-then-assert": "error"
   }
 }

--- a/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
@@ -8,14 +8,12 @@ import {
 installPwToolsCoreTestHooks();
 const mod = await import("./pw-tools-core.interactions.js");
 
-type EvaluateArg = unknown;
-
 function evaluateMockReturning(view: { x: number; y: number; width?: number; height?: number }) {
   // Caller reads { x, y, width, height } in one evaluate; default to a normal
   // desktop viewport so refs near the top stay in-viewport unless a test puts
   // them out of range explicitly.
   const result = { width: 1280, height: 720, ...view };
-  return vi.fn(async (arg: EvaluateArg) => {
+  return vi.fn(async (arg: unknown) => {
     if (typeof arg === "function") {
       return result;
     }

--- a/extensions/searxng/src/searxng-search-provider.test.ts
+++ b/extensions/searxng/src/searxng-search-provider.test.ts
@@ -1,4 +1,5 @@
 // Searxng tests cover searxng search provider plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveSearxngBaseUrl,
@@ -195,7 +196,7 @@ describe("searxng web search provider", () => {
 
   it("persists base URL to plugin config via setConfiguredCredentialValue", () => {
     const provider = createSearxngWebSearchProvider();
-    const config = {} as Record<string, unknown>;
+    const config: OpenClawConfig = {};
     const setConfiguredCredentialValue = provider.setConfiguredCredentialValue;
     if (!setConfiguredCredentialValue) {
       throw new Error("Expected SearXNG provider setConfiguredCredentialValue");
@@ -203,12 +204,6 @@ describe("searxng web search provider", () => {
 
     setConfiguredCredentialValue(config, "http://search.local:9000");
 
-    expect(
-      (
-        config as {
-          plugins?: { entries?: { searxng?: { config?: { webSearch?: { baseUrl?: string } } } } };
-        }
-      ).plugins?.entries?.searxng?.config?.webSearch?.baseUrl,
-    ).toBe("http://search.local:9000");
+    expect(resolveSearxngBaseUrl(config, {})).toBe("http://search.local:9000");
   });
 });

--- a/extensions/xai/.boundary-stubs/ollama-runtime-api.d.ts
+++ b/extensions/xai/.boundary-stubs/ollama-runtime-api.d.ts
@@ -1,6 +1,4 @@
 // Xai type declarations define plugin contracts.
-export type OllamaEmbeddingClient = unknown;
-
 export const buildAssistantMessage: (...args: unknown[]) => unknown;
 export const buildOllamaChatRequest: (...args: unknown[]) => unknown;
 export const convertToOllamaMessages: (...args: unknown[]) => unknown;

--- a/package.json
+++ b/package.json
@@ -1657,6 +1657,7 @@
     "lint:plugins:no-monolithic-plugin-sdk-entry-imports": "node --import tsx scripts/check-no-monolithic-plugin-sdk-entry-imports.ts",
     "lint:plugins:no-register-http-handler": "node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json src extensions",
     "lint:plugins:plugin-sdk-subpaths-exported": "node --import tsx scripts/check-plugin-sdk-subpath-exports.mts",
+    "lint:no-widen-then-assert": "node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json src extensions packages ui/src",
     "lint:scripts": "pnpm lint:docker-e2e && pnpm lint:tmp:no-raw-http2-imports && node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts",
     "lint:swift": "./scripts/lint-swift.sh",
     "lint:tmp:channel-agnostic-boundaries": "node --import tsx scripts/check-channel-agnostic-boundaries.mts",

--- a/scripts/oxlint-boundary-guards.mjs
+++ b/scripts/oxlint-boundary-guards.mjs
@@ -54,6 +54,7 @@ const FUNCTION_BOUNDARY_TYPES = new Set([
   "TSDeclareFunction",
   "TSEmptyBodyFunctionExpression",
 ]);
+const MAX_TRANSPARENT_ALIAS_DEPTH = 32;
 
 function unwrapExpressionParentheses(expression) {
   let current = expression;
@@ -144,6 +145,25 @@ function broadTypeKind(type) {
 
 function assertedExpression(node) {
   return unwrapExpressionParentheses(node.expression);
+}
+
+function assertedIdentifier(node) {
+  let expression = assertedExpression(node);
+  while (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+    expression = assertedExpression(expression);
+  }
+  return expression.type === "Identifier" ? expression : null;
+}
+
+function isNestedAssertion(node) {
+  let parent = node.parent;
+  while (parent?.type === "ParenthesizedExpression") {
+    parent = parent.parent;
+  }
+  return (
+    (parent?.type === "TSAsExpression" || parent?.type === "TSTypeAssertion") &&
+    assertedExpression(parent) === node
+  );
 }
 
 function assertionFromExpression(expression) {
@@ -339,6 +359,47 @@ function widenedBinding(variable, scopes) {
   return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
 }
 
+function resolveWidenedBinding(variable, scopes, boundary, assertedAt) {
+  const visitedVariables = new Set();
+  let current = variable;
+  for (let depth = 0; depth < MAX_TRANSPARENT_ALIAS_DEPTH; depth += 1) {
+    if (visitedVariables.has(current)) {
+      return null;
+    }
+    visitedVariables.add(current);
+
+    const widened = widenedBinding(current, scopes);
+    if (widened !== null) {
+      return widened;
+    }
+
+    const declarator = variableDeclarator(current);
+    if (
+      declarator === null ||
+      declarator.parent.type !== "VariableDeclaration" ||
+      declarator.parent.kind !== "const" ||
+      declarator.id.type !== "Identifier" ||
+      (declarator.id.typeAnnotation !== null && declarator.id.typeAnnotation !== undefined) ||
+      declarator.init === null ||
+      declarator.end >= assertedAt ||
+      current.references.some((reference) => reference.isWrite() && !reference.init) ||
+      functionBoundary(declarator) !== boundary
+    ) {
+      return null;
+    }
+
+    const initializer = unwrapExpressionParentheses(declarator.init);
+    if (initializer.type !== "Identifier") {
+      return null;
+    }
+    current = resolvedVariableForIdentifier(scopes, initializer);
+    if (current === null) {
+      return null;
+    }
+  }
+  return null;
+}
+
 function assertionIsNarrower(sourceText, broadKind, evidence, assertedType) {
   if (broadTypeKind(assertedType) !== null) {
     return false;
@@ -378,8 +439,11 @@ function noWidenThenAssertRule({ roots }) {
 
       let scopes = [];
       const checkAssertion = (node) => {
-        const expression = assertedExpression(node);
-        if (expression.type !== "Identifier") {
+        if (isNestedAssertion(node)) {
+          return;
+        }
+        const expression = assertedIdentifier(node);
+        if (expression === null) {
           return;
         }
 
@@ -387,11 +451,12 @@ function noWidenThenAssertRule({ roots }) {
         if (variable === null) {
           return;
         }
-        const widened = widenedBinding(variable, scopes);
+        const boundary = functionBoundary(node);
+        const widened = resolveWidenedBinding(variable, scopes, boundary, node.start);
         if (
           widened === null ||
           node.start <= widened.declaredAt ||
-          functionBoundary(node) !== widened.boundary ||
+          boundary !== widened.boundary ||
           !assertionIsNarrower(
             context.sourceCode.text,
             widened.broadKind,

--- a/scripts/oxlint-boundary-guards.mjs
+++ b/scripts/oxlint-boundary-guards.mjs
@@ -46,6 +46,380 @@ function restrictedCallRule({ allowedFiles = [], message, objects, property, roo
   };
 }
 
+// Adapted from dmmulroy/anti-slop, MIT.
+const FUNCTION_BOUNDARY_TYPES = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression) {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function unwrapTypeParentheses(type) {
+  let current = type;
+  while (current.type === "TSParenthesizedType") {
+    current = current.typeAnnotation;
+  }
+  return current;
+}
+
+function typeReferenceName(type) {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type) {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type) {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") {
+    return unwrapped.types.every(isBroadRecordKeyType);
+  }
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type) {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") {
+      return false;
+    }
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) {
+    return false;
+  }
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type) {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") {
+    return "top";
+  }
+  if (unwrapped.type === "TSObjectKeyword") {
+    return "object";
+  }
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(node) {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(expression) {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText, type) {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(sourceText, left, right) {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type) {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type) {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") {
+    return false;
+  }
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") {
+    return false;
+  }
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node) {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (FUNCTION_BOUNDARY_TYPES.has(current.type)) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(scopes, identifier) {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) {
+      return reference.resolved;
+    }
+  }
+  return null;
+}
+
+function variableDeclarator(variable) {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(expression, scopes, boundary, visitedVariables) {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) {
+      return null;
+    }
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") {
+    return null;
+  }
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) {
+    return null;
+  }
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(variable, scopes) {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) {
+    return null;
+  }
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(sourceText, broadKind, evidence, assertedType) {
+  if (broadTypeKind(assertedType) !== null) {
+    return false;
+  }
+  if (broadKind === "top") {
+    return true;
+  }
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) {
+    return true;
+  }
+  if (broadKind === "object") {
+    return isDefinitelyObjectType(assertedType);
+  }
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+function noWidenThenAssertRule({ roots }) {
+  return {
+    meta: {
+      type: "problem",
+      docs: {
+        description:
+          "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+      },
+      messages: {
+        widenThenAssert:
+          'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+      },
+    },
+    create(context) {
+      const filename = context.physicalFilename.replaceAll("\\", "/");
+      const cwd = context.cwd.replaceAll("\\", "/");
+      const repoPath = filename.startsWith(`${cwd}/`) ? filename.slice(cwd.length + 1) : filename;
+      if (!roots.some((root) => repoPath === root || repoPath.startsWith(`${root}/`))) {
+        return {};
+      }
+
+      let scopes = [];
+      const checkAssertion = (node) => {
+        const expression = assertedExpression(node);
+        if (expression.type !== "Identifier") {
+          return;
+        }
+
+        const variable = resolvedVariableForIdentifier(scopes, expression);
+        if (variable === null) {
+          return;
+        }
+        const widened = widenedBinding(variable, scopes);
+        if (
+          widened === null ||
+          node.start <= widened.declaredAt ||
+          functionBoundary(node) !== widened.boundary ||
+          !assertionIsNarrower(
+            context.sourceCode.text,
+            widened.broadKind,
+            widened.evidence,
+            node.typeAnnotation,
+          )
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "widenThenAssert",
+          data: { name: expression.name },
+        });
+      };
+
+      return {
+        Program() {
+          scopes = context.sourceCode.scopeManager.scopes;
+        },
+        TSAsExpression: checkAssertion,
+        TSTypeAssertion: checkAssertion,
+      };
+    },
+  };
+}
+
 export default {
   meta: { name: "openclaw-boundaries" },
   rules: {
@@ -61,6 +435,9 @@ export default {
       property: "registerHttpHandler",
       message:
         "Use registerHttpRoute({ path, auth, match, handler }) and registerPluginHttpRoute for dynamic webhook paths.",
+    }),
+    "no-widen-then-assert": noWidenThenAssertRule({
+      roots: ["src", "extensions", "packages", "ui/src", "test/fixtures/oxlint-boundary-guards"],
     }),
   },
 };

--- a/scripts/run-additional-boundary-checks.mts
+++ b/scripts/run-additional-boundary-checks.mts
@@ -62,6 +62,7 @@ export const BOUNDARY_CHECKS = (
     ["lint:tmp:no-raw-channel-fetch", "pnpm", ["run", "lint:tmp:no-raw-channel-fetch"]],
     ["lint:tmp:no-raw-http2-imports", "pnpm", ["run", "lint:tmp:no-raw-http2-imports"]],
     ["lint:agent:ingress-owner", "pnpm", ["run", "lint:agent:ingress-owner"]],
+    ["lint:no-widen-then-assert", "pnpm", ["run", "lint:no-widen-then-assert"]],
     [
       "lint:plugins:no-register-http-handler",
       "pnpm",

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { normalizeToolParameterSchema } from "@openclaw/ai/internal/openai";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
@@ -171,10 +172,10 @@ function toJsonAgentToolResult(params: {
 }
 
 function requireStringArg(input: unknown, key: string): string {
-  if (!input || typeof input !== "object") {
+  if (!isRecord(input)) {
     throw new Error(`${key} is required`);
   }
-  const value = Reflect.get(input, key);
+  const value = input[key];
   if (typeof value !== "string") {
     throw new Error(`${key} is required`);
   }

--- a/src/agents/delegation-capability.ts
+++ b/src/agents/delegation-capability.ts
@@ -72,12 +72,7 @@ function wrapReportOnlyTool(tool: AnyAgentTool, allowedActions: ReadonlySet<stri
         if (!allowedActions.has(readToolAction(params))) {
           throw new ToolAuthorizationError(REPORT_ONLY_ERROR);
         }
-        return await Reflect.apply(target.execute, undefined, [
-          toolCallId,
-          params,
-          signal,
-          onUpdate,
-        ]);
+        return await target.execute(toolCallId, params, signal, onUpdate);
       };
     },
   });

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
@@ -454,11 +454,7 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
   provider?: string | null,
 ): StreamFn {
   return (model, context, options) => {
-    const ctx = context as unknown as { messages?: unknown };
-    const messages = ctx?.messages;
-    if (!Array.isArray(messages)) {
-      return baseFn(model, context, options);
-    }
+    const messages = context.messages;
     const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
       modelApi: (model as { api?: unknown })?.api as string | null | undefined,
       provider,
@@ -509,10 +505,10 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
         nextMessages = validateAnthropicTurns(nextMessages);
       }
     }
-    const nextContext = {
-      ...(context as unknown as Record<string, unknown>),
-      messages: nextMessages,
-    } as unknown;
-    return baseFn(model, nextContext as typeof context, options);
+    const nextContext: typeof context = {
+      ...context,
+      messages: nextMessages as typeof context.messages,
+    };
+    return baseFn(model, nextContext, options);
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
@@ -454,7 +454,10 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
   provider?: string | null,
 ): StreamFn {
   return (model, context, options) => {
-    const messages = context.messages;
+    const messages = context?.messages;
+    if (!Array.isArray(messages)) {
+      return baseFn(model, context, options);
+    }
     const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
       modelApi: (model as { api?: unknown })?.api as string | null | undefined,
       provider,

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -51,9 +51,6 @@ type AgentRuntimeFailoverReason =
   | "unclassified"
   | "unknown";
 
-/** Provider/runtime config object passed through plugin boundaries. */
-type AgentRuntimeConfig = unknown;
-
 /** Provider model descriptor consumed by runtime-plan hooks. */
 type AgentRuntimeModel = {
   id?: string;
@@ -91,7 +88,7 @@ type AgentRuntimeTextTransforms = {
 type AgentRuntimeProviderHandle = {
   provider: string;
   modelId?: string | null;
-  config?: AgentRuntimeConfig;
+  config?: unknown;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   applyAutoEnable?: boolean;
@@ -341,7 +338,7 @@ type AgentRuntimeSystemPromptContribution = {
 
 /** Context passed when resolving provider system prompt contributions. */
 type AgentRuntimeSystemPromptContributionContext = {
-  config?: AgentRuntimeConfig;
+  config?: unknown;
   agentDir?: string;
   workspaceDir?: string;
   provider: string;
@@ -566,7 +563,7 @@ export type AgentRuntimePlan = {
 
 /** Inputs needed to build delivery-only runtime decisions. */
 export type BuildAgentRuntimeDeliveryPlanParams = {
-  config?: AgentRuntimeConfig;
+  config?: unknown;
   workspaceDir?: string;
   agentDir?: string;
   provider: string;
@@ -576,7 +573,7 @@ export type BuildAgentRuntimeDeliveryPlanParams = {
 
 /** Inputs needed to build the full prepared runtime plan. */
 export type BuildAgentRuntimePlanParams = {
-  config?: AgentRuntimeConfig;
+  config?: unknown;
   workspaceDir?: string;
   agentDir?: string;
   provider: string;

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -1086,8 +1086,6 @@ export interface ContextEventResult {
   messages?: AgentMessage[];
 }
 
-type BeforeProviderRequestEventResult = unknown;
-
 export interface ToolCallEventResult {
   /** Block tool execution. To modify arguments, mutate `event.input` in place instead. */
   block?: boolean;
@@ -1225,7 +1223,7 @@ export interface ExtensionAPI {
   on(event: "context", handler: ExtensionHandler<ContextEvent, ContextEventResult>): void;
   on(
     event: "before_provider_request",
-    handler: ExtensionHandler<BeforeProviderRequestEvent, BeforeProviderRequestEventResult>,
+    handler: ExtensionHandler<BeforeProviderRequestEvent, unknown>,
   ): void;
   on(event: "after_provider_response", handler: ExtensionHandler<AfterProviderResponseEvent>): void;
   on(

--- a/src/cli/machine-output-argv.ts
+++ b/src/cli/machine-output-argv.ts
@@ -11,8 +11,10 @@ export type MachineOutputResolverParams = {
 export type MachineOutputResolver = (params: MachineOutputResolverParams) => boolean;
 
 /** Normalize Node's absent `isTTY` property to the public resolver's boolean contract. */
-export function isMachineOutputStdoutTTY(stdout: object = process.stdout): boolean {
-  return Reflect.get(stdout, "isTTY") === true;
+export function isMachineOutputStdoutTTY(
+  stdout: { readonly isTTY?: boolean } = process.stdout,
+): boolean {
+  return stdout.isTTY === true;
 }
 
 /** Locate the root command after supported root options without loading descriptor catalogs. */

--- a/src/commands/doctor/shared/include-migration-ownership.ts
+++ b/src/commands/doctor/shared/include-migration-ownership.ts
@@ -6,14 +6,13 @@ import { isPathInside } from "../../../infra/path-safety.js";
 import { isRecord } from "../../../utils.js";
 
 export function containsAuthoredInclude(value: unknown): boolean {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
   if (Array.isArray(value)) {
     return value.some(containsAuthoredInclude);
   }
-  const record = value as Record<string, unknown>;
-  return Object.hasOwn(record, INCLUDE_KEY) || Object.values(record).some(containsAuthoredInclude);
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.hasOwn(value, INCLUDE_KEY) || Object.values(value).some(containsAuthoredInclude);
 }
 
 type ConfigPathMigrationOwnership =

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -14,6 +14,7 @@ import type {
   SessionLifecycleArtifactCleanupResult,
   SessionLifecycleStoreTarget,
 } from "./session-accessor.lifecycle-types.js";
+import type { TranscriptEvent } from "./session-accessor.types.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
 import type { TranscriptEntryAnchor } from "./transcript-entry-anchor.js";
 import type { SessionEntry } from "./types.js";
@@ -77,8 +78,6 @@ export type SessionTranscriptInstance = SessionEntrySummary & {
   updatedAtMs: number;
 };
 
-export type TranscriptEvent = unknown;
-
 export type TranscriptEventAppendOptions = {
   appendIntent?: "active-branch";
 };
@@ -119,6 +118,7 @@ export type {
   SessionTranscriptRawDeltaResult,
   SessionTranscriptVisibleMessageDeltaLimits,
   SessionTranscriptVisibleMessageDeltaResult,
+  TranscriptEvent,
 } from "./session-accessor.types.js";
 
 export type TranscriptMessageAppendOptions<TMessage> = {

--- a/src/infra/net/proxy/managed-proxy-undici.ts
+++ b/src/infra/net/proxy/managed-proxy-undici.ts
@@ -22,7 +22,7 @@ function readProxyUrlFromOptions(options: object | undefined): string | undefine
     return undefined;
   }
   if ("uri" in options) {
-    const uri: unknown = Reflect.get(options, "uri");
+    const uri = options.uri;
     return uri instanceof URL ? uri.href : typeof uri === "string" ? uri : undefined;
   }
   if ("httpsProxy" in options || "httpProxy" in options) {

--- a/test/fixtures/oxlint-boundary-guards/widen-then-assert-violation.test.ts
+++ b/test/fixtures/oxlint-boundary-guards/widen-then-assert-violation.test.ts
@@ -1,3 +1,13 @@
 const source = { id: "fixture" };
 const widened: unknown = source;
 widened as { readonly id: string };
+
+const nestedSource = { id: "nested" };
+const nestedWidened: unknown = nestedSource;
+nestedWidened as unknown as { readonly id: string };
+
+const aliasSource = { id: "alias" };
+const aliasWidened: unknown = aliasSource;
+const firstAlias = aliasWidened;
+const alias = firstAlias;
+alias as { readonly id: string };

--- a/test/fixtures/oxlint-boundary-guards/widen-then-assert-violation.test.ts
+++ b/test/fixtures/oxlint-boundary-guards/widen-then-assert-violation.test.ts
@@ -1,0 +1,3 @@
+const source = { id: "fixture" };
+const widened: unknown = source;
+widened as { readonly id: string };

--- a/test/scripts/oxlint-boundary-guards.test.ts
+++ b/test/scripts/oxlint-boundary-guards.test.ts
@@ -13,6 +13,11 @@ const cases = [
     violation: `${FIXTURES}/raw-window-open-violation.ts`,
     violations: 5,
   },
+  {
+    rule: "openclaw-boundaries/no-widen-then-assert",
+    violation: `${FIXTURES}/widen-then-assert-violation.test.ts`,
+    violations: 1,
+  },
 ];
 
 function runGuard(target: string) {
@@ -30,7 +35,7 @@ function runGuard(target: string) {
 }
 
 describe("oxlint boundary guards", () => {
-  it.each(cases)("matches legacy call-only semantics for $rule", (testCase) => {
+  it.each(cases)("reports expected violations for $rule", (testCase) => {
     const violation = runGuard(testCase.violation);
     const output = `${violation.stdout}${violation.stderr}`;
     expect(violation.status).toBe(1);

--- a/test/scripts/oxlint-boundary-guards.test.ts
+++ b/test/scripts/oxlint-boundary-guards.test.ts
@@ -16,7 +16,7 @@ const cases = [
   {
     rule: "openclaw-boundaries/no-widen-then-assert",
     violation: `${FIXTURES}/widen-then-assert-violation.test.ts`,
-    violations: 1,
+    violations: 3,
   },
 ];
 

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -246,6 +246,14 @@ describe("run-additional-boundary-checks", () => {
     });
   });
 
+  it("keeps widen-then-assert lint in CI boundary checks", () => {
+    expect(BOUNDARY_CHECKS).toContainEqual({
+      label: "lint:no-widen-then-assert",
+      command: "pnpm",
+      args: ["run", "lint:no-widen-then-assert"],
+    });
+  });
+
   it("keeps the Telegram grammY type import guard in source boundary checks", () => {
     expect(BOUNDARY_CHECKS).toContainEqual({
       label: "lint:extensions:telegram-grammy-types",


### PR DESCRIPTION
AI-assisted: yes (Codex). I reviewed the resulting code and validation evidence.

## What Problem This Solves

OpenClaw had no CI guard against immutable local flows that erase known type evidence through `unknown`, `any`, `object`, or broad record bindings and later recreate a narrower type with an assertion. Two verified instances already used that laundering pattern, and a small related set of reflection and unknown-alias findings obscured type contracts in the same scanned surfaces.

## Why This Change Was Made

This vendors exactly the upstream `no-widen-then-assert` detection logic from `dmmulroy/anti-slop` (MIT) into the existing `openclaw-boundaries` Oxlint plugin, enables it across `src`, `extensions`, `packages`, and `ui/src`, and wires it into the existing supplemental boundary-check CI shard. The new rule deliberately covers test files and keeps upstream's narrow immutable-local-binding semantics; it does not adopt any other anti-slop rule.

The two reported laundering flows now retain typed evidence through construction and a typed SearXNG config reader. Five verified reflection sites use their known callable/property/record contracts directly. Five redundant unknown aliases were inlined, canonicalized, or removed.

Three aliases remain intentionally unchanged:

- `SessionTranscriptEvent` is an exported published Plugin SDK raw-event contract.
- `BundledChannelRuntime` appears in exported published Plugin SDK signatures and intentionally prevents internal `PluginRuntime` leakage.
- `TranscriptEvent` in `session-accessor.types.ts` is the canonical storage-neutral raw transcript domain type; consumers validate individual persisted/legacy/plugin event shapes.

## User Impact

There is no end-user behavior change. Developers now get a focused CI error when a known immutable local value is widened and later asserted back to a narrower type, including in tests. Existing runtime behavior is preserved while the repaired sites expose more accurate TypeScript contracts.

## Evidence

Expected fixture violation:

```text
test/fixtures/oxlint-boundary-guards/widen-then-assert-violation.test.ts:3:1: error openclaw-boundaries(no-widen-then-assert): Binding "widened" discards type evidence and later recreates it with an assertion.
[oxlint] FAILED (exit 1)
```

Real-tree scan:

```text
node scripts/run-oxlint.mjs --openclaw-focused-config --config config/oxlint/boundary-guards.json src extensions packages ui/src
exit 0
```

Focused tests:

```text
node scripts/run-vitest.mjs <14 focused test files>
[test] passed 9 Vitest shards in 45.08s
Test Files: 14 passed
Tests: 183 passed
```

After the first CI run exposed a missing legacy fallback in the runner cleanup, the exact failed files and sanitizer suite passed on the corrected head:

```text
Test Files: 3 passed
Tests: 72 passed
[test] passed 1 Vitest shard in 25.53s
```

Changed gate:

```text
node scripts/check-changed.mjs
[check:changed] the remote backend never ran the checks (no run summary). Falling back to local execution.
```

The local fallback completed successfully across conflict/ratchet/dependency guards, formatting, Plugin SDK exports and surface budget, dead-export scans, six TypeScript graphs, core/extensions/scripts lint, import cycles, and policy guards.

Structured review:

```text
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.99)
```

Size:

```text
19 files changed, 428 insertions(+), 50 deletions(-)
production: +26/-37 (net -11)
outside vendored rule + fixture: +48/-50 (net -2)
```


Provenance: the vendored rule was adapted from dmmulroy/anti-slop at commit 446268e5d15baa968eaec669ff65358d36ae6259 (MIT, Copyright (c) 2026 Dillon Mulroy).
