### PR TITLE
fix: stop forked commands after Gateway timeouts

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -159,6 +159,8 @@ const rootEntries = [
   "src/state/openclaw-database-verify.worker.ts!",
   "src/agents/model-provider-auth.worker.ts!",
   "src/agents/prepared-model-catalog.worker.ts!",
+  // Spawned through computed sibling URLs by the service-child host and relay.
+  "src/process/supervisor/{service-child-relay,service-child-group-anchor}.ts!",
   // Loaded by URL from setup-inference-detection.ts; no static import edge exists.
   "src/system-agent/setup-inference-detection.worker.ts!",
   // Split runtime loaded through a path assembled in subagent-registry.ts.

--- a/package.json
+++ b/package.json
@@ -1907,7 +1907,7 @@
     "test:live:media:music": "node --import tsx test/e2e/qa-lab/media/hosted-media-provider-live.ts music",
     "test:live:media:video": "node --import tsx test/e2e/qa-lab/media/hosted-media-provider-live.ts video",
     "test:live:models-profiles": "node --import tsx scripts/test-live.mts -- src/agents/models.profiles.live.test.ts",
-    "test:macos:ci": "node --import tsx scripts/test-projects.mts src/daemon/launchd.test.ts src/daemon/runtime-paths.test.ts src/daemon/runtime-binary.test.ts src/gateway/worker-environments/workspace-rsync-path.test.ts src/infra/brew.test.ts src/infra/stable-node-path.test.ts test/scripts/vitest-process-group.test.ts test/scripts/package-mac-app.test.ts test/scripts/package-mac-dist.test.ts test/scripts/create-dmg.test.ts test/scripts/codesign-mac-app.test.ts test/scripts/notarize-mac-artifact.test.ts test/scripts/mac-elevation-host.test.ts",
+    "test:macos:ci": "node --import tsx scripts/test-projects.mts src/daemon/launchd.test.ts src/daemon/runtime-paths.test.ts src/daemon/runtime-binary.test.ts src/gateway/worker-environments/workspace-rsync-path.test.ts src/infra/brew.test.ts src/infra/stable-node-path.test.ts src/process/supervisor/adapters/child.service-lifecycle.test.ts test/scripts/vitest-process-group.test.ts test/scripts/package-mac-app.test.ts test/scripts/package-mac-dist.test.ts test/scripts/create-dmg.test.ts test/scripts/codesign-mac-app.test.ts test/scripts/notarize-mac-artifact.test.ts test/scripts/mac-elevation-host.test.ts",
     "test:max": "node --import tsx scripts/test-projects-max.mts",
     "test:parallels:linux": "bash scripts/e2e/parallels-linux-smoke.sh",
     "test:parallels:macos": "bash scripts/e2e/parallels-macos-smoke.sh",

--- a/src/process/decoded-output.ts
+++ b/src/process/decoded-output.ts
@@ -1,14 +1,7 @@
 import type { Readable } from "node:stream";
 import { createWindowsOutputDecoder } from "../infra/windows-encoding.js";
 
-/** Delivers process output without splitting encoded characters across chunks. */
-export function onDecodedOutput(
-  stream: Readable | null | undefined,
-  listener: (chunk: string) => void,
-): void {
-  if (!stream) {
-    return;
-  }
+export function onDecodedOutput(stream: Readable, listener: (chunk: string) => void): void {
   const decoder = createWindowsOutputDecoder();
   const emit = (text: string) => {
     if (text) {

--- a/src/process/decoded-output.ts
+++ b/src/process/decoded-output.ts
@@ -1,0 +1,29 @@
+import type { Readable } from "node:stream";
+import { createWindowsOutputDecoder } from "../infra/windows-encoding.js";
+
+/** Delivers process output without splitting encoded characters across chunks. */
+export function onDecodedOutput(
+  stream: Readable | null | undefined,
+  listener: (chunk: string) => void,
+): void {
+  if (!stream) {
+    return;
+  }
+  const decoder = createWindowsOutputDecoder();
+  const emit = (text: string) => {
+    if (text) {
+      listener(text);
+    }
+  };
+  let flushed = false;
+  const flush = () => {
+    if (flushed) {
+      return;
+    }
+    flushed = true;
+    emit(decoder.flush());
+  };
+  stream.on("data", (chunk: Buffer | string) => emit(decoder.decode(chunk)));
+  stream.once("end", flush);
+  stream.once("close", flush);
+}

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -193,6 +193,114 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
+  it("hard-cleans descendants that close lineage while the root exits during TERM grace", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const tempDir = tempDirs.make("openclaw-service-child-lineage-term-");
+    const descendantPath = path.join(tempDir, "descendant.cjs");
+    const rootPath = path.join(tempDir, "root.cjs");
+    await writeFile(
+      descendantPath,
+      `
+        const fs = require("node:fs");
+        process.on("SIGTERM", () => {
+          try { fs.closeSync(3); } catch {}
+        });
+        process.stdout.write("ready\\n");
+        setInterval(() => {}, 1000);
+      `,
+      "utf8",
+    );
+    await writeFile(
+      rootPath,
+      `
+        const { spawn } = require("node:child_process");
+        process.on("SIGTERM", () => process.exit(0));
+        const child = spawn(process.execPath, [${JSON.stringify(descendantPath)}], {
+          stdio: ["ignore", "pipe", "ignore", 3],
+        });
+        child.stdout.once("data", () => {
+          process.stdout.write(process.pid + " " + child.pid + "\\n");
+        });
+        setInterval(() => {}, 1000);
+      `,
+      "utf8",
+    );
+    const adapter = await createChildAdapter({
+      argv: [process.execPath, rootPath],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    await waitFor(() => /^\d+ \d+/u.test(output));
+    const [rootPid, descendantPid] = parsePidPair(output);
+    activePids.add(rootPid);
+    activePids.add(descendantPid);
+
+    adapter.kill("SIGTERM");
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+  });
+
+  it("preserves split UTF-8 sequences on service stdout and stderr", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const adapter = await createChildAdapter({
+      argv: [
+        process.execPath,
+        "-e",
+        `setTimeout(() => {
+          process.stdout.write(Buffer.from([0xf0, 0x9f]));
+          process.stderr.write(Buffer.from([0xf0, 0x9f]));
+          setTimeout(() => {
+            process.stdout.end(Buffer.from([0x98, 0x80]));
+            process.stderr.end(Buffer.from([0x98, 0x80]));
+          }, 50);
+        }, 100);`,
+      ],
+      stdinMode: "pipe-closed",
+    });
+    let stdout = "";
+    let stderr = "";
+    adapter.onStdout((chunk) => {
+      stdout += chunk;
+    });
+    adapter.onStderr((chunk) => {
+      stderr += chunk;
+    });
+
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    expect(stdout).toBe("😀");
+    expect(stderr).toBe("😀");
+  });
+
+  it("reports startup failure before secret-pipe failure without an unhandled rejection", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const unhandled: unknown[] = [];
+    const onUnhandled = (error: unknown) => {
+      unhandled.push(error);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await expect(
+        createChildAdapter({
+          argv: ["/definitely/not/a/real-command"],
+          stdinMode: "pipe-closed",
+          secretInput: {
+            fd: 3,
+            createData: () => Buffer.alloc(8 * 1024 * 1024, 120),
+          },
+        }),
+      ).rejects.toThrow("ENOENT");
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
   it("keeps stdin and the secret descriptor distinct from lifecycle channels", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const adapter = await createChildAdapter({

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -193,6 +193,110 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
+  it("self-cleans when lineage closes but a descendant retains output", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const tempDir = tempDirs.make("openclaw-service-child-natural-lineage-");
+    const descendantPath = path.join(tempDir, "descendant.cjs");
+    const rootPath = path.join(tempDir, "root.cjs");
+    await writeFile(
+      descendantPath,
+      `
+        const fs = require("node:fs");
+        fs.closeSync(3);
+        process.send("ready");
+        setInterval(() => {}, 1000);
+      `,
+      "utf8",
+    );
+    await writeFile(
+      rootPath,
+      `
+        const { spawn } = require("node:child_process");
+        const child = spawn(process.execPath, [${JSON.stringify(descendantPath)}], {
+          stdio: ["ignore", 1, 2, 3, "ipc"],
+        });
+        child.once("message", () => {
+          process.stdout.write(process.pid + " " + child.pid + "\\n", () => {
+            child.disconnect();
+            process.exit(0);
+          });
+        });
+      `,
+      "utf8",
+    );
+    const adapter = await createChildAdapter({
+      argv: [process.execPath, rootPath],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    await waitFor(() => /^\d+ \d+/u.test(output));
+    const [rootPid, descendantPid] = parsePidPair(output);
+    activePids.add(rootPid);
+    activePids.add(descendantPid);
+
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+  });
+
+  it("preserves the TERM grace for a delayed authentic root result", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const tempDir = tempDirs.make("openclaw-service-child-term-grace-");
+    const descendantPath = path.join(tempDir, "descendant.cjs");
+    const rootPath = path.join(tempDir, "root.cjs");
+    await writeFile(
+      descendantPath,
+      `
+        const fs = require("node:fs");
+        process.on("SIGTERM", () => {
+          fs.closeSync(3);
+          process.exit(0);
+        });
+        process.send("ready");
+        setInterval(() => {}, 1000);
+      `,
+      "utf8",
+    );
+    await writeFile(
+      rootPath,
+      `
+        const fs = require("node:fs");
+        const { spawn } = require("node:child_process");
+        const child = spawn(process.execPath, [${JSON.stringify(descendantPath)}], {
+          stdio: ["ignore", 1, 2, 3, "ipc"],
+        });
+        process.on("SIGTERM", () => {
+          fs.closeSync(3);
+          setTimeout(() => process.exit(0), 300);
+        });
+        child.once("message", () => {
+          process.stdout.write(process.pid + " " + child.pid + "\\n");
+          child.disconnect();
+        });
+        setInterval(() => {}, 1000);
+      `,
+      "utf8",
+    );
+    const adapter = await createChildAdapter({
+      argv: [process.execPath, rootPath],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    await waitFor(() => /^\d+ \d+/u.test(output));
+    const [rootPid, descendantPid] = parsePidPair(output);
+    activePids.add(rootPid);
+    activePids.add(descendantPid);
+
+    adapter.kill("SIGTERM");
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+  });
+
   it.each([
     { label: "after TERM grace", repeatKill: false },
     { label: "when repeated KILL arrives", repeatKill: true },

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -144,6 +144,34 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     expect(receivedBytes).toBe(outputBytes);
   });
 
+  it("retains output emitted before adapter listeners subscribe", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const adapter = await createChildAdapter({
+      argv: [
+        process.execPath,
+        "-e",
+        'process.stdout.write("early stdout"); process.stderr.write("early stderr");',
+      ],
+      stdinMode: "pipe-closed",
+    });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 100);
+    });
+
+    let stdout = "";
+    let stderr = "";
+    adapter.onStdout((chunk) => {
+      stdout += chunk;
+    });
+    adapter.onStderr((chunk) => {
+      stderr += chunk;
+    });
+
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    expect(stdout).toBe("early stdout");
+    expect(stderr).toBe("early stderr");
+  });
+
   it("preserves an exited root result when cleanup races forwarded output", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const outputBytes = 8 * 1024 * 1024;

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -193,7 +193,10 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
-  it("hard-cleans descendants that close lineage while the root exits during TERM grace", async () => {
+  it.each([
+    { label: "after TERM grace", repeatKill: false },
+    { label: "when repeated KILL arrives", repeatKill: true },
+  ])("hard-cleans output-holding descendants $label", async ({ repeatKill }) => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const tempDir = tempDirs.make("openclaw-service-child-lineage-term-");
     const descendantPath = path.join(tempDir, "descendant.cjs");
@@ -205,7 +208,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
         process.on("SIGTERM", () => {
           try { fs.closeSync(3); } catch {}
         });
-        process.stdout.write("ready\\n");
+        process.stdout.write(process.ppid + " " + process.pid + "\\n");
         setInterval(() => {}, 1000);
       `,
       "utf8",
@@ -215,11 +218,8 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       `
         const { spawn } = require("node:child_process");
         process.on("SIGTERM", () => process.exit(0));
-        const child = spawn(process.execPath, [${JSON.stringify(descendantPath)}], {
-          stdio: ["ignore", "pipe", "ignore", 3],
-        });
-        child.stdout.once("data", () => {
-          process.stdout.write(process.pid + " " + child.pid + "\\n");
+        spawn(process.execPath, [${JSON.stringify(descendantPath)}], {
+          stdio: ["ignore", 1, 2, 3],
         });
         setInterval(() => {}, 1000);
       `,
@@ -239,6 +239,12 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     activePids.add(descendantPid);
 
     adapter.kill("SIGTERM");
+    if (repeatKill) {
+      await waitFor(() => !isAlive(rootPid));
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(isAlive(descendantPid)).toBe(true);
+      adapter.kill("SIGKILL");
+    }
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -24,7 +24,9 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
     if (Date.now() >= deadline) {
       throw new Error("timed out waiting for process state");
     }
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
   }
 }
 
@@ -127,6 +129,47 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     await waitFor(() => !isAlive(descendantPid));
   });
 
+  it("flushes forwarded output before exposing the root result", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const outputBytes = 8 * 1024 * 1024;
+    const adapter = await createChildAdapter({
+      argv: [process.execPath, "-e", `process.stdout.write(Buffer.alloc(${outputBytes}, 120))`],
+      stdinMode: "pipe-closed",
+    });
+    let receivedBytes = 0;
+    adapter.onStdout((chunk) => {
+      receivedBytes += Buffer.byteLength(chunk);
+    });
+
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    expect(receivedBytes).toBe(outputBytes);
+  });
+
+  it("preserves an exited root result when cleanup races forwarded output", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const outputBytes = 8 * 1024 * 1024;
+    const adapter = await createChildAdapter({
+      argv: [
+        "/bin/sh",
+        "-c",
+        `${process.execPath} -e 'process.stdout.write(Buffer.alloc(${outputBytes}, 120))'; sleep 60 >/dev/null 2>&1 & exit 0`,
+      ],
+      stdinMode: "pipe-closed",
+    });
+    const rootPid = adapter.pid!;
+    activePids.add(rootPid);
+    let receivedBytes = 0;
+    adapter.onStdout((chunk) => {
+      receivedBytes += Buffer.byteLength(chunk);
+    });
+    await waitFor(() => !isAlive(rootPid));
+
+    adapter.kill("SIGTERM");
+
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    expect(receivedBytes).toBe(outputBytes);
+  });
+
   it("revalidates and escalates when the group ignores SIGTERM", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const adapter = await createChildAdapter({
@@ -195,6 +238,45 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
 
     await adapter.wait();
     await waitFor(() => !isAlive(rootPid));
+  });
+
+  it("defers an identity-loss rejection until the caller waits", async () => {
+    const tempDir = tempDirs.make("openclaw-service-child-identity-loss-");
+    const scriptPath = path.join(tempDir, "identity-loss.mts");
+    const childModuleUrl = new URL("./child.ts", import.meta.url).href;
+    await writeFile(
+      scriptPath,
+      `
+        process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+        const { createChildAdapter } = await import(${JSON.stringify(childModuleUrl)});
+        const adapter = await createChildAdapter({
+          argv: ["/bin/sh", "-c", "sleep 0.05; kill -KILL $PPID; sleep 0.05"],
+          stdinMode: "pipe-closed",
+        });
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        try {
+          await adapter.wait();
+          process.exit(2);
+        } catch {
+          process.exit(0);
+        }
+      `,
+      "utf8",
+    );
+    const host = spawn(process.execPath, ["--import", "tsx", scriptPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, OPENCLAW_SERVICE_MARKER: "openclaw" },
+    });
+    let stderr = "";
+    host.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      host.once("exit", resolve);
+    });
+
+    expect(exitCode, stderr).toBe(0);
   });
 
   it("fails closed when the service host exits", async () => {

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -30,6 +30,14 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
   }
 }
 
+function parsePidPair(output: string): [number, number] {
+  const match = /(\d+)\s+(\d+)/u.exec(output);
+  if (!match?.[1] || !match[2]) {
+    throw new Error(`expected PID pair in output: ${JSON.stringify(output)}`);
+  }
+  return [Number.parseInt(match[1], 10), Number.parseInt(match[2], 10)];
+}
+
 afterEach(async () => {
   delete process.env.OPENCLAW_SERVICE_MARKER;
   for (const pid of activePids) {
@@ -59,10 +67,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       output += chunk;
     });
     await waitFor(() => /^\d+ \d+/u.test(output));
-    const [rootPid, descendantPid] = output
-      .trim()
-      .split(/\s+/u)
-      .map((value) => Number.parseInt(value, 10));
+    const [rootPid, descendantPid] = parsePidPair(output);
     activePids.add(rootPid);
     activePids.add(descendantPid);
 
@@ -92,10 +97,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       noOutputTimeoutMs: timing.noOutputTimeoutMs,
     });
     const exit = await run.wait();
-    const [rootPid, descendantPid] = exit.stdout
-      .trim()
-      .split(/\s+/u)
-      .map((value) => Number.parseInt(value, 10));
+    const [rootPid, descendantPid] = parsePidPair(exit.stdout);
 
     expect(exit.reason).toBe(timing.reason);
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
@@ -118,10 +120,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     const startedAt = Date.now();
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
     const elapsed = Date.now() - startedAt;
-    const [, descendantPid] = output
-      .trim()
-      .split(/\s+/u)
-      .map((value) => Number.parseInt(value, 10));
+    const [, descendantPid] = parsePidPair(output);
     activePids.add(descendantPid);
 
     expect(elapsed).toBeLessThan(300);
@@ -185,10 +184,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       output += chunk;
     });
     await waitFor(() => /^\d+ \d+/u.test(output));
-    const [rootPid, descendantPid] = output
-      .trim()
-      .split(/\s+/u)
-      .map((value) => Number.parseInt(value, 10));
+    const [rootPid, descendantPid] = parsePidPair(output);
     activePids.add(rootPid);
     activePids.add(descendantPid);
 
@@ -317,10 +313,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       host.once("exit", resolve);
     });
     expect(exitCode, stderr).toBe(0);
-    const match = /PROBE (\d+) (\d+)/u.exec(stdout);
-    expect(match, stdout).not.toBeNull();
-    const rootPid = Number.parseInt(match![1], 10);
-    const descendantPid = Number.parseInt(match![2], 10);
+    const [rootPid, descendantPid] = parsePidPair(stdout);
     activePids.add(rootPid);
     activePids.add(descendantPid);
 

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -274,6 +274,42 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     expect(stderr).toBe("😀");
   });
 
+  it("flushes incomplete UTF-8 before exposing a root result with retained authority", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const descendantScript = "setTimeout(() => {}, 1500)";
+    const rootScript = `
+      const { spawn } = require("node:child_process");
+      const descendant = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], {
+        stdio: ["ignore", "ignore", "ignore", 3],
+      });
+      descendant.unref();
+      process.stderr.write(descendant.pid + "\\n");
+      process.stdout.write(Buffer.from([0x58, 0xe2, 0x82]), () => process.exit(0));
+    `;
+    let streamed = "";
+    const run = await createProcessSupervisor().spawn({
+      mode: "child",
+      argv: [process.execPath, "-e", rootScript],
+      stdinMode: "pipe-closed",
+      sessionId: "service-incomplete-utf8-test",
+      backendId: "service-incomplete-utf8-test",
+      onStdout: (chunk) => {
+        streamed += chunk;
+      },
+    });
+    const startedAt = Date.now();
+    const exit = await run.wait();
+    const elapsed = Date.now() - startedAt;
+    const descendantPid = Number.parseInt(exit.stderr.trim(), 10);
+    activePids.add(descendantPid);
+
+    expect(exit.stdout).toBe("X�");
+    expect(streamed).toBe("X�");
+    expect(elapsed).toBeLessThan(1_000);
+    expect(isAlive(descendantPid)).toBe(true);
+    await waitFor(() => !isAlive(descendantPid));
+  });
+
   it("reports startup failure before secret-pipe failure without an unhandled rejection", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const unhandled: unknown[] = [];

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -1,0 +1,247 @@
+import { spawn } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { createProcessSupervisor } from "../supervisor.js";
+import { createChildAdapter } from "./child.js";
+
+const activePids = new Set<number>();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("timed out waiting for process state");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+afterEach(async () => {
+  delete process.env.OPENCLAW_SERVICE_MARKER;
+  for (const pid of activePids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  }
+  await waitFor(() => [...activePids].every((pid) => !isAlive(pid))).catch(() => {});
+  activePids.clear();
+});
+
+describe.skipIf(process.platform === "win32")("service-managed child lifecycle", () => {
+  it("cancels the complete admitted command group before settling", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const adapter = await createChildAdapter({
+      argv: [
+        "/bin/sh",
+        "-c",
+        'sleep 60 >/dev/null 2>&1 & child=$!; printf "%s %s\\n" "$$" "$child"; wait',
+      ],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    await waitFor(() => /^\d+ \d+/u.test(output));
+    const [rootPid, descendantPid] = output
+      .trim()
+      .split(/\s+/u)
+      .map((value) => Number.parseInt(value, 10));
+    activePids.add(rootPid);
+    activePids.add(descendantPid);
+
+    adapter.kill("SIGTERM");
+    await adapter.wait();
+    await waitFor(() => !isAlive(rootPid));
+
+    expect(isAlive(descendantPid)).toBe(false);
+  });
+
+  it.each([
+    { reason: "overall-timeout" as const, timeoutMs: 100, noOutputTimeoutMs: undefined },
+    { reason: "no-output-timeout" as const, timeoutMs: undefined, noOutputTimeoutMs: 100 },
+  ])("removes the group before returning $reason", async (timing) => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const run = await createProcessSupervisor().spawn({
+      mode: "child",
+      argv: [
+        "/bin/sh",
+        "-c",
+        'sleep 60 >/dev/null 2>&1 & child=$!; printf "%s %s\\n" "$$" "$child"; wait',
+      ],
+      stdinMode: "pipe-closed",
+      sessionId: "service-lifecycle-test",
+      backendId: "service-lifecycle-test",
+      timeoutMs: timing.timeoutMs,
+      noOutputTimeoutMs: timing.noOutputTimeoutMs,
+    });
+    const exit = await run.wait();
+    const [rootPid, descendantPid] = exit.stdout
+      .trim()
+      .split(/\s+/u)
+      .map((value) => Number.parseInt(value, 10));
+
+    expect(exit.reason).toBe(timing.reason);
+    await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+  });
+
+  it("preserves root-result timing while retaining descendant cleanup ownership", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const adapter = await createChildAdapter({
+      argv: [
+        "/bin/sh",
+        "-c",
+        'sleep 0.4 >/dev/null 2>&1 & child=$!; printf "%s %s\\n" "$$" "$child"; exit 0',
+      ],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    const startedAt = Date.now();
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    const elapsed = Date.now() - startedAt;
+    const [, descendantPid] = output
+      .trim()
+      .split(/\s+/u)
+      .map((value) => Number.parseInt(value, 10));
+    activePids.add(descendantPid);
+
+    expect(elapsed).toBeLessThan(300);
+    expect(isAlive(descendantPid)).toBe(true);
+    await waitFor(() => !isAlive(descendantPid));
+  });
+
+  it("revalidates and escalates when the group ignores SIGTERM", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const adapter = await createChildAdapter({
+      argv: [
+        "/bin/sh",
+        "-c",
+        `trap '' TERM; /bin/sh -c 'trap "" TERM; sleep 60' >/dev/null 2>&1 & child=$!; printf "%s %s\\n" "$$" "$child"; wait`,
+      ],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    await waitFor(() => /^\d+ \d+/u.test(output));
+    const [rootPid, descendantPid] = output
+      .trim()
+      .split(/\s+/u)
+      .map((value) => Number.parseInt(value, 10));
+    activePids.add(rootPid);
+    activePids.add(descendantPid);
+
+    adapter.kill("SIGTERM");
+    await adapter.wait();
+    await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+  });
+
+  it("keeps stdin and the secret descriptor distinct from lifecycle channels", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const adapter = await createChildAdapter({
+      argv: [
+        "/bin/sh",
+        "-c",
+        'IFS= read -r secret <&3; IFS= read -r input; printf "%s:%s\\n" "${#secret}" "$input"',
+      ],
+      stdinMode: "pipe-open",
+      secretInput: {
+        fd: 3,
+        createData: () => Buffer.from("synthetic-secret\n", "utf8"),
+      },
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    adapter.stdin?.write("ordinary-input\n");
+    adapter.stdin?.end();
+
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    expect(output).toBe("16:ordinary-input\n");
+  });
+
+  it("fails closed when the command drops its lineage descriptor early", async () => {
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const adapter = await createChildAdapter({
+      argv: ["/bin/sh", "-c", `exec 3>&-; trap '' TERM; printf "%s\\n" "$$"; sleep 60`],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    await waitFor(() => /^\d+/u.test(output));
+    const rootPid = Number.parseInt(output, 10);
+    activePids.add(rootPid);
+
+    await adapter.wait();
+    await waitFor(() => !isAlive(rootPid));
+  });
+
+  it("fails closed when the service host exits", async () => {
+    const tempDir = tempDirs.make("openclaw-service-child-host-");
+    const scriptPath = path.join(tempDir, "host.mts");
+    const childModuleUrl = new URL("./child.ts", import.meta.url).href;
+    await writeFile(
+      scriptPath,
+      `
+        process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+        const { createChildAdapter } = await import(${JSON.stringify(childModuleUrl)});
+        const adapter = await createChildAdapter({
+          argv: ["/bin/sh", "-c", 'sleep 60 >/dev/null 2>&1 & child=$!; printf "%s %s\\\\n" "$$" "$child"; wait'],
+          stdinMode: "pipe-closed",
+        });
+        let output = "";
+        adapter.onStdout((chunk) => { output += chunk; });
+        while (!/^\\d+ \\d+/u.test(output)) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        process.stdout.write("PROBE " + output.trim() + "\\n", () => process.exit(0));
+      `,
+      "utf8",
+    );
+    const host = spawn(process.execPath, ["--import", "tsx", scriptPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, OPENCLAW_SERVICE_MARKER: "openclaw" },
+    });
+    let stdout = "";
+    let stderr = "";
+    host.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    host.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    const exitCode = await new Promise<number | null>((resolve) => {
+      host.once("exit", resolve);
+    });
+    expect(exitCode, stderr).toBe(0);
+    const match = /PROBE (\d+) (\d+)/u.exec(stdout);
+    expect(match, stdout).not.toBeNull();
+    const rootPid = Number.parseInt(match![1], 10);
+    const descendantPid = Number.parseInt(match![2], 10);
+    activePids.add(rootPid);
+    activePids.add(descendantPid);
+
+    await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+  });
+});

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -285,6 +285,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       await expect(
         createChildAdapter({
           argv: ["/definitely/not/a/real-command"],
+          exactEnv: true,
           stdinMode: "pipe-closed",
           secretInput: {
             fd: 3,

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -300,7 +300,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
           setTimeout(() => {
             fs.writeSync(1, "graceful stdout\\n");
             fs.writeSync(2, "graceful stderr\\n");
-            process.exit(0);
+            process.exit(23);
           }, 1500);
         });
         child.once("message", () => {
@@ -336,7 +336,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
 
     expect(exit).toMatchObject({
       reason: "manual-cancel",
-      exitCode: 0,
+      exitCode: 23,
       exitSignal: null,
     });
     expect(exit.stdout).toContain("graceful stdout\n");

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -241,7 +241,9 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     adapter.kill("SIGTERM");
     if (repeatKill) {
       await waitFor(() => !isAlive(rootPid));
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 200);
+      });
       expect(isAlive(descendantPid)).toBe(true);
       adapter.kill("SIGKILL");
     }

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -269,7 +269,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
-  it("preserves the TERM grace for a delayed authentic root result", async () => {
+  it("preserves the supervisor TERM grace for a delayed authentic root result", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const tempDir = tempDirs.make("openclaw-service-child-term-grace-");
     const descendantPath = path.join(tempDir, "descendant.cjs");
@@ -297,7 +297,11 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
         });
         process.on("SIGTERM", () => {
           fs.closeSync(3);
-          setTimeout(() => process.exit(0), 300);
+          setTimeout(() => {
+            fs.writeSync(1, "graceful stdout\\n");
+            fs.writeSync(2, "graceful stderr\\n");
+            process.exit(0);
+          }, 1500);
         });
         child.once("message", () => {
           process.stdout.write(process.pid + " " + child.pid + "\\n");
@@ -307,21 +311,38 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       `,
       "utf8",
     );
-    const adapter = await createChildAdapter({
+    let streamedStdout = "";
+    let streamedStderr = "";
+    const run = await createProcessSupervisor().spawn({
+      mode: "child",
       argv: [process.execPath, rootPath],
       stdinMode: "pipe-closed",
+      sessionId: "service-term-grace-test",
+      backendId: "service-term-grace-test",
+      onStdout: (chunk) => {
+        streamedStdout += chunk;
+      },
+      onStderr: (chunk) => {
+        streamedStderr += chunk;
+      },
     });
-    let output = "";
-    adapter.onStdout((chunk) => {
-      output += chunk;
-    });
-    await waitFor(() => /^\d+ \d+/u.test(output));
-    const [rootPid, descendantPid] = parsePidPair(output);
+    await waitFor(() => /^\d+ \d+/u.test(streamedStdout));
+    const [rootPid, descendantPid] = parsePidPair(streamedStdout);
     activePids.add(rootPid);
     activePids.add(descendantPid);
 
-    adapter.kill("SIGTERM");
-    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    run.cancel();
+    const exit = await run.wait();
+
+    expect(exit).toMatchObject({
+      reason: "manual-cancel",
+      exitCode: 0,
+      exitSignal: null,
+    });
+    expect(exit.stdout).toContain("graceful stdout\n");
+    expect(exit.stderr).toBe("graceful stderr\n");
+    expect(streamedStdout).toContain("graceful stdout\n");
+    expect(streamedStderr).toBe("graceful stderr\n");
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -399,6 +399,7 @@ describe("createChildAdapter", () => {
     try {
       await createChildAdapter({
         argv: ["node", "-e", "setTimeout(() => {}, 1000)"],
+        exactEnv: true,
         stdinMode: "pipe-open",
       });
       expect(createServiceChildRelayAdapterMock).toHaveBeenCalledWith(

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -13,20 +13,24 @@ import {
   mockLinuxOomWrapperShell,
 } from "./test-support.js";
 
-const { spawnWithFallbackMock, signalProcessTreeMock, createWindowsOutputDecoderMock } = vi.hoisted(
-  () => ({
-    spawnWithFallbackMock: vi.fn(),
-    signalProcessTreeMock: vi.fn(
-      (_pid: number, _signal: string, opts?: { onComplete?: () => void }) => {
-        opts?.onComplete?.();
-      },
-    ),
-    createWindowsOutputDecoderMock: vi.fn(() => ({
-      decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
-      flush: () => "",
-    })),
-  }),
-);
+const {
+  spawnWithFallbackMock,
+  signalProcessTreeMock,
+  createWindowsOutputDecoderMock,
+  createServiceChildRelayAdapterMock,
+} = vi.hoisted(() => ({
+  spawnWithFallbackMock: vi.fn(),
+  signalProcessTreeMock: vi.fn(
+    (_pid: number, _signal: string, opts?: { onComplete?: () => void }) => {
+      opts?.onComplete?.();
+    },
+  ),
+  createWindowsOutputDecoderMock: vi.fn(() => ({
+    decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
+    flush: () => "",
+  })),
+  createServiceChildRelayAdapterMock: vi.fn(),
+}));
 
 vi.mock("../../spawn-utils.js", () => ({
   spawnWithFallback: spawnWithFallbackMock,
@@ -38,6 +42,10 @@ vi.mock("../../kill-tree.js", () => ({
 
 vi.mock("../../../infra/windows-encoding.js", () => ({
   createWindowsOutputDecoder: createWindowsOutputDecoderMock,
+}));
+
+vi.mock("../service-child-relay-host.js", () => ({
+  createServiceChildRelayAdapter: createServiceChildRelayAdapterMock,
 }));
 
 let createChildAdapter: typeof import("./child.js").createChildAdapter;
@@ -167,11 +175,20 @@ describe("createChildAdapter", () => {
     ({ createChildAdapter } = await import("./child.js"));
     spawnWithFallbackMock.mockClear();
     signalProcessTreeMock.mockClear();
+    createServiceChildRelayAdapterMock.mockClear();
     createWindowsOutputDecoderMock.mockClear();
     createWindowsOutputDecoderMock.mockImplementation(() => ({
       decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
       flush: () => "",
     }));
+    createServiceChildRelayAdapterMock.mockResolvedValue({
+      pid: 9999,
+      onStdout: vi.fn(),
+      onStderr: vi.fn(),
+      wait: vi.fn(),
+      kill: vi.fn(),
+      dispose: vi.fn(),
+    });
     delete process.env.OPENCLAW_SERVICE_MARKER;
     vi.useRealTimers();
   });
@@ -377,18 +394,22 @@ describe("createChildAdapter", () => {
     expect(killMock).toHaveBeenCalledWith("SIGKILL");
   });
 
-  it("passes detached:false in service-managed mode where useDetached is false from the start (#71662)", async () => {
+  it("selects the exact service relay instead of direct shared-group signaling", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "1";
     try {
-      const { adapter, killMock } = await createAdapterHarness({ pid: 9999 });
-      adapter.kill();
-      await Promise.resolve();
-      expect(signalProcessTreeMock).toHaveBeenCalledWith(
-        9999,
-        "SIGKILL",
-        expect.objectContaining({ detached: false }),
+      await createChildAdapter({
+        argv: ["node", "-e", "setTimeout(() => {}, 1000)"],
+        stdinMode: "pipe-open",
+      });
+      expect(createServiceChildRelayAdapterMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "node",
+          args: ["-e", "setTimeout(() => {}, 1000)"],
+          stdinMode: "pipe-open",
+        }),
       );
-      expect(killMock).toHaveBeenCalledWith("SIGKILL");
+      expect(spawnWithFallbackMock).not.toHaveBeenCalled();
+      expect(signalProcessTreeMock).not.toHaveBeenCalled();
     } finally {
       delete process.env.OPENCLAW_SERVICE_MARKER;
     }
@@ -689,7 +710,8 @@ describe("createChildAdapter", () => {
     await expect(waitPromise).resolves.toEqual({ code: 0, signal: null });
   });
 
-  it("disables detached mode in service-managed runtime", async () => {
+  it("keeps the service relay out of Windows child mode", async () => {
+    setPlatform("win32");
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
 
     await createAdapterHarness({ pid: 7777 });
@@ -697,6 +719,7 @@ describe("createChildAdapter", () => {
     const spawnArgs = firstSpawnWithFallbackParams();
     expect(spawnArgs.options?.detached).toBe(false);
     expect(spawnArgs.fallbacks ?? []).toStrictEqual([]);
+    expect(createServiceChildRelayAdapterMock).not.toHaveBeenCalled();
   });
 
   it("keeps inherited env when no override env is provided on non-Linux", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,11 +1,11 @@
 // Child process adapter wraps spawned child processes for the supervisor.
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
 import { toErrorObject } from "../../../infra/errors.js";
-import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import {
   resolveWindowsExecutablePath,
   resolveWindowsSpawnProgramCandidate,
 } from "../../../plugin-sdk/windows-spawn.js";
+import { onDecodedOutput } from "../../decoded-output.js";
 import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import {
@@ -261,51 +261,9 @@ export async function createChildAdapter(params: {
       }
     : undefined;
 
-  const onStdout = (listener: (chunk: string) => void) => {
-    const stdoutDecoder = createWindowsOutputDecoder();
-    let flushed = false;
-    const flush = () => {
-      if (flushed) {
-        return;
-      }
-      flushed = true;
-      const tail = stdoutDecoder.flush();
-      if (tail) {
-        listener(tail);
-      }
-    };
-    child.stdout.on("data", (chunk) => {
-      const text = stdoutDecoder.decode(chunk);
-      if (text) {
-        listener(text);
-      }
-    });
-    child.stdout.once("end", flush);
-    child.stdout.once("close", flush);
-  };
+  const onStdout = (listener: (chunk: string) => void) => onDecodedOutput(child.stdout, listener);
 
-  const onStderr = (listener: (chunk: string) => void) => {
-    const stderrDecoder = createWindowsOutputDecoder();
-    let flushed = false;
-    const flush = () => {
-      if (flushed) {
-        return;
-      }
-      flushed = true;
-      const tail = stderrDecoder.flush();
-      if (tail) {
-        listener(tail);
-      }
-    };
-    child.stderr.on("data", (chunk) => {
-      const text = stderrDecoder.decode(chunk);
-      if (text) {
-        listener(text);
-      }
-    });
-    child.stderr.once("end", flush);
-    child.stderr.once("close", flush);
-  };
+  const onStderr = (listener: (chunk: string) => void) => onDecodedOutput(child.stderr, listener);
 
   let waitResult: { code: number | null; signal: NodeJS.Signals | null } | null = null;
   let waitError: unknown;

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -20,6 +20,7 @@ import {
   resolveTrustedWindowsCmdExe,
   resolveWindowsCommandShim,
 } from "../../windows-command.js";
+import { createServiceChildRelayAdapter } from "../service-child-relay-host.js";
 import type { ManagedRunStdin, SpawnProcessAdapter, SpawnSecretInput } from "../types.js";
 import { toStringEnv } from "./env.js";
 
@@ -107,6 +108,23 @@ export async function createChildAdapter(params: {
     : prepareOomScoreAdjustedSpawn(invocation.command, invocation.args, { env: baseEnv });
 
   const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : "inherit");
+
+  if (
+    process.platform !== "win32" &&
+    params.ownedWorker === undefined &&
+    isServiceManagedRuntime()
+  ) {
+    return await createServiceChildRelayAdapter({
+      command: preparedSpawn.command,
+      args: preparedSpawn.args,
+      cwd: params.cwd,
+      env: preparedSpawn.env,
+      stdinMode,
+      input: params.input,
+      secretInput: params.secretInput,
+      oomScoreWrapperSelected: preparedSpawn.wrapped,
+    });
+  }
 
   // A detached POSIX child is still a descendant in the service cgroup/job, but
   // owns a process group that can be killed without touching the node host.

--- a/src/process/supervisor/cancellation-policy.ts
+++ b/src/process/supervisor/cancellation-policy.ts
@@ -1,0 +1,2 @@
+// Every adapter must preserve the same graceful-cancel window before escalation.
+export const GRACEFUL_CANCEL_TIMEOUT_MS = 5_000;

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -152,9 +152,9 @@ export function runServiceChildGroupAnchor(): void {
       if (state !== "closing" || cleanupClaim !== claim || !start) {
         return;
       }
-      await closeAuthority(reason, false);
-      return;
     }
+    // Lineage EOF records descriptor closure, not group extinction. Once cleanup owns the
+    // group, only the live in-group anchor may finish it after the TERM grace boundary.
     await closeAuthority(reason, true);
   };
 
@@ -322,18 +322,20 @@ export function runServiceChildGroupAnchor(): void {
         command.stdin.end();
       }
     }
-    command.once("error", async (error) => {
-      if (state === "starting") {
-        await send({ type: "startup-error", error: error.message });
-        await closeAuthority("lineage-lost", false);
-      }
+    command.once("error", (error) => {
+      void (async () => {
+        if (state === "starting") {
+          await send({ type: "startup-error", error: error.message });
+          await closeAuthority("lineage-lost", false);
+        }
+      })();
     });
-    command.once("spawn", async () => {
+    command.once("spawn", () => {
       if (!command?.pid || state !== "starting") {
         return;
       }
       state = "active";
-      await send({
+      void send({
         type: "ready",
         commandPid: command.pid,
         anchorPid: process.pid,

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -1,0 +1,309 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { Socket } from "node:net";
+import type { Readable } from "node:stream";
+import {
+  encodeServiceChildMessage,
+  type ServiceChildAnchorMessage,
+  type ServiceChildAnchorPayload,
+  type ServiceChildStart,
+} from "./service-child-protocol.js";
+
+const TERM_GRACE_MS = 1_000;
+
+type AnchorState = "starting" | "active" | "closing" | "closed";
+type StdioEntry = "ignore" | "inherit" | "pipe" | number;
+type ServiceChildHostMessage =
+  | ServiceChildStart
+  | {
+      type: "cancel";
+      generation: string;
+      sequence: number;
+      signal: "SIGTERM" | "SIGKILL";
+    };
+
+function commandStdio(start: ServiceChildStart): {
+  stdio: StdioEntry[];
+  lineageFd: number;
+} {
+  const stdio: StdioEntry[] = [start.stdinMode === "inherit" ? "inherit" : "pipe", "pipe", "pipe"];
+  if (start.secretFd !== undefined) {
+    while (stdio.length <= start.secretFd) {
+      stdio.push("ignore");
+    }
+    stdio[start.secretFd] = start.secretFd;
+  }
+  let lineageFd = 3;
+  while (stdio[lineageFd] !== undefined && stdio[lineageFd] !== "ignore") {
+    lineageFd += 1;
+  }
+  while (stdio.length <= lineageFd) {
+    stdio.push("ignore");
+  }
+  stdio[lineageFd] = "pipe";
+  return { stdio, lineageFd };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+export function runServiceChildGroupAnchor(): void {
+  let start: ServiceChildStart | undefined;
+  let state: AnchorState = "starting";
+  let sequence = 0;
+  let lastHostSequence = 0;
+  let command: ChildProcess | undefined;
+  let control: Socket | undefined;
+  let rootSettled = false;
+  let rootExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+  let stdoutDrained = false;
+  let stderrDrained = false;
+  let lineageClosed = false;
+  let cleanupClaim: symbol | undefined;
+  let forceCleanup = false;
+  let resolveLineage!: () => void;
+  const lineageDone = new Promise<void>((resolve) => {
+    resolveLineage = resolve;
+  });
+
+  const send = async (message: ServiceChildAnchorPayload) => {
+    if (!start || !control || control.destroyed) {
+      return;
+    }
+    sequence += 1;
+    await new Promise<void>((resolve, reject) => {
+      control!.write(
+        encodeServiceChildMessage({
+          ...message,
+          generation: start!.generation,
+          sequence,
+        } as ServiceChildAnchorMessage),
+        (error) => (error ? reject(error) : resolve()),
+      );
+    });
+  };
+
+  const closeAuthority = async (
+    reason: Extract<ServiceChildAnchorMessage, { type: "closing" }>["reason"],
+    hardKill: boolean,
+  ) => {
+    if (!start || state === "closed") {
+      return;
+    }
+    state = "closed";
+    await send({ type: "closing", reason });
+    if (hardKill) {
+      // The live anchor is the sole authority: PID/PGID never leave this process as a kill target.
+      process.kill(0, "SIGKILL");
+      return;
+    }
+    control?.end(() => process.exit(0));
+  };
+
+  const requestCleanup = async (
+    reason: "cancel" | "lineage-lost" | "parent-lost",
+    signal: "SIGTERM" | "SIGKILL" = "SIGTERM",
+  ) => {
+    if (!start || state === "closed") {
+      return;
+    }
+    if (state === "closing") {
+      forceCleanup ||= signal === "SIGKILL";
+      return;
+    }
+    state = "closing";
+    const claim = Symbol("service-child-cleanup");
+    cleanupClaim = claim;
+    forceCleanup = signal === "SIGKILL";
+    if (!forceCleanup) {
+      // The anchor catches its own signal while every command-group member receives it.
+      process.kill(0, "SIGTERM");
+      await Promise.race([lineageDone, delay(TERM_GRACE_MS)]);
+    }
+    if (state !== "closing" || cleanupClaim !== claim || !start) {
+      return;
+    }
+    if (lineageClosed && rootExit && !forceCleanup) {
+      await closeAuthority(reason, false);
+      return;
+    }
+    await closeAuthority(reason, true);
+  };
+
+  const onControlMessage = (message: ServiceChildHostMessage) => {
+    if (
+      !start ||
+      message.type !== "cancel" ||
+      message.generation !== start.generation ||
+      message.sequence <= lastHostSequence ||
+      state === "closed"
+    ) {
+      return;
+    }
+    lastHostSequence = message.sequence;
+    void requestCleanup("cancel", message.signal);
+  };
+
+  const startCommand = async (next: ServiceChildStart) => {
+    start = next;
+    control = new Socket({ fd: start.controlFd, readable: true, writable: true });
+    control.setEncoding("utf8");
+    let pending = "";
+    control.on("data", (chunk: string) => {
+      pending += chunk;
+      for (;;) {
+        const newline = pending.indexOf("\n");
+        if (newline < 0) {
+          break;
+        }
+        const line = pending.slice(0, newline);
+        pending = pending.slice(newline + 1);
+        try {
+          onControlMessage(JSON.parse(line) as ServiceChildHostMessage);
+        } catch {
+          void requestCleanup("parent-lost");
+        }
+      }
+    });
+    control.once("close", () => {
+      if (state !== "closed") {
+        void requestCleanup("parent-lost");
+      }
+    });
+    control.once("error", () => {
+      if (state !== "closed") {
+        void requestCleanup("parent-lost");
+      }
+    });
+
+    const { stdio, lineageFd } = commandStdio(start);
+    try {
+      command = spawn(start.command, start.args, {
+        cwd: start.cwd,
+        env: start.env,
+        stdio,
+        detached: false,
+        windowsHide: true,
+      });
+    } catch (error) {
+      await send({
+        type: "startup-error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await closeAuthority("lineage-lost", false);
+      return;
+    }
+    const lineage = command.stdio[lineageFd] as Readable | null;
+    if (!lineage) {
+      await send({ type: "startup-error", error: "command lineage pipe was not created" });
+      await requestCleanup("lineage-lost", "SIGKILL");
+      return;
+    }
+    const markLineageClosed = () => {
+      if (lineageClosed) {
+        return;
+      }
+      lineageClosed = true;
+      resolveLineage();
+      if (state === "active") {
+        // Pipe EOF and root exit can be delivered in either event-loop order.
+        // Give the authentic root result one turn before classifying EOF as an early lease loss.
+        setImmediate(() => {
+          if (state !== "active") {
+            return;
+          }
+          if (rootSettled) {
+            void closeAuthority("lineage-closed", false);
+          } else if (!rootExit) {
+            void requestCleanup("lineage-lost");
+          }
+        });
+      }
+    };
+    lineage.once("end", markLineageClosed);
+    lineage.once("close", markLineageClosed);
+    lineage.once("error", markLineageClosed);
+    command.stdout?.on("data", (chunk) => process.stdout.write(chunk));
+    command.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    command.stdout?.on("error", () => {});
+    command.stderr?.on("error", () => {});
+    const settleRoot = async () => {
+      if (rootSettled || !rootExit || !stdoutDrained || !stderrDrained) {
+        return;
+      }
+      rootSettled = true;
+      await send({ type: "root-result", code: rootExit.code, signal: rootExit.signal });
+      if (lineageClosed && state === "active") {
+        await closeAuthority("lineage-closed", false);
+      }
+    };
+    const markStdoutDrained = () => {
+      stdoutDrained = true;
+      void settleRoot();
+    };
+    const markStderrDrained = () => {
+      stderrDrained = true;
+      void settleRoot();
+    };
+    command.stdout?.once("end", markStdoutDrained);
+    command.stdout?.once("close", markStdoutDrained);
+    command.stderr?.once("end", markStderrDrained);
+    command.stderr?.once("close", markStderrDrained);
+    if (start.stdinMode !== "inherit" && command.stdin) {
+      process.stdin.pipe(command.stdin);
+      if (start.stdinMode === "pipe-closed" && process.stdin.readableEnded) {
+        command.stdin.end();
+      }
+    }
+    command.once("error", async (error) => {
+      if (state === "starting") {
+        await send({ type: "startup-error", error: error.message });
+        await closeAuthority("lineage-lost", false);
+      }
+    });
+    command.once("spawn", async () => {
+      if (!command?.pid || state !== "starting") {
+        return;
+      }
+      state = "active";
+      await send({
+        type: "ready",
+        commandPid: command.pid,
+        anchorPid: process.pid,
+      });
+    });
+    command.once("exit", (code, signal) => {
+      rootExit = { code, signal };
+      void settleRoot();
+    });
+  };
+
+  process.on("SIGTERM", () => {
+    if (state === "active") {
+      void requestCleanup("parent-lost");
+    }
+  });
+  process.on("SIGINT", () => {
+    if (state === "active") {
+      void requestCleanup("parent-lost");
+    }
+  });
+  process.once("disconnect", () => {
+    if (state !== "closed") {
+      void requestCleanup("parent-lost");
+    }
+  });
+  process.on("message", (raw: unknown) => {
+    const message = raw as ServiceChildStart | { type: "parent-loss"; generation?: string };
+    if (message.type === "start" && state === "starting") {
+      void startCommand(message);
+    } else if (message.type === "parent-loss" && message.generation === start?.generation) {
+      void requestCleanup("parent-lost");
+    }
+  });
+}
+
+runServiceChildGroupAnchor();

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -55,14 +55,15 @@ export function runServiceChildGroupAnchor(): void {
   let lastHostSequence = 0;
   let command: ChildProcess | undefined;
   let control: Socket | undefined;
-  let rootSettled = false;
   let rootSettlementStarted = false;
+  let rootResultDelivery: Promise<void> | undefined;
   let rootExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
   let stdoutDrained = false;
   let stderrDrained = false;
   let lineageClosed = false;
-  let cleanupClaim: symbol | undefined;
   let forceCleanup = false;
+  let resolveForceCleanup: () => void = () => {};
+  const forceCleanupRequested = new Promise<void>((resolve) => (resolveForceCleanup = resolve));
   let resolveLineage!: () => void;
   const lineageDone = new Promise<void>((resolve) => {
     resolveLineage = resolve;
@@ -131,32 +132,36 @@ export function runServiceChildGroupAnchor(): void {
     }
     if (state === "closing") {
       forceCleanup ||= signal === "SIGKILL";
+      if (forceCleanup) {
+        resolveForceCleanup();
+      }
       return;
     }
     state = "closing";
-    const claim = Symbol("service-child-cleanup");
-    cleanupClaim = claim;
     forceCleanup = signal === "SIGKILL";
+    const termGraceDone = delay(TERM_GRACE_MS);
     if (!forceCleanup) {
       // The anchor catches its own signal while every command-group member receives it.
       process.kill(0, "SIGTERM");
-      await Promise.race([lineageDone, delay(TERM_GRACE_MS)]);
+      await Promise.race([lineageDone, termGraceDone, forceCleanupRequested]);
     }
-    if (state !== "closing" || cleanupClaim !== claim || !start) {
+    if (state !== "closing" || !start) {
       return;
     }
     if (lineageClosed && !rootExit && !forceCleanup) {
       // A normal root exit may close the lineage fd before libuv reports the
       // child exit. Give that exact child event a bounded observation window;
       // a still-running root that closed lineage remains a lease violation.
-      await Promise.race([rootExited, delay(LINEAGE_EXIT_OBSERVATION_MS)]);
+      await Promise.race([rootExited, delay(LINEAGE_EXIT_OBSERVATION_MS), forceCleanupRequested]);
     }
-    if (state !== "closing" || cleanupClaim !== claim || !start) {
+    if (state !== "closing" || !start) {
       return;
     }
     if (lineageClosed && rootExit && !forceCleanup) {
-      await rootSettledDone;
-      if (state !== "closing" || cleanupClaim !== claim || !start) {
+      // Output can outlive lineage and the root. It may preserve the authentic root
+      // result only within the existing TERM grace, and KILL must wake this wait.
+      await Promise.race([rootSettledDone, termGraceDone, forceCleanupRequested]);
+      if (state !== "closing" || !start) {
         return;
       }
     }
@@ -255,7 +260,7 @@ export function runServiceChildGroupAnchor(): void {
           if (state !== "active") {
             return;
           }
-          if (rootExit && rootSettled) {
+          if (rootExit) {
             void closeAuthority("lineage-closed", false);
           } else {
             void requestCleanup("lineage-lost");
@@ -267,12 +272,11 @@ export function runServiceChildGroupAnchor(): void {
     lineage.once("close", markLineageClosed);
     lineage.once("error", markLineageClosed);
     const settleRoot = async () => {
-      if (rootSettlementStarted || !rootExit || !stdoutDrained || !stderrDrained) {
+      if (rootSettlementStarted || !rootResultDelivery || !stdoutDrained || !stderrDrained) {
         return;
       }
       rootSettlementStarted = true;
-      await send({ type: "root-result", code: rootExit.code, signal: rootExit.signal });
-      rootSettled = true;
+      await rootResultDelivery;
       resolveRootSettled();
       if (lineageClosed && state === "active") {
         await closeAuthority("lineage-closed", false);
@@ -312,6 +316,9 @@ export function runServiceChildGroupAnchor(): void {
     });
     command.once("exit", (code, signal) => {
       rootExit = { code, signal };
+      // The host gates public settlement on output EOF, so record the authentic root
+      // result before cleanup can hard-close an output-holding descendant.
+      rootResultDelivery = send({ type: "root-result", code, signal });
       resolveRootExited();
       void settleRoot();
     });

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -15,15 +15,10 @@ const LINEAGE_EXIT_OBSERVATION_MS = 100;
 
 type AnchorState = "starting" | "active" | "closing" | "closed";
 type StdioEntry = "ignore" | "inherit" | "pipe" | number;
-type ServiceChildHostMessage =
-  | ServiceChildStart
-  | {
-      type: "cancel";
-      generation: string;
-      sequence: number;
-      signal: "SIGTERM" | "SIGKILL";
-    };
-
+type ServiceChildControlMessage = {
+  generation: string;
+  sequence: number;
+} & ({ type: "cancel"; signal: "SIGTERM" | "SIGKILL" } | { type: "startup-error-ack" });
 function commandStdio(start: ServiceChildStart): {
   stdio: StdioEntry[];
   lineageFd: number;
@@ -80,6 +75,10 @@ export function runServiceChildGroupAnchor(): void {
   const rootSettledDone = new Promise<void>((resolve) => {
     resolveRootSettled = resolve;
   });
+  let resolveStartupErrorAck!: () => void;
+  const startupErrorAcknowledged = new Promise<void>((resolve) => {
+    resolveStartupErrorAck = resolve;
+  });
 
   const send = async (message: ServiceChildAnchorPayload) => {
     if (!start || !control || control.destroyed) {
@@ -113,6 +112,14 @@ export function runServiceChildGroupAnchor(): void {
       return;
     }
     control?.end(() => process.exit(0));
+  };
+
+  const reportStartupFailure = async (error: string) => {
+    await send({ type: "startup-error", error });
+    // A write callback only proves kernel acceptance. Keep the exact anchor alive until the
+    // host records the authoritative spawn failure and acknowledges it on this same channel.
+    await startupErrorAcknowledged;
+    await closeAuthority("lineage-lost", false);
   };
 
   const requestCleanup = async (
@@ -158,10 +165,9 @@ export function runServiceChildGroupAnchor(): void {
     await closeAuthority(reason, true);
   };
 
-  const onControlMessage = (message: ServiceChildHostMessage) => {
+  const onControlMessage = (message: ServiceChildControlMessage) => {
     if (
       !start ||
-      message.type !== "cancel" ||
       message.generation !== start.generation ||
       message.sequence <= lastHostSequence ||
       state === "closed"
@@ -169,6 +175,10 @@ export function runServiceChildGroupAnchor(): void {
       return;
     }
     lastHostSequence = message.sequence;
+    if (message.type === "startup-error-ack") {
+      resolveStartupErrorAck();
+      return;
+    }
     void requestCleanup("cancel", message.signal);
   };
 
@@ -187,7 +197,7 @@ export function runServiceChildGroupAnchor(): void {
         const line = pending.slice(0, newline);
         pending = pending.slice(newline + 1);
         try {
-          onControlMessage(JSON.parse(line) as ServiceChildHostMessage);
+          onControlMessage(JSON.parse(line) as ServiceChildControlMessage);
         } catch {
           void requestCleanup("parent-lost");
         }
@@ -214,11 +224,7 @@ export function runServiceChildGroupAnchor(): void {
         windowsHide: true,
       });
     } catch (error) {
-      await send({
-        type: "startup-error",
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await closeAuthority("lineage-lost", false);
+      await reportStartupFailure(error instanceof Error ? error.message : String(error));
       return;
     }
     const lineage = command.stdio[lineageFd] as Readable | null;
@@ -323,12 +329,9 @@ export function runServiceChildGroupAnchor(): void {
       }
     }
     command.once("error", (error) => {
-      void (async () => {
-        if (state === "starting") {
-          await send({ type: "startup-error", error: error.message });
-          await closeAuthority("lineage-lost", false);
-        }
-      })();
+      if (state === "starting") {
+        void reportStartupFailure(error.message);
+      }
     });
     command.once("spawn", () => {
       if (!command?.pid || state !== "starting") {

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -9,6 +9,7 @@ import {
 } from "./service-child-protocol.js";
 
 const TERM_GRACE_MS = 1_000;
+const LINEAGE_EXIT_OBSERVATION_MS = 100;
 
 type AnchorState = "starting" | "active" | "closing" | "closed";
 type StdioEntry = "ignore" | "inherit" | "pipe" | number;
@@ -58,6 +59,7 @@ export function runServiceChildGroupAnchor(): void {
   let command: ChildProcess | undefined;
   let control: Socket | undefined;
   let rootSettled = false;
+  let rootSettlementStarted = false;
   let rootExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
   let stdoutDrained = false;
   let stderrDrained = false;
@@ -68,20 +70,28 @@ export function runServiceChildGroupAnchor(): void {
   const lineageDone = new Promise<void>((resolve) => {
     resolveLineage = resolve;
   });
+  let resolveRootExited!: () => void;
+  const rootExited = new Promise<void>((resolve) => {
+    resolveRootExited = resolve;
+  });
+  let resolveRootSettled!: () => void;
+  const rootSettledDone = new Promise<void>((resolve) => {
+    resolveRootSettled = resolve;
+  });
 
   const send = async (message: ServiceChildAnchorPayload) => {
     if (!start || !control || control.destroyed) {
       return;
     }
     sequence += 1;
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve) => {
       control!.write(
         encodeServiceChildMessage({
           ...message,
           generation: start!.generation,
           sequence,
         } as ServiceChildAnchorMessage),
-        (error) => (error ? reject(error) : resolve()),
+        () => resolve(),
       );
     });
   };
@@ -126,7 +136,20 @@ export function runServiceChildGroupAnchor(): void {
     if (state !== "closing" || cleanupClaim !== claim || !start) {
       return;
     }
+    if (lineageClosed && !rootExit && !forceCleanup) {
+      // A normal root exit may close the lineage fd before libuv reports the
+      // child exit. Give that exact child event a bounded observation window;
+      // a still-running root that closed lineage remains a lease violation.
+      await Promise.race([rootExited, delay(LINEAGE_EXIT_OBSERVATION_MS)]);
+    }
+    if (state !== "closing" || cleanupClaim !== claim || !start) {
+      return;
+    }
     if (lineageClosed && rootExit && !forceCleanup) {
+      await rootSettledDone;
+      if (state !== "closing" || cleanupClaim !== claim || !start) {
+        return;
+      }
       await closeAuthority(reason, false);
       return;
     }
@@ -209,44 +232,83 @@ export function runServiceChildGroupAnchor(): void {
       lineageClosed = true;
       resolveLineage();
       if (state === "active") {
-        // Pipe EOF and root exit can be delivered in either event-loop order.
-        // Give the authentic root result one turn before classifying EOF as an early lease loss.
-        setImmediate(() => {
+        // Pipe EOF and the child exit notification race independently. Wait
+        // briefly for the exact child event before treating EOF as lease loss.
+        void (async () => {
+          if (!rootExit) {
+            await Promise.race([rootExited, delay(LINEAGE_EXIT_OBSERVATION_MS)]);
+          }
           if (state !== "active") {
             return;
           }
-          if (rootSettled) {
+          if (rootExit) {
+            await rootSettledDone;
+          }
+          if (state !== "active") {
+            return;
+          }
+          if (rootExit && rootSettled) {
             void closeAuthority("lineage-closed", false);
-          } else if (!rootExit) {
+          } else {
             void requestCleanup("lineage-lost");
           }
-        });
+        })();
       }
     };
     lineage.once("end", markLineageClosed);
     lineage.once("close", markLineageClosed);
     lineage.once("error", markLineageClosed);
-    command.stdout?.on("data", (chunk) => process.stdout.write(chunk));
-    command.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    let stdoutEnded = false;
+    let stderrEnded = false;
+    let pendingStdoutWrites = 0;
+    let pendingStderrWrites = 0;
+    const maybeMarkStdoutDrained = () => {
+      if (!stdoutDrained && stdoutEnded && pendingStdoutWrites === 0) {
+        stdoutDrained = true;
+        void settleRoot();
+      }
+    };
+    const maybeMarkStderrDrained = () => {
+      if (!stderrDrained && stderrEnded && pendingStderrWrites === 0) {
+        stderrDrained = true;
+        void settleRoot();
+      }
+    };
+    command.stdout?.on("data", (chunk) => {
+      pendingStdoutWrites += 1;
+      process.stdout.write(chunk, () => {
+        pendingStdoutWrites -= 1;
+        maybeMarkStdoutDrained();
+      });
+    });
+    command.stderr?.on("data", (chunk) => {
+      pendingStderrWrites += 1;
+      process.stderr.write(chunk, () => {
+        pendingStderrWrites -= 1;
+        maybeMarkStderrDrained();
+      });
+    });
     command.stdout?.on("error", () => {});
     command.stderr?.on("error", () => {});
     const settleRoot = async () => {
-      if (rootSettled || !rootExit || !stdoutDrained || !stderrDrained) {
+      if (rootSettlementStarted || !rootExit || !stdoutDrained || !stderrDrained) {
         return;
       }
-      rootSettled = true;
+      rootSettlementStarted = true;
       await send({ type: "root-result", code: rootExit.code, signal: rootExit.signal });
+      rootSettled = true;
+      resolveRootSettled();
       if (lineageClosed && state === "active") {
         await closeAuthority("lineage-closed", false);
       }
     };
     const markStdoutDrained = () => {
-      stdoutDrained = true;
-      void settleRoot();
+      stdoutEnded = true;
+      maybeMarkStdoutDrained();
     };
     const markStderrDrained = () => {
-      stderrDrained = true;
-      void settleRoot();
+      stderrEnded = true;
+      maybeMarkStderrDrained();
     };
     command.stdout?.once("end", markStdoutDrained);
     command.stdout?.once("close", markStdoutDrained);
@@ -277,6 +339,7 @@ export function runServiceChildGroupAnchor(): void {
     });
     command.once("exit", (code, signal) => {
       rootExit = { code, signal };
+      resolveRootExited();
       void settleRoot();
     });
   };

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -151,10 +151,9 @@ export function runServiceChildGroupAnchor(): void {
       return;
     }
     if (lineageClosed && !rootExit && !forceCleanup) {
-      // A normal root exit may close the lineage fd before libuv reports the
-      // child exit. Give that exact child event a bounded observation window;
-      // a still-running root that closed lineage remains a lease violation.
-      await Promise.race([rootExited, delay(LINEAGE_EXIT_OBSERVATION_MS), forceCleanupRequested]);
+      // Cleanup already owns the group. A normal root exit may race lineage EOF,
+      // but the short observation window must not replace the configured TERM grace.
+      await Promise.race([rootExited, termGraceDone, forceCleanupRequested]);
     }
     if (state !== "closing" || !start) {
       return;
@@ -256,17 +255,15 @@ export function runServiceChildGroupAnchor(): void {
           if (state !== "active") {
             return;
           }
-          if (rootExit) {
+          if (rootExit && rootSettlementStarted) {
             await rootSettledDone;
           }
           if (state !== "active") {
             return;
           }
-          if (rootExit) {
-            void closeAuthority("lineage-closed", false);
-          } else {
-            void requestCleanup("lineage-lost");
-          }
+          // Root settlement can only complete after output EOF. If lineage is gone
+          // while output remains owned by a descendant, cleanup must reclaim the group.
+          void requestCleanup("lineage-lost");
         })();
       }
     };

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -63,7 +63,9 @@ export function runServiceChildGroupAnchor(): void {
   let lineageClosed = false;
   let forceCleanup = false;
   let resolveForceCleanup: () => void = () => {};
-  const forceCleanupRequested = new Promise<void>((resolve) => (resolveForceCleanup = resolve));
+  const forceCleanupRequested = new Promise<void>((resolve) => {
+    resolveForceCleanup = resolve;
+  });
   let resolveLineage!: () => void;
   const lineageDone = new Promise<void>((resolve) => {
     resolveLineage = resolve;

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { Socket } from "node:net";
-import type { Readable } from "node:stream";
+import { pipeline, type Readable } from "node:stream";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorMessage,
@@ -266,38 +266,6 @@ export function runServiceChildGroupAnchor(): void {
     lineage.once("end", markLineageClosed);
     lineage.once("close", markLineageClosed);
     lineage.once("error", markLineageClosed);
-    let stdoutEnded = false;
-    let stderrEnded = false;
-    let pendingStdoutWrites = 0;
-    let pendingStderrWrites = 0;
-    const maybeMarkStdoutDrained = () => {
-      if (!stdoutDrained && stdoutEnded && pendingStdoutWrites === 0) {
-        stdoutDrained = true;
-        void settleRoot();
-      }
-    };
-    const maybeMarkStderrDrained = () => {
-      if (!stderrDrained && stderrEnded && pendingStderrWrites === 0) {
-        stderrDrained = true;
-        void settleRoot();
-      }
-    };
-    command.stdout?.on("data", (chunk) => {
-      pendingStdoutWrites += 1;
-      process.stdout.write(chunk, () => {
-        pendingStdoutWrites -= 1;
-        maybeMarkStdoutDrained();
-      });
-    });
-    command.stderr?.on("data", (chunk) => {
-      pendingStderrWrites += 1;
-      process.stderr.write(chunk, () => {
-        pendingStderrWrites -= 1;
-        maybeMarkStderrDrained();
-      });
-    });
-    command.stdout?.on("error", () => {});
-    command.stderr?.on("error", () => {});
     const settleRoot = async () => {
       if (rootSettlementStarted || !rootExit || !stdoutDrained || !stderrDrained) {
         return;
@@ -310,18 +278,16 @@ export function runServiceChildGroupAnchor(): void {
         await closeAuthority("lineage-closed", false);
       }
     };
-    const markStdoutDrained = () => {
-      stdoutEnded = true;
-      maybeMarkStdoutDrained();
-    };
-    const markStderrDrained = () => {
-      stderrEnded = true;
-      maybeMarkStderrDrained();
-    };
-    command.stdout?.once("end", markStdoutDrained);
-    command.stdout?.once("close", markStdoutDrained);
-    command.stderr?.once("end", markStderrDrained);
-    command.stderr?.once("close", markStderrDrained);
+    // Output EOF is independent of lineage EOF. Pipeline closes each forwarded stream
+    // after its final write while the control channel retains descendant authority.
+    pipeline(command.stdout!, process.stdout, () => {
+      stdoutDrained = true;
+      void settleRoot();
+    });
+    pipeline(command.stderr!, process.stderr, () => {
+      stderrDrained = true;
+      void settleRoot();
+    });
     if (start.stdinMode !== "inherit" && command.stdin) {
       process.stdin.pipe(command.stdin);
       if (start.stdinMode === "pipe-closed" && process.stdin.readableEnded) {

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -89,12 +89,13 @@ export function runServiceChildGroupAnchor(): void {
     }
     sequence += 1;
     await new Promise<void>((resolve) => {
+      const framed = {
+        ...message,
+        generation: start!.generation,
+        sequence,
+      };
       control!.write(
-        encodeServiceChildMessage({
-          ...message,
-          generation: start!.generation,
-          sequence,
-        } as ServiceChildAnchorMessage),
+        encodeServiceChildMessage(framed as ServiceChildAnchorMessage), // SAFETY: typed payload plus live envelope forms the protocol union.
         () => resolve(),
       );
     });
@@ -203,6 +204,7 @@ export function runServiceChildGroupAnchor(): void {
         const line = pending.slice(0, newline);
         pending = pending.slice(newline + 1);
         try {
+          // SAFETY: the private host control channel only writes encoded control messages.
           onControlMessage(JSON.parse(line) as ServiceChildControlMessage);
         } catch {
           void requestCleanup("parent-lost");
@@ -233,6 +235,7 @@ export function runServiceChildGroupAnchor(): void {
       await reportStartupFailure(error instanceof Error ? error.message : String(error));
       return;
     }
+    // SAFETY: lineageFd was reserved as a pipe in this exact command stdio array.
     const lineage = command.stdio[lineageFd] as Readable | null;
     if (!lineage) {
       await send({ type: "startup-error", error: "command lineage pipe was not created" });
@@ -339,6 +342,7 @@ export function runServiceChildGroupAnchor(): void {
     }
   });
   process.on("message", (raw: unknown) => {
+    // SAFETY: the spawned relay is the sole sender on this private IPC channel.
     const message = raw as ServiceChildStart | { type: "parent-loss"; generation?: string };
     if (message.type === "start" && state === "starting") {
       void startCommand(message);

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { Socket } from "node:net";
 import { pipeline, type Readable } from "node:stream";
+import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorMessage,
@@ -10,7 +11,6 @@ import {
 type WithoutEnvelope<T> = T extends unknown ? Omit<T, "generation" | "sequence"> : never;
 type ServiceChildAnchorPayload = WithoutEnvelope<ServiceChildAnchorMessage>;
 
-const TERM_GRACE_MS = 1_000;
 const LINEAGE_EXIT_OBSERVATION_MS = 100;
 
 type AnchorState = "starting" | "active" | "closing" | "closed";
@@ -142,7 +142,7 @@ export function runServiceChildGroupAnchor(): void {
     }
     state = "closing";
     forceCleanup = signal === "SIGKILL";
-    const termGraceDone = delay(TERM_GRACE_MS);
+    const termGraceDone = delay(GRACEFUL_CANCEL_TIMEOUT_MS);
     if (!forceCleanup) {
       // The anchor catches its own signal while every command-group member receives it.
       process.kill(0, "SIGTERM");

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -4,9 +4,11 @@ import type { Readable } from "node:stream";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorMessage,
-  type ServiceChildAnchorPayload,
   type ServiceChildStart,
 } from "./service-child-protocol.js";
+
+type WithoutEnvelope<T> = T extends unknown ? Omit<T, "generation" | "sequence"> : never;
+type ServiceChildAnchorPayload = WithoutEnvelope<ServiceChildAnchorMessage>;
 
 const TERM_GRACE_MS = 1_000;
 const LINEAGE_EXIT_OBSERVATION_MS = 100;

--- a/src/process/supervisor/service-child-protocol.ts
+++ b/src/process/supervisor/service-child-protocol.ts
@@ -10,14 +10,10 @@ export type ServiceChildStart = {
   controlFd: number;
 };
 
-type ServiceChildHostMessage =
-  | ServiceChildStart
-  | {
-      type: "cancel";
-      generation: string;
-      sequence: number;
-      signal: "SIGTERM" | "SIGKILL";
-    };
+type ServiceChildControlMessage = {
+  generation: string;
+  sequence: number;
+} & ({ type: "cancel"; signal: "SIGTERM" | "SIGKILL" } | { type: "startup-error-ack" });
 
 type ServiceChildAnchorPayload =
   | {
@@ -50,7 +46,7 @@ export type ServiceChildRelayMessage =
   | { type: "relay-error"; generation: string; error: string };
 
 export function encodeServiceChildMessage(
-  message: ServiceChildHostMessage | ServiceChildAnchorMessage,
+  message: ServiceChildStart | ServiceChildControlMessage | ServiceChildAnchorMessage,
 ): string {
   return `${JSON.stringify(message)}\n`;
 }

--- a/src/process/supervisor/service-child-protocol.ts
+++ b/src/process/supervisor/service-child-protocol.ts
@@ -19,7 +19,7 @@ type ServiceChildHostMessage =
       signal: "SIGTERM" | "SIGKILL";
     };
 
-export type ServiceChildAnchorPayload =
+type ServiceChildAnchorPayload =
   | {
       type: "ready";
       commandPid: number;

--- a/src/process/supervisor/service-child-protocol.ts
+++ b/src/process/supervisor/service-child-protocol.ts
@@ -1,0 +1,56 @@
+export type ServiceChildStart = {
+  type: "start";
+  generation: string;
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  stdinMode: "inherit" | "pipe-open" | "pipe-closed";
+  secretFd?: number;
+  controlFd: number;
+};
+
+type ServiceChildHostMessage =
+  | ServiceChildStart
+  | {
+      type: "cancel";
+      generation: string;
+      sequence: number;
+      signal: "SIGTERM" | "SIGKILL";
+    };
+
+export type ServiceChildAnchorPayload =
+  | {
+      type: "ready";
+      commandPid: number;
+      anchorPid: number;
+    }
+  | {
+      type: "root-result";
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    }
+  | {
+      type: "closing";
+      reason: "cancel" | "lineage-closed" | "lineage-lost" | "parent-lost";
+    }
+  | {
+      type: "startup-error";
+      error: string;
+    };
+
+export type ServiceChildAnchorMessage = ServiceChildAnchorPayload & {
+  generation: string;
+  sequence: number;
+};
+
+export type ServiceChildRelayMessage =
+  | ServiceChildStart
+  | { type: "anchor-exit"; generation: string; code: number | null; signal: NodeJS.Signals | null }
+  | { type: "relay-error"; generation: string; error: string };
+
+export function encodeServiceChildMessage(
+  message: ServiceChildHostMessage | ServiceChildAnchorMessage,
+): string {
+  return `${JSON.stringify(message)}\n`;
+}

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -1,0 +1,336 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import type { Duplex, Writable } from "node:stream";
+import { fileURLToPath } from "node:url";
+import { toErrorObject } from "../../infra/errors.js";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { addSecretInputStdio, writeSecretInputToChild } from "../spawn-secret-input.js";
+import {
+  encodeServiceChildMessage,
+  type ServiceChildAnchorMessage,
+  type ServiceChildRelayMessage,
+  type ServiceChildStart,
+} from "./service-child-protocol.js";
+import type { ManagedRunStdin, SpawnProcessAdapter, SpawnSecretInput } from "./types.js";
+
+type ServiceAdapter = SpawnProcessAdapter<NodeJS.Signals | null>;
+type AuthorityState = "starting" | "active" | "closing" | "closed" | "identity-lost";
+type StdioEntry = "ignore" | "inherit" | "ipc" | "pipe" | number;
+
+const retainedRelays = new Map<string, ChildProcess>();
+
+function runtimeArgv(url: URL): string[] {
+  return url.pathname.endsWith(".ts")
+    ? ["--import", "tsx", fileURLToPath(url)]
+    : [fileURLToPath(url)];
+}
+
+function reserveStdioEntry(stdio: StdioEntry[], value: StdioEntry): number {
+  let fd = 3;
+  while (stdio[fd] !== undefined && stdio[fd] !== "ignore") {
+    fd += 1;
+  }
+  while (stdio.length <= fd) {
+    stdio.push("ignore");
+  }
+  stdio[fd] = value;
+  return fd;
+}
+
+function createManagedStdin(stream: Writable | null): ManagedRunStdin | undefined {
+  if (!stream) {
+    return undefined;
+  }
+  let ended = stream.writableEnded || stream.writableFinished;
+  let destroyed = stream.destroyed;
+  stream.once("finish", () => {
+    ended = true;
+  });
+  stream.once("close", () => {
+    ended = true;
+    destroyed = true;
+  });
+  stream.once("error", () => {
+    destroyed = true;
+  });
+  return {
+    get destroyed() {
+      return destroyed || stream.destroyed;
+    },
+    get writable() {
+      return !destroyed && !ended && stream.writable;
+    },
+    get writableEnded() {
+      return ended || stream.writableEnded;
+    },
+    get writableFinished() {
+      return stream.writableFinished;
+    },
+    write(data, callback) {
+      if (destroyed || ended || !stream.writable) {
+        callback?.(new Error("stdin is not writable"));
+        return;
+      }
+      try {
+        stream.write(data, callback);
+      } catch (error) {
+        callback?.(toErrorObject(error, "stdin write failed"));
+      }
+    },
+    end() {
+      ended = true;
+      stream.end();
+    },
+    destroy() {
+      ended = true;
+      destroyed = true;
+      stream.destroy();
+    },
+  };
+}
+
+export async function createServiceChildRelayAdapter(params: {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdinMode: "inherit" | "pipe-open" | "pipe-closed";
+  input?: string;
+  secretInput?: SpawnSecretInput;
+  oomScoreWrapperSelected: boolean;
+}): Promise<ServiceAdapter> {
+  const generation = randomUUID();
+  const relayUrl = resolveRuntimeWorkerUrl({
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "service-child-relay",
+    distWorkerPath: "process/supervisor/service-child-relay.js",
+  });
+  const stdio: StdioEntry[] = [params.stdinMode === "inherit" ? "inherit" : "pipe", "pipe", "pipe"];
+  addSecretInputStdio(stdio as Parameters<typeof addSecretInputStdio>[0], params.secretInput);
+  const controlFd = reserveStdioEntry(stdio, "pipe");
+  reserveStdioEntry(stdio, "ipc");
+
+  const relay = spawn(process.execPath, runtimeArgv(relayUrl), {
+    stdio,
+    detached: false,
+    windowsHide: true,
+    env: process.env,
+  });
+  retainedRelays.set(generation, relay);
+  relay.unref();
+
+  const control = relay.stdio[controlFd] as Duplex | null;
+  if (!relay.connected || !control) {
+    relay.kill("SIGKILL");
+    retainedRelays.delete(generation);
+    throw new Error("service child relay channels were not created");
+  }
+
+  const stdoutListeners = new Set<(chunk: string) => void>();
+  const stderrListeners = new Set<(chunk: string) => void>();
+  relay.stdout?.on("data", (chunk: Buffer | string) => {
+    const text = chunk.toString();
+    for (const listener of stdoutListeners) {
+      listener(text);
+    }
+  });
+  relay.stderr?.on("data", (chunk: Buffer | string) => {
+    const text = chunk.toString();
+    for (const listener of stderrListeners) {
+      listener(text);
+    }
+  });
+  relay.stdout?.on("error", () => {});
+  relay.stderr?.on("error", () => {});
+
+  let state: AuthorityState = "starting";
+  let commandPid: number | undefined;
+  let outboundSequence = 0;
+  let inboundSequence = 0;
+  let rootResult: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+  let closingReceipt = false;
+  let requestedSignal: "SIGTERM" | "SIGKILL" | undefined;
+  let waitError: Error | undefined;
+  let resolveStartup!: () => void;
+  let rejectStartup!: (error: Error) => void;
+  const startup = new Promise<void>((resolve, reject) => {
+    resolveStartup = resolve;
+    rejectStartup = reject;
+  });
+  let resolveWait!: (result: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  let rejectWait!: (error: Error) => void;
+  const waitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      resolveWait = resolve;
+      rejectWait = reject;
+    },
+  );
+  let waitSettled = false;
+
+  const settleWait = () => {
+    if (waitSettled) {
+      return;
+    }
+    if (waitError) {
+      waitSettled = true;
+      rejectWait(waitError);
+      return;
+    }
+    if (!rootResult) {
+      return;
+    }
+    if (requestedSignal && state !== "closed") {
+      return;
+    }
+    waitSettled = true;
+    resolveWait(rootResult);
+  };
+
+  const loseIdentity = (message: string) => {
+    if (state === "closed" || state === "identity-lost") {
+      return;
+    }
+    state = "identity-lost";
+    waitError = new Error(`service child cleanup identity lost: ${message}`);
+    if (!commandPid) {
+      rejectStartup(waitError);
+    }
+    settleWait();
+  };
+
+  let pending = "";
+  control.setEncoding("utf8");
+  control.on("data", (chunk: string) => {
+    pending += chunk;
+    for (;;) {
+      const newline = pending.indexOf("\n");
+      if (newline < 0) {
+        break;
+      }
+      const line = pending.slice(0, newline);
+      pending = pending.slice(newline + 1);
+      let message: ServiceChildAnchorMessage;
+      try {
+        message = JSON.parse(line) as ServiceChildAnchorMessage;
+      } catch {
+        loseIdentity("invalid anchor message");
+        continue;
+      }
+      if (message.generation !== generation || message.sequence <= inboundSequence) {
+        loseIdentity("stale anchor generation or sequence");
+        continue;
+      }
+      inboundSequence = message.sequence;
+      if (message.type === "ready" && state === "starting") {
+        commandPid = message.commandPid;
+        state = "active";
+        resolveStartup();
+      } else if (message.type === "root-result") {
+        rootResult ??= { code: message.code, signal: message.signal };
+        settleWait();
+      } else if (message.type === "closing") {
+        closingReceipt = true;
+        state = "closing";
+      } else if (message.type === "startup-error") {
+        loseIdentity(message.error);
+      }
+    }
+  });
+  control.once("close", () => {
+    // Correlation is not authority: only the receipt on this exact channel followed by
+    // its closure proves the in-group anchor disabled every future cleanup action.
+    if (!closingReceipt) {
+      loseIdentity("anchor channel closed without a matching closing receipt");
+      return;
+    }
+    state = "closed";
+    rootResult ??= { code: null, signal: requestedSignal ?? null };
+    settleWait();
+  });
+  control.on("error", (error) => {
+    loseIdentity(error.message);
+  });
+
+  relay.on("message", (raw: unknown) => {
+    const message = raw as ServiceChildRelayMessage;
+    if (!message || typeof message !== "object" || message.generation !== generation) {
+      return;
+    }
+    if (message.type === "relay-error") {
+      loseIdentity(message.error);
+    } else if (message.type === "anchor-exit" && state !== "closed" && !closingReceipt) {
+      loseIdentity(`anchor exited (${message.code ?? message.signal ?? "unknown"})`);
+    }
+  });
+  relay.once("error", (error) => {
+    loseIdentity(error.message);
+  });
+  relay.once("exit", (code, signal) => {
+    retainedRelays.delete(generation);
+    if (state !== "closed" && !closingReceipt) {
+      loseIdentity(`relay exited (${code ?? signal ?? "unknown"})`);
+    }
+  });
+
+  const start: ServiceChildStart = {
+    type: "start",
+    generation,
+    command: params.command,
+    args: params.args,
+    cwd: params.cwd,
+    env: params.env as Record<string, string> | undefined,
+    stdinMode: params.stdinMode,
+    secretFd: params.secretInput?.fd,
+    controlFd,
+  };
+  relay.send(start);
+
+  try {
+    await writeSecretInputToChild(relay, params.secretInput);
+    await startup;
+  } catch (error) {
+    relay.kill("SIGKILL");
+    retainedRelays.delete(generation);
+    throw error;
+  }
+
+  const stdin = createManagedStdin(relay.stdin);
+  if (params.input !== undefined) {
+    stdin?.write(params.input);
+    stdin?.end();
+  } else if (params.stdinMode === "pipe-closed") {
+    stdin?.end();
+  }
+
+  const kill = (signal: NodeJS.Signals = "SIGKILL") => {
+    if (state === "closed" || state === "identity-lost") {
+      return;
+    }
+    const normalized = signal === "SIGTERM" ? "SIGTERM" : "SIGKILL";
+    requestedSignal = normalized;
+    outboundSequence += 1;
+    // The host never converts the diagnostic command PID into group authority.
+    control.write(
+      encodeServiceChildMessage({
+        type: "cancel",
+        generation,
+        sequence: outboundSequence,
+        signal: normalized,
+      }),
+    );
+  };
+
+  return {
+    pid: commandPid,
+    stdin,
+    oomScoreWrapperSelected: params.oomScoreWrapperSelected,
+    onStdout: (listener) => stdoutListeners.add(listener),
+    onStderr: (listener) => stderrListeners.add(listener),
+    wait: async () => await waitPromise,
+    kill,
+    dispose: () => {
+      stdoutListeners.clear();
+      stderrListeners.clear();
+    },
+  };
+}

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import type { Duplex, Writable } from "node:stream";
+import type { Duplex, Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { toErrorObject } from "../../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
@@ -90,6 +90,55 @@ function createManagedStdin(stream: Writable | null): ManagedRunStdin | undefine
   };
 }
 
+function createOutputRelay(stream: Readable) {
+  const listeners = new Set<(chunk: string) => void>();
+  const pending: string[] = [];
+  let pendingBytes = 0;
+  let active = false;
+  const activate = (deliver: boolean) => {
+    if (active) {
+      return;
+    }
+    active = true;
+    if (deliver) {
+      for (const text of pending) {
+        for (const listener of listeners) {
+          listener(text);
+        }
+      }
+    }
+    pending.length = 0;
+    pendingBytes = 0;
+    stream.resume();
+  };
+  onDecodedOutput(stream, (text) => {
+    if (active) {
+      for (const listener of listeners) {
+        listener(text);
+      }
+      return;
+    }
+    pending.push(text);
+    pendingBytes += Buffer.byteLength(text);
+    // Bound host memory while retaining the rest in the native pipe until subscription.
+    if (pendingBytes >= stream.readableHighWaterMark) {
+      stream.pause();
+    }
+  });
+  return {
+    subscribe: (listener: (chunk: string) => void) => {
+      listeners.add(listener);
+      activate(true);
+    },
+    drain: () => activate(false),
+    clear: () => {
+      listeners.clear();
+      pending.length = 0;
+      pendingBytes = 0;
+    },
+  };
+}
+
 export async function createServiceChildRelayAdapter(params: {
   command: string;
   args: string[];
@@ -128,18 +177,8 @@ export async function createServiceChildRelayAdapter(params: {
   }
   const { stdout, stderr } = relay;
 
-  const stdoutListeners = new Set<(chunk: string) => void>();
-  const stderrListeners = new Set<(chunk: string) => void>();
-  onDecodedOutput(stdout, (text) => {
-    for (const listener of stdoutListeners) {
-      listener(text);
-    }
-  });
-  onDecodedOutput(stderr, (text) => {
-    for (const listener of stderrListeners) {
-      listener(text);
-    }
-  });
+  const stdoutRelay = createOutputRelay(stdout);
+  const stderrRelay = createOutputRelay(stderr);
   stdout.on("error", () => {});
   stderr.on("error", () => {});
 
@@ -346,9 +385,12 @@ export async function createServiceChildRelayAdapter(params: {
     pid: commandPid,
     stdin,
     oomScoreWrapperSelected: params.oomScoreWrapperSelected,
-    onStdout: (listener) => stdoutListeners.add(listener),
-    onStderr: (listener) => stderrListeners.add(listener),
+    onStdout: stdoutRelay.subscribe,
+    onStderr: stderrRelay.subscribe,
     wait: async () => {
+      // A caller may intentionally ignore one stream; wait still owns draining it.
+      stdoutRelay.drain();
+      stderrRelay.drain();
       settleWait();
       if (waitError) {
         throw waitError;
@@ -364,8 +406,8 @@ export async function createServiceChildRelayAdapter(params: {
     },
     kill,
     dispose: () => {
-      stdoutListeners.clear();
-      stderrListeners.clear();
+      stdoutRelay.clear();
+      stderrRelay.clear();
     },
   };
 }

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -156,6 +156,7 @@ export async function createServiceChildRelayAdapter(params: {
     distWorkerPath: "process/supervisor/service-child-relay.js",
   });
   const stdio: StdioEntry[] = [params.stdinMode === "inherit" ? "inherit" : "pipe", "pipe", "pipe"];
+  // SAFETY: stdio contains only SpawnStdioEntry values until lifecycle descriptors are reserved.
   addSecretInputStdio(stdio as Parameters<typeof addSecretInputStdio>[0], params.secretInput);
   const controlFd = reserveStdioEntry(stdio, "pipe");
   reserveStdioEntry(stdio, "ipc");
@@ -169,6 +170,7 @@ export async function createServiceChildRelayAdapter(params: {
   retainedRelays.set(generation, relay);
   relay.unref();
 
+  // SAFETY: controlFd was reserved as a pipe in this exact spawn stdio array.
   const control = relay.stdio[controlFd] as Duplex | null;
   if (!relay.connected || !control || !relay.stdout || !relay.stderr) {
     relay.kill("SIGKILL");
@@ -258,6 +260,7 @@ export async function createServiceChildRelayAdapter(params: {
       pending = pending.slice(newline + 1);
       let message: ServiceChildAnchorMessage;
       try {
+        // SAFETY: this private anchor channel only writes encoded anchor protocol messages.
         message = JSON.parse(line) as ServiceChildAnchorMessage;
       } catch {
         loseIdentity("invalid anchor message");
@@ -307,6 +310,7 @@ export async function createServiceChildRelayAdapter(params: {
   });
 
   relay.on("message", (raw: unknown) => {
+    // SAFETY: the spawned relay is the sole sender on this private IPC channel.
     const message = raw as ServiceChildRelayMessage;
     if (!message || typeof message !== "object" || message.generation !== generation) {
       return;
@@ -333,6 +337,7 @@ export async function createServiceChildRelayAdapter(params: {
     command: params.command,
     args: params.args,
     cwd: params.cwd,
+    // SAFETY: createChildAdapter normalizes defined environment values before this boundary.
     env: params.env as Record<string, string> | undefined,
     stdinMode: params.stdinMode,
     secretFd: params.secretInput?.fd,

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -121,7 +121,7 @@ export async function createServiceChildRelayAdapter(params: {
   relay.unref();
 
   const control = relay.stdio[controlFd] as Duplex | null;
-  if (!relay.connected || !control) {
+  if (!relay.connected || !control || !relay.stdout || !relay.stderr) {
     relay.kill("SIGKILL");
     retainedRelays.delete(generation);
     throw new Error("service child relay channels were not created");
@@ -229,6 +229,14 @@ export async function createServiceChildRelayAdapter(params: {
         state = "closing";
       } else if (message.type === "startup-error") {
         loseIdentity(message.error);
+        outboundSequence += 1;
+        control.write(
+          encodeServiceChildMessage({
+            type: "startup-error-ack",
+            generation,
+            sequence: outboundSequence,
+          }),
+        );
       }
     }
   });

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -157,14 +157,11 @@ export async function createServiceChildRelayAdapter(params: {
     resolveStartup = resolve;
     rejectStartup = reject;
   });
-  let resolveWait!: (result: { code: number | null; signal: NodeJS.Signals | null }) => void;
-  let rejectWait!: (error: Error) => void;
-  const waitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-    (resolve, reject) => {
-      resolveWait = resolve;
-      rejectWait = reject;
-    },
-  );
+  let resolveWait:
+    | ((result: { code: number | null; signal: NodeJS.Signals | null }) => void)
+    | undefined;
+  let rejectWait: ((error: Error) => void) | undefined;
+  let waitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | undefined;
   let waitSettled = false;
 
   const settleWait = () => {
@@ -173,7 +170,7 @@ export async function createServiceChildRelayAdapter(params: {
     }
     if (waitError) {
       waitSettled = true;
-      rejectWait(waitError);
+      rejectWait?.(waitError);
       return;
     }
     if (!rootResult) {
@@ -183,7 +180,7 @@ export async function createServiceChildRelayAdapter(params: {
       return;
     }
     waitSettled = true;
-    resolveWait(rootResult);
+    resolveWait?.(rootResult);
   };
 
   const loseIdentity = (message: string) => {
@@ -326,7 +323,20 @@ export async function createServiceChildRelayAdapter(params: {
     oomScoreWrapperSelected: params.oomScoreWrapperSelected,
     onStdout: (listener) => stdoutListeners.add(listener),
     onStderr: (listener) => stderrListeners.add(listener),
-    wait: async () => await waitPromise,
+    wait: async () => {
+      settleWait();
+      if (waitError) {
+        throw waitError;
+      }
+      if (rootResult && waitSettled) {
+        return rootResult;
+      }
+      waitPromise ??= new Promise((resolve, reject) => {
+        resolveWait = resolve;
+        rejectWait = reject;
+      });
+      return await waitPromise;
+    },
     kill,
     dispose: () => {
       stdoutListeners.clear();

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -6,6 +6,7 @@ import { toErrorObject } from "../../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
 import { onDecodedOutput } from "../decoded-output.js";
 import { addSecretInputStdio, writeSecretInputToChild } from "../spawn-secret-input.js";
+import { toStringEnv } from "./adapters/env.js";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorMessage,
@@ -24,6 +25,16 @@ function runtimeArgv(url: URL): string[] {
   return url.pathname.endsWith(".ts")
     ? ["--import", "tsx", fileURLToPath(url)]
     : [fileURLToPath(url)];
+}
+
+function readAnchorMessage(line: string): ServiceChildAnchorMessage {
+  // SAFETY: the exact private anchor channel writes only encoded anchor protocol messages.
+  return JSON.parse(line) as ServiceChildAnchorMessage;
+}
+
+function readRelayMessage(raw: unknown): ServiceChildRelayMessage {
+  // SAFETY: the spawned relay is the sole sender on this exact private IPC channel.
+  return raw as ServiceChildRelayMessage;
 }
 
 function reserveStdioEntry(stdio: StdioEntry[], value: StdioEntry): number {
@@ -260,8 +271,7 @@ export async function createServiceChildRelayAdapter(params: {
       pending = pending.slice(newline + 1);
       let message: ServiceChildAnchorMessage;
       try {
-        // SAFETY: this private anchor channel only writes encoded anchor protocol messages.
-        message = JSON.parse(line) as ServiceChildAnchorMessage;
+        message = readAnchorMessage(line);
       } catch {
         loseIdentity("invalid anchor message");
         continue;
@@ -310,8 +320,7 @@ export async function createServiceChildRelayAdapter(params: {
   });
 
   relay.on("message", (raw: unknown) => {
-    // SAFETY: the spawned relay is the sole sender on this private IPC channel.
-    const message = raw as ServiceChildRelayMessage;
+    const message = readRelayMessage(raw);
     if (!message || typeof message !== "object" || message.generation !== generation) {
       return;
     }
@@ -337,8 +346,7 @@ export async function createServiceChildRelayAdapter(params: {
     command: params.command,
     args: params.args,
     cwd: params.cwd,
-    // SAFETY: createChildAdapter normalizes defined environment values before this boundary.
-    env: params.env as Record<string, string> | undefined,
+    env: params.env ? toStringEnv(params.env) : undefined,
     stdinMode: params.stdinMode,
     secretFd: params.secretInput?.fd,
     controlFd,

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -4,6 +4,7 @@ import type { Duplex, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { toErrorObject } from "../../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { onDecodedOutput } from "../decoded-output.js";
 import { addSecretInputStdio, writeSecretInputToChild } from "../spawn-secret-input.js";
 import {
   encodeServiceChildMessage,
@@ -128,14 +129,12 @@ export async function createServiceChildRelayAdapter(params: {
 
   const stdoutListeners = new Set<(chunk: string) => void>();
   const stderrListeners = new Set<(chunk: string) => void>();
-  relay.stdout?.on("data", (chunk: Buffer | string) => {
-    const text = chunk.toString();
+  onDecodedOutput(relay.stdout, (text) => {
     for (const listener of stdoutListeners) {
       listener(text);
     }
   });
-  relay.stderr?.on("data", (chunk: Buffer | string) => {
-    const text = chunk.toString();
+  onDecodedOutput(relay.stderr, (text) => {
     for (const listener of stderrListeners) {
       listener(text);
     }
@@ -282,13 +281,19 @@ export async function createServiceChildRelayAdapter(params: {
   };
   relay.send(start);
 
-  try {
-    await writeSecretInputToChild(relay, params.secretInput);
-    await startup;
-  } catch (error) {
+  const [startupResult, secretDeliveryResult] = await Promise.allSettled([
+    startup,
+    writeSecretInputToChild(relay, params.secretInput),
+  ]);
+  const startupError = startupResult.status === "rejected" ? startupResult.reason : undefined;
+  const secretDeliveryError =
+    secretDeliveryResult.status === "rejected" ? secretDeliveryResult.reason : undefined;
+  if (startupError !== undefined || secretDeliveryError !== undefined) {
     relay.kill("SIGKILL");
     retainedRelays.delete(generation);
-    throw error;
+    // Startup owns command admission, so its exact failure wins over a concurrent
+    // backpressured secret pipe closing as a consequence of that failed admission.
+    throw startupError ?? secretDeliveryError;
   }
 
   const stdin = createManagedStdin(relay.stdin);

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -126,21 +126,22 @@ export async function createServiceChildRelayAdapter(params: {
     retainedRelays.delete(generation);
     throw new Error("service child relay channels were not created");
   }
+  const { stdout, stderr } = relay;
 
   const stdoutListeners = new Set<(chunk: string) => void>();
   const stderrListeners = new Set<(chunk: string) => void>();
-  onDecodedOutput(relay.stdout, (text) => {
+  onDecodedOutput(stdout, (text) => {
     for (const listener of stdoutListeners) {
       listener(text);
     }
   });
-  onDecodedOutput(relay.stderr, (text) => {
+  onDecodedOutput(stderr, (text) => {
     for (const listener of stderrListeners) {
       listener(text);
     }
   });
-  relay.stdout?.on("error", () => {});
-  relay.stderr?.on("error", () => {});
+  stdout.on("error", () => {});
+  stderr.on("error", () => {});
 
   let state: AuthorityState = "starting";
   let commandPid: number | undefined;
@@ -172,7 +173,11 @@ export async function createServiceChildRelayAdapter(params: {
       rejectWait?.(waitError);
       return;
     }
-    if (!rootResult) {
+    if (
+      !rootResult ||
+      !(stdout.readableEnded || stdout.closed) ||
+      !(stderr.readableEnded || stderr.closed)
+    ) {
       return;
     }
     if (requestedSignal && state !== "closed") {
@@ -181,6 +186,13 @@ export async function createServiceChildRelayAdapter(params: {
     waitSettled = true;
     resolveWait?.(rootResult);
   };
+
+  // Root result and output EOF cross different channels. Decoder flush listeners were
+  // registered first, so settlement observes both final text tails before disposal.
+  stdout.once("end", settleWait);
+  stdout.once("close", settleWait);
+  stderr.once("end", settleWait);
+  stderr.once("close", settleWait);
 
   const loseIdentity = (message: string) => {
     if (state === "closed" || state === "identity-lost") {

--- a/src/process/supervisor/service-child-relay.ts
+++ b/src/process/supervisor/service-child-relay.ts
@@ -96,6 +96,10 @@ export function runServiceChildRelay(): void {
       process.exitCode = 1;
       return;
     }
+    // The anchor owns forwarded output lifetime. Drop the relay's duplicate writers so
+    // root output can reach EOF while the anchor retains descendant cleanup authority.
+    process.stdout.destroy();
+    process.stderr.destroy();
     anchor.once("spawn", () => {
       anchor?.send(start);
       if (parentLost) {

--- a/src/process/supervisor/service-child-relay.ts
+++ b/src/process/supervisor/service-child-relay.ts
@@ -51,6 +51,7 @@ export function runServiceChildRelay(): void {
   process.once("SIGTERM", notifyParentLoss);
   process.once("SIGINT", notifyParentLoss);
   process.once("message", (raw: unknown) => {
+    // SAFETY: the spawned host is the sole sender on this private IPC channel.
     const start = raw as ServiceChildStart;
     if (!start || start.type !== "start" || !start.generation) {
       process.exitCode = 1;

--- a/src/process/supervisor/service-child-relay.ts
+++ b/src/process/supervisor/service-child-relay.ts
@@ -1,0 +1,115 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import type { ServiceChildRelayMessage, ServiceChildStart } from "./service-child-protocol.js";
+
+function runtimeArgv(url: URL): string[] {
+  return url.pathname.endsWith(".ts")
+    ? ["--import", "tsx", fileURLToPath(url)]
+    : [fileURLToPath(url)];
+}
+
+type StdioEntry = "ignore" | "inherit" | "ipc" | number;
+
+function reserveIpcFd(stdio: StdioEntry[]): void {
+  let fd = 3;
+  while (stdio[fd] !== undefined && stdio[fd] !== "ignore") {
+    fd += 1;
+  }
+  while (stdio.length <= fd) {
+    stdio.push("ignore");
+  }
+  stdio[fd] = "ipc";
+}
+
+export function runServiceChildRelay(): void {
+  let generation: string | undefined;
+  let anchor: ChildProcess | undefined;
+  let parentLost = false;
+
+  const report = (message: ServiceChildRelayMessage) => {
+    if (!process.connected) {
+      return;
+    }
+    try {
+      process.send?.(message);
+    } catch {
+      // Direct host/anchor channel closure remains the fail-closed authority path.
+    }
+  };
+  const notifyParentLoss = () => {
+    if (parentLost) {
+      return;
+    }
+    parentLost = true;
+    if (anchor?.connected) {
+      anchor.send({ type: "parent-loss", generation });
+    }
+  };
+
+  process.once("disconnect", notifyParentLoss);
+  process.once("SIGTERM", notifyParentLoss);
+  process.once("SIGINT", notifyParentLoss);
+  process.once("message", (raw: unknown) => {
+    const start = raw as ServiceChildStart;
+    if (!start || start.type !== "start" || !start.generation) {
+      process.exitCode = 1;
+      return;
+    }
+    generation = start.generation;
+    const anchorUrl = resolveRuntimeWorkerUrl({
+      currentModuleUrl: import.meta.url,
+      sourceWorkerName: "service-child-group-anchor",
+      distWorkerPath: "process/supervisor/service-child-group-anchor.js",
+    });
+    const stdio: StdioEntry[] = ["inherit", "inherit", "inherit"];
+    while (stdio.length <= start.controlFd) {
+      stdio.push("ignore");
+    }
+    stdio[start.controlFd] = start.controlFd;
+    if (start.secretFd !== undefined) {
+      while (stdio.length <= start.secretFd) {
+        stdio.push("ignore");
+      }
+      stdio[start.secretFd] = start.secretFd;
+    }
+    reserveIpcFd(stdio);
+    try {
+      anchor = spawn(process.execPath, runtimeArgv(anchorUrl), {
+        stdio,
+        detached: true,
+        windowsHide: true,
+        env: process.env,
+      });
+    } catch (error) {
+      report({
+        type: "relay-error",
+        generation,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      process.exitCode = 1;
+      return;
+    }
+    if (!anchor.connected) {
+      report({ type: "relay-error", generation, error: "anchor lifecycle IPC was not created" });
+      anchor.kill("SIGKILL");
+      process.exitCode = 1;
+      return;
+    }
+    anchor.once("spawn", () => {
+      anchor?.send(start);
+      if (parentLost) {
+        anchor?.send({ type: "parent-loss", generation });
+      }
+    });
+    anchor.once("error", (error) => {
+      report({ type: "relay-error", generation: generation!, error: error.message });
+    });
+    anchor.once("exit", (code, signal) => {
+      report({ type: "anchor-exit", generation: generation!, code, signal });
+      process.exit(code === 0 || signal === "SIGKILL" ? 0 : 1);
+    });
+  });
+}
+
+runServiceChildRelay();

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -8,6 +8,7 @@ import { getShellConfig } from "../../agents/shell-utils.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { createChildAdapter } from "./adapters/child.js";
 import { createPtyAdapter } from "./adapters/pty.js";
+import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
 import { createRunRegistry } from "./registry.js";
 import type {
   ManagedRun,
@@ -34,7 +35,6 @@ type StartingScope = {
   replacement?: Promise<ManagedRun>;
 };
 
-const GRACEFUL_CANCEL_TIMEOUT_MS = 5000;
 const DEFAULT_MAX_CAPTURED_OUTPUT_CHARS = 1024 * 1024;
 
 const loadSupervisorLogRuntime = createLazyRuntimeModule(

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -391,6 +391,9 @@ function buildCoreDistEntries(): Record<string, string> {
     "plugins/sdk-alias": "src/plugins/sdk-alias.ts",
     "facade-activation-check.runtime": "src/plugin-sdk/facade-activation-check.runtime.ts",
     "infra/warning-filter": "src/infra/warning-filter.ts",
+    "process/supervisor/service-child-relay": "src/process/supervisor/service-child-relay.ts",
+    "process/supervisor/service-child-group-anchor":
+      "src/process/supervisor/service-child-group-anchor.ts",
     "telegram-ingress-worker.runtime": bundledPluginFile(
       "telegram",
       "src/telegram-ingress-worker.runtime.ts",


### PR DESCRIPTION
Closes #120386

## What Problem This Solves

On macOS service-managed Gateway runs, foreground shell commands shared the Gateway process group. A timeout could kill the shell root while a forked descendant survived under PID 1. Signaling that shared group risked killing the Gateway, while retaining only a numeric PGID would permit stale-identity reuse. Verification exposed connected lifecycle races: root completion could drop an incomplete UTF-8 tail; descendant-held output could deadlock cleanup; natural lineage loss could hang forever without caller cancellation; and a 100 ms pre-cleanup observation window could truncate the configured TERM grace and replace an authentic delayed exit with a signal result.

## Why This Change Was Made

Route only POSIX service-managed child runs through a relay and dedicated process-group anchor. The live anchor is the sole cleanup authority and self-signals after exact channel, generation, sequence, and lifecycle checks; the host never probes or signals a stored PGID. Root output has a distinct lifetime from descendant authority, with decoder EOF gating public settlement. Cleanup shares one configured TERM grace across lineage, root, and output settlement, while repeated KILL resolves a closure-bound force-cleanup wake. The short lineage/root observation window is used only before cleanup ownership; once cleanup begins it cannot replace TERM grace. Natural lineage loss only awaits root settlement when settlement has actually started; otherwise it enters the same canonical cleanup path so descendant-held output cannot deadlock an uncancelled run. Direct-child, PTY, Windows, caller, stdin/secret, OOM, worker-message, and packaging paths remain canonical. Against the integration-policy base, production is net +872 lines for the new authority boundary and tests are net +603 lines; the growth is the concrete service-child lifecycle capability, protocol, relay host, and anchor, rather than downstream guards or duplicated caller policy.

## User Impact

Timed-out, cancelled, parent-abandoned, or naturally lineage-lost Gateway commands no longer leave forked descendants behind or hang indefinitely when a descendant retains stdout/stderr. Graceful roots receive the full configured TERM grace and preserve authentic exit metadata. Gateway health remains intact, unrelated or replacement groups are untouched, and final streamed/captured UTF-8 output is delivered before settlement.

## Evidence

The repaired and rebased exact head is `def54f63732e31ce30b15ef56d58e3948e2d97c3`. On the pre-fix `29f1445` code, the lifecycle reproduction showed the clean root losing its authentic result and settling as `exitCode: null, exitSignal: SIGTERM` after the short observation window consumed the grace period. The exact-head regression waits about 1.5 seconds after TERM, emits final stdout and stderr, exits with distinctive code 23, and proves both streamed and captured output, `exitCode: 23`, a null signal, and absence of the root and descendant PIDs.

The exact-head focused lifecycle suite passes 19/19 and the sibling supervisor, child, and PTY suites pass 71/71. The existing hosted [`macos-node` job](https://github.com/openclaw/openclaw/actions/runs/31977047267/job/95238105603) checked out that immutable SHA on `macos-15`, ran the lifecycle file through `test:macos:ci`, and passed all 19 tests, including `preserves the supervisor TERM grace for a delayed authentic root result` in 1.748 seconds. The complete exact-head [PR CI run](https://github.com/openclaw/openclaw/actions/runs/31977030200) also passed.

The earlier package-runtime proof covers the same production repair: a fresh Blacksmith Testbox built the canonical package, passed tar integrity and clean installation, then proved installed-package Gateway cleanup with health and readiness intact. Its tarball SHA-256 is `85517833c9f842f4b5c2a0095b0f5477804ad16e0a48b6677cbf10ac62936077`. The rebase added no new production behavior; the only post-review changes are the stronger distinctive-exit assertion and durable inclusion of the lifecycle suite in the existing macOS CI command. Final Codex autoreview reports no accepted or actionable findings at 0.99 confidence with TruffleHog clean.
