### PR TITLE
fix(claws): keep update JSON output parseable

### DIFF
--- a/src/claws/package-update.ts
+++ b/src/claws/package-update.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
 import { preflightPluginInstall } from "../plugins/plugin-install-preflight.js";
+import type { RuntimeEnv } from "../runtime.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import {
   digestClawPackageRef,
@@ -51,6 +52,7 @@ export async function applyClawPackageUpdate(
     readRefs?: typeof readClawPackageRefs;
     replaceExpected?: typeof replaceClawPackageRefExpected;
     packageDeps?: PackageInstallerDeps;
+    runtime?: RuntimeEnv;
     nowMs?: number;
   },
 ): Promise<ClawPackageUpdateExecution> {

--- a/src/claws/update-apply.ts
+++ b/src/claws/update-apply.ts
@@ -4,6 +4,7 @@ import { listAgentEntries } from "../agents/agent-scope.js";
 import { transformConfigFileWithRetry } from "../config/config.js";
 import type { AgentConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { RuntimeEnv } from "../runtime.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { clawTargetPackages } from "./application-provenance.js";
 import {
@@ -99,6 +100,7 @@ export async function applyClawUpdatePlan(
     sourceMcpServers: Record<string, Record<string, unknown>>;
     consentPlanIntegrity: string | undefined;
     packagePreflight?: ClawAddPlanContext["packagePreflight"];
+    runtime?: RuntimeEnv;
     commitConfig?: ConfigCommit;
     rebuildPlan?: typeof buildClawUpdatePlan;
     buildAddPlan?: typeof buildClawAddPlan;

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -945,6 +945,15 @@ describe("claws cli", () => {
 
   it("applies a supported update only after explicit consent", async () => {
     const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
+    const applyUpdate = mocks.applyClawUpdatePlan.getMockImplementation();
+    if (!applyUpdate) {
+      throw new Error("missing update fixture implementation");
+    }
+    mocks.applyClawUpdatePlan.mockImplementationOnce(async (...args) => {
+      const options = args[2] as { runtime?: typeof mocks.runtime };
+      (options.runtime ?? mocks.runtime).log("Installed plugin: demo");
+      return await applyUpdate(...args);
+    });
 
     await runCli([
       "claws",
@@ -977,6 +986,7 @@ describe("claws cli", () => {
         }),
       }),
     );
+    expect(mocks.logs).toHaveLength(1);
     expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
       schemaVersion: "openclaw.clawUpdateResult.v1",
       status: "complete",

--- a/src/cli/claws-update-cli.runtime.ts
+++ b/src/cli/claws-update-cli.runtime.ts
@@ -210,6 +210,7 @@ export async function runClawsUpdateCommand(
         sourceMcpServers: listedMcpServers.mcpServers,
         consentPlanIntegrity: opts.planIntegrity,
         packagePreflight: preflightClawPackage,
+        runtime: opts.json ? { ...runtime, log: () => undefined } : runtime,
         cronGateway: {
           add: async (input) => await callGatewayFromCli("cron.add", {}, input),
           get: async (id) => await callGatewayFromCli("cron.get", {}, { id }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw claws update --json` could receive plugin installer progress and restart messages before the update result, making stdout contain multiple values instead of one parseable JSON document.

## Why This Change Was Made

The Claw update CLI now carries its runtime through the update and package lifecycle owners, using a log-muted runtime only for JSON mode. Human-readable updates keep the original runtime, so experimental, installer, warning, restart, and completion messages remain visible.

The root cause was that update did not pass the runtime that `claws add` already uses for the same nested package installer. The installer therefore fell back to the process default stdout runtime.

Production LOC: +5/-0. Tests: +10/-0.

This is deliberately limited to update output. It does not change config shape, files or provenance semantics, rollback or compensation, package trust or security policy, schemas, protocols, the Plugin SDK, dependencies, or release behavior. The analogous remove-side nested-uninstall logging path is excluded from this PR and remains a separate follow-up.

## User Impact

`openclaw claws update --json` now emits exactly one JSON document on stdout even when the update installs a plugin package. Scripts can parse the result reliably, while interactive users retain the existing human-readable installer and restart guidance.

## Evidence

- Controlled regression: with only the five production additions removed and the regression test retained, `src/cli/claws-cli.test.ts` reported 35 passing tests and one expected failure because stdout contained the installer line plus JSON. Restoring the candidate produced 36/36 passing tests.
- Blacksmith Testbox build and explicit four-file changed gate passed on `b289ad98b6fe5287a525e6c9ebd8f3b78f45de5a`: format, core and test types, lint with zero warnings/errors, import cycles, and selected guards.
- Packed product proof built a local plugin and Claw v1/v2 artifacts, deleted the source directories, and exercised add/update from the packed artifacts under isolated `HOME`, config, and state roots. JSON update exited 0 with exactly one stdout JSON document and empty stderr; config, installed files, and SQLite-backed Claw provenance were present; cleanup completed.
- A separate source-blind validation repeated the exact packed flow and confirmed JSON output, human experimental/installer/restart/completion logs, isolated state, and cleanup.
- Testbox evidence: https://github.com/openclaw/openclaw/actions/runs/31876005764
- Fresh autoreview against `origin/main`: no accepted or actionable findings.
