### PR TITLE
fix(maintainers): preserve PR merge attribution

### DIFF
--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -230,14 +230,7 @@ merge_author_email_candidates() {
   local reviewer="$1"
   local reviewer_id="$2"
 
-  local gh_email
-  gh_email=$(gh_plain api user --jq '.email // ""' 2>/dev/null || true)
-  local git_email
-  git_email=$(git config user.email 2>/dev/null || true)
-
   printf '%s\n' \
-    "$gh_email" \
-    "$git_email" \
     "${reviewer_id}+${reviewer}@users.noreply.github.com" \
     "${reviewer}@users.noreply.github.com" | awk 'NF && !seen[$0]++'
 }

--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -221,6 +221,27 @@ wait_for_pr_head_sha() {
   return 1
 }
 
+is_author_email_merge_error() {
+  local msg="$1"
+  printf '%s\n' "$msg" | rg -qi 'author.?email|email.*associated|associated.*email|invalid.*email'
+}
+
+merge_author_email_candidates() {
+  local reviewer="$1"
+  local reviewer_id="$2"
+
+  local gh_email
+  gh_email=$(gh_plain api user --jq '.email // ""' 2>/dev/null || true)
+  local git_email
+  git_email=$(git config user.email 2>/dev/null || true)
+
+  printf '%s\n' \
+    "$gh_email" \
+    "$git_email" \
+    "${reviewer_id}+${reviewer}@users.noreply.github.com" \
+    "${reviewer}@users.noreply.github.com" | awk 'NF && !seen[$0]++'
+}
+
 pr_contributor_allows_human_trailers() {
   local contrib="${1:-}"
   local normalized

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -33,6 +33,18 @@ auto_merge_unavailable_error() {
     "$log_file"
 }
 
+commit_message_has_exact_line() {
+  local message="$1"
+  local expected="$2"
+  local line
+  while IFS= read -r line; do
+    if [ "$line" = "$expected" ]; then
+      return 0
+    fi
+  done <<< "$message"
+  return 1
+}
+
 mainline_drift_requires_sync() {
   local mainline_base="$1"
   local prepared_head_sha="$2"
@@ -242,7 +254,13 @@ merge_run() {
   source .local/prep.env
 
   local pr_meta_json
-  pr_meta_json=$(read_pr_view_json "$pr" "state,isDraft") || exit 1
+  pr_meta_json=$(read_pr_view_json "$pr" "number,title,state,isDraft,author") || exit 1
+  local pr_title
+  pr_title=$(printf '%s\n' "$pr_meta_json" | jq -r .title)
+  local pr_number
+  pr_number=$(printf '%s\n' "$pr_meta_json" | jq -r .number)
+  local contrib
+  contrib=$(printf '%s\n' "$pr_meta_json" | jq -r .author.login)
   local is_draft
   is_draft=$(printf '%s\n' "$pr_meta_json" | jq -r .isDraft)
   if [ "$is_draft" = "true" ]; then
@@ -306,6 +324,88 @@ merge_run() {
     exit 2
   fi
 
+  local attributed_merge=false
+  local reviewer=""
+  local reviewer_id=""
+  local reviewer_coauthor_email=""
+  local contrib_coauthor_email=""
+  local selected_merge_author_email=""
+  local reviewer_email_candidates=()
+  if [ "$merge_method" != "rebase" ]; then
+    attributed_merge=true
+    reviewer=$(gh_plain api user --jq .login)
+    reviewer_id=$(gh_plain api user --jq .id)
+    reviewer_coauthor_email="${reviewer_id}+${reviewer}@users.noreply.github.com"
+
+    if pr_contributor_allows_human_trailers "$contrib"; then
+      contrib_coauthor_email="${COAUTHOR_EMAIL:-}"
+      if [ -z "$contrib_coauthor_email" ] || [ "$contrib_coauthor_email" = "null" ]; then
+        if ! contrib_coauthor_email=$(resolve_contributor_coauthor_email "$contrib"); then
+          echo "Unable to resolve a co-author email for PR author $contrib"
+          exit 1
+        fi
+      fi
+    fi
+
+    local reviewer_email_candidate
+    while IFS= read -r reviewer_email_candidate; do
+      [ -n "$reviewer_email_candidate" ] || continue
+      reviewer_email_candidates+=("$reviewer_email_candidate")
+    done < <(merge_author_email_candidates "$reviewer" "$reviewer_id")
+    if [ "${#reviewer_email_candidates[@]}" -eq 0 ]; then
+      echo "Unable to resolve a candidate merge author email for reviewer $reviewer"
+      exit 1
+    fi
+    selected_merge_author_email="${reviewer_email_candidates[0]}"
+
+    {
+      echo "Merged via $merge_label."
+      echo
+      echo "Prepared head SHA: $PREP_HEAD_SHA"
+      if [ -n "$contrib_coauthor_email" ]; then
+        echo "Co-authored-by: $contrib <$contrib_coauthor_email>"
+      fi
+      echo "Co-authored-by: $reviewer <$reviewer_coauthor_email>"
+      echo "Reviewed-by: @$reviewer"
+    } > .local/merge-body.txt
+  fi
+
+  local MERGE_ERR_MSG=""
+  invoke_attributed_merge() {
+    local mode="$1"
+    local email="$2"
+    local merge_args=(pr merge "$pr")
+    if [ "$mode" = "auto" ]; then
+      merge_args+=(--auto)
+    fi
+    merge_args+=(
+      "$merge_flag"
+      --match-head-commit "$PREP_HEAD_SHA"
+      --author-email "$email"
+      --subject "$pr_title (#$pr_number)"
+      --body-file .local/merge-body.txt
+    )
+    gh_plain "${merge_args[@]}" >.local/merge-output.log 2>&1
+  }
+
+  run_attributed_merge() {
+    local mode="$1"
+    if invoke_attributed_merge "$mode" "$selected_merge_author_email"; then
+      return 0
+    fi
+
+    MERGE_ERR_MSG=$(cat .local/merge-output.log)
+    if is_author_email_merge_error "$MERGE_ERR_MSG" && [ "${#reviewer_email_candidates[@]}" -ge 2 ]; then
+      selected_merge_author_email="${reviewer_email_candidates[1]}"
+      echo "Retrying merge once with fallback author email: $selected_merge_author_email"
+      if invoke_attributed_merge "$mode" "$selected_merge_author_email"; then
+        return 0
+      fi
+      MERGE_ERR_MSG=$(cat .local/merge-output.log)
+    fi
+    return 1
+  }
+
   local merge_submitted=false
   local state=""
   # Auto-merge is only a post-verification landing strategy. Keep every
@@ -359,11 +459,7 @@ merge_run() {
     else
       # GitHub's EnablePullRequestAutoMergeInput contract keeps expectedHeadOid
       # as the head that must match to allow the eventual merge.
-      if gh_plain pr merge "$pr" \
-        --auto \
-        --squash \
-        --match-head-commit "$PREP_HEAD_SHA" \
-        >.local/merge-output.log 2>&1
+      if run_attributed_merge auto
       then
         auto_meta=$(read_pr_view_json "$pr" "state,headRefOid,mergeable,mergeStateStatus,autoMergeRequest") || exit 1
         auto_head_sha=$(printf '%s\n' "$auto_meta" | jq -r .headRefOid)
@@ -415,7 +511,12 @@ merge_run() {
   fi
 
   if [ "$merge_submitted" != "true" ]; then
-    if ! gh_plain pr merge "$pr" \
+    if [ "$attributed_merge" = "true" ]; then
+      if ! run_attributed_merge immediate; then
+        print_relevant_log_excerpt .local/merge-output.log
+        exit 1
+      fi
+    elif ! gh_plain pr merge "$pr" \
       "$merge_flag" \
       --match-head-commit "$PREP_HEAD_SHA" \
       >.local/merge-output.log 2>&1
@@ -453,6 +554,37 @@ merge_run() {
   fi
   local repo_nwo
   repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+  if [ "$attributed_merge" = "true" ]; then
+    local landed_commit_json
+    if ! landed_commit_json=$(gh_plain api "repos/$repo_nwo/commits/$landed_sha"); then
+      echo "Landed commit is not resolvable via repository commit endpoint: $landed_sha"
+      exit 1
+    fi
+    local landed_author_email
+    landed_author_email=$(printf '%s\n' "$landed_commit_json" | jq -r '.commit.author.email // ""')
+    if [ "$landed_author_email" != "$selected_merge_author_email" ]; then
+      echo "Landed commit author email mismatch (expected $selected_merge_author_email, got ${landed_author_email:-missing})."
+      exit 1
+    fi
+    local commit_body
+    commit_body=$(printf '%s\n' "$landed_commit_json" | jq -r .commit.message)
+    local expected_trailer
+    if [ -n "$contrib_coauthor_email" ]; then
+      expected_trailer="Co-authored-by: $contrib <$contrib_coauthor_email>"
+      commit_message_has_exact_line "$commit_body" "$expected_trailer" || {
+        echo "Missing PR author co-author trailer"
+        exit 1
+      }
+    else
+      echo "Skipping PR author co-author trailer check for bot/app author $contrib."
+    fi
+    expected_trailer="Co-authored-by: $reviewer <$reviewer_coauthor_email>"
+    commit_message_has_exact_line "$commit_body" "$expected_trailer" || {
+      echo "Missing reviewer co-author trailer"
+      exit 1
+    }
+  fi
 
   local landed_sha_url="https://github.com/$repo_nwo/commit/$landed_sha"
   local prep_sha_url="https://github.com/$repo_nwo/pull/$pr/commits/$PREP_HEAD_SHA"
@@ -501,6 +633,11 @@ merge_run() {
 
   echo "merge-run complete for PR #$pr"
   echo "landed commit: $landed_sha"
+  if [ "$attributed_merge" = "true" ]; then
+    echo "merge author email: $selected_merge_author_email"
+  else
+    echo "merge attribution: n/a (rebase)"
+  fi
   echo "completion comment: $comment_url"
   echo "$pr_url"
 }

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -553,8 +553,42 @@ merge_run() {
   fi
 
   if [ "$state" != "MERGED" ]; then
-    echo "PR state is $state after waiting."
-    exit 1
+    if [ "$auto_merge_requested" = "true" ] && [ "$merge_submitted" = "true" ]; then
+      auto_meta=$(gh pr view "$pr" --json state,headRefOid,autoMergeRequest)
+      state=$(printf '%s\n' "$auto_meta" | jq -r .state)
+      auto_head_sha=$(printf '%s\n' "$auto_meta" | jq -r .headRefOid)
+      existing_auto_method=$(printf '%s\n' "$auto_meta" | jq -r '.autoMergeRequest.mergeMethod // ""')
+
+      if [ "$state" != "MERGED" ]; then
+        if [ "$auto_head_sha" != "$PREP_HEAD_SHA" ]; then
+          echo "PR head changed while waiting for auto-merge (expected $PREP_HEAD_SHA, got $auto_head_sha)."
+          exit 1
+        fi
+        if [ -z "$existing_auto_method" ]; then
+          echo "Queued auto-merge is no longer enabled, but the PR did not merge before the timeout."
+          exit 1
+        fi
+
+        echo "Queued auto-merge did not land before the timeout; disabling it before returning."
+        gh_plain pr merge "$pr" --disable-auto >.local/merge-output.log 2>&1 || true
+        auto_meta=$(gh pr view "$pr" --json state,headRefOid,autoMergeRequest)
+        state=$(printf '%s\n' "$auto_meta" | jq -r .state)
+        auto_head_sha=$(printf '%s\n' "$auto_meta" | jq -r .headRefOid)
+        existing_auto_method=$(printf '%s\n' "$auto_meta" | jq -r '.autoMergeRequest.mergeMethod // ""')
+        if [ "$state" != "MERGED" ]; then
+          if [ "$auto_head_sha" != "$PREP_HEAD_SHA" ] || [ -n "$existing_auto_method" ]; then
+            echo "Unable to prove the timed-out auto-merge request was cleared at the verified head."
+            print_relevant_log_excerpt .local/merge-output.log
+            exit 1
+          fi
+          echo "The timed-out auto-merge request was cleared safely; re-run merge-run to retry."
+          exit 1
+        fi
+      fi
+    else
+      echo "PR state is $state after waiting."
+      exit 1
+    fi
   fi
 
   local landed_sha

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -396,11 +396,21 @@ merge_run() {
 
     MERGE_ERR_MSG=$(cat .local/merge-output.log)
     if is_author_email_merge_error "$MERGE_ERR_MSG" && [ "${#reviewer_email_candidates[@]}" -ge 2 ]; then
+      local primary_merge_author_email="$selected_merge_author_email"
+      local primary_merge_error="$MERGE_ERR_MSG"
       selected_merge_author_email="${reviewer_email_candidates[1]}"
       echo "Retrying merge once with fallback author email: $selected_merge_author_email"
       if invoke_attributed_merge "$mode" "$selected_merge_author_email"; then
         return 0
       fi
+      local fallback_merge_error
+      fallback_merge_error=$(cat .local/merge-output.log)
+      {
+        printf 'Primary author-email attempt (%s):\n%s\n\n' \
+          "$primary_merge_author_email" "$primary_merge_error"
+        printf 'Fallback author-email attempt (%s):\n%s\n' \
+          "$selected_merge_author_email" "$fallback_merge_error"
+      } >.local/merge-output.log
       MERGE_ERR_MSG=$(cat .local/merge-output.log)
     fi
     return 1

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -484,7 +484,8 @@ merge_run() {
         elif [ "$existing_auto_method" = "SQUASH" ]; then
           echo "AUTO-MERGE ENABLED for PR #$pr at $PREP_HEAD_SHA."
           echo "GitHub will land it via squash when required checks and branch up-to-dateness are satisfied."
-          return 0
+          merge_submitted=true
+          merge_label="squash auto-merge"
         else
           echo "GitHub accepted the auto-merge command but did not report a squash auto-merge request."
           print_relevant_log_excerpt .local/merge-output.log

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -15,12 +15,17 @@ type MergeScenario = {
   auto?: boolean;
   autoError?: string;
   autoResult?: "enabled" | "inconclusive" | "unavailable";
+  authorEmailFailures?: number;
   checks?: "fail" | "green" | "pending";
   commentEmpty?: boolean;
   commentFailures?: number;
+  commitMessage?: string;
   existingAutoMethod?: "" | "MERGE" | "REBASE" | "SQUASH";
+  landedAuthorEmail?: string;
+  mergeMethod?: "merge" | "rebase" | "squash";
   mergeStateStatus?: string;
   mergeable?: string;
+  prAuthor?: string;
   recommendation?: "ready" | "needs_work";
   reviewArtifacts?: "valid" | "invalid";
 };
@@ -34,6 +39,7 @@ function runMerge(scenario: MergeScenario = {}) {
   const bin = join(root, "bin");
   const commentAttempts = join(root, "comment-attempts");
   const commentBody = join(root, "comment-body");
+  const mergeAttempts = join(root, "merge-attempts");
   const lifecycle = join(root, "lifecycle.log");
   const rgCalls = join(root, "rg-calls.log");
   mkdirSync(bin, { recursive: true });
@@ -41,13 +47,15 @@ function runMerge(scenario: MergeScenario = {}) {
   writeFileSync(
     join(bin, "rg"),
     `#!/usr/bin/env node
-const { appendFileSync, readFileSync } = require("node:fs");
+const { appendFileSync, existsSync, readFileSync } = require("node:fs");
 const args = process.argv.slice(2);
 appendFileSync(process.env.OPENCLAW_TEST_RG_CALLS, JSON.stringify(args) + "\\n");
-const pattern = args.at(-2);
-const file = args.at(-1);
+const maybeFile = args.at(-1);
+const hasFile = maybeFile && existsSync(maybeFile);
+const pattern = args.at(hasFile ? -2 : -1);
+const input = hasFile ? readFileSync(maybeFile, "utf8") : readFileSync(0, "utf8");
 const flags = args.includes("-i") ? "i" : "";
-process.exit(new RegExp(pattern, flags).test(readFileSync(file, "utf8")) ? 0 : 1);
+process.exit(new RegExp(pattern, flags).test(input) ? 0 : 1);
 `,
   );
   chmodSync(join(bin, "rg"), 0o755);
@@ -125,6 +133,10 @@ git() {
     fi
     return 0
   fi
+  if [ "\${1-} \${2-}" = "config user.email" ]; then
+    printf 'reviewer-fallback@example.com\n'
+    return 0
+  fi
   return 0
 }
 node() {
@@ -149,6 +161,9 @@ gh_route() {
       ;;
     "pr view")
       case "$*" in
+        *"--json number,title,state,isDraft,author"*)
+          printf '%s\n' "$OPENCLAW_TEST_PR_META"
+          ;;
         *"--json state,isDraft"*)
           printf '%s\\n' '{"state":"OPEN","isDraft":false}'
           ;;
@@ -196,19 +211,29 @@ gh_route() {
           fi
           ;;
       esac
+      if [[ " $* " = *" --author-email "* ]]; then
+        local attempts=0
+        if [ -e "$OPENCLAW_TEST_MERGE_ATTEMPTS" ]; then
+          attempts=$(cat "$OPENCLAW_TEST_MERGE_ATTEMPTS")
+        fi
+        attempts=$((attempts + 1))
+        printf '%s\n' "$attempts" > "$OPENCLAW_TEST_MERGE_ATTEMPTS"
+        if [ "$attempts" -le "$OPENCLAW_TEST_AUTHOR_EMAIL_FAILURES" ]; then
+          echo 'GraphQL: author email is not associated with your account' >&2
+          return 1
+        fi
+      fi
       ;;
     "repo view") printf 'openclaw/openclaw\\n' ;;
     "api "*)
-      local api_arg
-      for api_arg in "$@"; do
-        case "$api_arg" in
-          repos/*/*/commits/*)
-            echo 'unexpected repository commit-resolution API probe' >&2
-            return 1
-            ;;
-        esac
-      done
       case "$*" in
+        "api user --jq .login") printf 'altaywtf\n' ;;
+        "api user --jq .id") printf '1234\n' ;;
+        *"api user --jq .email"*) printf 'reviewer@example.com\n' ;;
+        "api users/"*) printf '5678\n' ;;
+        *"repos/openclaw/openclaw/commits/$OPENCLAW_TEST_LANDED_SHA"*)
+          printf '%s\n' "$OPENCLAW_TEST_LANDED_COMMIT_JSON"
+          ;;
         *"issues/123/comments"*)
           local arg
           for arg in "$@"; do
@@ -255,6 +280,7 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       OPENCLAW_TEST_AUTO_REQUESTED: scenario.auto ? "true" : "false",
       OPENCLAW_TEST_AUTO_RESULT: scenario.autoResult ?? "enabled",
       OPENCLAW_TEST_AUTO_STATE: autoState,
+      OPENCLAW_TEST_AUTHOR_EMAIL_FAILURES: String(scenario.authorEmailFailures ?? 0),
       OPENCLAW_TEST_CHECKS_EXIT_STATUS: scenario.checks === "pending" ? "8" : "0",
       OPENCLAW_TEST_CHECKS_JSON: JSON.stringify(checks),
       OPENCLAW_TEST_COMMENT_ATTEMPTS: commentAttempts,
@@ -265,11 +291,34 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       OPENCLAW_TEST_DISABLED_AUTO_META: disabledAutoMeta,
       OPENCLAW_TEST_GH_CALLS: calls,
       OPENCLAW_TEST_LANDED_SHA: landedSha,
+      OPENCLAW_TEST_LANDED_COMMIT_JSON: JSON.stringify({
+        commit: {
+          author: {
+            email:
+              scenario.landedAuthorEmail ??
+              (scenario.authorEmailFailures
+                ? "reviewer-fallback@example.com"
+                : "reviewer@example.com"),
+          },
+          message:
+            scenario.commitMessage ??
+            `Fix Slack upload captions (#123)\n\nMerged via ${scenario.mergeMethod === "merge" ? "merge commit" : "squash"}.\n\nPrepared head SHA: ${headSha}\nCo-authored-by: contributor <5678+contributor@users.noreply.github.com>\nCo-authored-by: altaywtf <1234+altaywtf@users.noreply.github.com>\nReviewed-by: @altaywtf`,
+        },
+      }),
       OPENCLAW_TEST_LIFECYCLE: lifecycle,
+      OPENCLAW_TEST_MERGE_ATTEMPTS: mergeAttempts,
+      OPENCLAW_PR_MERGE_METHOD: scenario.mergeMethod ?? "squash",
       OPENCLAW_TEST_MERGE_SCRIPT: mergeScript,
       OPENCLAW_TEST_MERGE_STATE_STATUS: scenario.mergeStateStatus ?? "BEHIND",
       OPENCLAW_TEST_POST_AUTO_META: postAutoMeta,
       OPENCLAW_TEST_PRE_AUTO_META: preAutoMeta,
+      OPENCLAW_TEST_PR_META: JSON.stringify({
+        number: 123,
+        title: "Fix Slack upload captions",
+        state: "OPEN",
+        isDraft: false,
+        author: { login: scenario.prAuthor ?? "contributor" },
+      }),
       OPENCLAW_TEST_REVIEW_ARTIFACTS: scenario.reviewArtifacts ?? "valid",
       OPENCLAW_TEST_REVIEW_RECOMMENDATION: scenario.recommendation ?? "ready",
       OPENCLAW_TEST_RG_CALLS: rgCalls,
@@ -286,6 +335,12 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       : 0,
     commentBody: existsSync(commentBody) ? readFileSync(commentBody, "utf8") : "",
     lifecycle: existsSync(lifecycle) ? readFileSync(lifecycle, "utf8") : "",
+    mergeAttempts: existsSync(mergeAttempts)
+      ? Number(readFileSync(mergeAttempts, "utf8").trim())
+      : 0,
+    mergeBody: existsSync(join(localDir, "merge-body.txt"))
+      ? readFileSync(join(localDir, "merge-body.txt"), "utf8")
+      : "",
     rgCalls: existsSync(rgCalls) ? readFileSync(rgCalls, "utf8") : "",
   };
 }
@@ -336,19 +391,25 @@ describePosix("scripts/pr merge-run", () => {
     expect(result.calls).not.toContain("pr merge");
   });
 
-  it("keeps the default immediate pinned squash merge unchanged", () => {
+  it("lands the default pinned squash with verified reviewer and contributor attribution", () => {
     const result = runMerge({ mergeStateStatus: "CLEAN" });
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(result.calls).toContain(`plain pr merge 123 --squash --match-head-commit ${headSha}`);
+    expect(result.calls).toContain(
+      `plain pr merge 123 --squash --match-head-commit ${headSha} --author-email reviewer@example.com --subject Fix Slack upload captions (#123) --body-file .local/merge-body.txt`,
+    );
     expect(result.calls).toContain(`scripts/watch-pr-ci.mjs 123 ${headSha} --completion ci-run`);
     expect(result.calls).toContain("plain pr checks 123 --required --json name,bucket,state");
-    expect(result.calls).toContain("path pr view 123 --json state,isDraft");
+    expect(result.calls).toContain("path pr view 123 --json number,title,state,isDraft,author");
     expect(result.calls).not.toContain("--required --watch");
     expect(result.calls).not.toContain("--auto");
-    expect(result.calls).not.toMatch(/^(?:path|plain) api .*\/commits\//mu);
+    expect(result.calls).toContain(`plain api repos/openclaw/openclaw/commits/${landedSha}`);
     expect(result.calls).not.toContain("--json commits");
     expect(result.stdout).toContain("merge-run complete for PR #123");
+    expect(result.stdout).toContain("merge author email: reviewer@example.com");
+    expect(result.mergeBody).toBe(
+      `Merged via squash.\n\nPrepared head SHA: ${headSha}\nCo-authored-by: contributor <5678+contributor@users.noreply.github.com>\nCo-authored-by: altaywtf <1234+altaywtf@users.noreply.github.com>\nReviewed-by: @altaywtf\n`,
+    );
     expect(result.stdout).toContain(
       "completion comment: https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
     );
@@ -359,6 +420,62 @@ describePosix("scripts/pr merge-run", () => {
     expect(result.lifecycle).toBe(
       "comment\nremote-cleanup\nworktree-cleanup .worktrees/pr-123\nbranch-cleanup temp/pr-123\nbranch-cleanup pr-123\nbranch-cleanup pr-123-prep\n",
     );
+  });
+
+  it("fails closed when the landed commit is missing the reviewer trailer", () => {
+    const result = runMerge({
+      commitMessage: `Fix Slack upload captions (#123)\n\nCo-authored-by: contributor <5678+contributor@users.noreply.github.com>`,
+      mergeStateStatus: "CLEAN",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("Missing reviewer co-author trailer");
+    expect(result.lifecycle).toBe("");
+  });
+
+  it("fails closed when GitHub lands the commit under another author email", () => {
+    const result = runMerge({
+      landedAuthorEmail: "someone-else@example.com",
+      mergeStateStatus: "CLEAN",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("Landed commit author email mismatch");
+    expect(result.lifecycle).toBe("");
+  });
+
+  it("retries an author-email validation failure once with the next candidate", () => {
+    const result = runMerge({ authorEmailFailures: 1, mergeStateStatus: "CLEAN" });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.mergeAttempts).toBe(2);
+    expect(result.calls).toContain("--author-email reviewer-fallback@example.com");
+    expect(result.stdout).toContain(
+      "Retrying merge once with fallback author email: reviewer-fallback@example.com",
+    );
+    expect(result.stdout).toContain("merge author email: reviewer-fallback@example.com");
+  });
+
+  it("omits a contributor trailer for a bot author", () => {
+    const result = runMerge({
+      commitMessage: `Fix Slack upload captions (#123)\n\nCo-authored-by: altaywtf <1234+altaywtf@users.noreply.github.com>\nReviewed-by: @altaywtf`,
+      mergeStateStatus: "CLEAN",
+      prAuthor: "clawsweeper[bot]",
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.mergeBody).not.toContain("Co-authored-by: clawsweeper[bot]");
+    expect(result.stdout).toContain("Skipping PR author co-author trailer check");
+  });
+
+  it("keeps rebase landing free of single-commit attribution flags", () => {
+    const result = runMerge({ mergeMethod: "rebase", mergeStateStatus: "CLEAN" });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.calls).toContain(`plain pr merge 123 --rebase --match-head-commit ${headSha}`);
+    expect(result.calls).not.toContain("--author-email");
+    expect(result.calls).not.toContain(`plain api repos/openclaw/openclaw/commits/${landedSha}`);
+    expect(result.stdout).toContain("merge attribution: n/a (rebase)");
   });
 
   it("retries transient structured comment failures exactly three times", () => {
@@ -393,7 +510,7 @@ describePosix("scripts/pr merge-run", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.calls).toContain(
-      `plain pr merge 123 --auto --squash --match-head-commit ${headSha}`,
+      `plain pr merge 123 --auto --squash --match-head-commit ${headSha} --author-email reviewer@example.com --subject Fix Slack upload captions (#123) --body-file .local/merge-body.txt`,
     );
     expect(result.calls.match(/^plain pr merge /gmu)).toHaveLength(1);
     expect(result.stdout).toContain("AUTO-MERGE ENABLED");

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -28,6 +28,7 @@ type MergeScenario = {
   prAuthor?: string;
   recommendation?: "ready" | "needs_work";
   reviewArtifacts?: "valid" | "invalid";
+  statePollsBeforeMerge?: number;
 };
 
 function runMerge(scenario: MergeScenario = {}) {
@@ -42,6 +43,7 @@ function runMerge(scenario: MergeScenario = {}) {
   const mergeAttempts = join(root, "merge-attempts");
   const lifecycle = join(root, "lifecycle.log");
   const rgCalls = join(root, "rg-calls.log");
+  const statePolls = join(root, "state-polls");
   mkdirSync(bin, { recursive: true });
   mkdirSync(localDir, { recursive: true });
   writeFileSync(
@@ -183,7 +185,19 @@ gh_route() {
             printf '%s\\n' "$OPENCLAW_TEST_POST_AUTO_META"
           fi
           ;;
-        *"--json state --jq .state"*) printf 'MERGED\\n' ;;
+        *"--json state --jq .state"*)
+          local polls=0
+          if [ -e "$OPENCLAW_TEST_STATE_POLLS" ]; then
+            polls=$(cat "$OPENCLAW_TEST_STATE_POLLS")
+          fi
+          polls=$((polls + 1))
+          printf '%s\\n' "$polls" > "$OPENCLAW_TEST_STATE_POLLS"
+          if [ "$polls" -le "$OPENCLAW_TEST_STATE_POLLS_BEFORE_MERGE" ]; then
+            printf 'OPEN\\n'
+          else
+            printf 'MERGED\\n'
+          fi
+          ;;
         *"--json mergeCommit"*) printf '%s\\n' "$OPENCLAW_TEST_LANDED_SHA" ;;
         *"--json commits"*) printf '1\\n' ;;
         *"--json headRefName,headRepository"*)
@@ -229,7 +243,6 @@ gh_route() {
       case "$*" in
         "api user --jq .login") printf 'altaywtf\n' ;;
         "api user --jq .id") printf '1234\n' ;;
-        *"api user --jq .email"*) printf 'reviewer@example.com\n' ;;
         "api users/"*) printf '5678\n' ;;
         *"repos/openclaw/openclaw/commits/$OPENCLAW_TEST_LANDED_SHA"*)
           printf '%s\n' "$OPENCLAW_TEST_LANDED_COMMIT_JSON"
@@ -297,8 +310,8 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
             email:
               scenario.landedAuthorEmail ??
               (scenario.authorEmailFailures
-                ? "reviewer-fallback@example.com"
-                : "reviewer@example.com"),
+                ? "altaywtf@users.noreply.github.com"
+                : "1234+altaywtf@users.noreply.github.com"),
           },
           message:
             scenario.commitMessage ??
@@ -324,6 +337,8 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       OPENCLAW_TEST_RG_CALLS: rgCalls,
       OPENCLAW_TEST_ROOT: root,
       OPENCLAW_TEST_SCRIPTS_DIR: join(process.cwd(), "scripts"),
+      OPENCLAW_TEST_STATE_POLLS: statePolls,
+      OPENCLAW_TEST_STATE_POLLS_BEFORE_MERGE: String(scenario.statePollsBeforeMerge ?? 0),
       PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
     },
   });
@@ -342,6 +357,7 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       ? readFileSync(join(localDir, "merge-body.txt"), "utf8")
       : "",
     rgCalls: existsSync(rgCalls) ? readFileSync(rgCalls, "utf8") : "",
+    statePolls: existsSync(statePolls) ? Number(readFileSync(statePolls, "utf8").trim()) : 0,
   };
 }
 
@@ -396,8 +412,9 @@ describePosix("scripts/pr merge-run", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.calls).toContain(
-      `plain pr merge 123 --squash --match-head-commit ${headSha} --author-email reviewer@example.com --subject Fix Slack upload captions (#123) --body-file .local/merge-body.txt`,
+      `plain pr merge 123 --squash --match-head-commit ${headSha} --author-email 1234+altaywtf@users.noreply.github.com --subject Fix Slack upload captions (#123) --body-file .local/merge-body.txt`,
     );
+    expect(result.calls).not.toContain("--jq .email");
     expect(result.calls).toContain(`scripts/watch-pr-ci.mjs 123 ${headSha} --completion ci-run`);
     expect(result.calls).toContain("plain pr checks 123 --required --json name,bucket,state");
     expect(result.calls).toContain("path pr view 123 --json number,title,state,isDraft,author");
@@ -406,7 +423,7 @@ describePosix("scripts/pr merge-run", () => {
     expect(result.calls).toContain(`plain api repos/openclaw/openclaw/commits/${landedSha}`);
     expect(result.calls).not.toContain("--json commits");
     expect(result.stdout).toContain("merge-run complete for PR #123");
-    expect(result.stdout).toContain("merge author email: reviewer@example.com");
+    expect(result.stdout).toContain("merge author email: 1234+altaywtf@users.noreply.github.com");
     expect(result.mergeBody).toBe(
       `Merged via squash.\n\nPrepared head SHA: ${headSha}\nCo-authored-by: contributor <5678+contributor@users.noreply.github.com>\nCo-authored-by: altaywtf <1234+altaywtf@users.noreply.github.com>\nReviewed-by: @altaywtf\n`,
     );
@@ -449,11 +466,11 @@ describePosix("scripts/pr merge-run", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.mergeAttempts).toBe(2);
-    expect(result.calls).toContain("--author-email reviewer-fallback@example.com");
+    expect(result.calls).toContain("--author-email altaywtf@users.noreply.github.com");
     expect(result.stdout).toContain(
-      "Retrying merge once with fallback author email: reviewer-fallback@example.com",
+      "Retrying merge once with fallback author email: altaywtf@users.noreply.github.com",
     );
-    expect(result.stdout).toContain("merge author email: reviewer-fallback@example.com");
+    expect(result.stdout).toContain("merge author email: altaywtf@users.noreply.github.com");
   });
 
   it("reports both author-email failures when the fallback also fails", () => {
@@ -462,11 +479,11 @@ describePosix("scripts/pr merge-run", () => {
     expect(result.status).toBe(1);
     expect(result.mergeAttempts).toBe(2);
     expect(result.stdout).toContain(
-      "Primary author-email attempt (reviewer@example.com):",
+      "Primary author-email attempt (1234+altaywtf@users.noreply.github.com):",
     );
     expect(result.stdout).toContain("author email attempt 1 is not associated");
     expect(result.stdout).toContain(
-      "Fallback author-email attempt (reviewer-fallback@example.com):",
+      "Fallback author-email attempt (altaywtf@users.noreply.github.com):",
     );
     expect(result.stdout).toContain("author email attempt 2 is not associated");
   });
@@ -525,11 +542,23 @@ describePosix("scripts/pr merge-run", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.calls).toContain(
-      `plain pr merge 123 --auto --squash --match-head-commit ${headSha} --author-email reviewer@example.com --subject Fix Slack upload captions (#123) --body-file .local/merge-body.txt`,
+      `plain pr merge 123 --auto --squash --match-head-commit ${headSha} --author-email 1234+altaywtf@users.noreply.github.com --subject Fix Slack upload captions (#123) --body-file .local/merge-body.txt`,
     );
     expect(result.calls.match(/^plain pr merge /gmu)).toHaveLength(1);
     expect(result.stdout).toContain("AUTO-MERGE ENABLED");
     expect(result.stdout).toContain("required checks and branch up-to-dateness");
+  });
+
+  it("waits for queued squash auto-merge and verifies the landed attribution", () => {
+    const result = runMerge({ auto: true, statePollsBeforeMerge: 2 });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.calls.match(/^plain pr merge /gmu)).toHaveLength(1);
+    expect(result.statePolls).toBe(3);
+    expect(result.stdout).toContain("Landing not finalized yet (state=OPEN)");
+    expect(result.calls).toContain(`plain api repos/openclaw/openclaw/commits/${landedSha}`);
+    expect(result.stdout).toContain("merge author email: 1234+altaywtf@users.noreply.github.com");
+    expect(result.lifecycle).toContain("comment\nremote-cleanup\n");
   });
 
   it("falls back to the immediate merge when BEHIND is not the only obstacle", () => {

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -43,6 +43,7 @@ function runMerge(scenario: MergeScenario = {}) {
   const mergeAttempts = join(root, "merge-attempts");
   const lifecycle = join(root, "lifecycle.log");
   const rgCalls = join(root, "rg-calls.log");
+  const sideEffects = join(root, "side-effects.log");
   const statePolls = join(root, "state-polls");
   mkdirSync(bin, { recursive: true });
   mkdirSync(localDir, { recursive: true });
@@ -118,7 +119,9 @@ require_ready_review_recommendation() {
   fi
 }
 verify_prep_branch_matches_prepared_head() { :; }
-mark_pr_operation_side_effects_started() { :; }
+mark_pr_operation_side_effects_started() {
+  printf 'side-effects\n' >> "$OPENCLAW_TEST_SIDE_EFFECTS"
+}
 mainline_drift_requires_sync() { return 1; }
 print_relevant_log_excerpt() { cat "$1"; }
 repo_root() { printf '%s\\n' "$OPENCLAW_TEST_ROOT"; }
@@ -336,6 +339,7 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       OPENCLAW_TEST_REVIEW_RECOMMENDATION: scenario.recommendation ?? "ready",
       OPENCLAW_TEST_RG_CALLS: rgCalls,
       OPENCLAW_TEST_ROOT: root,
+      OPENCLAW_TEST_SIDE_EFFECTS: sideEffects,
       OPENCLAW_TEST_SCRIPTS_DIR: join(process.cwd(), "scripts"),
       OPENCLAW_TEST_STATE_POLLS: statePolls,
       OPENCLAW_TEST_STATE_POLLS_BEFORE_MERGE: String(scenario.statePollsBeforeMerge ?? 0),
@@ -357,6 +361,7 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       ? readFileSync(join(localDir, "merge-body.txt"), "utf8")
       : "",
     rgCalls: existsSync(rgCalls) ? readFileSync(rgCalls, "utf8") : "",
+    sideEffects: existsSync(sideEffects) ? readFileSync(sideEffects, "utf8") : "",
     statePolls: existsSync(statePolls) ? Number(readFileSync(statePolls, "utf8").trim()) : 0,
   };
 }
@@ -559,6 +564,18 @@ describePosix("scripts/pr merge-run", () => {
     expect(result.calls).toContain(`plain api repos/openclaw/openclaw/commits/${landedSha}`);
     expect(result.stdout).toContain("merge author email: 1234+altaywtf@users.noreply.github.com");
     expect(result.lifecycle).toContain("comment\nremote-cleanup\n");
+  });
+
+  it("clears a queued squash auto-merge that does not land before the timeout", () => {
+    const result = runMerge({ auto: true, statePollsBeforeMerge: 90 });
+
+    expect(result.status).toBe(1);
+    expect(result.statePolls).toBe(90);
+    expect(result.calls).toContain("plain pr merge 123 --disable-auto");
+    expect(result.stdout).toContain("did not land before the timeout; disabling it");
+    expect(result.stdout).toContain("timed-out auto-merge request was cleared safely");
+    expect(result.sideEffects).toBe("side-effects\n");
+    expect(result.lifecycle).toBe("");
   });
 
   it("falls back to the immediate merge when BEHIND is not the only obstacle", () => {

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -219,7 +219,7 @@ gh_route() {
         attempts=$((attempts + 1))
         printf '%s\n' "$attempts" > "$OPENCLAW_TEST_MERGE_ATTEMPTS"
         if [ "$attempts" -le "$OPENCLAW_TEST_AUTHOR_EMAIL_FAILURES" ]; then
-          echo 'GraphQL: author email is not associated with your account' >&2
+          echo "GraphQL: author email attempt $attempts is not associated with your account" >&2
           return 1
         fi
       fi
@@ -454,6 +454,21 @@ describePosix("scripts/pr merge-run", () => {
       "Retrying merge once with fallback author email: reviewer-fallback@example.com",
     );
     expect(result.stdout).toContain("merge author email: reviewer-fallback@example.com");
+  });
+
+  it("reports both author-email failures when the fallback also fails", () => {
+    const result = runMerge({ authorEmailFailures: 2, mergeStateStatus: "CLEAN" });
+
+    expect(result.status).toBe(1);
+    expect(result.mergeAttempts).toBe(2);
+    expect(result.stdout).toContain(
+      "Primary author-email attempt (reviewer@example.com):",
+    );
+    expect(result.stdout).toContain("author email attempt 1 is not associated");
+    expect(result.stdout).toContain(
+      "Fallback author-email attempt (reviewer-fallback@example.com):",
+    );
+    expect(result.stdout).toContain("author email attempt 2 is not associated");
   });
 
   it("omits a contributor trailer for a bot author", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainer squash merges could silently omit the PR author and reviewer co-author trailers.

Git history indicates that attribution was removed as part of the temporary rebase landing change in #96055. Squash landing was restored the next day in `da15cf48bf4`, but the attribution and post-merge verification machinery was not restored with it. This appears to be an incomplete revert rather than an intentional removal of attribution.

## Why This Change Was Made

Restores the previous deterministic attribution behavior expected by the maintainer workflow: reviewer-owned merge author selection with one validation-only fallback, an explicit subject and attribution body for squash and merge-commit landings, and verification of the landed author email and exact trailers before cleanup. Rebase remains explicitly unattributed because it does not create one landing commit to decorate.

## User Impact

Contributors and maintainers receive deterministic commit attribution again, and the wrapper fails closed if GitHub lands metadata that differs from the prepared merge plan.

## Evidence

- Red regression proof on current main: 7 new attribution cases failed while 13 existing wrapper cases passed.
- Cloudflare Crabbox `cbx_31d86a87ab70`: focused merge wrapper suite, 20/20 passed.
- Cloudflare Crabbox `cbx_13eca6753fb6`: Bash syntax, changed-file formatting, and root-test typecheck passed.
- Codex autoreview of exact commit `95eea20141db49fb8f37e66dfdd81a6c77f9764c`: clean, no actionable findings.
- Full `check:changed` could not complete on Cloudflare because its synced sandbox omits `.git`; Blacksmith was unauthenticated and AWS provider discovery timed out. PR CI remains the authoritative full gate.