### PR TITLE
fix(ci): avoid shadowed UI diagnostics errors

### DIFF
--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -2743,15 +2743,15 @@ async function captureControlUiE2eFailureDiagnosticsUnsafe(
         ),
       };
     });
-  } catch (error) {
-    captureErrors.push(`page.evaluate: ${String(error)}`);
+  } catch (captureError) {
+    captureErrors.push(`page.evaluate: ${String(captureError)}`);
   }
   let screenshotWritten = false;
   try {
     await page.screenshot({ fullPage: true, path: screenshotPath });
     screenshotWritten = true;
-  } catch (error) {
-    captureErrors.push(`page.screenshot: ${String(error)}`);
+  } catch (captureError) {
+    captureErrors.push(`page.screenshot: ${String(captureError)}`);
   }
   const report = {
     schemaVersion: 2,


### PR DESCRIPTION
## What Problem This Solves

Repairs repeated `main` failures in `check-lint-core-4` after Control UI E2E failure diagnostics were expanded.

## Root Cause

`captureControlUiFailureDiagnostics` already owns an outer `error` parameter. Its page-evaluation and screenshot catch clauses reused the same identifier, so the type-aware no-shadow gate rejected both paths.

## Fix

Give the two captured failures a distinct `captureError` name. Behavior and diagnostic output are unchanged.

Runtime production delta: 0. Test support: +4/-4 lines (net 0).

## Evidence

- Reproduced on exact-main runs [31871473781](https://github.com/openclaw/openclaw/actions/runs/31871473781) and [31871509765](https://github.com/openclaw/openclaw/actions/runs/31871509765).
- Exact failing type-aware oxlint command passed for `ui/src/test-helpers/control-ui-e2e.ts`.
- Focused Control UI E2E helper tests passed: 13/13.
- Formatting and `git diff --check` passed.
- Autoreview: no accepted/actionable findings.
- Exact-head CI passed at `2c57ed41f1982de1fa3456f003f5194689a1e725`: [31872106264](https://github.com/openclaw/openclaw/actions/runs/31872106264).
