### PR TITLE
fix(ui): show failed dashboard pin outcomes

### DIFF
--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -23,6 +23,10 @@ const cardboardProofDir = path.resolve(
   ".artifacts/control-ui-e2e/workboard-cardboard",
 );
 const workboardPinProofDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-pin");
+const workboardPinFailureProofDir = path.resolve(
+  process.cwd(),
+  ".artifacts/control-ui-e2e/workboard-pin-failure",
+);
 const pluginWidgetsProofDir = path.resolve(
   process.cwd(),
   ".artifacts/control-ui-e2e/workboard-plugin-widgets",
@@ -384,6 +388,87 @@ suite.define(() => {
         page.locator('.chat-tool-card__preview[data-kind="canvas"] [data-pin-widget]').isDisabled(),
       )
       .toBe(true);
+    await context.close();
+  });
+
+  it("shows a bounded visible outcome when a Canvas dashboard pin fails", async () => {
+    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+    if (recordProof) {
+      await mkdir(workboardPinFailureProofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      viewport: { height: 900, width: 1280 },
+      ...(recordProof
+        ? {
+            recordVideo: {
+              dir: workboardPinFailureProofDir,
+              size: { height: 900, width: 1280 },
+            },
+          }
+        : {}),
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey,
+      featureCapabilities: [GATEWAY_SERVER_CAPS.BOARD_WIDGET_PUT_CANVAS_DOC],
+      featureMethods: [
+        "board.get",
+        "board.update",
+        "board.widget.grant",
+        "board.widget.put",
+        "chat.metadata",
+        "chat.startup",
+      ],
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "canvas",
+              preview: {
+                kind: "canvas",
+                surface: "assistant_message",
+                render: "url",
+                title: "Stale release status",
+                viewId: "cv_stale",
+                url: "/__openclaw__/canvas/documents/cv_stale/index.html",
+                preferredHeight: 240,
+                sandbox: "scripts",
+              },
+            },
+          ],
+          timestamp: 1,
+        },
+      ],
+      methodResponses: {
+        "board.get": boardSnapshot,
+        "board.widget.put": {
+          __mockError: {
+            code: "NOT_FOUND",
+            message: `internal path detail ${"x".repeat(8_000)}`,
+          },
+        },
+      },
+    });
+    await showDashboard(page);
+
+    await page.goto(`${suite.server.baseUrl}dashboard`);
+    await page.locator(".board-session-surface").waitFor();
+    const preview = page.locator('.chat-tool-card__preview[data-kind="canvas"]');
+    const pin = preview.getByRole("button", { name: "Pin to dashboard" });
+    await preview.hover();
+    await pin.click();
+
+    await expect.poll(async () => (await gateway.getRequests("board.widget.put")).length).toBe(1);
+    const toast = page.locator("openclaw-toast-host .app-toast");
+    await toast.waitFor();
+    expect(await toast.textContent()).toContain("Could not pin to dashboard. Try again.");
+    expect(await pin.isEnabled()).toBe(true);
+    expect(await pin.getAttribute("title")).toBe("Could not pin to dashboard. Try again.");
+    expect(await page.getByText("internal path detail", { exact: false }).count()).toBe(0);
+    if (recordProof) {
+      await page.screenshot({ path: path.join(workboardPinFailureProofDir, "pin-failed.png") });
+    }
     await context.close();
   });
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5495,6 +5495,7 @@ export const en: TranslationMap = {
       widgetExportFailed: "Widget export failed. Try again.",
       pinToDashboard: "Pin to dashboard",
       pinToDashboardPending: "Pinning…",
+      pinToDashboardFailed: "Could not pin to dashboard. Try again.",
       pinnedToDashboard: "Pinned",
       fileChanges: "File changes",
       attemptedChanges: "Attempted changes",

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -372,6 +372,55 @@ describe("widget-card", () => {
     expect(app.querySelector("[data-pin-widget]")).toBeNull();
   });
 
+  it("announces a failed Canvas dashboard pin and leaves it retryable", async () => {
+    const pinWidget = vi.fn(async () => {
+      throw new Error("canvas document is stale");
+    });
+    const provider = {
+      sessionKey: "agent:main:main",
+      canPinWidgets: true,
+      pinWidget,
+      snapshot$: {
+        value: {
+          sessionKey: "agent:main:main",
+          revision: 0,
+          tabs: [],
+          widgets: [],
+        },
+        subscribe: () => () => {},
+      },
+    } as unknown as BoardProvider;
+    const toastHost = document.body.appendChild(document.createElement("openclaw-toast-host"));
+    const canvas = document.createElement("div");
+    render(
+      renderToolPreview(
+        {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          viewId: "cv_stale",
+          url: "/__openclaw__/canvas/documents/cv_stale/index.html",
+          sandbox: "scripts",
+        },
+        "chat_message",
+        { boardProvider: provider },
+      ),
+      canvas,
+    );
+
+    const button = canvas.querySelector<HTMLButtonElement>("[data-pin-widget]");
+    button?.click();
+
+    await vi.waitFor(() => {
+      expect(pinWidget).toHaveBeenCalledOnce();
+      expect(button?.disabled).toBe(false);
+      expect(toastHost.querySelector(".app-toast__message")?.textContent).toBe(
+        "Could not pin to dashboard. Try again.",
+      );
+    });
+    toastHost.remove();
+  });
+
   it("pins an MCP App using only its view identity", async () => {
     const pinMcpApp = vi.fn(async () => undefined);
     const provider = {

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -54,10 +54,12 @@ async function pinWidget(event: Event, pin: () => Promise<void>): Promise<void> 
     const pinnedLabel = t("chat.toolCards.pinnedToDashboard");
     button.title = button.ariaLabel = pinnedLabel;
     button.dataset.pinned = "true";
-  } catch (error) {
+  } catch {
     button.disabled = false;
     button.ariaLabel = t("chat.toolCards.pinToDashboard");
-    button.title = error instanceof Error ? error.message : String(error);
+    const failureLabel = t("chat.toolCards.pinToDashboardFailed");
+    button.title = failureLabel;
+    showToast({ message: failureLabel });
   }
 }
 


### PR DESCRIPTION
Closes #124040

## What Problem This Solves

Fixes an issue where users clicking **Pin to dashboard** on a Canvas or MCP transcript card would see no visible result when the Gateway rejected the pin. The control became retryable again, but the complete raw error was exposed only through the icon's hover title.

## Why This Change Was Made

The shared widget-card pin owner now restores the retryable state and publishes one bounded localized failure through both the button title and the existing accessible toast host. Canvas and MCP cards already converge on this helper, so the repair covers both without duplicating policy or changing their separate provider requests.

Successful pending and pinned states are unchanged. There is no board authority, security, Gateway protocol, public config, persistence/schema, Plugin SDK, replay, or product-policy change. The production increase is net +3 because the existing shared failure branch now owns one user-visible outcome and one localized string. No changelog edit is included; normal PR release-note context lives here under the repository's release-only changelog policy.

Provenance: clearly introduced by @steipete in #121419 and merged by @steipete as `f9730534fba2ee0bdea449a71890c1d10b754c9b` on August 10, 2026. That change converted the text action to an icon and consolidated Canvas/MCP failure handling into the shared helper while retaining title-only error projection.

## User Impact

Rejected Canvas and MCP dashboard pins now immediately show **Could not pin to dashboard. Try again.** The pin control remains enabled for another attempt, and raw internal Gateway details are not rendered to the operator.

Production LOC: +5/−2 (net +3) | Tests: +134/−0

## Evidence

- Final main baseline: `a02ed2cfda804d14df82699f4f1427ee68d27970`; exact candidate head: `00402d2187fd8b75fe68f4c7166387c9ebcc62de`.
- Pre-fix reproduction on the current-main behavior: focused widget-card suite fails 1/9 because the rejection produces no toast; the other 8 cases pass.
- Final focused proof: 9/9 pass, covering successful Canvas/MCP pin paths plus visible failure and retryability.
- Real Canvas lifecycle proof: 20/20 pass across managed document classification/serving, Gateway route/capability projection, a paired Linux node, and hosted Canvas HTTP/WebSocket flows.
- Source-blind validation: 3/3 clauses pass; 0 failed, blocked, or out of scope.
- Adversarial UI proof: an 8,000-character internal rejection is absent while the fixed bounded toast appears and the pin remains enabled.
- Changed gate: `coreTests, ui`, exit 0 on the exact candidate; formatting, core-test/UI types, oxlint/stylelint, i18n, dead exports, and boundary guards pass.
- Import cycles: 0 runtime value cycles. `git diff --check`: pass.
- Fresh branch autoreview: clean, no accepted/actionable findings.
- Exact-head GitHub CI: green, including aggregate `openclaw/ci-gate` ([run 31868360968](https://github.com/openclaw/openclaw/actions/runs/31868360968)). Native `OPENCLAW_TESTBOX=1` prepare: green with matching prep/PR head `00402d2187fd8b75fe68f4c7166387c9ebcc62de`.

### Chromium proof

![Failed Canvas pin shows a bounded retryable toast](https://github.com/user-attachments/assets/676f24fa-9b20-4e9e-97be-da04b6d97143)

https://github.com/user-attachments/assets/f7a99888-eb61-42a1-82ca-2d0d6cf418fa
