### PR TITLE
fix(gateway): preserve targetless media session ownership

### DIFF
--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -312,6 +312,8 @@ async function evaluateQueuedGeneratedMediaAgentResult(params: {
 /** Runs durable generated-media handoffs through the normal owning-session agent loop. */
 export async function deliverQueuedGeneratedMediaAgentTurn(params: {
   canonicalKey: string;
+  agentId: string;
+  storePath: string;
   entry: QueuedSessionDelivery;
   sessionEntry?: SessionEntry;
   stateDir?: string;
@@ -342,7 +344,9 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
             throw new Error("queued internal generated-media delivery has no owning session");
           }
           const appended = await appendAssistantMessageToSessionTranscript({
+            agentId: params.agentId,
             sessionKey: params.canonicalKey,
+            storePath: params.storePath,
             expectedSessionId: sessionId,
             ...(params.sessionEntry?.cronRunContinuation?.lifecycleRevision
               ? {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -2,6 +2,10 @@
 // session/channel context used when the gateway resumes an interrupted run.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import {
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
 import type { RestartSentinelPayload } from "../infra/restart-sentinel.js";
 import { resolveSystemEventOptionsOwnerAgentId } from "../infra/system-event-ownership.js";
 import {
@@ -36,6 +40,8 @@ type FailSessionDeliveryMock =
   typeof import("../infra/session-delivery-queue-storage.js").failSessionDelivery;
 type RecoverPendingSessionDeliveriesMock =
   typeof import("../infra/session-delivery-queue-recovery.js").recoverPendingSessionDeliveries;
+type AppendAssistantMessageToSessionTranscriptMock =
+  typeof import("../config/sessions/transcript.js").appendAssistantMessageToSessionTranscript;
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -152,11 +158,18 @@ const mocks = vi.hoisted(() => {
     failSessionDelivery: vi.fn<FailSessionDeliveryMock>(async () => {}),
     markSessionDeliveryAttemptStarted: vi.fn(async () => {}),
     markSessionDeliverySettlement: vi.fn(async () => {}),
-    appendAssistantMessageToSessionTranscript: vi.fn(async () => ({
-      ok: true as const,
-      sessionFile: "/tmp/session.jsonl",
-      messageId: "generated-media-transcript",
-    })),
+    appendAssistantMessageToSessionTranscript: vi.fn<AppendAssistantMessageToSessionTranscriptMock>(
+      async () => ({
+        ok: true as const,
+        target: {
+          agentId: "main",
+          sessionId: "main",
+          sessionKey: "agent:main:main",
+          storePath: "/tmp/sessions.json",
+        },
+        messageId: "generated-media-transcript",
+      }),
+    ),
     removeCronRunContinuationSessionIfIdle: vi.fn(async () => {}),
     settleCorrelatedSubagentDelivery: vi.fn(async () => {}),
     loadPendingSessionDelivery: vi.fn(),
@@ -600,6 +613,7 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.loadSessionEntry.mockReset();
     mocks.loadSessionEntry.mockImplementation((sessionKey: string) => ({
       cfg: {},
+      agentId: "main",
       entry: { sessionId: sessionKey, updatedAt: 0 },
       store: {},
       storePath: "/tmp/sessions.json",
@@ -1497,13 +1511,87 @@ describe("scheduleRestartSentinelWake", () => {
       },
     );
     expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
+      agentId: "main",
       sessionKey: "agent:main:main",
+      storePath: "/tmp/sessions.json",
       expectedSessionId: "agent:main:main",
       mediaUrls: ["/tmp/proof.png"],
       idempotencyKey: "image:task-internal:agent-loop:generated-media-transcript",
       updateMode: "inline",
     });
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("persists targetless global generated media in its resolved owner transcript", async () => {
+    const sessionId = "ops-global-session";
+    const opsStorePath = testState.statePath("agents", "ops", "sessions", "sessions.json");
+    const researchStorePath = testState.statePath(
+      "agents",
+      "research",
+      "sessions",
+      "sessions.json",
+    );
+    await upsertSessionEntryCore(
+      { agentId: "ops", sessionKey: "global", storePath: opsStorePath },
+      { sessionId, updatedAt: 1 },
+    );
+    await upsertSessionEntryCore(
+      { agentId: "research", sessionKey: "global", storePath: researchStorePath },
+      { sessionId: "research-global-session", updatedAt: 1 },
+    );
+    const { appendAssistantMessageToSessionTranscript } = await vi.importActual<
+      typeof import("../config/sessions/transcript.js")
+    >("../config/sessions/transcript.js");
+    mocks.appendAssistantMessageToSessionTranscript.mockImplementationOnce(
+      appendAssistantMessageToSessionTranscript,
+    );
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      agentId: "ops",
+      entry: { sessionId, updatedAt: 1 },
+      store: {},
+      storePath: opsStorePath,
+      canonicalKey: "global",
+      storeKeys: ["global"],
+      legacyKey: undefined,
+    });
+
+    await deliverGeneratedMedia({
+      id: "session-delivery-media-global",
+      sessionKey: "global",
+      messageId: "image:task-global:agent-loop",
+      route: { channel: "webchat", to: "global", chatType: "direct" },
+      expectedMediaUrls: ["/tmp/proof.png"],
+    });
+
+    const opsEvents = await loadTranscriptEvents({
+      agentId: "ops",
+      sessionId,
+      sessionKey: "global",
+      storePath: opsStorePath,
+    });
+    expect(opsEvents).toMatchObject([
+      { type: "session", id: sessionId },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "proof.png" }],
+        },
+      },
+    ]);
+    await expect(
+      loadTranscriptEvents({
+        agentId: "research",
+        sessionId: "research-global-session",
+        sessionKey: "global",
+        storePath: researchStorePath,
+      }),
+    ).resolves.toEqual([]);
+    expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+    expect(mocks.failSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.deferSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
   });
 
   it("persists proven internal media before retrying the missing subset", async () => {
@@ -1524,7 +1612,9 @@ describe("scheduleRestartSentinelWake", () => {
 
     expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
       expect.objectContaining({
+        agentId: "main",
         mediaUrls: ["/tmp/one.png"],
+        storePath: "/tmp/sessions.json",
         idempotencyKey: "image:task-internal-partial:agent-loop:generated-media-transcript",
       }),
     );

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -1,6 +1,5 @@
 // Gateway restart sentinel recovery.
 // Resumes pending restart continuations and outbound delivery after process restart.
-import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import {
   resolveCorrelatedSubagentDelivery,
   settleCorrelatedSubagentDelivery,
@@ -207,12 +206,12 @@ export async function deliverQueuedSessionDelivery(params: {
   stateDir?: string;
 }) {
   const queuedEntry = resolveCorrelatedSubagentDelivery(params.entry);
-  const { cfg, entry, storePath, canonicalKey } = loadSessionEntry(queuedEntry.sessionKey);
+  const { cfg, agentId, entry, storePath, canonicalKey } = loadSessionEntry(queuedEntry.sessionKey);
   const deliveryContext = resolveQueuedSessionDeliveryContext(queuedEntry);
 
   if (queuedEntry.kind === "systemEvent") {
-    const { agentId, text } = queuedEntry;
-    enqueueRestartSentinelWake(text, canonicalKey, agentId, deliveryContext);
+    const { agentId: systemEventAgentId, text } = queuedEntry;
+    enqueueRestartSentinelWake(text, canonicalKey, systemEventAgentId, deliveryContext);
     return;
   }
 
@@ -239,6 +238,8 @@ export async function deliverQueuedSessionDelivery(params: {
     await deliverQueuedGeneratedMediaAgentTurn({
       entry: queuedEntry,
       canonicalKey,
+      agentId,
+      storePath,
       sessionEntry: entry,
       ...(params.stateDir !== undefined ? { stateDir: params.stateDir } : {}),
     })
@@ -259,10 +260,6 @@ export async function deliverQueuedSessionDelivery(params: {
   const route = queuedEntry.route;
   const messageId = resolveQueuedRestartContinuationMessageId(queuedEntry);
   const userMessage = queuedEntry.message.trim();
-  const agentId = resolveSessionAgentId({
-    sessionKey: canonicalKey,
-    config: cfg,
-  });
   let dispatchError: unknown;
   const ctxPayload = finalizeInboundContext(
     {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an internally generated attachment recovered after a Gateway restart could be persisted through the wrong agent/session store when the durable delivery used a targetless `global` session key. Two agents can legally have the same literal key in separate stores, so re-deriving ownership from the key can misroute or lose the transcript attachment.

## Why This Change Was Made

The restart sentinel already resolves the authoritative `agentId`, canonical key, and store path together when it loads the queued session. This change carries those resolved facts into generated-media transcript persistence and removes the later redundant agent re-resolution. It does not change delivery/replay behavior, routing, config, protocol, schema, retention, or security policy.

Production code is net +1 line: the new owner arguments are absorbed by deleting the redundant resolver path. Tests are net +90 lines. No changelog entry is needed because this is internal restart-recovery correctness with no public surface change.

## User Impact

Targetless generated media recovered after restart now appears exactly once in the resolved owning agent's transcript. Another agent with the same `global` key remains untouched.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31874066179
- `pnpm build` passed against the synchronized three-file source hashes.
- Focused Gateway suite: 75/75 tests passed in `src/gateway/server-restart-sentinel.test.ts`.
- Full changed gate passed: format, lint, core/test types, import cycles, media guard, database-first guard, native schema guard, runtime-sidecar guard, and boundary checks.
- Built-Gateway restart proof used two agents with separate stores and the same targetless `global` key. The non-main `ops` owner received one stable attachment event; the `main` decoy received zero. The 68-byte attachment hash was `4b5c5c92cec3b23e6a294fc0eea43234ef5126c5a64f4c6c531ac8430ab0b844`.
- The durable session queue reached `completed_permanent` with retry count 0, no pending or failed rows, and no defer/advance/dead-letter metadata. A second Gateway start preserved the same event ID without duplication; both processes exited 0 and state/port cleanup passed.
- Fresh Codex autoreview: clean, no actionable findings (0.99 confidence).
