### PR TITLE
refactor(plugins): remove dead provider seams

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -17,7 +17,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { applyCliRuntimeRecallTimeoutDefault } from "./config.js";
 import plugin, { testing } from "./index.js";
 import { resolveActiveRecallForRun } from "./recall-state.js";
-import { hasRememberAcrossConversationsAgent } from "./session-policy.js";
 
 // Match only lone surrogates so valid supplementary-plane characters remain allowed.
 const UNPAIRED_SURROGATE_RE =
@@ -819,19 +818,6 @@ describe("active-memory plugin", () => {
     );
 
     expect(hoisted.getActiveMemorySearchManager).not.toHaveBeenCalled();
-  });
-
-  it("does not synthesize a main agent when every configured agent opts out", () => {
-    expect(
-      hasRememberAcrossConversationsAgent({
-        agents: {
-          list: [
-            { id: "personal", memory: { search: { rememberAcrossConversations: false } } },
-            { id: "support", memory: { search: { rememberAcrossConversations: false } } },
-          ],
-        },
-      }),
-    ).toBe(false);
   });
 
   it("keeps the outer hook timeout at the live-config ceiling", () => {

--- a/extensions/active-memory/session-policy.ts
+++ b/extensions/active-memory/session-policy.ts
@@ -127,12 +127,6 @@ function isActiveMemoryPluginEnabled(cfg: OpenClawConfig): boolean {
   return plugins.entries["active-memory"]?.enabled !== false;
 }
 
-function hasRememberAcrossConversationsAgent(cfg: OpenClawConfig): boolean {
-  const configuredAgentIds = cfg.agents?.list?.map((agent) => agent.id) ?? [];
-  const agentIds = configuredAgentIds.length > 0 ? configuredAgentIds : ["main"];
-  return agentIds.some((agentId) => resolveRememberAcrossConversations(cfg, agentId));
-}
-
 function shouldRememberAcrossConversations(cfg: OpenClawConfig, agentId: string): boolean {
   return resolveRememberAcrossConversations(cfg, agentId);
 }
@@ -438,7 +432,6 @@ export {
   isEnabledForAgent,
   isPrivateRecallDestination,
   isSessionActiveMemoryDisabled,
-  hasRememberAcrossConversationsAgent,
   lacksAdminToMutateActiveMemoryGlobal,
   resolveCommandSessionKey,
   setSessionActiveMemoryDisabled,

--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -45,17 +45,6 @@ async function withLiveChutesDiscovery<T>(
   }
 }
 
-function createAuthEchoFetchMock() {
-  return vi.fn().mockImplementation((_url, init?: { headers?: HeadersInit }) => {
-    const auth = readAuthorizationHeader(init);
-    return Promise.resolve(
-      jsonResponse({
-        data: [{ id: auth ? `${auth}-model` : "public-model" }],
-      }),
-    );
-  });
-}
-
 function readAuthorizationHeader(init?: { headers?: HeadersInit }): string {
   const headers = init?.headers;
   if (headers instanceof Headers) {
@@ -309,35 +298,6 @@ describe("chutes-models", () => {
       expect(requireChutesModel(modelsASecond, 0).id).toBe("private/model-a");
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
-  });
-
-  it("evicts oldest token entries when cache reaches max size", async () => {
-    const mockFetch = createAuthEchoFetchMock();
-
-    await withLiveChutesDiscovery(mockFetch, async () => {
-      for (let i = 0; i < 150; i += 1) {
-        await discoverChutesModels(`cache-token-${i}`);
-      }
-
-      await discoverChutesModels("cache-token-0");
-      expect(mockFetch).toHaveBeenCalledTimes(151);
-    });
-  });
-
-  it("prunes expired token cache entries during subsequent discovery", async () => {
-    const mockFetch = createAuthEchoFetchMock();
-
-    await withLiveChutesDiscovery(
-      mockFetch,
-      async () => {
-        await discoverChutesModels("token-a");
-        vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-        await discoverChutesModels("token-b");
-        await discoverChutesModels("token-a");
-        expect(mockFetch).toHaveBeenCalledTimes(3);
-      },
-      { now: "2026-03-01T00:00:00.000Z" },
-    );
   });
 
   it("does not cache 401 fallback under the failed token key", async () => {

--- a/extensions/xai/api.test.ts
+++ b/extensions/xai/api.test.ts
@@ -1,11 +1,6 @@
 // Xai tests cover api plugin behavior.
 import { describe, expect, it } from "vitest";
-import {
-  isXaiModelHint,
-  resolveXaiForwardCompatModel,
-  resolveXaiTransport,
-  XAI_BASE_URL,
-} from "./api.js";
+import { resolveXaiForwardCompatModel, resolveXaiTransport, XAI_BASE_URL } from "./api.js";
 
 describe("xai api helpers", () => {
   it("uses shared endpoint classification for native xAI transports", () => {
@@ -68,8 +63,4 @@ describe("xai api helpers", () => {
       expect(model?.reasoning).toBe(true);
     },
   );
-
-  it("detects xAI model hints", () => {
-    expect(isXaiModelHint("x-ai/grok-4")).toBe(true);
-  });
 });

--- a/extensions/xai/api.ts
+++ b/extensions/xai/api.ts
@@ -1,5 +1,4 @@
 // Xai API module exposes the plugin public contract.
-import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   applyXaiModelCompat,
   HTML_ENTITY_TOOL_CALL_ARGUMENTS_ENCODING,
@@ -26,20 +25,4 @@ export { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 export { applyXaiModelCompat, HTML_ENTITY_TOOL_CALL_ARGUMENTS_ENCODING, XAI_TOOL_SCHEMA_PROFILE };
 export { resolveXaiTransport } from "./provider-routing.js";
 
-export function isXaiModelHint(modelId: string): boolean {
-  return getModelProviderHint(modelId) === "x-ai";
-}
-
 export { normalizeNativeXaiModelId as normalizeXaiModelId };
-
-function getModelProviderHint(modelId: string): string | null {
-  const trimmed = normalizeOptionalLowercaseString(modelId);
-  if (!trimmed) {
-    return null;
-  }
-  const slashIndex = trimmed.indexOf("/");
-  if (slashIndex <= 0) {
-    return null;
-  }
-  return trimmed.slice(0, slashIndex) || null;
-}


### PR DESCRIPTION
## What Problem This Solves

Removes provider/plugin code and tests that no reachable runtime path uses, plus provider-local cache tests that replay behavior already owned by the shared catalog cache.

The deleted surfaces are an xAI model-hint parser left behind after its only compatibility hook was removed, Active Memory's obsolete aggregate opt-in predicate after activation became unconditional/per-agent, and Chutes eviction/expiry tests duplicated at the shared cache owner.

## Why This Change Was Made

Runtime policy should have one owner. xAI retains its live transport and forward-compat normalization, Active Memory retains per-agent `shouldRememberAcrossConversations`, and Chutes retains provider-specific auth/fallback/isolation tests while shared cache expiry and 100-entry eviction remain tested centrally.

Groq's superficially similar helper was deliberately retained: its top-level `api.ts` is shipped from the published provider package, so internal call-count alone is not sufficient evidence for deletion.

## User Impact

No user-visible behavior changes. Private unreachable code and duplicate provider-local cache proof are removed without changing provider routing, model normalization, activation, authentication, fallback, or catalog caching.

## Evidence

- xAI, Active Memory, Chutes, and shared provider-catalog owners: 5 files, 260 tests passed across three Vitest shards.
- `extensions` and `extensionTests` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready; extension typechecks, formatting, lint, doctor-contract guards, dead-export scan, and import-cycle checks passed.
- `git diff --check` passed.
- Fresh complete-branch structured autoreview reported no accepted/actionable findings.

Production delta: -24. Tests: +1/-64, net -63. Total net: -87. No docs, config, schema, protocol, dependency, or changelog change.