### PR TITLE
fix: restore live duplicate-tombstone assertions

### DIFF
--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -502,6 +502,7 @@ describe("LINE webhook spool", () => {
 
   it("keeps a completion tombstone and rejects a repeated delivery", async () => {
     await withQueue(async (queue) => {
+      const enqueue = vi.spyOn(queue, "enqueue");
       const event = createEvent({ webhookEventId: "event-duplicate" });
       const deliver = vi.fn(async (_event, _destination, control) => {
         await control.turnAdoptionLifecycle.onAdopted();
@@ -518,7 +519,10 @@ describe("LINE webhook spool", () => {
         await waitForVerdict(queue, "message:message-event-duplicate", "completed");
 
         await spool.accept(callback(event));
-        await spool.stop();
+        await expect(enqueue.mock.results.at(-1)?.value).resolves.toMatchObject({
+          kind: "completed",
+          duplicate: true,
+        });
 
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {
@@ -529,6 +533,7 @@ describe("LINE webhook spool", () => {
 
   it("deduplicates a redelivered message id even when webhookEventId changes", async () => {
     await withQueue(async (queue) => {
+      const enqueue = vi.spyOn(queue, "enqueue");
       const deliver = vi.fn(async (_event, _destination, control) => {
         await control.turnAdoptionLifecycle.onAdopted();
       });
@@ -548,7 +553,10 @@ describe("LINE webhook spool", () => {
         await spool.accept(
           callback(createEvent({ webhookEventId: "delivery-b", messageId: "shared-message" })),
         );
-        await spool.stop();
+        await expect(enqueue.mock.results.at(-1)?.value).resolves.toMatchObject({
+          kind: "completed",
+          duplicate: true,
+        });
 
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {

--- a/extensions/msteams/src/msteams-ingress.test.ts
+++ b/extensions/msteams/src/msteams-ingress.test.ts
@@ -166,6 +166,7 @@ describe("Microsoft Teams durable ingress", () => {
 
   it("keeps a completion tombstone and rejects a post-completion duplicate", async () => {
     await withQueue(async (queue) => {
+      const enqueue = vi.spyOn(queue, "enqueue");
       const dispatch = vi.fn(async (_activity, lifecycle) => {
         await lifecycle.onAdopted();
       });
@@ -176,7 +177,10 @@ describe("Microsoft Teams durable ingress", () => {
         await ingress.accept(incoming);
         await waitForVerdict(queue, "activity-duplicate", "completed");
         await ingress.accept(incoming);
-        await ingress.stop();
+        await expect(enqueue.mock.results.at(-1)?.value).resolves.toMatchObject({
+          kind: "completed",
+          duplicate: true,
+        });
         expect(dispatch).toHaveBeenCalledTimes(1);
       } finally {
         await ingress.stop();
@@ -186,6 +190,7 @@ describe("Microsoft Teams durable ingress", () => {
 
   it("deduplicates a concrete Bot Framework redelivery by activity.id", async () => {
     await withQueue(async (queue) => {
+      const enqueue = vi.spyOn(queue, "enqueue");
       const dispatch = vi.fn(async (_activity, lifecycle) => {
         await lifecycle.onAdopted();
       });
@@ -197,7 +202,10 @@ describe("Microsoft Teams durable ingress", () => {
         await ingress.accept(first);
         await waitForVerdict(queue, "bot-framework-redelivery", "completed");
         await ingress.accept(redelivery);
-        await ingress.stop();
+        await expect(enqueue.mock.results.at(-1)?.value).resolves.toMatchObject({
+          kind: "completed",
+          duplicate: true,
+        });
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0]?.[0]).toMatchObject({ text: "original" });
       } finally {

--- a/extensions/zalo/src/webhook-spool.test.ts
+++ b/extensions/zalo/src/webhook-spool.test.ts
@@ -119,6 +119,7 @@ describe("Zalo durable webhook ingress", () => {
 
   it("keeps a completion tombstone and rejects a post-completion duplicate", async () => {
     await withZaloWebhookTestQueue(async (queue) => {
+      const enqueue = vi.spyOn(queue, "enqueue");
       const deliver = vi.fn(async (_update, lifecycle) => {
         await lifecycle.onAdopted();
       });
@@ -134,7 +135,10 @@ describe("Zalo durable webhook ingress", () => {
         await ingress.accept(raw);
         await waitForZaloWebhookVerdict(queue, "duplicate", "completed");
         await ingress.accept(raw);
-        await ingress.stop();
+        await expect(enqueue.mock.results.at(-1)?.value).resolves.toMatchObject({
+          kind: "completed",
+          duplicate: true,
+        });
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {
         await ingress.stop();
@@ -144,6 +148,7 @@ describe("Zalo durable webhook ingress", () => {
 
   it("preserves old replay-guard parity for the same message id with changed payload bytes", async () => {
     await withZaloWebhookTestQueue(async (queue) => {
+      const enqueue = vi.spyOn(queue, "enqueue");
       const deliver = vi.fn(async (_update, lifecycle) => {
         await lifecycle.onAdopted();
       });
@@ -160,7 +165,10 @@ describe("Zalo durable webhook ingress", () => {
         await ingress.accept(
           rawEvent({ messageId: "redelivery", text: "transport redelivery", date: 2 }),
         );
-        await ingress.stop();
+        await expect(enqueue.mock.results.at(-1)?.value).resolves.toMatchObject({
+          kind: "completed",
+          duplicate: true,
+        });
         expect(deliver).toHaveBeenCalledTimes(1);
         expect(deliver.mock.calls[0]?.[0].message?.text).toBe("original");
       } finally {


### PR DESCRIPTION
Related: #123990

## What Problem This Solves

PR #123990 made the LINE, Microsoft Teams, and Zalo durable-ingress tests faster, but the resulting assertions could still pass when a duplicate was wrongly accepted while ingress remained live. Calling terminal `stop()` before checking delivery count drained or discarded pending work, masking a genuinely dispatchable accepted duplicate.

## Why This Change Was Made

The six duplicate-delivery cases now spy on the supplied real queue's `enqueue` method and assert that the second live admission resolves to `{ kind: "completed", duplicate: true }` before shutdown. That non-terminal enqueue verdict is the authoritative owner boundary: it proves the duplicate tombstone rejected the second admission while preserving the existing one-delivery and original-payload assertions. `stop()` remains only as `finally` cleanup, and no production or test-only seam was added.

## User Impact

There is no runtime behavior change. The correction restores regression coverage for duplicate tombstones without giving back the test-performance improvement from #123990.

## Evidence

- Fault injection on current `main` made an accepted duplicate remain dispatchable: the stop-based test still passed, while this live enqueue-verdict assertion failed immediately for the intended reason.
- Focused plugin proof: 40/40 tests passed across LINE, Microsoft Teams, and Zalo.
- Shared owner proof: 56/56 tests passed across `src/channels/message/ingress-queue.test.ts` and `src/channels/message/ingress-monitor.test.ts`.
- Path-scoped `check-changed` passed on Blacksmith Testbox `tbx_01m01v120xnmkcr9gav9z1n7sp`: https://github.com/openclaw/openclaw/actions/runs/31864643031
- Controlled Testbox A/B: candidate mean wall 19.150s versus 19.675s for the merged-fast base (-2.7%), and 18.0% faster than the original pre-#123990 baseline of 23.365s. Body time was effectively flat. RSS samples were effectively flat to slightly lower (-0.7%); this is not claimed as a material memory improvement.
- Exact local commands:
  - `node scripts/run-vitest.mjs extensions/line/src/webhook-spool.test.ts extensions/msteams/src/msteams-ingress.test.ts extensions/zalo/src/webhook-spool.test.ts --maxWorkers=1`
  - `node scripts/run-vitest.mjs src/channels/message/ingress-queue.test.ts src/channels/message/ingress-monitor.test.ts --maxWorkers=1`
  - `pnpm exec oxfmt --check extensions/line/src/webhook-spool.test.ts extensions/msteams/src/msteams-ingress.test.ts extensions/zalo/src/webhook-spool.test.ts`
  - `git diff --check origin/main...HEAD`
- LOC: tests +30/-6; production +0/-0. No new seam.
- Fresh autoreview on the rebased committed branch reported no accepted/actionable findings.
