### PR TITLE
fix(browser): keep close results bound to closed tab

### DIFF
--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -437,14 +437,19 @@ export async function executeActAction(params: {
   profile?: string;
   proxyRequest: BrowserProxyRequest | null;
   onTabActivity?: (targetId: string | undefined) => void;
+  onTabClose?: (targetId: string | undefined) => void;
 }): Promise<AgentToolResult<unknown>> {
   const { request, baseUrl, profile, proxyRequest } = params;
   const effectiveRequest = withConfiguredActTimeout(request, profile);
   // resolvedTargetId is the id the act actually ran against (retry paths swap
   // it), so page-state capture must use it rather than the original request's.
   const finishActResult = async (result: unknown, resolvedTargetId: string | undefined) => {
-    params.onTabActivity?.(resolvedTargetId);
     const aborted = readBrowserBatchAbort(result);
+    const onTabResult =
+      effectiveRequest.kind === "close" || aborted?.reason === "closed"
+        ? params.onTabClose
+        : params.onTabActivity;
+    onTabResult?.(resolvedTargetId);
     const formatted = formatActToolResult(result, aborted);
     if (!actObservedNavigation(result, aborted)) {
       return formatted;

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -2796,6 +2796,24 @@ describe("browser tool url alias support", () => {
     });
   });
 
+  it("untracks the selected tab when close omits targetId", async () => {
+    browserActionsMocks.browserAct.mockResolvedValueOnce({
+      ok: true,
+      targetId: "selected-tab",
+      url: "https://example.com",
+    });
+    const tool = createBrowserTool({ agentSessionKey: "agent:main:main" });
+
+    await tool.execute?.("call-1", { action: "close" });
+
+    expect(sessionTabRegistryMocks.untrackSessionBrowserTab).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      targetId: "selected-tab",
+      baseUrl: undefined,
+      profile: "openclaw",
+    });
+  });
+
   it("never creates tracking records from tab listing or focus", async () => {
     browserClientMocks.browserTabs.mockResolvedValueOnce([
       {
@@ -2816,6 +2834,41 @@ describe("browser tool url alias support", () => {
 
 describe("browser tool act compatibility", () => {
   registerBrowserToolAfterEachReset();
+
+  it.each([
+    {
+      name: "close",
+      request: { kind: "close", targetId: "closed-tab" },
+      result: { ok: true, targetId: "closed-tab", url: "https://example.com" },
+    },
+    {
+      name: "batch close",
+      request: {
+        kind: "batch",
+        targetId: "closed-tab",
+        actions: [{ kind: "close" }],
+      },
+      result: {
+        ok: true,
+        targetId: "closed-tab",
+        results: [{ ok: true }],
+        aborted: { reason: "closed", afterAction: 1, url: "https://example.com", skipped: 0 },
+      },
+    },
+  ])("retires session ownership after act:$name", async ({ request, result }) => {
+    browserActionsMocks.browserAct.mockResolvedValueOnce(result);
+    const tool = createBrowserTool({ agentSessionKey: "agent:main:main" });
+
+    await tool.execute?.("call-1", { action: "act", request });
+
+    expect(sessionTabRegistryMocks.untrackSessionBrowserTab).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      targetId: "closed-tab",
+      baseUrl: undefined,
+      profile: "openclaw",
+    });
+    expect(sessionTabRegistryMocks.touchSessionBrowserTab).not.toHaveBeenCalled();
+  });
 
   it("adds a clear note when a batch aborts after navigation", async () => {
     browserActionsMocks.browserAct.mockResolvedValueOnce({

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -659,7 +659,9 @@ export function createBrowserTool(opts?: {
                   body: { kind: "close" },
                   timeoutMs: toolTimeoutMs,
                 });
-            sessionTabs.untrack(targetId);
+            sessionTabs.untrack(
+              readStringValue((result as { targetId?: unknown }).targetId) ?? targetId,
+            );
             return jsonResult(result);
           }
           if (targetId) {
@@ -669,7 +671,7 @@ export function createBrowserTool(opts?: {
             });
             sessionTabs.untrack(targetId);
           } else {
-            await browserToolDeps.browserAct(
+            const result = await browserToolDeps.browserAct(
               baseUrl,
               { kind: "close" },
               {
@@ -677,6 +679,7 @@ export function createBrowserTool(opts?: {
                 timeoutMs: toolTimeoutMs,
               },
             );
+            sessionTabs.untrack(readStringValue(result.targetId));
           }
           return jsonResult({ ok: true });
         }
@@ -983,6 +986,7 @@ export function createBrowserTool(opts?: {
             profile,
             proxyRequest,
             onTabActivity: sessionTabs.touch,
+            onTabClose: sessionTabs.untrack,
           });
         }
         default:

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -734,7 +734,7 @@ export function registerBrowserAgentActRoutes(
                 ...(result.aborted ? { aborted: result.aborted } : {}),
                 ...(downloads ? { downloads } : {}),
               },
-              { resolveCurrentTarget: true },
+              { resolveCurrentTarget: result.aborted?.reason !== "closed" },
             );
           case "evaluate":
             return await jsonOk(
@@ -747,6 +747,7 @@ export function registerBrowserAgentActRoutes(
               resolveCurrentTarget: true,
             });
           case "resize":
+          case "close":
             return await jsonOk(downloads ? { downloads } : undefined);
           default:
             return await jsonOk(downloads ? { downloads } : undefined, {

--- a/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 // Browser tests cover server.agent contract form layout act commands plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import "../test-support/browser-security.mock.js";
 import { DEFAULT_DOWNLOAD_DIR, DEFAULT_TRACE_DIR, DEFAULT_UPLOAD_DIR } from "./paths.js";
 import {
@@ -15,6 +15,7 @@ import {
 import {
   getBrowserControlServerTestState,
   getPwMocks,
+  makeResponse,
   setBrowserControlServerSsrFPolicy,
   setBrowserControlServerTabUrl,
 } from "./server.control-server.test-harness.js";
@@ -720,6 +721,40 @@ describe("browser control server", () => {
       expect(pwMocks[mockName]).toHaveBeenCalled();
     },
   );
+
+  it("keeps act:close bound to the tab it closed", async () => {
+    const base = await startServerAndBase();
+    requirePwMock("closePageViaPlaywright").mockImplementationOnce(async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (!url.includes("/json/list")) {
+            return makeResponse({}, { ok: false, status: 500, text: "unexpected" });
+          }
+          return makeResponse([
+            {
+              id: "abce9999",
+              title: "Survivor",
+              url: "https://other",
+              webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/abce9999",
+              type: "page",
+            },
+          ]);
+        }),
+      );
+    });
+
+    const result = await postJson<{ ok?: boolean; targetId?: string; url?: string }>(
+      `${base}/act`,
+      { kind: "close", targetId: "abcd1234" },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      targetId: "abcd1234",
+      url: "https://example.com",
+    });
+  });
 
   it("wait/download rejects traversal path outside downloads dir", async () => {
     const base = await startServerAndBase();


### PR DESCRIPTION
Closes #124052

Related: #103785 and #110884

## What Problem This Solves

Fixes an issue where users closing a managed browser tab could receive the sole surviving tab as the close result, causing later browser work and session cleanup to use the wrong tab identity.

The broader post-action identity redesign remains tracked by #103785 and #110884. This PR intentionally fixes only close outcomes; navigation and renderer-swap continuity are unchanged.

## Why This Change Was Made

Close is a terminal target outcome, not navigation. The browser route now keeps direct and closed-batch results bound to the target that actually closed, while the agent-tool lifecycle retires that exact target for direct close, `act:close`, and batch close. Non-close action/navigation activity continues through the existing resolver unchanged.

This is the maintainer-approved bounded subset of the broader target-identity work: no extension-relay identity contract, browser security/profile policy, protocol, configuration, Plugin SDK, or persistence behavior changes.

Production LOC: +14/-4 (net +10) | Tests: +89/-1 (net +88)

The production growth is the close-specific lifecycle callback and three existing entry-point integrations; it avoids adding a parallel resolver, fallback, or compatibility path.

Provenance: the close route began resolving every managed action through the navigation resolver in #106964 (code author/PR author/merger `@steipete`, 2026-07-14). Generic post-action activity tracking was carried forward by #114814 (code author/PR author/merger `@obviyus`, 2026-07-28), and closed-batch outcomes were added in #113749 (`@steipete`, 2026-07-25).

## User Impact

Closing a tab no longer reports or touches an unrelated surviving tab. Session lifecycle cleanup stops retaining a tab that has already closed, while successful navigation and renderer-replacement behavior remain as before.

## Evidence

Candidate head: `31134240c5a95dd84bbe5d9733430a216fa8fa90`

Main baseline: `2e806ef0e2c99ea2968766944573e8ef16c33126` — [main CI passed](https://github.com/openclaw/openclaw/actions/runs/31868619808).

Blacksmith Testbox: `tbx_01m02125w4srvejt7z28hcjqcf` — [hydration/run](https://github.com/openclaw/openclaw/actions/runs/31869059991).

### Before

With only the three production hunks reversed against the candidate tests:

```text
keeps act:close bound to the tab it closed
untracks the selected tab when close omits targetId
retires session ownership after act:'close'
retires session ownership after act:'batch close'
Tests 4 failed | 192 passed (196)
```

### After

```text
Test Files 2 passed (2)
Tests 196 passed (196)
```

The exact five-file changed gate passed extension production/test typechecks, zero-warning lint, formatting, dependency and plugin-boundary guards, dead-export scan, database-first guard, runtime sidecar checks, and zero runtime import cycles.

Fresh structured autoreview reported no accepted/actionable findings.

### Real browser lifecycle proof

A source-built Gateway used task-owned state, a task-owned headless Chrome profile, a synthetic local page, and four verified-free ports. The run proved:

- action and navigation success;
- screenshot capture;
- active request cancellation (`curl` exit 28) followed by a successful snapshot;
- close response retained the exact closed target and the tab disappeared;
- Gateway restart stopped the first managed Chrome process;
- the stale pre-restart handle was rejected with recovery context;
- reconnect/open succeeded;
- explicit browser stop terminated the replacement Chrome process;
- the temporary profile directory was removed and all four ports were closed.

Sanitized synthetic evidence (SHA-256 `3b39d8ada441c620bdd7195763f639a7849a36689e2278d44a22a10080893a9b`):

![Task-owned browser lifecycle proof](https://github.com/user-attachments/assets/22b46f0c-8d57-4320-9872-671f6feefd80)

No changelog edit: release generation owns `CHANGELOG.md`.

AI-assisted implementation and review; the code path, dependency contract, focused regressions, exact changed gate, and real Chromium behavior were independently inspected and verified.
