### PR TITLE
fix(gateway): provider usage follows reloaded account config

### DIFF
--- a/src/gateway/server-methods/models-auth-status-usage-cache.ts
+++ b/src/gateway/server-methods/models-auth-status-usage-cache.ts
@@ -36,7 +36,7 @@ export type ProviderUsageStatus = Pick<
 
 type ProviderUsageCacheEntry = {
   agentDir: string;
-  configRef: object;
+  configRef: OpenClawConfig;
   credentialKey: string;
   providerKey: string;
   refreshedAt: number;
@@ -46,7 +46,7 @@ type ProviderUsageCacheEntry = {
 
 type ProviderUsageRefresh = {
   agentDir: string;
-  configRef: object;
+  configRef: OpenClawConfig;
   credentialKey: string;
   providerKey: string;
   promise: Promise<UsageSummary>;
@@ -158,7 +158,7 @@ function mapProviderUsage(usage: Awaited<ReturnType<typeof loadProviderUsageSumm
 function scheduleProviderUsageRefresh(params: {
   agentId: string;
   agentDir: string;
-  configRef: object;
+  configRef: OpenClawConfig;
   credentialKey: string;
   providerIds: UsageProviderId[];
   providerKey: string;
@@ -176,6 +176,7 @@ function scheduleProviderUsageRefresh(params: {
   const promise = loadProviderUsageSummary({
     providers: params.providerIds,
     agentDir: params.agentDir,
+    config: params.configRef,
     timeoutMs: 3500,
   })
     .then((usage) => {
@@ -222,7 +223,7 @@ function scheduleProviderUsageRefresh(params: {
 type ProviderUsageCacheParams = {
   agentId: string;
   agentDir: string;
-  configRef: object;
+  configRef: OpenClawConfig;
   credentialKey: string;
   forceRefresh?: boolean;
   providerIds: UsageProviderId[];

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -1010,6 +1010,8 @@ describe("models.authStatus", () => {
   });
 
   it("routes claude-cli OAuth profiles to Anthropic usage with plan and billing", async () => {
+    const runtimeConfig = {};
+    mocks.getRuntimeConfig.mockReturnValue(runtimeConfig);
     const profile = {
       profileId: "claude-cli",
       provider: "claude-cli",
@@ -1044,6 +1046,7 @@ describe("models.authStatus", () => {
     expect(mocks.loadProviderUsageSummary).toHaveBeenCalledWith({
       providers: ["anthropic"],
       agentDir: "/tmp/agent",
+      config: runtimeConfig,
       timeoutMs: 3500,
     });
     let result: ModelAuthStatusResult | undefined;
@@ -1087,6 +1090,7 @@ describe("models.authStatus", () => {
     expect(mocks.loadProviderUsageSummary).toHaveBeenCalledWith({
       providers: ["deepseek"],
       agentDir: "/tmp/agent",
+      config: expect.any(Object),
       timeoutMs: 3500,
     });
     let result: ModelAuthStatusResult | undefined;
@@ -1225,6 +1229,7 @@ describe("models.authStatus", () => {
     expect(mocks.loadProviderUsageSummary).toHaveBeenLastCalledWith({
       providers: ["openai"],
       agentDir: "/tmp/rebound-agent",
+      config: expect.any(Object),
       timeoutMs: 3500,
     });
   });

--- a/src/gateway/server-methods/usage.status-cache.test.ts
+++ b/src/gateway/server-methods/usage.status-cache.test.ts
@@ -114,6 +114,28 @@ describe("usage.status provider usage cache", () => {
     vi.restoreAllMocks();
   });
 
+  it("loads the cached provider snapshot from the exact runtime config", async () => {
+    mocks.loadProviderUsageSummary.mockImplementation(async (options) => ({
+      updatedAt: now,
+      providers:
+        options.config === config
+          ? [
+              {
+                provider: "openai",
+                displayName: "OpenAI",
+                windows: [{ label: "5h", usedPercent: 25 }],
+                accountEmail: "configured@example.com",
+              },
+            ]
+          : [],
+    }));
+
+    const result = (await runUsageStatus()) as {
+      providers: Array<{ accountEmail?: string }>;
+    };
+    expect(result.providers[0]?.accountEmail).toBe("configured@example.com");
+  });
+
   it("reuses byte-identical results within 60s and refreshes stale data in the background", async () => {
     const first = await runUsageStatus();
     const repeated = await runUsageStatus();


### PR DESCRIPTION
Related: #121799

## What Problem This Solves

Fixes an issue where provider usage could show no provider or the wrong account after runtime configuration changed, because the cache refresh could fetch through an ambient configuration different from the configuration that keyed the cache.

## Why This Change Was Made

The provider-usage cache now carries its exact `OpenClawConfig` into the provider loader. The configuration that determines cache ownership is therefore also the configuration used for provider discovery, account selection, and usage fetches.

This is complementary to #121799: that PR changes cold-read behavior and cache identity, but its current head still does not pass the exact runtime config into `loadProviderUsageSummary`. This PR does not change provider auth, routing, defaults, billing semantics, public protocol/SDK, configuration shape, persistence, or schema.

Production growth is one line (`+5/-4`): the single added capability is the missing owner-boundary handoff from cache refresh to provider loading. The other production edits tighten the existing cache config types.

## User Impact

Provider plan, quota, balance, and account data now follows the active runtime configuration after account or provider changes. Identical configuration reuses the correct cached value; a different account/configuration receives an isolated value; one provider error or timeout does not hide successful providers.

No `CHANGELOG.md` edit is included. Release generation owns changelog updates for normal fixes.

## Evidence

Exact candidate:

- Head: `fbc479feec2303aeba3f3b3770e978969114238f`
- Tree: `ecd20f392c9d4e8c9da7006048fec960c3408067`
- Base: `447393dc3221e14f63dc9b3818ddd04051553936`
- Production: `+5/-4` (net `+1`)
- Tests: `+27/-0`

Source-blind built-Gateway proof on Blacksmith Testbox `tbx_01m02aygy1hdqmja1jkqyca8a5` ([run 31876290317](https://github.com/openclaw/openclaw/actions/runs/31876290317)) used an isolated state directory, free loopback ports, and a controlled local provider with no external credentials:

- Ambient config/account B returned `proof-b / B@fixture.invalid`.
- Hot-applied runtime config A fetched `proof-a / A`; no B request occurred, and `usage.status` returned `A@fixture.invalid` instead of an empty healthy payload.
- The second A request was byte-identical and generated zero provider requests.
- Config/account C generated a new `proof-c / C` request and response rather than reusing A.
- Controlled success + HTTP 503 + timeout completed in 6.832s: successful A remained visible alongside `controlled provider error` and `Timeout` snapshots.
- A forced config revision contacted good/error/timeout providers again and completed in 6.892s with the successful provider preserved.
- Cleanup verified the Gateway exited, both owned ports closed, isolated state was removed, and the Testbox had zero fixture directories or Gateway processes.

Verification on the exact tree:

- Focused cache regression: 3/3 passed.
- `models.authStatus` sibling: 85/85 passed.
- Provider usage auth/load siblings: 18/18 passed.
- Full `pnpm build`: passed.
- Changed gate completed successfully through format, oxlint, core and test typechecks, import cycles, native schema, database-first, dependency, plugin-boundary, dead-export, sidecar, webhook, and pairing guards.
- Exact-tree finalizer: `git diff --check` passed and reported only the three intended files.
- Fresh Codex autoreview: clean, no accepted/actionable findings (`overall: patch is correct (0.99)`).
- Claude land decision: approved.
