### PR TITLE
fix(gateway): keep session history pageable after hidden tails

### DIFF
--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -169,20 +169,19 @@ export function buildSessionHistorySnapshot(params: {
     resolveCurrentUserProfileDisplay,
   });
   const visibleMessages = toSessionHistoryMessages(projected.messages);
+  const rawHistoryMessages = toSessionHistoryMessages(params.rawMessages);
   const history = paginateSessionMessages(visibleMessages, params.limit, params.cursor);
   if (
     !params.cursor &&
     typeof params.totalRawMessages === "number" &&
-    params.totalRawMessages > params.rawMessages.length &&
-    history.messages.length > 0
+    params.totalRawMessages > params.rawMessages.length
   ) {
-    const firstSeq = resolveMessageSeq(history.messages[0]);
+    const firstSeq = resolveMessageSeq(history.messages[0] ?? rawHistoryMessages[0]);
     history.hasMore = true;
     if (typeof firstSeq === "number") {
       history.nextCursor = String(firstSeq);
     }
   }
-  const rawHistoryMessages = toSessionHistoryMessages(params.rawMessages);
   return {
     history,
     rawTranscriptSeq:

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1068,6 +1068,52 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
+  test("keeps older SQLite history reachable past an all-silent bounded tail", async () => {
+    const storePath = await createSessionStoreFile();
+    const sessionId = "sess-silent-tail";
+    const sessionKey = "agent:main:main";
+    await writeSessionStore({
+      entries: { main: { sessionId, updatedAt: Date.now() } },
+      storePath,
+    });
+    await replaceTranscriptEvents({ agentId: AGENT_ID, sessionId, sessionKey, storePath }, [
+      { type: "session", version: 1, id: sessionId },
+      { message: { role: "assistant", content: "reachable older history" } },
+      ...Array.from({ length: 40 }, () => ({
+        message: { role: "assistant", content: "NO_REPLY" },
+      })),
+    ]);
+
+    await withGatewayHarness(async (harness) => {
+      const firstPage = await readSessionHistoryBody(harness.port, sessionKey, {
+        query: "?limit=1",
+      });
+      expect(firstPage.messages).toEqual([]);
+      expect(firstPage.hasMore).toBe(true);
+      expect(firstPage.nextCursor).toBe("2");
+
+      const stream = await openSessionHistorySse(harness.port, sessionKey, {
+        query: "?limit=1",
+      });
+      try {
+        const event = await readSseEvent(stream.reader, stream.streamState);
+        expect(event.event).toBe("history");
+        expect(event.data).toMatchObject({ messages: [], hasMore: true, nextCursor: "2" });
+      } finally {
+        await stream.reader.cancel();
+      }
+
+      const olderPage = await readSessionHistoryBody(harness.port, sessionKey, {
+        query: "?limit=1&cursor=2",
+      });
+      expect(olderPage.messages?.map((message) => message.content)).toEqual([
+        "reachable older history",
+      ]);
+      expect(olderPage.hasMore).toBe(false);
+      expect(olderPage.nextCursor).toBeUndefined();
+    });
+  });
+
   test("caps all-digit direct REST history limits that exceed safe integer range", async () => {
     const { storePath } = await seedSession({ text: "first message" });
     await appendVisibleAssistantMessage({


### PR DESCRIPTION
Related: #121386

## What Problem This Solves

Fixes an issue where HTTP/SSE session-history clients could be told that no older conversation existed when a bounded raw transcript tail contained only hidden rows, even though visible SQLite history remained earlier in the session.

## Why This Change Was Made

The raw bounded tail owns the pagination boundary even when display projection removes every row. The shared session-history projector now keeps `hasMore` true and derives the existing `nextCursor` from the first raw sequence, without exposing hidden rows or changing the HTTP/SSE response shape.

The existing ClawSweeper review recommends also consolidating the separate embedded-history path. Maintainer scope for this PR explicitly preserves the two-file HTTP/SSE repair; the embedded path is not claimed fixed here and should remain tracked separately rather than being silently bundled.

Production LOC: +3/-4 (net -1). Tests: +46/-0. `CHANGELOG.md` is intentionally unchanged; release generation owns changelog updates.

## User Impact

External HTTP/SSE history clients can page past an all-hidden tail and recover older visible conversation rows. Visible-row behavior, hidden-row filtering, retention, storage, configuration, and protocol shape are unchanged.

## Evidence

- Before: a real SQLite transcript with one visible row followed by 40 `NO_REPLY` rows returned `messages: []`, `hasMore: false`, and no cursor for `?limit=1`.
- After: REST and SSE return the same hidden first page with `hasMore: true` and `nextCursor: "2"`; requesting that cursor returns the older visible row.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31875210575
  - `src/gateway/session-history-state.test.ts`: 26/26 passed.
  - `src/gateway/sessions-history-http.test.ts`: 84/84 passed, including invalid cursor/limit bounds, archive rollover, pagination, SSE refresh, and cleanup siblings.
  - Changed gate passed: format, core production/test types, focused lint, storage/database-first guards, native schema-version guard, and zero runtime import cycles.
- Fresh autoreview: no accepted/actionable findings.
- `git diff --check`: clean.
