### PR TITLE
fix(release): avoid npm publish timeout on prior beta selector

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -1200,11 +1200,7 @@ jobs:
           fi
           current_selector_version="$(npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version)"
           current_selector_ref="v${current_selector_version}"
-          if ! git rev-parse --verify "${current_selector_ref}^{commit}" >/dev/null 2>&1; then
-            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin \
-              "refs/tags/${current_selector_ref}:refs/tags/${current_selector_ref}"
-          fi
-          current_selector_sha="$(git rev-parse "${current_selector_ref}^{commit}")"
+          current_selector_sha="$(git -C trusted-workflow rev-parse --verify "refs/tags/${current_selector_ref}^{commit}")"
           node trusted-workflow/scripts/plugin-sdk-api-release-evidence.mjs \
             --manifest "$MANIFEST_FILE" \
             --head "$EXPECTED_RELEASE_SHA" \

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -119,6 +119,10 @@ describe("minimal npm extended-stable workflow", () => {
       parsed.jobs?.preflight_openclaw_npm,
       "Checkout trusted Plugin SDK API tooling",
     );
+    const publishProvenanceRun = publishProvenance.run;
+    if (!publishProvenanceRun) {
+      throw new Error("Verify prepared tarball provenance is missing its run script");
+    }
 
     expect(input).toEqual({
       default: "",
@@ -141,28 +145,28 @@ describe("minimal npm extended-stable workflow", () => {
     expect(preflightDiff.run).toContain('git -C "$tooling_dir" status --porcelain');
     expect(preflightDiff.run).not.toContain('pkg.scripts?.["plugin-sdk:api:diff"]');
     expect(preflightDiff.run).toContain('pnpm --dir "$tooling_dir" run plugin-sdk:api:diff');
-    expect(publishProvenance.run).toContain("plugin-sdk-api-release-evidence.mjs");
-    expect(publishProvenance.run).toContain('--acknowledge "$PLUGIN_SDK_API_ACKNOWLEDGEMENT"');
-    expect(publishProvenance.run).toContain('npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version');
-    expect(publishProvenance.run).toContain(
+    expect(publishProvenanceRun).toContain("plugin-sdk-api-release-evidence.mjs");
+    expect(publishProvenanceRun).toContain('--acknowledge "$PLUGIN_SDK_API_ACKNOWLEDGEMENT"');
+    expect(publishProvenanceRun).toContain('npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version');
+    expect(publishProvenanceRun).toContain(
       'git -C trusted-workflow rev-parse --verify "refs/tags/${current_selector_ref}^{commit}"',
     );
-    expect(publishProvenance.run).not.toContain("git fetch");
-    expect(publishProvenance.run).toContain('--current-selector-ref "$current_selector_ref"');
-    expect(publishProvenance.run).toContain('--current-selector-sha "$current_selector_sha"');
-    expect(publishProvenance.run).toContain('--workflow-sha "$PREFLIGHT_WORKFLOW_SHA"');
+    expect(publishProvenanceRun).not.toContain("git fetch");
+    expect(publishProvenanceRun).toContain('--current-selector-ref "$current_selector_ref"');
+    expect(publishProvenanceRun).toContain('--current-selector-sha "$current_selector_sha"');
+    expect(publishProvenanceRun).toContain('--workflow-sha "$PREFLIGHT_WORKFLOW_SHA"');
     expect(downloadPreflight.run).toContain(
       '"plugin-sdk-api-release-diff-${PREFLIGHT_RUN_ID}-${PREFLIGHT_RUN_ATTEMPT}"',
     );
-    expect(publishProvenance.run).toContain(
+    expect(publishProvenanceRun).toContain(
       "Prepared Plugin SDK API evidence does not match its immutable artifact",
     );
     expect(
-      publishProvenance.run.indexOf(
+      publishProvenanceRun.indexOf(
         "Prepared Plugin SDK API evidence does not match its immutable artifact",
       ),
     ).toBeLessThan(
-      publishProvenance.run.indexOf('npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version'),
+      publishProvenanceRun.indexOf('npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version'),
     );
     expect(verifyPreflightRun.run).toContain(
       '"$preflight_head_branch" == "$EXPECTED_EXTENDED_STABLE_BRANCH"',

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -57,7 +57,7 @@ describe("minimal npm extended-stable workflow", () => {
     const gitFetchLines = source
       .split("\n")
       .filter((line) => /\bgit(?: -C "[^"]+")? fetch\b/u.test(line));
-    expect(gitFetchLines).toHaveLength(9);
+    expect(gitFetchLines).toHaveLength(8);
     expect(
       gitFetchLines.every((line) => line.includes("timeout --signal=TERM --kill-after=10s 120s")),
     ).toBe(true);
@@ -144,6 +144,10 @@ describe("minimal npm extended-stable workflow", () => {
     expect(publishProvenance.run).toContain("plugin-sdk-api-release-evidence.mjs");
     expect(publishProvenance.run).toContain('--acknowledge "$PLUGIN_SDK_API_ACKNOWLEDGEMENT"');
     expect(publishProvenance.run).toContain('npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version');
+    expect(publishProvenance.run).toContain(
+      'git -C trusted-workflow rev-parse --verify "refs/tags/${current_selector_ref}^{commit}"',
+    );
+    expect(publishProvenance.run).not.toContain("git fetch");
     expect(publishProvenance.run).toContain('--current-selector-ref "$current_selector_ref"');
     expect(publishProvenance.run).toContain('--current-selector-sha "$current_selector_sha"');
     expect(publishProvenance.run).toContain('--workflow-sha "$PREFLIGHT_WORKFLOW_SHA"');
@@ -152,6 +156,13 @@ describe("minimal npm extended-stable workflow", () => {
     );
     expect(publishProvenance.run).toContain(
       "Prepared Plugin SDK API evidence does not match its immutable artifact",
+    );
+    expect(
+      publishProvenance.run.indexOf(
+        "Prepared Plugin SDK API evidence does not match its immutable artifact",
+      ),
+    ).toBeLessThan(
+      publishProvenance.run.indexOf('npm view "openclaw@${RELEASE_NPM_DIST_TAG}" version'),
     );
     expect(verifyPreflightRun.run).toContain(
       '"$preflight_head_branch" == "$EXPECTED_EXTENDED_STABLE_BRANCH"',

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -2743,15 +2743,15 @@ async function captureControlUiE2eFailureDiagnosticsUnsafe(
         ),
       };
     });
-  } catch (error) {
-    captureErrors.push(`page.evaluate: ${String(error)}`);
+  } catch (evaluateError) {
+    captureErrors.push(`page.evaluate: ${String(evaluateError)}`);
   }
   let screenshotWritten = false;
   try {
     await page.screenshot({ fullPage: true, path: screenshotPath });
     screenshotWritten = true;
-  } catch (error) {
-    captureErrors.push(`page.screenshot: ${String(error)}`);
+  } catch (screenshotError) {
+    captureErrors.push(`page.screenshot: ${String(screenshotError)}`);
   }
   const report = {
     schemaVersion: 2,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where publishing a prepared beta release could time out while validating the current npm selector. During `v2026.8.1-beta.2`, the publish job's shallow release-tag checkout attempted to fetch `v2026.8.1-beta.1` and exhausted the 120-second fetch timeout, even though the trusted workflow checkout already contained all tags.

Incident evidence: https://github.com/openclaw/openclaw/actions/runs/31866304845/job/94967932650

## Why This Change Was Made

The publish-time npm selector recheck remains fail-closed, but its tag commit is now resolved from the existing trusted full-history checkout. This removes the redundant network fetch from the frozen release checkout while preserving the immutable manifest, release SHA, dist-tag, tarball digest, Plugin SDK evidence, acknowledgement, and trusted-workflow SHA checks.

Exact-head CI also exposed two merge-gate failures: this PR's new source-order assertion needed an explicit workflow-script type guard, and current `main` had two shadowed diagnostic catch bindings in the Control UI E2E helper. Both are repaired without changing runtime behavior.

## User Impact

Release operators can publish prepared beta candidates without a redundant prior-selector tag fetch blocking the core npm publish path. Candidate evidence and provenance enforcement are unchanged.

## Evidence

- Before fix: the focused regression failed with the selector still resolved from the release checkout; the observed workflow run exited 124 after 120 seconds fetching `v2026.8.1-beta.1`.
- `node scripts/run-vitest.mjs test/scripts/openclaw-npm-extended-stable-workflow.test.ts` — 14 passed.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/package-acceptance-workflow.test.ts` — 310 passed, 2 skipped.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile /tmp/openclaw-pr-124080-lead-test-root.tsbuildinfo` — passed.
- `node scripts/run-oxlint.mjs ui/src/test-helpers/control-ui-e2e.ts` — passed.
- `node scripts/check-changed.mjs --dry-run -- .github/workflows/openclaw-npm-release.yml test/scripts/openclaw-npm-extended-stable-workflow.test.ts` — lanes `testRoot, tooling`.
- `node_modules/.bin/oxfmt --check test/scripts/openclaw-npm-extended-stable-workflow.test.ts` — clean.
- `git diff --check` — clean.
- Codex autoreview (`--mode branch --base origin/main`) — no accepted/actionable findings.

AI-assisted: yes.
