### PR TITLE
fix(signal): deliver outbound attachments as data URIs to external-native daemons (#123815)

### DIFF
--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -555,10 +555,13 @@ export async function streamContainerEvents(params: {
 }
 
 /**
- * Convert local file paths to base64 data URIs for the container REST API.
- * The bbernhard container /v2/send only accepts `base64_attachments` (not file paths).
+ * Convert local file paths to base64 data URIs for transports that accept
+ * inline bytes (bbernhard container REST and native signal-cli JSON-RPC).
+ * The bbernhard container /v2/send only accepts `base64_attachments` (not file
+ * paths); native signal-cli accepts data URIs per RFC 2397, which removes the
+ * shared-filesystem assumption when the daemon runs under a different uid.
  */
-async function filesToBase64DataUris(
+export async function filesToBase64DataUris(
   filePaths: string[],
   maxAttachmentBytes: number,
 ): Promise<string[]> {

--- a/extensions/signal/src/media-access.test.ts
+++ b/extensions/signal/src/media-access.test.ts
@@ -15,6 +15,17 @@ const SIGNAL_IMAGE = Buffer.from(
   "base64",
 );
 
+// External-native sends deliver outbound bytes as RFC 2397 data URIs (the
+// daemon may not share the gateway filesystem); container and managed-native
+// transports still send gateway-local paths.
+function resolveTestOutboundAttachment(attachment: string): Promise<Buffer> {
+  const base64Marker = ";base64,";
+  if (attachment.startsWith("data:") && attachment.includes(base64Marker)) {
+    return Promise.resolve(Buffer.from(attachment.split(base64Marker)[1] ?? "", "base64"));
+  }
+  return fs.readFile(attachment);
+}
+
 type SignalMediaContext = {
   cfg: OpenClawConfig;
   to: string;
@@ -97,7 +108,9 @@ describe("Signal host-owned outbound media access", () => {
           const attachmentPath = envelope.params?.attachments?.[0];
           requests.push({
             envelope,
-            attachment: attachmentPath ? await fs.readFile(attachmentPath) : undefined,
+            attachment: attachmentPath
+              ? await resolveTestOutboundAttachment(attachmentPath)
+              : undefined,
           });
           response.writeHead(200, { "content-type": "application/json" });
           response.end(

--- a/extensions/signal/src/send.test.ts
+++ b/extensions/signal/src/send.test.ts
@@ -10,10 +10,22 @@ const resolveOutboundAttachmentFromUrlMock = vi.hoisted(() =>
     contentType: "image/png",
   })),
 );
+const filesToBase64DataUrisMock = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]) => ["data:image/png;filename=image.png;base64,aGVsbG8="]),
+);
 
 vi.mock("./client-adapter.js", () => ({
   signalRpcRequest: (...args: unknown[]) => signalRpcRequestMock(...args),
 }));
+
+vi.mock("./client-container.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./client-container.js")>("./client-container.js");
+  return {
+    ...actual,
+    filesToBase64DataUris: (...args: unknown[]) => filesToBase64DataUrisMock(...args),
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
@@ -50,6 +62,7 @@ describe("sendMessageSignal receipts", () => {
     clearSignalApprovalReactionTargetsForTest();
     signalRpcRequestMock.mockReset();
     resolveOutboundAttachmentFromUrlMock.mockClear();
+    filesToBase64DataUrisMock.mockClear();
   });
 
   it("routes a named container account across send, typing, and receipt RPCs", async () => {
@@ -205,9 +218,15 @@ describe("sendMessageSignal receipts", () => {
       maxBytes,
       expect.objectContaining({ localRoots: ["/tmp"] }),
     );
+    // external-native (SIGNAL_TEST_CFG) sends bytes as an RFC 2397 data URI
+    // instead of a gateway-local path the daemon may not be able to traverse.
+    expect(filesToBase64DataUrisMock).toHaveBeenCalledWith(["/tmp/image.png"], maxBytes);
     expect(signalRpcRequestMock).toHaveBeenCalledWith(
       "send",
-      expect.objectContaining({ attachments: ["/tmp/image.png"], message: "" }),
+      expect.objectContaining({
+        attachments: ["data:image/png;filename=image.png;base64,aGVsbG8="],
+        message: "",
+      }),
       expect.objectContaining({ maxAttachmentBytes: maxBytes }),
     );
     expect(result.messageId).toBe("1234567891");
@@ -758,17 +777,18 @@ describe("sendMessageSignal receipts", () => {
     });
 
     expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalled();
+    expect(filesToBase64DataUrisMock).toHaveBeenCalledWith(["/tmp/image.png"], expect.any(Number));
     expect(signalRpcRequestMock).toHaveBeenCalledTimes(2);
     expect(signalRpcRequestMock.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
-        attachments: ["/tmp/image.png"],
+        attachments: ["data:image/png;filename=image.png;base64,aGVsbG8="],
         quoteTimestamp: 1700000000001,
         quoteAuthor: "+15550002222",
       }),
     );
     expect(signalRpcRequestMock.mock.calls[1]?.[1]).toEqual(
       expect.objectContaining({
-        attachments: ["/tmp/image.png"],
+        attachments: ["data:image/png;filename=image.png;base64,aGVsbG8="],
         message: "caption",
       }),
     );

--- a/extensions/signal/src/send.test.ts
+++ b/extensions/signal/src/send.test.ts
@@ -18,14 +18,10 @@ vi.mock("./client-adapter.js", () => ({
   signalRpcRequest: (...args: unknown[]) => signalRpcRequestMock(...args),
 }));
 
-vi.mock("./client-container.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("./client-container.js")>("./client-container.js");
-  return {
-    ...actual,
-    filesToBase64DataUris: (...args: unknown[]) => filesToBase64DataUrisMock(...args),
-  };
-});
+vi.mock("./client-container.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./client-container.js")>()),
+  filesToBase64DataUris: (...args: unknown[]) => filesToBase64DataUrisMock(...args),
+}));
 
 vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
