### PR TITLE
perf(test): reduce LM Studio stream suite setup

### DIFF
--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -2,9 +2,11 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 // Lmstudio tests cover stream plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let wrapLmstudioInferencePreload: typeof import("./stream.js").wrapLmstudioInferencePreload;
+let defaultBaseUrl: string;
+let defaultBaseUrlSequence = 0;
 
 const ensureLmstudioModelLoadedMock = vi.hoisted(() => vi.fn());
 const resolveLmstudioProviderHeadersMock = vi.hoisted(() =>
@@ -14,27 +16,17 @@ const resolveLmstudioRuntimeApiKeyMock = vi.hoisted(() =>
   vi.fn(async (_params?: unknown) => undefined),
 );
 
-vi.mock("./models.fetch.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./models.fetch.js")>();
-  return {
-    ...actual,
-    ensureLmstudioModelLoaded: (params: unknown) => ensureLmstudioModelLoadedMock(params),
-  };
-});
+vi.mock("./models.fetch.js", () => ({
+  ensureLmstudioModelLoaded: (params: unknown) => ensureLmstudioModelLoadedMock(params),
+}));
 
-vi.mock("./runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./runtime.js")>();
-  return {
-    ...actual,
-    resolveLmstudioProviderHeaders: (params: unknown) => resolveLmstudioProviderHeadersMock(params),
-    resolveLmstudioRuntimeApiKey: (params: unknown) => resolveLmstudioRuntimeApiKeyMock(params),
-  };
-});
+vi.mock("./runtime.js", () => ({
+  resolveLmstudioProviderHeaders: (params: unknown) => resolveLmstudioProviderHeadersMock(params),
+  resolveLmstudioRuntimeApiKey: (params: unknown) => resolveLmstudioRuntimeApiKeyMock(params),
+}));
 
