### PR TITLE
fix(ui): keep the chat transcript anchored while the pane resizes

### DIFF
--- a/src/infra/ports-probe.test.ts
+++ b/src/infra/ports-probe.test.ts
@@ -38,33 +38,36 @@ async function withListeningServer(
 
 describe("tryListenOnPort", () => {
   it("can bind and release an ephemeral loopback port", async () => {
-    // The rebind proves release completed. A foreign process can steal the
-    // freed port between attempts on shared CI runners, so retry the whole
-    // cycle on a fresh ephemeral port; a real release regression fails every
-    // attempt because the collision is with our own lingering listener.
-    let lastRebindError: unknown;
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      let port;
-      try {
-        port = await tryListenOnPort({ port: 0, host: "127.0.0.1", exclusive: true });
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === "EPERM") {
-          return;
-        }
-        throw err;
-      }
-      expect(port).toBeGreaterThan(0);
-      try {
-        await tryListenOnPort({ port, host: "127.0.0.1", exclusive: true });
+    let port;
+    try {
+      port = await tryListenOnPort({ port: 0, host: "127.0.0.1", exclusive: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EPERM") {
         return;
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "EADDRINUSE") {
-          throw err;
-        }
-        lastRebindError = err;
       }
+      throw err;
     }
-    throw lastRebindError;
+    expect(port).toBeGreaterThan(0);
+    // Release proof stays tied to the allocated port: a lingering listener
+    // would accept this probe, a released port refuses it. A rebind assertion
+    // instead collides with any foreign outbound socket occupying the port on
+    // busy runners (EADDRINUSE flake) without detecting leaks any better.
+    await expect(
+      new Promise<"accepted" | "refused">((resolve, reject) => {
+        const socket = net.connect({ port, host: "127.0.0.1" });
+        socket.once("connect", () => {
+          socket.destroy();
+          resolve("accepted");
+        });
+        socket.once("error", (err) => {
+          if ((err as NodeJS.ErrnoException).code === "ECONNREFUSED") {
+            resolve("refused");
+            return;
+          }
+          reject(err);
+        });
+      }),
+    ).resolves.toBe("refused");
   });
 
   it("rejects when the port is already in use", async () => {

--- a/src/infra/ports-probe.test.ts
+++ b/src/infra/ports-probe.test.ts
@@ -38,19 +38,33 @@ async function withListeningServer(
 
 describe("tryListenOnPort", () => {
   it("can bind and release an ephemeral loopback port", async () => {
-    let port;
-    try {
-      port = await tryListenOnPort({ port: 0, host: "127.0.0.1", exclusive: true });
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "EPERM") {
-        return;
+    // The rebind proves release completed. A foreign process can steal the
+    // freed port between attempts on shared CI runners, so retry the whole
+    // cycle on a fresh ephemeral port; a real release regression fails every
+    // attempt because the collision is with our own lingering listener.
+    let lastRebindError: unknown;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      let port;
+      try {
+        port = await tryListenOnPort({ port: 0, host: "127.0.0.1", exclusive: true });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EPERM") {
+          return;
+        }
+        throw err;
       }
-      throw err;
+      expect(port).toBeGreaterThan(0);
+      try {
+        await tryListenOnPort({ port, host: "127.0.0.1", exclusive: true });
+        return;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EADDRINUSE") {
+          throw err;
+        }
+        lastRebindError = err;
+      }
     }
-    expect(port).toBeGreaterThan(0);
-    await expect(
-      tryListenOnPort({ port, host: "127.0.0.1", exclusive: true }),
-    ).resolves.toBeUndefined();
+    throw lastRebindError;
   });
 
   it("rejects when the port is already in use", async () => {

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -568,6 +568,7 @@ describe("test-projects args", () => {
           "extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts",
           "extensions/memory-core/src/memory/manager-registry.test.ts",
           "extensions/memory-core/src/memory/manager-search-orchestration.test.ts",
+          "extensions/memory-core/src/memory/manager-session-update-race.test.ts",
           "extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts",
           "extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts",
           "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",

--- a/ui/src/e2e/chat-resize-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-resize-anchor.e2e.test.ts
@@ -152,4 +152,52 @@ describeControlUiE2e("Chat transcript resize anchoring", () => {
       ).toBeLessThanOrEqual(60);
     }
   }, 120_000);
+
+  it("keeps an end-pinned transcript pinned across width-only resizes", async () => {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    contexts.add(context);
+    const page = await context.newPage();
+    const now = Date.now();
+    await installMockGateway(page, {
+      sessionKey: "agent:main:main",
+      historyMessages: Array.from({ length: MESSAGE_COUNT }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: messageContent(index),
+        timestamp: now - (MESSAGE_COUNT - index) * 60_000,
+      })),
+    });
+
+    // Fresh sessions open pinned to the end; leave the scroll untouched.
+    await page.goto(`${controlUi.baseUrl}chat`);
+    await page
+      .getByText(`Message number ${MESSAGE_COUNT - 1}:`)
+      .first()
+      .waitFor({
+        timeout: 15_000,
+      });
+    await settleFrames(page, 30);
+
+    const distanceFromEnd = () =>
+      page.evaluate(() => {
+        const scroller = document.querySelector<HTMLElement>(
+          ".chat-thread-inner--virtual",
+        )?.parentElement;
+        return scroller
+          ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
+          : Number.NaN;
+      });
+    expect(await distanceFromEnd()).toBeLessThanOrEqual(2);
+
+    // Width-only changes re-wrap every row; the end anchor must follow the
+    // new total size (virtualizer wasAtEnd compensation), not drift upward.
+    for (const width of [1000, 820, 1280]) {
+      await page.setViewportSize({ width, height: 900 });
+      await settleFrames(page, 30);
+      expect(await distanceFromEnd(), `distance from end at width ${width}`).toBeLessThanOrEqual(2);
+      await page
+        .getByText(`Message number ${MESSAGE_COUNT - 1}:`)
+        .first()
+        .waitFor({ state: "visible", timeout: 2_000 });
+    }
+  }, 120_000);
 });

--- a/ui/src/e2e/chat-resize-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-resize-anchor.e2e.test.ts
@@ -1,0 +1,155 @@
+// Regression: resizing the chat pane must not jump the transcript. The reader's
+// anchor row (topmost visible row) should stay in place while rows re-wrap.
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let controlUi: ControlUiE2eServer;
+const contexts = new Set<BrowserContext>();
+
+const MESSAGE_COUNT = 120;
+const filler =
+  "The quick brown fox jumps over the lazy dog while the virtualized transcript keeps every " +
+  "row height honest across pane widths. ";
+
+function messageContent(index: number): string {
+  // Vary paragraph counts so re-wrapping changes heights non-uniformly.
+  return `Message number ${index}: ${filler.repeat((index % 4) + 1)}`;
+}
+
+type AnchorSample = {
+  key: string | null;
+  topDelta: number;
+  scrollTop: number;
+  visibleKeys: string[];
+};
+
+async function sampleAnchor(page: Page, anchorKey: string | null): Promise<AnchorSample> {
+  return await page.evaluate((key) => {
+    const inner = document.querySelector<HTMLElement>(".chat-thread-inner--virtual");
+    const scroller = inner?.parentElement;
+    if (!inner || !scroller) {
+      return { key: null, topDelta: Number.NaN, scrollTop: Number.NaN, visibleKeys: [] };
+    }
+    const scrollerRect = scroller.getBoundingClientRect();
+    const rows = [...inner.querySelectorAll<HTMLElement>(".chat-virtual-row")]
+      .map((row) => ({
+        key: row.dataset.virtualRowKey ?? "",
+        rect: row.getBoundingClientRect(),
+      }))
+      .filter(({ rect }) => rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom)
+      .toSorted((left, right) => left.rect.top - right.rect.top);
+    const anchor = key === null ? rows[0] : rows.find((row) => row.key === key);
+    return {
+      key: anchor?.key ?? null,
+      topDelta: anchor ? anchor.rect.top - scrollerRect.top : Number.NaN,
+      scrollTop: scroller.scrollTop,
+      visibleKeys: rows.map((row) => row.key),
+    };
+  }, anchorKey);
+}
+
+async function settleFrames(page: Page, frames: number): Promise<void> {
+  await page.evaluate(
+    (count) =>
+      new Promise<void>((resolve) => {
+        const step = (remaining: number) => {
+          if (remaining <= 0) {
+            resolve();
+            return;
+          }
+          requestAnimationFrame(() => step(remaining - 1));
+        };
+        step(count);
+      }),
+    frames,
+  );
+}
+
+describeControlUiE2e("Chat transcript resize anchoring", () => {
+  beforeAll(async () => {
+    controlUi = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  }, 120_000);
+
+  afterAll(async () => {
+    for (const context of contexts) {
+      await context.close();
+    }
+    await browser?.close();
+    await controlUi?.close();
+  });
+
+  it("keeps the anchor row stable across pane width changes", async () => {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    contexts.add(context);
+    const page = await context.newPage();
+    const now = Date.now();
+    await installMockGateway(page, {
+      sessionKey: "agent:main:main",
+      historyMessages: Array.from({ length: MESSAGE_COUNT }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: messageContent(index),
+        timestamp: now - (MESSAGE_COUNT - index) * 60_000,
+      })),
+    });
+
+    await page.goto(`${controlUi.baseUrl}chat`);
+    await page
+      .getByText(`Message number ${MESSAGE_COUNT - 1}:`)
+      .first()
+      .waitFor({
+        timeout: 15_000,
+      });
+
+    // Scroll to the middle of the transcript and let the virtualizer settle.
+    await page.evaluate(() => {
+      const scroller = document.querySelector<HTMLElement>(
+        ".chat-thread-inner--virtual",
+      )?.parentElement;
+      if (scroller) {
+        scroller.scrollTop = Math.floor((scroller.scrollHeight - scroller.clientHeight) / 2);
+      }
+    });
+    await settleFrames(page, 30);
+
+    const before = await sampleAnchor(page, null);
+    expect(before.key).not.toBeNull();
+
+    const widths = [1000, 820, 1280];
+    const observations: { width: number; sample: AnchorSample }[] = [];
+    for (const width of widths) {
+      await page.setViewportSize({ width, height: 900 });
+      await settleFrames(page, 30);
+      const sample = await sampleAnchor(page, before.key);
+      observations.push({ width, sample });
+      console.log(
+        `[resize-anchor] width=${width} anchor=${before.key} topDelta=${sample.topDelta} ` +
+          `(was ${before.topDelta}) scrollTop=${sample.scrollTop} (was ${before.scrollTop}) ` +
+          `visible=${sample.visibleKeys.length ? sample.visibleKeys.join(",") : "<none>"}`,
+      );
+    }
+
+    for (const { width, sample } of observations) {
+      // The anchor row must remain visible after every width change...
+      expect(sample.key, `anchor visible at width ${width}`).toBe(before.key);
+      // ...and roughly hold its viewport position while its own text re-wraps.
+      expect(
+        Math.abs(sample.topDelta - before.topDelta),
+        `anchor drift at width ${width}`,
+      ).toBeLessThanOrEqual(60);
+    }
+  }, 120_000);
+});

--- a/ui/src/e2e/chat-resize-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-resize-anchor.e2e.test.ts
@@ -146,10 +146,14 @@ describeControlUiE2e("Chat transcript resize anchoring", () => {
       // The anchor row must remain visible after every width change...
       expect(sample.key, `anchor visible at width ${width}`).toBe(before.key);
       // ...and roughly hold its viewport position while its own text re-wraps.
+      // The fold-spanning anchor row's own re-wrap moves its top by a font-
+      // metric-dependent amount (42px on macOS, 63px on Linux CI at 820px);
+      // the pre-fix failure mode is the anchor leaving the viewport entirely
+      // with 250px+ scroll drift, so 120px keeps a wide detection margin.
       expect(
         Math.abs(sample.topDelta - before.topDelta),
         `anchor drift at width ${width}`,
-      ).toBeLessThanOrEqual(60);
+      ).toBeLessThanOrEqual(120);
     }
   }, 120_000);
 

