### PR TITLE
refactor(types): remove chained type assertions in extensions

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -1108,7 +1108,7 @@ function convertToolConfig(
     toolSpec: {
       name: tool.name,
       description: tool.description,
-      inputSchema: { json: tool.parameters as unknown as DocumentType },
+      inputSchema: { json: { ...tool.parameters } },
     },
   }));
 

--- a/extensions/anthropic/session-catalog-history.ts
+++ b/extensions/anthropic/session-catalog-history.ts
@@ -70,10 +70,10 @@ export async function importClaudeHistory(params: {
         continue;
       }
       // The idempotency key rides on the message so recovery re-imports dedupe.
-      const message = {
-        ...(imported as unknown as Record<string, unknown>),
+      const message: AgentMessage & { idempotencyKey: string } = {
+        ...imported,
         idempotencyKey: `claude-catalog:${params.threadId}:${item.uuid ?? index}`,
-      } as unknown as AgentMessage;
+      };
       await transcript.appendMessage({
         message,
         idempotencyLookup: "scan",

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -4,12 +4,7 @@
  * Builds launch args, starts/stops managed Chrome, probes CDP readiness, and
  * resolves WebSocket endpoints for browser control.
  */
-import {
-  type ChildProcess,
-  type ChildProcessWithoutNullStreams,
-  execFileSync,
-  spawn,
-} from "node:child_process";
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
@@ -1080,15 +1075,13 @@ export async function launchOpenClawChrome(
     }
     // stdio tuple: discard stdout to prevent buffer saturation in constrained
     // environments (e.g. Docker), while keeping stderr piped for diagnostics.
-    // Cast to ChildProcessWithoutNullStreams so callers can use .stderr safely;
-    // the tuple overload resolution varies across @types/node versions.
     const preparedSpawn = prepareOomScoreAdjustedSpawn(exe.path, args, {
       env,
     });
     const proc = spawn(preparedSpawn.command, preparedSpawn.args, {
       stdio: ["ignore", "ignore", "pipe"],
       env: preparedSpawn.env,
-    }) as unknown as ChildProcessWithoutNullStreams;
+    });
     const onAbort = () => {
       try {
         proc.kill("SIGKILL");
@@ -1218,7 +1211,7 @@ export async function launchOpenClawChrome(
     const onStderr = (chunk: Buffer | string) => {
       stderrDiagnostics.append(chunk);
     };
-    let proc: ChildProcessWithoutNullStreams | undefined;
+    let proc: ChildProcess | undefined;
     let releaseSpawnAbort: (() => void) | undefined;
 
     try {

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -1193,7 +1193,7 @@ function approvalKindForMethod(method: string): AgentApprovalEventData["kind"] {
 function emitApprovalEvent(params: EmbeddedRunAttemptParams, data: AgentApprovalEventData): void {
   void params.onAgentEvent?.({
     stream: "approval",
-    data: data as unknown as Record<string, unknown>,
+    data: { ...data },
   });
 }
 

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -2,7 +2,7 @@
 import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { refreshCodexAppServerAuthTokens } from "./auth-bridge.js";
 import type { CodexAppServerClient } from "./client.js";
-import type { CodexServiceTier, JsonValue } from "./protocol.js";
+import type { CodexServiceTier } from "./protocol.js";
 import { mergeCodexRateLimitsUpdate } from "./rate-limit-cache.js";
 import type { CodexAppServerAuthProfileLookup } from "./session-binding.js";
 
@@ -104,14 +104,15 @@ export function ensureCodexAppServerClientRuntime(
     if (runtime.context.authMode === "prepared-api-key") {
       throw new Error("ChatGPT token refresh is unavailable for prepared Codex API-key auth.");
     }
-    return (await refreshCodexAppServerAuthTokens({
+    const tokens = await refreshCodexAppServerAuthTokens({
       agentDir: runtime.context.agentDir,
       authProfileId: runtime.context.authProfileId,
       ...(runtime.context.authProfileStore
         ? { authProfileStore: runtime.context.authProfileStore }
         : {}),
       config: runtime.context.config,
-    })) as unknown as JsonValue;
+    });
+    return { ...tokens };
   });
   client.addNotificationHandler((notification) => {
     if (notification.method === "account/rateLimits/updated") {

--- a/extensions/codex/src/app-server/event-projector-assistant-message.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant-message.ts
@@ -103,7 +103,9 @@ export function createAssistantCommentaryMessage(
   timestamp: number,
 ): AssistantMessage {
   const attribution = resolveCodexLocalRuntimeAttribution(params);
-  return {
+  const message: AssistantMessage & {
+    openclawStreamFallback: { replacementText: string; source: "segment"; itemId: string };
+  } = {
     role: "assistant",
     content: [{ type: "text", text }],
     api: attribution.api ?? "openai-chatgpt-responses",
@@ -119,7 +121,8 @@ export function createAssistantCommentaryMessage(
       source: "segment",
       itemId,
     },
-  } as unknown as AssistantMessage;
+  };
+  return message;
 }
 
 export function createAssistantMirrorMessage(

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -9,9 +9,10 @@ import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 import { promptSnapshot } from "./user-prompt-message.js";
 
 type TurnTaintMetadata = { resultContentSource?: "network"; turnTainted?: true };
+const CODEX_META_KEY = "__openclaw";
 
 function readTurnTaintMetadata(message: AgentMessage): TurnTaintMetadata | undefined {
-  const metadata = (message as unknown as Record<string, unknown>)["__openclaw"];
+  const metadata = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   return metadata && typeof metadata === "object" && !Array.isArray(metadata)
     ? (metadata as TurnTaintMetadata)
     : undefined;

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -313,9 +313,8 @@ export class CodexToolTranscriptProjection {
     }
     this.rawNativeToolOutputByCallId.set(callId, text);
     const result = this.messages.find(
-      (message) =>
-        message.role === "toolResult" &&
-        (message as unknown as { toolCallId?: unknown }).toolCallId === callId,
+      (message): message is Extract<AgentMessage, { role: "toolResult" }> =>
+        message.role === "toolResult" && message.toolCallId === callId,
     );
     if (!result) {
       if (NATIVE_PATCH_REJECTION_RE.test(text)) {
@@ -336,11 +335,9 @@ export class CodexToolTranscriptProjection {
       id: callId,
       name: "apply_patch",
       text,
-      isError: (result as unknown as { isError?: unknown }).isError === true,
+      isError: result.isError,
     });
-    (result as unknown as { content: unknown }).content = (
-      replacement as unknown as { content: unknown }
-    ).content;
+    result.content = replacement.content;
   }
 
   async recordNativeToolResultWithDetails(item: CodexThreadItem | undefined): Promise<void> {
@@ -599,7 +596,9 @@ export class CodexToolTranscriptProjection {
     } as unknown as AgentMessage;
   }
 
-  private createToolResultMessage(params: ToolTranscriptResultInput): AgentMessage {
+  private createToolResultMessage(
+    params: ToolTranscriptResultInput,
+  ): Extract<AgentMessage, { role: "toolResult" }> {
     const text = truncateToolTranscriptText(params.text?.trim() || toolResultStatusText(params));
     return {
       role: "toolResult",
@@ -624,7 +623,7 @@ export class CodexToolTranscriptProjection {
         ? { __openclaw: { resultContentSource: params.resultContentSource } }
         : {}),
       timestamp: this.nextTranscriptTimestamp(),
-    } as unknown as AgentMessage;
+    } as unknown as Extract<AgentMessage, { role: "toolResult" }>;
   }
 }
 

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -14,7 +14,7 @@ import {
 } from "./attempt-steering.js";
 import { CodexAppServerEventProjector } from "./event-projector.js";
 import { createCodexNativeMcpAppResultDetailsPreparer } from "./native-mcp-app.js";
-import type { CodexTurnStartResponse, JsonObject } from "./protocol.js";
+import { isJsonObject, type CodexTurnStartResponse } from "./protocol.js";
 import { readRecentCodexRateLimits } from "./rate-limit-cache.js";
 import { readBoundedCodexRemoteWorkspaceFile } from "./remote-workspace-media.js";
 import type { CodexAttemptLifecycleController } from "./run-attempt-lifecycle-controller.js";
@@ -165,13 +165,16 @@ export async function activateCodexAttemptTurn(
     }
   }
   if (!state.completed && isTerminalTurnStatus(turn.turn.status)) {
+    if (!isJsonObject(turn.turn)) {
+      throw new Error("Codex turn completion payload is not a JSON object");
+    }
     await enqueueNotification(
       {
         method: "turn/completed",
         params: {
           threadId: resourceState.thread.threadId,
           turnId: activeTurnId,
-          turn: turn.turn as unknown as JsonObject,
+          turn: turn.turn,
         },
       },
       { threadId: resourceState.thread.threadId, turnId: activeTurnId },

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -33,6 +33,8 @@ import {
   codexLegacyDynamicToolsFingerprint,
 } from "./thread-lifecycle.js";
 
+const CODEX_META_KEY = "__openclaw";
+
 function isRestrictivePromptToolsAllow(toolsAllow: string[] | undefined): boolean {
   return toolsAllow !== undefined && !toolsAllow.some((name) => name.trim() === "*");
 }
@@ -327,8 +329,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       if (message.role !== "user" && message.role !== "assistant") {
         return false;
       }
-      const record = message as unknown as Record<string, unknown>;
-      const meta = record["__openclaw"];
+      const meta = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
       const mirrorIdentity =
         meta && typeof meta === "object" && !Array.isArray(meta)
           ? (meta as Record<string, unknown>).mirrorIdentity
@@ -345,8 +346,9 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
             : Number.NaN;
       return (
         !(
-          typeof record.idempotencyKey === "string" &&
-          record.idempotencyKey.startsWith("codex-app-server:")
+          "idempotencyKey" in message &&
+          typeof message.idempotencyKey === "string" &&
+          message.idempotencyKey.startsWith("codex-app-server:")
         ) &&
         mirrorOrigin !== "codex-app-server" &&
         !(typeof mirrorIdentity === "string" && mirrorIdentity.startsWith("codex-app-server:")) &&

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -475,9 +475,7 @@ export function normalizeStoredCodexAppServerBindingFingerprints(
   if (!stored || stored.state !== "active") {
     return stored;
   }
-  const binding = normalizeLegacyBindingFingerprints(
-    stored.binding as unknown as Record<string, unknown>,
-  );
+  const binding = normalizeLegacyBindingFingerprints({ ...stored.binding });
   return binding === stored.binding
     ? stored
     : readStoredCodexAppServerBinding({ ...stored, binding });

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -448,9 +448,12 @@ function normalizeLegacyBindingFingerprint(value: unknown): unknown {
   return hashCodexAppServerBindingFingerprint(value);
 }
 
-function normalizeLegacyBindingFingerprints(
-  record: Record<string, unknown>,
-): Record<string, unknown> {
+function normalizeLegacyBindingFingerprints<
+  T extends {
+    dynamicToolsFingerprint?: unknown;
+    userMcpServersFingerprint?: unknown;
+  },
+>(record: T): T {
   // Shipped sidecars can contain unbounded canonical JSON fingerprints. Bound
   // them at the legacy encoder so plugin-state registration cannot reject the row.
   let normalized = record;
@@ -463,7 +466,7 @@ function normalizeLegacyBindingFingerprints(
     if (normalized === record) {
       normalized = { ...record };
     }
-    normalized[key] = next;
+    Object.assign(normalized, { [key]: next });
   }
   return normalized;
 }
@@ -475,7 +478,7 @@ export function normalizeStoredCodexAppServerBindingFingerprints(
   if (!stored || stored.state !== "active") {
     return stored;
   }
-  const binding = normalizeLegacyBindingFingerprints({ ...stored.binding });
+  const binding = normalizeLegacyBindingFingerprints(stored.binding);
   return binding === stored.binding
     ? stored
     : readStoredCodexAppServerBinding({ ...stored, binding });

--- a/extensions/codex/src/app-server/settled-turn-finalizer.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.ts
@@ -130,13 +130,10 @@ export async function runCodexSettledTurnFinalization(
     throw new Error("Codex settled-turn final answer transcript attestation mismatch");
   }
   const persistedAssistant = persistedMessage;
-  const persistedAssistantRecord = persistedAssistant as unknown as {
-    idempotencyKey?: unknown;
-  };
+  const persistedIdempotencyKey =
+    "idempotencyKey" in persistedAssistant ? persistedAssistant.idempotencyKey : undefined;
   const assistantTranscriptIdempotencyKey =
-    typeof persistedAssistantRecord.idempotencyKey === "string"
-      ? persistedAssistantRecord.idempotencyKey.trim()
-      : "";
+    typeof persistedIdempotencyKey === "string" ? persistedIdempotencyKey.trim() : "";
   return {
     assistant: persistedAssistant,
     assistantTranscriptOwned: true,

--- a/extensions/codex/src/app-server/settled-turn-projection.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.ts
@@ -85,10 +85,9 @@ function serializeToolArguments(value: unknown): string {
   return requireBoundedText(serialized, "tool arguments");
 }
 
-function projectUserMessage(message: AgentMessage): JsonValue[] {
-  const record = message as unknown as Record<string, unknown>;
+function projectUserMessage(message: Extract<AgentMessage, { role: "user" }>): JsonValue[] {
   const upstreamUserText = readUpstreamUserText(message);
-  if (upstreamUserText && typeof record.content === "string") {
+  if (upstreamUserText && typeof message.content === "string") {
     return [
       {
         type: "message",
@@ -99,20 +98,22 @@ function projectUserMessage(message: AgentMessage): JsonValue[] {
       },
     ];
   }
-  if (typeof record.content === "string") {
+  if (typeof message.content === "string") {
     return [
       {
         type: "message",
         role: "user",
-        content: [{ type: "input_text", text: requireBoundedText(record.content, "user message") }],
+        content: [
+          { type: "input_text", text: requireBoundedText(message.content, "user message") },
+        ],
       },
     ];
   }
-  if (!Array.isArray(record.content)) {
+  if (!Array.isArray(message.content)) {
     throw new Error("Codex settled-turn projection found unsupported user content");
   }
   const content: JsonValue[] = [];
-  for (const value of record.content) {
+  for (const value of message.content) {
     if (!isRecord(value)) {
       throw new Error("Codex settled-turn projection found malformed user content");
     }
@@ -123,9 +124,7 @@ function projectUserMessage(message: AgentMessage): JsonValue[] {
       }
       continue;
     }
-    throw new Error(
-      `Codex settled-turn projection does not support user content ${String(value.type)}`,
-    );
+    throw new Error(`Codex settled-turn projection does not support user content ${value.type}`);
   }
   if (content.length === 0) {
     throw new Error("Codex settled-turn projection found an empty user message");
@@ -133,11 +132,11 @@ function projectUserMessage(message: AgentMessage): JsonValue[] {
   return [{ type: "message", role: "user", content }];
 }
 
-function projectAssistantMessage(message: Record<string, unknown>): {
+function projectAssistantMessage(message: Extract<AgentMessage, { role: "assistant" }>): {
   items: JsonValue[];
   calls: ProjectedToolReference[];
 } {
-  const values =
+  const values: unknown =
     typeof message.content === "string"
       ? [{ type: "text", text: message.content }]
       : message.content;
@@ -184,7 +183,7 @@ function projectAssistantMessage(message: Record<string, unknown>): {
   return { items, calls };
 }
 
-function projectToolResult(message: Record<string, unknown>): {
+function projectToolResult(message: Extract<AgentMessage, { role: "toolResult" }>): {
   item: JsonValue;
   result: ProjectedToolReference;
 } {
@@ -193,10 +192,11 @@ function projectToolResult(message: Record<string, unknown>): {
   if (!Array.isArray(message.content)) {
     throw new Error("Codex settled-turn projection found unsupported tool result content");
   }
-  if (message.isError !== undefined && typeof message.isError !== "boolean") {
+  const isErrorValue: unknown = message.isError;
+  if (isErrorValue !== undefined && typeof isErrorValue !== "boolean") {
     throw new Error("Codex settled-turn projection found invalid tool result status");
   }
-  const isError = message.isError === true;
+  const isError = isErrorValue === true;
   const parts: string[] = [];
   for (const value of message.content) {
     if (!isRecord(value)) {
@@ -237,18 +237,17 @@ function projectToolResult(message: Record<string, unknown>): {
 }
 
 function projectMessage(message: AgentMessage): ProjectedMessageGroup | undefined {
-  const record = message as unknown as Record<string, unknown>;
   let items: JsonValue[];
   let calls: ProjectedToolReference[] = [];
   let results: ProjectedToolReference[] = [];
   if (message.role === "user") {
     items = projectUserMessage(message);
   } else if (message.role === "assistant") {
-    const projected = projectAssistantMessage(record);
+    const projected = projectAssistantMessage(message);
     items = projected.items;
     calls = projected.calls;
   } else if (message.role === "toolResult") {
-    const projected = projectToolResult(record);
+    const projected = projectToolResult(message);
     items = [projected.item];
     results = [projected.result];
   } else {

--- a/extensions/codex/src/app-server/tool-progress-normalization.ts
+++ b/extensions/codex/src/app-server/tool-progress-normalization.ts
@@ -53,7 +53,7 @@ function sanitizeCodexAgentEventValue(value: unknown, seen = new WeakSet<object>
     }
     seen.add(value);
     const out: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    for (const [key, child] of Object.entries(value)) {
       out[key] =
         typeof child === "string"
           ? redactSensitiveFieldValue(key, child)
@@ -85,7 +85,7 @@ export function sanitizeCodexToolArguments(
 export function sanitizeCodexToolResponse(
   response: CodexDynamicToolCallResponse,
 ): Record<string, unknown> {
-  return sanitizeCodexAgentEventRecord(response as unknown as Record<string, unknown>);
+  return sanitizeCodexAgentEventRecord({ ...response });
 }
 
 /** Infers compact human-readable tool metadata from Codex dynamic-tool arguments. */

--- a/extensions/codex/src/app-server/transcript-history-projection.ts
+++ b/extensions/codex/src/app-server/transcript-history-projection.ts
@@ -141,7 +141,7 @@ function projectCodexThreadHistory(params: {
   let itemOffset = 0;
   for (const turn of selectTurnsThroughBoundary(params.thread, params.throughTurnId)) {
     for (const value of turn.items) {
-      const item = value as unknown as Record<string, unknown>;
+      const item = value;
       const itemId = normalizeOptionalString(item.id);
       const identity = `${turn.id}:${itemId ?? itemOffset}`;
       const timestampSeconds =

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -7,29 +7,30 @@ type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" |
 const MIRROR_ORIGIN_META_KEY = "mirrorOrigin" as const;
 const MIRROR_SOURCE_FINGERPRINT_META_KEY = "mirrorSourceFingerprint" as const;
 const CODEX_APP_SERVER_MIRROR_ORIGIN = "codex-app-server" as const;
+const CODEX_META_KEY = "__openclaw";
 
 export function attachCodexMirrorAttestation(
   message: AgentMessage,
   sourceFingerprint?: string,
 ): AgentMessage {
-  const record = message as unknown as Record<string, unknown>;
-  const existing = record["__openclaw"];
+  const existing = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   const baseMeta =
     existing && typeof existing === "object" && !Array.isArray(existing)
       ? (existing as Record<string, unknown>)
       : {};
-  return {
-    ...record,
-    __openclaw: {
+  const attested: AgentMessage & { [CODEX_META_KEY]: Record<string, unknown> } = {
+    ...message,
+    [CODEX_META_KEY]: {
       ...baseMeta,
       [MIRROR_ORIGIN_META_KEY]: CODEX_APP_SERVER_MIRROR_ORIGIN,
       ...(sourceFingerprint ? { [MIRROR_SOURCE_FINGERPRINT_META_KEY]: sourceFingerprint } : {}),
     },
-  } as unknown as AgentMessage;
+  };
+  return attested;
 }
 
 export function readCodexMirrorSourceFingerprint(message: AgentMessage): string | undefined {
-  const meta = (message as unknown as Record<string, unknown>)["__openclaw"];
+  const meta = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
     return undefined;
   }
@@ -38,16 +39,16 @@ export function readCodexMirrorSourceFingerprint(message: AgentMessage): string 
 }
 
 export function serializeCodexMirrorSourceEvidence(message: AgentMessage): string {
-  const record = message as unknown as Record<string, unknown>;
+  const content = "content" in message ? message.content : undefined;
   return JSON.stringify({
     role: message.role,
-    content: record.content,
+    content,
     ...(message.role === "user" ? { upstreamUserText: readUpstreamUserText(message) } : {}),
     ...(message.role === "toolResult"
       ? {
-          toolCallId: record.toolCallId,
-          toolName: record.toolName,
-          isError: record.isError === true,
+          toolCallId: message.toolCallId,
+          toolName: message.toolName,
+          isError: message.isError,
         }
       : {}),
   });

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -342,9 +342,7 @@ async function mirror(params: {
     const sourceFingerprint = fingerprintCodexMirrorSourceMessage(message);
     const sourceUserIdempotencyKey =
       message.role === "user"
-        ? normalizeOptionalString(
-            (message as unknown as { idempotencyKey?: unknown }).idempotencyKey,
-          )
+        ? normalizeOptionalString("idempotencyKey" in message ? message.idempotencyKey : undefined)
         : undefined;
     // Gateway-owned user keys keep optimistic client rows stable. Other rows use
     // the provider mirror identity so retries find the exact logical message.
@@ -375,10 +373,7 @@ async function mirror(params: {
       });
       for (const { dedupeIdentity, idempotencyKey, message, sourceFingerprint } of candidates) {
         const transcriptMessage = {
-          ...(attachCodexMirrorAttestation(message, sourceFingerprint) as unknown as Record<
-            string,
-            unknown
-          >),
+          ...attachCodexMirrorAttestation(message, sourceFingerprint),
           ...(idempotencyKey ? { idempotencyKey } : {}),
         } as AgentMessage;
         if (idempotencyKey && mirrorFacts.existingIdempotencyKeys.has(idempotencyKey)) {
@@ -423,10 +418,7 @@ async function mirror(params: {
         let messageToAppend = (
           idempotencyKey
             ? {
-                ...(attachCodexMirrorAttestation(
-                  nextMessage,
-                  sourceFingerprint,
-                ) as unknown as Record<string, unknown>),
+                ...attachCodexMirrorAttestation(nextMessage, sourceFingerprint),
                 idempotencyKey,
               }
             : attachCodexMirrorAttestation(nextMessage, sourceFingerprint)

--- a/extensions/codex/src/app-server/upstream-prompt-provenance.ts
+++ b/extensions/codex/src/app-server/upstream-prompt-provenance.ts
@@ -2,23 +2,22 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 
 const UPSTREAM_USER_TEXT_META_KEY = "upstreamUserText" as const;
 const MIRROR_IDENTITY_META_KEY = "mirrorIdentity" as const;
+const CODEX_META_KEY = "__openclaw";
 
 export function attachCodexMirrorIdentity<T extends AgentMessage>(message: T, identity: string): T {
-  const record = message as unknown as Record<string, unknown>;
-  const existing = record["__openclaw"];
+  const existing = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   const baseMeta =
     existing && typeof existing === "object" && !Array.isArray(existing)
       ? (existing as Record<string, unknown>)
       : {};
   return {
-    ...record,
+    ...message,
     __openclaw: { ...baseMeta, [MIRROR_IDENTITY_META_KEY]: identity },
-  } as unknown as T;
+  };
 }
 
 export function readMirrorIdentity(message: AgentMessage): string | undefined {
-  const record = message as unknown as { __openclaw?: unknown };
-  const meta = record["__openclaw"];
+  const meta = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
     return undefined;
   }
@@ -27,21 +26,19 @@ export function readMirrorIdentity(message: AgentMessage): string | undefined {
 }
 
 export function attachUpstreamUserText<T extends AgentMessage>(message: T, text: string): T {
-  const record = message as unknown as Record<string, unknown>;
-  const existing = record["__openclaw"];
+  const existing = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   const baseMeta =
     existing && typeof existing === "object" && !Array.isArray(existing)
       ? (existing as Record<string, unknown>)
       : {};
   return {
-    ...record,
+    ...message,
     __openclaw: { ...baseMeta, [UPSTREAM_USER_TEXT_META_KEY]: text },
-  } as unknown as T;
+  };
 }
 
 export function readUpstreamUserText(message: AgentMessage | undefined): string | undefined {
-  const record = message as unknown as { __openclaw?: unknown } | undefined;
-  const meta = record?.["__openclaw"];
+  const meta = message && CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
     return undefined;
   }

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -300,7 +300,7 @@ function buildUserInputResponse(
   questions: AgentHarnessUserInputQuestion[],
   inputText: string,
 ): JsonObject {
-  return buildAgentHarnessUserInputAnswers(questions, inputText) as unknown as JsonObject;
+  return { ...buildAgentHarnessUserInputAnswers(questions, inputText) };
 }
 
 function gatewayAnswersToCodexResponse(answers: Record<string, string[]>): JsonObject {
@@ -312,7 +312,7 @@ function gatewayAnswersToCodexResponse(answers: Record<string, string[]>): JsonO
 }
 
 function emptyUserInputResponse(): JsonObject {
-  return emptyAgentHarnessUserInputAnswers() as unknown as JsonObject;
+  return { ...emptyAgentHarnessUserInputAnswers() };
 }
 
 function readRequestId(record: JsonObject): string | number | undefined {

--- a/extensions/codex/src/app-server/user-prompt-message.ts
+++ b/extensions/codex/src/app-server/user-prompt-message.ts
@@ -47,9 +47,7 @@ function buildFromPrepared(
   return {
     role: "user",
     ...metadata,
-    ...(preparedUserMessage
-      ? (preparedUserMessage as unknown as Record<string, unknown>)
-      : { content: params.prompt }),
+    ...(preparedUserMessage ?? { content: params.prompt }),
   } as AgentMessage;
 }
 

--- a/extensions/diagnostics-otel/src/service-exporter-health.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.ts
@@ -150,14 +150,14 @@ export function createPublicExporterHealthEventEmitter(
  * Observes the exporter result callback, which runs only after the OTLP
  * transport has exhausted dependency-owned retries.
  */
-export function observeOtlpExporterHealth<TExporter extends object>(
+export function observeOtlpExporterHealth<TExporter extends ObservableOtlpExporter>(
   exporter: TExporter,
   params: {
     emitExporterEvent: (event: ExporterHealthUpdate) => void;
     signal: ExporterHealthUpdate["signal"];
   },
 ): TExporter {
-  const observed = exporter as unknown as ObservableOtlpExporter;
+  const observed = exporter;
   const exportItems = observed.export.bind(observed);
   const shutdown = observed.shutdown.bind(observed);
 

--- a/extensions/discord/src/actions/runtime.messaging.messages.ts
+++ b/extensions/discord/src/actions/runtime.messaging.messages.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 // Discord plugin module implements runtime.messaging.messages behavior.
 import {
   jsonResult,
@@ -208,9 +209,8 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
               inferChannelId,
               ctx.withOpts(),
             );
-            if (channelInfo && typeof channelInfo === "object") {
-              const record = channelInfo as unknown as Record<string, unknown>;
-              const resolved = record.guild_id ?? record.guildId;
+            if (isRecord(channelInfo)) {
+              const resolved = channelInfo.guild_id ?? channelInfo.guildId;
               if (typeof resolved === "string" && resolved.trim()) {
                 guildId = resolved.trim();
               }

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -70,19 +70,8 @@ async function runFfmpegToOutput(params: {
 function createRateLimitError(
   response: Response,
   body: { message: string; retry_after: number; global: boolean },
-  request?: Request,
 ): RateLimitError {
-  const fallbackRequest =
-    request ??
-    new Request("https://discord.com/api/v10/channels/voice/messages", {
-      method: "POST",
-    });
-  const RateLimitErrorCtor = RateLimitError as unknown as new (
-    response: Response,
-    body: { message: string; retry_after: number; global: boolean },
-    request?: Request,
-  ) => RateLimitError;
-  return new RateLimitErrorCtor(response, body, fallbackRequest);
+  return new RateLimitError(response, body);
 }
 
 type VoiceMessageMetadata = {

--- a/extensions/file-transfer/src/shared/policy.ts
+++ b/extensions/file-transfer/src/shared/policy.ts
@@ -356,8 +356,7 @@ export async function persistAllowAlways(input: {
     mutate: (draft) => {
       // Plugin config is intentionally plugin-owned; the root OpenClawConfig
       // type only guarantees `Record<string, unknown>` here.
-      const root = draft as unknown as Record<string, unknown>;
-      const plugins = (root.plugins ??= {}) as Record<string, unknown>;
+      const plugins = (draft.plugins ??= {}) as Record<string, unknown>;
       const entries = (plugins.entries ??= {}) as Record<string, unknown>;
       const pluginEntry = (entries["file-transfer"] ??= {}) as Record<string, unknown>;
       const pluginConfig = (pluginEntry.config ??= {}) as Record<string, unknown>;

--- a/extensions/firecrawl/src/firecrawl-fetch-provider-shared.ts
+++ b/extensions/firecrawl/src/firecrawl-fetch-provider-shared.ts
@@ -58,10 +58,10 @@ export const FIRECRAWL_WEB_FETCH_PROVIDER_SHARED = {
         };
   },
   setConfiguredCredentialValue: (configTarget, value) => {
-    const plugins = ensureRecord(configTarget as unknown as Record<string, unknown>, "plugins");
-    const entries = ensureRecord(plugins, "entries");
-    const firecrawlEntry = ensureRecord(entries, "firecrawl");
-    const pluginConfig = ensureRecord(firecrawlEntry, "config");
+    const plugins = (configTarget.plugins ??= {});
+    const entries = (plugins.entries ??= {});
+    const firecrawlEntry = (entries.firecrawl ??= {});
+    const pluginConfig = (firecrawlEntry.config ??= {});
     const webFetch = ensureRecord(pluginConfig, "webFetch");
     webFetch.apiKey = value;
   },

--- a/extensions/groq/index.ts
+++ b/extensions/groq/index.ts
@@ -80,7 +80,6 @@ function wrapGroqOversizedRequestRecovery(
     // retain the caller-visible throw semantics of the underlying transport.
     const initial = underlying(model, context, options);
     const output = createAssistantMessageEventStream();
-    const writable = output as unknown as { push(event: unknown): void; end(): void };
 
     void (async () => {
       try {
@@ -92,17 +91,17 @@ function wrapGroqOversizedRequestRecovery(
             retryWithoutTools = true;
             break;
           }
-          writable.push(event);
+          output.push(event);
           forwarded = true;
         }
         if (retryWithoutTools) {
           const fallback = await Promise.resolve(withoutTools(model, context, options));
           for await (const event of fallback) {
-            writable.push(event);
+            output.push(event);
           }
         }
       } catch (error) {
-        writable.push({
+        output.push({
           type: "error",
           reason: "error",
           error: {
@@ -125,7 +124,7 @@ function wrapGroqOversizedRequestRecovery(
           },
         });
       } finally {
-        writable.end();
+        output.end();
       }
     })();
 

--- a/extensions/imessage/src/message-resource-db.ts
+++ b/extensions/imessage/src/message-resource-db.ts
@@ -113,7 +113,7 @@ export function checkIMessageResourceBinding(params: {
   let db: import("node:sqlite").DatabaseSync | undefined;
   try {
     db = openNodeSqliteDatabase(dbPath, { readOnly: true });
-    const rows = db
+    const rows: IMessageChatRow[] = db
       .prepare(
         `SELECT cmj.chat_id AS chatId,
                 c.guid AS chatGuid,
@@ -123,7 +123,12 @@ export function checkIMessageResourceBinding(params: {
          JOIN chat c ON c.ROWID = cmj.chat_id
          WHERE m.guid = ?`,
       )
-      .all(messageGuid) as unknown as IMessageChatRow[];
+      .all(messageGuid)
+      .map((row) => ({
+        chatId: row.chatId,
+        chatGuid: row.chatGuid,
+        chatIdentifier: row.chatIdentifier,
+      }));
     const matched = rows.some(
       (row) =>
         (!hasChatId || row.chatId === chatId) &&

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
@@ -28,7 +28,7 @@ import {
 import { createRoomHistoryTracker, type HistoryEntry } from "./room-history.js";
 import { resolveMatrixInboundRoute } from "./route.js";
 import { logInboundDrop } from "./runtime-api.js";
-import type { MatrixRawEvent, RoomMessageEventContent } from "./types.js";
+import type { MatrixRawEvent } from "./types.js";
 
 export async function resolveMatrixIngressContent(config: {
   handler: MatrixHandlerRuntimeConfig;
@@ -372,7 +372,7 @@ export async function resolveMatrixIngressContent(config: {
     content = {
       msgtype: "m.text",
       body: pollSnapshot.text,
-    } as unknown as RoomMessageEventContent;
+    };
   }
 
   let media: {

--- a/extensions/matrix/src/matrix/sdk/verification-manager.ts
+++ b/extensions/matrix/src/matrix/sdk/verification-manager.ts
@@ -353,7 +353,7 @@ export class MatrixVerificationManager {
   }
 
   private ensureVerificationRequestTracked(session: MatrixVerificationSession): void {
-    const requestObj = session.request as unknown as object;
+    const requestObj = session.request;
     if (this.trackedVerificationRequests.has(requestObj)) {
       return;
     }
@@ -465,7 +465,7 @@ export class MatrixVerificationManager {
       session.reciprocateQrCallbacks = maybeReciprocateQr;
     }
 
-    const verifierObj = verifier as unknown as object;
+    const verifierObj = verifier;
     if (this.trackedVerificationVerifiers.has(verifierObj)) {
       this.ensureVerificationStarted(session);
       return;
@@ -577,9 +577,9 @@ export class MatrixVerificationManager {
 
   trackVerificationRequest(request: MatrixVerificationRequestLike): MatrixVerificationSummary {
     this.pruneVerificationSessions(Date.now());
-    const requestObj = request as unknown as object;
+    const requestObj = request;
     for (const existing of this.verificationSessions.values()) {
-      if ((existing.request as unknown as object) === requestObj) {
+      if (existing.request === requestObj) {
         this.touchVerificationSession(existing);
         return this.buildVerificationSummary(existing);
       }

--- a/extensions/msteams/src/monitor-handler/inbound-facts.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-facts.ts
@@ -57,8 +57,8 @@ export async function prepareMSTeamsDebounceEntry(params: {
   turnAdoptionLifecycle?: MSTeamsIngressLifecycle;
 }): Promise<MSTeamsDebounceEntry> {
   const activity = params.context.activity;
-  const attachments = Array.isArray(activity.attachments)
-    ? (activity.attachments as unknown as MSTeamsAttachmentLike[])
+  const attachments: MSTeamsAttachmentLike[] = Array.isArray(activity.attachments)
+    ? activity.attachments
     : [];
   const rawText = activity.text?.trim() ?? "";
   const htmlText = extractTextFromHtmlAttachments(attachments);

--- a/extensions/msteams/src/monitor-handler/reaction-handler.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.ts
@@ -24,12 +24,9 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
     const activity = context.activity;
 
     // Reactions are carried in reactionsAdded / reactionsRemoved on the activity.
-    const reactions: Array<{ type?: string }> =
-      direction === "added"
-        ? ((activity as unknown as { reactionsAdded?: Array<{ type?: string }> }).reactionsAdded ??
-          [])
-        : ((activity as unknown as { reactionsRemoved?: Array<{ type?: string }> })
-            .reactionsRemoved ?? []);
+    const rawReactions =
+      direction === "added" ? activity.reactionsAdded : activity.reactionsRemoved;
+    const reactions: Array<{ type?: string }> = Array.isArray(rawReactions) ? rawReactions : [];
 
     if (reactions.length === 0) {
       log.debug?.("reaction activity has no reactions; skipping");
@@ -65,9 +62,7 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
 
     // Resolve the agent route for this conversation/sender.
     // Extract teamId for team-scoped routing bindings (channel/group reactions).
-    const teamId = isDirectMessage
-      ? undefined
-      : (activity as unknown as { channelData?: { team?: { id?: string } } }).channelData?.team?.id;
+    const teamId = isDirectMessage ? undefined : activity.channelData?.team?.id;
     const route = core.channel.routing.resolveAgentRoute({
       cfg,
       channel: "msteams",
@@ -79,7 +74,7 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
     });
 
     // The replyToId points to the message that was reacted to.
-    const targetMessageId = (activity as unknown as { replyToId?: string }).replyToId ?? "unknown";
+    const targetMessageId = activity.replyToId ?? "unknown";
 
     for (const reaction of reactions) {
       const reactionType = reaction.type ?? "unknown";

--- a/extensions/ollama/src/config-compat.ts
+++ b/extensions/ollama/src/config-compat.ts
@@ -87,7 +87,7 @@ function migrateLegacyOllamaLocalConfig(config: OpenClawConfig): {
   changes: string[];
 } | null {
   const provider = config.models?.providers?.[OLLAMA_PROVIDER_ID];
-  if (!isLegacyOllamaLocalConfig(provider, config as unknown as Record<string, unknown>)) {
+  if (!isLegacyOllamaLocalConfig(provider, { ...config })) {
     return null;
   }
 

--- a/extensions/onepassword/src/tool.ts
+++ b/extensions/onepassword/src/tool.ts
@@ -35,7 +35,7 @@ const OnePasswordToolSchema = {
       description: "Internal. Injected by the gateway policy layer; never set this manually.",
     },
   },
-} as unknown as AnyAgentTool["parameters"];
+} satisfies AnyAgentTool["parameters"];
 
 function errorResult(error: unknown) {
   const code =

--- a/extensions/opencode/stream.ts
+++ b/extensions/opencode/stream.ts
@@ -4,6 +4,7 @@ import {
   streamSimple,
   type AssistantMessage,
   type AssistantMessageEvent,
+  type ToolCall,
 } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -140,7 +141,7 @@ function transformArguments(
 }
 
 function transformCall(
-  call: Record<string, unknown>,
+  call: Pick<ToolCall, "name" | "arguments"> | Record<string, unknown>,
   state: TransformState,
   toWire: boolean,
 ): void {
@@ -189,7 +190,7 @@ function restoreMessage(message: AssistantMessage, state: TransformState): Assis
   const restored = { ...message, content: message.content.map((block) => ({ ...block })) };
   for (const block of restored.content) {
     if (block.type === "toolCall") {
-      transformCall(block as unknown as Record<string, unknown>, state, false);
+      transformCall(block, state, false);
     }
   }
   return restored;
@@ -209,7 +210,7 @@ function restoreEvent(event: AssistantMessageEvent, state: TransformState): Assi
     }
   } else if (restored.type === "toolcall_end") {
     restored.toolCall = { ...restored.toolCall };
-    transformCall(restored.toolCall as unknown as Record<string, unknown>, state, false);
+    transformCall(restored.toolCall, state, false);
   } else if (restored.type === "done") {
     restored.message = restoreMessage(restored.message, state);
   } else if (restored.type === "error") {


### PR DESCRIPTION
## What Problem This Solves

A maintainer-requested static-analysis campaign found 185 chained type assertions in this assigned plugin lane. These assertions discard type evidence, obscure real owner contracts, and prevent clean enablement of the new rule across `extensions/*`.

## Why This Change Was Made

This removes the 57 sites that can be repaired without runtime behavior changes: preserving discriminants and literal structure, carrying typed objects through construction, narrowing dynamic values at existing boundaries, using the actual exporter capability constraint, and deleting stale Discord constructor compatibility. It also preserves the Codex binding normalizer's canonical no-op identity path after ClawSweeper identified an eager-clone regression. Sites that depend on SDK-private state, nominal duplicate dependencies, incomplete public contracts, or new runtime parsing are intentionally left for the rule-enablement or owner follow-up work below.

AI-assisted: yes. The final committed branch passed two independent Codex autoreview runs with no accepted/actionable findings.

## User Impact

No user-visible behavior changes. The affected plugin code keeps the same runtime values and flow while gaining stronger compile-time evidence. Production code shrinks by 25 lines.

## Evidence

- Baseline chained-assertion scan: 185 findings across 119 assigned files.
- Final chained-assertion scan: 128 findings, exactly matching the inventory below (57 fixed; 85 intentional; 43 deferred).
- Focused tests: 28 colocated test files across 8 Vitest shards, 537 tests passed.
- Follow-up Codex-focused reruns after lint cleanups: 15 passed, 72 passed, and 36 passed.
- ClawSweeper P3 follow-up: Codex session-binding identity test, 49 passed.
- `node scripts/check-changed.mjs`: passed the `extensions` and `extensionTests` lanes. Crabbox had no ready `ci-fast` provider, so the repository wrapper used its documented serialized local fallback.
- Exact-head CI run 31871454829: all relevant plugin/extension checks passed; unrelated `check-lint-core-4` failed on pre-existing `no-shadow` errors in `ui/src/test-helpers/control-ui-e2e.ts:2746` and `:2753`, reproduced unchanged on current `origin/main` (`d2be00e171f63`).
- `git diff --check`: passed.
- Production LOC: +138/-163 (net -25). Tests: +0/-0.
- Autoreview before commit: clean, no accepted/actionable findings.
- Autoreview on committed branch against `origin/main`: clean, no accepted/actionable findings.
- ClawSweeper rank-up moves: canonical binding identity restored; direct sibling Codex protocol/source verification cited below.
- Direct Codex contract inspection: sibling Codex `app-server-protocol/src/protocol/v2/thread_data.rs:256`, `item.rs:226`, `account.rs:282`, `turn.rs:407`, plus app-server emission/refresh paths in `bespoke_event_handling.rs:1287` and `external_auth.rs:67`.

### Intentional and deferred leftovers

- extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:196 — intentional — duplicate Anthropic SDK copies are nominally incompatible because of private fields.
- extensions/anthropic-vertex/stream-runtime.ts:44 — intentional — undici and DOM fetch return types come from distinct response type universes.
- extensions/browser/src/browser/bridge-server.ts:155 — deferred — Express registrar alignment is owned by the shared route contract outside this assigned file set.
- extensions/browser/src/browser/chrome-mcp-result.ts:87 — deferred — external data needs a full narrow parser; adding one here would alter runtime rejection semantics.
- extensions/browser/src/browser/pw-session-actions.ts:122 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/pw-session-actions.ts:98 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/pw-session.page-cdp.ts:39 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/pw-session.page-cdp.ts:57 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/pw-session.page-cdp.ts:96 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts:276 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts:368 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/pw-tools-core.state.ts:51 — intentional — Playwright/CDP overload and receiver typing is narrower than the runtime API.
- extensions/browser/src/browser/server-context.remote-tab-ops.harness.ts:170 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/browser/src/browser/server-context.remote-tab-ops.harness.ts:21 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/browser/src/browser/system-chrome-cookies.ts:289 — deferred — external data needs a full narrow parser; adding one here would alter runtime rejection semantics.
- extensions/browser/src/cli/browser-cli-actions-input/register.batch.ts:71 — deferred — external data needs a full narrow parser; adding one here would alter runtime rejection semantics.
- extensions/browser/src/server.ts:85 — deferred — Express registrar alignment is owned by the shared route contract outside this assigned file set.
- extensions/codex/src/app-server/codex-app-server.test-fixtures.ts:80 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/codex/src/app-server/event-projector-tool-transcript.ts:585 — deferred — emitted content intentionally exceeds the public AgentMessage content union; public surface cannot change in this lane.
- extensions/codex/src/app-server/event-projector-tool-transcript.ts:603 — deferred — emitted content intentionally exceeds the public AgentMessage content union; public surface cannot change in this lane.
- extensions/codex/src/app-server/run-attempt-resources.ts:63 — deferred — removing sentinel initialization requires a lifecycle-state refactor across attempt ownership.
- extensions/codex/src/app-server/run-attempt-resources.ts:64 — deferred — removing sentinel initialization requires a lifecycle-state refactor across attempt ownership.
- extensions/codex/src/app-server/run-attempt-resources.ts:66 — deferred — removing sentinel initialization requires a lifecycle-state refactor across attempt ownership.
- extensions/codex/src/app-server/run-attempt-runtime.ts:104 — deferred — supervised native model intentionally has unknown numeric limits that the public Model contract requires.
- extensions/codex/src/app-server/thread-lifecycle.test-fixtures.ts:106 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/copilot/harness.ts:316 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/copilot/src/attempt-execution.ts:360 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/copilot/src/attempt-execution.ts:378 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/copilot/src/attempt-execution.ts:383 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/copilot/src/attempt-transcript-journal.ts:43 — deferred — transcript metadata needs an honest local message extension type.
- extensions/copilot/src/byok-proxy.ts:144 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/copilot/src/isolated-completion.ts:252 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/copilot/src/runtime.ts:179 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/copilot/src/tool-bridge.ts:858 — intentional — Copilot SDK session/stream/tool types are nominal or version-skewed across package entrypoints.
- extensions/deepinfra/doctor-contract-api.ts:101 — deferred — raw config migration/patch shape needs an owning deep-partial or typed normalization contract.
- extensions/diagnostics-otel/src/service.ts:278 — intentional — trusted exporter health is a host-injected capability deliberately hidden from the public plugin context.
- extensions/diagnostics-prometheus/src/service.ts:1048 — intentional — trusted exporter health is a host-injected capability deliberately hidden from the public plugin context.
- extensions/discord/src/approval-native.ts:198 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/discord/src/components.modal.ts:22 — intentional — fallback constructor keeps partial test mocks loadable.
- extensions/discord/src/monitor/gateway-plugin.ts:272 — intentional — Discord gateway lifecycle accesses dependency-private mutable socket/client state.
- extensions/discord/src/monitor/gateway-plugin.ts:68 — intentional — Discord gateway lifecycle accesses dependency-private mutable socket/client state.
- extensions/discord/src/monitor/gateway-plugin.ts:72 — intentional — Discord gateway lifecycle accesses dependency-private mutable socket/client state.
- extensions/discord/src/monitor/message-handler.hydration.ts:45 — intentional — Discord message hydration reads dependency-private client/fallback fields.
- extensions/discord/src/monitor/message-handler.hydration.ts:64 — intentional — Discord message hydration reads dependency-private client/fallback fields.
- extensions/discord/src/monitor/provider.startup-log.ts:9 — intentional — startup diagnostics read a dependency-private reconnect counter.
- extensions/discord/src/monitor/thread-bindings.state.ts:389 — deferred — JSON round-trip persistence needs an owner validator without changing serialization semantics.
- extensions/discord/src/monitor/threading.starter.ts:64 — intentional — runtime isThread proof bridges the SDK's incomplete structural thread type.
- extensions/feishu/src/monitor.test-mocks.ts:25 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/github-copilot/index.ts:172 — deferred — raw config migration/patch shape needs an owning deep-partial or typed normalization contract.
- extensions/github-copilot/index.ts:184 — deferred — raw config migration/patch shape needs an owning deep-partial or typed normalization contract.
- extensions/google/realtime-voice-provider.ts:356 — intentional — Google Live preview fields and JSON Schema are accepted at runtime but absent/stale in SDK types.
- extensions/google/realtime-voice-provider.ts:904 — intentional — Google Live preview fields and JSON Schema are accepted at runtime but absent/stale in SDK types.
- extensions/google/transport-stream.ts:1666 — intentional — provider stream wrapper preserves a narrower generic return across SDK versions.
- extensions/googlechat/src/approval-native.ts:241 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/googlechat/src/google-auth.runtime.ts:279 — deferred — external data needs a full narrow parser; adding one here would alter runtime rejection semantics.
- extensions/imessage/src/approval-native.ts:103 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/line/src/outbound.ts:85 — intentional — LINE SDK tuple/message union cannot represent the dynamically assembled runtime batch.
- extensions/llm-task/index.ts:26 — deferred — factory parameter variance is owned by the public AnyAgentTool contract.
- extensions/longcat/doctor-contract-api.ts:94 — deferred — raw config migration/patch shape needs an owning deep-partial or typed normalization contract.
- extensions/matrix/src/approval-native.ts:255 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/matrix/src/matrix/actions/summary.ts:109 — deferred — external data needs a full narrow parser; adding one here would alter runtime rejection semantics.
- extensions/matrix/src/matrix/client/logging.ts:95 — intentional — Matrix SDK root logger exposes loglevel methods only at runtime.
- extensions/matrix/src/test-runtime.ts:131 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/microsoft-foundry/shared.ts:738 — deferred — raw config migration/patch shape needs an owning deep-partial or typed normalization contract.
- extensions/msteams/src/attachments/shared.ts:525 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members.
- extensions/msteams/src/sdk-proactive.ts:170 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members.
- extensions/msteams/src/sdk-proactive.ts:181 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members.
- extensions/msteams/src/sdk.ts:193 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members.
- extensions/msteams/src/sdk.ts:198 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members.
- extensions/msteams/src/sdk.ts:303 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members.
- extensions/msteams/src/sdk.ts:319 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members. (2 findings)
- extensions/msteams/src/sdk.ts:377 — intentional — Teams root/deep entrypoints and classes are nominally incompatible because of private SDK members. (2 findings)
- extensions/qa-lab/src/bus-server.ts:213 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/bus-server.ts:218 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/bus-server.ts:223 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/bus-server.ts:228 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/bus-server.ts:233 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/bus-server.ts:238 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/bus-server.ts:243 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/bus-server.ts:282 — deferred — HTTP body needs route-specific runtime parsing; adding it would change malformed-input behavior.
- extensions/qa-lab/src/harness-runtime.ts:31 — intentional — QA harness runtime/symbol metadata is intentionally structural and test-owned.
- extensions/qa-lab/src/suite-runtime-agent-session.ts:450 — intentional — QA harness runtime/symbol metadata is intentionally structural and test-owned.
- extensions/reef/protocol/envelope.ts:366 — deferred — persisted/wire record needs a complete owner parser; partial validation would change legacy behavior.
- extensions/reef/protocol/guard.ts:126 — deferred — persisted/wire record needs a complete owner parser; partial validation would change legacy behavior.
- extensions/reef/src/doctor-durable-state.ts:144 — deferred — persisted/wire record needs a complete owner parser; partial validation would change legacy behavior.
- extensions/reef/src/doctor-durable-state.ts:230 — deferred — persisted/wire record needs a complete owner parser; partial validation would change legacy behavior.
- extensions/signal/src/approval-native.ts:76 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/slack/src/approval-native.ts:172 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/slack/src/monitor/events/agent.ts:20 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/slack/src/monitor/events/assistant.ts:133 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/slack/src/monitor/events/messages.ts:396 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/slack/src/monitor/slash.ts:1065 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/slack/src/monitor/slash.ts:1144 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/slack/src/monitor/slash.ts:1150 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/slack/src/progress-blocks.ts:38 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/slack/src/streaming.ts:367 — intentional — Slack SDK event/task/stream internals are runtime-supported but missing or stale in published types.
- extensions/sms/src/channel.ts:457 — deferred — runtime adapter erasure needs an owning channel-runtime contract.
- extensions/synology-chat/src/channel.ts:386 — deferred — plugin construction needs an owning structural plugin type.
- extensions/synology-chat/src/test-http-utils.ts:13 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/synology-chat/src/test-http-utils.ts:56 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/telegram/src/approval-native.ts:130 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/telegram/src/client-fetch.ts:30 — intentional — grammy node-fetch and global DOM fetch use incompatible Response classes.
- extensions/telegram/src/client-fetch.ts:34 — intentional — grammy node-fetch and global DOM fetch use incompatible Response classes.
- extensions/telegram/src/doctor-contract.ts:354 — deferred — raw config migration/patch shape needs an owning deep-partial or typed normalization contract.
- extensions/telegram/src/fetch.ts:150 — intentional — Node DNS/undici overloads differ from the unified fetch/lookup runtime contract.
- extensions/telegram/src/fetch.ts:578 — intentional — Node DNS/undici overloads differ from the unified fetch/lookup runtime contract.
- extensions/telegram/src/outbound-media.ts:151 — intentional — Telegram method/message unions are selected and checked dynamically at runtime.
- extensions/telegram/src/telegram-ingress-supersede-auth.ts:69 — intentional — Telegram method/message unions are selected and checked dynamically at runtime.
- extensions/tlon/src/urbit/story.ts:119 — deferred — synthetic inline metadata needs an explicit local discriminated union.
- extensions/tlon/src/urbit/story.ts:234 — deferred — synthetic inline metadata needs an explicit local discriminated union.
- extensions/twitch/src/test-fixtures.ts:12 — intentional — test/harness fake supplies only the runtime members exercised by the fixture.
- extensions/voice-call/src/webhook.ts:317 — deferred — partial/full config alignment needs an owning config contract.
- extensions/whatsapp/src/approval-native.ts:75 — intentional — lazy approval adapter erases invariant generic payload types at the core boundary.
- extensions/whatsapp/src/inbound/group-metadata-cache.ts:241 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/whatsapp/src/inbound/group-metadata-cache.ts:248 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/whatsapp/src/inbound/group-metadata-cache.ts:260 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/whatsapp/src/inbound/message-delivery.ts:683 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/whatsapp/src/inbound/socket-session.ts:415 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/whatsapp/src/inbound/socket-session.ts:450 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/whatsapp/src/session.ts:421 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/whatsapp/src/session.ts:533 — intentional — Baileys event emitter/websocket callback overloads are narrower than the runtime hooks.
- extensions/workboard/src/store-core.ts:91 — deferred — one physical fallback store multiplexes typed namespaces; repair needs persistence-owner redesign.
- extensions/workboard/src/store-core.ts:95 — deferred — one physical fallback store multiplexes typed namespaces; repair needs persistence-owner redesign.
- extensions/workboard/src/store-core.ts:97 — deferred — one physical fallback store multiplexes typed namespaces; repair needs persistence-owner redesign.
- extensions/zalo/src/webhook-spool.ts:112 — deferred — external data needs a full narrow parser; adding one here would alter runtime rejection semantics.
- extensions/zalouser/src/zca-client.ts:12 — intentional — dynamic zca-js module namespace differs across published module formats.
