### PR TITLE
fix(ui): prevent oversized request frames from disconnecting

### DIFF
--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -173,6 +173,16 @@ type ConnectFrame = {
   };
 };
 
+const REQUEST_FRAME_ID = "00000000-0000-4000-8000-000000000000";
+
+function requestFrameBytes(method: string, params?: unknown): number {
+  const frame =
+    params === undefined
+      ? { type: "req", id: REQUEST_FRAME_ID, method }
+      : { type: "req", id: REQUEST_FRAME_ID, method, params };
+  return new TextEncoder().encode(JSON.stringify(frame)).byteLength;
+}
+
 type RequestTimingPayload = {
   id?: string;
   method?: string;
@@ -1121,6 +1131,69 @@ describe("GatewayBrowserClient", () => {
       client.stop();
       consoleError.mockRestore();
     }
+  });
+
+  it.each([
+    { name: "defined params exactly at the limit", method: "status.get", params: {}, delta: 0 },
+    { name: "defined params one byte over", method: "status.get", params: {}, delta: -1 },
+    { name: "undefined params exactly at the limit", method: "status.get", delta: 0 },
+    { name: "undefined params one byte over", method: "status.get", delta: -1 },
+    {
+      name: "UTF-8 method and params exactly at the limit",
+      method: "méthod.界",
+      params: { value: "🦞" },
+      delta: 0,
+    },
+    {
+      name: "UTF-8 method and params one byte over",
+      method: "méthod.界",
+      params: { value: "🦞" },
+      delta: -1,
+    },
+  ])("enforces $name", async ({ method, params, delta }) => {
+    const maxPayload = requestFrameBytes(method, params) + delta;
+    const onHello = vi.fn();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+      onHello,
+    });
+    const { ws, connectFrame } = await startConnect(client, `nonce-${method}-${delta}`);
+    ws.emitMessage({
+      type: "res",
+      id: connectFrame.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+        policy: { maxPayload, maxBufferedBytes: maxPayload * 2, tickIntervalMs: 30_000 },
+      },
+    });
+    await vi.waitFor(() => expect(onHello).toHaveBeenCalledOnce());
+
+    const sentBefore = ws.sent.length;
+    const request = client.request(method, params);
+    if (delta < 0) {
+      await expect(request).rejects.toThrow("Request exceeds the Gateway payload limit");
+      expect(ws.sent).toHaveLength(sentBefore);
+    } else {
+      const frame = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string; method?: string };
+      expect(frame.method).toBe(method);
+      expect(new TextEncoder().encode(ws.sent.at(-1)).byteLength).toBe(maxPayload);
+      ws.emitMessage({ type: "res", id: frame.id, ok: true, payload: { ok: true } });
+      await expect(request).resolves.toEqual({ ok: true });
+    }
+    if (method.includes("界")) {
+      expect(maxPayload).toBeGreaterThan(
+        JSON.stringify(
+          params === undefined
+            ? { type: "req", id: REQUEST_FRAME_ID, method }
+            : { type: "req", id: REQUEST_FRAME_ID, method, params },
+        ).length + delta,
+      );
+    }
+    client.stop();
   });
 
   it("does not let a stale hello runtime import publish or migrate recovery", async () => {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -278,6 +278,7 @@ async function buildGatewayConnectDevice(params: {
 
 export class GatewayBrowserClient {
   private readonly client: GatewayProtocolClient<ConnectPlan>;
+  private maxPayloadBytes: number | undefined;
   private scopeUpgradeRuntime: Promise<GatewayScopeUpgrade> | null = null;
   inboundActivitySeq = 0;
   private lastInboundActivityAtMs: number | null = null;
@@ -307,7 +308,10 @@ export class GatewayBrowserClient {
         this.buildConnectPlan(nonce, challengeTs, generation),
       buildConnectParams: (plan) => plan.params,
       onConnectHello: (hello, context) => this.handleConnectHello(hello, context.plan),
-      onHello: (hello) => this.opts.onHello?.(hello),
+      onHello: (hello) => {
+        this.maxPayloadBytes = hello.policy?.maxPayload;
+        this.opts.onHello?.(hello);
+      },
       onConnectFailure: (error, context) => {
         this.client.recordTiming("failed", context.generation, context.plan, {
           errorCode: error.code,
@@ -658,12 +662,19 @@ export class GatewayBrowserClient {
     });
   }
 
-  request<T = unknown>(
+  async request<T = unknown>(
     method: string,
     params?: unknown,
     options?: GatewayProtocolRequestOptions,
   ): Promise<T> {
-    return this.client.request<T>(method, params, options);
+    // The fixed request envelope outside this tuple uses a 36-byte UUID and 75 UTF-8 bytes.
+    const requestBytes = new TextEncoder().encode(JSON.stringify([method, params])).byteLength + 75;
+    if (this.maxPayloadBytes !== undefined && requestBytes > this.maxPayloadBytes) {
+      throw new Error(
+        "Request exceeds the Gateway payload limit. Shorten the message or remove one or more attachments and retry.",
+      );
+    }
+    return await this.client.request<T>(method, params, options);
   }
 
   async requestScopeUpgrade(options: { onPending?: (requestId: string) => void } = {}) {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -308,10 +308,7 @@ export class GatewayBrowserClient {
         this.buildConnectPlan(nonce, challengeTs, generation),
       buildConnectParams: (plan) => plan.params,
       onConnectHello: (hello, context) => this.handleConnectHello(hello, context.plan),
-      onHello: (hello) => {
-        this.maxPayloadBytes = hello.policy?.maxPayload;
-        this.opts.onHello?.(hello);
-      },
+      onHello: (hello) => this.opts.onHello?.(hello),
       onConnectFailure: (error, context) => {
         this.client.recordTiming("failed", context.generation, context.plan, {
           errorCode: error.code,
@@ -504,6 +501,7 @@ export class GatewayBrowserClient {
   }
 
   private handleConnectHello(hello: GatewayHelloOk, plan: ConnectPlan) {
+    this.maxPayloadBytes = hello.policy?.maxPayload;
     this.startTickWatch(hello);
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
@@ -667,8 +665,10 @@ export class GatewayBrowserClient {
     params?: unknown,
     options?: GatewayProtocolRequestOptions,
   ): Promise<T> {
-    // The fixed request envelope outside this tuple uses a 36-byte UUID and 75 UTF-8 bytes.
-    const requestBytes = new TextEncoder().encode(JSON.stringify([method, params])).byteLength + 75;
+    // The UUID request envelope adds 75 bytes with params, 61 when params is omitted.
+    const requestBytes =
+      new TextEncoder().encode(JSON.stringify([method, params])).byteLength +
+      (params === undefined ? 61 : 75);
     if (this.maxPayloadBytes !== undefined && requestBytes > this.maxPayloadBytes) {
       throw new Error(
         "Request exceeds the Gateway payload limit. Shorten the message or remove one or more attachments and retry.",

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -1,3 +1,5 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import {
@@ -54,6 +56,59 @@ async function pastePng(composer: Locator): Promise<void> {
 }
 
 suite.define(() => {
+  it("rejects a combined attachment frame before the Gateway connection is lost", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          attachmentMaxBytes: 256,
+          maxPayload: 700,
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.fill("Send both files");
+        await page.locator(".agent-chat__file-input").setInputFiles([
+          { name: "first.txt", mimeType: "text/plain", buffer: Buffer.alloc(200, 0x61) },
+          { name: "second.txt", mimeType: "text/plain", buffer: Buffer.alloc(200, 0x62) },
+        ]);
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
+
+        await composer.press("Enter");
+
+        const alert = page
+          .getByRole("alert")
+          .filter({ hasText: "Remove one or more attachments and retry" });
+        const outcome = await Promise.race([
+          alert.waitFor().then(() => "rejected" as const),
+          gateway.waitForRequest("chat.send").then(() => "sent" as const),
+        ]);
+        expect(outcome).toBe("rejected");
+        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
+        await expect.poll(() => composer.inputValue()).toBe("Send both files");
+
+        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({ path: path.join(artifactDir, "attachment-frame-rejected.png") });
+        }
+
+        await page.locator(".chat-attachment-remove").first().click();
+        await composer.press("Enter");
+        const request = await gateway.waitForRequest("chat.send");
+        expect(request.params).toMatchObject({
+          attachments: [{ fileName: "second.txt", mimeType: "text/plain" }],
+          message: "Send both files",
+        });
+      },
+    );
+  });
+
   it("waits for a pasted image before sending its complete gateway payload", async () => {
     await suite.withPage(
       {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -243,6 +243,7 @@ export type MockGatewayRequest = {
 };
 
 export type ControlUiMockGatewayScenario = {
+  attachmentMaxBytes?: number;
   agentModel?: string | null;
   assistantAgentId?: string;
   assistantName?: string;
@@ -277,6 +278,7 @@ export type ControlUiMockGatewayScenario = {
   /** Simulate a legacy Gateway that predates the advertised method catalog. */
   omitFeatureMethods?: boolean;
   historyMessages?: unknown[];
+  maxPayload?: number;
   /** Static payloads, parameter-matched cases, or call-ordered sequences. */
   methodResponses?: Record<string, unknown>;
   /** URL prefixes that retain the browser's real WebSocket transport. */
@@ -825,6 +827,7 @@ function normalizeScenario(
       ? basePathWithSlash.slice(0, -1)
       : basePathWithSlash;
   return {
+    attachmentMaxBytes: scenario.attachmentMaxBytes ?? 1_048_576,
     agentModel:
       scenario.agentModel === undefined ? "openai/gpt-5.5" : scenario.agentModel?.trim() || null,
     assistantAgentId: scenario.assistantAgentId?.trim() || defaultAgentId,
@@ -853,6 +856,7 @@ function normalizeScenario(
     featureMethods: scenario.featureMethods ?? [...defaultControlUiFeatureMethods],
     omitFeatureMethods: scenario.omitFeatureMethods ?? false,
     historyMessages: scenario.historyMessages ?? [],
+    maxPayload: scenario.maxPayload ?? 1_048_576,
     methodResponses: scenario.methodResponses ?? {},
     webSocketPassthroughPrefixes: scenario.webSocketPassthroughPrefixes ?? [],
     inFlightRun: scenario.inFlightRun ?? null,
@@ -1663,9 +1667,13 @@ function installControlUiMockGateway(
             version: scenario.serverVersion,
           },
           policy: {
-            maxPayload: 1_048_576,
+            maxPayload: scenario.maxPayload,
             maxBufferedBytes: 1_048_576,
             tickIntervalMs: 30_000,
+            attachments: {
+              maxBytes: scenario.attachmentMaxBytes,
+              maxImageBytes: scenario.attachmentMaxBytes,
+            },
             allowedSessionVisibilities: scenario.allowedSessionVisibilities,
             hasMultipleSessionSharingIdentities: scenario.hasMultipleSessionSharingIdentities,
           },

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -327,6 +327,11 @@ export type ControlUiMockGatewayScenario = {
 
 type NormalizedControlUiMockGatewayScenario = Required<ControlUiMockGatewayScenario>;
 
+const DEFAULT_MOCK_MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
+const DEFAULT_MOCK_ATTACHMENT_MAX_BYTES = Math.floor(
+  ((DEFAULT_MOCK_MAX_PAYLOAD_BYTES - 256 * 1024) * 3) / 4,
+);
+
 export type ControlUiE2eServer = {
   baseUrl: string;
   close: () => Promise<void>;
@@ -827,7 +832,7 @@ function normalizeScenario(
       ? basePathWithSlash.slice(0, -1)
       : basePathWithSlash;
   return {
-    attachmentMaxBytes: scenario.attachmentMaxBytes ?? 1_048_576,
+    attachmentMaxBytes: scenario.attachmentMaxBytes ?? DEFAULT_MOCK_ATTACHMENT_MAX_BYTES,
     agentModel:
       scenario.agentModel === undefined ? "openai/gpt-5.5" : scenario.agentModel?.trim() || null,
     assistantAgentId: scenario.assistantAgentId?.trim() || defaultAgentId,
@@ -856,7 +861,7 @@ function normalizeScenario(
     featureMethods: scenario.featureMethods ?? [...defaultControlUiFeatureMethods],
     omitFeatureMethods: scenario.omitFeatureMethods ?? false,
     historyMessages: scenario.historyMessages ?? [],
-    maxPayload: scenario.maxPayload ?? 1_048_576,
+    maxPayload: scenario.maxPayload ?? DEFAULT_MOCK_MAX_PAYLOAD_BYTES,
     methodResponses: scenario.methodResponses ?? {},
     webSocketPassthroughPrefixes: scenario.webSocketPassthroughPrefixes ?? [],
     inFlightRun: scenario.inFlightRun ?? null,
@@ -1672,7 +1677,7 @@ function installControlUiMockGateway(
             tickIntervalMs: 30_000,
             attachments: {
               maxBytes: scenario.attachmentMaxBytes,
-              maxImageBytes: scenario.attachmentMaxBytes,
+              maxImageBytes: Math.min(scenario.attachmentMaxBytes, 5 * 1024 * 1024),
             },
             allowedSessionVisibilities: scenario.allowedSessionVisibilities,
             hasMultipleSessionSharingIdentities: scenario.hasMultipleSessionSharingIdentities,


### PR DESCRIPTION
Follow-up to #123977.

AI-assisted implementation, reviewed by Claude and Codex.

## What Problem This Solves

Fixes an issue where Control UI users attaching multiple individually valid files could exceed the Gateway WebSocket request-frame limit, disconnecting the active socket before `chat.send` could return a visible rejection.

It also prevents a 14-byte false-rejection margin for valid no-parameter RPC requests at the exact advertised limit.

## Why This Change Was Made

The Control UI Gateway transport now owns one request-frame admission check using the `maxPayload` value advertised by the connected Gateway. It measures the exact UTF-8 request envelope before transport: 75 bytes outside the serialized method/params tuple when params are present, and 61 when params are omitted.

This keeps every Control UI request path consistent, including chat sends, session creation, retries, and non-chat RPCs. Existing attachment MIME, per-file, trusted-root, media, security, protocol, config, SDK, and delivery/replay behavior is unchanged.

Production LOC: +13/-2 (net +11). Tests and test support: +142/-1 (net +141).

## User Impact

Oversized aggregate attachment sends now stay in the browser. The draft and files remain visible, the UI explains that the message or attachments must be reduced, and retrying with one file succeeds without losing the Gateway connection.

No changelog edit is included; release-note context is carried by this PR.

## Evidence

Baseline: `03c1d7727cfdd7153070c60d5ce0c620cd400689`

Reviewed head: `31b7fbe84b84e14e21a97010de56ea4340647730`

Before the repair, the browser boundary reproduced two 200-byte files that each passed a 256-byte per-file limit but produced a 926-byte request against a 700-byte advertised frame ceiling; the request was sent instead of rejected locally.

After the repair:

- `ui/src/api/gateway.node.test.ts`: 67/67 passed, including defined/undefined params at the exact limit and one byte over, plus UTF-8 method/params byte accounting.
- `ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts`: 3/3 Chromium cases passed. The oversized aggregate emitted zero `chat.send` requests, preserved the draft and both files, and sent successfully after one file was removed.
- `ui/src/e2e/chat-large-paste-99213.e2e.test.ts`: 1/1 passed after aligning the baseline mock hello with the real Gateway's 25 MiB frame, frame-clamped attachment, and 5 MiB image ceilings.
- Gateway attachment policy/parser: 56/56 passed.
- Media trusted-root and cleanup: 13/13 passed.
- Changed gate passed: core/UI types, oxlint, stylelint, i18n, formatting, max-lines, dependency and dead-export guards.
- Runtime import cycles: 0. Madge import cycles: 0.
- Media download-helper and OpenGrep rule-metadata guards passed.
- Fresh branch-mode autoreview: no accepted/actionable findings.

Remote fast-check capacity was unavailable during local validation, so the repository's documented trusted-source local fallback ran the changed gate successfully.

### Visual proof

![Control UI rejects the oversized frame while preserving both files and the draft](https://github.com/user-attachments/assets/b7da85e7-a787-4259-82e5-989672091bda)
