### PR TITLE
improve(control-ui): continuous corner curvature with a radius scale

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -154,6 +154,19 @@ async function getBoundingBox(page: Page, selector: string) {
   return box;
 }
 
+/**
+ * Corner radii are expressed as their base step times the live corner scale,
+ * so these expectations stay true on engines that draw continuous curvature
+ * (`--openclaw-corner-radius-scale: 1.25`) and on engines that do not.
+ */
+async function readCornerScale(page: Page): Promise<number> {
+  return await page.evaluate(() =>
+    Number.parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--openclaw-corner-radius-scale"),
+    ),
+  );
+}
+
 function expectControlRect(rect: ControlRect | null, label: string): ControlRect {
   if (rect === null) {
     throw new Error(`Expected ${label} control rect`);
@@ -752,10 +765,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         return { chat: radii(chat), search: radii(search) };
       });
 
+      const searchRadius = `${14 * (await readCornerScale(page))}px`;
       expect(searchBar.height).toBeLessThan(64);
       expect(cornerRadii).toEqual({
         chat: ["0px", "0px", "0px", "0px"],
-        search: ["0px", "0px", "14px", "14px"],
+        search: ["0px", "0px", searchRadius, searchRadius],
       });
       expect(icons).toHaveLength(2);
       for (const icon of icons) {
@@ -937,11 +951,14 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         });
 
       const styles = await readGatewayMenuStyles();
