### PR TITLE
test(cua): trim generic browser transport replays

### DIFF
--- a/extensions/cua-computer/src/driver-client.test.ts
+++ b/extensions/cua-computer/src/driver-client.test.ts
@@ -146,33 +146,6 @@ describe("CUA Driver direct session", () => {
     await driver.dispose();
   });
 
-  it("passes browser tools through the same window-scoped direct SDK session", async () => {
-    const driver = createCuaDriver({ loadSdk: () => sdk as never });
-
-    await driver.callTool("browser_navigate", {
-      target_id: "target-1",
-      tab_id: "tab-1",
-      url: "https://example.com/",
-    });
-    const sessionOptions = mocks.createTrustedSession.mock.calls[0]?.[1];
-
-    expect(mocks.startSession).toHaveBeenCalledWith(
-      { session: sessionOptions.publicSession, captureScope: "window" },
-      undefined,
-    );
-    expect(mocks.callTool).toHaveBeenCalledWith(
-      "browser_navigate",
-      JSON.stringify({
-        target_id: "target-1",
-        tab_id: "tab-1",
-        url: "https://example.com/",
-        session: sessionOptions.publicSession,
-      }),
-      undefined,
-    );
-    await driver.dispose();
-  });
-
   it("keeps a missing native desktop library behind command availability", async () => {
     const loadSdk = vi.fn(() => {
       throw new Error("libX11.so.6: cannot open shared object file");

--- a/extensions/cua-computer/src/mcp-driver-client.test.ts
+++ b/extensions/cua-computer/src/mcp-driver-client.test.ts
@@ -177,18 +177,6 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
             }),
           );
           break;
-        case "browser_navigate":
-          fake.respond(
-            request,
-            toolResult({
-              status: "ok",
-              target_id: "target-1",
-              tab_id: "tab-1",
-              url: "https://example.com/",
-              refs_invalidated: true,
-            }),
-          );
-          break;
         case "end_session":
           fake.respond(request, toolResult({ session: "openclaw-test", active: false }));
           break;
@@ -221,12 +209,6 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
         delivery: { mode: 0, deliveredCount: 1 },
         evidence: [{ kind: 0 }],
       });
-      await driver.callTool("browser_navigate", {
-        target_id: "target-1",
-        tab_id: "tab-1",
-        url: "https://example.com/",
-      });
-
       await driver.dispose();
       await vi.waitFor(() => {
         closed = endpoint.requests.some(
@@ -242,17 +224,6 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
           (request) => request.method === "tools/call" && request.params?.name === "click",
         )?.params?.arguments,
       ).toMatchObject({ x: 20, y: 30, button: "left", count: 1, scope: "desktop" });
-      expect(
-        endpoint.requests.find(
-          (request) =>
-            request.method === "tools/call" && request.params?.name === "browser_navigate",
-        )?.params?.arguments,
-      ).toMatchObject({
-        target_id: "target-1",
-        tab_id: "tab-1",
-        url: "https://example.com/",
-        session: expect.stringMatching(/^openclaw-/),
-      });
     } finally {
       await endpoint.close();
     }
@@ -297,6 +268,9 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
       const calls = Array.from({ length: 65 }, () => driver.callTool("list_windows", {}));
       await expect(calls[64]).rejects.toThrow("too many pending requests");
       await vi.waitFor(() => expect(held).toHaveLength(64));
+      expect(held[0]?.params?.arguments).toMatchObject({
+        session: expect.stringMatching(/^openclaw-/),
+      });
       for (const request of held) {
         endpoint.respond(request, toolResult({ windows: [] }));
       }


### PR DESCRIPTION
## What Problem This Solves

Browser-action work added `browser_navigate` spot checks to direct and MCP transport tests even though both transports route arbitrary tool names through the same generic `callTool` path. Those checks duplicated browser-specific mapping coverage and would require maintenance for transport-neutral browser action changes.

## Why This Change Was Made

The direct browser-name replay is deleted. The MCP transport test drops its browser-only response, invocation, and request assertion; the only distinct invariant—OpenClaw session injection—moves to the existing generic `list_windows` pending-call test. Browser action names and arguments remain fully covered by `browser-actions.test.ts`.

## User Impact

No behavior change. Direct SDK and MCP proxy transports still start the correct session scope, inject the session identifier, normalize structured results, enforce pending-call bounds, and tear down on cancellation.

AI-assisted: yes.

## Evidence

- `driver-client.test.ts`, `mcp-driver-client.test.ts`, and `browser-actions.test.ts` — 3 files, 14 tests passed.
- `node scripts/check-changed.mjs -- extensions/cua-computer/src/driver-client.test.ts extensions/cua-computer/src/mcp-driver-client.test.ts` — extensionTests gate passed through the documented trusted-source local fallback after no Crabbox/Testbox provider was ready; extension test typecheck and lint passed.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Production delta: 0. Tests: +3/-56, net -53 lines.
