### PR TITLE
fix(gateway): keep managed media downloadable after reply finalization

### DIFF
--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -152,7 +152,8 @@ export type ReplyDeliveryContext = {
   replyToMode: ReplyToMode;
 };
 
-const REPLY_MEDIA_FAILURE_WARNING = "⚠️ Media failed.";
+const REPLY_MEDIA_FAILURE_WARNING =
+  "⚠️ Media failed. Try sending a smaller supported file or a different format.";
 
 /** Appends the standard media failure warning without duplicating it. */
 export function appendReplyMediaFailureWarning(text: string | undefined): string {

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -347,7 +347,7 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(2);
     expectFields(replyPayloads[0], {
-      text: "keep text\n⚠️ Media failed.",
+      text: "keep text\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,
@@ -1063,7 +1063,7 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(1);
     expectFields(replyPayloads[0], {
-      text: "⚠️ Media failed.",
+      text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -419,7 +419,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       applyReplyToMode: (payload) => payload,
       normalizeMediaPaths: async (payload) => ({
         ...payload,
-        text: "⚠️ Media failed.",
+        text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
         mediaUrl: absPath,
         mediaUrls: [absPath],
       }),

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -200,7 +200,9 @@ describe("createReplyMediaPathNormalizer", () => {
       path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
       5 * 1024 * 1024,
     );
-    expect(result.text).toBe("⚠️ Media failed.");
+    expect(result.text).toBe(
+      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
   });
 
   it.each([
@@ -432,7 +434,9 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: ["./out/missing.png"],
     });
 
-    expect(result.text).toBe("WA_MEDIA_DM_07\n⚠️ Media failed.");
+    expect(result.text).toBe(
+      "WA_MEDIA_DM_07\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
     expectNoMedia(result);
   });
 
@@ -445,7 +449,9 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: ["./out/missing.png", "https://example.com/ok.png"],
     });
 
-    expect(result.text).toBe("Here is the surviving attachment\n⚠️ Media failed.");
+    expect(result.text).toBe(
+      "Here is the surviving attachment\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
     expectMedia(result, "https://example.com/ok.png", ["https://example.com/ok.png"]);
   });
 
@@ -457,7 +463,9 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: ["./out/missing.png"],
     });
 
-    expect(result.text).toBe("⚠️ Media failed.");
+    expect(result.text).toBe(
+      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
     expectNoMedia(result);
   });
 

--- a/src/gateway/managed-image-actions.e2e.test.ts
+++ b/src/gateway/managed-image-actions.e2e.test.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { readImageProbeFromHeader } from "../media/image-ops.js";
 import {
+  cleanupManagedOutgoingMediaRecords,
   createManagedOutgoingMediaBlocks,
   MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX,
 } from "./managed-image-attachments.js";
