### PR TITLE
refactor(channels): centralize ingress lifecycle fan-out

### DIFF
--- a/extensions/imessage/src/monitor/ingress.test.ts
+++ b/extensions/imessage/src/monitor/ingress.test.ts
@@ -2,13 +2,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createIMessageDurableIngress, type IMessageIngressLifecycle } from "./ingress.js";
+import { createIMessageDurableIngress } from "./ingress.js";
 
 type IMessageIngressQueue = NonNullable<
   Parameters<typeof createIMessageDurableIngress>[0]["queue"]
@@ -53,16 +52,6 @@ async function withQueue<T>(
 
 function runtime() {
   return { error: vi.fn(), log: vi.fn() };
-}
-
-function lifecycle() {
-  return {
-    abortSignal: new AbortController().signal,
-    onAdopted: vi.fn(async () => {}),
-    onDeferred: vi.fn(),
-    onAdoptionFinalizing: vi.fn(),
-    onAbandoned: vi.fn(async () => {}),
-  } satisfies IMessageIngressLifecycle;
 }
 
 function deferred() {
@@ -492,27 +481,5 @@ describe("iMessage durable ingress", () => {
         await ingress.stop();
       }
     });
-  });
-
-  it("fans merged adoption to every constituent claim", async () => {
-    const first = lifecycle();
-    const second = lifecycle();
-    const merged = fanInChannelIngressLifecycles([first, second]);
-
-    await merged.lifecycle?.onAdopted();
-
-    expect(first.onAdopted).toHaveBeenCalledTimes(1);
-    expect(second.onAdopted).toHaveBeenCalledTimes(1);
-  });
-
-  it("completes every constituent claim when a flush has no dispatch", async () => {
-    const first = lifecycle();
-    const second = lifecycle();
-    const merged = fanInChannelIngressLifecycles([first, second]);
-
-    await merged.settle();
-
-    expect(first.onAdopted).toHaveBeenCalledTimes(1);
-    expect(second.onAdopted).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
@@ -1,18 +1,14 @@
-// Mattermost durable ingress tests cover append, recovery, tombstones, and merged adoption.
+// Mattermost durable ingress tests cover append, recovery, and tombstones.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  createMattermostIngressMonitor,
-  type MattermostIngressLifecycle,
-} from "./monitor-ingress.js";
+import { createMattermostIngressMonitor } from "./monitor-ingress.js";
 
 type MattermostIngressQueue = NonNullable<
   Parameters<typeof createMattermostIngressMonitor>[0]["queue"]
@@ -75,23 +71,6 @@ async function withStateDir<T>(fn: (stateDir: string) => Promise<T>): Promise<T>
 
 async function withQueue<T>(fn: (queue: MattermostIngressQueue) => Promise<T>): Promise<T> {
   return await withStateDir(async (stateDir) => await fn(createQueue(stateDir, "default")));
-}
-
-function testLifecycle() {
-  const calls = {
-    adopted: vi.fn(async () => {}),
-    deferred: vi.fn(),
-    finalizing: vi.fn(),
-    abandoned: vi.fn(async () => {}),
-  };
-  const lifecycle: MattermostIngressLifecycle = {
-    abortSignal: new AbortController().signal,
-    onAdopted: calls.adopted,
-    onDeferred: calls.deferred,
-    onAdoptionFinalizing: calls.finalizing,
-    onAbandoned: calls.abandoned,
-  };
-  return { calls, lifecycle };
 }
 
 afterEach(() => {
@@ -479,33 +458,5 @@ describe("Mattermost durable ingress", () => {
         await monitor.stop();
       }
     });
-  });
-});
-
-describe("Mattermost merged ingress lifecycle", () => {
-  it("fans adoption out to every constituent claim", async () => {
-    const first = testLifecycle();
-    const second = testLifecycle();
-    const merged = fanInChannelIngressLifecycles([first.lifecycle, second.lifecycle]);
-
-    merged.lifecycle?.onDeferred();
-    await merged.lifecycle?.onAdopted();
-    await merged.settle();
-
-    expect(first.calls.deferred).toHaveBeenCalledTimes(1);
-    expect(second.calls.deferred).toHaveBeenCalledTimes(1);
-    expect(first.calls.adopted).toHaveBeenCalledTimes(1);
-    expect(second.calls.adopted).toHaveBeenCalledTimes(1);
-  });
-
-  it("completes all claims when a gated flush never dispatches", async () => {
-    const first = testLifecycle();
-    const second = testLifecycle();
-    const merged = fanInChannelIngressLifecycles([first.lifecycle, second.lifecycle]);
-
-    await merged.settle();
-
-    expect(first.calls.adopted).toHaveBeenCalledTimes(1);
-    expect(second.calls.adopted).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -747,9 +747,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             async (terminalError: unknown) => {
               // Exhausted retries: release the drain claims so queue retry policy
               // owns redelivery instead of the stall watchdog dead-lettering them.
-              await Promise.all(
-                entries.map((entry) => Promise.resolve(entry.turnAdoptionLifecycle?.onAbandoned())),
-              );
+              await lifecycle?.onAbandoned();
               throw terminalError;
             },
           );

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -148,26 +148,21 @@ export function fanInChannelIngressLifecycles(
       await lifecycle.onAdopted();
     }
   };
-  const abandonAll = async () => {
-    await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onAbandoned()));
+  const fanOut = async (invoke: (lifecycle: ChannelIngressLifecycle) => void | Promise<void>) => {
+    await Promise.all(lifecycles.map(async (lifecycle) => await invoke(lifecycle)));
   };
-  const failAll = async (error: unknown) => {
-    await Promise.all(
-      lifecycles.map(async (lifecycle) =>
-        lifecycle.onFailed ? await lifecycle.onFailed(error) : await lifecycle.onAbandoned(),
-      ),
+  const abandonAll = () => fanOut((lifecycle) => lifecycle.onAbandoned());
+  const failAll = (error: unknown) =>
+    fanOut((lifecycle) =>
+      lifecycle.onFailed ? lifecycle.onFailed(error) : lifecycle.onAbandoned(),
     );
-  };
   const supportsCancellation = lifecycles.every((lifecycle) => lifecycle.onCancelled !== undefined);
   // Omit aggregate cancellation unless every durable source supports it. Callers
   // can then use settle/abandon without an acknowledged-but-unsettled claim.
-  const cancelAll = async () => {
-    await Promise.all(
-      lifecycles.map(async (lifecycle) =>
-        lifecycle.onCancelled ? await lifecycle.onCancelled() : await lifecycle.onAbandoned(),
-      ),
+  const cancelAll = () =>
+    fanOut((lifecycle) =>
+      lifecycle.onCancelled ? lifecycle.onCancelled() : lifecycle.onAbandoned(),
     );
-  };
   return {
     lifecycle: {
       abortSignal:


### PR DESCRIPTION
## What Problem This Solves

The ingress settlement repairs in #120104 and #124016 established the right behavior, but left the shared owner with three copies of the same concurrent lifecycle fan-out machinery. Signal also bypassed that aggregate lifecycle for one abandonment path, while iMessage and Mattermost retained four tests that directly re-tested the SDK helper without traversing their channel boundaries.

## Why This Change Was Made

This cleanup keeps one implementation of the fan-out contract in `fanInChannelIngressLifecycles`: every source is invoked even when another callback throws synchronously, while adoption remains deliberately sequential.

Signal now uses the aggregate lifecycle it already created from the same entries. The channel-local helper tests are removed in favor of the stronger canonical SDK coverage; real queue and monitor boundary tests remain unchanged.

No public API, configuration, schema, dependency, retry policy, or settlement behavior changes.

## User Impact

No behavior change. Modern failures still receive `onFailed(error)`, legacy sources still fall back to `onAbandoned()`, cancellation and argument-free abandonment retain their existing semantics, and Signal still abandons exhausted session-conflict retries before rethrowing the terminal error.

The result is one canonical fan-out implementation and less duplicated test policy.

## Evidence

Focused tests on the final local base:

- `node scripts/run-vitest.mjs src/plugin-sdk/channel-ingress-runtime.test.ts` — 7 passed
- `node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts` — 8 passed, including durable abandonment accounting across backoff, retry threshold, and restart
- `node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts` — 4 passed
- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/ingress.test.ts` — 13 passed
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor-ingress.test.ts` — 14 passed
- `node scripts/check-changed.mjs -- <changed paths>` — passed; remote backends were unavailable, so trusted-source proof used the documented local fallback
- Codex autoreview — clean, no accepted/actionable findings

Production LOC: +10/-17 (net -7). Tests: +3/-85 (net -82). Total: net -89.

Related: #120104, #124016, #108865.
