### PR TITLE
fix(agents): anchor runtime context carrier after active user turn for prompt-cache lineage (#123652)

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -21,7 +21,7 @@ import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
 import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import { bootstrapHarnessContextEngine } from "../../harness/context-engine-lifecycle.js";
-import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
+import { relocateCurrentRuntimeContextCarrierAfterActiveUser } from "../../internal-runtime-context.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import {
@@ -349,7 +349,7 @@ export function prepareEmbeddedAttemptSessionBoundary(input: {
       await baseConvertToLlm(
         // Wire-only relocation keeps the request append-only through the active
         // user turn without changing position-sensitive precheck normalization.
-        relocateCurrentRuntimeContextCarrierToTail(
+        relocateCurrentRuntimeContextCarrierAfterActiveUser(
           normalizeMessagesForLlmBoundary(messages, buildBoundaryOptions()),
         ),
       );

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -36,7 +36,7 @@ import {
 import { persistUserTurnTranscript } from "../../../sessions/user-turn-transcript.test-support.js";
 import {
   OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
-  relocateCurrentRuntimeContextCarrierToTail,
+  relocateCurrentRuntimeContextCarrierAfterActiveUser,
 } from "../../internal-runtime-context.js";
 import { normalizeMessagesForLlmBoundary } from "./attempt-llm-boundary.js";
 
@@ -520,7 +520,7 @@ function textOf(message: unknown): string | undefined {
 
 describe("prompt-cache tail carrier for current-turn metadata (issue #100271)", () => {
   const wire = (messages: AgentMsg[]) =>
-    relocateCurrentRuntimeContextCarrierToTail(
+    relocateCurrentRuntimeContextCarrierAfterActiveUser(
       normalizeMessagesForLlmBoundary(messages, { timezone: TZ }),
     ) as unknown as Array<Record<string, unknown>>;
 
@@ -585,6 +585,58 @@ describe("prompt-cache tail carrier for current-turn metadata (issue #100271)", 
     expect(wireN1.slice(0, sharedPrefixLen)).toEqual(wireN.slice(0, sharedPrefixLen));
     // In request N the carrier occupies the append-only slot right after q2.
     expect(isCarrier(wire(turnN)[3])).toBe(true);
+  });
+
+  it("keeps the carrier anchored after the active user through a same-turn tool loop (issue #123652)", () => {
+    // Tool loop: request N is P+U+X. The provider then emits reasoning +
+    // tool_call, the tool runs, and the next request replays P+U+Y+X where Y
+    // is the new reasoning/tool_call/tool_output block. Relocating the carrier
+    // to the absolute tail makes the carrier slot move (P+U+X -> P+U+Y+X), so
+    // the shared prefix stops at P+U and cached_tokens never advances. The
+    // carrier must stay anchored immediately after the active user turn so the
+    // provider-visible input is a strict prefix-extension (P+U+X -> P+U+X+Y).
+    const turnN: AgentMsg[] = [
+      storedUserMsg("q1", TS_TURN1 - 2000),
+      ASSISTANT_MSG,
+      runtimeCarrier(META, TS_TURN2),
+      currentUserMsg("q2", TS_TURN2),
+    ];
+    // Same turn, next loop iteration: the previous user turn is now followed by
+    // tool-loop scaffolding (assistant tool-call + tool result). On retry the
+    // runner re-installs the carrier immediately BEFORE the active user turn
+    // (insertRuntimeContextMessageForPrompt), matching the first-request shape.
+    const toolCallAssistant = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "shell", arguments: "{}" }],
+      timestamp: TS_TURN2 + 1000,
+    } as unknown as AgentMsg;
+    const toolResult = {
+      role: "toolResult",
+      content: [{ type: "toolResult", toolCallId: "call_1", content: "ok" }],
+      timestamp: TS_TURN2 + 2000,
+    } as unknown as AgentMsg;
+    const turnN1ToolLoop: AgentMsg[] = [
+      storedUserMsg("q1", TS_TURN1 - 2000),
+      ASSISTANT_MSG,
+      runtimeCarrier(META, TS_TURN2),
+      storedUserMsg("q2", TS_TURN2),
+      toolCallAssistant,
+      toolResult,
+    ];
+    const wireN = wire(turnN);
+    const wireN1 = wire(turnN1ToolLoop);
+
+    // The carrier stays immediately after the active user turn in both
+    // requests: same slot, so request N's bytes are a strict prefix of N+1's.
+    const carrierIndexN = wireN.findIndex(isCarrier);
+    const carrierIndexN1 = wireN1.findIndex(isCarrier);
+    expect(carrierIndexN).toBe(3);
+    expect(carrierIndexN1).toBe(3);
+    expect(wireN1.slice(0, carrierIndexN1).map((m) => JSON.stringify(m))).toEqual(
+      wireN.slice(0, carrierIndexN).map((m) => JSON.stringify(m)),
+    );
+    // Tool-loop scaffolding follows the carrier instead of displacing it.
+    expect(wireN1.slice(carrierIndexN1 + 1).length).toBe(2);
   });
 
   it("runtime-only (room-event) inline context is not strip-eligible, so it stays byte-stable in both positions", () => {

--- a/src/agents/internal-runtime-context.test.ts
+++ b/src/agents/internal-runtime-context.test.ts
@@ -15,7 +15,7 @@ import {
   OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
   OPENCLAW_RUNTIME_CONTEXT_NOTICE,
   OPENCLAW_RUNTIME_EVENT_HEADER,
-  relocateCurrentRuntimeContextCarrierToTail,
+  relocateCurrentRuntimeContextCarrierAfterActiveUser,
   stripInternalRuntimeContext,
 } from "./internal-runtime-context.js";
 
@@ -185,10 +185,10 @@ describe("internal runtime context codec", () => {
   });
 });
 
-describe("relocateCurrentRuntimeContextCarrierToTail", () => {
-  it("moves a before-user carrier to the absolute tail", () => {
+describe("relocateCurrentRuntimeContextCarrierAfterActiveUser", () => {
+  it("moves a before-user carrier to right after the active user turn", () => {
     const messages = [user("older"), assistant("reply"), carrier("meta"), user("active")];
-    const out = relocateCurrentRuntimeContextCarrierToTail(messages);
+    const out = relocateCurrentRuntimeContextCarrierAfterActiveUser(messages);
     expect(out.map((m) => m.role)).toEqual(["user", "assistant", "user", "custom"]);
     // Non-carrier order is preserved; the active user turn is no longer preceded
     // by the volatile carrier, so it caches as a stable prefix.
@@ -200,31 +200,34 @@ describe("relocateCurrentRuntimeContextCarrierToTail", () => {
     expect(out[out.length - 1]).toEqual(carrier("meta"));
   });
 
-  it("moves the carrier past tool-call/tool-result scaffolding to the absolute tail", () => {
+  it("keeps the carrier anchored after the active user, ahead of tool-call/tool-result scaffolding", () => {
     const messages = [
       carrier("meta"),
       user("active"),
       assistant("tool call"),
       toolResult("tool output"),
     ];
-    const out = relocateCurrentRuntimeContextCarrierToTail(messages);
-    expect(out.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "custom"]);
-    expect(out[out.length - 1]).toEqual(carrier("meta"));
+    const out = relocateCurrentRuntimeContextCarrierAfterActiveUser(messages);
+    // The carrier sits immediately after the active user turn; tool-loop
+    // scaffolding follows it so the wire stays a strict prefix-extension
+    // (P+U+X -> P+U+X+Y) instead of relocating the carrier past the new items.
+    expect(out.map((m) => m.role)).toEqual(["user", "custom", "assistant", "toolResult"]);
+    expect(out[1]).toEqual(carrier("meta"));
   });
 
-  it("is a no-op (same reference) when the carrier is already at the tail", () => {
-    const messages = [user("active"), assistant("tool call"), toolResult("out"), carrier("meta")];
-    const out = relocateCurrentRuntimeContextCarrierToTail(messages);
+  it("is a no-op (same reference) when the carrier is already placed after the active user", () => {
+    const messages = [user("active"), carrier("meta"), assistant("tool call"), toolResult("out")];
+    const out = relocateCurrentRuntimeContextCarrierAfterActiveUser(messages);
     expect(out).toBe(messages);
   });
 
   it("is a no-op when there is no carrier", () => {
     const messages = [user("active"), assistant("reply")];
-    expect(relocateCurrentRuntimeContextCarrierToTail(messages)).toBe(messages);
+    expect(relocateCurrentRuntimeContextCarrierAfterActiveUser(messages)).toBe(messages);
   });
 
   it("leaves a carrier in place when there is no active user turn to anchor after", () => {
     const messages = [carrier("meta"), assistant("reply")];
-    expect(relocateCurrentRuntimeContextCarrierToTail(messages)).toBe(messages);
+    expect(relocateCurrentRuntimeContextCarrierAfterActiveUser(messages)).toBe(messages);
   });
 });

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -349,43 +349,47 @@ export function stripHistoricalRuntimeContextCustomMessages<T>(messages: T[]): T
 }
 
 /**
- * Moves current-turn runtime-context carrier messages to the absolute tail of
- * the request (after the active user turn and any tool-call scaffolding).
+ * Moves current-turn runtime-context carrier messages to immediately after the
+ * active user turn, ahead of any tool-loop scaffolding.
  *
  * Prompt-cache rationale: a per-turn carrier that is stripped on replay makes
  * the next request diverge at the carrier's slot. Placed BEFORE the active user
  * turn, that slot precedes everything that gets reused, so the whole tail
- * (user turn + tool loop) re-bills every turn. Placed at the ABSOLUTE tail, the
- * divergence lands exactly where the next turn's new bytes (the assistant reply)
- * begin anyway, so the request is an append-only prefix-extension through the
- * active user turn — only the trailing carrier is ever re-billed.
+ * (user turn + tool loop) re-bills every turn. Placed at the ABSOLUTE tail,
+ * the carrier relocates again whenever same-turn tool items are inserted ahead
+ * of it (P+U+X → P+U+Y+X), so the provider-visible input is not a strict
+ * prefix-extension and the shared-prefix cache stops advancing. Placed
+ * immediately AFTER the active user turn (P+U+X → P+U+X+Y), the carrier slot is
+ * byte-stable across the tool loop and only genuinely new bytes are re-billed.
  *
  * Runs after {@link stripHistoricalRuntimeContextCustomMessages}, so only the
  * current-turn carrier(s) remain. When there is no active user turn to anchor
  * after, messages are returned unchanged.
  */
-export function relocateCurrentRuntimeContextCarrierToTail<T>(messages: T[]): T[] {
-  const lastIndex = messages.length - 1;
-  if (lastIndex < 0 || !messages.some(isOpenClawRuntimeContextCustomMessage)) {
-    return messages;
-  }
-  // Already tail-placed (a contiguous carrier run ends the array): no-op so the
-  // serialized bytes stay stable across re-attempts of the same request.
-  let firstNonCarrierFromEnd = lastIndex;
-  while (
-    firstNonCarrierFromEnd >= 0 &&
-    isOpenClawRuntimeContextCustomMessage(messages[firstNonCarrierFromEnd])
-  ) {
-    firstNonCarrierFromEnd -= 1;
-  }
-  const rest = messages.filter((message) => !isOpenClawRuntimeContextCustomMessage(message));
-  // No active user turn to anchor after — leave placement to the strip pass.
-  if (!rest.some(isUserMessage)) {
-    return messages;
-  }
-  if (firstNonCarrierFromEnd === rest.length - 1) {
+export function relocateCurrentRuntimeContextCarrierAfterActiveUser<T>(messages: T[]): T[] {
+  if (!messages.some(isOpenClawRuntimeContextCustomMessage)) {
     return messages;
   }
   const carriers = messages.filter(isOpenClawRuntimeContextCustomMessage);
-  return [...rest, ...carriers];
+  const rest = messages.filter((message) => !isOpenClawRuntimeContextCustomMessage(message));
+  // The active user turn is the last user-role message. Tool-loop items use
+  // dedicated roles (assistant tool-call / toolResult) and carriers use
+  // role "custom", so the last user-role message is the anchor the carrier
+  // must sit right after.
+  const activeUserIndex = rest.findLastIndex(isUserMessage);
+  // No active user turn to anchor after — leave placement to the strip pass.
+  if (activeUserIndex === -1) {
+    return messages;
+  }
+  const relocated = [
+    ...rest.slice(0, activeUserIndex + 1),
+    ...carriers,
+    ...rest.slice(activeUserIndex + 1),
+  ];
+  // Already placed immediately after the active user turn: no-op so the
+  // serialized bytes stay stable across re-attempts of the same request.
+  if (relocated.length === messages.length && relocated.every((m, i) => m === messages[i])) {
+    return messages;
+  }
+  return relocated;
 }


### PR DESCRIPTION
## What Problem

Fixes #123652. In Azure/OpenAI Responses requests for GPT-5.6 Sol, OpenClaw sends `runtimeContextCarrier` as a provider-visible tail user message. During a same-turn tool loop the runner inserts new reasoning/tool_call/tool_output items ahead of that tail, so the carrier slot moves between consecutive requests (`P+U+X` → `P+U+Y+X`). The provider-visible `input[]` is then not a strict prefix-extension, and `cached_tokens` stays flat instead of advancing with the shared prefix (observed: `cached_tokens: 0 → 45,148 → 45,148 → 45,148`).

## Why

`relocateCurrentRuntimeContextCarrierToTail` moved the carrier to the absolute tail "so the next turn's new bytes begin where the divergence lands" — but that reasoning only holds across turns, not within a turn. Same-turn tool-loop items are inserted by the runner *after* the last user message, i.e. ahead of the absolute tail, so the tail-placed carrier relocates again on every loop iteration and the shared-prefix cache can never advance. The carrier is per-turn metadata; its stable slot is immediately *after the active user turn* (the last user-role message), where nothing that gets reused sits after it. With that anchor, request N+1 is a strict prefix-extension of request N (`P+U+X` → `P+U+X+Y`) and only genuinely new bytes re-bill.

## User Impact

Tool-loop-heavy sessions on Azure/OpenAI Responses (GPT-5.6 Sol and any full-`input[]`-replay provider with `prompt_cache_key`) stop re-billing the entire conversation tail on every tool call. `cached_tokens` resumes advancing with the shared prefix, cutting prompt-token cost and latency on multi-tool turns. Wire position of runtime metadata moves from absolute tail to after the active user turn; position-sensitive precheck normalization is untouched (the relocation still runs wire-only after `normalizeMessagesForLlmBoundary`).

## Evidence

[AI-assisted] Implementation and test updates; fix authored against issue #123652.

New regression test `keeps the carrier anchored after the active user through a same-turn tool loop (issue #123652)` fails on pre-fix code (carrier tail-places, so `P+U+X` → `P+U+Y+X`):

```text
$ # pre-fix production code + new tests
× keeps the active user turn bare, tail-places the carrier, and drops it from replayed history
× request N+1 is a strict prefix-extension of request N through the active user turn
× keeps the carrier anchored after the active user through a same-turn tool loop (issue #123652)
      Tests  3 failed | 12 passed (15)
```

With the fix, the full affected surface passes:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-embedded-agent-run.config.ts \
    src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  16:29:52
   Duration  42.48s (transform 31.68s, setup 2.37s, import 37.67s, tests 1.66s, environment 0ms)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts \
    src/agents/internal-runtime-context.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  16:29:45
   Duration  730ms (transform 372ms, setup 207ms, import 237ms, tests 22ms, environment 0ms)
```

The new test asserts both requests keep the carrier at the same slot (index 3) and that `wireN1.slice(0, carrierIndex)` byte-matches `wireN.slice(0, carrierIndex)` — i.e. request N is a strict prefix of request N+1 through the tool loop. No stale references to the removed `relocateCurrentRuntimeContextCarrierToTail` remain (`grep` clean across `src/` and `extensions/`).
