### PR TITLE
fix(gateway): node tunnel recovery reports ready before validation

### DIFF
--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -195,70 +195,70 @@ describe("node worker tunnel manager", () => {
     );
   });
 
-  it("keeps same-owner starts behind restored workspace validation", async () => {
-    const record = environment();
-    const validation = createDeferred();
-    const manifest = { version: 1 as const, baseCommit: null, entries: [] };
-    const rawManifest = serializeWorkerWorkspaceManifest(manifest);
-    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
-    const outputs = [`quiesced ${"c".repeat(32)}`, manifestRef, ""];
-    const nodeTransport = transport();
-    nodeTransport.invoke = vi.fn(async () => ({
-      ok: true,
-      payloadJSON: JSON.stringify({
-        workspaceDir: "/node/workspace",
-        stdout: outputs.shift() ?? "",
-        stderr: "",
-        code: 0,
-        signal: null,
-        killed: false,
-        termination: "exit",
-      }),
-    }));
-    const prepareSync = vi.fn(async () => {
-      await validation.promise;
-      return {
-        snapshot: { manifest, manifestRef, rawManifest, root: "/gateway/workspace" },
-        token: "restore-token",
-      };
-    });
-    const transfer = {
-      prepareSync,
-      close: vi.fn(async () => {}),
-      revoke: vi.fn(),
-    } as unknown as NodeWorkspaceTransferService;
-    const manager = createNodeWorkerTunnelManager({
-      gatewayDeviceId: "gateway-device-1",
-      getEnvironment: () => record,
-      getTransport: () => nodeTransport,
-      launchNodeWorker: vi.fn(),
-      validateWorkerTurn: () => true,
-      workspaceTransfer: transfer,
-    });
-    manager.bindWorkspaceBindingResolver(async () => ({
-      localPath: "/gateway/workspace",
-      manifestRef,
-      remoteWorkspaceDir: "/node/workspace",
-    }));
+  it.each(["success", "failure"] as const)(
+    "keeps same-owner starts behind restored workspace validation on %s",
+    async (outcome) => {
+      const record = environment();
+      const validation = createDeferred();
+      const manifest = { version: 1 as const, baseCommit: null, entries: [] };
+      const rawManifest = serializeWorkerWorkspaceManifest(manifest);
+      const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+      const outputs = [`quiesced ${"c".repeat(32)}`, manifestRef, ""];
+      const nodeTransport = transport();
+      nodeTransport.invoke = vi.fn(async () => ({
+        ok: true,
+        payloadJSON: JSON.stringify({
+          workspaceDir: "/node/workspace",
+          stdout: outputs.shift() ?? "",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        }),
+      }));
+      const prepareSync = vi.fn(async () => {
+        await validation.promise;
+        if (outcome === "failure") throw new Error("restored workspace validation failed");
+        return {
+          snapshot: { manifest, manifestRef, rawManifest, root: "/gateway/workspace" },
+          token: "restore-token",
+        };
+      });
+      const transfer = {
+        prepareSync,
+        close: vi.fn(async () => {}),
+        revoke: vi.fn(),
+      } as unknown as NodeWorkspaceTransferService;
+      const manager = createNodeWorkerTunnelManager({
+        gatewayDeviceId: "gateway-device-1",
+        getEnvironment: () => record,
+        getTransport: () => nodeTransport,
+        launchNodeWorker: vi.fn(),
+        validateWorkerTurn: () => true,
+        workspaceTransfer: transfer,
+      });
+      manager.bindWorkspaceBindingResolver(async () => ({
+        localPath: "/gateway/workspace",
+        manifestRef,
+        remoteWorkspaceDir: "/node/workspace",
+      }));
 
-    const first = manager.start(startRequest());
-    await vi.waitFor(() => expect(prepareSync).toHaveBeenCalledOnce());
-    const second = manager.start(startRequest());
-    const secondSettled = vi.fn();
-    void second.then(
-      () => secondSettled(),
-      () => secondSettled(),
-    );
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    expect(secondSettled).not.toHaveBeenCalled();
-    validation.resolve();
-
-    const handle = await first;
-    await expect(second).resolves.toBe(handle);
-    expect(manager.status("environment-1")).toBe("connected");
-  });
+      const first = manager.start(startRequest());
+      await vi.waitFor(() => expect(prepareSync).toHaveBeenCalledOnce());
+      expect(manager.status("environment-1")).toBe("connecting");
+      const second = manager.start(startRequest());
+      const secondSettled = vi.fn();
+      void second.then(secondSettled, secondSettled);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(secondSettled).not.toHaveBeenCalled();
+      validation.resolve();
+      const results = await Promise.allSettled([first, second]);
+      const expectedStatus = outcome === "success" ? "fulfilled" : "rejected";
+      expect(results.map((result) => result.status)).toEqual([expectedStatus, expectedStatus]);
+      expect(manager.status("environment-1")).toBe(outcome === "success" ? "connected" : "stopped");
+    },
+  );
 
   it("keeps concurrent workspace commands on the admitted build while launch capacity is full", async () => {
     const record = environment();

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -242,7 +242,6 @@ describe("node worker tunnel manager", () => {
         manifestRef,
         remoteWorkspaceDir: "/node/workspace",
       }));
-
       const first = manager.start(startRequest());
       await vi.waitFor(() => expect(prepareSync).toHaveBeenCalledOnce());
       expect(manager.status("environment-1")).toBe("connecting");

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -195,6 +195,71 @@ describe("node worker tunnel manager", () => {
     );
   });
 