-afterAll(() => {
-  vi.doUnmock("./models.fetch.js");
-  vi.doUnmock("./runtime.js");
-  vi.resetModules();
+beforeAll(async () => {
+  ({ wrapLmstudioInferencePreload } = await import("./stream.js"));
 });
 
 type StreamEvent = { type: string } & Record<string, unknown>;
@@ -143,7 +135,7 @@ function createWrappedLmstudioStream(
       models: {
         providers: {
           lmstudio: {
-            baseUrl: params?.baseUrl ?? "http://localhost:1234",
+            baseUrl: params?.baseUrl ?? defaultBaseUrl,
             models: [],
           },
         },
@@ -190,9 +182,10 @@ function runWrappedLmstudioStream(
 }
 
 describe("lmstudio stream wrapper", () => {
-  beforeEach(async () => {
-    vi.resetModules();
-    ({ wrapLmstudioInferencePreload } = await import("./stream.js"));
+  beforeEach(() => {
+    // Production preload state is keyed by base URL, model, and context length.
+    // Give each test a real cache namespace while preserving within-test reuse.
+    defaultBaseUrl = `http://lmstudio-test-${defaultBaseUrlSequence++}.localhost:1234`;
   });
 
   afterEach(() => {
@@ -238,7 +231,7 @@ describe("lmstudio stream wrapper", () => {
     expectSingleDoneEvent(events);
     expectEnsureLoadedFields({
       modelKey: variantKey,
-      baseUrl: "http://localhost:1234/v1",
+      baseUrl: `${defaultBaseUrl}/v1`,
     });
     expectBaseStreamModelFields(baseStream, {
       provider: "lmstudio",
@@ -305,7 +298,7 @@ describe("lmstudio stream wrapper", () => {
         models: {
           providers: {
             lmstudio: {
-              baseUrl: "http://localhost:1234",
+              baseUrl: defaultBaseUrl,
               models: [],
             },
           },
@@ -388,7 +381,7 @@ describe("lmstudio stream wrapper", () => {
         models: {
           providers: {
             lmstudio: {
-              baseUrl: "http://localhost:1234",
+              baseUrl: defaultBaseUrl,
               params: { preload: false },
               models: [],
             },
@@ -438,7 +431,7 @@ describe("lmstudio stream wrapper", () => {
         models: {
           providers: {
             lmstudio: {
-              baseUrl: "http://localhost:1234",
+              baseUrl: defaultBaseUrl,
               models: [],
             },
           },
@@ -557,7 +550,7 @@ describe("lmstudio stream wrapper", () => {
         models: {
           providers: {
             lmstudio: {
-              baseUrl: "http://localhost:1234",
+              baseUrl: defaultBaseUrl,
               models: [],
             },
           },
@@ -634,7 +627,7 @@ describe("lmstudio stream wrapper", () => {
         models: {
           providers: {
             lmstudio: {
-              baseUrl: "http://localhost:1234",
+              baseUrl: defaultBaseUrl,
               models: [],
             },
           },
@@ -720,7 +713,7 @@ describe("lmstudio stream wrapper", () => {
         models: {
           providers: {
             lmstudio: {
-              baseUrl: "http://localhost:1234",
+              baseUrl: defaultBaseUrl,
               models: [],
             },
           },
@@ -806,7 +799,7 @@ describe("lmstudio stream wrapper", () => {
         models: {
           providers: {
             lmstudio: {
-              baseUrl: "http://localhost:1234",
+              baseUrl: defaultBaseUrl,
               params: { preload: false },
               models: [],
             },


### PR DESCRIPTION
## What Problem This Solves

The 26-test LM Studio stream suite rebuilt the Plugin SDK, LLM, provider, and stream module graph before every test. That made this focused suite unnecessarily slow and memory-heavy, with roughly 11 seconds of test-body time and about 1.5 GiB peak RSS in the controlled baseline.

## Why This Change Was Made

The suite now installs exact mocks for the three seams consumed by the stream owner and imports the real stream module once. Each test receives a unique production cache namespace through its LM Studio base URL, preserving within-test preload deduplication, cooldown, retry, canonical-model-key, cancellation, compatibility, and payload behavior without adding a test-only production seam.

Real model-loading behavior remains owned by `models.test.ts`; provider-header and runtime API-key behavior remains owned by `runtime.test.ts`. This is an AI-assisted maintainer change that I reviewed and understand.

## User Impact

There is no product runtime behavior change. Maintainers and CI get a materially lighter LM Studio stream test suite while retaining the same 26 tests and owner-boundary coverage.

## Evidence

Controlled same-Testbox A/B, excluding one warmup per state: https://github.com/openclaw/openclaw/actions/runs/31876152650

| Metric | Before mean | After mean | Improvement |
| --- | ---: | ---: | ---: |
| Wall | 20.680s | 17.935s | -13.3% |
| Vitest | 15.005s | 11.035s | -26.5% |
| Test body | 11.325s | 6.315s | -44.2% |
| CPU user | 23.600s | 19.745s | -16.3% |
| Peak RSS | 1,570,314 KiB | 891,888 KiB | -43.2% (~662.5 MiB) |

Behavior and isolation proof:

- Replacing the unique per-test base URL with one constant production cache key made 5 of 26 cooldown/backoff tests fail from cross-test state leakage.
- Mutating the preload handoff to use the wrong model key made 4 of 26 owner-boundary assertions fail.
- Filtered late-test execution: 1 passed, 25 skipped.
- Target stream suite: 26/26 passed.
- LM Studio owner suite: 154/154 passed across 5 files.
- Extension boundary tests: 28/28 passed across 2 files.
- Targeted formatting and `git diff --check`: passed.
- Rebased remote changed gate: all 18 extension-test steps passed on Testbox `tbx_01m02c3dgm6hg08dm0rr55hzp9`: https://github.com/openclaw/openclaw/actions/runs/31877142937
- Fresh committed-branch autoreview against current `origin/main`: clean, no accepted/actionable findings.
- Stable patch-id before and after rebase: `53ed70cc8b9b69d3eff77e549d291ccd0cbac26d`.
- LOC: tests +25/-32; production +0/-0.

No release, package publication, version bump, dependency change, schema/protocol change, baseline/snapshot/budget change, or `CHANGELOG.md` edit is included or requested.
