### PR TITLE
fix: queued chat follow-ups stay stuck after missed terminal events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1780,12 +1780,25 @@ jobs:
           --configLoader runner
           ui/src/e2e/mcp-app-conformance.e2e.test.ts
 
-      - name: Test Control UI auth transports with a real Gateway
+      - name: Test Control UI browser flows with a real Gateway
+        env:
+          OPENCLAW_CAPTURE_UI_PROOF: "1"
+          OPENCLAW_UI_E2E_ARTIFACT_DIR: .artifacts/control-ui-e2e/chat-flow-real-gateway
         run: >-
           node scripts/run-vitest.mjs run
           --config test/vitest/vitest.ui-e2e.config.ts
           --configLoader runner
+          ui/src/e2e/chat-flow.real-gateway.e2e.test.ts
           ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+
+      - name: Upload Control UI real-Gateway behavior proof
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: control-ui-real-gateway-proof-${{ github.run_attempt }}
+          path: .artifacts/control-ui-e2e/chat-flow-real-gateway
+          if-no-files-found: warn
+          retention-days: 7
 
   control-ui-i18n:
     permissions:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6597,7 +6597,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       .map((step: WorkflowStep) => step.run);
     expect(realGatewayRuns).toEqual([
       "node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mcp-app-conformance.e2e.test.ts",
-      "node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
+      "node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.real-gateway.e2e.test.ts ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
     ]);
     const realGatewayRunContract = realGatewayRuns.join("\n");
     expect(realGatewayRunContract).not.toContain("--retry");

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -6,6 +6,7 @@ import { UiE2eSequencer } from "./vitest.ui-e2e.sequencer.ts";
 
 const uiE2eIncludePatterns = ["ui/src/**/*.e2e.test.ts"];
 const uiE2eRealGatewayTestFiles = [
+  "ui/src/e2e/chat-flow.real-gateway.e2e.test.ts",
   "ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
   "ui/src/e2e/mcp-app-conformance.e2e.test.ts",
 ];

--- a/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.follow-ups.e2e.test.ts
@@ -4,6 +4,7 @@ import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
   installMockGateway,
+  pauseVirtualClock,
   requireRecord,
   requireString,
   waitForRequests,
