### PR TITLE
refactor(gateway): retire the legacy numeric ChatAbortMarker and dead registry surface

### DIFF
--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -27,8 +27,7 @@ import {
   resolveNodeCommandAllowlist,
 } from "./node-command-policy.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
-import { createSessionMessageSubscriberRegistry } from "./server-chat-state.js";
-import { createChatRunRegistry } from "./server-chat.js";
+import { createChatRunState, createSessionMessageSubscriberRegistry } from "./server-chat-state.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import { handleNodeInvokeResult } from "./server-methods/nodes.handlers.invoke-result.js";
 import type { GatewayClient as GatewayMethodClient } from "./server-methods/types.js";
@@ -916,7 +915,7 @@ describe("gateway broadcaster", () => {
 
 describe("chat run registry", () => {
   test("queues and removes runs per session", () => {
-    const registry = createChatRunRegistry();
+    const registry = createChatRunState().registry;
 
     registry.add("s1", { sessionKey: "main", clientRunId: "c1" });
     registry.add("s1", { sessionKey: "main", clientRunId: "c2" });

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -25,11 +25,10 @@ export type ChatRunRegistration = {
 };
 
 export type ChatRunEntry = ChatRunRegistration & {
-  registeredAtMs: number;
   registeredSequence: number;
 };
 
-export type ChatAbortMarker = number | { abortedAtMs: number; sequence: number };
+export type ChatAbortMarker = { abortedAtMs: number; sequence: number };
 
 let chatRunOrderingSequence = 0;
 
@@ -42,7 +41,6 @@ function nextChatRunOrderingSequence(): number {
 function createChatRunEntry(entry: ChatRunRegistration): ChatRunEntry {
   return {
     ...entry,
-    registeredAtMs: Date.now(),
     registeredSequence: nextChatRunOrderingSequence(),
   };
 }
@@ -52,34 +50,24 @@ export function createChatAbortMarker(now = Date.now()): ChatAbortMarker {
   return { abortedAtMs: now, sequence: nextChatRunOrderingSequence() };
 }
 
-/** Return the wall-clock timestamp used by maintenance TTL pruning for both legacy and structured markers. */
+/** Return the wall-clock timestamp used by maintenance TTL pruning. */
 export function chatAbortMarkerTimestampMs(marker: ChatAbortMarker): number {
-  return typeof marker === "number" ? marker : marker.abortedAtMs;
+  return marker.abortedAtMs;
 }
 
 /**
  * Return whether an abort marker should suppress events for the given chat run registration.
- * Structured markers compare the monotonic sequence first so same-millisecond aborts stay ordered;
- * legacy numeric markers fall back to timestamp comparison, and a missing entry preserves old suppress-on-presence behavior.
+ * The shared monotonic sequence keeps same-millisecond aborts ordered; a missing
+ * entry preserves suppress-on-presence behavior.
  */
 export function isChatAbortMarkerCurrent(
   marker: ChatAbortMarker | undefined,
-  entry?: Pick<ChatRunEntry, "registeredAtMs" | "registeredSequence">,
+  entry?: Pick<ChatRunEntry, "registeredSequence">,
 ): boolean {
   if (marker === undefined) {
     return false;
   }
-  if (!entry) {
-    return true;
-  }
-  if (typeof marker !== "number" && typeof entry.registeredSequence === "number") {
-    return marker.sequence >= entry.registeredSequence;
-  }
-  if (typeof entry.registeredAtMs !== "number") {
-    return true;
-  }
-  const abortedAtMs = typeof marker === "number" ? marker : marker.abortedAtMs;
-  return abortedAtMs >= entry.registeredAtMs;
+  return !entry || marker.sequence >= entry.registeredSequence;
 }
 
 export type BufferedAgentEvent = {
@@ -180,7 +168,6 @@ export type ChatRunRegistry = {
   peek: (sessionId: string) => ChatRunEntry | undefined;
   shift: (sessionId: string) => ChatRunEntry | undefined;
   remove: (sessionId: string, clientRunId: string, sessionKey?: string) => ChatRunEntry | undefined;
-  clear: () => void;
 };
 
 function createChatRunRegistryForStore(store: ChatRunRecordStore): ChatRunRegistry {
@@ -238,19 +225,7 @@ function createChatRunRegistryForStore(store: ChatRunRecordStore): ChatRunRegist
     return entry;
   };
 
-  const clear = () => {
-    for (const [runId, record] of store.runs) {
-      delete record.registrations;
-      store.releaseIfEmpty(runId);
-    }
-  };
-
-  return { add, peek, shift, remove, clear };
-}
-
-/** Create the FIFO registry that maps session IDs to active chat runs. */
-export function createChatRunRegistry(): ChatRunRegistry {
-  return createChatRunRegistryForStore(createChatRunRecordStore());
+  return { add, peek, shift, remove };
 }
 
 export type ChatRunState = {
@@ -755,9 +730,4 @@ function createToolEventRecipientRegistryForStore(
   };
 
   return { add, get, markFinal };
-}
-
-/** Create the run-id recipient registry used for streaming tool events. */
-export function createToolEventRecipientRegistry(): ToolEventRecipientRegistry {
-  return createToolEventRecipientRegistryForStore(createChatRunRecordStore());
 }

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -94,7 +94,6 @@ import {
   createSessionEventSubscriberRegistry,
   createChatAbortMarker,
   createSessionMessageSubscriberRegistry,
-  createToolEventRecipientRegistry,
   resolveChatErrorKindFromError,
   type AgentEventHandlerOptions,
 } from "./server-chat.js";
@@ -169,7 +168,7 @@ describe("agent event handler", () => {
       vi.fn<NonNullable<AgentEventHandlerOptions["clearTrackedActiveRun"]>>();
     const agentRunSeq = new Map<string, number>();
     const chatRunState = createChatRunState();
-    const toolEventRecipients = createToolEventRecipientRegistry();
+    const toolEventRecipients = chatRunState.toolEventRecipients;
     const sessionEventSubscribers = createSessionEventSubscriberRegistry();
     const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
 
@@ -3289,8 +3288,8 @@ describe("agent event handler", () => {
 
   it.each([
     {
-      name: "older timestamp",
-      marker: () => 1_000,
+      name: "older sequence",
+      marker: () => ({ abortedAtMs: 1_000, sequence: -2 }),
     },
     {
       name: "same-millisecond older sequence",
@@ -4422,7 +4421,8 @@ describe("agent event handler", () => {
       isControlUiVisible: false,
       verboseLevel: "off",
     });
-    chatRunState.getOrCreate("run-hidden-commentary-aborted").abortMarker = 1_000;
+    chatRunState.getOrCreate("run-hidden-commentary-aborted").abortMarker =
+      createChatAbortMarker(1_000);
 
     emitAgentEvent(handler, "run-hidden-commentary-aborted", "assistant", {
       text: "This aborted commentary must not be mirrored.",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -68,11 +68,9 @@ import { formatForLog } from "./ws-log.js";
 
 export {
   createChatAbortMarker,
-  createChatRunRegistry,
   createChatRunState,
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
-  createToolEventRecipientRegistry,
 } from "./server-chat-state.js";
 export type {
   ChatAbortMarker,

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -6,6 +6,7 @@ import type { HealthSummary } from "./health/types.js";
 const CURATOR_INITIAL_DELAY_MS = 5 * 60_000;
 const CURATOR_SWEEP_INTERVAL_MS = 24 * 60 * 60_000;
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import { createChatAbortMarker } from "./server-chat-state.js";
 import { DEDUPE_MAX, DEDUPE_TTL_MS } from "./server-constants.js";
 import { pendingChatSendDedupeKey } from "./server-shared.js";
 import { createGatewayMaintenanceStateForTest } from "./test-helpers.maintenance-state.js";
@@ -792,7 +793,7 @@ describe("startGatewayMaintenanceTimers", () => {
     const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
     const deps = createMaintenanceTimerDeps();
     const runId = "run-aborted";
-    deps.chatRunState.getOrCreate(runId).abortMarker = staleRunTimestamp();
+    deps.chatRunState.getOrCreate(runId).abortMarker = createChatAbortMarker(staleRunTimestamp());
     seedStaleRunBuffers(deps, runId);
     seedBufferedAgentEvent(deps, runId);
     const agentText = deps.chatRunState.getOrCreate(runId).agentText?.assistant;

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -39,7 +39,7 @@ import {
 } from "../chat-display-projection.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import type { HealthSummary } from "../health/types.js";
-import { createChatRunState } from "../server-chat-state.js";
+import { createChatAbortMarker, createChatRunState } from "../server-chat-state.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
@@ -2891,7 +2891,7 @@ describe("exec approval handlers", () => {
 
   it("rejects approval registration after the owning run was aborted", async () => {
     const { manager, handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    context.chatRunState.getOrCreate("run-aborted").abortMarker = Date.now();
+    context.chatRunState.getOrCreate("run-aborted").abortMarker = createChatAbortMarker();
 
     await requestExecApproval({
       handlers,
@@ -2941,7 +2941,8 @@ describe("exec approval handlers", () => {
       "approval-allowed-before-abort",
     );
     expect(manager.resolve("approval-allowed-before-abort", "allow-once")).toBe(true);
-    context.chatRunState.getOrCreate("run-allowed-before-abort").abortMarker = Date.now();
+    context.chatRunState.getOrCreate("run-allowed-before-abort").abortMarker =
+      createChatAbortMarker();
     await requestPromise;
 
     const waitRespond = vi.fn();

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -33,7 +33,6 @@ import {
   createChatRunState,
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
-  createToolEventRecipientRegistry,
 } from "./server-chat-state.js";
 import type { TaskEventPayload } from "./server-methods/task-summary.js";
 import { TerminalSessionManager } from "./terminal/session-manager.js";
@@ -163,8 +162,10 @@ function createParams(): SubscriptionParams {
     broadcastToConnIds: vi.fn(),
     nodeSendToSession: vi.fn(),
     agentRunSeq: new Map(),
-    chatRunState: createChatRunState(),
-    toolEventRecipients: createToolEventRecipientRegistry(),
+    ...(() => {
+      const chatRunState = createChatRunState();
+      return { chatRunState, toolEventRecipients: chatRunState.toolEventRecipients };
+    })(),
     sessionEventSubscribers: createSessionEventSubscriberRegistry(),
     sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
     chatAbortControllers: new Map(),


### PR DESCRIPTION
## What Problem This Solves

Dead surface in the gateway chat-run state owner, found by the round-5 run-lifecycle lane:

- The numeric `ChatAbortMarker` variant was in-process rollout compat for #91013 (June 2026). Abort markers are process-local, in-memory only (`ChatRunRecord.abortMarker` — nothing persists them), so no shipped contract can carry the old shape across a restart; every production producer has gone through `createChatAbortMarker` (structured) since. Only tests assigned raw numbers, and tests alone are not contracts.
- Deleting the numeric branch also kills the `registeredAtMs` timestamp fallback in `isChatAbortMarkerCurrent` (every entry is stamped by `createChatRunEntry`, so `registeredSequence` is always present) — which makes `ChatRunEntry.registeredAtMs` entirely write-only. Deleted too.
- `ChatRunRegistry.clear` had zero callers (restart teardown clears through `chatRunState.clear()`, which owns the whole store).
- The standalone `createChatRunRegistry`/`createToolEventRecipientRegistry` factories were consumed only by tests; production always goes through `createChatRunState()`. Tests now use the state-owned instances and the `server-chat.ts` barrel re-exports are gone.

## Why This Change Was Made

Lean-code doctrine: compat is opt-in and this variant never had a contract — it was a live-rollout convenience that became permanent architecture. The sequence comparison is now the sole ordering authority for abort freshness, removing a two-signal inference (sequence-else-timestamp) where one recorded fact belongs.

## User Impact

None visible — pure dead-surface removal. Net −32 production LOC.

## Evidence

- `node scripts/run-vitest.mjs run` over all five touched suites (`server-chat.agent-events`, `gateway-misc`, `server-maintenance`, `server-runtime-subscriptions`, `server-methods`) — 462/462 green.
- Producer sweep: `createChatAbortMarker` call sites at `chat-abort.ts:633`, `server-close.ts:440`, `chat-abort-authorization.ts:233` are the only marker producers; grep proves no remaining numeric assignment or `registeredAtMs` reader outside the deleted code.
- `pnpm tsgo`, `pnpm check:test-types` (they enumerated every stale call site), oxfmt/oxlint clean; autoreview clean (0.99).

Production LOC +8/−40 (net −32); tests +17/−15.
