### PR TITLE
fix: keep doctor lint from migrating shared state

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -189,9 +189,12 @@ function filterCompletedWorkspaceBootstrapFile(
   });
 }
 
-async function isWorkspaceSetupCompletedForContext(workspaceDir: string): Promise<boolean> {
+async function isWorkspaceSetupCompletedForContext(
+  workspaceDir: string,
+  readOnlyState = false,
+): Promise<boolean> {
   try {
-    return await isWorkspaceSetupCompleted(workspaceDir);
+    return await isWorkspaceSetupCompleted(workspaceDir, readOnlyState ? { readOnly: true } : {});
   } catch {
     return false;
   }
@@ -227,6 +230,7 @@ export async function resolveBootstrapFilesForRun(params: {
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
+  readOnlyState?: boolean;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
   const session = {
@@ -234,7 +238,10 @@ export async function resolveBootstrapFilesForRun(params: {
     chatType: params.chatType,
     workspaceDir: params.workspaceDir,
   };
-  const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(params.workspaceDir);
+  const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(
+    params.workspaceDir,
+    params.readOnlyState,
+  );
   const rawFiles = params.sessionKey
     ? await getOrLoadBootstrapFiles({
         workspaceDir: params.workspaceDir,
@@ -289,6 +296,7 @@ export async function resolveBootstrapContextForRun(params: {
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
+  readOnlyState?: boolean;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -62,6 +62,19 @@ function insertPersistedAttestationHash(filename: string, sha256: string): void 
 }
 
 describe("workspace state store", () => {
+  it("does not create shared state for a read-only snapshot", () => {
+    const statePath = resolveOpenClawStateSqlitePath(testState!.env);
+    expect(fs.existsSync(statePath)).toBe(false);
+
+    expect(
+      readWorkspaceStateSnapshot(workspaceDir(), {
+        env: testState!.env,
+        readOnly: true,
+      }),
+    ).toMatchObject({ setupExists: false, setup: { version: 1 } });
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+
   it("round-trips setup and attestation state after a database restart", () => {
     const dir = workspaceDir();
     mergeWorkspaceSetupState(dir, {

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -7,6 +7,7 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -96,6 +97,8 @@ type WorkspaceStateDatabase = Pick<
   | "migration_sources"
 >;
 
+type WorkspaceStateDatabaseHandle = Pick<ReturnType<typeof openOpenClawStateDatabase>, "db">;
+
 const MAX_WORKSPACE_IDENTITY_SYMLINKS = 40;
 
 type WorkspaceIdentityResolution = {
@@ -182,7 +185,7 @@ export function resolveWorkspaceStateIdentity(workspaceDir: string): WorkspaceSt
 
 function resolveWorkspaceIdentityFromDatabase(params: {
   workspaceDir: string;
-  database: ReturnType<typeof openOpenClawStateDatabase>;
+  database: WorkspaceStateDatabaseHandle;
 }): WorkspaceIdentityResolution {
   const aliases = resolveWorkspaceStateAliases(params.workspaceDir);
   const canonicalIdentity = aliases.at(-1)!;
@@ -232,7 +235,7 @@ function resolveWorkspaceIdentityFromDatabase(params: {
 }
 
 function registerWorkspacePathAliases(params: {
-  database: ReturnType<typeof openOpenClawStateDatabase>;
+  database: WorkspaceStateDatabaseHandle;
   identity: WorkspaceStateIdentity;
   aliases: readonly WorkspaceStateIdentity[];
   updatedAtMs: number;
@@ -271,7 +274,7 @@ function registerWorkspacePathAliases(params: {
 }
 
 export function registerWorkspaceStateAliasesInTransaction(params: {
-  database: ReturnType<typeof openOpenClawStateDatabase>;
+  database: WorkspaceStateDatabaseHandle;
   workspaceDirs: readonly string[];
   identity: WorkspaceStateIdentity;
   updatedAtMs: number;
@@ -292,7 +295,7 @@ export function registerWorkspaceStateAliasesInTransaction(params: {
 
 function readSnapshotFromDatabase(params: {
   identity: WorkspaceStateIdentity;
-  database: ReturnType<typeof openOpenClawStateDatabase>;
+  database: WorkspaceStateDatabaseHandle;
 }): WorkspaceStateSnapshot {
   const identity = params.identity;
   const kysely = getNodeSqliteKysely<WorkspaceStateDatabase>(params.database.db);
@@ -368,6 +371,23 @@ export function readWorkspaceStateSnapshot(
   workspaceDir: string,
   options: OpenClawStateDatabaseOptions = {},
 ): WorkspaceStateSnapshot {
+  if (options.readOnly) {
+    const snapshot = withExistingOpenClawStateDatabaseReadOnly(
+      (database) =>
+        runSqliteDeferredTransactionSync(database.db, () => {
+          const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
+          return readSnapshotFromDatabase({ identity: resolution.identity, database });
+        }),
+      options,
+    );
+    return (
+      snapshot ?? {
+        identity: resolveWorkspaceStateIdentity(workspaceDir),
+        setupExists: false,
+        setup: { version: WORKSPACE_SETUP_STATE_VERSION },
+      }
+    );
+  }
   const database = openOpenClawStateDatabase(options);
   const initial = runSqliteDeferredTransactionSync(database.db, () => {
     const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -681,8 +681,11 @@ function readCanonicalWorkspaceStateSnapshot(
   return snapshot;
 }
 
-export async function isWorkspaceSetupCompleted(dir: string): Promise<boolean> {
-  const state = readCanonicalWorkspaceStateSnapshot(dir).setup;
+export async function isWorkspaceSetupCompleted(
+  dir: string,
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<boolean> {
+  const state = readCanonicalWorkspaceStateSnapshot(dir, options).setup;
   return typeof state.setupCompletedAt === "string" && state.setupCompletedAt.trim().length > 0;
 }
 

--- a/src/commands/doctor-device-pairing.test.ts
+++ b/src/commands/doctor-device-pairing.test.ts
@@ -108,6 +108,28 @@ describe("noteDevicePairingHealth", () => {
     noteMock.mockReset();
   });
 
+  it("does not create shared state while collecting local pairing findings", async () => {
+    await withTempDir("openclaw-doctor-device-pairing-readonly-", async (stateDir) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_TEST_FAST: "1",
+        },
+        async () => {
+          await expect(
+            collectDevicePairingHealthFindings({
+              cfg: { gateway: { mode: "local" } },
+              healthOk: false,
+            }),
+          ).resolves.toEqual([]);
+          await expect(
+            fs.stat(path.join(stateDir, "state", "openclaw.sqlite")),
+          ).rejects.toMatchObject({ code: "ENOENT" });
+        },
+      );
+    });
+  });
+
   it("warns about pending scope upgrades from local pairing state when the gateway is down", async () => {
     await withApprovedOperatorPairing(async ({ identity, publicKey }) => {
       const pending = await requestDevicePairing({

--- a/src/commands/doctor-device-pairing.ts
+++ b/src/commands/doctor-device-pairing.ts
@@ -11,7 +11,7 @@ import { loadDeviceAuthTokens } from "../infra/device-auth-store.js";
 import { loadDeviceIdentityIfPresent } from "../infra/device-identity.js";
 import {
   listApprovedPairedDeviceRoles,
-  listDevicePairing,
+  listDevicePairingReadOnly,
   summarizeDeviceTokens,
   type DeviceAuthTokenSummary,
   type DevicePairingPendingRequest,
@@ -140,7 +140,7 @@ async function loadDoctorPairingSnapshot(params: {
   if (params.cfg.gateway?.mode === "remote") {
     return null;
   }
-  const local = await listDevicePairing();
+  const local = await listDevicePairingReadOnly();
   return {
     pending: local.pending,
     paired: local.paired.map((device) => normalizeLocalPairedDevice(device)),

--- a/src/commands/doctor-heartbeat-task-migration.test.ts
+++ b/src/commands/doctor-heartbeat-task-migration.test.ts
@@ -12,8 +12,10 @@ import { readCronJobScratchState, writeCronJobScratch } from "../cron/scratch-st
 import { CronService } from "../cron/service.js";
 import { loadCronJobsStore, resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import { resolveHeartbeatSession } from "../infra/heartbeat-runner.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
   collectHeartbeatTaskMigrationFindings,
   maybeMigrateHeartbeatTasksToCron,
@@ -146,6 +148,43 @@ async function createExistingInboxJob(fixture: Awaited<ReturnType<typeof createF
 }
 
 describe("heartbeat scratch task cron migration", () => {
+  it("does not create shared state while detecting heartbeat tasks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-task-detect-"));
+    tempDirs.push(root);
+    const env = { ...process.env, HOME: path.join(root, "home"), OPENCLAW_STATE_DIR: root };
+    const cfg = {
+      agents: { defaults: { heartbeat: { every: "30m" } }, list: [{ id: "main" }] },
+    } as OpenClawConfig;
+
+    await expect(collectHeartbeatTaskMigrationFindings(cfg, env)).resolves.toEqual([]);
+    await expect(fs.stat(resolveOpenClawStateSqlitePath(env))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not migrate older shared state while detecting heartbeat tasks", async () => {
+    const fixture = await createFixture(2_000_000_000_000);
+    closeOpenClawStateDatabaseForTest();
+    const statePath = resolveOpenClawStateSqlitePath(fixture.env);
+    const older = openNodeSqliteDatabase(statePath);
+    older.exec(`
+      PRAGMA user_version = 7;
+      UPDATE schema_meta SET schema_version = 7 WHERE meta_key = 'primary';
+    `);
+    older.close();
+
+    await expect(
+      collectHeartbeatTaskMigrationFindings(fixture.cfg, fixture.env),
+    ).resolves.toHaveLength(1);
+
+    const after = openNodeSqliteDatabase(statePath, { readOnly: true });
+    expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 7 });
+    expect(
+      after.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+    ).toEqual({ schema_version: 7 });
+    after.close();
+  });
+
   it("previews, preserves cadence, clears the block, and reruns idempotently", async () => {
     const fixture = await createFixture(2_000_000_000_000);
 

--- a/src/commands/doctor-heartbeat-task-migration.ts
+++ b/src/commands/doctor-heartbeat-task-migration.ts
@@ -11,7 +11,10 @@ import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { heartbeatTaskDeclarationKey, isHeartbeatTaskCronJob } from "../cron/heartbeat-task.js";
 import { cronSchedulingInputsEqual } from "../cron/schedule-identity.js";
-import { readHeartbeatMonitorScratch } from "../cron/scratch-store.js";
+import {
+  readHeartbeatMonitorScratch,
+  readHeartbeatMonitorScratchReadOnly,
+} from "../cron/scratch-store.js";
 import { computeJobNextRunAtMs, hasScheduledNextRunAtMs } from "../cron/service/jobs-scheduling.js";
 import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import { cronStoreKey } from "../cron/store/key.js";
@@ -94,9 +97,9 @@ export async function collectHeartbeatTaskMigrationFindings(
   const storePath = resolveCronJobsStorePathFromConfig(cfg, env);
   const findings: HealthFinding[] = [];
   for (const agent of resolveHeartbeatAgents(cfg)) {
-    let monitor: ReturnType<typeof readHeartbeatMonitorScratch>;
+    let monitor: ReturnType<typeof readHeartbeatMonitorScratchReadOnly>;
     try {
-      monitor = readHeartbeatMonitorScratch(storePath, agent.agentId, { env });
+      monitor = readHeartbeatMonitorScratchReadOnly(storePath, agent.agentId, { env });
     } catch (error) {
       findings.push(
         migrationFinding({

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -11,7 +11,7 @@ import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
 import { resolveExecPolicyScopeSnapshot } from "../infra/exec-approvals-effective.js";
 import {
-  loadExecApprovals,
+  loadExecApprovalsReadOnly,
   resolveExecApprovalsDisplayPath,
   type ExecAsk,
   type ExecMode,
@@ -88,7 +88,7 @@ function execAskRank(value: ExecAsk): number {
 
 function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
   const warnings: string[] = [];
-  const approvals = loadExecApprovals();
+  const approvals = loadExecApprovalsReadOnly();
   const defaultRequestedSecuritySource = "OpenClaw default (full)";
   const defaultRequestedAskSource = "OpenClaw default (off)";
 

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -37,12 +37,24 @@ vi.mock("../plugins/status.js", () => ({
     mocks.buildPluginCompatibilityWarnings(...args),
 }));
 
-vi.mock("../tasks/task-flow-runtime-internal.js", () => ({
-  listTaskFlowRecords: () => mocks.listTaskFlowRecords(),
+vi.mock("../tasks/task-flow-registry.store.sqlite.js", () => ({
+  loadTaskFlowRegistryStateFromSqliteReadOnly: () => ({
+    flows: new Map(
+      mocks.listTaskFlowRecords().map((flow) => [(flow as { flowId: string }).flowId, flow]),
+    ),
+  }),
 }));
 
-vi.mock("../tasks/runtime-internal.js", () => ({
-  listTasksForFlowId: (flowId: string) => mocks.listTasksForFlowId(flowId),
+vi.mock("../tasks/task-registry.store.sqlite.js", () => ({
+  loadTaskRegistryStateFromSqliteReadOnly: () => ({
+    tasks: new Map(
+      mocks
+        .listTaskFlowRecords()
+        .flatMap((flow) => mocks.listTasksForFlowId((flow as { flowId: string }).flowId))
+        .map((task) => [(task as { taskId: string }).taskId, task]),
+    ),
+    deliveryStates: new Map(),
+  }),
 }));
 
 async function runNoteWorkspaceStatusForTest(

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -17,8 +17,9 @@ import {
   buildPluginCompatibilityWarnings,
   buildPluginRegistrySnapshotReport,
 } from "../plugins/status.js";
-import { listTasksForFlowId } from "../tasks/runtime-internal.js";
-import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
+import { loadTaskFlowRegistryStateFromSqliteReadOnly } from "../tasks/task-flow-registry.store.sqlite.js";
+import { loadTaskRegistryStateFromSqliteReadOnly } from "../tasks/task-registry.store.sqlite.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
 
 type NoteWorkspaceStatusOptions = {
   pluginVersionDrift?: PluginVersionDriftReport;
@@ -33,13 +34,28 @@ type TaskFlowRecoveryFinding = {
 };
 
 function collectTaskFlowRecoveryFindings(): TaskFlowRecoveryFinding[] {
-  return listTaskFlowRecords().flatMap((flow) => {
-    const tasks = listTasksForFlowId(flow.flowId);
+  const flows = [...loadTaskFlowRegistryStateFromSqliteReadOnly().flows.values()].toSorted(
+    (left, right) => right.createdAt - left.createdAt,
+  );
+  const tasksByFlowId = new Map<string, TaskRecord[]>();
+  for (const task of loadTaskRegistryStateFromSqliteReadOnly().tasks.values()) {
+    const flowId = task.parentFlowId?.trim();
+    if (flowId) {
+      const linkedTasks = tasksByFlowId.get(flowId);
+      if (linkedTasks) {
+        linkedTasks.push(task);
+      } else {
+        tasksByFlowId.set(flowId, [task]);
+      }
+    }
+  }
+  return flows.flatMap((flow) => {
+    const linkedTasks = tasksByFlowId.get(flow.flowId) ?? [];
     const findings: TaskFlowRecoveryFinding[] = [];
     if (
       flow.syncMode === "managed" &&
       flow.status === "running" &&
-      tasks.length === 0 &&
+      linkedTasks.length === 0 &&
       flow.waitJson === undefined
     ) {
       findings.push({
@@ -51,7 +67,7 @@ function collectTaskFlowRecoveryFindings(): TaskFlowRecoveryFinding[] {
       flow.endedAt == null &&
       flow.status === "blocked" &&
       flow.blockedTaskId &&
-      !tasks.some((task) => task.taskId === flow.blockedTaskId)
+      !linkedTasks.some((task) => task.taskId === flow.blockedTaskId)
     ) {
       findings.push({
         flowId: flow.flowId,

--- a/src/cron/scratch-store.ts
+++ b/src/cron/scratch-store.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -79,13 +80,11 @@ export function readCronJobScratchState(
   return readScratchStateFromDatabase(db, cronStoreKey(storePath), jobId);
 }
 
-/** Resolves the current heartbeat monitor and its scratch with one narrow SQLite query. */
-export function readHeartbeatMonitorScratch(
+function readHeartbeatMonitorScratchFromDatabase(
+  db: DatabaseSync,
   storePath: string,
   agentId: string,
-  options: OpenClawStateDatabaseOptions = {},
 ): { jobId: string; state: CronJobScratchState } | undefined {
-  const { db } = openOpenClawStateDatabase(options);
   const storeKey = cronStoreKey(storePath);
   const cronDb = getCronStoreKysely(db);
   const row = executeSqliteQuerySync(
@@ -123,6 +122,28 @@ export function readHeartbeatMonitorScratch(
       updated_at_ms: row.updated_at_ms,
     }),
   };
+}
+
+/** Resolves the current heartbeat monitor and its scratch with one narrow SQLite query. */
+export function readHeartbeatMonitorScratch(
+  storePath: string,
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): { jobId: string; state: CronJobScratchState } | undefined {
+  const { db } = openOpenClawStateDatabase(options);
+  return readHeartbeatMonitorScratchFromDatabase(db, storePath, agentId);
+}
+
+/** Reads heartbeat scratch from existing shared state without creating or migrating it. */
+export function readHeartbeatMonitorScratchReadOnly(
+  storePath: string,
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): { jobId: string; state: CronJobScratchState } | undefined {
+  return withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) => readHeartbeatMonitorScratchFromDatabase(db, storePath, agentId),
+    options,
+  );
 }
 
 /** Writes, clears, or compare-and-swaps one scratch row. */

--- a/src/flows/doctor-core-bootstrap-size-check.test.ts
+++ b/src/flows/doctor-core-bootstrap-size-check.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CORE_HEALTH_CHECKS } from "./doctor-core-checks.js";
 import type { HealthCheck } from "./health-checks.js";
 
@@ -21,10 +21,30 @@ describe("core/doctor/bootstrap-size", () => {
   let tmp: string | undefined;
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     if (tmp !== undefined) {
       await fs.rm(tmp, { recursive: true, force: true });
       tmp = undefined;
     }
+  });
+
+  it("does not create shared state while inspecting bootstrap files", async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-bootstrap-readonly-"));
+    await fs.writeFile(join(tmp, "AGENTS.md"), "bootstrap", "utf-8");
+    const stateDir = join(tmp, "state-root");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    await expect(
+      getBootstrapSizeCheck().detect({
+        mode: "lint",
+        runtime,
+        cfg: { agents: { defaults: { workspace: tmp } } },
+        cwd: tmp,
+      }),
+    ).resolves.toEqual([]);
+    await expect(fs.stat(join(stateDir, "state", "openclaw.sqlite"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("honors the per-agent bootstrapMaxChars override in health findings", async () => {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -581,6 +581,7 @@ const bootstrapSizeCheck: HealthCheck = {
       workspaceDir,
       config: ctx.cfg,
       agentId: defaultAgentId,
+      readOnlyState: true,
     });
     const analysis = analyzeBootstrapBudget({
       files: buildBootstrapInjectionStats({

--- a/src/infra/device-pairing-store-readonly.ts
+++ b/src/infra/device-pairing-store-readonly.ts
@@ -1,0 +1,17 @@
+// Read-only device pairing snapshots avoid joining the shared-state writer lifecycle.
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import {
+  readDevicePairingStoreStateFromDatabase,
+  type DevicePairingStoreState,
+} from "./device-pairing-store.js";
+
+/** Load pairing state without creating or migrating the shared state database. */
+export function loadDevicePairingStoreStateReadOnly(baseDir?: string): DevicePairingStoreState {
+  const options = baseDir ? { env: { ...process.env, OPENCLAW_STATE_DIR: baseDir } } : {};
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(
+      ({ db }) => readDevicePairingStoreStateFromDatabase(db),
+      options,
+    ) ?? { pendingById: {}, pairedByDeviceId: {} }
+  );
+}

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -44,7 +44,7 @@ import {
 } from "./kysely-sync.js";
 import { clearApnsRegistrationFromDatabase } from "./push-apns-store-transaction.js";
 
-type DevicePairingStoreState = {
+export type DevicePairingStoreState = {
   pendingById: Record<string, DevicePairingPendingRecord>;
   pairedByDeviceId: Record<string, PairedDevice>;
 };
@@ -365,18 +365,7 @@ function fromBootstrapRow(row: DeviceBootstrapTokens): DeviceBootstrapTokenRecor
   };
 }
 
-/** Load the full pending + paired device snapshot from the shared state DB. */
-export function loadDevicePairingStoreState(baseDir?: string): DevicePairingStoreState {
-  const database = openOpenClawStateDatabase(resolveDevicePairingStateDbOptions(baseDir));
-  const { db } = database;
-  const validityToken = readDevicePairingStoreValidityToken(db);
-  if (
-    devicePairingStoreCache?.connection === db &&
-    devicePairingStoreCache.path === database.path &&
-    devicePairingStoreValidityTokensEqual(devicePairingStoreCache.validityToken, validityToken)
-  ) {
-    return structuredClone(devicePairingStoreCache.state);
-  }
+export function readDevicePairingStoreStateFromDatabase(db: DatabaseSync): DevicePairingStoreState {
   const kysely = getNodeSqliteKysely<OpenClawStateKyselyDatabase>(db);
   const pendingById: Record<string, DevicePairingPendingRecord> = {};
   for (const row of executeSqliteQuerySync(
@@ -392,7 +381,22 @@ export function loadDevicePairingStoreState(baseDir?: string): DevicePairingStor
   ).rows) {
     pairedByDeviceId[row.device_id] = fromPairedRow(row);
   }
-  const state = { pendingById, pairedByDeviceId };
+  return { pendingById, pairedByDeviceId };
+}
+
+/** Load the full pending + paired device snapshot from the shared state DB. */
+export function loadDevicePairingStoreState(baseDir?: string): DevicePairingStoreState {
+  const database = openOpenClawStateDatabase(resolveDevicePairingStateDbOptions(baseDir));
+  const { db } = database;
+  const validityToken = readDevicePairingStoreValidityToken(db);
+  if (
+    devicePairingStoreCache?.connection === db &&
+    devicePairingStoreCache.path === database.path &&
+    devicePairingStoreValidityTokensEqual(devicePairingStoreCache.validityToken, validityToken)
+  ) {
+    return structuredClone(devicePairingStoreCache.state);
+  }
+  const state = readDevicePairingStoreStateFromDatabase(db);
   devicePairingStoreCache = {
     connection: db,
     path: database.path,

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -14,6 +14,7 @@ import {
   roleScopesAllow,
 } from "../shared/operator-scope-compat.js";
 import { revokeDeviceBootstrapTokensForDevice } from "./device-bootstrap.js";
+import { loadDevicePairingStoreStateReadOnly } from "./device-pairing-store-readonly.js";
 import {
   loadDevicePairingStoreState,
   loadPairedDevicePairingStoreRecord,
@@ -215,6 +216,18 @@ async function loadState(baseDir?: string): Promise<DevicePairingStateFile> {
   pruneExpiredPending(state.pendingById, now, PAIRING_PENDING_TTL_MS);
   // Pending node-surface requests share the pairing TTL; requests refresh
   // their ts on reconnect so an actively retrying node keeps one alive.
+  for (const device of Object.values(state.pairedByDeviceId)) {
+    if (device.pendingNodeSurface && now - device.pendingNodeSurface.ts > PAIRING_PENDING_TTL_MS) {
+      delete device.pendingNodeSurface;
+    }
+  }
+  return state;
+}
+
+async function loadStateReadOnly(baseDir?: string): Promise<DevicePairingStateFile> {
+  const state: DevicePairingStateFile = loadDevicePairingStoreStateReadOnly(baseDir);
+  const now = Date.now();
+  pruneExpiredPending(state.pendingById, now, PAIRING_PENDING_TTL_MS);
   for (const device of Object.values(state.pairedByDeviceId)) {
     if (device.pendingNodeSurface && now - device.pendingNodeSurface.ts > PAIRING_PENDING_TTL_MS) {
       delete device.pendingNodeSurface;
@@ -796,6 +809,18 @@ function scopesWithinApprovedDeviceBaseline(params: {
 
 export async function listDevicePairing(baseDir?: string): Promise<DevicePairingList> {
   const state = await loadState(baseDir);
+  const pending = Object.values(state.pendingById)
+    .map(toPublicPendingDevicePairingRequest)
+    .toSorted((a, b) => b.ts - a.ts);
+  const paired = Object.values(state.pairedByDeviceId).toSorted(
+    (a, b) => b.approvedAtMs - a.approvedAtMs,
+  );
+  return { pending, paired };
+}
+
+/** List pairing state without creating or migrating shared state. */
+export async function listDevicePairingReadOnly(baseDir?: string): Promise<DevicePairingList> {
+  const state = await loadStateReadOnly(baseDir);
   const pending = Object.values(state.pendingById)
     .map(toPublicPendingDevicePairingRequest)
     .toSorted((a, b) => b.ts - a.ts);

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   ensureExecApprovals,
   loadExecApprovals,
+  loadExecApprovalsReadOnly,
   readExecApprovalsSnapshot,
   restoreExecApprovalsSnapshot,
   restoreExecApprovalsSnapshotLocked,
@@ -104,6 +105,39 @@ afterEach(() => {
 });
 
 describe("exec approvals SQLite store", () => {
+  it("does not create shared state for a read-only load", () => {
+    const statePath = resolveOpenClawStateSqlitePath();
+    expect(fs.existsSync(statePath)).toBe(false);
+
+    expect(loadExecApprovalsReadOnly()).toMatchObject({
+      version: 1,
+      agents: {},
+    });
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+
+  it("does not migrate older shared state for a read-only load", () => {
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "allowlist" },
+      agents: {},
+    });
+    const statePath = resolveOpenClawStateSqlitePath();
+    closeOpenClawStateDatabaseForTest();
+    const older = new DatabaseSync(statePath);
+    older.exec(`
+      PRAGMA user_version = 7;
+      UPDATE schema_meta SET schema_version = 7 WHERE meta_key = 'primary';
+    `);
+    older.close();
+
+    expect(loadExecApprovalsReadOnly().defaults?.security).toBe("allowlist");
+
+    const after = new DatabaseSync(statePath, { readOnly: true });
+    expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 7 });
+    after.close();
+  });
+
   it("uses a permissive missing-row default without creating the row", () => {
     expect(loadExecApprovals()).toEqual({
       version: 1,

--- a/src/infra/exec-approvals-store.ts
+++ b/src/infra/exec-approvals-store.ts
@@ -6,6 +6,7 @@ import {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -60,15 +61,31 @@ function warnFailClosed(message: string, error?: unknown): void {
   }
 }
 
-function readExecApprovalsSnapshotFromDatabase(): ExecApprovalsSnapshot {
-  assertNoPendingLegacyExecApprovals();
-  const { db } = openOpenClawStateDatabase();
+function snapshotFromExecApprovalsDatabase(
+  db: ReturnType<typeof openOpenClawStateDatabase>["db"],
+): ExecApprovalsSnapshot {
   return snapshotFromExecApprovalsRow({
     path: resolveExecApprovalsDisplayPath(),
     row: readExecApprovalsConfigRow(db),
     onMalformed: () =>
       warnFailClosed("exec approvals SQLite row is malformed; denying host execution"),
   });
+}
+
+function readExecApprovalsSnapshotFromDatabase(): ExecApprovalsSnapshot {
+  assertNoPendingLegacyExecApprovals();
+  return snapshotFromExecApprovalsDatabase(openOpenClawStateDatabase().db);
+}
+
+function readExecApprovalsSnapshotFromDatabaseReadOnly(): ExecApprovalsSnapshot {
+  assertNoPendingLegacyExecApprovals();
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => snapshotFromExecApprovalsDatabase(db)) ??
+    snapshotFromExecApprovalsRow({
+      path: resolveExecApprovalsDisplayPath(),
+      row: undefined,
+    })
+  );
 }
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
@@ -87,6 +104,19 @@ export function loadExecApprovals(): ExecApprovalsFile {
     return readExecApprovalsSnapshot().file;
   } catch (error) {
     if (!(error instanceof ExecApprovalsStoreUnavailableError)) {
+      throw error;
+    }
+    warnFailClosed("exec approvals SQLite state is unavailable; denying host execution", error);
+    return createFailClosedExecApprovalsFallback();
+  }
+}
+
+/** Loads exec approvals without creating or migrating shared state. */
+export function loadExecApprovalsReadOnly(): ExecApprovalsFile {
+  try {
+    return readExecApprovalsSnapshotFromDatabaseReadOnly().file;
+  } catch (error) {
+    if (error instanceof ExecApprovalsMigrationRequiredError) {
       throw error;
     }
     warnFailClosed("exec approvals SQLite state is unavailable; denying host execution", error);

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -33,6 +33,7 @@ export {
   ensureExecApprovalsSnapshot,
   loadExecApprovals,
   loadExecApprovalsAsync,
+  loadExecApprovalsReadOnly,
   readExecApprovalsSnapshot,
   restoreExecApprovalsSnapshot,
   restoreExecApprovalsSnapshotLocked,

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { Insertable, Selectable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -212,6 +213,18 @@ export function loadTaskFlowRegistryStateFromSqlite(): TaskFlowRegistryStoreSnap
   return {
     flows: new Map(rows.map((row) => [row.flow_id, rowToFlowRecord(row)])),
   };
+}
+
+/** Loads task flows without creating or migrating shared state. */
+export function loadTaskFlowRegistryStateFromSqliteReadOnly(): TaskFlowRegistryStoreSnapshot {
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+      const rows = selectFlowRows(db);
+      return {
+        flows: new Map(rows.map((row) => [row.flow_id, rowToFlowRecord(row)])),
+      };
+    }) ?? { flows: new Map() }
+  );
 }
 
 export function saveTaskFlowRegistryStateToSqlite(snapshot: TaskFlowRegistryStoreSnapshot) {

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./task-flow-registry.js";
 import {
   loadTaskFlowRegistryStateFromSqlite,
+  loadTaskFlowRegistryStateFromSqliteReadOnly,
   saveTaskFlowRegistryStateToSqlite,
 } from "./task-flow-registry.store.sqlite.js";
 import {
@@ -100,6 +101,21 @@ describe("task-flow-registry store runtime", () => {
     vi.useRealTimers();
     restoreOriginalStateDir();
     resetTaskFlowRegistryForTests();
+  });
+
+  it("does not create shared state for a read-only flow snapshot", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-flow-store-readonly-" },
+      async (state) => {
+        process.env.OPENCLAW_STATE_DIR = state.stateDir;
+        resetTaskFlowRegistryForTests({ persist: false });
+        const statePath = resolveOpenClawStateSqlitePath();
+        expect(() => statSync(statePath)).toThrow();
+
+        expect(loadTaskFlowRegistryStateFromSqliteReadOnly().flows.size).toBe(0);
+        expect(() => statSync(statePath)).toThrow();
+      },
+    );
   });
 
   it("uses the configured flow store for restore and save", () => {

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -5,6 +5,7 @@ import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-syn
 import { assertSqliteTableIntegrity } from "../infra/sqlite-integrity.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -354,6 +355,26 @@ export function loadTaskRegistryStateFromSqlite(): TaskRegistryStoreSnapshot {
       ),
     };
   });
+}
+
+/** Loads task records without creating or migrating shared state. */
+export function loadTaskRegistryStateFromSqliteReadOnly(): TaskRegistryStoreSnapshot {
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db, path }) =>
+      runSqliteDeferredTransactionSync(db, () => {
+        assertSqliteTableIntegrity(db, path, "task_runs");
+        assertSqliteTableIntegrity(db, path, "task_delivery_state");
+        const taskRows = selectTaskRows(db);
+        const deliveryRows = selectTaskDeliveryStateRows(db);
+        return {
+          tasks: new Map(taskRows.map((row) => [row.task_id, rowToTaskRecord(row)])),
+          deliveryStates: new Map(
+            deliveryRows.map((row) => [row.task_id, rowToTaskDeliveryState(row)]),
+          ),
+        };
+      }),
+    ) ?? { tasks: new Map(), deliveryStates: new Map() }
+  );
 }
 
 export function listTaskRegistryRecordsByOwnerKeyFromSqlite(ownerKey: string): TaskRecord[] {

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -43,6 +43,7 @@ import {
 } from "./task-registry.store.js";
 import {
   loadTaskRegistryStateFromSqlite,
+  loadTaskRegistryStateFromSqliteReadOnly,
   saveTaskRegistryStateToSqlite,
 } from "./task-registry.store.sqlite.js";
 import type { TaskDeliveryState, TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
@@ -133,6 +134,20 @@ function createUnsafeTaskOwnerIndex(database: DatabaseSync): void {
 }
 
 describe("task-registry store runtime", () => {
+  it("does not create shared state for a read-only task snapshot", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-store-readonly-" },
+      async () => {
+        const statePath = resolveOpenClawStateSqlitePath();
+        expect(() => statSync(statePath)).toThrow();
+
+        const snapshot = loadTaskRegistryStateFromSqliteReadOnly();
+        expect(snapshot.tasks.size).toBe(0);
+        expect(snapshot.deliveryStates.size).toBe(0);
+        expect(() => statSync(statePath)).toThrow();
+      },
+    );
+  });
   let testState: OpenClawTestState;
 
   beforeAll(async () => {


### PR DESCRIPTION
Related: #119583

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --lint --all --json` against an existing environment could have the supposedly read-only command open the shared SQLite database through writable owners and migrate it. During a candidate-runtime preflight, that can make the still-running older gateway unable to read its own durable state.

## Why This Change Was Made

Every lint check now reads existing state through its owning non-creating, non-migrating SQLite seam: heartbeat scratch, exec approvals, workspace setup, task/task-flow status, and device pairing. Ordinary runtime and explicit repair paths retain their existing writable migration behavior. A process-wide write switch or post-hoc rollback was rejected because either can expose partially migrated state or turn diagnostics into hidden write failures.

## User Impact

Operators can run the documented read-only doctor lint flow on older shared-state schemas without advancing the schema, creating a database, or adding WAL/SHM artifacts. Normal gateway startup, repair, pairing, approvals, and workspace/task persistence continue to migrate and write as before.

## Evidence

- Red on the exact schema-7 parent (`72e67904be8b17985b18893ece68fccaea50cb59`): heartbeat-only and full `--all` lint advanced `PRAGMA user_version` from 7 to 8 and changed the database digest.
- Green on exact head `a620205caa18c09559efbe16800c6328074ed0cf`: full `--lint --all --json` returned parseable JSON while schema version, seeded rows, database SHA-256, and state-directory inventory remained identical; no WAL/SHM appeared (98.1s check execution).
- Absent-database regressions cover heartbeat scratch, exec approvals, workspace setup/bootstrap, task registry, task-flow registry, and device pairing.
- Focused owner/runtime suites: 94 tests passed; task/task-flow registry suites: 53 passed; CLI policy/registration/lint suites: 68 passed; device pairing: 9 passed; workspace status: 12 passed.
- Existing writable repair/runtime tests remain green as negative controls.
- `oxlint` for all changed files: 0 warnings/errors. `oxfmt --check` and `git diff --check`: passed.
- Source-blind behavior contract: passed against a copied schema-7 environment.
- Autoreview (Codex, high reasoning) and TruffleHog: clean on the exact patch.

Production LOC: +226/-43 (net +183). This growth is the explicit owner boundary needed to preserve diagnostic output across five independent stores without changing ordinary writable callers. Tests: +176/-5.

AI-assisted: yes. I reviewed the owner paths, reproduction, generated diff, and validation results.
