### PR TITLE
fix(ui): stale terminal actions exit visibly

### DIFF
--- a/ui/src/components/terminal/terminal-connection.test.ts
+++ b/ui/src/components/terminal/terminal-connection.test.ts
@@ -524,6 +524,29 @@ describe("TerminalConnection", () => {
     ]);
   });
 
+  it.each([
+    ["terminal.input", (conn: TerminalConnection) => conn.input("s1", "echo lost\n")],
+    ["terminal.resize", (conn: TerminalConnection) => conn.resize("s1", 120, 40)],
+  ] as const)("marks the session unavailable when %s rejects its live owner", async (_, act) => {
+    const { client, conn } = makeHarness();
+    const exits: unknown[] = [];
+    await openSession(conn, { onExit: (info) => exits.push(info) });
+    client.nextResponse = { ok: false };
+
+    await act(conn);
+
+    expect(exits).toEqual([
+      {
+        exitCode: null,
+        signal: null,
+        reason: "disconnected",
+        error: "Terminal session is no longer available. Open a new terminal session.",
+      },
+    ]);
+    expect(conn.size).toBe(0);
+    expect(client.listenerCount()).toBe(0);
+  });
+
   it("buffers output that races ahead of sink registration and replays it in order", async () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];

--- a/ui/src/components/terminal/terminal-connection.ts
+++ b/ui/src/components/terminal/terminal-connection.ts
@@ -569,11 +569,25 @@ export class TerminalConnection {
   }
 
   async input(sessionId: string, data: string): Promise<void> {
-    await this.client.request("terminal.input", { sessionId, data }).catch(() => undefined);
+    await this.requestAction("terminal.input", sessionId, { sessionId, data });
   }
 
   async resize(sessionId: string, cols: number, rows: number): Promise<void> {
-    await this.client.request("terminal.resize", { sessionId, cols, rows }).catch(() => undefined);
+    await this.requestAction("terminal.resize", sessionId, { sessionId, cols, rows });
+  }
+
+  private async requestAction(method: string, sessionId: string, params: unknown): Promise<void> {
+    const stream = this.streams.get(sessionId);
+    const result = await this.client.request<{ ok: boolean }>(method, params).catch(() => null);
+    if (result?.ok !== false || !stream || this.streams.get(sessionId) !== stream) {
+      return;
+    }
+    this.deliverExit(sessionId, stream, {
+      exitCode: null,
+      signal: null,
+      reason: "disconnected",
+      error: "Terminal session is no longer available. Open a new terminal session.",
+    });
   }
 
   /** Closes a session server-side and drops its local stream state. */


### PR DESCRIPTION
Closes #124042

## What Problem This Solves

Fixes an issue where Control UI operators could keep typing into a falsely live terminal tab after session ownership changed. When `terminal.input` or `terminal.resize` explicitly returned `{ "ok": false }`, the browser discarded that authoritative result and silently lost the action if the separate exit event was absent or raced.

## Why This Change Was Made

The browser terminal connection now projects an explicit negative input/resize acknowledgement through its canonical exit path with actionable recovery guidance. It captures the exact stream before sending the action and confirms that stream is still current before exiting, so a late response from an old action cannot close a replacement stream using the same session id. Transport exceptions retain the existing transient liveness/reconnect behavior.

The shared action helper adds net +14 production lines because both action siblings need one response policy and the ownership check must preserve the exact pre-request stream identity across the asynchronous boundary. This does not change command authorization, Gateway protocol, configuration, persistence, replay, or retry behavior.

Pinned dependency proof: `@lydell/node-pty@1.2.0-beta.14` exposes independent data and exit events, and its Unix implementation delays exit until the PTY socket closes to preserve late output. It does not guarantee delivery of a Gateway ownership event across connection take-over, so the explicit Gateway action result remains authoritative at the browser projection owner.

## User Impact

Stale terminal input and resize actions now end with a visible exited tab and: “Terminal session is no longer available. Open a new terminal session.” Operators no longer see a running shell that silently ignores keystrokes, while brief transport failures continue using the established reconnect behavior.

## Evidence

![Stale terminal tab exits with actionable guidance](https://github.com/user-attachments/assets/58eb2960-512a-437c-af53-9c37be548de6)

https://github.com/user-attachments/assets/3f2ed065-bad8-4932-9b05-b2296d581006

- Frozen current-main base: `60babddd626adcad473ae7b2b1b4417892a7828d`
- Exact PR head: `172dc67ee66cd857b0d331f71d2a772b94770f47`; its sole parent is the frozen base. Stable patch id `68bcc338b403cd522785ddaa80c01d995f9c29f1` is unchanged from the prior head.
- Pre-fix boundary regression: 39 passed, exactly 2 failed (`terminal.input`, `terminal.resize` rejection projection).
- Fixed boundary regression: 41/41 passed.
- Owner/sibling sweep: 148 passed; 5 platform-inapplicable process cases skipped.
- Source-blind real Gateway/PTY proof: ordered unique output, `stty` reported 37×101 after resize, detached output replayed once, stale-owner input and resize returned `ok=false`, exit code 7 was preserved, explicit close succeeded, both shell PIDs disappeared, and the final terminal list was empty.
- Live Control UI race proof: a real old-owner request was rejected and its response held across a same-session replacement; releasing it did not close the replacement. The next current-stream rejection visibly exited with guidance.
- Cleanup: proof Gateway PID stopped, loopback port closed, zero children, zero established clients, zero task-owned Unix sockets.
- `pnpm build` passed locally and on Blacksmith Testbox run [31920514638](https://github.com/openclaw/openclaw/actions/runs/31920514638).
- Frozen-base changed gate passed on Testbox `tbx_01m0448czyh6z937s9qekn24jn`: conflict/max-lines/dependency/patch/dead-export/i18n checks, core-test and UI typechecks, core lint, UI style lint, and formatting.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `git diff --check`: clean.
- Fresh Codex autoreview: no findings, patch correct, confidence 0.98.
- Exact-head PR CI [31921728793](https://github.com/openclaw/openclaw/actions/runs/31921728793) is green after one unrelated UI E2E fixture rerun. The earlier native-locale blocker is gone; its fix is included in the frozen base via `2d322d1ae761`.
- LOC: production +16/−2 (net +14); tests +23/−0.

No changelog change: release generation owns `CHANGELOG.md`.
