### PR TITLE
fix(discord): stop voice playback after leaving session

### DIFF
--- a/extensions/discord/src/voice/segment.ts
+++ b/extensions/discord/src/voice/segment.ts
@@ -1,7 +1,7 @@
 // Discord plugin module implements segment behavior.
-import path from "node:path";
 import { Readable } from "node:stream";
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -171,32 +171,35 @@ export async function processDiscordVoiceSegment(params: {
     `tts ok (${voiceReplyAudio.speakText.length} chars): guild ${entry.guildId} channel ${entry.channelId}`,
   );
 
+  const releaseAudio =
+    voiceReplyAudio.mode === "stream"
+      ? voiceReplyAudio.release
+      : () => unlinkIfExists(voiceReplyAudio.audioPath);
+  // Synthesis can settle after leave; release before the playback queue gets ownership.
+  if (entry.sessionLifecycle.status === "stopped") {
+    await releaseAudio?.();
+    return;
+  }
   params.enqueuePlayback(entry, async () => {
     const voiceSdk = loadDiscordVoiceSdk();
-    const releaseAudioStream =
-      voiceReplyAudio.mode === "stream" ? voiceReplyAudio.release : undefined;
     try {
-      if (voiceReplyAudio.mode === "stream") {
-        logVoiceVerbose(`playback start: guild ${entry.guildId} channel ${entry.channelId} stream`);
-        const nodeStream = Readable.fromWeb(
-          voiceReplyAudio.audioStream as import("node:stream/web").ReadableStream<Uint8Array>,
-        );
-        const resource = voiceSdk.createAudioResource(createDiscordOpusPlaybackStream(nodeStream), {
-          inputType: voiceSdk.StreamType.Opus,
-        });
-        entry.player.play(resource);
-      } else {
-        logVoiceVerbose(
-          `playback start: guild ${entry.guildId} channel ${entry.channelId} file ${path.basename(voiceReplyAudio.audioPath)}`,
-        );
-        const resource = voiceSdk.createAudioResource(
-          createDiscordOpusPlaybackStream(voiceReplyAudio.audioPath),
-          {
-            inputType: voiceSdk.StreamType.Opus,
-          },
-        );
-        entry.player.play(resource);
+      // Queued playback can outlive its session; a stopped player is reusable by the SDK.
+      if (entry.sessionLifecycle.status === "stopped") {
+        return;
       }
+      const input =
+        voiceReplyAudio.mode === "stream"
+          ? Readable.fromWeb(
+              voiceReplyAudio.audioStream as import("node:stream/web").ReadableStream<Uint8Array>,
+            )
+          : voiceReplyAudio.audioPath;
+      logVoiceVerbose(
+        `playback start: guild ${entry.guildId} channel ${entry.channelId} ${voiceReplyAudio.mode}`,
+      );
+      const resource = voiceSdk.createAudioResource(createDiscordOpusPlaybackStream(input), {
+        inputType: voiceSdk.StreamType.Opus,
+      });
+      entry.player.play(resource);
       await voiceSdk
         .entersState(entry.player, voiceSdk.AudioPlayerStatus.Playing, PLAYBACK_READY_TIMEOUT_MS)
         .catch(() => undefined);
@@ -205,7 +208,7 @@ export async function processDiscordVoiceSegment(params: {
         .catch(() => undefined);
       logVoiceVerbose(`playback done: guild ${entry.guildId} channel ${entry.channelId}`);
     } finally {
-      await releaseAudioStream?.();
+      await releaseAudio?.();
     }
   });
 }

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { MockCallSource } from "./manager.e2e.test-support.js";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
@@ -220,6 +223,7 @@ defineDiscordVoiceTests(
           route: { sessionKey: "discord:g1:1001", agentId: "agent-1" },
           connection: createConnectionMock(),
           player: createAudioPlayerMock(),
+          sessionLifecycle: { status: "active" },
           playbackQueue: Promise.resolve(),
           processingQueue: Promise.resolve(),
           capture: createVoiceCaptureState(),
@@ -282,6 +286,10 @@ defineDiscordVoiceTests(
     });
 
     it("runs voice replies under Discord voice output policy", async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-voice-"));
+      const audioPath = path.join(tempDir, "reply.mp3");
+      await fs.writeFile(audioPath, "voice");
+      textToSpeechMock.mockResolvedValueOnce({ success: true, audioPath });
       agentCommandMock.mockResolvedValueOnce({
         payloads: [{ text: "hello back" }],
       } as never);
@@ -292,7 +300,18 @@ defineDiscordVoiceTests(
         client,
         {},
       );
-      await processVoiceSegment(manager, "u-guest");
+      try {
+        await processVoiceSegment(manager, "u-guest");
+        await vi.waitFor(async () => {
+          const exists = await fs.access(audioPath).then(
+            () => true,
+            () => false,
+          );
+          expect(exists).toBe(false);
+        });
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
 
       const commandArgs = lastAgentCommandArgs() as
         | { message?: string; messageChannel?: string; messageProvider?: string }
@@ -366,6 +385,51 @@ defineDiscordVoiceTests(
         throw new Error("expected Discord audio resource input");
       }
       await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+    });
+
+    it("releases late TTS without playback after the voice session leaves", async () => {
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      decodeOpusStreamMock.mockResolvedValueOnce(Buffer.alloc(96_000));
+      agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "late voice reply" }] });
+      const release = vi.fn(async () => undefined);
+      let resolveStream!: (value: unknown) => void;
+      textToSpeechStreamMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStream = resolve;
+        }),
+      );
+      connection.receiver.subscribe.mockReturnValueOnce({
+        on: vi.fn(),
+        off: vi.fn(),
+        destroy: vi.fn(),
+        destroyed: false,
+        async *[Symbol.asyncIterator]() {},
+      });
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+
+      const speaking = handleSpeakingStart(manager, entry, "u-speaker");
+      await vi.waitFor(() => expect(textToSpeechStreamMock).toHaveBeenCalledOnce());
+      await manager.leave({ guildId: "g1" });
+      resolveStream({
+        success: true,
+        audioStream: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        release,
+      });
+      await speaking;
+      await entry.processingQueue;
+      await entry.playbackQueue;
+
+      expect(entry.player.play).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledOnce();
     });
 
     it("passes per-channel system prompt context to voice agent runs", async () => {

--- a/extensions/discord/src/voice/voice-test-harness.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-harness.test-support.ts
@@ -550,6 +550,7 @@ function buildVoiceTestHarness() {
         route: { sessionKey: "discord:g1:1001", agentId: "agent-1" },
         connection: createConnectionMock(),
         player: createAudioPlayerMock(),
+        sessionLifecycle: { status: "active" },
         playbackQueue: Promise.resolve(),
         processingQueue: Promise.resolve(),
         capture: createVoiceCaptureState(),


### PR DESCRIPTION
Closes #124026

## What Problem This Solves

Fixes an issue where users leaving a Discord voice session could still hear a TTS reply when synthesis or queued playback finished after the session stopped. The same path retained file-backed speech artifacts after ephemeral voice playback.

## Why This Change Was Made

The Discord voice segment now treats the exact session lifecycle as authoritative both after synthesis and when queued playback begins. Streaming and file-backed audio share one playback/cleanup branch, so late work is discarded and resources are released after success, discard, or playback error.

`@discordjs/voice` 0.19.2 explicitly documents that an `AudioPlayer` is reusable and unaffected by a voice connection becoming unavailable, so `player.stop()` alone cannot fence later `play()` calls:

- Reusable player contract: https://github.com/discordjs/discord.js/blob/2a067216c410e402f3ada7cd9eb29f566636b0ad/packages/voice/src/audio/AudioPlayer.ts#L204-L213
- New-resource playback: https://github.com/discordjs/discord.js/blob/2a067216c410e402f3ada7cd9eb29f566636b0ad/packages/voice/src/audio/AudioPlayer.ts#L365-L452
- Current-resource stop: https://github.com/discordjs/discord.js/blob/2a067216c410e402f3ada7cd9eb29f566636b0ad/packages/voice/src/audio/AudioPlayer.ts#L485-L500

No channel configuration, authentication, protocol, Plugin SDK, delivery/replay, or provider contract changes are included.

Production LOC: +27/-24 (net +3) | Tests/support: +66/-1 (net +65). The production growth records the two lifecycle ownership checks and file cleanup; duplicate stream/file playback branches were consolidated to keep the change bounded.

## User Impact

Leaving or stopping a Discord `stt-tts` voice session is terminal for that session's pending speech. Late synthesis no longer restarts playback, provider streams are released promptly, and file-backed playback artifacts are removed after use.

AI-assisted: yes. The implementation and proof were reviewed directly and with the repository Codex autoreview workflow. Agent transcript intentionally omitted per repository policy.

## Evidence

- Baseline: `6e5bf3ec55cb2c24ad74442d08ca68f51485ad23`; exact PR head: `88ed109f5e5498311e82cc633af8e6e7788b77c6`.
- Pre-fix boundary regression: 1 failed / 28 passed; `player.play()` was called once after `leave`. No intervening current-main commit touched the three-file surface.
- Owner and sibling proof: focused Discord voice runtime 29/29 and lifecycle/receive/audio suites 108/108 total on Blacksmith Testbox `tbx_01m01wwdna8j2af3xj1gndpce2`. Actions hydration: https://github.com/openclaw/openclaw/actions/runs/31866018837
- Final source-blind proof matched all three local/remote file hashes at exact head on Testbox `tbx_01m01xfzwhrxzdx3ppj0kajzrs`: controlled runtime 29/29; two distinct valid 6,444-byte RIFF/WAVE outputs; 1.5-second timeout child terminated with no scratch/final output; all task state cleaned. Actions hydration: https://github.com/openclaw/openclaw/actions/runs/31866468423
- The actual `@discordjs/voice` 0.19.2 player accepted a new resource after idle/stop and moved to `buffering`, then returned to `idle` on forced stop. This directly confirms why session lifecycle—not player state—must fence late work.
- Exact-head hosted CI passed, including `openclaw/ci-gate`, selected tests, production/test types, lint, package boundaries, architecture, media guards, cycles, CodeQL channel-runtime, dependency guard, and security guard: https://github.com/openclaw/openclaw/actions/runs/31866432890
- Fresh final autoreview: clean; no accepted/actionable findings, correctness confidence 0.98.
- Native review artifacts validated with `READY FOR /prepare-pr`, zero findings, behavioral sweep pass, and issue validation valid.
- No external Discord message or authenticated provider call was made. The real-channel leg is intentionally absent because no external target was approved; controlled runtime plus the real player contract covers the changed lifecycle boundary.

```json
{
  "surface": "discord voice stt-tts",
  "proofMode": "controlled channel runtime, real discord.js player, local speech engine",
  "focusedTests": { "passed": 29, "failed": 0 },
  "ownerSiblingTests": { "passed": 108, "failed": 0 },
  "latePlaybackAfterLeave": false,
  "streamReleased": true,
  "fileArtifactRemoved": true,
  "realPlayerReusableAfterStop": true,
  "externalDiscordSend": false,
  "externalProvider": false
}
```
