### PR TITLE
fix(gateway): stop reporting failed OpenAI HTTP runs as successful

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2017,6 +2017,20 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(body).not.toContain(privateDetail);
   });
 
+  it("rejects resolved error stop reasons", async () => {
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [{ text: "Command may have changed state", isError: true }],
+      meta: { stopReason: "error" },
+    } as never);
+
+    const res = await postChatCompletions(enabledPort, {
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(500);
+  });
+
   it("forwards response_format into streamParams", async () => {
     const port = enabledPort;
     const mockAgentOnce = (payloads: Array<{ text: string }>) => {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1997,6 +1997,26 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects resolved terminal agent failures without exposing provider details", async () => {
+    const privateDetail = "raw provider detail should stay private";
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [{ text: "Command may have changed state", isError: true }],
+      meta: { error: { kind: "incomplete_turn", message: privateDetail } },
+    } as never);
+
+    const res = await postChatCompletions(enabledPort, {
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const body = await res.text();
+    expect(res.status).toBe(500);
+    expect(JSON.parse(body)).toEqual({
+      error: { message: "internal error", type: "api_error" },
+    });
+    expect(body).not.toContain(privateDetail);
+  });
+
   it("forwards response_format into streamParams", async () => {
     const port = enabledPort;
     const mockAgentOnce = (payloads: Array<{ text: string }>) => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1087,8 +1087,11 @@ export async function handleOpenAiHttpRequest(
         return true;
       }
 
+      const meta = (result as { meta?: { error?: unknown } } | null)?.meta;
+      if (meta?.error) {
+        throw new Error("agent run failed");
+      }
       const usage = resolveChatCompletionUsage(result);
-      const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
       // `tool_choice` is an HTTP client-tool contract. The provider may still

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1087,8 +1087,8 @@ export async function handleOpenAiHttpRequest(
         return true;
       }
 
-      const meta = (result as { meta?: { error?: unknown } } | null)?.meta;
-      if (meta?.error) {
+      const meta = (result as { meta?: { error?: unknown; stopReason?: unknown } } | null)?.meta;
+      if (meta?.error || meta?.stopReason === "error") {
         throw new Error("agent run failed");
       }
       const usage = resolveChatCompletionUsage(result);

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1808,6 +1808,25 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects resolved terminal agent failures without exposing provider details", async () => {
+    const privateDetail = "raw provider detail should stay private";
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [{ text: "Command may have changed state", isError: true }],
+      meta: { error: { kind: "incomplete_turn", message: privateDetail } },
+    } as never);
+
+    const res = await postResponses(enabledPort, { model: "openclaw", input: "hi" });
+    const body = await res.text();
+    expect(res.status).toBe(500);
+    expect(JSON.parse(body)).toMatchObject({
+      status: "failed",
+      output: [],
+      error: { code: "api_error", message: "internal error" },
+    });
+    expect(body).not.toContain(privateDetail);
+  });
+
   it.each(
     STREAM_FAILURE_CASES.flatMap((failure) =>
       [false, true].map((emitErrorLifecycle) => ({

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1827,6 +1827,17 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(body).not.toContain(privateDetail);
   });
 
+  it("rejects resolved error stop reasons", async () => {
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [{ text: "Command may have changed state", isError: true }],
+      meta: { stopReason: "error" },
+    } as never);
+
+    const res = await postResponses(enabledPort, { model: "openclaw", input: "hi" });
+    expect(res.status).toBe(500);
+  });
+
   it.each(
     STREAM_FAILURE_CASES.flatMap((failure) =>
       [false, true].map((emitErrorLifecycle) => ({

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -709,12 +709,12 @@ export async function handleOpenResponsesHttpRequest(
         return true;
       }
 
-      if ((result as { meta?: { error?: unknown } } | null)?.meta?.error) {
+      const meta = (result as { meta?: { error?: unknown; stopReason?: unknown } } | null)?.meta;
+      if (meta?.error || meta?.stopReason === "error") {
         throw new Error("agent run failed");
       }
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
       const usage = extractUsageFromResult(result);
-      const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
       // A `required`/pinned `tool_choice` must reject a text-only turn instead

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -709,6 +709,9 @@ export async function handleOpenResponsesHttpRequest(
         return true;
       }
 
+      if ((result as { meta?: { error?: unknown } } | null)?.meta?.error) {
+        throw new Error("agent run failed");
+      }
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
       const usage = extractUsageFromResult(result);
       const meta = (result as { meta?: unknown } | null)?.meta;
@@ -1168,6 +1171,9 @@ export async function handleOpenResponsesHttpRequest(
         abortSignal: abortController.signal,
       });
 
+      if (closed) {
+        return;
+      }
       finalUsage = extractUsageFromResult(result);
 
       if (unrepresentableAssistantReplacement) {


### PR DESCRIPTION
Closes #124038

## What Problem This Solves

OpenAI-compatible non-streaming clients could receive HTTP 200 success when the underlying agent run had already resolved with authoritative terminal failure metadata. Chat Completions returned a normal `finish_reason: "stop"`; Responses returned `status: "completed"`.

## Why This Change Was Made

`agentCommandFromIngress` intentionally returns a resolved run result and records terminal failure in either `result.meta.error` or `result.meta.stopReason === "error"`. The HTTP adapters own the public projection of that result. They checked abort state and then built successful protocol responses without checking those terminal facts, even though the CLI, embedded-runner, fallback, and diagnostic projections classify them as failure.

The bounded repair checks both forms at both non-streaming HTTP projection boundaries and reuses each adapter's existing bounded, redacted HTTP 500 path. Responses streaming also stops immediately when the client has already closed, matching the existing Chat Completions guard and preventing post-disconnect fallback work from reaching the response.

Streaming JSON/SSE shapes remain unchanged. This does not change protocol, config, auth, provider routing, persistence, security, tool choice, usage, or session behavior.

## User Impact

OpenAI-compatible clients can reliably distinguish a failed agent run from a completed response. Successful requests keep their existing output and usage behavior, while internal provider details remain redacted.

## Evidence

- Frozen base: `60babddd626adcad473ae7b2b1b4417892a7828d`; expanded exact head: `065167684121365b8e5c78a3b9bb5ae2043cfd43`.
- Pre-fix provenance: all four endpoint regressions failed for the intended reason (`expected 500`, `received 200`) across the `meta.error` and error-only stop-reason forms.
- Focused exact-head tests: 117/117 passed across `src/gateway/openai-http.test.ts` and `src/gateway/openresponses-http.test.ts`.
- Source-blind isolated Gateway HTTP proof used temporary state, a free loopback port, a deterministic result producer, and a separate validator client:

```json
{"ok":true,"statuses":{"chatSuccess":200,"responsesSuccess":200,"chatMetaError":500,"responsesMetaError":500,"chatStopError":500,"responsesStopError":500,"gatewayHealthyAfter":200},"disconnects":{"clientsAborted":1,"upstreamAborts":1,"lateProviderCompletions":1,"lateBytesObserved":0},"leakedPrivateDetail":false}
```

- Exact failure bodies:
  - Chat Completions: `{"error":{"message":"internal error","type":"api_error"}}`
  - Responses: failed response resource with `error.code="api_error"` and `error.message="internal error"`
- Full build passed on Blacksmith Testbox `tbx_01m047nt06kq1sez7whyqyhnpc` in [run 31922851351](https://github.com/openclaw/openclaw/actions/runs/31922851351).
- Exact four-file frozen-base changed gate passed after backend fallback: formatting, dependency/policy guards, dead exports, production and core-test types, changed-file lint, native schema/storage guards, media/runtime sidecar guards, webhook/auth guards, and import cycles (`0 runtime value cycle(s)`).
- `git diff --check` passed.
- Fresh structured autoreview: clean, no accepted/actionable findings.
- Exact-head hosted CI [run 31924560640](https://github.com/openclaw/openclaw/actions/runs/31924560640) completed with 117 successes, 16 intentional skips, and zero failures.

Production LOC: +11/-2 (net +9) | Tests: +64/-0

The production growth is the two endpoint-local terminal checks plus the missing Responses closed-stream guard. A shared terminal projector would add policy for a two-check invariant and risk broadening streaming semantics.

## Provenance

The frozen history boundary attributes the affected lines to `eeabc2cf69a0fbe1036e37542151db8e2b82add0`, but that is a graft/boundary commit and not the introducing change. Earlier available history shows `90fdb16ee594c3aee6e220399d4edb75d1eff5a6` retained the already-existing omission. The true introduction predates the available lineage, so original author/PR attribution is unknown. The previous `9947a267...` attribution was removed because that commit is unrelated to this Gateway surface.

## Best-Fix Verdict

Best bounded fix. The adapters are the owners translating a resolved agent result into their public HTTP contracts. Changing `agentCommandFromIngress` to reject would affect every ingress caller; importing the broader projector from #123053 would mix this defect with replay-schema and continuation-policy changes that still require a separate compatibility decision. Embeddings remains an unaffected sibling.

## Current State

The defect still reproduces on the frozen base, and no equivalent repair was present there before merge. #123053 remains open and is not a superseding fix; it is the broader outcome-projection proposal.

Post-merge review disposition: the exact-head ClawSweeper refresh completed after the earlier live read still showed its active placeholder and shortly before the native merge. It proposed additionally mapping timeout, timeout-phase, and independently resolved abort metadata. Those findings and matching rank-up moves are intentionally not included here: the renewed maintainer decision explicitly bounded this four-file repair to `meta.error` and `stopReason === "error"` without agent-run semantic expansion. Timeout/abort projection also requires a distinct client-visible status/error contract rather than assuming the existing generic 500 path. That broader decision remains out of scope for this merged PR and overlaps #123053.
