### PR TITLE
fix(release): preflight plugin npm trusted publishers

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1,5 +1,5 @@
 name: Plugin NPM Release
-run-name: ${{ github.event_name == 'workflow_dispatch' && (inputs.preflight_only && format('Plugin NPM Preflight [{0}] {1}', inputs.npm_dist_tag, inputs.ref) || format('Plugin NPM Release [{0}] {1}', inputs.npm_dist_tag, inputs.ref)) || format('Plugin NPM Release [default] {0}', github.sha) }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && (inputs.preflight_only && inputs.trusted_publisher_preflight && format('Plugin NPM Trusted Publisher Preflight [{0}] {1}', inputs.npm_dist_tag, inputs.ref) || inputs.preflight_only && format('Plugin NPM Artifact Preflight [{0}] {1}', inputs.npm_dist_tag, inputs.ref) || format('Plugin NPM Release [{0}] {1}', inputs.npm_dist_tag, inputs.ref)) || format('Plugin NPM Release [default] {0}', github.sha) }}
 
 on:
   push:
@@ -52,6 +52,11 @@ on:
         required: true
         default: false
         type: boolean
+      trusted_publisher_preflight:
+        description: During preflight_only, verify npm trusted-publisher OIDC exchange instead of packing artifacts
+        required: true
+        default: false
+        type: boolean
       npm_dist_tag:
         description: Optional npm dist-tag override
         required: true
@@ -99,6 +104,7 @@ jobs:
         env:
           NPM_DIST_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_dist_tag || 'default' }}
           PREFLIGHT_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only || false }}
+          TRUSTED_PUBLISHER_PREFLIGHT: ${{ github.event_name == 'workflow_dispatch' && inputs.trusted_publisher_preflight || false }}
           PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
           RELEASE_PUBLISH_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.release_publish_run_id || '' }}
