### PR TITLE
fix(codex): keep yolo approvals disabled

### DIFF
--- a/extensions/codex/src/app-server/app-server-policy.test.ts
+++ b/extensions/codex/src/app-server/app-server-policy.test.ts
@@ -1,75 +1,9 @@
 // Codex tests cover app server policy plugin behavior.
 import { describe, expect, it } from "vitest";
-import {
-  resolveCodexAppServerForModelProvider,
-  resolveCodexAppServerForOpenClawToolPolicy,
-} from "./app-server-policy.js";
-import { readCodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { resolveCodexAppServerForModelProvider } from "./app-server-policy.js";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 
 describe("Codex app-server policy", () => {
-  it("keeps implicit Codex yolo approval policy when untrusted approvals are disallowed", () => {
-    const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
-
-    const resolved = resolveCodexAppServerForOpenClawToolPolicy({
-      appServer,
-      pluginConfig: readCodexPluginConfig({}),
-      env: {},
-      shouldPromote: true,
-      canUseUntrustedApprovalPolicy: false,
-    });
-
-    expect(resolved.approvalPolicy).toBe("never");
-  });
-
-  it("promotes implicit yolo approval policy when OpenClaw tool policy requires review", () => {
-    const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
-
-    const resolved = resolveCodexAppServerForOpenClawToolPolicy({
-      appServer,
-      pluginConfig: readCodexPluginConfig({}),
-      env: {},
-      shouldPromote: true,
-      canUseUntrustedApprovalPolicy: true,
-    });
-
-    expect(resolved.approvalPolicy).toBe("untrusted");
-  });
-
-  it("preserves explicit operator app-server policy", () => {
-    const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
-    const requirementsAppServer = resolveCodexAppServerRuntimeOptions({
-      env: {},
-      requirementsToml:
-        'allowed_approval_policies = ["never"]\nallowed_sandbox_modes = ["workspace-write"]\n',
-    });
-
-    const explicitConfig = resolveCodexAppServerForOpenClawToolPolicy({
-      appServer,
-      pluginConfig: readCodexPluginConfig({ appServer: { mode: "yolo" } }),
-      env: {},
-      shouldPromote: true,
-      canUseUntrustedApprovalPolicy: true,
-    });
-    const explicitEnv = resolveCodexAppServerForOpenClawToolPolicy({
-      appServer,
-      pluginConfig: readCodexPluginConfig({}),
-      env: { OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY: "never" },
-      shouldPromote: true,
-      canUseUntrustedApprovalPolicy: true,
-    });
-    const explicitRequirements = resolveCodexAppServerForOpenClawToolPolicy({
-      appServer: requirementsAppServer,
-      pluginConfig: readCodexPluginConfig({}),
-      env: {},
-      shouldPromote: true,
-      canUseUntrustedApprovalPolicy: true,
-    });
-
-    expect(explicitConfig.approvalPolicy).toBe("never");
-    expect(explicitEnv.approvalPolicy).toBe("never");
-    expect(explicitRequirements.approvalPolicy).toBe("never");
-  });
-
   it("keeps model-backed reviewers for explicit OpenAI model providers", () => {
     const appServer = resolveCodexAppServerRuntimeOptions({
       env: {},

--- a/extensions/codex/src/app-server/app-server-policy.ts
+++ b/extensions/codex/src/app-server/app-server-policy.ts
@@ -1,51 +1,7 @@
-/**
- * Policy promotion for Codex app-server runs that can safely use OpenClaw tool
- * approvals.
- */
 import {
   canUseCodexModelBackedApprovalsReviewerForModel,
   type CodexAppServerRuntimeOptions,
-  type CodexPluginConfig,
-  type OpenClawExecPolicyForCodexAppServer,
 } from "./config.js";
-
-/**
- * Promotes implicit `never` approval policy to `untrusted` only when runtime
- * requirements allow OpenClaw to handle tool approvals.
- */
-export function resolveCodexAppServerForOpenClawToolPolicy(params: {
-  appServer: CodexAppServerRuntimeOptions;
-  pluginConfig: CodexPluginConfig;
-  env: NodeJS.ProcessEnv;
-  shouldPromote: boolean;
-  canUseUntrustedApprovalPolicy: boolean;
-  execPolicy?: OpenClawExecPolicyForCodexAppServer;
-}): CodexAppServerRuntimeOptions {
-  if (
-    !params.shouldPromote ||
-    !params.canUseUntrustedApprovalPolicy ||
-    params.appServer.approvalPolicy !== "never"
-  ) {
-    return params.appServer;
-  }
-  const explicitMode =
-    params.execPolicy?.mode === "full" ||
-    params.pluginConfig.appServer?.mode !== undefined ||
-    isCodexAppServerPolicyMode(params.env.OPENCLAW_CODEX_APP_SERVER_MODE);
-  const explicitApprovalPolicy =
-    params.pluginConfig.appServer?.approvalPolicy !== undefined ||
-    isConfiguredCodexAppServerApprovalPolicy(
-      params.env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY,
-    ) ||
-    params.appServer.approvalPolicySource === "requirements";
-  if (explicitMode || explicitApprovalPolicy) {
-    return params.appServer;
-  }
-  return {
-    ...params.appServer,
-    approvalPolicy: "untrusted",
-  };
-}
 
 export function resolveCodexAppServerForModelProvider(params: {
   appServer: CodexAppServerRuntimeOptions;
@@ -74,18 +30,6 @@ export function resolveCodexAppServerForModelProvider(params: {
     ...params.appServer,
     approvalsReviewer: "user",
   };
-}
-
-function isCodexAppServerPolicyMode(value: unknown): boolean {
-  return value === "guardian" || value === "yolo";
-}
-
-function isConfiguredCodexAppServerApprovalPolicy(value: unknown): boolean {
-  // Keep the retired env alias explicit so policy promotion does not override
-  // the canonical on-request value produced by config normalization.
-  return (
-    value === "never" || value === "on-request" || value === "on-failure" || value === "untrusted"
-  );
 }
 
 function isCodexModelBackedApprovalsReviewer(value: string): boolean {

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -273,83 +273,7 @@ describe("Codex app-server approval bridge", () => {
     });
   });
 
-  it.each([
-    ["item/commandExecution/requestApproval", "cmd-policy-allow", { command: "gh run view 1" }],
-    [
-      "item/fileChange/requestApproval",
-      "patch-policy-allow",
-      { reason: "write memory/2026-07-29.md" },
-    ],
-  ] as const)(
-    "auto-accepts %s when the promoted OpenClaw tool policy allows it",
-    async (method, itemId, requestFields) => {
-      const params = createParams();
-
-      const result = await handleCodexAppServerApprovalRequest({
-        method,
-        requestParams: {
-          ...codexTestTurnIds(),
-          itemId,
-          ...requestFields,
-        },
-        paramsForRun: params,
-        ...codexTestTurnIds(),
-        autoApproveOpenClawToolPolicy: true,
-      });
-
-      expect(result).toEqual({ decision: "accept" });
-      expect(mockCallGatewayTool).not.toHaveBeenCalled();
-      findApprovalEvent(params, {
-        status: "approved",
-        message: "Codex app-server approval accepted by OpenClaw tool policy.",
-      });
-    },
-  );
-
-  it("preserves the initiating requester when re-running policy for a promoted file approval", async () => {
-    const params = createParams();
-    params.senderId = "owner-1";
-    params.senderIsOwner = true;
-    params.memberRoleIds = ["role-a", "role-b"];
-    mockRunBeforeToolCallHook.mockImplementation(async ({ params: hookParams, ctx }) =>
-      ctx?.requester?.senderIsOwner === true
-        ? { blocked: false, params: hookParams }
-        : { blocked: true, reason: "owner required", kind: "veto" },
-    );
-
-    const result = await handleCodexAppServerApprovalRequest({
-      method: "item/fileChange/requestApproval",
-      requestParams: {
-        ...codexTestTurnIds(),
-        itemId: "patch-owner-policy",
-      },
-      paramsForRun: params,
-      ...codexTestTurnIds(),
-      autoApproveOpenClawToolPolicy: true,
-    });
-
-    expect(result).toEqual({ decision: "accept" });
-    expect(mockRunBeforeToolCallHook).toHaveBeenCalledWith(
-      expect.objectContaining({
-        toolName: "apply_patch",
-        ctx: expect.objectContaining({
-          requester: {
-            channel: "telegram",
-            accountId: "default",
-            senderId: "owner-1",
-            senderIsOwner: true,
-            roleIds: ["role-a", "role-b"],
-          },
-        }),
-      }),
-    );
-    expect(mockCallGatewayTool).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    ["promoted tool policy", { autoApproveOpenClawToolPolicy: true }],
-    ["full-auto runtime policy", { autoApprove: true }],
-  ] as const)("keeps permission grants on the human path under %s", async (_label, policy) => {
+  it("keeps permission grants on the human path under full-auto runtime policy", async () => {
     const params = createParams();
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:permission-policy-allow", status: "accepted" })
@@ -370,7 +294,7 @@ describe("Codex app-server approval bridge", () => {
       },
       paramsForRun: params,
       ...codexTestTurnIds(),
-      ...policy,
+      autoApprove: true,
     });
 
     expect(result).toEqual({

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -71,7 +71,6 @@ export async function handleCodexAppServerApprovalRequest(params: {
     "allowedEvents" | "generation" | "relayId"
   >;
   autoApprove?: boolean;
-  autoApproveOpenClawToolPolicy?: boolean;
   signal?: AbortSignal;
   onNativeToolFailureDisposition?: (
     itemId: string,
@@ -123,16 +122,6 @@ export async function handleCodexAppServerApprovalRequest(params: {
       return resolvePolicyApproval(policyOutcome.outcome);
     }
     const canAutoApproveConcreteToolCall = CONCRETE_TOOL_AUTO_APPROVAL_METHODS.has(params.method);
-    if (
-      canAutoApproveConcreteToolCall &&
-      params.autoApproveOpenClawToolPolicy === true &&
-      policyOutcome?.outcome === "allowed"
-    ) {
-      return resolvePolicyApproval(
-        "approved-once",
-        "Codex app-server approval accepted by OpenClaw tool policy.",
-      );
-    }
     if (canAutoApproveConcreteToolCall && params.autoApprove === true) {
       return resolvePolicyApproval(
         "approved-session",

--- a/extensions/codex/src/app-server/approval-requester.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/approval-requester.real-binary.live.test.ts
@@ -5,7 +5,10 @@ import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
-import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  createAgentHarnessHostCapabilitiesForTest,
+  createMockPluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import type { PluginHookToolContext } from "openclaw/plugin-sdk/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -26,7 +29,7 @@ afterEach(() => {
 });
 
 describeLive("Codex app-server approval requester real-binary bridge", () => {
-  it("preserves an owner requester through promoted apply_patch approval", async () => {
+  it("runs owner-gated apply_patch under default yolo without approval requests", async () => {
     await withTempDir("openclaw-codex-approval-requester-", async (root) => {
       const workspace = path.join(root, "workspace");
       const agentDir = path.join(root, "agent");
@@ -44,6 +47,7 @@ describeLive("Codex app-server approval requester real-binary bridge", () => {
         authProfileId: null,
         timeoutMs: 120_000,
       });
+      let closeHost: (() => void) | undefined;
       try {
         const listed = await client.request<CodexModelListResponse>(
           "model/list",
@@ -121,6 +125,12 @@ describeLive("Codex app-server approval requester real-binary bridge", () => {
             agentEvents.push(event);
           },
         } as unknown as EmbeddedRunAttemptParams;
+        const host = await createAgentHarnessHostCapabilitiesForTest({
+          attempt: params,
+          pluginId: "codex",
+        });
+        params.hostCapabilities = host.capabilities;
+        closeHost = host.close;
 
         const result = await runCodexAppServerAttempt(params, {
           bindingStore: createCodexTestBindingStore(),
@@ -131,22 +141,15 @@ describeLive("Codex app-server approval requester real-binary bridge", () => {
 
         expect(result.terminal.kind, JSON.stringify(result.terminal)).toBe("ok");
         expect(await fs.readFile(target, "utf8")).toBe("REAL_BINARY_OWNER_OK\n");
-        expect(serverRequestMethods).toContain("item/fileChange/requestApproval");
+        expect(
+          serverRequestMethods.filter((method) => method.endsWith("/requestApproval")),
+        ).toEqual([]);
         expect(hookRequesters).toEqual(
           expect.arrayContaining([expect.objectContaining({ senderIsOwner: true })]),
         );
-        expect(agentEvents).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              stream: "approval",
-              data: expect.objectContaining({
-                status: "approved",
-                message: "Codex app-server approval accepted by OpenClaw tool policy.",
-              }),
-            }),
-          ]),
-        );
+        expect(agentEvents.filter((event) => event.stream === "approval")).toEqual([]);
       } finally {
+        closeHost?.();
         await client.closeAndWait();
       }
     });

--- a/extensions/codex/src/app-server/config-contracts.ts
+++ b/extensions/codex/src/app-server/config-contracts.ts
@@ -20,7 +20,7 @@ export type OpenClawExecApprovalFloorsForCodexAppServer = {
   ask?: OpenClawExecAsk;
 };
 export type OpenClawExecPolicyForCodexAppServer = {
-  mode?: OpenClawExecMode;
+  mode: OpenClawExecMode;
   security: OpenClawExecSecurity;
   ask: OpenClawExecAsk;
   touched: boolean;

--- a/extensions/codex/src/app-server/config-exec-policy.ts
+++ b/extensions/codex/src/app-server/config-exec-policy.ts
@@ -161,8 +161,7 @@ export function assertCodexAppServerAllowedForOpenClawExecMode(
 
 function createDefaultOpenClawExecPolicy(): OpenClawExecPolicy {
   return {
-    security: "full",
-    ask: "off",
+    ...resolveOpenClawExecPolicyForMode("full"),
     touched: false,
   };
 }

--- a/extensions/codex/src/app-server/config-requirements.ts
+++ b/extensions/codex/src/app-server/config-requirements.ts
@@ -11,24 +11,6 @@ import { readNonEmptyString } from "./config-utils.js";
 const UNIX_CODEX_REQUIREMENTS_PATH = "/etc/codex/requirements.toml";
 const WINDOWS_CODEX_REQUIREMENTS_SUFFIX = "\\OpenAI\\Codex\\requirements.toml";
 
-export function isCodexAppServerApprovalPolicyAllowedByRequirements(
-  policy: CodexAppServerApprovalPolicy,
-  params: {
-    env?: NodeJS.ProcessEnv;
-    requirementsToml?: string | null;
-    requirementsPath?: string;
-    readRequirementsFile?: (path: string) => string | undefined;
-    platform?: NodeJS.Platform;
-  } = {},
-): boolean {
-  const content = readCodexRequirementsToml(params);
-  if (content === undefined) {
-    return true;
-  }
-  const allowedApprovalPolicies = parseAllowedApprovalPoliciesFromCodexRequirements(content);
-  return allowedApprovalPolicies === undefined || allowedApprovalPolicies.has(policy);
-}
-
 export function readCodexRequirementsToml(params: {
   env?: NodeJS.ProcessEnv;
   requirementsToml?: string | null;

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -34,7 +34,6 @@ export {
   resolveCodexAppServerUserHomeDir,
   resolveCodexModelBackedReviewerPolicyContext,
 } from "./config-reviewer.js";
-export { isCodexAppServerApprovalPolicyAllowedByRequirements } from "./config-requirements.js";
 export {
   codexAppServerStartOptionsKey,
   codexSandboxPolicyForTurn,

--- a/extensions/codex/src/app-server/run-attempt-connection.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.test.ts
@@ -5,7 +5,6 @@ import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtim
 import { describe, expect, it, vi } from "vitest";
 import * as appServerPolicy from "./app-server-policy.js";
 import * as bindingConnection from "./binding-connection.js";
-import * as codexConfig from "./config.js";
 import { prepareCodexAttemptConnection } from "./run-attempt-connection.js";
 import { createParams, setupRunAttemptTestHooks, tempDir } from "./run-attempt-test-harness.js";
 import {
@@ -37,10 +36,6 @@ describe("prepareCodexAttemptConnection", () => {
 
     const resolveConnection = vi.spyOn(bindingConnection, "resolveCodexBindingAppServerConnection");
     const resolveModelPolicy = vi.spyOn(appServerPolicy, "resolveCodexAppServerForModelProvider");
-    const readApprovalRequirements = vi.spyOn(
-      codexConfig,
-      "isCodexAppServerApprovalPolicyAllowedByRequirements",
-    );
     const stat = vi.spyOn(fs, "stat");
 
     const connection = await prepareCodexAttemptConnection({
@@ -51,7 +46,6 @@ describe("prepareCodexAttemptConnection", () => {
     expect(connection.effectiveWorkspace).toBe(workspaceDir);
     expect(resolveConnection).toHaveBeenCalledTimes(1);
     expect(resolveModelPolicy).toHaveBeenCalledTimes(1);
-    expect(readApprovalRequirements).not.toHaveBeenCalled();
     expect(stat.mock.calls.filter(([candidate]) => candidate === workspaceDir)).toHaveLength(0);
     expect(connection.mutable.startupBinding?.threadId).toBe(
       existingThread ? "thread-existing" : undefined,
@@ -100,7 +94,7 @@ describe("prepareCodexAttemptConnection", () => {
     expect(resolveModelPolicy).toHaveBeenCalledTimes(2);
   });
 
-  it("still checks enterprise requirements before promoting tool approvals", async () => {
+  it("keeps effective default yolo ahead of generic tool approval hooks", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
     );
@@ -109,20 +103,12 @@ describe("prepareCodexAttemptConnection", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.agentDir = path.join(tempDir, "agent");
     registerCodexTestSessionIdentity(sessionFile, params.sessionId, params.sessionKey);
-    const readApprovalRequirements = vi.spyOn(
-      codexConfig,
-      "isCodexAppServerApprovalPolicyAllowedByRequirements",
-    );
-
     const connection = await prepareCodexAttemptConnection({
       params,
       options: { bindingStore: testCodexAppServerBindingStore },
     });
 
-    expect(readApprovalRequirements).toHaveBeenCalledOnce();
-    expect(readApprovalRequirements).toHaveBeenCalledWith("untrusted");
-    expect(connection.appServer.approvalPolicy).toBe("untrusted");
-    expect(connection.approvalPolicyPromotedForOpenClawToolPolicy).toBe(true);
+    expect(connection.appServer.approvalPolicy).toBe("never");
   });
 
   it("does not give OpenClaw ownership of an explicit operator approval policy", async () => {
@@ -144,6 +130,5 @@ describe("prepareCodexAttemptConnection", () => {
     });
 
     expect(connection.appServer.approvalPolicy).toBe("untrusted");
-    expect(connection.approvalPolicyPromotedForOpenClawToolPolicy).toBe(false);
   });
 });

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -1,6 +1,4 @@
 import {
-  embeddedAgentLog,
-  getBeforeToolCallPolicyDiagnosticState,
   isActiveHarnessContextEngine,
   resolveSandboxContext,
   resolveSessionAgentIds,
@@ -14,10 +12,7 @@ import {
   resolveDiagnosticModelContentCapturePolicy,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { loadExecApprovals } from "openclaw/plugin-sdk/exec-approvals-runtime";
-import {
-  resolveCodexAppServerForModelProvider,
-  resolveCodexAppServerForOpenClawToolPolicy,
-} from "./app-server-policy.js";
+import { resolveCodexAppServerForModelProvider } from "./app-server-policy.js";
 import {
   resolveCodexAppServerAuthProfileId,
   resolveCodexAppServerAuthProfileIdForAgent,
@@ -26,7 +21,6 @@ import {
 import { resolveCodexBindingAppServerConnection } from "./binding-connection.js";
 import {
   isCodexRemoteExecPlacementSandbox,
-  isCodexAppServerApprovalPolicyAllowedByRequirements,
   readCodexPluginConfig,
   resolveCodexAppServerHomeScope,
   resolveCodexComputerUseConfig,
@@ -100,7 +94,6 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     config: params.config,
     agentId: params.agentId,
   });
-  const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
   preDynamicStartupStages.mark("config");
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   await ensureCodexWorkspaceDirOnce(resolvedWorkspace);
@@ -290,41 +283,14 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     await ensureCodexWorkspaceDirOnce(effectiveWorkspace);
   }
   preDynamicStartupStages.mark("effective-workspace");
-  const shouldPromoteApprovalPolicy =
-    beforeToolCallPolicy.hasBeforeToolCallHook ||
-    beforeToolCallPolicy.trustedToolPolicies.length > 0;
-  const resolvePolicyAppServer = () =>
-    resolveCodexAppServerForOpenClawToolPolicy({
-      appServer: configuredAppServer,
-      pluginConfig,
-      env: process.env,
-      shouldPromote: shouldPromoteApprovalPolicy,
-      execPolicy,
-      canUseUntrustedApprovalPolicy:
-        shouldPromoteApprovalPolicy &&
-        configuredAppServer.approvalPolicy === "never" &&
-        (configuredAppServer.start.transport !== "stdio" ||
-          isCodexAppServerApprovalPolicyAllowedByRequirements("untrusted")),
-    });
-  let policyAppServer = resolvePolicyAppServer();
   let appServer = resolveCodexAppServerForModelProvider({
-    appServer: policyAppServer,
+    appServer: configuredAppServer,
     provider: reviewerPolicyContext.modelProvider,
     model: reviewerPolicyContext.model,
     config: params.config,
     env: process.env,
     agentDir,
   });
-  let approvalPolicyPromotedForOpenClawToolPolicy =
-    configuredAppServer.approvalPolicy === "never" && appServer.approvalPolicy === "untrusted";
-  if (approvalPolicyPromotedForOpenClawToolPolicy) {
-    embeddedAgentLog.info("codex app-server approval policy promoted for OpenClaw tool policy", {
-      from: "never",
-      to: "untrusted",
-      beforeToolCallHook: beforeToolCallPolicy.hasBeforeToolCallHook,
-      trustedToolPolicies: beforeToolCallPolicy.trustedToolPolicies,
-    });
-  }
   preDynamicStartupStages.mark("app-server-policy");
   preDynamicStartupStages.mark("native-hook-relay");
   const terminalState = {
@@ -386,17 +352,14 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
       modelProvider: reviewerPolicyContext.modelProvider,
       model: reviewerPolicyContext.model,
     });
-    policyAppServer = resolvePolicyAppServer();
     appServer = resolveCodexAppServerForModelProvider({
-      appServer: policyAppServer,
+      appServer: configuredAppServer,
       provider: reviewerPolicyContext.modelProvider,
       model: reviewerPolicyContext.model,
       config: params.config,
       env: process.env,
       agentDir,
     });
-    approvalPolicyPromotedForOpenClawToolPolicy =
-      configuredAppServer.approvalPolicy === "never" && appServer.approvalPolicy === "untrusted";
   }
   const nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -458,7 +421,6 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     effectiveWorkspace,
     effectiveCwd,
     appServer,
-    approvalPolicyPromotedForOpenClawToolPolicy,
     nativeHookRelayEvents,
     runAbortController,
     terminalState,

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -44,14 +44,7 @@ export function createCodexAttemptServerRequestController(
   const { context } = prompt;
   const { runtime, attemptTools } = context;
   const { connection } = runtime;
-  const {
-    params,
-    computerUseConfig,
-    runAbortController,
-    appServer,
-    approvalPolicyPromotedForOpenClawToolPolicy,
-    sessionAgentId,
-  } = connection;
+  const { params, computerUseConfig, runAbortController, appServer, sessionAgentId } = connection;
   const {
     toolBridge,
     toolOutcomeOrdinals,
@@ -139,7 +132,6 @@ export function createCodexAttemptServerRequestController(
             turnId,
             nativeHookRelay: resourceState.nativeHookRelay,
             autoApprove: shouldAutoApproveCodexAppServerApprovals(appServer),
-            autoApproveOpenClawToolPolicy: approvalPolicyPromotedForOpenClawToolPolicy,
             signal,
             onNativeToolFailureDisposition: (itemId, disposition) =>
               projector?.recordNativeToolApprovalFailure(itemId, disposition),

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -274,7 +274,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
-  it("auto-answers promoted command and workspace file approvals when the hook allows", async () => {
+  it("auto-answers defensive yolo command and workspace file approvals when the hook allows", async () => {
     const approvalSpy = vi.spyOn(approvalBridge, "handleCodexAppServerApprovalRequest");
     const beforeToolCall = vi.fn(() => undefined);
     initializeGlobalHookRunner(
@@ -293,7 +293,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     await harness.waitForMethod("turn/start");
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
-    expect((startRequest?.params as { approvalPolicy?: string })?.approvalPolicy).toBe("untrusted");
+    expect((startRequest?.params as { approvalPolicy?: string })?.approvalPolicy).toBe("never");
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toMatchObject({
       approvalContext: {
@@ -313,10 +313,8 @@ describe("runCodexAppServerAttempt native hook relay", () => {
         cwd: workspaceDir,
       },
     });
-    expect(approvalSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ autoApproveOpenClawToolPolicy: true }),
-    );
-    expect(commandResponse).toEqual({ decision: "accept" });
+    expect(approvalSpy).toHaveBeenCalledWith(expect.objectContaining({ autoApprove: true }));
+    expect(commandResponse).toEqual({ decision: "acceptForSession" });
     await expect(
       harness.handleServerRequest({
         id: "request-file-policy-allow",
@@ -329,7 +327,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
           grantRoot: workspaceDir,
         },
       }),
-    ).resolves.toEqual({ decision: "accept" });
+    ).resolves.toEqual({ decision: "acceptForSession" });
 
     expect(beforeToolCall).toHaveBeenCalledWith(
       expect.objectContaining({ toolName: "apply_patch" }),
@@ -341,7 +339,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
-  it("fails a promoted unattended approval immediately when the hook requires review", async () => {
+  it("fails a defensive unattended yolo approval immediately when the hook requires review", async () => {
     const onResolution = vi.fn();
     initializeGlobalHookRunner(
       createMockPluginRegistry([

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4159,11 +4159,10 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.toolMetas.filter((meta) => meta.isError === true)).toHaveLength(2);
   });
 
-  it("promotes implicit Codex yolo approval policy when OpenClaw tool policy exists", async () => {
+  it("keeps effective default Codex yolo when OpenClaw tool policy exists", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
     );
-    const info = vi.spyOn(embeddedAgentLog, "info").mockImplementation(() => undefined);
     const { sessionFile, workspaceDir } = createRunPaths();
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
@@ -4172,17 +4171,12 @@ describe("runCodexAppServerAttempt", () => {
     await run;
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startParams = startRequest?.params as Record<string, unknown> | undefined;
-    expect(startParams?.approvalPolicy).toBe("untrusted");
+    const turnRequest = harness.requests.find((request) => request.method === "turn/start");
+    const turnParams = turnRequest?.params as Record<string, unknown> | undefined;
+    expect(startParams?.approvalPolicy).toBe("never");
     expect(startParams?.sandbox).toBe("danger-full-access");
-    expect(info).toHaveBeenCalledWith(
-      "codex app-server approval policy promoted for OpenClaw tool policy",
-      {
-        from: "never",
-        to: "untrusted",
-        beforeToolCallHook: true,
-        trustedToolPolicies: [],
-      },
-    );
+    expect(turnParams?.approvalPolicy).toBe("never");
+    expect(turnParams?.sandboxPolicy).toEqual({ type: "dangerFullAccess" });
   });
   it("keeps explicit Codex yolo mode unpromoted when OpenClaw tool policy exists", async () => {
     initializeGlobalHookRunner(
@@ -4242,7 +4236,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(startParams?.sandbox).toBe("danger-full-access");
   });
 
-  it("ignores invalid Codex app-server env overrides when promoting tool policy approval", async () => {
+  it("ignores invalid Codex app-server env overrides without weakening default yolo", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
     );
@@ -4256,7 +4250,7 @@ describe("runCodexAppServerAttempt", () => {
     await run;
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startParams = startRequest?.params as Record<string, unknown> | undefined;
-    expect(startParams?.approvalPolicy).toBe("untrusted");
+    expect(startParams?.approvalPolicy).toBe("never");
   });
   it("preserves a healthy binding when invalid image cleanup hits a transient thread", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where team/default YOLO sessions surfaced Codex command-approval cards for routine commands whenever a generic OpenClaw tool policy was present.

## Why This Change Was Made

The default OpenClaw exec policy omitted its closed `mode: "full"` fact. An obsolete downstream promotion therefore treated the default as implicit and changed Codex `approvalPolicy` from `never` to `untrusted`. This change makes the default policy complete and removes that promotion plus its compensating auto-approval path.

## User Impact

Routine commands no longer pause for approval in YOLO sessions. Explicit guardian/untrusted policies still prompt, and native `PreToolUse`/`before_tool_call` denials remain visible and enforced independently.

## Evidence

- Pre-fix owner-boundary expectation failed with `Expected: "never"` / `Received: "untrusted"`.
- Focused Vitest passed: 253 tests across app-server policy, attempt connection, approval bridge, run attempt, and native hook relay suites.
- `node scripts/check-changed.mjs -- <14 changed paths>` passed locally, including formatting, extension production/test type checks, oxlint, dead exports, boundaries, guards, and import cycles. This is local trusted-source proof; remote proof was unavailable.
- `git diff --check` passed.
- Final Codex autoreview on the exact uncommitted diff was clean with score 0.98 and no accepted/actionable findings.
- Upstream Codex contracts were checked directly in `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`, `codex-rs/app-server-protocol/src/protocol/v2/turn.rs`, `codex-rs/app-server/src/request_processors/turn_processor.rs`, `codex-rs/protocol/src/protocol.rs`, `codex-rs/core/src/exec_policy.rs`, and `codex-rs/core/src/tools/sandboxing.rs`: thread start/resume accept approval policy, turn start applies a sticky override, and `AskForApproval::Never` runs ordinary unmatched commands without prompting while rejecting prompt-required flows.
- Production LOC: +6/-139 (net -133). Tests: +37/-199 (net -162).
- Live gap: the updated real-binary test reached the real Codex binary/model endpoint but stopped on HTTP 401 missing authentication before model execution, so this is not claimed as a live pass.
- UI gap: pre-merge UI proof is infeasible because team.openclaw.ai is still running the old deployed build. The available screenshot contains private team/session details and is intentionally not uploaded to this public PR.

## Release-note context

Codex YOLO sessions no longer surface approval prompts for routine commands merely because an OpenClaw tool policy is installed; explicit approval modes and policy denials are unchanged.
