### PR TITLE
fix(ui): agent roster stays current during delayed startup

### DIFF
--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -90,7 +90,10 @@ suite.define(() => {
               defaultId: "research",
               mainKey: "main",
               scope: "agent",
-              agents: [{ id: "research", name: "Research" }],
+              agents: [
+                { id: "research", name: "Research" },
+                { id: "writer", name: "Writer" },
+              ],
             },
           },
         });
@@ -118,6 +121,35 @@ suite.define(() => {
         });
 
         await expect.poll(async () => (await agentName.textContent())?.trim()).toBe("Research");
+        await expect
+          .poll(() =>
+            page.locator("openclaw-chat-pane").evaluate((pane) => {
+              const state = (
+                pane as HTMLElement & {
+                  state?: {
+                    agentsList?: { agents?: Array<{ id?: string }>; defaultId?: string };
+                    agentsSelectedId?: string;
+                  };
+                }
+              ).state;
+              return {
+                defaultId: state?.agentsList?.defaultId,
+                ids: state?.agentsList?.agents?.map((agent) => agent.id),
+                selectedId: state?.agentsSelectedId,
+              };
+            }),
+          )
+          .toEqual({
+            defaultId: "research",
+            ids: ["research", "writer"],
+            selectedId: "research",
+          });
+
+        await sidebar.getByRole("button", { name: /Switch agent/ }).click();
+        const agentMenu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
+        await agentMenu.getByText("Research", { exact: true }).waitFor();
+        await agentMenu.getByText("Writer", { exact: true }).waitFor();
+        expect(await agentMenu.getByText("Stale Main", { exact: true }).count()).toBe(0);
         await screenshot(page, "00-refreshed-roster-wins.png");
       },
     );

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -68,6 +68,49 @@ const multiAgentRoster = [
 ];
 
 suite.define(() => {
+  it("keeps a newer in-flight roster ahead of delayed chat startup", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1440 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          defaultAgentId: "main",
+          deferredMethods: ["chat.startup"],
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        await gateway.deferNext("agents.list");
+        await gateway.emitGatewayEvent("config.changed", { path: "agents.entries" });
+        await gateway.waitForRequest("agents.list");
+        await gateway.resolveDeferred("chat.startup", {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+            agents: [{ id: "main", name: "Stale Main" }],
+          },
+          messages: [],
+          metadata: { models: [] },
+          sessionId: "control-ui-e2e-session",
+          thinkingLevel: null,
+        });
+        await gateway.resolveDeferred("agents.list", {
+          defaultId: "research",
+          mainKey: "main",
+          scope: "agent",
+          agents: [{ id: "research", name: "Research" }],
+        });
+
+        const sidebar = page.locator("openclaw-app-sidebar");
+        await expect
+          .poll(async () =>
+            (await sidebar.locator(".sidebar-agent-card__name").textContent())?.trim(),
+          )
+          .toBe("Research");
+      },
+    );
+  });
+
   it("keeps a refreshed roster ahead of delayed chat startup", async () => {
     if (captureUiProof) {
       await mkdir(proofDir, { recursive: true });

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -68,6 +68,61 @@ const multiAgentRoster = [
 ];
 
 suite.define(() => {
+  it("keeps a refreshed roster ahead of delayed chat startup", async () => {
+    if (captureUiProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+        ...(captureUiProof
+          ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1440 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          defaultAgentId: "main",
+          deferredMethods: ["chat.startup"],
+          methodResponses: {
+            "agents.list": {
+              defaultId: "research",
+              mainKey: "main",
+              scope: "agent",
+              agents: [{ id: "research", name: "Research" }],
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        await gateway.emitGatewayEvent("config.changed", { path: "agents.entries" });
+        await gateway.waitForRequest("agents.list");
+
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const agentName = sidebar.locator(".sidebar-agent-card__name");
+        await expect.poll(async () => (await agentName.textContent())?.trim()).toBe("Research");
+
+        await gateway.resolveDeferred("chat.startup", {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+            agents: [{ id: "main", name: "Stale Main" }],
+          },
+          messages: [],
+          metadata: { models: [] },
+          sessionId: "control-ui-e2e-session",
+          thinkingLevel: null,
+        });
+
+        await expect.poll(async () => (await agentName.textContent())?.trim()).toBe("Research");
+        await screenshot(page, "00-refreshed-roster-wins.png");
+      },
+    );
+  });
+
   it("scopes pages from the chip and keeps Agents settings independent", async () => {
     await suite.withPage(
       {

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -146,7 +146,7 @@ describe("createAgentCapability lifecycle", () => {
       scope: "per-sender" as const,
       agents: [{ id: "main" }, { id: "research" }],
     };
-    agents.adoptList(adopted, client);
+    agents.adoptList(adopted, client, agents.state.listRevision);
 
     expect(agents.state.agentsList).toEqual(adopted);
     expect(agents.state.agentsLoading).toBe(false);
@@ -154,6 +154,35 @@ describe("createAgentCapability lifecycle", () => {
     pending.resolve({ defaultId: "main", agents: [{ id: "main" }] });
     await staleLoad;
     expect(agents.state.agentsList).toEqual(adopted);
+    agents.dispose();
+  });
+
+  it("rejects startup adoption after a newer list request begins", async () => {
+    const pending = deferred<unknown>();
+    const request = vi.fn<TestRequest>().mockReturnValue(pending.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const harness = createGatewayHarness(client);
+    const agents = createAgentCapability(harness.gateway);
+    const startupRevision = agents.state.listRevision;
+
+    const currentLoad = agents.refreshList();
+    expect(
+      agents.adoptList(
+        { defaultId: "stale", mainKey: "main", scope: "per-sender", agents: [{ id: "stale" }] },
+        client,
+        startupRevision,
+      ),
+    ).toBe(false);
+
+    const current = {
+      defaultId: "research",
+      mainKey: "main",
+      scope: "per-sender" as const,
+      agents: [{ id: "research" }],
+    };
+    pending.resolve(current);
+    await currentLoad;
+    expect(agents.state.agentsList).toEqual(current);
     agents.dispose();
   });
 

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -132,6 +132,31 @@ function createSaveState(): {
 }
 
 describe("createAgentCapability lifecycle", () => {
+  it("keeps an adopted startup roster ahead of an older list request", async () => {
+    const pending = deferred<unknown>();
+    const request = vi.fn<TestRequest>().mockReturnValue(pending.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const harness = createGatewayHarness(client);
+    const agents = createAgentCapability(harness.gateway);
+
+    const staleLoad = agents.refreshList();
+    const adopted = {
+      defaultId: "research",
+      mainKey: "main",
+      scope: "per-sender" as const,
+      agents: [{ id: "main" }, { id: "research" }],
+    };
+    agents.adoptList(adopted, client);
+
+    expect(agents.state.agentsList).toEqual(adopted);
+    expect(agents.state.agentsLoading).toBe(false);
+
+    pending.resolve({ defaultId: "main", agents: [{ id: "main" }] });
+    await staleLoad;
+    expect(agents.state.agentsList).toEqual(adopted);
+    agents.dispose();
+  });
+
   it("starts a fresh list request after a same-client reconnect", async () => {
     const first = deferred<unknown>();
     const second = deferred<unknown>();

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -73,6 +73,7 @@ type AgentFilesStatus = {
 type AgentCapabilityState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
+  listRevision: number;
   agentsLoading: boolean;
   agentsError: string | null;
   agentsList: AgentsListResult | null;
@@ -80,7 +81,11 @@ type AgentCapabilityState = {
 
 export type AgentCapability = {
   readonly state: AgentCapabilityState;
-  adoptList: (result: AgentsListResult, client: GatewayBrowserClient) => void;
+  adoptList: (
+    result: AgentsListResult,
+    client: GatewayBrowserClient,
+    expectedRevision?: number,
+  ) => boolean;
   ensureList: () => Promise<AgentsListResult | null>;
   refreshList: () => Promise<AgentsListResult | null>;
   files: (agentId: string | null | undefined) => AgentFilesStatus;
@@ -238,6 +243,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   const state: AgentCapabilityState = {
     client: gateway.snapshot.client,
     connected: gateway.snapshot.phase === "connected",
+    listRevision: 0,
     agentsLoading: false,
     agentsError: null,
     agentsList: null,
@@ -248,11 +254,10 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   const listeners = new Set<(state: AgentCapabilityState) => void>();
   let disposed = false;
   let agentsRequest: Promise<AgentsListResult | null> | null = null;
-  let agentsRequestOwner: symbol | null = null;
 
   const retireAgentsRequest = () => {
     agentsRequest = null;
-    agentsRequestOwner = null;
+    state.listRevision += 1;
     state.agentsLoading = false;
   };
 
@@ -282,14 +287,13 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     if (agentsRequest && !force) {
       return agentsRequest;
     }
+    const revision = ++state.listRevision;
     state.agentsLoading = true;
     state.agentsError = null;
     publish();
-    const owner = Symbol();
-    agentsRequestOwner = owner;
     const request = loadAgentsList(scope.client)
       .then((result) => {
-        const current = lifecycle.isCurrent(scope) && agentsRequestOwner === owner;
+        const current = lifecycle.isCurrent(scope) && state.listRevision === revision;
         if (current) {
           state.agentsList = result;
           state.agentsError = null;
@@ -297,7 +301,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
         return current ? result : null;
       })
       .catch((err: unknown) => {
-        if (lifecycle.isCurrent(scope) && agentsRequestOwner === owner) {
+        if (lifecycle.isCurrent(scope) && state.listRevision === revision) {
           state.agentsError = isMissingOperatorReadScopeError(err)
             ? formatMissingOperatorReadScopeMessage("agent list")
             : String(err);
@@ -305,10 +309,9 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
         return null;
       })
       .finally(() => {
-        const currentRequest = agentsRequestOwner === owner;
+        const currentRequest = state.listRevision === revision;
         if (currentRequest) {
           agentsRequest = null;
-          agentsRequestOwner = null;
         }
         if (currentRequest && lifecycle.isCurrent(scope)) {
           state.agentsLoading = false;
@@ -395,16 +398,16 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     get state() {
       return state;
     },
-    adoptList(result, client) {
-      if (state.client !== client || !state.connected) {
-        return;
+    adoptList(result, client, expectedRevision = state.listRevision) {
+      if (state.client !== client || !state.connected || state.listRevision !== expectedRevision) {
+        return false;
       }
-      // The startup projection began after any direct load it replaces; retire that
-      // owner so a late completion cannot overwrite the adopted roster.
+      // Startup adoption retires older direct loads so late completions cannot overwrite it.
       retireAgentsRequest();
       state.agentsList = result;
       state.agentsError = null;
       publish();
+      return true;
     },
     ensureList: () => loadList(false),
     refreshList: () => loadList(true),

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -250,6 +250,12 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   let agentsRequest: Promise<AgentsListResult | null> | null = null;
   let agentsRequestOwner: symbol | null = null;
 
+  const retireAgentsRequest = () => {
+    agentsRequest = null;
+    agentsRequestOwner = null;
+    state.agentsLoading = false;
+  };
+
   const publish = () => {
     if (disposed) {
       return;
@@ -372,8 +378,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     state.client = snapshot.client;
     state.connected = connected;
     if (clientChanged || !connected) {
-      agentsRequest = null;
-      agentsRequestOwner = null;
+      retireAgentsRequest();
       fileRequests.clear();
       fileRequestOwners.clear();
       for (const status of files.values()) {
@@ -382,7 +387,6 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
       files.clear();
       state.agentsList = null;
       state.agentsError = null;
-      state.agentsLoading = false;
     }
     publish();
   });
@@ -395,6 +399,9 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
       if (state.client !== client || !state.connected) {
         return;
       }
+      // The startup projection began after any direct load it replaces; retire that
+      // owner so a late completion cannot overwrite the adopted roster.
+      retireAgentsRequest();
       state.agentsList = result;
       state.agentsError = null;
       publish();
@@ -435,9 +442,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
       fileRequests.clear();
       fileRequestOwners.clear();
       files.clear();
-      agentsRequest = null;
-      agentsRequestOwner = null;
-      state.agentsLoading = false;
+      retireAgentsRequest();
     },
   };
 }

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -2737,7 +2737,42 @@ describe("loadChatHistory filtering", () => {
     expect(state.chatMessagesBySession?.has("agent:main:main")).toBe(false);
   });
 
+  it("rejects a stale startup roster before mutating chat-local selection", async () => {
+    const currentRoster = {
+      agents: [{ id: "research", name: "Research" }],
+      defaultId: "research",
+      mainKey: "main",
+      scope: "per-sender" as const,
+    };
+    const onAgentsList = vi.fn(() => false);
+    const { state } = createResolvedHistoryState(
+      {
+        agentsList: {
+          agents: [{ id: "main", name: "Stale Main" }],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "per-sender",
+        },
+        messages: [],
+      },
+      {
+        agentsError: "keep newer roster status",
+        agentsList: currentRoster,
+        agentsSelectedId: "research",
+        onAgentsList,
+      },
+    );
+
+    await loadChatHistory(state, { startup: true });
+
+    expect(onAgentsList).toHaveBeenCalledOnce();
+    expect(state.agentsError).toBe("keep newer roster status");
+    expect(state.agentsList).toBe(currentRoster);
+    expect(state.agentsSelectedId).toBe("research");
+  });
+
   it("loads startup history with agents in one request", async () => {
+    const onAgentsList = vi.fn(() => true);
     const { request, state } = createResolvedHistoryState(
       {
         messages: [{ role: "assistant", content: [{ type: "text", text: "ready" }] }],
@@ -2748,7 +2783,11 @@ describe("loadChatHistory filtering", () => {
           scope: "agent",
         },
       },
-      { agentsError: "previous agents.list failure", sessionKey: "global" },
+      {
+        agentsError: "previous agents.list failure",
+        onAgentsList,
+        sessionKey: "global",
+      },
     );
 
     await loadChatHistory(state, { startup: true });
@@ -2763,6 +2802,7 @@ describe("loadChatHistory filtering", () => {
     expect(state.agentsError).toBeNull();
     expect(state.agentsList?.defaultId).toBe("ops");
     expect(state.agentsSelectedId).toBe("ops");
+    expect(onAgentsList).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -297,7 +297,7 @@ export type ChatState = {
   lastLocalTerminalReconcile?: { runId: string | null } | null;
   chatReplyTarget?: unknown;
   agentsError?: string | null;
-  onAgentsList?: (agentsList: AgentsListResult, client: GatewayBrowserClient) => void;
+  onAgentsList?: (agentsList: AgentsListResult, client: GatewayBrowserClient) => boolean;
   resetChatInputHistoryNavigation?: () => void;
   assistantAgentId?: string | null;
   agentsList?: ChatAgentsListSnapshot | null;
@@ -1520,9 +1520,11 @@ export function applyChatAgentsList(
   if (!agentsList || state.client !== client || !state.connected) {
     return;
   }
+  if (state.onAgentsList && !state.onAgentsList(agentsList, client)) {
+    return;
+  }
   state.agentsList = agentsList;
   state.agentsError = null;
-  state.onAgentsList?.(agentsList, client);
   const selectedId =
     typeof state.agentsSelectedId === "string" && state.agentsSelectedId.trim()
       ? normalizeAgentId(state.agentsSelectedId)

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -362,6 +362,13 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
         this.connectedClient === startupClient &&
         state.client === startupClient &&
         state.connected;
+      // chat.startup and agents.list share roster ownership. A startup response may
+      // adopt only while no newer direct roster publication has replaced its baseline.
+      state.onAgentsList = (agentsList, client) => {
+        if (clientIsCurrent() && this.context.agents.state.agentsList === agentsListBeforeStartup) {
+          this.context.agents.adoptList(agentsList, client);
+        }
+      };
       const finishStartup = async () => {
         if (!clientIsCurrent()) {
           return;
@@ -402,6 +409,9 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       });
       this.deferSessionHydrationUntilTranscript(startupSessionKey, historyRefresh);
       void historyRefresh.finally(() => {
+        if (clientIsCurrent()) {
+          state.onAgentsList = undefined;
+        }
         void finishStartup();
       });
       void refreshChatModelAuthStatus(state).finally(() => state.requestUpdate?.());

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -362,17 +362,13 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
         this.connectedClient === startupClient &&
         state.client === startupClient &&
         state.connected;
-      // chat.startup and agents.list share roster ownership. A startup response may
-      // adopt only while no newer direct roster publication has replaced its baseline.
       state.onAgentsList = (agentsList, client) => {
-        if (
-          !clientIsCurrent() ||
-          this.context.agents.state.agentsList !== agentsListBeforeStartup
-        ) {
-          return false;
+        const ownsRoster =
+          clientIsCurrent() && this.context.agents.state.agentsList === agentsListBeforeStartup;
+        if (ownsRoster) {
+          this.context.agents.adoptList(agentsList, client);
         }
-        this.context.agents.adoptList(agentsList, client);
-        return true;
+        return ownsRoster;
       };
       const finishStartup = async () => {
         if (!clientIsCurrent()) {

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -365,9 +365,14 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       // chat.startup and agents.list share roster ownership. A startup response may
       // adopt only while no newer direct roster publication has replaced its baseline.
       state.onAgentsList = (agentsList, client) => {
-        if (clientIsCurrent() && this.context.agents.state.agentsList === agentsListBeforeStartup) {
-          this.context.agents.adoptList(agentsList, client);
+        if (
+          !clientIsCurrent() ||
+          this.context.agents.state.agentsList !== agentsListBeforeStartup
+        ) {
+          return false;
         }
+        this.context.agents.adoptList(agentsList, client);
+        return true;
       };
       const finishStartup = async () => {
         if (!clientIsCurrent()) {

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -357,6 +357,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       const startupGeneration = this.connectionGeneration;
       const startupSessionKey = state.sessionKey;
       const agentsListBeforeStartup = this.context.agents.state.agentsList;
+      const rosterRevisionBeforeStartup = this.context.agents.state.listRevision;
       const clientIsCurrent = () =>
         this.connectionGeneration === startupGeneration &&
         this.connectedClient === startupClient &&
@@ -364,10 +365,8 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
         state.connected;
       state.onAgentsList = (agentsList, client) => {
         const ownsRoster =
-          clientIsCurrent() && this.context.agents.state.agentsList === agentsListBeforeStartup;
-        if (ownsRoster) {
-          this.context.agents.adoptList(agentsList, client);
-        }
+          clientIsCurrent() &&
+          this.context.agents.adoptList(agentsList, client, rosterRevisionBeforeStartup);
         return ownsRoster;
       };
       const finishStartup = async () => {

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -1,5 +1,3 @@
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { AgentsListResult } from "../../api/types.ts";
 import { fetchAssistantIdentity } from "../../app/assistant-identity.ts";
 import {
   dispatchCommandClientPresentation,
@@ -214,9 +212,6 @@ export function createPageState(
     selectedChatSessionArchived: false,
     agentsList: context.agents.state.agentsList,
     agentsSelectedId: context.agentSelection.state.selectedId,
-    onAgentsList: (agentsList: AgentsListResult, client: GatewayBrowserClient) => {
-      context.agents.adoptList(agentsList, client);
-    },
     refreshSessionsAfterChat: new Map<string, { sessionKey: string; agentId?: string }>(),
     pendingAbort: null,
     pendingSessionMessageReloadSessionKey: null,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI could briefly or persistently switch back to an older agent roster and the wrong selected agent when a delayed `chat.startup` response completed after a newer roster refresh.

## Why This Change Was Made

`chat.startup` and direct `agents.list` now share one monotonic roster publication owner. Direct request start advances ownership; accepted startup adoption advances it and retires older direct loads. The single `ownsRoster` decision rejects delayed startup data before either shared or chat-local roster, error, or selection state can change. Reconnect still retires request ownership; no agent, config, protocol, auth, persistence, or default contract changes.

## User Impact

The sidebar, chat agent selector, and active agent remain aligned with the newest Gateway roster during navigation, config refreshes, and reconnects. A stale startup response can no longer resurrect a removed agent or switch the operator back to an older default.

## Evidence

- Before: focused regression failed because a delayed startup roster replaced the newer chat-local roster and selected agent.
- After: 234 focused unit/lifecycle tests and 4 Playwright Control UI tests pass on head `a3e540a53c913`.
- ClawSweeper P1 addressed: the added inverse-order regression defers both RPCs, starts a newer `agents.list`, resolves stale startup first, then proves the newer direct response remains authoritative.
- Changed gate passes: formatting, Control UI i18n, lint/style, core-test and UI types, dead-code/export checks, dependency guards, and diff checks. Runtime and Madge cycle checks both report zero cycles.
- Source-blind validation passed 4/4 clauses across all 59 video frames: `Research` remains selected; the switcher contains `Research` and `Writer`; stale `Main` never appears; no Gateway error is visible.
- Production LOC: +39/-24 (net +15). Tests: +225/-1. No changelog change; release generation owns `CHANGELOG.md`.
- Local heavy gate fallback was used because the CI-fast remote backend was unavailable; hosted exact-head CI remains the landing gate.

![Control UI agent roster remains current](https://github.com/user-attachments/assets/bfe2cd64-0116-4b60-a7b3-add6b57f42d1)

https://github.com/user-attachments/assets/9daec38b-d4a3-4b04-97ad-a3002b660015