@@ -12,6 +13,112 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
+  it("recovers a queued follow-up when terminal events are missed", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await page.clock.install();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "agent.wait": { status: "ok", endedAt: Date.now() },
+      },
+      sessionInfo: { hasActiveRun: false, key: "main", status: "done" },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
+      await page.locator("[data-settings-follow-up-mode]").selectOption("queue");
+      await page.goto(`${suite.server.baseUrl}chat?session=main`);
+      await expect.poll(() => new URL(page.url()).pathname).toMatch(/\/chat\/main$/);
+
+      await page.locator(".agent-chat__composer-combobox textarea").fill("finish silently");
+      await page.getByRole("button", { name: "Send message" }).click();
+      const initialSend = await gateway.waitForRequest("chat.send");
+      const activeRunId = requireString(
+        requireRecord(initialSend.params).idempotencyKey,
+        "active chat run id",
+      );
+      await gateway.setMethodResponse("chat.history", {
+        messages: [
+          {
+            __openclaw: { idempotencyKey: `${activeRunId}:user` },
+            content: [{ text: "finish silently", type: "text" }],
+            role: "user",
+            timestamp: Date.now(),
+          },
+        ],
+        sessionId: "control-ui-e2e-session",
+        sessionInfo: { hasActiveRun: false, key: "global", status: "done" },
+        thinkingLevel: null,
+      });
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [activeRunId],
+        clientRunId: activeRunId,
+        hasActiveRun: true,
+        message: {
+          __openclaw: {
+            id: "persisted-silent-user",
+            idempotencyKey: `${activeRunId}:user`,
+            seq: 1,
+          },
+          content: [{ text: "finish silently", type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "persisted-silent-user",
+        messageSeq: 1,
+        session: {
+          activeRunIds: [activeRunId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+      await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
+      await gateway.setMethodResponse("chat.send", { runId: "recovered-run", status: "ok" });
+
+      await pauseVirtualClock(page);
+      const followUp = "send after the missed terminal";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(followUp);
+      await page.getByRole("button", { name: "Queue message" }).click();
+      const queue = page.locator(".chat-queue");
+      await queue.getByText(followUp).waitFor({ timeout: 10_000 });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/missed-terminal-queued.png`,
+          fullPage: true,
+        });
+      }
+
+      await page.clock.fastForward(15_000);
+
+      await gateway.waitForRequest("agent.wait");
+      await page.clock.runFor(1_000);
+      const sends = await waitForRequests(gateway, "chat.send", 2);
+      expect(requireRecord(sends[1]?.params)).toMatchObject({
+        message: followUp,
+        sessionKey: "main",
+      });
+      await queue.waitFor({ state: "detached", timeout: 10_000 });
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/missed-terminal-recovered.png`,
+          fullPage: true,
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("opens a git-backed agent draft from the sidebar new-session action", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/e2e/chat-flow.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.real-gateway.e2e.test.ts
@@ -1,0 +1,605 @@
+import fs from "node:fs/promises";
+import { createServer, type Server as HttpServer } from "node:http";
+import net from "node:net";
+import path from "node:path";
+// Real Control UI/Gateway proof for queued follow-up recovery after missed terminal events.
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../../../src/config/config.js";
+import type { OpenClawConfig } from "../../../src/config/types.openclaw.js";
+import type { GatewayServer } from "../../../src/gateway/server.js";
+import { buildMockOpenAiResponsesProvider } from "../../../src/gateway/test-openai-responses-model.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../../src/test-utils/openclaw-test-state.js";
+import {
+  canRunPlaywrightChromium,
+  controlUiE2eWaitTimeoutMs,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeRealGateway = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const artifactDir = path.resolve(
+  process.cwd(),
+  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() ||
+    ".artifacts/control-ui-e2e/chat-flow-real-gateway",
+);
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const authToken = "chat-flow-real-gateway-proof";
+const firstPrompt = "REAL_GATEWAY_FIRST_TURN";
+const followUp = "REAL_GATEWAY_FIFO_FOLLOW_UP";
+
+type JsonRecord = Record<string, unknown>;
+
+type TraceEntry = {
+  direction: "browser-to-gateway" | "gateway-to-browser";
+  kind: "event" | "request" | "response";
+  method?: string;
+  event?: string;
+  dropped?: boolean;
+  params?: JsonRecord;
+  payload?: JsonRecord;
+};
+
+type RecoveryProxy = {
+  armEventLoss: () => void;
+  close: () => Promise<void>;
+  droppedEvents: string[];
+  firstRunId: string | null;
+  port: number;
+  trace: TraceEntry[];
+  url: string;
+};
+
+let browser: Browser;
+let context: BrowserContext;
+let controlUi: ControlUiE2eServer;
+let gateway: GatewayServer;
+let providerServer: HttpServer;
+let proxy: RecoveryProxy;
+let state: OpenClawTestState;
+
+function parseFrame(data: RawData): JsonRecord | null {
+  try {
+    const text = Array.isArray(data)
+      ? Buffer.concat(data).toString("utf8")
+      : data instanceof ArrayBuffer
+        ? Buffer.from(data).toString("utf8")
+        : data.toString("utf8");
+    return asNullableRecord(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+async function getFreePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("failed to allocate a loopback port");
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
+}
+
+function openAiResponseEvents(text: string, id: string): string {
+  const message = {
+    type: "message",
+    id,
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+  return [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress", content: [] },
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        status: "completed",
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+    },
+  ]
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .concat("data: [DONE]\n\n")
+    .join("");
+}
+
+async function startProvider(): Promise<{ baseUrl: string; server: HttpServer }> {
+  let requestCount = 0;
+  const server = createServer((_request, response) => {
+    requestCount += 1;
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    const finish = () => {
+      response.end(
+        openAiResponseEvents(
+          requestCount === 1 ? "REAL_GATEWAY_FIRST_REPLY" : "REAL_GATEWAY_SECOND_REPLY",
+          `real-gateway-proof-${requestCount}`,
+        ),
+      );
+    };
+    if (requestCount === 1) {
+      setTimeout(finish, 2_000);
+    } else {
+      finish();
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("proof provider did not bind a loopback port");
+  }
+  return { baseUrl: `http://127.0.0.1:${address.port}/v1`, server };
+}
+
+function terminalSessionEvent(frame: JsonRecord, firstRunId: string): boolean {
+  const event = stringValue(frame.event);
+  const payload = asNullableRecord(frame.payload);
+  if (!payload) {
+    return false;
+  }
+  if (event === "chat") {
+    return (
+      payload.runId === firstRunId &&
+      ["final", "aborted", "error"].includes(stringValue(payload.state) ?? "")
+    );
+  }
+  if (event !== "session.message" && event !== "sessions.changed") {
+    return false;
+  }
+  const session = asNullableRecord(payload.session);
+  const hasActiveRun = payload.hasActiveRun ?? session?.hasActiveRun;
+  // The isolated proof setup owns one session. Intentionally lose every idle
+  // publication until the exact-run watchdog starts, matching a browser that
+  // missed both the terminal chat frame and the later session-state update.
+  return hasActiveRun === false;
+}
+
+async function startRecoveryProxy(gatewayUrl: string): Promise<RecoveryProxy> {
+  const trace: TraceEntry[] = [];
+  const droppedEvents: string[] = [];
+  const requestMethods = new Map<string, string>();
+  const sockets = new Set<WebSocket>();
+  const websocketServer = new WebSocketServer({ noServer: true });
+  let droppedSequenceCount = 0;
+  let firstRunId: string | null = null;
+  let eventLossArmed = false;
+  let recoveryStarted = false;
+  let chatSendCount = 0;
+  const server = createServer((_request, response) => response.writeHead(404).end());
+
+  server.on("upgrade", (request, socket, head) => {
+    websocketServer.handleUpgrade(request, socket, head, (browserSocket) => {
+      const upstream = new WebSocket(gatewayUrl, {
+        origin: typeof request.headers.origin === "string" ? request.headers.origin : undefined,
+      });
+      sockets.add(browserSocket);
+      sockets.add(upstream);
+      const pending: Array<{ data: RawData; isBinary: boolean }> = [];
+
+      browserSocket.on("message", (data, isBinary) => {
+        const frame = parseFrame(data);
+        if (frame?.type === "req") {
+          const id = stringValue(frame.id);
+          const method = stringValue(frame.method);
+          if (id && method) {
+            requestMethods.set(id, method);
+            if (method === "chat.send") {
+              chatSendCount += 1;
+            }
+            if (method === "agent.wait") {
+              recoveryStarted = true;
+            }
+            if (["chat.send", "agent.wait", "chat.history"].includes(method)) {
+              trace.push({
+                direction: "browser-to-gateway",
+                kind: "request",
+                method,
+                params: asNullableRecord(frame.params) ?? undefined,
+              });
+            }
+          }
+        }
+        if (upstream.readyState === WebSocket.OPEN) {
+          upstream.send(data, { binary: isBinary });
+        } else {
+          pending.push({ data, isBinary });
+        }
+      });
+
+      upstream.on("open", () => {
+        for (const frame of pending.splice(0)) {
+          upstream.send(frame.data, { binary: frame.isBinary });
+        }
+      });
+
+      upstream.on("message", (data, isBinary) => {
+        const frame = parseFrame(data);
+        if (frame?.type === "res") {
+          const id = stringValue(frame.id);
+          const method = id ? requestMethods.get(id) : undefined;
+          const payload = asNullableRecord(frame.payload);
+          if (method === "chat.send" && chatSendCount === 1 && payload) {
+            firstRunId = stringValue(payload.runId);
+          }
+          if (method && ["chat.send", "agent.wait", "chat.history"].includes(method)) {
+            trace.push({
+              direction: "gateway-to-browser",
+              kind: "response",
+              method,
+              payload: payload ?? undefined,
+            });
+          }
+        }
+        const event = frame?.type === "event" ? stringValue(frame.event) : null;
+        const isFirstRunTerminal = Boolean(
+          firstRunId && frame && terminalSessionEvent(frame, firstRunId),
+        );
+        const isMissedSessionUpdate =
+          eventLossArmed && (event === "session.message" || event === "sessions.changed");
+        if (!recoveryStarted && (isFirstRunTerminal || isMissedSessionUpdate)) {
+          const droppedEvent = event ?? "unknown";
+          droppedEvents.push(droppedEvent);
+          trace.push({
+            direction: "gateway-to-browser",
+            dropped: true,
+            event: droppedEvent,
+            kind: "event",
+          });
+          if (typeof frame?.seq === "number") {
+            droppedSequenceCount += 1;
+          }
+          return;
+        }
+        if (
+          frame?.type === "event" &&
+          ["chat", "session.message", "sessions.changed"].includes(stringValue(frame.event) ?? "")
+        ) {
+          trace.push({
+            direction: "gateway-to-browser",
+            dropped: false,
+            event: stringValue(frame.event) ?? "unknown",
+            kind: "event",
+          });
+        }
+        if (browserSocket.readyState === WebSocket.OPEN) {
+          if (event && droppedSequenceCount > 0 && typeof frame?.seq === "number") {
+            browserSocket.send(JSON.stringify({ ...frame, seq: frame.seq - droppedSequenceCount }));
+          } else {
+            browserSocket.send(data, { binary: isBinary });
+          }
+        }
+      });
+
+      const closePeer = (peerSocket: WebSocket) => {
+        sockets.delete(peerSocket);
+        if (
+          peerSocket.readyState === WebSocket.OPEN ||
+          peerSocket.readyState === WebSocket.CONNECTING
+        ) {
+          peerSocket.close();
+        }
+      };
+      browserSocket.on("close", () => closePeer(upstream));
+      upstream.on("close", () => closePeer(browserSocket));
+      browserSocket.on("error", () => closePeer(upstream));
+      upstream.on("error", () => closePeer(browserSocket));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("recovery proxy did not bind a loopback port");
+  }
+  return {
+    armEventLoss: () => {
+      eventLossArmed = true;
+    },
+    close: async () => {
+      for (const socket of sockets) {
+        socket.terminate();
+      }
+      sockets.clear();
+      await new Promise<void>((resolve, reject) => {
+        websocketServer.close(() => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      });
+    },
+    droppedEvents,
+    get firstRunId() {
+      return firstRunId;
+    },
+    port: address.port,
+    trace,
+    url: `ws://127.0.0.1:${address.port}`,
+  };
+}
+
+function requests(method: string): TraceEntry[] {
+  return proxy.trace.filter((entry) => entry.kind === "request" && entry.method === method);
+}
+
+async function screenshot(page: Page, fileName: string): Promise<void> {
+  if (!captureUiProof) {
+    return;
+  }
+  await page.screenshot({ path: path.join(artifactDir, fileName), fullPage: true });
+}
+
+describeRealGateway("Control UI queued follow-up recovery with a real Gateway", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    await fs.mkdir(artifactDir, { recursive: true });
+    controlUi = await startControlUiE2eServer(undefined, { source: true });
+    const provider = await startProvider();
+    providerServer = provider.server;
+    const model = buildMockOpenAiResponsesProvider(provider.baseUrl);
+    const gatewayPort = await getFreePort();
+    state = await createOpenClawTestState({
+      label: "chat-flow-real-gateway",
+      layout: "home",
+      env: {
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: model.modelRef },
+          models: {
+            [model.modelRef]: { params: { openaiWsWarmup: false, transport: "sse" } },
+          },
+          skipBootstrap: true,
+          workspace: state.workspaceDir,
+        },
+      },
+      gateway: {
+        auth: { mode: "token", token: authToken },
+        controlUi: { allowedOrigins: [new URL(controlUi.baseUrl).origin], enabled: false },
+        port: gatewayPort,
+      },
+      models: { mode: "replace", providers: { [model.providerId]: model.config } },
+      ui: { prefs: { chatFollowUpMode: "queue" } },
+    };
+    await state.writeConfig(cfg);
+    state.applyEnv();
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    const { startGatewayServer } = await import("../../../src/gateway/server.js");
+    gateway = await startGatewayServer(gatewayPort, {
+      auth: { mode: "token", token: authToken },
+      bind: "loopback",
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+    proxy = await startRecoveryProxy(`ws://127.0.0.1:${gatewayPort}`);
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    context = await browser.newContext({
+      locale: "en-US",
+      recordVideo: captureUiProof
+        ? { dir: artifactDir, size: { height: 900, width: 1280 } }
+        : undefined,
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    const cleanup = [];
+    for (const operation of [
+      () => context?.close(),
+      () => browser?.close(),
+      () => proxy?.close(),
+      () => gateway?.close({ reason: "real queued follow-up proof complete" }),
+      () => controlUi?.close(),
+      () =>
+        providerServer
+          ? new Promise<void>((resolve) => {
+              providerServer.close(() => {
+                resolve();
+              });
+            })
+          : Promise.resolve(),
+    ]) {
+      try {
+        await operation();
+        cleanup.push({ status: "fulfilled" as const });
+      } catch (reason) {
+        cleanup.push({ reason, status: "rejected" as const });
+      }
+    }
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    state?.restoreEnv();
+    await state?.cleanup();
+    expect(
+      cleanup
+        .filter((result) => result.status === "rejected")
+        .map((result) => String(result.reason)),
+    ).toEqual([]);
+  }, 60_000);
+
+  it(
+    "uses agent.wait, reloads history, and drains FIFO after terminal events are missed",
+    { timeout: 90_000 },
+    async () => {
+      const page = await context.newPage();
+      page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
+      await page.addInitScript(
+        ({ gatewayUrl, token }) => {
+          (
+            window as Window & {
+              ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+            }
+          )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = { gatewayUrl, token };
+        },
+        { gatewayUrl: proxy.url, token: authToken },
+      );
+
+      expect((await page.goto(`${controlUi.baseUrl}chat?session=main`))?.status()).toBe(200);
+      await page.locator("openclaw-app-shell").waitFor({ timeout: 60_000 });
+      await expect.poll(() => new URL(page.url()).pathname).toMatch(/\/chat\/main$/u);
+
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill(firstPrompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+      await expect.poll(() => requests("chat.send").length).toBe(1);
+      await page.getByRole("button", { name: "Stop generating" }).waitFor();
+
+      await composer.fill(followUp);
+      await page.getByRole("button", { name: "Queue message" }).click();
+      const queue = page.locator(".chat-queue");
+      await queue.getByText(followUp).waitFor();
+      proxy.armEventLoss();
+      await screenshot(page, "01-real-gateway-queued-after-dropped-events.png");
+
+      await expect.poll(() => proxy.firstRunId).toMatch(/^[-A-Za-z0-9_]+$/u);
+      const browserRunState = await page.locator("openclaw-chat-pane").evaluate((element) => {
+        const paneState = (
+          element as HTMLElement & {
+            state?: {
+              chatRunId?: unknown;
+              connected?: unknown;
+            };
+          }
+        ).state;
+        return {
+          chatRunId: paneState?.chatRunId,
+          connected: paneState?.connected,
+        };
+      });
+      expect(browserRunState).toMatchObject({
+        chatRunId: proxy.firstRunId,
+        connected: true,
+      });
+      await expect.poll(() => proxy.droppedEvents.includes("chat"), { timeout: 15_000 }).toBe(true);
+      expect(
+        proxy.droppedEvents.some(
+          (event) => event === "session.message" || event === "sessions.changed",
+        ),
+      ).toBe(true);
+      expect(requests("chat.send")).toHaveLength(1);
+      await expect
+        .poll(() => requests("agent.wait").length, { timeout: 25_000 })
+        .toBeGreaterThan(0);
+      const waitRequest = requests("agent.wait")[0];
+      expect(waitRequest?.params).toMatchObject({ runId: proxy.firstRunId, timeoutMs: 50 });
+
+      await expect.poll(() => requests("chat.send").length).toBe(2);
+      const secondSend = requests("chat.send")[1];
+      expect(secondSend?.params).toMatchObject({ message: followUp });
+      const waitIndex = proxy.trace.indexOf(waitRequest as TraceEntry);
+      const historyIndex = proxy.trace.findIndex(
+        (entry, index) =>
+          index > waitIndex && entry.kind === "request" && entry.method === "chat.history",
+      );
+      const secondSendIndex = proxy.trace.indexOf(secondSend as TraceEntry);
+      expect(historyIndex).toBeGreaterThan(waitIndex);
+      expect(historyIndex).toBeLessThan(secondSendIndex);
+
+      await queue.waitFor({ state: "detached", timeout: 15_000 });
+      await page
+        .getByRole("paragraph")
+        .filter({ hasText: /^REAL_GATEWAY_SECOND_REPLY$/u })
+        .waitFor();
+      await screenshot(page, "02-real-gateway-recovered-fifo-delivered.png");
+
+      const proof = {
+        setup: {
+          browser: "Chromium via Playwright",
+          controlUi: "source-served production Control UI",
+          gateway: "real in-process Gateway over loopback WebSocket",
+          provider: "loopback OpenAI Responses SSE transport",
+          sessionStore: "isolated real OpenClaw state",
+        },
+        missedEvents: [...new Set(proxy.droppedEvents)].toSorted(),
+        recovery: {
+          exactRunAgentWait: waitRequest?.params?.runId === proxy.firstRunId,
+          agentWaitTimeoutMs: waitRequest?.params?.timeoutMs,
+          historyReloadAfterWait: waitIndex < historyIndex,
+          fifoSendAfterHistory: historyIndex < secondSendIndex,
+          queuedMessage: followUp,
+          queueCleared: (await queue.count()) === 0,
+          secondAssistantVisible: true,
+        },
+        trace: proxy.trace.map((entry) => ({
+          direction: entry.direction,
+          dropped: entry.dropped,
+          event: entry.event,
+          kind: entry.kind,
+          method: entry.method,
+          params:
+            entry.direction === "browser-to-gateway" && entry.method === "agent.wait"
+              ? {
+                  runId: entry.params?.runId === proxy.firstRunId ? "<first-run-id>" : "<other>",
+                  timeoutMs: entry.params?.timeoutMs,
+                }
+              : entry.direction === "browser-to-gateway" && entry.method === "chat.send"
+                ? { message: entry.params?.message }
+                : entry.direction === "browser-to-gateway" && entry.method === "chat.history"
+                  ? { limit: entry.params?.limit, sessionKey: entry.params?.sessionKey }
+                  : undefined,
+          payload:
+            entry.direction === "gateway-to-browser" && entry.method === "agent.wait"
+              ? { status: entry.payload?.status }
+              : entry.direction === "gateway-to-browser" && entry.method === "chat.send"
+                ? { runId: "<redacted>", status: entry.payload?.status }
+                : undefined,
+        })),
+      };
+      await fs.writeFile(
+        path.join(artifactDir, "real-gateway-recovery-proof.json"),
+        `${JSON.stringify(proof, null, 2)}\n`,
+      );
+      expect(proof.recovery).toMatchObject({
+        exactRunAgentWait: true,
+        fifoSendAfterHistory: true,
+        historyReloadAfterWait: true,
+        queueCleared: true,
+        secondAssistantVisible: true,
+      });
+    },
+  );
+});

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -16,6 +16,7 @@ import {
   type ChatCommandResetOptions,
 } from "./chat-commands.ts";
 import { loadChatHistory, type ChatHistoryResult, type ChatState } from "./chat-history.ts";
+import { scheduleChatOutboxRunWatch } from "./chat-outbox-run-watch.ts";
 import {
   excludeComposerAttachments,
   readQueuedMessageById,
@@ -31,7 +32,7 @@ import {
   type StoredChatOutboxScope,
 } from "./composer-persistence.ts";
 import { isQueuedMessageBeingEdited } from "./queued-message-edit.ts";
-import { isChatBusy } from "./run-lifecycle.ts";
+import { isChatBusy, reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import {
   chatMessagesContainQueuedSend,
   OFFLINE_QUEUE_STORAGE_ERROR,
@@ -108,6 +109,49 @@ function getStoredChatOutboxClientState(client: GatewayBrowserClient): StoredCha
   return created;
 }
 
+export function scheduleStoredChatOutboxRunWatch(
+  host: ChatHost,
+  scope: StoredChatOutboxScope,
+  dependencies: ChatOutboxDrainDependencies,
+) {
+  const client = host.client;
+  const runId = host.chatRunId;
+  if (!host.connected || !client || !runId) {
+    return;
+  }
+  const connectionEpoch = host.connectionEpoch;
+  scheduleChatOutboxRunWatch({
+    client,
+    connectionEpoch,
+    runId,
+    isCurrent: () =>
+      host.connected &&
+      host.client === client &&
+      host.connectionEpoch === connectionEpoch &&
+      host.chatRunId === runId &&
+      visibleSessionMatches(host, scope.sessionKey, scope.agentId) &&
+      Boolean(readStoredChatOutbox(host, scope)),
+    onTerminal: async (projection) => {
+      reconcileChatRunLifecycle(host, {
+        ...projection,
+        runId,
+        sessionKey: host.sessionKey,
+        sessionKeys: [scope.sessionKey],
+        clearLocalRun: true,
+        clearChatStream: true,
+        clearToolStream: projection.yielded !== true,
+        publishRunStatus: false,
+        armLocalTerminalReconcile: projection.yielded !== true,
+      });
+      try {
+        await loadChatHistory(host as unknown as ChatState);
+      } finally {
+        await scheduleStoredChatOutboxDrain(host, scope, dependencies);
+      }
+    },
+  });
+}
+
 export function retryableGatewayDelayMs(err: unknown): number | null {
   if (!(err instanceof GatewayRequestError) || !err.retryable) {
     return null;
@@ -169,11 +213,21 @@ async function readCurrentStoredChatHistory(
   connectionEpoch: number | undefined,
   dependencies: ChatOutboxDrainDependencies,
 ): Promise<ChatHistoryResult | "blocked" | "continue"> {
+  const historySessionKey =
+    isUiGlobalSessionKey(outbox.sessionKey) &&
+    !isUiGlobalSessionKey(host.sessionKey) &&
+    visibleSessionMatches(host, outbox.sessionKey, outbox.agentId)
+      ? host.sessionKey
+      : outbox.sessionKey;
   let history: ChatHistoryResult;
   try {
     history = await client.request<ChatHistoryResult>("chat.history", {
-      sessionKey: outbox.sessionKey,
-      ...(isUiGlobalSessionKey(outbox.sessionKey) && outbox.agentId
+      // Global is the durable browser scope for main-session aliases, but a
+      // per-sender Gateway can keep the visible transcript at agent:<id>:main.
+      // Reconcile that visible canonical route so an already-delivered head
+      // cannot become unconfirmed and block later FIFO rows.
+      sessionKey: historySessionKey,
+      ...(isUiGlobalSessionKey(historySessionKey) && outbox.agentId
         ? { agentId: outbox.agentId }
         : {}),
       limit: 1000,
@@ -602,10 +656,15 @@ export async function resumeStoredChatOutboxes(
   if (!host.connected || !host.client) {
     return;
   }
+  const outboxes = listStoredChatOutboxes(host);
+  const visibleOutbox = outboxes.find((outbox) =>
+    visibleSessionMatches(host, outbox.sessionKey, outbox.agentId),
+  );
+  if (visibleOutbox) {
+    scheduleStoredChatOutboxRunWatch(host, visibleOutbox, dependencies);
+  }
   await Promise.allSettled(
-    listStoredChatOutboxes(host).map((outbox) =>
-      scheduleStoredChatOutboxDrain(host, outbox, dependencies),
-    ),
+    outboxes.map((outbox) => scheduleStoredChatOutboxDrain(host, outbox, dependencies)),
   );
 }
 

--- a/ui/src/pages/chat/chat-outbox-run-watch.ts
+++ b/ui/src/pages/chat/chat-outbox-run-watch.ts
@@ -1,0 +1,138 @@
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+
+type ChatRunWaitResult = {
+  status?: unknown;
+  endedAt?: unknown;
+  error?: unknown;
+  stopReason?: unknown;
+  livenessState?: unknown;
+  yielded?: unknown;
+  pendingError?: unknown;
+};
+
+type ChatOutboxRunWaitProjection =
+  | { yielded: true; outcome?: never; sessionStatus?: never }
+  | {
+      yielded?: false;
+      outcome: "done" | "interrupted";
+      sessionStatus: "done" | "failed" | "killed" | "timeout";
+    };
+
+type ChatOutboxRunWatch = {
+  connectionEpoch: number | undefined;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type ChatOutboxRunWatchOptions = {
+  client: GatewayBrowserClient;
+  connectionEpoch: number | undefined;
+  delayMs?: number;
+  isCurrent: () => boolean;
+  onTerminal: (projection: ChatOutboxRunWaitProjection) => Promise<void>;
+  runId: string;
+};
+
+const CHAT_OUTBOX_RUN_WATCH_IDLE_MS = 15_000;
+const CHAT_OUTBOX_RUN_WATCH_RETRY_MS = 5_000;
+const CHAT_OUTBOX_RUN_WATCH_WAIT_MS = 50;
+
+const chatOutboxRunWatches = new WeakMap<GatewayBrowserClient, Map<string, ChatOutboxRunWatch>>();
+
+function runWatchesFor(client: GatewayBrowserClient): Map<string, ChatOutboxRunWatch> {
+  const existing = chatOutboxRunWatches.get(client);
+  if (existing) {
+    return existing;
+  }
+  const created = new Map<string, ChatOutboxRunWatch>();
+  chatOutboxRunWatches.set(client, created);
+  return created;
+}
+
+function isTerminalChatRunWait(result: ChatRunWaitResult | undefined): result is ChatRunWaitResult {
+  if (!result) {
+    return false;
+  }
+  const status = typeof result.status === "string" ? result.status.trim().toLowerCase() : "";
+  if (status === "pending" || result.pendingError === true) {
+    return false;
+  }
+  if (status === "ok" || status === "error") {
+    return true;
+  }
+  if (status !== "timeout") {
+    return false;
+  }
+  return (
+    result.endedAt != null ||
+    result.error != null ||
+    result.stopReason != null ||
+    result.livenessState != null ||
+    result.yielded === true
+  );
+}
+
+function projectTerminalChatRunWait(result: ChatRunWaitResult): ChatOutboxRunWaitProjection {
+  const status = typeof result.status === "string" ? result.status.trim().toLowerCase() : "";
+  const stopReason =
+    typeof result.stopReason === "string" ? result.stopReason.trim().toLowerCase() : "";
+  if (status === "ok" && result.yielded === true && stopReason === "end_turn") {
+    return { yielded: true };
+  }
+  if (status === "ok") {
+    return { outcome: "done", sessionStatus: "done" };
+  }
+  if (status === "timeout") {
+    return { outcome: "interrupted", sessionStatus: "timeout" };
+  }
+  const cancelled =
+    stopReason === "aborted" ||
+    stopReason === "restart" ||
+    stopReason === "superseded" ||
+    stopReason === "rpc" ||
+    stopReason === "stop";
+  return {
+    outcome: "interrupted",
+    sessionStatus: cancelled ? "killed" : "failed",
+  };
+}
+
+async function probeChatOutboxRun(options: ChatOutboxRunWatchOptions): Promise<void> {
+  if (!options.isCurrent()) {
+    return;
+  }
+  let result: ChatRunWaitResult | undefined;
+  try {
+    result = await options.client.request<ChatRunWaitResult>("agent.wait", {
+      runId: options.runId,
+      timeoutMs: CHAT_OUTBOX_RUN_WATCH_WAIT_MS,
+    });
+  } catch {
+    // A reconnect or transient request failure must not discard the queued turn.
+  }
+  if (!options.isCurrent()) {
+    return;
+  }
+  if (!isTerminalChatRunWait(result)) {
+    scheduleChatOutboxRunWatch({ ...options, delayMs: CHAT_OUTBOX_RUN_WATCH_RETRY_MS });
+    return;
+  }
+  await options.onTerminal(projectTerminalChatRunWait(result));
+}
+
+export function scheduleChatOutboxRunWatch(options: ChatOutboxRunWatchOptions): void {
+  const watches = runWatchesFor(options.client);
+  const existing = watches.get(options.runId);
+  if (existing && existing.connectionEpoch === options.connectionEpoch) {
+    return;
+  }
+  if (existing) {
+    // Logical reconnects can retain the browser client. Replace the stale
+    // epoch's timer so durable resume cannot permanently disarm recovery.
+    clearTimeout(existing.timer);
+  }
+  const timer = setTimeout(() => {
+    watches.delete(options.runId);
+    void probeChatOutboxRun(options);
+  }, options.delayMs ?? CHAT_OUTBOX_RUN_WATCH_IDLE_MS);
+  watches.set(options.runId, { connectionEpoch: options.connectionEpoch, timer });
+}

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -12,6 +12,7 @@ import {
   flushStoredChatOutbox,
   retryableGatewayDelayMs,
   scheduleStoredChatOutboxDrain as scheduleOutboxDrain,
+  scheduleStoredChatOutboxRunWatch,
   scheduleStoredChatOutboxRetry,
   UNCONFIRMED_CHAT_SEND_ERROR,
   type ChatOutboxDrainDependencies,
@@ -638,6 +639,9 @@ export async function deliverChatQueueItem(
       );
       if (typeof parked === "string") {
         drainResult = parked;
+        if (parked === "pending") {
+          scheduleStoredChatOutboxRunWatch(host, outbox, chatOutboxDrainDependencies);
+        }
         if (parked === "pending" && outbox.queue[0]?.id !== item.id) {
           // Reconcile older restored rows without delaying this turn's active-run policy.
           void scheduleOutboxDrain(host, outbox, chatOutboxDrainDependencies);

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -7469,6 +7469,297 @@ describe("handleSendChat", () => {
     ).toMatchObject({ expectedLeafEntryId: "leaf-after-terminal" });
   });
 
+  it.each([
+    {
+      name: "completion",
+      waitResult: { status: "ok", endedAt: 1 },
+      sessionStatus: "done" as const,
+      expectedSends: 1,
+    },
+    {
+      name: "hard timeout",
+      waitResult: { status: "timeout", endedAt: 1, stopReason: "timeout" },
+      sessionStatus: "timeout" as const,
+      expectedSends: 1,
+    },
+    {
+      name: "direct cancellation",
+      waitResult: { status: "error", endedAt: 1, stopReason: "aborted" },
+      sessionStatus: "killed" as const,
+      expectedSends: 1,
+    },
+    ...["restart", "superseded", "rpc", "stop"].map((stopReason) => ({
+      name: `${stopReason} cancellation`,
+      waitResult: { status: "error", endedAt: 1, stopReason },
+      sessionStatus: "killed" as const,
+      expectedSends: 1,
+    })),
+    {
+      name: "yielded continuation",
+      waitResult: { status: "ok", endedAt: 1, stopReason: "end_turn", yielded: true },
+      sessionStatus: "running" as const,
+      expectedSends: 1,
+    },
+  ])("reconciles $name before recovering a queued follow-up", async (testCase) => {
+    vi.useFakeTimers();
+    try {
+      const host = makeChatHost({
+        requestHandlers: {
+          "agent.wait": () => ({ runId: "stale-run", ...testCase.waitResult }),
+          "chat.history": () => ({
+            messages: [],
+            sessionInfo: row("agent:main", {
+              hasActiveRun: false,
+              status: testCase.sessionStatus,
+            }),
+          }),
+          "chat.send": (params: unknown) => {
+            const payload = requireRecord(params, "recovered follow-up payload");
+            return { runId: payload.idempotencyKey, status: "ok" };
+          },
+        },
+        chatFollowUpMode: "queue",
+        chatMessage: "send after the missed terminal",
+        chatRunId: "stale-run",
+      });
+      const reconcileRunTerminal = vi.spyOn(host.sessions, "reconcileRunTerminal");
+
+      await handleSendChat(host);
+
+      expect(host.chatRunId).toBe("stale-run");
+      expect(listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue)).toEqual([
+        expect.objectContaining({
+          text: "send after the missed terminal",
+          sendState: "waiting-idle",
+        }),
+      ]);
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(host.request).toHaveBeenCalledWith("agent.wait", {
+        runId: "stale-run",
+        timeoutMs: 50,
+      });
+      expect(host.chatRunId).toBeNull();
+      expect(reconcileRunTerminal).toHaveBeenCalledWith({
+        runId: "stale-run",
+        status: testCase.sessionStatus,
+        sessionKeys: expect.arrayContaining(["agent:main"]),
+        endedAt: expect.any(Number),
+      });
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(
+        testCase.expectedSends,
+      );
+      expect(listStoredChatOutboxes(host)).toHaveLength(testCase.expectedSends === 1 ? 0 : 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reconciles a visible global outbox through its canonical Gateway session", async () => {
+    vi.useFakeTimers();
+    try {
+      const firstRunId = "real-first-run";
+      const canonicalSessionKey = "agent:main:main";
+      const historySessionKeys: string[] = [];
+      let terminal = false;
+      const host = makeChatHost({
+        requestHandlers: {
+          "agent.wait": () => {
+            terminal = true;
+            return { runId: firstRunId, status: "ok", endedAt: Date.now() };
+          },
+          "chat.history": (params: unknown) => {
+            const payload = requireRecord(params, "canonical history payload");
+            const requestedSessionKey = String(payload.sessionKey);
+            historySessionKeys.push(requestedSessionKey);
+            return requestedSessionKey === canonicalSessionKey && terminal
+              ? {
+                  messages: [
+                    {
+                      role: "user",
+                      __openclaw: { idempotencyKey: `${firstRunId}:user` },
+                    },
+                  ],
+                  sessionInfo: row(canonicalSessionKey, {
+                    hasActiveRun: false,
+                    status: "done",
+                  }),
+                }
+              : {
+                  messages: [],
+                  sessionInfo: row(requestedSessionKey, {
+                    hasActiveRun: !terminal,
+                    status: terminal ? "done" : "running",
+                  }),
+                };
+          },
+          "chat.send": (params: unknown) => {
+            const payload = requireRecord(params, "canonical follow-up payload");
+            return { runId: payload.idempotencyKey, status: "ok" };
+          },
+        },
+        agentsList: { defaultId: "main", mainKey: "main" },
+        chatFollowUpMode: "queue",
+        chatMessage: "follow-up behind delivered head",
+        chatRunId: firstRunId,
+        sessionKey: canonicalSessionKey,
+      });
+      expect(
+        admitStoredChatComposerQueueItem(host, canonicalSessionKey, {
+          id: "delivered-head",
+          text: "already delivered first turn",
+          createdAt: 1,
+          sendAttempts: 1,
+          sendRequestStartedAtMs: 1,
+          sendRunId: firstRunId,
+          sendState: "waiting-reconnect",
+        }),
+      ).toBe(true);
+
+      await handleSendChat(host);
+      expect(listStoredChatOutboxes(host)).toEqual([
+        expect.objectContaining({
+          agentId: "main",
+          sessionKey: "global",
+          queue: [
+            expect.objectContaining({ id: "delivered-head" }),
+            expect.objectContaining({ text: "follow-up behind delivered head" }),
+          ],
+        }),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(host.request).toHaveBeenCalledWith("agent.wait", {
+        runId: firstRunId,
+        timeoutMs: 50,
+      });
+      expect(historySessionKeys).not.toContain("global");
+      expect(historySessionKeys).toContain(canonicalSessionKey);
+      expect(host.request).toHaveBeenCalledWith(
+        "chat.send",
+        expect.objectContaining({ message: "follow-up behind delivered head" }),
+      );
+      expect(listStoredChatOutboxes(host)).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-arms missed-terminal recovery for the current connection epoch", async () => {
+    vi.useFakeTimers();
+    try {
+      let terminal = false;
+      const host = makeChatHost({
+        requestHandlers: {
+          "agent.wait": () => {
+            terminal = true;
+            return { runId: "reconnected-run", status: "ok", endedAt: Date.now() };
+          },
+          "chat.history": () => ({
+            messages: [],
+            sessionInfo: row("agent:main", {
+              activeRunIds: terminal ? [] : ["reconnected-run"],
+              hasActiveRun: !terminal,
+              status: terminal ? "done" : "running",
+            }),
+          }),
+          "chat.send": (params: unknown) => {
+            const payload = requireRecord(params, "reconnected follow-up payload");
+            return { runId: payload.idempotencyKey, status: "ok" };
+          },
+        },
+        chatFollowUpMode: "queue",
+        chatMessage: "send after reconnect recovery",
+        chatRunId: "reconnected-run",
+        connectionEpoch: 1,
+      });
+      expect(
+        admitStoredChatComposerQueueItem(host, "agent:other:main", {
+          id: "older-other-session-row",
+          text: "unrelated older session",
+          createdAt: 1,
+          sendState: "waiting-idle",
+          sessionKey: "agent:other:main",
+          agentId: "other",
+        }),
+      ).toBe(true);
+
+      await handleSendChat(host);
+      host.connectionEpoch = 2;
+      await retryReconnectableQueuedChatSends(host);
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(host.request).toHaveBeenCalledWith("agent.wait", {
+        runId: "reconnected-run",
+        timeoutMs: 50,
+      });
+      expect(host.chatRunId).toBeNull();
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
+      expect(listStoredChatOutboxes(host)).toEqual([
+        expect.objectContaining({
+          agentId: "other",
+          sessionKey: "global",
+          queue: [expect.objectContaining({ id: "older-other-session-row" })],
+        }),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { name: "the run is still active", firstWait: { status: "timeout" } },
+    { name: "the recovery probe fails", firstWait: new Error("gateway closed") },
+  ])("keeps the follow-up queued when $name", async ({ firstWait }) => {
+    vi.useFakeTimers();
+    try {
+      let waitCalls = 0;
+      const host = makeChatHost({
+        requestHandlers: {
+          "agent.wait": () => {
+            waitCalls += 1;
+            if (waitCalls === 1) {
+              if (firstWait instanceof Error) {
+                throw firstWait;
+              }
+              return firstWait;
+            }
+            return { runId: "active-run", status: "ok", endedAt: Date.now() };
+          },
+          "chat.history": () => ({
+            messages: [],
+            sessionInfo: row("agent:main", { hasActiveRun: false, status: "done" }),
+          }),
+          "chat.send": (params: unknown) => {
+            const payload = requireRecord(params, "retried recovery payload");
+            return { runId: payload.idempotencyKey, status: "ok" };
+          },
+        },
+        chatFollowUpMode: "queue",
+        chatMessage: "wait for the active run",
+        chatRunId: "active-run",
+      });
+
+      await handleSendChat(host);
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(host.chatRunId).toBe("active-run");
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+      expect(listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue)).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(waitCalls).toBe(2);
+      expect(host.chatRunId).toBeNull();
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("omits the active leaf when draining a restored outbox", async () => {
     const host = makeChatHost({
       client: null,


### PR DESCRIPTION
Closes #42213

## What Problem This Solves

Fixes an issue where Control UI users who queued a follow-up during an active run could see it remain stuck indefinitely when the browser missed both the run's terminal event and the later session-state update.

## Why This Change Was Made

Adds a bounded exact-run recovery watchdog owned by the durable chat outbox. It waits before probing the authoritative `agent.wait` state, keeps active or ambiguous runs queued, replaces stale watches across logical reconnects, and preserves canonical done, timeout, cancellation, and yielded session outcomes before reloading history and resuming FIFO delivery.

The live proof also exposed an alias boundary hidden by mocks: the durable main-session outbox is stored under `global` + agent, while a per-sender Gateway can keep its transcript at `agent:<id>:main`. Visible global outboxes now reconcile through the visible canonical Gateway route, preventing an already-delivered head from becoming `unconfirmed` and blocking later FIFO rows. Background outboxes retain their own routing.

The positive production delta (+207/-6 lines) is the watchdog capability, its isolated lifecycle owner, and the canonical visible-history reconciliation. The watchdog is scoped only to visible durable outboxes with blocked work and adds no protocol or configuration surface.

Carries forward the recovery direction from #42258 and #90618; contributor attribution is preserved in the commit trailer.

## User Impact

Queued follow-ups recover automatically after missed terminal/session events instead of requiring another prompt or page intervention. Active runs remain protected from premature sends, reconnects preserve recovery, and main-session aliases no longer strand delivered queue heads.

## Real Behavior Proof

Added a deterministic real-stack test at [`ui/src/e2e/chat-flow.real-gateway.e2e.test.ts`](https://github.com/openclaw/openclaw/blob/bf2f75fcc0e2262050a1c910ab2e46cd9f6268b2/ui/src/e2e/chat-flow.real-gateway.e2e.test.ts). It uses:

- production Control UI source in real Chromium via Playwright;
- a real in-process Gateway over loopback WebSocket with token auth;
- an isolated real OpenClaw config/session store;
- a loopback OpenAI Responses SSE provider;
- a transparent WebSocket fault proxy that intentionally drops the first run's terminal `chat`, `session.message`, and `sessions.changed` frames while preserving the connection sequence.

Observed after-fix trace (run IDs redacted):

```text
DROP chat(final), session.message(idle), sessions.changed(idle)
REQ  agent.wait  { runId: <first-run-id>, timeoutMs: 50 }
RES  agent.wait  { status: "ok" }
REQ  chat.history { sessionKey: "agent:main:main", limit: 100 }
REQ  chat.history { sessionKey: "agent:main:main", limit: 1000 }
REQ  chat.send    { message: "REAL_GATEWAY_FIFO_FOLLOW_UP" }
UI   durable queue cleared; REAL_GATEWAY_SECOND_REPLY rendered
```

This first ran red against the prior patch: `agent.wait` and canonical history reload succeeded, but outbox reconciliation queried the persisted `global` alias, marked the delivered first row `unconfirmed`, and left the follow-up at `sendAttempts: 0`. The canonical visible-history fix makes the same real setup pass.

Exact-head CI passed [`checks-ui-e2e-real-gateway`](https://github.com/openclaw/openclaw/actions/runs/31896107665/job/95039666259) and uploaded [`control-ui-real-gateway-proof-1`](https://github.com/openclaw/openclaw/actions/runs/31896107665/artifacts/9249883940) for seven days. The 1.48 MB artifact contains the redacted JSON trace, before/after screenshots, and browser video.

## Evidence

- Real Control UI + Gateway proof: `OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/pr124054-real-proof node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.real-gateway.e2e.test.ts` — 1 passed.
- Complete real-Gateway browser lane: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.real-gateway.e2e.test.ts ui/src/e2e/control-ui-auth-transports.e2e.test.ts` — 3 passed.
- Focused chat delivery suite: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts` — 303 passed.
- Workflow contract: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'gates current Control UI changes'` — 1 passed.
- Changed-file gate completed formatting, conflict/attribution/dependency guards, dead-code scans, i18n verification, and core-test/UI/root-test typechecks. Its delegated Crabbox startup was unavailable locally; the local fallback reached lint, the three reported proof-harness lint findings were fixed, and the final targeted core lint passed.
- Earlier full Control UI unit suite: `pnpm --dir ui test` — 658 files passed, 9,464 tests passed, 1 skipped.
- Earlier mocked browser follow-up suite — 13 passed.
- Independent P1-depth OpenAI and Claude reviews: no remaining actionable findings before the real-stack addition.
