### PR TITLE
test(codex): trim duplicate app-server regressions

### DIFF
--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -279,35 +279,6 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(snapshot).toContain(coda);
   });
 
-  it("lets a later unphased message replace an earlier final answer", async () => {
-    const projector = await createProjector(await createParams());
-
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
-      }),
-    );
-    await projector.handleNotification(agentMessageDelta("First candidate", "answer-1"));
-    await projector.handleNotification(
-      forCurrentTurn("item/completed", {
-        item: {
-          type: "agentMessage",
-          id: "answer-1",
-          phase: "final_answer",
-          text: "First candidate",
-        },
-      }),
-    );
-    await projector.handleNotification(agentMessageDelta("Later unphased reply", "answer-2"));
-    await projector.handleNotification(
-      turnCompleted([{ type: "agentMessage", id: "answer-2", text: "Later unphased reply" }]),
-    );
-
-    const result = projector.buildResult(buildEmptyToolTelemetry());
-    expect(result.assistantTexts).toEqual(["Later unphased reply"]);
-    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
-  });
-
   it("drops a pre-unphased final when a later final follows the replacement", async () => {
     const projector = await createProjector(await createParams());
 
@@ -451,52 +422,6 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
     expect(result.assistantTexts).toEqual(["After sleep"]);
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("First candidate");
-  });
-
-  it("drops a trailing silent final when an earlier audible final remains", async () => {
-    const projector = await createProjector(await createParams());
-
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
-      }),
-    );
-    await projector.handleNotification(agentMessageDelta("Keep this answer", "answer-1"));
-    await projector.handleNotification(
-      forCurrentTurn("item/completed", {
-        item: {
-          type: "agentMessage",
-          id: "answer-1",
-          phase: "final_answer",
-          text: "Keep this answer",
-        },
-      }),
-    );
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
-      }),
-    );
-    await projector.handleNotification(agentMessageDelta("NO_REPLY", "answer-2"));
-    await projector.handleNotification(
-      forCurrentTurn("item/completed", {
-        item: {
-          type: "agentMessage",
-          id: "answer-2",
-          phase: "final_answer",
-          text: "NO_REPLY",
-        },
-      }),
-    );
-    await projector.handleNotification(
-      turnCompleted([
-        { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "NO_REPLY" },
-      ]),
-    );
-
-    const result = projector.buildResult(buildEmptyToolTelemetry());
-    expect(result.assistantTexts).toEqual(["Keep this answer"]);
-    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("NO_REPLY");
   });
 
   it("drops a trailing JSON silent payload when an earlier audible final remains", async () => {

--- a/extensions/codex/src/app-server/run-attempt-connection.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.test.ts
@@ -94,23 +94,6 @@ describe("prepareCodexAttemptConnection", () => {
     expect(resolveModelPolicy).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps effective default yolo ahead of generic tool approval hooks", async () => {
-    initializeGlobalHookRunner(
-      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
-    );
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    const params = createParams(sessionFile, workspaceDir);
-    params.agentDir = path.join(tempDir, "agent");
-    registerCodexTestSessionIdentity(sessionFile, params.sessionId, params.sessionKey);
-    const connection = await prepareCodexAttemptConnection({
-      params,
-      options: { bindingStore: testCodexAppServerBindingStore },
-    });
-
-    expect(connection.appServer.approvalPolicy).toBe("never");
-  });
-
   it("does not give OpenClaw ownership of an explicit operator approval policy", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),


### PR DESCRIPTION
## What Problem This Solves

Removes three Codex app-server tests that repeat stronger regressions at the same or more observable boundary: an intermediate prepared approval-policy assertion, a simple unphased replacement sequence, and a plain silent-final sequence.

## Why This Change Was Made

The retained wire-level yolo test verifies both `thread/start` and `turn/start` approval/sandbox payloads. The retained unphased-plus-silent-final sequence proves replacement survives a later terminal item. The retained JSON silent payload test captures the structured regression, while the shared delivery contract independently covers plain, padded, and JSON silent classification.

Direct sibling Codex inspection confirms the underlying contracts: phase is optional with legacy-final semantics, `turn/completed.items` is only a last-message summary, and `Never` is the no-approval policy applied through turn settings.

## User Impact

No runtime behavior changes. Codex coverage stays focused on the strongest wire and event sequences instead of retaining simpler subsets.

## Evidence

- Codex connection, full run-attempt, event projector, delivery contract, and shared token owners: 5 files, 245 tests passed across two Vitest shards.
- `extensionTests` changed gate passed through the documented trusted-source local fallback because no Crabbox/Testbox provider was ready; extension test typecheck, formatting, lint, dead-export scan, and plugin/dependency guards passed.
- `git diff --check` passed.
- Fresh complete-branch structured autoreview reported no accepted/actionable findings.
- Direct sibling Codex source at `2ca575026cef066a58c70f6bdee4feafa6e63d3a` inspected:
  - `codex-rs/protocol/src/items.rs:116-134` and `models.rs:794-808`
  - `codex-rs/app-server/src/thread_state.rs:174-187`
  - `codex-rs/app-server/src/bespoke_event_handling.rs:979-1034,1277-1302`
  - `codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs:268-300`
  - `codex-rs/protocol/src/protocol.rs:914-937`
  - `codex-rs/app-server/src/request_processors/turn_processor.rs:532-550,685-824`

Production delta: 0. Tests: -92. No docs, config, schema, protocol, dependency, or changelog change.