### PR TITLE
fix(memory): keep local provider healthy when search is cancelled

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -143,6 +143,58 @@ describe("memory index", () => {
     expect(queryCalls).toBe(3);
   });
 
+  it("keeps a healthy local provider active when the caller cancels search", async () => {
+    const cfg = createCfg({
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+
+    const close = vi.fn(async () => {});
+    let queryCalls = 0;
+    const fields = manager as unknown as {
+      provider: {
+        id: string;
+        model: string;
+        embedQuery: (text: string) => Promise<number[]>;
+        embedBatch: (texts: string[]) => Promise<number[][]>;
+        close: () => Promise<void>;
+      };
+      providerKey: string;
+      providerLifecycle: { mode: "active"; providerId: string };
+      computeProviderKey: () => string;
+    };
+    fields.provider = {
+      id: "local",
+      model: "mock-embed",
+      embedQuery: async () => {
+        queryCalls += 1;
+        return [1, 0, 0, 0];
+      },
+      embedBatch: async (texts) => texts.map(() => [1, 0, 0, 0]),
+      close,
+    };
+    fields.providerLifecycle = { mode: "active", providerId: "local" };
+    fields.providerKey = fields.computeProviderKey();
+    await manager.sync({ reason: "test", force: true });
+
+    const abortReason = new Error("memory search was cancelled");
+    await expect(
+      manager.search("alpha", { signal: AbortSignal.abort(abortReason) }),
+    ).rejects.toMatchObject({ cause: abortReason });
+
+    expect(manager.status()).toMatchObject({
+      provider: "local",
+      custom: {
+        providerState: { mode: "active", providerId: "local" },
+        providerUnavailableReason: undefined,
+      },
+    });
+    await expect(manager.search("alpha")).resolves.not.toStrictEqual([]);
+    expect(queryCalls).toBe(1);
+    expect(close).not.toHaveBeenCalled();
+  });
+
   it("supplements thin strict FTS results for conversational queries", async () => {
     const cases = [
       {

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -285,12 +285,12 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           );
         } catch (err) {
           releaseSemanticProvider();
-          this.markLocalEmbeddingProviderDegraded(err);
-          // An aborted caller already stopped waiting; skip fallback-provider
-          // activation so the abandoned search stops instead of re-embedding.
+          // An aborted caller already stopped waiting; keep the provider generation
+          // healthy and skip fallback activation instead of poisoning later searches.
           if (opts?.signal?.aborted) {
             throw err;
           }
+          this.markLocalEmbeddingProviderDegraded(err);
           const message = formatErrorMessage(err);
           const activatedFallback = this.shouldFallbackOnError(err)
             ? await this.activateFallbackProvider(message).catch((fallbackErr: unknown) => {
@@ -331,7 +331,9 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
               );
             } catch (fallbackErr) {
               releaseFallbackProvider();
-              this.markLocalEmbeddingProviderDegraded(fallbackErr);
+              if (!opts?.signal?.aborted) {
+                this.markLocalEmbeddingProviderDegraded(fallbackErr);
+              }
               throw fallbackErr;
             } finally {
               releaseFallbackProvider();


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Closes #124050

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where cancelling a built-in memory embedding search could mark a healthy local provider unavailable, change status from local/active to none/degraded, and prevent the next search from using the provider.

## Why This Change Was Made

Caller cancellation now wins before local-provider degradation for both primary and fallback query generations. Genuine provider errors retain the existing retry, fallback, retirement, and degradation behavior; cancellation only ends the abandoned search.

The search orchestrator owns the distinction because it has both the caller signal and the generation/fallback transition. Moving the check into provider adapters would duplicate cancellation policy and would not protect both generations consistently.

History traces the ordering to the memory manager split in #122540 on August 12, 2026. The code author, PR author, and merger were Peter Steinberger (`@steipete`).

## User Impact

Local semantic memory remains healthy after a cancelled or timed-out search, status continues to report the active provider, and a later search can recover immediately. There are no provider auth, routing, configuration/default, SQLite schema/data, SDK/protocol, retention, or release changes.

No changelog entry: normal PR changelogs are release-owned; this body records the release-note context.

## Evidence

- Current-main reproduction (`f24bd8a2a29942bb54cfcb2932762186059ae774`): 1/13 failed for the intended reason. Status changed from local/active to none/degraded with `Local embeddings degraded: memory search was cancelled`.
- Rebased fix head `1dd46f9195aad050076a3df68407bb67eecab29c`: focused search orchestration 13/13 passed, including a later successful search on the original provider with no close.
- Provider lifecycle, fallback, leases, pre-abort/in-flight retry cancellation, and CLI siblings: 105/105 passed.
- Exact-path changed gate passed: format, lint, extension production/test types, doctor contracts, dependency/deprecation, database-first, dead-export, sidecar, and import-cycle guards.
- Full production build passed.
- Isolated built CLI proof: one task-owned file indexed; deep status reported a clean valid FTS-only index; search returned the randomized `cobalt-fern-49649` canary.
- Isolated foreground Gateway on port 49649 returned healthy RPC; no credentials or operator state were used.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31868191356 (`tbx_01m01zwfgfk3n23fk5ejnwxv6c`, stopped).
- Fresh Codex autoreview on the rebased patch: clean, no accepted/actionable findings; correctness confidence 0.99.
- Production LOC: +6/-4 (net +2). Tests: +52/-0. The +2 covers the fallback-generation sibling so cancellation cannot poison either active query generation.
