### PR TITLE
fix(gateway): give prepared chat.send media one abandonment-discard owner

### DIFF
--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -460,11 +460,19 @@ export async function admitChatSend(params: {
     };
   };
   let releaseGatewayRootContinuation: (() => void) | undefined;
+  // Prepared inbound media has no transcript reference until the user turn
+  // persists; every abandonment exit funnels through cleanupAdmittedRun, so
+  // the armed discard here is the single custody owner for that window. The
+  // handler disarms it once the media becomes referenced (durable admission
+  // or ACK handing ownership to dispatch, which persists on all paths).
+  let discardAbandonedPreparedMedia: (() => void) | undefined;
   const cleanupAdmittedRun: typeof activeRunAbort.cleanup = (options) => {
     activeRunAbort.cleanup(options);
     releaseInitialGatewayWorkAdmission();
     releaseGatewayRootContinuation?.();
     releaseGatewayRootContinuation = undefined;
+    discardAbandonedPreparedMedia?.();
+    discardAbandonedPreparedMedia = undefined;
   };
   const rejectActiveLeafChanged = async () => {
     if (
@@ -525,6 +533,9 @@ export async function admitChatSend(params: {
       rejectSessionRoutingChanged,
       retainGatewayWorkAdmission,
       restartSafeAdmission,
+      setDiscardAbandonedPreparedMedia: (discard: (() => void) | undefined) => {
+        discardAbandonedPreparedMedia = discard;
+      },
       setReleaseGatewayRootContinuation: (release: (() => void) | undefined) => {
         releaseGatewayRootContinuation = release;
       },

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -73,15 +73,24 @@ async function handleChatSendWithOptions(
   if (!preparedAttachments.ok) {
     return;
   }
+  // Prepared inbound media has no transcript reference until the user turn
+  // persists; every pre-ACK abandonment exit funnels through
+  // cleanupAdmittedRun, which fires this armed discard. The hasPersisted gate
+  // protects the restart-safe path, which persists durably before its abort
+  // and routing exits; dispatch owns persistence after the ACK disarms this.
+  let preparedMediaRecorder: { hasPersisted: () => boolean } | undefined;
+  admitted.value.setDiscardAbandonedPreparedMedia(() => {
+    if (!preparedMediaRecorder?.hasPersisted()) {
+      void discardPreparedChatSendAttachments(preparedAttachments.value.offloadedRefs);
+    }
+  });
   if (activeRunAbort.controller.signal.aborted) {
-    void discardPreparedChatSendAttachments(preparedAttachments.value.offloadedRefs);
     finishAbortedChatSend();
     return;
   }
   // Attachment preparation can suspend. Recheck immediately before the
   // synchronous ACK path so aborts and hot routing reloads cannot cross it.
   if (sessionRoutingChanged(context.getRuntimeConfig())) {
-    void discardPreparedChatSendAttachments(preparedAttachments.value.offloadedRefs);
     admitted.value.rejectSessionRoutingChanged();
     return;
   }
@@ -129,6 +138,7 @@ async function handleChatSendWithOptions(
       recorder: userTurnRecorder,
       replyContextFieldsPromise,
     } = userTurn;
+    preparedMediaRecorder = userTurnRecorder;
     if (restartSafeAdmission) {
       const persistedUserTurn = await persistGatewayUserTurnTranscript();
       // A matching idempotency row and lifecycle claim commit atomically, so
@@ -252,6 +262,10 @@ async function handleChatSendWithOptions(
       },
       { config: cfg },
     );
+    // After the ACK, dispatch owns the turn: its error lifecycle persists the
+    // user transcript (which references the media) on every path, so a
+    // post-ACK cleanupAdmittedRun must not race that persist with a discard.
+    admitted.value.setDiscardAbandonedPreparedMedia(undefined);
     respond(true, ackPayload, undefined, { runId: clientRunId });
     const chatSendAckedAtMs = chatSendTiming?.ackedAtMs ?? performance.now();
     startChatDispatch({

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2112,6 +2112,68 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("chat.send discards prepared inbound media when setup throws before the ACK", async () => {
+    openDirectChatSession();
+    try {
+      await writeStoredMainSession({
+        modelProvider: "test-provider",
+        model: "vision-model",
+      });
+      const context = createDirectChatContext({
+        // Throwing from addChatRun exercises handleChatSendSetupError — one of
+        // the pre-persistence exits that previously leaked staged media.
+        addChatRun: vi.fn(() => {
+          throw new Error("setup exploded before ack");
+        }),
+        getRuntimeConfig: () => ({}),
+      });
+      const inboundDir = path.join(getMediaDir(), "inbound");
+      const inboundBaseline = new Set(await fs.readdir(inboundDir).catch(() => []));
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      await callDirectChat("chat.send", {
+        id: "setup-error-media",
+        params: makeChatSendParams({
+          message: "setup error with media",
+          idempotencyKey: "idem-setup-error-media",
+          attachments: [
+            {
+              // Non-image attachments always offload into the inbound media
+              // store during preparation; the failed send must discard them.
+              type: "file",
+              mimeType: "text/plain",
+              fileName: "notes.txt",
+              content: Buffer.from("offloaded inbound media").toString("base64"),
+            },
+          ],
+        }),
+        client: {
+          connId: "conn-owner",
+          connect: { device: { id: "dev-owner" }, scopes: ["operator.write"] },
+        } as never,
+        respond: ((ok, payload, error) => {
+          responses.push({ ok, payload, error });
+        }) as RespondFn,
+        context,
+      });
+      expect(responses).toEqual([
+        {
+          ok: false,
+          payload: expect.objectContaining({ status: "error" }),
+          error: expect.anything(),
+        },
+      ]);
+      // Prepared inbound media has no transcript reference on this exit; the
+      // admission cleanup owner must discard it or the file is orphaned
+      // forever (the inbound sweep is off unless attachments.ttlHours is set).
+      await waitForFast(async () => {
+        const remaining = await fs.readdir(inboundDir).catch(() => []);
+        expect(remaining.filter((name) => !inboundBaseline.has(name))).toEqual([]);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      resetDirectChatSession();
+    }
+  });
+
   test("chat.abort cancels chat.send during attachment preparation before ACK", async () => {
     openDirectChatSession();
     const firstCatalogSnapshot =


### PR DESCRIPTION
## What Problem This Solves

#123983 fixed two of six pre-persistence exits in chat.send that orphan staged inbound media. Prepared attachments live in `~/.openclaw/media/inbound` with no transcript reference until the user turn persists, and the inbound sweep is disabled unless `attachments.ttlHours` is set — so on default installs every leaked file is orphaned permanently. Four sibling exits still leaked:

- the post-reply-context abort check (`chat-send-handler.ts` steer window),
- the post-reply-context routing-change check,
- the pre-ACK injection settle's `onAborted` / `onActiveLeafChanged` outcomes,
- any setup throw routed to `handleChatSendSetupError` (e.g. restart-safe admission failing `"chat turn was not durably admitted"` — by construction the media is unreferenced at that moment).

## Why This Change Was Made

Instead of adding four more inline discards (and leaving the next new exit to leak again), custody moves to the lifecycle owner: every abandonment exit already funnels through `cleanupAdmittedRun`, which now fires an armed discard gated on the user-turn recorder's persisted fact. The restart-safe path persists durably before its abort/routing exits, and steer injections carry the same recorder, so the `hasPersisted()` gate is correct on every path. The ACK disarms the owner because dispatch's error lifecycle persists the referencing transcript on all post-ACK paths. The two inline discards #123983 added are deleted — one owner instead of six call sites, and future exits are covered by construction.

## User Impact

Default-install operators no longer accumulate permanently orphaned media files when a send with attachments is aborted, steered into a changed leaf, hit by a hot config reload, or killed by a setup error.

## Evidence

- New regression test drives the setup-error exit with an offloaded attachment (`addChatRun` throws pre-ACK) and asserts the inbound dir returns to baseline — **fails pre-fix** (verified via stash), passes post-fix.
- The original #123983 abort-during-preparation test still passes through the new owner (its inline discards were replaced, not duplicated).
- `node scripts/run-vitest.mjs run src/gateway/server.chat.gateway-server-chat-b.test.ts` — 101/101; `src/gateway/server-chat.agent-events.test.ts` — 145/145.
- `pnpm tsgo`, `pnpm check:test-types`, oxfmt/oxlint clean; autoreview clean (0.93).

Production LOC +27/−2 (≈+11 code, remainder custody-invariant comments required by repo comment policy); tests +62.
