### PR TITLE
feat(macos): Computer Use provider readiness checklist

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -20575,17 +20575,6 @@
       ]
     },
     {
-      "id": "native.apple.c8aea204934bc72d",
-      "source": "Accessibility grant may be stale",
-      "surface": "apple",
-      "sites": [
-        {
-          "kind": "conditional-branch",
-          "path": "apps/macos/Sources/OpenClaw/ComputerActionService.swift"
-        }
-      ]
-    },
-    {
       "id": "native.apple.8749684a8c17f426",
       "source": "Accessibility permission is required to paste.",
       "surface": "apple",
@@ -30918,10 +30907,6 @@
       "surface": "apple",
       "sites": [
         {
-          "kind": "conditional-branch",
-          "path": "apps/macos/Sources/OpenClaw/ComputerActionService.swift"
-        },
-        {
           "kind": "ui-localized-call",
           "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         },
@@ -33941,17 +33926,6 @@
         {
           "kind": "ui-call",
           "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift"
-        }
-      ]
-    },
-    {
-      "id": "native.apple.2f563e685fcd2e50",
-      "source": "Missing permission",
-      "surface": "apple",
-      "sites": [
-        {
-          "kind": "conditional-branch",
-          "path": "apps/macos/Sources/OpenClaw/ComputerActionService.swift"
         }
       ]
     },

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -20553,6 +20553,17 @@
       ]
     },
     {
+      "id": "native.apple.1f848d6b8b8c9a5b",
+      "source": "Accessibility",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.dad3a39ff4502cb0",
       "source": "Accessibility access is required to attach text from \\(appName).",
       "surface": "apple",
@@ -22703,6 +22714,10 @@
         {
           "kind": "ui-call",
           "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift"
+        },
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         }
       ]
     },
@@ -23171,6 +23186,17 @@
         {
           "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.1b206a7a4565f60b",
+      "source": "CUA daemon",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         }
       ]
     },
@@ -24643,17 +24669,6 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/AgentAutomationDetailScreen.swift"
-        }
-      ]
-    },
-    {
-      "id": "native.apple.173d1e07a2d80eb6",
-      "source": "Computer Control access",
-      "surface": "apple",
-      "sites": [
-        {
-          "kind": "ui-named-argument",
-          "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         }
       ]
     },
@@ -30876,6 +30891,28 @@
       ]
     },
     {
+      "id": "native.apple.a32c9e42458c9b1c",
+      "source": "Grant OpenClaw in System Settings → Privacy & Security → Accessibility, then reopen it.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call-multiline",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.cdb8cc9716727acf",
+      "source": "Grant OpenClaw in System Settings → Privacy & Security → Screen Recording, then reopen it.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call-multiline",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.a2b0395080861914",
       "source": "Granted",
       "surface": "apple",
@@ -30883,6 +30920,10 @@
         {
           "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/ComputerActionService.swift"
+        },
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         },
         {
           "kind": "ui-call",
@@ -31971,6 +32012,17 @@
         {
           "kind": "conditional-branch",
           "path": "apps/ios/Sources/Design/SettingsProTabSections.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.cff202e57912738d",
+      "source": "Keep OpenClaw open while it checks the embedded CUA daemon.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         }
       ]
     },
@@ -35748,6 +35800,17 @@
       ]
     },
     {
+      "id": "native.apple.e0a495b711628049",
+      "source": "Not granted",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.6141dea69ca38164",
       "source": "Not listening",
       "surface": "apple",
@@ -35796,6 +35859,17 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/RootSidebar.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.b4f3bc6fe500677b",
+      "source": "Not ready",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         }
       ]
     },
@@ -40782,6 +40856,17 @@
       ]
     },
     {
+      "id": "native.apple.bb3054116d83e716",
+      "source": "Reopen OpenClaw to retry the embedded CUA daemon.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.d103d60717e1d702",
       "source": "Repairing the OpenClaw Gateway update…",
       "surface": "apple",
@@ -42020,6 +42105,10 @@
           "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift"
         },
         {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
+        },
+        {
           "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
         },
@@ -42554,6 +42643,17 @@
         {
           "kind": "ui-named-argument",
           "path": "apps/ios/Sources/Design/SettingsProTabActions.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.9c4ba1b5e037c818",
+      "source": "Screen Recording",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         }
       ]
     },
