### PR TITLE
fix(ui): use session-key equivalence for active-row lookups in model/thinking/fast-mode paths

### DIFF
--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -122,6 +122,25 @@ describe("chat-model-select-state", () => {
     });
   });
 
+  it("finds the active row across the legacy main alias window", () => {
+    // Pre-hello (or legacy-alias) states select "main" while the row list
+    // already carries the canonical agent:main:main key; a strict compare
+    // missed the row and the picker fell back to the agent default.
+    const sessionsResult = createSessionsListResult({
+      model: "gpt-5.3-codex",
+      modelProvider: "openai",
+    });
+    const session = expectDefined(sessionsResult.sessions[0], "alias fixture row");
+    sessionsResult.sessions[0] = { ...session, key: "agent:main:main" };
+    const value = resolveChatModelOverrideValue(
+      createChatModelState({
+        chatModelCatalog: DEFAULT_CHAT_MODEL_CATALOG,
+        sessionsResult,
+      }),
+    );
+    expect(value).toBe("openai/gpt-5.3-codex");
+  });
+
   it("uses the server-qualified value when the active session provider is present", () => {
     const state = createChatModelState({
       chatModelCatalog: createModelCatalog(DEEPSEEK_CHAT_MODEL),

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -6,6 +6,7 @@ import type {
   SessionsListResult,
 } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
+import { areUiSessionKeysEquivalent } from "../sessions/session-key.ts";
 import {
   buildCatalogDisplayLookup,
   buildChatModelOptionFromLookup,
@@ -72,7 +73,9 @@ type ChatFastModeSelectStateInput = {
 const FAST_MODE_PROVIDER_IDS = new Set(["anthropic", "minimax", "minimax-portal", "openai", "xai"]);
 
 function resolveActiveSessionRow(state: ChatModelSelectStateInput) {
-  return state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey);
+  return state.sessionsResult?.sessions?.find((row) =>
+    areUiSessionKeysEquivalent(row.key, state.sessionKey),
+  );
 }
 
 export function resolveChatModelOverrideValue(state: ChatModelSelectStateInput): string {
@@ -304,7 +307,9 @@ function hasCatalogProviderMetadata(value: string, catalog: ModelCatalogEntry[])
 export function resolveChatFastModeSelectState(
   input: ChatFastModeSelectStateInput,
 ): ChatFastModeSelectState {
-  const activeRow = input.sessionsResult?.sessions?.find((row) => row.key === input.sessionKey);
+  const activeRow = input.sessionsResult?.sessions?.find((row) =>
+    areUiSessionKeysEquivalent(row.key, input.sessionKey),
+  );
   const activeProvider = normalizeChatModelProviderId(activeRow?.modelProvider ?? "") || null;
   const defaultProvider =
     normalizeChatModelProviderId(input.sessionsResult?.defaults?.modelProvider ?? "") || null;

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -4,7 +4,6 @@ import {
   normalizeThinkLevel,
   resolveThinkingDefaultForModelCore,
 } from "../../../../src/auto-reply/thinking.shared.js";
-// Control UI module implements thinking behavior.
 import type {
   GatewaySessionRow,
   GatewayThinkingLevelOption,
@@ -13,6 +12,8 @@ import type {
 } from "../../api/types.ts";
 import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import { sessionModelMatchesDefaults } from "../session-model-defaults.ts";
+// Control UI module implements thinking behavior.
+import { areUiSessionKeysEquivalent } from "../sessions/session-key.ts";
 
 type ThinkingSessionDefaults = SessionsListResult["defaults"] | undefined;
 
@@ -216,7 +217,10 @@ export function resolveChatThinkingSelectState(params: {
   sessionsResult: SessionsListResult | null;
 }): ChatThinkingSelectState {
   const session =
-    params.session ?? params.sessionsResult?.sessions?.find((row) => row.key === params.sessionKey);
+    params.session ??
+    params.sessionsResult?.sessions?.find((row) =>
+      areUiSessionKeysEquivalent(row.key, params.sessionKey),
+    );
   const persisted = session?.thinkingLevel;
   const currentOverride =
     typeof persisted === "string" && persisted.trim()

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -332,7 +332,7 @@ function patchSessionRow(
   host.sessionsResult = {
     ...current,
     sessions: current.sessions.map((row) =>
-      row.key === sessionKey ? Object.assign({}, row, patch) : row,
+      areUiSessionKeysEquivalent(row.key, sessionKey) ? Object.assign({}, row, patch) : row,
     ),
   };
 }
@@ -345,7 +345,9 @@ export function switchChatFastMode(
   if (!host.client || !host.connected) {
     return Promise.resolve(false);
   }
-  const activeRow = host.sessionsResult?.sessions?.find((row) => row.key === targetSessionKey);
+  const activeRow = host.sessionsResult?.sessions?.find((row) =>
+    areUiSessionKeysEquivalent(row.key, targetSessionKey),
+  );
   const previousFastMode = activeRow?.fastMode;
   const previousEffectiveFastMode = activeRow?.effectiveFastMode;
   const next: FastMode | undefined =
@@ -480,7 +482,9 @@ export function switchChatThinkingLevel(
   if (!host.client || !host.connected) {
     return Promise.resolve(false);
   }
-  const activeRow = host.sessionsResult?.sessions?.find((row) => row.key === targetSessionKey);
+  const activeRow = host.sessionsResult?.sessions?.find((row) =>
+    areUiSessionKeysEquivalent(row.key, targetSessionKey),
+  );
   const previousThinkingLevel = activeRow?.thinkingLevel;
   const normalizedNext =
     (normalizeThinkLevel(nextThinkingLevel) ?? nextThinkingLevel.trim()) || undefined;


### PR DESCRIPTION
## What Problem This Solves

Found by the round-4 agents-page/model-switching investigation lane. Six active-row lookups in the model/thinking/fast-mode paths strict-compared `row.key === sessionKey`, while the sibling locked-session check in the same flow already used `areUiSessionKeysEquivalent` — drift introduced when #104045 upgraded only the model-switch path. In alias/transition windows (pre-hello state where the selection is legacy `"main"` while rows carry canonical `agent:main:main`), the strict compare misses the row: the optimistic thinking/fast-mode row patch finds nothing (the click produces no immediate visible change until the next list refresh), and `resolveChatModelOverrideValue`/`resolveChatFastModeSelectState`/thinking display resolvers fall back to agent defaults instead of the active row. This is exactly the multi-signal-rot pattern the doctrine flags: one comparison policy, six divergent copies.

## Why This Change Was Made

All six sites (`model-select-state.ts` ×2, `thinking.ts` ×1, `chat-session.ts` ×3 — the local row patch plus the fast-mode and thinking previous-value reads) now route through the equivalence helper the rest of the flow uses. One spelling per concept; the steady-state behavior is identical because `resolveSessionKey` normalization already makes strict equality correct outside the alias windows.

## User Impact

Clicking a thinking level or fast-mode toggle during the brief pre-hello/legacy-alias window now updates the visible row immediately instead of appearing to do nothing until a refresh; the model picker shows the active session's model rather than the agent default in the same window.

## Evidence

- New regression test "finds the active row across the legacy main alias window" fails pre-fix (falls back to the default `openai/gpt-5` instead of the row's `openai/gpt-5.3-codex`) and passes post-fix.
- Suites green: `ui/src/lib/chat` + `chat-view.test.ts` (8927 passed | 50 skipped), `pnpm check:import-cycles` clean (new cross-module import), `pnpm tsgo:ui`, oxlint, oxfmt clean.
- Autoreview (Codex, high): clean, "patch is correct (0.99)".
- Production LOC: +20 −7 (formatting expansion of the three multi-line finds; semantic change is one helper call per site). Mechanical unification, no new state.