--- a/ui/src/pages/chat/components/chat-transcript-controller.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.ts
@@ -249,10 +249,10 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
             instance.scrollToEnd({ behavior: "auto" });
           }
           if (widthChanged) {
-            // Cached offscreen sizes belong to the old wrapping width. Reset
-            // them, seed current rows, then repeat after any same-commit
-            // re-stamp has attached and completed layout.
-            instance.measure();
+            // Keep stale offscreen sizes as estimates — a full measure() wipe
+            // has no scroll compensation and teleports the reader. resizeItem
+            // re-seeds connected rows with fold-based compensation, so the
+            // anchor row holds still; offscreen rows correct as they connect.
             this.measureConnectedRows();
             this.queueConnectedRowMeasure();
           }


### PR DESCRIPTION
## What Problem This Solves

Resizing the chat pane (window resize, sidebar/split drag, dashboard dock) made the transcript text jump wildly: the reader was teleported to different messages and the view kept shifting for several frames while row measurements trickled back in. Reported live on team.openclaw.ai running ~main.

**Before** (viewport resized 1280→1100→960→820→back, reader mid-transcript):

https://github.com/user-attachments/assets/78b7464a-58ad-4f96-94b3-c23954de6beb

**After** (same sequence — the anchor row holds still while text re-wraps):

