### PR TITLE
fix(agents): deliver Codex input choices in Telegram and web chat

### DIFF
--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -1,3 +1,4 @@
+import { markReplyPayloadForSourceSuppressionDelivery } from "../../auto-reply/reply-payload.js";
 import type { MessagePresentation } from "../../interactive/payload.js";
 import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
 
@@ -79,7 +80,9 @@ export async function deliverAgentHarnessUserInputPrompt(
 ): Promise<void> {
   const text = formatAgentHarnessUserInputPrompt(questions, options);
   if (params.onBlockReply) {
-    await params.onBlockReply({ text, presentation: options.presentation });
+    await params.onBlockReply(
+      markReplyPayloadForSourceSuppressionDelivery({ text, presentation: options.presentation }),
+    );
     return;
   }
   await params.onPartialReply?.({ text });
@@ -159,14 +162,14 @@ export function buildAgentHarnessQuestionPromptPayload(params: {
     new Set(normalizedOptionValues).size === candidateOptionValues.length
       ? candidateOptionValues
       : undefined;
-  return {
+  return markReplyPayloadForSourceSuppressionDelivery({
     text: `${prompt}\n\n${questionReplyGuidance(params.questions)}`,
     ...(presentation ? { presentation, presentationTextMode: "fallback" as const } : {}),
     // Native callbacks need Gateway option order even when presentation controls are reordered.
     channelData: {
       askUser: { questionId: params.questionId, ...(optionValues ? { optionValues } : {}) },
     },
-  };
+  });
 }
 
 function questionReplyGuidance(questions: readonly AgentHarnessUserInputQuestion[]): string {

--- a/src/auto-reply/reply/dispatch-from-config.send-policy-routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.send-policy-routing.test-utils.ts
@@ -1,6 +1,10 @@
 // Imported by dispatch-from-config.test.ts to keep its mocked suite in one Vitest module graph.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerAgentHarness } from "../../agents/harness/registry.js";
+import {
+  buildAgentHarnessQuestionPromptPayload,
+  deliverAgentHarnessUserInputPrompt,
+} from "../../agents/harness/user-input-bridge.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { settleReplyDispatcher } from "../dispatch-dispatcher.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
@@ -161,6 +165,54 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
     }
     expect(onBlockReplyQueued).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "gateway-backed choice",
+      deliver: async (onBlockReply: NonNullable<GetReplyOptions["onBlockReply"]>) => {
+        await onBlockReply(
+          buildAgentHarnessQuestionPromptPayload({
+            questionId: "question-owned-by-harness",
+            questions: [
+              {
+                id: "color",
+                header: "Color",
+                question: "Choose a color",
+                options: [{ label: "Red" }, { label: "Blue" }],
+              },
+            ],
+          }),
+        );
+      },
+    },
+    {
+      name: "plain secret",
+      deliver: async (onBlockReply: NonNullable<GetReplyOptions["onBlockReply"]>) => {
+        await deliverAgentHarnessUserInputPrompt({ onBlockReply }, [
+          { id: "token", header: "Token", question: "Enter your token", isSecret: true },
+        ]);
+      },
+    },
+  ])("delivers $name harness questions in direct message-tool-only turns", async ({ deliver }) => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = { sessionId: "s1", updatedAt: 0, sendPolicy: "allow" };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await deliver(requireBlockReplyHandler(opts?.onBlockReply));
+      return [];
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ ChatType: "direct", SessionKey: "test:harness-question" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledTimes(1);
   });
 
   it("keeps hook-cancelled marked blocks out of delivery and queued callbacks", async () => {


### PR DESCRIPTION
<!-- Closes the reported Codex input-delivery regression. -->
Closes #123561

## What Problem This Solves

Fixes an issue where users running the native Codex harness in a message-tool-only turn would never see `request_user_input` choices in Telegram or web chat. The question remained pending, so the run waited indefinitely.

## Why This Change Was Made

Harness-owned input prompts now carry the existing source-suppression delivery marker at their canonical producer. This covers gateway-backed choices and the sibling secret/plain prompt path without Codex-, Telegram-, or UI-specific policy.

Root cause: #110372 added the portable harness question producer, but its block payload lacked the internal delivery marker. `message_tool_only` therefore suppressed the originating source reply before channel/UI delivery even though Gateway question registration and answer routing were healthy.

Overlap checked: #102261 is a broad interactive-parity feature stack; it does not provide this focused owner-boundary repair. No PR references #123561.

## User Impact

Codex questions appear in the originating Telegram chat or web chat while ordinary assistant source replies remain suppressed. Users can answer instead of seeing a silent hang.

## Evidence

- Live pre-fix Telegram reproduction on base `3d643f7b7b6`: Codex emitted a two-choice request; Gateway `question.list` showed it pending; Telegram recorded typing only—no prompt or buttons. Diagnostic resolution reached Codex with the exact answer, proving registration/wait/answer healthy and isolating delivery suppression.
- Regression test before production edit: `delivers gateway-backed choice harness questions in direct message-tool-only turns` failed with zero block deliveries.
- Post-fix grouped owner proof: 8 suites, 427 tests passed, including gateway-backed choice and secret/plain prompt cases.
- `node scripts/run-oxlint.mjs <2 touched files>`
- `pnpm tsgo`
- `pnpm check:test-types`
- `pnpm check:import-cycles` — 0 runtime value cycles
- `oxfmt --check <2 touched files>` and `git diff --check`
- Distill: canonical placement accepted; sibling producer found and covered. Greybeard: zero performance findings.
- Production LOC: +6/-3, net +3. Tests: +52/-0. Growth is the two existing metadata applications at the canonical harness boundary; no new branch, fallback, or state.

Final exact-head ClawSweeper and Telegram proof follow under the fast-lane gates.