### PR TITLE
fix(gateway): report plugin HTTP dispatch failures as 500

### DIFF
--- a/src/gateway/server-http.request-trace.test.ts
+++ b/src/gateway/server-http.request-trace.test.ts
@@ -238,4 +238,35 @@ describe("gateway HTTP request error cleanup", () => {
       errorLog.mockRestore();
     }
   });
+
+  it("preserves plugin route ownership when plugin dispatch fails", async () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handlePluginRequest = vi.fn(async () => {
+      throw new Error("plugin route dispatch failed");
+    });
+    const server = createGatewayHttpServer({
+      clients: new Set(),
+      controlUiEnabled: false,
+      controlUiBasePath: "",
+      openAiChatCompletionsEnabled: false,
+      openResponsesEnabled: false,
+      handleHooksRequest: async () => false,
+      handlePluginRequest,
+      resolvedAuth,
+      getRuntimeConfig: () => ({}),
+    });
+    const port = await listen(server);
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/plugin-failure`);
+
+      expect(response.status).toBe(500);
+      expect(await response.text()).toBe("Internal Server Error");
+      expect(handlePluginRequest).toHaveBeenCalledOnce();
+    } finally {
+      server.closeAllConnections();
+      await closeServer(server);
+      errorLog.mockRestore();
+    }
+  });
 });

--- a/src/gateway/server-http.request-trace.test.ts
+++ b/src/gateway/server-http.request-trace.test.ts
@@ -263,6 +263,10 @@ describe("gateway HTTP request error cleanup", () => {
       expect(response.status).toBe(500);
       expect(await response.text()).toBe("Internal Server Error");
       expect(handlePluginRequest).toHaveBeenCalledOnce();
+      expect(errorLog).toHaveBeenCalledWith(
+        "[gateway-http] unhandled error in request handler:",
+        expect.objectContaining({ message: "plugin route dispatch failed" }),
+      );
     } finally {
       server.closeAllConnections();
       await closeServer(server);

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -130,7 +130,6 @@ function isWebSocketUpgradeRequest(req: IncomingMessage): boolean {
 }
 
 type GatewayHttpRequestStage = {
-  name: string;
   run: () => Promise<boolean> | boolean;
 };
 
@@ -292,7 +291,6 @@ export function createGatewayHttpServer(opts: {
         });
       const requestStages: GatewayHttpRequestStage[] = [
         {
-          name: "gateway-probes",
           run: () =>
             handleGatewayProbeRequest(
               req,
@@ -307,59 +305,48 @@ export function createGatewayHttpServer(opts: {
         },
       ];
       const addRequestStage = (
-        name: string,
         enabled: boolean,
         run: GatewayHttpRequestStage["run"],
         admitted = false,
       ) => {
         if (enabled) {
           requestStages.push({
-            name,
             run: admitted ? () => runWithGatewayHttpWorkAdmission(res, run) : run,
           });
         }
       };
-      const addAdmittedStage = (
-        name: string,
-        enabled: boolean,
-        run: GatewayHttpRequestStage["run"],
-      ) => addRequestStage(name, enabled, run, true);
+      const addAdmittedStage = (enabled: boolean, run: GatewayHttpRequestStage["run"]) =>
+        addRequestStage(enabled, run, true);
 
       const workerGatewayRoute = classifyWorkerGatewayPath(scopedRequestPath);
-      addRequestStage("worker-gateway", workerGatewayRoute !== "outside", () => {
+      addRequestStage(workerGatewayRoute !== "outside", () => {
         respondNotFound(res);
         return true;
       });
 
-      addAdmittedStage(
-        "worker-bundle-transfer",
-        classifyNodeWorkerBundleTransferPath(scopedRequestPath) !== "outside",
-        () =>
-          handleNodeWorkerBundleTransferHttpRequest({
-            req,
-            res,
-            clientIp: resolveRequestClientIp(req, trustedProxies, allowRealIpFallback),
-            rateLimiter: joinRateLimiter,
-            callback: opts.handleNodeWorkerBundleTransferRequest,
-          }),
+      addAdmittedStage(classifyNodeWorkerBundleTransferPath(scopedRequestPath) !== "outside", () =>
+        handleNodeWorkerBundleTransferHttpRequest({
+          req,
+          res,
+          clientIp: resolveRequestClientIp(req, trustedProxies, allowRealIpFallback),
+          rateLimiter: joinRateLimiter,
+          callback: opts.handleNodeWorkerBundleTransferRequest,
+        }),
       );
 
-      addAdmittedStage(
-        "worker-transfer",
-        classifyNodeWorkspaceTransferPath(scopedRequestPath) !== "outside",
-        () =>
-          handleNodeWorkspaceTransferHttpRequest({
-            req,
-            res,
-            clientIp: resolveRequestClientIp(req, trustedProxies, allowRealIpFallback),
-            rateLimiter: joinRateLimiter,
-            callback: opts.handleNodeWorkspaceTransferRequest,
-          }),
+      addAdmittedStage(classifyNodeWorkspaceTransferPath(scopedRequestPath) !== "outside", () =>
+        handleNodeWorkspaceTransferHttpRequest({
+          req,
+          res,
+          clientIp: resolveRequestClientIp(req, trustedProxies, allowRealIpFallback),
+          rateLimiter: joinRateLimiter,
+          callback: opts.handleNodeWorkspaceTransferRequest,
+        }),
       );
 
       const devicePairingJoinShortcode = parseDevicePairingJoinRequestPath(scopedRequestPath);
       if (devicePairingJoinShortcode !== null) {
-        addAdmittedStage("device-pairing-join", true, async () =>
+        addAdmittedStage(true, async () =>
           (await getDevicePairingJoinHttpModule()).handleDevicePairingJoinHttpRequest({
             req,
             res,
@@ -374,59 +361,45 @@ export function createGatewayHttpServer(opts: {
       // this exact GET and 405 every provider redirect. The claim is exact-path
       // and config-gated, so preceding hooks cannot shadow any hook route.
       addAdmittedStage(
-        "mcp-oauth-callback",
         req.method === "GET" &&
           scopedRequestPath === "/oauth/mcp/callback" &&
           Boolean(opts.handleMcpOAuthCallbackRequest),
         () => opts.handleMcpOAuthCallbackRequest?.(req, res) ?? false,
       );
-      addRequestStage("hooks", true, () => handleHooksRequest(req, res));
+      addRequestStage(true, () => handleHooksRequest(req, res));
       addAdmittedStage(
-        "watch-node",
         Boolean(opts.handleWatchNodeRequest) && scopedRequestPath.startsWith("/api/nodes/watch/"),
         () => opts.handleWatchNodeRequest?.(req, res) ?? false,
       );
       addAdmittedStage(
-        "models",
         openAiCompatEnabled &&
           (scopedRequestPath === "/v1/models" || scopedRequestPath.startsWith("/v1/models/")),
         async () =>
           (await getModelsHttpModule()).handleOpenAiModelsHttpRequest(req, res, routeAuth),
       );
-      addAdmittedStage(
-        "embeddings",
-        openAiCompatEnabled && scopedRequestPath === "/v1/embeddings",
-        async () =>
-          (await getEmbeddingsHttpModule()).handleOpenAiEmbeddingsHttpRequest(req, res, routeAuth),
+      addAdmittedStage(openAiCompatEnabled && scopedRequestPath === "/v1/embeddings", async () =>
+        (await getEmbeddingsHttpModule()).handleOpenAiEmbeddingsHttpRequest(req, res, routeAuth),
       );
-      addAdmittedStage("tools-invoke", scopedRequestPath === "/tools/invoke", async () =>
+      addAdmittedStage(scopedRequestPath === "/tools/invoke", async () =>
         (await getToolsInvokeHttpModule()).handleToolsInvokeHttpRequest(req, res, routeAuth),
       );
-      addAdmittedStage(
-        "sessions-kill",
-        /^\/sessions\/[^/]+\/kill$/.test(scopedRequestPath),
-        async () =>
-          (await getSessionKillHttpModule()).handleSessionKillHttpRequest(req, res, routeAuth),
+      addAdmittedStage(/^\/sessions\/[^/]+\/kill$/.test(scopedRequestPath), async () =>
+        (await getSessionKillHttpModule()).handleSessionKillHttpRequest(req, res, routeAuth),
       );
-      addAdmittedStage(
-        "sessions-history",
-        /^\/sessions\/[^/]+\/history$/.test(scopedRequestPath),
-        async () =>
-          (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
-            ...routeAuth,
-            getResolvedAuth,
-          }),
+      addAdmittedStage(/^\/sessions\/[^/]+\/history$/.test(scopedRequestPath), async () =>
+        (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
+          ...routeAuth,
+          getResolvedAuth,
+        }),
       );
-      addAdmittedStage(
-        "board-widget",
-        scopedRequestPath.startsWith("/__openclaw__/board/"),
-        async () => (await getBoardHttpModule()).handleBoardHttpRequest(req, res),
+      addAdmittedStage(scopedRequestPath.startsWith("/__openclaw__/board/"), async () =>
+        (await getBoardHttpModule()).handleBoardHttpRequest(req, res),
       );
       const userProfileAvatarPath = canonicalizeUserProfileAvatarPath(
         scopedRequestPath,
         controlUiRouteBasePath,
       );
-      addAdmittedStage("user-profile-avatar", userProfileAvatarPath !== undefined, async () =>
+      addAdmittedStage(userProfileAvatarPath !== undefined, async () =>
         (await getUserProfilesHttpModule()).handleUserProfileAvatarHttpRequest(
           req,
           res,
@@ -434,17 +407,13 @@ export function createGatewayHttpServer(opts: {
           routeAuth,
         ),
       );
-      addAdmittedStage(
-        "openresponses",
-        openResponsesEnabled && scopedRequestPath === "/v1/responses",
-        async () =>
-          (await getOpenResponsesHttpModule()).handleOpenResponsesHttpRequest(req, res, {
-            ...routeAuth,
-            config: openResponsesConfig,
-          }),
+      addAdmittedStage(openResponsesEnabled && scopedRequestPath === "/v1/responses", async () =>
+        (await getOpenResponsesHttpModule()).handleOpenResponsesHttpRequest(req, res, {
+          ...routeAuth,
+          config: openResponsesConfig,
+        }),
       );
       addAdmittedStage(
-        "openai",
         openAiChatCompletionsEnabled && scopedRequestPath === "/v1/chat/completions",
         async () =>
           (await getOpenAiHttpModule()).handleOpenAiHttpRequest(req, res, {
@@ -453,7 +422,6 @@ export function createGatewayHttpServer(opts: {
           }),
       );
       addRequestStage(
-        "control-ui-approval-document",
         isControlUiApprovalDocumentPath({
           basePath: controlUiBasePath,
           pathname: scopedRequestPath,
@@ -471,7 +439,7 @@ export function createGatewayHttpServer(opts: {
           return true;
         },
       );
-      addRequestStage("node-capability-auth", Boolean(nodeCapability), async () => {
+      addRequestStage(Boolean(nodeCapability), async () => {
         const { authorizePluginNodeCapabilityRequest } = await getPluginNodeCapabilityAuthModule();
         const ok = await authorizePluginNodeCapabilityRequest({
           req,
@@ -491,7 +459,6 @@ export function createGatewayHttpServer(opts: {
         return false;
       });
       addRequestStage(
-        "canvas-documents",
         Boolean(nodeCapability) &&
           isCoreCanvasHostEnabled(configSnapshot) &&
           isCanvasDocumentHttpPath(scopedRequestPath),
@@ -500,7 +467,6 @@ export function createGatewayHttpServer(opts: {
       // This page must remain reachable when a plugin route is broken so the
       // operator can disable it. Other explicit plugin routes retain precedence.
       addRequestStage(
-        "control-ui-plugin-manager",
         controlUiEnabled &&
           isControlUiPluginManagerRequest({
             basePath: controlUiBasePath,
@@ -515,7 +481,6 @@ export function createGatewayHttpServer(opts: {
         (mcpAppRoute === "shell" || mcpAppRoute === "view")
       ) {
         requestStages.push({
-          name: "mcp-app-standalone",
           run: async () =>
             await runWithGatewayHttpWorkAdmission(res, async () => {
               const standalone = await getMcpAppStandaloneModule();
@@ -536,7 +501,6 @@ export function createGatewayHttpServer(opts: {
         // Auth and dispatch stay separate so authorized context reaches the handler.
         requestStages.push(
           {
-            name: "plugin-auth",
             run: async () => {
               if (
                 !(shouldEnforcePluginGatewayAuth ?? shouldEnforceDefaultPluginGatewayAuth)(
@@ -568,7 +532,6 @@ export function createGatewayHttpServer(opts: {
             },
           },
           {
-            name: "plugin-http",
             run: () =>
               handlePluginRequest(req, res, pluginPathContext, {
                 gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
@@ -581,7 +544,6 @@ export function createGatewayHttpServer(opts: {
       }
 
       addRequestStage(
-        "chat-managed-media",
         scopedRequestPath.startsWith("/api/chat/media/outgoing/") ||
           (controlUiRouteBasePath.length > 0 &&
             scopedRequestPath.startsWith(`${controlUiRouteBasePath}/api/chat/media/outgoing/`)),
@@ -593,7 +555,6 @@ export function createGatewayHttpServer(opts: {
           ),
       );
       addRequestStage(
-        "control-ui-catalog-icon",
         controlUiEnabled &&
           [CONTROL_UI_PLUGIN_ICON_PATH_PREFIX, CONTROL_UI_CATALOG_ICON_PATH_PREFIX].some((prefix) =>
             scopedRequestPath.startsWith(`${controlUiRouteBasePath}${prefix}/`),
@@ -606,7 +567,6 @@ export function createGatewayHttpServer(opts: {
           ),
       );
       addRequestStage(
-        "control-ui-workspace-icon",
         controlUiEnabled &&
           scopedRequestPath.startsWith(
             `${controlUiRouteBasePath}${CONTROL_UI_WORKSPACE_ICON_PATH_PREFIX}/`,
@@ -618,16 +578,16 @@ export function createGatewayHttpServer(opts: {
             controlUiRouteOptions,
           ),
       );
-      addRequestStage("control-ui-assistant-media", controlUiEnabled, async () =>
+      addRequestStage(controlUiEnabled, async () =>
         (await getControlUiModule()).handleControlUiAssistantMediaRequest(req, res, {
           ...controlUiRouteOptions,
           agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
         }),
       );
-      addRequestStage("control-ui-avatar", controlUiEnabled, async () =>
+      addRequestStage(controlUiEnabled, async () =>
         (await getControlUiModule()).handleControlUiAvatarRequest(req, res, controlUiRouteOptions),
       );
-      addRequestStage("control-ui-http", controlUiEnabled, handleControlUiRequest);
+      addRequestStage(controlUiEnabled, handleControlUiRequest);
 
       if (await runGatewayHttpRequestStages(requestStages)) {
         return;

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -132,25 +132,14 @@ function isWebSocketUpgradeRequest(req: IncomingMessage): boolean {
 type GatewayHttpRequestStage = {
   name: string;
   run: () => Promise<boolean> | boolean;
-  continueOnError?: boolean;
 };
 
 async function runGatewayHttpRequestStages(
   stages: readonly GatewayHttpRequestStage[],
 ): Promise<boolean> {
   for (const stage of stages) {
-    try {
-      if (await stage.run()) {
-        return true;
-      }
-    } catch (err) {
-      if (!stage.continueOnError) {
-        throw err;
-      }
-      // Log and skip the failing stage so subsequent stages (control-ui,
-      // gateway-probes, etc.) remain reachable. A common trigger is a
-      // plugin-owned route/runtime code still failing to load an optional dependency.
-      console.error(`[gateway-http] stage "${stage.name}" threw — skipping:`, err);
+    if (await stage.run()) {
+      return true;
     }
   }
   return false;
@@ -544,8 +533,7 @@ export function createGatewayHttpServer(opts: {
         let pluginGatewayAuthSatisfied = false;
         let pluginGatewayRequestAuth: AuthorizedGatewayHttpRequest | undefined;
         let pluginRequestOperatorScopes: string[] | undefined;
-        // Auth and dispatch stay separate so authorized context reaches the handler while
-        // plugin failures can still fall through to core and Control UI routes.
+        // Auth and dispatch stay separate so authorized context reaches the handler.
         requestStages.push(
           {
             name: "plugin-auth",
@@ -581,7 +569,6 @@ export function createGatewayHttpServer(opts: {
           },
           {
             name: "plugin-http",
-            continueOnError: true,
             run: () =>
               handlePluginRequest(req, res, pluginPathContext, {
                 gatewayAuthSatisfied: pluginGatewayAuthSatisfied,


### PR DESCRIPTION
Closes #124032

AI-assisted maintainer repair.

## What Problem This Solves

Fixes an issue where callers of plugin-owned Gateway HTTP routes received `404 Not Found` when plugin dispatch threw before writing a response. The route had been found, but the router swallowed its owned failure and continued as if no route had claimed the request.

## Why This Change Was Made

The Gateway HTTP stage runner now has one failure policy: thrown stage failures propagate to the existing outer bounded 500/log/response-cleanup owner, while explicit `false` results continue normal ordered fallthrough. Removing the plugin-only exception path also removes the now-unused stage-name metadata and helper parameters.

The repair preserves route order, work admission, plugin authentication, ordinary false-return fallthrough, worker bundle/workspace transfer stages, and the existing 500 responder. It does not change auth/security policy, protocol, configuration, Plugin SDK, persistence, replay semantics, or fallback behavior.

Production LOC: +46/-99 (net -53) | Tests: +35/-0

## User Impact

Plugin HTTP callers now receive a bounded `500 Internal Server Error` for pre-response dispatch failures instead of a misleading 404. Operators retain the canonical Gateway error log and can distinguish a broken handler from an absent route.

## Evidence

Current-main base: `6e5bf3ec55cb2c24ad74442d08ca68f51485ad23`  
Exact head: `e1ea7b2f35bd01b193555c6605704a53240a04fc`

Negative control before the repair:

- controlled loopback listener expected status 500 but received 404 after plugin dispatch threw before response headers.

Focused owner/auth/sibling proof:

```text
node scripts/run-vitest.mjs run src/gateway/server-http.request-trace.test.ts src/gateway/server.plugin-http-auth.test.ts src/gateway/server/plugins-http.test.ts
```

Result: 58/58 passed.

Focused listener proof:

```text
node scripts/run-vitest.mjs run src/gateway/server-http.request-trace.test.ts
```

Result: 9/9 passed. The regression starts a task-owned server on a free loopback port and proves exact status `500`, body `Internal Server Error`, one plugin dispatch, the canonical bounded error log, and listener cleanup. Existing sibling tests preserve plugin-auth and ordinary `false` fallthrough.

Exact-head Testbox changed gate:

- Blacksmith Testbox `tbx_01m01x2jntsvt96612f2y8jmb4`
- Run: https://github.com/openclaw/openclaw/actions/runs/31866156970
- Passed: conflict markers, env/max-lines/changelog/doctor guards, dependency pins, oxfmt, deprecated API and plugin-boundary guards, wrapper/patch guards, Knip production/full/script scans, core and core-test tsgo, targeted type-aware Oxlint, native-schema/database-first/media/runtime-sidecar/import-cycle checks, webhook body-order guard, and pairing guards.

Additional checks:

- targeted oxfmt: clean
- `git diff --check origin/main...HEAD`: clean
- fresh Codex autoreview on the rebased complete branch: clean, no accepted/actionable findings
