### PR TITLE
fix(ui,gateway): refresh the agents-page model catalog on picker open and give catalog errors a next step

### DIFF
--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -578,14 +578,20 @@ export async function projectSessionsPatchEntry(params: {
       if (!params.loadGatewayModelCatalog) {
         return {
           ok: false,
-          error: errorShape(ErrorCodes.UNAVAILABLE, "model catalog unavailable"),
+          error: errorShape(
+            ErrorCodes.UNAVAILABLE,
+            "model catalog is still loading; retry in a few seconds",
+          ),
         };
       }
       const catalog = await loadPreparedModelCatalogForPatch();
       if (!catalog) {
         return {
           ok: false,
-          error: errorShape(ErrorCodes.UNAVAILABLE, "model catalog unavailable"),
+          error: errorShape(
+            ErrorCodes.UNAVAILABLE,
+            "model catalog is still loading; retry in a few seconds",
+          ),
         };
       }
       const resolved = resolveSessionPatchModelSelection({

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -53,6 +53,7 @@ type TestAgentsPage = HTMLElement & {
   };
   ensureAgentIdentities: () => void;
   loadActivePanelData: () => void;
+  ensureModelCatalog: (options?: { refresh?: boolean }) => void;
   refreshCron: () => Promise<void>;
   requestUpdate: () => void;
   runCronTask: <T>(task: (cronState: CronState) => Promise<T>) => Promise<T>;
@@ -391,6 +392,31 @@ describe("AgentsPage gateway lifecycle", () => {
     expect(page.chatModelCatalog).toEqual(workerModels);
     expect(request).toHaveBeenCalledTimes(2);
     expect(request).toHaveBeenNthCalledWith(2, "chat.metadata", { agentId: "worker" });
+  });
+
+  it("re-reads a cached model catalog when the picker asks for a refresh", async () => {
+    const oldModels = [{ id: "old", name: "Old Model", alias: "opus", provider: "anthropic" }];
+    const nextModels = [{ id: "new", name: "Opus 4.8", alias: "opus", provider: "anthropic" }];
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ models: oldModels })
+      .mockResolvedValueOnce({ models: nextModels });
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.routeData = { panel: "overview" } as AgentsRouteData;
+    setPageGateway(page, { request } as unknown as GatewayBrowserClient);
+    page.agentsSelectedId = "main";
+
+    page.loadActivePanelData();
+    await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(oldModels));
+
+    // Without refresh the per-agent cache answers; provider-key changes would
+    // stay invisible for the connection lifetime.
+    page.ensureModelCatalog();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    page.ensureModelCatalog({ refresh: true });
+    await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(nextModels));
+    expect(request).toHaveBeenCalledTimes(2);
   });
 
   it("rejects an old-client model catalog after the Gateway client changes", async () => {

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -544,13 +544,13 @@ class AgentsPage
     }
   }
 
-  private ensureModelCatalog() {
+  private ensureModelCatalog(options: { refresh?: boolean } = {}) {
     const client = this.client;
     const agentId = this.resolveSelectedAgentId();
     if (!client || !this.connected || !agentId) {
       return;
     }
-    if (this.chatModelCatalogClient === client) {
+    if (!options.refresh && this.chatModelCatalogClient === client) {
       const cached = this.chatModelCatalogByAgentId.get(agentId);
       if (cached) {
         this.chatModelCatalog = cached;
@@ -1114,7 +1114,10 @@ class AgentsPage
             stageAgentPrimaryModel(this.context.runtimeConfig, agentId, modelId);
             void refreshVisibleToolsEffectiveForCurrentSession(this);
           },
-          onModelCatalogRetry: () => this.ensureModelCatalog(),
+          // Availability facts (provider keys added/removed, new models) go
+          // stale in the per-agent cache; opening the picker re-reads them,
+          // mirroring the chat composer's on-open refresh.
+          onModelCatalogRetry: () => this.ensureModelCatalog({ refresh: true }),
           onModelFallbacksChange: (agentId, fallbacks) => {
             if (this.canCall("config.set", "operator.admin")) {
               stageAgentModelFallbacks(this.context.runtimeConfig, agentId, fallbacks);

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -311,6 +311,7 @@ export function renderAgentOverview(params: {
             ],
             disabled,
             onChange: (value) => onModelChange(agent.id, value || null),
+            onOpen: params.onModelCatalogRetry,
           }),
         })}
         ${renderSettingsRow({


### PR DESCRIPTION
## What Problem This Solves

Two findings from the round-4 agents-page investigation lane, both "recorded fact goes stale / dead-end failure text" class:

1. **Agents-page model catalog cached for the whole connection.** `ensureModelCatalog` answered from `chatModelCatalogByAgentId` unconditionally (cleared only on connection change), so availability facts — a provider key added or removed, new models after login — never reached the overview picker for the rest of the session. The chat composer's sibling picker refreshes on open (`onModelPickerOpen → refreshChatModelCatalogOnDemand`); the agents picker had no on-open path at all, and `onModelCatalogRetry` was only reachable from the error callout.
2. **Dead-end error text.** `sessions.patch` failing model resolution returned "model catalog unavailable" — no cause, no next step. Doctrine: failure text states what to try next.

## Why This Change Was Made

The catalog owner (`ensureModelCatalog`) gains a `refresh` bypass of the per-agent cache, and the overview picker's `onOpen` routes through the same existing retry handler — mirroring the chat-composer pattern rather than adding a parallel loader or cache invalidation event. The error string now says the catalog is still loading and to retry, which is what UNAVAILABLE means on that path (the gateway is warming its prepared catalog).

## User Impact

Adding a provider key and then opening an agent's model picker shows the newly available models immediately instead of requiring a reconnect. A model switch that races catalog warm-up tells the operator to retry in a few seconds instead of presenting an unexplained failure.

## Evidence

- New regression test "re-reads a cached model catalog when the picker asks for a refresh" fails pre-fix (cache answers, second RPC never fires) and passes post-fix; also asserts the no-refresh path still serves the cache (no extra RPCs on ordinary renders).
- Full `ui/src/pages/agents` suite 172 passed | 1 skipped; `src/gateway/sessions-patch.test.ts` 85 passed; `server.sessions.agent-model-catalog` 4 passed.
- `pnpm tsgo`, `pnpm tsgo:ui`, oxlint, oxfmt clean. Autoreview (Codex, high): clean, "patch is correct (0.99)".
- Production LOC: +15 −5 across 3 files (comment-inclusive). Justified: wires an existing owner seam to an existing component hook; no new cache, no new state.
