### PR TITLE
fix(cli): name the agent escapes each command supports

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -31,7 +31,7 @@ Flags:
 
 | Flag                 | Description                                                            |
 | -------------------- | ---------------------------------------------------------------------- |
-| `--agent <id>`       | One configured agent store (default: configured default agent).        |
+| `--agent <id>`       | One configured agent store (required for multiple explicit agents).    |
 | `--all-agents`       | Aggregate all configured agent stores.                                 |
 | `--store <path>`     | Explicit store path (cannot combine with `--agent` or `--all-agents`). |
 | `--active <minutes>` | Only show sessions updated within the past N minutes.                  |

--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -56,6 +56,12 @@ describe("agent roster resolution", () => {
     expect(tryResolveDefaultAgentId(duplicateDefaults)).toBeUndefined();
   });
 
+  it("keeps the generic selection hint free of surface-specific assumptions", () => {
+    expect(() => resolveDefaultAgentId({ agents: { entries: { alpha: {}, beta: {} } } })).toThrow(
+      "Multiple agents are configured, but this operation has no explicit owner. Select an agent explicitly; CLI callers can pass --agent <id>, channels can add a binding, and ambient services can set their agentId target.",
+    );
+  });
+
   it("requires an explicit system owner when a roster has multiple agents", () => {
     expect(
       resolveSystemAgentTargetAgentId({

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -130,10 +130,14 @@ vi.mock("../../runtime.js", () => ({
 }));
 
 describe("registerStatusHealthSessionsCommands", () => {
-  async function runCli(args: string[]) {
+  function createProgram() {
     const program = new Command();
     registerStatusHealthSessionsCommands(program);
-    await program.parseAsync(args, { from: "user" });
+    return program;
+  }
+
+  async function runCli(args: string[]) {
+    await createProgram().parseAsync(args, { from: "user" });
   }
 
   beforeEach(() => {
@@ -245,6 +249,19 @@ describe("registerStatusHealthSessionsCommands", () => {
       agent: "work",
       allAgents: false,
     });
+  });
+
+  it("documents explicit selection for multi-agent session-store commands", () => {
+    const sessions = createProgram().commands.find((command) => command.name() === "sessions");
+    const list = sessions?.commands.find((command) => command.name() === "list");
+    const cleanup = sessions?.commands.find((command) => command.name() === "cleanup");
+
+    expect(list?.options.find((option) => option.long === "--agent")?.description).toBe(
+      "Agent id to inspect (required for multiple explicit agents)",
+    );
+    expect(cleanup?.options.find((option) => option.long === "--agent")?.description).toBe(
+      "Agent id to maintain (required for multiple explicit agents)",
+    );
   });
 
   it("runs sessions command with --all-agents forwarding", async () => {

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -68,7 +68,7 @@ function addSessionsListOptions(command: Command): Command {
     .option("--json", "Output as JSON", false)
     .option("--verbose", "Verbose logging", false)
     .option("--store <path>", "Path to session store (default: resolved from config)")
-    .option("--agent <id>", "Agent id to inspect (default: configured default agent)")
+    .option("--agent <id>", "Agent id to inspect (required for multiple explicit agents)")
     .option("--all-agents", "Aggregate sessions across all configured agents", false)
     .option("--active <minutes>", "Only show sessions updated within the past N minutes")
     .option("--limit <count>", 'Max sessions to show (default: 100; use "all" for full output)');
@@ -358,7 +358,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .command("cleanup")
     .description("Run session-store maintenance now")
     .option("--store <path>", "Path to session store (default: resolved from config)")
-    .option("--agent <id>", "Agent id to maintain (default: configured default agent)")
+    .option("--agent <id>", "Agent id to maintain (required for multiple explicit agents)")
     .option("--all-agents", "Run maintenance across all configured agents", false)
     .option("--dry-run", "Preview maintenance actions without writing", false)
     .option("--enforce", "Apply maintenance even when configured mode is warn", false)
@@ -434,7 +434,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--tail <count>", "Number of existing trajectory events to show", "80")
     .option("--follow", "Continue following for new trajectory events", false)
     .option("--store <path>", "Path to session store (default: resolved from config)")
-    .option("--agent <id>", "Agent id to inspect (default: configured default agent)")
+    .option("--agent <id>", "Agent id to inspect (required for multiple explicit agents)")
     .option("--all-agents", "Aggregate sessions across all configured agents", false)
     .action(async (opts, command) => {
       const parentOpts = command.parent?.opts() as SessionsListCliOptions | undefined;

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -1,6 +1,10 @@
 // Skills CLI command tests cover skill command registration and subcommand behavior.
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentSelectionRequiredError,
+  type AgentSelectionContext,
+} from "../agents/agent-scope-config.js";
 import { registerSkillsCli } from "./skills-cli.js";
 
 const ORIGINAL_STDIN_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
@@ -95,7 +99,9 @@ const mocks = vi.hoisted(() => {
   return {
     callGatewayMock: vi.fn(),
     loadConfigMock: vi.fn((_options?: unknown) => ({})),
-    resolveDefaultAgentIdMock: vi.fn((_configForTest: unknown) => "main"),
+    resolveDefaultAgentIdMock: vi.fn(
+      (_configForTest: unknown, _context?: AgentSelectionContext) => "main",
+    ),
     resolveAgentIdByWorkspacePathMock: vi.fn(
       (_configForTest: unknown, _workspacePath: string): string | undefined => undefined,
     ),
@@ -252,7 +258,8 @@ vi.mock("../config/config.js", () => ({
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentIdByWorkspacePath: (config: unknown, workspacePath: string) =>
     mocks.resolveAgentIdByWorkspacePathMock(config, workspacePath),
-  resolveDefaultAgentId: (config: unknown) => mocks.resolveDefaultAgentIdMock(config),
+  resolveDefaultAgentId: (config: unknown, context?: AgentSelectionContext) =>
+    mocks.resolveDefaultAgentIdMock(config, context),
   resolveAgentWorkspaceDir: (config: unknown, agentId: string) =>
     mocks.resolveAgentWorkspaceDirMock(config, agentId),
 }));
@@ -1473,22 +1480,24 @@ describe("skills cli commands", () => {
     });
 
     expect(resolveAgentIdByWorkspacePathMock).toHaveBeenCalledWith({}, "/tmp/unrelated");
-    expect(resolveDefaultAgentIdMock).toHaveBeenCalledWith({});
+    expect(resolveDefaultAgentIdMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ hint: "Pass --agent <id>." }),
+    );
     expectStatusWorkspaceCall("/tmp/workspace-main");
   });
 
-  it("renders named agent-selection errors without the internal class name", async () => {
-    const error = new Error(
-      "Multiple agents are configured, but this operation has no explicit owner.",
-    );
-    error.name = "AgentSelectionRequiredError";
-    resolveDefaultAgentIdMock.mockImplementationOnce(() => {
-      throw error;
+  it("renders the supported skills escape without advertising --all-agents", async () => {
+    resolveDefaultAgentIdMock.mockImplementationOnce((_config, context) => {
+      throw new AgentSelectionRequiredError(["main", "helper", "third"], context);
     });
 
     await expect(runCommand(["skills", "list"])).rejects.toThrow("__exit__:1");
 
-    expect(runtimeErrors).toStrictEqual([error.message]);
+    expect(runtimeErrors).toStrictEqual([
+      "Multiple agents are configured, but the skills command has no explicit owner. Pass --agent <id>.",
+    ]);
+    expect(runtimeErrors[0]).not.toContain("--all-agents");
   });
 
   it("redacts secrets from rendered skills CLI errors", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -154,7 +154,13 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   const inferredAgentId = explicitAgentId
     ? undefined
     : resolveAgentIdByWorkspacePath(config, options?.cwd ?? process.cwd());
-  const agentId = explicitAgentId ?? inferredAgentId ?? resolveDefaultAgentId(config);
+  const agentId =
+    explicitAgentId ??
+    inferredAgentId ??
+    resolveDefaultAgentId(config, {
+      surface: "the skills command",
+      hint: "Pass --agent <id>.",
+    });
   return {
     config,
     agentId,

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -157,10 +157,7 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   const agentId =
     explicitAgentId ??
     inferredAgentId ??
-    resolveDefaultAgentId(config, {
-      surface: "the skills command",
-      hint: "Pass --agent <id>.",
-    });
+    resolveDefaultAgentId(config, { surface: "the skills command", hint: "Pass --agent <id>." });
   return {
     config,
     agentId,

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -1,7 +1,7 @@
 // Model command shared tests cover shared config and provider helper behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
+import { loadValidConfigOrThrow, resolveModelsTargetAgent, updateConfig } from "./shared.js";
 
 const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
@@ -39,6 +39,16 @@ describe("models/shared", () => {
 
     await expect(loadValidConfigOrThrow()).rejects.toThrowError(
       "Invalid config at /tmp/openclaw.json\n- providers.openai.apiKey: Required",
+    );
+  });
+
+  it("names only the supported model-command escape for an ambiguous roster", () => {
+    expect(() =>
+      resolveModelsTargetAgent({
+        agents: { ownership: "explicit", entries: { main: {}, helper: {}, third: {} } },
+      }),
+    ).toThrow(
+      "Multiple agents are configured, but the model command has no explicit owner. Pass --agent <id>.",
     );
   });
 

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -159,10 +159,7 @@ export function resolveModelsTargetAgent(
 } {
   const agentId =
     resolveKnownAgentId({ cfg, rawAgentId }) ??
-    resolveDefaultAgentId(cfg, {
-      surface: "the model command",
-      hint: "Pass --agent <id>.",
-    });
+    resolveDefaultAgentId(cfg, { surface: "the model command", hint: "Pass --agent <id>." });
   const agentDir = resolveAgentDir(cfg, agentId);
   return { agentId, agentDir };
 }

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -157,7 +157,12 @@ export function resolveModelsTargetAgent(
   agentId: string;
   agentDir: string;
 } {
-  const agentId = resolveKnownAgentId({ cfg, rawAgentId }) ?? resolveDefaultAgentId(cfg);
+  const agentId =
+    resolveKnownAgentId({ cfg, rawAgentId }) ??
+    resolveDefaultAgentId(cfg, {
+      surface: "the model command",
+      hint: "Pass --agent <id>.",
+    });
   const agentDir = resolveAgentDir(cfg, agentId);
   return { agentId, agentDir };
 }

--- a/src/commands/session-store-targets.ts
+++ b/src/commands/session-store-targets.ts
@@ -1,7 +1,4 @@
-import {
-  AgentSelectionRequiredError,
-  type AgentSelectionContext,
-} from "../agents/agent-scope-config.js";
+import { AgentSelectionRequiredError } from "../agents/agent-scope-config.js";
 /**
  * Session store target resolution wrapper for CLI commands.
  *
@@ -20,7 +17,7 @@ import type { RuntimeEnv } from "../runtime.js";
 const SESSION_STORE_SELECTION_CONTEXT = {
   surface: "session-store selection",
   hint: "Pass --agent <id> to select one agent, or --all-agents to include every configured agent.",
-} satisfies AgentSelectionContext;
+};
 
 /** Resolves session store targets or exits the current command on validation errors. */
 export function resolveSessionStoreTargetsOrExit(params: {
@@ -31,11 +28,10 @@ export function resolveSessionStoreTargetsOrExit(params: {
   try {
     return resolveSessionStoreTargets(params.cfg, params.opts);
   } catch (error) {
-    const displayError =
-      error instanceof AgentSelectionRequiredError
-        ? new AgentSelectionRequiredError(error.agentIds, SESSION_STORE_SELECTION_CONTEXT)
-        : error;
-    params.runtime.error(formatErrorMessage(displayError));
+    if (error instanceof AgentSelectionRequiredError) {
+      error = new AgentSelectionRequiredError(error.agentIds, SESSION_STORE_SELECTION_CONTEXT);
+    }
+    params.runtime.error(formatErrorMessage(error));
     params.runtime.exit(1);
     return null;
   }

--- a/src/commands/session-store-targets.ts
+++ b/src/commands/session-store-targets.ts
@@ -28,10 +28,11 @@ export function resolveSessionStoreTargetsOrExit(params: {
   try {
     return resolveSessionStoreTargets(params.cfg, params.opts);
   } catch (error) {
-    if (error instanceof AgentSelectionRequiredError) {
-      error = new AgentSelectionRequiredError(error.agentIds, SESSION_STORE_SELECTION_CONTEXT);
-    }
-    params.runtime.error(formatErrorMessage(error));
+    const displayError =
+      error instanceof AgentSelectionRequiredError
+        ? new AgentSelectionRequiredError(error.agentIds, SESSION_STORE_SELECTION_CONTEXT)
+        : error;
+    params.runtime.error(formatErrorMessage(displayError));
     params.runtime.exit(1);
     return null;
   }

--- a/src/commands/session-store-targets.ts
+++ b/src/commands/session-store-targets.ts
@@ -1,3 +1,7 @@
+import {
+  AgentSelectionRequiredError,
+  type AgentSelectionContext,
+} from "../agents/agent-scope-config.js";
 /**
  * Session store target resolution wrapper for CLI commands.
  *
@@ -13,6 +17,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 
+const SESSION_STORE_SELECTION_CONTEXT = {
+  surface: "session-store selection",
+  hint: "Pass --agent <id> to select one agent, or --all-agents to include every configured agent.",
+} satisfies AgentSelectionContext;
+
 /** Resolves session store targets or exits the current command on validation errors. */
 export function resolveSessionStoreTargetsOrExit(params: {
   cfg: OpenClawConfig;
@@ -22,7 +31,11 @@ export function resolveSessionStoreTargetsOrExit(params: {
   try {
     return resolveSessionStoreTargets(params.cfg, params.opts);
   } catch (error) {
-    params.runtime.error(formatErrorMessage(error));
+    const displayError =
+      error instanceof AgentSelectionRequiredError
+        ? new AgentSelectionRequiredError(error.agentIds, SESSION_STORE_SELECTION_CONTEXT)
+        : error;
+    params.runtime.error(formatErrorMessage(displayError));
     params.runtime.exit(1);
     return null;
   }

--- a/src/commands/sessions.default-agent-store.test.ts
+++ b/src/commands/sessions.default-agent-store.test.ts
@@ -181,6 +181,24 @@ describe("sessionsCommand default store agent selection", () => {
     expect(logs[0]).toContain("Session store: /tmp/sessions-voice.voice.sqlite");
   });
 
+  it("names both supported escapes when an explicit roster has no session-list owner", async () => {
+    loadConfigMock.mockReturnValue({
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, helper: {}, third: {} },
+      },
+    });
+    const { runtime } = createRuntime();
+
+    await sessionsCommand({}, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Multiple agents are configured, but session-store selection has no explicit owner. Pass --agent <id> to select one agent, or --all-agents to include every configured agent.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("uses all configured agent stores with --all-agents", async () => {
     listSessionEntriesMock.mockReset();
     listSessionEntriesMock


### PR DESCRIPTION
Related: #123929

## What Problem This Solves

Fixes an issue where multi-agent CLI failures inherited a generic selection hint that did not match the command's real escape hatches. Session listing and cleanup omitted their useful `--all-agents` selector, while the same generic wording could imply CLI support outside the surface that raised the error.

This is the agent-selection hint follow-up explicitly recorded in #123929.

## Why This Change Was Made

The existing `AgentSelectionContext` remains the only hint mechanism. The shared session-store CLI presentation boundary re-contextualizes `AgentSelectionRequiredError` once because list, cleanup, and tail all expose the same `--agent <id>` / `--all-agents` pair. Skills workspace selection and model target selection pass their own context at their existing shared CLI owners, where only `--agent <id>` is supported. The generic resolver fallback is unchanged for channel, Gateway, and ambient-service callers.

The session target resolver still does not fall back to `agents.defaults.systemAgent.agentId`. Explicit fleets intentionally have no default owner, while `systemAgent.agentId` owns ambient system-agent and Custodian work. An operator-facing read command with an aggregate selector should require `--agent` or `--all-agents` instead of silently treating the ambient system agent as the session-store default. The CLI help and sessions reference now say `--agent` is required for multiple explicit agents.

## User Impact

Operators now get an escape that the command actually accepts:

| Command | `--agent <id>` | `--all-agents` | Ambiguity guidance |
| --- | --- | --- | --- |
| `sessions list` | yes | yes | names both |
| `sessions cleanup` | yes | yes | names both |
| `skills list` | yes | no | names `--agent <id>` only |
| `models list` | yes | no | names `--agent <id>` only |
| `agents show` | no | no | no selection operation is registered; `agents show --help` resolves parent help and does not raise this error |

Before, all affected commands inherited:

```text
Multiple agents are configured, but this operation has no explicit owner. Select an agent explicitly; CLI callers can pass --agent <id>, channels can add a binding, and ambient services can set their agentId target.
```

After:

```text
$ openclaw sessions list
Multiple agents are configured, but session-store selection has no explicit owner. Pass --agent <id> to select one agent, or --all-agents to include every configured agent.

$ openclaw skills list
Multiple agents are configured, but the skills command has no explicit owner. Pass --agent <id>.

$ openclaw models list
Multiple agents are configured, but the model command has no explicit owner. Pass --agent <id>.
```

## Evidence

AI-assisted by Codex. Validation used an isolated three-agent roster with `agents.ownership: "explicit"`, `agents.defaults.systemAgent.agentId: "main"`, a private `OPENCLAW_STATE_DIR`, `OPENCLAW_SKIP_CHANNELS=1`, and a derived non-default Gateway port.

- Full `pnpm build` passed in Blacksmith Testbox `tbx_01m01sz14hzzgacjvh3s7h4rxa` (Actions run 31863859093).
- Live built-CLI proof on that Testbox: bare sessions list/cleanup, skills list, and models list exited 1 with the text above; `sessions list --agent main`, `sessions list --all-agents`, `sessions cleanup --all-agents --dry-run`, `skills list --agent main`, and `models list --agent main` all exited 0. The all-agent outputs enumerated `main`, `helper`, and `third`.
- `--help` on the built CLI confirmed the selector table above.
- The pre-fix regressions failed for the intended reason: sessions rendered the generic hint without `--all-agents`; skills and models received no surface context; sessions help claimed a configured default.
- `node scripts/run-vitest.mjs src/commands/sessions.default-agent-store.test.ts src/commands/models/shared.test.ts src/commands/session-store-targets.test.ts src/commands/sessions-cleanup.test.ts src/commands/sessions-tail.test.ts` — 28 passed.
- `node scripts/run-vitest.mjs src/cli/program/register.status-health-sessions.test.ts src/cli/skills-cli.commands.test.ts` — 111 passed.
- `node scripts/run-vitest.mjs src/agents/agent-scope-config.test.ts` — 12 passed; the generic/non-CLI fallback text is unchanged.
- `node scripts/check-changed.mjs` — passed on final head in Testbox `tbx_01m01v9s13xgjrkdjyazjp8xy8` (Actions run 31864837554): core/core-test types, changed-file lint/format, import cycles, dead exports, and selected guards.
- Autoreview (`.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`) — clean after the final error-handling fix, no accepted/actionable findings.

Production LOC: +21/-6 (net +15). Tests: +74/-14 (net +60). Docs: +1/-1. The production growth records the supported selector contract at the three CLI owner boundaries while leaving generic resolver behavior unchanged.
