### PR TITLE
fix(android): resample realtime mic audio to gateway rate

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -146,6 +146,11 @@ internal class AndroidAudioInputSession private constructor(
   internal val appliedPreferredDeviceKey: String?
     get() = synchronized(lock) { appliedPreferredInputKey }
 
+  /** AudioRecord's actual negotiated sample rate; callers that resample capture
+   * to a wire rate must verify this matches the requested rate before trusting it. */
+  internal val actualSampleRateHz: Int
+    get() = audioRecord.sampleRate
+
   fun startRecording() {
     synchronized(lock) {
       check(!closed) { "audio input session closed" }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCaptureResampler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCaptureResampler.kt
@@ -1,0 +1,126 @@
+package ai.openclaw.app.voice
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+/**
+ * Converts little-endian PCM16 mono audio from a device-portable hardware
+ * capture rate to the realtime wire rate the Gateway declared in
+ * talk.session.create's audio contract. Android hardware capture and the
+ * realtime wire format are separate invariants (Android 14 CDD only
+ * guarantees 16k/44.1k/48k raw PCM capture; the wire rate is whatever the
+ * Gateway configured for the provider) and must never be conflated by
+ * sending unconverted PCM at the wrong clock.
+ *
+ * Only exact integer downsample ratios are supported (anti-alias FIR
+ * lowpass + decimate-by-M, or a passthrough when the rates already match).
+ * [resolveRealtimeCaptureResampler] returns null for any other ratio so the
+ * caller fails closed instead of shipping mis-clocked audio.
+ */
+internal class RealtimeCaptureResampler private constructor(
+  private val decimationFactor: Int,
+  private val taps: DoubleArray,
+) {
+  companion object {
+    fun create(decimationFactor: Int): RealtimeCaptureResampler {
+      if (decimationFactor <= 1) return RealtimeCaptureResampler(1, DoubleArray(0))
+      val numTaps = 8 * decimationFactor + 1
+      val center = (numTaps - 1) / 2.0
+      val cutoff = 1.0 / (2.0 * decimationFactor)
+      val raw =
+        DoubleArray(numTaps) { n ->
+          val x = n - center
+          val ideal = if (x == 0.0) 2.0 * cutoff else sin(2.0 * PI * cutoff * x) / (PI * x)
+          val window = 0.54 - 0.46 * cos(2.0 * PI * n / (numTaps - 1))
+          ideal * window
+        }
+      val gain = raw.sum()
+      return RealtimeCaptureResampler(decimationFactor, DoubleArray(numTaps) { raw[it] / gain })
+    }
+  }
+
+  private val historyLen = (taps.size - 1).coerceAtLeast(0)
+  private val history = DoubleArray(historyLen)
+  private var phase = 0
+  private var pendingByte: Byte? = null
+
+  /** Consumes one capture-rate PCM16 chunk (first [length] bytes of [input]) and returns wire-rate PCM16 bytes. */
+  fun process(
+    input: ByteArray,
+    length: Int,
+  ): ByteArray {
+    val samples = consumeBytes(input, length)
+    if (decimationFactor == 1) return samplesToBytes(samples)
+    if (samples.isEmpty()) return ByteArray(0)
+    val combined = DoubleArray(historyLen + samples.size)
+    history.copyInto(combined)
+    samples.copyInto(combined, historyLen)
+    val outputs = ArrayList<Double>(samples.size / decimationFactor + 1)
+    for (i in samples.indices) {
+      if ((phase + i) % decimationFactor == decimationFactor - 1) {
+        val windowEnd = historyLen + i
+        var acc = 0.0
+        for (k in taps.indices) acc += taps[k] * combined[windowEnd - k]
+        outputs.add(acc)
+      }
+    }
+    phase = (phase + samples.size) % decimationFactor
+    combined.copyInto(history, destinationOffset = 0, startIndex = samples.size, endIndex = samples.size + historyLen)
+    return samplesToBytes(outputs.toDoubleArray())
+  }
+
+  /** Merges a carried-over odd trailing byte with [input] and decodes little-endian PCM16 samples. */
+  private fun consumeBytes(
+    input: ByteArray,
+    length: Int,
+  ): DoubleArray {
+    val usableLength = length.coerceIn(0, input.size)
+    val prefix = pendingByte
+    pendingByte = null
+    val merged =
+      if (prefix == null) {
+        input
+      } else {
+        ByteArray(usableLength + 1).also { buf ->
+          buf[0] = prefix
+          System.arraycopy(input, 0, buf, 1, usableLength)
+        }
+      }
+    val mergedLength = usableLength + if (prefix == null) 0 else 1
+    val sampleCount = mergedLength / 2
+    val samples = DoubleArray(sampleCount)
+    for (i in 0 until sampleCount) {
+      val base = i * 2
+      val lo = merged[base].toInt() and 0xff
+      val hi = merged[base + 1].toInt()
+      samples[i] = ((lo) or (hi shl 8)).toShort().toInt().toDouble()
+    }
+    if (mergedLength % 2 == 1) pendingByte = merged[mergedLength - 1]
+    return samples
+  }
+
+  private fun samplesToBytes(samples: DoubleArray): ByteArray {
+    val out = ByteArray(samples.size * 2)
+    for (i in samples.indices) {
+      val clamped = samples[i].roundToInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+      out[i * 2] = (clamped and 0xff).toByte()
+      out[i * 2 + 1] = ((clamped shr 8) and 0xff).toByte()
+    }
+    return out
+  }
+}
+
+/**
+ * Resolves the capture-to-wire converter for [captureRateHz] -> [wireRateHz], or null when the
+ * ratio isn't an exact integer downsample (caller must fail closed rather than guess a conversion).
+ */
+internal fun resolveRealtimeCaptureResampler(
+  captureRateHz: Int,
+  wireRateHz: Int,
+): RealtimeCaptureResampler? {
+  if (captureRateHz <= 0 || wireRateHz <= 0 || captureRateHz < wireRateHz) return null
+  if (captureRateHz % wireRateHz != 0) return null
+  return RealtimeCaptureResampler.create(captureRateHz / wireRateHz)
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -223,7 +223,16 @@ class TalkModeManager internal constructor(
 ) {
   companion object {
     private const val tag = "TalkMode"
-    private const val realtimeSampleRateHz = 24_000
+
+    // Realtime playback (provider -> device) is Gateway-declared PCM16 wire
+    // audio, played back verbatim; realtime capture (device -> provider) uses
+    // a device-portable hardware rate and is resampled to the Gateway's
+    // declared wire rate before appendAudio (see startRealtimeCaptureLocked).
+    // These are deliberately separate constants: Android 14 CDD only
+    // guarantees 16k/44.1k/48k raw PCM capture, so capture cannot assume the
+    // wire rate is a usable AudioRecord rate on every device.
+    private const val realtimeOutputSampleRateHz = 24_000
+    private const val realtimeCapturePortableSampleRateHz = 48_000
     private const val realtimeAudioFrameMs = 100
     private const val chatFinalWaitMs = 45_000L
     private const val maxCachedRunCompletions = 128
@@ -342,6 +351,8 @@ class TalkModeManager internal constructor(
   private val audioInputGeneration = AtomicLong(0L)
 
   @Volatile private var realtimeSessionId: String? = null
+  private var realtimeWireAudioSampleRateHz: Int? = null
+  private var realtimeWireAudioEncoding: String? = null
   private var realtimeCaptureJob: Job? = null
   private var realtimeAppendJob: Job? = null
   private val realtimeCapturePauseLock = Any()
@@ -1137,6 +1148,12 @@ class TalkModeManager internal constructor(
       throw CancellationException("realtime talk stopped while connecting")
     }
 
+    // Capture must resample to whatever wire rate the Gateway declares here,
+    // never a rate Android assumes on its own (see realtimeCapturePortableSampleRateHz).
+    val audioContract = root?.get("audio").asObjectOrNull()
+    realtimeWireAudioEncoding = audioContract?.get("inputEncoding").asStringOrNull()
+    realtimeWireAudioSampleRateHz = audioContract?.get("inputSampleRateHz").asIntOrNull()
+
     val capturePaused =
       synchronized(realtimeCapturePauseLock) {
         // Session publication and capture installation are one transition. PTT
@@ -1231,6 +1248,22 @@ class TalkModeManager internal constructor(
   /** Caller holds [realtimeCapturePauseLock] so PTT cannot miss newly installed jobs. */
   @SuppressLint("MissingPermission")
   private fun startRealtimeCaptureLocked(sessionId: String) {
+    val wireSampleRateHz = realtimeWireAudioSampleRateHz
+    val wireEncoding = realtimeWireAudioEncoding
+    val resampler =
+      if (wireEncoding == "pcm16" && wireSampleRateHz != null) {
+        resolveRealtimeCaptureResampler(realtimeCapturePortableSampleRateHz, wireSampleRateHz)
+      } else {
+        null
+      }
+    if (resampler == null) {
+      Log.w(
+        tag,
+        "realtime capture rejected: unsupported wire audio format encoding=$wireEncoding sampleRateHz=$wireSampleRateHz",
+      )
+      failRealtimeRelay(sessionId, "unsupported realtime audio format")
+      return
+    }
     realtimeCaptureJob?.cancel()
     realtimeAppendJob?.cancel()
     val inputGeneration = audioInputGeneration.incrementAndGet()
@@ -1272,11 +1305,11 @@ class TalkModeManager internal constructor(
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         var audioInput: AndroidAudioInputSession? = null
         try {
-          val frameBytes = realtimeSampleRateHz * 2 * realtimeAudioFrameMs / 1000
+          val frameBytes = realtimeCapturePortableSampleRateHz * 2 * realtimeAudioFrameMs / 1000
           val openedAudioInput =
             AndroidAudioInputSession.open(
               context,
-              realtimeSampleRateHz,
+              realtimeCapturePortableSampleRateHz,
               frameBytes,
               preferredAudioInputDevice(),
               { key ->
@@ -1284,14 +1317,18 @@ class TalkModeManager internal constructor(
               },
             )
           audioInput = openedAudioInput
+          check(openedAudioInput.actualSampleRateHz == realtimeCapturePortableSampleRateHz) {
+            "AudioRecord negotiated ${openedAudioInput.actualSampleRateHz}Hz, requested $realtimeCapturePortableSampleRateHz"
+          }
           val buffer = ByteArray(frameBytes)
           audioInput.startRecording()
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
             _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.pcm16Level(buffer, read))
-            if (!shouldAppendRealtimeCapturedFrame(read)) continue
-            audioFrames.trySend(buffer.copyOf(read))
+            val resampled = resampler.process(buffer, read)
+            if (!shouldAppendRealtimeCapturedFrame(resampled.size)) continue
+            audioFrames.trySend(resampled)
           }
         } catch (err: Throwable) {
           if (err is CancellationException) throw err
@@ -1491,14 +1528,14 @@ class TalkModeManager internal constructor(
         realtimeAudioTrack ?: run {
           val minBuffer =
             AudioTrack.getMinBufferSize(
-              realtimeSampleRateHz,
+              realtimeOutputSampleRateHz,
               AudioFormat.CHANNEL_OUT_MONO,
               AudioFormat.ENCODING_PCM_16BIT,
             )
           val bufferSizeBytes =
             maxOf(
               minBuffer * 2,
-              realtimeSampleRateHz * 2 * realtimePlaybackBufferMs / 1000,
+              realtimeOutputSampleRateHz * 2 * realtimePlaybackBufferMs / 1000,
               bytes.size * 4,
             )
           val created =
@@ -1514,7 +1551,7 @@ class TalkModeManager internal constructor(
                 AudioFormat
                   .Builder()
                   .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                  .setSampleRate(realtimeSampleRateHz)
+                  .setSampleRate(realtimeOutputSampleRateHz)
                   .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
                   .build(),
               ).setTransferMode(AudioTrack.MODE_STREAM)
@@ -1543,7 +1580,7 @@ class TalkModeManager internal constructor(
         TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
       _isSpeaking.value = true
       setStatus(nativeText("Speaking…"))
-      val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
+      val durationMs = ((writtenBytes / 2.0) / realtimeOutputSampleRateHz * 1000.0).toLong()
       realtimeWrittenFrames += writtenBytes / 2L
       val now = SystemClock.elapsedRealtime()
       realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
@@ -1678,6 +1715,8 @@ class TalkModeManager internal constructor(
         val currentSessionId = realtimeSessionId
         val currentCaptureJobs = realtimeCaptureJob to realtimeAppendJob
         realtimeSessionId = null
+        realtimeWireAudioSampleRateHz = null
+        realtimeWireAudioEncoding = null
         realtimeCaptureJob = null
         realtimeAppendJob = null
         realtimeCapturePause = null
@@ -3327,6 +3366,11 @@ private fun JsonElement?.asStringOrNull(): String? = (this as? JsonPrimitive)?.t
 private fun JsonElement?.asDoubleOrNull(): Double? {
   val primitive = this as? JsonPrimitive ?: return null
   return primitive.content.toDoubleOrNull()
+}
+
+private fun JsonElement?.asIntOrNull(): Int? {
+  val primitive = this as? JsonPrimitive ?: return null
+  return primitive.content.toIntOrNull()
 }
 
 private fun JsonElement?.asBooleanOrNull(): Boolean? {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -125,6 +125,27 @@ internal suspend fun requestPhoneRealtimeSessionWithLanguageFallback(
     request(null)
   }
 
+internal data class RealtimeWireAudioContract(
+  val encoding: String?,
+  val sampleRateHz: Int?,
+)
+
+/**
+ * TalkSessionCreateResultSchema.audio is optional (older/simpler Gateway peers omit it
+ * entirely); an absent field is the established legacy PCM16/24kHz relay format iOS also
+ * still defaults to (RealtimeTalkRelaySession.configureAudioContract), not an unsupported
+ * contract. A field that IS present but doesn't parse as a usable pcm16 rate stays
+ * fail-closed via the caller's existing null checks.
+ */
+internal fun parseRealtimeWireAudioContract(root: JsonObject?): RealtimeWireAudioContract {
+  val rawAudioContract = root?.get("audio") ?: return RealtimeWireAudioContract("pcm16", 24_000)
+  val audioContract = rawAudioContract.asObjectOrNull()
+  return RealtimeWireAudioContract(
+    encoding = audioContract?.get("inputEncoding").asStringOrNull(),
+    sampleRateHz = audioContract?.get("inputSampleRateHz").asIntOrNull(),
+  )
+}
+
 private enum class TalkStatusState {
   Off,
   Active,
@@ -1150,9 +1171,9 @@ class TalkModeManager internal constructor(
 
     // Capture must resample to whatever wire rate the Gateway declares here,
     // never a rate Android assumes on its own (see realtimeCapturePortableSampleRateHz).
-    val audioContract = root?.get("audio").asObjectOrNull()
-    realtimeWireAudioEncoding = audioContract?.get("inputEncoding").asStringOrNull()
-    realtimeWireAudioSampleRateHz = audioContract?.get("inputSampleRateHz").asIntOrNull()
+    val wireAudioContract = parseRealtimeWireAudioContract(root)
+    realtimeWireAudioEncoding = wireAudioContract.encoding
+    realtimeWireAudioSampleRateHz = wireAudioContract.sampleRateHz
 
     val capturePaused =
       synchronized(realtimeCapturePauseLock) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureResamplerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureResamplerTest.kt
@@ -1,0 +1,180 @@
+package ai.openclaw.app.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+class RealtimeCaptureResamplerTest {
+  @Test
+  fun rejectsRatiosThatArentAnExactIntegerDownsample() {
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 48_000, wireRateHz = 22_050))
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 16_000, wireRateHz = 24_000))
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 48_000, wireRateHz = 0))
+    assertNull(resolveRealtimeCaptureResampler(captureRateHz = 0, wireRateHz = 24_000))
+  }
+
+  @Test
+  fun equalRatePassesThroughUnchanged() {
+    val resampler = resolveRealtimeCaptureResampler(captureRateHz = 24_000, wireRateHz = 24_000)!!
+    val input = sineSamples(freqHz = 440.0, sampleRateHz = 24_000, count = 480)
+    val bytes = pcm16Bytes(input)
+
+    val output = resampler.process(bytes, bytes.size)
+
+    assertEquals(bytes.size, output.size)
+    assertTrue(bytes.contentEquals(output))
+  }
+
+  @Test
+  fun downsample48kTo24kHalvesTheSampleCount() {
+    val resampler = resolveRealtimeCaptureResampler(captureRateHz = 48_000, wireRateHz = 24_000)!!
+    val chunk = pcm16Bytes(sineSamples(freqHz = 1_000.0, sampleRateHz = 48_000, count = 4_800))
+
+    val output = resampler.process(chunk, chunk.size)
+
+    // 100ms of 48kHz capture (4,800 samples) must become 100ms of 24kHz wire
+    // audio (2,400 samples) -- the frame represents the Gateway-advertised
+    // rate, not the capture rate.
+    assertEquals(2_400 * 2, output.size)
+  }
+
+  @Test
+  fun chunkBoundariesProduceNoGapsOrDuplicationVersusOneShotProcessing() {
+    val signal = sineSamples(freqHz = 300.0, sampleRateHz = 48_000, count = 9_600)
+    val bytes = pcm16Bytes(signal)
+
+    val wholeChunk = resolveRealtimeCaptureResampler(48_000, 24_000)!!.process(bytes, bytes.size)
+
+    val piecemeal = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val out = java.io.ByteArrayOutputStream()
+    var offset = 0
+    // Odd, uneven chunk sizes -- not a clean divisor of the frame or the
+    // decimation factor -- exercise both chunk-boundary continuity and
+    // odd-sized input handling in one pass.
+    val chunkSizesBytes = intArrayOf(37, 501, 2, 1200, 4001, 999)
+    var chunkIndex = 0
+    while (offset < bytes.size) {
+      val size = minOf(chunkSizesBytes[chunkIndex % chunkSizesBytes.size], bytes.size - offset)
+      chunkIndex += 1
+      val piece = bytes.copyOfRange(offset, offset + size)
+      out.write(piecemeal.process(piece, piece.size))
+      offset += size
+    }
+
+    assertTrue(wholeChunk.contentEquals(out.toByteArray()))
+  }
+
+  @Test
+  fun constantSignalReachesASteadyStateConstantOutput() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val level = 5_000
+    val bytes = pcm16Bytes(IntArray(9_600) { level })
+
+    val output = pcm16Samples(resampler.process(bytes, bytes.size))
+
+    // Skip the filter's warm-up transient (zero-initialized history); the
+    // rest of a sustained DC input must settle back to the input level.
+    for (sample in output.drop(64)) {
+      assertEquals(level.toDouble(), sample.toDouble(), 3.0)
+    }
+  }
+
+  @Test
+  fun belowNyquistToneKeepsItsFrequencyAfterDecimation() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val freqHz = 1_000.0
+    val durationSamples = 48_000 // 1 second, safely below the 12kHz output Nyquist
+    val bytes = pcm16Bytes(sineSamples(freqHz, 48_000, durationSamples))
+
+    val output = pcm16Samples(resampler.process(bytes, bytes.size))
+
+    val steadyState = output.drop(64)
+    val crossings = zeroCrossings(steadyState)
+    val steadySeconds = steadyState.size / 24_000.0
+    val estimatedHz = crossings / 2.0 / steadySeconds
+
+    assertEquals(freqHz, estimatedHz, 25.0)
+  }
+
+  @Test
+  fun aliasSensitiveHighFrequencyIsAttenuatedNotAliasedThrough() {
+    // 20kHz at 48kHz capture is above the 12kHz output Nyquist; naive
+    // drop-every-other-sample decimation aliases it into the 4kHz audible
+    // band. The anti-alias filter must suppress it instead.
+    val freqHz = 20_000.0
+    val captureCount = 9_600
+    val samples = sineSamples(freqHz, 48_000, captureCount)
+    val bytes = pcm16Bytes(samples)
+
+    val filtered = pcm16Samples(resolveRealtimeCaptureResampler(48_000, 24_000)!!.process(bytes, bytes.size))
+    val naive = DoubleArray(samples.size / 2) { samples[it * 2].toDouble() }
+
+    assertTrue(rms(filtered.map { it.toDouble() }) < rms(naive.toList()) * 0.25)
+  }
+
+  @Test
+  fun fullScaleSquareEdgesStayWithinPcm16Bounds() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val samples = IntArray(4_800) { if (it % 2 == 0) Short.MAX_VALUE.toInt() else Short.MIN_VALUE.toInt() }
+    val bytes = pcm16Bytes(samples)
+
+    val output = pcm16Samples(resampler.process(bytes, bytes.size))
+
+    for (sample in output) {
+      assertTrue(sample >= Short.MIN_VALUE.toInt() && sample <= Short.MAX_VALUE.toInt())
+    }
+  }
+
+  @Test
+  fun freshInstancesDoNotShareStateAcrossSessions() {
+    val leftoverOddByte = byteArrayOf(0x11, 0x22, 0x33)
+    resolveRealtimeCaptureResampler(48_000, 24_000)!!.process(leftoverOddByte, leftoverOddByte.size)
+
+    // A brand new instance for a new capture session (as startRealtimeCaptureLocked
+    // creates on every start/PTT-resume) must behave identically to the very
+    // first instance ever created, regardless of what a prior session did.
+    val a = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val b = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val bytes = pcm16Bytes(sineSamples(500.0, 48_000, 4_800))
+
+    assertTrue(a.process(bytes, bytes.size).contentEquals(b.process(bytes, bytes.size)))
+  }
+
+  private fun sineSamples(
+    freqHz: Double,
+    sampleRateHz: Int,
+    count: Int,
+    amplitude: Int = 16_000,
+  ): IntArray = IntArray(count) { n -> (amplitude * sin(2.0 * PI * freqHz * n / sampleRateHz)).roundToInt() }
+
+  private fun pcm16Bytes(samples: IntArray): ByteArray {
+    val bytes = ByteArray(samples.size * 2)
+    for (i in samples.indices) {
+      bytes[i * 2] = (samples[i] and 0xff).toByte()
+      bytes[i * 2 + 1] = ((samples[i] shr 8) and 0xff).toByte()
+    }
+    return bytes
+  }
+
+  private fun pcm16Samples(bytes: ByteArray): IntArray =
+    IntArray(bytes.size / 2) { i ->
+      val lo = bytes[i * 2].toInt() and 0xff
+      val hi = bytes[i * 2 + 1].toInt()
+      ((lo) or (hi shl 8)).toShort().toInt()
+    }
+
+  private fun zeroCrossings(samples: List<Int>): Int {
+    var count = 0
+    for (i in 1 until samples.size) {
+      if ((samples[i - 1] < 0) != (samples[i] < 0)) count += 1
+    }
+    return count
+  }
+
+  private fun rms(samples: List<Double>): Double = sqrt(samples.sumOf { it * it } / samples.size)
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -913,8 +915,12 @@ class TalkModeManagerTest {
     }
 
   @Test
-  fun resumingRealtimeCaptureFailsClosedWithoutAWireAudioContract() =
+  fun resumingRealtimeCaptureFailsClosedWhenWireAudioContractNeverResolved() =
     runTest {
+      // Distinct from an absent talk.session.create `audio` field (which now resolves to
+      // the legacy pcm16/24kHz contract, see parseRealtimeWireAudioContract tests below):
+      // this is the fields simply never having been populated at all, which must still
+      // fail closed rather than silently guess a rate.
       val manager =
         createManager(
           scope = this,
@@ -933,6 +939,61 @@ class TalkModeManagerTest {
       assertFalse(manager.isEnabled.value)
       assertNull(readPrivateField(manager, "realtimeCaptureJob"))
     }
+
+  @Test
+  fun absentAudioContractParsesToTheLegacyPcm16TwentyFourKhzWireFormat() {
+    // talk.session.create's `audio` field is optional (TalkSessionCreateResultSchema);
+    // older/simpler Gateway peers omit it, and iOS's RealtimeTalkRelaySession still
+    // defaults to this exact pcm16/24kHz contract in that case. Android must match, not
+    // treat an absent field as an unsupported contract.
+    val root = Json.parseToJsonElement("""{"relaySessionId":"relay-1"}""").jsonObject
+
+    val contract = parseRealtimeWireAudioContract(root)
+
+    assertEquals("pcm16", contract.encoding)
+    assertEquals(24_000, contract.sampleRateHz)
+  }
+
+  @Test
+  fun presentAudioContractIsParsedAsDeclared() {
+    val root =
+      Json
+        .parseToJsonElement(
+          """{"relaySessionId":"relay-1","audio":{"inputEncoding":"pcm16","inputSampleRateHz":48000}}""",
+        ).jsonObject
+
+    val contract = parseRealtimeWireAudioContract(root)
+
+    assertEquals("pcm16", contract.encoding)
+    assertEquals(48_000, contract.sampleRateHz)
+  }
+
+  @Test
+  fun malformedAudioContractStaysUnresolvedForFailClosed() {
+    // Present but not an object at all -- an explicitly unsupported shape, not an
+    // omission, so it must not fall back to the legacy contract.
+    val notAnObject = Json.parseToJsonElement("""{"relaySessionId":"relay-1","audio":"unsupported"}""").jsonObject
+    // Present as an object but missing the fields this client understands.
+    val emptyObject = Json.parseToJsonElement("""{"relaySessionId":"relay-1","audio":{}}""").jsonObject
+
+    for (root in listOf(notAnObject, emptyObject)) {
+      val contract = parseRealtimeWireAudioContract(root)
+      assertNull(contract.encoding)
+      assertNull(contract.sampleRateHz)
+    }
+  }
+
+  @Test
+  fun legacyFallbackWireRateResolvesToTheSame48kTo24kResamplerPath() {
+    // Locks the composition end to end: an absent audio contract must land on exactly
+    // the same capture-portable-rate -> wire-rate conversion already proven correct by
+    // RealtimeCaptureResamplerTest, not a rate the resampler rejects.
+    val contract = parseRealtimeWireAudioContract(Json.parseToJsonElement("""{"relaySessionId":"relay-1"}""").jsonObject)
+
+    val resampler = resolveRealtimeCaptureResampler(48_000, contract.sampleRateHz!!)
+
+    assertTrue(resampler != null)
+  }
 
   @Test
   fun replacementRelayPublishedDuringPushToTalkResumesCapture() =

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -891,6 +891,8 @@ class TalkModeManagerTest {
       val pause = readPrivateField(manager, "realtimeCapturePause")!!
       setPrivateField(pause, "sessionId", "relay-1")
       setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "realtimeWireAudioSampleRateHz", 24_000)
+      setPrivateField(manager, "realtimeWireAudioEncoding", "pcm16")
       setMutableStateFlow(manager, "_isListening", false)
       setMutableStateFlow(manager, "_statusText", nativeText("Thinking…"))
 
@@ -911,6 +913,28 @@ class TalkModeManagerTest {
     }
 
   @Test
+  fun resumingRealtimeCaptureFailsClosedWithoutAWireAudioContract() =
+    runTest {
+      val manager =
+        createManager(
+          scope = this,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setMutableStateFlow(manager, "_isListening", false)
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertFalse(manager.isListening.value)
+      assertFalse(manager.isEnabled.value)
+      assertNull(readPrivateField(manager, "realtimeCaptureJob"))
+    }
+
+  @Test
   fun replacementRelayPublishedDuringPushToTalkResumesCapture() =
     runTest {
       val manager =
@@ -924,6 +948,8 @@ class TalkModeManagerTest {
       setPrivateField(pause, "sessionId", "relay-replacement")
       setPrivateField(pause, "restartRelay", true)
       setPrivateField(manager, "realtimeSessionId", "relay-replacement")
+      setPrivateField(manager, "realtimeWireAudioSampleRateHz", 24_000)
+      setPrivateField(manager, "realtimeWireAudioEncoding", "pcm16")
 
       manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android realtime Talk users on some devices had voice input silently fail: the microphone opened successfully, reported the correct audio route, and was not muted, yet captured audio was entirely zero, making Talk unusable.

## Why This Change Was Made

This PR fixes the failure by separating capture rate from wire rate. Android realtime Talk captured microphone audio directly at the Gateway relay's wire sample rate (24 kHz PCM16) by opening `AudioRecord` at 24 kHz. On a physical Xiaomi 11T Pro (Android 14) that opened successfully, reported an active and unmuted route, yet produced entirely zero-amplitude PCM for the whole session; the same capture path at 48 kHz, on the same device, captured real speech correctly. Hardware capture rate and wire format are separate contracts and should never be conflated.

Capture now uses that 48 kHz rate — Android-owned, not tied to any provider — and streams through a new provider-neutral resampler (Hamming-window sinc lowpass FIR, decimate-by-integer-ratio) before `talk.session.appendAudio`. The rate to convert to comes from `talk.session.create`'s response, which already carries an `audio.inputSampleRateHz` field for the negotiated session (observed as 24 kHz on this Gateway build; the field itself is generic). `TalkSessionCreateResultSchema.audio` is optional at the schema level, and some Gateway peers omit it entirely — this is the same legacy PCM16/24 kHz wire contract the iOS client already defaults to when its own `audio` field is absent (`RealtimeTalkRelaySession.configureAudioContract`). `parseRealtimeWireAudioContract` resolves an absent `audio` field to that legacy default, so capture is resampled to whichever rate it resolves to, declared or legacy, instead of assuming the wire always matches the 48 kHz capture rate. The resampler only accepts an exact integer downsample ratio (e.g. 48000/24000 = 2); before the microphone is opened, an `audio` field that is present but doesn't resolve to a supported pcm16 rate — non-integer ratio, non-positive, or above the capture rate — still fails the session closed instead of proceeding to capture and silently sending mis-clocked audio. This generality is not scope beyond the bug: a resampler hardcoded to the one ratio observed today would reintroduce the same kind of rate assumption this fix removes, the first time the Gateway's declared rate changes. No OpenAI- or GPT-Live-specific logic was added; the fix is provider-neutral.

## User Impact

Android realtime Talk voice input now works on the tested device, where direct 24 kHz microphone capture previously produced no audio at all. Bluetooth routing, input-level metering, and session lifecycle keep their existing caller-visible behavior; the resampler adds its own internal per-session state, scoped to one capture attempt (see `shouldAppendRealtimeCapturedFrame` and the `Channel` in `startRealtimeCaptureLocked`, both unchanged). Gateway peers that omit `talk.session.create`'s `audio` field keep working exactly as before this PR — they now resolve to the same legacy PCM16/24 kHz wire contract instead of failing the session closed.

## Evidence

Head: `5461cf5359c4ccf0b98fe151cce198cf931273e2`. Base: `fdd5fa98e8c0eaa29d9612f6ddb6ff2e3c6a64cc` (`upstream/main`). This PR's commits are built directly on that base and were not rebased after proof, so the proof below and the reviewed diff share the same starting point.

All device evidence below is from one physical Xiaomi 11T Pro (Android 14, API 34), package `ai.openclaw.app`, same debug signing key across every build referenced here (so on-device installs never lost pairing). The unit and build gates further below ran locally, not on-device.

**Root-cause A/B** — two matched debug builds differing only in one capture-rate literal (24000 vs 48000), same `AudioRecord` builder path, `VOICE_RECOGNITION` source, PCM16 mono, and route:

```
Direct 24 kHz capture:
  framesNonzero=0/177
  maxAbs=0
  RMS=0 (silence, speech, and loud speech)
  AudioRecord active, actual sample rate=24000, built-in mic route, not system-silenced

Direct 48 kHz capture:
  real speech PCM captured, nonzero
  UI input level tracked speech
```

**Production remediation** — a separate build containing the `RealtimeCaptureResampler` fix (sha256 `6d79bef3db8e88ec2ca5c8700b144acf1524eafeadd1d74d2139572537cdb64`):

```
ROOT_CAUSE_PROOF=PASS
UNIT_DSP_PROOF=PASS
BUILTIN_E2E=PASS (48 kHz capture -> resample -> 24 kHz wire -> appendAudio -> provider ASR ->
  correct transcript -> spoken assistant reply, across independent sessions)
MULTI_TURN=FAIL, capture and resample sub-verdict=PASS (see "Not in scope" below)
BLUETOOTH_E2E=PASS on second attempt (classic SCO headset, WBS negotiated; same 48 kHz
  application-facing capture path routed to the Bluetooth input), 3 complete conversational turns
RESTART=PASS, 6 clean session transitions including a Bluetooth -> built-in route switch,
  each with a fresh capture session and no stale recorder/resampler state
```

That build additionally contained one unrelated, already-tracked change from the same working branch (an Android-side model-gating removal), which is a no-op for the realtime model used throughout this proof — confirmed by diffing the two builds' source, not just asserted. This PR's diff was isolated to just the `RealtimeCaptureResampler` fix above and rebuilt. `RealtimeCaptureResampler.kt` and the capture logic in `TalkModeManager.kt` are identical between the two builds, diffed line-for-line, not just asserted — the APK bytes differ because this toolchain's debug build isn't bit-reproducible even for unchanged source. The rebuild re-passed every gate listed at the end of this section; it was not reinstalled on the device, since the source it packages is unchanged from the build that was.

**Not in scope**, observed during proof but not caused by this fix: on two repeated attempts of one phrase, the provider correctly transcribed the captured audio (proving capture, resample, wire rate, and ASR all worked for that turn) and then ended the turn early with a malformed reply — a response-generation failure strictly downstream of everything this PR touches, not a capture regression. There is no pre-fix baseline to compare against for this: before this fix, capture produced no usable audio at all, so no turn ever reached response generation to compare. Separately, one Bluetooth session-establishment attempt produced no transcript and self-ended; an immediate retry on the same route completed three full turns normally, and the cause was not identified.

**Known limitation, deferred**: `AudioRecord.actualSampleRateHz` (see `AndroidAudioInputSession.kt`) can in principle report a rate other than the requested 48 kHz on some device or route — not observed on the tested device, where every session above negotiated exactly 48 kHz. `startRealtimeCaptureLocked`'s `check(openedAudioInput.actualSampleRateHz == realtimeCapturePortableSampleRateHz)` fails that session closed today rather than adapting the resampler to the negotiated rate. Adapting instead of failing is a reasonable follow-up, but it has no device coverage yet, so it is deliberately left out of this PR rather than shipped untested.

**Missing-`audio`-field regression fix, added after the review above found this PR's original fail-closed handling of an absent `audio` field was a backward-compatibility regression**: `TalkSessionCreateResultSchema.audio` (`packages/gateway-protocol/src/schema/channels.ts`) is declared `Type.Optional(Type.Unknown())`, and the iOS client already defaults to the same legacy PCM16/24 kHz contract when its own `audio` field is absent (`RealtimeTalkRelaySession.configureAudioContract` in `apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift`, `defaultSampleRateHz = 24000`). `parseRealtimeWireAudioContract` in `TalkModeManager.kt` now resolves an absent `audio` field to that same legacy contract instead of failing the session closed. An `audio` field that is present but malformed, or that declares an encoding or rate `resolveRealtimeCaptureResampler` does not support, still fails closed exactly as before.

Only this parsing decision changed. The physical device proof above was captured against a Gateway build that declares its `audio` contract explicitly (`inputEncoding="pcm16"`, `inputSampleRateHz=24000`), so it proves the declared-contract path end to end on real hardware; it does not, and was never asked to, exercise the absent-field branch added here. That branch is covered by the four unit tests below instead, down to the point where the legacy fallback values feed into the same `resolveRealtimeCaptureResampler` call the device-proven path already uses.

Locked by four new tests in `apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt`: `absentAudioContractParsesToTheLegacyPcm16TwentyFourKhzWireFormat`, `presentAudioContractIsParsedAsDeclared`, `malformedAudioContractStaysUnresolvedForFailClosed`, and `legacyFallbackWireRateResolvesToTheSame48kTo24kResamplerPath`. The last of these calls `resolveRealtimeCaptureResampler` directly on the legacy fallback values to confirm they resolve through the same path as a declared contract. This fix is limited to the absent-field branch inside `parseRealtimeWireAudioContract`; the declared-contract path, the 48 kHz capture rate, and the resampler itself are unchanged.

New tests added in `RealtimeCaptureResamplerTest.kt`: frame and sample count conversion, cross-chunk continuity across odd and uneven chunk sizes, DC steady-state behavior, sub-Nyquist sine frequency preservation, alias-band attenuation versus naive decimation, PCM16 saturation bounds, per-session state isolation, equal-rate passthrough, and fail-closed behavior for unsupported declared-rate ratios passed into `resolveRealtimeCaptureResampler` in `RealtimeCaptureResampler.kt` (non-integer, non-positive, and oversized). A wire rate that never resolves at all (the `null` case) is rejected one level up, by the caller's own null check on `parseRealtimeWireAudioContract`'s result, before `resolveRealtimeCaptureResampler` is even called — that path is what `malformedAudioContractStaysUnresolvedForFailClosed` locks.

Gates (focused + full, all local, run against the final diff): `RealtimeCaptureResamplerTest` / `TalkModeManagerTest` / `AndroidAudioInputSessionTest` focused — PASS. Full `testPlayDebugUnitTest` — PASS. `ktlintCheck` — PASS. `lintPlayDebug` — PASS. `assemblePlayDebug` — PASS. `git diff --check` — clean.
