### PR TITLE
refactor(types): remove chained type assertions in runtime boundaries

### DIFF
--- a/src/auto-reply/reply/agent-runner.test-fixtures.ts
+++ b/src/auto-reply/reply/agent-runner.test-fixtures.ts
@@ -17,7 +17,7 @@ export function createTestFollowupRun(overrides: Partial<FollowupRun["run"]> = {
       sessionFile: "/tmp/session.jsonl",
       workspaceDir: "/tmp",
       config: {},
-      skillsSnapshot: {},
+      skillsSnapshot: { prompt: "", skills: [] },
       provider: "anthropic",
       model: "claude",
       thinkLevel: "low",
@@ -29,7 +29,7 @@ export function createTestFollowupRun(overrides: Partial<FollowupRun["run"]> = {
       skipProviderRuntimeHints: true,
       ...overrides,
     },
-  } as unknown as FollowupRun;
+  } satisfies FollowupRun;
 }
 
 export async function writeTestSessionStore(

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -1,4 +1,5 @@
 /** Loads, normalizes, quarantines, and persists cron service store state. */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
 import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
@@ -134,6 +135,12 @@ function warnInvalidPersistedCronJob(params: {
   );
 }
 
+function isValidatedCronJob(
+  value: Record<string, unknown>,
+): value is CronJob & Record<string, unknown> {
+  return getInvalidPersistedCronJobReason(value) === null;
+}
+
 /** Loads and normalizes the cron store, quarantining invalid persisted rows before runtime use. */
 export async function ensureLoaded(
   state: CronServiceState,
@@ -163,7 +170,7 @@ export async function ensureLoaded(
   const loadNowMs = state.deps.nowMs();
   // Persisted cron rows are validated lazily, so treat them as raw records at the
   // store boundary and only trust the CronJob shape after validation below.
-  const loadedJobs = (loaded.store.jobs ?? []) as unknown as Record<string, unknown>[];
+  const loadedJobs = (loaded.store.jobs ?? []).filter(isRecord);
   const jobs: CronJob[] = [];
   const durableNextRunAtMsByJobId = new Map<string, number | undefined>();
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
@@ -190,11 +197,16 @@ export async function ensureLoaded(
     }
     const hydratedRaw = normalized ?? raw;
     let invalidReason = rawInvalidReason ?? getInvalidPersistedCronJobReason(hydratedRaw);
-    const hydratedSchedule = (hydratedRaw.schedule ?? {}) as Record<string, unknown>;
-    if (!invalidReason && hydratedRaw.enabled !== false && hydratedSchedule.kind === "every") {
+    const hydratedSchedule = isRecord(hydratedRaw.schedule) ? hydratedRaw.schedule : {};
+    if (
+      !invalidReason &&
+      isValidatedCronJob(hydratedRaw) &&
+      hydratedRaw.enabled &&
+      hydratedSchedule.kind === "every"
+    ) {
       try {
         assertTimeScheduleSatisfiable(
-          { ...(hydratedRaw as unknown as CronJob), state: {} },
+          { ...hydratedRaw, state: {} },
           loadNowMs,
           computeJobNextRunAtMs,
         );
@@ -226,7 +238,10 @@ export async function ensureLoaded(
       continue;
     }
     // Validated above, so the raw record is now a trusted CronJob.
-    const hydrated = hydratedRaw as unknown as CronJob;
+    if (!isValidatedCronJob(hydratedRaw)) {
+      continue;
+    }
+    const hydrated = hydratedRaw;
     jobs.push(hydrated);
     // Capture the value SQLite actually held before schedule-identity repair
     // mutates the runtime view. A later save can then publish that transition.

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -193,13 +193,13 @@ function bindCronJobRow(storeKey: string, job: CronStoredJob, sortOrder: number)
     job_json: JSON.stringify(stripJobRuntimeFields(job)),
     state_json: JSON.stringify(job.state ?? {}),
     runtime_updated_at_ms: job.updatedAtMs,
-    schedule_identity: tryCronScheduleIdentity(job as unknown as Record<string, unknown>) ?? null,
+    schedule_identity: tryCronScheduleIdentity({ ...job }) ?? null,
     sort_order: sortOrder,
   };
 }
 
 function normalizeCronJobForSqlite(job: CronStoreFile["jobs"][number]): CronStoredJob | null {
-  const raw = structuredClone(job) as unknown as Record<string, unknown>;
+  const raw: Record<string, unknown> = { ...structuredClone(job) };
   const hadDeleteAfterRun = Object.hasOwn(raw, "deleteAfterRun");
   normalizeCronJobIdentityFields(raw);
   const normalized = normalizeCronJobInput(raw, { applyDefaults: true });
@@ -570,7 +570,7 @@ export function updateCronRuntimeRows(
           ...bindStateColumns(job.state ?? {}),
           state_json: JSON.stringify(job.state ?? {}),
           runtime_updated_at_ms: job.updatedAtMs,
-          schedule_identity: tryCronScheduleIdentity(job as unknown as Record<string, unknown>),
+          schedule_identity: tryCronScheduleIdentity({ ...job }),
         })
         .where("store_key", "=", storeKey)
         .where("job_id", "=", job.id),

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -161,7 +161,7 @@ type PendingEntry<TPayload = ExecApprovalRequestPayload> = {
   record: ExecApprovalRecord<TPayload>;
   resolve: (decision: ExecApprovalDecision | null) => void;
   reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
+  timer: ReturnType<typeof setTimeout> | null;
   cleanupTimer: ReturnType<typeof setTimeout> | null;
   handoffRetainCount: number;
   handoffReleasedAtMs: number | null;
@@ -367,7 +367,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       record,
       resolve: resolvePromise!,
       reject: rejectPromise!,
-      timer: null as unknown as ReturnType<typeof setTimeout>,
+      timer: null,
       cleanupTimer: null,
       handoffRetainCount: 0,
       handoffReleasedAtMs: null,
@@ -757,7 +757,9 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     if (!pending || pending.record.resolvedAtMs !== undefined) {
       return false;
     }
-    clearTimeout(pending.timer);
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
     pending.record.resolvedAtMs = params.resolvedAtMs;
     if (params.decision === null) {
       delete pending.record.decision;
@@ -875,12 +877,16 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
   }
 
   private scheduleExpiryTimer(entry: PendingEntry<TPayload>): void {
-    const timerDelayMs = resolveApprovalTimeoutMs(entry.record.expiresAtMs - Date.now());
-    entry.timer = setTimeout(() => {
+    entry.timer = this.createExpiryTimer(entry.record);
+  }
+
+  private createExpiryTimer(record: ExecApprovalRecord<TPayload>): ReturnType<typeof setTimeout> {
+    const timerDelayMs = resolveApprovalTimeoutMs(record.expiresAtMs - Date.now());
+    return setTimeout(() => {
       try {
-        this.expireDue(entry.record.id);
+        this.expireDue(record.id);
       } catch (error) {
-        this.reportError(error, { approvalId: entry.record.id, operation: "expire" });
+        this.reportError(error, { approvalId: record.id, operation: "expire" });
       }
     }, timerDelayMs);
   }

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -21,7 +21,7 @@ export type McpToolSchemaEntry = {
 
 function readLoopbackToolField(tool: McpLoopbackTool, key: "name" | "description" | "parameters") {
   try {
-    return (tool as unknown as Record<typeof key, unknown>)[key];
+    return tool[key];
   } catch {
     return undefined;
   }
@@ -45,7 +45,7 @@ function readLoopbackToolDescription(tool: McpLoopbackTool): string | undefined 
 function readLoopbackToolParameters(tool: McpLoopbackTool): Record<string, unknown> | undefined {
   let value;
   try {
-    value = (tool as unknown as { parameters?: unknown }).parameters;
+    value = tool.parameters;
   } catch {
     return undefined;
   }

--- a/src/gateway/question-manager.ts
+++ b/src/gateway/question-manager.ts
@@ -116,15 +116,15 @@ export class QuestionManager {
       expiresAtMs,
       status: "pending",
     };
+    const expiryTimer = setTimeout(() => this.expire(record.id), timeoutMs);
     const entry: QuestionEntry = {
       record,
-      expiryTimer: null as unknown as ReturnType<typeof setTimeout>,
+      expiryTimer,
       cleanupTimer: null,
       waiters: new Set(),
       onResolved: params.onResolved,
     };
     this.entries.set(record.id, entry);
-    entry.expiryTimer = setTimeout(() => this.expire(record.id), timeoutMs);
     unrefTimer(entry.expiryTimer);
     return record;
   }

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -888,6 +888,10 @@ export const cronHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(candidate, validateCronUpdateParams, "cron.update", respond)) {
       return;
     }
+    if (!normalizedPatch) {
+      respondInvalidCronParams(respond, "cron.update", "patch did not normalize");
+      return;
+    }
     const p = candidate as {
       id?: string;
       jobId?: string;
@@ -912,7 +916,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const patch = p.patch as unknown as CronJobPatch;
+    const patch: CronJobPatch = normalizedPatch;
     const cfg = context.getRuntimeConfig();
     const currentJob = await context.cron.readJob(jobId);
     if (

--- a/src/gateway/server-methods/sessions-compaction-runner.ts
+++ b/src/gateway/server-methods/sessions-compaction-runner.ts
@@ -4,7 +4,7 @@ import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { compactEmbeddedAgentSession } from "../../agents/embedded-agent.js";
 import { resolveManualCompactionCliTarget } from "../../agents/session-runtime-compat.js";
 import { preflightManualSessionCompaction } from "../../agents/sessions/manual-compaction-preflight.js";
-import type { SessionEntry as AgentSessionEntry } from "../../agents/sessions/session-manager.js";
+import { isIndexedSessionEntry } from "../../agents/sessions/session-manager-codec.js";
 import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -14,7 +14,6 @@ import {
   resolveSessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
 import {
-  isCanonicalSessionTranscriptEntry,
   scanSessionTranscriptTree,
   selectSessionTranscriptTreePathNodes,
 } from "../../config/sessions/transcript-tree.js";
@@ -71,7 +70,7 @@ export async function preflightGatewaySessionCompaction(
     const tree = scanSessionTranscriptTree(transcriptEvents);
     const branch = selectSessionTranscriptTreePathNodes(tree, tree.leafId)
       .map((node) => node.entry)
-      .filter(isCanonicalSessionTranscriptEntry) as unknown as AgentSessionEntry[];
+      .filter(isIndexedSessionEntry);
     const preflight = preflightManualSessionCompaction(branch, {
       enabled: true,
       reserveTokens: 0,

--- a/src/gateway/server-reload-restart.ts
+++ b/src/gateway/server-reload-restart.ts
@@ -183,14 +183,8 @@ class GatewayRestartTransaction {
       acceptedConfig &&
       configDebt.restartOwnedPaths.every((path) =>
         isDeepStrictEqual(
-          getConfigValueAtPath(
-            configDebt.nextConfig as unknown as Record<string, unknown>,
-            path.split("."),
-          ),
-          getConfigValueAtPath(
-            acceptedConfig as unknown as Record<string, unknown>,
-            path.split("."),
-          ),
+          getConfigValueAtPath({ ...configDebt.nextConfig }, path.split(".")),
+          getConfigValueAtPath({ ...acceptedConfig }, path.split(".")),
         ),
       );
     if (!retainsConfigDebt) {

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -211,9 +211,9 @@ export async function prepareGatewayKernelState(params: {
   const channelLogs = Object.fromEntries(
     listGatewayStartupChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
   ) as Record<ChannelId, ReturnType<typeof createSubsystemLogger>>;
-  const channelRuntimeEnvs = Object.fromEntries(
+  const channelRuntimeEnvs: Partial<Record<ChannelId, RuntimeEnv>> = Object.fromEntries(
     Object.entries(channelLogs).map(([id, logger]) => [id, runtimeForLogger(logger)]),
-  ) as unknown as Record<ChannelId, RuntimeEnv>;
+  );
   const listStartupChannelGatewayMethods = () => {
     const methods: string[] = [];
     for (const plugin of listGatewayStartupChannelPlugins()) {

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -435,7 +435,7 @@ export async function readSessionLeafStateFromTranscriptAsync(
 }
 
 function readSessionLeafStateFromRecords(
-  records: readonly Record<string, unknown>[],
+  records: readonly { type?: unknown; id?: unknown }[],
 ): { entryId: string; leafId: string | null } | null {
   let latestEntryId: string | undefined;
   for (const record of records) {
@@ -620,7 +620,7 @@ async function captureCompactionCheckpointSnapshotAsync(params: {
     if (typeof params.sessionManager?.getEntries !== "function") {
       return null;
     }
-    const entryRecords = params.sessionManager.getEntries() as unknown as Record<string, unknown>[];
+    const entryRecords = params.sessionManager.getEntries();
     const transcriptState = readSessionLeafStateFromRecords(entryRecords);
     const position = resolveCompactionCheckpointTranscriptPosition({
       preferredLeafId: liveLeafId,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -239,7 +239,7 @@ export async function projectSessionsPatchEntry(params: {
   };
 
   const existing = params.existingEntry
-    ? projectCanonicalSessionEntryShape(params.existingEntry as unknown as Record<string, unknown>)
+    ? projectCanonicalSessionEntryShape({ ...params.existingEntry })
     : undefined;
   // Existing entries without session ids are placeholder aliases; assigning an id makes them real.
   const next: SessionEntry = existing?.sessionId

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -666,9 +666,8 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           abortController: new AbortController(),
           launchTasks: new Set<Promise<unknown>>(),
         };
-        const entry = { ...base, handle: undefined as unknown as WorkerTunnelHandle };
-        const created = createHandle(entry, restoredWorkspace);
-        entry.handle = created.handle;
+        const created = createHandle(base, restoredWorkspace);
+        const entry = Object.assign(base, { handle: created.handle });
         entries.set(entry.environmentId, entry);
         try {
           await created.validateRestoredWorkspace();

--- a/src/gateway/ws-log.ts
+++ b/src/gateway/ws-log.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // Gateway WebSocket log formatting.
 // Redacts and compacts request/response/event metadata for console diagnostics.
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
@@ -164,7 +165,7 @@ function renderSingleErrorForLog(error: Error): string {
   if (error.message) {
     parts.push(error.message);
   }
-  const codeValue = (error as unknown as { code?: unknown }).code;
+  const codeValue = isRecord(error) ? error.code : undefined;
   const code =
     typeof codeValue === "string" || typeof codeValue === "number" ? String(codeValue) : "";
   if (code) {
@@ -175,12 +176,12 @@ function renderSingleErrorForLog(error: Error): string {
 
 function renderErrorChainForLog(error: Error): string {
   const segments: string[] = [renderSingleErrorForLog(error)];
-  let current: unknown = (error as unknown as { cause?: unknown }).cause;
+  let current: unknown = error.cause;
   let depth = 0;
   while (current !== undefined && current !== null && depth < 8) {
     if (current instanceof Error) {
       segments.push(renderSingleErrorForLog(current));
-      current = (current as unknown as { cause?: unknown }).cause;
+      current = current.cause;
     } else {
       segments.push(stringifyNonErrorCause(current));
       current = undefined;

--- a/src/infra/agent-activity-events.ts
+++ b/src/infra/agent-activity-events.ts
@@ -8,7 +8,7 @@ type AgentItemEventStatus = "running" | "completed" | "failed" | "blocked";
 type AgentItemEventKind = "tool" | "command" | "patch" | "search" | "analysis" | (string & {});
 
 /** Payload for a single item shown in the agent activity stream. */
-export type AgentItemEventData = {
+export type AgentItemEventData = Record<string, unknown> & {
   itemId: string;
   phase: AgentItemEventPhase;
   kind: AgentItemEventKind;
@@ -32,7 +32,7 @@ export type AgentItemEventData = {
 };
 
 /** Incremental command output payload associated with an item/tool call. */
-export type AgentCommandOutputEventData = {
+export type AgentCommandOutputEventData = Record<string, unknown> & {
   itemId: string;
   phase: "delta" | "end";
   title: string;
@@ -46,7 +46,7 @@ export type AgentCommandOutputEventData = {
 };
 
 /** Patch summary payload emitted after an agent applies file changes. */
-export type AgentPatchSummaryEventData = {
+export type AgentPatchSummaryEventData = Record<string, unknown> & {
   itemId: string;
   phase: "end";
   title: string;
@@ -60,7 +60,7 @@ export type AgentPatchSummaryEventData = {
 
 type AgentActivityEventDataByStream = {
   item: AgentItemEventData;
-  approval: AgentApprovalEventData;
+  approval: AgentApprovalEventData & Record<string, unknown>;
   command_output: AgentCommandOutputEventData;
   patch: AgentPatchSummaryEventData;
 };
@@ -79,7 +79,7 @@ export function emitAgentActivityEvent(params: AgentActivityEventParams): void {
   emitAgentEvent({
     runId: params.runId,
     stream: params.stream,
-    data: params.data as unknown as Record<string, unknown>,
+    data: params.data,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
   });
 }

--- a/src/infra/exec-policy.ts
+++ b/src/infra/exec-policy.ts
@@ -7,10 +7,20 @@ type ExecPolicyLayer = {
   ask?: ExecAsk;
 };
 
+type RequiredExecPolicy = Required<Pick<ExecPolicyLayer, "security" | "ask">>;
+
+export function applyExecPolicyLayer<TBase extends ExecPolicyLayer & RequiredExecPolicy>(
+  base: TBase,
+  layer?: ExecPolicyLayer,
+): Omit<TBase, keyof ExecPolicyLayer> & ExecPolicyLayer & RequiredExecPolicy;
 export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
   base: TBase,
   layer?: ExecPolicyLayer,
-): TBase & ExecPolicyLayer {
+): Omit<TBase, keyof ExecPolicyLayer> & ExecPolicyLayer;
+export function applyExecPolicyLayer(
+  base: ExecPolicyLayer,
+  layer?: ExecPolicyLayer,
+): ExecPolicyLayer {
   if (!layer) {
     return base;
   }
@@ -19,7 +29,7 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
       ...base,
       mode: layer.mode,
       ...resolveExecPolicyForMode(layer.mode),
-    } as unknown as TBase & ExecPolicyLayer;
+    };
   }
   if (layer.security !== undefined || layer.ask !== undefined) {
     const { mode: _mode, ...baseWithoutMode } = base;
@@ -27,7 +37,7 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
       ...baseWithoutMode,
       security: layer.security ?? base.security,
       ask: layer.ask ?? base.ask,
-    } as unknown as TBase & ExecPolicyLayer;
+    };
   }
   return base;
 }

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -1,6 +1,6 @@
 // SSRF policy helpers validate hostnames/IP literals, build pinned DNS lookups,
 // and create dispatcher policies for guarded network fetches.
-import { lookup as dnsLookupCb, type LookupAddress } from "node:dns";
+import { lookup as dnsLookupCb, type LookupAddress, type LookupOptions } from "node:dns";
 import { lookup as dnsLookup } from "node:dns/promises";
 import {
   extractEmbeddedIpv4FromIpv6,
@@ -487,15 +487,6 @@ export function createPinnedLookup(params: {
     throw new Error(`Pinned lookup requires at least one address for ${params.hostname}`);
   }
   const fallback = params.fallback ?? dnsLookupCb;
-  const fallbackLookup = fallback as unknown as (
-    hostname: string,
-    callback: LookupCallback,
-  ) => void;
-  const fallbackWithOptions = fallback as unknown as (
-    hostname: string,
-    options: unknown,
-    callback: LookupCallback,
-  ) => void;
   const records = params.addresses.map((address) => ({
     address,
     family: address.includes(":") ? 6 : 4,
@@ -513,9 +504,12 @@ export function createPinnedLookup(params: {
     const normalized = normalizeHostname(host);
     if (!normalized || normalized !== normalizedHost) {
       if (typeof options === "function" || options === undefined) {
-        return fallbackLookup(host, cb);
+        return fallback(host, cb);
       }
-      return fallbackWithOptions(host, options, cb);
+      if (typeof options === "number") {
+        return fallback(host, options, cb);
+      }
+      return fallback(host, options as LookupOptions, cb);
     }
 
     const opts =

--- a/src/infra/state-migrations.session-store.ts
+++ b/src/infra/state-migrations.session-store.ts
@@ -243,7 +243,8 @@ export function normalizeSessionEntry(
   entry: SessionEntryLike,
   sessionKey?: string,
 ): SessionEntry | null {
-  const shaped = normalizePersistedSessionEntryShape(entry, { sessionKey });
+  const { room, ...entryWithoutRoom } = entry;
+  const shaped = normalizePersistedSessionEntryShape(entryWithoutRoom, { sessionKey });
   if (!shaped) {
     return null;
   }
@@ -254,11 +255,9 @@ export function normalizeSessionEntry(
         ? normalized.updatedAt
         : Date.now();
   }
-  const rec = normalized as unknown as Record<string, unknown>;
-  if (typeof rec.groupChannel !== "string" && typeof rec.room === "string") {
-    rec.groupChannel = rec.room;
+  if (typeof normalized.groupChannel !== "string" && typeof room === "string") {
+    normalized.groupChannel = room;
   }
-  delete rec.room;
   return normalized;
 }
 

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -352,10 +352,7 @@ function logToFile(
   if (level === "silent") {
     return;
   }
-  const safeLevel = level;
-  const method = (fileLogger as unknown as Record<string, unknown>)[safeLevel] as
-    | ((...args: unknown[]) => void)
-    | undefined;
+  const method = fileLogger[level];
   if (typeof method !== "function") {
     return;
   }

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -18,6 +18,10 @@ type CallPluginToolParams = {
   arguments?: unknown;
 };
 
+type ToolWithBeforeToolCallHookContext = AnyAgentTool & {
+  [BEFORE_TOOL_CALL_HOOK_CONTEXT]?: unknown;
+};
+
 function toMcpContentBlock(block: unknown): unknown {
   if (!isRecord(block)) {
     return { type: "text", text: coerceChatContentText(block) };
@@ -56,7 +60,7 @@ function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
 }
 
 function resolveBeforeToolCallRunId(tool: AnyAgentTool): string | undefined {
-  const context = (tool as unknown as Record<symbol, unknown>)[BEFORE_TOOL_CALL_HOOK_CONTEXT];
+  const context = (tool as ToolWithBeforeToolCallHookContext)[BEFORE_TOOL_CALL_HOOK_CONTEXT];
   return isRecord(context) && typeof context.runId === "string" ? context.runId : undefined;
 }
 

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -1049,7 +1049,7 @@ export async function runCliEntry(params: {
     });
     const outputBase = path.join(outputDir, path.parse(mediaPath).name);
 
-    const templCtx: TemplateContext = {
+    const templCtx: TemplateContext & Record<string, unknown> = {
       ...ctx,
       AttachmentPath: mediaPath,
       AttachmentUrl: params.attachment.url ?? params.attachment.path ?? mediaPath,
@@ -1074,7 +1074,7 @@ export async function runCliEntry(params: {
       "MediaTranscribedIndexes",
       "MediaStaged",
     ]) {
-      delete (templCtx as unknown as Record<string, unknown>)[key];
+      delete templCtx[key];
     }
     const argv = [command, ...args].map((part, index) =>
       index === 0 ? part : applyTemplate(part, templCtx),

--- a/src/media/store.remote.runtime.ts
+++ b/src/media/store.remote.runtime.ts
@@ -35,13 +35,13 @@ export async function saveRemoteMediaForStore(params: {
 }): Promise<SavedMedia> {
   const resolvePinned = params.resolvePinnedHostnameForTest;
   const lookupFn: LookupFn | undefined = resolvePinned
-    ? ((async (hostname: string) => {
+    ? async (hostname, _options) => {
         const pinned = await resolvePinned(hostname);
         return pinned.addresses.map((address) => ({
           address,
           family: address.includes(":") ? 6 : 4,
         }));
-      }) as unknown as LookupFn)
+      }
     : undefined;
   const { id, path, size, contentType } = await saveRemoteMedia({
     url: params.source,

--- a/src/meeting-bot/realtime-local-audio-transport.ts
+++ b/src/meeting-bot/realtime-local-audio-transport.ts
@@ -74,8 +74,7 @@ export function createLocalMeetingRealtimeAudioTransport(params: {
   const input = splitCommand(params.inputCommand);
   const output = splitCommand(params.outputCommand);
   const spawnFn: MeetingRealtimeAudioSpawn =
-    params.spawn ??
-    ((command, args, options) => spawn(command, args, options) as unknown as BridgeProcess);
+    params.spawn ?? ((command, args, options) => spawn(command, args, options));
   const spawnOutputProcess = () =>
     spawnFn(output.command, output.args, { stdio: ["pipe", "ignore", "pipe"] });
   let outputProcess = spawnOutputProcess();

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveVoiceModelRefs } from "../tts/voice-models.js";
@@ -42,11 +43,8 @@ type CapabilityContractKey =
   | "videoGenerationProviders"
   | "musicGenerationProviders";
 
-type ProviderFor<K extends CapabilityProviderRegistryKey> = PluginRegistry[K][number] extends {
-  provider: infer T;
-}
-  ? T
-  : never;
+export type CapabilityProviderFor<K extends CapabilityProviderRegistryKey> =
+  PluginRegistry[K][number]["provider"];
 type CapabilityPluginResolution = {
   runtimePluginIds: string[];
   bundledCompatPluginIds: string[];
@@ -149,24 +147,29 @@ function createCapabilityProviderLoadOptions(params: {
 function findProviderById<K extends CapabilityProviderRegistryKey>(
   entries: PluginRegistry[K],
   providerId: string,
-): ProviderFor<K> | undefined {
+): CapabilityProviderFor<K> | undefined {
   const normalizedProviderId = normalizeCapabilityProviderId(providerId);
   if (!normalizedProviderId) {
     return undefined;
   }
-  const providerEntries = entries as unknown as Array<{
-    provider: ProviderFor<K> & { id?: unknown; aliases?: unknown };
-  }>;
-  for (const entry of providerEntries) {
+  for (const entry of entries) {
+    const provider: unknown = entry.provider;
+    if (!isRecord(provider)) {
+      continue;
+    }
     if (
-      typeof entry.provider.id === "string" &&
-      normalizeCapabilityProviderId(entry.provider.id) === normalizedProviderId
+      typeof provider.id === "string" &&
+      normalizeCapabilityProviderId(provider.id) === normalizedProviderId
     ) {
-      return entry.provider;
+      return entry.provider as CapabilityProviderFor<K>;
     }
   }
-  for (const entry of providerEntries) {
-    const aliases = Array.isArray(entry.provider.aliases) ? entry.provider.aliases : [];
+  for (const entry of entries) {
+    const provider: unknown = entry.provider;
+    if (!isRecord(provider)) {
+      continue;
+    }
+    const aliases = Array.isArray(provider.aliases) ? provider.aliases : [];
     if (
       aliases.some(
         (alias) =>
@@ -174,7 +177,7 @@ function findProviderById<K extends CapabilityProviderRegistryKey>(
           normalizeCapabilityProviderId(alias) === normalizedProviderId,
       )
     ) {
-      return entry.provider;
+      return entry.provider as CapabilityProviderFor<K>;
     }
   }
   return undefined;
@@ -183,12 +186,12 @@ function findProviderById<K extends CapabilityProviderRegistryKey>(
 function mergeCapabilityProviders<K extends CapabilityProviderRegistryKey>(
   left: PluginRegistry[K],
   right: PluginRegistry[K],
-): ProviderFor<K>[] {
-  const merged = new Map<string, ProviderFor<K>>();
-  const unnamed: ProviderFor<K>[] = [];
+): CapabilityProviderFor<K>[] {
+  const merged = new Map<string, CapabilityProviderFor<K>>();
+  const unnamed: CapabilityProviderFor<K>[] = [];
   const addEntries = (entries: PluginRegistry[K]) => {
     for (const entry of entries) {
-      const provider = entry.provider as ProviderFor<K> & { id?: string };
+      const provider = entry.provider as CapabilityProviderFor<K> & { id?: string };
       if (!provider.id) {
         unnamed.push(provider);
         continue;
@@ -363,10 +366,10 @@ function filterLoadedProvidersForRequestedConfig<K extends CapabilityProviderReg
     params.key !== "realtimeVoiceProviders" &&
     params.key !== "mediaUnderstandingProviders"
   ) {
-    return [] as unknown as PluginRegistry[K];
+    return [];
   }
   if (params.requested.size === 0) {
-    return [] as unknown as PluginRegistry[K];
+    return [];
   }
   return params.entries.filter((entry) => {
     const provider = entry.provider as { id?: unknown; aliases?: unknown };
@@ -495,7 +498,7 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
   key: K;
   providerId: string;
   cfg?: OpenClawConfig;
-}): ProviderFor<K> | undefined {
+}): CapabilityProviderFor<K> | undefined {
   if (shouldSkipCapabilityResolution(params)) {
     return undefined;
   }
@@ -549,7 +552,7 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
 export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
   key: K;
   cfg?: OpenClawConfig;
-}): ProviderFor<K>[] {
+}): CapabilityProviderFor<K>[] {
   if (shouldSkipCapabilityResolution(params)) {
     return [];
   }
@@ -573,12 +576,12 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
       : undefined;
   if (activeProviders.length > 0 && params.key !== "memoryEmbeddingProviders") {
     if (!missingRequestedProviders && !shouldMergeManifestProvidersWhenActive(params.key)) {
-      return activeProviders.map((entry) => entry.provider) as ProviderFor<K>[];
+      return activeProviders.map((entry) => entry.provider) as CapabilityProviderFor<K>[];
     }
     if (missingRequestedProviders) {
       removeActiveProviderIds(missingRequestedProviders, activeProviders);
       if (missingRequestedProviders.size === 0) {
-        return activeProviders.map((entry) => entry.provider) as ProviderFor<K>[];
+        return activeProviders.map((entry) => entry.provider) as CapabilityProviderFor<K>[];
       }
     }
   }
@@ -650,7 +653,7 @@ export function prepareMediaCapabilityProviders(params: {
 }) {
   const providers = <K extends CapabilityProviderRegistryKey>(
     key: K,
-  ): readonly ProviderFor<K>[] | undefined => {
+  ): readonly CapabilityProviderFor<K>[] | undefined => {
     if (shouldSkipCapabilityResolution({ key, cfg: params.cfg })) {
       return [];
     }
@@ -687,7 +690,7 @@ export function prepareMediaCapabilityProviders(params: {
     }
     return Object.freeze(
       availableEntries.map((entry) => entry.provider),
-    ) as readonly ProviderFor<K>[];
+    ) as readonly CapabilityProviderFor<K>[];
   };
   return Object.freeze({
     mediaUnderstandingProviders: providers("mediaUnderstandingProviders"),

--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -100,7 +100,7 @@ function asLegacyTtsConfig(value: unknown): OpenClawConfig {
 }
 
 function asLegacyOpenClawConfig(value: Record<string, unknown>): OpenClawConfig {
-  return value as unknown as OpenClawConfig;
+  return asLegacyTtsConfig(value);
 }
 
 function mockCallAt(mock: { mock: { calls: Array<Array<unknown>> } }, index: number): unknown[] {
@@ -182,11 +182,8 @@ async function withMockedSpeechFetch(
   audioLength: number,
 ) {
   const originalFetch = globalThis.fetch;
-  const fetchMock = vi.fn(async () => ({
-    ok: true,
-    arrayBuffer: async () => new ArrayBuffer(audioLength),
-  }));
-  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const fetchMock = vi.fn(async () => new Response(new Uint8Array(audioLength)));
+  globalThis.fetch = fetchMock;
   try {
     await run(fetchMock);
   } finally {
@@ -559,12 +556,12 @@ export function describeTtsConfigContract() {
         },
         {
           name: "override",
-          cfg: {
+          cfg: asLegacyTtsConfig({
             ...baseCfg,
             tts: {
               edge: { outputFormat: "audio-24khz-96kbitrate-mono-mp3" },
             },
-          } as unknown as OpenClawConfig,
+          }),
           expected: "audio-24khz-96kbitrate-mono-mp3",
         },
       ] as const)("$name", ({ cfg, expected, name }) => {
@@ -796,22 +793,22 @@ export function describeTtsConfigContract() {
         },
         {
           name: "config wins over env",
-          cfg: {
+          cfg: asLegacyTtsConfig({
             ...baseCfg,
             tts: { ...baseCfg.tts, openai: { baseUrl: "http://my-server:9000/v1" } },
-          } as unknown as OpenClawConfig,
+          }),
           env: { OPENAI_TTS_BASE_URL: "http://localhost:8880/v1" },
           expected: "http://my-server:9000/v1",
         },
         {
           name: "config slash trimming",
-          cfg: {
+          cfg: asLegacyTtsConfig({
             ...baseCfg,
             tts: {
               ...baseCfg.tts,
               openai: { baseUrl: "http://my-server:9000/v1///" },
             },
-          } as unknown as OpenClawConfig,
+          }),
           env: { OPENAI_TTS_BASE_URL: undefined },
           expected: "http://my-server:9000/v1",
         },

--- a/src/plugins/embedding-provider-runtime-shared.ts
+++ b/src/plugins/embedding-provider-runtime-shared.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolvePluginCapabilityProvider,
   resolvePluginCapabilityProviders,
+  type CapabilityProviderFor,
 } from "./capability-provider-runtime.js";
 
 type EmbeddingProviderCapabilityKey = "embeddingProviders" | "memoryEmbeddingProviders";
@@ -29,16 +30,18 @@ export function resolveRuntimeEmbeddingProviderLookupIds(params: {
 }
 
 /** Lists registered and plugin-contributed embedding provider adapters for a capability key. */
-export function listRuntimeEmbeddingProviderAdapters<TAdapter extends { id: string }>(params: {
-  key: EmbeddingProviderCapabilityKey;
+export function listRuntimeEmbeddingProviderAdapters<
+  K extends EmbeddingProviderCapabilityKey,
+>(params: {
+  key: K;
   cfg?: OpenClawConfig;
-  registered: TAdapter[];
-}): TAdapter[] {
+  registered: CapabilityProviderFor<K>[];
+}): CapabilityProviderFor<K>[] {
   const merged = new Map(params.registered.map((adapter) => [adapter.id, adapter]));
   const capabilityAdapters = resolvePluginCapabilityProviders({
     key: params.key,
     cfg: params.cfg,
-  }) as unknown as TAdapter[];
+  });
   for (const adapter of capabilityAdapters) {
     if (!merged.has(adapter.id)) {
       merged.set(adapter.id, adapter);
@@ -48,12 +51,16 @@ export function listRuntimeEmbeddingProviderAdapters<TAdapter extends { id: stri
 }
 
 /** Resolves one embedding provider adapter from registered providers before plugin capabilities. */
-export function getRuntimeEmbeddingProviderAdapter<TAdapter extends { id: string }>(params: {
-  key: EmbeddingProviderCapabilityKey;
+export function getRuntimeEmbeddingProviderAdapter<
+  K extends EmbeddingProviderCapabilityKey,
+>(params: {
+  key: K;
   cfg?: OpenClawConfig;
   lookupIds: string[];
-  getRegisteredProvider: (id: string) => RegisteredAdapterEntry<TAdapter> | undefined;
-}): TAdapter | undefined {
+  getRegisteredProvider: (
+    id: string,
+  ) => RegisteredAdapterEntry<CapabilityProviderFor<K>> | undefined;
+}): CapabilityProviderFor<K> | undefined {
   // Resolve each exact id before trying the next configured alias. Otherwise a
   // registered alias can shadow a plugin-owned adapter for the requested id.
   for (const candidateId of params.lookupIds) {
@@ -65,7 +72,7 @@ export function getRuntimeEmbeddingProviderAdapter<TAdapter extends { id: string
       key: params.key,
       providerId: candidateId,
       cfg: params.cfg,
-    }) as TAdapter | undefined;
+    });
     if (provider) {
       return provider;
     }

--- a/src/plugins/hook-isolation.ts
+++ b/src/plugins/hook-isolation.ts
@@ -2,11 +2,6 @@ import type { PluginHookName } from "./types.js";
 
 export class HookIsolationError extends Error {}
 
-type WebAssemblyMemoryConstructor = {
-  new (...args: unknown[]): object;
-  prototype: object;
-};
-
 function containsSharedMemory(value: unknown, seen: Set<object>): boolean {
   if (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer) {
     return true;
@@ -22,7 +17,7 @@ function containsSharedMemory(value: unknown, seen: Set<object>): boolean {
   }
   const webAssemblyMemory = (
     globalThis as unknown as {
-      WebAssembly?: { Memory?: WebAssemblyMemoryConstructor };
+      WebAssembly?: { Memory?: { new (...args: unknown[]): object; prototype: object } };
     }
   ).WebAssembly?.Memory;
   if (

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -29,6 +29,8 @@ const MAX_PLUGIN_NEXT_TURN_INJECTION_TEXT_LENGTH = 32 * 1024;
 const MAX_PLUGIN_NEXT_TURN_INJECTION_IDEMPOTENCY_KEY_LENGTH = 512;
 const MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION = 32;
 
+type MutableSessionEntry = SessionEntry & Record<string, unknown>;
+
 function normalizeNamespace(value: string): string {
   return value.trim();
 }
@@ -326,7 +328,7 @@ export async function patchPluginSessionExtension(params: {
     },
     (entry, context) => {
       params.assertCurrent?.();
-      const entryRecord = entry as unknown as Record<string, unknown>;
+      const entryRecord = entry as MutableSessionEntry;
       const pluginExtensions = { ...entry.pluginExtensions };
       const pluginState = { ...pluginExtensions[pluginId] };
       if (params.unset === true) {

--- a/src/plugins/session-catalog-history-import.ts
+++ b/src/plugins/session-catalog-history-import.ts
@@ -177,9 +177,9 @@ export async function importSessionCatalogHistory(params: {
         continue;
       }
       const message = {
-        ...(imported as unknown as Record<string, unknown>),
+        ...imported,
         idempotencyKey: `${params.catalogId}-catalog:${params.threadId}:${item.id ?? index}`,
-      } as unknown as AgentMessage;
+      };
       await transcript.appendMessage({
         message,
         idempotencyLookup: "scan",

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -61,7 +61,7 @@ async function readCapturedResponseBodyBounded(
   maxBytes: number,
 ): Promise<CapturedResponseBodyResult> {
   const clone = response.clone();
-  const body = (clone as unknown as { body?: ReadableStream<Uint8Array> | null }).body;
+  const body = clone.body;
   if (!body || typeof body.getReader !== "function") {
     // A real null-body Response consumes as empty. Response-like objects without
     // a stream cannot be read under a byte cap, so never call arrayBuffer().
@@ -76,7 +76,7 @@ async function readCapturedResponseBodyBounded(
   let stalled = false;
   try {
     while (true) {
-      let next: Awaited<ReturnType<typeof reader.read>>;
+      let next: Awaited<ReturnType<typeof readChunkWithIdleTimeout>>;
       try {
         next = await readChunkWithIdleTimeout(
           reader,

--- a/src/secrets/runtime-config-collectors-memory.ts
+++ b/src/secrets/runtime-config-collectors-memory.ts
@@ -40,7 +40,11 @@ export function collectAgentMemorySearchAssignments(params: {
   let defaultApiKeyAssignmentCollected = false;
   const collectedDefaultHeaderKeys = new Set<string>();
   const collectForAgent = ({ entry: rawAgent, source }: ListedAgentEntry) => {
-    const rawAgentRecord = rawAgent as unknown as Record<string, unknown>;
+    const rawAgentValue: unknown = rawAgent;
+    if (!isRecord(rawAgentValue)) {
+      return;
+    }
+    const rawAgentRecord = rawAgentValue;
     const agentMemory = isRecord(rawAgentRecord.memory) ? rawAgentRecord.memory : undefined;
     const memorySearch = isRecord(agentMemory?.search) ? agentMemory.search : undefined;
     const remote = isRecord(memorySearch?.remote) ? memorySearch.remote : undefined;
@@ -48,7 +52,7 @@ export function collectAgentMemorySearchAssignments(params: {
     const agentPath =
       source.kind === "entries" ? `agents.entries.${source.key}` : `agents.list.${source.index}`;
     const active =
-      rawAgentRecord.enabled !== false &&
+      rawAgentRecord["enabled"] !== false &&
       (memorySearch?.enabled ?? defaultsMemorySearch?.enabled ?? true) !== false;
     const owner = {
       ownerKind: "capability",
@@ -58,7 +62,7 @@ export function collectAgentMemorySearchAssignments(params: {
       contract: {
         defaults: defaultsMemorySearch,
         override: memorySearch,
-        agentEnabled: rawAgentRecord.enabled,
+        agentEnabled: rawAgentRecord["enabled"],
       },
     } satisfies SecretAssignmentOwner;
 

--- a/src/secrets/runtime-config-collectors-sandbox.ts
+++ b/src/secrets/runtime-config-collectors-sandbox.ts
@@ -78,7 +78,11 @@ export function collectAgentSandboxAssignments(params: {
 
   for (const candidate of candidates) {
     const rawAgent = candidate.entry;
-    const rawAgentRecord = rawAgent as unknown as Record<string, unknown>;
+    const rawAgentValue: unknown = rawAgent;
+    if (!isRecord(rawAgentValue)) {
+      continue;
+    }
+    const rawAgentRecord = rawAgentValue;
     const agentId = normalizeAgentId(candidate.entryId);
     if (seenAgentIds.has(agentId)) {
       continue;
@@ -99,8 +103,8 @@ export function collectAgentSandboxAssignments(params: {
             ? (defaultsSandbox.scope as "agent" | "session" | "shared")
             : undefined,
       perSession:
-        typeof sandbox?.perSession === "boolean"
-          ? sandbox.perSession
+        typeof sandbox?.["perSession"] === "boolean"
+          ? sandbox["perSession"]
           : typeof defaultsSandbox?.perSession === "boolean"
             ? defaultsSandbox.perSession
             : undefined,
@@ -112,7 +116,7 @@ export function collectAgentSandboxAssignments(params: {
     const owner = sandboxSecretOwner(agentId, {
       defaults: defaultsSandbox,
       override: sandbox,
-      agentEnabled: rawAgentRecord.enabled,
+      agentEnabled: rawAgentRecord["enabled"],
     });
 
     for (const key of SANDBOX_SSH_SECRET_KEYS) {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -797,7 +797,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       ok: true as const,
       path: target.storePath,
       key: target.canonicalKey ?? opts.key,
-      entry: applied.entry as unknown as Record<string, unknown>,
+      entry: { ...applied.entry },
       resolved: {
         modelProvider: resolved.provider,
         model: resolved.model,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -499,10 +499,10 @@ export function beginTuiShutdown(params: {
   clearTimeoutFn?: (timer: TuiProcessExitTimer) => void;
   setTimeoutFn?: TuiProcessExitTimeout;
 }): TuiProcessExitTimer {
-  const setTimeoutFn =
-    params.setTimeoutFn ??
-    ((callback, timeoutMs) => setTimeout(callback, timeoutMs) as unknown as TuiProcessExitTimer);
-  const hardExitTimer = setTimeoutFn(params.forceExit, params.hardExitMs);
+  const hardExit = params.setTimeoutFn
+    ? { kind: "custom" as const, timer: params.setTimeoutFn(params.forceExit, params.hardExitMs) }
+    : { kind: "native" as const, timer: setTimeout(params.forceExit, params.hardExitMs) };
+  const hardExitTimer = hardExit.timer;
   hardExitTimer.unref?.();
   // Stop referenced animations before transport teardown can stall or redraw.
   params.disposeStatus();
@@ -529,10 +529,11 @@ export function beginTuiShutdown(params: {
     })
     .finally(() => {
       if (params.keepHardExitArmed !== true) {
-        const clearTimeoutFn =
-          params.clearTimeoutFn ??
-          ((timer) => clearTimeout(timer as unknown as ReturnType<typeof setTimeout>));
-        clearTimeoutFn(hardExitTimer);
+        if (params.clearTimeoutFn) {
+          params.clearTimeoutFn(hardExitTimer);
+        } else if (hardExit.kind === "native") {
+          clearTimeout(hardExit.timer);
+        }
       }
       params.disposeStatus();
     })
@@ -607,23 +608,23 @@ export function scheduleProcessExitAfterTuiReturn(
   } = {},
 ): TuiProcessExitTimer {
   const delayMs = Math.max(0, Math.floor(params.delayMs ?? TUI_PROCESS_EXIT_AFTER_RETURN_MS));
-  const setTimeoutFn =
-    params.setTimeoutFn ??
-    ((callback, timeoutMs) => setTimeout(callback, timeoutMs) as unknown as TuiProcessExitTimer);
   const exit = params.exit ?? ((code?: number) => process.exit(code));
   const writeStderr =
     params.writeStderr ??
     ((text: string) => {
       process.stderr.write(text);
     });
-  const timer = setTimeoutFn(() => {
+  const onTimeout = () => {
     try {
       writeStderr("openclaw tui forcing process exit after return\n");
     } catch {
       // Best effort only; forced exit must not depend on stderr.
     }
     exit(0);
-  }, delayMs);
+  };
+  const timer = params.setTimeoutFn
+    ? params.setTimeoutFn(onTimeout, delayMs)
+    : setTimeout(onTimeout, delayMs);
   timer.unref?.();
   return timer;
 }


### PR DESCRIPTION
## What Problem This Solves

Removes chained type assertions from the assigned core runtime boundaries where existing type evidence, validated record guards, exact overloads, or initialization state can express the contract honestly. This is the remaining `src/*` campaign lane covering gateway, infra, plugins, cron, media, TUI, and related runtime helpers.

## Why This Change Was Made

The original 92 findings hid structural mismatches behind `as unknown as`. This change removes 52 of them by preserving owner types through construction, using the canonical record guard, modeling required/optional policy overloads, and keeping timer and event identity behavior intact. Sites that are genuine host/dependency quirks or would require public generic/owner contract changes are left unchanged and reported below instead of being cosmetically rephrased.

Production LOC: +185/-148 (net +37) | Test support: +11/-14 (net -3). The positive production delta is concentrated in explicit overloads and validated boundary types; wrapper-heavy and behavior-changing attempts were reverted.

## User Impact

No intended runtime behavior change. The patch improves static safety and keeps existing timer scheduling, event object identity, stream behavior, plugin runtime laziness, and persistence validation semantics.

## Evidence

- Chained-assertion scan: 92 initial findings; 52 fixed; 40 remaining exactly as listed below.
- Focused proof: `node scripts/run-vitest.mjs <36 targeted files>` routed 11 Vitest shards; 36 files and 1,012 tests passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs`: passed formatting, dead exports, core/extension production and test typechecks, core/extension lint, schema/storage guards, and import-cycle checks. The configured remote backend was unavailable, so the documented local worktree-scoped fallback ran.
- Autoreview: `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean; no accepted/actionable findings.

### Intentional leftovers (22)

- `src/runtime.ts:34` — Vitest attaches mock metadata to the console function outside the standard function type.
- `src/gateway/test-http-response.ts:25` — intentionally incomplete `ServerResponse` test double.
- `src/gateway/test-http-response.ts:39` — intentionally incomplete `IncomingMessage` test double.
- `src/gateway/test-http-response.ts:40` — intentionally incomplete `ServerResponse` test double.
- `src/gateway/mcp-app-standalone.ts:235` — browser-global host surface compiled from the Node-owned standalone app module.
- `src/process/exec-spawn.ts:44` — Execa's discriminated generic option union is not preserved through the sanitized option spread.
- `src/plugins/runtime/index.ts:339` — lazy `defineProperty` initialization completes the runtime typestate at runtime.
- `src/infra/net/runtime-fetch.ts:45` — Undici and DOM `FormData`/`BodyInit` live in distinct type namespaces.
- `src/infra/net/runtime-fetch.ts:101` — Undici and DOM fetch request types live in distinct type namespaces.
- `src/media/runtime-prompt-image-provenance.ts:34` — process-global symbol metadata is attached to an array without changing provider-visible bytes.
- `src/infra/diagnostic-trace-propagation.ts:81` — generic event types are intentionally erased only inside the cross-copy global registry.
- `src/shared/json-schema-defaults.ts:676` — the normalization dependency's `JsonSchemaValue` excludes arrays although this runtime walker handles them.
- `src/plugins/loader-runtime-load.ts:141` — discovery intentionally supplies a config-only runtime that the registry wraps with lazy capabilities.
- `src/acp/server.ts:190` — Node `stream/web` and ACP SDK DOM stream types are structurally incompatible namespaces.
- `src/acp/client.ts:202` — Node `stream/web` and ACP SDK DOM stream types are structurally incompatible namespaces.
- `src/process/command-queue.capacity-groups.ts:76` — process-global singleton migration adds fields absent from the current inferred initializer type.
- `src/plugins/hook-isolation.ts:19` — optional WebAssembly host globals are absent from the configured TypeScript global surface.
- `src/infra/backup-volatile-stat-cache.ts:7` — node-tar consumes a deliberately partial synthetic `Stats` object for volatile-path suppression.
- `src/infra/unhandled-rejections.ts:22` — process-global symbol registry shared across duplicated SDK module instances.
- `src/infra/unhandled-rejections.ts:32` — process-global symbol registry shared across duplicated SDK module instances.
- `src/meeting-bot/plugin-shell.ts:251` — zero-runtime type factory exposes compile-time meeting plugin aliases.
- `src/proxy-capture/store.sqlite.ts:865` — constructor overloads intentionally project different return contracts from runtime argument dispatch.

### Deferred leftovers (18)

- `src/gateway/server-methods/chat-transcript-inject.ts:96` — gateway audio content exceeds the current model-owned assistant-content contract.
- `src/meeting-bot/platform-adapter.ts:142` — generic `Health` may add required fields; fixing requires narrowing the public adapter contract.
- `src/meeting-bot/platform-adapter.ts:246` — generic `Transcript` may add required fields; fixing requires narrowing the public adapter contract.
- `src/meeting-bot/browser-controller.ts:200` — generic meeting health construction requires an owner contract for extra fields.
- `src/meeting-bot/browser-controller.ts:222` — generic meeting health construction requires an owner contract for extra fields.
- `src/meeting-bot/browser-controller.ts:289` — generic meeting health construction requires an owner contract for extra fields.
- `src/meeting-bot/browser-controller.ts:391` — generic meeting health construction requires an owner contract for extra fields.
- `src/meeting-bot/browser-controller.ts:466` — generic meeting health construction requires an owner contract for extra fields.
- `src/channels/plugins/config-schema.ts:81` — changing the catchall schema generic would alter a public Plugin SDK type surface.
- `src/channels/plugins/config-schema.ts:81` — the return projection depends on that same public generic contract.
- `src/channels/plugins/config-schema.ts:150` — Zod refinement widens the public generic schema result.
- `src/trajectory/export.ts:176` — legacy pre-v2 rows need an explicit pre-migration entry type owned by the parser.
- `src/trajectory/export.ts:186` — legacy compaction targets need that same parser-owned entry type.
- `src/plugins/interactive.ts:188` — reconstructing generic handler context requires a narrower public interactive context contract.
- `src/gateway/cli-session-history.claude.ts:486` — external CLI history is transcript-like but not a complete `AgentMessage`.
- `src/gateway/cli-session-history.claude.ts:487` — redaction returns `AgentMessage` while this importer promises transcript-like records.
- `src/infra/state-migrations.meeting-transcripts-files.ts:178` — the summary guard does not currently validate array element types; tightening it would change accepted legacy data.
- `src/plugins/registry-runtime.ts:184` — wrapping an overloaded inbound-context builder requires preserving its public overload set at the owner.
