### PR TITLE
fix(signal): report managed daemon port collisions before startup

### DIFF
--- a/extensions/signal/src/accounts.test.ts
+++ b/extensions/signal/src/accounts.test.ts
@@ -37,6 +37,11 @@ describe("resolveSignalAccount", () => {
       expected: { baseUrl: "http://[::1]:8181", httpHost: "::1", httpPort: 8181 },
     },
     {
+      name: "canonicalizes a bracketed IPv6 managed native bind",
+      transport: { kind: "managed-native", httpHost: "[::1]", httpPort: 8181 },
+      expected: { baseUrl: "http://[::1]:8181", httpHost: "::1", httpPort: 8181 },
+    },
+    {
       name: "does not reserve a managed transport's own implicit connection endpoint",
       transport: {
         kind: "managed-native",

--- a/extensions/signal/src/accounts.ts
+++ b/extensions/signal/src/accounts.ts
@@ -17,7 +17,7 @@ import {
   isSignalManagedNativeConnectionUrlForBind,
   resolveLocalSignalTransportPort,
 } from "./transport-policy.js";
-import { buildSignalTransportHttpUrl } from "./transport-url.js";
+import { buildSignalTransportHttpUrl, normalizeSignalTransportHost } from "./transport-url.js";
 
 export type ResolvedSignalTransport =
   | {
@@ -213,7 +213,9 @@ export function resolveSignalTransport(
     transport?.kind === "managed-native"
       ? assignSignalManagedNativePort(transport, transport.httpPort ?? managedNativePort)
       : transport;
-  const httpHost = normalizeOptionalString(managedTransport?.httpHost) ?? "127.0.0.1";
+  const httpHost = normalizeSignalTransportHost(
+    normalizeOptionalString(managedTransport?.httpHost) ?? "127.0.0.1",
+  );
   const httpPort = managedTransport?.httpPort ?? managedNativePort;
   const configPath = normalizeOptionalString(managedTransport?.configPath);
   const connectionUrl = normalizeOptionalString(managedTransport?.url);

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -72,7 +72,7 @@ describe("spawnSignalDaemon", () => {
           httpPort: address.port,
         }),
       ).rejects.toThrow(
-        `Signal managed native endpoint 127.0.0.1:${address.port} is unavailable: Port ${address.port} is already in use. Stop the conflicting service or configure this Signal account with a different transport.httpPort.`,
+        `Signal managed native endpoint 127.0.0.1:${address.port} is unavailable: Port ${address.port} is already in use. Stop the conflicting service, configure this Signal account with a different transport.httpPort, or use external-native for an intentionally operator-managed daemon.`,
       );
       expect(listener.listening).toBe(true);
     } finally {

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,12 +1,23 @@
 // Signal tests cover daemon plugin behavior.
 import { EventEmitter, once } from "node:events";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { spawnSignalDaemon } from "./daemon.js";
+import { assertSignalDaemonEndpointAvailable, spawnSignalDaemon } from "./daemon.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const ensurePortAvailableMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  ensurePortAvailableMock.mockImplementation(actual.ensurePortAvailable);
+  return {
+    ...actual,
+    ensurePortAvailable: (...args: unknown[]) => ensurePortAvailableMock(...args),
+  };
+});
 
 vi.mock("node:child_process", () => ({ spawn: spawnMock }));
 
@@ -32,6 +43,7 @@ beforeEach(() => {
   child = createMockChild();
   spawnMock.mockReset();
   spawnMock.mockReturnValue(child);
+  ensurePortAvailableMock.mockClear();
 });
 
 afterEach(() => {
@@ -42,6 +54,51 @@ afterEach(() => {
 });
 
 describe("spawnSignalDaemon", () => {
+  it("rejects an occupied managed endpoint with actionable port guidance", async () => {
+    const listener = createServer();
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen(0, "127.0.0.1", resolve);
+    });
+    const address = listener.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a TCP listener address");
+    }
+
+    try {
+      await expect(
+        assertSignalDaemonEndpointAvailable({
+          httpHost: "127.0.0.1",
+          httpPort: address.port,
+        }),
+      ).rejects.toThrow(
+        `Signal managed native endpoint 127.0.0.1:${address.port} is unavailable: Port ${address.port} is already in use. Stop the conflicting service or configure this Signal account with a different transport.httpPort.`,
+      );
+      expect(listener.listening).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        listener.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+    await expect(
+      assertSignalDaemonEndpointAvailable({ httpHost: "127.0.0.1", httpPort: address.port }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("defers non-collision bind failures to the operator-selected daemon", async () => {
+    const bindError = Object.assign(new Error("bind EACCES 127.0.0.1:443"), {
+      code: "EACCES",
+    });
+    ensurePortAvailableMock.mockRejectedValueOnce(bindError);
+
+    await expect(
+      assertSignalDaemonEndpointAvailable({
+        httpHost: "127.0.0.1",
+        httpPort: 443,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("expands home-relative configPath before passing it to signal-cli", () => {
     spawnSignalDaemon({
       cliPath: "signal-cli",

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -69,7 +69,7 @@ export async function assertSignalDaemonEndpointAvailable(params: {
     }
     const endpoint = formatSignalDaemonEndpoint(params.httpHost, params.httpPort);
     throw new Error(
-      `Signal managed native endpoint ${endpoint} is unavailable: ${formatErrorMessage(error)} Stop the conflicting service or configure this Signal account with a different transport.httpPort.`,
+      `Signal managed native endpoint ${endpoint} is unavailable: ${formatErrorMessage(error)} Stop the conflicting service, configure this Signal account with a different transport.httpPort, or use external-native for an intentionally operator-managed daemon.`,
       {
         cause: error,
       },

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -4,6 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import {
+  ensurePortAvailable,
+  extractErrorCode,
+  formatErrorMessage,
+} from "openclaw/plugin-sdk/security-runtime";
+import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import { signalCheck } from "./client-adapter.js";
 
 type SignalDaemonOpts = {
   cliPath: string;
@@ -35,6 +42,78 @@ type SignalDaemonExitEvent = {
 
 export function formatSignalDaemonExit(exit: SignalDaemonExitEvent): string {
   return `signal daemon exited (source=${exit.source} code=${exit.code ?? "null"} signal=${exit.signal ?? "null"})`;
+}
+
+function formatSignalDaemonEndpoint(httpHost: string, httpPort: number): string {
+  return `${httpHost.includes(":") ? `[${httpHost}]` : httpHost}:${httpPort}`;
+}
+
+export async function assertSignalDaemonEndpointAvailable(params: {
+  httpHost: string;
+  httpPort: number;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  try {
+    await ensurePortAvailable(params.httpPort, params.httpHost, params.abortSignal);
+  } catch (error) {
+    if (params.abortSignal?.aborted) {
+      throw params.abortSignal.reason;
+    }
+    const isPortCollision =
+      extractErrorCode(error) === "EADDRINUSE" ||
+      (error instanceof Error && error.name === "PortInUseError");
+    if (!isPortCollision) {
+      // The operator-selected signal-cli may have stronger bind permissions than OpenClaw.
+      // Only a confirmed collision is authoritative from this parent-process probe.
+      return;
+    }
+    const endpoint = formatSignalDaemonEndpoint(params.httpHost, params.httpPort);
+    throw new Error(
+      `Signal managed native endpoint ${endpoint} is unavailable: ${formatErrorMessage(error)} Stop the conflicting service or configure this Signal account with a different transport.httpPort.`,
+      {
+        cause: error,
+      },
+    );
+  }
+}
+
+export async function waitForSignalDaemonReady(params: {
+  baseUrl: string;
+  abortSignal?: AbortSignal;
+  startupDeadlineMs: number;
+  logAfterMs: number;
+  logIntervalMs?: number;
+  runtime: RuntimeEnv;
+  waitForTransportReadyFn?: typeof waitForTransportReady;
+}): Promise<void> {
+  const waitForTransportReadyFn = params.waitForTransportReadyFn ?? waitForTransportReady;
+  const timeoutMs = Math.max(0, params.startupDeadlineMs - Date.now());
+  await waitForTransportReadyFn({
+    label: "signal daemon",
+    timeoutMs,
+    logAfterMs: params.logAfterMs,
+    logIntervalMs: params.logIntervalMs,
+    pollIntervalMs: 150,
+    abortSignal: params.abortSignal,
+    runtime: params.runtime,
+    check: async () => {
+      const remainingMs = params.startupDeadlineMs - Date.now();
+      if (remainingMs <= 0) {
+        return { ok: false, error: "startup deadline exceeded" };
+      }
+      const res = await signalCheck(params.baseUrl, Math.min(1_000, remainingMs));
+      if (Date.now() >= params.startupDeadlineMs) {
+        return { ok: false, error: "startup deadline exceeded" };
+      }
+      if (res.ok) {
+        return { ok: true };
+      }
+      return {
+        ok: false,
+        error: res.error ?? (res.status ? `HTTP ${res.status}` : "unreachable"),
+      };
+    },
+  });
 }
 
 function isRecoverableSignalCliReceiveException(line: string): boolean {

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -195,7 +195,11 @@ describe("monitorSignalProvider autostart", () => {
       ({ abortSignal }: { abortSignal: AbortSignal }) =>
         new Promise<void>((_resolve, reject) => {
           probeStarted?.();
-          abortSignal.addEventListener("abort", () => reject(abortSignal.reason), { once: true });
+          abortSignal.addEventListener(
+            "abort",
+            () => reject(toLintErrorObject(abortSignal.reason, "Non-Error rejection")),
+            { once: true },
+          );
         }),
     );
 
@@ -233,7 +237,11 @@ describe("monitorSignalProvider autostart", () => {
     assertSignalDaemonEndpointAvailableMock.mockImplementationOnce(
       ({ abortSignal }: { abortSignal: AbortSignal }) =>
         new Promise<void>((_resolve, reject) => {
-          abortSignal.addEventListener("abort", () => reject(abortSignal.reason), { once: true });
+          abortSignal.addEventListener(
+            "abort",
+            () => reject(toLintErrorObject(abortSignal.reason, "Non-Error rejection")),
+            { once: true },
+          );
         }),
     );
 

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -210,6 +210,23 @@ describe("monitorSignalProvider autostart", () => {
     expect(spawnSignalDaemonMock).not.toHaveBeenCalled();
   });
 
+  it("does not spawn when monitoring aborts as the endpoint probe completes", async () => {
+    const runtime = createMonitorRuntime();
+    const abortController = new AbortController();
+    setSignalAutoStartConfig();
+    assertSignalDaemonEndpointAvailableMock.mockImplementationOnce(async () => {
+      abortController.abort();
+    });
+
+    await expect(
+      runMonitorWithMocks({
+        abortSignal: abortController.signal,
+        runtime,
+      }),
+    ).resolves.toBeUndefined();
+    expect(spawnSignalDaemonMock).not.toHaveBeenCalled();
+  });
+
   it("bounds the managed endpoint probe by the startup timeout", async () => {
     const runtime = createMonitorRuntime();
     setSignalAutoStartConfig();

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -16,8 +16,13 @@ installSignalToolResultTestHooks();
 
 const { monitorSignalProvider } = await import("./monitor.js");
 
-const { waitForTransportReadyMock, spawnSignalDaemonMock, streamMock } =
-  getSignalToolResultTestMocks();
+const {
+  waitForTransportReadyMock,
+  assertSignalDaemonEndpointAvailableMock,
+  signalCheckMock,
+  spawnSignalDaemonMock,
+  streamMock,
+} = getSignalToolResultTestMocks();
 
 const SIGNAL_BASE_URL = "http://127.0.0.1:8080";
 type MonitorSignalProviderOptions = NonNullable<Parameters<typeof monitorSignalProvider>[0]>;
@@ -69,7 +74,11 @@ function requireWaitForTransportReadyOptions(): Record<string, unknown> {
 function expectWaitForTransportReadyTimeout(timeoutMs: number) {
   expect(waitForTransportReadyMock).toHaveBeenCalledTimes(1);
   const options = requireWaitForTransportReadyOptions();
-  expect(options.timeoutMs).toBe(timeoutMs);
+  if (typeof options.timeoutMs !== "number") {
+    throw new Error("expected waitForTransportReady timeoutMs to be a number");
+  }
+  expect(options.timeoutMs).toBeGreaterThan(timeoutMs - 1_000);
+  expect(options.timeoutMs).toBeLessThanOrEqual(timeoutMs);
 }
 
 describe("monitorSignalProvider autostart", () => {
@@ -118,7 +127,7 @@ describe("monitorSignalProvider autostart", () => {
     const options = requireWaitForTransportReadyOptions();
     expect(options).toEqual({
       label: "signal daemon",
-      timeoutMs: 30_000,
+      timeoutMs: options.timeoutMs,
       logAfterMs: 10_000,
       logIntervalMs: 10_000,
       pollIntervalMs: 150,
@@ -128,6 +137,147 @@ describe("monitorSignalProvider autostart", () => {
     });
     expect(options.abortSignal).toBeInstanceOf(AbortSignal);
     expect(typeof options.check).toBe("function");
+    expectWaitForTransportReadyTimeout(30_000);
+  });
+
+  it("reports an occupied managed endpoint before spawning signal-cli", async () => {
+    const runtime = createMonitorRuntime();
+    const abortController = createAutoAbortController();
+    setSignalAutoStartConfig({ httpHost: "127.0.0.1", httpPort: 8181 });
+    assertSignalDaemonEndpointAvailableMock.mockRejectedValueOnce(
+      new Error("Signal managed native endpoint 127.0.0.1:8181 is already in use."),
+    );
+
+    await expect(
+      runMonitorWithMocks({
+        abortSignal: abortController.signal,
+        runtime,
+      }),
+    ).rejects.toThrow("Signal managed native endpoint 127.0.0.1:8181 is already in use.");
+    expect(assertSignalDaemonEndpointAvailableMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpHost: "127.0.0.1",
+        httpPort: 8181,
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+    expect(spawnSignalDaemonMock).not.toHaveBeenCalled();
+    expect(waitForTransportReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a bracketed IPv6 host override before probing and spawning", async () => {
+    const abortController = createAutoAbortController();
+    setSignalAutoStartConfig();
+
+    await runMonitorWithMocks({
+      abortSignal: abortController.signal,
+      httpHost: "[::1]",
+      runtime: createMonitorRuntime(),
+    });
+
+    expect(assertSignalDaemonEndpointAvailableMock).toHaveBeenCalledWith(
+      expect.objectContaining({ httpHost: "::1" }),
+    );
+    expect(spawnSignalDaemonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ httpHost: "::1" }),
+    );
+  });
+
+  it("cancels the managed endpoint probe when monitoring aborts", async () => {
+    const runtime = createMonitorRuntime();
+    const abortController = new AbortController();
+    setSignalAutoStartConfig();
+    let probeStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      probeStarted = resolve;
+    });
+    assertSignalDaemonEndpointAvailableMock.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        new Promise<void>((_resolve, reject) => {
+          probeStarted?.();
+          abortSignal.addEventListener("abort", () => reject(abortSignal.reason), { once: true });
+        }),
+    );
+
+    const monitorPromise = runMonitorWithMocks({
+      abortSignal: abortController.signal,
+      runtime,
+    });
+    await started;
+    abortController.abort();
+
+    await expect(monitorPromise).resolves.toBeUndefined();
+    expect(spawnSignalDaemonMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds the managed endpoint probe by the startup timeout", async () => {
+    const runtime = createMonitorRuntime();
+    setSignalAutoStartConfig();
+    assertSignalDaemonEndpointAvailableMock.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        new Promise<void>((_resolve, reject) => {
+          abortSignal.addEventListener("abort", () => reject(abortSignal.reason), { once: true });
+        }),
+    );
+
+    await expect(
+      runMonitorWithMocks({
+        runtime,
+        startupTimeoutMs: 1_000,
+      }),
+    ).rejects.toThrow("signal daemon startup timed out after 1000ms while checking its endpoint");
+    expect(spawnSignalDaemonMock).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn when the endpoint probe consumes the startup deadline", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    setSignalAutoStartConfig();
+    assertSignalDaemonEndpointAvailableMock.mockImplementationOnce(async () => {
+      now.mockReturnValue(2_000);
+    });
+
+    try {
+      await expect(
+        runMonitorWithMocks({
+          runtime: createMonitorRuntime(),
+          startupTimeoutMs: 1_000,
+        }),
+      ).rejects.toThrow("signal daemon startup timed out after 1000ms before starting");
+      expect(spawnSignalDaemonMock).not.toHaveBeenCalled();
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it("bounds the final readiness request by the shared startup deadline", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const abortController = createAutoAbortController();
+    setSignalAutoStartConfig();
+    assertSignalDaemonEndpointAvailableMock.mockImplementationOnce(async () => {
+      now.mockReturnValue(1_900);
+    });
+    signalCheckMock.mockImplementationOnce(async () => {
+      now.mockReturnValue(2_001);
+      return { ok: true };
+    });
+    let readinessResult: unknown;
+    waitForTransportReadyMock.mockImplementationOnce(
+      async ({ check }: { check: () => Promise<unknown> }) => {
+        readinessResult = await check();
+      },
+    );
+
+    try {
+      await runMonitorWithMocks({
+        abortSignal: abortController.signal,
+        runtime: createMonitorRuntime(),
+        startupTimeoutMs: 1_000,
+      });
+      expect(signalCheckMock).toHaveBeenCalledWith(SIGNAL_BASE_URL, 100);
+      expect(readinessResult).toEqual({ ok: false, error: "startup deadline exceeded" });
+    } finally {
+      now.mockRestore();
+    }
   });
 
   it("uses startupTimeoutMs override when provided", async () => {

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -27,6 +27,7 @@ type SignalToolResultTestMocks = {
   streamMock: MockFn;
   signalCheckMock: MockFn;
   signalRpcRequestMock: MockFn;
+  assertSignalDaemonEndpointAvailableMock: MockFn;
   spawnSignalDaemonMock: MockFn;
 };
 
@@ -40,6 +41,7 @@ const upsertPairingRequestMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const streamMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const signalCheckMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const signalRpcRequestMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
+const assertSignalDaemonEndpointAvailableMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const spawnSignalDaemonMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const signalToolResultSessionStore = vi.hoisted(() => ({ path: "" }));
 let signalToolResultStateDir: string | undefined;
@@ -82,6 +84,7 @@ export function getSignalToolResultTestMocks(): SignalToolResultTestMocks {
     streamMock,
     signalCheckMock,
     signalRpcRequestMock,
+    assertSignalDaemonEndpointAvailableMock,
     spawnSignalDaemonMock,
   };
 }
@@ -259,6 +262,8 @@ vi.mock("./daemon.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./daemon.js")>();
   return {
     ...actual,
+    assertSignalDaemonEndpointAvailable: (...args: unknown[]) =>
+      assertSignalDaemonEndpointAvailableMock(...args),
     spawnSignalDaemon: (...args: unknown[]) => spawnSignalDaemonMock(...args),
   };
 });
@@ -339,6 +344,7 @@ export function installSignalToolResultTestHooks() {
     streamMock.mockReset();
     signalCheckMock.mockReset().mockResolvedValue({ ok: true });
     signalRpcRequestMock.mockReset().mockResolvedValue({});
+    assertSignalDaemonEndpointAvailableMock.mockReset().mockResolvedValue(undefined);
     spawnSignalDaemonMock.mockReset().mockReturnValue(createMockSignalDaemonHandle());
     readAllowFromStoreMock.mockReset().mockResolvedValue([]);
     upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIRCODE", created: true });

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -517,6 +517,11 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       }
       throw error;
     }
+    // Abort can land after the probe resolves but before this continuation resumes.
+    // Recheck at the spawn boundary so a cancelled monitor never creates a daemon.
+    if (opts.abortSignal?.aborted) {
+      return;
+    }
     if (Date.now() >= startupDeadline) {
       throw new Error(
         `signal daemon startup timed out after ${startupTimeoutMs}ms before starting`,

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -45,10 +45,15 @@ import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runti
 import { resolveSignalAccount, resolveSignalReplyToMode } from "./accounts.js";
 import { isSignalNativeApprovalHandlerConfigured } from "./approval-native.js";
 import { addSignalApprovalReactionHintToStructuredPayload } from "./approval-reactions.js";
-import { signalRpcRequest, signalCheck } from "./client-adapter.js";
+import { signalRpcRequest } from "./client-adapter.js";
 import type { SignalTransportKind } from "./client-adapter.js";
 import { createSignalDaemonLifecycle } from "./daemon-lifecycle.js";
-import { spawnSignalDaemon, type SignalDaemonHandle } from "./daemon.js";
+import {
+  assertSignalDaemonEndpointAvailable,
+  spawnSignalDaemon,
+  type SignalDaemonHandle,
+  waitForSignalDaemonReady,
+} from "./daemon.js";
 import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
 import type {
@@ -67,6 +72,7 @@ import {
   runSignalSseLoop,
   type SignalStatusSink,
 } from "./sse-reconnect.js";
+import { normalizeSignalTransportHost } from "./transport-url.js";
 
 export type MonitorSignalOpts = {
   runtime?: RuntimeEnv;
@@ -192,37 +198,6 @@ function buildSignalReactionSystemEventText(params: {
   const base = `Signal reaction added: ${params.emojiLabel} by ${params.actorLabel} msg ${params.messageId}`;
   const withTarget = params.targetLabel ? `${base} from ${params.targetLabel}` : base;
   return params.groupLabel ? `${withTarget} in ${params.groupLabel}` : withTarget;
-}
-
-async function waitForSignalDaemonReady(params: {
-  baseUrl: string;
-  abortSignal?: AbortSignal;
-  timeoutMs: number;
-  logAfterMs: number;
-  logIntervalMs?: number;
-  runtime: RuntimeEnv;
-  waitForTransportReadyFn?: typeof waitForTransportReady;
-}): Promise<void> {
-  const waitForTransportReadyFn = params.waitForTransportReadyFn ?? waitForTransportReady;
-  await waitForTransportReadyFn({
-    label: "signal daemon",
-    timeoutMs: params.timeoutMs,
-    logAfterMs: params.logAfterMs,
-    logIntervalMs: params.logIntervalMs,
-    pollIntervalMs: 150,
-    abortSignal: params.abortSignal,
-    runtime: params.runtime,
-    check: async () => {
-      const res = await signalCheck(params.baseUrl, 1000);
-      if (res.ok) {
-        return { ok: true };
-      }
-      return {
-        ok: false,
-        error: res.error ?? (res.status ? `HTTP ${res.status}` : "unreachable"),
-      };
-    },
-  });
 }
 
 const SIGNAL_ATTACHMENT_RPC_RESPONSE_HEADROOM_BYTES = 64 * 1024;
@@ -507,14 +482,46 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const monitorTaskRunner = createSignalMonitorTaskRunner(runtime);
   let daemonHandle: SignalDaemonHandle | null = null;
   let ingressMonitor: SignalIngressMonitor | undefined;
+  const startupDeadline = Date.now() + startupTimeoutMs;
 
   if (autoStart) {
     const cliPath = opts.cliPath ?? managedTransport?.cliPath ?? "signal-cli";
     const configPath =
       normalizeOptionalString(opts.configPath) ??
       normalizeOptionalString(managedTransport?.configPath);
-    const httpHost = opts.httpHost ?? managedTransport?.httpHost ?? "127.0.0.1";
+    const httpHost = normalizeSignalTransportHost(
+      opts.httpHost ?? managedTransport?.httpHost ?? "127.0.0.1",
+    );
     const httpPort = opts.httpPort ?? managedTransport?.httpPort ?? 8080;
+    const startupTimeoutSignal = AbortSignal.timeout(startupTimeoutMs);
+    const endpointProbeSignal = opts.abortSignal
+      ? AbortSignal.any([opts.abortSignal, startupTimeoutSignal])
+      : startupTimeoutSignal;
+    // Readiness alone cannot prove ownership: an unrelated service can answer /api/v1/check
+    // while signal-cli exits on EADDRINUSE. Probe the configured bind before starting it.
+    try {
+      await assertSignalDaemonEndpointAvailable({
+        httpHost,
+        httpPort,
+        abortSignal: endpointProbeSignal,
+      });
+    } catch (error) {
+      if (opts.abortSignal?.aborted) {
+        return;
+      }
+      if (startupTimeoutSignal.aborted || Date.now() >= startupDeadline) {
+        throw new Error(
+          `signal daemon startup timed out after ${startupTimeoutMs}ms while checking its endpoint`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+    if (Date.now() >= startupDeadline) {
+      throw new Error(
+        `signal daemon startup timed out after ${startupTimeoutMs}ms before starting`,
+      );
+    }
     daemonHandle = spawnSignalDaemon({
       cliPath,
       ...(configPath ? { configPath } : {}),
@@ -538,7 +545,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       await waitForSignalDaemonReady({
         baseUrl,
         abortSignal: daemonLifecycle.abortSignal,
-        timeoutMs: startupTimeoutMs,
+        startupDeadlineMs: startupDeadline,
         logAfterMs: 10_000,
         logIntervalMs: 10_000,
         runtime,

--- a/src/infra/ports-probe.test.ts
+++ b/src/infra/ports-probe.test.ts
@@ -37,6 +37,21 @@ async function withListeningServer(
 }
 
 describe("tryListenOnPort", () => {
+  it("rejects an already-aborted bind without opening a listener", async () => {
+    const abortController = new AbortController();
+    const reason = new Error("probe cancelled");
+    abortController.abort(reason);
+
+    await expect(
+      tryListenOnPort({
+        port: 0,
+        host: "127.0.0.1",
+        exclusive: true,
+        signal: abortController.signal,
+      }),
+    ).rejects.toBe(reason);
+  });
+
   it("can bind and release an ephemeral loopback port", async () => {
     let port;
     try {

--- a/src/infra/ports-probe.ts
+++ b/src/infra/ports-probe.ts
@@ -1,6 +1,6 @@
 // Probes local ports and reports listener availability.
 import net from "node:net";
-import { isErrno } from "./errors.js";
+import { isErrno, toErrorObject } from "./errors.js";
 import type { PortUsageStatus } from "./ports-types.js";
 
 const PORT_PROBE_HOSTS = ["127.0.0.1", "0.0.0.0", "::1", "::"];
@@ -39,7 +39,7 @@ export async function tryListenOnPort(params: ListenOnPortParams): Promise<numbe
     const clearAbort = () => params.signal?.removeEventListener("abort", onAbort);
     const onAbort = () => {
       clearAbort();
-      reject(params.signal?.reason);
+      reject(toErrorObject(params.signal?.reason, "Port probe aborted"));
     };
     params.signal?.addEventListener("abort", onAbort, { once: true });
     const tester = net

--- a/src/infra/ports-probe.ts
+++ b/src/infra/ports-probe.ts
@@ -13,6 +13,8 @@ type ListenOnPortParams = {
   host?: string;
   /** Whether the probe should request an exclusive server handle from Node. */
   exclusive?: boolean;
+  /** Cancels an in-flight bind, including hostname resolution. */
+  signal?: AbortSignal;
 };
 
 /** Opens and closes an ephemeral listener, returning the allocated port. */
@@ -20,6 +22,9 @@ export function tryListenOnPort(params: ListenOnPortParams & { port: 0 }): Promi
 /** Opens and closes a temporary listener to verify that an explicit port can be bound. */
 export function tryListenOnPort(params: ListenOnPortParams): Promise<void>;
 export async function tryListenOnPort(params: ListenOnPortParams): Promise<number | void> {
+  if (params.signal?.aborted) {
+    throw params.signal.reason;
+  }
   const listenOptions: net.ListenOptions = { port: params.port };
   if (params.host) {
     listenOptions.host = params.host;
@@ -27,18 +32,36 @@ export async function tryListenOnPort(params: ListenOnPortParams): Promise<numbe
   if (typeof params.exclusive === "boolean") {
     listenOptions.exclusive = params.exclusive;
   }
+  if (params.signal) {
+    listenOptions.signal = params.signal;
+  }
   return await new Promise<number | void>((resolve, reject) => {
+    const clearAbort = () => params.signal?.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      clearAbort();
+      reject(params.signal?.reason);
+    };
+    params.signal?.addEventListener("abort", onAbort, { once: true });
     const tester = net
       .createServer()
-      .once("error", (err) => reject(err))
+      .once("error", (error) => {
+        clearAbort();
+        reject(error);
+      })
       .once("listening", () => {
         const address = tester.address();
         if (!address || typeof address === "string") {
-          tester.close(() => reject(new Error("expected TCP listener address")));
+          tester.close(() => {
+            clearAbort();
+            reject(new Error("expected TCP listener address"));
+          });
           return;
         }
         // Binding succeeded; close immediately so the real server can claim the same port.
-        tester.close(() => resolve(params.port === 0 ? address.port : undefined));
+        tester.close(() => {
+          clearAbort();
+          resolve(params.port === 0 ? address.port : undefined);
+        });
       })
       .listen(listenOptions);
   });

--- a/src/infra/ports.ts
+++ b/src/infra/ports.ts
@@ -30,10 +30,14 @@ export async function describePortOwner(port: number): Promise<string | undefine
 }
 
 /** Probes Node's wildcard bind by default; callers may scope checks to their owned interface. */
-export async function ensurePortAvailable(port: number, host?: string): Promise<void> {
+export async function ensurePortAvailable(
+  port: number,
+  host?: string,
+  signal?: AbortSignal,
+): Promise<void> {
   // Detect EADDRINUSE early with a friendly message.
   try {
-    const probe = host ? { port, host } : { port };
+    const probe = { port, ...(host ? { host } : {}), ...(signal ? { signal } : {}) };
     await tryListenOnPort(probe);
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {


### PR DESCRIPTION
## New behavior

Managed-native Signal accounts now stop before daemon startup when their configured HTTP endpoint is already occupied. The startup error names the host and port and tells the operator to stop the conflicting service or choose a different `transport.httpPort`.

- The conflicting service is left untouched; OpenClaw does not silently choose another port.
- Bracketed IPv6 hosts are normalized before both the probe and `signal-cli` use them.
- Only a confirmed address collision blocks startup. Other bind errors are left to the operator-selected `signal-cli`, which may run with different permissions.
- The endpoint probe, daemon spawn, and every readiness request share one startup deadline and abort lifecycle.

## Visual proof

<img width="800" height="600" alt="Managed Signal port collision is rejected before daemon startup while the unrelated listener stays live" src="https://github.com/user-attachments/assets/bbebf79b-7671-4392-bd70-c36ee872ac08" />

**Collision proof:** A real service occupies the configured loopback endpoint. Managed Signal startup returns the exact collision and remediation before spawning its daemon, while the unrelated listener remains live.

<img width="1400" height="600" alt="Managed Signal startup stays inside one deadline and installed signal-cli accepts canonical and bracketed IPv6 binds" src="https://github.com/user-attachments/assets/850b77ef-8d15-4116-8763-535122a2e8bd" />

**Deadline and dependency proof:** A health endpoint delayed by 500ms is rejected in about 136ms under a 120ms startup budget. Installed `signal-cli 0.14.6+morph027+2` reaches a listener with both the canonical `::1:PORT` argument and bracketed `[::1]:PORT` input.

**State:** Exact local candidate head; real TCP/HTTP listeners on ephemeral loopback ports; installed `signal-cli`; browser captures from sanitized loopback proof pages.

## How to verify

Start a TCP listener on the configured managed-native Signal endpoint, then start the Signal monitor. Startup should fail before `signal-cli` is spawned, name the occupied endpoint, and leave the existing listener available.

For the shared deadline, delay the daemon health endpoint past `startupTimeoutMs`. OpenClaw should reject before spawn if the probe consumed the budget and otherwise cap each health request to the remaining budget.

Focused exact-head checks passed: 54 Signal/port-probe tests, core and plugin production/test typechecks, formatting, lint, and diff validation.

## Implementation notes

Previously, managed startup spawned `signal-cli daemon --http HOST:PORT` before establishing that the configured endpoint was available. An unrelated listener therefore surfaced only as a late daemon exit.

The probe now runs at the managed-daemon lifecycle boundary and reuses the shared port-availability owner. It is an early diagnostic, not a reservation: if another process claims the endpoint after the probe closes, the existing daemon-exit path remains authoritative. Daemon readiness lives with the daemon owner, rejects an expired pre-spawn budget, and bounds each health request by the same deadline. External-native transports and persisted configuration are unchanged.

Production delta: +157/-42. Tests and test support: +238/-5. The production growth adds the canonical cancellable bind path, one shared startup deadline, and host normalization; it does not add a fallback daemon path or change any config/default surface.