+      const menuRadius = 10 * (await readCornerScale(page));
 
       expect(styles).toEqual({
-        menu: { borderRadius: "10px", padding: "4px" },
+        menu: { borderRadius: `${menuRadius}px`, padding: "4px" },
         item: {
-          borderRadius: "6px",
+          // Item radius plus the 4px menu padding equals the panel radius, so
+          // the item edge stays optically parallel to the menu edge.
+          borderRadius: `${menuRadius - 4}px`,
           fontSize: "13px",
           minHeight: "28px",
           padding: "0px 8px",
@@ -1954,7 +1971,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(geometry.footer).not.toBeNull();
       expect(geometry.textarea).not.toBeNull();
 
-      expect(geometry.bubble?.borderRadius).toBe(10);
+      const mediumRadius = 10 * (await readCornerScale(page));
+      expect(geometry.bubble?.borderRadius).toBe(mediumRadius);
       expect(
         new Set([
           geometry.bubble?.paddingTop,
@@ -1967,7 +1985,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       // keeps the text on the tool-row left edge.
       expect(geometry.assistantBubble?.paddingLeft).toBe(0);
       expect(geometry.assistantBubble?.paddingRight).toBe(0);
-      expect(geometry.composer?.borderRadius).toBe(10);
+      expect(geometry.composer?.borderRadius).toBe(mediumRadius);
 
       const composerInset = width <= 768 ? 4 : 8;
       const textareaBlockInset = width <= 768 ? 10 : composerInset;

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -226,20 +226,23 @@
      surfaces. Board layout math mirrors this value numerically. */
   --widget-frame-inset: var(--space-3);
 
-  /* Radii - Slightly larger for modern feel */
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
-  --radius-xl: 20px;
+  /* Radii - Slightly larger for modern feel. Every step runs through one scale
+     so the corner refinement below can widen the whole app from a single knob;
+     --radius-full is shape, not scale, and stays fully round. */
+  --openclaw-corner-radius-scale: 1;
+  --radius-sm: calc(6px * var(--openclaw-corner-radius-scale));
+  --radius-md: calc(10px * var(--openclaw-corner-radius-scale));
+  --radius-lg: calc(14px * var(--openclaw-corner-radius-scale));
+  --radius-xl: calc(20px * var(--openclaw-corner-radius-scale));
   --radius-full: 9999px;
-  --radius: 10px;
+  --radius: var(--radius-md);
 
-  /* Menu items stay optically parallel to their panel edge: radius 6 + padding 4
-     = panel radius 10. Shared knobs keep transient menus from drifting again. */
-  --menu-radius: var(--radius-md);
-  --menu-item-radius: var(--radius-sm);
-  --menu-item-height: 28px;
+  /* Menu items stay optically parallel to their panel edge: item radius +
+     padding = panel radius. Deriving the item keeps that true at any scale. */
   --menu-padding: 4px;
+  --menu-radius: var(--radius-md);
+  --menu-item-radius: calc(var(--menu-radius) - var(--menu-padding));
+  --menu-item-height: 28px;
 
   /* Transitions - Crisp and responsive */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
@@ -268,6 +271,59 @@
 @media (pointer: coarse) {
   :root {
     --menu-item-height: 44px;
+  }
+}
+
+/* Continuous corner curvature. Where the engine can draw a superellipse the
+   corner keeps curving into the edge instead of stopping on a tangent, which
+   reads as a shorter arc than a circular corner of the same radius — the 1.25
+   scale gives that back. Border, shadow, outline and overflow clipping all
+   follow the drawn shape, so this stays a paint-level refinement.
+   The whole thing is gated: engines without corner-shape keep today's radii
+   and today's arcs, unchanged.
+   The shape is opt-in per surface rather than universal because a superellipse
+   flattens the ends of anything fully rounded, and pills, circles, avatars and
+   status dots are a third of this app's corners. Add new shared surfaces to
+   the list below; leaving one out only keeps its current corner. */
+@supports (corner-shape: superellipse(1.5)) {
+  :root {
+    --openclaw-corner-radius-scale: 1.25;
+  }
+
+  /* Dialogs and overlays */
+  .exec-approval-card,
+  .exec-approval-list,
+  .cmd-palette,
+  .login-gate__card,
+  .md-preview-dialog__panel,
+  .md-preview-dialog__reader,
+  /* Menus, popovers and select panels */
+  wa-dropdown::part(menu),
+  wa-popover::part(body),
+  wa-select::part(listbox),
+  wa-select::part(combobox),
+  .slash-menu,
+  .chat-reply-context-menu,
+  .chat-selection-popup,
+  /* Panels, cards and message surfaces */
+  .card,
+  .settings-group,
+  .option-card,
+  .agent-tool-card,
+  .chat-thread,
+  .chat-bubble,
+  /* Composer */
+  .agent-chat__input,
+  /* Navigation and list rows */
+  .nav-item,
+  .list-item,
+  .sidebar-recent-session,
+  .settings-sidebar__item,
+  /* Buttons and text controls */
+  .btn,
+  .settings-input,
+  .field :is(input, textarea, select) {
+    corner-shape: superellipse(1.5);
   }
 }
 

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -242,12 +242,12 @@
      exported to embedded MCP apps in mcp-app-theme.ts). */
   --openclaw-corner-radius-scale: 1;
 
-  /* Menu items stay optically parallel to their panel edge: item radius +
-     padding = panel radius. Deriving the item keeps that true at any scale. */
-  --menu-padding: 4px;
+  /* Menu items stay optically parallel to their panel edge: radius 6 + padding 4
+     = panel radius 10. Shared knobs keep transient menus from drifting again. */
   --menu-radius: var(--radius-md);
-  --menu-item-radius: calc(var(--menu-radius) - var(--menu-padding));
+  --menu-item-radius: var(--radius-sm);
   --menu-item-height: 28px;
+  --menu-padding: 4px;
 
   /* Transitions - Crisp and responsive */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
@@ -291,76 +291,130 @@
    status dots are a third of this app's corners. Add new shared surfaces to
    the list below; leaving one out only keeps its current corner.
    --openclaw-corner-radius-scale flips to 1.25 at :root — that part is a
-   harmless capability signal, not a radius. The --radius-* tokens that
-   consumers actually draw with are redeclared locally, scaled through that
-   signal, only on the selectors below, so only opted-in surfaces widen;
-   :root consumers that stay `round` (.run-inspector__panel) and the
-   canonical tokens exported to embedded MCP apps (mcp-app-theme.ts) keep
-   drawing the base radii untouched. */
+   harmless capability signal, not a radius: nothing in the canonical
+   --radius-* chain reads it, so it cannot widen an unrelated consumer.
+   Every rule below sets border-radius directly instead of redeclaring a
+   --radius-* custom property on the matched selector. Custom properties
+   inherit: a redeclared --radius-md on .settings-group would also reach
+   .settings-segmented nested inside it, even though that selector never
+   opted in and draws no corner-shape — an inflated `round` corner, not a
+   refinement. border-radius itself is not inherited, so a direct value
+   stops at the matched element; every nested non-opted descendant keeps
+   reading the untouched canonical token from :root.
+   base.css loads before every other stylesheet (see ui/src/styles.css), so
+   a same-specificity override here would lose to the selector's own
+   border-radius declaration in its home file, which always loads later.
+   Each selector below is doubled (`.card.card`) to outrank that one bare
+   declaration by specificity regardless of load order — deliberately not
+   !important, so a genuinely more specific state override elsewhere (e.g.
+   `.chat:has(> .agent-chat__search-bar)`, `.chat-task-detail__transcript >
+   .chat-thread`, both already in the app) keeps winning as it did before
+   this block existed, instead of every such rule needing a matching
+   !important of its own. */
 @supports (corner-shape: superellipse(1.5)) {
   :root {
     --openclaw-corner-radius-scale: 1.25;
   }
 
-  /* Dialogs, overlays, panels, cards, composer, nav/list rows and controls
-     draw straight from --radius-*, so redeclaring the scaled tokens on the
-     matched element is enough for its own border-radius to pick them up. */
-  .exec-approval-card,
-  .exec-approval-list,
-  .cmd-palette,
-  .login-gate__card,
-  .md-preview-dialog__panel,
-  .md-preview-dialog__reader,
-  .card,
-  .settings-group,
-  .option-card,
-  .agent-tool-card,
-  .chat-thread,
-  .chat-bubble,
-  .agent-chat__input,
-  .nav-item,
-  .list-item,
-  .sidebar-recent-session,
-  .settings-sidebar__item,
-  .btn,
-  .settings-input,
-  .field :is(input, textarea, select) {
-    --radius-sm: calc(6px * var(--openclaw-corner-radius-scale));
-    --radius-md: calc(10px * var(--openclaw-corner-radius-scale));
-    --radius-lg: calc(14px * var(--openclaw-corner-radius-scale));
-    --radius-xl: calc(20px * var(--openclaw-corner-radius-scale));
+  .exec-approval-card.exec-approval-card,
+  .exec-approval-list.exec-approval-list,
+  .cmd-palette.cmd-palette,
+  .login-gate__card.login-gate__card,
+  .card.card,
+  .settings-group.settings-group {
+    border-radius: calc(14px * var(--openclaw-corner-radius-scale));
     corner-shape: superellipse(1.5);
   }
 
-  /* Menu panels draw from --menu-radius/--menu-item-radius, not --radius-*
-     directly. A custom property's nested var() references resolve relative
-     to wherever THAT property is declared, not wherever it's later read, so
-     redeclaring only --radius-md here would leave --menu-radius and
-     --menu-item-radius pinned to their :root (unscaled) computation —
-     redeclaring the derived tokens themselves is what lets both the panel
-     and its items draw the scaled radius. wa-dropdown/wa-popover/wa-select
-     redeclare on the host rather than the ::part() below: menu items are
-     light-DOM children slotted into the part, and slotted content inherits
-     custom properties from its light-DOM parent (the host), not from the
-     shadow part it renders inside — the host is the only common ancestor. */
-  .slash-menu,
-  .chat-reply-context-menu,
-  .chat-selection-popup,
+  .agent-tool-card.agent-tool-card,
+  .chat-thread.chat-thread,
+  .chat-bubble.chat-bubble,
+  .agent-chat__input.agent-chat__input,
+  .nav-item.nav-item,
+  .list-item.list-item,
+  .sidebar-recent-session.sidebar-recent-session,
+  .settings-sidebar__item.settings-sidebar__item,
+  .btn.btn,
+  .settings-input.settings-input,
+  .field.field :is(input, textarea, select) {
+    border-radius: calc(10px * var(--openclaw-corner-radius-scale));
+    corner-shape: superellipse(1.5);
+  }
+
+  .option-card.option-card {
+    border-radius: calc(20px * var(--openclaw-corner-radius-scale));
+    corner-shape: superellipse(1.5);
+  }
+
+  /* The transcript search bar's bottom corners round with its .card ancestor
+     so the two edges stay optically parallel; it carries no corner-shape of
+     its own (only two corners are rounded, and .chat:has(> .agent-chat__search-bar)
+     zeroes .card's own radius while the search bar is present — see
+     chat/layout.css). */
+  .agent-chat__search-bar.agent-chat__search-bar {
+    border-radius: 0 0 calc(14px * var(--openclaw-corner-radius-scale))
+      calc(14px * var(--openclaw-corner-radius-scale));
+  }
+
+  /* These two add a fixed cosmetic offset on top of the --radius-xl step in
+     their home rule (components.css); only the --radius-xl portion scales,
+     matching that intent. */
+  .md-preview-dialog__panel.md-preview-dialog__panel {
+    border-radius: calc(20px * var(--openclaw-corner-radius-scale) + 6px);
+    corner-shape: superellipse(1.5);
+  }
+
+  .md-preview-dialog__reader.md-preview-dialog__reader {
+    border-radius: calc(20px * var(--openclaw-corner-radius-scale) + 2px);
+    corner-shape: superellipse(1.5);
+  }
+
+  /* Menu panels and items get the same direct-property treatment: item
+     radius is computed inline as panel-minus-padding rather than read from
+     --menu-item-radius, so nothing here is inheritable either. */
+  .slash-menu.slash-menu,
+  .chat-reply-context-menu.chat-reply-context-menu,
+  .chat-selection-popup.chat-selection-popup {
+    border-radius: calc(10px * var(--openclaw-corner-radius-scale));
+    corner-shape: superellipse(1.5);
+  }
+
+  .slash-menu-item.slash-menu-item,
+  .chat-reply-context-menu.chat-reply-context-menu button,
+  .chat-selection-popup.chat-selection-popup button {
+    border-radius: calc(10px * var(--openclaw-corner-radius-scale) - 4px);
+  }
+
+  /* wa-dropdown/wa-popover/wa-select: the panel gets the same direct
+     border-radius as the part below, so nothing it contains inherits a
+     token from it. Their items are light-DOM children slotted into that
+     part with feature-specific classes (not a single enumerable selector,
+     and occasionally a plain <button> rather than <wa-dropdown-item>), so
+     --menu-radius/--menu-item-radius stay redeclared on the host purely to
+     reach those items by inheritance — the one remaining inheritable-token
+     exception in this block. It is bounded to these three purpose-built
+     menu/select components, whose entire subtree is menu chrome by
+     construction, unlike the arbitrary-content containers above. */
   wa-dropdown,
   wa-popover,
   wa-select {
-    --radius-md: calc(10px * var(--openclaw-corner-radius-scale));
-    --menu-radius: var(--radius-md);
+    --menu-radius: calc(10px * var(--openclaw-corner-radius-scale));
     --menu-item-radius: calc(var(--menu-radius) - var(--menu-padding));
   }
 
-  .slash-menu,
-  .chat-reply-context-menu,
-  .chat-selection-popup,
+  /* Unlike the doubled classes above, this generic tag selector must outrank
+     dozens of concrete per-feature panels (.cron-job-menu::part(menu),
+     .usage-export-menu::part(menu), and so on app-wide) that each declare
+     their own border-radius from --menu-radius. A bare type selector can
+     never out-specificity a class selector no matter how it's repeated, so
+     !important is the only way for one generic rule to cover every
+     wa-dropdown/wa-popover/wa-select panel by design, matching this PR's
+     "any wa-dropdown, wa-popover or wa-select gets the treatment" intent. */
   wa-dropdown::part(menu),
   wa-popover::part(body),
   wa-select::part(listbox),
   wa-select::part(combobox) {
+    border-radius: calc(10px * var(--openclaw-corner-radius-scale)) !important;
     corner-shape: superellipse(1.5);
   }
 }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -321,7 +321,8 @@
   .cmd-palette.cmd-palette,
   .login-gate__card.login-gate__card,
   .card.card,
-  .settings-group.settings-group {
+  .settings-group.settings-group,
+  .option-card__choice.option-card__choice {
     border-radius: calc(14px * var(--openclaw-corner-radius-scale));
     corner-shape: superellipse(1.5);
   }
@@ -347,13 +348,17 @@
   }
 
   /* The transcript search bar's bottom corners round with its .card ancestor
-     so the two edges stay optically parallel; it carries no corner-shape of
-     its own (only two corners are rounded, and .chat:has(> .agent-chat__search-bar)
-     zeroes .card's own radius while the search bar is present — see
-     chat/layout.css). */
+     so the two edges stay optically parallel; only two corners are rounded,
+     and .chat:has(> .agent-chat__search-bar) zeroes .card's own radius while
+     the search bar is present (see chat/layout.css). corner-shape still
+     needs to be set here even though the top two corners are 0 (a 0-radius
+     corner draws no curve either way): the bottom two are standing in for
+     .card's own squircle corner at the seam, so they need the same shape,
+     not just the same radius, to actually match it. */
   .agent-chat__search-bar.agent-chat__search-bar {
     border-radius: 0 0 calc(14px * var(--openclaw-corner-radius-scale))
       calc(14px * var(--openclaw-corner-radius-scale));
+    corner-shape: superellipse(1.5);
   }
 
   /* These two add a fixed cosmetic offset on top of the --radius-xl step in
@@ -379,10 +384,15 @@
     corner-shape: superellipse(1.5);
   }
 
+  /* Items pick up corner-shape too, not just the scaled radius: corner-shape
+     doesn't inherit, and a bigger round radius sitting inside a squircle
+     panel with no shape of its own reads as an unrelated smaller circle
+     poking out of a superellipse, not a coherent nested row. */
   .slash-menu-item.slash-menu-item,
   .chat-reply-context-menu.chat-reply-context-menu button,
   .chat-selection-popup.chat-selection-popup button {
     border-radius: calc(10px * var(--openclaw-corner-radius-scale) - 4px);
+    corner-shape: superellipse(1.5);
   }
 
   /* wa-dropdown/wa-popover/wa-select: the panel gets the same direct

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -226,16 +226,21 @@
      surfaces. Board layout math mirrors this value numerically. */
   --widget-frame-inset: var(--space-3);
 
-  /* Radii - Slightly larger for modern feel. Every step runs through one scale
-     so the corner refinement below can widen the whole app from a single knob;
-     --radius-full is shape, not scale, and stays fully round. */
-  --openclaw-corner-radius-scale: 1;
-  --radius-sm: calc(6px * var(--openclaw-corner-radius-scale));
-  --radius-md: calc(10px * var(--openclaw-corner-radius-scale));
-  --radius-lg: calc(14px * var(--openclaw-corner-radius-scale));
-  --radius-xl: calc(20px * var(--openclaw-corner-radius-scale));
+  /* Radii - Slightly larger for modern feel */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
   --radius-full: 9999px;
-  --radius: var(--radius-md);
+  --radius: 10px;
+
+  /* Corner-scale signal: whatever the @supports block below sets this to,
+     tests and other introspection can read it to learn the active multiplier
+     without duplicating the @supports check. It is intentionally not part of
+     the calc() above — the tokens stay usable by consumers that must not
+     inherit the widened surface treatment (excluded selectors, the tokens
+     exported to embedded MCP apps in mcp-app-theme.ts). */
+  --openclaw-corner-radius-scale: 1;
 
   /* Menu items stay optically parallel to their panel edge: item radius +
      padding = panel radius. Deriving the item keeps that true at any scale. */
@@ -284,45 +289,78 @@
    The shape is opt-in per surface rather than universal because a superellipse
    flattens the ends of anything fully rounded, and pills, circles, avatars and
    status dots are a third of this app's corners. Add new shared surfaces to
-   the list below; leaving one out only keeps its current corner. */
+   the list below; leaving one out only keeps its current corner.
+   --openclaw-corner-radius-scale flips to 1.25 at :root — that part is a
+   harmless capability signal, not a radius. The --radius-* tokens that
+   consumers actually draw with are redeclared locally, scaled through that
+   signal, only on the selectors below, so only opted-in surfaces widen;
+   :root consumers that stay `round` (.run-inspector__panel) and the
+   canonical tokens exported to embedded MCP apps (mcp-app-theme.ts) keep
+   drawing the base radii untouched. */
 @supports (corner-shape: superellipse(1.5)) {
   :root {
     --openclaw-corner-radius-scale: 1.25;
   }
 
-  /* Dialogs and overlays */
+  /* Dialogs, overlays, panels, cards, composer, nav/list rows and controls
+     draw straight from --radius-*, so redeclaring the scaled tokens on the
+     matched element is enough for its own border-radius to pick them up. */
   .exec-approval-card,
   .exec-approval-list,
   .cmd-palette,
   .login-gate__card,
   .md-preview-dialog__panel,
   .md-preview-dialog__reader,
-  /* Menus, popovers and select panels */
-  wa-dropdown::part(menu),
-  wa-popover::part(body),
-  wa-select::part(listbox),
-  wa-select::part(combobox),
-  .slash-menu,
-  .chat-reply-context-menu,
-  .chat-selection-popup,
-  /* Panels, cards and message surfaces */
   .card,
   .settings-group,
   .option-card,
   .agent-tool-card,
   .chat-thread,
   .chat-bubble,
-  /* Composer */
   .agent-chat__input,
-  /* Navigation and list rows */
   .nav-item,
   .list-item,
   .sidebar-recent-session,
   .settings-sidebar__item,
-  /* Buttons and text controls */
   .btn,
   .settings-input,
   .field :is(input, textarea, select) {
+    --radius-sm: calc(6px * var(--openclaw-corner-radius-scale));
+    --radius-md: calc(10px * var(--openclaw-corner-radius-scale));
+    --radius-lg: calc(14px * var(--openclaw-corner-radius-scale));
+    --radius-xl: calc(20px * var(--openclaw-corner-radius-scale));
+    corner-shape: superellipse(1.5);
+  }
+
+  /* Menu panels draw from --menu-radius/--menu-item-radius, not --radius-*
+     directly. A custom property's nested var() references resolve relative
+     to wherever THAT property is declared, not wherever it's later read, so
+     redeclaring only --radius-md here would leave --menu-radius and
+     --menu-item-radius pinned to their :root (unscaled) computation —
+     redeclaring the derived tokens themselves is what lets both the panel
+     and its items draw the scaled radius. wa-dropdown/wa-popover/wa-select
+     redeclare on the host rather than the ::part() below: menu items are
+     light-DOM children slotted into the part, and slotted content inherits
+     custom properties from its light-DOM parent (the host), not from the
+     shadow part it renders inside — the host is the only common ancestor. */
+  .slash-menu,
+  .chat-reply-context-menu,
+  .chat-selection-popup,
+  wa-dropdown,
+  wa-popover,
+  wa-select {
+    --radius-md: calc(10px * var(--openclaw-corner-radius-scale));
+    --menu-radius: var(--radius-md);
+    --menu-item-radius: calc(var(--menu-radius) - var(--menu-padding));
+  }
+
+  .slash-menu,
+  .chat-reply-context-menu,
+  .chat-selection-popup,
+  wa-dropdown::part(menu),
+  wa-popover::part(body),
+  wa-select::part(listbox),
+  wa-select::part(combobox) {
     corner-shape: superellipse(1.5);
   }
 }

--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -99,7 +99,35 @@ const ROUND_CASES: readonly CornerCase[] = [
   },
 ];
 
-const ALL_CASES = [...CORNER_CASES, ...ROUND_CASES];
+// Consumers of the shared --radius-* tokens that are NOT named in the base.css
+// corner block. The 1.25 scale must stay scoped to the opted-in selector list
+// (declared as a local custom-property override, not at :root) or these
+// unrelated surfaces inflate their radius while staying `round` — a regressed
+// look with no matching corner-shape. .run-inspector__panel stands in for the
+// whole excluded class: any --radius-md consumer outside the opted list.
+const EXCLUDED_CASES: readonly CornerCase[] = [
+  {
+    circular: "10px",
+    markup: '<div class="run-inspector__panel">Panel</div>',
+    selector: ".run-inspector__panel",
+    superelliptical: "10px",
+  },
+];
+
+const ALL_CASES = [...CORNER_CASES, ...ROUND_CASES, ...EXCLUDED_CASES];
+
+// The radius tokens themselves, read at :root exactly like
+// collectMcpAppStyleVariables() in mcp-app-theme.ts reads them for embedded
+// MCP apps. They must stay canonical/unscaled even under the superelliptical
+// fixture: an MCP app is a separate origin that only ever sees this snapshot,
+// so a :root-level scale would leak the corner refinement into a contract
+// that never opted into it.
+const ROOT_RADIUS_TOKENS = {
+  "--radius": "10px",
+  "--radius-lg": "14px",
+  "--radius-sm": "6px",
+  "--radius-xl": "20px",
+} as const;
 
 function readUiCss(): string {
   return [
@@ -108,6 +136,7 @@ function readUiCss(): string {
     "ui/src/styles/layout.css",
     "ui/src/styles/option-card.css",
     "ui/src/styles/chat/layout.css",
+    "ui/src/pages/activity/run-inspector.css",
   ]
     .map((file) => readStyleSheet(file))
     .join("\n");
@@ -143,6 +172,24 @@ async function probeCorners(browser: Browser, fixtureFile: string): Promise<Corn
       },
       ALL_CASES.map((corner) => corner.selector),
     );
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+async function probeRootRadiusTokens(
+  browser: Browser,
+  fixtureFile: string,
+): Promise<Record<string, string>> {
+  const page = await browser.newPage();
+  try {
+    await page.goto(`file://${fixtureFile}`);
+    return await page.evaluate((tokens: readonly string[]) => {
+      const style = getComputedStyle(document.documentElement);
+      return Object.fromEntries(
+        tokens.map((token) => [token, style.getPropertyValue(token).trim()]),
+      );
+    }, Object.keys(ROOT_RADIUS_TOKENS));
   } finally {
     await page.close().catch(() => {});
   }
@@ -192,6 +239,10 @@ describeCornerShape("Control UI corner curvature", () => {
           corner.selector,
           { radius: corner.superelliptical, shape: "round" },
         ]),
+        ...EXCLUDED_CASES.map((corner) => [
+          corner.selector,
+          { radius: corner.superelliptical, shape: "round" },
+        ]),
       ]),
     );
   });
@@ -204,5 +255,11 @@ describeCornerShape("Control UI corner curvature", () => {
         ALL_CASES.map((corner) => [corner.selector, { radius: corner.circular, shape: "round" }]),
       ),
     );
+  });
+
+  it("keeps the :root radius tokens MCP apps read canonical under the scale", async () => {
+    const probe = await probeRootRadiusTokens(browser, superellipticalFixture);
+
+    expect(probe).toEqual(ROOT_RADIUS_TOKENS);
   });
 });

