### PR TITLE
fix(ui): show skill titles in chat reference picker

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13854,7 +13854,7 @@ public struct CommandEntry: Codable, Sendable {
     public let description: String
     public let category: AnyCodable?
     public let source: AnyCodable
-    public let skillname: String?
+    public let skilldisplayname: String?
     public let skillmodelvisible: Bool?
     public let scope: AnyCodable
     public let acceptsargs: Bool
@@ -13868,7 +13868,7 @@ public struct CommandEntry: Codable, Sendable {
         description: String,
         category: AnyCodable? = nil,
         source: AnyCodable,
-        skillname: String? = nil,
+        skilldisplayname: String? = nil,
         skillmodelvisible: Bool? = nil,
         scope: AnyCodable,
         acceptsargs: Bool,
@@ -13881,7 +13881,7 @@ public struct CommandEntry: Codable, Sendable {
         self.description = description
         self.category = category
         self.source = source
-        self.skillname = skillname
+        self.skilldisplayname = skilldisplayname
         self.skillmodelvisible = skillmodelvisible
         self.scope = scope
         self.acceptsargs = acceptsargs
@@ -13896,7 +13896,7 @@ public struct CommandEntry: Codable, Sendable {
         case description
         case category
         case source
-        case skillname = "skillName"
+        case skilldisplayname = "skillDisplayName"
         case skillmodelvisible = "skillModelVisible"
         case scope
         case acceptsargs = "acceptsArgs"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13854,6 +13854,7 @@ public struct CommandEntry: Codable, Sendable {
     public let description: String
     public let category: AnyCodable?
     public let source: AnyCodable
+    public let skillname: String?
     public let skillmodelvisible: Bool?
     public let scope: AnyCodable
     public let acceptsargs: Bool
@@ -13867,6 +13868,7 @@ public struct CommandEntry: Codable, Sendable {
         description: String,
         category: AnyCodable? = nil,
         source: AnyCodable,
+        skillname: String? = nil,
         skillmodelvisible: Bool? = nil,
         scope: AnyCodable,
         acceptsargs: Bool,
@@ -13879,6 +13881,7 @@ public struct CommandEntry: Codable, Sendable {
         self.description = description
         self.category = category
         self.source = source
+        self.skillname = skillname
         self.skillmodelvisible = skillmodelvisible
         self.scope = scope
         self.acceptsargs = acceptsargs
@@ -13893,6 +13896,7 @@ public struct CommandEntry: Codable, Sendable {
         case description
         case category
         case source
+        case skillname = "skillName"
         case skillmodelvisible = "skillModelVisible"
         case scope
         case acceptsargs = "acceptsArgs"

--- a/packages/gateway-protocol/src/schema/commands.ts
+++ b/packages/gateway-protocol/src/schema/commands.ts
@@ -97,8 +97,8 @@ export const CommandEntrySchema = closedObject({
   description: Type.String({ maxLength: COMMAND_DESCRIPTION_MAX_LENGTH }),
   category: Type.Optional(CommandCategorySchema),
   source: CommandSourceSchema,
-  /** Declared skill name used by clients for human-facing skill references. */
-  skillName: Type.Optional(BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH)),
+  /** Human-readable skill title used by client display surfaces. */
+  skillDisplayName: Type.Optional(BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH)),
   /** Whether a skill command is also present in the model-visible skill catalog. */
   skillModelVisible: Type.Optional(Type.Boolean()),
   scope: CommandScopeSchema,

--- a/packages/gateway-protocol/src/schema/commands.ts
+++ b/packages/gateway-protocol/src/schema/commands.ts
@@ -97,6 +97,8 @@ export const CommandEntrySchema = closedObject({
   description: Type.String({ maxLength: COMMAND_DESCRIPTION_MAX_LENGTH }),
   category: Type.Optional(CommandCategorySchema),
   source: CommandSourceSchema,
+  /** Declared skill name used by clients for human-facing skill references. */
+  skillName: Type.Optional(BoundedNonEmptyString(COMMAND_NAME_MAX_LENGTH)),
   /** Whether a skill command is also present in the model-visible skill catalog. */
   skillModelVisible: Type.Optional(Type.Boolean()),
   scope: CommandScopeSchema,

--- a/src/gateway/server-methods/commands-list-result.ts
+++ b/src/gateway/server-methods/commands-list-result.ts
@@ -240,7 +240,10 @@ export function buildCommandsListResult(params: {
       ...mapCommand(cmd, skill ? "skill" : "native", includeArgs, nameSurface, provider),
       ...(skill
         ? {
-            skillName: clampString(skill.skillName, COMMAND_NAME_MAX_LENGTH),
+            skillDisplayName: clampString(
+              skill.displayName ?? skill.skillName,
+              COMMAND_NAME_MAX_LENGTH,
+            ),
             skillModelVisible: skill.modelVisible !== false,
           }
         : {}),

--- a/src/gateway/server-methods/commands-list-result.ts
+++ b/src/gateway/server-methods/commands-list-result.ts
@@ -238,7 +238,12 @@ export function buildCommandsListResult(params: {
     const skill = skillsByKey.get(cmd.key);
     commands.push({
       ...mapCommand(cmd, skill ? "skill" : "native", includeArgs, nameSurface, provider),
-      ...(skill ? { skillModelVisible: skill.modelVisible !== false } : {}),
+      ...(skill
+        ? {
+            skillName: clampString(skill.skillName, COMMAND_NAME_MAX_LENGTH),
+            skillModelVisible: skill.modelVisible !== false,
+          }
+        : {}),
     });
   }
 

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -9,6 +9,7 @@ import type { ChatCommandDefinition } from "../../auto-reply/commands-registry.t
 const mockSkillCommands = [
   {
     skillName: "code-review",
+    displayName: "Code Review",
     name: "code_review",
     description: "Run code review",
     modelVisible: true,
@@ -368,7 +369,7 @@ describe("commands.list handler", () => {
     const commands = listCommands();
     const skill = commands.find((c) => c.name === "code_review");
     expect(skill?.source).toBe("skill");
-    expect(skill?.skillName).toBe("code-review");
+    expect(skill?.skillDisplayName).toBe("Code Review");
     expect(skill?.skillModelVisible).toBe(true);
     expect(skill?.category).toBe("tools");
   });

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -368,6 +368,7 @@ describe("commands.list handler", () => {
     const commands = listCommands();
     const skill = commands.find((c) => c.name === "code_review");
     expect(skill?.source).toBe("skill");
+    expect(skill?.skillName).toBe("code-review");
     expect(skill?.skillModelVisible).toBe(true);
     expect(skill?.category).toBe("tools");
   });

--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -71,12 +71,14 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     const { buildWorkspaceSkillCommandSpecs } = await import("./command-specs.js");
     const prefix = "a".repeat(98);
     const entry = createFixtureSkillEntry("emoji-skill");
+    entry.skill.displayName = "Emoji Skill";
     entry.skill.description = `${prefix}😀 extra text beyond the limit`;
 
     const specs = buildWorkspaceSkillCommandSpecs("/workspace", {
       entries: [entry],
     });
 
+    expect(specs[0]?.displayName).toBe("Emoji Skill");
     expect(specs[0]?.description).toBe(entry.skill.description);
     expect(specs[0]?.skillFile).toBe(entry.skill.filePath);
   });

--- a/src/skills/discovery/command-specs.ts
+++ b/src/skills/discovery/command-specs.ts
@@ -170,6 +170,7 @@ export function buildWorkspaceSkillCommandSpecs(
 
     specs.push({
       name: unique,
+      displayName: entry.skill.displayName ?? rawName,
       skillFile: canonicalizePath(entry.skill.filePath),
       skillName: rawName,
       description,

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { openRootFileSync } from "../../infra/boundary-file-read.js";
 import type { ParsedSkillFrontmatter } from "../types.js";
 import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
-import { createSyntheticSourceInfo, type Skill } from "./skill-contract.js";
+import {
+  createSyntheticSourceInfo,
+  resolveSkillDisplayName,
+  type Skill,
+} from "./skill-contract.js";
 import { computeSkillPromptVersion } from "./skill-version.js";
 
 type LoadedLocalSkill = {
@@ -82,6 +86,7 @@ function loadSingleSkillDirectory(params: {
   return {
     skill: {
       name,
+      displayName: resolveSkillDisplayName(raw, name),
       description,
       filePath,
       baseDir,

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -80,6 +80,7 @@ disable-model-invocation: true
     expect(result.skills).toEqual([
       expect.objectContaining({
         name: "json5-metadata",
+        displayName: "JSON5 Metadata",
         description: "Skill with JSON5-style metadata.",
         disableModelInvocation: true,
         filePath: skillFile,

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -13,7 +13,7 @@ import {
 import { expandTildePath } from "../../shared/tilde-path.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
 import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
-import { formatSkillsForPromptCore } from "./skill-contract.js";
+import { formatSkillsForPromptCore, resolveSkillDisplayName } from "./skill-contract.js";
 import { computeSkillPromptVersion } from "./skill-version.js";
 
 /** Max name length per spec */
@@ -24,6 +24,8 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 
 export interface Skill {
   name: string;
+  /** Human-readable title from the first Markdown H1, falling back to the identifier. */
+  displayName?: string;
   description: string;
   filePath: string;
   baseDir: string;
@@ -247,6 +249,7 @@ function loadSkillFromFile(
     return {
       skill: {
         name,
+        displayName: resolveSkillDisplayName(rawContent, name),
         description: frontmatter.description,
         filePath,
         baseDir: skillDir,

--- a/src/skills/loading/skill-contract.test.ts
+++ b/src/skills/loading/skill-contract.test.ts
@@ -2,7 +2,11 @@
 import { formatSkillsForPrompt as upstreamFormatSkillsForPrompt } from "openclaw/plugin-sdk/agent-sessions";
 import { describe, expect, it } from "vitest";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
-import { formatSkillsForPromptCore, type Skill } from "./skill-contract.js";
+import {
+  formatSkillsForPromptCore,
+  resolveSkillDisplayName,
+  type Skill,
+} from "./skill-contract.js";
 import { formatSkillsCompactForPrompt as formatSkillsCompact } from "./skill-contract.js";
 
 function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/SKILL.md`): Skill {
@@ -14,6 +18,23 @@ function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/S
     source: "workspace",
   });
 }
+
+describe("resolveSkillDisplayName", () => {
+  it("uses the first Markdown H1 after frontmatter", () => {
+    expect(
+      resolveSkillDisplayName(
+        `---\nname: auto-review\ndescription: Review code.\n---\n# Auto Review\n`,
+        "auto-review",
+      ),
+    ).toBe("Auto Review");
+  });
+
+  it("humanizes the identifier when the skill has no H1", () => {
+    expect(resolveSkillDisplayName("Skill body without a title.\n", "patrick-daily_brief")).toBe(
+      "Patrick Daily Brief",
+    );
+  });
+});
 
 describe("formatSkillsCompact", () => {
   it("keeps the full-format XML output aligned with the upstream formatter for visible skills", () => {

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -4,6 +4,8 @@ import type { SourceInfo } from "../../agents/sessions/source-info.js";
 
 export interface Skill {
   name: string;
+  /** Human-readable title from the first Markdown H1, falling back to the identifier. */
+  displayName?: string;
   description: string;
   /** Additional loading guidance rendered with the location in full and compact catalogs. */
   locationNote?: string;
@@ -31,6 +33,23 @@ export function escapeSkillXml(str: string): string {
 }
 
 const COMPACT_DESCRIPTION_MAX_CHARS = 220;
+const SKILL_FRONTMATTER_BLOCK = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/u;
+const SKILL_TITLE_HEADING = /^#\s+(.+?)\s*#*\s*$/mu;
+
+function humanizeSkillIdentifier(value: string): string {
+  return value
+    .trim()
+    .split(/[-_]+/u)
+    .filter(Boolean)
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
+
+export function resolveSkillDisplayName(content: string, fallbackName: string): string {
+  const body = content.replace(SKILL_FRONTMATTER_BLOCK, "");
+  const heading = body.match(SKILL_TITLE_HEADING)?.[1]?.trim();
+  return heading || humanizeSkillIdentifier(fallbackName) || fallbackName;
+}
 
 function truncateSkillDescription(description: string, maxChars: number): string {
   const normalized = description.replace(/\s+/g, " ").trim();

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -233,6 +233,7 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
       dir: path.join(workspaceDir, "skills", "short-desc"),
       name: "short-desc",
       description: "Short description",
+      body: "# Short Description\n",
     });
     await writeSkill({
       dir: path.join(workspaceDir, "skills", "tool-dispatch"),
@@ -251,6 +252,7 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     const cmd = commands.find((entry) => entry.skillName === "tool-dispatch");
 
     expect(longCmd?.description).toBe(longDescription);
+    expect(shortCmd?.displayName).toBe("Short Description");
     expect(shortCmd?.description).toBe("Short description");
     expect(cmd?.dispatch).toEqual({ kind: "tool", toolName: "sessions_send", argMode: "raw" });
     expect(cmd?.skillSource).toBe("workspace");

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -67,6 +67,8 @@ export type ExplicitSkillSelection = {
 
 export type SkillCommandSpec = {
   name: string;
+  /** Human-readable skill title for display surfaces. */
+  displayName?: string;
   /** Canonical SKILL.md path for file-scoped usage accounting. */
   skillFile?: string;
   skillName: string;

--- a/ui/src/e2e/chat-skill-references.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-references.e2e.test.ts
@@ -24,7 +24,7 @@ suite.define(() => {
             acceptsArgs: true,
             description: "Pre-commit and ship code review.",
             name: "autoreview",
-            skillName: "auto-review",
+            skillDisplayName: "Auto Review",
             scope: "both",
             source: "skill",
             skillModelVisible: true,
@@ -34,7 +34,7 @@ suite.define(() => {
             acceptsArgs: true,
             description: "Build and review technical documentation.",
             name: "technical_documentation",
-            skillName: "technical-documentation",
+            skillDisplayName: "Technical Documentation",
             scope: "both",
             source: "skill",
             skillModelVisible: true,
@@ -78,7 +78,7 @@ suite.define(() => {
         await expect.poll(() => picker.getByRole("option").count()).toBe(1);
         await expect
           .poll(() => picker.getByRole("option").first().textContent())
-          .toContain("$auto-review");
+          .toContain("Auto Review");
         if (artifactDir) {
           await page.screenshot({
             path: path.join(artifactDir, "skill-reference-picker.png"),
@@ -86,14 +86,14 @@ suite.define(() => {
           });
         }
         await composer.press("Enter");
-        await expect.poll(() => composer.inputValue()).toBe("Review this with $auto-review ");
+        await expect.poll(() => composer.inputValue()).toBe("Review this with $autoreview ");
 
         await composer.fill(`${await composer.inputValue()}and $technical`);
         await expect.poll(() => picker.getByRole("option").count()).toBe(1);
         await composer.press("Tab");
         await expect
           .poll(() => composer.inputValue())
-          .toBe("Review this with $auto-review and $technical-documentation ");
+          .toBe("Review this with $autoreview and $technical_documentation ");
 
         if (artifactDir) {
           await page.screenshot({
@@ -105,7 +105,7 @@ suite.define(() => {
         await page.getByRole("button", { name: "Send message" }).click();
         const request = await gateway.waitForRequest("chat.send");
         expect((request.params as { message?: unknown }).message).toBe(
-          "Review this with $auto-review and $technical-documentation",
+          "Review this with $autoreview and $technical_documentation",
         );
 
         await composer.fill("Print $HOME");

--- a/ui/src/e2e/chat-skill-references.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-references.e2e.test.ts
@@ -24,6 +24,7 @@ suite.define(() => {
             acceptsArgs: true,
             description: "Pre-commit and ship code review.",
             name: "autoreview",
+            skillName: "auto-review",
             scope: "both",
             source: "skill",
             skillModelVisible: true,
@@ -33,6 +34,7 @@ suite.define(() => {
             acceptsArgs: true,
             description: "Build and review technical documentation.",
             name: "technical_documentation",
+            skillName: "technical-documentation",
             scope: "both",
             source: "skill",
             skillModelVisible: true,
@@ -76,16 +78,22 @@ suite.define(() => {
         await expect.poll(() => picker.getByRole("option").count()).toBe(1);
         await expect
           .poll(() => picker.getByRole("option").first().textContent())
-          .toContain("$autoreview");
+          .toContain("$auto-review");
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, "skill-reference-picker.png"),
+            fullPage: true,
+          });
+        }
         await composer.press("Enter");
-        await expect.poll(() => composer.inputValue()).toBe("Review this with $autoreview ");
+        await expect.poll(() => composer.inputValue()).toBe("Review this with $auto-review ");
 
         await composer.fill(`${await composer.inputValue()}and $technical`);
         await expect.poll(() => picker.getByRole("option").count()).toBe(1);
         await composer.press("Tab");
         await expect
           .poll(() => composer.inputValue())
-          .toBe("Review this with $autoreview and $technical_documentation ");
+          .toBe("Review this with $auto-review and $technical-documentation ");
 
         if (artifactDir) {
           await page.screenshot({
@@ -97,7 +105,7 @@ suite.define(() => {
         await page.getByRole("button", { name: "Send message" }).click();
         const request = await gateway.waitForRequest("chat.send");
         expect((request.params as { message?: unknown }).message).toBe(
-          "Review this with $autoreview and $technical_documentation",
+          "Review this with $auto-review and $technical-documentation",
         );
 
         await composer.fill("Print $HOME");

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -328,11 +328,11 @@ describe("parseSlashCommand", () => {
     expect(getSkillCommandCompletions("pro").map((command) => command.name)).toEqual(["prose"]);
   });
 
-  it("normalizes hyphenated skill reference queries", () => {
+  it("matches skill queries against both display titles and command tokens", () => {
     applyRemoteEntries([
       {
         name: "release_notes",
-        skillName: "release-notes",
+        skillDisplayName: "Release Notes",
         textAliases: ["/release_notes"],
         description: "Draft release notes.",
         source: "skill",
@@ -342,11 +342,11 @@ describe("parseSlashCommand", () => {
       },
     ]);
 
-    expect(getSkillCommandCompletions("release-n")).toMatchObject([
-      { name: "release_notes", skillName: "release-notes" },
+    expect(getSkillCommandCompletions("notes")).toMatchObject([
+      { name: "release_notes", skillDisplayName: "Release Notes" },
     ]);
     expect(getSkillCommandCompletions("release_n")).toMatchObject([
-      { name: "release_notes", skillName: "release-notes" },
+      { name: "release_notes", skillDisplayName: "Release Notes" },
     ]);
   });
 

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -332,6 +332,7 @@ describe("parseSlashCommand", () => {
     applyRemoteEntries([
       {
         name: "release_notes",
+        skillName: "release-notes",
         textAliases: ["/release_notes"],
         description: "Draft release notes.",
         source: "skill",
@@ -341,8 +342,11 @@ describe("parseSlashCommand", () => {
       },
     ]);
 
-    expect(getSkillCommandCompletions("release-n").map((command) => command.name)).toEqual([
-      "release_notes",
+    expect(getSkillCommandCompletions("release-n")).toMatchObject([
+      { name: "release_notes", skillName: "release-notes" },
+    ]);
+    expect(getSkillCommandCompletions("release_n")).toMatchObject([
+      { name: "release_notes", skillName: "release-notes" },
     ]);
   });
 

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -30,6 +30,7 @@ export type SlashCommandDef = {
   /** Progressive disclosure tier. Defaults to "standard" when omitted. */
   tier?: SlashCommandTier;
   source?: "native" | "plugin" | "skill";
+  skillName?: string;
   skillModelVisible?: boolean;
   clientPresentation?: NonNullable<CommandEntry["clientPresentation"]>;
 };
@@ -49,6 +50,7 @@ type CommandLike = {
   category?: string;
   tier?: string;
   source?: "native" | "plugin" | "skill";
+  skillName?: string;
   skillModelVisible?: boolean;
   clientPresentation?: NonNullable<CommandEntry["clientPresentation"]>;
 };
@@ -261,6 +263,7 @@ function toSlashCommand(
     argOptions: getArgOptions(command),
     tier: source === "local" ? mapTier(command) : "standard",
     ...(resolvedSource ? { source: resolvedSource } : {}),
+    ...(command.skillName ? { skillName: command.skillName } : {}),
     ...(command.skillModelVisible !== undefined
       ? { skillModelVisible: command.skillModelVisible }
       : {}),
@@ -424,6 +427,10 @@ function normalizeCommandEntry(
       entry.source === "native" || entry.source === "plugin" || entry.source === "skill"
         ? entry.source
         : undefined,
+    skillName:
+      typeof entry.skillName === "string"
+        ? clampText(entry.skillName, MAX_REMOTE_NAME_LENGTH).trim() || undefined
+        : undefined,
     skillModelVisible:
       typeof entry.skillModelVisible === "boolean" ? entry.skillModelVisible : undefined,
     clientPresentation:
@@ -545,20 +552,33 @@ export function getSlashCommandCompletions(
   });
 }
 
+const SKILL_REFERENCE_NAME_PATTERN = /^[-a-z0-9_:]+$/u;
+
+export function getSkillReferenceName(command: SlashCommandDef): string {
+  const skillName = normalizeLowercaseStringOrEmpty(command.skillName ?? "");
+  return skillName && SKILL_REFERENCE_NAME_PATTERN.test(skillName) ? skillName : command.name;
+}
+
 export function getSkillCommandCompletions(filter: string): SlashCommandDef[] {
   const lower = normalizeLowercaseStringOrEmpty(filter);
-  const normalized = lower.replace(/-/gu, "_");
+  const normalized = lower.replace(/[\s_]+/gu, "-");
   return SLASH_COMMANDS.filter(
     (command) => command.source === "skill" && command.skillModelVisible === true,
   )
-    .filter(
-      (command) =>
+    .filter((command) => {
+      const referenceName = getSkillReferenceName(command);
+      const commandLookup = normalizeLowercaseStringOrEmpty(command.name).replace(/[\s_]+/gu, "-");
+      return (
         !lower ||
-        command.name.startsWith(lower) ||
-        command.name.replace(/-/gu, "_").startsWith(normalized) ||
-        normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(lower),
-    )
-    .toSorted((left, right) => left.name.localeCompare(right.name));
+        referenceName.startsWith(lower) ||
+        referenceName.replace(/[\s_]+/gu, "-").startsWith(normalized) ||
+        commandLookup.startsWith(normalized) ||
+        normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(lower)
+      );
+    })
+    .toSorted((left, right) =>
+      getSkillReferenceName(left).localeCompare(getSkillReferenceName(right)),
+    );
 }
 
 type ParsedSlashCommand = {

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -30,7 +30,7 @@ export type SlashCommandDef = {
   /** Progressive disclosure tier. Defaults to "standard" when omitted. */
   tier?: SlashCommandTier;
   source?: "native" | "plugin" | "skill";
-  skillName?: string;
+  skillDisplayName?: string;
   skillModelVisible?: boolean;
   clientPresentation?: NonNullable<CommandEntry["clientPresentation"]>;
 };
@@ -50,7 +50,7 @@ type CommandLike = {
   category?: string;
   tier?: string;
   source?: "native" | "plugin" | "skill";
-  skillName?: string;
+  skillDisplayName?: string;
   skillModelVisible?: boolean;
   clientPresentation?: NonNullable<CommandEntry["clientPresentation"]>;
 };
@@ -263,7 +263,7 @@ function toSlashCommand(
     argOptions: getArgOptions(command),
     tier: source === "local" ? mapTier(command) : "standard",
     ...(resolvedSource ? { source: resolvedSource } : {}),
-    ...(command.skillName ? { skillName: command.skillName } : {}),
+    ...(command.skillDisplayName ? { skillDisplayName: command.skillDisplayName } : {}),
     ...(command.skillModelVisible !== undefined
       ? { skillModelVisible: command.skillModelVisible }
       : {}),
@@ -427,9 +427,9 @@ function normalizeCommandEntry(
       entry.source === "native" || entry.source === "plugin" || entry.source === "skill"
         ? entry.source
         : undefined,
-    skillName:
-      typeof entry.skillName === "string"
-        ? clampText(entry.skillName, MAX_REMOTE_NAME_LENGTH).trim() || undefined
+    skillDisplayName:
+      typeof entry.skillDisplayName === "string"
+        ? clampText(entry.skillDisplayName, MAX_REMOTE_NAME_LENGTH).trim() || undefined
         : undefined,
     skillModelVisible:
       typeof entry.skillModelVisible === "boolean" ? entry.skillModelVisible : undefined,
@@ -552,11 +552,8 @@ export function getSlashCommandCompletions(
   });
 }
 
-const SKILL_REFERENCE_NAME_PATTERN = /^[-a-z0-9_:]+$/u;
-
-export function getSkillReferenceName(command: SlashCommandDef): string {
-  const skillName = normalizeLowercaseStringOrEmpty(command.skillName ?? "");
-  return skillName && SKILL_REFERENCE_NAME_PATTERN.test(skillName) ? skillName : command.name;
+export function getSkillDisplayName(command: SlashCommandDef): string {
+  return command.skillDisplayName?.trim() || command.name;
 }
 
 export function getSkillCommandCompletions(filter: string): SlashCommandDef[] {
@@ -566,19 +563,18 @@ export function getSkillCommandCompletions(filter: string): SlashCommandDef[] {
     (command) => command.source === "skill" && command.skillModelVisible === true,
   )
     .filter((command) => {
-      const referenceName = getSkillReferenceName(command);
+      const displayName = normalizeLowercaseStringOrEmpty(getSkillDisplayName(command));
+      const displayLookup = displayName.replace(/[\s_]+/gu, "-");
       const commandLookup = normalizeLowercaseStringOrEmpty(command.name).replace(/[\s_]+/gu, "-");
       return (
         !lower ||
-        referenceName.startsWith(lower) ||
-        referenceName.replace(/[\s_]+/gu, "-").startsWith(normalized) ||
+        displayName.includes(lower) ||
+        displayLookup.includes(normalized) ||
         commandLookup.startsWith(normalized) ||
         normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(lower)
       );
     })
-    .toSorted((left, right) =>
-      getSkillReferenceName(left).localeCompare(getSkillReferenceName(right)),
-    );
+    .toSorted((left, right) => getSkillDisplayName(left).localeCompare(getSkillDisplayName(right)));
 }
 
 type ParsedSlashCommand = {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3600,13 +3600,14 @@ describe("chat composer sizing", () => {
 
 describe("chat slash menu accessibility", () => {
   function replaceSkillCommands(
-    ...skills: Array<{ key: string; name?: string; description: string }>
+    ...skills: Array<{ key: string; name?: string; skillName?: string; description: string }>
   ) {
     replaceSlashCommands([
       ...buildFallbackSlashCommands(),
-      ...skills.map(({ key, name = key, description }) => ({
+      ...skills.map(({ key, name = key, skillName, description }) => ({
         key,
         name,
+        skillName,
         description,
         source: "skill" as const,
         skillModelVisible: true,
@@ -3749,7 +3750,11 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("opens a skill picker for $ references anywhere in a normal prompt", async () => {
-    replaceSkillCommands({ key: "prose", description: "Draft polished prose." });
+    replaceSkillCommands({
+      key: "prose_writer",
+      skillName: "prose-writer",
+      description: "Draft polished prose.",
+    });
     const onSlashIntent = vi.fn(async () => undefined);
     const { container } = createReactiveDraftHarness({ onSlashIntent });
 
@@ -3760,7 +3765,7 @@ describe("chat slash menu accessibility", () => {
     const listbox = container.querySelector<HTMLElement>("#chat-single-skill-menu-listbox");
     const renderedTextarea = container.querySelector<HTMLTextAreaElement>("textarea");
     expect(listbox?.getAttribute("aria-label")).toBe("Skill references");
-    expect(listbox?.querySelector(".slash-menu-name")?.textContent).toBe("$prose");
+    expect(listbox?.querySelector(".slash-menu-name")?.textContent).toBe("$prose-writer");
     expect(renderedTextarea?.getAttribute("aria-controls")).toBe("chat-single-skill-menu-listbox");
     expect(renderedTextarea?.getAttribute("aria-expanded")).toBe("true");
     expect(onSlashIntent).toHaveBeenCalledOnce();

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3600,14 +3600,14 @@ describe("chat composer sizing", () => {
 
 describe("chat slash menu accessibility", () => {
   function replaceSkillCommands(
-    ...skills: Array<{ key: string; name?: string; skillName?: string; description: string }>
+    ...skills: Array<{ key: string; name?: string; skillDisplayName?: string; description: string }>
   ) {
     replaceSlashCommands([
       ...buildFallbackSlashCommands(),
-      ...skills.map(({ key, name = key, skillName, description }) => ({
+      ...skills.map(({ key, name = key, skillDisplayName, description }) => ({
         key,
         name,
-        skillName,
+        skillDisplayName,
         description,
         source: "skill" as const,
         skillModelVisible: true,
@@ -3752,7 +3752,7 @@ describe("chat slash menu accessibility", () => {
   it("opens a skill picker for $ references anywhere in a normal prompt", async () => {
     replaceSkillCommands({
       key: "prose_writer",
-      skillName: "prose-writer",
+      skillDisplayName: "Prose Writer",
       description: "Draft polished prose.",
     });
     const onSlashIntent = vi.fn(async () => undefined);
@@ -3765,14 +3765,18 @@ describe("chat slash menu accessibility", () => {
     const listbox = container.querySelector<HTMLElement>("#chat-single-skill-menu-listbox");
     const renderedTextarea = container.querySelector<HTMLTextAreaElement>("textarea");
     expect(listbox?.getAttribute("aria-label")).toBe("Skill references");
-    expect(listbox?.querySelector(".slash-menu-name")?.textContent).toBe("$prose-writer");
+    expect(listbox?.querySelector(".slash-menu-name")?.textContent).toBe("Prose Writer");
     expect(renderedTextarea?.getAttribute("aria-controls")).toBe("chat-single-skill-menu-listbox");
     expect(renderedTextarea?.getAttribute("aria-expanded")).toBe("true");
     expect(onSlashIntent).toHaveBeenCalledOnce();
   });
 
   it("fills a selected $ skill without submitting the surrounding prompt", async () => {
-    replaceSkillCommands({ key: "prose", description: "Draft polished prose." });
+    replaceSkillCommands({
+      key: "prose_writer",
+      skillDisplayName: "Prose Writer",
+      description: "Draft polished prose.",
+    });
     let draft = "";
     const onDraftChange = vi.fn((next: string) => {
       draft = next;
@@ -3783,12 +3787,12 @@ describe("chat slash menu accessibility", () => {
 
     keydownComposer(container, "Enter");
 
-    expect(draft).toBe("Polish this with $prose:");
+    expect(draft).toBe("Polish this with $prose_writer:");
     expect(onSend).not.toHaveBeenCalled();
     expect(container.querySelector(".skill-menu")).toBeNull();
     await Promise.resolve();
     const completed = container.querySelector<HTMLTextAreaElement>("textarea");
-    expect(completed?.selectionStart).toBe("Polish this with $prose:".length);
+    expect(completed?.selectionStart).toBe("Polish this with $prose_writer:".length);
   });
 
   it("consumes a trailing hyphen from an incomplete skill query", () => {
@@ -3866,7 +3870,7 @@ describe("chat slash menu accessibility", () => {
     keydownComposer(container, "ArrowDown");
     expect(
       container.querySelector(".skill-menu .slash-menu-item--active .slash-menu-name")?.textContent,
-    ).toBe("$beta");
+    ).toBe("beta");
     keydownComposer(container, "Enter");
 
     expect(draft).toBe("Use $beta ");

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -3,7 +3,7 @@ import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import {
   getSkillCommandCompletions,
-  getSkillReferenceName,
+  getSkillDisplayName,
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
@@ -176,7 +176,7 @@ export function getActiveSkillMenuOptionLabel(state: ChatComposerState): string 
     return "";
   }
   const command = state.skillMenuItems[state.skillMenuIndex];
-  return command ? `$${getSkillReferenceName(command)} ${getSlashCommandDescription(command)}` : "";
+  return command ? `${getSkillDisplayName(command)} ${getSlashCommandDescription(command)}` : "";
 }
 
 export function scrollActiveSkillMenuOptionIntoView(
@@ -222,7 +222,7 @@ export function selectSkillMention(
     return;
   }
   const suffix = target.end === current.length ? " " : "";
-  const replacement = `$${getSkillReferenceName(command)}${suffix}`;
+  const replacement = `$${command.name}${suffix}`;
   const next = `${current.slice(0, target.start)}${replacement}${current.slice(target.end)}`;
   const retainedBeforeCaret = Math.max(0, currentCaret - target.end);
   const nextCaret = target.start + replacement.length + retainedBeforeCaret;
@@ -280,7 +280,7 @@ export function renderSkillMenu(
                   >
                     <span class="slash-menu-leading">
                       <span class="slash-menu-icon">${icons.zap}</span>
-                      <span class="slash-menu-name">$${getSkillReferenceName(command)}</span>
+                      <span class="slash-menu-name">${getSkillDisplayName(command)}</span>
                     </span>
                     <span class="slash-menu-trailing">
                       <span class="slash-menu-desc">${getSlashCommandDescription(command)}</span>

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -3,6 +3,7 @@ import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import {
   getSkillCommandCompletions,
+  getSkillReferenceName,
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
@@ -175,7 +176,7 @@ export function getActiveSkillMenuOptionLabel(state: ChatComposerState): string 
     return "";
   }
   const command = state.skillMenuItems[state.skillMenuIndex];
-  return command ? `$${command.name} ${getSlashCommandDescription(command)}` : "";
+  return command ? `$${getSkillReferenceName(command)} ${getSlashCommandDescription(command)}` : "";
 }
 
 export function scrollActiveSkillMenuOptionIntoView(
@@ -221,7 +222,7 @@ export function selectSkillMention(
     return;
   }
   const suffix = target.end === current.length ? " " : "";
-  const replacement = `$${command.name}${suffix}`;
+  const replacement = `$${getSkillReferenceName(command)}${suffix}`;
   const next = `${current.slice(0, target.start)}${replacement}${current.slice(target.end)}`;
   const retainedBeforeCaret = Math.max(0, currentCaret - target.end);
   const nextCaret = target.start + replacement.length + retainedBeforeCaret;
@@ -279,7 +280,7 @@ export function renderSkillMenu(
                   >
                     <span class="slash-menu-leading">
                       <span class="slash-menu-icon">${icons.zap}</span>
-                      <span class="slash-menu-name">$${command.name}</span>
+                      <span class="slash-menu-name">$${getSkillReferenceName(command)}</span>
                     </span>
                     <span class="slash-menu-trailing">
                       <span class="slash-menu-desc">${getSlashCommandDescription(command)}</span>


### PR DESCRIPTION
## Summary

- derive a human-readable skill title from the first Markdown H1 in `SKILL.md`, with a humanized identifier fallback
- expose that title to Control UI as `skillDisplayName`
- show the title in the `$` skill picker with no `$` prefix while preserving the stable `$command_token` inserted into the composer

## Behavior

For a skill whose identifier is `auto-review`, title is `Auto Review`, and command token is `autoreview`:

- typing `$auto` shows **Auto Review** in the picker
- the picker does not show `$` or the kebab-case identifier
- selecting it inserts `$autoreview`, preserving runtime reference compatibility
- search matches both the human-readable title and command token
- older Gateways without `skillDisplayName` fall back to the command name

## Visual proof

Picker shows the human-readable title with no `$` prefix:

![Skill picker showing Auto Review](https://raw.githubusercontent.com/openclaw/openclaw/proof-ui-skill-reference-names/.github/pr-proof/skill-reference-picker.png)

Selection still inserts stable runtime reference tokens:

![Composer containing $autoreview and $technical_documentation](https://raw.githubusercontent.com/openclaw/openclaw/proof-ui-skill-reference-names/.github/pr-proof/skill-references-selected.png)

The screenshots are generated by the Chromium E2E test and hosted on the non-merge proof branch `proof-ui-skill-reference-names`.

## Validation

- `pnpm protocol:check`
- focused skill/Gateway tests: 72 passed
- Control UI unit tests: 278 passed
- Chromium skill-reference E2E: 1 passed
- `pnpm ui:build`
- targeted `oxfmt` and `oxlint`: clean

`pnpm check:changed` could not start because the local Crabbox binary failed its own `--version`/`--help` sanity check; the targeted checks above completed successfully.