@@ -47831,6 +47931,10 @@
           "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift"
         },
         {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
+        },
+        {
           "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift"
         },
@@ -47867,6 +47971,10 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift"
+        },
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         },
         {
           "kind": "conditional-branch",
@@ -48272,6 +48380,17 @@
         {
           "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.9fdb78560dae9056",
+      "source": "Use a packaged OpenClaw build that includes the CUA driver.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift"
         }
       ]
     },

--- a/apps/macos/Sources/OpenClaw/ComputerActionService.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerActionService.swift
@@ -341,14 +341,6 @@ struct ComputerControlPermissionSnapshot: Equatable, Sendable {
         case missing([Bucket])
         case accessibilityGrantMayBeStale
 
-        var statusText: String {
-            switch self {
-            case .granted: "Granted"
-            case .missing: "Missing permission"
-            case .accessibilityGrantMayBeStale: "Accessibility grant may be stale"
-            }
-        }
-
         var detailText: String {
             switch self {
             case .granted:

--- a/apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerControlReadinessView.swift
@@ -1,0 +1,208 @@
+import AppKit
+import OpenClawIPC
+import SwiftUI
+
+struct ComputerControlReadinessRow: Equatable, Identifiable {
+    enum ID: Hashable {
+        case provider
+        case accessibility
+        case screenRecording
+        case cuaDaemon
+    }
+
+    enum Status: Equatable {
+        case available
+        case granted
+        case running
+        case unavailable
+        case notGranted
+        case notReady
+        case unknown
+
+        var text: String {
+            switch self {
+            case .available: String(localized: "Available")
+            case .granted: String(localized: "Granted")
+            case .running: String(localized: "Running")
+            case .unavailable: String(localized: "Unavailable")
+            case .notGranted: String(localized: "Not granted")
+            case .notReady: String(localized: "Not ready")
+            case .unknown: String(localized: "Unknown")
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .available, .granted, .running: "checkmark.circle"
+            case .unavailable, .notGranted, .notReady: "exclamationmark.circle"
+            case .unknown: "questionmark.circle"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .available, .granted, .running: .green
+            case .unavailable, .notGranted, .notReady: .orange
+            case .unknown: .secondary
+            }
+        }
+    }
+
+    let id: ID
+    let title: String
+    let status: Status
+    let nextStep: String?
+}
+
+enum ComputerControlReadinessPresentation {
+    static func rows(
+        provider: ComputerControlProvider,
+        cuaDriverAvailable: Bool,
+        permissions: [Capability: CapabilityAuthorizationStatus],
+        cuaDaemonReady: Bool?) -> [ComputerControlReadinessRow]
+    {
+        let providerAvailable = provider == .peekaboo || cuaDriverAvailable
+        var rows = [
+            ComputerControlReadinessRow(
+                id: .provider,
+                title: provider.displayName,
+                status: providerAvailable ? .available : .unavailable,
+                nextStep: providerAvailable
+                    ? nil
+                    : String(localized: "Use a packaged OpenClaw build that includes the CUA driver.")),
+            self.permissionRow(
+                id: .accessibility,
+                title: String(localized: "Accessibility"),
+                status: permissions[.accessibility],
+                nextStep: String(
+                    localized: """
+                    Grant OpenClaw in System Settings → Privacy & Security → Accessibility, then reopen it.
+                    """)),
+            self.permissionRow(
+                id: .screenRecording,
+                title: String(localized: "Screen Recording"),
+                status: permissions[.screenRecording],
+                nextStep: String(
+                    localized: """
+                    Grant OpenClaw in System Settings → Privacy & Security → Screen Recording, then reopen it.
+                    """)),
+        ]
+
+        if provider == .cua {
+            let status: ComputerControlReadinessRow.Status = if !cuaDriverAvailable {
+                .unavailable
+            } else if let cuaDaemonReady {
+                cuaDaemonReady ? .running : .notReady
+            } else {
+                .unknown
+            }
+            let nextStep: String? = switch status {
+            case .running:
+                nil
+            case .unavailable:
+                String(localized: "Use a packaged OpenClaw build that includes the CUA driver.")
+            case .notReady:
+                String(localized: "Reopen OpenClaw to retry the embedded CUA daemon.")
+            case .unknown:
+                String(localized: "Keep OpenClaw open while it checks the embedded CUA daemon.")
+            case .available, .granted, .notGranted:
+                nil
+            }
+            rows.append(ComputerControlReadinessRow(
+                id: .cuaDaemon,
+                title: String(localized: "CUA daemon"),
+                status: status,
+                nextStep: nextStep))
+        }
+        return rows
+    }
+
+    private static func permissionRow(
+        id: ComputerControlReadinessRow.ID,
+        title: String,
+        status: CapabilityAuthorizationStatus?,
+        nextStep: String) -> ComputerControlReadinessRow
+    {
+        switch status ?? .unknown {
+        case .granted:
+            ComputerControlReadinessRow(id: id, title: title, status: .granted, nextStep: nil)
+        case .notGranted:
+            ComputerControlReadinessRow(id: id, title: title, status: .notGranted, nextStep: nextStep)
+        case .unknown:
+            ComputerControlReadinessRow(id: id, title: title, status: .unknown, nextStep: nextStep)
+        }
+    }
+}
+
+@MainActor
+struct ComputerControlReadinessView: View {
+    let provider: ComputerControlProvider
+    let cuaDriverAvailable: Bool
+
+    @State private var permissions: [Capability: CapabilityAuthorizationStatus] = [:]
+    @State private var cuaDaemonReady: Bool?
+
+    init(provider: ComputerControlProvider, cuaDriverAvailable: Bool) {
+        self.provider = provider
+        self.cuaDriverAvailable = cuaDriverAvailable
+        self._cuaDaemonReady = State(initialValue: Self.cuaDaemonReadiness(
+            provider: provider,
+            cuaDriverAvailable: cuaDriverAvailable))
+    }
+
+    var body: some View {
+        ForEach(self.rows) { row in
+            SettingsCardRow(
+                title: .verbatim(row.title),
+                subtitle: row.nextStep.map(SettingsTextValue.verbatim))
+            {
+                Label {
+                    Text(verbatim: row.status.text)
+                } icon: {
+                    Image(systemName: row.status.icon)
+                }
+                .font(.caption.weight(.medium))
+                .foregroundStyle(row.status.color)
+            }
+        }
+        .task(id: self.provider) {
+            await self.refreshPermissions()
+            self.refreshCuaDaemonReadiness()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task { await self.refreshPermissions() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openclawPermissionsChanged)) { _ in
+            Task { await self.refreshPermissions() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openclawCuaDriverAvailabilityChanged)) { _ in
+            self.refreshCuaDaemonReadiness()
+        }
+    }
+
+    private var rows: [ComputerControlReadinessRow] {
+        ComputerControlReadinessPresentation.rows(
+            provider: self.provider,
+            cuaDriverAvailable: self.cuaDriverAvailable,
+            permissions: self.permissions,
+            cuaDaemonReady: self.cuaDaemonReady)
+    }
+
+    private func refreshPermissions() async {
+        self.permissions = await PermissionManager.authorizationStatus([.accessibility, .screenRecording])
+    }
+
+    private func refreshCuaDaemonReadiness() {
+        self.cuaDaemonReady = Self.cuaDaemonReadiness(
+            provider: self.provider,
+            cuaDriverAvailable: self.cuaDriverAvailable)
+    }
+
+    private static func cuaDaemonReadiness(
+        provider: ComputerControlProvider,
+        cuaDriverAvailable: Bool) -> Bool?
+    {
+        guard provider == .cua, cuaDriverAvailable else { return nil }
+        return CuaDriverHostCoordinator.shared.workerEndpoint != nil
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -29,7 +29,6 @@ struct GeneralSettings: View {
     @State private var gatewayStatus: GatewayEnvironmentStatus = .checking
     @State private var remoteStatus: RemoteStatus = .idle
     @State private var showRemoteAdvanced = false
-    @State private var computerControlPermissions = ComputerControlPermissionSnapshot.probe()
     @State private var cookieSyncManager = CookieSyncManager.shared
     private let isPreview = ProcessInfo.processInfo.isPreview
     private var isNixMode: Bool {
@@ -73,12 +72,6 @@ struct GeneralSettings: View {
         }
         .onChange(of: self.computerControlProviderRaw) { _, _ in
             self.state.applyComputerControlHostState()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            self.refreshComputerControlPermissions()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openclawPermissionsChanged)) { _ in
-            self.refreshComputerControlPermissions()
         }
         .onDisappear { self.gatewayDiscovery.stop() }
     }
@@ -148,17 +141,10 @@ struct GeneralSettings: View {
 
                 self.computerControlProviderRow
 
-                SettingsCardRow(
-                    title: "Computer Control access",
-                    subtitle: .verbatim(self.computerControlPermissions.diagnostic.detailText))
-                {
-                    Label {
-                        Text(verbatim: self.computerControlPermissions.diagnostic.statusText)
-                    } icon: {
-                        Image(systemName: self.computerControlPermissionIcon)
-                    }
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(self.computerControlPermissionColor)
+                if self.computerControlEnabled {
+                    ComputerControlReadinessView(
+                        provider: self.selectedComputerControlProvider,
+                        cuaDriverAvailable: self.cuaDriverBundled)
                 }
 
                 SettingsCardToggleRow(
@@ -377,33 +363,12 @@ struct GeneralSettings: View {
     private func updateActiveWork(active: Bool) {
         guard !self.isPreview else { return }
         if active {
-            self.refreshComputerControlPermissions()
             self.refreshGatewayStatus()
             if self.page == .connection {
                 self.gatewayDiscovery.start()
             }
         } else {
             self.gatewayDiscovery.stop()
-        }
-    }
-
-    private func refreshComputerControlPermissions() {
-        guard self.page == .general, self.isActive, !self.isPreview else { return }
-        self.computerControlPermissions = .probe()
-    }
-
-    private var computerControlPermissionIcon: String {
-        switch self.computerControlPermissions.diagnostic {
-        case .granted: "checkmark.circle.fill"
-        case .missing: "exclamationmark.circle.fill"
-        case .accessibilityGrantMayBeStale: "exclamationmark.triangle.fill"
-        }
-    }
-
-    private var computerControlPermissionColor: Color {
-        switch self.computerControlPermissions.diagnostic {
-        case .granted: .green
-        case .missing, .accessibilityGrantMayBeStale: .orange
         }
     }
 
@@ -906,12 +871,13 @@ extension GeneralSettings {
         CuaDriverArtifact.bundledExecutableURL != nil
     }
 
+    private var selectedComputerControlProvider: ComputerControlProvider {
+        ComputerControlProvider.current()
+    }
+
     private var computerControlProviderBinding: Binding<ComputerControlProvider> {
         Binding(
-            get: {
-                let selected = ComputerControlProvider(rawValue: self.computerControlProviderRaw) ?? .peekaboo
-                return selected == .cua && !self.cuaDriverBundled ? .peekaboo : selected
-            },
+            get: { self.selectedComputerControlProvider },
             set: { provider in
                 guard provider != .cua || self.cuaDriverBundled else { return }
                 self.computerControlProviderRaw = provider.rawValue

--- a/apps/macos/Tests/OpenClawIPCTests/ComputerControlSettingsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ComputerControlSettingsTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawIPC
 import Testing
 @testable import OpenClaw
 
@@ -61,5 +62,69 @@ struct ComputerControlSettingsTests {
         #expect(decoded["v"] as? Int == 1)
         #expect(decoded["socketPath"] as? String == endpoint.socketPath)
         #expect(decoded["binaryPath"] as? String == endpoint.binaryPath)
+    }
+
+    @Test func `readiness rows never promote unknown or unavailable state`() {
+        struct Scenario {
+            let provider: ComputerControlProvider
+            let cuaDriverAvailable: Bool
+            let permissions: [Capability: CapabilityAuthorizationStatus]
+            let cuaDaemonReady: Bool?
+            let expectedStatuses: [ComputerControlReadinessRow.Status]
+        }
+
+        let granted: [Capability: CapabilityAuthorizationStatus] = [
+            .accessibility: .granted,
+            .screenRecording: .granted,
+        ]
+        let scenarios = [
+            Scenario(
+                provider: .peekaboo,
+                cuaDriverAvailable: false,
+                permissions: granted,
+                cuaDaemonReady: nil,
+                expectedStatuses: [.available, .granted, .granted]),
+            Scenario(
+                provider: .cua,
+                cuaDriverAvailable: true,
+                permissions: granted,
+                cuaDaemonReady: true,
+                expectedStatuses: [.available, .granted, .granted, .running]),
+            Scenario(
+                provider: .cua,
+                cuaDriverAvailable: true,
+                permissions: [:],
+                cuaDaemonReady: nil,
+                expectedStatuses: [.available, .unknown, .unknown, .unknown]),
+            Scenario(
+                provider: .cua,
+                cuaDriverAvailable: true,
+                permissions: [.accessibility: .notGranted, .screenRecording: .notGranted],
+                cuaDaemonReady: false,
+                expectedStatuses: [.available, .notGranted, .notGranted, .notReady]),
+            Scenario(
+                provider: .cua,
+                cuaDriverAvailable: false,
+                permissions: granted,
+                cuaDaemonReady: true,
+                expectedStatuses: [.unavailable, .granted, .granted, .unavailable]),
+        ]
+
+        for scenario in scenarios {
+            let rows = ComputerControlReadinessPresentation.rows(
+                provider: scenario.provider,
+                cuaDriverAvailable: scenario.cuaDriverAvailable,
+                permissions: scenario.permissions,
+                cuaDaemonReady: scenario.cuaDaemonReady)
+            #expect(rows.map(\.status) == scenario.expectedStatuses)
+            for row in rows {
+                switch row.status {
+                case .available, .granted, .running:
+                    #expect(row.nextStep == nil)
+                case .unavailable, .notGranted, .notReady, .unknown:
+                    #expect(row.nextStep?.isEmpty == false)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What Problem This Solves

The Computer Control provider picker shipped in #123635 without showing whether the selected provider could actually run. Operators had to infer readiness from logs and could not distinguish missing grants, an unavailable provider, or a CUA daemon that never became ready.

## Why This Change Was Made

Settings now renders a compact checklist for the selected provider using the existing owners of each fact: the validated bundled-artifact gate for provider availability, tri-state macOS permission status for Accessibility and Screen Recording, and the CUA coordinator endpoint published only after process and socket readiness. Unknown and failing states stay explicit, and each failure includes one short next step.

The previous aggregate access row was removed so it cannot contradict the selected-provider checklist. There are no protocol, SQLite, config, or provider lifecycle changes.

## User Impact

Operators can tell directly in Settings whether Peekaboo or CUA is usable. CUA adds an explicit daemon row, while ready rows stay terse and recovery detail appears only when action is needed. Development builds still keep an absent CUA artifact unselectable with the existing `CUA (driver not bundled)` reason.

## Evidence

Before — the picker and one aggregate access result:

![Computer Control before readiness checklist](https://github.com/user-attachments/assets/4e67e8bb-9766-4933-bcd5-aead0aec2aea)

Peekaboo selected and ready:

![Peekaboo selected with provider and permission readiness](https://github.com/user-attachments/assets/c9250a1e-fbba-4de7-a47a-1d4b54629446)

CUA selected and ready, with the embedded daemon running:

![CUA selected with provider, permission, and daemon readiness](https://github.com/user-attachments/assets/9a9747ae-ff7b-4f82-8734-3ad37b636c63)

CUA selected but not ready under a signed fault-injection bundle whose child exits before socket readiness:

![CUA selected with daemon not ready and recovery guidance](https://github.com/user-attachments/assets/22104b9b-4341-4242-92cf-d1888916acc1)

All post-change images are exact Settings-window captures from signed app bundles launched with isolated W3-GATE profiles; the operator-installed app was never driven or captured. The ready CUA run had a live direct app-owned daemon child. The negative run used a separately signed test-bundle copy with an executable child that exits immediately, so the canonical coordinator endpoint remained absent.

- `swift test --package-path apps/macos --parallel` — passed, 1,698 tests discovered
- focused `ComputerControlSettingsTests` — 5 passed
- `scripts/format-swift.sh macos` — clean
- `scripts/lint-swift.sh macos` — 334 macOS and 22 helper files, 0 violations
- `pnpm native:i18n:baseline` and `pnpm native:i18n:verify` — 4,235 entries, clean
- `node scripts/check-native-state-schema-version.mjs` — passed at v8
- `git diff --check` — passed
- source-blind behavior contract — 5 passed, 0 failed or blocked
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings

Production LOC: +217/-43 (net +174) | Tests: +65/-0 | Generated native i18n inventory: +130/-11. The production growth is the requested selected-provider checklist plus its production-used readiness presentation; the integration removes 43 lines of the older aggregate permission UI.
