### PR TITLE
fix(backup): failed backups no longer claim completion

### DIFF
--- a/src/commands/backup-sqlite.test.ts
+++ b/src/commands/backup-sqlite.test.ts
@@ -223,6 +223,26 @@ describe("SQLite backup commands", () => {
     ).rejects.toThrow("Choose exactly one SQLite snapshot source");
   });
 
+  it("does not claim completion when a corrupt database also rejects outcome recording", async () => {
+    const tempDir = tempDirs.make("openclaw-backup-sqlite-corrupt-");
+    const stateDir = path.join(tempDir, "state");
+    const repositoryPath = path.join(tempDir, "snapshots");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    const databasePath = resolveOpenClawStateSqlitePath();
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    await fs.writeFile(databasePath, Buffer.alloc(32));
+    const runtime = createRuntimeCapture();
+
+    await expect(
+      backupSqliteCreateCommand(runtime, { global: true, repository: repositoryPath }),
+    ).rejects.toThrow(/cannot be snapshotted safely/u);
+
+    expect(runtime.errors).toEqual([
+      "Warning: the backup outcome could not be recorded: file is not a database",
+    ]);
+    await expect(fs.readdir(repositoryPath)).resolves.toEqual([]);
+  });
+
   it("requires repository, snapshot, and restore target paths", async () => {
     const runtime = createRuntimeCapture();
 

--- a/src/commands/backup-sqlite.ts
+++ b/src/commands/backup-sqlite.ts
@@ -107,7 +107,7 @@ function recordSqliteOutcomeBestEffort(
     recordBackupRunOutcome({ kind: "sqlite-snapshot", ...params });
   } catch (error) {
     runtime.error(
-      `Warning: backup completed, but its run record could not be written: ${formatErrorMessage(error)}`,
+      `Warning: the backup outcome could not be recorded: ${formatErrorMessage(error)}`,
     );
   }
 }

--- a/src/commands/backup.create-verify.test.ts
+++ b/src/commands/backup.create-verify.test.ts
@@ -1,5 +1,5 @@
 // Backup create/verify tests cover archive creation, runtime output, and verification failure handling.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import { backupCreateCommand } from "./backup.js";
 
@@ -7,6 +7,7 @@ const createBackupArchiveMock = vi.hoisted(() => vi.fn());
 const backupVerifyCommandMock = vi.hoisted(() => vi.fn());
 const writeRuntimeJsonMock = vi.hoisted(() => vi.fn());
 const formatBackupCreateSummaryMock = vi.hoisted(() => vi.fn(() => ["backup ok"]));
+const recordBackupRunOutcomeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../infra/backup-create.js", () => ({
   createBackupArchive: createBackupArchiveMock,
@@ -25,6 +26,10 @@ vi.mock("../runtime.js", async () => {
   };
 });
 
+vi.mock("../state/backup-run-records.js", () => ({
+  recordBackupRunOutcome: recordBackupRunOutcomeMock,
+}));
+
 function createRuntime(): RuntimeEnv {
   return {
     log: vi.fn(),
@@ -42,6 +47,15 @@ function requireBackupVerifyCall(): [RuntimeEnv, Record<string, unknown>] {
 }
 
 describe("backupCreateCommand verify wrapper", () => {
+  beforeEach(() => {
+    createBackupArchiveMock.mockReset();
+    backupVerifyCommandMock.mockReset();
+    writeRuntimeJsonMock.mockReset();
+    formatBackupCreateSummaryMock.mockReset();
+    formatBackupCreateSummaryMock.mockReturnValue(["backup ok"]);
+    recordBackupRunOutcomeMock.mockReset();
+  });
+
   it("optionally verifies the archive after writing it", async () => {
     createBackupArchiveMock.mockResolvedValue({
       archivePath: "/tmp/openclaw-backup.tar.gz",
@@ -79,5 +93,20 @@ describe("backupCreateCommand verify wrapper", () => {
     });
     expect(verifyLog).not.toBe(runtime.log);
     expect(typeof verifyLog).toBe("function");
+  });
+
+  it("does not claim completion when both backup and outcome recording fail", async () => {
+    const backupError = new Error("snapshot failed");
+    createBackupArchiveMock.mockRejectedValue(backupError);
+    recordBackupRunOutcomeMock.mockImplementation(() => {
+      throw new Error("record failed");
+    });
+    const runtime = createRuntime();
+
+    await expect(backupCreateCommand(runtime)).rejects.toBe(backupError);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Warning: the backup outcome could not be recorded: record failed",
+    );
   });
 });

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -75,7 +75,7 @@ function recordBackupOutcomeBestEffort(
     recordBackupRunOutcome({ kind: "archive", ...params });
   } catch (error) {
     runtime.error(
-      `Warning: backup completed, but its run record could not be written: ${formatErrorMessage(error)}`,
+      `Warning: the backup outcome could not be recorded: ${formatErrorMessage(error)}`,
     );
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed archive or SQLite backup could print `backup completed` when the best-effort backup-run record also failed. The command still exited nonzero, but the leading warning contradicted the actual outcome and could mislead an operator during recovery.

## Why This Change Was Made

Both backup command wrappers now describe the secondary failure neutrally: the backup outcome could not be recorded. This covers backup-success/record-failure and backup-failure/record-failure without changing backup bytes, archive or snapshot format, secret inclusion, SQLite schema, rollback, cleanup, exit status, stdout, or JSON behavior. Git-backed backups already used the equivalent neutral outcome wording.

Production LOC: +2/-2 (net 0) | Tests: +50/-1

## User Impact

Operators now receive truthful diagnostics when backup execution and backup-run recording fail together. Existing successful backup behavior and every backup safety boundary remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/commands/backup.test.ts src/commands/backup.atomic.test.ts src/commands/backup.create-verify.test.ts src/commands/backup-restore.test.ts src/commands/backup-schedule.test.ts src/commands/backup-sqlite.test.ts src/commands/backup-verify.test.ts` — 63 passed, 1 skipped.
- Regression provenance: both new tests fail on the prior wording and pass on this head.
- `node --import tsx scripts/build-all.mts cliStartup` — built CLI profile passed.
- Built CLI with an authentic corrupt mode-0600 state database:
  - archive create: exit 1, zero stdout bytes, truthful stderr, source retained, zero archive/temp artifacts;
  - SQLite create with `--json`: exit 1, zero stdout bytes, truthful stderr, source retained, zero snapshot/temp artifacts.
- `node scripts/check-changed.mjs --timed -- <four changed files>` — passed through the documented trusted-source local fallback, including format, core production/test types, changed-file lint, database-first guards, and zero runtime import cycles.
- Fresh structured autoreview: clean, no actionable findings.
- Duplicate search found no equivalent open issue or pull request.
- Docs remain aligned; no changelog or docs change is needed because the public CLI and storage contracts are unchanged.

Exact-head CI passed at `fce6482afc4a1de95458f9dafdecddafc35ab3c3`: https://github.com/openclaw/openclaw/actions/runs/31877249241. It includes the full dist build, generated plugin assets, built-runtime and CLI launcher smokes, Windows, types, lint, guards, and the aggregate `openclaw/ci-gate`.