+import { readManagedImageRecord } from "./managed-image-record-store.js";
 import { connectGatewayClient, disconnectGatewayClient } from "./test-helpers.e2e.js";
 import {
   installGatewayTestHooks,
@@ -114,6 +116,23 @@ describe("managed image actions Gateway E2E", () => {
           expect(rootFull.headers.get("content-type")).toBe("image/png");
           expect(Buffer.from(await rootFull.arrayBuffer())).toEqual(source);
 
+          const partial = await fetch(fullUrl, { headers: { Range: "bytes=3-10" } });
+          expect(partial.status).toBe(206);
+          expect(partial.headers.get("content-range")).toBe(`bytes 3-10/${source.byteLength}`);
+          expect(Buffer.from(await partial.arrayBuffer())).toEqual(source.subarray(3, 11));
+
+          const head = await fetch(fullUrl, { method: "HEAD" });
+          expect(head.status).toBe(200);
+          expect(head.headers.get("content-length")).toBe(String(source.byteLength));
+          expect((await head.arrayBuffer()).byteLength).toBe(0);
+
+          const unsatisfiable = await fetch(fullUrl, {
+            headers: { Range: `bytes=${source.byteLength}-` },
+          });
+          expect(unsatisfiable.status).toBe(416);
+          expect(unsatisfiable.headers.get("content-range")).toBe(`bytes */${source.byteLength}`);
+          expect((await unsatisfiable.arrayBuffer()).byteLength).toBe(0);
+
           fullUrl.pathname = `/rosita${fullUrl.pathname}`;
 
           const full = await fetch(fullUrl);
@@ -137,8 +156,59 @@ describe("managed image actions Gateway E2E", () => {
           });
           expect(authenticated.status).toBe(200);
           expect(Buffer.from(await authenticated.arrayBuffer())).toEqual(source);
-        } finally {
+
+          const wrongIdentity = new URL(fullUrl);
+          wrongIdentity.pathname = wrongIdentity.pathname.replace(
+            /\/[0-9a-f-]+\/full$/u,
+            "/22222222-2222-4222-8222-222222222222/full",
+          );
+          const wrong = await fetch(wrongIdentity, {
+            headers: { Authorization: `Bearer ${GATEWAY_TOKEN}` },
+          });
+          expect(wrong.status).toBe(404);
+          expect(await wrong.text()).toBe("not found");
+
+          vi.useFakeTimers({ toFake: ["Date"] });
+          vi.setSystemTime(Date.parse(download.expiresAt ?? "") + 1);
+          try {
+            const expired = await fetch(fullUrl);
+            expect(expired.status).toBe(401);
+            expect(await expired.text()).toContain("unauthorized");
+          } finally {
+            vi.useRealTimers();
+          }
+
           await disconnectGatewayClient(client);
+          const afterDisconnect = await fetch(fullUrl);
+          expect(afterDisconnect.status).toBe(200);
+          expect(Buffer.from(await afterDisconnect.arrayBuffer())).toEqual(source);
+
+          const record = readManagedImageRecord(
+            artifactId.slice(MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX.length),
+            stateDir,
+          );
+          if (!record) {
+            throw new Error("managed image record disappeared before cleanup");
+          }
+          const originalPath = path.join(
+            record.original.mediaRoot,
+            record.original.mediaSubdir,
+            record.original.mediaId,
+          );
+          const cleanup = await cleanupManagedOutgoingMediaRecords({
+            stateDir,
+            sessionKey: SESSION_KEY,
+            forceDeleteSessionRecords: true,
+          });
+          expect(cleanup).toMatchObject({ deletedRecordCount: 1, deletedFileCount: 1 });
+          expect(readManagedImageRecord(record.attachmentId, stateDir)).toBeNull();
+          await expect(fs.access(originalPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+          const afterCleanup = await fetch(fullUrl);
+          expect(afterCleanup.status).toBe(404);
+          expect(await afterCleanup.text()).toBe("not found");
+        } finally {
+          await disconnectGatewayClient(client).catch(() => {});
         }
       },
       { serverOptions: { auth: { mode: "token", token: GATEWAY_TOKEN } } },

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -27,6 +27,7 @@ import { withEnvAsync } from "../test-utils/env.js";
 import {
   attachManagedImageRecordToMessage,
   insertManagedImageRecord,
+  listManagedImageRecordEntries,
   MANAGED_OUTGOING_ORIGINALS_SUBDIR,
   readManagedImageRecord,
 } from "./managed-image-record-store.js";
@@ -912,6 +913,34 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(authorizeGatewayHttpRequestOrReplyMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a managed audio filename stable in artifact downloads", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir, {
+      filename: "meeting-note.mp3",
+      contentType: "audio/mpeg",
+      body: Buffer.from([0xff, 0xfb, 0x90, 0x00]),
+    });
+    const canonicalPath = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "sessions.sqlite"),
+      entry: { sessionId: "sess-1" },
+    });
+    readSessionMessagesMock.mockResolvedValue([
+      {
+        role: "assistant",
+        content: [{ type: "audio", url: canonicalPath, openUrl: canonicalPath }],
+        __openclaw: { id: "msg-1" },
+      },
+    ]);
+
+    const download = await resolveManagedOutgoingImageArtifactDownload({
+      sessionKey,
+      artifactId: `${MANAGED_OUTGOING_MEDIA_ARTIFACT_ID_PREFIX}${attachmentId}`,
+      stateDir,
+    });
+
+    expect(download?.title).toBe("meeting-note.mp3");
+  });
+
   it("serves a bounded thumbnail through the full-image artifact ticket", async () => {
     const source = createSolidPngBuffer(640, 320, { r: 24, g: 64, b: 128 });
     const { attachmentId, sessionKey } = await createFixture(stateDir, { body: source });
@@ -1368,6 +1397,28 @@ describe("createManagedOutgoingImageBlocks", () => {
       mimeType: "audio/x-caf",
       playback: "transcode",
     });
+  });
+
+  it("does not publish a record when playback inspection fails", async () => {
+    const sourcePath = path.join(stateDir, "workspace", "voice.mp3");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    resolvePlaybackModeForSourceMock.mockRejectedValueOnce(
+      new Error("synthetic playback inspection failure"),
+    );
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [sourcePath],
+      stateDir,
+      localRoots: [path.dirname(sourcePath)],
+      allowLocalNonImage: true,
+      continueOnPrepareError: true,
+    });
+
+    expect(blocks).toEqual([]);
+    expect(listManagedImageRecordEntries({ stateDir })).toEqual([]);
+    await expectPathMissing(path.join(stateDir, "media", "outgoing", "originals"));
   });
 
   it.each(["audio", "video"] as const)("caps managed %s data URLs by media kind", async (kind) => {

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1202,7 +1202,7 @@ async function resolveManagedOutgoingMediaArtifactDownloadForRecord(
     artifactId: buildManagedOutgoingArtifactId(record.attachmentId, kind),
     sessionKey: record.sessionKey,
     type: kind,
-    title: record.alt,
+    title: kind === "image" ? record.alt : (record.original.filename ?? record.alt),
     ...(record.original.contentType ? { mimeType: record.original.contentType } : {}),
     ...(record.original.sizeBytes != null ? { sizeBytes: record.original.sizeBytes } : {}),
     url: `${canonicalUrl}?${params.toString()}`,
@@ -1504,7 +1504,6 @@ export async function createManagedOutgoingMediaBlocks(params: {
               : attachmentMetadata?.name?.trim() || label,
         },
       };
-      insertManagedImageRecord(record, stateDir);
       let playback: "native" | "transcode" | undefined;
       if (mediaKind === "audio" || mediaKind === "video") {
         const opened = await openLocalFileSafely({ filePath: savedOriginal.path });
@@ -1522,6 +1521,7 @@ export async function createManagedOutgoingMediaBlocks(params: {
         }
       }
       const block = buildManagedMediaBlock(record, playback);
+      insertManagedImageRecord(record, stateDir);
       const durationMs = asNonNegativeFiniteNumber(attachmentMetadata?.durationMs);
       const width = asNonNegativeFiniteNumber(attachmentMetadata?.width);
       const height = asNonNegativeFiniteNumber(attachmentMetadata?.height);

--- a/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
+++ b/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { expectErrorDetails, expectFields } from "./artifacts.test-support.js";
+
+const hoisted = vi.hoisted(() => ({
+  loadSessionEntry: vi.fn(),
+  resolveManagedArtifactDownload: vi.fn(),
+  resolveManagedUrlDownload: vi.fn(),
+  visitSessionMessagesAsync: vi.fn(),
+}));
+
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    loadGatewaySessionEntryReadOnly: hoisted.loadSessionEntry,
+  };
+});
+
+vi.mock("../session-transcript-readers.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-transcript-readers.js")>(
+    "../session-transcript-readers.js",
+  );
+  return { ...actual, visitSessionMessagesAsync: hoisted.visitSessionMessagesAsync };
+});
+
+vi.mock("../managed-image-attachments.js", async () => {
+  const actual = await vi.importActual<typeof import("../managed-image-attachments.js")>(
+    "../managed-image-attachments.js",
+  );
+  return {
+    ...actual,
+    resolveManagedOutgoingMediaArtifactDownload: hoisted.resolveManagedArtifactDownload,
+    resolveManagedOutgoingMediaUrlDownload: hoisted.resolveManagedUrlDownload,
+  };
+});
+
+const { artifactsHandlers } = await import("./artifacts.js");
+
+describe("managed artifact lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.loadSessionEntry.mockReturnValue({
+      storePath: "/tmp/sessions.sqlite",
+      entry: { sessionId: "sess-main" },
+    });
+    hoisted.resolveManagedArtifactDownload.mockResolvedValue(null);
+    hoisted.visitSessionMessagesAsync.mockImplementation(async (_scope, visit) => {
+      visit(
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "image",
+              artifactId: "artifact_managed_image_11111111-1111-4111-8111-111111111111",
+              url: "/api/chat/media/outgoing/agent%3Amain%3Amain/22222222-2222-4222-8222-222222222222/full",
+            },
+          ],
+          __openclaw: { seq: 2 },
+        },
+        2,
+      );
+      return 1;
+    });
+  });
+
+  it("does not retarget a stale managed artifact id through a different block URL", async () => {
+    const artifactId = "artifact_managed_image_11111111-1111-4111-8111-111111111111";
+    const calls: Array<{ ok: boolean; error?: unknown }> = [];
+
+    await artifactsHandlers["artifacts.download"]?.({
+      req: { type: "req", id: "download", method: "artifacts.download", params: {} },
+      params: { sessionKey: "agent:main:main", artifactId },
+      client: null,
+      isWebchatConnect: () => false,
+      respond: (ok, _payload, error) => calls.push({ ok, error }),
+      context: { getRuntimeConfig: () => ({}) } as never,
+    });
+
+    expect(calls[0]?.ok).toBe(false);
+    expectFields(expectErrorDetails(calls), { type: "artifact_not_found", artifactId });
+    expect(hoisted.resolveManagedUrlDownload).not.toHaveBeenCalled();
+    expect(hoisted.visitSessionMessagesAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -529,6 +529,16 @@ function requireQueryable(params: ArtifactQuery, respond: RespondFn): boolean {
   return false;
 }
 
+function respondArtifactNotFound(respond: RespondFn, requestedArtifactId: string): void {
+  respond(
+    false,
+    undefined,
+    artifactError("artifact_not_found", "artifact not found", {
+      artifactId: requestedArtifactId,
+    }),
+  );
+}
+
 async function runArtifactSessionOperation<T>(
   respond: RespondFn,
   operation: () => Promise<T> | T,
@@ -619,13 +629,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
     }
     const { artifact } = found.value;
     if (!artifact) {
-      respond(
-        false,
-        undefined,
-        artifactError("artifact_not_found", "artifact not found", {
-          artifactId: params.artifactId,
-        }),
-      );
+      respondArtifactNotFound(respond, params.artifactId);
       return;
     }
     respond(true, { artifact: toSummary(artifact) });
@@ -685,6 +689,8 @@ export const artifactsHandlers: GatewayRequestHandlers = {
         });
         return;
       }
+      respondArtifactNotFound(respond, params.artifactId);
+      return;
     }
     const found = await runArtifactSessionOperation(respond, () =>
       findArtifact(admittedQuery, cfg, { downloadArtifactId: params.artifactId }),
@@ -694,13 +700,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
     }
     const { artifact } = found.value;
     if (!artifact) {
-      respond(
-        false,
-        undefined,
-        artifactError("artifact_not_found", "artifact not found", {
-          artifactId: params.artifactId,
-        }),
-      );
+      respondArtifactNotFound(respond, params.artifactId);
       return;
     }
     if (artifact.download.mode === "unsupported") {

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import {
+  appendReplyMediaFailureWarning,
   readPairingQrReplyChannelData,
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
@@ -237,6 +238,7 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
   let strippedTextPayloadCount = 0;
   for (const entry of plan) {
     const payload = entry.payload;
+    let managedMediaPrepareFailed = false;
     const text = sanitizeAssistantDisplayText(payload.text, {
       preserveBoundaries: preserveTextBoundaries,
     });
@@ -277,6 +279,7 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
           allowLocalNonImage: mediaGroup.trustedLocalMedia,
           continueOnPrepareError: true,
           onPrepareError: (error) => {
+            managedMediaPrepareFailed = true;
             params.onManagedMediaPrepareError?.(error.message);
           },
         });
@@ -295,6 +298,9 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
     }
     preparedMedia.sort((left, right) => left.sourceIndex - right.sourceIndex);
     content.push(...preparedMedia.flatMap((preparedEntry) => preparedEntry.blocks));
