### PR TITLE
fix(state): retire entry_valid write-triggers and settle legacy cleared shells

### DIFF
--- a/src/commands/doctor-session-canonical-keys.test.ts
+++ b/src/commands/doctor-session-canonical-keys.test.ts
@@ -188,7 +188,7 @@ describe("doctor canonical session-key repair", () => {
         path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
       });
       database.db
-        .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+        .prepare("UPDATE session_nodes SET entry_json = ?, entry_valid = 0 WHERE session_key = ?")
         .run(
           JSON.stringify({ sessionId: "\0invalid", subject: "legacy", updatedAt: 10 }),
           "agent:main:main",
@@ -690,14 +690,16 @@ describe("doctor canonical session-key repair", () => {
           .prepare("SELECT entry_json FROM session_nodes WHERE session_key = ?")
           .get("agent:main:child") as { entry_json: string }
       ).entry_json;
-      database.db.prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?").run(
-        JSON.stringify({
-          ...(JSON.parse(canonicalJson) as object),
-          icon: "archive",
-          spawnedBy: null,
-        }),
-        "agent:main:child",
-      );
+      database.db
+        .prepare("UPDATE session_nodes SET entry_json = ?, entry_valid = 0 WHERE session_key = ?")
+        .run(
+          JSON.stringify({
+            ...(JSON.parse(canonicalJson) as object),
+            icon: "archive",
+            spawnedBy: null,
+          }),
+          "agent:main:child",
+        );
       expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
         foundGroups: 1,
         repairedGroups: 1,

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -49,7 +49,11 @@ import {
   branchCompactionCheckpointSession,
   restoreCompactionCheckpointSession,
 } from "./session-accessor.sqlite-checkpoint.js";
-import { listSessionEntryRows, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
+import {
+  listSessionEntriesReadOnly,
+  listSessionEntryRows,
+  replaceSessionEntrySync,
+} from "./session-accessor.sqlite-entry.js";
 import { forkSessionEntryFromParentTarget } from "./session-accessor.sqlite-parent-session.js";
 import { loadTranscriptEventsSync } from "./session-accessor.sqlite-read.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
@@ -1273,7 +1277,7 @@ describe("sqlite session normalization", () => {
     });
   });
 
