### PR TITLE
fix(ui): remove question expiry timer

### DIFF
--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -261,6 +261,14 @@ describe("shared question panel", () => {
     expect(container.querySelector(".chat-question-panel__skip")).toBeNull();
   });
 
+  it("does not render the request expiry countdown", async () => {
+    drawGateway(gatewayPrompt());
+    await panelIn(container);
+
+    expect(container.querySelector(".chat-question-panel__countdown")).toBeNull();
+    expect(container.textContent).not.toContain("1:00");
+  });
+
   it("manages collapse state when no controlled callback is supplied", async () => {
     render(
       html`<openclaw-chat-question-panel

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -4,7 +4,6 @@ import { property, state } from "lit/decorators.js";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
-import { formatCountdown } from "../../../lib/format.ts";
 
 type QuestionPanelQuestion = {
   questionId: string;
@@ -22,7 +21,6 @@ type QuestionPanelViewModel = {
   collapsed: boolean;
   disabled: boolean;
   submitting?: boolean;
-  countdown?: string;
   answersById?: Record<string, string[]>;
   error?: string | null;
   requestPosition?: { current: number; total: number };
@@ -86,10 +84,6 @@ export function createGatewayQuestionPanelProps(
       collapsed: options.collapsed ?? false,
       disabled: prompt.status !== "pending" || prompt.submitting,
       submitting: prompt.submitting,
-      countdown:
-        prompt.status === "pending"
-          ? formatCountdown(prompt.expiresAtMs, options.nowMs)
-          : undefined,
       answersById: promptDraftAnswers(prompt),
       error: prompt.error,
       requestPosition: options.requestPosition,
@@ -522,13 +516,6 @@ class ChatQuestionPanel extends LitElement {
                   ${icons.chevronRight}
                 </button>
               </div>`
-            : nothing}
-          ${model.countdown
-            ? html`<span
-                class="chat-question-panel__countdown"
-                title=${t("chat.questions.timeRemaining")}
-                >${model.countdown}</span
-              >`
             : nothing}
           <button
             class="chat-question-panel__collapse"

--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -101,14 +101,6 @@ openclaw-chat-question-panel {
   white-space: nowrap;
 }
 
-.chat-question-panel__countdown {
-  margin-left: auto;
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: calc(var(--control-ui-text-sm) - 1px);
-  font-variant-numeric: tabular-nums;
-}
-
 .chat-question-panel__collapse {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove the visible expiry countdown from the Control UI question panel
- remove the unused countdown view-model field and styles
- keep question expiration behavior unchanged

## Testing
- `pnpm exec vitest run src/pages/chat/components/chat-question-card.test.ts`
- `pnpm exec oxfmt --check ui/src/pages/chat/components/chat-question-card.ts ui/src/pages/chat/components/chat-question-card.test.ts ui/src/styles/chat/question-card.css`
- `git diff --cached --check`