@@ -952,17 +948,7 @@ describe("Signal native JSON-RPC recipient delivery", () => {
       { timestamp: 1234567893, results: [{ type: "SUCCESS" }] },
       { timestamp: 1234567894 },
     ];
-    const requests: Array<{
-      method: string | undefined;
-      path: string | undefined;
-      contentType: string | undefined;
-      jsonrpc: unknown;
-      rpcMethod: unknown;
-      account: unknown;
-      recipient: unknown;
-      groupId: unknown;
-      message: unknown;
-    }> = [];
+    const requests: Array<Record<string, unknown>> = [];
     const server = http.createServer((request, response) => {
       let body = "";
       request.setEncoding("utf8");
@@ -974,12 +960,7 @@ describe("Signal native JSON-RPC recipient delivery", () => {
           id?: string;
           jsonrpc?: string;
           method?: string;
-          params?: {
-            account?: string;
-            recipient?: string[];
-            groupId?: string;
-            message?: string;
-          };
+          params?: Record<string, unknown>;
         };
         requests.push({
           method: request.method,

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -24,6 +24,7 @@ import {
   registerSignalApprovalReactionTargetForOutboundMessage,
 } from "./approval-reactions.js";
 import { signalRpcRequest, type SignalTransportKind } from "./client-adapter.js";
+import { filesToBase64DataUris } from "./client-container.js";
 import { markdownToSignalText, type SignalTextStyleRange } from "./format.js";
 import { normalizeSignalMessagingTarget } from "./normalize.js";
 import { registerSignalReplyContext } from "./reply-authors.js";
@@ -335,7 +336,19 @@ export async function sendMessageSignal(
       localRoots: opts.mediaLocalRoots,
       readFile: opts.mediaReadFile,
     });
-    attachments = [resolved.path];
+    const transportKind = opts.transportKind ?? accountInfo.transport.kind;
+    // External-native signal-cli often runs as a separate service user. The
+    // staged outbound file lives under ~/.openclaw/media/outbound (0700,
+    // gateway-owned), so a differently-privileged daemon cannot traverse the
+    // path — delivery fails at the last hop with AttachmentInvalidException.
+    // Pass the already-approved bytes as an RFC 2397 data URI over the open
+    // JSON-RPC connection instead of a filesystem path. The container REST
+    // transport performs the same base64 conversion itself, and managed-native
+    // shares the gateway uid, so both keep the path form.
+    attachments =
+      transportKind === "external-native"
+        ? await filesToBase64DataUris([resolved.path], maxBytes)
+        : [resolved.path];
     outboundMedia = {
       contentType: resolved.contentType,
       kind: kindFromMime(resolved.contentType ?? undefined) ?? "unknown",


### PR DESCRIPTION
## What Problem This Solves

Fixes #123815. Outbound Signal attachments are handed to signal-cli as a gateway-local filesystem path (`extensions/signal/src/send.ts` → `attachments = [resolved.path]`). The staged file lives under `~/.openclaw/media/outbound` which is `0700` and gateway-owned, so an `external-native` signal-cli daemon running as a separate service user cannot traverse the path and every image/video send fails at the last hop with `AttachmentInvalidException (Permission denied)`. OpenClaw re-asserts `0700` on `media` on every generation, so the chmod workaround is undone before the send.

## Why

The plugin already converts local files to RFC 2397 data URIs for the bbernhard container transport (`filesToBase64DataUris` in `client-container.ts`), and native signal-cli's `send` accepts data URIs (`-a, --attachment ... Can be either a file path or a data URI`, RFC 2397, with an optional `filename=` parameter). Reusing that same conversion for `external-native` sends removes the shared-filesystem/uid assumption entirely: the bytes travel over the already-open JSON-RPC connection. `managed-native` (same uid as gateway) and `container` (converts itself) keep the path form, so behavior is unchanged everywhere else.

## User Impact

Hardened deployments that confine signal-cli to its own service user (its state directory is the Signal account) regain full outbound media support instead of discovering a silent last-hop `Permission denied` after every generated image/video. No config change required; non-external-native transports are untouched.

## Evidence

[AI-assisted] Implementation and test updates; fix authored against issue #123815.

Regression tests pass on the modified `send.test.ts` (external-native now converts to data URIs; quote-fallback replay safety intact) and `client-container.test.ts` (base64 conversion contract unchanged):

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-signal.config.ts extensions/signal/src/send.test.ts
 Test Files  1 passed (1)
      Tests  36 passed (36)
   Start at  16:19:27
   Duration  12.55s (transform 4.75s, setup 921ms, import 7.74s, tests 3.40s, environment 0ms)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-signal.config.ts extensions/signal/src/client-container.test.ts
 Test Files  1 passed (1)
      Tests  84 passed (84)
   Start at  16:19:46
   Duration  9.20s (transform 4.61s, setup 804ms, import 7.53s, tests 465ms, environment 0ms)
```

New assertion coverage in `send.test.ts`:

```text
✓ attaches a media receipt for attachment sends
  → expect(filesToBase64DataUrisMock).toHaveBeenCalledWith(["/tmp/image.png"], maxBytes)
  → attachments: ["data:image/png;filename=image.png;base64,aGVsbG8="]
✓ keeps media sends when native quote metadata is rejected
  → both quoted and fallback sends carry the data-URI attachment
```

The only transport gated to the new behavior is `external-native` (`transportKind === "external-native"`), matching the issue's repro (separate-uid daemon). Pre-existing `tsc` errors in `extensions/signal/src/monitor/*` (plugin-sdk `channel-ingress-runtime` typing) are unrelated and reproduce on clean `main`.

Harness fix on top of the implementation (CI regression, same PR): the fake signal-cli JSON-RPC server in `media-access.test.ts` read `attachments[0]` with `fs.readFile`, which fails with `ENOENT` once external-native sends carry data URIs. It now decodes RFC 2397 `data:` attachments before comparing bytes; the 4 host-owned outbound media tests failed before this fix and pass after:

```text
$ node scripts/run-vitest.mjs extensions/signal/src/media-access.test.ts
 ✓ extension-signal  extensions/signal/src/media-access.test.ts (13 tests)
 Test Files  1 passed (1)
      Tests  13 passed (13)

$ node scripts/run-vitest.mjs extensions/signal/src/send.test.ts extensions/signal/src/media-access.test.ts
 Test Files  2 passed (2)
      Tests  49 passed (49)

$ pnpm exec oxlint extensions/signal/src/send.test.ts extensions/signal/src/media-access.test.ts
 Found 0 warnings and 0 errors.
```

`send.test.ts` stays within the 1000-line oxlint budget (997 counted) by compressing the `client-container` mock factory and the real-RPC request collector typing.
