### PR TITLE
fix(acp): cancel pending prompts when the bridge shuts down (AI-assisted)

### DIFF
--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -21,6 +21,11 @@ export type AcpSessionStore = {
   deleteSession: (sessionId: string) => boolean;
 };
 
+type InMemoryAcpSessionStore = AcpSessionStore & {
+  /** Releases every record when the registry's lifecycle owner shuts down. */
+  dispose: () => void;
+};
+
 type AcpSessionStoreOptions = {
   maxSessions?: number;
   idleTtlMs?: number;
@@ -31,7 +36,9 @@ const DEFAULT_MAX_SESSIONS = 5_000;
 const DEFAULT_IDLE_TTL_MS = 24 * 60 * 60 * 1_000;
 
 /** Creates the bounded in-memory ACP session registry used by local ACP runtime clients. */
-export function createInMemorySessionStore(options: AcpSessionStoreOptions = {}): AcpSessionStore {
+export function createInMemorySessionStore(
+  options: AcpSessionStoreOptions = {},
+): InMemoryAcpSessionStore {
   const maxSessions = resolveIntegerOption(options.maxSessions, DEFAULT_MAX_SESSIONS, { min: 1 });
   const idleTtlMs = resolveIntegerOption(options.idleTtlMs, DEFAULT_IDLE_TTL_MS, { min: 1_000 });
   const now = options.now ?? Date.now;
@@ -188,6 +195,14 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
 
   const deleteSession: AcpSessionStore["deleteSession"] = (sessionId) => removeSession(sessionId);
 
+  const dispose: InMemoryAcpSessionStore["dispose"] = () => {
+    for (const session of sessions.values()) {
+      session.abortController?.abort();
+    }
+    sessions.clear();
+    runIdToSessionId.clear();
+  };
+
   return {
     createSession,
     hasSession,
@@ -197,7 +212,6 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
     clearActiveRun,
     cancelActiveRun,
     deleteSession,
+    dispose,
   };
 }
-
-export const defaultAcpSessionStore = createInMemorySessionStore();

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -203,7 +203,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     // events can both resume asynchronously, and must not reopen the shared DB.
     const activeAgent = agent;
     agent = null;
-    activeAgent?.shutdown();
+    await activeAgent?.shutdown();
     const gatewayStop = gateway.stopAndWait().catch((err: unknown) => {
       console.warn(`acp: gateway stop failed during shutdown: ${formatErrorMessage(err)}`);
     });

--- a/src/acp/translator.lifecycle.test.ts
+++ b/src/acp/translator.lifecycle.test.ts
@@ -2,6 +2,7 @@ import type {
   CloseSessionRequest,
   InitializeRequest,
   ListSessionsRequest,
+  NewSessionRequest,
   PromptRequest,
   PromptResponse,
   ResumeSessionRequest,
@@ -75,6 +76,14 @@ function createPromptRequest(sessionId: string): PromptRequest {
     prompt: [{ type: "text", text: "hello" }],
     _meta: {},
   } as PromptRequest;
+}
+
+function createNewSessionRequest(): NewSessionRequest {
+  return {
+    cwd: "/tmp/openclaw",
+    mcpServers: [],
+    _meta: {},
+  } as NewSessionRequest;
 }
 
 function createGatewaySessions(rows: GatewaySessionRow[]) {
@@ -495,6 +504,64 @@ describe("acp translator stable lifecycle handlers", () => {
     });
     await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
     expect(sessionStore.hasSession("session-1")).toBe(false);
+  });
+
+  it("drains only its own pending work and sessions during shutdown", async () => {
+    const sentRunIds: string[] = [];
+    const requestA = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.send") {
+        const runId = params?.idempotencyKey;
+        if (typeof runId === "string") {
+          sentRunIds.push(runId);
+        }
+        return { runId, status: "started" };
+      }
+      if (method === "sessions.list") {
+        return createGatewaySessions([]);
+      }
+      return { ok: true };
+    });
+    const requestB = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return createGatewaySessions([]);
+      }
+      return { ok: true };
+    });
+    const agentA = new AcpGatewayAgent(
+      createAcpConnection(),
+      createAcpGateway(requestA as GatewayClient["request"]),
+    );
+    const agentB = new AcpGatewayAgent(
+      createAcpConnection(),
+      createAcpGateway(requestB as GatewayClient["request"]),
+    );
+    const sessionA = await agentA.newSession(createNewSessionRequest());
+    const sessionB = await agentB.newSession(createNewSessionRequest());
+    const pending = await startPendingPrompt({
+      agent: agentA,
+      sentRunIds,
+      sessionId: sessionA.sessionId,
+    });
+
+    await agentA.shutdown();
+
+    await expect(settlePromptQuickly(pending.promptPromise)).resolves.toEqual({
+      stopReason: "cancelled",
+    });
+    const abortCall = requestA.mock.calls.find(([method]) => method === "chat.abort");
+    expect(abortCall?.[1]).toEqual({
+      sessionKey: `acp-bridge:${sessionA.sessionId}`,
+      runId: pending.runId,
+    });
+    await expect(
+      agentA.closeSession(createCloseSessionRequest(sessionA.sessionId)),
+    ).rejects.toThrow(`Session ${sessionA.sessionId} not found`);
+    await expect(
+      agentB.closeSession(createCloseSessionRequest(sessionA.sessionId)),
+    ).rejects.toThrow(`Session ${sessionA.sessionId} not found`);
+    await expect(
+      agentB.closeSession(createCloseSessionRequest(sessionB.sessionId)),
+    ).resolves.toEqual({});
   });
 
   it("rejects close for missing sessions", async () => {

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -26,6 +26,9 @@ import type { AcpTranslatorSessionUpdates } from "./translator.session-updates.j
 
 // Maximum allowed prompt size (2MB) to prevent DoS via memory exhaustion (CWE-400, GHSA-cxpw-2g23-2vgw)
 const MAX_PROMPT_BYTES = 2 * 1024 * 1024;
+// Shutdown owns only a brief best-effort abort window so EOF and signals cannot
+// inherit the Gateway client's normal request timeout before process teardown.
+const ACP_SHUTDOWN_ABORT_TIMEOUT_MS = 1_000;
 
 type ChatSendAck = {
   runId?: unknown;
@@ -123,8 +126,20 @@ export class AcpTranslatorPromptStream {
     );
   }
 
-  shutdown(): void {
+  async shutdown(): Promise<void> {
     this.disconnects.shutdown();
+    await Promise.all(
+      [...this.pendingPrompts.values()].map((pending) =>
+        this.cancelSessionWork(
+          {
+            sessionId: pending.sessionId,
+            sessionKey: pending.sessionKey,
+            activeRunId: pending.idempotencyKey,
+          },
+          ACP_SHUTDOWN_ABORT_TIMEOUT_MS,
+        ),
+      ),
+    );
   }
 
   handleGatewayReconnect(): void {
@@ -310,11 +325,14 @@ export class AcpTranslatorPromptStream {
     await this.cancelSessionWork(session);
   }
 
-  async cancelSessionWork(session: {
-    sessionId: string;
-    sessionKey: string;
-    activeRunId: string | null;
-  }): Promise<void> {
+  async cancelSessionWork(
+    session: {
+      sessionId: string;
+      sessionKey: string;
+      activeRunId: string | null;
+    },
+    abortTimeoutMs?: number,
+  ): Promise<void> {
     // Capture runId before cancelActiveRun clears session.activeRunId.
     const activeRunId = session.activeRunId;
 
@@ -324,10 +342,13 @@ export class AcpTranslatorPromptStream {
 
     if (scopedRunId) {
       try {
-        await this.gateway.request("chat.abort", {
+        const abortParams = {
           sessionKey: session.sessionKey,
           runId: scopedRunId,
-        });
+        };
+        await (abortTimeoutMs === undefined
+          ? this.gateway.request("chat.abort", abortParams)
+          : this.gateway.request("chat.abort", abortParams, { timeoutMs: abortTimeoutMs }));
       } catch (err) {
         this.log(`cancel error: ${String(err)}`);
       }

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -24,7 +24,7 @@ import type {
   SetSessionModeRequest,
   SetSessionModeResponse,
 } from "@agentclientprotocol/sdk";
-import { defaultAcpSessionStore, type AcpSessionStore } from "@openclaw/acp-core/session";
+import { createInMemorySessionStore, type AcpSessionStore } from "@openclaw/acp-core/session";
 import type { AcpServerOptions } from "@openclaw/acp-core/types";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
@@ -60,6 +60,9 @@ export class AcpGatewayAgent implements Agent {
   private readonly sessionUpdates: AcpTranslatorSessionUpdates;
   private readonly promptStream: AcpTranslatorPromptStream;
   private readonly sessionLifecycle: AcpTranslatorSessionLifecycle;
+  private readonly ownedSessionStore:
+    | ReturnType<typeof createInMemorySessionStore>
+    | undefined;
   private readonly approvalRelays = new Map<string, AcpPendingApprovalRelay>();
   private readonly log: (msg: string) => void;
 
@@ -69,7 +72,9 @@ export class AcpGatewayAgent implements Agent {
     opts: AcpGatewayAgentOptions = {},
   ) {
     this.log = opts.verbose ? (msg: string) => process.stderr.write(`[acp] ${msg}\n`) : () => {};
-    const sessionStore = opts.sessionStore ?? defaultAcpSessionStore;
+    const sessionStore = opts.sessionStore ?? createInMemorySessionStore();
+    // Injected stores remain caller-owned; only the agent-created registry follows shutdown.
+    this.ownedSessionStore = opts.sessionStore === undefined ? sessionStore : undefined;
     this.sessionUpdates = new AcpTranslatorSessionUpdates({
       connection,
       eventLedger: opts.eventLedger ?? createInMemoryAcpEventLedger(),
@@ -115,9 +120,13 @@ export class AcpGatewayAgent implements Agent {
     this.log("ready");
   }
 
-  shutdown(): void {
+  async shutdown(): Promise<void> {
     this.sessionUpdates.stop();
-    this.promptStream.shutdown();
+    try {
+      await this.promptStream.shutdown();
+    } finally {
+      this.ownedSessionStore?.dispose();
+    }
   }
 
   handleGatewayReconnect(): void {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -60,9 +60,7 @@ export class AcpGatewayAgent implements Agent {
   private readonly sessionUpdates: AcpTranslatorSessionUpdates;
   private readonly promptStream: AcpTranslatorPromptStream;
   private readonly sessionLifecycle: AcpTranslatorSessionLifecycle;
-  private readonly ownedSessionStore:
-    | ReturnType<typeof createInMemorySessionStore>
-    | undefined;
+  private readonly ownedSessionStore: ReturnType<typeof createInMemorySessionStore> | undefined;
   private readonly approvalRelays = new Map<string, AcpPendingApprovalRelay>();
   private readonly log: (msg: string) => void;
 
@@ -72,9 +70,15 @@ export class AcpGatewayAgent implements Agent {
     opts: AcpGatewayAgentOptions = {},
   ) {
     this.log = opts.verbose ? (msg: string) => process.stderr.write(`[acp] ${msg}\n`) : () => {};
-    const sessionStore = opts.sessionStore ?? createInMemorySessionStore();
     // Injected stores remain caller-owned; only the agent-created registry follows shutdown.
-    this.ownedSessionStore = opts.sessionStore === undefined ? sessionStore : undefined;
+    let sessionStore: AcpSessionStore;
+    if (opts.sessionStore === undefined) {
+      this.ownedSessionStore = createInMemorySessionStore();
+      sessionStore = this.ownedSessionStore;
+    } else {
+      this.ownedSessionStore = undefined;
+      sessionStore = opts.sessionStore;
+    }
     this.sessionUpdates = new AcpTranslatorSessionUpdates({
       connection,
       eventLedger: opts.eventLedger ?? createInMemoryAcpEventLedger(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where closing ACP stdio or stopping the bridge during an accepted turn could leave the ACP prompt unresolved while the Gateway run continued. Reused processes could also retain stale bridge session records.

## Why This Change Was Made

The ACP lifecycle owner now drains pending prompts through the existing exact-run cancellation path, with a bounded one-second abort request during shutdown. Each agent owns and disposes only its default in-memory session registry, caller-injected stores remain caller-owned behind the narrow generic contract, and Gateway teardown waits for agent shutdown to finish. Current `main` already removed the cleanup-only test seam.

This does not change protocol versions, schema versions, operator state, documentation, or `CHANGELOG.md`.

## User Impact

ACP clients now receive a terminal cancelled response and accepted Gateway work is aborted when the bridge shuts down. New bridge instances no longer inherit stale sessions from earlier agents in the same process.

## Evidence

- Exact reviewed head `4af96316bda45b02c7f302fc0c3f6721b1aa1c4c` is a patch-identical rebase onto `f2c721b0acc8abe0c3c89571db3ed43bcdfe6334`; range-diff marks both commits unchanged.
- Pre-fix regression: expected `pending` to equal `{ stopReason: "cancelled" }`.
- `node scripts/run-vitest.mjs src/acp/translator.lifecycle.test.ts` — 14 tests passed.
- `node scripts/run-vitest.mjs packages/acp-core/src/session.test.ts` — 10 tests passed.
- `node scripts/run-vitest.mjs src/acp/translator.cancel-scoping.test.ts` — 8 tests passed.
- `node scripts/run-vitest.mjs src/acp/server.startup.test.ts` — 22 tests passed.
- `node scripts/check-changed.mjs -- packages/acp-core/src/session.ts src/acp/server.ts src/acp/translator.lifecycle.test.ts src/acp/translator.prompt-stream.ts src/acp/translator.ts` — `core` and `coreTests` passed. Remote Testbox/Crabbox was unavailable because the Blacksmith CLI and broker authentication were unavailable, so the trusted-source wrapper explicitly fell back to local execution.
- Final `autoreview --mode branch --base origin/main` was clean, with no accepted or actionable findings.
- Production LOC: +64/-16 (net +48). Tests: +67/-0. Overall: +131/-16. Positive production growth establishes the lifecycle owner boundary, bounded asynchronous abort drain, and per-agent registry disposal.
- Visual/live proof gap: this is an ACP stdio bridge shutdown boundary, not a Control UI flow. No live IDE recording was captured; the deterministic two-agent boundary regression is the primary operator-visible proof of the exact lifecycle ordering.
- AI-assisted: yes.

No transcript logs are attached.
