### PR TITLE
fix(gateway): run full node teardown when a node token is revoked

### DIFF
--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -214,6 +214,55 @@ describe("deviceHandlers", () => {
     });
   });
 
+  it("clears node runtime state and reconciles workers after revoking a node token", async () => {
+    const nodeId = "revoked-node-device";
+    revokeDeviceTokenMock.mockResolvedValue({
+      ok: true,
+      entry: { token: "raw-node-token", role: "node", scopes: [], revokedAtMs: 456 },
+    });
+    await seedNodeWakeState(nodeId);
+    enqueueNodePendingWork({ nodeId, type: "location.request" });
+    const wakeLifecycle = captureNodeWakeLifecycle(nodeId);
+    const workerEnvironmentService = {};
+    const reconciledDevices: string[] = [];
+    bindDeviceWorkerReconciliation(workerEnvironmentService, async (deviceId) => {
+      reconciledDevices.push(deviceId);
+      return [];
+    });
+    const opts = createOptions(
+      "device.token.revoke",
+      { deviceId: nodeId, role: "node" },
+      // Non-operator role management requires an admin-scoped caller.
+      { client: createClient(["operator.admin"], "admin-device", { isDeviceTokenAuth: true }) },
+    );
+    Object.assign(opts.context, { workerEnvironmentService });
+
+    await expectDefined(
+      deviceHandlers["device.token.revoke"],
+      'deviceHandlers["device.token.revoke"] test invariant',
+    )(opts);
+
+    // Revocation ends node authority like pairing removal: the same teardown
+    // owner must run so pending work, wake state, surface caps, and worker
+    // placements are not stranded on a dead node.
+    expect(getNodeWakeStateSnapshot(nodeId)).toBeUndefined();
+    expect(wakeLifecycle.aborted).toBe(true);
+    expect(drainNodePendingWork(nodeId).items.map((item) => item.id)).toEqual(["baseline-status"]);
+    const nodeRegistry = opts.context.nodeRegistry as unknown as {
+      updateSurface: ReturnType<typeof vi.fn>;
+    };
+    expect(nodeRegistry.updateSurface).toHaveBeenCalledWith(nodeId, {
+      caps: [],
+      commands: [],
+      permissions: undefined,
+    });
+    expect(reconciledDevices).toEqual([nodeId]);
+    expect(opts.context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+      role: "node",
+      reason: "device-token-revoked",
+    });
+  });
+
   it("disconnects active clients after removing a paired device", async () => {
     removePairedDeviceMock.mockResolvedValue({ deviceId: "device-1", removedAtMs: 123 });
     const opts = createOptions("device.pair.remove", { deviceId: " device-1 " });

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -818,7 +818,11 @@ export const deviceHandlers: GatewayRequestHandlers = {
       role: entry.role,
     });
     if (entry.role === "node") {
-      invalidateNodeWakeState(normalizedDeviceId);
+      // Revoking a node token ends its authority like pairing removal does:
+      // run the same teardown owner so pending actions/work, wake state,
+      // surface caps, and worker placements are not stranded on a dead node.
+      clearRemovedNodeRuntimeState({ nodeId: normalizedDeviceId, context });
+      await reconcileRevokedDeviceWorker(context, normalizedDeviceId);
     }
     // Mark affected clients invalid *before* responding so any RPCs already
     // pipelined into their WS socket buffer are rejected at the per-request


### PR DESCRIPTION
## What Problem This Solves

`device.token.revoke` for `role=node` only invalidated wake state, while its sibling `device.pair.remove` — the other way node authority permanently ends — runs the full teardown owner: `clearRemovedNodeRuntimeState` (pending actions, pending node work, wake state, surface caps, remote node info) plus `reconcileRevokedDeviceWorker` (worker environments + active placement reconciliation). A node whose token was revoked therefore kept stranded pending work, stale surface caps/commands in the node registry, and live worker placements until a gateway restart.

## Why This Change Was Made

One-sided teardown is exactly the sibling-surface asymmetry the Repair Doctrine flags: both exits end node authority permanently, so both must run the same owner. The intentionally narrower paths stay narrow — rotate and pairing-reapproval keep only wake-state invalidation because the node remains paired there and reconnects with the new token/generation.

## User Impact

Operators revoking a node token (instead of removing the pairing) no longer leave ghost node state behind: pending work stops accumulating for a dead node, its registry surface clears, and device-backed worker placements reconcile immediately.

## Evidence

- New regression test mirrors the existing `device.pair.remove` teardown coverage (wake snapshot gone, wake lifecycle aborted, pending work drained to baseline, `updateSurface` cleared, worker reconciliation invoked with the device id) — **fails pre-fix** (stash proof), passes post-fix.
- `node scripts/run-vitest.mjs run src/gateway/server-methods/devices.test.ts` — 47/47; `src/gateway/server.device-token-rotate-authz.test.ts` + `src/gateway/server-methods/nodes.test.ts` — 30/30.
- `pnpm tsgo`, `pnpm check:test-types`, oxfmt/oxlint clean; autoreview clean (0.98).

Production LOC +5/−1 (the teardown call + invariant comment; wake-state call absorbed into the owner); tests +49.
