### PR TITLE
fix(codex): managed turns use the bundled app-server version

### DIFF
--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -16,6 +16,7 @@ import { createCodexAppServerAgentHarness } from "./harness.js";
 import { buildCodexMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { readCodexPluginConfig } from "./src/app-server/config.js";
 import { createCodexAppServerConnectionHealthService } from "./src/app-server/connection-health.js";
+import { setManagedCodexPluginRoot } from "./src/app-server/managed-binary.js";
 import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
@@ -60,6 +61,9 @@ export default definePluginEntry({
   name: "Codex",
   description: "Codex app-server harness and native session supervision.",
   register(api) {
+    // Bundled modules may execute from a shared dist chunk, so import.meta.url
+    // cannot identify the owning plugin package or its pinned dependencies.
+    setManagedCodexPluginRoot(api.rootDir);
     const resolveCurrentConfig = () =>
       api.runtime.config?.current ? (api.runtime.config.current() as OpenClawConfig) : undefined;
     const resolvePluginConfig = (resolveConfig: () => OpenClawConfig | undefined) => {

--- a/extensions/codex/src/app-server/managed-binary.test.ts
+++ b/extensions/codex/src/app-server/managed-binary.test.ts
@@ -2,11 +2,12 @@
 import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerStartOptions } from "./config.js";
 import {
   resolveManagedCodexAppServerStartOptions,
   resolveManagedCodexNativeCommand,
+  setManagedCodexPluginRoot,
 } from "./managed-binary.js";
 
 function startOptions(
@@ -33,6 +34,8 @@ const MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND =
   "/Applications/ChatGPT.app/Contents/Resources/codex";
 
 describe("managed Codex app-server binary", () => {
+  afterEach(() => setManagedCodexPluginRoot(undefined));
+
   it("resolves the platform-native artifact behind the managed npm launcher", () => {
     const packageJsonPath =
       "/repo/extensions/codex/node_modules/@openai/codex-darwin-arm64/package.json";
@@ -62,7 +65,7 @@ describe("managed Codex app-server binary", () => {
     ).toBe(MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND);
   });
 
-  it("leaves explicit command overrides unchanged", async () => {
+  it("leaves explicit command overrides unchanged without probing managed paths", async () => {
     const explicitOptions = startOptions("config");
     const pathExists = vi.fn(async () => false);
 
@@ -146,7 +149,7 @@ describe("managed Codex app-server binary", () => {
     });
   });
 
-  it("falls back to the plugin-local binary when neither desktop bundle exists", async () => {
+  it("falls back to the source plugin-local binary when neither desktop bundle exists", async () => {
     const pluginRoot = path.join("/tmp", "openclaw", "extensions", "codex");
     const pluginLocalCommand = managedCommandPath(pluginRoot, "darwin");
     const pathExists = vi.fn(async (filePath: string) => filePath === pluginLocalCommand);
@@ -185,6 +188,50 @@ describe("managed Codex app-server binary", () => {
     });
   });
 
+  it("prefers the bundled plugin binary over a stale hoisted package binary", async () => {
+    const installRoot = path.join("/tmp", "openclaw-package");
+    const packageRoot = path.join(installRoot, "node_modules", "openclaw");
+    const bundledPluginRoot = path.join(packageRoot, "dist", "extensions", "codex");
+    const bundledCommand = managedCommandPath(bundledPluginRoot, "linux");
+    const hoistedCommand = managedCommandPath(installRoot, "linux");
+    const pathExists = vi.fn(
+      async (filePath: string) => filePath === bundledCommand || filePath === hoistedCommand,
+    );
+    setManagedCodexPluginRoot(bundledPluginRoot);
+
+    await expect(
+      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
+        platform: "linux",
+        pathExists,
+      }),
+    ).resolves.toEqual({
+      ...startOptions("managed"),
+      command: bundledCommand,
+      commandSource: "resolved-managed",
+      managedFallbackCommandPaths: [hoistedCommand],
+    });
+  });
+
+  it("falls back to the hoisted package when the bundled plugin binary is absent", async () => {
+    const installRoot = path.join("/tmp", "openclaw-package");
+    const packageRoot = path.join(installRoot, "node_modules", "openclaw");
+    const bundledPluginRoot = path.join(packageRoot, "dist", "extensions", "codex");
+    const hoistedCommand = managedCommandPath(installRoot, "linux");
+    const pathExists = vi.fn(async (filePath: string) => filePath === hoistedCommand);
+    setManagedCodexPluginRoot(bundledPluginRoot);
+
+    await expect(
+      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
+        platform: "linux",
+        pathExists,
+      }),
+    ).resolves.toEqual({
+      ...startOptions("managed"),
+      command: hoistedCommand,
+      commandSource: "resolved-managed",
+    });
+  });
+
   it("finds Codex bins hoisted into an isolated npm project root", async () => {
     const projectRoot = path.join("/tmp", "state", "npm", "projects", "openclaw-codex-hash");
     const pluginRoot = path.join(projectRoot, "node_modules", "@openclaw", "codex");
@@ -204,7 +251,7 @@ describe("managed Codex app-server binary", () => {
     });
   });
 
-  it("finds Windows Codex shims hoisted into an isolated npm project root", async () => {
+  it("finds a Windows codex.cmd shim in an isolated npm root using win32 paths", async () => {
     const projectRoot = path.win32.join(
       "C:\\",
       "Users",

--- a/extensions/codex/src/app-server/managed-binary.ts
+++ b/extensions/codex/src/app-server/managed-binary.ts
@@ -13,16 +13,12 @@ import { MANAGED_CODEX_APP_SERVER_PACKAGE } from "./version.js";
 
 const CODEX_APP_SERVER_MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_PLUGIN_ROOT = resolveDefaultCodexPluginRoot(CODEX_APP_SERVER_MODULE_DIR);
+let registeredCodexPluginRoot: string | undefined;
 // ChatGPT.app is the current desktop owner; keep Codex.app as the legacy fallback.
 const MACOS_DESKTOP_CODEX_APP_SERVER_COMMANDS = [
   "/Applications/ChatGPT.app/Contents/Resources/codex",
   "/Applications/Codex.app/Contents/Resources/codex",
 ] as const;
-
-type ManagedCodexAppServerPaths = {
-  commandPath: string;
-  candidateCommandPaths: string[];
-};
 
 type ResolveManagedCodexAppServerOptions = {
   platform?: NodeJS.Platform;
@@ -37,6 +33,11 @@ type ResolveManagedCodexNativeCommandOptions = {
   resolvePackageJson?: (packageName: string, root: string) => string | undefined;
 };
 
+/** Records the process-stable plugin root prepared by OpenClaw's plugin loader. */
+export function setManagedCodexPluginRoot(pluginRoot: string | undefined): void {
+  registeredCodexPluginRoot = pluginRoot;
+}
+
 /** Rewrites managed stdio start options to point at an executable Codex binary path. */
 export async function resolveManagedCodexAppServerStartOptions(
   startOptions: CodexAppServerStartOptions,
@@ -47,14 +48,14 @@ export async function resolveManagedCodexAppServerStartOptions(
   }
 
   const platform = options.platform ?? process.platform;
-  const paths = resolveManagedCodexAppServerPaths({
+  const candidateCommandPaths = resolveManagedCodexAppServerCommandCandidates(
+    options.pluginRoot ?? registeredCodexPluginRoot ?? CODEX_PLUGIN_ROOT,
     platform,
-    pluginRoot: options.pluginRoot,
-    managedCommandOrder: startOptions.managedCommandOrder,
-  });
+    startOptions.managedCommandOrder ?? "package-first",
+  );
   const pathExists = options.pathExists ?? commandPathExists;
   const commandPaths = await findManagedCodexAppServerCommandPaths({
-    candidateCommandPaths: paths.candidateCommandPaths,
+    candidateCommandPaths,
     pathExists,
     platform,
   });
@@ -176,24 +177,6 @@ function resolvePackageJsonFromRoot(packageName: string, root: string): string |
   } catch {
     return undefined;
   }
-}
-
-/** Returns the preferred and fallback managed Codex binary paths for a plugin root. */
-function resolveManagedCodexAppServerPaths(params: {
-  platform?: NodeJS.Platform;
-  pluginRoot?: string;
-  managedCommandOrder?: CodexManagedCommandOrder;
-}): ManagedCodexAppServerPaths {
-  const platform = params.platform ?? process.platform;
-  const candidateCommandPaths = resolveManagedCodexAppServerCommandCandidates(
-    params.pluginRoot ?? CODEX_PLUGIN_ROOT,
-    platform,
-    params.managedCommandOrder ?? "package-first",
-  );
-  return {
-    commandPath: candidateCommandPaths[0] ?? "",
-    candidateCommandPaths,
-  };
 }
 
 function resolveManagedCodexAppServerCommandCandidates(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary Codex turns could fail their app-server version handshake in packaged installs that contained both the Codex plugin's current pinned binary and an older hoisted `@openai/codex` binary. The managed resolver selected the stale hoisted command first.

## Why This Change Was Made

The Codex plugin now records the authoritative `rootDir` supplied by OpenClaw's plugin loader and resolves managed binaries from that owning package first. Existing ancestor/package fallbacks remain intact, so missing owner-local binaries still fall through safely; explicit command overrides and macOS desktop-first Computer Use ordering are unchanged.

This keeps bundle-layout policy in plugin discovery instead of reconstructing `dist/extensions` paths inside the resolver. It restores the ownership contract established by #71808, which assigned the managed app-server version to the Codex plugin.

## User Impact

Packaged, upgraded, and fresh installs with mixed Codex dependency versions now start the extension-pinned app-server for ordinary managed turns instead of failing because an unrelated hoisted version is stale. Source installs, separately installed plugins, macOS desktop-first Computer Use, Linux, Windows, explicit overrides, and managed fallback behavior remain compatible.

Release note: Fixed packaged Codex managed turns selecting a stale hoisted app-server binary instead of the bundled plugin's pinned version.

## Evidence

- Exact-base red fixture: with extension-local 0.147.0 and hoisted 0.145.0 present, unmodified main selected the hoisted command and failed the 0.147.0 version requirement.
- Focused resolver regression: 14/14 tests pass, covering registered bundled owner root, stale hoisted fallback, source and installed layouts, explicit overrides, desktop-first ordering, missing-local fallback, Linux, and Windows `codex.cmd` paths.
- Source-blind behavior validation: 6/6 contract clauses pass.
- Built Linux package proof: Blacksmith Testbox `tbx_01m029b7p6eh5t71bak0zxtdtb` selected `dist/extensions/codex/node_modules/.bin/codex`, reported `codex-cli 0.147.0`, completed initialize as 0.147.0, and never started the stale hoisted launcher. [Run](https://github.com/openclaw/openclaw/actions/runs/31875116337)
- Exact-head changed gate: extension production/test typechecks, changed-file lint/format, dependency and patch guards, plugin boundaries, dead exports, database-first guard, runtime sidecars, and import cycles passed on Blacksmith Testbox `tbx_01m02a395r2vy4bk3fgf57wpw9`. [Run](https://github.com/openclaw/openclaw/actions/runs/31875662398)
- Fresh autoreview: 0 findings; patch correct with 0.98 confidence.
