### PR TITLE
fix(worker-environments): bound node workspace retain convergence loop

### DIFF
--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -98,6 +98,7 @@ function createHarness(
       applied: boolean;
       deleted: number;
       hasMore: boolean;
+      bundleDeleted?: number;
       bundleGeneration?: number;
       bundleStatus?: { bundleHash: string; status: "installed" | "missing" };
     }>;
@@ -105,9 +106,11 @@ function createHarness(
     currentBundleStatus?: NodeWorkerBundleStatusObservation;
     invokeError?: string;
     onInvoke?: (index: number) => void;
+    loop?: { applied: boolean; deleted: number; hasMore: boolean; bundleDeleted?: number };
   } = {},
 ) {
   const results = [...(params.results ?? [{ applied: true, deleted: 0, hasMore: false }])];
+  const loopResult = params.loop;
   let invokeIndex = 0;
   const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => {
     params.onInvoke?.(invokeIndex++);
@@ -116,7 +119,9 @@ function createHarness(
     }
     return {
       ok: true,
-      payloadJSON: JSON.stringify(results.shift() ?? { applied: true, deleted: 0, hasMore: false }),
+      payloadJSON: JSON.stringify(
+        loopResult ?? results.shift() ?? { applied: true, deleted: 0, hasMore: false },
+      ),
     };
   });
   let currentBundleStatus = params.currentBundleStatus;
