### PR TITLE
fix(ci): manual full CI fails in temporary workflow fixtures

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -57,8 +57,8 @@ const AMBIGUOUS_MAIN_PUSH_GUARD = `if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$
 fi`;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const TSX_IMPORT = import.meta.resolve("tsx");
-const WORKSPACE_NODE_MODULES = path.dirname(
-  path.dirname(fileURLToPath(import.meta.resolve("tsx/package.json"))),
+const TYPESCRIPT_NODE_MODULES = path.dirname(
+  path.dirname(fileURLToPath(import.meta.resolve("typescript/package.json"))),
 );
 const MATURITY_GENERATED_PR_PATHS = [
   "qa/maturity-scores.yaml",
@@ -1021,7 +1021,7 @@ function runProtocolSinceFixture(checkout: string, baseSha: string) {
   );
   const nodeModules = path.join(checkout, "node_modules");
   if (!existsSync(nodeModules)) {
-    symlinkSync(WORKSPACE_NODE_MODULES, nodeModules, "dir");
+    symlinkSync(TYPESCRIPT_NODE_MODULES, nodeModules, "dir");
   }
   return spawnSync(process.execPath, ["--import", TSX_IMPORT, "scripts/check-protocol-since.mts"], {
     cwd: checkout,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { runInNewContext } from "node:vm";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
@@ -55,6 +56,10 @@ const AMBIGUOUS_MAIN_PUSH_GUARD = `if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$
   exit 1
 fi`;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const TSX_IMPORT = import.meta.resolve("tsx");
+const WORKSPACE_NODE_MODULES = path.dirname(
+  path.dirname(fileURLToPath(import.meta.resolve("tsx/package.json"))),
+);
 const MATURITY_GENERATED_PR_PATHS = [
   "qa/maturity-scores.yaml",
   "docs/maturity/scorecard.md",
@@ -144,19 +149,24 @@ function runWorkflowShellScript(
   try {
     let moduleIndex = 0;
     const moduleRoot = options.cwd ?? process.cwd();
-    const rewritten = script.replace(
-      /node (?:--import tsx )?--input-type=module <<'([A-Z][A-Z0-9_]*)'\n([\s\S]*?)\n\1(?=\n|$)/gu,
-      (_match, _marker: string, body: string) => {
-        const modulePath = path.join(
-          moduleRoot,
-          `.openclaw-${path.basename(root)}-${moduleIndex}.mjs`,
-        );
-        moduleIndex += 1;
-        modulePaths.push(modulePath);
-        writeFileSync(modulePath, `${body}\n`, "utf8");
-        return `${quoteShell(process.execPath)} --import ${quoteShell(import.meta.resolve("tsx"))} ${quoteShell(modulePath)}`;
-      },
-    );
+    const rewritten = script
+      .replace(
+        /node (?:--import tsx )?--input-type=module <<'([A-Z][A-Z0-9_]*)'\n([\s\S]*?)\n\1(?=\n|$)/gu,
+        (_match, _marker: string, body: string) => {
+          const modulePath = path.join(
+            moduleRoot,
+            `.openclaw-${path.basename(root)}-${moduleIndex}.mjs`,
+          );
+          moduleIndex += 1;
+          modulePaths.push(modulePath);
+          writeFileSync(modulePath, `${body}\n`, "utf8");
+          return `${quoteShell(process.execPath)} --import ${quoteShell(TSX_IMPORT)} ${quoteShell(modulePath)}`;
+        },
+      )
+      .replaceAll(
+        "manifest_node_args+=(--import tsx)",
+        `manifest_node_args+=(--import ${quoteShell(TSX_IMPORT)})`,
+      );
     const scriptPath = path.join(root, "run.sh");
     writeFileSync(scriptPath, rewritten.endsWith("\n") ? rewritten : `${rewritten}\n`, "utf8");
     return spawnSync("bash", [scriptPath], {
@@ -1011,9 +1021,9 @@ function runProtocolSinceFixture(checkout: string, baseSha: string) {
   );
   const nodeModules = path.join(checkout, "node_modules");
   if (!existsSync(nodeModules)) {
-    symlinkSync(path.resolve("node_modules"), nodeModules, "dir");
+    symlinkSync(WORKSPACE_NODE_MODULES, nodeModules, "dir");
   }
-  return spawnSync(process.execPath, ["--import", "tsx", "scripts/check-protocol-since.mts"], {
+  return spawnSync(process.execPath, ["--import", TSX_IMPORT, "scripts/check-protocol-since.mts"], {
     cwd: checkout,
     encoding: "utf8",
     env: { ...process.env, PROTOCOL_SINCE_BASE_SHA: baseSha },


### PR DESCRIPTION
Closes #124071

## What Problem This Solves

Fixes an issue where maintainers running manual full CI would see the required core-tooling workflow-guard lane fail because temporary manifest fixtures could not resolve the `tsx` loader from their isolated working directories.

## Why This Change Was Made

The test harness now resolves the workspace loader once and injects its absolute path into both supported workflow command shapes. Temporary protocol checkouts also link to the actual workspace dependency root instead of assuming the active worktree has a complete local `node_modules` tree.

The production workflow is unchanged; this repair stays inside the fixture owner.

## User Impact

No end-user behavior changes. Maintainers can run manual full CI and release-validation CI without deterministic fixture-only loader failures.

Production/tooling LOC: +0/-0 (net 0) | Test support: +25/-15 (net +10)

## Evidence

- Before: main run 31868007268, `checks-node-core-tooling-6`, failed five `ci-workflow-guards` cases with `ERR_MODULE_NOT_FOUND` for bare `tsx` from `/tmp/openclaw-ci-manifest-*`.
- After rebase onto green main `7bb3909e4b5ab98d01deef532d02f3e4f7f10e10`: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 119 passed, 2 skipped.
- `node scripts/check-changed.mjs -- test/scripts/ci-workflow-guards.test.ts` — passed via the documented local fallback after no remote provider was ready.
- `git diff --check` and repository formatter/type/lint gates — passed.
- Fresh Codex autoreview against the rebased branch — clean, no accepted/actionable findings.
