### PR TITLE
fix(ui): Models refreshes after Gateway reconnect

### DIFF
--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -837,4 +837,170 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       await context.close();
     }
   });
+
+  it("reloads the selected agent and clears a failed model draft after reconnect", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1280 },
+      ...(recordVisuals
+        ? { recordVideo: { dir: artifactDir, size: { height: 1000, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const initialConfig = {
+      agents: { defaults: { model: "openai/initial-model" } },
+    };
+    const gateway = await installMockGateway(page, {
+      defaultAgentId: "main",
+      featureMethods: ["chat.metadata", "chat.startup", "config.patch"],
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            { id: "main", name: "Main" },
+            { id: "writer", name: "Writer" },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "config.get": {
+          config: initialConfig,
+          sourceConfig: initialConfig,
+          hash: "model-providers-reconnect-1",
+          issues: [],
+          raw: JSON.stringify(initialConfig),
+          valid: true,
+        },
+        "models.list": {
+          models: [
+            { id: "initial-model", name: "Initial Model", provider: "openai", available: true },
+            { id: "saved-model", name: "Saved Model", provider: "openai", available: true },
+            { id: "failed-draft", name: "Failed Draft", provider: "openai", available: true },
+          ],
+        },
+        "models.authStatus": {
+          ts: NOW,
+          providers: [
+            {
+              provider: "openai",
+              displayName: "OpenAI",
+              status: "ok",
+              profiles: [{ profileId: "openai:writer", type: "oauth", status: "ok" }],
+            },
+          ],
+        },
+        "usage.status": { updatedAt: NOW, providers: [] },
+        "sessions.usage": { aggregates: { byProvider: [] } },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}settings/model-providers`);
+      const agentPicker = page.locator(".agent-scope-control openclaw-agent-select");
+      await agentPicker.locator(".agent-select__trigger").click();
+      await agentPicker.locator('wa-dropdown-item[aria-label="Writer"]').click();
+      await expect
+        .poll(async () => (await agentPicker.locator(".agent-select__label").textContent())?.trim())
+        .toBe("Writer");
+      await expect
+        .poll(() => modelPickerValue(page.locator(".model-providers__defaults wa-select").first()))
+        .toBe("openai/initial-model");
+
+      const primary = page.locator(".model-providers__defaults wa-select").first();
+      const savedConfig = {
+        agents: { defaults: { model: "openai/saved-model" } },
+      };
+      await gateway.setMethodResponse("config.get", {
+        config: savedConfig,
+        sourceConfig: savedConfig,
+        hash: "model-providers-reconnect-saved",
+        issues: [],
+        raw: JSON.stringify(savedConfig),
+        valid: true,
+      });
+      await selectModelPicker(primary, "openai/saved-model");
+      await page
+        .locator(".settings-section", {
+          has: page.getByRole("heading", { name: "Default models" }),
+        })
+        .getByRole("button", { name: "Save" })
+        .click();
+      await expect
+        .poll(async () =>
+          page.getByRole("status").filter({ hasText: "Default models saved" }).count(),
+        )
+        .toBeGreaterThan(0);
+
+      await selectModelPicker(primary, "openai/failed-draft");
+      await gateway.deferNext("config.patch");
+      await page
+        .locator(".settings-section", {
+          has: page.getByRole("heading", { name: "Default models" }),
+        })
+        .getByRole("button", { name: "Save" })
+        .click();
+      await gateway.waitForRequest("config.patch");
+      await gateway.rejectDeferred("config.patch", {
+        code: "INVALID_REQUEST",
+        message: "synthetic model save rejected",
+      });
+      await page.getByRole("alert").filter({ hasText: "synthetic model save rejected" }).waitFor();
+      if (recordVisuals) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, "05-reconnect-save-error.png"),
+        });
+      }
+
+      const reconnectedConfig = {
+        agents: { defaults: { model: "openai/reconnected-model" } },
+      };
+      await gateway.setMethodResponse("config.get", {
+        config: reconnectedConfig,
+        sourceConfig: reconnectedConfig,
+        hash: "model-providers-reconnect-2",
+        issues: [],
+        raw: JSON.stringify(reconnectedConfig),
+        valid: true,
+      });
+      await gateway.setMethodResponse("models.list", {
+        models: [
+          {
+            id: "reconnected-model",
+            name: "Reconnected Model",
+            provider: "openai",
+            available: true,
+          },
+        ],
+      });
+      const authRequestCount = (await gateway.getRequests("models.authStatus")).length;
+      await gateway.closeLatest(1012, "model provider reconnect proof");
+      await expect
+        .poll(async () => (await gateway.getRequests("models.authStatus")).length)
+        .toBeGreaterThan(authRequestCount);
+      await expect
+        .poll(() => modelPickerValue(page.locator(".model-providers__defaults wa-select").first()))
+        .toBe("openai/reconnected-model");
+      await expect.poll(() => page.getByRole("alert").count()).toBe(0);
+      await expect
+        .poll(async () => (await agentPicker.locator(".agent-select__label").textContent())?.trim())
+        .toBe("Writer");
+      for (const request of (await gateway.getRequests("models.authStatus")).slice(
+        authRequestCount,
+      )) {
+        expect(request.params).toEqual(expect.objectContaining({ agentId: "writer" }));
+      }
+      if (recordVisuals) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, "06-reconnected-model.png"),
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -13,6 +13,7 @@ import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { normalizeAgentLabel } from "../../lib/agents/display.ts";
+import { createGatewayConnectionLifecycle } from "../../lib/gateway-connection-lifecycle.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -116,8 +117,10 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
 
   /** Client the current data was loaded from; a new client means stale data. */
   private dataClient: GatewayBrowserClient | null = null;
-  private observedClient: GatewayBrowserClient | null = null;
-  private clientEpoch = 0;
+  private readonly connectionLifecycle = createGatewayConnectionLifecycle({
+    client: null,
+    phase: "stopped",
+  });
   // Global config writes survive agent switches; their card state does not.
   private agentEpoch = 0;
   private probeEpochs = new Map<string, number>();
@@ -173,6 +176,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     );
 
   override disconnectedCallback() {
+    this.connectionLifecycle.transition({ client: null, phase: "stopped" });
     void this.refreshTask.run([null, "", false]);
     this.subscriptions.clear();
     super.disconnectedCallback();
@@ -194,8 +198,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
 
   override updated() {
     const snapshot = this.context.gateway.snapshot;
-    if (snapshot.client !== this.observedClient) {
-      this.resetClientState(snapshot.client);
+    if (this.connectionLifecycle.transition(snapshot)) {
+      this.resetConnectionState(snapshot.client, snapshot.phase === "connected");
     }
     if (
       !this.context.agents.state.agentsList &&
@@ -217,9 +221,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     }
   }
 
-  private resetClientState(client: GatewayBrowserClient | null) {
-    this.observedClient = client;
-    this.clientEpoch += 1;
+  private resetConnectionState(client: GatewayBrowserClient | null, connected: boolean) {
     void this.refreshTask.run([null, this.selectedAgentId, false]);
     this.busy = {};
     this.messages = {};
@@ -233,17 +235,13 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     this.addProviderId = "";
     this.addProviderKey = "";
     this.defaultsDraft = null;
-    if (client !== this.dataClient) {
+    if (!connected || client !== this.dataClient) {
       this.data = null;
     }
   }
 
   private isCurrentClient(client: GatewayBrowserClient, epoch: number): boolean {
-    return (
-      this.clientEpoch === epoch &&
-      this.observedClient === client &&
-      this.context.gateway.snapshot.client === client
-    );
+    return this.connectionLifecycle.isCurrent({ client, epoch });
   }
 
   private resolveSelectedAgentId(): string {
@@ -353,7 +351,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     if (!client) {
       return { ok: false };
     }
-    const clientEpoch = this.clientEpoch;
+    const clientEpoch = this.connectionLifecycle.epoch;
     const agentEpoch = this.agentEpoch;
     return runModelProviderConfigMutation(
       {
@@ -436,7 +434,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     if (!client || !this.canMutate() || this.busy[key] || this.probeUnsupported) {
       return;
     }
-    const clientEpoch = this.clientEpoch;
+    const clientEpoch = this.connectionLifecycle.epoch;
     const agentId = this.selectedAgentId;
     const probeEpoch = (this.probeEpochs.get(cardId) ?? 0) + 1;
     this.probeEpochs.set(cardId, probeEpoch);
@@ -492,7 +490,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     if (!client || !this.canMutate() || this.busy[key]) {
       return;
     }
-    const clientEpoch = this.clientEpoch;
+    const clientEpoch = this.connectionLifecycle.epoch;
     const agentId = this.selectedAgentId;
     const agentEpoch = this.agentEpoch;
     this.clearProbe(cardId);


### PR DESCRIPTION
Closes #124062

## What Problem This Solves

Fixes an issue where operators using Settings → Models could keep seeing a stale failed draft, error, provider data, and effective model after the Gateway reconnected with the same browser client object. The page also skipped its agent-scoped auth refresh, so its visible outcome could contradict the new connection's authoritative state.

## Why This Change Was Made

The Models page now uses the shared phase-aware Gateway connection lifecycle instead of treating browser-client object identity as a connection generation. A reconnect retires connection-scoped UI state and fences old async outcomes; the existing selected-agent owner then reloads config, catalog, and auth without changing any public config, provider, auth, Gateway protocol, SDK, or persistence contract.

This is the canonical owner-boundary repair: it deletes the page-local client epoch and reuses the lifecycle already shared by agents, sessions, chat, and page controllers. Production changes are net negative: **+14/-16 (net -2)**. Tests are **+166/-0**.

No `CHANGELOG.md` edit is included; this PR body carries the user-facing release-note context for release generation.

## User Impact

After reconnect, Models clears stale save/error/draft/busy/probe state, keeps the concrete selected agent, reloads authoritative model/provider data, and remains retryable. Operators no longer see a failed pre-reconnect draft or model presented as current after the connection changed.

## Evidence

Pre-fix reproduction on current main:

- Focused Control UI E2E fails because `models.authStatus` remains at 5 calls after reconnect instead of refreshing.

Exact candidate proof (`9a56954594a6e1f8dfee39e0f2caae6fbe89ffbe`):

- `node scripts/run-vitest.mjs ui/src/pages/model-providers/model-providers-page.test.ts ui/src/lib/gateway-connection-lifecycle.test.ts` — 30/30 passed.
- Models Control UI E2E — 6/6 passed on Blacksmith Testbox `tbx_01m021eph18arw9910h5bw9rnj`.
- `pnpm check:changed` — passed on the same Testbox, including format, lint, UI/test types, and Control UI i18n.
- `pnpm check:import-cycles` — 0 runtime value cycles.
- `git diff --check` — passed.
- Source-blind behavior contract — passed all save/error/reconnect/Writer ownership clauses and anti-cheat probes.
- Autoreview — clean, no accepted/actionable findings.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31869343167

Rejected save before reconnect:

![Rejected model save](https://github.com/user-attachments/assets/06697460-38a9-4533-a027-2e6cfdbf22bf)

Recovered authoritative Writer state:

![Recovered Writer model](https://github.com/user-attachments/assets/26c47bb4-b148-4e0c-bf67-017c9e029d1a)

Full save → error → reconnect → recovery flow: https://github.com/user-attachments/assets/b8735be0-fb76-43aa-ac5c-d00c7ea29dc6
