### PR TITLE
fix(gateway): keep same-sequence history rows reachable

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -325,26 +325,48 @@ describe("SessionHistorySseState", () => {
     ).toBe(true);
   });
 
-  test("keeps cursors when a paginated history page starts with a message-tool mirror", () => {
-    const snapshot = buildSessionHistorySnapshot({
-      rawMessages: [
-        userTextMessage("reply here", 1),
-        {
-          role: "assistant",
-          content: [messageToolCall("call-message-cursor", "Cursor-visible reply.")],
-          __openclaw: { seq: 2 },
-        },
-        messageToolResult("call-message-cursor", "cursor", 3),
-        assistantTextMessage("NO_REPLY", 4),
-      ],
-      limit: 1,
-    });
+  test("keeps same-sequence projected rows reachable across cursor pages", () => {
+    const rawMessages = [
+      userTextMessage("reply here", 1),
+      {
+        role: "assistant",
+        content: [messageToolCall("call-message-cursor", "Cursor-visible reply.")],
+        __openclaw: { seq: 2 },
+      },
+      messageToolResult("call-message-cursor", "cursor", 3),
+      assistantTextMessage("NO_REPLY", 4),
+    ];
 
-    expect(snapshot.history.nextCursor).toBe("3");
-    expect(snapshot.history.messages[0]?.["__openclaw"]?.seq).toBe(3);
-    expect(
-      (snapshot.history.messages[0] as { content?: Array<{ text?: string }> }).content?.[0]?.text,
-    ).toBe("Cursor-visible reply.");
+    const newest = buildSessionHistorySnapshot({ rawMessages, limit: 1 }).history;
+    expect(newest.messages).toMatchObject([
+      { role: "toolResult", toolCallId: "call-message-cursor", __openclaw: { seq: 3 } },
+      {
+        role: "assistant",
+        content: [{ text: "Cursor-visible reply." }],
+        openclawMessageToolMirror: { toolCallId: "call-message-cursor" },
+        __openclaw: { seq: 3 },
+      },
+    ]);
+    expect(newest.nextCursor).toBe("3");
+
+    const middle = buildSessionHistorySnapshot({
+      rawMessages,
+      limit: 1,
+      cursor: newest.nextCursor,
+    }).history;
+    expect(middle.messages).toMatchObject([
+      { role: "assistant", content: [{ id: "call-message-cursor" }], __openclaw: { seq: 2 } },
+    ]);
+    expect(middle.nextCursor).toBe("2");
+
+    const oldest = buildSessionHistorySnapshot({
+      rawMessages,
+      limit: 1,
+      cursor: middle.nextCursor,
+    }).history;
+    expect(oldest.messages).toEqual([userTextMessage("reply here", 1)]);
+    expect(oldest.hasMore).toBe(false);
+    expect(oldest.nextCursor).toBeUndefined();
   });
 
   test("does not coerce partial cursor values", () => {

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -327,24 +327,35 @@ describe("SessionHistorySseState", () => {
 
   test("keeps same-sequence projected rows reachable across cursor pages", () => {
     const rawMessages = [
-      userTextMessage("reply here", 1),
+      userTextMessage("send both here", 1),
       {
-        role: "assistant",
-        content: [messageToolCall("call-message-cursor", "Cursor-visible reply.")],
+        role: "assistant" as const,
+        content: [
+          messageToolCall("call-message-first", "First visible reply."),
+          messageToolCall("call-message-second", "Second visible reply."),
+        ],
         __openclaw: { seq: 2 },
       },
-      messageToolResult("call-message-cursor", "cursor", 3),
-      assistantTextMessage("NO_REPLY", 4),
+      messageToolResult("call-message-first", "first", 3),
+      messageToolResult("call-message-second", "second", 4),
+      assistantTextMessage("NO_REPLY", 5),
     ];
 
     const newest = buildSessionHistorySnapshot({ rawMessages, limit: 1 }).history;
     expect(newest.messages).toMatchObject([
-      { role: "toolResult", toolCallId: "call-message-cursor", __openclaw: { seq: 3 } },
+      { role: "toolResult", toolCallId: "call-message-first", __openclaw: { seq: 3 } },
+      { role: "toolResult", toolCallId: "call-message-second", __openclaw: { seq: 4 } },
       {
         role: "assistant",
-        content: [{ text: "Cursor-visible reply." }],
-        openclawMessageToolMirror: { toolCallId: "call-message-cursor" },
+        content: [{ text: "First visible reply." }],
+        openclawMessageToolMirror: { toolCallId: "call-message-first" },
         __openclaw: { seq: 3 },
+      },
+      {
+        role: "assistant",
+        content: [{ text: "Second visible reply." }],
+        openclawMessageToolMirror: { toolCallId: "call-message-second" },
+        __openclaw: { seq: 4 },
       },
     ]);
     expect(newest.nextCursor).toBe("3");
@@ -355,7 +366,11 @@ describe("SessionHistorySseState", () => {
       cursor: newest.nextCursor,
     }).history;
     expect(middle.messages).toMatchObject([
-      { role: "assistant", content: [{ id: "call-message-cursor" }], __openclaw: { seq: 2 } },
+      {
+        role: "assistant",
+        content: [{ id: "call-message-first" }, { id: "call-message-second" }],
+        __openclaw: { seq: 2 },
+      },
     ]);
     expect(middle.nextCursor).toBe("2");
 
@@ -364,7 +379,7 @@ describe("SessionHistorySseState", () => {
       limit: 1,
       cursor: middle.nextCursor,
     }).history;
-    expect(oldest.messages).toEqual([userTextMessage("reply here", 1)]);
+    expect(oldest.messages).toEqual([userTextMessage("send both here", 1)]);
     expect(oldest.hasMore).toBe(false);
     expect(oldest.nextCursor).toBeUndefined();
   });

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -145,7 +145,16 @@ function paginateSessionMessages(
       endExclusive = messages.length;
     }
   }
-  const start = typeof limit === "number" && limit > 0 ? Math.max(0, endExclusive - limit) : 0;
+  let start = typeof limit === "number" && limit > 0 ? Math.max(0, endExclusive - limit) : 0;
+  const boundarySeq = resolveMessageSeq(messages[start]);
+  // Projection can expand one transcript record into several display rows.
+  // Keep equal-seq runs atomic because the public cursor cannot address a row within the run.
+  while (start > 0) {
+    if (boundarySeq === undefined || resolveMessageSeq(messages[start - 1]) !== boundarySeq) {
+      break;
+    }
+    start -= 1;
+  }
   const paginatedMessages = messages.slice(start, endExclusive);
   const firstSeq = resolveMessageSeq(paginatedMessages[0]);
   return buildPaginatedSessionHistory({

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -146,14 +146,24 @@ function paginateSessionMessages(
     }
   }
   let start = typeof limit === "number" && limit > 0 ? Math.max(0, endExclusive - limit) : 0;
-  const boundarySeq = resolveMessageSeq(messages[start]);
-  // Projection can expand one transcript record into several display rows.
-  // Keep equal-seq runs atomic because the public cursor cannot address a row within the run.
-  while (start > 0) {
-    if (boundarySeq === undefined || resolveMessageSeq(messages[start - 1]) !== boundarySeq) {
-      break;
+  // Projection can interleave several rows from the same transcript records.
+  // Close the page over their seq groups because the public cursor cannot split one.
+  const pageSeqs = new Set(
+    messages.slice(start, endExclusive).map(resolveMessageSeq).filter(Boolean),
+  );
+  const gapSeqs = new Set<number>();
+  for (let index = start - 1; index >= 0; index--) {
+    const seq = resolveMessageSeq(messages[index]);
+    if (seq === undefined) {
+      continue;
     }
-    start -= 1;
+    gapSeqs.add(seq);
+    if (!pageSeqs.has(seq)) {
+      continue;
+    }
+    start = index;
+    gapSeqs.forEach((gapSeq) => pageSeqs.add(gapSeq));
+    gapSeqs.clear();
   }
   const paginatedMessages = messages.slice(start, endExclusive);
   const firstSeq = resolveMessageSeq(paginatedMessages[0]);

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1108,21 +1108,37 @@ describe("session history HTTP endpoints", () => {
           content: [
             {
               type: "toolCall",
-              id: "call-message-cursor",
+              id: "call-message-first",
               name: "message",
-              arguments: { action: "send", message: "Cursor-visible reply." },
+              arguments: { action: "send", message: "First visible reply." },
+            },
+            {
+              type: "toolCall",
+              id: "call-message-second",
+              name: "message",
+              arguments: { action: "send", message: "Second visible reply." },
             },
           ],
           timestamp: sharedTimestamp,
         },
       },
       {
-        id: "history-tool-result",
+        id: "history-tool-result-first",
         message: {
           role: "toolResult",
           toolName: "message",
-          toolCallId: "call-message-cursor",
-          content: { ok: true, messageId: "same-sequence-result" },
+          toolCallId: "call-message-first",
+          content: { ok: true, messageId: "same-sequence-first" },
+          timestamp: sharedTimestamp,
+        },
+      },
+      {
+        id: "history-tool-result-second",
+        message: {
+          role: "toolResult",
+          toolName: "message",
+          toolCallId: "call-message-second",
+          content: { ok: true, messageId: "same-sequence-second" },
           timestamp: sharedTimestamp,
         },
       },
@@ -1140,8 +1156,10 @@ describe("session history HTTP endpoints", () => {
         query: "?limit=1",
       });
       expect(firstPage.messages?.map(sessionHistoryRowIdentity)).toEqual([
-        "3:toolResult:call-message-cursor",
-        "3:mirror:Cursor-visible reply.",
+        "3:toolResult:call-message-first",
+        "4:toolResult:call-message-second",
+        "3:mirror:First visible reply.",
+        "4:mirror:Second visible reply.",
       ]);
       expect(firstPage.hasMore).toBe(true);
       expect(firstPage.nextCursor).toBe("3");
@@ -1177,13 +1195,15 @@ describe("session history HTTP endpoints", () => {
       const chronologicalRows = pages.toReversed().flatMap((page) => page.messages ?? []);
       expect(chronologicalRows.map(sessionHistoryRowIdentity)).toEqual([
         "1:user:reply here",
-        "2:assistant:call-message-cursor",
-        "3:toolResult:call-message-cursor",
-        "3:mirror:Cursor-visible reply.",
+        "2:assistant:call-message-first",
+        "3:toolResult:call-message-first",
+        "4:toolResult:call-message-second",
+        "3:mirror:First visible reply.",
+        "4:mirror:Second visible reply.",
       ]);
       expect(
         chronologicalRows.map((message) => requireRecord(message, "history timestamp").timestamp),
-      ).toEqual(Array.from({ length: 4 }, () => sharedTimestamp));
+      ).toEqual(Array.from({ length: 6 }, () => sharedTimestamp));
       expect(
         pages
           .flatMap((page) => page.messages ?? [])

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -297,6 +297,20 @@ type SessionHistoryBody = {
   hasMore?: boolean;
 };
 
+function sessionHistoryRowIdentity(message: unknown): string {
+  const record = requireRecord(message, "session history row");
+  const metadata = requireRecord(record["__openclaw"], "session history row metadata");
+  const firstContent = Array.isArray(record.content)
+    ? requireRecord(record.content[0], "session history row content")
+    : undefined;
+  const label =
+    (typeof firstContent?.text === "string" ? firstContent.text : undefined) ??
+    (typeof firstContent?.id === "string" ? firstContent.id : undefined) ??
+    (typeof record.toolCallId === "string" ? record.toolCallId : "");
+  const kind = record.openclawMessageToolMirror ? "mirror" : String(record.role);
+  return `${String(metadata.seq)}:${kind}:${label}`;
+}
+
 async function readSessionHistoryBody(
   port: number,
   sessionKey: string,
@@ -1065,6 +1079,119 @@ describe("session history HTTP endpoints", () => {
       expect(secondBody.messages?.map((message) => message["__openclaw"]?.seq)).toEqual([1]);
       expect(secondBody.hasMore).toBe(false);
       expect(secondBody.nextCursor).toBeUndefined();
+    });
+  });
+
+  test("keeps same-sequence SQLite projection rows reachable over REST and SSE", async () => {
+    const storePath = await createSessionStoreFile();
+    const sessionId = "sess-same-sequence";
+    const sessionKey = "agent:main:main";
+    const sharedTimestamp = Date.UTC(2026, 7, 15, 9, 30, 0);
+    await writeSessionStore({
+      entries: { main: { sessionId, updatedAt: sharedTimestamp } },
+      storePath,
+    });
+    await replaceTranscriptEvents({ agentId: AGENT_ID, sessionId, sessionKey, storePath }, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        id: "history-user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "reply here" }],
+          timestamp: sharedTimestamp,
+        },
+      },
+      {
+        id: "history-tool-call",
+        message: {
+          ...makeTranscriptAssistantMessage({ text: "" }),
+          content: [
+            {
+              type: "toolCall",
+              id: "call-message-cursor",
+              name: "message",
+              arguments: { action: "send", message: "Cursor-visible reply." },
+            },
+          ],
+          timestamp: sharedTimestamp,
+        },
+      },
+      {
+        id: "history-tool-result",
+        message: {
+          role: "toolResult",
+          toolName: "message",
+          toolCallId: "call-message-cursor",
+          content: { ok: true, messageId: "same-sequence-result" },
+          timestamp: sharedTimestamp,
+        },
+      },
+      {
+        id: "history-hidden-control",
+        message: {
+          ...makeTranscriptAssistantMessage({ text: "NO_REPLY" }),
+          timestamp: sharedTimestamp,
+        },
+      },
+    ]);
+
+    await withGatewayHarness(async (harness) => {
+      const firstPage = await readSessionHistoryBody(harness.port, sessionKey, {
+        query: "?limit=1",
+      });
+      expect(firstPage.messages?.map(sessionHistoryRowIdentity)).toEqual([
+        "3:toolResult:call-message-cursor",
+        "3:mirror:Cursor-visible reply.",
+      ]);
+      expect(firstPage.hasMore).toBe(true);
+      expect(firstPage.nextCursor).toBe("3");
+
+      const stream = await openSessionHistorySse(harness.port, sessionKey, {
+        query: "?limit=1",
+      });
+      try {
+        const event = await readSseEvent(stream.reader, stream.streamState);
+        expect(event.event).toBe("history");
+        const data = event.data as SessionHistoryBody;
+        expect(data.messages?.map(sessionHistoryRowIdentity)).toEqual(
+          firstPage.messages?.map(sessionHistoryRowIdentity),
+        );
+        expect(data).toMatchObject({ hasMore: true, nextCursor: "3" });
+      } finally {
+        await stream.reader.cancel();
+      }
+
+      const pages: SessionHistoryBody[] = [firstPage];
+      const seenCursors = new Set<string>();
+      let cursor = firstPage.nextCursor;
+      while (cursor) {
+        expect(seenCursors.has(cursor)).toBe(false);
+        seenCursors.add(cursor);
+        const page = await readSessionHistoryBody(harness.port, sessionKey, {
+          query: `?limit=1&cursor=${encodeURIComponent(cursor)}`,
+        });
+        pages.push(page);
+        cursor = page.hasMore ? page.nextCursor : undefined;
+      }
+
+      const chronologicalRows = pages.toReversed().flatMap((page) => page.messages ?? []);
+      expect(chronologicalRows.map(sessionHistoryRowIdentity)).toEqual([
+        "1:user:reply here",
+        "2:assistant:call-message-cursor",
+        "3:toolResult:call-message-cursor",
+        "3:mirror:Cursor-visible reply.",
+      ]);
+      expect(
+        chronologicalRows.map((message) => requireRecord(message, "history timestamp").timestamp),
+      ).toEqual(Array.from({ length: 4 }, () => sharedTimestamp));
+      expect(
+        pages
+          .flatMap((page) => page.messages ?? [])
+          .some((message) => sessionHistoryRowIdentity(message).includes("NO_REPLY")),
+      ).toBe(false);
+      expect(seenCursors).toEqual(new Set(["3", "2"]));
+      expect(pages.at(-1)).toMatchObject({ hasMore: false });
+      expect(pages.at(-1)?.nextCursor).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Related: #121386
Related: #124120

## What Problem This Solves

Fixes an issue where HTTP/SSE session-history clients could permanently miss a visible row when display projection produced several rows with the same transcript sequence and a page limit split that sequence group.

## Why This Change Was Made

The existing public cursor addresses transcript sequences, not individual projected rows. The shared REST/SSE paginator now closes each tentative page over every included sequence group, including interleaved message-tool result/mirror rows, while preserving display order and the existing cursor and response shape.

This is a focused continuation of the hidden-tail repair in #124120. Issue #121386 remains broader embedded-history context and is not closed or claimed fully resolved here.

Production LOC: +20/-1 (net +19). Tests: +202/-18. The original contiguous-run repair was +9 production LOC, but independent review found a valid two-send projection shaped as seq 3 result, seq 4 result, seq 3 mirror, seq 4 mirror; the extra closure logic is required to satisfy the full sequence-group invariant rather than only adjacent siblings.

No protocol, HTTP/SSE schema, SQLite schema, migration, retention, config, security, release, or deployment surface changes. `CHANGELOG.md` and docs are intentionally unchanged; this body carries release-note context and the public API contract is unchanged.

AI-assisted; maintainer-reviewed.

## User Impact

External session-history clients can follow the existing sequence cursor without duplicate, skipped, looping, or hidden rows. A page may exceed its requested row limit only when needed to keep an indivisible sequence group reachable.

## Evidence

- Pre-fix against `b37b048`: the strengthened owner regression failed 1/26 because the newest `limit=1` page returned only the seq-4 mirror and stranded the interleaved seq-3/seq-4 siblings.
- Post-fix state owner suite: 26/26 passed.
- Real SQLite + isolated Gateway REST/SSE suite: 85/85 passed on Blacksmith Testbox [run 31877896740](https://github.com/openclaw/openclaw/actions/runs/31877896740).
  - The first page preserves the interleaved seq-3 and seq-4 result/mirror groups and returns cursor 3.
  - Following cursors reconstructs all six visible row identities in display order with no duplicate, skip, or loop.
  - REST and initial SSE identities/cursors match; `NO_REPLY` remains hidden.
  - #124120's all-hidden-tail continuation regression remains green.
- Source-blind behavior validation: all six REST/SSE contract clauses passed; 85/85 tests, exit 0.
- Projection sibling suite: 21/21 passed.
- Changed gate passed: formatting, core production/test types, focused lint, and changed guards.
- Explicit storage/architecture guards passed: database-first legacy stores, session accessor, transcript reader, synchronous SQLite transaction boundary, SQLite schema baseline, native schema version, and zero runtime import cycles.
- Fresh autoreview: no accepted/actionable findings; patch correctness 0.98.
- `git diff --check`: clean.
