### PR TITLE
fix(memory): stop cancelled searches before returning results

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -1,6 +1,7 @@
 // Memory Core tests cover manager search orchestration behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import {
   createManagerIndexFixture,
@@ -193,6 +194,81 @@ describe("memory index", () => {
     await expect(manager.search("alpha")).resolves.not.toStrictEqual([]);
     expect(queryCalls).toBe(1);
     expect(close).not.toHaveBeenCalled();
+  });
+
+  it("rejects caller cancellation during hybrid fallback scanning", async () => {
+    const manager = await getPersistentManager(
+      createCfg({
+        minScore: 0,
+        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+
+    const fields = manager as unknown as {
+      db: DatabaseSync;
+      ensureVectorReady: (dimensions?: number) => Promise<boolean>;
+    };
+    fields.ensureVectorReady = async () => false;
+    const insertChunk = fields.db.prepare(
+      "INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    );
+    for (let index = 0; index < 4096; index += 1) {
+      insertChunk.run(
+        `cancel-scan-${index}`,
+        `memory/cancel-scan-${index}.md`,
+        "memory",
+        1,
+        1,
+        `cancel-scan-hash-${index}`,
+        "mock-embed",
+        `fallback scan row ${index}`,
+        JSON.stringify([0, 1, 0, 0]),
+        index,
+      );
+    }
+
+    const originalPrepare = fields.db.prepare.bind(fields.db);
+    let scannedBatches = 0;
+    const prepareSpy = vi.spyOn(fields.db, "prepare").mockImplementation((sql: string) => {
+      const statement = originalPrepare(sql);
+      if (!sql.includes("SELECT rowid, id, path")) {
+        return statement;
+      }
+      return {
+        all: (...args: Parameters<typeof statement.all>) => {
+          scannedBatches += 1;
+          return statement.all(...args);
+        },
+      } as unknown as typeof statement;
+    });
+
+    try {
+      const caller = new AbortController();
+      const abortReason = new Error("caller stopped hybrid memory search");
+      const pending = manager.search("alpha", { signal: caller.signal });
+      setImmediate(() => caller.abort(abortReason));
+
+      await expect(pending).rejects.toBe(abortReason);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(scannedBatches).toBe(1);
+
+      const healthyResults = await manager.search("alpha");
+      expect(healthyResults.some((result) => result.path === "memory/2026-01-12.md")).toBe(true);
+
+      fields.ensureVectorReady = async () => {
+        throw new Error("vector store unavailable");
+      };
+      const degradedResults = await manager.search("alpha");
+      expect(degradedResults.some((result) => result.path === "memory/2026-01-12.md")).toBe(true);
+    } finally {
+      prepareSpy.mockRestore();
+    }
   });
 
   it("supplements thin strict FTS results for conversational queries", async () => {

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -364,6 +364,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
             candidates,
             sourceFilterList,
             vectorProviderIdentity,
+            opts?.signal,
           ).catch((err: unknown) => {
             log.warn(`memory search: vector query failed: ${formatErrorMessage(err)}`);
             return [];
@@ -425,6 +426,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
     limit: number,
     sourceFilterList: MemorySource[],
     providerIdentity: { model: string; aliases: string[] },
+    signal?: AbortSignal,
   ): Promise<Array<MemorySearchResult & { id: string }>> {
     const results = await searchVector({
       db: this.db,
@@ -434,6 +436,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       queryVec,
       limit,
       snippetMaxChars: SNIPPET_MAX_CHARS,
+      signal,
       ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
       sourceFilterVec: this.buildSourceFilter("c", sourceFilterList),
       sourceFilterChunks: this.buildSourceFilter(undefined, sourceFilterList),

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -366,6 +366,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
             vectorProviderIdentity,
             opts?.signal,
           ).catch((err: unknown) => {
+            opts?.signal?.throwIfAborted();
             log.warn(`memory search: vector query failed: ${formatErrorMessage(err)}`);
             return [];
           })

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -9,6 +9,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import { bm25RankToScore, buildFtsQuery } from "./hybrid.js";
 import { searchKeyword, searchPathKeyword, searchVector } from "./manager-search.js";
+import { runMemorySearchWithDeadline } from "./search-deadline.js";
 import { vectorToBlob } from "./vector-blob.js";
 
 function insertKeywordFixture(
@@ -1125,6 +1126,57 @@ describe("searchVector sqlite-vec KNN", () => {
       } finally {
         clearInterval(heartbeatInterval);
       }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("stops fallback scanning when the caller aborts and keeps later searches healthy", async () => {
+    const db = createFallbackDb();
+    try {
+      for (let index = 0; index < 4096; index += 1) {
+        insertFallbackChunk(db, {
+          id: `chunk-${index}`,
+          model: "target-model",
+          vector: index === 4095 ? [1, 0] : [0, 1],
+        });
+      }
+
+      let scannedBatches = 0;
+      const countedDb = {
+        prepare: (sql: string) => {
+          const statement = db.prepare(sql);
+          if (!sql.includes("SELECT rowid, id, path")) {
+            return statement;
+          }
+          return {
+            all: (...args: Parameters<typeof statement.all>) => {
+              scannedBatches += 1;
+              return statement.all(...args);
+            },
+          };
+        },
+      } as unknown as DatabaseSync;
+      const caller = new AbortController();
+      const abortReason = new Error("caller stopped memory search");
+      const pending = runMemorySearchWithDeadline({
+        timeoutMs: 5_000,
+        parentSignal: caller.signal,
+        run: async (signal) => await searchVectorFixture(countedDb, { signal }),
+      });
+      setImmediate(() => caller.abort(abortReason));
+
+      await expect(pending).rejects.toBe(abortReason);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(scannedBatches).toBe(1);
+
+      const healthyResults = await searchVectorFixture(db, { limit: 1 });
+      expect(healthyResults.map((result) => result.id)).toEqual(["chunk-4095"]);
     } finally {
       db.close();
     }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -449,6 +449,7 @@ export async function searchVector(params: {
   queryVec: number[];
   limit: number;
   snippetMaxChars: number;
+  signal?: AbortSignal;
   ensureVectorReady: (dimensions: number) => Promise<boolean>;
   sourceFilterVec: { sql: string; params: SearchSource[] };
   sourceFilterChunks: { sql: string; params: SearchSource[] };
@@ -456,6 +457,7 @@ export async function searchVector(params: {
   if (params.queryVec.length === 0 || params.limit <= 0) {
     return [];
   }
+  params.signal?.throwIfAborted();
   const providerModels = resolveProviderModels(params.providerModel, params.providerModelAliases);
   const vectorModelFilter = buildModelFilter("c.model", providerModels);
   const searchFallback = () =>
@@ -467,8 +469,11 @@ export async function searchVector(params: {
       queryVec: params.queryVec,
       limit: params.limit,
       snippetMaxChars: params.snippetMaxChars,
+      signal: params.signal,
     });
-  if (await params.ensureVectorReady(params.queryVec.length)) {
+  const vectorReady = await params.ensureVectorReady(params.queryVec.length);
+  params.signal?.throwIfAborted();
+  if (vectorReady) {
     // Use sqlite-vec's native KNN (MATCH ? AND k = ?) for candidate selection,
     // which runs in ~O(log N + k) via the vec0 index, instead of the previous
     // full-table scan over vec_distance_cosine(). Keep vec_distance_cosine() in
@@ -560,6 +565,7 @@ async function searchChunksByEmbedding(params: {
   queryVec: number[];
   limit: number;
   snippetMaxChars: number;
+  signal?: AbortSignal;
 }): Promise<SearchRowResult[]> {
   if (params.limit <= 0) {
     return [];
@@ -634,6 +640,7 @@ async function searchChunksByEmbedding(params: {
       break;
     }
     await yieldToEventLoop();
+    params.signal?.throwIfAborted();
   }
   topResults.sort((a, b) => b.score - a.score);
   // Read provenance once for the final retained set, not per scored candidate.


### PR DESCRIPTION
Related: #124050

## What Problem This Solves

Fixes an issue where cancelling built-in memory search after query embedding could leave an in-process vector fallback scan running and allow hybrid search to return ordinary keyword matches as if the cancelled request had succeeded.

## Why This Change Was Made

Carry the caller cancellation signal through vector readiness and fallback SQLite scanning, check it at the existing 256-row cooperative yield boundary, and let cancellation win in hybrid orchestration before the existing vector-error degradation path. Genuine un-aborted vector failures still degrade to keyword results.

The change stays inside Memory Core search ownership. It does not change provider health policy, auth/routing, configuration/defaults, SQLite schema or data, SDK/protocol contracts, retention, or migrations.

## User Impact

Cancelled memory searches now reject with the exact caller reason, stop within one bounded scan batch, perform no later SQLite scan work, and never surface keyword results as successful output. Later healthy searches continue to work on the same provider and index. Large indexes avoid CPU work after the caller has already abandoned the search.

## Evidence

- Rebased pre-fix manager reproduction: hybrid search resolved a keyword result from `memory/2026-01-12.md` after caller abort instead of rejecting.
- Real 4,096-row manager and direct SQLite regressions: exact abort reason, one 256-row batch, no work in later event-loop turns, and a successful subsequent search.
- Genuine un-aborted vector-store failure still returns the keyword result.
- Focused tests: 36 direct vector/SQLite, 2 manager cancellation, 4 deadline, 2 Gateway `memory_search`, and 2 CLI search/output tests passed.
- Exact-head changed gate passed: unskipped deadcode, production/test types, changed-file lint, format, plugin/dependency/database-first/sidecar guards, and zero runtime import cycles.
- Full production build passed, including compiler shards, Plugin SDK declaration verification, postbuild checks, and Control UI production build.
- Madge import cycles: 0. `git diff --check`: clean.
- Fresh branch autoreview: clean; no accepted/actionable findings.
- Production LOC: +12/-1 (net +11). Tests: +128/-0. The production growth carries one existing caller signal through the vector owner and enforces it at readiness, scan, and hybrid-result boundaries.
- No changelog entry: normal PR changelogs are release-owned; this body records the release-note context.