https://github.com/user-attachments/assets/0cc071fc-40a0-4183-9681-433786c76487

## Why This Change Was Made

The width-change path in the transcript virtualizer host called `instance.measure()`, wiping the entire item-size cache. That wipe has no scroll compensation: every offscreen row collapses to the 120px default estimate, so the content above the viewport changes height wholesale while `scrollTop` stays fixed — the visible range now maps to different rows. The subsequent corrections (sync `resizeItem` seed pass, rAF repeat, per-row ResizeObserver) each shift content again, frame by frame.

The wipe dates to #115059 (session-switch measurement retention) and was refined by #117687 and #123713 without addressing anchoring. The repair deletes the wipe and keeps stale offscreen sizes as estimates: the existing synchronous `resizeItem` pass re-seeds connected rows *with* fold-based scroll compensation (rows entirely above the fold adjust `scrollTop` by their delta), so the anchor row holds still, and offscreen rows correct lazily as they connect — the standard dynamic-virtualizer model. End-pinned transcripts keep following the tail through the existing height-change `scrollToEnd` path.

## User Impact

Resizing the window, dragging the split, or docking the chat pane no longer loses the reading position. Mid-transcript readers stay on the same message; end-pinned sessions stay pinned.

## Evidence

- New regression e2e `ui/src/e2e/chat-resize-anchor.e2e.test.ts`: seeds 120 mixed-width messages, scrolls mid-transcript, resizes 1280→1000→820→1280. **Pre-fix**: the anchor row leaves the viewport entirely and `scrollTop` drifts 7021→7278. **Post-fix**: 0px drift at 1000, 42px at 820 (the anchor row itself spans the fold and re-wraps), byte-identical `scrollTop` back at 1280. Asserted bound: ≤60px.
- Sibling suites green: `chat-panel-reflow.e2e.test.ts` (the overlap regression that motivated the wipe), `board-split-transcript.e2e.test.ts`, all 9 `chat-transcript-controller.test.ts` unit tests.
- `check:changed` lanes green (format, typecheck core/UI, lint, i18n verify, knip dead-export local scans); remote proof backends were unavailable mid-run, local fallback used per policy.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no findings.
- Production LOC delta: net 0 (4+/4−, one code line removed, comment reshaped); +152 test lines.


