### PR TITLE
test(acp): remove cleanup-only session seam

### DIFF
--- a/packages/acp-core/src/session.test.ts
+++ b/packages/acp-core/src/session.test.ts
@@ -1,5 +1,5 @@
 // ACP Core tests cover session behavior.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createInMemorySessionStore } from "./session.js";
 
 describe("acp session manager", () => {
@@ -13,10 +13,6 @@ describe("acp session manager", () => {
   beforeEach(() => {
     nowMs = 1_000;
     store = createInMemorySessionStore({ now });
-  });
-
-  afterEach(() => {
-    store.clearAllSessionsForTest();
   });
 
   it("tracks active runs and clears on cancel", () => {
@@ -95,24 +91,20 @@ describe("acp session manager", () => {
       idleTtlMs: Number.NaN,
       now,
     });
-    try {
-      boundedStore.createSession({
-        sessionId: "first",
-        sessionKey: "acp:first",
-        cwd: "/tmp",
-      });
-      advance(1);
-      boundedStore.createSession({
-        sessionId: "second",
-        sessionKey: "acp:second",
-        cwd: "/tmp",
-      });
+    boundedStore.createSession({
+      sessionId: "first",
+      sessionKey: "acp:first",
+      cwd: "/tmp",
+    });
+    advance(1);
+    boundedStore.createSession({
+      sessionId: "second",
+      sessionKey: "acp:second",
+      cwd: "/tmp",
+    });
 
-      expect(boundedStore.hasSession("first")).toBe(true);
-      expect(boundedStore.hasSession("second")).toBe(true);
-    } finally {
-      boundedStore.clearAllSessionsForTest();
-    }
+    expect(boundedStore.hasSession("first")).toBe(true);
+    expect(boundedStore.hasSession("second")).toBe(true);
   });
 
   it("falls back for non-finite max session options", () => {
@@ -121,26 +113,22 @@ describe("acp session manager", () => {
       idleTtlMs: 24 * 60 * 60 * 1_000,
       now,
     });
-    try {
-      for (let index = 0; index < 5_000; index += 1) {
-        const session = boundedStore.createSession({
-          sessionId: `session-${index}`,
-          sessionKey: `acp:${index}`,
-          cwd: "/tmp",
-        });
-        boundedStore.setActiveRun(session.sessionId, `run-${index}`, new AbortController());
-      }
-
-      expect(() =>
-        boundedStore.createSession({
-          sessionId: "overflow",
-          sessionKey: "acp:overflow",
-          cwd: "/tmp",
-        }),
-      ).toThrow(/session limit reached/i);
-    } finally {
-      boundedStore.clearAllSessionsForTest();
+    for (let index = 0; index < 5_000; index += 1) {
+      const session = boundedStore.createSession({
+        sessionId: `session-${index}`,
+        sessionKey: `acp:${index}`,
+        cwd: "/tmp",
+      });
+      boundedStore.setActiveRun(session.sessionId, `run-${index}`, new AbortController());
     }
+
+    expect(() =>
+      boundedStore.createSession({
+        sessionId: "overflow",
+        sessionKey: "acp:overflow",
+        cwd: "/tmp",
+      }),
+    ).toThrow(/session limit reached/i);
   });
 
   it("reaps idle sessions before enforcing the max session cap", () => {
@@ -149,25 +137,21 @@ describe("acp session manager", () => {
       idleTtlMs: 1_000,
       now,
     });
-    try {
-      boundedStore.createSession({
-        sessionId: "old",
-        sessionKey: "acp:old",
-        cwd: "/tmp",
-      });
-      advance(2_000);
-      const fresh = boundedStore.createSession({
-        sessionId: "fresh",
-        sessionKey: "acp:fresh",
-        cwd: "/tmp",
-      });
+    boundedStore.createSession({
+      sessionId: "old",
+      sessionKey: "acp:old",
+      cwd: "/tmp",
+    });
+    advance(2_000);
+    const fresh = boundedStore.createSession({
+      sessionId: "fresh",
+      sessionKey: "acp:fresh",
+      cwd: "/tmp",
+    });
 
-      expect(fresh.sessionId).toBe("fresh");
-      expect(boundedStore.getSession("old")).toBeUndefined();
-      expect(boundedStore.hasSession("old")).toBe(false);
-    } finally {
-      boundedStore.clearAllSessionsForTest();
-    }
+    expect(fresh.sessionId).toBe("fresh");
+    expect(boundedStore.getSession("old")).toBeUndefined();
+    expect(boundedStore.hasSession("old")).toBe(false);
   });
 
   it("uses soft-cap eviction for the oldest idle session when full", () => {
@@ -176,35 +160,31 @@ describe("acp session manager", () => {
       idleTtlMs: 24 * 60 * 60 * 1_000,
       now,
     });
-    try {
-      const first = boundedStore.createSession({
-        sessionId: "first",
-        sessionKey: "acp:first",
-        cwd: "/tmp",
-      });
-      advance(100);
-      const second = boundedStore.createSession({
-        sessionId: "second",
-        sessionKey: "acp:second",
-        cwd: "/tmp",
-      });
-      const controller = new AbortController();
-      boundedStore.setActiveRun(second.sessionId, "run-2", controller);
-      advance(100);
+    const first = boundedStore.createSession({
+      sessionId: "first",
+      sessionKey: "acp:first",
+      cwd: "/tmp",
+    });
+    advance(100);
+    const second = boundedStore.createSession({
+      sessionId: "second",
+      sessionKey: "acp:second",
+      cwd: "/tmp",
+    });
+    const controller = new AbortController();
+    boundedStore.setActiveRun(second.sessionId, "run-2", controller);
+    advance(100);
 
-      const third = boundedStore.createSession({
-        sessionId: "third",
-        sessionKey: "acp:third",
-        cwd: "/tmp",
-      });
+    const third = boundedStore.createSession({
+      sessionId: "third",
+      sessionKey: "acp:third",
+      cwd: "/tmp",
+    });
 
-      expect(third.sessionId).toBe("third");
-      expect(boundedStore.getSession(first.sessionId)).toBeUndefined();
-      const retainedSession = boundedStore.getSession(second.sessionId);
-      expect(retainedSession?.sessionId).toBe("second");
-    } finally {
-      boundedStore.clearAllSessionsForTest();
-    }
+    expect(third.sessionId).toBe("third");
+    expect(boundedStore.getSession(first.sessionId)).toBeUndefined();
+    const retainedSession = boundedStore.getSession(second.sessionId);
+    expect(retainedSession?.sessionId).toBe("second");
   });
 
   it("rejects when full and no session is evictable", () => {
@@ -213,23 +193,19 @@ describe("acp session manager", () => {
       idleTtlMs: 24 * 60 * 60 * 1_000,
       now,
     });
-    try {
-      const only = boundedStore.createSession({
-        sessionId: "only",
-        sessionKey: "acp:only",
-        cwd: "/tmp",
-      });
-      boundedStore.setActiveRun(only.sessionId, "run-only", new AbortController());
+    const only = boundedStore.createSession({
+      sessionId: "only",
+      sessionKey: "acp:only",
+      cwd: "/tmp",
+    });
+    boundedStore.setActiveRun(only.sessionId, "run-only", new AbortController());
 
-      expect(() =>
-        boundedStore.createSession({
-          sessionId: "next",
-          sessionKey: "acp:next",
-          cwd: "/tmp",
-        }),
-      ).toThrow(/session limit reached/i);
-    } finally {
-      boundedStore.clearAllSessionsForTest();
-    }
+    expect(() =>
+      boundedStore.createSession({
+        sessionId: "next",
+        sessionKey: "acp:next",
+        cwd: "/tmp",
+      }),
+    ).toThrow(/session limit reached/i);
   });
 });

--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -19,7 +19,6 @@ export type AcpSessionStore = {
   clearActiveRun: (sessionId: string) => void;
   cancelActiveRun: (sessionId: string) => boolean;
   deleteSession: (sessionId: string) => boolean;
-  clearAllSessionsForTest: () => void;
 };
 
 type AcpSessionStoreOptions = {
@@ -189,14 +188,6 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
 
   const deleteSession: AcpSessionStore["deleteSession"] = (sessionId) => removeSession(sessionId);
 
-  const clearAllSessionsForTest: AcpSessionStore["clearAllSessionsForTest"] = () => {
-    for (const session of sessions.values()) {
-      session.abortController?.abort();
-    }
-    sessions.clear();
-    runIdToSessionId.clear();
-  };
-
   return {
     createSession,
     hasSession,
@@ -206,7 +197,6 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
     clearActiveRun,
     cancelActiveRun,
     deleteSession,
-    clearAllSessionsForTest,
   };
 }
 

--- a/src/acp/translator.bridge-test-helpers.ts
+++ b/src/acp/translator.bridge-test-helpers.ts
@@ -127,8 +127,6 @@ export async function expectOversizedPromptRejected(params: { sessionId: string;
   const session = sessionStore.getSession(params.sessionId);
   expect(session?.activeRunId).toBeNull();
   expect(session?.abortController).toBeNull();
-
-  sessionStore.clearAllSessionsForTest();
 }
 
 export type MockCallSource = { mock: { calls: Array<Array<unknown>> } };

--- a/src/acp/translator.event-ledger.test.ts
+++ b/src/acp/translator.event-ledger.test.ts
@@ -277,8 +277,6 @@ describe("ACP translator event ledger replay", () => {
     await expect(
       eventLedger.readReplayBySessionId({ sessionId: firstSession.sessionKey }),
     ).resolves.toEqual({ complete: false, events: [] });
-
-    firstSessionStore.clearAllSessionsForTest();
   });
 
   it("does not replay prompts that Gateway rejected before accepting the send", async () => {

--- a/src/acp/translator.final-snapshots.test.ts
+++ b/src/acp/translator.final-snapshots.test.ts
@@ -61,12 +61,10 @@ describe("acp final chat snapshots", () => {
       },
     });
     expect(sessionStore.getSession("snapshot-session")?.activeRunId).toBeNull();
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("does not duplicate text when final repeats the last delta snapshot", async () => {
-    const { agent, sessionUpdate, promptPromise, runId, sessionStore } =
-      await createSnapshotHarness();
+    const { agent, sessionUpdate, promptPromise, runId } = await createSnapshotHarness();
 
     await agent.handleGatewayEvent({
       event: "chat",
@@ -101,12 +99,10 @@ describe("acp final chat snapshots", () => {
           "agent_message_chunk",
     );
     expect(chunks).toHaveLength(1);
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("emits only the missing tail when the final snapshot extends prior deltas", async () => {
-    const { agent, sessionUpdate, promptPromise, runId, sessionStore } =
-      await createSnapshotHarness();
+    const { agent, sessionUpdate, promptPromise, runId } = await createSnapshotHarness();
 
     await agent.handleGatewayEvent({
       event: "chat",
@@ -148,6 +144,5 @@ describe("acp final chat snapshots", () => {
         content: { type: "text", text: " world" },
       },
     });
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.lifecycle.test.ts
+++ b/src/acp/translator.lifecycle.test.ts
@@ -160,8 +160,6 @@ describe("acp translator stable lifecycle handlers", () => {
     expect(typeof agent.closeSession).toBe("function");
     expect(capabilities.sessionCapabilities?.fork).toBeUndefined();
     expect("unstable_listSessions" in agent).toBe(false);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("lists Gateway sessions through the stable handler with opaque cursors and cwd filtering", async () => {
@@ -219,8 +217,6 @@ describe("acp translator stable lifecycle handlers", () => {
       limit: 5,
       includeDerivedTitles: true,
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("does not include sessions without workspace metadata in cwd-filtered lists", async () => {
@@ -244,8 +240,6 @@ describe("acp translator stable lifecycle handlers", () => {
 
     expect(result.sessions.map((session) => session.sessionId)).toEqual(["agent:main:a1"]);
     expect(result.sessions.map((session) => session.cwd)).toEqual(["/work/a"]);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("lists Gateway sessions with invalid updated timestamps", async () => {
@@ -271,8 +265,6 @@ describe("acp translator stable lifecycle handlers", () => {
 
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0]?.updatedAt).toBeUndefined();
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("rejects session/list cursors when the cwd filter changes", async () => {
@@ -314,8 +306,6 @@ describe("acp translator stable lifecycle handlers", () => {
     await expect(
       agent.listSessions(createListSessionsRequest({ cursor: filtered.nextCursor })),
     ).rejects.toThrow(/cursor does not match the cwd filter/i);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("rejects relative cwd filters for session/list", async () => {
@@ -327,8 +317,6 @@ describe("acp translator stable lifecycle handlers", () => {
     await expect(
       agent.listSessions(createListSessionsRequest({ cwd: "relative/path" })),
     ).rejects.toThrow(/requires an absolute cwd/i);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("resumes an existing Gateway session without replaying transcript history", async () => {
@@ -378,8 +366,6 @@ describe("acp translator stable lifecycle handlers", () => {
         },
       },
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("rejects resume for a missing Gateway session without creating bridge state", async () => {
@@ -399,7 +385,6 @@ describe("acp translator stable lifecycle handlers", () => {
     ).rejects.toThrow(/Session missing-session not found/i);
 
     expect(sessionStore.hasSession("missing-session")).toBe(false);
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("resolves prompts when chat send returns a terminal timeout ack", async () => {
@@ -521,7 +506,5 @@ describe("acp translator stable lifecycle handlers", () => {
     await expect(agent.closeSession(createCloseSessionRequest("missing-session"))).rejects.toThrow(
       /Session missing-session not found/i,
     );
-
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -24,7 +24,6 @@ type Harness = {
   request: ReturnType<typeof vi.fn>;
   requestPermission: ReturnType<typeof vi.fn>;
   runId: string;
-  sessionStore: ReturnType<typeof createInMemorySessionStore>;
 };
 
 function createApprovalEvent(params: {
@@ -152,14 +151,12 @@ async function createHarness(
     request,
     requestPermission,
     runId: runId!,
-    sessionStore,
   };
 }
 
 async function cleanupHarness(harness: Harness): Promise<void> {
   await harness.agent.cancel({ sessionId: SESSION_ID } as CancelNotification);
   await harness.promptPromise;
-  harness.sessionStore.clearAllSessionsForTest();
 }
 
 function approvalResolveCalls(request: ReturnType<typeof vi.fn>) {
@@ -386,7 +383,6 @@ describe("ACP translator permission relay", () => {
     await agent.cancel({ sessionId: SESSION_ID } as CancelNotification);
     await agent.cancel({ sessionId: SECOND_SESSION_ID } as CancelNotification);
     await Promise.all([firstPrompt, secondPrompt]);
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("allows approval relay retry when Gateway resolution fails", async () => {

--- a/src/acp/translator.session-config.test.ts
+++ b/src/acp/translator.session-config.test.ts
@@ -36,8 +36,6 @@ describe("acp setSessionMode bridge behavior", () => {
     await expect(
       agent.setSessionMode(createSetSessionModeRequest("mode-session", "high")),
     ).rejects.toThrow(/gateway rejected mode/i);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("emits current mode and thought-level config updates after a successful mode change", async () => {
@@ -90,8 +88,6 @@ describe("acp setSessionMode bridge behavior", () => {
       "thought_level",
       { currentValue: "high" },
     );
-
-    sessionStore.clearAllSessionsForTest();
   });
 });
 
@@ -149,8 +145,6 @@ describe("acp setSessionConfigOption bridge behavior", () => {
       "thought_level",
       { currentValue: "minimal" },
     );
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("updates non-mode ACP config options through gateway session patches", async () => {
@@ -200,8 +194,6 @@ describe("acp setSessionConfigOption bridge behavior", () => {
       "reasoning_level",
       { currentValue: "stream" },
     );
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("updates fast mode ACP config options through gateway session patches", async () => {
@@ -257,8 +249,6 @@ describe("acp setSessionConfigOption bridge behavior", () => {
       "fast_mode",
       { currentValue: "on" },
     );
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("accepts forwarded timeout config options without failing OpenClaw ACP bridge turns", async () => {
@@ -303,8 +293,6 @@ describe("acp setSessionConfigOption bridge behavior", () => {
     expect(Array.isArray(result.configOptions)).toBe(true);
 
     expect(requestMock.mock.calls.some(([method]) => method === "sessions.patch")).toBe(false);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("rejects non-string ACP config option values", async () => {
@@ -355,8 +343,6 @@ describe("acp setSessionConfigOption bridge behavior", () => {
           requireAcpObject(params, "sessions.patch params").key === "bool-config-session",
       ),
     ).toBe(false);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it('maps response_usage "inherit" selection to sessions.patch with responseUsage: null', async () => {
@@ -407,8 +393,6 @@ describe("acp setSessionConfigOption bridge behavior", () => {
         ([method]) => method === "sessions.patch",
       ),
     ).toBe(true);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it('maps response_usage "off" selection to sessions.patch with responseUsage: "off"', async () => {
@@ -457,7 +441,5 @@ describe("acp setSessionConfigOption bridge behavior", () => {
         ([method]) => method === "sessions.patch",
       ),
     ).toBe(true);
-
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.session-lineage-meta.test.ts
+++ b/src/acp/translator.session-lineage-meta.test.ts
@@ -149,8 +149,6 @@ describe("acp session lineage metadata", () => {
         },
       },
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("keeps snapshot lineage in the Gateway session key namespace", async () => {
@@ -216,7 +214,5 @@ describe("acp session lineage metadata", () => {
         },
       },
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -27,8 +27,6 @@ describe("acp session creation rate limit", () => {
     await expect(agent.newSession(createNewSessionRequest())).rejects.toThrow(
       /session creation rate limit exceeded/i,
     );
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("does not count loadSession refreshes for an existing session ID", async () => {
@@ -46,8 +44,6 @@ describe("acp session creation rate limit", () => {
     await expect(agent.loadSession(createLoadSessionRequest("new-session"))).rejects.toThrow(
       /session creation rate limit exceeded/i,
     );
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("falls back for non-finite session creation rate limit overrides", async () => {
@@ -66,7 +62,5 @@ describe("acp session creation rate limit", () => {
     await expect(agent.newSession(createNewSessionRequest())).resolves.toMatchObject({
       sessionId: expect.any(String),
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.session-setup.test.ts
+++ b/src/acp/translator.session-setup.test.ts
@@ -35,7 +35,6 @@ describe("acp unsupported bridge session setup", () => {
 
     expect(sessionStore.hasSession("docs-session")).toBe(false);
     expect(sessionUpdate).not.toHaveBeenCalled();
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("rejects per-session MCP servers on loadSession", async () => {
@@ -55,7 +54,6 @@ describe("acp unsupported bridge session setup", () => {
 
     expect(sessionStore.hasSession("docs-session")).toBe(false);
     expect(sessionUpdate).not.toHaveBeenCalled();
-    sessionStore.clearAllSessionsForTest();
   });
 });
 
@@ -71,8 +69,6 @@ describe("acp session UX bridge behavior", () => {
 
     expect(sessionKey).toMatch(/^acp-bridge:/);
     expect(isAcpSessionKey(sessionKey)).toBe(false);
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("returns initial modes and thought-level config options for new sessions", async () => {
@@ -101,8 +97,6 @@ describe("acp session UX bridge behavior", () => {
     // Unset session inherits the configured default → control reads "inherit", not "off".
     expectConfigOption(result.configOptions, "response_usage", { currentValue: "inherit" });
     expectConfigOption(result.configOptions, "elevated_level", { currentValue: "off" });
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("replays user text, assistant text, and hidden assistant thinking on loadSession", async () => {
@@ -229,8 +223,6 @@ describe("acp session UX bridge behavior", () => {
         },
       },
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("falls back to an empty transcript when sessions.get fails during loadSession", async () => {
@@ -276,7 +268,5 @@ describe("acp session UX bridge behavior", () => {
     expect(result.modes?.currentModeId).toBe("adaptive");
     expectSessionUpdate(sessionUpdate, "agent:main:recover", "available_commands_update");
     expect(sessionUpdatePayloads(sessionUpdate, "user_message_chunk")).toEqual([]);
-
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.session-snapshot.test.ts
+++ b/src/acp/translator.session-snapshot.test.ts
@@ -86,8 +86,6 @@ describe("acp session metadata and usage updates", () => {
         },
       },
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 
   it("still resolves prompts when snapshot updates fail after completion", async () => {
@@ -141,7 +139,5 @@ describe("acp session metadata and usage updates", () => {
     const session = sessionStore.getSession("usage-session");
     expect(session?.activeRunId).toBeNull();
     expect(session?.abortController).toBeNull();
-
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/acp/translator.tool-streaming.test.ts
+++ b/src/acp/translator.tool-streaming.test.ts
@@ -121,7 +121,5 @@ describe("acp tool streaming bridge behavior", () => {
         locations: [{ path: "src/app.ts", line: 12 }],
       },
     });
-
-    sessionStore.clearAllSessionsForTest();
   });
 });

--- a/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
@@ -124,6 +124,13 @@ describe("Control UI build admission over WebSocket", () => {
     }
     const origin = `http://127.0.0.1:${address.port}`;
     let connectedClient: unknown = null;
+    // Hold the injected close until the post-rejection frame reaches the handler;
+    // otherwise socket timing can make the no-RPC assertion vacuous.
+    let releasePostRejectionFrame = () => {};
+    const postRejectionFrameObserved = new Promise<void>((resolve) => {
+      releasePostRejectionFrame = resolve;
+    });
+    let closeRequested = false;
 
     wss.on("connection", (socket, request) => {
       const send = (value: unknown) => socket.send(JSON.stringify(value));
@@ -151,7 +158,11 @@ describe("Control UI build admission over WebSocket", () => {
         refreshHealthSnapshot: vi.fn(),
         send,
         close: (code, reason) => {
-          setTimeout(() => socket.close(code, reason), 25);
+          if (closeRequested) {
+            return;
+          }
+          closeRequested = true;
+          void postRejectionFrameObserved.then(() => socket.close(code, reason));
         },
         isClosed: () => socket.readyState >= WebSocket.CLOSING,
         clearHandshakeTimer: vi.fn(),
@@ -163,7 +174,12 @@ describe("Control UI build admission over WebSocket", () => {
         setHandshakeState: vi.fn(),
         advanceHandshakePhase: vi.fn(),
         setCloseCause: vi.fn(),
-        setLastFrameMeta: setLastFrameMetaMock,
+        setLastFrameMeta: (meta) => {
+          setLastFrameMetaMock(meta);
+          if (meta.method === "health" && meta.id === "post-rejection-rpc") {
+            releasePostRejectionFrame();
+          }
+        },
         originCheckMetrics: { hostHeaderFallbackAccepted: 0 },
         logGateway: createLogger() as never,
         logHealth: createLogger() as never,

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -553,30 +553,22 @@ describe("test-projects args", () => {
     ]);
   });
 
-  it("routes extension helper targets to importing extension tests", () => {
-    expect(
-      buildVitestRunPlans(["extensions/memory-core/src/memory/test-runtime-mocks.ts"]),
-    ).toEqual([
+  it("routes direct and transitive extension helper importers to the owning config", () => {
+    const helper = "extensions/memory-core/src/memory/test-runtime-mocks.ts";
+    const plans = buildVitestRunPlans([helper]);
+
+    expect(plans).toEqual([
       {
         config: "test/vitest/vitest.extension-memory.config.ts",
         forwardedArgs: [],
-        includePatterns: [
-          "extensions/memory-core/src/memory/index.test.ts",
-          "extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts",
-          "extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts",
-          "extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts",
-          "extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts",
-          "extensions/memory-core/src/memory/manager-registry.test.ts",
-          "extensions/memory-core/src/memory/manager-search-orchestration.test.ts",
-          "extensions/memory-core/src/memory/manager-session-update-race.test.ts",
+        includePatterns: expect.arrayContaining([
           "extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts",
-          "extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts",
-          "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",
-          "extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts",
-        ],
+          "extensions/memory-core/src/memory/manager-session-update-race.test.ts",
+        ]),
         watchMode: false,
       },
     ]);
+    expect(plans[0]?.includePatterns).not.toContain(helper);
   });
 
   it("routes top-level test helpers to importing repo tests", () => {

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -20,6 +20,7 @@ import {
   validateLiveShardReportPayload,
 } from "../../scripts/test-live-shard.mts";
 import { expectNoReaddirSyncDuring } from "../../src/test-utils/fs-scan-assertions.js";
+import { waitForPidFile } from "../helpers/process-wait.js";
 
 describe("scripts/test-live-shard", () => {
   const allFiles = collectAllLiveTestFiles();
@@ -586,12 +587,8 @@ describe("scripts/test-live-shard", () => {
           },
         );
 
-        await waitFor(() => existsSync(childPidPath), 5_000);
-        await waitFor(() => existsSync(descendantPidPath), 5_000);
-        childPid = Number(readFileSync(childPidPath, "utf8"));
-        descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
-        expect(Number.isInteger(childPid)).toBe(true);
-        expect(Number.isInteger(descendantPid)).toBe(true);
+        childPid = await waitForPidFile(childPidPath, 5_000);
+        descendantPid = await waitForPidFile(descendantPidPath, 5_000);
 
         runner.kill("SIGTERM");
 


### PR DESCRIPTION
## What Problem This Solves

Removes a test-only ACP session-store cleanup API that no production caller used. Forty-five cleanup calls were clearing test-local stores after each scenario even though every test already constructs a fresh store and real pending work is settled through production cancellation or close paths.

Exact-head CI also exposed three existing `main` test defects: an exhaustive extension-helper importer inventory broke whenever a new importing test landed, a signal-cleanup test treated an empty newly created PID file as PID `0`, and a WebSocket admission test allowed its injected close timer to win before the post-rejection frame reached the handler.

## Why This Change Was Made

The ACP helper was leftover infrastructure from an older suite-shared store. This change removes the method from the private store contract and deletes the cleanup-only calls without adding a replacement seam, while retaining lifecycle, cancellation, eviction, active-run, and prompt-settlement assertions at their behavioral owners.

The CI repairs replace the frozen importer inventory with direct/transitive routing invariants, reuse the shared PID-file readiness helper, and explicitly hold the test-injected WebSocket close until the post-rejection frame is observed. No production signal, routing, Gateway, or admission behavior changes.

## User Impact

No user-visible behavior changes. The ACP session store has ten fewer production lines, tests no longer preserve a cleanup path that production does not use, and the affected CI shards no longer fail on unrelated importer additions, PID-file open/truncate timing, or socket-close scheduling.

## Evidence

- Focused ACP, tooling, and Gateway proof: 17 files, 205 tests passed across the owning Vitest shards.
- The exact failed signal-cleanup case passed 20 consecutive runs.
- The two-case WebSocket admission file passed 20 consecutive runs, 40 total parameterized cases.
- `@openclaw/acp-core` package build passed, including declarations.
- Complete-branch `node scripts/check-changed.mjs -- <changed paths>` passed the `core`, `coreTests`, `testRoot`, and `tooling` lanes; the subsequent Gateway-only `coreTests` gate also passed. The remote backend was unavailable, so the documented trusted-source local fallback ran successfully.
- `git diff --check` passed.
- Fresh structured autoreview on the complete branch reported no accepted/actionable findings.
- Exact-head failures repaired: run 31867681620 (routing inventory and PID readiness) and run 31868676609 (post-rejection WebSocket frame synchronization).

Production delta: -10. Tests and test support: +111/-204, net -93. Total net: -103. No docs, config, schema, protocol, dependency, or changelog change.