### PR TITLE
refactor(agents): route terminal-reason groups through the canonical classifier

### DIFF
--- a/src/agents/embedded-agent-runner/run/terminal-outcome.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-outcome.ts
@@ -1,5 +1,6 @@
 import {
   buildAgentRunTerminalOutcomeFromAttempt,
+  classifyAgentRunTerminalOutcome,
   type AgentRunTerminalOutcome,
 } from "../../agent-run-terminal-outcome.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
@@ -29,15 +30,11 @@ export function resolveEmbeddedRunAttemptTerminalOutcome(params: {
 }
 
 export function isEmbeddedRunTerminalTimeout(outcome: AgentRunTerminalOutcome): boolean {
-  return outcome.reason === "hard_timeout" || outcome.reason === "timed_out";
+  return classifyAgentRunTerminalOutcome(outcome) === "timeout";
 }
 
 export function isEmbeddedRunTerminalAbort(outcome: AgentRunTerminalOutcome): boolean {
-  return (
-    outcome.reason === "aborted" ||
-    outcome.reason === "cancelled" ||
-    outcome.reason === "superseded"
-  );
+  return classifyAgentRunTerminalOutcome(outcome) === "cancellation";
 }
 
 export function isEmbeddedRunTerminalInterrupted(outcome: AgentRunTerminalOutcome): boolean {

--- a/src/agents/subagents/announce/subagent-announce-output.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.ts
@@ -10,7 +10,10 @@ import type { SessionTranscriptRuntimeTarget } from "../../../config/sessions/se
 import { resolveFreshSessionTotalTokens } from "../../../config/sessions/types.js";
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
 import { formatDurationCompact } from "../../../infra/format-time/format-duration.js";
-import { buildAgentRunTerminalOutcomeFromWaitResult } from "../../agent-run-terminal-outcome.js";
+import {
+  buildAgentRunTerminalOutcomeFromWaitResult,
+  classifyAgentRunTerminalOutcome,
+} from "../../agent-run-terminal-outcome.js";
 import { wrapPromptDataBlock } from "../../sanitize-for-prompt.js";
 import { extractStoredAssistantText, sanitizeTextContent } from "../../tools/chat-history-text.js";
 import {
@@ -340,23 +343,23 @@ export function applySubagentWaitOutcome(params: {
   const terminalOutcome = buildAgentRunTerminalOutcomeFromWaitResult(params.wait);
   let outcome = next.outcome;
   // Capture/announcement callers can pass raw wait snapshots that bypass the
-  // primary normalizers, so preserve the shared timeout/cancel precedence here.
-  if (terminalOutcome?.status === "timeout") {
-    outcome = { status: "timeout" };
-  } else if (
-    terminalOutcome?.reason === "aborted" ||
-    terminalOutcome?.reason === "cancelled" ||
-    terminalOutcome?.reason === "superseded"
-  ) {
-    outcome = { status: "error", error: "subagent run terminated" };
-  } else if (
-    terminalOutcome?.reason === "blocked" ||
-    terminalOutcome?.reason === "abandoned" ||
-    terminalOutcome?.reason === "failed"
-  ) {
-    outcome = { status: "error", error: terminalOutcome.error ?? waitError };
-  } else if (terminalOutcome?.reason === "completed") {
-    outcome = { status: "ok" };
+  // primary normalizers, so apply the canonical classification here instead
+  // of re-enumerating reason groups.
+  if (terminalOutcome) {
+    switch (classifyAgentRunTerminalOutcome(terminalOutcome)) {
+      case "timeout":
+        outcome = { status: "timeout" };
+        break;
+      case "cancellation":
+        outcome = { status: "error", error: "subagent run terminated" };
+        break;
+      case "failure":
+        outcome = { status: "error", error: terminalOutcome.error ?? waitError };
+        break;
+      case "success":
+        outcome = { status: "ok" };
+        break;
+    }
   }
   next.outcome = outcome ? withSubagentOutcomeTiming(outcome, next) : undefined;
   return next;

--- a/src/agents/subagents/registry/subagent-registry-run-wait.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-wait.ts
@@ -6,7 +6,10 @@ import { callGateway } from "../../../gateway/call.js";
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import type { DetachedTaskFindResult } from "../../../tasks/detached-task-runtime-contract.js";
-import { buildAgentRunTerminalOutcomeFromWaitResult } from "../../agent-run-terminal-outcome.js";
+import {
+  buildAgentRunTerminalOutcomeFromWaitResult,
+  classifyAgentRunTerminalOutcome,
+} from "../../agent-run-terminal-outcome.js";
 import { isRecoverableAgentWaitError, waitForAgentRun } from "../../run-wait.js";
 import {
   type SubagentRunOutcome,
@@ -289,9 +292,8 @@ export class SubagentWaitManager {
       const waitTerminalOutcome = buildAgentRunTerminalOutcomeFromWaitResult(wait);
       const waitBlocked = waitTerminalOutcome?.reason === "blocked";
       const waitAborted =
-        waitTerminalOutcome?.reason === "aborted" ||
-        waitTerminalOutcome?.reason === "cancelled" ||
-        waitTerminalOutcome?.reason === "superseded";
+        waitTerminalOutcome !== undefined &&
+        classifyAgentRunTerminalOutcome(waitTerminalOutcome) === "cancellation";
       const waitStatus = waitTerminalOutcome?.status ?? wait.status;
       if (wait.yielded === true && waitStatus !== "timeout" && !waitBlocked) {
         this.options.clearPendingLifecycleError(runId);

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -811,12 +811,9 @@ export function createAgentEventHandler({
         ))
     ) {
       if (!isAborted) {
+        // peek() (chatLink) and this shift() run in one synchronous frame, so
+        // the shifted head is exactly the peeked entry.
         const finished = chatLink ? chatRunState.registry.shift(evt.runId) : undefined;
-        if (chatLink && !finished) {
-          clearRunContextForEvent(evt);
-          return;
-        }
-
         const terminalSessionKey = finished?.sessionKey ?? sessionKey;
         const terminalRunId = finished?.clientRunId ?? eventRunId;
         const terminalAgentId = finished?.agentId ?? sessionAgentId;


### PR DESCRIPTION
## What Problem This Solves

Root `AGENTS.md` names the invariant: agent-run terminal state normalizes via `src/agents/agent-run-terminal-outcome.ts` — projections must not rederive timeout/cancel precedence. Three consumers re-enumerated the terminal reason groups by hand, so any future `AgentRunTerminalReason` value would silently misclassify in those projections while the canonical classifier handled it correctly:

- `subagent-announce-output.ts` `applySubagentWaitOutcome` — a hand-written four-way partition (timeout / aborted|cancelled|superseded / blocked|abandoned|failed / completed), byte-equivalent to the canonical classification.
- `subagent-registry-run-wait.ts` `waitAborted` — `aborted|cancelled|superseded` is exactly `classification === "cancellation"` (`waitBlocked` stays finer-grained intentionally).
- `embedded-agent-runner/run/terminal-outcome.ts` — `isEmbeddedRunTerminalTimeout`/`Abort` re-enumerated the same groups.

## Why This Change Was Made

All three now route through `classifyAgentRunTerminalOutcome`, the exported four-way classification already used by session-lifecycle, chat-state, TUI, and gateway-wire projections. One recorded fact instead of four copies of the partition.

Rider (same lifecycle neighborhood): dropped the provably unreachable `chatLink && !finished` guard in `finalizeLifecycleEvent` — `registry.peek` and `registry.shift` run in one synchronous frame with no await between them, so the shifted head is exactly the peeked entry; a comment records the invariant.

## User Impact

None visible today — behavior is byte-equivalent for every current reason value. The fix removes the silent-misclassification trap for future reason values.

## Evidence

- Behavior equivalence verified against `buildAgentRunTerminalOutcome` (status `"timeout"` iff reason ∈ {hard_timeout, timed_out}) and the `AGENT_RUN_TERMINAL_CLASSIFICATION` table.
- `node scripts/run-vitest.mjs run src/agents/subagents` — 1089/1089 across 38 files; `src/agents/agent-run-terminal-outcome.test.ts` + `src/agents/embedded-agent-runner` — 903/903; `src/gateway/server-chat.agent-events.test.ts` — in the 13-test run, green.
- `pnpm tsgo`, `pnpm check:test-types`, oxfmt/oxlint clean; autoreview clean (0.98).

Production LOC +32/−33 (net −1); no test changes needed — existing suites pin the partition.
