### PR TITLE
improve(test): speed up Mattermost send suite

### DIFF
--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -2,7 +2,7 @@ import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbou
 // Mattermost tests cover send plugin behavior.
 import { expectProvidedCfgSkipsRuntimeLoad } from "openclaw/plugin-sdk/channel-test-helpers";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let sendMessageMattermost: typeof import("./send.js").sendMessageMattermost;
 let parseMattermostTarget: typeof import("./target-resolution.js").parseMattermostTarget;
@@ -226,16 +226,24 @@ vi.mock("../runtime.js", () => ({
   }),
 }));
 
+beforeAll(async () => {
+  ({ sendMessageMattermost } = await import("./send.js"));
+  ({ parseMattermostTarget } = await import("./target-resolution.js"));
+});
+
 describe("sendMessageMattermost", () => {
-  beforeEach(async () => {
-    vi.resetModules();
+  let defaultAccountSequence = 0;
+
+  beforeEach(() => {
     mockState.loadConfig.mockReset();
     mockState.loadConfig.mockReturnValue({});
     mockState.recordActivity.mockReset();
     mockState.resolveMattermostAccount.mockReset();
+    // Production caches are keyed by token; keep each test in its own real namespace.
+    const cacheNamespace = `mattermost-cache-${defaultAccountSequence++}`;
     mockState.resolveMattermostAccount.mockReturnValue({
       accountId: "default",
-      botToken: "bot-token",
+      botToken: cacheNamespace,
       baseUrl: "https://mattermost.example.com",
       config: {},
     });
@@ -257,8 +265,6 @@ describe("sendMessageMattermost", () => {
     mockState.fetchMattermostUserTeams.mockResolvedValue([{ id: "team-1" }]);
     mockState.fetchMattermostChannelByName.mockResolvedValue({ id: "town-square" });
     mockState.uploadMattermostFile.mockResolvedValue({ id: "file-1" });
-    ({ sendMessageMattermost } = await import("./send.js"));
-    ({ parseMattermostTarget } = await import("./target-resolution.js"));
   });
 
   it("uses provided cfg and skips runtime loadConfig", async () => {
@@ -965,8 +971,7 @@ describe("sendMessageMattermost user-first resolution", () => {
 describe("sendMessageMattermost outbound cache bounds", () => {
   const baseUrl = "https://mattermost.example.com";
 
-  beforeEach(async () => {
-    vi.resetModules();
+  beforeEach(() => {
     vi.clearAllMocks();
     mockState.resolveMattermostAccount.mockReturnValue({
       accountId: "default",
@@ -989,7 +994,6 @@ describe("sendMessageMattermost outbound cache bounds", () => {
     mockState.fetchMattermostChannelByName.mockImplementation(
       async (_client, _teamId: string, name: string) => ({ id: `channel-${name}` }),
     );
-    ({ sendMessageMattermost } = await import("./send.js"));
   });
 
   const send = async (to: string, token: string) =>


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable runtime and memory overhead in the Mattermost send test suite. The suite retained per-test `vi.resetModules()` and dynamic owner imports after its old test-only cache reset was removed, so every test rebuilt the real send and target-resolution module graph.

## Why This Change Was Made

The test file now imports the real send and target-resolution owners once, after mocks are installed, while preserving every test and assertion. Default-account tests use a unique `botToken` namespace per test because the production caches are keyed by base URL and token; cache-bound tests keep their explicit independent tokens. This exercises real production isolation without adding a production seam, clearing caches, weakening assertions, or using timing shortcuts.

The one-time import is deliberately file-scoped. An earlier candidate put `beforeAll` inside the first describe block, which made a filtered run of the later cache-bound suite fail with `sendMessageMattermost is not a function`; moving the hook to file scope fixed that filtered path.

## User Impact

No product behavior changes. Mattermost's test suite keeps the same 49 tests and production composition while running with materially lower body time, CPU, and peak memory.

## Evidence

- Controlled corrected-shape A/B on the same Blacksmith Testbox (`tbx_01m0286f8cx9x8rgrjj1yn93k0`, [run 31874291639](https://github.com/openclaw/openclaw/actions/runs/31874291639), stopped):
  - wall: 17.955s -> 14.645s (-18.4%)
  - harness: 17.685s -> 14.305s (-19.1%)
  - Vitest: 15.060s -> 11.635s (-22.7%)
  - test body: 4.900s -> 0.524s (-89.3%)
  - import: 9.550s -> 10.500s (+9.9% noise); the real owner graph still imports once
  - CPU user/sys: 20.560s/2.475s -> 16.425s/1.950s
  - peak RSS: 2,388,506 -> 1,394,596 KiB (-41.6%, about 971 MiB)
- Filtered cache-bound suite: 4/4 passed after the file-scoped hook correction.
- Constant-token mutation: collapsing the unique namespace to one token caused 6/49 failures through stale `channel-second` classification; restoring unique production cache keys returned the file to green.
- Owner and sibling proof: 65/65 passed across the send, target-resolution, real-HTTP loopback, and channel send-loopback tests.
- Extension boundaries: 28/28 passed across `extension-import-boundaries` and `extension-test-boundary`.
- Fresh current-base changed gate: all 18 steps passed on `tbx_01m0297956c23rpb7g2vbc2x9a`, [run 31875025720](https://github.com/openclaw/openclaw/actions/runs/31875025720), stopped.
- Targeted formatting and `git diff --check` passed. Fresh committed-branch autoreview reported no actionable findings.
- Diff: tests +13/-9; production +0/-0. No changelog, dependency, schema, protocol, baseline, budget, or production seam changes.