+    if (managedMediaPrepareFailed) {
+      content.push({ type: "text", text: appendReplyMediaFailureWarning(undefined) });
+    }
   }
 
   if (content.length > 0) {

--- a/src/gateway/server-methods/chat-reply-media.test.ts
+++ b/src/gateway/server-methods/chat-reply-media.test.ts
@@ -174,7 +174,9 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
 
     expect(payload?.mediaUrl).toBeUndefined();
     expect(payload?.mediaUrls).toBeUndefined();
-    expect(requireString(payload?.text, "suppressed media text")).toBe("⚠️ Media failed.");
+    expect(requireString(payload?.text, "suppressed media text")).toBe(
+      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
   });
 
   it("does not stage sensitive media before display suppression", async () => {
@@ -200,6 +202,28 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(payload?.mediaUrl).toBeUndefined();
     expect(payload?.mediaUrls).toEqual([dataUrl]);
     await expectOutboundMediaMissing(stateDir);
+  });
+
+  it("projects bounded retry guidance when managed media preparation fails", async () => {
+    const source = "data:audio/mpeg;base64,not-valid!";
+    const errors: string[] = [];
+
+    const content = await buildAssistantDisplayContentFromReplyPayloads({
+      sessionKey: TEST_SESSION_KEY,
+      agentId: "main",
+      payloads: [{ mediaUrls: [source] }],
+      onManagedMediaPrepareError: (message) => errors.push(message),
+    });
+
+    expect(content).toEqual([
+      {
+        type: "text",
+        text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      },
+    ]);
+    expect(errors).toEqual(["Invalid image data URL"]);
+    expect(JSON.stringify(content)).not.toContain(source);
+    expect(Buffer.byteLength(JSON.stringify(content))).toBeLessThan(256);
   });
 
   it("preserves local audio paths for WebChat audio embedding", async () => {
@@ -342,7 +366,13 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
       managedMediaLocalRoots: [workspaceDir],
     });
 
