### PR TITLE
improve(test): reduce Tlon monitor test runtime

### DIFF
--- a/extensions/tlon/src/monitor/index.test.ts
+++ b/extensions/tlon/src/monitor/index.test.ts
@@ -1,14 +1,17 @@
 // Tlon monitor tests cover authentication, inbound context, and shutdown lifecycle.
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
-import { saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   authenticateMock,
+  buildChannelInboundEnvelopeMock,
+  builtInboundContextPayload,
+  createChannelInboundEnvelopeBuilderMock,
+  formatInboundMediaUnavailableTextMock,
   sleepWithAbortMock,
+  saveRemoteMediaMock,
   sseClientMock,
   ingressMock,
   inboundRuntimeMock,
@@ -16,7 +19,12 @@ const {
   realUrbitFixture,
 } = vi.hoisted(() => ({
   authenticateMock: vi.fn(),
+  buildChannelInboundEnvelopeMock: vi.fn(),
+  builtInboundContextPayload: { kind: "tlon-inbound-context" },
+  createChannelInboundEnvelopeBuilderMock: vi.fn(),
+  formatInboundMediaUnavailableTextMock: vi.fn(),
   sleepWithAbortMock: vi.fn(),
+  saveRemoteMediaMock: vi.fn(),
   sseClientMock: {
     scry: vi.fn().mockResolvedValue({}),
     subscribe: vi.fn().mockResolvedValue(undefined),
@@ -59,18 +67,24 @@ const {
 
 const runningServers: Server[] = [];
 
-vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
-  return {
-    ...actual,
-    sleepWithAbort: sleepWithAbortMock,
-  };
-});
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
+  resolveHumanDelayConfig: vi.fn(() => undefined),
+}));
 
-vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>();
-  return { ...actual, saveRemoteMedia: vi.fn() };
-});
+vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
+  createChannelInboundEnvelopeBuilder: createChannelInboundEnvelopeBuilderMock,
+  formatInboundMediaUnavailableText: formatInboundMediaUnavailableTextMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  sleepWithAbort: sleepWithAbortMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  MAX_IMAGE_BYTES: 6 * 1024 * 1024,
+  readRemoteMediaBuffer: vi.fn(),
+  saveRemoteMedia: saveRemoteMediaMock,
+}));
 
 vi.mock("../runtime.js", () => ({
   getTlonRuntime: () => ({
@@ -138,10 +152,11 @@ vi.mock("./ingress.js", () => ({
 import { monitorTlonProvider } from "./index.js";
 import { extractMessageText } from "./utils.js";
 
-const saveRemoteMediaMock = vi.mocked(saveRemoteMedia);
-
 beforeEach(() => {
-  inboundRuntimeMock.buildContext.mockImplementation(buildChannelInboundEventContext);
+  createChannelInboundEnvelopeBuilderMock.mockReturnValue(buildChannelInboundEnvelopeMock);
+  buildChannelInboundEnvelopeMock.mockReturnValue("tlon-envelope");
+  formatInboundMediaUnavailableTextMock.mockReturnValue("formatted-inbound-body");
+  inboundRuntimeMock.buildContext.mockReturnValue(builtInboundContextPayload);
 });
 
 afterEach(async () => {
@@ -228,6 +243,18 @@ describe("monitorTlonProvider inbound media truth", () => {
         })),
       ];
       const originalText = extractMessageText(content);
+      const expectedMedia = Array.from({ length: Math.min(imageCount, 8) }, (_, index) => index)
+        .filter((index) => !failedIndexes.includes(index))
+        .map((index) => ({
+          path: `/tmp/openclaw/media/inbound/photo-${index}.png`,
+          contentType: "image/png",
+        }));
+      const expectedMediaPrompt = [
+        ...expectedMedia.map(
+          ({ path, contentType }) => `[media attached: ${path} (${contentType}) | ${path}]`,
+        ),
+        originalText,
+      ].join("\n");
 
       const monitor = monitorTlonProvider({ abortSignal: controller.signal, runtime });
       try {
@@ -252,26 +279,62 @@ describe("monitorTlonProvider inbound media truth", () => {
           },
         });
 
+        expect(createChannelInboundEnvelopeBuilderMock).toHaveBeenCalledOnce();
+        expect(createChannelInboundEnvelopeBuilderMock).toHaveBeenCalledWith({
+          cfg: {
+            channels: {
+              tlon: {
+                code: "code",
+                network: { dangerouslyAllowPrivateNetwork: true },
+                ownerShip: "~nec",
+                ship: "~zod",
+                url: "https://urbit.example.com",
+              },
+            },
+          },
+          route: {
+            accountId: "default",
+            agentId: "main",
+            dmScope: "main",
+            sessionKey: "agent:main:main",
+          },
+        });
+        expect(buildChannelInboundEnvelopeMock).toHaveBeenCalledOnce();
+        expect(buildChannelInboundEnvelopeMock).toHaveBeenCalledWith({
+          body: expectedMediaPrompt,
+          channel: "Tlon",
+          from: "~nec [owner]",
+          timestamp: 1_700_000_000_000,
+        });
+        expect(formatInboundMediaUnavailableTextMock).toHaveBeenCalledWith({
+          body: originalText,
+          notice: expectedNotice,
+        });
+        expect(inboundRuntimeMock.buildContext).toHaveBeenCalledOnce();
+        const buildContextCall = inboundRuntimeMock.buildContext.mock.calls[0];
+        if (!buildContextCall) {
+          throw new Error("expected inbound context call");
+        }
+        const [contextInput] = buildContextCall;
+        expect(contextInput.message).toMatchObject({
+          body: "tlon-envelope",
+          bodyForAgent: "formatted-inbound-body",
+          commandBody: originalText,
+          rawBody: originalText,
+        });
+        expect(contextInput.extra.Attachments).toHaveLength(expectedAttachments);
+        expect(contextInput.extra.Attachments).toEqual(expectedMedia);
+
         expect(inboundRuntimeMock.dispatch).toHaveBeenCalledOnce();
         const dispatchCall = inboundRuntimeMock.dispatch.mock.calls[0];
         if (!dispatchCall) {
           throw new Error("expected inbound dispatch call");
         }
         const [{ ctxPayload, replyOptions }] = dispatchCall;
-        expect(ctxPayload.BodyForAgent).toBe(`${originalText}\n\n${expectedNotice}`);
-        expect(ctxPayload.RawBody).toBe(originalText);
-        expect(ctxPayload.CommandBody).toBe(originalText);
-        expect(ctxPayload.BodyForCommands).toBe(originalText);
-        expect(ctxPayload.Attachments).toHaveLength(expectedAttachments);
+        expect(contextInput).not.toBe(builtInboundContextPayload);
+        expect(ctxPayload).toBe(builtInboundContextPayload);
         expect(replyOptions.media).toHaveLength(expectedAttachments);
-        expect(replyOptions.media).toEqual(
-          Array.from({ length: Math.min(imageCount, 8) }, (_, index) => index)
-            .filter((index) => !failedIndexes.includes(index))
-            .map((index) => ({
-              path: `/tmp/openclaw/media/inbound/photo-${index}.png`,
-              contentType: "image/png",
-            })),
-        );
+        expect(replyOptions.media).toEqual(expectedMedia);
       } finally {
         controller.abort();
         await monitor;


### PR DESCRIPTION
## What Problem This Solves

The Tlon monitor tests paid to load a broad core graph even though the monitor already receives an injected Tlon runtime. Partial `importOriginal` mocks for Plugin SDK runtime/media modules and the real core channel-context helper dominated import time, CPU, and memory for nine focused tests.

## Why This Change Was Made

The test now mocks the exact Plugin SDK seams it consumes: human-delay resolution, channel-inbound envelope/formatter construction, abortable sleep, and media constants/functions. The real Tlon monitor, Urbit client and loopback SSE lifecycle, Tlon media composition, ingress, and dispatch wiring remain intact; this adds no production or test-only seam.

The first lead review found two composition gaps. The revision now tracks a distinct inner envelope builder and asserts its exact factory configuration plus the Tlon invocation (`channel`, owner sender label, timestamp, and byte-exact media prompt). It also makes `buildContext` return a distinct sentinel and requires dispatch to receive that object by identity, while separately asserting the raw context input, attachment facts, unavailable notice, and reply media.

Generic channel-envelope and media-helper semantics remain owned by the core envelope/media tests. This file continues to prove Tlon's composition of those seams.

## User Impact

There is no production behavior change. Maintainers get the same nine Tlon monitor tests with substantially lower import cost, CPU demand, and peak RSS.

## Evidence

- Controlled same-Testbox A/B on the exact candidate:
  - wall: `7.355s -> 5.130s` (`-30.3%`)
  - harness: `7.075s -> 4.855s` (`-31.4%`)
  - Vitest: `4.380s -> 2.185s` (`-50.1%`)
  - import: `3.700s -> 1.655s` (`-55.3%`)
  - test body: `0.3800s -> 0.2615s` (`-31.2%`)
  - CPU user: `7.670s -> 5.220s`
  - CPU sys: `0.880s -> 0.525s`
  - max RSS: `1,114,342 -> 757,214 KiB` (`-32.0%`)
- Mutation proof:
  - changing the unavailable notice failed both target cases;
  - changing the production envelope channel to a wrong value failed both cases at the tracked inner-envelope assertion;
  - both mutations were reverted.
- Owner/sibling proof: `node scripts/run-vitest.mjs extensions/tlon/src/monitor/index.test.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/monitor/ingress.test.ts extensions/tlon/src/monitor/tracking.test.ts --maxWorkers=1` — 4 files / 26 tests passed.
- Exact path-scoped changed gate passed on Blacksmith Testbox `tbx_01m01y1xf3244wtd0y1k0e5zgr`: https://github.com/openclaw/openclaw/actions/runs/31866871032. The one-shot lease was stopped after success.
- Revised worker proof also passed on Testbox `tbx_01m01xaatfmqg32qhyexxqw56d`: https://github.com/openclaw/openclaw/actions/runs/31866338265. That lease was stopped.
- `git diff --check origin/main...HEAD` passed.
- Targeted `oxfmt --check` passed.
- Fresh committed-branch autoreview against `origin/main` reported no accepted or actionable findings.
- LOC: tests `+92/-29` (net `+63`); production `+0/-0`; still 9 tests; no new seam.