--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -1,0 +1,208 @@
+// Control UI tests cover the continuous corner curvature contract.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const describeCornerShape = canRunPlaywrightChromium(chromiumExecutablePath)
+  ? describe
+  : describe.skip;
+
+// The `@supports` condition base.css gates the whole refinement on. Rewriting
+// its value to one no engine implements is how this file reproduces Firefox
+// and Safari from the shipped stylesheet instead of a hand-copied fallback.
+const SUPPORTS_CONDITION = "@supports (corner-shape: superellipse(1.5))";
+const UNSUPPORTED_CONDITION = "@supports (corner-shape: openclaw-unsupported-shape)";
+
+type CornerCase = {
+  /** Corner radius an engine without `corner-shape` keeps drawing. */
+  readonly circular: string;
+  readonly markup: string;
+  readonly selector: string;
+  /** Radius once the 1.25 corner scale applies. */
+  readonly superelliptical: string;
+};
+
+// One row per surface family named in the base.css corner block, plus the
+// fully-rounded chrome that must stay a true arc: a superellipse would flatten
+// the ends of every pill, avatar and status dot in the app.
+const CORNER_CASES: readonly CornerCase[] = [
+  {
+    circular: "10px",
+    markup: '<button class="btn" type="button">Send</button>',
+    selector: ".btn",
+    superelliptical: "12.5px",
+  },
+  {
+    circular: "14px",
+    markup: '<div class="card">Card</div>',
+    selector: ".card",
+    superelliptical: "17.5px",
+  },
+  {
+    circular: "20px",
+    markup: '<div class="option-card">Option</div>',
+    selector: ".option-card",
+    superelliptical: "25px",
+  },
+  {
+    circular: "14px",
+    markup: '<div class="exec-approval-card">Approval</div>',
+    selector: ".exec-approval-card",
+    superelliptical: "17.5px",
+  },
+  {
+    circular: "10px",
+    markup: '<div class="agent-chat__input">Composer</div>',
+    selector: ".agent-chat__input",
+    superelliptical: "12.5px",
+  },
+  {
+    circular: "10px",
+    markup: '<div class="sidebar-recent-session">Session</div>',
+    selector: ".sidebar-recent-session",
+    superelliptical: "12.5px",
+  },
+  {
+    circular: "10px",
+    markup: '<a class="nav-item" href="#/chat">Chat</a>',
+    selector: ".nav-item",
+    superelliptical: "12.5px",
+  },
+];
+
+const ROUND_CASES: readonly CornerCase[] = [
+  {
+    circular: "9999px",
+    markup: '<span class="pill">Pill</span>',
+    selector: ".pill",
+    superelliptical: "9999px",
+  },
+  {
+    circular: "9999px",
+    markup: '<span class="chip">Chip</span>',
+    selector: ".chip",
+    superelliptical: "9999px",
+  },
+  {
+    circular: "9999px",
+    markup: '<span class="statusDot"></span>',
+    selector: ".statusDot",
+    superelliptical: "9999px",
+  },
+];
+
+const ALL_CASES = [...CORNER_CASES, ...ROUND_CASES];
+
+function readUiCss(): string {
+  return [
+    "ui/src/styles/base.css",
+    "ui/src/styles/components.css",
+    "ui/src/styles/layout.css",
+    "ui/src/styles/option-card.css",
+    "ui/src/styles/chat/layout.css",
+  ]
+    .map((file) => readStyleSheet(file))
+    .join("\n");
+}
+
+function fixtureDocument(css: string): string {
+  return `<!doctype html><html data-theme-mode="light"><head><style>${css}</style></head><body>
+    <main>${ALL_CASES.map((corner) => corner.markup).join("")}</main>
+  </body></html>`;
+}
+
+type CornerProbe = Record<string, { radius: string; shape: string }>;
+
+async function probeCorners(browser: Browser, fixtureFile: string): Promise<CornerProbe> {
+  const page = await browser.newPage();
+  try {
+    await page.goto(`file://${fixtureFile}`);
+    return await page.evaluate(
+      (selectors: readonly string[]) => {
+        return Object.fromEntries(
+          selectors.map((selector) => {
+            const element = document.querySelector(selector);
+            if (!element) {
+              throw new Error(`Missing corner fixture element for ${selector}`);
+            }
+            const style = getComputedStyle(element);
+            return [
+              selector,
+              { radius: style.borderTopLeftRadius, shape: style.getPropertyValue("corner-shape") },
+            ];
+          }),
+        );
+      },
+      ALL_CASES.map((corner) => corner.selector),
+    );
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+let fixtureDirectory: string;
+let superellipticalFixture: string;
+let circularFixture: string;
+let browser: Browser;
+
+beforeAll(async () => {
+  if (!canRunPlaywrightChromium(chromiumExecutablePath)) {
+    return;
+  }
+  const css = readUiCss();
+  expect(css.split(SUPPORTS_CONDITION)).toHaveLength(2);
+  fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "corner-shape-"));
+  superellipticalFixture = path.join(fixtureDirectory, "superelliptical.html");
+  circularFixture = path.join(fixtureDirectory, "circular.html");
+  fs.writeFileSync(superellipticalFixture, fixtureDocument(css), "utf8");
+  fs.writeFileSync(
+    circularFixture,
+    fixtureDocument(css.replace(SUPPORTS_CONDITION, UNSUPPORTED_CONDITION)),
+    "utf8",
+  );
+  browser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
+});
+
+afterAll(async () => {
+  await browser?.close().catch(() => {});
+  if (fixtureDirectory) {
+    fs.rmSync(fixtureDirectory, { force: true, recursive: true });
+  }
+});
+
+describeCornerShape("Control UI corner curvature", () => {
+  it("scales and reshapes the surfaces that carry the app silhouette", async () => {
+    const probe = await probeCorners(browser, superellipticalFixture);
+
+    expect(probe).toEqual(
+      Object.fromEntries([
+        ...CORNER_CASES.map((corner) => [
+          corner.selector,
+          { radius: corner.superelliptical, shape: "superellipse(1.5)" },
+        ]),
+        ...ROUND_CASES.map((corner) => [
+          corner.selector,
+          { radius: corner.superelliptical, shape: "round" },
+        ]),
+      ]),
+    );
+  });
+
+  it("keeps today's corners on engines without corner-shape", async () => {
+    const probe = await probeCorners(browser, circularFixture);
+
+    expect(probe).toEqual(
+      Object.fromEntries(
+        ALL_CASES.map((corner) => [corner.selector, { radius: corner.circular, shape: "round" }]),
+      ),
+    );
+  });
+});