@@ -107,6 +113,10 @@ jobs:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
+          if [[ "${TRUSTED_PUBLISHER_PREFLIGHT}" == "true" && "${PREFLIGHT_ONLY}" != "true" ]]; then
+            echo "trusted_publisher_preflight requires preflight_only=true." >&2
+            exit 1
+          fi
           if [[ "${PREFLIGHT_ONLY}" == "true" ]]; then
             if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] || [[ ! "${WORKFLOW_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
               echo "Plugin npm preflight must run from a trusted main workflow revision." >&2
@@ -318,14 +328,14 @@ jobs:
 
   preview_plugin_pack:
     needs: preview_plugins_npm
-    if: needs.preview_plugins_npm.outputs.has_candidates == 'true' || (github.event_name == 'workflow_dispatch' && inputs.preflight_only && needs.preview_plugins_npm.outputs.has_selection == 'true')
+    if: (needs.preview_plugins_npm.outputs.has_candidates == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.preflight_only)) || (github.event_name == 'workflow_dispatch' && inputs.preflight_only && !inputs.trusted_publisher_preflight && needs.preview_plugins_npm.outputs.has_selection == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        plugin: ${{ fromJson(github.event_name == 'workflow_dispatch' && inputs.preflight_only && needs.preview_plugins_npm.outputs.all_matrix || needs.preview_plugins_npm.outputs.matrix) }}
+        plugin: ${{ fromJson(github.event_name == 'workflow_dispatch' && inputs.preflight_only && !inputs.trusted_publisher_preflight && needs.preview_plugins_npm.outputs.all_matrix || needs.preview_plugins_npm.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -595,7 +605,7 @@ jobs:
   verify_plugin_npm_preflight:
     name: Preflight plugin npm package (${{ matrix.plugin.packageName }})
     needs: [preview_plugins_npm, preview_plugin_pack]
-    if: ${{ github.event_name == 'workflow_dispatch' && ((inputs.preflight_only && needs.preview_plugins_npm.outputs.has_selection == 'true') || (!inputs.preflight_only && needs.preview_plugins_npm.outputs.has_candidates == 'true')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' && ((inputs.preflight_only && !inputs.trusted_publisher_preflight && needs.preview_plugins_npm.outputs.has_selection == 'true') || (!inputs.preflight_only && needs.preview_plugins_npm.outputs.has_candidates == 'true')) }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -603,7 +613,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        plugin: ${{ fromJson(inputs.preflight_only && needs.preview_plugins_npm.outputs.all_matrix || needs.preview_plugins_npm.outputs.matrix) }}
+        plugin: ${{ fromJson(inputs.preflight_only && !inputs.trusted_publisher_preflight && needs.preview_plugins_npm.outputs.all_matrix || needs.preview_plugins_npm.outputs.matrix) }}
     steps:
       - name: Checkout trusted npm preflight tooling
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1006,6 +1016,50 @@ jobs:
             echo "- Tarball SHA-256: \`${TARBALL_SHA256}\`"
             echo "- Publication: **not attempted**"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  trusted_publisher_preflight:
+    name: Trusted publisher OIDC exchange
+    needs: preview_plugins_npm
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only && inputs.trusted_publisher_preflight && needs.preview_plugins_npm.outputs.has_selection == 'true' }}
+    runs-on: ubuntu-latest
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout trusted OIDC preflight tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+
+      - name: Setup trusted Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Verify npm trusted-publisher exchange
+        env:
+          PLUGIN_MATRIX: ${{ needs.preview_plugins_npm.outputs.all_matrix }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { preflightNpmTrustedPublisher } from "./scripts/npm-trusted-publisher-preflight.mjs";
+
+          let selection;
+          try {
+            selection = JSON.parse(process.env.PLUGIN_MATRIX);
+          } catch {
+            throw new Error("Plugin npm selection is not valid JSON.");
+          }
+          if (!Array.isArray(selection) || selection.length === 0) {
+            throw new Error("Plugin npm selection must be a non-empty array.");
+          }
+          for (const entry of selection) {
+            await preflightNpmTrustedPublisher(entry?.packageName);
+          }
+          NODE
 
   publish_plugins_npm:
     needs:

--- a/scripts/npm-trusted-publisher-preflight.mjs
+++ b/scripts/npm-trusted-publisher-preflight.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { readBoundedResponseText } from "./lib/bounded-response.mjs";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
+
+const AUDIENCE = "npm:registry.npmjs.org";
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const REQUEST_TIMEOUT_MS = 20_000;
+const RESPONSE_BODY_MAX_BYTES = 16 * 1024;
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/u;
+
+async function requestToken(url, init, label, tokenField) {
+  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetch(url, {
+      ...init,
+      signal,
+    });
+  } catch (error) {
+    const detail =
+      error instanceof Error && error.name === "TimeoutError" ? " timed out" : " failed";
+    throw new Error(`${label}${detail}.`, { cause: error });
+  }
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`${label} failed (HTTP ${response.status}).`);
+  }
+
+  let text;
+  try {
+    text = await readBoundedResponseText(response, label, RESPONSE_BODY_MAX_BYTES, { signal });
+  } catch (error) {
+    const detail =
+      error instanceof Error && error.name === "TimeoutError"
+        ? " timed out"
+        : " returned an invalid response body";
+    throw new Error(`${label}${detail}.`, { cause: error });
+  }
+
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON.`, { cause: error });
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error(`${label} returned an invalid response shape.`);
+  }
+  const token = body[tokenField];
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error(`${label} response is missing ${tokenField}.`);
+  }
+  return token;
+}
+
+export async function preflightNpmTrustedPublisher(packageName) {
+  if (
+    typeof packageName !== "string" ||
+    packageName.length > 214 ||
+    !PACKAGE_NAME_PATTERN.test(packageName)
+  ) {
+    throw new Error("A canonical npm package name is required.");
+  }
+
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const githubRequestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  if (!requestUrl || !githubRequestToken) {
+    throw new Error("GitHub OIDC request credentials are unavailable; grant id-token: write.");
+  }
+
+  let githubOidcUrl;
+  try {
+    githubOidcUrl = new URL(requestUrl);
+  } catch {
+    throw new Error("GitHub OIDC request URL is invalid.");
+  }
+  githubOidcUrl.searchParams.append("audience", AUDIENCE);
+  const githubOidcToken = await requestToken(
+    githubOidcUrl.href,
+    {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${githubRequestToken}`,
+      },
+    },
+    "GitHub OIDC token request",
+    "value",
+  );
+
+  // npm-package-arg's escapedName preserves the scope and escapes only its slash.
+  const escapedPackageName = packageName.replace("/", "%2f");
+  await requestToken(
+    `${NPM_REGISTRY}/-/npm/v1/oidc/token/exchange/package/${escapedPackageName}`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${githubOidcToken}`,
+      },
+    },
+    `npm trusted-publisher exchange for ${packageName}`,
+    "token",
+  );
+
+  console.log(`npm trusted-publisher OIDC exchange verified for ${packageName}.`);
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  try {
+    await preflightNpmTrustedPublisher(process.argv[2]);
+  } catch (error) {
+    console.error(
+      error instanceof Error ? error.message : "npm trusted-publisher preflight failed.",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/npm-trusted-publisher-preflight.mjs
+++ b/scripts/npm-trusted-publisher-preflight.mjs
@@ -89,7 +89,7 @@ export async function preflightNpmTrustedPublisher(packageName) {
   );
 
   // npm-package-arg's escapedName preserves the scope and escapes only its slash.
-  const escapedPackageName = packageName.replace("/", "%2f");
+  const escapedPackageName = packageName.replaceAll("/", "%2f");
   await requestToken(
     `${NPM_REGISTRY}/-/npm/v1/oidc/token/exchange/package/${escapedPackageName}`,
     {

--- a/test/scripts/npm-trusted-publisher-preflight.test.ts
+++ b/test/scripts/npm-trusted-publisher-preflight.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { preflightNpmTrustedPublisher } from "../../scripts/npm-trusted-publisher-preflight.mjs";
+
+const githubRequestToken = "github-request-secret";
+const githubOidcToken = "github-oidc-secret";
+const npmToken = "npm-exchange-secret";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}
+
+describe("npm trusted-publisher preflight", () => {
+  beforeEach(() => {
+    vi.stubEnv(
+      "ACTIONS_ID_TOKEN_REQUEST_URL",
+      "https://token.actions.githubusercontent.com/request?job=123",
+    );
+    vi.stubEnv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", githubRequestToken);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("requests the npm audience and exchanges the GitHub token for the exact package", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ value: githubOidcToken }))
+      .mockResolvedValueOnce(jsonResponse({ token: npmToken }));
+    vi.stubGlobal("fetch", fetchMock);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await preflightNpmTrustedPublisher("@openclaw/fish-audio-speech");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const githubCall = fetchMock.mock.calls[0];
+    const npmCall = fetchMock.mock.calls[1];
+    expect(githubCall).toBeDefined();
+    expect(npmCall).toBeDefined();
+    const [githubUrl, githubInit] = githubCall!;
+    expect(githubUrl).toBe(
+      "https://token.actions.githubusercontent.com/request?job=123&audience=npm%3Aregistry.npmjs.org",
+    );
+    expect(githubInit).toMatchObject({
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${githubRequestToken}`,
+      },
+    });
+    const [npmUrl, npmInit] = npmCall!;
+    expect(npmUrl).toBe(
+      "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@openclaw%2ffish-audio-speech",
+    );
+    expect(npmInit).toMatchObject({
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${githubOidcToken}`,
+      },
+    });
+    expect(log).toHaveBeenCalledWith(
+      "npm trusted-publisher OIDC exchange verified for @openclaw/fish-audio-speech.",
+    );
+  });
+
+  it("reports a GitHub token request failure without attempting npm exchange", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({}, 403));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(preflightNpmTrustedPublisher("@openclaw/fish-audio-speech")).rejects.toThrow(
+      "GitHub OIDC token request failed (HTTP 403).",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an npm exchange failure without leaking response or request tokens", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ value: githubOidcToken }))
+      .mockResolvedValueOnce(
+        jsonResponse({ message: `${githubRequestToken} ${githubOidcToken} ${npmToken}` }, 404),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const error = await preflightNpmTrustedPublisher("@openclaw/fish-audio-speech").catch(
+      (cause: unknown) => cause,
+    );
+    expect(error).toBeInstanceOf(Error);
+    const visibleError = error instanceof Error ? error.message : String(error);
+    expect(visibleError).toBe(
+      "npm trusted-publisher exchange for @openclaw/fish-audio-speech failed (HTTP 404).",
+    );
+    expect(visibleError).not.toContain(githubRequestToken);
+    expect(visibleError).not.toContain(githubOidcToken);
+    expect(visibleError).not.toContain(npmToken);
+  });
+
+  it("rejects an npm exchange response without a token", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ value: githubOidcToken }))
+      .mockResolvedValueOnce(jsonResponse({ token: "" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(preflightNpmTrustedPublisher("@openclaw/fish-audio-speech")).rejects.toThrow(
+      "npm trusted-publisher exchange for @openclaw/fish-audio-speech response is missing token.",
+    );
+  });
+});

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -34,6 +34,7 @@ type WorkflowInput = {
 };
 type Workflow = {
   on?: {
+    push?: { paths?: string[] };
     workflow_dispatch?: {
       inputs?: Record<string, WorkflowInput>;
     };
@@ -72,6 +73,13 @@ describe("plugin npm extended-stable workflow", () => {
     const inputs = workflow().on?.workflow_dispatch?.inputs;
     expect(inputs?.preflight_only).toEqual({
       description: "Prepare and verify immutable plugin npm artifacts without publishing",
+      required: true,
+      default: false,
+      type: "boolean",
+    });
+    expect(inputs?.trusted_publisher_preflight).toEqual({
+      description:
+        "During preflight_only, verify npm trusted-publisher OIDC exchange instead of packing artifacts",
       required: true,
       default: false,
       type: "boolean",
@@ -164,12 +172,18 @@ describe("plugin npm extended-stable workflow", () => {
     expect(trusted.env).toMatchObject({
       PREFLIGHT_ONLY:
         "${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only || false }}",
+      TRUSTED_PUBLISHER_PREFLIGHT:
+        "${{ github.event_name == 'workflow_dispatch' && inputs.trusted_publisher_preflight || false }}",
       RELEASE_PUBLISH_RUN_ID:
         "${{ github.event_name == 'workflow_dispatch' && inputs.release_publish_run_id || '' }}",
       SOURCE_REF: "${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}",
       WORKFLOW_REF: "${{ github.ref }}",
       WORKFLOW_SHA: "${{ github.workflow_sha }}",
     });
+    expect(trusted.run).toContain(
+      '[[ "${TRUSTED_PUBLISHER_PREFLIGHT}" == "true" && "${PREFLIGHT_ONLY}" != "true" ]]',
+    );
+    expect(trusted.run).toContain("trusted_publisher_preflight requires preflight_only=true");
     expect(trusted.run).toContain('[[ "${WORKFLOW_REF}" != "refs/heads/main" ]]');
     expect(trusted.run).toContain('git merge-base --is-ancestor "${WORKFLOW_SHA}" origin/main');
     expect(trusted.run).toContain('[[ ! "${SOURCE_REF}" =~ ^[0-9a-fA-F]{40}$ ]]');
@@ -191,6 +205,7 @@ describe("plugin npm extended-stable workflow", () => {
     const parsed = workflow();
     const preview = parsed.jobs?.preview_plugin_pack;
     expect(preview?.if).toContain("inputs.preflight_only");
+    expect(preview?.if).toContain("!inputs.trusted_publisher_preflight");
     expect(preview?.strategy?.matrix?.plugin).toContain("all_matrix");
 
     const prepare = step(preview, "Prepare immutable npm preflight artifact");
@@ -241,6 +256,7 @@ describe("plugin npm extended-stable workflow", () => {
 
     const verify = parsed.jobs?.verify_plugin_npm_preflight;
     expect(verify?.needs).toEqual(["preview_plugins_npm", "preview_plugin_pack"]);
+    expect(verify?.if).toContain("!inputs.trusted_publisher_preflight");
     expect(verify?.strategy?.matrix?.plugin).toContain("all_matrix");
     expect(verify?.strategy?.matrix?.plugin).toContain("matrix");
     expect(verify?.name).toBe("Preflight plugin npm package (${{ matrix.plugin.packageName }})");
@@ -313,6 +329,7 @@ describe("plugin npm extended-stable workflow", () => {
       "verify_plugins_npm",
     ]) {
       expect(parsed.jobs?.[jobName]?.if, jobName).toContain("!inputs.preflight_only");
+      expect(parsed.jobs?.[jobName]?.if, jobName).not.toContain("trusted_publisher_preflight");
     }
 
     for (const jobName of [
@@ -331,6 +348,44 @@ describe("plugin npm extended-stable workflow", () => {
       expect(serialized.replaceAll("clawHub: false", ""), jobName).not.toMatch(/\bclawhub\b/iu);
       expect(serialized, jobName).not.toMatch(/\b(?:android|macos|windows)\b/iu);
     }
+  });
+
+  it("runs one trusted-publisher exchange job directly after selected-package planning", () => {
+    const parsed = workflow();
+    expect(parsed.on?.push?.paths).not.toContain("scripts/npm-trusted-publisher-preflight.mjs");
+    expect(readFileSync(workflowPath, "utf8")).toContain(
+      "inputs.preflight_only && inputs.trusted_publisher_preflight && format('Plugin NPM Trusted Publisher Preflight",
+    );
+    expect(readFileSync(workflowPath, "utf8")).toContain("Plugin NPM Artifact Preflight");
+    const oidc = parsed.jobs?.trusted_publisher_preflight;
+    expect(oidc?.name).toBe("Trusted publisher OIDC exchange");
+    expect(oidc?.needs).toBe("preview_plugins_npm");
+    expect(oidc?.if).toContain("inputs.preflight_only");
+    expect(oidc?.if).toContain("inputs.trusted_publisher_preflight");
+    expect(oidc?.if).toContain("has_selection == 'true'");
+    expect(oidc?.environment).toBe("npm-release");
+    expect(oidc?.["runs-on"]).toBe("ubuntu-latest");
+    expect(oidc?.permissions).toEqual({ contents: "read", "id-token": "write" });
+    expect(oidc?.strategy).toBeUndefined();
+    expect(step(oidc, "Checkout trusted OIDC preflight tooling").with).toMatchObject({
+      "persist-credentials": false,
+      ref: "${{ github.workflow_sha }}",
+    });
+    expect(step(oidc, "Setup trusted Node").with?.["node-version"]).toBe("${{ env.NODE_VERSION }}");
+    const exchange = step(oidc, "Verify npm trusted-publisher exchange");
+    expect(exchange.env?.PLUGIN_MATRIX).toBe("${{ needs.preview_plugins_npm.outputs.all_matrix }}");
+    expect(exchange.run).toContain(
+      'import { preflightNpmTrustedPublisher } from "./scripts/npm-trusted-publisher-preflight.mjs"',
+    );
+    expect(exchange.run).toContain("JSON.parse(process.env.PLUGIN_MATRIX)");
+    expect(exchange.run).toContain("selection must be a non-empty array");
+    expect(exchange.run).toContain("for (const entry of selection)");
+    expect(exchange.run).toContain("await preflightNpmTrustedPublisher(entry?.packageName)");
+    const serialized = JSON.stringify(oidc);
+    expect(serialized).not.toContain("secrets.");
+    expect(serialized).not.toContain("NPM_TOKEN");
+    expect(serialized).not.toMatch(/\bnpm publish\b/u);
+    expect(serialized).not.toMatch(/\bnpm dist-tag\b/u);
   });
 
   it("attests the canonical Meta provider package and install route", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin release operators could select the existing-package OIDC route even when npm had no matching trusted-publisher configuration, causing the publish job to fail late with `ENEEDAUTH`. This happened for `@openclaw/fish-audio-speech` during the v2026.8.1-beta.2 release: https://github.com/openclaw/openclaw/actions/runs/31863860804/job/94962239580

## Why This Change Was Made

The npm package has been configured for repository `openclaw/openclaw`, workflow `plugin-npm-release.yml`, environment `npm-release`, and publish permission. This PR adds a separate protected preflight subtype that requests the GitHub OIDC token, performs npm's package-specific token exchange, and immediately discards the returned npm token. It does not invoke `npm publish`, change dist-tags, or mutate a package version; the existing artifact-only preflight remains secretless and unchanged.

The live check is routed directly from validated package selection and runs once in the `npm-release` environment, rather than rebuilding or packing every selected plugin.

## User Impact

Release operators can verify trusted-publisher configuration before the next plugin version is published. Missing or mismatched npm trust settings now fail in a safe, non-publishing workflow instead of during the release publish step.

## Evidence

- npm trusted-publisher record verified after repair: GitHub repository `openclaw/openclaw`, workflow `plugin-npm-release.yml`, environment `npm-release`, permission `createPackage`.
- `node scripts/run-vitest.mjs test/scripts/npm-trusted-publisher-preflight.test.ts test/scripts/plugin-npm-extended-stable-workflow.test.ts` — 16 tests passed.
- `actionlint .github/workflows/plugin-npm-release.yml` — passed.
- `node --check scripts/npm-trusted-publisher-preflight.mjs` — passed.
- `node scripts/check-changed.mjs -- <touched files>` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31872630706
- `git diff --check` — passed.
- Codex autoreview — no accepted/actionable findings.
- Production/tooling LOC: +177/-5 (new non-publishing OIDC verification capability). Tests: +166/-0.

AI-assisted; reviewed and understood by the maintainer.
