### PR TITLE
fix(codex): preserve native child continuation on yield

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -56,18 +56,18 @@ type NativeSubagentMonitorClient = Pick<
   "request" | "addNotificationHandler" | "addCloseHandler"
 >;
 
+type ParentOwner = {
+  turnId?: string;
+  claimDirectChild?: (threadId: string) => (() => void) | undefined;
+  rejectPendingDirectChild?: (threadId: string, reason: string) => void;
+  onDirectChildAccepted?: () => void;
+};
+
 type ParentState = {
   parentThreadId: string;
   // Overlapping runs share this parent; the last owner releases it only after
   // detached children finish recovery and delivery.
-  owners: Map<
-    symbol,
-    {
-      turnId?: string;
-      claimDirectChild?: (threadId: string) => (() => void) | undefined;
-      rejectPendingDirectChild?: (threadId: string, reason: string) => void;
-    }
-  >;
+  owners: Map<symbol, ParentOwner>;
   requesterSessionKey?: string;
   taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   agentId?: string;
@@ -196,6 +196,7 @@ function registerMonitor(params: {
   retainParentThread?: (threadId: string) => (() => void) | undefined;
   claimDirectChild?: (threadId: string) => (() => void) | undefined;
   rejectPendingDirectChild?: (threadId: string, reason: string) => void;
+  onDirectChildAccepted?: () => void;
 }): { bindTurn: (turnId: string) => void; unregister: () => void } {
   let monitor = monitors.get(params.client);
   if (!monitor) {
@@ -261,6 +262,7 @@ function registerMonitor(params: {
     agentId: params.agentId,
     claimDirectChild: params.claimDirectChild,
     rejectPendingDirectChild: params.rejectPendingDirectChild,
+    onDirectChildAccepted: params.onDirectChildAccepted,
   });
 }
 
@@ -363,6 +365,7 @@ class Monitor {
     agentId?: string;
     claimDirectChild?: (threadId: string) => (() => void) | undefined;
     rejectPendingDirectChild?: (threadId: string, reason: string) => void;
+    onDirectChildAccepted?: () => void;
   }): { bindTurn: (turnId: string) => void; unregister: () => void } {
     const parentThreadId = params.parentThreadId.trim();
     if (!parentThreadId) {
@@ -390,6 +393,7 @@ class Monitor {
     state.owners.set(owner, {
       claimDirectChild: params.claimDirectChild,
       rejectPendingDirectChild: params.rejectPendingDirectChild,
+      onDirectChildAccepted: params.onDirectChildAccepted,
     });
     this.prepareParentTaskRuntime(state);
     for (const childState of this.childStates.values()) {
@@ -1387,9 +1391,7 @@ class Monitor {
   private resolveParentOwner(
     state: ParentState,
     turnIdInput: string | undefined,
-  ):
-    | { turnId?: string; claimDirectChild?: (threadId: string) => (() => void) | undefined }
-    | undefined {
+  ): ParentOwner | undefined {
     const turnId = turnIdInput?.trim();
     if (!turnId) {
       return undefined;
@@ -1402,7 +1404,7 @@ class Monitor {
     state: ParentState,
     turnIdInput: string | undefined,
     evidence: DirectSpawnEvidence,
-    owner: { claimDirectChild?: (threadId: string) => (() => void) | undefined } | undefined,
+    owner: ParentOwner | undefined,
   ): ChildState | undefined {
     const childState = this.registerChildThread(state.parentThreadId, evidence.childThreadId, {
       ...(evidence.agentPath === undefined ? {} : { agentPath: evidence.agentPath }),
@@ -1410,6 +1412,8 @@ class Monitor {
     });
     if (!owner) {
       this.bufferPendingDirectSpawnEvidence(turnIdInput, evidence);
+    } else if (childState) {
+      owner.onDirectChildAccepted?.();
     }
     return childState;
   }
@@ -1443,7 +1447,7 @@ class Monitor {
 
   private drainPendingDirectSpawnEvidence(
     state: ParentState,
-    owner: { claimDirectChild?: (threadId: string) => (() => void) | undefined },
+    owner: ParentOwner,
     turnId: string,
   ): void {
     const pending = this.pendingDirectSpawnEvidence.get(turnId);
@@ -1453,10 +1457,13 @@ class Monitor {
     }
     for (const evidence of pending) {
       if (evidence.parentThreadId === state.parentThreadId) {
-        this.registerChildThread(state.parentThreadId, evidence.childThreadId, {
+        const childState = this.registerChildThread(state.parentThreadId, evidence.childThreadId, {
           ...(evidence.agentPath === undefined ? {} : { agentPath: evidence.agentPath }),
           claimDirectChild: owner.claimDirectChild,
         });
+        if (childState) {
+          owner.onDirectChildAccepted?.();
+        }
       }
     }
   }

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -494,6 +494,7 @@ export async function finalizeCodexAttempt(
     ...(terminalAnchor ? { contextEngineTerminalAnchor: terminalAnchor } : {}),
     ...(settledTurnFinalizationContext ? { settledTurnFinalizationContext } : {}),
     ...(resourceState.runtimeArtifact ? { runtimeArtifact: resourceState.runtimeArtifact } : {}),
+    ...(resourceState.runtimeContinuationStarted ? { runtimeContinuationStarted: true } : {}),
     ...(!finalAborted && !effectiveTimedOut && !finalPromptError && preparedAuthBinding
       ? { authBindingFingerprint: preparedAuthBinding.fingerprint }
       : {}),

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -72,6 +72,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
     nativeSubagentMonitor: undefined as
       | ReturnType<typeof codexNativeSubagentMonitorRuntime.register>
       | undefined,
+    runtimeContinuationStarted: false,
     nativePreToolUseFailureFallbackActive: false,
     nativePreToolUseFailureFallbackTerminalReason: undefined as
       | CodexNativePreToolUseFailure["disposition"]
@@ -187,6 +188,13 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       claimDirectChild: (childThreadId) => state.nativeHookRelay?.claimDirectChild(childThreadId),
       rejectPendingDirectChild: (childThreadId, reason) =>
         state.nativeHookRelay?.rejectPendingDirectChild(childThreadId, reason),
+      ...(params.sessionKey && params.agentHarnessTaskRuntimeScope
+        ? {
+            onDirectChildAccepted: () => {
+              state.runtimeContinuationStarted = true;
+            },
+          }
+        : {}),
     });
   };
   const releaseCurrentRoute = () => {

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts
@@ -30,6 +30,8 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
   it.each([
     {
       name: "Codex multi-agent V1",
+      bindBeforeClaim: false,
+      hasDeliveryScope: true,
       childThreadId: "child-v1",
       childClaim: {
         type: "collabAgentToolCall",
@@ -41,6 +43,8 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
     },
     {
       name: "Codex multi-agent V2",
+      bindBeforeClaim: true,
+      hasDeliveryScope: true,
       childThreadId: "child-v2",
       childClaim: {
         type: "subAgentActivity",
@@ -49,9 +53,21 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
         agentPath: "/root/child-v2",
       },
     },
+    {
+      name: "Codex multi-agent V2 without delivery scope",
+      bindBeforeClaim: true,
+      hasDeliveryScope: false,
+      childThreadId: "child-v2-no-delivery",
+      childClaim: {
+        type: "subAgentActivity",
+        kind: "started",
+        agentThreadId: "child-v2-no-delivery",
+        agentPath: "/root/child-v2-no-delivery",
+      },
+    },
   ] as const)(
     "retains and fences a live child through sessions_yield ($name)",
-    async ({ childThreadId, childClaim }) => {
+    async ({ bindBeforeClaim, hasDeliveryScope, childThreadId, childClaim }) => {
       const sessionFile = path.join(tempDir, `${childThreadId}-yield-session.jsonl`);
       const workspaceDir = path.join(tempDir, `${childThreadId}-yield-workspace`);
       let resolveTurnStart: ((value: undefined) => void) | undefined;
@@ -71,6 +87,9 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
       setCodexTestModelSupportsTools(params, true);
       const fixture = await createAdmittedHostCapabilityTestFixture(params);
       params.hostCapabilities = fixture.hostCapabilities;
+      if (hasDeliveryScope) {
+        params.agentHarnessTaskRuntimeScope = fixture.agentHarnessTaskRuntimeScope;
+      }
 
       const beforeToolCall = vi.fn(async (event: unknown) =>
         (event as { params?: { command?: string } }).params?.command === "deny-child"
@@ -87,6 +106,12 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
       let relayId: string | undefined;
       try {
         await harness.waitForMethod("turn/start");
+        if (bindBeforeClaim) {
+          resolveTurnStart?.(undefined);
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+        }
         const startRequest = harness.requests.find((request) => request.method === "thread/start");
         relayId = extractRelayIdFromThreadRequest(startRequest?.params);
         const preDiscoveryPayload = {
@@ -200,10 +225,11 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
             item: childClaim,
           },
         } as unknown as CodexServerNotification);
-        // The app-server can publish the direct-spawn item after starting its
-        // turn but before turn/start responds. Binding must replay this exact
-        // evidence rather than dropping the already-pending child hook.
-        resolveTurnStart?.(undefined);
+        // Cover both exact-turn admission paths: an already-bound owner and
+        // evidence buffered before turn/start responds.
+        if (!bindBeforeClaim) {
+          resolveTurnStart?.(undefined);
+        }
         await expect(Promise.all([firstPending, duplicatePending])).resolves.toEqual([
           { stdout: "", stderr: "", exitCode: 0 },
           { stdout: "", stderr: "", exitCode: 0 },
@@ -232,6 +258,7 @@ describe("runCodexAppServerAttempt native hook relay retention", () => {
         await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
         const result = await run;
         expect(readAttemptTerminal(result)).toMatchObject({ aborted: false, promptError: null });
+        expect(result.runtimeContinuationStarted).toBe(hasDeliveryScope ? true : undefined);
         const terminalLifecycleEvents = (params.onAgentEvent as ReturnType<typeof vi.fn>).mock.calls
           .map(([event]) => event as { stream?: string; data?: Record<string, unknown> })
           .filter(

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -393,7 +393,7 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     });
   });
 
-  it("does not fallback after structured replay state records potential side effects", () => {
+  it("does not fallback after a yielded empty result records potential side effects", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "openai",
       model: "gpt-5.5",
@@ -402,7 +402,8 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
         meta: {
           durationMs: 42,
           replayInvalid: true,
-          agentHarnessResultClassification: "reasoning-only",
+          yielded: true,
+          stopReason: "end_turn",
         },
       },
     });

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
@@ -182,6 +182,7 @@ interface YieldContinuationAttempt {
   didSendDeterministicApprovalPrompt?: boolean;
   successfulCronAdds?: number;
   acceptedSessionSpawns?: readonly { runId: string; childSessionKey: string }[];
+  runtimeContinuationStarted?: boolean;
   messagingToolSentTexts?: readonly string[];
   messagingToolSentMediaUrls?: readonly string[];
   messagingToolSentTargets?: readonly MessagingToolSend[];
@@ -201,6 +202,7 @@ export function hasYieldContinuationEvidence(attempt: YieldContinuationAttempt):
       messagingToolSentTargets: attempt.messagingToolSentTargets ?? [],
     }) ||
     hasAcceptedSessionSpawn(attempt.acceptedSessionSpawns) ||
+    attempt.runtimeContinuationStarted === true ||
     hasAsyncActivity(attempt.toolMetas) ||
     (attempt.successfulCronAdds ?? 0) > 0
   );

--- a/src/agents/embedded-agent-runner/run/run-attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-result.ts
@@ -25,6 +25,10 @@ export function normalizeEmbeddedRunAttemptResult(
       | EmbeddedRunAttemptForRunner["currentAttemptReplayMetadata"]
       | null;
   };
+  const runtimeContinuationReplayMetadata =
+    raw.runtimeContinuationStarted === true
+      ? { hadPotentialSideEffects: true, replaySafe: false }
+      : undefined;
   return {
     ...attempt,
     assistantTexts: raw.assistantTexts ?? [],
@@ -41,8 +45,10 @@ export function normalizeEmbeddedRunAttemptResult(
       completedCount: 0,
       activeCount: 0,
     },
-    replayMetadata: raw.replayMetadata ?? { hadPotentialSideEffects: true, replaySafe: false },
-    currentAttemptReplayMetadata: raw.currentAttemptReplayMetadata ?? undefined,
+    replayMetadata: runtimeContinuationReplayMetadata ??
+      raw.replayMetadata ?? { hadPotentialSideEffects: true, replaySafe: false },
+    currentAttemptReplayMetadata:
+      runtimeContinuationReplayMetadata ?? raw.currentAttemptReplayMetadata ?? undefined,
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -282,6 +282,8 @@ export type EmbeddedRunAttemptResult = {
     asyncTaskId?: string;
   }>;
   acceptedSessionSpawns?: AcceptedSessionSpawn[];
+  /** This attempt accepted work whose future output has a runtime-owned delivery path. */
+  runtimeContinuationStarted?: boolean;
   lastAssistant: AssistantMessage | undefined;
   /**
    * Omission preserves the legacy `lastAssistant` fallback; explicit `undefined`

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
@@ -134,6 +134,26 @@ describe("sessions_yield orchestration", () => {
       expect(result.meta.stopReason).toBe("end_turn");
       expect(result.meta.yielded).toBe(true);
     });
+
+    it("yield with runtime continuation — diagnostic suppressed", async () => {
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          yieldDetected: true,
+          assistantTexts: [],
+          runtimeContinuationStarted: true,
+        }),
+      );
+
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        runId: "run-yield-runtime-continuation-suppressed",
+      });
+
+      expect(result.payloads).toBeUndefined();
+      expect(result.meta.stopReason).toBe("end_turn");
+      expect(result.meta.yielded).toBe(true);
+      expect(result.meta.replayInvalid).toBe(true);
+    });
   });
 
   it("normal attempt without yield has no stopReason override", async () => {

--- a/src/agents/harness/host-capability.test-support.ts
+++ b/src/agents/harness/host-capability.test-support.ts
@@ -1,3 +1,4 @@
+import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
@@ -10,6 +11,7 @@ type HostAttempt = Parameters<typeof createAgentHarnessHostCapabilities>[0]["att
 type AdmittedHostCapabilityTestFixture = Readonly<{
   admittedRunContext: AdmittedRunContext;
   hostCapabilities: ReturnType<typeof createAgentHarnessHostCapabilities>["capabilities"];
+  agentHarnessTaskRuntimeScope?: ReturnType<typeof createAgentHarnessTaskRuntimeScope>;
   closeHost: () => void;
   closeAdmission: () => void;
 }>;
@@ -35,6 +37,13 @@ export async function createAdmittedHostCapabilityTestFixture(
   return {
     admittedRunContext,
     hostCapabilities: host.capabilities,
+    ...(attempt.sessionKey
+      ? {
+          agentHarnessTaskRuntimeScope: createAgentHarnessTaskRuntimeScope({
+            requesterSessionKey: attempt.sessionKey,
+          }),
+        }
+      : {}),
     closeHost: host.close,
     closeAdmission: admission.close,
   };


### PR DESCRIPTION
Fixes #123028

## What Problem This Solves

Fixes an issue where a parent using the native Codex runtime could spawn a child, call `sessions_yield`, and receive a false “without a continuation source” warning even though the child was still running and would deliver its result automatically.

## Why This Change Was Made

The Codex runtime now records a typed, same-attempt continuation fact only after a direct native child is accepted **and** the parent has an owned delivery scope. Core yield resolution consumes that fact, and replay/fallback handling treats the started child as a side effect so recovery cannot duplicate it.

This keeps the existing warning for genuine no-source yields and avoids scanning session-wide descendant state.

## User Impact

Native Codex parent turns can yield for an active child without telling users to send an unnecessary resume message. The child completion continues through the existing automatic delivery path.

## Evidence

### Docker live-provider verdict: passed

- Scenario: `spawn_agent -> sessions_yield -> delayed child -> delivered marker`
- Container runtime: `@openai/codex 0.147.0`
- Model: `openai/gpt-5.6-luna`
- Result: exit `0`; 1 passed, 1 skipped; 346.8 seconds
- Assertions: yield succeeded; false warning absent; child succeeded; delivery status was `delivered`; terminal summary contained the randomized child marker
- Cleanup: temporary instrumentation restored byte-for-byte; no live container remained
- Full local evidence retained outside the repository at `/tmp/openclaw-123028-docker-live-proof-20260815T025727Z.{log,json}`; log SHA-256 `788484a494951d3c40e8eee08b09243f7e4d1fb5adebafec4f686e3c66053304`
- The post-proof rebase preserved the patch exactly (`git range-diff` equality; stable patch ID `c1a1b17b97640720053cff711b18ec86c3cd4464`).

### Focused validation

- `pnpm exec vitest run extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/embedded-agent-runner/run.shared-integration.test.ts` — 4 files, 166 tests passed
- `pnpm check:changed` — passed locally after Testbox routing reported the `blacksmith` CLI unavailable and did not start a remote run
- `pnpm plugin-sdk:check-exports` — passed
- `pnpm plugin-sdk:surface:check` — passed
- `pnpm lint:plugins:plugin-sdk-subpaths-exported` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings
- `git diff --check origin/main...HEAD` — passed

Tests cover buffered V1 and already-bound V2 native-child evidence, absence of an owned delivery scope, replay/fallback fencing, and a genuine no-source yield.

## AI Assistance

AI-assisted: Codex helped investigate, implement, test, and review this change. I reviewed the final diff and validation evidence and understand the submitted code.
