### PR TITLE
fix(workers): clean stale bundle install staging

### DIFF
--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -95,13 +95,14 @@ describe("node worker bundle installer", () => {
     return { gatewayUrl: `ws://127.0.0.1:${address.port}`, requests };
   }
 
-  it("atomically installs and reuses an exact namespaced bundle", async () => {
+  it("atomically installs, reuses, and cleans prior-hash crash staging", async () => {
     const fixture = await bundleFixture();
+    const staleBundleHash = "f".repeat(64);
     const staleStaging = path.join(
       root,
       fixture.input.gatewayNamespace,
       "bundles",
-      `.staging-${fixture.input.build.bundleHash}-crashed`,
+      `.staging-${staleBundleHash}-crashed`,
     );
     await fs.mkdir(staleStaging, { recursive: true });
     const served = await serve(fixture.archive, fixture.input.archive.token);

--- a/src/node-host/node-worker-bundle-installer.ts
+++ b/src/node-host/node-worker-bundle-installer.ts
@@ -165,12 +165,11 @@ async function validateInstalledBundle(
   }
 }
 
-async function removeStaleInstallStaging(bundlesRoot: string, bundleHash: string): Promise<void> {
-  const prefix = `.staging-${bundleHash}-`;
+async function removeStaleInstallStaging(bundlesRoot: string): Promise<void> {
   const entries = await fsp.readdir(bundlesRoot, { withFileTypes: true });
   await Promise.all(
     entries.map(async (entry) => {
-      if (entry.name.startsWith(prefix) && entry.isDirectory() && !entry.isSymbolicLink()) {
+      if (entry.name.startsWith(".staging-") && entry.isDirectory() && !entry.isSymbolicLink()) {
         await fsp.rm(path.join(bundlesRoot, entry.name), { recursive: true, force: true });
       }
     }),
@@ -227,7 +226,8 @@ export class NodeWorkerBundleInstaller {
     signal?: AbortSignal;
   }): Promise<WorkerAdmissionHandshake> {
     const { input } = params;
-    const key = `${input.gatewayNamespace}\0${input.build.bundleHash}`;
+    // One namespace owns every staging sibling, so serialize it before sweeping crash residue.
+    const key = input.gatewayNamespace;
     return await this.#operations.enqueue(key, async () => {
       try {
         params.signal?.throwIfAborted();
@@ -237,7 +237,7 @@ export class NodeWorkerBundleInstaller {
           return structuredClone(input.build);
         }
         await fsp.mkdir(bundlesRoot, { recursive: true, mode: 0o700 });
-        await removeStaleInstallStaging(bundlesRoot, input.build.bundleHash);
+        await removeStaleInstallStaging(bundlesRoot);
         const operationRoot = await fsp.mkdtemp(
           path.join(bundlesRoot, `.staging-${input.build.bundleHash}-`),
         );


### PR DESCRIPTION
## What Problem This Solves

Closes #124055.

An interrupted node worker bundle install for hash A can leave its archive, extracted tree, and temporary home under `.staging-<hash-A>-*` even after a later bundle B installs successfully in the same Gateway namespace.

Current main reproduces the leak because both the install queue and stale cleanup are scoped to the incoming bundle hash. That contradicts the actual owner boundary: one Gateway namespace owns every bundle install staging sibling.

## Why This Change Was Made

The node bundle installer now serializes installs per Gateway namespace and sweeps every namespace-owned `.staging-*` directory before starting a new install. This lets bundle B reclaim interrupted bundle A residue without allowing concurrent cross-hash installs to delete each other's active staging.

This is the canonical owner repair rather than a downstream cleanup pass. Installed bundle contents, logical hashes, transfer capabilities, receipts, activation, and error behavior are unchanged.

The separate mid-stream transfer authority-revocation concern from #123985 is intentionally out of scope and untouched. This change adds no protocol, configuration, schema, security-authority, SDK, or persistence contract.

Production LOC: +5/-5 (net 0). Tests: +3/-2 (net +1).

## User Impact

Persistent node hosts no longer retain old-hash install scratch data after a later Gateway bundle succeeds. There is no new operator action, configuration, or public API.

## Evidence

- Frozen current-main repro (`2e806ef0e2c99ea2968766944573e8ef16c33126`): old hash `ffff…` survives after exact bundle `ca84…` installs (`staleSurvived: true`).
- Exact candidate `14aefc45c5e9cc98cfd9efd9c9b84ceb4455d51c`: the same original-order repro reports `staleRemoved: true`.
- 40 focused tests passed across node-host installer/private-command, worker protocol, shared archive, Gateway transfer service/HTTP, and Gateway installer lanes.
- Source-blind two-process proof used an isolated Gateway and node-host process on a free loopback port with real archive bytes. Expected and installed hashes both equaled `b67096fea0dcaa1af3be0d96fd1ac0802196cf8cf5437c20e330cbcefc2b3ced`; the installed entry printed `worker-activated`; capability replay returned 404; the fault process exited 42; node and Gateway exited 0; the port closed; runtime state was removed.
- Blacksmith Testbox changed gate passed on exact head: `tbx_01m020qptxgz7jvn06sjkw6608`, run https://github.com/openclaw/openclaw/actions/runs/31868817026. It covered format, core and test types, lint, import cycles, database/state guards, dependency/boundary guards, and the remaining changed checks.
- Exact-head PR CI passed for `14aefc45c5e9cc98cfd9efd9c9b84ceb4455d51c`: https://github.com/openclaw/openclaw/actions/runs/31869382506.
- Current main CI was green at the rebase base: https://github.com/openclaw/openclaw/actions/runs/31868619808.
- `git diff --check`: passed.
- Final commit-mode autoreview: clean, no accepted/actionable findings; best-fix judgment confirmed namespace-level serialization and cleanup.
- Build/package proof was not required because no lazy-loading, dynamic-import, build output, packaging, or published boundary changed.
- Duplicate search found no existing issue or PR for this root cause.
