### PR TITLE
fix(diagnostics): recover stale overlapping tool calls

### DIFF
--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -115,6 +115,7 @@ export function applyCodexTurnNotificationState(params: {
     updateActiveCompletionBlockerItemIds(notification, params.activeCompletionBlockerItemIds);
     turnWatches.touchActivity(`notification:${notification.method}`, {
       details: describeNotificationActivity(notification),
+      toolCallId: readNotificationItemId(notification),
       attemptProgress: true,
     });
     params.onReportExecutionNotification(notification);

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -56,7 +56,7 @@ export function createCodexAttemptTurnWatchController(params: {
   onCompleted: () => void;
   onRecordEvent: (name: string, fields: Record<string, unknown>) => void;
   onAttemptProgress: (reason: string, details?: Record<string, unknown>) => void;
-  onProgressDiagnostic: (reason: string) => void;
+  onProgressDiagnostic: (reason: string, toolCallId?: string) => void;
 }) {
   const timers: Partial<Record<WatchTimerKind, Timer>> = {};
   let completionIdleWatchArmed = false;
@@ -412,6 +412,7 @@ export function createCodexAttemptTurnWatchController(params: {
       options?: {
         arm?: boolean;
         details?: Record<string, unknown>;
+        toolCallId?: string;
         attemptProgress?: boolean;
         attemptTimeoutMs?: number;
       },
@@ -423,7 +424,7 @@ export function createCodexAttemptTurnWatchController(params: {
       if (options?.attemptProgress) {
         recordAttemptProgress(reason, options);
       }
-      params.onProgressDiagnostic(reason);
+      params.onProgressDiagnostic(reason, options?.toolCallId);
       if (options?.arm) {
         completionIdleWatchArmed = true;
         completionIdleWatchPinnedByTerminalError = false;

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -204,12 +204,13 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
         backend: "codex-app-server",
       });
     },
-    onProgressDiagnostic: (reason) => {
+    onProgressDiagnostic: (reason, toolCallId) => {
       emitTrustedDiagnosticEvent({
         type: "run.progress",
         runId: params.runId,
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
+        ...(toolCallId ? { toolCallId } : {}),
         reason: `codex_app_server:${reason}`,
       });
     },

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3311,7 +3311,11 @@ describe("runCodexAppServerAttempt", () => {
     } finally {
       stopDiagnostics();
     }
-    expect(diagnosticEvents.map((event) => event.type)).toEqual([
+    expect(
+      diagnosticEvents
+        .filter((event) => event.type.startsWith("tool.execution."))
+        .map((event) => event.type),
+    ).toEqual([
       "tool.execution.started",
       "tool.execution.error",
     ]);
@@ -3367,7 +3371,11 @@ describe("runCodexAppServerAttempt", () => {
     } finally {
       stopDiagnostics();
     }
-    expect(diagnosticEvents.map((event) => event.type)).toEqual([
+    expect(
+      diagnosticEvents
+        .filter((event) => event.type.startsWith("tool.execution."))
+        .map((event) => event.type),
+    ).toEqual([
       "tool.execution.started",
       "tool.execution.completed",
     ]);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3315,10 +3315,7 @@ describe("runCodexAppServerAttempt", () => {
       diagnosticEvents
         .filter((event) => event.type.startsWith("tool.execution."))
         .map((event) => event.type),
-    ).toEqual([
-      "tool.execution.started",
-      "tool.execution.error",
-    ]);
+    ).toEqual(["tool.execution.started", "tool.execution.error"]);
     expect(diagnosticEvents.at(-1)).toMatchObject({
       terminalReason: "failed",
       errorCode: "tool_outcome_unknown",
@@ -3375,10 +3372,7 @@ describe("runCodexAppServerAttempt", () => {
       diagnosticEvents
         .filter((event) => event.type.startsWith("tool.execution."))
         .map((event) => event.type),
-    ).toEqual([
-      "tool.execution.started",
-      "tool.execution.completed",
-    ]);
+    ).toEqual(["tool.execution.started", "tool.execution.completed"]);
     expect(JSON.stringify(diagnosticEvents)).not.toContain("sensitive warm-resume query");
   });
 

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -2482,21 +2482,28 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
-  it("correlates native tool progress diagnostics with the app-server item", async () => {
+  it("joins native tool start and output progress on the app-server item ID", async () => {
     const harness = createStartedThreadHarness();
     const params = makeTestParams({ timeoutMs: 1_000 });
-    const progressEvents: DiagnosticEventPayload[] = [];
+    const boundaryEvents: Array<{
+      type: "start" | "progress";
+      toolCallId: string | undefined;
+    }> = [];
     const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      if (event.type === "tool.execution.started" && event.toolCallId === "command-1") {
+        boundaryEvents.push({ type: "start", toolCallId: event.toolCallId });
+      }
       if (
         event.type === "run.progress" &&
         event.reason === "codex_app_server:notification:item/commandExecution/outputDelta"
       ) {
-        progressEvents.push(event);
+        boundaryEvents.push({ type: "progress", toolCallId: event.toolCallId });
       }
     });
     try {
       const run = runCodexAppServerAttempt(params);
       await harness.waitForMethod("turn/start");
+      await harness.notify(startedCommand("command-1", "sleep 30"));
       await harness.notify({
         method: "item/commandExecution/outputDelta",
         params: {
@@ -2506,14 +2513,17 @@ describe("runCodexAppServerAttempt turn watches", () => {
           delta: "still running",
         },
       });
-      await vi.waitFor(() => expect(progressEvents).toHaveLength(1), { interval: 1 });
+      await vi.waitFor(() => expect(boundaryEvents).toHaveLength(2), { interval: 1 });
       await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       await run;
     } finally {
       stopDiagnostics();
     }
 
-    expect(progressEvents[0]).toMatchObject({ toolCallId: "command-1" });
+    expect(boundaryEvents).toEqual([
+      { type: "start", toolCallId: "command-1" },
+      { type: "progress", toolCallId: "command-1" },
+    ]);
   });
 
   it("does not idle-timeout when terminal completion queues behind projection", async () => {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -2482,6 +2482,40 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
+  it("correlates native tool progress diagnostics with the app-server item", async () => {
+    const harness = createStartedThreadHarness();
+    const params = makeTestParams({ timeoutMs: 1_000 });
+    const progressEvents: DiagnosticEventPayload[] = [];
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      if (
+        event.type === "run.progress" &&
+        event.reason === "codex_app_server:notification:item/commandExecution/outputDelta"
+      ) {
+        progressEvents.push(event);
+      }
+    });
+    try {
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      await harness.notify({
+        method: "item/commandExecution/outputDelta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "command-1",
+          delta: "still running",
+        },
+      });
+      await vi.waitFor(() => expect(progressEvents).toHaveLength(1), { interval: 1 });
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+    } finally {
+      stopDiagnostics();
+    }
+
+    expect(progressEvents[0]).toMatchObject({ toolCallId: "command-1" });
+  });
+
   it("does not idle-timeout when terminal completion queues behind projection", async () => {
     const harness = createStartedThreadHarness();
     const params = makeTestParams({ timeoutMs: 120 });

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -384,6 +384,7 @@ export type DiagnosticRunProgressEvent = DiagnosticBaseEvent & {
   sessionKey?: string;
   sessionId?: string;
   runId?: string;
+  toolCallId?: string;
   reason: string;
 };
 

--- a/src/logging/diagnostic-run-activity-recovery.ts
+++ b/src/logging/diagnostic-run-activity-recovery.ts
@@ -28,6 +28,16 @@ export type DiagnosticRecoveryModelCall = DiagnosticRecoveryMarker & {
   requestTimeoutMs?: number;
 };
 
+export function diagnosticToolKey(event: {
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  toolCallId?: string;
+  toolName?: string;
+}): string {
+  return `${event.runId ?? event.sessionId ?? event.sessionKey ?? "unknown"}:${event.toolCallId ?? event.toolName ?? "unknown"}`;
+}
+
 export function recordDiagnosticToolProgress(
   tools: Map<string, DiagnosticRecoveryTool>,
   key: string | undefined,

--- a/src/logging/diagnostic-run-activity-recovery.ts
+++ b/src/logging/diagnostic-run-activity-recovery.ts
@@ -19,12 +19,34 @@ export type DiagnosticRecoveryTool = DiagnosticRecoveryMarker & {
   toolCallId?: string;
   startedAt: number;
   lastProgressAt: number;
+  lastProgressReason: string;
+  tracksCorrelatedProgress?: true;
 };
 
 export type DiagnosticRecoveryModelCall = DiagnosticRecoveryMarker & {
   sessionKey?: string;
   requestTimeoutMs?: number;
 };
+
+export function recordDiagnosticToolProgress(
+  tools: Map<string, DiagnosticRecoveryTool>,
+  key: string | undefined,
+  reason: string,
+  now: number,
+): void {
+  const tool = key ? tools.get(key) : tools.size === 1 ? tools.values().next().value : undefined;
+  if (tool) {
+    if (key) {
+      for (const activeTool of tools.values()) {
+        if (activeTool.runId === tool.runId) {
+          activeTool.tracksCorrelatedProgress = true;
+        }
+      }
+    }
+    tool.lastProgressAt = now;
+    tool.lastProgressReason = reason;
+  }
+}
 
 type DiagnosticRecoveryActivity = {
   activeEmbeddedRuns: Map<string, DiagnosticRecoveryEmbeddedRun>;

--- a/src/logging/diagnostic-run-activity-snapshot.ts
+++ b/src/logging/diagnostic-run-activity-snapshot.ts
@@ -7,6 +7,7 @@ import {
   type DiagnosticRepeatedRequestActivity,
   resolveRepeatedRequestNoProgressAgeMs,
 } from "./diagnostic-repeated-request-activity.js";
+import type { DiagnosticRecoveryTool } from "./diagnostic-run-activity-recovery.js";
 
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
@@ -20,13 +21,12 @@ export type DiagnosticSessionActivitySnapshot = {
   activeModelCallRequestTimeoutMs?: number;
 };
 
-type SnapshotTool = { toolName: string; toolCallId?: string; startedAt: number };
 type SnapshotActivity = DiagnosticArgumentChurnActivity &
   DiagnosticRepeatedRequestActivity & {
     activeEmbeddedRuns: ReadonlyMap<string, { runId: string; sequence: number }>;
     activeModelCalls: ReadonlyMap<string, unknown>;
     activeCoreModelCalls: ReadonlyMap<object, ReadonlyMap<string, { requestTimeoutMs?: number }>>;
-    activeTools: ReadonlyMap<string, SnapshotTool>;
+    activeTools: ReadonlyMap<string, DiagnosticRecoveryTool>;
     lastProgressAt: number;
     lastProgressReason?: string;
   };
@@ -57,25 +57,33 @@ export function buildDiagnosticSessionActivitySnapshot(
         : activity.activeEmbeddedRuns.size > 0
           ? "embedded_run"
           : undefined;
-  let activeTool: SnapshotTool | undefined;
-  for (const tool of activity.activeTools.values()) {
-    if (!activeTool || tool.startedAt < activeTool.startedAt) {
-      activeTool = tool;
-    }
-  }
   const churnProgress = resolveArgumentChurnProgress(
     activity,
     activity.activeEmbeddedRuns.values(),
     now,
   );
+  let activeTool: DiagnosticRecoveryTool | undefined;
+  let activeToolProgress = churnProgress;
+  for (const tool of activity.activeTools.values()) {
+    const toolProgress = tool.tracksCorrelatedProgress ? tool : churnProgress;
+    if (
+      !activeTool ||
+      toolProgress.lastProgressAt < activeToolProgress.lastProgressAt ||
+      (toolProgress.lastProgressAt === activeToolProgress.lastProgressAt &&
+        tool.startedAt < activeTool.startedAt)
+    ) {
+      activeTool = tool;
+      activeToolProgress = toolProgress;
+    }
+  }
   return {
     activeWorkKind,
     ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
     activeToolName: activeTool?.toolName,
     activeToolCallId: activeTool?.toolCallId,
     activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,
-    lastProgressAgeMs: Math.max(0, now - churnProgress.lastProgressAt),
-    lastProgressReason: churnProgress.lastProgressReason,
+    lastProgressAgeMs: Math.max(0, now - activeToolProgress.lastProgressAt),
+    lastProgressReason: activeToolProgress.lastProgressReason,
     repeatedRequestNoProgressAgeMs: resolveRepeatedRequestNoProgressAgeMs(
       activity,
       activity.activeEmbeddedRuns.values(),

--- a/src/logging/diagnostic-run-activity.test-support.ts
+++ b/src/logging/diagnostic-run-activity.test-support.ts
@@ -8,7 +8,7 @@ type DiagnosticModelStartedActivityEvent = Pick<
 
 type DiagnosticRunProgressActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "run.progress" }>,
-  "runId" | "sessionId" | "sessionKey" | "reason"
+  "runId" | "sessionId" | "sessionKey" | "toolCallId" | "reason"
 > & { progressKind?: "semantic" | "liveness" };
 
 type DiagnosticRunActivityTestApi = {

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -40,6 +40,7 @@ import {
   ownerRefsForRecovery,
   ownerRefsForStartedEvent,
   pruneActivityStartedBeforeRecoveryCutoff,
+  recordDiagnosticToolProgress,
   rememberRecoveredOwnerStartEventCutoffs,
   shouldIgnoreRecoveredOwnerStartEvent,
 } from "./diagnostic-run-activity-recovery.js";
@@ -47,7 +48,6 @@ import {
   buildDiagnosticSessionActivitySnapshot,
   type DiagnosticSessionActivitySnapshot,
 } from "./diagnostic-run-activity-snapshot.js";
-
 export type { DiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity-snapshot.js";
 export type { DiagnosticEmbeddedRunOwner } from "../infra/diagnostic-model-request-provenance.js";
 
@@ -79,7 +79,7 @@ type ModelStartedActivityEvent = Pick<
 
 type RunProgressEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "run.progress" }>,
-  "runId" | "sessionId" | "sessionKey" | "reason"
+  "runId" | "sessionId" | "sessionKey" | "toolCallId" | "reason"
 > & { progressKind?: "semantic" | "liveness" };
 
 // Quiet-but-alive tools are normal agent behavior; the CLI byte watchdog kills
@@ -265,10 +265,10 @@ function toolKey(event: {
   sessionId?: string;
   sessionKey?: string;
   toolCallId?: string;
-  toolName: string;
+  toolName?: string;
 }): string {
   return `${event.runId ?? event.sessionId ?? event.sessionKey ?? "unknown"}:${
-    event.toolCallId ?? event.toolName
+    event.toolCallId ?? event.toolName ?? "unknown"
   }`;
 }
 
@@ -291,6 +291,7 @@ function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
     toolCallId: event.toolCallId,
     startedAt: now,
     lastProgressAt: now,
+    lastProgressReason: `tool:${event.toolName}:started`,
   });
   touchSessionActivity(activity, `tool:${event.toolName}:started`, now);
 }
@@ -419,12 +420,15 @@ function applyRunProgress(params: RunProgressEvent, semantic = false): void {
   if (!activity) {
     return;
   }
+  const now = Date.now();
+  const toolProgressKey = params.toolCallId ? toolKey({ ...params, runId }) : undefined;
+  recordDiagnosticToolProgress(activity.activeTools, toolProgressKey, params.reason, now);
   // Only an explicit fact from the current owner may clear its recovery evidence.
   if (!semantic || !runId) {
-    touchSessionActivity(activity, params.reason);
+    touchSessionActivity(activity, params.reason, now);
     return;
   }
-  touchSemanticSessionActivity(activity, params.reason, { runId });
+  touchSemanticSessionActivity(activity, params.reason, { runId, now });
 }
 
 function recordRunCompleted(

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -32,6 +32,7 @@ import {
   clearRecoveredOwnerEmbeddedRuns,
   clearRecoveredOwnerMarkers,
   countActiveCoreModelCalls,
+  diagnosticToolKey,
   type DiagnosticRecoveryEmbeddedRun,
   type DiagnosticRecoveryModelCall,
   type DiagnosticRecoveryTool,
@@ -260,18 +261,6 @@ function touchSemanticSessionActivity(
   touchSessionActivity(activity, reason, params.now);
 }
 
-function toolKey(event: {
-  runId?: string;
-  sessionId?: string;
-  sessionKey?: string;
-  toolCallId?: string;
-  toolName?: string;
-}): string {
-  return `${event.runId ?? event.sessionId ?? event.sessionKey ?? "unknown"}:${
-    event.toolCallId ?? event.toolName ?? "unknown"
-  }`;
-}
-
 function modelCallKey(event: { runId?: string; provider?: string; model?: string }): string {
   return `${event.runId ?? "unknown"}:${event.provider ?? "provider"}:${event.model ?? "model"}`;
 }
@@ -282,7 +271,7 @@ function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
     return;
   }
   const now = Date.now();
-  activity.activeTools.set(toolKey(event), {
+  activity.activeTools.set(diagnosticToolKey(event), {
     runId: event.runId,
     sessionId: event.sessionId,
     sessionKey: event.sessionKey,
@@ -306,7 +295,7 @@ function recordToolEnded(
   if (!activity) {
     return;
   }
-  activity.activeTools.delete(toolKey(event));
+  activity.activeTools.delete(diagnosticToolKey(event));
   touchSessionActivity(activity, `tool:${event.toolName}:ended`);
 }
 
@@ -421,7 +410,7 @@ function applyRunProgress(params: RunProgressEvent, semantic = false): void {
     return;
   }
   const now = Date.now();
-  const toolProgressKey = params.toolCallId ? toolKey({ ...params, runId }) : undefined;
+  const toolProgressKey = params.toolCallId ? diagnosticToolKey({ ...params, runId }) : undefined;
   recordDiagnosticToolProgress(activity.activeTools, toolProgressKey, params.reason, now);
   // Only an explicit fact from the current owner may clear its recovery evidence.
   if (!semantic || !runId) {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1000,6 +1000,113 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "the older call stalls while the newer call progresses",
+      gapMs: 14 * 60_000,
+      progressCallId: "call-2",
+      progressTicks: 4,
+    },
+    {
+      name: "the newer call stalls while the older call progresses",
+      gapMs: 60_000,
+      progressCallId: "call-1",
+      progressTicks: 30,
+    },
+  ])(
+    "recovers an overlapping stale tool when $name",
+    ({ gapMs, progressCallId, progressTicks }) => {
+      const recoverStuckSession = vi.fn();
+
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "call-1",
+      });
+
+      vi.advanceTimersByTime(gapMs);
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "collab.wait",
+        toolCallId: "call-2",
+      });
+      for (let i = 0; i < progressTicks; i += 1) {
+        vi.advanceTimersByTime(29_000);
+        markDiagnosticRunProgressForTest({
+          sessionId: "s1",
+          sessionKey: "main",
+          runId: "run-1",
+          toolCallId: progressCallId,
+          reason: "codex_app_server:notification:item/updated",
+        });
+        vi.advanceTimersByTime(1_000);
+      }
+
+      expectRecoveryCall(
+        recoverStuckSession,
+        { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+        ["ageMs", "stateGeneration"],
+      );
+    },
+  );
+
+  it("keeps parallel tools alive when their progress is not tool-correlated", () => {
+    const recoverStuckSession = vi.fn();
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticToolStartedForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      runId: "run-1",
+      toolName: "bash",
+      toolCallId: "call-1",
+    });
+    vi.advanceTimersByTime(60_000);
+    markDiagnosticToolStartedForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      runId: "run-1",
+      toolName: "collab.wait",
+      toolCallId: "call-2",
+    });
+
+    for (let i = 0; i < 30; i += 1) {
+      vi.advanceTimersByTime(29_000);
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        reason: "cli_live:stream_progress",
+      });
+      vi.advanceTimersByTime(1_000);
+    }
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
   it("recovers stale model calls through the active embedded-run abort path", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();


### PR DESCRIPTION
## New behavior

Stuck-session recovery now evaluates each overlapping tool call against its own progress clock. If one Codex tool keeps producing output while a sibling tool is silent, the progressing call no longer hides the stalled call from recovery.

- Codex command-output notifications carry their app-server item ID into diagnostics.
- Progress refreshes only the matching active tool; an uncorrelated update is used only when exactly one tool is active.
- Recovery selects the least-recently progressing tool, with start time as the deterministic tie-breaker.

## Visual proof

<img width="1385" height="1083" alt="Overlapping tool recovery selects the stalled call while preserving uncorrelated sibling liveness" src="https://github.com/user-attachments/assets/eef976a4-72e0-4268-a0be-2489d77634ed" />

**What this shows:** When an older Codex tool keeps producing output while a newer overlapping tool is silent, the direct base follows the progressing call and leaves recovery ineligible. This PR selects the newer stalled call and makes it eligible after 15 minutes. The sibling check also shows that parallel tools with healthy uncorrelated Claude-live progress remain ineligible for recovery.

**State:** The same production diagnostic-event script runs on direct base `fa9ab1d40cd` and PR head `226d5379e5a`. `older-progressing-call` emits a correlated output delta every 30 seconds while `newer-stalled-call` is silent. A second PR-head scenario emits uncorrelated `cli_live:stream_progress` every 30 seconds across two active tools. Browser capture from a sanitized loopback proof page. The head-only follow-up commit adds the joined start/output-delta regression test without changing production behavior.

## How to verify

Run the focused production-event scenario from either checkout:

```sh
node --import tsx /tmp/openclaw-recovery-overlap-proof.mjs
```

On the direct base, it selects `older-progressing-call`, reports zero minutes since progress, and leaves blocked-tool recovery ineligible. On this branch, it selects `newer-stalled-call`, reports 15 minutes since progress, and makes recovery eligible.

Verify the uncorrelated sibling path on the PR branch:

```sh
node --import tsx /tmp/openclaw-recovery-uncorrelated-proof.mjs
```

It reports zero minutes since progress and leaves blocked-tool recovery ineligible after 15 minutes of parallel activity.

Focused exact-head validation:

```text
src/logging/diagnostic.test.ts: 86 passed
src/logging/diagnostic-run-activity.test.ts: 26 passed
extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
  -t "joins native tool start and output progress on the app-server item ID": 1 passed, 96 skipped
oxlint on the touched core and Codex files: passed
git diff --check: passed
```

The joined regression failed on the direct base because the start diagnostic carried `command-1` while the output-progress diagnostic had no tool-call ID. It passes on the exact PR head with both diagnostics carrying `command-1`.

## Implementation notes

Codex app-server notifications expose the same `itemId` for command start and output deltas. OpenClaw carries that existing identity through `run.progress`; it does not invent a second correlation scheme. This was checked directly against the exact OpenClaw dependency tag, OpenAI Codex `rust-v0.147.0` at `be6e8eac029b183056b7e4402879f15d2c85f61b`:

- [`CommandExecutionOutputDeltaNotification` requires `item_id`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1406-L1415).
- [Command start builds its item from `ExecCommandBeginEvent`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L428-L445), whose [thread item ID is the event `call_id`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server-protocol/src/protocol/item_builders.rs#L96-L112).
- The same output-delta mapping [sets `item_id` from the delta event's `call_id`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L436-L445).

The production delta is +58/-24 (net +34). That state belongs at the recovery owner: one optional tool-call identity crosses the Codex diagnostic boundary, and each active tool records whether correlated progress is authoritative plus its latest timestamp. Removing that state recreates the session-wide clock that caused the bug; keeping it in the diagnostic owner also avoids provider-specific policy in core recovery callers.
