### PR TITLE
fix(ui): slow active-run spinner

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5800,7 +5800,7 @@ td.data-table-key-col {
 
 .session-run-spinner,
 .session-glyph__ring {
-  animation: session-run-spin 0.8s linear infinite;
+  animation: session-run-spin 1.6s linear infinite;
 }
 
 @keyframes session-run-spin {


### PR DESCRIPTION
## Summary
- slow the active-run spinner from a 0.8s rotation to 1.6s
- preserve the existing linear animation and reduced-motion behavior

## Testing
- `git diff --check`
