### PR TITLE
refactor(config): delete dead compat surfaces and write-only error payload

### DIFF
--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -294,7 +294,6 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
             context.previousHash !== params.expectedConfigHash
           ) {
             throw new ConfigMutationConflictError("config changed before first-agent creation", {
-              currentHash: context.previousHash,
               retryable: false,
             });
           }

--- a/src/agents/tools/web-search-provider-config.ts
+++ b/src/agents/tools/web-search-provider-config.ts
@@ -5,7 +5,6 @@
  */
 import { resolvePluginWebSearchConfig } from "../../config/plugin-web-search-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isLegacyWebSearchProviderConfigKey } from "../../config/web-search-legacy-provider-keys.js";
 
 /** Reads the legacy top-level web search credential value. */
 export function getTopLevelCredentialValue(searchConfig?: Record<string, unknown>): unknown {
@@ -55,9 +54,6 @@ export function mergeScopedSearchConfig(
 ): Record<string, unknown> | undefined {
   const next: Record<string, unknown> = { ...searchConfig };
   delete next.apiKey;
-  if (isLegacyWebSearchProviderConfigKey(key)) {
-    delete next[key];
-  }
   if (!pluginConfig) {
     return Object.keys(next).length > 0 ? next : undefined;
   }

--- a/src/agents/tools/web-search-provider-config.ts
+++ b/src/agents/tools/web-search-provider-config.ts
@@ -5,6 +5,7 @@
  */
 import { resolvePluginWebSearchConfig } from "../../config/plugin-web-search-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isLegacyWebSearchProviderConfigKey } from "../../config/web-search-legacy-provider-keys.js";
 
 /** Reads the legacy top-level web search credential value. */
 export function getTopLevelCredentialValue(searchConfig?: Record<string, unknown>): unknown {
@@ -54,6 +55,9 @@ export function mergeScopedSearchConfig(
 ): Record<string, unknown> | undefined {
   const next: Record<string, unknown> = { ...searchConfig };
   delete next.apiKey;
+  if (isLegacyWebSearchProviderConfigKey(key)) {
+    delete next[key];
+  }
   if (!pluginConfig) {
     return Object.keys(next).length > 0 ? next : undefined;
   }

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -72,8 +72,7 @@ export function resolveTextChunkLimit(
       return undefined;
     }
     const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
-    const providerConfig = (channelsConfig?.[provider] ??
-      (cfg as Record<string, unknown> | undefined)?.[provider]) as ProviderChunkConfig | undefined;
+    const providerConfig = channelsConfig?.[provider] as ProviderChunkConfig | undefined;
     return resolveChunkLimitForProvider(providerConfig, accountId);
   })();
   if (typeof providerOverride === "number" && providerOverride > 0) {
@@ -110,8 +109,7 @@ export function resolveChunkMode(
     return DEFAULT_CHUNK_MODE;
   }
   const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
-  const providerConfig = (channelsConfig?.[provider] ??
-    (cfg as Record<string, unknown> | undefined)?.[provider]) as ProviderChunkConfig | undefined;
+  const providerConfig = channelsConfig?.[provider] as ProviderChunkConfig | undefined;
   const mode = resolveChunkModeForProvider(providerConfig, accountId);
   return mode ?? DEFAULT_CHUNK_MODE;
 }

--- a/src/auto-reply/reply/block-streaming.ts
+++ b/src/auto-reply/reply/block-streaming.ts
@@ -51,8 +51,7 @@ function resolveProviderBlockStreamingCoalesce(params: {
     return undefined;
   }
   const channelsConfig = cfg.channels as Record<string, unknown> | undefined;
-  const providerCfg =
-    channelsConfig?.[providerKey] ?? (cfg as Record<string, unknown>)[providerKey];
+  const providerCfg = channelsConfig?.[providerKey];
   if (!providerCfg || typeof providerCfg !== "object") {
     return undefined;
   }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -112,10 +112,6 @@ function classifyHeartbeatPendingFinalDelivery(text: string, ackMaxChars: number
   };
 }
 
-function resolveHeartbeatAckMaxChars(_cfg: OpenClawConfig, _agentId: string): number {
-  return DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
-}
-
 const sessionResetModelRuntimeLoader = createLazyImportLoader(
   () => import("./session-reset-model.runtime.js"),
 );
@@ -697,7 +693,7 @@ export async function getReplyFromConfig(
     if (opts?.isHeartbeat) {
       const heartbeatPending = classifyHeartbeatPendingFinalDelivery(
         text,
-        resolveHeartbeatAckMaxChars(cfg, agentId),
+        DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
       );
       if (heartbeatPending.shouldClear) {
         Object.assign(sessionEntry, PENDING_FINAL_DELIVERY_CLEAR_PATCH);

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -128,15 +128,12 @@ function projectUpdaterResultOntoSourceConfig(params: {
 }
 
 function assertWriteOptionRecordFresh(params: {
-  currentHash: string | null;
   current?: Record<string, string>;
   expected?: Record<string, string>;
   message: string;
 }): void {
   if (!isDeepStrictEqual(params.current ?? {}, params.expected ?? {})) {
-    throw new ConfigMutationConflictError(params.message, {
-      currentHash: params.currentHash,
-    });
+    throw new ConfigMutationConflictError(params.message);
   }
 }
 
@@ -157,23 +154,18 @@ async function assertRecordsOnlyUpdateConfigFresh(params: {
     writeOptions.expectedConfigPath !== prepared.snapshot.path
   ) {
     throw new ConfigMutationConflictError("config path changed since last load", {
-      currentHash,
       retryable: false,
     });
   }
   if (params.baseHash !== undefined && params.baseHash !== currentHash) {
-    throw new ConfigMutationConflictError("config changed since last load", {
-      currentHash,
-    });
+    throw new ConfigMutationConflictError("config changed since last load");
   }
   assertWriteOptionRecordFresh({
-    currentHash,
     current: prepared.writeOptions.includeFileTargetsForWrite,
     expected: params.writeOptions?.includeFileTargetsForWrite,
     message: "included config target changed since last load",
   });
   assertWriteOptionRecordFresh({
-    currentHash,
     current: prepared.writeOptions.includeFileHashesForWrite,
     expected: params.writeOptions?.includeFileHashesForWrite,
     message: "included config changed since last load",

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -157,12 +157,9 @@ vi.mock("../config/config.js", () => ({
     }
   },
   ConfigMutationConflictError: class ConfigMutationConflictError extends Error {
-    readonly currentHash: string | null;
-
-    constructor(message: string, params: { currentHash: string | null }) {
+    constructor(message: string) {
       super(message);
       this.name = "ConfigMutationConflictError";
-      this.currentHash = params.currentHash;
     }
   },
   parseConfigJson5: (raw: string) => {

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -998,9 +998,7 @@ describe("runConfigureWizard", () => {
         if (callCount === 1) {
           // First call: simulate plugin mutating config during promptAuthConfig
           expect(params.baseHash).toBe(originalHash);
-          throw new ConfigMutationConflictError("config changed since last load", {
-            currentHash: newHashAfterMutation,
-          });
+          throw new ConfigMutationConflictError("config changed since last load");
         }
         // Second call: succeeds with refreshed hash
         expect(params.baseHash).toBe(newHashAfterMutation);
@@ -1084,7 +1082,6 @@ describe("runConfigureWizard", () => {
     });
     mocks.assertConfigPathForWrite.mockImplementation(() => {
       throw new ConfigMutationConflictError("config path changed since last load", {
-        currentHash: null,
         retryable: false,
       });
     });

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -73,9 +73,7 @@ async function runNonInteractiveMigrationImport(params: {
       }
       const latestConfig = latest.exists ? (latest.sourceConfig ?? latest.config) : {};
       if (!isDeepStrictEqual(latestConfig, expectedConfig)) {
-        throw new ConfigMutationConflictError("config changed during migration promotion", {
-          currentHash: latest.hash ?? null,
-        });
+        throw new ConfigMutationConflictError("config changed during migration promotion");
       }
       const committed = await replaceConfigFile({
         nextConfig: config,

--- a/src/config/channel-capabilities.ts
+++ b/src/config/channel-capabilities.ts
@@ -35,7 +35,7 @@ export function resolveChannelCapabilities(params: {
   }
 
   const channelsConfig = cfg.channels as Record<string, unknown> | undefined;
-  const channelConfig = (channelsConfig?.[channel] ?? (cfg as Record<string, unknown>)[channel]) as
+  const channelConfig = channelsConfig?.[channel] as
     | {
         accounts?: Record<string, { capabilities?: CapabilitiesConfig }>;
         capabilities?: CapabilitiesConfig;

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -400,7 +400,6 @@ export async function readConfigFileSnapshotForWriteFromContext(
   const assertConfigPathForWrite = () => {
     if (resolveConfigPathForDeps(context.deps) !== context.configPath) {
       throw new ConfigMutationConflictError("config path changed since last load", {
-        currentHash: null,
         retryable: false,
       });
     }

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1230,7 +1230,6 @@ describe("config io write", () => {
         }
         if (activeConfigPath !== configPath) {
           throw new ConfigMutationConflictError("config path changed since last load", {
-            currentHash: null,
             retryable: false,
           });
         }

--- a/src/config/io.write-safety.ts
+++ b/src/config/io.write-safety.ts
@@ -17,7 +17,6 @@ export function assertBaseSnapshotStillCurrent(
 ): void {
   if (snapshot.path !== configPath) {
     throw new ConfigMutationConflictError("config path changed since last load", {
-      currentHash: null,
       retryable: false,
     });
   }
@@ -41,7 +40,7 @@ export function assertBaseSnapshotStillCurrent(
     currentExists !== snapshot.exists ||
     (currentExists && expectedHash !== null && currentHash !== expectedHash)
   ) {
-    throw new ConfigMutationConflictError("config changed since last load", { currentHash });
+    throw new ConfigMutationConflictError("config changed since last load");
   }
 }
 

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -236,7 +236,7 @@ describe("config mutate helpers", () => {
         },
       });
     ioMocks.writeConfigFile
-      .mockRejectedValueOnce(new ConfigMutationConflictError("stale", { currentHash: "hash-2" }))
+      .mockRejectedValueOnce(new ConfigMutationConflictError("stale"))
       .mockResolvedValueOnce(undefined);
 
     const result = await transformConfigFileWithRetry({
@@ -294,9 +294,7 @@ describe("config mutate helpers", () => {
         snapshot: fresh,
         writeOptions: { expectedConfigPath: fresh.path },
       });
-    ioMocks.writeConfigFile.mockRejectedValueOnce(
-      new ConfigMutationConflictError("stale", { currentHash: fresh.hash ?? null }),
-    );
+    ioMocks.writeConfigFile.mockRejectedValueOnce(new ConfigMutationConflictError("stale"));
 
     const transform = vi.fn((config: OpenClawConfig) => ({ nextConfig: config }));
 
@@ -367,7 +365,6 @@ describe("config mutate helpers", () => {
         assertConfigPathForWrite: () => {
           if (activeConfigPath !== snapshot.path) {
             throw new ConfigMutationConflictError("config path changed since last load", {
-              currentHash: null,
               retryable: false,
             });
           }
@@ -1722,7 +1719,6 @@ describe("config mutate helpers", () => {
     const assertConfigPathForWrite = () => {
       if (activeConfigPath !== firstConfigPath) {
         throw new ConfigMutationConflictError("config path changed since last load", {
-          currentHash: null,
           retryable: false,
         });
       }
@@ -1783,7 +1779,6 @@ describe("config mutate helpers", () => {
       }
       if (activeConfigPath !== configPath) {
         throw new ConfigMutationConflictError("config path changed since last load", {
-          currentHash: null,
           retryable: false,
         });
       }
@@ -1836,7 +1831,6 @@ describe("config mutate helpers", () => {
       const assertConfigPathForWrite = () => {
         if (activeConfigPath !== configPath) {
           throw new ConfigMutationConflictError("config path changed since last load", {
-            currentHash: null,
             retryable: false,
           });
         }

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -178,7 +178,6 @@ function assertManagedRuntimeEnvGeneration(generation: number): void {
   if (getPublishedConfigRuntimeEnvState().generation !== generation) {
     throw new ConfigMutationConflictError(
       "active config environment changed while preparing write",
-      { currentHash: null },
     );
   }
 }
@@ -186,9 +185,7 @@ function assertManagedRuntimeEnvGeneration(generation: number): void {
 function assertBaseHashMatches(snapshot: ConfigFileSnapshot, expectedHash?: string): string | null {
   const currentHash = resolveConfigSnapshotHash(snapshot) ?? null;
   if (expectedHash !== undefined && expectedHash !== currentHash) {
-    throw new ConfigMutationConflictError("config changed since last load", {
-      currentHash,
-    });
+    throw new ConfigMutationConflictError("config changed since last load");
   }
   return currentHash;
 }
@@ -199,7 +196,6 @@ function assertExpectedConfigPathMatches(
 ): void {
   if (expectedConfigPath !== undefined && expectedConfigPath !== snapshot.path) {
     throw new ConfigMutationConflictError("config path changed since last load", {
-      currentHash: resolveConfigSnapshotHash(snapshot) ?? null,
       retryable: false,
     });
   }
@@ -309,7 +305,6 @@ async function withConfigMutationSnapshotLock<T>(
     lockPath = outcome.lockPath;
   }
   throw new ConfigMutationConflictError("config path changed repeatedly while acquiring lock", {
-    currentHash: null,
     retryable: false,
   });
 }
@@ -473,16 +468,12 @@ async function resolveExpectedRootBoundIncludeFile(params: {
       (error instanceof Error &&
         error.message.startsWith("Config include write path has no approved existing root:"))
     ) {
-      throw new ConfigMutationConflictError("included config target changed since last load", {
-        currentHash: null,
-      });
+      throw new ConfigMutationConflictError("included config target changed since last load");
     }
     throw error;
   }
   if (path.normalize(target.absolutePath) !== path.normalize(params.expectedAbsolutePath)) {
-    throw new ConfigMutationConflictError("included config target changed since last load", {
-      currentHash: null,
-    });
+    throw new ConfigMutationConflictError("included config target changed since last load");
   }
   return target;
 }
@@ -510,9 +501,7 @@ async function assertRootConfigStillMatchesSnapshot(snapshot: ConfigFileSnapshot
   const currentHash = hashConfigIncludeRaw(currentRaw);
   const expectedHash = hashConfigIncludeRaw(snapshot.exists ? (snapshot.raw ?? null) : null);
   if (currentHash !== expectedHash) {
-    throw new ConfigMutationConflictError("config changed while preparing include write", {
-      currentHash,
-    });
+    throw new ConfigMutationConflictError("config changed while preparing include write");
   }
 }
 
@@ -610,9 +599,7 @@ async function writeRootBoundJsonFile(params: {
   const currentRaw = await readRootBoundFileRawIfExists(targetAtCommit);
   const currentHash = hashConfigIncludeRaw(currentRaw);
   if (currentHash !== hashConfigIncludeRaw(params.expectedRaw)) {
-    throw new ConfigMutationConflictError("included config changed while preparing write", {
-      currentHash,
-    });
+    throw new ConfigMutationConflictError("included config changed while preparing write");
   }
   const content = formatJsonFileValue(params.value);
   // The include fast path bypasses writeConfigFile(); keep its authority guard
@@ -669,9 +656,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
   const allowedRoots: readonly string[] = [];
   const expectedIncludeTarget = params.writeOptions?.includeFileTargetsForWrite?.[includePath];
   if (!expectedIncludeTarget) {
-    throw new ConfigMutationConflictError("included config target changed since last load", {
-      currentHash: null,
-    });
+    throw new ConfigMutationConflictError("included config target changed since last load");
   }
   const assertConfigPathForWrite = params.writeOptions?.assertConfigPathForWrite;
   if (!assertConfigPathForWrite) {
@@ -694,9 +679,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
   const previousIncludeHash = hashConfigIncludeRaw(previousIncludeRaw);
   const expectedIncludeHash = params.writeOptions?.includeFileHashesForWrite?.[includePath];
   if (expectedIncludeHash !== undefined && expectedIncludeHash !== previousIncludeHash) {
-    throw new ConfigMutationConflictError("included config changed since last load", {
-      currentHash: previousIncludeHash,
-    });
+    throw new ConfigMutationConflictError("included config changed since last load");
   }
   const envForRestore =
     resolveWriteEnvSnapshotForPath({
@@ -711,9 +694,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
     previousIncludeRaw === null &&
     (!snapshotHasBrokenInclude || expectedIncludeHash === undefined)
   ) {
-    throw new ConfigMutationConflictError("included config changed since last load", {
-      currentHash: previousIncludeHash,
-    });
+    throw new ConfigMutationConflictError("included config changed since last load");
   }
   let includedValueToWrite = nextConfigRecord[key];
   if (previousIncludeRaw !== null) {
@@ -725,9 +706,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
     } catch {
       // A validated replacement is the repair path for a malformed include.
       if (!snapshotHasBrokenInclude || expectedIncludeHash === undefined) {
-        throw new ConfigMutationConflictError("included config changed since last load", {
-          currentHash: previousIncludeHash,
-        });
+        throw new ConfigMutationConflictError("included config changed since last load");
       }
     }
     if (parsedInclude) {
@@ -739,9 +718,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
       });
       const snapshotIncludedValue = (params.snapshot.sourceConfig as Record<string, unknown>)[key];
       if (!isDeepStrictEqual(currentIncludedValue, snapshotIncludedValue)) {
-        throw new ConfigMutationConflictError("included config changed since last load", {
-          currentHash: previousIncludeHash,
-        });
+        throw new ConfigMutationConflictError("included config changed since last load");
       }
       includedValueToWrite = restoreEnvVarRefs(
         includedValueToWrite,
@@ -816,9 +793,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
   await assertRootConfigStillMatchesSnapshot(params.snapshot);
   const includeRawAtCommit = await readRootBoundFileRawIfExists(includeTarget);
   if (hashConfigIncludeRaw(includeRawAtCommit) !== hashConfigIncludeRaw(previousIncludeRaw)) {
-    throw new ConfigMutationConflictError("included config changed while preparing write", {
-      currentHash: hashConfigIncludeRaw(includeRawAtCommit),
-    });
+    throw new ConfigMutationConflictError("included config changed while preparing write");
   }
   await writeRootBoundJsonFile({
     configPath: params.snapshot.path,

--- a/src/config/mutation-conflict.ts
+++ b/src/config/mutation-conflict.ts
@@ -1,12 +1,10 @@
 /** Raised when a config write loses an optimistic snapshot race. */
 export class ConfigMutationConflictError extends Error {
-  readonly currentHash: string | null;
   readonly retryable: boolean;
 
-  constructor(message: string, params: { currentHash: string | null; retryable?: boolean }) {
+  constructor(message: string, params: { retryable?: boolean } = {}) {
     super(message);
     this.name = "ConfigMutationConflictError";
-    this.currentHash = params.currentHash;
     this.retryable = params.retryable ?? true;
   }
 }

--- a/src/config/web-search-legacy-provider-keys.ts
+++ b/src/config/web-search-legacy-provider-keys.ts
@@ -13,7 +13,3 @@ export const LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS = new Set([
   "searxng",
   "tavily",
 ]);
-
-export function isLegacyWebSearchProviderConfigKey(key: string): boolean {
-  return LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS.has(key);
-}

--- a/src/config/web-search-legacy-provider-keys.ts
+++ b/src/config/web-search-legacy-provider-keys.ts
@@ -13,3 +13,7 @@ export const LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS = new Set([
   "searxng",
   "tavily",
 ]);
+
+export function isLegacyWebSearchProviderConfigKey(key: string): boolean {
+  return LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS.has(key);
+}

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -139,10 +139,6 @@ function projectToolSearchCodeEventForChannelPayload<T extends { data?: unknown 
   return { ...payload, data: projectedData };
 }
 
-function resolveHeartbeatAckMaxChars(): number {
-  return DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
-}
-
 function resolveHeartbeatContext(runId: string, sourceRunId?: string) {
   const primary = getAgentRunContext(runId);
   if (primary?.isHeartbeat) {
@@ -208,7 +204,7 @@ function normalizeHeartbeatChatFinalText(params: {
 
   const stripped = stripHeartbeatToken(params.text, {
     mode: "heartbeat",
-    maxAckChars: resolveHeartbeatAckMaxChars(),
+    maxAckChars: DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   });
   if (!stripped.didStrip) {
     return { suppress: false, text: params.text };

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -154,9 +154,7 @@ beforeEach(() => {
       nextConfig: OpenClawConfig;
     }) => {
       if (snapshot.hash !== storedHash) {
-        throw new ConfigMutationConflictError("config changed since last load", {
-          currentHash: storedHash,
-        });
+        throw new ConfigMutationConflictError("config changed since last load");
       }
       storedConfig = nextConfig;
       storedHash = `next-hash-${nextHash}`;
@@ -451,9 +449,7 @@ describe("config.patch hash-free ui.prefs LWW", () => {
     configWriteMocks.commitGatewayConfigWrite.mockImplementationOnce(async () => {
       storedConfig = { ui: { prefs: { locale: "de" } } };
       storedHash = "raced-hash";
-      throw new ConfigMutationConflictError("config changed since last load", {
-        currentHash: storedHash,
-      });
+      throw new ConfigMutationConflictError("config changed since last load");
     });
 
     const { respond } = await invokeConfigPatch({

--- a/src/infra/heartbeat-runner-config.ts
+++ b/src/infra/heartbeat-runner-config.ts
@@ -4,7 +4,6 @@ import { listAgentIds, listAgentEntries, resolveAgentConfig } from "../agents/ag
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../agents/thinking-runtime.js";
 import {
-  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   resolveHeartbeatPromptCore as resolveHeartbeatPromptText,
   resolveHeartbeatPromptForResponseTool,
 } from "../auto-reply/heartbeat.js";
@@ -291,10 +290,6 @@ export function shouldUseHeartbeatResponseToolPrompt(params: {
     return false;
   }
   return usesCodexHarness(params);
-}
-
-export function resolveHeartbeatAckMaxChars(_cfg: OpenClawConfig, _heartbeat?: HeartbeatConfig) {
-  return DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
 }
 
 export function isHeartbeatTypingEnabled(params: {

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -13,7 +13,7 @@ import {
   resolveHeartbeatScratchProposalFromReplyResult,
   resolveHeartbeatToolResponseFromReplyResult,
 } from "../auto-reply/heartbeat-tool-response.js";
-import { stripHeartbeatToken } from "../auto-reply/heartbeat.js";
+import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
 import { resolveReplyOperationAgentTurn } from "../auto-reply/reply/reply-operation-agent-turn-state.js";
 import {
   REPLY_OPERATION_RUN_STATE,
@@ -59,7 +59,6 @@ import { emitHeartbeatEvent } from "./heartbeat-events.js";
 import {
   heartbeatLog,
   resolveAmbientHeartbeatAgentId,
-  resolveHeartbeatAckMaxChars,
   resolveHeartbeatForWake,
   resolveHeartbeatTimeoutOverrideSeconds,
   shouldUseHeartbeatResponseToolPrompt,
@@ -322,7 +321,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     typeof pendingFinalDeliveryText === "string" &&
     stripHeartbeatToken(pendingFinalDeliveryText, {
       mode: "heartbeat",
-      maxAckChars: resolveHeartbeatAckMaxChars(cfg, heartbeat),
+      maxAckChars: DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
     }).shouldSkip;
   if (
     recentSessionEntry?.pendingFinalDelivery !== undefined &&

--- a/src/infra/heartbeat-runner-run.ts
+++ b/src/infra/heartbeat-runner-run.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "../auto-reply/heartbeat.js";
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { resolveSourceReplyDeliveryMode } from "../auto-reply/reply/source-reply-delivery-mode.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
@@ -7,7 +8,6 @@ import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js"
 import {
   isHeartbeatTypingEnabled,
   heartbeatLog,
-  resolveHeartbeatAckMaxChars,
   resolveHeartbeatChannelPlugin,
   resolveHeartbeatTypingIntervalSeconds,
 } from "./heartbeat-runner-config.js";
@@ -41,7 +41,7 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
   if (prepared.kind === "skipped") {
     return { status: "skipped", reason: prepared.reason };
   }
-  const { cfg, agentId, heartbeat, startedAt } = wake;
+  const { cfg, agentId, startedAt } = wake;
   const { delivery, visibility, replyPrefix, runSessionKey } = prepared;
   const { outboundPolicySessionKey, hasRelayableExecCompletion } = prepared;
 
@@ -168,7 +168,7 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
           ctx: { ChatType: delivery.chatType, Provider: delivery.channel },
         }) === "message_tool_only",
       responsePrefix: resolveHeartbeatResponsePrefix(),
-      ackMaxChars: resolveHeartbeatAckMaxChars(cfg, heartbeat),
+      ackMaxChars: DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
     });
     return await finalizeHeartbeatOutcome({
       opts,

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -986,9 +986,7 @@ describe("runSetupWizard", () => {
       if (writeAttempts === 1) {
         diskConfig = { ...diskConfig, ui: { ...diskConfig.ui, seamColor: "green" } };
         diskHash = "external-edit";
-        throw new ConfigMutationConflictError("config changed since last load", {
-          currentHash: diskHash,
-        });
+        throw new ConfigMutationConflictError("config changed since last load");
       }
       diskConfig = structuredClone(params.nextConfig);
       diskHash = `committed-${writeAttempts}`;
@@ -1894,9 +1892,7 @@ describe("runSetupWizard", () => {
       if (writeAttempts === 2) {
         diskConfig = { ...diskConfig, ui: { seamColor: "green" } };
         diskHash = "external-pending-edit";
-        throw new ConfigMutationConflictError("config changed since last load", {
-          currentHash: diskHash,
-        });
+        throw new ConfigMutationConflictError("config changed since last load");
       }
       diskConfig = structuredClone(params.nextConfig);
       diskHash = `pending-${writeAttempts + 1}`;

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -253,9 +253,7 @@ async function runSetupWizardOnce(
           }
           const latestConfig = latest.exists ? (latest.sourceConfig ?? latest.config) : {};
           if (!isDeepStrictEqual(latestConfig, expectedConfig)) {
-            throw new ConfigMutationConflictError("config changed during migration promotion", {
-              currentHash: latest.hash ?? null,
-            });
+            throw new ConfigMutationConflictError("config changed during migration promotion");
           }
           return await writeWizardConfigFile(cfg, {
             allowConfigSizeDrop: true,


### PR DESCRIPTION
## What Problem This Solves

Round-5 config-lane investigation surfaced four dead compat surfaces that the codebase pays for on every relevant path. Per the lean-code and canonical-shape doctrine (runtime consumes only current shapes; doctor owns migrations; no just-in-case fallbacks), these are deletions, not fixes-with-guards:

1. **`ConfigMutationConflictError.currentHash` was write-only.** ~20 throw sites threaded a `currentHash` param — some doing real work on the failure path purely to populate it (`io.write-safety.ts` hashed the whole config raw; `mutate.ts` hashed include files) — and no consumer anywhere reads it. Consumers read `.retryable` only; the gateway response carries only the message.
2. **Root-level channel-key fallbacks were unreachable.** Three hot-path helpers (`chunk.ts` per-outbound-message chunk limits, `block-streaming.ts`, `channel-capabilities.ts`) read `cfg.channels[provider] ?? cfg[provider]` — a pre-`channels.*` top-level key fallback. The root schema is `z.strictObject`, so a validated config can never carry `cfg.telegram` at the root; doctor owns those moves. Survived from the pre-strict-schema era.
3. **`resolveHeartbeatAckMaxChars` existed as three identical constant-returning stubs** (heartbeat-runner-config, server-chat, get-reply) — leftovers from the retired `heartbeat.ackMaxChars` config key. Constant inlined, stubs deleted.
4. **`mergeScopedSearchConfig`'s legacy web-search key delete was a no-op** — the agent-runtime schema rejects those keys at validation, so a validated config cannot carry them. The now-orphaned `isLegacyWebSearchProviderConfigKey` helper went too; the schema-side Set remains the rejection boundary.

## Why This Change Was Made

Standing round-5 directive: every fix arrives as a simplification. All four deletions were verified against the strict root schema, current consumers (grep + type check), and — for the shipped-contract question — a parallel doctor-pipeline audit that confirmed doctor migrations own every legacy shape still reachable from release tags. No runtime path loses capability; the deleted branches could not execute on any validated config.

## User Impact

None visible — that is the point. Failure paths stop hashing files to populate a field nobody reads; per-message chunk resolution stops probing a config shape that cannot exist.

## Evidence

- Full `src/config` suite: 235 files, 3270 tests passed. `chunk.test.ts` (72), `update-cli.test.ts`, heartbeat-runner suites (240+24), `configure.wizard.test.ts` (25), `server-methods/config.test.ts` (25), `wizard/setup.test.ts` + `io.write-config` + `mutate` (127+58+47) all green.
- `pnpm tsgo` clean; `pnpm check:test-types` clean; oxlint/oxfmt clean.
- Autoreview (Codex, high): clean, no accepted findings, "patch is correct (0.99)".
- Production LOC: **+36 −124 (net −88 including test-support edits; prod files alone net ~−77)**. Pure deletion PR; the +36 is import reshuffling and slimmed constructor signatures.
