### PR TITLE
fix(acp): don't send inherited thinking default as an ACP config control

### DIFF
--- a/src/agents/subagents/spawn/acp-spawn-runtime.ts
+++ b/src/agents/subagents/spawn/acp-spawn-runtime.ts
@@ -25,10 +25,7 @@ import {
   type SessionBindingRecord,
 } from "../../../infra/outbound/session-binding-service.js";
 import { resolveAgentConfig } from "../../agent-scope.js";
-import {
-  resolveConfiguredSubagentSpawnModelSelection,
-  resolveThinkingDefault,
-} from "../../model-selection.js";
+import { resolveConfiguredSubagentSpawnModelSelection } from "../../model-selection.js";
 import type { PreparedSpawnThreadBinding } from "../../spawn-plan.js";
 import { persistAcpSpawnSessionFileBestEffort } from "./acp-spawn-requester.js";
 import { splitModelRef } from "./subagent-spawn-plan.js";
@@ -117,17 +114,7 @@ export function resolveAcpSpawnRuntimeOptions(params: {
     };
   }
 
-  let thinking = thinkingPlan.thinkingOverride;
-  if (!thinking && model) {
-    const { provider, model: modelId } = splitModelRef(model);
-    if (provider && modelId) {
-      thinking = resolveThinkingDefault({
-        cfg: params.cfg,
-        provider,
-        model: modelId,
-      });
-    }
-  }
+  const thinking = params.thinking ? thinkingPlan.thinkingOverride : undefined;
 
   const timeoutSeconds = resolveAcpRuntimeTimeoutSeconds(params.runTimeoutSeconds);
   const runtimeOptions =

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1041,7 +1041,7 @@ describe("spawnAcpDirect", () => {
     expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
   });
 
-  it("applies existing subagent model and model-profile thinking defaults to ACP runtime options", async () => {
+  it("does not apply model-profile thinking defaults to ACP runtime options", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),
       agents: {
@@ -1075,12 +1075,11 @@ describe("spawnAcpDirect", () => {
       agent: "codex",
       runtimeOptions: {
         model: "openai/gpt-5.4",
-        thinking: "high",
       },
     });
   });
 
-  it("uses configured runtime=acp agent defaults before launching the external ACP agent", async () => {
+  it("does not apply configured runtime=acp agent thinking defaults", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),
       agents: {
@@ -1121,7 +1120,6 @@ describe("spawnAcpDirect", () => {
       agent: "codex",
       runtimeOptions: {
         model: "openai/gpt-5.5",
-        thinking: "low",
       },
     });
   });
@@ -1165,7 +1163,6 @@ describe("spawnAcpDirect", () => {
       agent: "codex",
       runtimeOptions: {
         model: "anthropic/claude-sonnet-4-6",
-        thinking: "off",
       },
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `sessions_spawn runtime="acp" agentId="claude"` could fail on a host with `agents.defaults.thinkingDefault` configured, even when the spawn call did not include a `thinking` parameter. The exact error was:

```text
AcpRuntimeError: ACP backend "acpx" does not accept config key "thinking".: code=ACP_BACKEND_UNSUPPORTED_CONTROL
```

Reproduction:

1. Run OpenClaw on a host whose `agents.defaults.thinkingDefault` is set.
2. Use `sessions_spawn runtime="acp" agentId="claude"` without an explicit `thinking` parameter.
3. Observe ACP session startup fail with the error above.

## Why This Change Was Made

The ACP spawn path used the host's global/agent thinking default when the caller did not provide `thinking`, then emitted the inherited value as an ACP config control. `claude-agent-acp` 0.25.3 advertises only `model` and `mode`; it has no thinking or effort config key, so no thinking value can be valid for that backend.

Before:

```ts
let thinking = thinkingPlan.thinkingOverride;
if (!thinking && model) {
  const { provider, model: modelId } = splitModelRef(model);
  if (provider && modelId) {
    thinking = resolveThinkingDefault({
      cfg: params.cfg,
      provider,
      model: modelId,
    });
  }
}
```

After:

```ts
const thinking = params.thinking ? thinkingPlan.thinkingOverride : undefined;
```

This keeps validation and error handling for an invalid explicitly requested thinking level, but omits the ACP config control when the spawn caller did not explicitly request one. Non-ACP subagent thinking inheritance is unchanged because this change is local to the ACP spawn runtime-options path.

## User Impact

ACP Claude spawns no longer fail solely because the host has a thinking default configured. Explicit ACP spawn thinking requests retain their existing validation and forwarding behavior.

## Evidence

Validated on OpenClaw v2026.6.11 with `claude-agent-acp` 0.25.3:

- Before the fix, the reproduction failed 100% of the time with `ACP_BACKEND_UNSUPPORTED_CONTROL`.
- After the fix and a real gateway restart, the ACP smoke test returned `ACP-BRIDGE-OK`.
- The updated focused test failed against the pre-fix source in all three inherited-default cases, showing the unexpected `thinking` controls (`high`, `low`, and `off`).
- `pnpm test src/agents/subagents/spawn/acp-spawn.test.ts`: 71 tests passed.
- `pnpm tsgo`: passed.
- `pnpm format:check src/agents/subagents/spawn/acp-spawn-runtime.ts src/agents/subagents/spawn/acp-spawn.test.ts`: passed.
- `node scripts/run-oxlint.mjs src/agents/subagents/spawn/acp-spawn-runtime.ts src/agents/subagents/spawn/acp-spawn.test.ts`: 0 warnings, 0 errors.

AI-assisted: the change was prepared with an AI coding assistant and reviewed against the source and focused tests.