--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -76,6 +76,12 @@ const CORNER_CASES: readonly CornerCase[] = [
     selector: ".nav-item",
     superelliptical: "12.5px",
   },
+  {
+    circular: "14px",
+    markup: '<div class="settings-group">Group</div>',
+    selector: ".settings-group",
+    superelliptical: "17.5px",
+  },
 ];
 
 const ROUND_CASES: readonly CornerCase[] = [
@@ -100,16 +106,27 @@ const ROUND_CASES: readonly CornerCase[] = [
 ];
 
 // Consumers of the shared --radius-* tokens that are NOT named in the base.css
-// corner block. The 1.25 scale must stay scoped to the opted-in selector list
-// (declared as a local custom-property override, not at :root) or these
-// unrelated surfaces inflate their radius while staying `round` — a regressed
-// look with no matching corner-shape. .run-inspector__panel stands in for the
-// whole excluded class: any --radius-md consumer outside the opted list.
+// corner block. The 1.25 scale must stay scoped to the opted-in selectors
+// (set as a direct border-radius, not an inheritable custom property) or
+// these unrelated surfaces inflate their radius while staying `round` — a
+// regressed look with no matching corner-shape. .run-inspector__panel is a
+// sibling of every opted surface, standing in for any --radius-md consumer
+// outside the opted list entirely. .settings-segmented is nested INSIDE the
+// opted .settings-group instead: border-radius does not inherit, so even a
+// non-opted descendant of an opted container must keep its canonical radius
+// and initial `round` shape — a redeclared --radius-* custom property on the
+// container would leak into it, which is exactly the regression this proves.
 const EXCLUDED_CASES: readonly CornerCase[] = [
   {
     circular: "10px",
     markup: '<div class="run-inspector__panel">Panel</div>',
     selector: ".run-inspector__panel",
+    superelliptical: "10px",
+  },
+  {
+    circular: "10px",
+    markup: '<div class="settings-group"><div class="settings-segmented">Segmented</div></div>',
+    selector: ".settings-segmented",
     superelliptical: "10px",
   },
 ];
@@ -136,6 +153,7 @@ function readUiCss(): string {
     "ui/src/styles/layout.css",
     "ui/src/styles/option-card.css",
     "ui/src/styles/chat/layout.css",
+    "ui/src/styles/settings.css",
     "ui/src/pages/activity/run-inspector.css",
   ]
     .map((file) => readStyleSheet(file))

--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -24,6 +24,11 @@ const UNSUPPORTED_CONDITION = "@supports (corner-shape: openclaw-unsupported-sha
 type CornerCase = {
   /** Corner radius an engine without `corner-shape` keeps drawing. */
   readonly circular: string;
+  /** Which physical corner to probe; most fixtures round all four equally,
+   * so "topLeft" (the default) stands in for the rest. Only a directional
+   * shorthand like .agent-chat__search-bar's `0 0 var(...) var(...)` needs
+   * "bottomLeft" — its top corners are permanently 0 either way. */
+  readonly corner?: "bottomLeft" | "topLeft";
   readonly markup: string;
   readonly selector: string;
   /** Radius once the 1.25 corner scale applies. */
@@ -47,10 +52,22 @@ const CORNER_CASES: readonly CornerCase[] = [
     superelliptical: "17.5px",
   },
   {
+    // Real DOM shape from option-card.ts: .option-card__choice is a button
+    // nested two levels inside .option-card, not a synthetic flat div. The
+    // .option-card__choice case below reuses this same markup — an empty
+    // markup string there, not a duplicate copy of it.
     circular: "20px",
-    markup: '<div class="option-card">Option</div>',
+    markup:
+      '<section class="option-card" role="group"><div class="option-card__choices">' +
+      '<button type="button" class="option-card__choice">Choice</button></div></section>',
     selector: ".option-card",
     superelliptical: "25px",
+  },
+  {
+    circular: "14px",
+    markup: "",
+    selector: ".option-card__choice",
+    superelliptical: "17.5px",
   },
   {
     circular: "14px",
@@ -80,6 +97,59 @@ const CORNER_CASES: readonly CornerCase[] = [
     circular: "14px",
     markup: '<div class="settings-group">Group</div>',
     selector: ".settings-group",
+    superelliptical: "17.5px",
+  },
+  {
+    // Real DOM shape from chat-composer-slash-menu.ts: .slash-menu-item is a
+    // div two levels below .slash-menu (through .slash-menu__scroll and
+    // .slash-menu-group), not a direct child. Item radius is panel radius
+    // minus 4px (calc(10px * scale - 4px) in base.css), so it reads a
+    // different number from the panel at both scales — a real assertion,
+    // not a copy of the panel's own expected value.
+    circular: "10px",
+    markup:
+      '<div class="slash-menu" role="listbox"><div class="slash-menu__scroll">' +
+      '<div class="slash-menu-group"><div class="slash-menu-item" role="option">Item</div>' +
+      "</div></div></div>",
+    selector: ".slash-menu",
+    superelliptical: "12.5px",
+  },
+  {
+    circular: "6px",
+    markup: "",
+    selector: ".slash-menu-item",
+    superelliptical: "8.5px",
+  },
+  {
+    // Real DOM shape from chat-thread-interactions.ts: the item is a plain
+    // <button>, matched by the base.css descendant tag selector
+    // `.chat-reply-context-menu button`, not a class carried on the item
+    // itself the way .slash-menu-item is.
+    circular: "10px",
+    markup:
+      '<div class="chat-reply-context-menu" role="menu">' +
+      '<button type="button" role="menuitem">Reply</button></div>',
+    selector: ".chat-reply-context-menu",
+    superelliptical: "12.5px",
+  },
+  {
+    circular: "6px",
+    markup: "",
+    selector: ".chat-reply-context-menu button",
+    superelliptical: "8.5px",
+  },
+  {
+    // Real DOM shape from chat-thread-interactions.ts. Found and fixed
+    // alongside the two P2s above during a final invariant sweep of every
+    // selector in the base.css corner block: this one already scaled its
+    // (bottom-only) radius but never carried corner-shape, same "radius
+    // grew, shape didn't follow" gap as the menu items. Its only non-zero
+    // corners are the bottom two (`border-radius: 0 0 var(...) var(...)`),
+    // so this is the one case that needs the bottom-left probe.
+    circular: "14px",
+    corner: "bottomLeft",
+    markup: '<div class="agent-chat__search-bar"><input type="text" /></div>',
+    selector: ".agent-chat__search-bar",
     superelliptical: "17.5px",
   },
 ];
@@ -173,22 +243,24 @@ async function probeCorners(browser: Browser, fixtureFile: string): Promise<Corn
   try {
     await page.goto(`file://${fixtureFile}`);
     return await page.evaluate(
-      (selectors: readonly string[]) => {
+      (probes: readonly { selector: string; corner: "bottomLeft" | "topLeft" }[]) => {
         return Object.fromEntries(
-          selectors.map((selector) => {
+          probes.map(({ selector, corner }) => {
             const element = document.querySelector(selector);
             if (!element) {
               throw new Error(`Missing corner fixture element for ${selector}`);
             }
             const style = getComputedStyle(element);
-            return [
-              selector,
-              { radius: style.borderTopLeftRadius, shape: style.getPropertyValue("corner-shape") },
-            ];
+            const radius =
+              corner === "bottomLeft" ? style.borderBottomLeftRadius : style.borderTopLeftRadius;
+            return [selector, { radius, shape: style.getPropertyValue("corner-shape") }];
           }),
         );
       },
-      ALL_CASES.map((corner) => corner.selector),
+      ALL_CASES.map((corner) => ({
+        selector: corner.selector,
+        corner: corner.corner ?? "topLeft",
+      })),
     );
   } finally {
     await page.close().catch(() => {});

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -98,6 +98,7 @@ const nodeDrivenBrowserLayoutTests = [
   "src/pages/chat/chat-responsive.browser.test.ts",
   "src/components/form-controls.browser.test.ts",
   "src/pages/sessions/view.browser.test.ts",
+  "src/styles/corner-shape.browser.test.ts",
   "src/styles/cursor-policy.browser.test.ts",
   "src/styles/chat-file-link-presentation.browser.test.ts",
   "src/styles/chat-github-link-presentation.browser.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Control UI corners are drawn as plain circular arcs, and the radius scale behind them is four unrelated literals. Two things follow from that.

A circular corner ends on a tangent: the curve stops and the straight edge begins at a visible break. At the radii this app uses, the corner reads tighter and harder than the value suggests, and the effect is strongest exactly where the surface is largest — approval dialogs, settings groups, option cards, the composer.

And the scale itself has no owner. `--radius-sm/md/lg/xl` are independent values, `--radius` restated `10px` beside `--radius-md`, and `--menu-item-radius` restated `6px` next to a comment explaining that it is really "panel radius minus menu padding". Any future adjustment to the app's corner language means editing every one of them and hoping the relationships still hold.

## Why This Change Was Made

Every radius step now runs through a single knob, `--openclaw-corner-radius-scale`, and where the engine can draw a superellipse the app opts into continuous corner curvature: the corner keeps curving into the edge instead of stopping on a tangent, and the 1.25 scale gives the arc back the visual weight the tangent break was taking away. Border, shadow, outline and overflow clipping all follow the drawn shape, so this stays a paint-level refinement — no layout or DOM changes.

The whole refinement sits inside one `@supports (corner-shape: superellipse(1.5))` block in `ui/src/styles/base.css`. On an engine without `corner-shape` the block never applies: the scale stays `1` and every corner keeps today's radius and today's arc. That path is unchanged by construction, and it is asserted, not assumed — see Evidence.

Two deliberate boundaries:

- **The shape is opt-in per surface family, not universal.** A superellipse flattens the ends of anything fully rounded, and pills, chips, avatars, status dots and circular icon actions are roughly a third of this app's corners. They keep true arcs. The block lists the shared surface families instead; leaving one out only keeps its current corner, which is the safe direction to fail.
- **Fully-rounded chrome is shape, not scale.** `--radius-full` stays `9999px` in both paths.

`--menu-item-radius` is now derived as `--menu-radius - --menu-padding`, which is the optical relation its own comment already documented (item edge stays parallel to the panel edge). It resolves to today's `6px` unscaled and stays correct at any scale.

### Support matrix

| Engine | Corners |
| --- | --- |
| Chrome / Edge 139+ | continuous curvature, radii scaled ×1.25 |
| Firefox, Safari, older Chromium | today's radii, today's circular arcs |

### Token values

| Token | Today | With `corner-shape` |
| --- | --- | --- |
| `--radius-sm` | 6px | 7.5px |
| `--radius-md` | 10px | 12.5px |
| `--radius-lg` | 14px | 17.5px |
| `--radius-xl` | 20px | 25px |
| `--menu-radius` | 10px | 12.5px |
| `--menu-item-radius` | 6px | 8.5px |
| `--radius-full` | 9999px | 9999px |

Surfaces that pick up both the scale and the shape: approval/confirm dialog shells, the command palette, menu and popover panels (including `wa-dropdown`, `wa-popover` and `wa-select` parts), cards, settings groups, option cards, agent tool cards, chat thread and bubbles, the composer, sidebar session rows, nav and list rows, buttons, and text inputs.

## User Impact

On Chrome and Edge 139 or newer the Control UI gets a softer, more continuous corner language across dialogs, menus, panels, the composer, sidebar rows and buttons, with pills and circular chrome deliberately untouched. Everywhere else the UI looks exactly as it does today — nothing to configure, nothing to opt into, and no way for the change to regress an unsupported browser.

## Evidence

Screenshots below are before/after pairs composed at 1:1 pixel scale, light and dark, captured with headed Chromium 151 under Xvfb on a Blacksmith Testbox, driving the mocked Control UI (`pnpm dev:ui:mock`). "Before" is the fallback path — the same page with the corner scale forced back to `1` and every corner returned to `round`, which is what an engine without `corner-shape` renders.

**Corner detail (`--radius-xl` surface, 20px → 25px)**

<img width="900" alt="Macro corner comparison, dark" src="https://github.com/user-attachments/assets/168eb060-83ec-4dc8-99b0-7b63c3c6f0d5" />

<img width="900" alt="Macro corner comparison, light" src="https://github.com/user-attachments/assets/2ac2e525-cf19-41c4-914a-693a09595c17" />

**Surface families — dialog, card, option card, menu, sidebar row, buttons, pills, composer, input**

<img width="900" alt="Surface gallery, dark" src="https://github.com/user-attachments/assets/5bec0b41-b835-4542-b0ce-3fdcafaeac40" />

<img width="900" alt="Surface gallery, light" src="https://github.com/user-attachments/assets/b83e45b3-5e95-41e7-b26f-042fdd534bec" />

Pills, chips and the status dot are identical on both sides — that is the intended exclusion, not a missed surface.

**Chat**

<img width="900" alt="Chat view, dark" src="https://github.com/user-attachments/assets/316bf099-80af-4aad-9a8e-32cb42ce486a" />

<img width="900" alt="Chat view, light" src="https://github.com/user-attachments/assets/9853358e-e713-407b-a60b-c286cefbf259" />

**Settings**

<img width="900" alt="Settings appearance, dark" src="https://github.com/user-attachments/assets/f25a47ac-cf58-4087-9f39-ce0f077fcd35" />

<img width="900" alt="Settings appearance, light" src="https://github.com/user-attachments/assets/4b0e647b-3bca-4f17-ab94-c39ac5ee98d7" />

### Computed styles from the same run

`chromium=151.0.7922.34 corner_shape_supported=true`

| Selector | Fallback path | Enhanced path |
| --- | --- | --- |
| `.btn` | `10px round` | `12.5px superellipse(1.5)` |
| `.card` | `14px round` | `17.5px superellipse(1.5)` |
| `.settings-group` | `14px round` | `17.5px superellipse(1.5)` |
| `.option-card` | `20px round` | `25px superellipse(1.5)` |
| `.exec-approval-card` | `14px round` | `17.5px superellipse(1.5)` |
| `.agent-chat__input` | `10px round` | `12.5px superellipse(1.5)` |
| `.sidebar-recent-session` | `10px round` | `12.5px superellipse(1.5)` |
| `.nav-item` | `10px round` | `12.5px superellipse(1.5)` |
| `.pill` | `9999px round` | `9999px round` |
| `.statusDot` | `9999px round` | `9999px round` |

### Tests and checks

- New `ui/src/styles/corner-shape.browser.test.ts` drives real Chromium over the shipped stylesheets twice: once as shipped, and once with the `@supports` condition rewritten to a value no engine implements. The second case is how the no-support path is proven rather than assumed — it asserts every surface back at `10 / 14 / 20px` and `round`, including the pills. Both pass.
- `ui/src/pages/chat/chat-responsive.browser.test.ts` pinned bubble, composer, transcript-search and gateway-menu radii to unscaled literals. Those assertions now read the live corner scale and multiply, so they hold on both paths; the menu item is asserted as `panel radius − menu padding`, which is the invariant it was really protecting.
- `pnpm test:ui` — 659 files, 9458 tests, 1 skipped, green (Blacksmith Testbox, Linux, Node 24).
- `pnpm lint:ui:styles` (stylelint), `tsgo -p tsconfig.ui.json`, UI test typecheck shards, and oxlint on the touched files — all green on the same box.
- `pnpm test:ui:e2e` on that Testbox reported four failing files: `ui/src/e2e/activity-run-inspector.e2e.test.ts`, `ui/src/e2e/chat-flow.follow-ups.e2e.test.ts`, `ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts`, `ui/src/pages/secrets/secrets.e2e.test.ts`. All four pass locally on this branch (30 tests, macOS, same Chromium build), and none of the failures is a geometry or radius assertion — they are a mobile scroll-height check, a notice ordering check, a model-select click intercepted mid-retry, and a dialog field timeout, i.e. load-sensitive flakes on a busy 4-vCPU VM that was also hosting the screenshot server. The confirming baseline run on the same box was killed (exit 137, out of memory) before it finished, so the pre-existing-versus-introduced classification rests on the local pass rather than a same-box baseline. Worth a clean e2e lane on CI before this leaves draft.

Production delta is `+66 / −10` lines in one file, `ui/src/styles/base.css`; everything else is tests.