@@ -607,5 +612,162 @@ describe("node workspace retain coordinator", () => {
     expect(invoke).toHaveBeenCalledTimes(2);
     expect(invoke.mock.calls[1]?.[0].params).toMatchObject({ sequence: 2 });
     await coordinator.stop();
+  });
+
+  it("aborts a node worker that never converges instead of looping forever (BUG-056)", async () => {
+    // A buggy worker replies {applied:true, hasMore:true} without deleting.
+    // Pre-fix the for(;;) loop never resolves; post-fix it bails after
+    // MAX_CONSECUTIVE_NO_PROGRESS_RESPONSES replies and drain warns instead.
+    const { coordinator, invoke, warn } = createHarness({
+      loop: { applied: true, deleted: 0, hasMore: true },
+    });
+
+    await coordinator.start();
+
+    // The constant is module-private (knip --production rejects unused
+    // exports); keep this literal in sync with the source constant.
+    expect(invoke).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("workspace retain did not converge"));
+    await coordinator.stop();
+  });
+
+  it("preserves legitimate retain pagination beyond 100 pages", async () => {
+    // A fixed 100-page cap would misclassify healthy backlogs above 25,600
+    // stale entries; progressing pagination (deleted > 0 per round) must run
+    // to hasMore:false regardless of page count.
+    const results = Array.from({ length: 150 }, () => ({
+      applied: true,
+      deleted: 256,
+      hasMore: true,
+    }));
+    results.push({ applied: true, deleted: 1, hasMore: false });
+    const { coordinator, invoke, warn } = createHarness({ results });
+
+    await coordinator.start();
+
+    expect(invoke).toHaveBeenCalledTimes(151);
+    expect(warn).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("treats bundle-only deletion as forward progress (BUG-056 bundle lane)", async () => {
+    // A legal bundle-only response carries { deleted: 0, hasMore: true,
+    // bundleDeleted: >0 }: the workspace lane is already clean while bundle
+    // cleanup still paginates (up to 16 candidates per page). The pre-fix
+    // guard checked only `deleted`, so a healthy bundle backlog tripped the
+    // no-progress detector after three rounds. Both lanes must count.
+    const results = Array.from({ length: 10 }, () => ({
+      applied: true,
+      deleted: 0,
+      hasMore: true,
+      bundleDeleted: 16,
+    }));
+    results.push({ applied: true, deleted: 0, hasMore: false, bundleDeleted: 4 });
+    const { coordinator, invoke, warn } = createHarness({ results });
+
+    await coordinator.start();
+
+    expect(invoke).toHaveBeenCalledTimes(11);
+    expect(warn).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("still converges when only the bundle lane makes progress across many pages", async () => {
+    // Bundle cleanup deletes at most 16 candidates per page; a large bundle
+    // backlog therefore requires many positive-progress responses. A buggy
+    // 3-strike guard keyed on workspace `deleted` alone would abort this
+    // healthy run after the third page.
+    const results = Array.from({ length: 50 }, () => ({
+      applied: true,
+      deleted: 0,
+      hasMore: true,
+      bundleDeleted: 16,
+    }));
+    results.push({ applied: true, deleted: 0, hasMore: false, bundleDeleted: 3 });
+    const { coordinator, invoke, warn } = createHarness({ results });
+
+    await coordinator.start();
+
+    expect(invoke).toHaveBeenCalledTimes(51);
+    expect(warn).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("still aborts when neither workspace nor bundle lane deletes (BUG-056)", async () => {
+    // A genuinely stuck worker replies { deleted: 0, bundleDeleted: 0,
+    // hasMore: true }; the converged guard must still trip after the limit.
+    const { coordinator, invoke, warn } = createHarness({
+      loop: { applied: true, deleted: 0, hasMore: true, bundleDeleted: 0 },
+    });
+
+    await coordinator.start();
+
+    expect(invoke).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("workspace retain did not converge"));
+    await coordinator.stop();
+  });
+
+  it("bounds a slow-but-progressing node worker with the convergence deadline", async () => {
+    // A slow worker that always makes a little progress (deleted > 0) never
+    // trips the no-progress detector, so the wall-clock deadline bounds it.
+    // Fake timers advance the clock past the deadline between rounds.
+    vi.useFakeTimers();
+    const { coordinator, invoke, warn } = createHarness({
+      loop: { applied: true, deleted: 1, hasMore: true },
+    });
+    try {
+      invoke.mockImplementation(async () => {
+        // Advance 20 minutes per round: round 1 stays inside the 30-minute
+        // deadline, round 2 crosses it.
+        vi.setSystemTime(Date.now() + 20 * 60_000);
+        return {
+          ok: true,
+          payloadJSON: JSON.stringify({ applied: true, deleted: 1, hasMore: true }),
+        };
+      });
+
+      await coordinator.start();
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("workspace retain did not converge"),
+      );
+      await coordinator.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps the in-flight RPC at the remaining convergence deadline", async () => {
+    // An RPC begun just before expiry used to get a fresh 10-minute timeout.
+    // The remaining budget must cap the final dispatch: after a 29-minute
+    // first round, the second RPC gets 60s, not 600s.
+    vi.useFakeTimers();
+    const { coordinator, invoke, warn } = createHarness({
+      loop: { applied: true, deleted: 1, hasMore: true },
+    });
+    try {
+      let call = 0;
+      invoke.mockImplementation(async () => {
+        call += 1;
+        vi.setSystemTime(Date.now() + (call === 1 ? 29 * 60_000 : 2 * 60_000));
+        return {
+          ok: true,
+          payloadJSON: JSON.stringify({ applied: true, deleted: 1, hasMore: true }),
+        };
+      });
+
+      await coordinator.start();
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(invoke.mock.calls[0]?.[0].timeoutMs).toBe(10 * 60_000);
+      expect(invoke.mock.calls[1]?.[0].timeoutMs).toBe(60_000);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("workspace retain did not converge within"),
+      );
+      await coordinator.stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
@@ -20,6 +20,12 @@ import type { WorkerEnvironmentService } from "./service.js";
 import { listRetainedWorkerBundleHashes } from "./worker-bundle-retention.js";
 
 const RETAIN_COMMAND_TIMEOUT_MS = 10 * 60_000;
+// BUG-056: a buggy worker may keep replying {applied:true, hasMore:true}.
+// Healthy workers set hasMore only after deleting a full batch, so zero
+// deletions mean no progress (bail after 3); a deadline bounds slow progress.
+// Constants stay private so knip --production does not flag unused exports.
+const MAX_CONSECUTIVE_NO_PROGRESS_RESPONSES = 3;
+const RETAIN_CONVERGENCE_DEADLINE_MS = 3 * RETAIN_COMMAND_TIMEOUT_MS;
 const TERMINAL_ENVIRONMENT_STATES = new Set(["destroyed", "failed", "orphaned"]);
 
 type NodeWorkspaceRetainCoordinatorOptions = {
@@ -185,12 +191,22 @@ export function createNodeWorkspaceRetainCoordinator(
         `Node bundle retention skipped (${node.nodeId}): ${retainedBundleHashes.length} retained hashes exceed the bounded maintenance request`,
       );
     }
+    const convergenceDeadline = Date.now() + RETAIN_CONVERGENCE_DEADLINE_MS;
+    let consecutiveNoProgressResponses = 0;
     for (;;) {
+      // Cap each RPC timeout at the remaining convergence budget so an
+      // in-flight call cannot hold the serialized coordinator past the deadline.
+      const remainingBudget = convergenceDeadline - Date.now();
+      if (remainingBudget <= 0) {
+        throw new Error(
+          `workspace retain did not converge within ${RETAIN_CONVERGENCE_DEADLINE_MS}ms (node worker is progressing too slowly)`,
+        );
+      }
       const result = await currentTransport.invoke({
         node,
         command: NODE_WORKER_WORKSPACE_RETAIN_COMMAND,
         params: input,
-        timeoutMs: RETAIN_COMMAND_TIMEOUT_MS,
+        timeoutMs: Math.min(RETAIN_COMMAND_TIMEOUT_MS, remainingBudget),
         signal: abortController.signal,
         isDispatchAuthorized: () => !stopped && transport === currentTransport,
       });
@@ -242,6 +258,27 @@ export function createNodeWorkspaceRetainCoordinator(
           currentTransport.acceptBundleStatus?.(node, undefined);
         }
         return;
+      }
+      // hasMore:true is the healthy worker's normal pagination signal
+      // (deleted >= 256 per batch); keep going while progress is made. Only
+      // repeated zero-deletion hasMore replies violate the protocol; drain's
+      // per-node catch warns and the next sweep retries.
+      //
+      // Progress is reported across two independent cleanup lanes — workspace
+      // deletion (`deleted`) and bundle cleanup (`bundleDeleted`). A legal
+      // bundle-only response carries { deleted: 0, hasMore: true, bundleDeleted: >0 },
+      // so both counts must be considered: a response that deletes only bundles
+      // is genuine forward progress and must not trip the no-progress guard.
+      const totalDeleted = retained.deleted + (retained.bundleDeleted ?? 0);
+      if (totalDeleted === 0) {
+        consecutiveNoProgressResponses += 1;
+        if (consecutiveNoProgressResponses >= MAX_CONSECUTIVE_NO_PROGRESS_RESPONSES) {
+          throw new Error(
+            `workspace retain did not converge: node worker returned hasMore:true without deleting stale entries ${MAX_CONSECUTIVE_NO_PROGRESS_RESPONSES} consecutive times`,
+          );
+        }
+      } else {
+        consecutiveNoProgressResponses = 0;
       }
     }
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a node worker that never finishes its workspace retain batch would trap the gateway's retain coordinator in an unbounded loop, starving workspace retainment for every node until the gateway was restarted.

- **Problem**: `publishSnapshot` drives a `for (;;)` loop that only exits when the node worker returns `!applied || !hasMore`. The node worker is a separate process reached via RPC; an older or buggy worker that keeps returning `{ applied: true, hasMore: true }` violates the private batching protocol and the loop never terminates — each iteration re-invokes the transport with a 10-minute per-call timeout, so the loop can run indefinitely. Because `drain()` reuses a single `operation = drain()` promise to serialize work, a stuck `publishSnapshot` keeps `drain` from ever returning, permanently occupying the coordinator and starving retain for **all** nodes, not just the offending one, until `stop()` aborts.
- **Solution (this revision)**: Bound the convergence loop by *progress*, not by page count. A healthy node worker only reports `hasMore: true` after deleting a full page (`WORKSPACE_RETENTION_DELETE_LIMIT = 256` entries, `src/node-host/node-worker-workspace.ts`), so:
  - `hasMore: true` with `deleted > 0` continues — a legitimate backlog may paginate through any number of pages;
  - `hasMore: true` with `deleted === 0` for **3 consecutive responses** is a protocol violation and aborts the node's retain cycle (`MAX_CONSECUTIVE_NO_PROGRESS_RESPONSES`);
  - a slow-but-progressing worker cannot hold the coordinator forever: the whole convergence loop is bounded by a **hard 30-minute deadline** (`RETAIN_CONVERGENCE_DEADLINE_MS = 3 × RETAIN_COMMAND_TIMEOUT_MS`), and every dispatch passes the smaller of the normal 10-minute timeout and the **remaining budget** as `timeoutMs` — so an RPC that starts just before expiry is capped by the time left, and a call cannot be dispatched once the budget is exhausted (the same remaining-budget pattern used by `workspace-sync.ts`).
- **What changed**:
  - `src/gateway/worker-environments/node-workspace-retain-coordinator.ts`: replaced the fixed `MAX_RETAIN_ITERATIONS = 100` page cap (from the earlier revision) with consecutive-no-progress detection plus a wall-clock convergence deadline; the loop returns on `!applied || !hasMore` exactly as before, and on failure `drain`'s existing per-node catch converts the error to a `warn`, the coordinator releases, and the next 60-second placement reconciliation sweep retries that node. The no-progress guard sums both cleanup lanes — workspace deletion (`deleted`) and bundle cleanup (`bundleDeleted`) — because a legal bundle-only response carries `{ deleted: 0, hasMore: true, bundleDeleted: >0 }` (bundle cleanup paginates up to 16 candidates per page, `src/node-host/node-worker-bundle-installer.ts`); counting only `deleted` would misclassify a healthy bundle backlog as stuck after three rounds.
  - `src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts`: updated the BUG-056 never-converging regression (aborts after 3 no-progress rounds), added a **>100-page legitimate pagination regression** (150 full pages then completion), added a **slow-but-progressing deadline regression**, added a **near-deadline RPC cap regression** (the final dispatch gets the remaining budget as its timeout, not a fresh 10 minutes), and added **bundle-lane progress regressions** (bundle-only deletion across 10 and 50 pages counts as forward progress; a response deleting on neither lane still aborts).
- **What did NOT change**: `RETAIN_COMMAND_TIMEOUT_MS`, the `AbortController`/`isDispatchAuthorized` guards, the worker-side cleanup logic, the retain protocol schema, and the `drain`/`schedule`/`stop` control flow are untouched.

## Why This Change Was Made

The retain coordinator was introduced in #123889 (preserve node workspaces across restarts). Its private batching protocol assumes the node worker returns `hasMore: false` after a finite number of batches. That assumption is safe for an in-process function, but the node worker is a separate process whose version the gateway does not control — an older or buggy worker can keep returning `hasMore: true` indefinitely, and nothing in the original loop guarded against it.

The first revision added a fixed 100-iteration cap. ClawSweeper review on this PR correctly flagged it: `hasMore` is the worker's **normal** pagination signal after every 256 deletions, so a healthy backlog needing more than 100 pages (more than 25,600 stale entries) would be misreported as a convergence failure and deferred to a later sweep. The worker contract makes `hasMore: true` with `deleted === 0` impossible for a healthy worker (all three `hasMore` sites in `collectRetainedWorkspaceSnapshot` only fire once `deleted >= 256`), so "did it delete anything?" is the correct discriminator between legitimate pagination and a stuck worker.

- **Best fix**: progress-aware continuation (keep going while deletions happen) plus a bounded failure deadline (stop slow-but-progressing workers after 30 minutes). This preserves legitimate pagination at any scale while still bounding both classes of malformed worker:
  - never-progressing (`hasMore: true`, `deleted: 0`) → aborts after 3 consecutive responses;
  - slow-but-progressing (e.g., replying just under the 10-minute per-call timeout) → aborts at the 30-minute deadline instead of occupying the coordinator for ~16 hours.
- **Alternative considered**: keeping a page-count cap (higher or lower). Rejected — any fixed page count is a heuristic that can collide with legitimate backlogs of unbounded size; progress is the protocol's real invariant.
- **Risk**: a wall-clock deadline could theoretically interrupt an extremely large legitimate cleanup. In practice a single node's stale workspace count is bounded by disk contents, healthy rounds delete 256 entries in milliseconds, and the 30-minute budget covers millions of entries; on the rare false positive the node is simply skipped and retried by the next reconciliation sweep.

## User Impact

Operators no longer risk a single misbehaving node worker silently hanging the gateway's workspace retention for every node, and legitimate large cleanups are no longer false-failed:

- A node worker that keeps claiming more work without deleting anything now produces a visible `warn` log (`workspace retain did not converge: node worker returned hasMore:true without deleting stale entries 3 consecutive times`) and is skipped for that retain cycle, while the coordinator keeps serving other nodes.
- A healthy node with a very large stale backlog (previously >25,600 entries would false-fail under the 100-page cap) now completes any number of pages with no warning.
- A slow-but-progressing abnormal worker is bounded to at most 30 minutes of coordinator time instead of ~16 hours.
- The coordinator retries the failed node on the next 60-second placement reconciliation sweep, so no cleanup is permanently lost.

## Evidence

- **Real environment tested**: Linux x86_64, Node v22.22.3, branch `fix/bug-056-retain-coordinator-unbounded-loop` rebased on `origin/main`.
- **Real node-worker subprocess proof (after fix)** — the production `NodeWorkerSupervisor` runs in a spawned child Node process answering retain commands over JSON-lines stdio, against a real temp workspace seeded with 40,000 stale generations (157 pages of 256). The coordinator's retain snapshot includes `generation: 7` (the environment's authoritative owner epoch), which the worker correctly retains; all 39,999 stale generations are deleted across 157 pages with **zero warnings**:

  ```console
  $ node --import tsx /home/code/github/contributions/pr-124049-evidence/run-retain-proof.mts
  seeded 40000 stale generations (~157 pages of 256)
  page 001: deleted=256 hasMore=true
  ...
  page 156: deleted=256 hasMore=true
  page 157: deleted= 63 hasMore=false

  RESULT real-worker backlog: pages=157 (>100 required), total deleted=39999/40000, retained generation dirs remaining=["7"], warns=0
  PASS: legitimate pagination beyond 100 pages converges without warning; authoritative generation retained

  RESULT no-progress buggy worker: invoke calls=3, warns=1
  PASS: never-converging worker aborts after 3 no-progress rounds

  ALL PROOF SCENARIOS PASSED
  ```

- **Behavior matrix** (worker retain result → coordinator outcome):

  ```text
  worker result                            => pre-fix (for(;;))       => 100-page-cap revision  => this fix
  {applied:true, hasMore:true, deleted:0}  => hangs forever            => warn after 100 rounds  => warn after 3 rounds
  {applied:true, hasMore:true, deleted:256} x150 then hasMore:false    => completes               => false FAIL at page 100 => completes (151 calls, no warn)
  {applied:true, hasMore:false}            => completes (1)            => completes (1)           => completes (1) [unchanged]
  slow progress (deleted:1) every round    => runs forever             => warn after 100 rounds   => hard stop at 30-minute deadline; final RPC timeout capped to remaining budget
  ```

- **Focused tests**:

  ```console
  $ OPENCLAW_GATEWAY_PROJECT_SHARDS=0 npx vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
   Test Files  1 passed (1)
        Tests  22 passed (22)
  ```

  Regression credibility: against the earlier 100-page-cap code, the new `>100 pages` and `deadline` tests fail (the cap revision stops at page 100 and never checks the deadline); against the original `for (;;)` code, the BUG-056 test hangs until timeout; against the first progress-aware revision, the `near-deadline RPC cap` test fails (the pre-fix code always passed a fresh 10-minute timeout). All new/updated tests pass only with this fix.
- **Bundle-lane progress proof (ClawSweeper round-2 finding)** — the review found the no-progress guard checked only `deleted`, so a legal bundle-only response `{ deleted: 0, hasMore: true, bundleDeleted: 16 }` would trip the 3-strike guard on a healthy bundle backlog. Verified pre-fix fail → post-fix pass by temporarily reverting only the source file (`git stash push -- <source>`) while keeping the new tests, then restoring:

  ```console
  $ node scripts/run-vitest.mjs src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts   # pre-fix source
  × treats bundle-only deletion as forward progress (BUG-056 bundle lane)
    AssertionError: expected "vi.fn()" to be called 11 times, but got 3 times
  × still converges when only the bundle lane makes progress across many pages
    AssertionError: expected "vi.fn()" to be called 51 times, but got 3 times
   Tests  2 failed | 20 passed (22)

  $ git stash pop && node scripts/run-vitest.mjs src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts   # post-fix source
   Test Files  1 passed (1)
        Tests  22 passed (22)
  ```

  The pre-fix guard aborts both bundle-only backlogs after exactly 3 rounds (the no-progress limit); post-fix it counts `deleted + bundleDeleted` and both backlogs run to `hasMore: false`. The stuck-worker regression (`deleted: 0, bundleDeleted: 0, hasMore: true`) still aborts after 3 rounds post-fix.
- **CI-like shard**: the gateway-core project shard ran locally on this branch: 351/359 files passed (5583/5648 tests); the 8 failing files (control-ui session PRs, rsync/tunnel/transfer/sync, tools-invoke HTTP) also fail on `origin/main` (baseline full shard: 344/359 files passed) and are pre-existing environment/parallel-interference flakes unrelated to this change — `tools-invoke-http.test.ts` passes 41/41 when run alone, and this PR's own test file passes in the shard. The 30-minute-deadline change is additive to that already-verified surface (single local loop policy + its focused regressions). Lint/format/type: `oxfmt --check` clean, `oxlint -c .oxlintrc.json` clean, `tsgo --ignoreConfig` adds no new errors on the changed files, and `pnpm tsgo:test:src` passes (reported `--ignoreConfig` errors are pre-existing path-mapping noise present on `origin/main` too).
- **What was not tested**: the production WebSocket transport between gateway and node host (the proof uses the real worker subprocess over JSON-lines stdio, exercising the same command handler and worker code); a real node host daemon paired with a real gateway. `What was not tested` in the earlier revision (full device-worker integration environment) still applies.
- **Open PR collision check**: searched open PRs touching `node-workspace-retain-coordinator.ts`; none do. The file was introduced in #123889 (merged 2026-08-14) and this PR remains the only one touching it.

### Regression test plan

- Existing retain behaviors (snapshot publication, incomplete-placement retain, bounded multi-batch cleanup with same sequence, reconnect republish) — unchanged, still pass.
- New never-converging-worker path — updated BUG-056 test asserts abort at exactly 3 no-progress rounds.
- New >100-page legitimate pagination path — 150 full pages then completion, no warning.
- New slow-but-progressing path — fake-timer deadline trip, bounded invocation count, warning emitted.
- New bundle-lane-only progress path — bundle-only deletion (`deleted: 0, bundleDeleted: 16`) across 10 and 50 pages counts as forward progress and runs to `hasMore: false`; a response deleting on neither lane still aborts after 3 rounds.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude (Claude Code, glm-5.2) for the original BUG-056 implementation; this revision was implemented in the Codex open-source workflow (Codex agent) after ClawSweeper review, and re-verified with the real-worker subprocess proof above.
- Prompts / session excerpts: original user request fixed BUG-056 (retain coordinator unbounded loop) found via `/local-code-analysis`. Follow-ups: ClawSweeper finding "Preserve valid retain pagination beyond 100 pages" was analyzed (worker contract at `node-worker-workspace.ts:513` — `hasMore` only after 256 deletions), a progress-aware + deadline plan was written and approved by the user; a second ClawSweeper finding ("Cap the in-flight RPC at the remaining deadline") was addressed by passing the remaining budget as each dispatch's timeout, matching the existing `workspace-sync.ts` pattern, with a near-deadline regression.
- Confirmed understanding of code changes: Yes — the fix replaces the page-count cap with (1) consecutive no-progress detection using the protocol's `deleted` progress signal, (2) a wall-clock convergence deadline enforced before every dispatch by capping `timeoutMs` at the remaining budget; both error paths reuse `drain`'s existing per-node catch for graceful degradation and the 60-second sweep for retry.
- autoreview: N/A — the autoreview helper's Codex engine cannot run in this environment (isolated Codex execution falls back to the OpenAI API which is region-blocked); the diff was reviewed manually by the implementing agent plus the ClawSweeper re-review on this PR.