-  it("marks identity-only row updates pending validation", async () => {
+  it("fails loud for identity-only row updates bypassing the accessor", async () => {
     const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
     const sessionKey = "agent:main:identity-update";
     await replaceSessionEntry(
@@ -1281,15 +1285,16 @@ describe("sqlite session normalization", () => {
       { sessionId: "identity-session", updatedAt: 10 },
     );
     const database = openOpenClawAgentDatabase({ agentId: "main", env, path: paths.sqlitePath });
+    // Direct-SQL identity mutation without the retired entry_valid write-triggers: the
+    // runtime validator still rejects the row on a fresh read because the persisted
+    // sessionId no longer matches current_session_id.
     database.db
-      .prepare("UPDATE session_nodes SET updated_at = 11 WHERE session_key = ?")
-      .run(sessionKey);
+      .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+      .run(JSON.stringify({ sessionId: "identity-session-changed", updatedAt: 10 }), sessionKey);
 
-    expect(
-      database.db
-        .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
-        .get(sessionKey),
-    ).toEqual({ entry_valid: 0 });
+    expect(() =>
+      listSessionEntriesReadOnly({ agentId: "main", env, storePath: paths.sqlitePath }),
+    ).toThrow("openclaw doctor --fix");
   });
 
   it("writes a valid session beside an unrelated malformed legacy row", async () => {

--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -40,9 +40,6 @@ describe("legacy media persistence additive schema repair", () => {
     const { DatabaseSync } = requireNodeSqlite();
     const database = new DatabaseSync(databasePath);
     database.exec(`
-      DROP TRIGGER session_nodes_entry_valid_after_insert;
-      DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-      DROP TRIGGER session_nodes_entry_valid_after_identity_update;
       DROP INDEX idx_agent_session_nodes_entry_valid_pending;
       DROP TABLE session_key_contract;
       ALTER TABLE session_nodes DROP COLUMN entry_valid;

--- a/src/state/openclaw-agent-db-session-migrations.test.ts
+++ b/src/state/openclaw-agent-db-session-migrations.test.ts
@@ -3,6 +3,7 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { buildConversationRef } from "../routing/conversation-ref.js";
 import {
   backfillSessionConversations,
+  ensureSessionEntryValidityProjection,
   migrateConversationDeliveryTargetColumn,
 } from "./openclaw-agent-db-session-migrations.js";
 
@@ -385,5 +386,105 @@ describe("agent DB conversation migration", () => {
         )
         .get(),
     ).toEqual({ count: 0 });
+  });
+
+  it("does not install entry_valid write-triggers and drops triggers left by older binaries", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    databases.push(database);
+    database.exec(`
+      CREATE TABLE session_nodes (
+        session_key TEXT PRIMARY KEY,
+        current_session_id TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        entry_valid INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TRIGGER session_nodes_entry_valid_after_insert
+      AFTER INSERT ON session_nodes
+      BEGIN
+        UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
+      END;
+      CREATE TRIGGER session_nodes_entry_valid_after_entry_update
+      AFTER UPDATE OF entry_json ON session_nodes
+      BEGIN
+        UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
+      END;
+      CREATE TRIGGER session_nodes_entry_valid_after_identity_update
+      AFTER UPDATE OF current_session_id, updated_at ON session_nodes
+      BEGIN
+        UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
+      END;
+    `);
+
+    ensureSessionEntryValidityProjection(database);
+
+    const remaining = database
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'session_nodes_entry_valid_%'",
+      )
+      .all();
+    expect(remaining).toEqual([]);
+  });
+
+  it("settles legacy pending rows and normalizes legacy cleared shells", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    databases.push(database);
+    database.exec(`
+      CREATE TABLE session_nodes (
+        session_key TEXT PRIMARY KEY,
+        current_session_id TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        entry_valid INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+    const insert = database.prepare(
+      "INSERT INTO session_nodes (session_key, current_session_id, entry_json, entry_valid, updated_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    insert.run(
+      "agent:main:main",
+      "session-main",
+      JSON.stringify({ sessionId: "session-main", updatedAt: 100 }),
+      0,
+      100,
+    );
+    insert.run(
+      "agent:main:cron:legacy-run",
+      "session-cron",
+      JSON.stringify({ delivery: { kind: "none" } }),
+      -1,
+      100,
+    );
+    insert.run(
+      "agent:main:shell",
+      "session-shell",
+      JSON.stringify({ sessionId: "session-shell", updatedAt: 200 }),
+      -1,
+      200,
+    );
+
+    ensureSessionEntryValidityProjection(database);
+
+    expect(
+      database
+        .prepare(
+          "SELECT session_key, entry_valid, entry_json FROM session_nodes ORDER BY session_key",
+        )
+        .all(),
+    ).toEqual([
+      { session_key: "agent:main:cron:legacy-run", entry_valid: -1, entry_json: "{}" },
+      {
+        session_key: "agent:main:main",
+        entry_valid: 1,
+        entry_json: JSON.stringify({ sessionId: "session-main", updatedAt: 100 }),
+      },
+      {
+        session_key: "agent:main:shell",
+        entry_valid: -1,
+        entry_json: JSON.stringify({ sessionId: "session-shell", updatedAt: 200 }),
+      },
+    ]);
   });
 });

--- a/src/state/openclaw-agent-db-session-migrations.test.ts
+++ b/src/state/openclaw-agent-db-session-migrations.test.ts
@@ -427,7 +427,7 @@ describe("agent DB conversation migration", () => {
     expect(remaining).toEqual([]);
   });
 
-  it("settles legacy pending rows and normalizes legacy cleared shells", () => {
+  it("settles legacy pending rows and normalizes only proven legacy cleared shells", () => {
     const sqlite = requireNodeSqlite();
     const database = new sqlite.DatabaseSync(":memory:");
     databases.push(database);
@@ -439,9 +439,16 @@ describe("agent DB conversation migration", () => {
         entry_valid INTEGER NOT NULL DEFAULT 0,
         updated_at INTEGER NOT NULL
       );
+      CREATE TABLE session_windows (
+        session_id TEXT PRIMARY KEY,
+        session_key TEXT NOT NULL
+      );
     `);
     const insert = database.prepare(
       "INSERT INTO session_nodes (session_key, current_session_id, entry_json, entry_valid, updated_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    const insertWindow = database.prepare(
+      "INSERT INTO session_windows (session_id, session_key) VALUES (?, ?)",
     );
     insert.run(
       "agent:main:main",
@@ -450,10 +457,20 @@ describe("agent DB conversation migration", () => {
       0,
       100,
     );
+    // Proven legacy cleared shell: {"delivery":{"kind":"none"}} with a retained window.
     insert.run(
       "agent:main:cron:legacy-run",
       "session-cron",
       JSON.stringify({ delivery: { kind: "none" } }),
+      -1,
+      100,
+    );
+    insertWindow.run("session-cron", "agent:main:cron:legacy-run");
+    // Partial-but-recoverable row without identity: must be preserved for Doctor repair.
+    insert.run(
+      "agent:main:malformed",
+      "session-malformed",
+      JSON.stringify({ delivery: { kind: "none" }, icon: "archive" }),
       -1,
       100,
     );
@@ -479,6 +496,11 @@ describe("agent DB conversation migration", () => {
         session_key: "agent:main:main",
         entry_valid: 1,
         entry_json: JSON.stringify({ sessionId: "session-main", updatedAt: 100 }),
+      },
+      {
+        session_key: "agent:main:malformed",
+        entry_valid: -1,
+        entry_json: JSON.stringify({ delivery: { kind: "none" }, icon: "archive" }),
       },
       {
         session_key: "agent:main:shell",

--- a/src/state/openclaw-agent-db-session-migrations.ts
+++ b/src/state/openclaw-agent-db-session-migrations.ts
@@ -336,30 +336,69 @@ export function ensureSessionEntryValidityProjection(db: DatabaseSync): void {
       update.run(parseSqliteSessionEntryRecord(row) ? 1 : -1, row.session_key);
     }
   }
-  // Rows left by older writers can carry an explicit -1 with a non-{} entry_json (e.g. a
-  // legacy cleared shell serialized as {"delivery":{"kind":"none"}}). The canonical-key
-  // validator only accepts -1 paired with "{}" plus a retained window, so normalize any
-  // -1 row whose entry_json has no valid entry identity into the canonical cleared shell.
+  // Rows left by older binaries can carry an explicit -1 with a non-{} entry_json
+  // (their cleared-shell encoding was {"delivery":{"kind":"none"}}). The canonical-key
+  // validator only accepts -1 paired with "{}" plus a retained window, so those proven
+  // legacy cleared shells are normalized here. Conversion is deliberately restricted to
+  // that exact shell signature with a matching retained window: any other malformed or
+  // partially recoverable row is left untouched so Doctor's repair inventory can hydrate
+  // it from promoted columns instead of losing recovery evidence.
   const selectShells = db.prepare(
-    "SELECT session_key, entry_json FROM session_nodes WHERE entry_valid = -1 AND entry_json != '{}'",
+    `SELECT n.session_key, n.current_session_id, n.entry_json
+       FROM session_nodes n
+      WHERE n.entry_valid = -1
+        AND n.entry_json != '{}'
+        AND n.entry_json IS NOT NULL`,
   );
+  // session_windows may not exist yet on very old schemas; the retained-window check is
+  // only a safety gate for the legacy-shell normalization, so degrade gracefully.
+  const windowsTable = readSqliteTableColumns(db, "session_windows");
+  const retainedWindow = windowsTable
+    ? db.prepare("SELECT session_id FROM session_windows WHERE session_id = ? AND session_key = ?")
+    : null;
   const settleShell = db.prepare(
     "UPDATE session_nodes SET entry_valid = -1, entry_json = ? WHERE session_key = ?",
   );
-  for (const row of selectShells.all() as Array<{ session_key: string; entry_json: string }>) {
-    let hasIdentity: boolean;
+  for (const row of selectShells.all() as Array<{
+    session_key: string;
+    current_session_id: string;
+    entry_json: string;
+  }>) {
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(row.entry_json) as unknown;
-      hasIdentity = hasValidSessionEntryIdentity(
-        (parsed ?? {}) as { sessionId?: unknown; updatedAt?: unknown },
-      );
+      parsed = JSON.parse(row.entry_json);
     } catch {
-      hasIdentity = false;
+      parsed = undefined;
     }
-    if (!hasIdentity) {
-      settleShell.run("{}", row.session_key);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      continue;
     }
+    const record = parsed as Record<string, unknown>;
+    // Legacy cleared-shell signature: no entry identity and only the delivery marker.
+    if (
+      hasValidSessionEntryIdentity(record as { sessionId?: unknown; updatedAt?: unknown }) ||
+      Object.keys(record).length !== 1 ||
+      !isLegacyClearedShellDelivery(record.delivery)
+    ) {
+      continue;
+    }
+    if (
+      !retainedWindow ||
+      (!retainedWindow.get(row.current_session_id, row.session_key) &&
+        !retainedWindow.get(row.session_key, row.session_key))
+    ) {
+      continue;
+    }
+    settleShell.run("{}", row.session_key);
   }
+}
+
+function isLegacyClearedShellDelivery(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const delivery = value as Record<string, unknown>;
+  return Object.keys(delivery).length === 1 && delivery.kind === "none";
 }
 
 export function migrateSessionEntryStatusProjection(

--- a/src/state/openclaw-agent-db-session-migrations.ts
+++ b/src/state/openclaw-agent-db-session-migrations.ts
@@ -3,7 +3,10 @@ import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion"
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType, type ChatType } from "../channels/chat-type.js";
-import { parseSqliteSessionEntryRecord } from "../config/sessions/session-entry-json.js";
+import {
+  parseSqliteSessionEntryRecord,
+  hasValidSessionEntryIdentity,
+} from "../config/sessions/session-entry-json.js";
 import { normalizeAccountId } from "../routing/account-id.js";
 import { buildConversationRef, normalizeConversationPeerId } from "../routing/conversation-ref.js";
 import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
@@ -301,22 +304,17 @@ export function ensureSessionEntryValidityProjection(db: DatabaseSync): void {
       "ALTER TABLE session_nodes ADD COLUMN entry_valid INTEGER NOT NULL DEFAULT 0 CHECK (entry_valid IN (-1, 0, 1))",
     );
   }
+  // The entry_valid write-triggers were retired: they raced every session_nodes write
+  // against a pending (0) marker that only well-formed write paths settled. Interrupted
+  // paths (shutdown drain, aborted turns) left rows stuck at 0, which the canonical-key
+  // runtime validation then rejected with SessionCanonicalKeyMigrationRequiredError —
+  // including rejecting doctor's own repair pass. All current write paths set
+  // entry_valid explicitly (1 for entries, -1 for cleared shells), so the triggers are
+  // redundant; drop any installed by older binaries.
   db.exec(`
-    CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_insert
-    AFTER INSERT ON session_nodes
-    BEGIN
-      UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-    END;
-    CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_entry_update
-    AFTER UPDATE OF entry_json ON session_nodes
-    BEGIN
-      UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-    END;
-    CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_identity_update
-    AFTER UPDATE OF current_session_id, updated_at ON session_nodes
-    BEGIN
-      UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-    END;
+    DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_insert;
+    DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_entry_update;
+    DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_identity_update;
   `);
   const selectPending = db.prepare(
     "SELECT current_session_id, entry_json, session_key, updated_at FROM session_nodes WHERE entry_valid = 0 ORDER BY session_key LIMIT 256",
@@ -336,6 +334,30 @@ export function ensureSessionEntryValidityProjection(db: DatabaseSync): void {
     }
     for (const row of rows) {
       update.run(parseSqliteSessionEntryRecord(row) ? 1 : -1, row.session_key);
+    }
+  }
+  // Rows left by older writers can carry an explicit -1 with a non-{} entry_json (e.g. a
+  // legacy cleared shell serialized as {"delivery":{"kind":"none"}}). The canonical-key
+  // validator only accepts -1 paired with "{}" plus a retained window, so normalize any
+  // -1 row whose entry_json has no valid entry identity into the canonical cleared shell.
+  const selectShells = db.prepare(
+    "SELECT session_key, entry_json FROM session_nodes WHERE entry_valid = -1 AND entry_json != '{}'",
+  );
+  const settleShell = db.prepare(
+    "UPDATE session_nodes SET entry_valid = -1, entry_json = ? WHERE session_key = ?",
+  );
+  for (const row of selectShells.all() as Array<{ session_key: string; entry_json: string }>) {
+    let hasIdentity: boolean;
+    try {
+      const parsed = JSON.parse(row.entry_json) as unknown;
+      hasIdentity = hasValidSessionEntryIdentity(
+        (parsed ?? {}) as { sessionId?: unknown; updatedAt?: unknown },
+      );
+    } catch {
+      hasIdentity = false;
+    }
+    if (!hasIdentity) {
+      settleShell.run("{}", row.session_key);
     }
   }
 }

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3359,9 +3359,6 @@ describe("openclaw agent database", () => {
       );
     try {
       shippedSchema.exec(`
-        DROP TRIGGER session_nodes_entry_valid_after_insert;
-        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
         DROP INDEX idx_agent_session_nodes_entry_valid_pending;
         DROP TABLE session_key_contract;
         ALTER TABLE session_nodes DROP COLUMN entry_valid;
@@ -3408,9 +3405,6 @@ describe("openclaw agent database", () => {
           1000,
         );
       drifted.exec(`
-        DROP TRIGGER session_nodes_entry_valid_after_insert;
-        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
         DROP INDEX idx_agent_session_nodes_entry_valid_pending;
         DROP TABLE session_key_contract;
         ALTER TABLE session_nodes DROP COLUMN entry_valid;

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -75,24 +75,6 @@ CREATE TABLE IF NOT EXISTS session_key_contract (
 
 INSERT OR IGNORE INTO session_key_contract (id, main_key, updated_at) VALUES (1, 'main', 0);
 
-CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_insert
-AFTER INSERT ON session_nodes
-BEGIN
-  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-END;
-
-CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_entry_update
-AFTER UPDATE OF entry_json ON session_nodes
-BEGIN
-  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-END;
-
-CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_identity_update
-AFTER UPDATE OF current_session_id, updated_at ON session_nodes
-BEGIN
-  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-END;
-
 CREATE TABLE IF NOT EXISTS session_windows (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,


### PR DESCRIPTION
## What Problem This Solves

Upgrading to the 2026.8.1 line (session-entry-validity projection) can wedge the gateway in an unrecoverable `SessionCanonicalKeyMigrationRequiredError` loop:

1. **Trigger-created pending rows never settle.** The `session_nodes` `entry_valid` write-triggers mark **every** insert/update as pending (`entry_valid = 0`), relying on each write path to settle the row afterward. Well-formed paths do (`writeSessionEntry` → 1, clear/transcript paths → -1 with `{}`), but **interrupted paths** — gateway shutdown drain, aborted turns, restart handoff — can leave a row stuck at `0`.
2. **The validator rejects `0` forever.** `assertCanonicalSqliteSessionKeysCurrent` only accepts `1` (valid entry) or `-1` paired with `{}` (cleared shell). A row stuck at `0` makes **every** session read fail with `SessionCanonicalKeyMigrationRequiredError` — including the reads that gate writes, so the gateway cannot repair the row itself.
3. **`doctor --fix` cannot complete.** The error message recommends `openclaw doctor --fix`, but doctor's repair pass reads the session store first and hits the same validation error, so the recommended fix deadlocks.
4. **Model fallback misfires.** The runtime classifies `SessionCanonicalKeyMigrationRequiredError` as a model candidate failure, so a healthy provider (e.g. MiniMax M3 returning 200 OK) gets silently fallbacked to the backup model on every affected turn.

Observed in the field: after upgrading to `2026.8.1-beta.2`, the main session row was left at `entry_valid = 0` by a shutdown drain, and every user message then (a) logged the same `SessionCanonicalKeyMigrationRequiredError`, (b) fallbacked M3 → deepseek-v4-flash despite M3 being healthy, and (c) could not be fixed with the recommended `doctor --fix` (it aborted on the same error). 28 legacy cron `run:` rows also carried `entry_valid = -1` with a non-`{}` `entry_json` (`{"delivery":{"kind":"none"}}`), which the validator permanently rejects because it only accepts `-1` + `{}` with a retained window.

## Change

- **Retire the entry_valid write-triggers.** They are redundant: every current write path sets `entry_valid` explicitly (`writeSessionEntry` writes 1, clear/transcript paths write -1 together with `{}`). The schema no longer installs them, and `ensureSessionEntryValidityProjection` now drops any installed by older binaries instead of re-creating them. Interrupted writes can no longer produce an unrecoverable `0` state.
- **Settle legacy cleared shells on open, conservatively.** `ensureSessionEntryValidityProjection` normalizes rows with `entry_valid = -1` whose `entry_json` is exactly the legacy cleared-shell signature (`{"delivery":{"kind":"none"}}`, no entry identity) **and** which have a matching retained session window, into the canonical `{}` cleared form. Any other malformed or partially recoverable row is deliberately left untouched so Doctor's repair inventory can hydrate it from promoted columns instead of losing recovery evidence (ClawSweeper P1).

## Evidence

- **Reproduction:** gateway `journalctl` shows repeated `SessionCanonicalKeyMigrationRequiredError: invalid persisted session row requires repair for agent:main:main; stop the Gateway and run openclaw doctor --fix` on every dispatch; `model-fallback/decision` logs `candidate_failed requested=minimax/MiniMax-M3 ... next=deepseek/deepseek-v4-flash` while `provider-transport-fetch` concurrently logs M3 `status=200`.
- **Root cause trace:** a watchdog sampling `session_nodes` every 500 ms captured `agent:main:main` flipping from `entry_valid = 1` (run active) to `entry_valid = 0` exactly when the gateway received SIGTERM (`root transaction drain timeout reached with 1 root(s) still active`), and remaining `0` for 30+ seconds. Database inspection confirmed the three `session_nodes_entry_valid_after_*` triggers installed and firing.
- **`doctor --fix` deadlock:** running the recommended command aborts with the same `SessionCanonicalKeyMigrationRequiredError` before completing any repair.
- **Real behavior proof (cold-open after fix):** on the affected production host, after the fix the agent database opens with **0 invalid rows** (`问题数: 0`), **0 remaining triggers** (`剩余触发器: []`), and **0 `SessionCanonicalKeyMigrationRequiredError` / model-fallback events in the following 10 minutes** while the gateway serves sessions and the primary model (M3) responds 200 OK without fallback.

## Tests

- `src/state/openclaw-agent-db-session-migrations.test.ts`: new cases asserting (a) `ensureSessionEntryValidityProjection` installs no triggers and drops ones left by older binaries, (b) legacy pending rows settle to `1`, (c) rows matching the exact legacy cleared-shell signature with a retained window normalize to `{}`, and (d) partial-but-recoverable rows are preserved untouched for Doctor repair.
- Updated existing tests that relied on the trigger writing `entry_valid = 0` (they now set the pending marker explicitly or assert the equivalent fail-loud runtime validation).
- `vitest` suites for the agent DB, session migrations, additive schema repair, doctor canonical-key repair, and session-accessor conformance all pass.