### PR TITLE
refactor(ui): delete the permanently no-op onModelChanged seam

### DIFF
--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -381,8 +381,9 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     pageState.confirmConversationReset = () => this.confirmConversationReset();
     pageState.exportCurrentChat = () =>
       exportChatMarkdown(pageState.chatMessages, pageState.assistantName);
+    // Effective-tools previews key their requests on the model override, so a
+    // post-switch refresh only needs a re-render.
     pageState.refreshCurrentSessionTools = async () => {
-      await pageState.onModelChanged?.();
       pageState.requestUpdate?.();
     };
     pageState.refreshCurrentChat = async () => {

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -43,7 +43,6 @@ type ChatModelSettingsHost = ChatSessionRefreshHost & {
   chatModelCatalog: Parameters<typeof resolveChatModelOverrideValue>[0]["chatModelCatalog"];
   chatModelSwitchPromises?: Record<string, Promise<boolean>>;
   chatThinkingLevel: string | null;
-  onModelChanged?: () => unknown;
   sessions: SessionCapability;
   sessionsResult?: SessionsListResult | null;
   requestUpdate?: () => void;
@@ -444,7 +443,6 @@ export async function switchChatModel(
           ...scopedAgentParamsForSession(host, targetSessionKey),
           ownsModelOverride,
           reconcile: async () => {
-            await host.onModelChanged?.();
             await refreshCurrentChatSessionList(host);
           },
         },

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -120,7 +120,6 @@ export type ChatPageHost = ChatHost &
     imageLightboxRequestVersion: number;
     querySelector: (selectors: string) => Element | null;
     renderLifecycle: RenderLifecycle;
-    onModelChanged: () => Promise<void> | void;
     resetToolStream: () => void;
     resetChatScroll: () => void;
     resetChatInputHistoryNavigation: () => void;

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -268,7 +268,6 @@ export function createPageState(
   } as unknown as ChatPageHost;
 
   state.resetToolStream = () => resetToolStream(state as never);
-  state.onModelChanged = () => undefined;
   state.resetChatInputHistoryNavigation = () => resetChatInputHistoryNavigation(state);
   state.resetChatScroll = () => resetChatScroll(state);
   state.scrollToBottom = (options) => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -76,14 +76,6 @@ function registerChatAttachmentPayload(
   return attachment;
 }
 
-async function refreshVisibleToolsEffectiveForCurrentSessionForTest(state: ChatHeaderTestState) {
-  const agentId = state.agentsSelectedId ?? "main";
-  const sessionKey = state.sessionKey;
-  await state.client?.request("tools.effective", { agentId, sessionKey });
-  const override = state.sessions.state.modelOverrides[sessionKey];
-  state.toolsEffectiveResultKey = `${agentId}:${sessionKey}:model=${override ?? "(default)"}`;
-  state.toolsEffectiveResult = { agentId, profile: "coding", groups: [] };
-}
 const buildChatItemsMock = vi.fn(
   (props: {
     messages: unknown[];
@@ -255,7 +247,6 @@ type ChatHeaderTestState = {
   toolsEffectiveResult: unknown;
   applySettings(patch: Partial<UiSettings>): void;
   loadAssistantIdentity(): void;
-  onModelChanged(): void | Promise<void>;
   resetChatInputHistoryNavigation(): void;
   resetChatScroll(): void;
   resetToolStream(): void;
@@ -501,8 +492,6 @@ function createChatHeaderState(
     resetChatInputHistoryNavigation: vi.fn(),
     resetToolStream: vi.fn(),
     resetChatScroll: vi.fn(),
-    onModelChanged: (): Promise<void> =>
-      refreshVisibleToolsEffectiveForCurrentSessionForTest(state),
   };
   sessions.subscribe((next) => {
     state.sessionsResult = next.result;
@@ -6357,7 +6346,12 @@ describe("chat model controls", () => {
           return patchResult;
         },
       ),
-      refresh: async () => {},
+      // The list refresh is the reconcile step switchChatModel awaits; holding
+      // it open models a slow reconciliation inside the settings lane.
+      refresh: async () => {
+        reconciliationStarted.resolve();
+        await releaseReconciliation.promise;
+      },
       setModelOverride: vi.fn(),
       patchRowLocal: vi.fn(),
     };
@@ -6379,10 +6373,6 @@ describe("chat model controls", () => {
           thinkingLevel: "high",
         },
       ]),
-      onModelChanged: async () => {
-        reconciliationStarted.resolve();
-        await releaseReconciliation.promise;
-      },
     } as unknown as Parameters<typeof switchChatModel>[0];
 
     const modelSwitch = switchChatModel(host, "openai/gpt-5.6-sol");


### PR DESCRIPTION
## What Problem This Solves

Found by the round-4 agents-page/model-switching investigation lane. `state.onModelChanged` has been `() => undefined` since the original Control UI refactor (65e12328aa2) and is never overridden anywhere. Three production call sites awaited it: the model-switch `reconcile` in `chat-session.ts`, `refreshCurrentSessionTools` in `chat-pane-lifecycle.ts` (reached from `/model`-class slash commands), and the host contract in `chat-state-host.ts`. A decoy seam is architecture that pretends to exist — readers trace the calls expecting effective-tools refresh behavior that actually comes from elsewhere (the composer capability host keys its `tools.effective` requests on the model override, so a re-render alone picks up the change).

## Why This Change Was Made

Deleting the field and its await sites is the honest shape: `refreshCurrentSessionTools` collapses to `requestUpdate`, and the model-switch reconcile keeps awaiting the canonical session-list refresh it always relied on. Two tests used the seam as their deferral hook; they now hold the `sessions.refresh` barrier open instead — which is the async step the production code actually awaits, so the tests prove the real lane ordering rather than a fabricated one.

## User Impact

None visible — the seam never did anything. The gain is maintainability: no more phantom refresh hook for future readers to wire incorrectly.

## Evidence

- Full `ui/src/pages/chat` + `ui/src/lib/agents`: 2898 passed | 11 skipped, including the reconciliation-lane and patch-ordering tests now barriered on the real refresh step.
- `pnpm tsgo:ui`, oxlint, oxfmt clean.
- Autoreview (Codex, high): clean, "patch is correct (0.99)".
- Production LOC: +2 −5 (net −3); tests +6 −16.
