### PR TITLE
fix(plugin-sdk): installed llama providers fail to load after upgrade

### DIFF
--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createLocalEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import {
   createPluginRegistryFixture,
@@ -130,6 +131,14 @@ function configuredOptions() {
 }
 
 describe("llama.cpp provider plugin", () => {
+  it("keeps pre-managed installed provider imports loadable without reviving the old runtime", async () => {
+    await expect(createLocalEmbeddingProvider({}, {})).rejects.toThrow(
+      "The legacy in-process llama.cpp embedding runtime is retired",
+    );
+    expect(mocks.ensureModel).not.toHaveBeenCalled();
+    expect(mocks.prepareServer).not.toHaveBeenCalled();
+  });
+
   it("uses the normal OpenAI-compatible text transport", () => {
     expect(registerTextProvider()).toEqual(
       expect.objectContaining({

--- a/src/plugin-sdk/memory-core-host-engine-embeddings.ts
+++ b/src/plugin-sdk/memory-core-host-engine-embeddings.ts
@@ -1,4 +1,18 @@
 // Memory core host embedding exports expose host embedding primitives to the memory plugin.
+
+/**
+ * @deprecated Load-only bridge for published llama.cpp provider releases from before the
+ * managed llama-server cutover. Remove after managed releases have replaced the old npm
+ * latest and extended-stable packages and their upgrade window has closed.
+ */
+export function createLocalEmbeddingProvider(..._args: unknown[]): Promise<never> {
+  return Promise.reject(
+    new Error(
+      "The legacy in-process llama.cpp embedding runtime is retired. Run `openclaw update repair` to install the managed llama-server provider, then restart OpenClaw.",
+    ),
+  );
+}
+
 export {
   applyEmbeddingBatchOutputLine,
   buildBatchHeaders,

--- a/src/plugins/loader.native-module-loader.test.ts
+++ b/src/plugins/loader.native-module-loader.test.ts
@@ -74,6 +74,55 @@ function writePackagedPluginFixture(id: string) {
   return pluginRoot;
 }
 
+function writePreManagedLlamaCppProviderFixture() {
+  const pluginRoot = tempDirs.make("openclaw-plugin-loader-");
+  fs.mkdirSync(path.join(pluginRoot, "dist"));
+  fs.writeFileSync(
+    path.join(pluginRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "@openclaw/llama-cpp-provider",
+        version: "2026.7.2-beta.7",
+        type: "module",
+        openclaw: {
+          extensions: ["./dist/index.js"],
+          runtimeExtensions: ["./dist/index.js"],
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: "llama-cpp",
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {},
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(pluginRoot, "dist", "index.js"),
+    [
+      'import { createLocalEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";',
+      'export default { id: "llama-cpp", register() {',
+      '  if (typeof createLocalEmbeddingProvider !== "function") throw new Error("missing bridge");',
+      "} };",
+    ].join("\n"),
+    "utf-8",
+  );
+  return pluginRoot;
+}
+
 afterEach(() => {
   vi.resetModules();
   vi.doUnmock("./plugin-module-loader-cache.js");
@@ -168,5 +217,29 @@ describe("createPluginModuleLoader", () => {
 
     expect(registry.plugins.find((plugin) => plugin.id === "npm-demo")?.status).toBe("loaded");
     expect(sourceLoaderCalls).toStrictEqual([]);
+  });
+
+  it("loads the released pre-managed llama.cpp provider import through the SDK alias", async () => {
+    const { loadOpenClawPlugins } = await importFreshModule<typeof import("./loader.js")>(
+      import.meta.url,
+      "./loader.js?scope=llama-cpp-upgrade-compat",
+    );
+    const pluginRoot = writePreManagedLlamaCppProviderFixture();
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = tempDirs.make("openclaw-plugin-loader-");
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      onlyPluginIds: ["llama-cpp"],
+      config: {
+        plugins: {
+          enabled: true,
+          load: { paths: [pluginRoot] },
+          allow: ["llama-cpp"],
+          entries: { "llama-cpp": { enabled: true } },
+        },
+      },
+    });
+
+    expect(registry.plugins.find((plugin) => plugin.id === "llama-cpp")?.status).toBe("loaded");
   });
 });

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -568,6 +568,7 @@ describe("test-projects args", () => {
           "extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts",
           "extensions/memory-core/src/memory/manager-registry.test.ts",
           "extensions/memory-core/src/memory/manager-search-orchestration.test.ts",
+          "extensions/memory-core/src/memory/manager-session-update-race.test.ts",
           "extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts",
           "extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts",
           "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",


### PR DESCRIPTION
Related: #123105

AI-assisted: Codex investigated, implemented, and validated this change under maintainer direction. No agent transcript is attached.

## What Problem This Solves

Fixes an issue where users upgrading OpenClaw across the managed llama-server cutover could have a previously installed @openclaw/llama-cpp-provider abort during ESM evaluation. The released provider imports createLocalEmbeddingProvider from the public plugin SDK, but that named export was removed before installed packages had converged, so plugin loading failed before registration or supported update repair could run.

## Why This Change Was Made

This restores only a deprecated, load-only binding at the existing public SDK subpath. It always rejects with retirement and `openclaw update repair` guidance; it does not restore DEFAULT_LOCAL_MODEL, node-llama-cpp, its worker, or any in-process native runtime. The current provider remains exclusively backed by the separately managed llama-server CLI.

The regression coverage loads the exact released named-import shape through the real plugin loader/SDK alias boundary. An adjacent provider test proves invoking the bridge fails closed without model or server activity, while the existing current-provider tests continue to cover managed llama-server behavior.

The first exact-head CI run also exposed a current-main tooling regression from #124024: its new memory race test was missing from the test-project importer expectation. This PR includes the one-line expectation repair required to restore green main CI.

## User Impact

An older installed llama.cpp provider can evaluate and register far enough for the supported update-repair flow to replace it. Until replacement, any attempt to invoke the retired in-process embedding path fails explicitly with the recovery command. After the managed provider is installed, repeated clean starts continue through llama-server without using this bridge.

## Evidence

- Red on unmodified canonical main: exact registry packages 2026.7.1 and 2026.7.2-beta.7 both failed with `SyntaxError: ... does not provide an export named 'createLocalEmbeddingProvider'`; current managed 2026.8.1-beta.2 loaded.
- Exact proposed head: `node scripts/run-vitest.mjs extensions/llama-cpp/index.test.ts src/plugins/loader.native-module-loader.test.ts` — 2 files, 9 tests passed.
- Exact proposed content on Blacksmith Testbox `tbx_01m01w78ct6kcf7z6vepa1gqsz`: `check:changed` passed SDK export/surface checks, typechecks, type-aware lint, plugin boundaries, dead-code, schema, sidecar, and import-cycle guards (exit 0, 15m41s). Local/Testbox SHA-256 values matched for all changed files and the newly changed lint-control files.
- Source-blind package upgrade contract: C1-C5 passed with exact verified registry tarballs, lifecycle scripts disabled, the legacy optional native dependency omitted and import-denied, beta.7 import green, bridge rejection green, beta.2 replacement green, and a second clean-process start green. Run: https://github.com/openclaw/openclaw/actions/runs/31865520081
- `pnpm build` passed on the retained Testbox, including all 145 public plugin SDK subpaths.
- Current-main CI repair: `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts` — 84 tests passed after adding the missing #124024 importer expectation.
- Mandatory autoreview: both the compatibility patch and the one-line CI repair were clean with no accepted/actionable findings (0.99 confidence).
