### PR TITLE
fix(memory): retain transcript updates during active sync

### DIFF
--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -230,7 +230,13 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     }
     if (pending.length > 0) {
       this.sessionsDirty = true;
-      void this.sync({ reason: "session-delta" }).catch((err: unknown) => {
+      // Keep both identity and file keys so every transcript backend enters the
+      // targeted queue instead of letting an active sync clear this newer event.
+      void this.sync({
+        reason: "session-delta",
+        sessions: pendingTargets,
+        archiveFiles: pending,
+      }).catch((err: unknown) => {
         log.warn(`memory sync failed (session update): ${String(err)}`);
       });
     }

--- a/extensions/memory-core/src/memory/manager-session-update-race.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-update-race.test.ts
@@ -1,0 +1,99 @@
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { MemorySessionSyncTarget } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+
+describe("memory session update sync", () => {
+  const fixture = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+  const { createConfig, getFreshManager, seedSessionTranscript } = fixture;
+
+  it("indexes an update that arrives before an active sync clears dirty state", async () => {
+    fixture.setStateDir(path.join(fixture.paths.workspace, ".state-session-update-during-sync"));
+    const sessionId = "session-update-during-sync";
+    const sessionKey = `agent:main:proof:${sessionId}`;
+    const updatedMarker = "UPDATE DURING ACTIVE SYNC 811";
+    const manager = await getFreshManager(
+      createConfig({ provider: "none", sources: ["sessions"], sessionMemory: true }),
+      "cli",
+    );
+    const owner = manager as unknown as {
+      queuedSessionSync: Promise<void> | null;
+      sessionPendingTargets: Map<string, MemorySessionSyncTarget>;
+      sessionsDirty: boolean;
+      sessionsReconcileDirty: boolean;
+      syncArchiveFiles: (params: unknown) => Promise<void>;
+      processSessionUpdateBatch: () => Promise<void>;
+    };
+    let releaseActiveSync = () => {};
+    const activeSyncGate = new Promise<void>((resolve) => {
+      releaseActiveSync = resolve;
+    });
+    let markActiveSyncIndexed = () => {};
+    const activeSyncIndexed = new Promise<void>((resolve) => {
+      markActiveSyncIndexed = resolve;
+    });
+    let syncArchiveFilesSpy: { mockRestore: () => void } | undefined;
+    try {
+      await seedSessionTranscript({
+        sessionId,
+        sessionKey,
+        messages: [{ role: "user", timestamp: Date.now(), content: "initial transcript" }],
+      });
+      await manager.sync({ reason: "test-baseline", force: true });
+
+      owner.sessionsDirty = true;
+      owner.sessionsReconcileDirty = true;
+      const syncArchiveFiles = owner.syncArchiveFiles.bind(manager);
+      syncArchiveFilesSpy = vi
+        .spyOn(owner, "syncArchiveFiles")
+        .mockImplementationOnce(async (params) => {
+          await syncArchiveFiles(params);
+          markActiveSyncIndexed();
+          await activeSyncGate;
+        });
+      const activeSync = manager.sync({ reason: "test-active" });
+      await activeSyncIndexed;
+
+      await seedSessionTranscript({
+        sessionId,
+        sessionKey,
+        messages: [{ role: "assistant", timestamp: Date.now(), content: updatedMarker }],
+      });
+      owner.sessionPendingTargets.set(sessionKey, { agentId: "main", sessionId, sessionKey });
+      await owner.processSessionUpdateBatch();
+      const queuedSessionSync = owner.queuedSessionSync;
+      expect(queuedSessionSync).not.toBeNull();
+
+      releaseActiveSync();
+      await activeSync;
+      await queuedSessionSync;
+
+      const observer = new DatabaseSync(resolveOpenClawAgentSqlitePath({ agentId: "main" }), {
+        readOnly: true,
+      });
+      try {
+        const row = observer
+          .prepare(
+            "SELECT COUNT(*) AS count FROM memory_index_chunks WHERE source = 'sessions' AND text LIKE ?",
+          )
+          .get(`%${updatedMarker}%`) as { count: number };
+        expect(row.count).toBeGreaterThan(0);
+      } finally {
+        observer.close();
+      }
+      expect(manager.status().dirty).toBe(false);
+    } finally {
+      syncArchiveFilesSpy?.mockRestore();
+      releaseActiveSync();
+      await manager.close?.();
+      fixture.restoreStateDir();
+    }
+  });
+});

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -880,7 +880,8 @@ describe("session startup catch-up", () => {
     await Promise.resolve();
 
     expect(harness.getDirtyArchiveFiles()).toEqual([session.sessionKey]);
-    expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+    expect(harness.syncCalls[0]?.archiveFiles).toEqual([session.sessionKey]);
+    expect(harness.syncCalls[0]?.sessions).toHaveLength(1);
   });
 
   it("keeps targeted indexing on the SQLite store resolved by its corpus snapshot", async () => {
@@ -1063,7 +1064,7 @@ describe("session startup catch-up", () => {
         await harness.waitForSessionSync();
 
         expect(harness.getDirtyArchiveFiles()).toEqual([session.filePath]);
-        expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+        expect(harness.syncCalls[0]?.archiveFiles).toEqual([session.filePath]);
         expect(harness.indexedPaths).toEqual([
           `sessions/main/thread.jsonl.${reason}.2026-06-23T10-00-00.000Z`,
         ]);


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Closes #124023

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a transcript update arriving during an active memory sync could remain absent from memory search while status falsely reported the index as clean. The debounced update joined the already-running unscoped promise, then that stale sync cleared the newer dirty state without scheduling a follow-up.

## Why This Change Was Made

The transcript listener now hands the session identity and archive path to the existing manager-owned targeted-sync queue. That queue already owns ordering, deduplication, and failure retention, so the newer update runs after the stale active sync instead of joining it.

Both target keys are intentional: session identities resolve SQLite-backed transcripts, while archive paths resolve file-backed and reset/deleted transcript archives. File, SQLite, restart, FTS, provider, and retention behavior otherwise remain on their existing canonical paths.

The regression came through the manager split in c077e801ddd4ce30903087fd7caca4d3e411431a. Earlier targeted-session work established the intended ownership boundary; no equivalent fix is present on current main.

## User Impact

Memory search now indexes the newest transcript content after an overlapping sync, and status no longer becomes falsely clean for that ordering window. There are no config, environment, protocol, SQLite schema/version, persistent-data-shape, migration, SDK, provider auth/routing, or retention changes.

No changelog entry: this is a focused internal lifecycle correctness repair with no public surface change.

## Evidence

- Pre-fix deterministic race: targeted queue remained null, updated index rows were 0, and manager dirty state was false.
- Regression/focused owner tests: 29/29 passed.
- Hosted owner/sibling tests: 90/90 passed across session race, sync control, startup catch-up, and memory index suites.
- Exact-path changed gate passed, including formatting, lint, extension production/test typechecks, dead-code, database-first, and import-cycle guards.
- Normal production build and private-QA build both passed.
- Source-blind built CLI/Gateway proof on a randomized free port and task-owned state: FTS recalled a randomized marker before restart, unrelated query returned 0 rows, empty input was rejected, and recall persisted after Gateway restart.
- Credential-free QA scenario `memory-tools-channel-context`: 1 passed, 0 failed, 0 skipped; the `memory_search` to memory-read channel flow returned the seeded fact.
- Hosted proof: https://github.com/openclaw/openclaw/actions/runs/31864633128
- Fresh Codex autoreview: clean, no accepted/actionable findings; patch-correct confidence 0.96.
- Diff: production +7/-1 (net +6); tests +102/-2 (net +100); three files total.
