### PR TITLE
fix(gateway): publish approval expiry after replay

### DIFF
--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -128,10 +128,8 @@ type ExecApprovalManagerOptions<TPayload> = {
     context: { approvalId: string; approvalKind: OperatorApprovalKind; operation: "expire" },
   ) => void;
   onLifecycle?: (event: OperatorApprovalLifecycleEvent) => void;
-  /** Timer-driven timeout expiry. The gateway owns the approval clock, so this
-   * is the only place reviewer surfaces can learn an approval expired without
-   * trusting their own (skewed) clocks; resolve/authority-close paths publish
-   * through their own callers. */
+  /** Durable timeout expiry can be first observed by a timer, lookup, or replay.
+   * Publish from the local settlement owner so every ordering reaches reviewers. */
   onExpired?: (record: OperatorApprovalRecord, liveRecord: ExecApprovalRecord<TPayload>) => void;
   validateAgentRuntimeDelegatedAuthority?: (authority: AgentRuntimeDelegatedAuthority) => boolean;
 };
@@ -628,6 +626,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     localResolutionSource: ExecApprovalResolutionSource = "operator",
   ): boolean {
     const persistence = this.options.persistence;
+    const liveRecord = this.pending.get(record.id)?.record;
     if (
       record.kind !== this.approvalKind ||
       (persistence && record.runtimeEpoch !== persistence.runtimeEpoch) ||
@@ -656,6 +655,13 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     });
     if (settled) {
       this.emitLifecycle({ phase: "terminal", record });
+      if (record.status === "expired" && liveRecord) {
+        try {
+          this.options.onExpired?.(record, liveRecord);
+        } catch (error) {
+          this.reportError(error, { approvalId: record.id, operation: "expire" });
+        }
+      }
     }
     return settled;
   }
@@ -903,15 +909,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       this.scheduleExpiryTimer(entry);
       return false;
     }
-    const expired = result.outcome === "denied" || result.outcome === "expired";
-    if (expired && "record" in result && result.liveRecord) {
-      try {
-        this.options.onExpired?.(result.record, result.liveRecord);
-      } catch (error) {
-        this.reportError(error, { approvalId: recordId, operation: "expire" });
-      }
-    }
-    return expired;
+    return result.outcome === "denied" || result.outcome === "expired";
   }
 
   private resolveLocal(

--- a/src/gateway/operator-approval-session-events.test.ts
+++ b/src/gateway/operator-approval-session-events.test.ts
@@ -541,12 +541,14 @@ describe("operator approval session events", () => {
         managerHolder.current?.reconcileDurableTerminal(record) ?? false,
     });
     const runtime = harness.runtime;
+    const onExpired = vi.fn();
     const manager = new ExecApprovalManager({
       approvalKind: "exec",
       persistence: { runtimeEpoch: "session-events", databaseOptions },
       resolveAllowedDecisions: () => ["allow-once", "deny"],
       resolveAudienceSessionKeys: () => [SOURCE_SESSION_KEY, PARENT_SESSION_KEY],
       onLifecycle: (event) => runtime.publish(event),
+      onExpired,
     });
     managerHolder.current = manager;
     harness.subscribers.subscribe("parent-reviewer", PARENT_SESSION_KEY, {
@@ -572,6 +574,14 @@ describe("operator approval session events", () => {
       truncated: false,
     });
     await expect(decisionPromise).resolves.toBeNull();
+    expect(onExpired).toHaveBeenCalledOnce();
+    expect(onExpired).toHaveBeenCalledWith(
+      expect.objectContaining({ id: record.id, status: "expired" }),
+      expect.objectContaining({
+        id: record.id,
+        request: expect.objectContaining({ command: "printf replay-expiry" }),
+      }),
+    );
     expect(harness.broadcastToConnIds).toHaveBeenCalledOnce();
     expect(harness.broadcastToConnIds).toHaveBeenCalledWith(
       "session.approval",


### PR DESCRIPTION
Closes #124076

## What Problem This Solves

Fixes an issue where operators reviewing exec or plugin approvals could keep seeing a stale pending control when durable timeout expiry was first observed by `approval.get` or reconnect replay instead of the scheduled timer. The Gateway had already denied the action and settled the waiter, but reviewer/native surfaces received no terminal expiry event.

## Why This Change Was Made

Move expiry publication from the timer-only branch to the shared successful local-settlement owner. Timer, lookup/get, and reconnect replay now publish the same terminal outcome exactly once when—and only when—the matching live waiter is settled.

The durable approval row remains the sole authorization and decision owner. This does not change scopes, authentication, TTL policy, schema/version, protocol, configuration, SDK, defaults, provenance, or consumption semantics. Late allow/deny remains non-applying, and terminal expiry keeps `consumed_at_ms` / `consumed_by` null.

Production LOC: +11/-13 (net -2) | Tests: +10/-0

No changelog entry: release generation owns `CHANGELOG.md`.

## User Impact

Reviewer/native and opted-in session surfaces now converge on the Gateway's canonical timeout result even when lookup or reconnect replay discovers the deadline first. Stale approval controls retire with an explicit expired outcome instead of appearing actionable after the command was already denied.

## Evidence

Baseline: `f2c721b0acc8a2e35c11ad208d1e58bacdb87de0`

Exact head: `874d1de0482369429877ca46dc64d1f6e44d37ca`

Built Gateway proof head (patch-identical before mechanical rebase): `7e1d5426477655078b64b85804d8f2ebabcaf1fa`

### Original-order regression

Before the repair, reconnect replay transitioned the durable row and settled the waiter, but the expiry publication hook was called 0 times. The focused regression now asserts one publication with the original live request.

### Built Gateway Testbox proof

- Provider: Blacksmith Testbox
- Lease: `tbx_01m0240wmk9074991781xgkzsf` (`jade-shrimp-6ad4`)
- Run: https://github.com/openclaw/openclaw/actions/runs/31871207637
- Target: built `dist/entry.js`, task-owned state, free loopback port, separate requester/reviewer devices
- Result: 1/1 passed

Observed:

```text
rowBefore: pending, decision=null, consumed=null
lookup: expired, kind=exec
waiter: settlements=1, decision=null, reason=timeout
published: reviewer resolved=1, same-id/kind session terminal=1
rowAfter: expired, decision=deny, reason=timeout, consumed=null
late allow: applied=false, status=expired
reconnect: pending replay=0, duplicate events=0
restart: status=expired, duplicate events=0
```

### Focused and static proof

- 163 approval manager, publication wiring, replay, unified resolve, and legacy sibling tests passed
- Private-QA-capable production build passed
- Full changed gate passed:
  - format and changed-file lint
  - core production and test types
  - database-first and native schema-version guards
  - plugin/package/dependency boundaries
  - security pairing/webhook guards
  - dead exports and runtime sidecar guards
  - import cycles: 0
  - `git diff --check`
- TruffleHog: clean
- Fresh adversarial autoreview: no findings; patch correct (0.97 confidence)

