### PR TITLE
refactor(control-ui): group tool activity in the chat transcript

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4188,7 +4188,6 @@ ui/src/pages/chat/chat-state-events.ts	6
 ui/src/pages/chat/chat-state-page.ts	5
 ui/src/pages/chat/chat-state-route.ts	1
 ui/src/pages/chat/chat-thread-build.ts	2
-ui/src/pages/chat/chat-thread-grouping.ts	2
 ui/src/pages/chat/chat-thread-items.ts	4
 ui/src/pages/chat/components/chat-attachments.ts	2
 ui/src/pages/chat/components/chat-audio-player.ts	1

--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -48,17 +48,6 @@ async function captureFactrowProof(
   });
 }
 
-async function expandCompletedWorkGroups(page: import("playwright").Page) {
-  const workSummaries = page.locator(".chat-work-group > .chat-activity-group__summary");
-  await workSummaries.first().waitFor();
-  for (let index = 0; index < (await workSummaries.count()); index += 1) {
-    const summary = workSummaries.nth(index);
-    if ((await summary.getAttribute("aria-expanded")) !== "true") {
-      await summary.click();
-    }
-  }
-}
-
 suite.define(() => {
   it("keeps an earlier autonomous failure visible after a later turn recovers", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
@@ -86,7 +75,6 @@ suite.define(() => {
 
     await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
     await page.getByText("Recovered on the next autonomous turn.", { exact: true }).waitFor();
-    await expandCompletedWorkGroups(page);
 
     expect(await page.locator(".chat-tool-msg-summary__label").allTextContents()).toEqual([
       "Tool output",
@@ -432,7 +420,6 @@ suite.define(() => {
     const row = page.locator(".chat-tool-msg-summary", { hasText: message });
     await row.waitFor();
 
-    expect(await page.locator(".chat-work-group").count()).toBe(0);
     expect(await row.locator(".chat-tool-msg-summary__label").textContent()).toBe("Message");
     expect(await row.locator(".chat-tool-msg-summary__names").textContent()).toBe(message);
     await captureToolActivityProof(page, "message-only-turn-visible");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5861,6 +5861,7 @@ export const en: TranslationMap = {
       fileChanges: "File changes",
       attemptedChanges: "Attempted changes",
       failed: "failed",
+      interrupted: "Interrupted",
       running: "Running",
       completed: "Completed",
       exitCode: "Exit code {code}",
@@ -5909,10 +5910,6 @@ export const en: TranslationMap = {
         emptyOne: "Ran a tool call",
         emptyMany: "Ran {count} tool calls",
       },
-    },
-    workRun: {
-      workedFor: "Worked for {duration}",
-      worked: "Worked",
     },
     backgroundTasks: {
       label: "Background tasks",

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -189,6 +189,10 @@ export type MessageContentItem =
       args?: unknown;
     }
   | {
+      type: "thinking" | "reasoning" | "redacted_thinking";
+      thinking?: string;
+    }
+  | {
       type: "attachment";
       attachment: {
         url: string;
@@ -250,6 +254,8 @@ export type ToolCard = {
   live?: boolean;
   /** True once a result landed, including historical results with empty output. */
   completed?: boolean;
+  /** True when the owning live run ended before a result landed. */
+  interrupted?: boolean;
   messageId?: string;
   preview?: {
     kind: "canvas";
@@ -274,4 +280,4 @@ export type ToolCard = {
   };
 };
 
-export type ToolCardOutcome = "running" | "succeeded" | "failed" | "unknown";
+export type ToolCardOutcome = "running" | "succeeded" | "failed" | "interrupted" | "unknown";

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -74,6 +74,7 @@ const rawAudioSourceSchema = z
   .catch(undefined);
 const rawContentBlockSchema = z.looseObject({
   text: optionalMessageStringSchema,
+  thinking: optionalMessageStringSchema,
   source: rawAudioSourceSchema,
   attachment: rawAttachmentSchema,
   preview: rawCanvasPreviewSchema,
@@ -641,6 +642,13 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
             rawText: item.rawText ?? null,
           },
         ];
+      }
+      if (
+        item.type === "thinking" ||
+        item.type === "reasoning" ||
+        item.type === "redacted_thinking"
+      ) {
+        return [{ type: item.type, thinking: item.thinking }];
       }
       if (isTextContentBlock(item, role)) {
         if (isAssistantMessage) {

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -177,6 +177,9 @@ export function resolveToolCardOutcome(
   if (isToolCardError(card)) {
     return "failed";
   }
+  if (card.interrupted) {
+    return "interrupted";
+  }
   if (runActive === true && card.live === true && card.completed !== true) {
     return "running";
   }
@@ -353,7 +356,11 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
         args,
         inputText: serializeToolInput(args),
         ...(isLiveToolStream
-          ? { live: true, completed: m["__openclawToolStreamResultReceived"] === true }
+          ? {
+              live: true,
+              completed: m["__openclawToolStreamResultReceived"] === true,
+              interrupted: m["__openclawToolStreamInterrupted"] === true,
+            }
           : {}),
         ...(liveDiffStat ? { liveDiffStat } : {}),
         messageId: transcriptMessageId,

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -4,17 +4,23 @@ import {
   isToolCallContentType,
   isToolResultContentType,
 } from "../../../../src/chat/tool-content.js";
-import type { ChatItem, MessageGroup, ToolCard } from "../../lib/chat/chat-types.ts";
+import type {
+  ChatItem,
+  MessageContentItem,
+  MessageGroup,
+  NormalizedMessage,
+  ToolCard,
+} from "../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
-import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
+import {
+  isStandaloneToolMessageForDisplay,
+  normalizeMessage,
+  normalizeRoleForGrouping,
+} from "../../lib/chat/message-normalizer.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
 import { extractToolCardsCached } from "../../lib/chat/tool-cards.ts";
 import { resolveMessageToolUseId, resolveToolBlockId } from "./chat-thread-items.ts";
-import {
-  assistantGroupIsForwardedBoundary,
-  chatItemStartsUserTurn,
-  safeNormalizeMessage,
-} from "./chat-turn-boundary.ts";
+import { assistantGroupIsForwardedBoundary, safeNormalizeMessage } from "./chat-turn-boundary.ts";
 
 export function isKeyedAssistantStreamFallbackMessage(message: unknown): boolean {
   const record = asRecord(message);
@@ -23,6 +29,46 @@ export function isKeyedAssistantStreamFallbackMessage(message: unknown): boolean
   }
   const fallback = asRecord(record?.openclawStreamFallback);
   return typeof fallback?.itemId === "string" && fallback.itemId.trim().length > 0;
+}
+
+// Assistant text and artifacts are visible outcomes and stay top-level;
+// reasoning and tool blocks are intermediate activity.
+function hasVisibleReplyBlocks(
+  message: unknown,
+  normalized: NormalizedMessage | null = safeNormalizeMessage(message),
+): boolean {
+  if (extractTextCached(message)?.trim()) {
+    return true;
+  }
+  return (normalized?.content ?? []).some((block) => {
+    if (block.type === "text") {
+      return Boolean(block.text?.trim());
+    }
+    if (isReasoningContentBlock(block)) {
+      return false;
+    }
+    return !isToolCallContentType(block.type) && !isToolResultContentType(block.type);
+  });
+}
+
+function isReasoningContentBlock(block: MessageContentItem): boolean {
+  return (
+    block.type === "thinking" || block.type === "reasoning" || block.type === "redacted_thinking"
+  );
+}
+
+// normalizeMessage rewrites any message containing tool blocks to toolResult.
+// Preserve the raw assistant role so model-authored words never disappear
+// inside a collapsed tool disclosure.
+function messageCarriesAssistantReply(
+  message: unknown,
+  normalized: NormalizedMessage | null = safeNormalizeMessage(message),
+): boolean {
+  return (
+    normalizeLowercaseStringOrEmpty(asRecord(message)?.role) === "assistant" &&
+    !isStandaloneToolMessageForDisplay(message) &&
+    hasVisibleReplyBlocks(message, normalized)
+  );
 }
 
 function stampReplyAttribution(
@@ -60,6 +106,7 @@ function stampReplyAttribution(
 export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
+  let groupCarriesVisibleReply = false;
 
   for (const item of items) {
     if (item.kind !== "message") {
@@ -85,16 +132,24 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       currentGroup?.role === "assistant" &&
       isKeyedAssistantStreamFallbackMessage(currentGroup.messages[0]?.message) !==
         isKeyedAssistantStreamFallbackMessage(item.message);
+    const carriesVisibleReply =
+      role === "tool" && messageCarriesAssistantReply(item.message, normalized);
+    const splitsVisibleReplyFromToolWork =
+      role === "tool" &&
+      currentGroup?.role === "tool" &&
+      groupCarriesVisibleReply !== carriesVisibleReply;
 
     if (
       !currentGroup ||
       startsProjectedTurn ||
       currentGroup.role !== role ||
       splitsAssistantCommentary ||
+      splitsVisibleReplyFromToolWork ||
       (shouldSplitBySender &&
         (currentGroup.senderLabel !== senderLabel ||
           senderIdentityKey(currentGroup.sender) !== senderIdentityKey(sender)))
     ) {
+      groupCarriesVisibleReply = carriesVisibleReply;
       if (currentGroup) {
         result.push(currentGroup);
       }
@@ -494,14 +549,6 @@ export function coalesceStreamRuns(
   flush();
   return result;
 }
-/** Collapsed rollup of a completed turn's intermediate work (tools, commentary). */
-type WorkGroupRenderItem = {
-  kind: "work-group";
-  key: string;
-  groups: MessageGroup[];
-  durationMs: number | null;
-};
-
 type ActivityRunRenderItem = {
   kind: "activity-run";
   key: string;
@@ -510,188 +557,89 @@ type ActivityRunRenderItem = {
 
 type TurnRenderItem = RenderChatItem | StreamRunRenderItem;
 
-function isCollapsibleWorkGroup(item: TurnRenderItem): item is MessageGroup {
-  if (item.kind !== "group" || item.isStreaming) {
-    return false;
-  }
-  const role = item.role.toLowerCase();
-  return role === "tool" || (role === "assistant" && !assistantGroupIsForwardedBoundary(item));
-}
-
-// Attachment/canvas/media-only replies carry no text but are still the turn's
-// visible outcome; they must never fold into the work rollup. Normalized
-// content passes unknown block types through (e.g. raw image blocks), so
-// anything that is not a tool block counts as visible reply content.
-function assistantGroupHasVisibleReplyContent(group: MessageGroup): boolean {
-  return group.messages.some(({ message }) => {
-    if (extractTextCached(message)?.trim()) {
-      return true;
-    }
-    const content = safeNormalizeMessage(message)?.content ?? [];
-    return content.some((block) => {
-      if (block.type === "text") {
-        return Boolean(block.text?.trim());
-      }
-      return !isToolCallContentType(block.type) && !isToolResultContentType(block.type);
-    });
-  });
-}
-
 export function assistantGroupCanOwnActiveRunStatus(group: MessageGroup): boolean {
   return (
     group.role.toLowerCase() === "assistant" &&
     !assistantGroupIsForwardedBoundary(group) &&
-    assistantGroupHasVisibleReplyContent(group)
+    group.messages.some(({ message }) => hasVisibleReplyBlocks(message))
   );
 }
 
-// History carries no final-vs-commentary marker (commentary exists only as
-// live stream segments), so the last assistant group with visible content
-// stands in for the final reply. Turns whose last content is commentary
-// merely collapse less; the visible reply is never folded away.
-function isFinalReplyGroup(item: TurnRenderItem): boolean {
+function groupFoldsIntoActivity(group: MessageGroup): boolean {
   return (
-    isCollapsibleWorkGroup(item) &&
-    item.role.toLowerCase() === "assistant" &&
-    assistantGroupHasVisibleReplyContent(item)
+    group.messages.some((item) => extractToolCardsCached(item.message, item.key).length > 0) &&
+    !group.messages.some(({ message }) => messageCarriesAssistantReply(message))
   );
 }
 
-/**
- * Once a turn is done, its intermediate work (tool groups and assistant
- * commentary before the final reply) collapses behind one "Worked for X"
- * disclosure so the thread reads final-output-first. Live turns stay fully
- * expanded; the collapse itself is the done signal.
- */
-export function collapseCompletedTurnWork(
-  items: TurnRenderItem[],
-  opts: { sessionKey: string; runWorking: boolean; searchActive?: boolean },
-): Array<TurnRenderItem | WorkGroupRenderItem> {
-  const [scope, agentId, kind, sessionId, ...extraParts] = normalizeLowercaseStringOrEmpty(
-    opts.sessionKey,
-  ).split(":");
-  const isDashboardSession =
-    scope === "agent" &&
-    Boolean(agentId) &&
-    kind === "dashboard" &&
-    Boolean(sessionId) &&
-    extraParts.length === 0;
-  // Channel sessions can also be opened in the Control UI, but their full
-  // transcript remains the canonical presentation on message surfaces.
-  if (!isDashboardSession || opts.searchActive) {
-    return items;
+function groupNeedsActivityDisclosure(group: MessageGroup): boolean {
+  if (group.messages.length > 1) {
+    return true;
   }
-  const turns: TurnRenderItem[][] = [];
-  let currentTurn: TurnRenderItem[] = [];
-  for (const item of items) {
-    if (item.kind !== "stream-run" && chatItemStartsUserTurn(item) && currentTurn.length > 0) {
-      turns.push(currentTurn);
-      currentTurn = [];
-    }
-    currentTurn.push(item);
-  }
-  if (currentTurn.length > 0) {
-    turns.push(currentTurn);
-  }
-
-  const result: Array<TurnRenderItem | WorkGroupRenderItem> = [];
-  for (const [turnIndex, turn] of turns.entries()) {
-    // In-flight content (stream runs, streaming groups) marks the turn live.
-    // While the run works, the trailing turn also stays expanded so activity
-    // is watchable until the terminal rebuild collapses it.
-    const isLive =
-      (opts.runWorking && turnIndex === turns.length - 1) ||
-      turn.some(
-        (item) => item.kind === "stream-run" || (item.kind === "group" && item.isStreaming),
-      );
-    if (isLive) {
-      result.push(...turn);
-      continue;
-    }
-    let finalReplyIndex = -1;
-    for (let index = turn.length - 1; index >= 0; index -= 1) {
-      const candidate = turn[index];
-      if (candidate && isFinalReplyGroup(candidate)) {
-        finalReplyIndex = index;
-        break;
-      }
-    }
-    // Without a final reply, the tool rows are the turn's only visible result.
-    // Keep them exposed instead of replacing the result with an opaque rollup.
-    if (finalReplyIndex === -1) {
-      result.push(...turn);
-      continue;
-    }
-    const segmentEnd = finalReplyIndex - 1;
-    let segmentStart = segmentEnd + 1;
-    for (let index = segmentEnd; index >= 0; index -= 1) {
-      const candidate = turn[index];
-      if (!candidate || !isCollapsibleWorkGroup(candidate)) {
-        break;
-      }
-      segmentStart = index;
-    }
-    const groups = turn.slice(segmentStart, segmentEnd + 1) as MessageGroup[];
-    const firstGroup = groups[0];
-    if (!firstGroup) {
-      result.push(...turn);
-      continue;
-    }
-    const boundary = turn[0];
-    const boundaryTimestamp =
-      boundary &&
-      boundary.kind !== "stream-run" &&
-      chatItemStartsUserTurn(boundary) &&
-      "timestamp" in boundary
-        ? boundary.timestamp
-        : null;
-    const startTimestamp = boundaryTimestamp == null ? firstGroup.timestamp : boundaryTimestamp;
-    const finalReply = turn[finalReplyIndex] as MessageGroup;
-    const endTimestamp = finalReply.timestamp;
-    const durationMs = endTimestamp > startTimestamp ? endTimestamp - startTimestamp : null;
-    result.push(...turn.slice(0, segmentStart));
-    result.push({
-      kind: "work-group",
-      // The final reply survives older-history prepends; the first work row does not.
-      key: `work:${finalReply.key}`,
-      groups,
-      durationMs,
-    });
-    result.push(...turn.slice(segmentEnd + 1));
-  }
-  return result;
+  return (
+    group.messages.reduce(
+      (count, item) => count + extractToolCardsCached(item.message, item.key).length,
+      0,
+    ) > 1
+  );
 }
 
-type CompletedTurnRenderItem = TurnRenderItem | WorkGroupRenderItem;
+function groupContainsOnlyReasoning(group: MessageGroup): boolean {
+  return (
+    normalizeRoleForGrouping(group.role) === "assistant" &&
+    group.messages.every(({ message }) => {
+      const content = safeNormalizeMessage(message)?.content ?? [];
+      return content.length > 0 && content.every(isReasoningContentBlock);
+    })
+  );
+}
 
-/** Presentation-only rollup for tool groups separated by projected turn boundaries. */
+/** Canonical presentation rollup for each contiguous run of tool activity. */
 export function coalesceActivityRuns(
-  items: CompletedTurnRenderItem[],
+  items: TurnRenderItem[],
   opts: { searchActive?: boolean } = {},
-): Array<CompletedTurnRenderItem | ActivityRunRenderItem> {
+): Array<TurnRenderItem | ActivityRunRenderItem> {
   if (opts.searchActive) {
     return items;
   }
-  const result: Array<CompletedTurnRenderItem | ActivityRunRenderItem> = [];
+  const result: Array<TurnRenderItem | ActivityRunRenderItem> = [];
   let groups: MessageGroup[] = [];
+  let pendingReasoning: MessageGroup[] = [];
   const flush = () => {
     const [first] = groups;
     if (!first) {
       return;
     }
+    const needsDisclosure = groups.length > 1 || groupNeedsActivityDisclosure(first);
     result.push(
-      groups.length === 1 ? first : { kind: "activity-run", key: `activity:${first.key}`, groups },
+      needsDisclosure ? { kind: "activity-run", key: `activity:${first.key}`, groups } : first,
     );
     groups = [];
   };
+  const flushPendingReasoning = () => {
+    result.push(...pendingReasoning);
+    pendingReasoning = [];
+  };
   for (const item of items) {
-    if (item.kind === "group" && item.role.toLowerCase() === "tool") {
+    if (item.kind === "group" && groupFoldsIntoActivity(item)) {
+      groups.push(...pendingReasoning);
+      pendingReasoning = [];
       groups.push(item);
       continue;
     }
+    if (item.kind === "group" && groupContainsOnlyReasoning(item)) {
+      if (groups.length > 0) {
+        groups.push(item);
+      } else {
+        pendingReasoning.push(item);
+      }
+      continue;
+    }
     flush();
+    flushPendingReasoning();
     result.push(item);
   }
   flush();
+  flushPendingReasoning();
   return result;
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -11,7 +11,6 @@ import {
   buildCachedChatItems,
   coalesceActivityRuns,
   coalesceStreamRuns,
-  collapseCompletedTurnWork,
   getExpansionStateVersion,
   getExpandedToolCards,
   getExpandedUserMessages,
@@ -64,10 +63,6 @@ describe("persistedMessageEntryId", () => {
 
 type CachedChatItemsProps = Parameters<typeof buildCachedChatItems>[0];
 type ChatQueueItem = NonNullable<CachedChatItemsProps["queue"]>[number];
-type WorkGroupItem = Extract<
-  ReturnType<typeof collapseCompletedTurnWork>[number],
-  { kind: "work-group" }
->;
 type ActivityRunItem = Extract<
   ReturnType<typeof coalesceActivityRuns>[number],
   { kind: "activity-run" }
@@ -718,287 +713,6 @@ describe("assistant commentary grouping", () => {
   });
 });
 
-describe("collapseCompletedTurnWork", () => {
-  const collapsedItems = (props: Partial<CachedChatItemsProps>, runWorking = false) =>
-    collapseCompletedTurnWork(coalesceStreamRuns(buildCachedChatItems(createProps(props))), {
-      sessionKey: "agent:main:dashboard:test-session",
-      runWorking,
-    });
-
-  function requireWorkGroup(value: unknown): WorkGroupItem {
-    const record = requireRecord(value);
-    expect(record.kind).toBe("work-group");
-    return value as WorkGroupItem;
-  }
-
-  const toolResult = (id: string, timestamp: number, isError = false) => ({
-    role: "toolResult",
-    toolCallId: id,
-    toolName: "bash",
-    isError,
-    content: isError ? "boom" : "ok",
-    timestamp,
-  });
-
-  it("collapses a completed turn's work behind one worked-for rollup", () => {
-    const items = collapsedItems({
-      messages: [
-        userMessage("do it", 1_000),
-        assistantMessage("Checking…", 2_000),
-        toolResult("call-1", 3_000),
-        assistantMessage("All done.", 10_000),
-      ],
-    });
-
-    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
-    const work = requireWorkGroup(items[1]);
-    expect(work.groups).toHaveLength(2);
-    expect(work.durationMs).toBe(9_000);
-    expect(requireGroup(items[2]).role).toBe("assistant");
-  });
-
-  it.each([
-    "agent:main:main",
-    "agent:main:telegram:direct:42",
-    "agent:main::dashboard:malformed",
-    "agent:main:dashboard:session:extra",
-  ])("keeps completed work expanded for non-dashboard session %s", (sessionKey) => {
-    const items = coalesceStreamRuns(
-      buildCachedChatItems(
-        createProps({
-          sessionKey,
-          messages: [
-            userMessage("do it", 1_000),
-            assistantMessage("Checking…", 2_000),
-            toolResult("call-1", 3_000),
-            assistantMessage("All done.", 10_000),
-          ],
-        }),
-      ),
-    );
-
-    const rendered = collapseCompletedTurnWork(items, { sessionKey, runWorking: false });
-
-    expect(rendered.map((item) => item.kind)).toEqual(["group", "group", "group", "group"]);
-  });
-
-  it("keeps the trailing turn expanded while the run works", () => {
-    const items = collapsedItems(
-      {
-        runWorking: true,
-        messages: [userMessage("do it", 1_000), toolResult("call-1", 2_000)],
-      },
-      true,
-    );
-
-    expect(items.some((item) => item.kind === "work-group")).toBe(false);
-  });
-
-  it("keeps reply-less turns expanded after the run finishes", () => {
-    const messages = [userMessage("do it", 1_000), toolResult("call-1", 2_000)];
-
-    // A reply-less executing turn stays expanded while live and remains visible
-    // after completion instead of becoming an opaque worked-for rollup.
-    expect(collapsedItems({ messages }, true).some((item) => item.kind === "work-group")).toBe(
-      false,
-    );
-
-    const idle = collapsedItems({ messages });
-    expect(idle.map((item) => item.kind)).toEqual(["group", "group"]);
-    expect(requireGroup(idle[1]).role).toBe("tool");
-  });
-
-  it("keeps failed work visible in turns that never replied", () => {
-    const items = collapsedItems({
-      messages: [userMessage("go", 1_000), toolResult("call-1", 2_000, true)],
-    });
-
-    expect(items.map((item) => item.kind)).toEqual(["group", "group"]);
-    expect(requireGroup(items[1]).role).toBe("tool");
-  });
-
-  it("collapses failed work once the turn recovered with a reply", () => {
-    const items = collapsedItems({
-      messages: [
-        userMessage("go", 1_000),
-        toolResult("call-1", 2_000, true),
-        assistantMessage("Recovered via another route.", 3_000),
-      ],
-    });
-
-    expect(requireWorkGroup(items[1]).groups).toHaveLength(1);
-  });
-
-  it("keeps work after the final reply visible", () => {
-    const items = collapsedItems({
-      messages: [
-        userMessage("go", 1_000),
-        toolResult("call-1", 2_000),
-        assistantMessage("Done.", 3_000),
-        toolResult("call-2", 4_000),
-      ],
-    });
-
-    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group", "group"]);
-    expect(requireGroup(items[3]).role).toBe("tool");
-  });
-
-  it("does not collapse across dividers", () => {
-    const items = collapsedItems({
-      messages: [
-        userMessage("go", 1_000),
-        toolResult("call-1", 2_000),
-        {
-          role: "system",
-          content: "",
-          timestamp: 3_000,
-          __openclaw: { kind: "compaction", id: "c1" },
-        },
-        assistantMessage("Done.", 4_000),
-      ],
-    });
-
-    expect(items.some((item) => item.kind === "work-group")).toBe(false);
-    expect(items.some((item) => item.kind === "divider")).toBe(true);
-  });
-
-  it("keeps attachment-only final replies outside the work rollup", () => {
-    const items = collapsedItems({
-      messages: [
-        userMessage("render it", 1_000),
-        toolResult("call-1", 2_000),
-        assistantMessage(
-          [
-            {
-              type: "image",
-              url: "/media/screenshot.png",
-              source: { type: "url", url: "/media/screenshot.png" },
-            },
-          ],
-          3_000,
-        ),
-      ],
-    });
-
-    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
-    expect(requireGroup(items[2]).role).toBe("assistant");
-  });
-
-  it("keeps search matches visible instead of folding them into a rollup", () => {
-    const items = collapseCompletedTurnWork(
-      coalesceStreamRuns(
-        buildCachedChatItems(
-          createProps({
-            messages: [
-              userMessage("do it", 1_000),
-              toolResult("call-1", 2_000),
-              assistantMessage("All done.", 3_000),
-            ],
-            searchOpen: true,
-            searchQuery: "ok",
-          }),
-        ),
-      ),
-      {
-        sessionKey: "agent:main:dashboard:test-session",
-        runWorking: false,
-        searchActive: true,
-      },
-    );
-
-    expect(items.some((item) => item.kind === "work-group")).toBe(false);
-  });
-
-  it("collapses each completed turn independently", () => {
-    const items = collapsedItems({
-      messages: [
-        userMessage("first", 1_000),
-        toolResult("call-1", 2_000),
-        assistantMessage("First done.", 3_000),
-        userMessage("second", 4_000),
-        toolResult("call-2", 5_000),
-        assistantMessage("Second done.", 6_000),
-      ],
-    });
-
-    const workGroups = items.filter((item) => item.kind === "work-group");
-    expect(workGroups).toHaveLength(2);
-    expect(new Set(workGroups.map((item) => item.key)).size).toBe(2);
-  });
-
-  it("keeps recovery work separate when a system notice starts the next turn", () => {
-    const items = collapsedItems({
-      messages: [
-        userMessage("first", 1_000),
-        toolResult("call-1", 2_000),
-        assistantMessage("First done.", 3_000),
-        userMessage("[System] Continue the interrupted turn.", 4_000, {
-          provenance: { kind: "internal_system", sourceTool: "main_session_restart_recovery" },
-        }),
-        toolResult("call-2", 5_000),
-        assistantMessage("Recovery done.", 6_000),
-      ],
-    });
-
-    const workGroups = items.filter((item) => item.kind === "work-group");
-    expect(workGroups).toHaveLength(2);
-    expect(workGroups.map((item) => messageRecord(groupAt(item.groups, 0)).toolCallId)).toEqual([
-      "call-1",
-      "call-2",
-    ]);
-  });
-
-  it("collapses hidden-input runs independently without changing duration arithmetic", () => {
-    const items = collapsedItems({
-      messages: [
-        {
-          ...toolResult("call-1", 1_000),
-          __openclaw: { id: "work-1", seq: 1, turnBoundary: true },
-        },
-        assistantMessage("First run done.", 3_000, {
-          __openclaw: { id: "reply-1", seq: 2 },
-        }),
-        {
-          ...toolResult("call-2", 4_000),
-          __openclaw: { id: "work-2", seq: 3, turnBoundary: true },
-        },
-        assistantMessage("Second run done.", 9_000, {
-          __openclaw: { id: "reply-2", seq: 4 },
-        }),
-      ],
-    });
-
-    expect(items.map((item) => item.kind)).toEqual(["work-group", "group", "work-group", "group"]);
-    expect(requireWorkGroup(items[0]).durationMs).toBe(2_000);
-    expect(requireWorkGroup(items[2]).durationMs).toBe(5_000);
-  });
-
-  it("keeps a completed-work row keyed to its final reply as older work is prepended", () => {
-    resetChatThreadState();
-    const finalReply = assistantMessage("Done.", 3_000, {
-      __openclaw: { id: "final-reply", seq: 3 },
-    });
-    const initial = collapsedItems({
-      messages: [toolResult("call-1", 2_000), finalReply],
-    });
-    const initialWork = requireWorkGroup(initial[0]);
-
-    const prepended = collapsedItems({
-      messages: [
-        assistantMessage("Checking.", 1_000, {
-          __openclaw: { id: "older-commentary", seq: 1 },
-        }),
-        toolResult("call-1", 2_000),
-        finalReply,
-      ],
-    });
-    const prependedWork = requireWorkGroup(prepended[0]);
-
-    expect(prependedWork.key).toBe(initialWork.key);
-    expect(prependedWork.durationMs).toBeGreaterThan(initialWork.durationMs ?? 0);
-  });
-});
-
 describe("coalesceActivityRuns", () => {
   const toolResult = (id: string, timestamp: number, overrides: Record<string, unknown> = {}) => ({
     role: "toolResult",
@@ -1055,7 +769,7 @@ describe("coalesceActivityRuns", () => {
     expect(appended.key).toBe(initial.key);
   });
 
-  it("treats every non-tool item as a hard presentation boundary", () => {
+  it("treats user messages and dividers as hard presentation boundaries", () => {
     const groups = projectedToolGroups();
     const userBoundary: MessageGroup = {
       kind: "group",
@@ -1089,6 +803,130 @@ describe("coalesceActivityRuns", () => {
 
     expect(singleton[0]).toBe(groups[0]);
     expect(coalesceActivityRuns(searchInput, { searchActive: true })).toBe(searchInput);
+  });
+
+  it("promotes one group with parallel tool cards into an activity disclosure", () => {
+    const parallelGroup: MessageGroup = {
+      kind: "group",
+      key: "group:tool:parallel",
+      role: "tool",
+      messages: [
+        {
+          key: "tool:parallel",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "toolCall", id: "call-a", name: "read", arguments: { path: "a.ts" } },
+              { type: "toolCall", id: "call-b", name: "read", arguments: { path: "b.ts" } },
+              { type: "toolResult", id: "call-a", name: "read", text: "A" },
+              { type: "toolResult", id: "call-b", name: "read", text: "B" },
+            ],
+          },
+        },
+      ],
+      timestamp: 1_000,
+      isStreaming: false,
+    };
+
+    expect(requireActivityRun(coalesceActivityRuns([parallelGroup])[0]).groups).toEqual([
+      parallelGroup,
+    ]);
+  });
+
+  it("keeps assistant reply text outside adjacent tool activity", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        paneId: "activity-run-mixed-reply",
+        messages: [
+          toolResult("call-1", 1_000),
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "The result is ready." },
+              {
+                type: "tool_use",
+                id: "call-2",
+                name: "bash",
+                input: { command: "echo done" },
+              },
+            ],
+            timestamp: 2_000,
+          },
+        ],
+      }),
+    ).filter((item): item is MessageGroup => item.kind === "group");
+
+    expect(items).toHaveLength(2);
+    expect(coalesceActivityRuns(items)).toEqual(items);
+  });
+
+  it("folds reasoning carried by a tool call while keeping visible artifacts top-level", () => {
+    const toolItems = buildCachedChatItems(
+      createProps({
+        paneId: "activity-run-reasoning-tool",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "Inspect the file first." },
+              { type: "reasoning", thinking: "Then compare the result." },
+              { type: "redacted_thinking" },
+              {
+                type: "toolCall",
+                id: "call-reasoning",
+                name: "read",
+                arguments: { path: "src/report.ts" },
+              },
+            ],
+            timestamp: 1_000,
+          },
+          toolResult("call-reasoning", 2_000, { toolName: "read" }),
+        ],
+      }),
+    ).filter((item): item is MessageGroup => item.kind === "group");
+    expect(toolItems).toHaveLength(1);
+
+    const reasoning: MessageGroup = {
+      kind: "group",
+      key: "group:assistant:reasoning",
+      role: "assistant",
+      messages: [
+        {
+          key: "assistant:reasoning",
+          message: {
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "Compare both results." }],
+          },
+        },
+      ],
+      timestamp: 2_500,
+      isStreaming: false,
+    };
+    const visibleArtifact: MessageGroup = {
+      ...reasoning,
+      key: "group:assistant:artifact",
+      messages: [
+        {
+          key: "assistant:artifact",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "Render the image." },
+              { type: "image", url: "/media/result.png" },
+            ],
+          },
+        },
+      ],
+    };
+    const groups = projectedToolGroups().slice(0, 2);
+    const withToolReasoning = coalesceActivityRuns([toolItems[0]!, groups[0]!]);
+    const withReasoning = coalesceActivityRuns([reasoning, ...groups]);
+    const withArtifact = coalesceActivityRuns([visibleArtifact, ...groups]);
+
+    expect(requireActivityRun(withToolReasoning[0]).groups[0]).toBe(toolItems[0]);
+    expect(requireActivityRun(withReasoning[0]).groups[0]).toBe(reasoning);
+    expect(withArtifact[0]).toBe(visibleArtifact);
+    expect(requireActivityRun(withArtifact[1]).groups).toEqual(groups);
   });
 });
 

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -26,7 +26,6 @@ export {
   assistantGroupCanOwnActiveRunStatus,
   coalesceActivityRuns,
   coalesceStreamRuns,
-  collapseCompletedTurnWork,
 } from "./chat-thread-grouping.ts";
 
 type CachedChatItems = {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -285,12 +285,6 @@ function renderStreamGroupMock(
   </div>`;
 }
 
-function renderWorkGroupSummaryMock(
-  ..._args: Parameters<typeof chatMessage.renderWorkGroupSummary>
-): ReturnType<typeof chatMessage.renderWorkGroupSummary> {
-  return html`<div class="chat-work-group"></div>`;
-}
-
 beforeEach(() => {
   vi.spyOn(chatThread, "buildCachedChatItems").mockImplementation(buildChatItemsMock);
   vi.spyOn(chatThread, "getExpandedToolCards").mockReturnValue(new Map<string, boolean>());
@@ -301,7 +295,6 @@ beforeEach(() => {
   );
   vi.spyOn(chatMessage, "renderMessageGroup").mockImplementation(renderMessageGroupMock);
   vi.spyOn(chatMessage, "renderStreamGroup").mockImplementation(renderStreamGroupMock);
-  vi.spyOn(chatMessage, "renderWorkGroupSummary").mockImplementation(renderWorkGroupSummaryMock);
 });
 
 function createSessionsResultFromRows(

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -8,7 +8,7 @@ import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { normalizeRoleForGrouping } from "../../../lib/chat/message-normalizer.ts";
 import { formatSenderLabel } from "../../../lib/chat/sender-label.ts";
 import { summarizeToolGroup } from "../../../lib/chat/tool-call-grouping.ts";
-import { extractToolCardsCached } from "../../../lib/chat/tool-cards.ts";
+import { extractToolCardsCached, resolveToolCardOutcome } from "../../../lib/chat/tool-cards.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import { resolveIdentityHue } from "../../../lib/identity-avatar.ts";
@@ -233,18 +233,17 @@ export function renderActivityGroup(
   const cards = groups.flatMap((group) =>
     group.messages.flatMap((item) => extractToolCardsCached(item.message, item.key)),
   );
-  const latestGroup = groups[groups.length - 1] ?? firstGroup;
-  const latestCards = latestGroup.messages.flatMap((item) =>
-    extractToolCardsCached(item.message, item.key),
-  );
   // While a run is live, the newest still-running call names the group so
   // the collapsed header reads like a status line; afterwards it aggregates.
   const runningCard = opts.runActive
-    ? latestCards.findLast((card) => isRunningToolCard(card, opts.runActive))
+    ? cards.findLast((card) => isRunningToolCard(card, opts.runActive))
     : undefined;
   const groupSummaryLabel = runningCard
     ? `${resolveToolRowText(runningCard, opts.runActive)}…`
     : summarizeToolGroup(cards.map((card) => ({ name: card.name, args: card.args })));
+  const hasInterrupted = cards.some(
+    (card) => resolveToolCardOutcome(card, opts.runActive) === "interrupted",
+  );
   const activityDisclosureId = `activity:${firstGroup.key}`;
   const activityBodyId = `activity-body-${fnv1aUtf16(firstGroup.key).toString(16)}`;
   const activityExpanded =
@@ -274,6 +273,11 @@ export function renderActivityGroup(
               <span class="chat-activity-group__label" title=${groupSummaryLabel}
                 >${groupSummaryLabel}</span
               >
+              ${hasInterrupted
+                ? html`<span class="chat-tool-row__outcome"
+                    >${t("chat.toolCards.interrupted")}</span
+                  >`
+                : nothing}
             </span>
             <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
           </button>
@@ -351,15 +355,6 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
 
   if (normalizedRole === "tool" && opts.showToolCalls === false) {
     return nothing;
-  }
-
-  const groupedToolCards =
-    normalizedRole === "tool"
-      ? group.messages.flatMap((item) => extractToolCardsCached(item.message, item.key))
-      : [];
-
-  if (normalizedRole === "tool" && (group.messages.length > 1 || groupedToolCards.length > 1)) {
-    return renderActivityGroup([group], opts);
   }
 
   const messageActionDetails = group.messages.map((item) =>

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -1,17 +1,13 @@
 import { html, nothing } from "lit";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
-import { icons } from "../../../components/icons.ts";
-import { t } from "../../../i18n/index.ts";
 import type { AssistantIdentity } from "../../../lib/assistant-identity.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
-import { formatDurationCompact } from "../../../lib/format.ts";
 import { renderChatAvatar } from "../chat-avatar.ts";
 import type { ChatRunStartupPhase } from "../chat-run-startup.ts";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
 import { renderChatTimestamp } from "./chat-message-timestamp.ts";
 import { renderChatQuestionSummary } from "./chat-question-card.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
-import { shouldToggleSelectableDisclosure, syncToolDisclosureOverflow } from "./chat-tool-cards.ts";
 import { renderChatWorkingIndicator } from "./chat-working-indicator.ts";
 
 /** A contiguous run of in-flight streaming items rendered under one assistant group. */
@@ -139,45 +135,6 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
             </div>
           `
         : nothing}
-    </div>
-  `;
-}
-
-/**
- * Collapsed-turn rollup header: one slim "Worked for X" disclosure standing in
- * for the turn's intermediate work once the run is done. The check icon is
- * the turn's done indicator; the expanded groups render after this row.
- */
-export function renderWorkGroupSummary(
-  item: { key: string; durationMs: number | null },
-  opts: { expanded: boolean; onToggle: () => void },
-) {
-  const duration = formatDurationCompact(item.durationMs);
-  const label = duration ? t("chat.workRun.workedFor", { duration }) : t("chat.workRun.worked");
-  return html`
-    <div class="chat-group tool chat-group--work" data-chat-row-key=${item.key}>
-      <div class="chat-group-messages">
-        <div class="chat-activity-group chat-work-group ${opts.expanded ? "is-open" : ""}">
-          <button
-            class="chat-inline-disclosure chat-activity-group__summary"
-            type="button"
-            aria-expanded=${String(opts.expanded)}
-            @pointerenter=${syncToolDisclosureOverflow}
-            @focus=${syncToolDisclosureOverflow}
-            @click=${(event: MouseEvent) => {
-              if (shouldToggleSelectableDisclosure(event)) {
-                opts.onToggle();
-              }
-            }}
-          >
-            <span class="chat-tool-disclosure__content">
-              <span class="chat-activity-group__label" title=${label}>${label}</span>
-            </span>
-            <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
-          </button>
-          <div class="chat-work-group__separator" aria-hidden="true"></div>
-        </div>
-      </div>
     </div>
   `;
 }

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -415,6 +415,23 @@ function renderMessageGroups(
   render(html`${groups.map((group) => renderTestMessageGroup(group, opts))}`, container);
 }
 
+function renderActivityGroups(
+  container: HTMLElement,
+  groups: MessageGroup[],
+  opts: Partial<RenderMessageGroupOptions> = {},
+) {
+  render(
+    renderActivityGroup(groups, {
+      showReasoning: true,
+      showToolCalls: true,
+      assistantName: "OpenClaw",
+      assistantAvatar: null,
+      ...opts,
+    }),
+    container,
+  );
+}
+
 function clearConfirmedActionSkip() {
   localStorageValues.delete("openclaw:skip-rewind-confirm");
 }
@@ -2261,7 +2278,7 @@ describe("grouped chat rendering", () => {
       ),
     ]);
 
-    renderMessageGroups(container, [group], {
+    renderActivityGroups(container, [group], {
       isToolMessageExpanded: (id) => (id === "activity:tool-group" ? false : undefined),
     });
 
@@ -2291,7 +2308,7 @@ describe("grouped chat rendering", () => {
       ),
     ]);
 
-    renderMessageGroups(container, [group], {
+    renderActivityGroups(container, [group], {
       isToolMessageExpanded: (id) => (id === "activity:parallel-tool-group" ? false : undefined),
     });
 
@@ -2389,7 +2406,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelectorAll(".chat-activity-group__body > .chat-bubble")).toHaveLength(3);
   });
 
-  it("uses the newest group's live card label without inheriting an earlier failure", () => {
+  it("keeps the latest running card active through trailing reasoning", () => {
     const container = document.createElement("div");
     const groups = [
       createToolGroup("live-first", [
@@ -2418,6 +2435,13 @@ describe("grouped chat rendering", () => {
           }),
         ],
         { isStreaming: true },
+      ),
+      createMessageGroup(
+        createAssistantMessage([
+          { type: "thinking", thinking: "Check the edited file before replying." },
+        ]),
+        "assistant",
+        { key: "live-reasoning" },
       ),
     ];
     const opts = { showReasoning: true, showToolCalls: true, runActive: true };
@@ -2541,7 +2565,7 @@ describe("grouped chat rendering", () => {
       { timestamp: 1000, isStreaming: true },
     );
 
-    renderMessageGroups(container, [group], { runActive: true });
+    renderActivityGroups(container, [group], { runActive: true });
 
     expect(container.querySelector(".chat-activity-group__label")?.textContent).toBe(
       "Editing a.ts…",
@@ -2568,7 +2592,7 @@ describe("grouped chat rendering", () => {
       ),
     ]);
 
-    renderMessageGroups(container, [group], { onToggleToolMessageExpanded });
+    renderActivityGroups(container, [group], { onToggleToolMessageExpanded });
 
     expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
     const activitySummary = expectElement(
@@ -2610,7 +2634,7 @@ describe("grouped chat rendering", () => {
       ),
     ]);
 
-    renderMessageGroups(container, [group]);
+    renderActivityGroups(container, [group]);
 
     expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
     expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
@@ -2648,7 +2672,7 @@ describe("grouped chat rendering", () => {
       ),
     ]);
 
-    renderMessageGroups(container, [group], {
+    renderActivityGroups(container, [group], {
       isToolMessageExpanded: (id) => id === "activity:recovered-tool-group",
     });
 
@@ -2678,7 +2702,7 @@ describe("grouped chat rendering", () => {
       ),
     ]);
 
-    renderMessageGroups(container, [group], { showToolCalls: false });
+    renderActivityGroups(container, [group], { showToolCalls: false });
 
     expect(container.querySelector(".chat-activity-group")).toBeNull();
   });
@@ -3029,6 +3053,61 @@ describe("grouped chat rendering", () => {
     renderMessageGroups(container, groups, { isToolMessageExpanded: () => true });
 
     expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("Exit code 1");
+    container.remove();
+  });
+
+  it("keeps an interrupted live tool visible after its run stops", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const groups = [
+      createMessageGroup(
+        createAssistantMessage(
+          [createToolCall("call-interrupted", "shell", { command: "sleep 10" })],
+          {
+            id: "tool-interrupted",
+            toolCallId: "call-interrupted",
+            __openclawToolStreamLive: true,
+            __openclawToolStreamResultReceived: false,
+            __openclawToolStreamInterrupted: true,
+          },
+        ),
+        "tool",
+      ),
+    ];
+
+    renderMessageGroups(container, groups, { isToolMessageExpanded: () => false });
+
+    expect(container.querySelector(".chat-tool-row__outcome")?.textContent).toBe("Interrupted");
+    container.remove();
+  });
+
+  it("does not present an interrupted progress card as successfully updated", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const groups = [
+      createMessageGroup(
+        createAssistantMessage(
+          [
+            createToolCall("call-progress-interrupted", "progress_card", {
+              plan: [{ step: "Verify the fix", status: "in_progress" }],
+            }),
+          ],
+          {
+            id: "progress-interrupted",
+            toolCallId: "call-progress-interrupted",
+            __openclawToolStreamLive: true,
+            __openclawToolStreamResultReceived: false,
+            __openclawToolStreamInterrupted: true,
+          },
+        ),
+        "tool",
+      ),
+    ];
+
+    renderMessageGroups(container, groups, { isToolMessageExpanded: () => false });
+
+    expect(container.querySelector(".chat-progress-card-receipt")).toBeNull();
+    expect(container.querySelector(".chat-tool-row__outcome")?.textContent).toBe("Interrupted");
     container.remove();
   });
 

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -8,5 +8,5 @@ export {
 } from "./chat-message-confirmation.ts";
 export { renderActivityGroup, renderMessageGroup } from "./chat-message-group.ts";
 export type { MessageReplyTarget } from "./chat-message-markdown.ts";
-export { renderStreamGroup, renderWorkGroupSummary } from "./chat-message-stream.ts";
+export { renderStreamGroup } from "./chat-message-stream.ts";
 export type { StreamGroupOptions, StreamGroupPart } from "./chat-message-stream.ts";

--- a/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
@@ -601,6 +601,9 @@ describe("isRunningToolCard", () => {
 
     expect(resolveToolCardOutcome(call, false)).toBe("unknown");
     expect(resolveToolCardOutcome({ ...call, live: true }, true)).toBe("running");
+    expect(resolveToolCardOutcome({ ...call, live: true, interrupted: true }, false)).toBe(
+      "interrupted",
+    );
     expect(resolveToolCardOutcome({ ...call, completed: true, outputText: "" }, false)).toBe(
       "succeeded",
     );
@@ -619,6 +622,16 @@ describe("isRunningToolCard", () => {
     });
     expect(running).toHaveLength(1);
     expect(running[0]).toMatchObject({ live: true, completed: false });
+
+    const interrupted = extractToolCards({
+      role: "assistant",
+      toolCallId: "call-live",
+      __openclawToolStreamLive: true,
+      __openclawToolStreamResultReceived: false,
+      __openclawToolStreamInterrupted: true,
+      content: [{ type: "toolcall", name: "bash", arguments: { command: "sleep 5" } }],
+    });
+    expect(interrupted[0]).toMatchObject({ live: true, completed: false, interrupted: true });
 
     const finished = extractToolCards({
       role: "assistant",

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -664,11 +664,13 @@ export function renderToolOutcome(outcome: ToolCardOutcome, exitCode?: number) {
       ? exitCode === undefined
         ? t("chat.toolCards.failed")
         : t("chat.toolCards.exitCode", { code: String(exitCode) })
-      : outcome === "running"
-        ? t("chat.toolCards.running")
-        : outcome === "succeeded"
-          ? t("chat.toolCards.completed")
-          : null;
+      : outcome === "interrupted"
+        ? t("chat.toolCards.interrupted")
+        : outcome === "running"
+          ? t("chat.toolCards.running")
+          : outcome === "succeeded"
+            ? t("chat.toolCards.completed")
+            : null;
   return label ? html`<div class="chat-tool-card__outcome">${label}</div>` : nothing;
 }
 
@@ -764,13 +766,17 @@ export function renderToolCard(
   },
 ) {
   const outcome = resolveToolCardOutcome(card, opts.runActive);
-  const progressReceipt = renderProgressCardReceipt(card, outcome);
+  // An interrupted update produced no successful progress receipt; keep its
+  // terminal fact visible through the generic tool row.
+  const progressReceipt =
+    outcome === "interrupted" ? null : renderProgressCardReceipt(card, outcome);
   if (progressReceipt) {
     return progressReceipt;
   }
   const view = resolveToolCallView({ name: card.name, args: card.args, details: card.details });
   const display = resolveToolDisplay({ name: card.name, args: card.args, detailMode: "explain" });
   const isRunning = outcome === "running";
+  const isInterrupted = outcome === "interrupted";
   const expanded = opts.expanded || isRunning;
   const icon = TOOL_ROW_ICONS[view.kind] ?? display.icon;
   const workspaceFilePath =
@@ -806,6 +812,9 @@ export function renderToolCard(
                 opts.onOpenWorkspaceFile,
               )}</span
             >
+            ${isInterrupted
+              ? html`<span class="chat-tool-row__outcome">${t("chat.toolCards.interrupted")}</span>`
+              : nothing}
             <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
           </div>`
         : html`<button
@@ -826,6 +835,9 @@ export function renderToolCard(
             <span class="chat-tool-disclosure__content"
               >${renderToolRowContent(card, view, outcome)}</span
             >
+            ${isInterrupted
+              ? html`<span class="chat-tool-row__outcome">${t("chat.toolCards.interrupted")}</span>`
+              : nothing}
             <span class="chat-tool-row__chevron" aria-hidden="true">${icons.chevronRight}</span>
           </button>`}
       ${expanded

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -1,6 +1,6 @@
 // Chat-item projection, expansion, reply hydration, and guarded row rendering.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { html, nothing, type TemplateResult } from "lit";
+import { nothing, type TemplateResult } from "lit";
 import { guard } from "lit/directives/guard.js";
 import { classifySessionKind } from "../../../../../src/sessions/classify-session-kind.js";
 import { i18n } from "../../../i18n/index.ts";
@@ -20,7 +20,6 @@ import {
   buildCachedChatItems,
   coalesceActivityRuns,
   coalesceStreamRuns,
-  collapseCompletedTurnWork,
   getExpansionStateVersion,
   getExpandedAssistantMessages,
   getExpandedToolCards,
@@ -39,7 +38,6 @@ import {
   renderActivityGroup,
   renderMessageGroup,
   renderStreamGroup,
-  renderWorkGroupSummary,
   type MessageReplyTarget,
   type StreamGroupOptions,
   type StreamGroupPart,
@@ -130,9 +128,6 @@ function latestTranscriptAnnouncement(
 function chatRenderItemGuardDependencies(item: ChatRenderItem): readonly unknown[] {
   if (item.kind === "stream-run") {
     return [item.key, ...item.parts];
-  }
-  if (item.kind === "work-group") {
-    return [item.key, item.durationMs, ...item.groups];
   }
   if (item.kind === "activity-run") {
     return [item.key, ...item.groups];
@@ -456,26 +451,10 @@ export function projectChatTranscript(
         runOutputTokens: props.runOutputTokens,
       });
     }
-    if (item.kind === "work-group") {
-      const workExpanded = expandedToolCards.get(item.key) ?? false;
-      return html`
-        ${renderWorkGroupSummary(item, {
-          expanded: workExpanded,
-          onToggle: () => {
-            setExpansionState(expandedToolCards, item.key, !workExpanded);
-            requestUpdate();
-          },
-        })}
-        ${workExpanded ? item.groups.map((group) => renderGroupItem(group)) : nothing}
-      `;
-    }
     if (item.kind === "activity-run") {
       const firstGroup = item.groups[0];
       if (!firstGroup) {
         return nothing;
-      }
-      if (item.groups.length === 1) {
-        return renderGroupItem(firstGroup);
       }
       return renderActivityGroup(item.groups, renderGroupOptions(firstGroup));
     }
@@ -489,14 +468,9 @@ export function projectChatTranscript(
     }
     return nothing;
   });
-  const collapsedItems = coalesceActivityRuns(
-    collapseCompletedTurnWork(coalesceStreamRuns(chatItems), {
-      sessionKey: props.sessionKey,
-      runWorking: Boolean(props.runWorking),
-      searchActive: searchFiltering,
-    }),
-    { searchActive: searchFiltering },
-  );
+  const collapsedItems = coalesceActivityRuns(coalesceStreamRuns(chatItems), {
+    searchActive: searchFiltering,
+  });
   // Watch/settle on actual indicator visibility (not runWorking): queued
   // sends show the claw before the run starts, and the recap must never
   // stack under a visible working row.

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -502,6 +502,100 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     expect(rowActive(host)).toBe(true);
   });
 
+  it.each(["done", "interrupted"] as const)(
+    "marks open tools interrupted when their owning run ends as %s",
+    (outcome) => {
+      const identity = "r1:call-open";
+      const siblingIdentity = "r2:call-open";
+      const completedIdentity = "r1:call-complete";
+      const message = {
+        role: "assistant",
+        runId: "r1",
+        toolCallId: "call-open",
+        content: [{ type: "toolcall", name: "bash", arguments: { command: "sleep 10" } }],
+        __openclawToolStreamLive: true,
+        __openclawToolStreamResultReceived: false,
+      };
+      const host = makeHost({
+        chatRunId: "r1",
+        toolStreamById: new Map([
+          [
+            identity,
+            {
+              toolCallId: "call-open",
+              runId: "r1",
+              name: "bash",
+              args: { command: "sleep 10" },
+              startedAt: 1,
+              receivedAt: 1,
+              message,
+            },
+          ],
+          [
+            siblingIdentity,
+            {
+              toolCallId: "call-open",
+              runId: "r2",
+              name: "bash",
+              args: { command: "sleep 20" },
+              startedAt: 2,
+              receivedAt: 2,
+              message: { ...message, runId: "r2" },
+            },
+          ],
+          [
+            completedIdentity,
+            {
+              toolCallId: "call-complete",
+              runId: "r1",
+              name: "bash",
+              args: { command: "true" },
+              resultReceived: true,
+              startedAt: 3,
+              receivedAt: 3,
+              message: {
+                ...message,
+                toolCallId: "call-complete",
+                __openclawToolStreamResultReceived: true,
+              },
+            },
+          ],
+        ]),
+        toolStreamOrder: [identity, siblingIdentity, completedIdentity],
+        chatToolMessages: [
+          message,
+          { ...message, runId: "r2" },
+          {
+            ...message,
+            toolCallId: "call-complete",
+            __openclawToolStreamResultReceived: true,
+          },
+        ],
+        chatStreamSegments: [],
+        toolStreamSyncTimer: null,
+      });
+
+      reconcileChatRunLifecycle(host, {
+        outcome,
+        runId: "r1",
+        sessionKey: "s1",
+        clearLocalRun: true,
+        clearChatStream: true,
+        publishRunStatus: false,
+      });
+
+      expect(host.toolStreamById?.get(identity)).toMatchObject({
+        interrupted: true,
+        message: { __openclawToolStreamInterrupted: true },
+      });
+      expect(host.chatToolMessages?.[0]).toMatchObject({
+        __openclawToolStreamInterrupted: true,
+      });
+      expect(host.toolStreamById?.get(siblingIdentity)?.interrupted).toBeUndefined();
+      expect(host.toolStreamById?.get(completedIdentity)?.interrupted).toBeUndefined();
+    },
+  );
+
   it("does not clear an unidentified active row from an unowned terminal event", () => {
     const host = makeHost({
       sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: true, status: "running" }]),

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -23,6 +23,7 @@ import { formatConnectError } from "./connect-error.ts";
 import { resetChatInputHistoryNavigation, type ChatInputHistoryState } from "./input-history.ts";
 // Control UI chat module implements run lifecycle behavior.
 import {
+  interruptOpenToolStream,
   resetToolStream,
   type CompactionStatus,
   type FallbackStatus,
@@ -441,6 +442,12 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
   const occurredAt = Date.now();
   const runId = options.runId ?? host.chatRunId ?? null;
   const sessionKey = toSessionKey(options.sessionKey) ?? host.sessionKey;
+
+  // Any terminal run leaves unresolved calls without an owning producer.
+  // Record that fact before cleanup so the transcript never shows unknown work.
+  if (options.outcome && canResetToolStream(host)) {
+    interruptOpenToolStream(host, runId);
+  }
 
   if (options.clearIndicators ?? true) {
     clearRunIndicators(host, runId);

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -246,6 +246,113 @@ describe("app-tool-stream throttled projections", () => {
 });
 
 describe("app-tool-stream result blocks", () => {
+  it("drops orphan progress but retains an orphan final result", () => {
+    const host = createHost();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        handleAgentEvent(
+          host,
+          agentEvent("run-1", 1, "tool", {
+            phase: "update",
+            name: "bash",
+            toolCallId: "orphan-progress",
+            partialResult: "still running",
+          }),
+        ),
+      ).toBe(false);
+      expect(host.toolStreamById.size).toBe(0);
+
+      expect(
+        handleAgentEvent(
+          host,
+          agentEvent("run-1", 2, "tool", {
+            phase: "result",
+            name: "bash",
+            toolCallId: "orphan-result",
+            result: "finished",
+          }),
+        ),
+      ).toBe(true);
+      expect(
+        host.toolStreamById.get(buildToolStreamIdentity("run-1", "orphan-result")),
+      ).toMatchObject({ output: "finished", resultReceived: true });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does not let orphan progress fence out a later start for the same call", () => {
+    const host = createHost();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        handleAgentEvent(
+          host,
+          agentEvent("run-1", 10, "tool", {
+            phase: "update",
+            name: "bash",
+            toolCallId: "late-start",
+            partialResult: "orphan",
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        handleAgentEvent(
+          host,
+          agentEvent("run-1", 1, "tool", {
+            phase: "start",
+            name: "bash",
+            toolCallId: "late-start",
+            args: { command: "echo ready" },
+          }),
+        ),
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("keeps the newest command output when the live projection is bounded", () => {
+    const host = createHost();
+    const result = `old-prefix-${"x".repeat(120_000)}-newest-tail`;
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "result",
+        name: "bash",
+        toolCallId: "long-output",
+        result,
+      }),
+    );
+
+    const output = host.toolStreamById.get(buildToolStreamIdentity("run-1", "long-output"))?.output;
+    expect(output).toMatch(/^\[output truncated; showing latest 120000 chars\]\n/);
+    expect(output).not.toContain("old-prefix");
+    expect(output).toMatch(/-newest-tail$/);
+  });
+
+  it("keeps the beginning of bounded non-command output", () => {
+    const host = createHost();
+    const result = `old-prefix-${"x".repeat(120_000)}-newest-tail`;
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "result",
+        name: "read",
+        toolCallId: "long-read",
+        result,
+      }),
+    );
+
+    const output = host.toolStreamById.get(buildToolStreamIdentity("run-1", "long-read"))?.output;
+    expect(output).toContain("old-prefix");
+    expect(output).not.toContain("newest-tail");
+    expect(output).toContain("showing first 120000");
+  });
+
   it("projects live edit counts and lets the resolved result replace them without flicker", () => {
     useToolStreamFakeTimers();
     try {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -4,6 +4,7 @@ import {
   normalizeNullableString as toTrimmedString,
   normalizeLowercaseStringOrEmpty,
 } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { stripInlineDirectiveTagsForDelivery } from "../../../../src/utils/directive-tags.js";
 import type { ExecApprovalRequest } from "../../app/exec-approval.ts";
 import type {
@@ -12,6 +13,7 @@ import type {
   ChatStreamSegment,
 } from "../../lib/chat/chat-types.ts";
 import type { DiffStat } from "../../lib/chat/tool-call-diff.ts";
+import { resolveToolCallKind } from "../../lib/chat/tool-call-view.ts";
 import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { formatUnknownText, truncateText } from "../../lib/format.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
@@ -60,6 +62,8 @@ export type ToolStreamEntry = {
   exitCode?: number;
   /** True once a result event landed, even when the output text is empty. */
   resultReceived?: boolean;
+  /** The owning run ended before this call received a result. */
+  interrupted?: boolean;
   startedAt: number;
   receivedAt: number;
   message: Record<string, unknown>;
@@ -193,7 +197,7 @@ function extractToolOutputText(value: unknown): string | null {
   return parts.join("\n");
 }
 
-function formatToolOutput(value: unknown): string | null {
+function formatToolOutput(value: unknown, keepLatest = false): string | null {
   if (value === null || value === undefined) {
     return null;
   }
@@ -213,11 +217,17 @@ function formatToolOutput(value: unknown): string | null {
       text = formatUnknownText(value);
     }
   }
-  const truncated = truncateText(text, TOOL_OUTPUT_CHAR_LIMIT);
-  if (!truncated.truncated) {
-    return truncated.text;
+  if (text.length <= TOOL_OUTPUT_CHAR_LIMIT) {
+    return text;
   }
-  return `${truncated.text}\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`;
+  if (!keepLatest) {
+    const truncated = truncateText(text, TOOL_OUTPUT_CHAR_LIMIT);
+    return `${truncated.text}\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`;
+  }
+  return `[output truncated; showing latest ${TOOL_OUTPUT_CHAR_LIMIT} chars]\n${sliceUtf16Safe(
+    text,
+    -TOOL_OUTPUT_CHAR_LIMIT,
+  )}`;
 }
 
 function readLiveDiffStat(value: unknown): DiffStat | undefined {
@@ -296,6 +306,7 @@ function buildToolStreamMessage(entry: ToolStreamEntry): Record<string, unknown>
     // so historical output-less calls (aborted runs) stay inert.
     __openclawToolStreamLive: true,
     __openclawToolStreamResultReceived: entry.resultReceived === true,
+    __openclawToolStreamInterrupted: entry.interrupted === true,
     ...(entry.resultReceived !== true && entry.liveDiffStat
       ? { __openclawToolStreamDiffStat: entry.liveDiffStat }
       : {}),
@@ -357,6 +368,26 @@ export function resetToolStream(host: ToolStreamHost) {
   host.waitingApprovalStatuses?.clear();
   // Resolution can beat the overlay queue update. Keep tombstones across transient stream resets
   // until snapshot reconciliation observes the approval leaving the queue.
+}
+
+export function interruptOpenToolStream(host: ToolStreamHost, runId: string | null): boolean {
+  if (!runId) {
+    return false;
+  }
+  let changed = false;
+  for (const entry of host.toolStreamById.values()) {
+    if (entry.runId !== runId || entry.resultReceived) {
+      continue;
+    }
+    entry.interrupted = true;
+    entry.liveDiffStat = undefined;
+    entry.message = buildToolStreamMessage(entry);
+    changed = true;
+  }
+  if (changed) {
+    flushToolStreamSync(host);
+  }
+  return changed;
 }
 
 function activityEventIdentity(payload: AgentEventPayload): string | null {
@@ -934,6 +965,52 @@ function handleGuardianEvent(host: ToolStreamHost, payload: AgentEventPayload): 
   return true;
 }
 
+type ValidatedToolActivityEvent = {
+  data: Record<string, unknown>;
+  phase: "start" | "input_delta" | "update" | "result";
+  toolCallId: string;
+  toolStreamIdentity: string;
+};
+
+function validateToolActivityEvent(
+  host: ToolStreamHost,
+  payload: AgentEventPayload,
+): ValidatedToolActivityEvent | null {
+  const data = payload.data ?? {};
+  const toolCallId = toTrimmedString(data.toolCallId);
+  const phase = data.phase;
+  if (!toolCallId) {
+    console.warn("[control-ui] Dropped tool activity without a valid target", {
+      phase: toTrimmedString(phase) ?? "unknown",
+      runId: payload.runId,
+    });
+    return null;
+  }
+  if (phase !== "start" && phase !== "input_delta" && phase !== "update" && phase !== "result") {
+    console.warn("[control-ui] Dropped tool activity with an invalid phase", {
+      phase: toTrimmedString(phase) ?? "unknown",
+      runId: payload.runId,
+      toolCallId,
+    });
+    return null;
+  }
+  const toolStreamIdentity = buildToolStreamIdentity(payload.runId, toolCallId);
+  if (
+    !host.toolStreamById.has(toolStreamIdentity) &&
+    (phase === "input_delta" || phase === "update")
+  ) {
+    // Progress has no standalone outcome. Without a start it would poison the
+    // sequence fence and create a row that can never resolve.
+    console.warn("[control-ui] Dropped orphaned tool progress", {
+      phase,
+      runId: payload.runId,
+      toolCallId,
+    });
+    return null;
+  }
+  return { data, phase, toolCallId, toolStreamIdentity };
+}
+
 export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload): boolean {
   if (!payload) {
     return false;
@@ -944,6 +1021,11 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   // active chat run; individual run-owned projections apply their own match.
   const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
   if (sessionKey && !uiSessionEventMatches(host, sessionKey, toTrimmedString(payload.agentId))) {
+    return false;
+  }
+  const toolActivity =
+    payload.stream === "tool" ? validateToolActivityEvent(host, payload) : undefined;
+  if (payload.stream === "tool" && !toolActivity) {
     return false;
   }
   // History can replay an older active-run snapshot after newer live activity.
@@ -1000,18 +1082,12 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return true;
   }
 
-  if (payload.stream !== "tool") {
+  if (!toolActivity) {
     return false;
   }
 
-  const data = payload.data ?? {};
-  const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : "";
-  if (!toolCallId) {
-    return false;
-  }
-  const toolStreamIdentity = buildToolStreamIdentity(payload.runId, toolCallId);
+  const { data, phase, toolCallId, toolStreamIdentity } = toolActivity;
   let entry = host.toolStreamById.get(toolStreamIdentity);
-  const phase = typeof data.phase === "string" ? data.phase : "";
   // A started call owns its concrete identity even when later events omit or
   // contradict it; an unnamed placeholder can still adopt its first real name.
   const name =
@@ -1022,11 +1098,12 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     host.chatRunStartup = { state: "activity", runId: payload.runId };
   }
   const args = phase === "start" ? data.args : undefined;
+  const keepLatestOutput = resolveToolCallKind(name, args ?? entry?.args) === "command";
   const output =
     phase === "update"
-      ? formatToolOutput(data.partialResult)
+      ? formatToolOutput(data.partialResult, keepLatestOutput)
       : phase === "result"
-        ? formatToolOutput(data.result)
+        ? formatToolOutput(data.result, keepLatestOutput)
         : undefined;
   const resultDetails = phase === "result" ? readRecord(data.result)?.details : undefined;
   const resultIsError =
@@ -1086,6 +1163,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     }
     if (phase === "result") {
       entry.liveDiffStat = undefined;
+      entry.interrupted = false;
       entry.resultReceived = true;
     }
   }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -125,6 +125,12 @@
     transform 150ms ease-out;
 }
 
+.chat-tool-row__outcome {
+  flex: 0 0 auto;
+  color: var(--warn);
+  font-size: var(--control-ui-text-xs);
+}
+
 .chat-tool-row__chevron svg {
   width: 14px;
   height: 14px;
@@ -1112,25 +1118,8 @@
   overflow-y: auto;
 }
 
-/* Completed-turn work rollup: slim "Worked for X" disclosure standing in for
-   the turn's intermediate tool/commentary groups. Sits snug above the final
-   reply, aligned with the message column via a gutter matching the avatar. */
-.chat-group--work {
-  padding-bottom: 8px;
-}
-
-.chat-work-group .chat-activity-group__label {
-  color: inherit;
-}
-
 .chat-group--activity .chat-activity-group__label {
   color: inherit;
-}
-
-.chat-work-group__separator {
-  width: 100%;
-  height: 1px;
-  background: var(--border);
 }
 
 /* Reading indicator = working claw: the brand pincer claws in place where the


### PR DESCRIPTION
## What Problem This Solves

#125240 replaced the Control UI's old tool-card styling with lightweight transcript activity, but the transcript still had two competing grouping paths: `collapseCompletedTurnWork` produced a separate `Worked for …` rollup while `coalesceActivityRuns` produced semantic activity summaries. Mixed assistant text plus tool calls could also normalize into the tool role and disappear inside a collapsed disclosure.

Live lifecycle gaps compounded the readability problem: orphan progress could create a row with no outcome, terminal runs could leave unresolved calls in an unknown state, and bounded command output retained the oldest text instead of the most recent result.

## Why This Change Was Made

This rewrite starts from current `main` and keeps #125240's lightweight presentation. The transcript projection is now the only disclosure owner:

- contiguous pure tool/reasoning work becomes one semantic activity run;
- singleton tool rows stay lightweight and direct;
- assistant text, attachments, canvas/media, user turns, dividers, and search results remain outside activity disclosures;
- the obsolete `work-group` projection, renderer, CSS, i18n, and tests are removed.

The live tool producer now validates phases and targets before sequence fencing, drops orphan progress while retaining orphan results, records unresolved calls as interrupted whenever their exact owning run terminates, and keeps the newest 120,000 characters only for command-like output. Read/fetch output retains the existing prefix behavior.

No Gateway protocol, config, or storage changes are included.

## User Impact

- Completed work reads as `Ran 2 commands, read a file, edited a file…` instead of `Worked for 5s`.
- Final replies and visible artifacts never move inside tool detail.
- Interrupted tools remain visibly marked rather than silently becoming unknown.
- Malformed/orphan progress no longer creates permanent activity rows or poisons later valid events.
- Long command output preserves the newest diagnostic lines.

Production delta: `+271 / -294` (`-23` net). Test delta: `+426 / -315` (`+111` net). Tooling ratchet: `-1` stale baseline entry.

## Evidence

Pre-fix focused regressions failed for mixed reply/tool grouping, orphan progress, command-tail truncation, and interrupted tool state. The same cases pass after the owner-boundary repair.

- `node scripts/run-vitest.mjs ui/src/lib/chat/message-normalizer.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/tool-stream.node.test.ts ui/src/pages/chat/run-lifecycle.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-tool-cards.node.test.ts` — 774 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts --reporter=verbose` — 6 passed in Chromium against the mocked Gateway.
- `node scripts/check-changed.mjs -- <changed paths>` — formatting, ratchets, deadcode, i18n, typecheck, oxlint, stylelint, and script checks passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted …` — clean; no accepted/actionable findings.

Recorder verdict:

```json
{
  "workRollups": 0,
  "activityGroups": 2,
  "expandedSummary": "Ran 2 commands, read a file, edited a file, used web_search",
  "finalReplyInsideActivity": false
}
```

| Active tool work | Completed, collapsed | Completed, expanded |
| --- | --- | --- |
| ![Active semantic activity](https://github.com/user-attachments/assets/b89564de-7f0c-4be3-9445-98f3950c842e) | ![Completed semantic activity](https://github.com/user-attachments/assets/643b7e4f-cbe2-47cf-9625-a2f342acb236) | ![Expanded lightweight activity](https://github.com/user-attachments/assets/0883285d-4592-467c-85f9-9eff2262bc29) |
