### PR TITLE
fix(ios): keep tool details visible in dark mode

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -224,7 +224,7 @@ struct ChatToolActivityRow: View {
             if let detailLine = self.detailLine {
                 Text(detailLine)
                     .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(OpenClawChatTheme.assistantText.opacity(0.62))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }


### PR DESCRIPTION
## What Problem This Solves

In the native iOS chat, collapsed tool rows rendered their detail text with SwiftUI's hierarchical `.secondary` style. In dark appearance inside the plain button row, that style resolved nearly black against the dark chat canvas, leaving only the tool title (for example, `Bash`) visibly readable.

## Why This Change Was Made

The bug was reproduced on an iPhone 16 / iOS 26.5 simulator while testing the source-built app against a real Gateway. Light appearance showed the command detail; switching the same running app to dark appearance made it effectively disappear.

The row now derives its muted detail from the app's explicit adaptive assistant label color, preserving the existing visual hierarchy with `0.62` opacity while keeping the text legible in both appearances.

## User Impact

Tool activity in dark-mode iOS chat keeps the command/path summary visible instead of reducing every collapsed row to only its tool name.

## Evidence

Exact reviewed head: `19b858caeb427f4d12b699d07f9220ffa3d9cd6f`.

### Before: source-built iOS dark appearance

The source-built iPhone 16 / iOS 26.5 simulator was connected to a real Gateway. Collapsed tool rows showed the `Bash` titles while their command details were effectively invisible. The screenshot is cropped and sanitized.

![Before: iOS dark-mode tool rows with invisible details](https://github.com/user-attachments/assets/dfb7cc71-45e4-499f-9d1b-56896dc7f3ad)

### After: exact-head shared native row

The exact production `ChatToolActivityRow` was rendered in native macOS dark appearance with sanitized `Bash` (`echo visual-proof`) and `Read` (`docs/verification.md`) details. Both details remain legible and visually subordinate at the production `0.62` opacity. The harness imports `OpenClawChatUI` and does not duplicate the row's color logic.

![After: exact-head shared native tool rows with legible details](https://github.com/user-attachments/assets/a8675584-519a-4976-84fe-87f3cd7dc01c)

```text
$ PR124021_PROOF_OUTPUT=proof/after-macos-dark.png \
    swift test --filter ChatToolActivityVisualProofTests
Test Suite 'ChatToolActivityVisualProofTests' passed
Executed 1 test, with 0 failures
```

Additional focused validation:

- `swift test --filter ChatThemeTests` (1 passed)
- `swift test --filter ChatToolActivityTests` (6 passed)
- `git diff --check`
- Production delta: `+1/-1` (net zero)
- Hosted `ios-build`: passed
- Hosted `macos-swift`: passed

The repository's generated Xcode project still has an unrelated simulator test-host/dyld launch defect, so the repeatable after-fix artifact is produced through the shared Swift package's real macOS rendering path. This directly validates the cross-platform component while the original real-Gateway iOS reproduction establishes the reported platform behavior.

AI-assisted: yes. I reproduced the issue, reviewed the owning shared chat row/theme code, and validated the final diff locally.
