### PR TITLE
refactor(types): remove chained type assertions in agents and sessions

### DIFF
--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -45,7 +45,7 @@ import type {
   ToolOutcomeObserver,
 } from "./agent-tools.before-tool-call.types.js";
 import { normalizeFileToolPathParam } from "./agent-tools.params.js";
-import { BEFORE_TOOL_CALL_SOURCE_TOOL } from "./before-tool-call-metadata.js";
+import { getBeforeToolCallSourceTool } from "./before-tool-call-metadata.js";
 import { getChannelAgentToolMeta } from "./channel-tools.js";
 import { resolveAgentRunAbortLifecycleFields } from "./run-termination.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
@@ -79,9 +79,7 @@ export function resolveToolTerminalPresentation(params: {
   result: Awaited<ReturnType<AnyAgentTool["execute"]>>;
 }): string | undefined {
   try {
-    const sourceTool = Reflect.get(params.tool, BEFORE_TOOL_CALL_SOURCE_TOOL);
-    const presentationTool =
-      sourceTool && typeof sourceTool === "object" ? (sourceTool as AnyAgentTool) : params.tool;
+    const presentationTool = getBeforeToolCallSourceTool(params.tool) ?? params.tool;
     const text = getToolTerminalPresentation(presentationTool)?.(
       params.toolParams,
       params.result,

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -79,8 +79,7 @@ export function resolveToolTerminalPresentation(params: {
   result: Awaited<ReturnType<AnyAgentTool["execute"]>>;
 }): string | undefined {
   try {
-    const taggedTool = params.tool as unknown as Record<symbol, unknown>;
-    const sourceTool = taggedTool[BEFORE_TOOL_CALL_SOURCE_TOOL];
+    const sourceTool = Reflect.get(params.tool, BEFORE_TOOL_CALL_SOURCE_TOOL);
     const presentationTool =
       sourceTool && typeof sourceTool === "object" ? (sourceTool as AnyAgentTool) : params.tool;
     const text = getToolTerminalPresentation(presentationTool)?.(

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -63,6 +63,9 @@ import {
   BEFORE_TOOL_CALL_HOOK_CONTEXT,
   BEFORE_TOOL_CALL_SOURCE_TOOL,
   BEFORE_TOOL_CALL_WRAPPED,
+  clearBeforeToolCallWrappedMarker,
+  getBeforeToolCallHookContext,
+  getBeforeToolCallSourceTool,
   type BeforeToolCallDiagnosticOptions,
 } from "./before-tool-call-metadata.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
@@ -688,13 +691,8 @@ export function rewrapToolWithBeforeToolCallHook(
   ctx?: HookContext,
   options: { approvalMode?: "request" | "report" | "deny"; emitDiagnostics?: boolean } = {},
 ): AnyAgentTool {
-  const source = Reflect.get(tool, BEFORE_TOOL_CALL_SOURCE_TOOL);
-  const wrappedContext = Reflect.get(tool, BEFORE_TOOL_CALL_HOOK_CONTEXT);
-  const preservedContext =
-    wrappedContext && typeof wrappedContext === "object"
-      ? (wrappedContext as HookContext)
-      : undefined;
-  const sourceTool = source && typeof source === "object" ? (source as AnyAgentTool) : tool;
+  const preservedContext = getBeforeToolCallHookContext(tool);
+  const sourceTool = getBeforeToolCallSourceTool(tool) ?? tool;
   if (sourceTool === tool) {
     return wrapToolWithBeforeToolCallHook(tool, ctx ?? preservedContext, options);
   }
@@ -703,7 +701,7 @@ export function rewrapToolWithBeforeToolCallHook(
     ...tool,
     execute: sourceTool.execute,
   };
-  Reflect.deleteProperty(rewrapSource, BEFORE_TOOL_CALL_WRAPPED);
+  clearBeforeToolCallWrappedMarker(rewrapSource);
   copyPluginToolMeta(tool, rewrapSource);
   copyChannelAgentToolMeta(tool as never, rewrapSource as never);
   copyToolTerminalPresentation(tool, rewrapSource);

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -688,9 +688,8 @@ export function rewrapToolWithBeforeToolCallHook(
   ctx?: HookContext,
   options: { approvalMode?: "request" | "report" | "deny"; emitDiagnostics?: boolean } = {},
 ): AnyAgentTool {
-  const taggedTool = tool as unknown as Record<symbol, unknown>;
-  const source = taggedTool[BEFORE_TOOL_CALL_SOURCE_TOOL];
-  const wrappedContext = taggedTool[BEFORE_TOOL_CALL_HOOK_CONTEXT];
+  const source = Reflect.get(tool, BEFORE_TOOL_CALL_SOURCE_TOOL);
+  const wrappedContext = Reflect.get(tool, BEFORE_TOOL_CALL_HOOK_CONTEXT);
   const preservedContext =
     wrappedContext && typeof wrappedContext === "object"
       ? (wrappedContext as HookContext)
@@ -704,7 +703,7 @@ export function rewrapToolWithBeforeToolCallHook(
     ...tool,
     execute: sourceTool.execute,
   };
-  delete (rewrapSource as unknown as Record<symbol, unknown>)[BEFORE_TOOL_CALL_WRAPPED];
+  Reflect.deleteProperty(rewrapSource, BEFORE_TOOL_CALL_WRAPPED);
   copyPluginToolMeta(tool, rewrapSource);
   copyChannelAgentToolMeta(tool as never, rewrapSource as never);
   copyToolTerminalPresentation(tool, rewrapSource);

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -88,9 +88,10 @@ const DAILY_MEMORY_PATH_RE = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
 function eraseFileToolParameters<TParameters extends TSchema, TDetails>(
   tool: AgentTool<TParameters, TDetails>,
 ): AnyAgentTool {
+  const execute = tool.execute;
   return Object.assign(tool, {
     execute: (...args: Parameters<AnyAgentTool["execute"]>) =>
-      tool.execute(args[0], args[1] as Static<TParameters>, args[2], args[3]),
+      execute(args[0], args[1] as Static<TParameters>, args[2], args[3]),
   });
 }
 

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -7,7 +7,6 @@ import path from "node:path";
 import { URL } from "node:url";
 import { detectMime } from "@openclaw/media-core/mime";
 import { formatByteSize } from "@openclaw/normalization-core";
-import type { Static, TSchema } from "typebox";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
 import { isMissingPathError, toErrorObject } from "../infra/errors.js";
 import {
@@ -39,7 +38,7 @@ import {
   withMemoryWriteProvenance,
 } from "./memory-write-provenance.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
-import type { AgentTool, AgentToolResult } from "./runtime/index.js";
+import type { AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import {
@@ -84,16 +83,6 @@ type ReadTruncationDetails = {
 const READ_CONTINUATION_NOTICE_RE =
   /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
 const DAILY_MEMORY_PATH_RE = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
-
-function eraseFileToolParameters<TParameters extends TSchema, TDetails>(
-  tool: AgentTool<TParameters, TDetails>,
-): AnyAgentTool {
-  const execute = tool.execute;
-  return Object.assign(tool, {
-    execute: (...args: Parameters<AnyAgentTool["execute"]>) =>
-      execute(args[0], args[1] as Static<TParameters>, args[2], args[3]),
-  });
-}
 
 function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number {
   const contextWindowTokens = options?.modelContextWindowTokens;
@@ -896,11 +885,9 @@ type SandboxToolParams = {
 export function createSandboxedReadTool(
   params: SandboxToolParams & { createTool?: typeof createReadTool },
 ) {
-  const base = eraseFileToolParameters(
-    (params.createTool ?? createReadTool)(params.root, {
-      operations: createSandboxReadOperations(params),
-    }),
-  );
+  const base = (params.createTool ?? createReadTool)(params.root, {
+    operations: createSandboxReadOperations(params),
+  }) as unknown as AnyAgentTool;
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
@@ -911,11 +898,9 @@ export function createSandboxedReadTool(
 export function createSandboxedWriteTool(
   params: SandboxToolParams & { createTool?: typeof createWriteTool },
 ) {
-  const base = eraseFileToolParameters(
-    (params.createTool ?? createWriteTool)(params.root, {
-      operations: createSandboxWriteOperations(params),
-    }),
-  );
+  const base = (params.createTool ?? createWriteTool)(params.root, {
+    operations: createSandboxWriteOperations(params),
+  }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
 }
 
@@ -923,11 +908,9 @@ export function createSandboxedWriteTool(
 export function createSandboxedEditTool(
   params: SandboxToolParams & { createTool?: typeof createEditTool },
 ) {
-  const base = eraseFileToolParameters(
-    (params.createTool ?? createEditTool)(params.root, {
-      operations: createSandboxEditOperations(params),
-    }),
-  );
+  const base = (params.createTool ?? createEditTool)(params.root, {
+    operations: createSandboxEditOperations(params),
+  }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
 }
 
@@ -940,11 +923,9 @@ export function createHostWorkspaceWriteTool(
     createTool?: typeof createWriteTool;
   },
 ) {
-  const base = eraseFileToolParameters(
-    (options?.createTool ?? createWriteTool)(root, {
-      operations: createHostWriteOperations(root, options),
-    }),
-  );
+  const base = (options?.createTool ?? createWriteTool)(root, {
+    operations: createHostWriteOperations(root, options),
+  }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
 }
 
@@ -957,11 +938,9 @@ export function createHostWorkspaceEditTool(
     createTool?: typeof createEditTool;
   },
 ) {
-  const base = eraseFileToolParameters(
-    (options?.createTool ?? createEditTool)(root, {
-      operations: createHostEditOperations(root, options),
-    }),
-  );
+  const base = (options?.createTool ?? createEditTool)(root, {
+    operations: createHostEditOperations(root, options),
+  }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
 }
 
@@ -1024,15 +1003,13 @@ export function wrapReadToolWithSkillContent(
     }
     return content;
   };
-  const virtualBase = eraseFileToolParameters(
-    createReadTool("/", {
-      operations: {
-        resolvePath: (filePath) => filePath,
-        access: async (filePath) => void readContent(filePath),
-        readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
-      },
-    }),
-  );
+  const virtualBase = createReadTool("/", {
+    operations: {
+      resolvePath: (filePath) => filePath,
+      access: async (filePath) => void readContent(filePath),
+      readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
+    },
+  }) as unknown as AnyAgentTool;
   const virtualRead = createOpenClawReadTool(virtualBase, options);
   return {
     ...tool,

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -89,8 +89,8 @@ function eraseFileToolParameters<TParameters extends TSchema, TDetails>(
   tool: AgentTool<TParameters, TDetails>,
 ): AnyAgentTool {
   return Object.assign({}, tool, {
-    execute: (toolCallId, params, signal, onUpdate) =>
-      tool.execute(toolCallId, params as Static<TParameters>, signal, onUpdate),
+    execute: (...args: Parameters<AnyAgentTool["execute"]>) =>
+      tool.execute(args[0], args[1] as Static<TParameters>, args[2], args[3]),
   });
 }
 

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { URL } from "node:url";
 import { detectMime } from "@openclaw/media-core/mime";
 import { formatByteSize } from "@openclaw/normalization-core";
+import type { Static, TSchema } from "typebox";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
 import { isMissingPathError, toErrorObject } from "../infra/errors.js";
 import {
@@ -38,7 +39,7 @@ import {
   withMemoryWriteProvenance,
 } from "./memory-write-provenance.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
-import type { AgentToolResult } from "./runtime/index.js";
+import type { AgentTool, AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import {
@@ -83,6 +84,15 @@ type ReadTruncationDetails = {
 const READ_CONTINUATION_NOTICE_RE =
   /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
 const DAILY_MEMORY_PATH_RE = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
+
+function eraseFileToolParameters<TParameters extends TSchema, TDetails>(
+  tool: AgentTool<TParameters, TDetails>,
+): AnyAgentTool {
+  return Object.assign({}, tool, {
+    execute: (toolCallId, params, signal, onUpdate) =>
+      tool.execute(toolCallId, params as Static<TParameters>, signal, onUpdate),
+  });
+}
 
 function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number {
   const contextWindowTokens = options?.modelContextWindowTokens;
@@ -154,13 +164,13 @@ function withToolResultText(
   if (replaced) {
     return {
       ...result,
-      content: nextContent as unknown as AgentToolResult<unknown>["content"],
+      content: nextContent,
     };
   }
-  const textBlock = { type: "text", text } as unknown as TextContentBlock;
+  const textBlock = { type: "text", text } satisfies TextContentBlock;
   return {
     ...result,
-    content: [textBlock] as unknown as AgentToolResult<unknown>["content"],
+    content: [textBlock],
   };
 }
 
@@ -885,9 +895,11 @@ type SandboxToolParams = {
 export function createSandboxedReadTool(
   params: SandboxToolParams & { createTool?: typeof createReadTool },
 ) {
-  const base = (params.createTool ?? createReadTool)(params.root, {
-    operations: createSandboxReadOperations(params),
-  }) as unknown as AnyAgentTool;
+  const base = eraseFileToolParameters(
+    (params.createTool ?? createReadTool)(params.root, {
+      operations: createSandboxReadOperations(params),
+    }),
+  );
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
@@ -898,9 +910,11 @@ export function createSandboxedReadTool(
 export function createSandboxedWriteTool(
   params: SandboxToolParams & { createTool?: typeof createWriteTool },
 ) {
-  const base = (params.createTool ?? createWriteTool)(params.root, {
-    operations: createSandboxWriteOperations(params),
-  }) as unknown as AnyAgentTool;
+  const base = eraseFileToolParameters(
+    (params.createTool ?? createWriteTool)(params.root, {
+      operations: createSandboxWriteOperations(params),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
 }
 
@@ -908,9 +922,11 @@ export function createSandboxedWriteTool(
 export function createSandboxedEditTool(
   params: SandboxToolParams & { createTool?: typeof createEditTool },
 ) {
-  const base = (params.createTool ?? createEditTool)(params.root, {
-    operations: createSandboxEditOperations(params),
-  }) as unknown as AnyAgentTool;
+  const base = eraseFileToolParameters(
+    (params.createTool ?? createEditTool)(params.root, {
+      operations: createSandboxEditOperations(params),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
 }
 
@@ -923,9 +939,11 @@ export function createHostWorkspaceWriteTool(
     createTool?: typeof createWriteTool;
   },
 ) {
-  const base = (options?.createTool ?? createWriteTool)(root, {
-    operations: createHostWriteOperations(root, options),
-  }) as unknown as AnyAgentTool;
+  const base = eraseFileToolParameters(
+    (options?.createTool ?? createWriteTool)(root, {
+      operations: createHostWriteOperations(root, options),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
 }
 
@@ -938,9 +956,11 @@ export function createHostWorkspaceEditTool(
     createTool?: typeof createEditTool;
   },
 ) {
-  const base = (options?.createTool ?? createEditTool)(root, {
-    operations: createHostEditOperations(root, options),
-  }) as unknown as AnyAgentTool;
+  const base = eraseFileToolParameters(
+    (options?.createTool ?? createEditTool)(root, {
+      operations: createHostEditOperations(root, options),
+    }),
+  );
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
 }
 
@@ -1003,13 +1023,15 @@ export function wrapReadToolWithSkillContent(
     }
     return content;
   };
-  const virtualBase = createReadTool("/", {
-    operations: {
-      resolvePath: (filePath) => filePath,
-      access: async (filePath) => void readContent(filePath),
-      readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
-    },
-  }) as unknown as AnyAgentTool;
+  const virtualBase = eraseFileToolParameters(
+    createReadTool("/", {
+      operations: {
+        resolvePath: (filePath) => filePath,
+        access: async (filePath) => void readContent(filePath),
+        readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
+      },
+    }),
+  );
   const virtualRead = createOpenClawReadTool(virtualBase, options);
   return {
     ...tool,

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -88,7 +88,7 @@ const DAILY_MEMORY_PATH_RE = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
 function eraseFileToolParameters<TParameters extends TSchema, TDetails>(
   tool: AgentTool<TParameters, TDetails>,
 ): AnyAgentTool {
-  return Object.assign({}, tool, {
+  return Object.assign(tool, {
     execute: (...args: Parameters<AnyAgentTool["execute"]>) =>
       tool.execute(args[0], args[1] as Static<TParameters>, args[2], args[3]),
   });

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -16,6 +16,7 @@ import {
   syncPersistedExternalCliAuthProfiles,
 } from "./external-auth.js";
 import type { ExternalCliAuthDiscovery } from "./external-cli-discovery.js";
+import { isLegacyOAuthRef } from "./legacy-oauth-ref.js";
 import {
   AuthProfileMigrationRequiredError,
   AuthProfileStoreUnreadableError,
@@ -131,19 +132,20 @@ function resolveRuntimeAuthProfileLoadOptions(
   return { ...options, inheritedAuthDir: mode.agentDir };
 }
 
-function hasInlineOAuthTokenMaterial(credential: Record<string, unknown>): boolean {
-  return INLINE_OAUTH_TOKEN_FIELDS.some((field) => credential[field] !== undefined);
+function hasInlineOAuthTokenMaterial(credential: object): boolean {
+  return INLINE_OAUTH_TOKEN_FIELDS.some((field) => Reflect.get(credential, field) !== undefined);
 }
 
 function hasChangedInlineOAuthTokenMaterial(params: {
-  credential: Record<string, unknown>;
-  existingCredential: Record<string, unknown>;
+  credential: object;
+  existingCredential: object;
 }): boolean {
   return INLINE_OAUTH_TOKEN_FIELDS.some((field) => {
-    if (params.credential[field] === undefined) {
+    const credentialValue = Reflect.get(params.credential, field);
+    if (credentialValue === undefined) {
       return false;
     }
-    return !isDeepStrictEqual(params.credential[field], params.existingCredential[field]);
+    return !isDeepStrictEqual(credentialValue, Reflect.get(params.existingCredential, field));
   });
 }
 
@@ -155,16 +157,14 @@ function preserveLegacyOAuthRefsOnSave(params: {
     return params.payload;
   }
   let nextProfiles: typeof params.payload.profiles | undefined;
-  for (const [profileId, credential] of Object.entries(
-    params.payload.profiles as Record<string, unknown>,
-  )) {
-    if (!isRecord(credential) || credential.oauthRef !== undefined || credential.type !== "oauth") {
+  for (const [profileId, credential] of Object.entries(params.payload.profiles)) {
+    if (credential.type !== "oauth" || credential.oauthRef !== undefined) {
       continue;
     }
     const existingCredential = params.existingRaw.profiles[profileId];
     if (
       !isRecord(existingCredential) ||
-      existingCredential.oauthRef === undefined ||
+      !isLegacyOAuthRef(existingCredential.oauthRef) ||
       existingCredential.type !== "oauth"
     ) {
       continue;
@@ -181,7 +181,7 @@ function preserveLegacyOAuthRefsOnSave(params: {
     nextProfiles[profileId] = {
       ...credential,
       oauthRef: existingCredential.oauthRef,
-    } as unknown as (typeof nextProfiles)[string];
+    };
   }
   return nextProfiles ? { ...params.payload, profiles: nextProfiles } : params.payload;
 }

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -5,7 +5,7 @@
  * descriptions that match runtime validation.
  */
 import { Type } from "typebox";
-import { optionalStringEnum, stringEnum } from "./schema/typebox.js";
+import { optionalStringEnum } from "./schema/typebox.js";
 
 const EXEC_TOOL_HOST_VALUES = ["auto", "sandbox", "gateway", "node"] as const;
 const PROCESS_TOOL_ACTIONS = [
@@ -86,9 +86,10 @@ export const nodeExecSchema = Type.Object({
 
 /** Parameters accepted by the process-control tool. */
 export const processSchema = Type.Object({
-  action: stringEnum(PROCESS_TOOL_ACTIONS, {
+  action: Type.String({
+    enum: [...PROCESS_TOOL_ACTIONS],
     description: "Process action (list|poll|log|write|send-keys|submit|paste|kill|clear|remove)",
-  }) as unknown as Type.TString,
+  }),
   sessionId: Type.Optional(Type.String({ description: "Session id for actions other than list" })),
   data: Type.Optional(Type.String({ description: "Data to write for write" })),
   keys: Type.Optional(

--- a/src/agents/before-tool-call-metadata.ts
+++ b/src/agents/before-tool-call-metadata.ts
@@ -11,14 +11,12 @@ export const BEFORE_TOOL_CALL_HOOK_CONTEXT = Symbol("beforeToolCallHookContext")
 
 /** Return true when a tool already carries the before_tool_call wrapper marker. */
 export function isToolWrappedWithBeforeToolCallHook(tool: AnyAgentTool): boolean {
-  const taggedTool = tool as unknown as Record<symbol, unknown>;
-  return taggedTool[BEFORE_TOOL_CALL_WRAPPED] === true;
+  return Reflect.get(tool, BEFORE_TOOL_CALL_WRAPPED) === true;
 }
 
 /** Toggle diagnostic event emission on an existing before_tool_call wrapper. */
 export function setBeforeToolCallDiagnosticsEnabled(tool: AnyAgentTool, enabled: boolean): void {
-  const taggedTool = tool as unknown as Record<symbol, unknown>;
-  const options = taggedTool[BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS];
+  const options = Reflect.get(tool, BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS);
   if (options && typeof options === "object" && "emitDiagnostics" in options) {
     (options as BeforeToolCallDiagnosticOptions).emitDiagnostics = enabled;
   }
@@ -33,15 +31,14 @@ export function copyBeforeToolCallHookMarker(source: AnyAgentTool, target: AnyAg
     value: true,
     enumerable: true,
   });
-  const taggedSource = source as unknown as Record<symbol, unknown>;
-  const sourceTool = taggedSource[BEFORE_TOOL_CALL_SOURCE_TOOL];
+  const sourceTool = Reflect.get(source, BEFORE_TOOL_CALL_SOURCE_TOOL);
   if (sourceTool && typeof sourceTool === "object") {
     Object.defineProperty(target, BEFORE_TOOL_CALL_SOURCE_TOOL, {
       value: sourceTool,
       enumerable: false,
     });
   }
-  const hookContext = taggedSource[BEFORE_TOOL_CALL_HOOK_CONTEXT];
+  const hookContext = Reflect.get(source, BEFORE_TOOL_CALL_HOOK_CONTEXT);
   Object.defineProperty(target, BEFORE_TOOL_CALL_HOOK_CONTEXT, {
     value: hookContext,
     enumerable: false,

--- a/src/agents/before-tool-call-metadata.ts
+++ b/src/agents/before-tool-call-metadata.ts
@@ -1,3 +1,4 @@
+import type { HookContext } from "./agent-tools.before-tool-call.types.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 export type BeforeToolCallDiagnosticOptions = {
@@ -9,16 +10,39 @@ export const BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS = Symbol("beforeToolCallDiagnos
 export const BEFORE_TOOL_CALL_SOURCE_TOOL = Symbol("beforeToolCallSourceTool");
 export const BEFORE_TOOL_CALL_HOOK_CONTEXT = Symbol("beforeToolCallHookContext");
 
+type BeforeToolCallMetadataTool = AnyAgentTool & {
+  [BEFORE_TOOL_CALL_WRAPPED]?: true;
+  [BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS]?: BeforeToolCallDiagnosticOptions;
+  [BEFORE_TOOL_CALL_SOURCE_TOOL]?: AnyAgentTool;
+  [BEFORE_TOOL_CALL_HOOK_CONTEXT]?: HookContext;
+};
+
+function withBeforeToolCallMetadata(tool: AnyAgentTool): BeforeToolCallMetadataTool {
+  return tool;
+}
+
+export function getBeforeToolCallSourceTool(tool: AnyAgentTool): AnyAgentTool | undefined {
+  return withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_SOURCE_TOOL];
+}
+
+export function getBeforeToolCallHookContext(tool: AnyAgentTool): HookContext | undefined {
+  return withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_HOOK_CONTEXT];
+}
+
+export function clearBeforeToolCallWrappedMarker(tool: AnyAgentTool): void {
+  delete withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_WRAPPED];
+}
+
 /** Return true when a tool already carries the before_tool_call wrapper marker. */
 export function isToolWrappedWithBeforeToolCallHook(tool: AnyAgentTool): boolean {
-  return Reflect.get(tool, BEFORE_TOOL_CALL_WRAPPED) === true;
+  return withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_WRAPPED] === true;
 }
 
 /** Toggle diagnostic event emission on an existing before_tool_call wrapper. */
 export function setBeforeToolCallDiagnosticsEnabled(tool: AnyAgentTool, enabled: boolean): void {
-  const options = Reflect.get(tool, BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS);
-  if (options && typeof options === "object" && "emitDiagnostics" in options) {
-    (options as BeforeToolCallDiagnosticOptions).emitDiagnostics = enabled;
+  const options = withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS];
+  if (options) {
+    options.emitDiagnostics = enabled;
   }
 }
 
@@ -31,14 +55,14 @@ export function copyBeforeToolCallHookMarker(source: AnyAgentTool, target: AnyAg
     value: true,
     enumerable: true,
   });
-  const sourceTool = Reflect.get(source, BEFORE_TOOL_CALL_SOURCE_TOOL);
-  if (sourceTool && typeof sourceTool === "object") {
+  const sourceTool = getBeforeToolCallSourceTool(source);
+  if (sourceTool) {
     Object.defineProperty(target, BEFORE_TOOL_CALL_SOURCE_TOOL, {
       value: sourceTool,
       enumerable: false,
     });
   }
-  const hookContext = Reflect.get(source, BEFORE_TOOL_CALL_HOOK_CONTEXT);
+  const hookContext = getBeforeToolCallHookContext(source);
   Object.defineProperty(target, BEFORE_TOOL_CALL_HOOK_CONTEXT, {
     value: hookContext,
     enumerable: false,

--- a/src/agents/compaction-planning-projection.ts
+++ b/src/agents/compaction-planning-projection.ts
@@ -14,7 +14,7 @@ type ProjectionBudget = {
 };
 
 export function readCompactionPlanningOmittedChars(message: AgentMessage): number {
-  const value = (message as unknown as Record<string, unknown>)[OMITTED_CHARS_FIELD];
+  const value = Reflect.get(message, OMITTED_CHARS_FIELD);
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
 
@@ -204,11 +204,10 @@ function projectStringFields(
   fields: readonly string[],
   budget: ProjectionBudget,
 ): AgentMessage {
-  const record = message as unknown as Record<string, unknown>;
   let omittedChars = readCompactionPlanningOmittedChars(message);
-  let next: Record<string, unknown> | undefined;
+  let next: AgentMessage | undefined;
   for (const field of fields) {
-    const value = record[field];
+    const value = Reflect.get(message, field);
     if (typeof value !== "string") {
       continue;
     }
@@ -216,13 +215,11 @@ function projectStringFields(
     if (!projected) {
       continue;
     }
-    next ??= { ...record };
-    next[field] = projected.text;
+    next ??= { ...message };
+    Reflect.set(next, field, projected.text);
     omittedChars += projected.omittedChars;
   }
-  return next
-    ? ({ ...next, [OMITTED_CHARS_FIELD]: omittedChars } as unknown as AgentMessage)
-    : message;
+  return next ? Object.assign(next, { [OMITTED_CHARS_FIELD]: omittedChars }) : message;
 }
 
 function projectMessage(message: AgentMessage, budget: ProjectionBudget): AgentMessage {
@@ -268,11 +265,10 @@ function projectMessage(message: AgentMessage, budget: ProjectionBudget): AgentM
   if (!changed) {
     return source;
   }
-  return {
-    ...(source as unknown as Record<string, unknown>),
+  return Object.assign({}, source, {
     content: projectedContent,
     [OMITTED_CHARS_FIELD]: readCompactionPlanningOmittedChars(source) + omittedChars,
-  } as unknown as AgentMessage;
+  });
 }
 
 export function projectCompactionPlanningMessages(messages: AgentMessage[]): AgentMessage[] {

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -220,7 +220,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
               : undefined,
           workspaceOnly: options.applyPatchWorkspaceOnly,
           memoryWriteProvenance: options.memoryWriteProvenance,
-        }) as unknown as AnyAgentTool,
+        }),
       );
     }
     shell.push(
@@ -244,7 +244,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
               finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
             }
           : undefined,
-      }) as unknown as AnyAgentTool,
+      }),
       createLazyProcessTool(options.processDefaults),
     );
   }

--- a/src/agents/embedded-agent-helpers/images.ts
+++ b/src/agents/embedded-agent-helpers/images.ts
@@ -78,11 +78,7 @@ export async function sanitizeSessionMessagesImages(
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
       const content = Array.isArray(toolMsg.content) ? toolMsg.content : [];
-      const nextContent = (await sanitizeContentBlocksImages(
-        content,
-        label,
-        imageSanitization,
-      )) as unknown as typeof toolMsg.content;
+      const nextContent = await sanitizeContentBlocksImages(content, label, imageSanitization);
       out.push({ ...toolMsg, content: ensureNonEmptyContent(dropEmptyTextBlocks(nextContent)) });
       continue;
     }
@@ -91,11 +87,7 @@ export async function sanitizeSessionMessagesImages(
       const userMsg = msg as Extract<AgentMessage, { role: "user" }>;
       const content = userMsg.content;
       if (Array.isArray(content)) {
-        const nextContent = await sanitizeContentBlocksImages(
-          content as unknown as ContentBlock[],
-          label,
-          imageSanitization,
-        );
+        const nextContent = await sanitizeContentBlocksImages(content, label, imageSanitization);
         out.push({ ...userMsg, content: ensureNonEmptyContent(dropEmptyTextBlocks(nextContent)) });
         continue;
       }

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -220,7 +220,7 @@ export function normalizeOpenAIResponsesToolCallIds(messages: AgentMessage[]): A
         }
         assistantChanged = true;
         return {
-          ...(block as unknown as Record<string, unknown>),
+          ...block,
           id: nextId,
         } as typeof block;
       });
@@ -332,7 +332,7 @@ export function downgradeOpenAIFunctionCallReasoningPairs(
         assistantChanged = true;
         localRewrittenIds.set(toolCallBlock.id, pairing.callId);
         return {
-          ...(block as unknown as Record<string, unknown>),
+          ...block,
           id: pairing.callId,
         } as typeof block;
       });

--- a/src/agents/embedded-agent-helpers/turns.ts
+++ b/src/agents/embedded-agent-helpers/turns.ts
@@ -28,15 +28,15 @@ function isAbortedAssistantTurn(message: AgentMessage): boolean {
   return stopReason === "aborted" || stopReason === "error";
 }
 
-function extractToolResultMatchIds(record: Record<string, unknown>): Set<string> {
+function extractToolResultMatchIds(record: object): Set<string> {
   const ids = new Set<string>();
   for (const value of [
-    record.toolUseId,
-    record.toolCallId,
-    record.tool_use_id,
-    record.tool_call_id,
-    record.callId,
-    record.call_id,
+    Reflect.get(record, "toolUseId"),
+    Reflect.get(record, "toolCallId"),
+    Reflect.get(record, "tool_use_id"),
+    Reflect.get(record, "tool_call_id"),
+    Reflect.get(record, "callId"),
+    Reflect.get(record, "call_id"),
   ]) {
     const id = normalizeOptionalString(value);
     if (id) {
@@ -46,8 +46,12 @@ function extractToolResultMatchIds(record: Record<string, unknown>): Set<string>
   return ids;
 }
 
-function extractToolResultMatchName(record: Record<string, unknown>): string | null {
-  return normalizeOptionalString(record.toolName) ?? normalizeOptionalString(record.name) ?? null;
+function extractToolResultMatchName(record: object): string | null {
+  return (
+    normalizeOptionalString(Reflect.get(record, "toolName")) ??
+    normalizeOptionalString(Reflect.get(record, "name")) ??
+    null
+  );
 }
 
 function collectAnyToolResultIds(message: AgentMessage): Set<string> {
@@ -61,8 +65,7 @@ function collectAnyToolResultIds(message: AgentMessage): Set<string> {
       ids.add(toolResultId);
     }
   } else if (role === "tool") {
-    const record = message as unknown as Record<string, unknown>;
-    for (const id of extractToolResultMatchIds(record)) {
+    for (const id of extractToolResultMatchIds(message)) {
       ids.add(id);
     }
   }
@@ -102,10 +105,9 @@ function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set
   };
 
   if (role === "toolResult") {
-    const record = message as unknown as Record<string, unknown>;
     addMatch(
       [
-        ...extractToolResultMatchIds(record),
+        ...extractToolResultMatchIds(message),
         ...(() => {
           const canonicalId = extractToolResultId(
             message as Extract<AgentMessage, { role: "toolResult" }>,
@@ -113,11 +115,10 @@ function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set
           return canonicalId ? [canonicalId] : [];
         })(),
       ],
-      extractToolResultMatchName(record),
+      extractToolResultMatchName(message),
     );
   } else if (role === "tool") {
-    const record = message as unknown as Record<string, unknown>;
-    addMatch(extractToolResultMatchIds(record), extractToolResultMatchName(record));
+    addMatch(extractToolResultMatchIds(message), extractToolResultMatchName(message));
   }
 
   return matches;

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -206,7 +206,6 @@ function fingerprintPreparedExtraParamsModel(model?: ProviderRuntimeModel): unkn
   if (!model) {
     return null;
   }
-  const record = model as unknown as Record<string, unknown>;
   return {
     api: model.api,
     provider: model.provider,
@@ -216,10 +215,10 @@ function fingerprintPreparedExtraParamsModel(model?: ProviderRuntimeModel): unkn
     reasoning: model.reasoning,
     input: model.input,
     cost: model.cost,
-    compat: record.compat ?? null,
+    compat: Reflect.get(model, "compat") ?? null,
     contextWindow: model.contextWindow,
     contextTokens: model.contextTokens ?? null,
-    headers: record.headers ?? null,
+    headers: Reflect.get(model, "headers") ?? null,
     maxTokens: model.maxTokens,
     maxTokensSource: model.maxTokensSource ?? null,
     params: model.params ?? null,

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -136,7 +136,7 @@ function annotateInterSessionUserMessages(messages: AgentMessage[]): AgentMessag
       }
       touched = true;
       out.push({
-        ...(msg as unknown as Record<string, unknown>),
+        ...msg,
         content: annotated,
       } as AgentMessage);
       continue;
@@ -168,7 +168,7 @@ function annotateInterSessionUserMessages(messages: AgentMessage[]): AgentMessag
       };
       touched = true;
       out.push({
-        ...(msg as unknown as Record<string, unknown>),
+        ...msg,
         content: nextContent,
       } as AgentMessage);
       continue;
@@ -176,7 +176,7 @@ function annotateInterSessionUserMessages(messages: AgentMessage[]): AgentMessag
 
     touched = true;
     out.push({
-      ...(msg as unknown as Record<string, unknown>),
+      ...msg,
       content: [
         {
           type: "text",
@@ -593,7 +593,7 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
       continue;
     }
     out[i] = {
-      ...(message as unknown as Record<string, unknown>),
+      ...message,
       usage: normalizedUsage,
     } as AgentMessage;
     touched = true;

--- a/src/agents/embedded-agent-runner/run/attempt-history.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history.ts
@@ -201,7 +201,7 @@ type PersistedSender = {
 };
 
 function readPersistedSender(message: AgentMessage): PersistedSender | undefined {
-  const openclaw = (message as unknown as Record<string, unknown>)["__openclaw"];
+  const openclaw = Reflect.get(message, "__openclaw");
   if (!openclaw || typeof openclaw !== "object" || Array.isArray(openclaw)) {
     return undefined;
   }

--- a/src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts
@@ -581,7 +581,7 @@ function stripHistoricalInboundMetadataFromUserMessages(
 function stripUnsafeBlockedRunMetadata(messages: AgentMessage[]): AgentMessage[] {
   let changed = false;
   const nextMessages = messages.map((message) => {
-    const openclaw = (message as unknown as Record<string, unknown>)["__openclaw"];
+    const openclaw = Reflect.get(message, "__openclaw");
     if (!openclaw || typeof openclaw !== "object") {
       return message;
     }
@@ -603,10 +603,9 @@ function stripUnsafeBlockedRunMetadata(messages: AgentMessage[]): AgentMessage[]
       beforeAgentRunBlocked: safeBlocked,
     };
     changed = true;
-    return {
-      ...(message as unknown as Record<string, unknown>),
+    return Object.assign({}, message, {
       __openclaw: nextOpenClaw,
-    } as unknown as AgentMessage;
+    });
   });
   return changed ? nextMessages : messages;
 }

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
@@ -28,8 +28,7 @@ function isMidTurnPrecheckAssistantError(message: AgentMessage | undefined): boo
   if (!message || message.role !== "assistant") {
     return false;
   }
-  const record = message as unknown as { stopReason?: unknown; errorMessage?: unknown };
-  return record.stopReason === "error" && record.errorMessage === MID_TURN_PRECHECK_ERROR_MESSAGE;
+  return message.stopReason === "error" && message.errorMessage === MID_TURN_PRECHECK_ERROR_MESSAGE;
 }
 
 export function removeTrailingMidTurnPrecheckAssistantError(params: {

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -85,7 +85,7 @@ function resolveMessageMediaFacts(message: AgentMessage): MediaFact[] {
 }
 
 function wasStructurallyMediaPruned(message: AgentMessage): boolean {
-  const meta = (message as unknown as Record<string, unknown>)["__openclaw"];
+  const meta = Reflect.get(message, "__openclaw");
   return (
     Boolean(meta) &&
     typeof meta === "object" &&

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -580,7 +580,7 @@ async function materializePromptMediaMessages(
       continue;
     }
     const runtimeMedia = readRuntimePromptMediaFacts(message);
-    const meta = (message as unknown as Record<string, unknown>)["__openclaw"];
+    const meta = Reflect.get(message, "__openclaw");
     const resolvedMedia = runtimeMedia ?? readPersistedMediaFacts(message) ?? [];
     const runtimeImageOrder = readRuntimePromptImageOrder(message);
     const mediaImageLayout = readPersistedMediaImageLayout(message);
@@ -637,9 +637,9 @@ async function materializePromptMediaMessages(
       content: projectedContent,
     } as AgentMessage;
     if (Object.keys(nextMeta).length > 0) {
-      (hydratedMessage as unknown as Record<string, unknown>)["__openclaw"] = nextMeta;
+      Reflect.set(hydratedMessage, "__openclaw", nextMeta);
     } else {
-      delete (hydratedMessage as unknown as Record<string, unknown>)["__openclaw"];
+      Reflect.deleteProperty(hydratedMessage, "__openclaw");
     }
     if (runtimeMedia) {
       attachRuntimePromptMediaFacts(hydratedMessage, runtimeMedia, runtimeImageOrder);

--- a/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.ts
+++ b/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.ts
@@ -25,16 +25,16 @@ export function wrapStreamFnWithMessageTransform(
   materializeProviderContext?: ProviderContextMaterializer,
 ): StreamFn {
   return (model, context, options) => {
-    const messages = (context as unknown as { messages?: unknown })?.messages;
+    const messages = context?.messages;
     const nextMessages = Array.isArray(messages)
       ? transform(messages as AgentMessage[], model)
       : messages;
     const nextContext =
       Array.isArray(messages) && nextMessages !== messages
-        ? ({
-            ...(context as unknown as Record<string, unknown>),
-            messages: nextMessages,
-          } as typeof context)
+        ? {
+            ...context,
+            messages: nextMessages as typeof context.messages,
+          }
         : context;
     if (!materializeProviderContext) {
       return streamFn(model, nextContext, options);

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -176,12 +176,11 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
   }
 
   if (message.role === "branchSummary" || message.role === "compactionSummary") {
-    const summary = message.summary;
     const [prefix, suffix] =
       message.role === "branchSummary"
         ? [BRANCH_SUMMARY_PREFIX, BRANCH_SUMMARY_SUFFIX]
         : [COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX];
-    return tokens + estimateStringTokenPressure(prefix + summary + suffix);
+    return tokens + estimateStringTokenPressure(prefix + message.summary + suffix);
   }
 
   if (message.role === "assistant") {

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -9,7 +9,7 @@ import {
   MIN_PROMPT_BUDGET_TOKENS,
 } from "../../agent-compaction-constants.js";
 import { SAFETY_MARGIN } from "../../compaction.js";
-import type { AgentMessage, BashExecutionMessage } from "../../runtime/index.js";
+import type { AgentMessage } from "../../runtime/index.js";
 import {
   BRANCH_SUMMARY_PREFIX,
   BRANCH_SUMMARY_SUFFIX,
@@ -155,50 +155,53 @@ function estimateContentTokenPressure(
 }
 
 function estimateMessageTokenPressure(message: AgentMessage): number {
-  const role: unknown = Reflect.get(message, "role");
+  // Provider replay can carry legacy aliases outside the canonical AgentMessage union.
+  const legacy: Record<string, unknown> = isRecord(message) ? message : {};
   let tokens = MESSAGE_BOUNDARY_OVERHEAD_TOKENS;
 
-  if (role === "toolResult" || role === "tool" || Reflect.get(message, "type") === "toolResult") {
-    tokens += estimateContentTokenPressure(Reflect.get(message, "content"), "tool-result");
-    tokens += estimateIdentifierTokenPressure(
-      Reflect.get(message, "toolName") ?? Reflect.get(message, "tool_name"),
-    );
+  if (message.role === "toolResult" || legacy.role === "tool" || legacy.type === "toolResult") {
+    const content = message.role === "toolResult" ? message.content : legacy.content;
+    const toolName = message.role === "toolResult" ? message.toolName : legacy.toolName;
+    tokens += estimateContentTokenPressure(content, "tool-result");
+    tokens += estimateIdentifierTokenPressure(toolName ?? legacy.tool_name);
     return tokens;
   }
 
-  if (role === "bashExecution") {
-    if (Reflect.get(message, "excludeFromContext") === true) {
+  if (message.role === "bashExecution") {
+    if (message.excludeFromContext === true) {
       return 0;
     }
-    tokens += estimateStringTokenPressure(bashExecutionToText(message as BashExecutionMessage));
+    tokens += estimateStringTokenPressure(bashExecutionToText(message));
     return tokens;
   }
 
-  if (role === "branchSummary" || role === "compactionSummary") {
-    const rawSummary = Reflect.get(message, "summary");
-    const summary = typeof rawSummary === "string" ? rawSummary : "";
+  if (message.role === "branchSummary" || message.role === "compactionSummary") {
+    const summary = message.summary;
     const [prefix, suffix] =
-      role === "branchSummary"
+      message.role === "branchSummary"
         ? [BRANCH_SUMMARY_PREFIX, BRANCH_SUMMARY_SUFFIX]
         : [COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX];
     return tokens + estimateStringTokenPressure(prefix + summary + suffix);
   }
 
-  if (role === "assistant") {
-    const content = Reflect.get(message, "content");
+  if (message.role === "assistant") {
+    const content = message.content;
     if (Array.isArray(content)) {
       for (const block of content) {
-        if (isRecord(block) && (block.type === "toolCall" || block.type === "tool_use")) {
-          tokens += estimateAssistantToolCallTokenPressure(block);
-        } else {
-          tokens += estimateContentBlockTokenPressure(block);
+        if (isRecord(block)) {
+          const blockType: unknown = block.type;
+          if (blockType === "toolCall" || blockType === "tool_use") {
+            tokens += estimateAssistantToolCallTokenPressure(block);
+            continue;
+          }
         }
+        tokens += estimateContentBlockTokenPressure(block);
       }
     } else {
       tokens += estimateContentTokenPressure(content);
     }
 
-    const toolCalls = Reflect.get(message, "toolCalls") ?? Reflect.get(message, "tool_calls");
+    const toolCalls = legacy.toolCalls ?? legacy.tool_calls;
     if (Array.isArray(toolCalls)) {
       for (const toolCall of toolCalls) {
         tokens += isRecord(toolCall)
@@ -209,7 +212,7 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
     return tokens;
   }
 
-  tokens += estimateContentTokenPressure(Reflect.get(message, "content"));
+  tokens += estimateContentTokenPressure(legacy.content);
   return tokens;
 }
 

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -9,7 +9,7 @@ import {
   MIN_PROMPT_BUDGET_TOKENS,
 } from "../../agent-compaction-constants.js";
 import { SAFETY_MARGIN } from "../../compaction.js";
-import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentMessage, BashExecutionMessage } from "../../runtime/index.js";
 import {
   BRANCH_SUMMARY_PREFIX,
   BRANCH_SUMMARY_SUFFIX,
@@ -171,7 +171,8 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
     if (message.excludeFromContext === true) {
       return 0;
     }
-    tokens += estimateStringTokenPressure(bashExecutionToText(message));
+    const bashMessage: BashExecutionMessage = message;
+    tokens += estimateStringTokenPressure(bashExecutionToText(bashMessage));
     return tokens;
   }
 
@@ -184,9 +185,8 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
   }
 
   if (message.role === "assistant") {
-    const content = message.content;
-    if (Array.isArray(content)) {
-      for (const block of content) {
+    if (Array.isArray(message.content)) {
+      for (const block of message.content) {
         if (isRecord(block)) {
           const blockType: unknown = block.type;
           if (blockType === "toolCall" || blockType === "tool_use") {
@@ -197,7 +197,7 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
         tokens += estimateContentBlockTokenPressure(block);
       }
     } else {
-      tokens += estimateContentTokenPressure(content);
+      tokens += estimateContentTokenPressure(message.content);
     }
 
     const toolCalls = legacy.toolCalls ?? legacy.tool_calls;

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -155,36 +155,37 @@ function estimateContentTokenPressure(
 }
 
 function estimateMessageTokenPressure(message: AgentMessage): number {
-  const record = message as unknown as Record<string, unknown>;
+  const role: unknown = Reflect.get(message, "role");
   let tokens = MESSAGE_BOUNDARY_OVERHEAD_TOKENS;
 
-  if (record.role === "toolResult" || record.role === "tool" || record.type === "toolResult") {
-    tokens += estimateContentTokenPressure(record.content, "tool-result");
-    tokens += estimateIdentifierTokenPressure(record.toolName ?? record.tool_name);
-    return tokens;
-  }
-
-  if (record.role === "bashExecution") {
-    if (record.excludeFromContext === true) {
-      return 0;
-    }
-    tokens += estimateStringTokenPressure(
-      bashExecutionToText(record as unknown as BashExecutionMessage),
+  if (role === "toolResult" || role === "tool" || Reflect.get(message, "type") === "toolResult") {
+    tokens += estimateContentTokenPressure(Reflect.get(message, "content"), "tool-result");
+    tokens += estimateIdentifierTokenPressure(
+      Reflect.get(message, "toolName") ?? Reflect.get(message, "tool_name"),
     );
     return tokens;
   }
 
-  if (record.role === "branchSummary" || record.role === "compactionSummary") {
-    const summary = typeof record.summary === "string" ? record.summary : "";
+  if (role === "bashExecution") {
+    if (Reflect.get(message, "excludeFromContext") === true) {
+      return 0;
+    }
+    tokens += estimateStringTokenPressure(bashExecutionToText(message as BashExecutionMessage));
+    return tokens;
+  }
+
+  if (role === "branchSummary" || role === "compactionSummary") {
+    const rawSummary = Reflect.get(message, "summary");
+    const summary = typeof rawSummary === "string" ? rawSummary : "";
     const [prefix, suffix] =
-      record.role === "branchSummary"
+      role === "branchSummary"
         ? [BRANCH_SUMMARY_PREFIX, BRANCH_SUMMARY_SUFFIX]
         : [COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX];
     return tokens + estimateStringTokenPressure(prefix + summary + suffix);
   }
 
-  if (record.role === "assistant") {
-    const content = record.content;
+  if (role === "assistant") {
+    const content = Reflect.get(message, "content");
     if (Array.isArray(content)) {
       for (const block of content) {
         if (isRecord(block) && (block.type === "toolCall" || block.type === "tool_use")) {
@@ -197,7 +198,7 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
       tokens += estimateContentTokenPressure(content);
     }
 
-    const toolCalls = record.toolCalls ?? record.tool_calls;
+    const toolCalls = Reflect.get(message, "toolCalls") ?? Reflect.get(message, "tool_calls");
     if (Array.isArray(toolCalls)) {
       for (const toolCall of toolCalls) {
         tokens += isRecord(toolCall)
@@ -208,7 +209,7 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
     return tokens;
   }
 
-  tokens += estimateContentTokenPressure(record.content);
+  tokens += estimateContentTokenPressure(Reflect.get(message, "content"));
   return tokens;
 }
 

--- a/src/agents/embedded-agent-runner/run/prompt-image-metadata.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-image-metadata.ts
@@ -10,7 +10,7 @@ export type MediaImageLayout = {
 export function readPersistedImageBlockFactIndexes(
   message: AgentMessage,
 ): ImageFactIndex[] | undefined {
-  const meta = (message as unknown as Record<string, unknown>)["__openclaw"];
+  const meta = Reflect.get(message, "__openclaw");
   const value =
     meta && typeof meta === "object" && !Array.isArray(meta)
       ? (meta as Record<string, unknown>).mediaImageBlockFactIndexes
@@ -24,7 +24,7 @@ export function readPersistedImageBlockFactIndexes(
 }
 
 export function readPersistedMediaImageLayout(message: AgentMessage): MediaImageLayout | undefined {
-  const meta = (message as unknown as Record<string, unknown>)["__openclaw"];
+  const meta = Reflect.get(message, "__openclaw");
   if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
     return undefined;
   }

--- a/src/agents/embedded-agent-runner/run/session-bootstrap.ts
+++ b/src/agents/embedded-agent-runner/run/session-bootstrap.ts
@@ -12,7 +12,7 @@ import {
   updateSessionEntry,
 } from "../../../config/sessions/session-accessor.js";
 import { resolvePersistedSessionStoreOwnerForTarget } from "../../../config/sessions/session-store-owner.js";
-import type { InternalSessionEntry, SessionEntry } from "../../../config/sessions/types.js";
+import type { InternalSessionEntry } from "../../../config/sessions/types.js";
 import type { ContextEngineSessionTarget } from "../../../context-engine/types.js";
 import { emitAgentEventIfCurrent } from "../../../infra/agent-events.js";
 import { getAgentRunContext } from "../../../infra/agent-run-registry.js";
@@ -320,9 +320,9 @@ export async function claimAgentSessionWriter(params: RunEmbeddedAgentParams): P
       ) {
         throw new Error(`Session changed before writer claim commit: ${snapshot.sessionKey}`);
       }
-      return {
+      return Object.assign({}, entry, {
         activeWriterRunId: params.runId,
-      } as Partial<InternalSessionEntry> as Partial<SessionEntry>;
+      });
     },
     { skipMaintenance: true },
   );

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -469,22 +469,20 @@ function wrapRetryStreamWithRecoveryNotification(
       wrapRetryStreamWithRecoveryNotification(resolved as ReturnType<StreamFn>, notify),
     ) as ReturnType<StreamFn>;
   }
-  const streamWithResult = retryStream as unknown as {
-    result?: () => Promise<AssistantMessage>;
-  };
-  if (typeof streamWithResult.result !== "function") {
+  const resultMethod = Reflect.get(retryStream, "result");
+  if (typeof resultMethod !== "function") {
     return retryStream;
   }
-  const result = streamWithResult.result.bind(streamWithResult);
+  const result = resultMethod.bind(retryStream) as () => Promise<AssistantMessage>;
   let notified = false;
-  streamWithResult.result = async () => {
+  Reflect.set(retryStream, "result", async () => {
     const message = await result();
     if (!notified && isSuccessfulRecoveryRetryResult(message)) {
       notified = true;
       await notify();
     }
     return message;
-  };
+  });
   return retryStream;
 }
 
@@ -584,16 +582,15 @@ export function wrapAnthropicStreamWithRecovery(
       id: sessionMeta.id,
       onRecoveredAnthropicThinking: sessionMeta.onRecoveredAnthropicThinking,
     };
-    const contextRecord = context as unknown as { messages?: unknown };
-    const originalMessages = Array.isArray(contextRecord.messages)
-      ? (contextRecord.messages as AgentMessage[])
+    const originalMessages = Array.isArray(context.messages)
+      ? (context.messages as AgentMessage[])
       : [];
     const retry = () => {
       const cleanedMessages = stripAllThinkingBlocks(originalMessages);
       const nextContext = {
-        ...(context as unknown as Record<string, unknown>),
-        messages: cleanedMessages,
-      } as typeof context;
+        ...context,
+        messages: cleanedMessages as typeof context.messages,
+      };
       return innerStreamFn(model, nextContext, options);
     };
     const notify = () =>

--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
@@ -158,27 +158,29 @@ function estimateMessageChars(msg: AgentMessage): number {
     return estimateToolResultContentChars(content);
   }
 
-  const record = msg as unknown as Record<string, unknown>;
+  const role: unknown = Reflect.get(msg, "role");
 
-  if (record.role === "bashExecution") {
-    if (record.excludeFromContext === true) {
+  if (role === "bashExecution") {
+    if (Reflect.get(msg, "excludeFromContext") === true) {
       return 0;
     }
-    return bashExecutionToText(msg as unknown as Parameters<typeof bashExecutionToText>[0]).length;
+    return bashExecutionToText(msg as Parameters<typeof bashExecutionToText>[0]).length;
   }
 
-  if (record.role === "branchSummary") {
-    const summary = typeof record.summary === "string" ? record.summary : "";
+  if (role === "branchSummary") {
+    const rawSummary = Reflect.get(msg, "summary");
+    const summary = typeof rawSummary === "string" ? rawSummary : "";
     return (BRANCH_SUMMARY_PREFIX + summary + BRANCH_SUMMARY_SUFFIX).length;
   }
 
-  if (record.role === "compactionSummary") {
-    const summary = typeof record.summary === "string" ? record.summary : "";
+  if (role === "compactionSummary") {
+    const rawSummary = Reflect.get(msg, "summary");
+    const summary = typeof rawSummary === "string" ? rawSummary : "";
     return (COMPACTION_SUMMARY_PREFIX + summary + COMPACTION_SUMMARY_SUFFIX).length;
   }
 
-  if (record.role === "custom") {
-    const content = record.content;
+  if (role === "custom") {
+    const content = Reflect.get(msg, "content");
     if (typeof content === "string") {
       return content.length;
     }

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -55,7 +55,7 @@ export function markTranscriptPromptText(message: AgentMessage, text: string): v
 }
 
 function getTranscriptPromptText(message: AgentMessage): string | undefined {
-  const value = (message as unknown as Record<string, unknown>)[TRANSCRIPT_PROMPT_TEXT_KEY];
+  const value = Reflect.get(message, TRANSCRIPT_PROMPT_TEXT_KEY);
   return typeof value === "string" ? value : undefined;
 }
 
@@ -72,11 +72,11 @@ function restoreTranscriptPromptText(
     return cached;
   }
   const content = (message as { content?: unknown }).content;
-  const { [TRANSCRIPT_PROMPT_TEXT_KEY]: _transcriptPromptText, ...messageRest } =
-    message as unknown as Record<string, unknown>;
+  const messageRest = { ...message };
+  Reflect.deleteProperty(messageRest, TRANSCRIPT_PROMPT_TEXT_KEY);
   let restoredMessage: AgentMessage = message;
   if (typeof content === "string") {
-    restoredMessage = { ...messageRest, content: transcriptText } as unknown as AgentMessage;
+    restoredMessage = Object.assign(messageRest, { content: transcriptText });
   } else if (Array.isArray(content)) {
     let restored = false;
     const nextContent = content.map((block) => {
@@ -91,7 +91,7 @@ function restoreTranscriptPromptText(
       return Object.assign({}, block, { text: transcriptText });
     });
     if (restored) {
-      restoredMessage = { ...messageRest, content: nextContent } as unknown as AgentMessage;
+      restoredMessage = Object.assign(messageRest, { content: nextContent });
     }
   }
   cache.set(message, restoredMessage);
@@ -102,9 +102,9 @@ function stripTranscriptPromptMarker(message: AgentMessage): AgentMessage {
   if (getTranscriptPromptText(message) === undefined) {
     return message;
   }
-  const { [TRANSCRIPT_PROMPT_TEXT_KEY]: _transcriptPromptText, ...messageRest } =
-    message as unknown as Record<string, unknown>;
-  return messageRest as unknown as AgentMessage;
+  const messageRest = { ...message };
+  Reflect.deleteProperty(messageRest, TRANSCRIPT_PROMPT_TEXT_KEY);
+  return messageRest;
 }
 
 function projectTranscriptPromptMessages(
@@ -135,8 +135,8 @@ function replaceToolResultContent(
   replacement: string | unknown[],
 ): AgentMessage {
   const content = (msg as { content?: unknown }).content;
-  const sourceRecord = msg as unknown as Record<string, unknown>;
-  const { details: _details, ...rest } = sourceRecord;
+  const rest = { ...msg };
+  Reflect.deleteProperty(rest, "details");
   return {
     ...rest,
     content:

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../../plugins/provider-runtime.js";
 import type { ProviderToolSchemaDiagnostic } from "../../plugins/types.js";
 import type { AgentTool } from "../runtime/index.js";
-import type { AnyAgentTool } from "../tools/common.js";
 import { log } from "./logger.js";
 
 type ProviderToolSchemaParams<TSchemaType extends TSchema = TSchema, TResult = unknown> = {
@@ -39,7 +38,7 @@ function buildProviderToolSchemaContext<TSchemaType extends TSchema = TSchema, T
     modelId: params.modelId,
     modelApi: params.modelApi,
     model: params.model,
-    tools: params.tools as unknown as AnyAgentTool[],
+    tools: params.tools,
   };
 }
 

--- a/src/agents/embedded-agent-subscribe.tool-text-diagnostics.ts
+++ b/src/agents/embedded-agent-subscribe.tool-text-diagnostics.ts
@@ -19,8 +19,8 @@ function hasStructuredToolInvocation(message: AssistantMessage): boolean {
     if (!block || typeof block !== "object") {
       return false;
     }
-    const record = block as unknown as Record<string, unknown>;
-    const type = typeof record.type === "string" ? record.type.trim() : "";
+    const rawType = Reflect.get(block, "type");
+    const type = typeof rawType === "string" ? rawType.trim() : "";
     if (
       type === "toolCall" ||
       type === "toolUse" ||
@@ -31,7 +31,10 @@ function hasStructuredToolInvocation(message: AssistantMessage): boolean {
     ) {
       return true;
     }
-    return Array.isArray(record.tool_calls) || Array.isArray(record.toolCalls);
+    return (
+      Array.isArray(Reflect.get(block, "tool_calls")) ||
+      Array.isArray(Reflect.get(block, "toolCalls"))
+    );
   });
 }
 

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -163,9 +163,10 @@ export function extractAssistantThinking(msg: AssistantMessage): string {
       if (!block || typeof block !== "object") {
         return "";
       }
-      const record = block as unknown as Record<string, unknown>;
-      if (record.type === "thinking" && typeof record.thinking === "string") {
-        const thinking = record.thinking.trim();
+      const type: unknown = Reflect.get(block, "type");
+      const rawThinking = Reflect.get(block, "thinking");
+      if (type === "thinking" && typeof rawThinking === "string") {
+        const thinking = rawThinking.trim();
         if (thinking) {
           return thinking;
         }
@@ -175,7 +176,8 @@ export function extractAssistantThinking(msg: AssistantMessage): string {
         // .filter(Boolean) below drops the bubble — a diagnostic placeholder is not reasoning
         // content and must not be shown on any channel. The signed block stays on the message
         // for API replay; this only governs display.
-        if (typeof record.thinkingSignature === "string" && record.thinkingSignature.trim()) {
+        const thinkingSignature = Reflect.get(block, "thinkingSignature");
+        if (typeof thinkingSignature === "string" && thinkingSignature.trim()) {
           return "";
         }
       }

--- a/src/agents/harness/transcript-visibility.ts
+++ b/src/agents/harness/transcript-visibility.ts
@@ -11,9 +11,8 @@ export function projectAgentHarnessTranscriptMessageForDisplay<T extends AgentMe
   if (!params.hidden) {
     return params.message;
   }
-  const record = params.message as unknown as Record<string, unknown>;
-  if (record.display === false) {
+  if (Reflect.get(params.message, "display") === false) {
     return params.message;
   }
-  return { ...record, display: false } as unknown as T;
+  return Object.assign({}, params.message, { display: false });
 }

--- a/src/agents/lazy-exec-tool.ts
+++ b/src/agents/lazy-exec-tool.ts
@@ -12,6 +12,7 @@ import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type BashToolsModule = typeof import("./bash-tools.js");
+type LoadedExecTool = ReturnType<BashToolsModule["createExecTool"]>;
 
 const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
   () => import("./bash-tools.js"),
@@ -26,14 +27,14 @@ export function createLazyExecTool(
   defaults?: ExecToolDefaults,
   presentation?: LazyExecToolPresentation,
 ): AnyAgentTool {
-  let loadedTool: AnyAgentTool | undefined;
-  let loadingTool: Promise<AnyAgentTool> | undefined;
+  let loadedTool: LoadedExecTool | undefined;
+  let loadingTool: Promise<LoadedExecTool> | undefined;
   const loadTool = () => {
     if (loadedTool) {
       return Promise.resolve(loadedTool);
     }
     loadingTool ??= bashToolsModuleLoader.load().then(({ createExecTool }) => {
-      loadedTool = createExecTool(defaults) as unknown as AnyAgentTool;
+      loadedTool = createExecTool(defaults);
       return loadedTool;
     });
     return loadingTool;
@@ -57,8 +58,13 @@ export function createLazyExecTool(
       (await loadTool()).prepareBeforeToolCallParams?.(...args) ?? args[0],
     finalizeBeforeToolCallParams: (params, preparedParams) =>
       loadedTool?.finalizeBeforeToolCallParams?.(params, preparedParams) ?? params,
-    execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
-      (await loadTool()).execute(...args),
+    execute: async (toolCallId, params, signal, onUpdate) =>
+      (await loadTool()).execute(
+        toolCallId,
+        params as Parameters<LoadedExecTool["execute"]>[1],
+        signal,
+        onUpdate,
+      ),
   } as AnyAgentTool;
 }
 

--- a/src/agents/lazy-process-tool.ts
+++ b/src/agents/lazy-process-tool.ts
@@ -6,6 +6,7 @@ import { processSchema } from "./bash-tools.schemas.js";
 import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 
 type BashToolsModule = typeof import("./bash-tools.js");
+type LoadedProcessTool = ReturnType<BashToolsModule["createProcessTool"]>;
 
 const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
   () => import("./bash-tools.js"),
@@ -13,11 +14,11 @@ const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
 
 /** Build process lazily so tool discovery does not load the shell runtime. */
 export function createLazyProcessTool(defaults?: ProcessToolDefaults): AnyAgentTool {
-  let loadedTool: AnyAgentTool | undefined;
+  let loadedTool: LoadedProcessTool | undefined;
   const loadTool = async () => {
     if (!loadedTool) {
       const { createProcessTool } = await bashToolsModuleLoader.load();
-      loadedTool = createProcessTool(defaults) as unknown as AnyAgentTool;
+      loadedTool = createProcessTool(defaults);
     }
     return loadedTool;
   };
@@ -28,7 +29,12 @@ export function createLazyProcessTool(defaults?: ProcessToolDefaults): AnyAgentT
     displaySummary: PROCESS_TOOL_DISPLAY_SUMMARY,
     description: describeProcessTool({ hasCronTool: defaults?.hasCronTool === true }),
     parameters: processSchema,
-    execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
-      (await loadTool()).execute(...args),
+    execute: async (toolCallId, params, signal, onUpdate) =>
+      (await loadTool()).execute(
+        toolCallId,
+        params as Parameters<LoadedProcessTool["execute"]>[1],
+        signal,
+        onUpdate,
+      ),
   } as AnyAgentTool;
 }

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -32,10 +32,12 @@ function getProviderModelId(model: ProviderModelConfig): string | undefined {
 }
 
 function normalizeModelCostForCatalog(model: ProviderModelConfig): ProviderModelConfig {
-  const cost = model.cost as unknown as Record<string, number | undefined>;
+  const cost = model.cost;
   if (
     !cost ||
-    ["input", "output", "cacheRead", "cacheWrite"].every((key) => cost[key] !== undefined)
+    (["input", "output", "cacheRead", "cacheWrite"] as const).every(
+      (key) => cost[key] !== undefined,
+    )
   ) {
     return model;
   }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -222,10 +222,10 @@ export function stripToolResultDetails(messages: AgentMessage[]): AgentMessage[]
       out.push(msg);
       continue;
     }
-    const sanitized = { ...(msg as object) } as { details?: unknown };
-    delete sanitized.details;
+    const sanitized = { ...msg };
+    Reflect.deleteProperty(sanitized, "details");
     touched = true;
-    out.push(sanitized as unknown as AgentMessage);
+    out.push(sanitized);
   }
   return touched ? out : messages;
 }

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -487,11 +487,10 @@ export abstract class AgentSessionBase {
       return;
     }
 
-    const targetRecord = target as unknown as Record<string, unknown>;
-    for (const key of Object.keys(targetRecord)) {
-      delete targetRecord[key];
+    for (const key of Object.keys(target)) {
+      Reflect.deleteProperty(target, key);
     }
-    Object.assign(targetRecord, replacement);
+    Object.assign(target, replacement);
   }
 
   /** Emit extension events based on agent events */

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -100,10 +100,10 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     } satisfies PersistedUserTurnMessage;
     const imageFactIndexes = readRuntimePromptImageFactIndexes(images);
     return imageFactIndexes
-      ? ({
+      ? Object.assign({}, message, {
           ...message,
           __openclaw: { mediaImageBlockFactIndexes: imageFactIndexes },
-        } as unknown as PersistedUserTurnMessage)
+        })
       : message;
   }
 

--- a/src/agents/sessions/compaction/compaction.ts
+++ b/src/agents/sessions/compaction/compaction.ts
@@ -3,7 +3,6 @@
  *
  * Local callers keep the historic throwing API while agent-core returns explicit Result objects.
  */
-import type { StreamFn as CoreStreamFn } from "../../../../packages/llm-core/src/index.js";
 import type { Model } from "../../../llm/types.js";
 import {
   calculateContextTokens,
@@ -86,7 +85,7 @@ export async function generateSummary(
       customInstructions,
       previousSummary,
       thinkingLevel,
-      streamFn as unknown as CoreStreamFn | undefined,
+      streamFn,
       openClawAgentCoreRuntime,
     ),
   );
@@ -112,7 +111,7 @@ export async function compact(
       customInstructions,
       signal,
       thinkingLevel,
-      streamFn as unknown as CoreStreamFn | undefined,
+      streamFn,
       openClawAgentCoreRuntime,
     ),
   );

--- a/src/agents/sessions/session-manager-branching.ts
+++ b/src/agents/sessions/session-manager-branching.ts
@@ -165,9 +165,7 @@ export class SessionManagerBranching extends SessionManagerEntries {
     const updatedAt = Date.now();
     const nextTarget = { ...persistenceTarget, sessionId: newSessionId };
     const nextEntry = {
-      ...(previousEntry
-        ? projectCanonicalSessionEntryShape(previousEntry as unknown as Record<string, unknown>)
-        : { updatedAt }),
+      ...(previousEntry ? projectCanonicalSessionEntryShape({ ...previousEntry }) : { updatedAt }),
       sessionId: newSessionId,
       updatedAt,
     };

--- a/src/agents/subagents/completion/subagent-completion-delivery.ts
+++ b/src/agents/subagents/completion/subagent-completion-delivery.ts
@@ -63,11 +63,10 @@ function findSubagentForTask(task: TaskRecord): SubagentRunRecord | undefined {
 function publishCommittedRecords(subagent: SubagentRunRecord, task: TaskRecord): void {
   const live = subagentRuns.get(subagent.runId);
   if (live) {
-    const mutable = live as unknown as Record<string, unknown>;
-    for (const key of Object.keys(mutable)) {
-      delete mutable[key];
+    for (const key of Object.keys(live)) {
+      Reflect.deleteProperty(live, key);
     }
-    Object.assign(mutable, subagent);
+    Object.assign(live, subagent);
   } else {
     subagentRuns.set(subagent.runId, subagent);
   }

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
@@ -197,9 +197,8 @@ export function suspendPendingFinalDelivery(
   try {
     params.persistOrThrow(args.runId);
   } catch (error) {
-    const mutableEntry = args.entry as unknown as Record<string, unknown>;
-    for (const key of Object.keys(mutableEntry)) {
-      delete mutableEntry[key];
+    for (const key of Object.keys(args.entry)) {
+      Reflect.deleteProperty(args.entry, key);
     }
     Object.assign(args.entry, previousEntry);
     throw error;

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-completion.ts
@@ -134,11 +134,10 @@ export async function completeSubagentRunAttempt(
       if (!snapshot) {
         return;
       }
-      const target = currentEntry as unknown as Record<string, unknown>;
-      for (const key of Object.keys(target)) {
-        delete target[key];
+      for (const key of Object.keys(currentEntry)) {
+        Reflect.deleteProperty(currentEntry, key);
       }
-      Object.assign(target, snapshot);
+      Object.assign(currentEntry, snapshot);
     };
     const recoveryRequested = completeParams.recoverInterrupted === true;
     if (

--- a/src/agents/subagents/registry/subagent-registry-run-wait.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-wait.ts
@@ -195,11 +195,10 @@ export class SubagentWaitManager {
   }
 
   protected restoreRunRecord(entry: SubagentRunRecord, snapshot: SubagentRunRecord): void {
-    const target = entry as unknown as Record<string, unknown>;
-    for (const key of Object.keys(target)) {
-      delete target[key];
+    for (const key of Object.keys(entry)) {
+      Reflect.deleteProperty(entry, key);
     }
-    Object.assign(target, snapshot);
+    Object.assign(entry, snapshot);
   }
 
   protected markOlderKillReconciliationsSuperseded(next: SubagentRunRecord) {

--- a/src/agents/subagents/registry/subagent-registry-suspended-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-suspended-delivery.ts
@@ -62,9 +62,8 @@ export async function discardSuspendedPendingFinalDelivery(params: {
       skipRequesterSettleWake: true,
     });
   } catch (error) {
-    const mutableEntry = entry as unknown as Record<string, unknown>;
-    for (const key of Object.keys(mutableEntry)) {
-      delete mutableEntry[key];
+    for (const key of Object.keys(entry)) {
+      Reflect.deleteProperty(entry, key);
     }
     Object.assign(entry, snapshot);
     if (wasResumed) {

--- a/src/agents/subagents/spawn/subagent-attachments.ts
+++ b/src/agents/subagents/spawn/subagent-attachments.ts
@@ -96,11 +96,7 @@ type SubagentAttachmentRequest =
   | { status: "error"; error: string };
 
 function resolveAttachmentLimits(config: OpenClawConfig): AttachmentLimits {
-  const attachmentsCfg = (
-    config as unknown as {
-      tools?: { sessions_spawn?: { attachments?: Record<string, unknown> } };
-    }
-  ).tools?.sessions_spawn?.attachments;
+  const attachmentsCfg = config.tools?.sessions_spawn?.attachments;
   return {
     enabled: attachmentsCfg?.enabled === true,
     maxTotalBytes:

--- a/src/agents/thinking-signatures.ts
+++ b/src/agents/thinking-signatures.ts
@@ -25,19 +25,16 @@ export function isThinkingBlock(block: AssistantContentBlock): boolean {
 function stripSignatureFieldsFromThinkingBlock(
   block: AssistantContentBlock,
 ): AssistantContentBlock {
-  const record = block as unknown as Record<string, unknown>;
-  const stripped: Record<string, unknown> = {};
-  for (const key of Object.keys(record)) {
-    if (key === "thinkingSignature" || key === "signature" || key === "thought_signature") {
-      continue;
-    }
-    // data is the signature payload for redacted_thinking blocks
-    if (key === "data" && record.type === "redacted_thinking") {
-      continue;
-    }
-    stripped[key] = record[key];
+  const stripped = { ...block };
+  Reflect.deleteProperty(stripped, "thinkingSignature");
+  Reflect.deleteProperty(stripped, "signature");
+  Reflect.deleteProperty(stripped, "thought_signature");
+  // data is the signature payload for redacted_thinking blocks
+  const type: unknown = Reflect.get(block, "type");
+  if (type === "redacted_thinking") {
+    Reflect.deleteProperty(stripped, "data");
   }
-  return stripped as unknown as AssistantContentBlock;
+  return stripped;
 }
 
 function stripThinkingSignaturesFromMessage(message: AgentMessage): AgentMessage {
@@ -51,12 +48,12 @@ function stripThinkingSignaturesFromMessage(message: AgentMessage): AgentMessage
       newContent.push(block);
       continue;
     }
-    const record = block as unknown as Record<string, unknown>;
+    const type: unknown = Reflect.get(block, "type");
     const hasSignature =
-      record.thinkingSignature != null ||
-      record.signature != null ||
-      record.thought_signature != null ||
-      (record.type === "redacted_thinking" && record.data != null);
+      Reflect.get(block, "thinkingSignature") != null ||
+      Reflect.get(block, "signature") != null ||
+      Reflect.get(block, "thought_signature") != null ||
+      (type === "redacted_thinking" && Reflect.get(block, "data") != null);
     if (!hasSignature) {
       newContent.push(block);
       continue;

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -363,7 +363,7 @@ function rewriteAssistantToolCallIds(params: {
       return block;
     }
     changed = true;
-    return Object.assign({}, block as unknown as Record<string, unknown>, { id: nextId });
+    return Object.assign({}, block, { id: nextId });
   });
 
   if (!changed) {

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -134,10 +134,9 @@ function inferImageFileName(params: {
   label?: string;
   mediaPathHint?: string;
 }): string | undefined {
-  const rec = params.block as unknown as Record<string, unknown>;
   const explicitKeys = ["fileName", "filename", "path", "url"] as const;
   for (const key of explicitKeys) {
-    const raw = rec[key];
+    const raw = Reflect.get(params.block, key);
     if (typeof raw !== "string" || raw.trim().length === 0) {
       continue;
     }
@@ -147,8 +146,9 @@ function inferImageFileName(params: {
     }
   }
 
-  if (typeof rec.name === "string" && rec.name.trim().length > 0) {
-    return rec.name.trim();
+  const name = Reflect.get(params.block, "name");
+  if (typeof name === "string" && name.trim().length > 0) {
+    return name.trim();
   }
 
   if (params.mediaPathHint) {

--- a/src/agents/tool-search-transcript.ts
+++ b/src/agents/tool-search-transcript.ts
@@ -4,14 +4,16 @@ import { toToolSearchJsonSafe } from "./tool-search-json.js";
 import type { ToolSearchTargetTranscriptProjection } from "./tool-search-types.js";
 
 function readMessageToolResultId(message: AgentMessage): string | undefined {
-  const record = message as unknown as Record<string, unknown>;
-  const role = typeof record.role === "string" ? record.role : "";
+  const role: unknown = message.role;
   const canUseDirectId = role === "toolResult" || role === "tool";
-  const direct = record.toolCallId ?? record.toolUseId ?? record.tool_use_id;
+  const direct =
+    Reflect.get(message, "toolCallId") ??
+    Reflect.get(message, "toolUseId") ??
+    Reflect.get(message, "tool_use_id");
   if (canUseDirectId && typeof direct === "string" && direct.trim()) {
     return direct;
   }
-  const content = record.content;
+  const content = Reflect.get(message, "content");
   if (!Array.isArray(content)) {
     return undefined;
   }

--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -1022,12 +1022,11 @@ export function createComputerTool(options?: {
     | { nodeId: string; providerGeneration: string; observationId: string }
     | undefined;
   const replaceParameterSchema = (actions: readonly ComputerUseV2ActionName[]) => {
-    const next = createComputerToolSchema(actions) as unknown as Record<string, unknown>;
-    const target = parameterSchema as unknown as Record<string, unknown>;
-    for (const key of Object.keys(target)) {
-      delete target[key];
+    const next = createComputerToolSchema(actions);
+    for (const key of Object.keys(parameterSchema)) {
+      Reflect.deleteProperty(parameterSchema, key);
     }
-    Object.assign(target, next);
+    Object.assign(parameterSchema, next);
   };
   const bindNodeCapabilities = (node: NodeListNode) => {
     const next = node.computerUse;
@@ -1412,7 +1411,7 @@ export function createComputerTool(options?: {
               gatewayOpts,
               nodeId,
               command: COMPUTER_ACT_COMMAND,
-              commandParams: wireParams as unknown as Record<string, unknown>,
+              commandParams: { ...wireParams },
               timeoutMs: invokeTimeoutMs,
               idempotencyKey: computerActIdempotencyKey({
                 scope: options?.idempotencyScope,

--- a/src/agents/tools/image-tool.helpers.ts
+++ b/src/agents/tools/image-tool.helpers.ts
@@ -255,10 +255,7 @@ export function resolveProviderVisionModelFromConfig(params: {
   if (isMinimaxVlmProvider(params.provider)) {
     return null;
   }
-  const providerCfg = findNormalizedProviderValue(
-    params.cfg?.models?.providers,
-    params.provider,
-  ) as unknown as { models?: Array<{ id?: string; input?: string[] }> } | undefined;
+  const providerCfg = findNormalizedProviderValue(params.cfg?.models?.providers, params.provider);
   const models = providerCfg?.models ?? [];
   const picked = models.find((m) => Boolean((m?.id ?? "").trim()) && m.input?.includes("image"));
   const id = (picked?.id ?? "").trim();

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -204,7 +204,7 @@ export async function readResponseText(
       ? Math.floor(maxBytesRaw)
       : undefined;
 
-  const body = (res as unknown as { body?: unknown }).body;
+  const body = res.body;
   if (
     maxBytes &&
     body &&

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -66,10 +66,9 @@ export function applyInputProvenanceToUserMessage(
   if (existing) {
     return message;
   }
-  return {
-    ...(message as unknown as Record<string, unknown>),
+  return Object.assign({}, message, {
     provenance: inputProvenance,
-  } as unknown as AgentMessage;
+  });
 }
 
 export function isInterSessionInputProvenance(value: unknown): boolean {

--- a/src/sessions/user-turn-transcript-runtime-context.ts
+++ b/src/sessions/user-turn-transcript-runtime-context.ts
@@ -33,12 +33,11 @@ export function attachRuntimeUserTurnTranscriptContext(
 export function takeRuntimeUserTurnTranscriptContext(
   runtimeMessage: AgentMessage,
 ): RuntimeUserTurnTranscriptContext | undefined {
-  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
-  const context = record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT] as
+  const context = Reflect.get(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT) as
     | RuntimeUserTurnTranscriptContext
     | undefined;
   if (context) {
-    delete record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT];
+    Reflect.deleteProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT);
   }
   return context;
 }
@@ -58,12 +57,11 @@ export function attachRuntimeUserTurnTranscriptRecorder(
 export function takeRuntimeUserTurnTranscriptRecorder(
   runtimeMessage: AgentMessage,
 ): UserTurnTranscriptRecorder | undefined {
-  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
-  const recorder = record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER] as
+  const recorder = Reflect.get(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_RECORDER) as
     | UserTurnTranscriptRecorder
     | undefined;
   if (recorder) {
-    delete record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER];
+    Reflect.deleteProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_RECORDER);
   }
   return recorder;
 }

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -121,7 +121,7 @@ export function buildLateMediaAttachedProjection(message: AgentMessage): {
 }
 
 function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown> | undefined {
-  return asOptionalRecord((message as unknown as Record<string, unknown>)["__openclaw"]);
+  return asOptionalRecord(Reflect.get(message, "__openclaw"));
 }
 export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
   const normalizedMedia = (params.media ?? []).map(normalizeStructuredMediaEntryForTranscript);
@@ -165,7 +165,8 @@ function buildLateResolvedMediaMessage(params: {
   ) {
     return undefined;
   }
-  const resolved = params.resolvedMessage as unknown as Record<string, unknown>;
+  const resolvedIdempotencyKey = Reflect.get(params.resolvedMessage, "idempotencyKey");
+  const resolvedTimestamp = Reflect.get(params.resolvedMessage, "timestamp");
   const admittedContent = params.admittedMessage?.content;
   const resolvedContent = params.resolvedMessage.content;
   let content = resolvedContent;
@@ -178,16 +179,16 @@ function buildLateResolvedMediaMessage(params: {
     });
   }
   const idempotencyKey =
-    typeof resolved.idempotencyKey === "string" && resolved.idempotencyKey.length > 0
-      ? `${resolved.idempotencyKey}:late-media`
-      : `late-media:${typeof resolved.timestamp === "number" ? resolved.timestamp : Date.now()}`;
+    typeof resolvedIdempotencyKey === "string" && resolvedIdempotencyKey.length > 0
+      ? `${resolvedIdempotencyKey}:late-media`
+      : `late-media:${typeof resolvedTimestamp === "number" ? resolvedTimestamp : Date.now()}`;
   // Like #111204, mark late-media scaffolding as wire-only so UIs never render it.
   return {
-    ...resolved,
+    ...params.resolvedMessage,
     content,
     idempotencyKey,
     __openclaw: { ...readOpenClawMessageMeta(params.resolvedMessage), lateMedia: true },
-  } as unknown as PersistedUserTurnMessage;
+  } as PersistedUserTurnMessage;
 }
 
 function isBeforeAgentRunBlockedMessage(message: AgentMessage): boolean {
@@ -222,18 +223,16 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   ) {
     return params.runtimeMessage;
   }
-  const runtimeMessage = params.runtimeMessage as unknown as Record<string, unknown>;
-  const preparedMessage = params.preparedMessage as unknown as Record<string, unknown>;
   const runtimeMeta = readOpenClawMessageMeta(params.runtimeMessage);
   const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
   return {
-    ...runtimeMessage,
-    ...preparedMessage,
+    ...params.runtimeMessage,
+    ...params.preparedMessage,
     ...(preparedMeta ? { __openclaw: { ...runtimeMeta, ...preparedMeta } } : {}),
     ...(userMessageHasImageContent(params.runtimeMessage)
       ? { content: params.runtimeMessage.content }
       : {}),
-  } as unknown as AgentMessage;
+  } as AgentMessage;
 }
 
 /** Restores only auth state that write hooks must not be able to forge or erase. */
@@ -250,9 +249,9 @@ export function restorePreparedUserTurnOperationalMetaForRuntime(params: {
     return params.runtimeMessage;
   }
   return {
-    ...(params.runtimeMessage as unknown as Record<string, unknown>),
+    ...params.runtimeMessage,
     __openclaw: { ...readOpenClawMessageMeta(params.runtimeMessage), senderIsOwner },
-  } as unknown as AgentMessage;
+  } as AgentMessage;
 }
 
 /** Applies before-message hooks while preserving user-turn transcript metadata. */
@@ -263,12 +262,10 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   if (!params.beforeMessageWrite) {
     return message;
   }
-  const originalMessage = message as unknown as { idempotencyKey?: unknown };
+  const originalIdempotencyKey = Reflect.get(message, "idempotencyKey");
   const idempotencyKey =
-    typeof originalMessage.idempotencyKey === "string" ? originalMessage.idempotencyKey : undefined;
-  const provenance = normalizeInputProvenance(
-    (message as unknown as { provenance?: unknown }).provenance,
-  );
+    typeof originalIdempotencyKey === "string" ? originalIdempotencyKey : undefined;
+  const provenance = normalizeInputProvenance(Reflect.get(message, "provenance"));
   const originalMeta = readOpenClawMessageMeta(message);
   const senderIsOwner = originalMeta?.senderIsOwner;
   const replyToId = normalizeOptionalString(originalMeta?.replyToId);
@@ -326,10 +323,10 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
     ...(mediaImageLayout === undefined ? {} : { mediaImageLayout }),
   };
   return {
-    ...(nextUserMessage as unknown as Record<string, unknown>),
+    ...nextUserMessage,
     ...(idempotencyKey ? { idempotencyKey } : {}),
     ...(Object.keys(protectedMeta).length > 0 ? { __openclaw: protectedMeta } : {}),
-  } as unknown as PersistedUserTurnMessage;
+  } as PersistedUserTurnMessage;
 }
 
 // Store-backed persistence resolves the current session transcript file lazily


### PR DESCRIPTION
## What Problem This Solves

Removes unsafe chained type assertions from the agents and sessions production surface where the existing code discarded useful type evidence. The remaining assertions are explicitly documented where they represent intentional runtime/provider boundaries or require an owner-contract change outside this worker's assigned files.

## Why This Change Was Made

The refactor preserves type evidence through typed construction, `Reflect` property access, discriminated narrowing, schema-preserving adapters, and typed literal construction. Runtime behavior and public plugin surfaces are unchanged; no test files were modified.

## User Impact

No user-visible behavior changes. Maintainers get stronger static guarantees across agent tools, transcripts, compaction, subagent lifecycle rollback, media handling, and session persistence.

## Evidence

- Chained-assertion scan: 131 before; 26 after; 105 fixed.
- Focused Vitest: 7 shards, 67 files, 968 passed, 2 skipped.
- `node scripts/check-changed.mjs`: passed all selected `core` and `coreTests` format, typecheck, lint, architecture, and guard lanes. The remote `ci-fast` backend was unavailable, so the repository wrapper fell back to serialized local execution.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`: passed.
- `node scripts/run-tsgo-core-test-shards.mjs`: passed.
- `node --import tsx scripts/check-extension-package-tsc-boundary.mts --mode=compile`: passed all 123 plugins.
- Autoreview: clean; no accepted/actionable findings.
- Production numstat: +294/-297 (net -3). Tests: +0/-0.

Intentional/deferred leftovers (verbatim):

- [intentional] `src/agents/mcp-http-fetch.ts:18` — undici's response type is bridged to the DOM/MCP fetch contract and converted to a global `Response` after guarded fetching.
- [deferred] `src/agents/tool-search-transcript.ts:77` — JSON-safe tool-call input is intentionally `unknown`; fixing this requires an owning projection type that distinguishes record arguments from arbitrary JSON.
- [deferred] `src/agents/tool-search-transcript.ts:91` — JSON-safe tool-result content needs an owning parsed content-block contract before narrowing without changing persisted bytes.
- [intentional] `src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts:115` — the wrapper intentionally replaces the existing stream's async-iterator method while preserving stream identity.
- [intentional] `src/agents/failover/provider-patterns.ts:55` — optional provider runtime hooks are loaded through a cycle-avoiding dynamic require boundary.
- [intentional] `src/agents/model-auth-model.ts:279` — `Authorization: null` intentionally violates the SDK's string-header type to suppress generated authorization for no-auth local servers.
- [intentional] `src/agents/embedded-agent-helpers/images.ts:104` — provider replay assistant blocks intentionally cross the tool-image sanitizer's narrower content-block contract.
- [intentional] `src/agents/embedded-agent-helpers/images.ts:105` — sanitized provider replay content intentionally returns to the assistant-message content contract.
- [deferred] `src/agents/embedded-agent-runner/run/attempt-stream.ts:244` — the synthetic yield stream needs its owning helper to return the canonical stream/message contract; that helper is outside this worker's file list.
- [deferred] `src/agents/model-provider-auth.ts:296` — the generic stable runtime-value hasher is typed only for `OpenClawConfig`; correcting that owner is outside this worker's file list.
- [intentional] `src/agents/agent-hooks/compaction-safeguard.ts:451` — GitHub Copilot dynamic headers intentionally consume the standard-message projection of the broader agent transcript.
- [intentional] `src/agents/agent-model-discovery.ts:76` — captured model records intentionally allow a missing API so provider normalization hooks can fill it.
- [intentional] `src/agents/agent-model-discovery.ts:89` — provider normalization intentionally receives that partially discovered model at the provider-hook boundary.
- [intentional] `src/agents/agent-model-discovery.ts:101` — transport normalization intentionally receives the provider-normalized model at the same hook boundary.
- [deferred] `src/agents/subagents/spawn/subagent-depth.ts:38` — the generic store projection claims caller-selected optional fields; fixing it requires the capability-store caller contract outside this worker's file list.
- [intentional] `src/agents/embedded-agent-runner/run/images.ts:618` — provider-only video content intentionally crosses the canonical `AgentMessage` array during transient provider-context materialization.
- [deferred] `src/agents/embedded-agent-runner/run/attempt-prompt-support.ts:75` — plugin metadata lookup is identity-only but its owning getter is typed as a full erased tool; widening that owner is outside this worker's file list.
- [deferred] `src/agents/sessions/session-manager-codec.ts:409` — legacy session headers are deliberately accepted with only type/id; strengthening the persisted header parser would change compatibility behavior.
- [deferred] `src/agents/mcp-pagination.ts:107` — the defaulted `TOutput = TInput` generic does not encode that `mapItem` is required when output differs; an honest overload expands this shared API and is deferred.
- [intentional] `src/agents/modes/interactive/theme/theme.ts:554` — the theme proxy intentionally forwards arbitrary string/symbol property reads to the initialized receiver.
- [deferred] `src/agents/agent-tools.read.ts:888` — safely erasing the read tool's schema requires the shared tool-type owner to preserve identity-backed metadata.
- [deferred] `src/agents/agent-tools.read.ts:901` — safely erasing the sandbox write tool's schema requires the shared tool-type owner to preserve identity-backed metadata.
- [deferred] `src/agents/agent-tools.read.ts:911` — safely erasing the sandbox edit tool's schema requires the shared tool-type owner to preserve identity-backed metadata.
- [deferred] `src/agents/agent-tools.read.ts:926` — safely erasing the host write tool's schema requires the shared tool-type owner to preserve identity-backed metadata.
- [deferred] `src/agents/agent-tools.read.ts:941` — safely erasing the host edit tool's schema requires the shared tool-type owner to preserve identity-backed metadata.
- [deferred] `src/agents/agent-tools.read.ts:1006` — safely erasing the virtual read tool's schema requires the shared tool-type owner to preserve identity-backed metadata.
