### PR TITLE
fix(onboard): workspace failure no longer publishes config

### DIFF
--- a/src/commands/onboard-non-interactive/local.default-agent.test.ts
+++ b/src/commands/onboard-non-interactive/local.default-agent.test.ts
@@ -226,6 +226,28 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
     expect(mocks.ensureWorkspaceAndSessions).not.toHaveBeenCalled();
   });
 
+  it("does not publish config when the existing agent workspace cannot be provisioned", async () => {
+    mocks.ensureWorkspaceAndSessions.mockRejectedValueOnce(new Error("workspace is unwritable"));
+
+    await expect(
+      runNonInteractiveLocalSetup({
+        opts: {
+          nonInteractive: true,
+          mode: "local",
+          authChoice: "skip",
+          skipHooks: true,
+          skipSkills: true,
+          skipHealth: true,
+        },
+        runtime,
+        baseConfig: { agents: { entries: { ops: { default: true } } } },
+      }),
+    ).rejects.toThrow("workspace is unwritable");
+
+    expect(mocks.commitConfig).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
+  });
+
   it("provisions and reports the keyed default agent while preserving the global workspace", async () => {
     const baseConfig = {
       agents: {

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -281,6 +281,12 @@ export async function runNonInteractiveLocalSetup(params: {
     nextConfig = applySkipBootstrapConfig(nextConfig);
   }
 
+  const finalTarget = resolveOnboardingAgentTarget(nextConfig, selectedAgentId);
+  await ensureOnboardingAgentWorkspace(finalTarget, runtime, {
+    skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
+    skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
+  });
+
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
   nextConfig = await commitNonInteractiveOnboardConfig({
     nextConfig,
@@ -288,12 +294,6 @@ export async function runNonInteractiveLocalSetup(params: {
     reset: opts.reset,
   });
   logConfigUpdated(runtime);
-
-  const finalTarget = resolveOnboardingAgentTarget(nextConfig, selectedAgentId);
-  await ensureOnboardingAgentWorkspace(finalTarget, runtime, {
-    skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
-    skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
-  });
 
   const daemonRuntimeRaw = opts.daemonRuntime ?? DEFAULT_GATEWAY_DAEMON_RUNTIME;
   let daemonInstallStatus:


### PR DESCRIPTION
Closes #124091

## What Problem This Solves

Fixes an issue where operators rerunning non-interactive onboarding could receive a workspace failure after OpenClaw had already published config changes, a backup, wizard metadata, and `Updated config` output.

## Why This Change Was Made

The local non-interactive owner now completes the selected existing agent's fallible workspace provisioning before applying wizard metadata or invoking the authoritative config writer. This makes the setup boundary atomic without adding rollback logic or changing any public flag, JSON/config shape, daemon behavior, provider/auth path, or successful setup behavior.

Production LOC: +6/-6 (net 0) | Tests: +22/-0

Provenance: the commit-before-provision ordering dates to the initial non-interactive local owner in `9947a2676817f0a0ea8c7bd7c7059fb63e0b9314` (PR #89793, authored and merged by @vincentkoc) and was carried through selected-agent workspace routing in #112738.

No changelog or docs change is needed: the patch restores the existing documented config/workspace setup contract and does not change the public surface.

## User Impact

On an unprovisionable existing-agent workspace, onboarding still exits 1 with the same actionable error, but stdout remains empty, config bytes stay identical, and no backup or partial config diff is published. Successful onboarding remains unchanged.

## Evidence

Source-blind built CLI on latest `main` plus the byte-verified patch, isolated `HOME`/state, no real service install or provider credentials (`run_3390968bec53`):

- Before: exit 1; `Updated config` on stdout; backup created; config hash changed; Gateway/tool/wizard metadata committed.
- After: exit 1; empty stdout; actionable stderr; identical config SHA-256; no backup; empty config diff.
- Focused owner regression: 6/6 passed, and the new case fails on pre-fix ordering because `commitConfig` is called once.
- Two independent full builds passed.
- Format, targeted core lint, core production types, and core test types passed.
- Stable patch ID stayed `0295d1e3a1ac2efc7b6626f39834e4a98e39bbb0` across the current-main rebase.
- Fresh autoreview and exact-head CI/native prepare are required before merge.

Best-fix verdict: best. Moving provisioning later would preserve the partial-publication bug; adding rollback would create a second config transaction and more failure modes; guarding only output would hide mutated state.
