### PR TITLE
fix(ui): keep cross-agent outbox sends moving

### DIFF
--- a/ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts
@@ -1,0 +1,233 @@
+import { expect, it } from "vitest";
+import {
+  chatSessionListResponse,
+  controlUiSessionPath,
+  controlUiSessionUrl,
+  createChatFlowE2eSuite,
+  expectRequestCountStable,
+  installMockGateway,
+  requireRecord,
+  requireString,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("drains an inactive agent outbox while the selected global agent is active", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const agentsList = {
+      agents: [
+        { id: "main", name: "Main" },
+        { id: "work", name: "Work" },
+      ],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    };
+    const historyResponse = (active: boolean) => ({
+      messages: [],
+      sessionId: active ? "main-global-session" : "work-global-session",
+      sessionInfo: {
+        activeRunIds: active ? ["main-active-run"] : [],
+        hasActiveRun: active,
+        key: "global",
+        status: active ? "running" : "done",
+      },
+      thinkingLevel: null,
+    });
+    const sessionsResponse = (active: boolean) =>
+      chatSessionListResponse([
+        {
+          activeRunIds: active ? ["main-active-run"] : [],
+          hasActiveRun: active,
+          key: "global",
+          kind: "global",
+          label: "Main Session",
+          status: active ? "running" : "done",
+          updatedAt: Date.now(),
+        },
+      ]);
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "agents.list": agentsList,
+        "chat.history": {
+          cases: [
+            { match: { agentId: "work", sessionKey: "global" }, response: historyResponse(true) },
+            { match: { agentId: "main", sessionKey: "global" }, response: historyResponse(true) },
+          ],
+        },
+        "chat.startup": {
+          cases: [
+            {
+              match: { agentId: "work" },
+              response: { ...historyResponse(false), agentsList },
+            },
+            {
+              match: { agentId: "main" },
+              response: { ...historyResponse(true), agentsList },
+            },
+          ],
+        },
+        "sessions.list": {
+          cases: [
+            { match: { agentId: "work" }, response: sessionsResponse(false) },
+            { match: { agentId: "main" }, response: sessionsResponse(true) },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:work:main"));
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor({ state: "visible", timeout: 10_000 });
+      await gateway.setOnline(false);
+      await page.locator(".agent-chat__offline-hint").waitFor({ timeout: 10_000 });
+
+      const prompt = "deliver the work outbox independently";
+      await composer.fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+      const queue = page.locator(".chat-queue");
+      await queue.getByText("Waiting for reconnect").waitFor({ timeout: 10_000 });
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/inactive-agent-offline.png`,
+          fullPage: true,
+        });
+      }
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
+      await page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: { context: { agentSelection: { set: (agentId: string) => void } } };
+        };
+        app.runtime?.context.agentSelection.set("main");
+      });
+      await gateway.setOnline(true);
+      await page
+        .locator(".agent-chat__offline-hint")
+        .waitFor({ state: "detached", timeout: 10_000 });
+      await page.evaluate(async () => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: { context: { sessions: { refresh: (options: unknown) => Promise<void> } } };
+        };
+        await app.runtime?.context.sessions.refresh({ agentId: "main", force: true });
+      });
+
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.list")).some(
+            (entry) => requireRecord(entry.params).agentId === "main",
+          ),
+        )
+        .toBe(true);
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.history")).length)
+        .toBeGreaterThan(0);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      await gateway.deferNext("chat.send");
+      await gateway.setMethodResponse("chat.history", {
+        cases: [
+          { match: { agentId: "work", sessionKey: "global" }, response: historyResponse(false) },
+          { match: { agentId: "main", sessionKey: "global" }, response: historyResponse(true) },
+        ],
+      });
+      await gateway.emitGatewayEvent("sessions.changed", {
+        activeRunIds: ["main-active-run"],
+        agentId: "main",
+        hasActiveRun: true,
+        key: "global",
+        kind: "global",
+        status: "running",
+      });
+
+      const request = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(request.params);
+      expect(params).toMatchObject({ agentId: "work", message: prompt, sessionKey: "global" });
+      const runId = requireString(params.idempotencyKey, "inactive-agent outbox run id");
+      await expectRequestCountStable(gateway, "chat.send", 1);
+      const workPath = controlUiSessionPath("agent:work:main");
+      await page.evaluate((pathname) => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: {
+            context: {
+              agentSelection: { set: (agentId: string) => void };
+              navigate: (routeId: string, options: { pathname: string }) => void;
+            };
+          };
+        };
+        if (!app.runtime) {
+          throw new Error("OpenClaw application runtime is unavailable");
+        }
+        app.runtime.context.agentSelection.set("work");
+        app.runtime.context.navigate("chat", { pathname });
+      }, workPath);
+      await page.waitForURL((url) => url.pathname === workPath);
+      await gateway.setHistoryMessages([
+        {
+          content: prompt,
+          idempotencyKey: `${runId}:user`,
+          role: "user",
+          timestamp: Date.now(),
+        },
+      ]);
+      await gateway.emitGatewayEvent("session.message", {
+        agentId: "work",
+        clientRunId: runId,
+        hasActiveRun: true,
+        message: {
+          __openclaw: { id: "work-outbox-user", idempotencyKey: `${runId}:user`, seq: 1 },
+          content: [{ text: prompt, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "work-outbox-user",
+        messageSeq: 1,
+        sessionKey: "global",
+        status: "running",
+      });
+      await page.locator(".chat-group.user").getByText(prompt).waitFor({ timeout: 10_000 });
+      await gateway.resolveDeferred("chat.send", { runId, status: "started" });
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/inactive-agent-dispatched.png`,
+          fullPage: true,
+        });
+      }
+
+      await gateway.emitGatewayEvent("chat", {
+        agentId: "work",
+        message: {
+          content: [{ text: "Work outbox delivered.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId,
+        sessionKey: "global",
+        state: "final",
+      });
+      await queue.waitFor({ state: "detached", timeout: 10_000 });
+      await page
+        .locator(".chat-group.assistant")
+        .getByText("Work outbox delivered.", { exact: true })
+        .waitFor({ timeout: 10_000 });
+      await expectRequestCountStable(gateway, "chat.send", 1);
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/inactive-agent-delivered.png`,
+          fullPage: true,
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -242,9 +242,12 @@ async function reconcileStoredChatOutboxHead(
   const neverAttempted =
     (item.sendAttempts ?? 0) === 0 && item.sendRequestStartedAtMs === undefined;
   if (neverAttempted) {
-    const row = host.sessions.state.result?.sessions.find((session) =>
-      areUiSessionKeysEquivalent(session.key, outbox.sessionKey),
-    );
+    const row =
+      !isUiGlobalSessionKey(outbox.sessionKey) || host.sessions.state.agentId === outbox.agentId
+        ? host.sessions.state.result?.sessions.find((session) =>
+            areUiSessionKeysEquivalent(session.key, outbox.sessionKey),
+          )
+        : undefined;
     if (row && isSessionRunActive(row)) {
       return "blocked";
     }

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -4227,15 +4227,26 @@ describe("handleSendChat", () => {
     expect(listStoredChatOutboxes(host)).toStrictEqual([]);
   });
 
-  it("keeps global outboxes for different agents isolated", async () => {
+  it("does not block another agent's global outbox behind the selected agent's active run", async () => {
     const sends: Array<Record<string, unknown>> = [];
+    const historyAgentIds: unknown[] = [];
+    let selectedAgentActive = true;
     const host = makeChatHost({
       requestHandlers: {
-        "chat.history": () =>
-          Promise.resolve({
+        "sessions.list": () =>
+          createSessionsResult([
+            row("global", {
+              hasActiveRun: selectedAgentActive,
+              status: selectedAgentActive ? "running" : "done",
+            }),
+          ]),
+        "chat.history": (params: unknown) => {
+          historyAgentIds.push(requireRecord(params, "agent-scoped history params").agentId);
+          return Promise.resolve({
             messages: [],
             sessionInfo: row("global", { hasActiveRun: false, status: "done" }),
-          }),
+          });
+        },
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "chat.send payload");
           sends.push(payload);
@@ -4264,16 +4275,36 @@ describe("handleSendChat", () => {
     writeChatQueueForScope(host, "global", [workItem], "work");
     expect(admitQueuedMessageForSession(host, "global", mainItem)).toBe(true);
     expect(admitQueuedMessageForSession(host, "global", workItem)).toBe(true);
+    await host.sessions.refresh({ agentId: "main", force: true });
+    expect(host.request).toHaveBeenCalledWith(
+      "sessions.list",
+      expect.objectContaining({ agentId: "main" }),
+    );
+    expect(host.sessions.state.error).toBeNull();
+    expect(host.sessions.state).toMatchObject({
+      agentId: "main",
+      result: { sessions: [expect.objectContaining({ hasActiveRun: true, key: "global" })] },
+    });
 
     await retryReconnectableQueuedChatSends(host);
 
-    expect(sends).toHaveLength(2);
-    expect(sends).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ agentId: "main", message: "send as main" }),
-        expect.objectContaining({ agentId: "work", message: "send as work" }),
-      ]),
-    );
+    expect(sends).toEqual([expect.objectContaining({ agentId: "work", message: "send as work" })]);
+    expect(historyAgentIds).toEqual(["work"]);
+    expect(listStoredChatOutboxes(host)).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        queue: [expect.objectContaining({ id: mainItem.id })],
+      }),
+    ]);
+
+    selectedAgentActive = false;
+    await host.sessions.refresh({ agentId: "main", force: true });
+    await retryReconnectableQueuedChatSends(host);
+
+    expect(sends).toEqual([
+      expect.objectContaining({ agentId: "work", message: "send as work" }),
+      expect.objectContaining({ agentId: "main", message: "send as main" }),
+    ]);
     expect(listStoredChatOutboxes(host)).toStrictEqual([]);
   });
 


### PR DESCRIPTION
Regression provenance: #123966

## What Problem This Solves

Fixes an issue where a Control UI message queued for one agent while offline could remain stuck after reconnect when another agent's global session had an active run. Global session keys are shared across agents, so the selected agent's active row could incorrectly block a different agent's outbox before its own history was checked.

## Why This Change Was Made

The outbox drain now uses the fast active-run session-row shortcut for a global session only when the session catalog owner matches the outbox agent. Otherwise it follows the existing agent-specific `chat.history` reconciliation path.

This preserves send ordering, idempotency, retry, replay, and uncertain-send handling. It does not change delivery semantics, Gateway protocol, configuration, security, persistence, or retry policy. Production code is +6/-3 (net +3); the growth binds the cached active-run fact to its existing agent owner. Tests are +275/-11 (net +264). No changelog entry is included because changelog generation is release-owned.

## User Impact

Control UI users can queue a message for Work, navigate to Main, and reconnect while Main remains busy without dead-ending Work's message. Work dispatches exactly once through its own session history; Main remains independently queued until its own run becomes idle.

This PR is AI-assisted and has been reviewed for the complete behavior and ownership boundary.

## Evidence

Pre-fix proof on the rebased parent:

- The focused unit regression expected one Work dispatch and received none.
- The real browser regression observed zero Work-scoped `chat.history` requests because Main's active `global` row blocked the drain first.

Fixed-head proof (`c2b14c7a5dfd83297fabaee58e78ffe027cd00af`):

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts` — 291 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts --reporter=verbose` — passed; exact one Work dispatch, navigation-safe ACK, visible final, queue cleanup.
- Same command for `ui/src/e2e/chat-flow.history-recovery.e2e.test.ts` — 8 sibling cases passed; 9 browser lifecycle cases total with the new regression.
- `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/gateway/gateway.test.ts -t "accepts a gateway agent request over ws" --reporter=verbose` — isolated real Gateway + deterministic Responses provider passed.
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts ui/src/pages/chat/chat-outbox-drain.ts ui/src/pages/chat/chat-send.test.ts` — changed gate passed after the remote workload router reported no ready provider and used the documented trusted-source local fallback; formatting, i18n, types, lint, stylelint, dependency and dead-export guards passed.
- `node --import tsx scripts/check-import-cycles.ts` — 0 runtime value cycles.
- Exact-commit autoreview — clean, no accepted/actionable findings, correctness confidence 0.98.
- ClawSweeper rank-up move — rebased onto current main with stable patch ID unchanged; the 291-case unit file and focused browser regression passed again on the rebased head.

Mock-browser verdict:

```json
{"scenario":"control-ui-cross-agent-global-outbox","mainActive":true,"workHistoryReconciled":true,"dispatches":[{"agentId":"work","count":1}],"visibleUserTurn":true,"visibleFinal":true,"queueCleared":true,"errorsVisible":false}
```

Offline queue:

![Work message waiting for reconnect](https://github.com/user-attachments/assets/53584523-54f3-4fd3-8dc0-589e17eb02fc)

Accepted Work turn while Main remains active:

![Work turn dispatched once](https://github.com/user-attachments/assets/30cd7215-2771-4bb5-aa77-f6afb5076b6d)

Visible final with the outbox cleared:

![Work final delivered and queue cleared](https://github.com/user-attachments/assets/17c6b4cf-1b10-419a-81f7-24d6be7f3d10)

Recorded lifecycle:

https://github.com/user-attachments/assets/9eb7222d-e69e-4271-9a9a-529d0fa72a87
