### PR TITLE
fix: first turn after /new stays below transcript fuse

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -10,6 +10,7 @@ import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   loadSessionEntry,
+  readSessionTranscriptActiveStats,
   readTranscriptStatsSync,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
@@ -3270,15 +3271,33 @@ describe("runMemoryFlushIfNeeded", () => {
     });
   });
 
-  it("leaves an under-limit SQLite Codex session to native token compaction", async () => {
+  it("leaves a reset SQLite Codex session below the byte fuse for native compaction", async () => {
     const storePath = path.join(rootDir, "sqlite-codex-under-byte-guard.json");
     const sessionKey = "agent:main:main";
     const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
     await upsertSessionEntryCore(scope, { sessionId: "session", updatedAt: 10 });
     await replaceTranscriptEvents(scope, [
-      { message: { role: "user", content: "small" }, type: "message" },
+      {
+        type: "message",
+        id: "discarded-old",
+        parentId: null,
+        message: { role: "user", content: "x".repeat(20_000) },
+      },
+      {
+        type: "reset",
+        id: "reset-boundary",
+        parentId: "discarded-old",
+        timestamp: "2026-08-15T00:00:00.000Z",
+        reason: "new",
+      },
+      {
+        type: "message",
+        id: "fresh-turn",
+        parentId: "reset-boundary",
+        message: { role: "user", content: "small" },
+      },
     ]);
-    expect(readTranscriptStatsSync(scope).sizeBytes).toBeLessThan(10 * 1024);
+    expect(readSessionTranscriptActiveStats(scope).sizeBytes).toBeLessThan(10 * 1024);
 
     const sessionEntry: SessionEntry = {
       sessionId: "session",
@@ -3307,7 +3326,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey,
       }),
       defaultModel: "gpt-5.5",
-      agentCfgContextTokens: 350_000,
+      agentCfgContextTokens: 1_000_000,
       sessionEntry,
       sessionStore: { [sessionKey]: sessionEntry },
       sessionKey,

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -154,6 +154,162 @@ describe("SQLite active transcript event projection", () => {
     });
   });
 
+  it("stops counting discarded transcript bytes after a reset", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "discarded-old",
+          parentId: null,
+          message: { role: "user", content: `discarded ${"x".repeat(20_000)}` },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "discarded-old",
+      timestamp: "2026-08-15T00:00:00.000Z",
+      reason: "new",
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "post-reset",
+          parentId: "reset-boundary",
+          message: { role: "user", content: "fresh turn" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+
+    expect(readSessionTranscriptActiveStats(scope)).toMatchObject({ eventCount: 1 });
+    expect(readSessionTranscriptActiveStats(scope).sizeBytes).toBeLessThan(1_000);
+  });
+
+  it("counts paired reset tool results without counting discarded orphan results", async () => {
+    const assistantMessage = {
+      role: "assistant" as const,
+      api: "openai-responses" as const,
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      content: [{ type: "toolCall" as const, id: "call-1", name: "read", arguments: {} }],
+      stopReason: "toolUse" as const,
+      timestamp: Date.parse("2026-08-15T00:00:00.000Z"),
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    };
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "discarded-old",
+          parentId: null,
+          message: { role: "user", content: `discarded ${"x".repeat(12_000)}` },
+        },
+        {
+          eventId: "kept-user",
+          parentId: "discarded-old",
+          message: { role: "user", content: "kept question" },
+        },
+        { eventId: "kept-assistant", parentId: "kept-user", message: assistantMessage },
+        {
+          eventId: "kept-result",
+          parentId: "kept-assistant",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "read",
+            content: [{ type: "text", text: `paired ${"p".repeat(3_000)}` }],
+            isError: false,
+            timestamp: Date.parse("2026-08-15T00:00:01.000Z"),
+          },
+        },
+        {
+          eventId: "discarded-orphan",
+          parentId: "kept-result",
+          message: {
+            role: "toolResult",
+            toolCallId: "orphan-call",
+            toolName: "read",
+            content: [{ type: "text", text: `orphan ${"o".repeat(20_000)}` }],
+            isError: false,
+            timestamp: Date.parse("2026-08-15T00:00:02.000Z"),
+          },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "discarded-orphan",
+      timestamp: "2026-08-15T00:00:03.000Z",
+      reason: "new",
+      firstKeptEntryId: "kept-user",
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "post-reset",
+          parentId: "reset-boundary",
+          message: { role: "user", content: "fresh turn" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+
+    const stats = readSessionTranscriptActiveStats(scope);
+    expect(stats.eventCount).toBe(4);
+    expect(stats.sizeBytes).toBeGreaterThan(3_000);
+    expect(stats.sizeBytes).toBeLessThan(8_000);
+
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "second-post-reset",
+          parentId: "post-reset",
+          message: { role: "assistant", content: "fresh answer" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(5);
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it("keeps counting genuinely oversized post-reset events", async () => {
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: null,
+      timestamp: "2026-08-15T00:00:00.000Z",
+      reason: "new",
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "post-reset",
+          parentId: "reset-boundary",
+          message: { role: "user", content: "x".repeat(20_000) },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+
+    expect(readSessionTranscriptActiveStats(scope).sizeBytes).toBeGreaterThan(20_000);
+  });
+
   it("defers mixed legacy and canonical rebuilds off request stacks", async () => {
     await persistSessionTranscriptTurn(scope, {
       messages: [

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -16,6 +16,7 @@ import type {
 import {
   readTranscriptProjectionGeneration,
   readVisibleMessageRange,
+  readVisibleTranscriptStats,
   resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
@@ -148,35 +149,12 @@ export function readRecentSessionTranscriptActiveEvents(
   });
 }
 
-/** Reads active-path event count and JSONL byte size without materializing payloads. */
+/** Reads logical transcript event count and JSONL byte size. */
 export function readSessionTranscriptActiveStats(scope: SessionTranscriptReadScope): {
   eventCount: number;
   sizeBytes: number;
 } {
-  return withCurrentProjectionSnapshot(scope, (projection) => {
-    const db = getActiveTranscriptKysely(projection.database);
-    const row = executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events as active")
-        .innerJoin("transcript_events as event", (join) =>
-          join
-            .onRef("event.session_id", "=", "active.session_id")
-            .onRef("event.seq", "=", "active.event_seq"),
-        )
-        .select((eb) => [
-          eb.fn.count<number>("active.event_seq").as("event_count"),
-          /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
-          sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
-            + COUNT(*)`.as("size_bytes"),
-        ])
-        .where("active.session_id", "=", projection.resolved.sessionId),
-    );
-    return {
-      eventCount: row?.event_count ?? 0,
-      sizeBytes: row?.size_bytes ?? 0,
-    };
-  });
+  return withCurrentProjectionSnapshot(scope, readVisibleTranscriptStats);
 }
 
 /** Reads one append-stable forward page from the materialized active-message projection. */

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -1,4 +1,7 @@
 // Reset boundaries project a logical message window without rewriting raw cursor positions.
+import type { SessionTreeEntry } from "@openclaw/agent-core";
+import { sql } from "kysely";
+import { selectResetKeptEntries } from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -37,10 +40,14 @@ type ResetWindowMessageEvent = {
 };
 
 type ResetMessageWindow = {
+  boundarySeq: number;
   generation: string | undefined;
   indexedSeq: number;
+  keptContextEventCount: number;
   keptMessagePositions: number[];
+  keptContextSizeBytes: number;
   postBoundaryMessagePosition: number;
+  boundaryActivePosition: number;
 };
 
 type ResetMessageWindowCacheEntry = {
@@ -195,6 +202,8 @@ function findLatestResetMessageWindow(
         .limit(1),
     )?.message_position ?? projection.state.activeMessageCount;
   let keptMessagePositions: number[] = [];
+  let keptContextEventCount = 0;
+  let keptContextSizeBytes = 0;
   if (typeof reset.firstKeptEntryId === "string") {
     const firstKept = executeSqliteQueryTakeFirstSync(
       projection.database.db,
@@ -210,7 +219,7 @@ function findLatestResetMessageWindow(
         .where("identity.event_id", "=", reset.firstKeptEntryId),
     );
     if (firstKept && firstKept.active_position < latestBoundary.active_position) {
-      keptMessagePositions = executeSqliteQuerySync(
+      const candidates = executeSqliteQuerySync(
         projection.database.db,
         db
           .selectFrom("session_transcript_active_events as active")
@@ -226,24 +235,39 @@ function findLatestResetMessageWindow(
           .where("active.message_position", "is not", null)
           .orderBy("active.active_position", "asc"),
       ).rows.flatMap((row) => {
-        if (row.message_position === null) {
-          return [];
-        }
         try {
-          const role = (JSON.parse(row.event_json) as { message?: { role?: unknown } }).message
-            ?.role;
-          return role === "user" || role === "assistant" ? [row.message_position] : [];
+          return [{ ...row, event: JSON.parse(row.event_json) as SessionTreeEntry }];
         } catch {
           return [];
         }
       });
+      const keptEntries = new Set(selectResetKeptEntries(candidates.map((row) => row.event)));
+      const keptRows = candidates.filter((row) => keptEntries.has(row.event));
+      keptContextEventCount = keptRows.length;
+      keptContextSizeBytes = keptRows.reduce(
+        (total, row) => total + Buffer.byteLength(row.event_json, "utf8") + 1,
+        0,
+      );
+      // History presentation exposes user/assistant rows, while fresh-thread context
+      // also retains paired tool results. The fuse stats above must cover that context.
+      keptMessagePositions = keptRows.flatMap((row) => {
+        if (row.message_position === null || row.event.type !== "message") {
+          return [];
+        }
+        const role = row.event.message.role;
+        return role === "user" || role === "assistant" ? [row.message_position] : [];
+      });
     }
   }
   return {
+    boundarySeq: latestBoundary.seq,
     generation,
     indexedSeq: projection.state.indexedSeq,
+    keptContextEventCount,
     keptMessagePositions,
+    keptContextSizeBytes,
     postBoundaryMessagePosition,
+    boundaryActivePosition: latestBoundary.active_position,
   };
 }
 
@@ -254,6 +278,17 @@ function resolveResetMessageWindow(projection: ResetWindowProjection): ResetMess
   if (cached) {
     if (cached.generation === generation && cached.indexedSeq === projection.state.indexedSeq) {
       return cached.window;
+    }
+    if (cached.generation === generation && cached.window) {
+      const latestBoundary = readLatestActiveBoundaryMetadata(projection);
+      if (
+        latestBoundary?.event_type === "reset" &&
+        latestBoundary.seq === cached.window.boundarySeq
+      ) {
+        const window = { ...cached.window, indexedSeq: projection.state.indexedSeq };
+        cacheResetMessageWindow(key, { generation, indexedSeq: window.indexedSeq, window });
+        return window;
+      }
     }
   }
   const window = findLatestResetMessageWindow(projection, generation);
@@ -329,4 +364,35 @@ export function resolveVisibleMessagePositionRange(
     positions.push(visible.postStart + logical - visible.kept.length);
   }
   return positions;
+}
+
+/** Reads logical transcript bytes, reusing cached retained-tail facts after resets. */
+export function readVisibleTranscriptStats(projection: ResetWindowProjection): {
+  eventCount: number;
+  sizeBytes: number;
+} {
+  const window = resolveResetMessageWindow(projection);
+  const db = getResetWindowKysely(projection.database);
+  const base = db
+    .selectFrom("session_transcript_active_events as active")
+    .innerJoin("transcript_events as event", (join) =>
+      join
+        .onRef("event.session_id", "=", "active.session_id")
+        .onRef("event.seq", "=", "active.event_seq"),
+    )
+    .select((eb) => [
+      eb.fn.count<number>("active.event_seq").as("event_count"),
+      /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
+      sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
+        + COUNT(*)`.as("size_bytes"),
+    ])
+    .where("active.session_id", "=", projection.resolved.sessionId);
+  const row = executeSqliteQueryTakeFirstSync(
+    projection.database.db,
+    window ? base.where("active.active_position", ">", window.boundaryActivePosition) : base,
+  );
+  return {
+    eventCount: (row?.event_count ?? 0) + (window?.keptContextEventCount ?? 0),
+    sizeBytes: (row?.size_bytes ?? 0) + (window?.keptContextSizeBytes ?? 0),
+  };
 }


### PR DESCRIPTION
Closes #119984
Closes #123334

## What Problem This Solves

Fixes an issue where the first turn after `/new` could immediately fail with “Context is too large and auto-compaction could not recover this turn” when discarded SQLite transcript rows from the previous reset generation exceeded `maxActiveTranscriptBytes`.

This also resolves the remaining current-main cause behind #123334. Keeping the OpenClaw channel session ID and durable rows across `/new` is intentional; current binding lifecycle tests prove that the retired in-place Codex generation can be reclaimed and rebound to a fresh native thread.

## Why This Change Was Made

The authoritative transcript statistics reader now uses the same reset-window owner as model context. It counts the exact retained reset prelude—including valid paired tool results—plus post-reset events, while excluding discarded history and orphaned retained results. Cached retained-tail facts are reused across ordinary post-reset appends and invalidated when the reset boundary, branch, compaction, or projection generation changes.

This is a fresh-current-main successor to #120059, whose root-cause direction was correct. Current `main` added paired tool-result retention after that contributor head, so merging it unchanged would undercount model-visible reset context. Credit to @ayaangazali for identifying the canonical reset-window owner and supplying the original focused repair.

The change does not rotate session IDs, change Codex/OpenClaw runtime selection, modify config/default surfaces, alter SQLite schema, or change explicit Codex context-window/native auto-compaction settings.

Production LOC: +76/-32 (net +44), justified by making reset-window projection the shared owner of logical statistics and adding bounded cache invalidation. Tests: +179/-4.

## User Impact

After `/new`, discarded pre-reset bytes can no longer keep a Codex-backed session stuck above the transcript fuse. A genuinely oversized new generation is still protected, and both fresh and persisted/upgraded OpenAI selections remain on the Codex runtime.

## Evidence

- Base red at `26ff3c96071726e582a05e720e64829e1749c9f4`: logical history was three messages, but the fuse still measured 32,929 bytes from discarded rows. [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/31874730386)
- Focused head proof: discarded pre-reset bytes, paired-result accounting, oversized post-reset negative control, cache reuse, branch-change invalidation, and persisted 1M Codex budget all pass. [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/31875948913)
- Source-blind behavior validation: 16/16 reset-window cases and the persisted-Codex fuse contract pass. [Run 1](https://github.com/openclaw/openclaw/actions/runs/31875321127), [verbose run](https://github.com/openclaw/openclaw/actions/runs/31875376992)
- Current-main lifecycle proof: same-ID `/new` preservation, persisted Codex migration, 1.05M native rollout window, in-place binding reclaim, and cleared-binding fresh-thread start pass. [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/31875655000)
- Fresh OpenAI selection policy: 19/19 pass. [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/31875725699)
- Changed-file gate: formatting, core/core-test typecheck, lint, dependency/boundary guards, database-first guard, and import-cycle checks pass. [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/31875775263)
- Required Codex autoreview: clean, no actionable findings; paired tool-result context ownership and cache invalidation were explicitly reviewed.
- Direct Codex contract inspection at `openai/codex@85fc4def358b`: unavailable thread IDs return `thread not found`; `thread/start` owns a new native thread; `thread/compact/start` loads the binding then submits `Op::Compact`; native `model_context_window` and `model_auto_compact_token_limit` remain independent configuration fields.

Real gateway proof is not claimed: the Testbox API-key attempt failed before a model turn because the active runtime snapshot had no resolved OpenAI API key. The staged Codex-auth rerun was stopped without a behavior verdict after the live lane was declared externally blocked. No private Rosita data was used.
