### PR TITLE
improve(test): reduce DeepInfra model test import overhead

### DIFF
--- a/extensions/deepinfra/provider-models.test.ts
+++ b/extensions/deepinfra/provider-models.test.ts
@@ -3,15 +3,9 @@ import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-cata
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const isProviderApiKeyConfiguredMock = vi.hoisted(() => vi.fn<(p: unknown) => boolean>());
-vi.mock("openclaw/plugin-sdk/provider-auth", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/provider-auth")>(
-    "openclaw/plugin-sdk/provider-auth",
-  );
-  return {
-    ...actual,
-    isProviderApiKeyConfigured: isProviderApiKeyConfiguredMock,
-  };
-});
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  isProviderApiKeyConfigured: isProviderApiKeyConfiguredMock,
+}));
 
 import {
   buildDeepInfraModelDefinition,


### PR DESCRIPTION
## What Problem This Solves

The DeepInfra model tests paid to load the full provider-auth implementation even though the suite replaces its only consumed behavior. The partial-real mock used `vi.importActual()` plus a spread, importing a 674-line auth graph whose real behavior was unobservable in this file.

## Why This Change Was Made

The test now provides an exact one-export mock for `isProviderApiKeyConfigured`. DeepInfra owns this call contract, while `src/plugin-sdk/provider-auth.test.ts` retains real implementation coverage for the provider-auth owner. The exact mock also fails loudly if DeepInfra starts consuming another export instead of silently importing more of the auth graph.

This is test-only: all existing 22 file tests and assertions remain unchanged, there is no new production seam, and the final PR diff is tests +3/-9 with production +0/-0.

## User Impact

There is no user-visible behavior change. The benefit is a faster and lighter DeepInfra test path with the same behavioral coverage.

## Evidence

- Controlled same-Testbox A/B: wall 6.955s -> 4.405s (-36.7%); harness 6.675s -> 4.115s (-38.4%); Vitest 4.070s -> 1.445s (-64.5%); import 3.395s -> 0.759s (-77.6%); body 0.054s -> 0.0645s (noise); CPU user 7.610s -> 4.765s; CPU sys 0.900s -> 0.380s; max RSS 868,288 -> 638,188 KiB (-26.5%, about 224.7 MiB).
- Mutation proof: changing the production provider handoff to `mutated-deepinfra` made the two auth-profile fallback tests fail for the intended reason; the mutation was reverted before this commit.
- Fresh rebased-head proof: 4 DeepInfra files / 42 tests, real provider-auth owner / 61 tests, and boundary/architecture paths / 65 tests passed (168 total).
- Fresh path-scoped changed gate passed on Blacksmith Testbox `tbx_01m024a4rrddewkzxr924qzkc3`: https://github.com/openclaw/openclaw/actions/runs/31871413481
- `git diff --check origin/main...HEAD`, targeted `oxfmt --check`, and fresh rebased-branch autoreview passed.

## Bounded current-main CI repair

The original exact-head CI run failed only because current `main` had two `eslint(no-shadow)` errors in `ui/src/test-helpers/control-ui-e2e.ts`: the diagnostic helper's `catch (error)` bindings shadowed its outer `error` parameter. This was not part of the DeepInfra performance change or its metrics.

The smallest repair renamed those bindings to `evaluateError` and `screenshotError` with no behavior change. The CI log and the exact repository OXLint wrapper both reproduced the two failures; targeted OXLint, OXFmt, the Control UI helper sanity test (2/2), and the complete two-file changed gate then passed on Blacksmith Testbox `tbx_01m025cqgesamm4ebx12aqcv36`: https://github.com/openclaw/openclaw/actions/runs/31872218262

While this PR was being rebased, the identical repair landed independently on `main` as [`f2c721b0acc`](https://github.com/openclaw/openclaw/commit/f2c721b0acc). Git skipped the now-redundant UI commit during rebase, so the final PR remains the one-file DeepInfra test optimization described above.
