### PR TITLE
fix(ui): dedupe chat header owner presence

### DIFF
--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -328,6 +328,9 @@ it("detects only other viewers watching the requested session", () => {
   expect(hasSessionPresenceViewers(payload, "self", "self-instance", "agent:main:other")).toBe(
     true,
   );
+  expect(
+    hasSessionPresenceViewers(payload, "self", "self-instance", "agent:main:other", "alice"),
+  ).toBe(false);
 });
 
 it.each([

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -113,10 +113,15 @@ export function hasSessionPresenceViewers(
   authenticatedSelfUserId: string | undefined,
   selfInstanceId: string | undefined,
   sessionKey: string,
+  excludeUserId?: string,
 ): boolean {
   const projection = projectPresencePayload(value, authenticatedSelfUserId, selfInstanceId);
+  const excludedUserId = normalized(excludeUserId);
   return projection.users.some(
-    (user) => user.id !== projection.selfUserId && user.watchedSessions.includes(sessionKey),
+    (user) =>
+      user.id !== projection.selfUserId &&
+      user.id !== excludedUserId &&
+      user.watchedSessions.includes(sessionKey),
   );
 }
 

--- a/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
+++ b/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
@@ -1,0 +1,99 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat header owner presence capture",
+  startServerBeforeBrowser: true,
+});
+
+const outputDir = path.resolve(
+  process.cwd(),
+  process.env.OPENCLAW_CHAT_HEADER_CAPTURE_OUTPUT_DIR ??
+    ".artifacts/control-ui-e2e/chat-header-owner-presence",
+);
+const screenshotPath = path.join(outputDir, "chat-header.png");
+
+suite.define(() => {
+  it("captures the owner chip with another active viewer", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 760, width: 1180 },
+      },
+      async ({ page }) => {
+        const sessionKey = "agent:main:owner-present";
+        await installMockGateway(page, {
+          hasMultipleSessionSharingIdentities: true,
+          presenceUsers: [
+            { self: true, id: "profile-operator", name: "Operator" },
+            {
+              id: "profile-ada",
+              name: "Ada",
+              watchedSessions: [sessionKey],
+            },
+            {
+              id: "profile-zoe",
+              name: "Zoe",
+              watchedSessions: [sessionKey],
+            },
+          ],
+          sessionKey,
+          methodResponses: {
+            "sessions.list": {
+              count: 1,
+              creators: [
+                { id: "profile-ada", label: "Ada" },
+                { id: "profile-zoe", label: "Zoe" },
+              ],
+              defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+              path: "",
+              sessions: [
+                {
+                  contextTokens: null,
+                  createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+                  displayName: "Owner presence",
+                  hasActiveRun: false,
+                  key: sessionKey,
+                  kind: "direct",
+                  label: "Owner presence",
+                  model: "gpt-5.5",
+                  modelProvider: "openai",
+                  status: "done",
+                  totalTokens: 0,
+                  updatedAt: Date.parse("2026-08-14T12:00:00.000Z"),
+                },
+              ],
+              ts: Date.parse("2026-08-14T12:00:00.000Z"),
+            },
+          },
+        });
+
+        const response = await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        expect(response?.status()).toBe(200);
+        const header = page.locator(".chat-pane__header").first();
+        await header.waitFor({ state: "visible" });
+        await expect.poll(() => header.locator(".session-owner-chip--header").count()).toBe(1);
+        await expect
+          .poll(() => header.locator(".viewer-facepile").getAttribute("data-viewer-count"))
+          .toBe("1");
+        await expect.poll(() => header.locator('[data-viewer-id="profile-ada"]').count()).toBe(0);
+        await expect.poll(() => header.locator('[data-viewer-id="profile-zoe"]').count()).toBe(1);
+        await expect
+          .poll(() => header.locator(".session-owner-chip--header").getAttribute("class"))
+          .not.toContain("session-owner-chip--away");
+
+        const clip = await header.boundingBox();
+        if (!clip) {
+          throw new Error("Chat header did not expose a screenshot bounding box");
+        }
+        await mkdir(outputDir, { recursive: true });
+        await page.screenshot({ animations: "disabled", clip, path: screenshotPath });
+        process.stdout.write(`Chat header screenshot: ${screenshotPath}\n`);
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -13,7 +13,10 @@ import {
 import { sessionMenuReasons } from "../../components/session-menu-access.ts";
 import { listSessionCreators } from "../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
-import { hasSessionPresenceViewers } from "../../components/viewer-facepile.ts";
+import {
+  hasSessionPresenceViewers,
+  projectPresencePayload,
+} from "../../components/viewer-facepile.ts";
 import { workspaceIconRouteUrl } from "../../components/workspace-icon.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -335,6 +338,17 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
       reclaimingKey: this.headerPlacementReclaimingKey,
       row,
     });
+    const key = this.state?.sessionKey ?? "";
+    const selfId = sharingSnapshot.selfUser?.id;
+    const instanceId = sharingSnapshot.client?.instanceId;
+    const result = this.state?.sessionsResult;
+    const showOwnerChip =
+      (result?.creators ?? listSessionCreators(result?.sessions ?? [])).length >= 2;
+    const renderedOwnerId = showOwnerChip ? row?.createdActor?.id : undefined;
+    const presence = projectPresencePayload(this.presencePayload, selfId, instanceId);
+    const ownerViewing = presence.users.some(
+      (user) => user.id === renderedOwnerId && user.watchedSessions.includes(key),
+    );
     const header = renderChatPaneHeader({
       paneId: this.paneId,
       narrow: this.narrow,
@@ -342,11 +356,8 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
       navDrawerOpen: this.navDrawerOpen,
       title: this.paneTitle,
       session: row,
-      showOwnerChip:
-        (
-          this.state?.sessionsResult?.creators ??
-          listSessionCreators(this.state?.sessionsResult?.sessions ?? [])
-        ).length >= 2,
+      showOwnerChip,
+      ownerViewing,
       catalog,
       editing: this.headerEditing && this.headerRenameSessionKey === row?.key,
       renameValue: this.headerRenameValue,
@@ -379,18 +390,14 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
       workspaceAction: renderSessionWorkspaceToggle(sessionWorkspace),
       presence:
         !catalog &&
-        hasSessionPresenceViewers(
-          this.presencePayload,
-          this.context.gateway.snapshot.selfUser?.id,
-          this.context.gateway.snapshot.client?.instanceId,
-          this.state?.sessionKey ?? "",
-        )
+        hasSessionPresenceViewers(this.presencePayload, selfId, instanceId, key, renderedOwnerId)
           ? html`<openclaw-viewer-facepile
               class="chat-pane__presence"
               .presencePayload=${this.presencePayload}
-              .selfUserId=${this.context.gateway.snapshot.selfUser?.id}
-              .selfInstanceId=${this.context.gateway.snapshot.client?.instanceId}
-              .sessionKey=${this.state?.sessionKey}
+              .selfUserId=${selfId}
+              .selfInstanceId=${instanceId}
+              .sessionKey=${key}
+              .excludeUserId=${renderedOwnerId}
               .maxVisible=${4}
               variant="session"
             ></openclaw-viewer-facepile>`

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -2,7 +2,8 @@
 
 import { html, nothing, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GatewaySessionRow } from "../../../api/types.ts";
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import type { GatewaySessionRow, PresenceEntry, SessionsListResult } from "../../../api/types.ts";
 import type {
   NativeGatewaysCapability,
   NativeGatewaysSnapshot,
@@ -12,12 +13,17 @@ import {
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
   type ShellNavDrawerToggleDetail,
 } from "../../../components/command-palette-contract.ts";
+import type { SessionCapability } from "../../../lib/sessions/index.ts";
+import { createTestChatPane } from "../chat-pane.test-support.ts";
+import type { ChatPageHost } from "../chat-state-host.ts";
+import { createBackgroundTasksProps } from "./chat-background-tasks.ts";
 import {
   canRevealSessionWorkspace,
   renderChatPaneHeader,
   resolveChatPaneParentSession,
   resolveChatPaneWorkspace,
 } from "./chat-pane-header.ts";
+import { createSessionWorkspaceProps } from "./chat-session-workspace.ts";
 
 type ChatPaneHeaderProps = Parameters<typeof renderChatPaneHeader>[0];
 
@@ -109,6 +115,46 @@ function mount(patch: Partial<ChatPaneHeaderProps> = {}) {
   props.gatewaysSnapshot ??= props.nativeGateways?.snapshot;
   render(html`${renderChatPaneHeader(props)}`, container);
   return { container, props };
+}
+
+function mountIntegratedPresenceHeader(params: {
+  creators: NonNullable<SessionsListResult["creators"]>;
+  presence: PresenceEntry[];
+}) {
+  const client = { instanceId: "self-instance" } as unknown as GatewayBrowserClient;
+  const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+  const session = row({
+    key: state.sessionKey,
+    createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+  });
+  state.settings = {} as ChatPageHost["settings"];
+  state.sessionsResult = {
+    ts: 1,
+    path: "",
+    count: 1,
+    creators: params.creators,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [session],
+  };
+  pane.context.gateway.snapshot.selfUser = { id: "profile-self" };
+  pane.presencePayload = { presence: params.presence };
+  const container = document.createElement("div");
+  document.body.append(container);
+  containers.push(container);
+  const renderHeader = () =>
+    render(
+      pane.renderPaneHeader(
+        createSessionWorkspaceProps(state),
+        createBackgroundTasksProps(state),
+        session,
+        false,
+        undefined,
+        false,
+      ),
+      container,
+    );
+  renderHeader();
+  return { container, pane, renderHeader };
 }
 
 describe("chat pane header", () => {
@@ -424,6 +470,101 @@ describe("chat pane header", () => {
       session: row({ createdActor: { type: "human", id: "profile-ada", label: "Ada" } }),
     });
     expect(dormant.container.querySelector("openclaw-session-owner-chip")).toBeNull();
+  });
+
+  it.each([
+    {
+      name: "excludes the creator when the owner chip is shown",
+      creators: [
+        { type: "human", id: "profile-ada", label: "Ada" },
+        { type: "human", id: "profile-zoe", label: "Zoe" },
+      ],
+      viewers: ["profile-ada", "profile-zoe"],
+      expectedChip: true,
+      expectedViewers: ["profile-zoe"],
+    },
+    {
+      name: "keeps the creator when the owner chip is hidden",
+      creators: [{ type: "human", id: "profile-ada", label: "Ada" }],
+      viewers: ["profile-ada", "profile-zoe"],
+      expectedChip: false,
+      expectedViewers: ["profile-ada", "profile-zoe"],
+    },
+    {
+      name: "omits the facepile when the shown owner is the only viewer",
+      creators: [
+        { type: "human", id: "profile-ada", label: "Ada" },
+        { type: "human", id: "profile-zoe", label: "Zoe" },
+      ],
+      viewers: ["profile-ada"],
+      expectedChip: true,
+      expectedViewers: [],
+    },
+  ])("$name", async ({ creators, viewers, expectedChip, expectedViewers }) => {
+    const sessionKey = "agent:main:current";
+    const { container } = mountIntegratedPresenceHeader({
+      creators,
+      presence: viewers.map((id) => ({
+        instanceId: `${id}-instance`,
+        ts: 1,
+        user: { id, name: id },
+        watchedSessions: [sessionKey],
+      })),
+    });
+    const ownerChip = container.querySelector<HTMLElement & { updateComplete?: Promise<unknown> }>(
+      "openclaw-session-owner-chip",
+    );
+    const facepile = container.querySelector<HTMLElement & { updateComplete?: Promise<unknown> }>(
+      "openclaw-viewer-facepile",
+    );
+
+    await Promise.all([ownerChip?.updateComplete, facepile?.updateComplete]);
+    expect(ownerChip !== null).toBe(expectedChip);
+    expect(
+      [...container.querySelectorAll(".viewer-facepile [data-viewer-id]")].map((avatar) =>
+        avatar.getAttribute("data-viewer-id"),
+      ),
+    ).toEqual(expectedViewers);
+    expect(facepile !== null).toBe(expectedViewers.length > 0);
+  });
+
+  it("updates the header owner vitality from live session presence", async () => {
+    const sessionKey = "agent:main:current";
+    const creators = [
+      { type: "human" as const, id: "profile-ada", label: "Ada" },
+      { type: "human" as const, id: "profile-zoe", label: "Zoe" },
+    ];
+    const guest = {
+      instanceId: "profile-zoe-instance",
+      ts: 1,
+      user: { id: "profile-zoe", name: "Zoe" },
+      watchedSessions: [sessionKey],
+    } satisfies PresenceEntry;
+    const mounted = mountIntegratedPresenceHeader({ creators, presence: [guest] });
+    const ownerChip = mounted.container.querySelector<
+      HTMLElement & { updateComplete?: Promise<unknown> }
+    >("openclaw-session-owner-chip");
+
+    await ownerChip?.updateComplete;
+    expect(mounted.container.querySelector(".session-owner-chip--header")?.classList).toContain(
+      "session-owner-chip--away",
+    );
+    mounted.pane.presencePayload = {
+      presence: [
+        {
+          instanceId: "profile-ada-instance",
+          ts: 1,
+          user: { id: "profile-ada", name: "Ada" },
+          watchedSessions: [sessionKey],
+        },
+        guest,
+      ],
+    };
+    mounted.renderHeader();
+    await ownerChip?.updateComplete;
+    expect(mounted.container.querySelector(".session-owner-chip--header")?.classList).not.toContain(
+      "session-owner-chip--away",
+    );
   });
 
   it("renders the durable session actor avatar with the header attribution semantics", async () => {

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -44,6 +44,7 @@ type ChatPaneHeaderProps = {
   title: string;
   session: GatewaySessionRow | undefined;
   showOwnerChip?: boolean;
+  ownerViewing?: boolean;
   catalog: boolean;
   editing: boolean;
   renameValue: string;
@@ -446,6 +447,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         props.showOwnerChip ? props.session?.createdActor : undefined,
         "header",
         "created",
+        props.ownerViewing,
       )}
       ${renderChatPanePlacement(props)} ${props.presence ?? nothing} ${props.faceControl ?? nothing}
       ${props.sharingControl ?? nothing}


### PR DESCRIPTION
Related: #123938

## What Problem This Solves

Fixes an issue where multi-user Control UI sessions showed the creator twice in the chat header—once as the durable owner chip and again in the live viewer facepile—and did not dim the owner chip when that creator was away.

## Why This Change Was Made

The chat header now follows the landed sidebar pattern from #123938: one shared rendered-owner decision drives both the owner chip and facepile exclusion, and live presence drives the chip's viewing/away vitality. The facepile visibility check accepts the same optional exclusion so an owner-only session does not leave an empty facepile shell.

## User Impact

Chat headers show each person once. The creator remains visible as the durable owner identity, other active viewers remain in the facepile, and the owner avatar fades when the creator is not watching the session.

## Evidence

Mocked-Gateway Playwright capture, clipped to the chat header. Ada is the creator and Zoe is the second viewer.

| Before | After |
| --- | --- |
| ![Before: Ada duplicated in the owner chip and viewer facepile](https://github.com/user-attachments/assets/8865a335-04d3-41e4-b475-1845ec9521cb) | ![After: Ada appears only in the owner chip and Zoe remains in the facepile](https://github.com/user-attachments/assets/b0f07bdb-ec98-401d-a169-be78f39bc230) |

- Focused UI suites: 2 files, 58 tests passed.
- Header capture E2E: 1 file, 1 test passed.
- Changed-file gate: core/UI typechecks, formatting, dead exports, i18n verification, core lint, and style lint passed (`CHECK_CHANGED_OK`).
- Autoreview: clean in local pre-commit mode and in branch mode against `origin/main`.
- Production LOC: +30/-16, net +14. Tests: +244/-1, net +243.
- Existing size-agnostic `.session-owner-chip--away` CSS covers the header chip; no stylesheet change was needed.