-    expect(content).toEqual([expect.objectContaining({ type: "audio", mimeType: "audio/mpeg" })]);
+    expect(content).toEqual([
+      expect.objectContaining({ type: "audio", mimeType: "audio/mpeg" }),
+      {
+        type: "text",
+        text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      },
+    ]);
   });
 
   it("preserves media order across interleaved trust classes", async () => {
@@ -384,7 +414,9 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
 
     expect(payload?.mediaUrl).toBeUndefined();
     expect(payload?.mediaUrls).toBeUndefined();
-    expect(requireString(payload?.text, "suppressed media text")).toBe("⚠️ Media failed.");
+    expect(requireString(payload?.text, "suppressed media text")).toBe(
+      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
     await expectOutboundMediaMissing(stateDir);
   });
 

--- a/src/gateway/server-methods/chat-send-nonagent-finalization.ts
+++ b/src/gateway/server-methods/chat-send-nonagent-finalization.ts
@@ -242,14 +242,16 @@ export async function finalizeChatSendNonAgentReplies(params: {
     getAgentScopedMediaLocalRoots(cfg, transcriptAgentId),
     latestStorePath ? [latestStorePath] : undefined,
   );
+  let managedMediaPrepareFailed = false;
   const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
-    sessionKey,
-    agentId,
+    sessionKey: transcriptSessionKey,
+    agentId: transcriptAgentId,
     payloads: finalPayloads,
     managedMediaLocalRoots: mediaLocalRoots,
     includeSensitiveMedia: false,
     includeSensitiveDisplay: true,
     onManagedMediaPrepareError: (message) => {
+      managedMediaPrepareFailed = true;
       context.logGateway.warn(`webchat media embedding skipped attachment: ${message}`);
     },
     onSensitiveDisplayPrepareError: (message) => {
@@ -269,12 +271,13 @@ export async function finalizeChatSendNonAgentReplies(params: {
   const persistedAssistantContent = replaceAssistantContentTextBlocks(
     hasSensitiveMedia
       ? await buildAssistantDisplayContentFromReplyPayloads({
-          sessionKey,
-          agentId,
+          sessionKey: transcriptSessionKey,
+          agentId: transcriptAgentId,
           payloads: finalPayloads,
           managedMediaLocalRoots: mediaLocalRoots,
           includeSensitiveMedia: false,
           onManagedMediaPrepareError: (message) => {
+            managedMediaPrepareFailed = true;
             context.logGateway.warn(`webchat media embedding skipped attachment: ${message}`);
           },
         })
@@ -297,7 +300,9 @@ export async function finalizeChatSendNonAgentReplies(params: {
     : "";
   const transcriptReply =
     mediaMessage?.transcriptText ||
-    buildTranscriptReplyText(finalPayloads) ||
+    (managedMediaPrepareFailed
+      ? transcriptDisplayReply
+      : buildTranscriptReplyText(finalPayloads)) ||
     transcriptDisplayReply;
   let message: Record<string, unknown> | undefined;
   const shouldAppendAssistantTranscript = Boolean(

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2756,7 +2756,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     mockState.sessionIdsByKey.set(targetSessionKey, targetSessionId);
     mockState.finalPayload = setReplyPayloadMetadata(
-      { text: "bound history reply" },
+      {
+        text: "bound history reply",
+        mediaUrl: `data:image/png;base64,${TINY_PNG_BASE64}`,
+      },
       {
         sourceReplyTranscriptMirror: {
           sessionKey: targetSessionKey,
@@ -2783,6 +2786,30 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       agentId: "main",
       sessionKey: `agent:main:${targetSessionKey}`,
     });
+    expect(JSON.stringify(assistantUpdate?.message)).toContain(
+      `/api/chat/media/outgoing/${encodeURIComponent(targetSessionKey)}/`,
+    );
+    expect(JSON.stringify(assistantUpdate?.message)).not.toContain(
+      "/api/chat/media/outgoing/agent%3Amain%3Amain/",
+    );
+  });
+
+  it("replaces failed managed media with bounded visible guidance", async () => {
+    await createTranscriptFixture("openclaw-chat-send-managed-media-failure-");
+    const source = "data:audio/mpeg;base64,not-valid!";
+    mockState.finalPayload = { mediaUrl: source };
+    const { send } = createChatRequestFixture();
+
+    const payload = await send({ idempotencyKey: "idem-managed-media-failure" });
+
+    const serialized = JSON.stringify(payload?.message);
+    expect(serialized).toContain(
+      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    );
+    expect(serialized).not.toContain(source);
+    expect(Buffer.byteLength(serialized)).toBeLessThan(1_024);
+    const assistantEntries = await readActiveAssistantTranscriptMessages();
+    expect(JSON.stringify(assistantEntries)).not.toContain(source);
   });
 
   it("does not cross a plugin-bound session rotation during finalization", async () => {


### PR DESCRIPTION
Closes #124047

## What Problem This Solves

Fixes an issue where managed outgoing image, audio, and video replies could become unavailable or produce unsafe fallback text when reply preparation crossed transcript/session ownership boundaries.

The same lifecycle break also allowed a failed playback inspection to leave stale metadata, a stale managed artifact ID to retarget through another block URL, and audio/video artifact titles to change between list/get and download.

## Why This Change Was Made

Managed outgoing media now follows one ownership invariant from preparation through transcript projection, artifact resolution, HTTP serving, and cleanup:

- media is materialized under the durable target transcript/session;
- the managed record is published only after fallible playback inspection succeeds;
- a managed artifact ID resolves only its own record, while legacy URL upgrade remains limited to blocks without a managed ID;
- audio/video downloads retain the stored filename used by artifact list/get;
- preparation failures become one bounded, redacted retry message instead of falling through to a raw path, URL, or base64 payload.

The existing HTTP authentication, ticket, session, status/body, range, protocol, config, SDK, schema, and delivery-replay contracts are unchanged. Inactive-transcript retention in #117266 and targetless internal-source buffer routing are deliberately excluded.

Best-fix verdict: this is the canonical owner-boundary repair. Downstream fetch retries, consumer-only guards, URL fallback after managed-ID failure, and catch-time metadata rollback were rejected because they preserve split ownership or mask the producer failure.

Provenance: the incomplete ownership was carried forward across #106740, #112016, #115042, #115842, and #115987. The blamed code author, PR author, and squash merger were `@steipete` for each; no bot/automerge trigger was involved. #112016 retargeted transcript persistence without retargeting managed media construction, #115042 introduced managed ID/URL download fallback and image-derived titles, and #115987 added fallible playback inspection after record insertion.

## User Impact

Managed media remains downloadable from the transcript that owns it, failed preparation leaves no stale record/file and shows a short next step, stale IDs fail explicitly instead of selecting another attachment, and audio/video titles stay consistent across artifact APIs.

## Evidence

Exact reviewed head before the patch-identical CI rebase: `ef80220ce76456a261cefa403ec2fff1db1f03a4`. Current PR head: `7a9078e04e768423af4166f0e0aa1127b8e2ebed`; stable patch ID remains `1680948fa0612dfebd648192f91338a1f76e16f2`.

- Pre-fix owner regressions: 6 intended failures with 347 surrounding passes.
- Post-fix focused Gateway proof: 353/353 assertions passed across the record, artifact, projection, and finalization owners.
- Media-warning siblings: 115/115 assertions passed.
- Source-blind isolated Gateway/free-port proof with actual staged bytes:
  - full fetch: HTTP 200 with exact bytes;
  - range fetch: HTTP 206 with exact requested bytes and `Content-Range`;
  - HEAD: HTTP 200 with no body;
  - unsatisfiable range: HTTP 416 with no body;
  - wrong identity: HTTP 404 with body `not found`;
  - expired ticket: HTTP 401;
  - fetch after WebSocket disconnect: HTTP 200 with exact bytes;
  - forced cleanup: managed row and file removed, then HTTP 404 with body `not found`.
- Bounded failure guidance is source-free and under 1 KiB; the pre-fix oversized fallback exceeded 22 MB.
- Binding-owned media URLs encode the target session, audio/video download titles match stored filenames, and injected inspection failure leaves no managed record or file.
- Full changed gate passed format, lint, production/test types, import cycles, native schema version, database-first/media-download guards, and boundary checks.
- Fresh isolated autoreview before the patch-identical CI rebase: no accepted/actionable findings; patch correct with 0.96 confidence. Current-head review is rerun before prepare.
- Reconciled merged attachment work #123977 and #123983; neither overlaps this 13-file owner patch. Stable patch ID is unchanged from the approved local commit.

Production LOC: +34/-22 (net +12). Tests: +285/-13 (net +272). The positive production delta records one missing failure fact at the preparation owner and consolidates exact artifact-not-found handling; it adds no new abstraction, configuration, protocol, schema, or fallback path.

No changelog entry: release generation owns `CHANGELOG.md`.