## CI + Review Notes

First CI run failed only on `checks-node-compact-large-17`: `src/infra/ports-probe.test.ts > can bind and release an ephemeral loopback port` hit `EADDRINUSE` — an unrelated, flaky-by-construction assertion (bind→release→rebind races foreign processes stealing the freed port on shared runners). Per repo doctrine the landing PR carries the fix: the cycle now retries on a fresh ephemeral port (bounded, 5 attempts); a genuine release regression still fails every attempt. Focused proof: 4 consecutive green runs; Codex autoreview clean.


**ClawSweeper findings addressed** (head `265612feb68`):
- *Rebind proof tied to one allocated port*: replaced the retry with a connect probe against the same allocated port — a lingering listener accepts, a released port refuses (`ECONNREFUSED`). No retry remains, and the probe doesn't collide with foreign outbound sockets that transiently occupy local ports on busy runners (the actual flake class). Accepted-path proven against a live listener.
- *Width-only end-pin proof*: added an end-pinned e2e case — the transcript stays within 2px of the end across 1280→1000→820→1280 width-only resizes, exercising the virtualizer's `wasAtEnd` compensation in a real browser.
- *Exact-head CI*: green on `db944816566`; watching the new head.


**Red-main repair carried per doctrine** (head `0984f2e08a5`): #124024 added `extensions/memory-core/src/memory/manager-session-update-race.test.ts` on main without updating the cross-lane routing expectation in `src/scripts/test-projects.test.ts`, breaking the `core-tooling` shard on every merge ref including it (first seen here as `checks-node-compact-small-42`). This PR registers the file in the expectation (rebased onto latest main so the fix is locally provable; tooling suite green locally). The Linux drift bound on the new e2e also gained renderer headroom (63px observed on CI vs 42px on macOS; bound now 120px, still far under the pre-fix 250px+/anchor-lost failure mode).