+  it("keeps same-owner starts behind restored workspace validation", async () => {
+    const record = environment();
+    const validation = createDeferred();
+    const manifest = { version: 1 as const, baseCommit: null, entries: [] };
+    const rawManifest = serializeWorkerWorkspaceManifest(manifest);
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    const outputs = [`quiesced ${"c".repeat(32)}`, manifestRef, ""];
+    const nodeTransport = transport();
+    nodeTransport.invoke = vi.fn(async () => ({
+      ok: true,
+      payloadJSON: JSON.stringify({
+        workspaceDir: "/node/workspace",
+        stdout: outputs.shift() ?? "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      }),
+    }));
+    const prepareSync = vi.fn(async () => {
+      await validation.promise;
+      return {
+        snapshot: { manifest, manifestRef, rawManifest, root: "/gateway/workspace" },
+        token: "restore-token",
+      };
+    });
+    const transfer = {
+      prepareSync,
+      close: vi.fn(async () => {}),
+      revoke: vi.fn(),
+    } as unknown as NodeWorkspaceTransferService;
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: () => record,
+      getTransport: () => nodeTransport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: transfer,
+    });
+    manager.bindWorkspaceBindingResolver(async () => ({
+      localPath: "/gateway/workspace",
+      manifestRef,
+      remoteWorkspaceDir: "/node/workspace",
+    }));
+
+    const first = manager.start(startRequest());
+    await vi.waitFor(() => expect(prepareSync).toHaveBeenCalledOnce());
+    const second = manager.start(startRequest());
+    const secondSettled = vi.fn();
+    void second.then(
+      () => secondSettled(),
+      () => secondSettled(),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(secondSettled).not.toHaveBeenCalled();
+    validation.resolve();
+
+    const handle = await first;
+    await expect(second).resolves.toBe(handle);
+    expect(manager.status("environment-1")).toBe("connected");
+  });
+
   it("keeps concurrent workspace commands on the admitted build while launch capacity is full", async () => {
     const record = environment();
     const manifest = { version: 1 as const, baseCommit: null, entries: [] };

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -219,17 +219,16 @@ describe("node worker tunnel manager", () => {
       }));
       const prepareSync = vi.fn(async () => {
         await validation.promise;
-        if (outcome === "failure") throw new Error("restored workspace validation failed");
+        if (outcome === "failure") {
+          throw new Error("restored workspace validation failed");
+        }
         return {
           snapshot: { manifest, manifestRef, rawManifest, root: "/gateway/workspace" },
           token: "restore-token",
         };
       });
-      const transfer = {
-        prepareSync,
-        close: vi.fn(async () => {}),
-        revoke: vi.fn(),
-      } as unknown as NodeWorkspaceTransferService;
+      const transfer = workspaceTransfer();
+      transfer.prepareSync = prepareSync;
       const manager = createNodeWorkerTunnelManager({
         gatewayDeviceId: "gateway-device-1",
         getEnvironment: () => record,
@@ -250,7 +249,9 @@ describe("node worker tunnel manager", () => {
       const second = manager.start(startRequest());
       const secondSettled = vi.fn();
       void second.then(secondSettled, secondSettled);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(secondSettled).not.toHaveBeenCalled();
       validation.resolve();
       const results = await Promise.allSettled([first, second]);

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -308,7 +308,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
   };
 
   const createHandle = (
-    entry: Omit<NodeTunnelEntry, "handle">,
+    entry: Omit<NodeTunnelEntry, "handle" | "readiness">,
     restoredWorkspace: NodeWorkerWorkspaceBinding | undefined,
   ): { handle: WorkerTunnelHandle; validateRestoredWorkspace: () => Promise<void> } => {
     let workspaceReady = restoredWorkspace !== undefined;
@@ -674,9 +674,8 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
         };
         const readiness = createDeferredCore<WorkerTunnelHandle>();
         void readiness.promise.catch(() => undefined);
-        const pendingEntry = Object.assign(base, { readiness });
-        const created = createHandle(pendingEntry, restoredWorkspace);
-        const entry = Object.assign(pendingEntry, { handle: created.handle });
+        const created = createHandle(base, restoredWorkspace);
+        const entry = Object.assign(base, { readiness, handle: created.handle });
         entries.set(entry.environmentId, entry);
         try {
           await created.validateRestoredWorkspace();

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -3,6 +3,7 @@ import type { WorkerAdmissionHandshake } from "../../../packages/gateway-protoco
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { NODE_WORKER_WORKSPACE_EXEC_COMMAND } from "../../infra/node-commands.js";
 import type { SpawnResult } from "../../process/exec.js";
+import { createDeferredCore, type Deferred } from "../../shared/deferred.js";
 import type { NodeWorkerSupervisorReceipt } from "../../worker/node-supervisor-protocol.js";
 import {
   parseNodeWorkerWorkspaceExecResult,
@@ -114,6 +115,7 @@ type NodeTunnelEntry = NodeWorkerTunnelStartRequest & {
   gatewayNamespace: string;
   handle: WorkerTunnelHandle;
   launchTasks: Set<Promise<unknown>>;
+  readiness: Deferred<WorkerTunnelHandle>;
   stopPromise?: Promise<void>;
 };
 
@@ -614,6 +616,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       return entry.stopPromise;
     }
     entry.abortController.abort(new Error("node worker tunnel owner stopped"));
+    entry.readiness.reject(new Error("node worker tunnel stopped before connecting"));
     entry.stopPromise = Promise.allSettled(entry.launchTasks).then(() => {
       if (entries.get(entry.environmentId) === entry) {
         entries.delete(entry.environmentId);
@@ -628,25 +631,28 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       resolveWorkspaceBinding = resolver;
     },
     async start(request: NodeWorkerTunnelStartRequest): Promise<WorkerTunnelHandle> {
+      const current = entries.get(request.environmentId);
+      if (current) {
+        if (request.ownerEpoch < current.ownerEpoch) {
+          throw new Error("node worker tunnel owner epoch is stale");
+        }
+        if (request.ownerEpoch === current.ownerEpoch) {
+          if (
+            current.abortController.signal.aborted ||
+            current.deviceId !== request.deviceId ||
+            current.sessionId !== request.sessionId ||
+            !sameWorkerBuild(current.expectedBuild, request.expectedBuild)
+          ) {
+            throw new Error("node worker tunnel owner binding changed within one epoch");
+          }
+          // Same-owner starts share restored-workspace validation so recovery cannot report false readiness.
+          return await current.readiness.promise;
+        }
+      }
       const pending = { ownerEpoch: request.ownerEpoch, cancelled: false };
       pendingStarts.set(request.environmentId, pending);
       try {
-        const current = entries.get(request.environmentId);
         if (current) {
-          if (request.ownerEpoch < current.ownerEpoch) {
-            throw new Error("node worker tunnel owner epoch is stale");
-          }
-          if (request.ownerEpoch === current.ownerEpoch) {
-            if (
-              current.abortController.signal.aborted ||
-              current.deviceId !== request.deviceId ||
-              current.sessionId !== request.sessionId ||
-              !sameWorkerBuild(current.expectedBuild, request.expectedBuild)
-            ) {
-              throw new Error("node worker tunnel owner binding changed within one epoch");
-            }
-            return current.handle;
-          }
           await stopEntry(current);
         }
         if (pending.cancelled || pendingStarts.get(request.environmentId) !== pending) {
@@ -666,16 +672,21 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           abortController: new AbortController(),
           launchTasks: new Set<Promise<unknown>>(),
         };
-        const created = createHandle(base, restoredWorkspace);
-        const entry = Object.assign(base, { handle: created.handle });
+        const readiness = createDeferredCore<WorkerTunnelHandle>();
+        void readiness.promise.catch(() => undefined);
+        const pendingEntry = Object.assign(base, { readiness });
+        const created = createHandle(pendingEntry, restoredWorkspace);
+        const entry = Object.assign(pendingEntry, { handle: created.handle });
         entries.set(entry.environmentId, entry);
         try {
           await created.validateRestoredWorkspace();
           if (pending.cancelled || pendingStarts.get(request.environmentId) !== pending) {
             throw new Error("node worker tunnel start was cancelled");
           }
+          readiness.resolve(entry.handle);
           return entry.handle;
         } catch (error) {
+          readiness.reject(error);
           await stopEntry(entry);
           throw error;
         }

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -645,8 +645,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           ) {
             throw new Error("node worker tunnel owner binding changed within one epoch");
           }
-          // Same-owner starts share restored-workspace validation so recovery cannot report false readiness.
-          return await current.readiness.promise;
+          return current.readiness.promise; // Share restored-workspace validation without false readiness.
         }
       }
       const pending = { ownerEpoch: request.ownerEpoch, cancelled: false };
@@ -713,6 +712,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       await options.workspaceTransfer.closeAll();
     },
     status(environmentId: string): WorkerTunnelStatus {
+      if (pendingStarts.get(environmentId)?.cancelled === false) return "connecting";
       const entry = entries.get(environmentId);
       return entry && !entry.abortController.signal.aborted ? "connected" : "stopped";
     },

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -712,9 +712,9 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       await options.workspaceTransfer.closeAll();
     },
     status(environmentId: string): WorkerTunnelStatus {
-      if (pendingStarts.get(environmentId)?.cancelled === false) return "connecting";
       const entry = entries.get(environmentId);
-      return entry && !entry.abortController.signal.aborted ? "connected" : "stopped";
+      const status = entry && !entry.abortController.signal.aborted ? "connected" : "stopped";
+      return pendingStarts.get(environmentId)?.cancelled === false ? "connecting" : status;
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a recovered node-worker tunnel could report ready to a concurrent same-owner caller before restored-workspace validation completed. If that validation later failed, one caller had already received a handle that recovery was about to tear down, creating a false-ready launch and a dead-end failure instead of one consistent recovery outcome.

## Why This Change Was Made

Each published node tunnel entry now owns one readiness barrier. Exact same-owner starts reuse that barrier; it resolves only after restored-workspace validation succeeds and rejects on validation failure or stop. While that barrier is pending, the externally projected tunnel status remains `connecting`; success publishes `connected`, and failure or stop publishes `stopped`. Stale epochs, changed same-epoch bindings, and higher-epoch replacement keep their existing behavior.

The change preserves current main's typed entry construction plus the node bundle-install and stale-bundle checks. Tunnel, route, and turn authority identities, Gateway protocol, persistence, and replay behavior are unchanged.

## User Impact

Concurrent recovery and launch callers now observe one authoritative node-tunnel outcome. A placement cannot be reported ready while its restored workspace is still being validated.

## Evidence

- Pre-fix original-order regression: the focused suite failed because the second same-owner start settled while `prepareSync` was still blocked (`1 failed, 8 passed`).
- Focused owner/sibling proof: 101 tests passed across node tunnel, environment access, node launch adapter, SSH tunnel, node supervisor, and worker connection suites.
- Real isolated Gateway + node-host E2E: `test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts` passed connect, invoke/status, forced node-control reconnect and route replacement, terminal receipt, one visible assistant result, workspace reconciliation, active placement continuity, and cleanup.
- Full private-QA build passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/31876125913: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`.
- Changed gate passed on the same final-tree Testbox: formatting, changed-file lint, production and test types, database/architecture guards, and zero runtime import cycles.
- `git diff --check` passed.
- Fresh autoreview passed with no accepted/actionable findings.
- Exact reviewed head: `129b00c3486ca573fe7db2639dab280bf1357514`.

Production LOC: +28/-18 (net +10). Tests: +65/-0. The production growth is the missing shared lifecycle barrier at the node-tunnel owner; the raw churn includes the ClawSweeper-requested status projection, with no downstream guard or parallel recovery path.

No changelog entry: `CHANGELOG.md` is release-owned. AI-assisted; I understand and reviewed the lifecycle and identity boundaries.
