### PR TITLE
test(core): trim duplicate strict-subset assertions

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  CONTEXT_WINDOW_HARD_MIN_TOKENS,
   evaluateContextWindowGuard,
   formatContextWindowBlockMessage,
   formatContextWindowWarningMessage,
@@ -310,10 +309,6 @@ describe("context-window-guard", () => {
     expect(guard.warnBelowTokens).toBe(12_000);
     expect(guard.shouldWarn).toBe(true);
     expect(guard.shouldBlock).toBe(false);
-  });
-
-  it("exports the public hard-min floor as expected", () => {
-    expect(CONTEXT_WINDOW_HARD_MIN_TOKENS).toBe(4_000);
   });
 
   it("derives percentage-based guard thresholds above the safe floors", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -511,11 +511,6 @@ describe("calculateMaxToolResultChars", () => {
     expect(DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS).toBe(16_000);
   });
 
-  it("auto-scales above the low-context cap for very large windows", () => {
-    const result = calculateMaxToolResultChars(2_000_000); // 2M token window
-    expect(result).toBeGreaterThan(DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS);
-  });
-
   it("uses a larger auto cap for 128K contexts", () => {
     const result = calculateMaxToolResultChars(128_000);
     expect(result).toBe(32_000);

--- a/src/logging/levels.test.ts
+++ b/src/logging/levels.test.ts
@@ -1,6 +1,5 @@
 // Log level tests cover allowed levels and level ordering.
 
-import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { levelToMinLevel } from "./levels.js";
 
@@ -16,20 +15,5 @@ describe("levelToMinLevel", () => {
 
   it("maps silent to Infinity to suppress all logs", () => {
     expect(levelToMinLevel("silent")).toBe(Number.POSITIVE_INFINITY);
-  });
-
-  it("fatal has a higher value than trace (not inverted)", () => {
-    expect(levelToMinLevel("fatal")).toBeGreaterThan(levelToMinLevel("trace"));
-  });
-
-  it("each level is strictly more restrictive than the one below it", () => {
-    const ordered = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
-    for (let i = 1; i < ordered.length; i++) {
-      expect(
-        levelToMinLevel(expectDefined(ordered[i], "ordered[i] test invariant")),
-      ).toBeGreaterThan(
-        levelToMinLevel(expectDefined(ordered[i - 1], "ordered[i - 1] test invariant")),
-      );
-    }
   });
 });

--- a/test/scripts/bench-model.test.ts
+++ b/test/scripts/bench-model.test.ts
@@ -27,8 +27,6 @@ describe("scripts/bench-model", () => {
   });
 
   it("rejects unknown args before checking provider credentials", () => {
-    expect(() => testing.parseArgs(["--wat"])).toThrow("Unknown argument: --wat");
-
     const result = runBenchModel(["--wat"]);
 
     expect(result.status).toBe(1);

--- a/test/scripts/summarize-cpuprofile.test.ts
+++ b/test/scripts/summarize-cpuprofile.test.ts
@@ -23,8 +23,6 @@ describe("scripts/perf/summarize-cpuprofile.mjs", () => {
   });
 
   it("prints help without treating it as a profile path", () => {
-    expect(shouldPrintHelp(["--help"])).toBe(true);
-    expect(shouldPrintHelp(["--limit", "-h", "a.cpuprofile"])).toBe(false);
     expect(shouldPrintHelp(["--limit", "--", "--help"])).toBe(false);
     expect(shouldPrintHelp(["--limit=1e3", "--help"])).toBe(false);
     expect(shouldPrintHelp(["--", "--help"])).toBe(false);
@@ -46,7 +44,6 @@ describe("scripts/perf/summarize-cpuprofile.mjs", () => {
   it("rejects malformed limit flags instead of falling back", () => {
     for (const args of [
       ["--limit", "3frames", "a.cpuprofile"],
-      ["--limit", "-h", "a.cpuprofile"],
       ["--limit", "--", "--help"],
       ["--limit", "0", "a.cpuprofile"],
       ["--limit=1e3", "a.cpuprofile"],
@@ -70,8 +67,6 @@ describe("scripts/perf/summarize-cpuprofile.mjs", () => {
   });
 
   it("rejects unknown options instead of treating them as profile paths", () => {
-    expect(() => parseArgs(["--wat"])).toThrow("Unknown option: --wat");
-
     const result = spawnSync(process.execPath, ["scripts/perf/summarize-cpuprofile.mjs", "--wat"], {
       cwd: process.cwd(),
       encoding: "utf8",

--- a/test/scripts/test-shell-completion.test.ts
+++ b/test/scripts/test-shell-completion.test.ts
@@ -15,13 +15,7 @@ afterEach(async () => {
 });
 
 describe("test-shell-completion script", () => {
-  it("parses explicit shell overrides", () => {
-    expect(shellCompletionTesting.parseArgs(["--shell", "bash", "--check-only"])).toEqual({
-      checkOnly: true,
-      force: false,
-      help: false,
-      shell: "bash",
-    });
+  it("parses an attached shell override", () => {
     expect(shellCompletionTesting.parseArgs(["--shell=fish"])).toEqual({
       checkOnly: false,
       force: false,
@@ -30,8 +24,7 @@ describe("test-shell-completion script", () => {
     });
   });
 
-  it("rejects unknown or malformed arguments before touching shell state", () => {
-    expect(() => shellCompletionTesting.parseArgs(["--wat"])).toThrow("Unknown argument: --wat");
+  it("rejects malformed arguments before touching shell state", () => {
     expect(() => shellCompletionTesting.parseArgs(["--shell"])).toThrow("--shell requires a value");
     expect(() => shellCompletionTesting.parseArgs(["--shell", "--check-only"])).toThrow(
       "--shell requires a value",


### PR DESCRIPTION
## What Problem This Solves

Removes test assertions that were strict subsets of stronger checks in the same owner suites or direct in-process replays of the exact executable CLI scenarios immediately below them.

The deleted rows covered relational log ordering already implied by exact tslog IDs, a direct context-window constant already pinned through block behavior and public error text, a 2M context-window comparison that shares the exact 200K+ cap branch, and parser assertions duplicated by stronger spawned-process proofs.

## Why This Change Was Made

Tests should fail for distinct behavior regressions, not merely restate a stronger neighboring assertion. This change keeps exact mappings, thresholds, boundary behavior, production callers, distinct parser edge cases, executable exit/output checks, and the separate aggregate-pressure tier while removing only redundant subsets.

The public context-window constant and parser testing exports remain because production onboarding or retained edge-case tests still use them.

## User Impact

No user-visible behavior changes. The affected suites have fewer assertions to update when implementation or test organization changes without changing behavior.

## Evidence

- Logging, context-window/onboarding, tool-result truncation, benchmark CLI, CPU-profile summarizer, and shell-completion owners: 9 files, 183 tests passed across four Vitest shards.
- `coreTests`, `testRoot`, and `tooling` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready; test typechecks, formatting, lint, dead-export scan, and plugin/dependency guards passed.
- `git diff --check` passed.
- Fresh complete-branch structured autoreview reported no accepted/actionable findings.
- Direct tslog dependency inspection confirmed exact IDs 1 through 6 and filtering by `logLevelId < minLevel`, so the retained exact map strictly subsumes the removed relational checks.
- The first hosted run exposed an unrelated Control UI E2E no-shadow failure already fixed on current `main` by `f2c721b0acc`; this branch was rebased onto that repair and all focused/local gates remained green.

Production delta: 0. Tests: +2/-42, net -40. No docs, config, schema, protocol, dependency, or changelog change.